### PR TITLE
fix(input): add default input height

### DIFF
--- a/src/dev-app/input/input-demo.html
+++ b/src/dev-app/input/input-demo.html
@@ -55,6 +55,18 @@
           </mat-form-field>
         </td>
       </tr></table>
+      <table style="width: 100%" cellspacing="0"><tr>
+        <td>
+          <mat-form-field class="demo-full-width">
+            <input matInput type="datetime-local" placeholder="Date">
+          </mat-form-field>
+        </td>
+        <td>
+          <mat-form-field class="demo-full-width">
+            <input matInput type="number" placeholder="Duration">
+          </mat-form-field>
+        </td>
+      </tr></table>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/material/form-field/form-field-input.scss
+++ b/src/material/form-field/form-field-input.scss
@@ -70,6 +70,9 @@
   &[type='month'],
   &[type='week'],
   &[type='time'] {
+    // Hack to prevent a line break on Safari input date fields:
+    white-space: pre;
+
     &::after {
       content: ' ';
       white-space: pre;

--- a/src/material/input/_input-theme.scss
+++ b/src/material/input/_input-theme.scss
@@ -69,5 +69,11 @@
   // be misaligned w.r.t. the placeholder. Adding this margin corrects it.
   input.mat-input-element {
     margin-top: -$line-spacing * 1em;
+    height: $line-height * 1em;
+  }
+
+  input.mat-input-safari::first-line {
+    // Hack for 1px input content clipping on Safari:
+    line-height: $line-height * 1em;
   }
 }

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -73,6 +73,7 @@ const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase =
      */
     'class': 'mat-input-element mat-form-field-autofill-control',
     '[class.mat-input-server]': '_isServer',
+    '[class.mat-input-safari]': '_isSafari',
     // Native input properties that are overwritten by Angular inputs need to be synced with
     // the native input element. Otherwise property bindings for those don't work.
     '[attr.id]': 'id',
@@ -96,6 +97,9 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   private _inputValueAccessor: {value: any};
   /** The aria-describedby attribute on the input for improved a11y. */
   _ariaDescribedby: string;
+
+  /** Whether the component is being rendered in Safari. */
+  _isSafari = false;
 
   /** Whether the component is being rendered on the server. */
   _isServer = false;
@@ -265,6 +269,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
       });
     }
 
+    this._isSafari = this._platform.SAFARI;
     this._isServer = !this._platform.isBrowser;
     this._isNativeSelect = element.nodeName.toLowerCase() === 'select';
 

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -10,6 +10,7 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     protected _elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
     protected _id: string;
     _isNativeSelect: boolean;
+    _isSafari: boolean;
     _isServer: boolean;
     protected _neverEmptyInputTypes: string[];
     protected _platform: Platform;


### PR DESCRIPTION
Fixes an issue where inputs are not aligned when using flex-layout and datetime-local, because there is no default height for input fields in the code, and the default browser's height for datetime-local input fields is not the same as other inputs.

Fixes #8012