### PR TITLE
fix(tabs): tabs distorted on edge #4562

### DIFF
--- a/src/lib/tabs/tab-body.scss
+++ b/src/lib/tabs/tab-body.scss
@@ -1,6 +1,7 @@
 .mat-tab-body-content {
   height: 100%;
-  overflow: auto;
+  // In MS Edge, the content is distorted after the 
+  // transition has ocurred. Ref: #4562
   overflow: unset;
 
   .mat-tab-group-dynamic-height & {

--- a/src/lib/tabs/tab-body.scss
+++ b/src/lib/tabs/tab-body.scss
@@ -1,6 +1,7 @@
 .mat-tab-body-content {
   height: 100%;
   overflow: auto;
+  overflow: unset;
 
   .mat-tab-group-dynamic-height & {
     overflow: hidden;


### PR DESCRIPTION
On Microsoft Edge, when you switch tabs the content of the tab is distorted. If a user interacts with the content area, it then appears.

Reference: [Video](https://www.screencast.com/t/ElCqSxjpiB)

Addresses:  #4562