### PR TITLE
fix(autocomplete): top option group not scrolled into view when going up

### DIFF
--- a/src/lib/autocomplete/autocomplete-trigger.ts
+++ b/src/lib/autocomplete/autocomplete-trigger.ts
@@ -387,14 +387,18 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     const labelCount = _countGroupLabelsBeforeOption(index,
         this.autocomplete.options, this.autocomplete.optionGroups);
 
-    const newScrollPosition = _getOptionScrollPosition(
-      index + labelCount,
-      AUTOCOMPLETE_OPTION_HEIGHT,
-      this.autocomplete._getScrollTop(),
-      AUTOCOMPLETE_PANEL_HEIGHT
-    );
+    if (index === 0 && labelCount === 1) {
+      this.autocomplete._setScrollTop(0);
+    } else {
+      const newScrollPosition = _getOptionScrollPosition(
+        index + labelCount,
+        AUTOCOMPLETE_OPTION_HEIGHT,
+        this.autocomplete._getScrollTop(),
+        AUTOCOMPLETE_PANEL_HEIGHT
+      );
 
-    this.autocomplete._setScrollTop(newScrollPosition);
+      this.autocomplete._setScrollTop(newScrollPosition);
+    }
   }
 
   /**

--- a/src/lib/autocomplete/autocomplete.spec.ts
+++ b/src/lib/autocomplete/autocomplete.spec.ts
@@ -1114,6 +1114,28 @@ describe('MatAutocomplete', () => {
           .toBe(128, 'Expected panel to reveal the sixth option.');
     }));
 
+    it('should scroll back to the top when reaching the first option with preceding group label',
+      fakeAsync(() => {
+        fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+        tick();
+        fixture.detectChanges();
+        expect(container.scrollTop).toBe(0, 'Expected the panel not to scroll.');
+
+        // Press the down arrow five times.
+        [1, 2, 3, 4, 5].forEach(() => {
+          fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+          tick();
+        });
+
+        // Press the up arrow five times.
+        [1, 2, 3, 4, 5].forEach(() => {
+          fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+          tick();
+        });
+
+        expect(container.scrollTop).toBe(0, 'Expected panel to be scrolled to the top.');
+      }));
+
     it('should scroll to active options on UP arrow', fakeAsync(() => {
       fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
       tick();


### PR DESCRIPTION
Fixes the case where the user won't be able to see the top option group when reaching the first option via the arrow keys.