### PR TITLE
feat(autocomplete): dynamic [displayWith] and fix(autocomplete): Write values synchronously

### DIFF
--- a/src/demo-app/autocomplete/autocomplete-demo.html
+++ b/src/demo-app/autocomplete/autocomplete-demo.html
@@ -9,7 +9,8 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
     <mat-form-field floatLabel="never">
       <mat-label>State</mat-label>
       <input matInput [matAutocomplete]="reactiveAuto" [formControl]="stateCtrl">
-      <mat-autocomplete #reactiveAuto="matAutocomplete" [displayWith]="displayFn">
+      <mat-autocomplete #reactiveAuto="matAutocomplete"
+                        [displayWith]="displayName ? displayNameFn : displayCodeFn">
         <mat-option *ngFor="let state of tempStates" [value]="state">
           <span>{{ state.name }}</span>
           <span class="demo-secondary-text"> ({{ state.code }}) </span>
@@ -22,6 +23,11 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <button mat-button (click)="stateCtrl.setValue(states[10])">SET VALUE</button>
       <button mat-button (click)="stateCtrl.enabled ? stateCtrl.disable() : stateCtrl.enable()">
         TOGGLE DISABLED
+      </button>
+      <button mat-button (click)="displayName = !displayName"
+              [ngSwitch]="displayName">
+        <ng-container *ngSwitchCase="true">DISPLAY CODE</ng-container>
+        <ng-container *ngSwitchCase="false">DISPLAY NAME</ng-container>
       </button>
     </mat-card-actions>
 

--- a/src/demo-app/autocomplete/autocomplete-demo.ts
+++ b/src/demo-app/autocomplete/autocomplete-demo.ts
@@ -32,6 +32,7 @@ export class AutocompleteDemo {
   stateCtrl: FormControl;
   currentState = '';
   currentGroupedState = '';
+  displayName = true;
   topHeightCtrl = new FormControl(0);
 
   reactiveStates: Observable<State[]>;
@@ -102,7 +103,7 @@ export class AutocompleteDemo {
     this.reactiveStates = this.stateCtrl.valueChanges
       .pipe(
         startWith(this.stateCtrl.value),
-        map(val => this.displayFn(val)),
+        map(val => this.displayNameFn(val)),
         map(name => this.filterStates(name))
       );
 
@@ -121,8 +122,12 @@ export class AutocompleteDemo {
         }, []);
   }
 
-  displayFn(value: any): string {
+  displayNameFn(value: any): string {
     return value && typeof value === 'object' ? value.name : value;
+  }
+
+  displayCodeFn(value: any): string {
+    return value && typeof value === 'object' ? value.code : value;
   }
 
   filterStates(val: string) {

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -31,6 +31,7 @@ import {
 } from '@angular/material/core';
 import {ActiveDescendantKeyManager} from '@angular/cdk/a11y';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {Subject} from 'rxjs';
 
 
 /**
@@ -113,7 +114,16 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   @ContentChildren(MatOptgroup) optionGroups: QueryList<MatOptgroup>;
 
   /** Function that maps an option's control value to its display value in the trigger. */
-  @Input() displayWith: ((value: any) => string) | null = null;
+  @Input()
+  get displayWith() {
+    return this._displayWith;
+  }
+  set displayWith(value: any) {
+    this._displayWith = typeof value === 'function' ? value : null;
+    this._displayWithChange.next();
+  }
+  private _displayWith: ((value: any) => string) | null = null;
+  readonly _displayWithChange = new Subject<void>();
 
   /**
    * Whether the first option should be highlighted when the autocomplete panel is opened.


### PR DESCRIPTION
When the displayWith function changes, the autocomplete trigger needs to rewrite the trigger value. Since we're listening to changes to displayWith, we no longer need to wait for stability before writing values, so we can write synchronously.

It was necessary to clean up some of the observables and make a single shared click stream. Otherwise, different subscribers would see different results since unpublished observables are evaluated once per subscription in DFS order.

Demo: https://angular-material-devapp-97d86.firebaseapp.com/autocomplete