### PR TITLE
fix(tabs): mark tab body as a scrollable container

### DIFF
--- a/src/lib/tabs/tab-body.html
+++ b/src/lib/tabs/tab-body.html
@@ -4,6 +4,7 @@
         params: {animationDuration: animationDuration}
      }"
      (@translateTab.start)="_onTranslateTabStarted($event)"
-     (@translateTab.done)="_translateTabComplete.next($event)">
+     (@translateTab.done)="_translateTabComplete.next($event)"
+     cdkScrollable>
   <ng-template matTabBodyHost></ng-template>
 </div>

--- a/src/lib/tabs/tab-body.spec.ts
+++ b/src/lib/tabs/tab-body.spec.ts
@@ -7,6 +7,8 @@ import {MatRippleModule} from '@angular/material/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTabBody, MatTabBodyPortal} from './tab-body';
 import {Subject} from 'rxjs';
+import {ScrollDispatchModule, CdkScrollable} from '@angular/cdk/scrolling';
+import {By} from '@angular/platform-browser';
 
 
 describe('MatTabBody', () => {
@@ -177,6 +179,33 @@ describe('MatTabBody', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance.tabBody._position).toBe('left');
+  });
+
+  it('should mark the tab body content as a scrollable container', () => {
+    TestBed
+      .resetTestingModule()
+      .configureTestingModule({
+        imports: [
+          CommonModule,
+          PortalModule,
+          MatRippleModule,
+          NoopAnimationsModule,
+          ScrollDispatchModule
+        ],
+        declarations: [
+          MatTabBody,
+          MatTabBodyPortal,
+          SimpleTabBodyApp,
+        ]
+      })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(SimpleTabBodyApp);
+    const tabBodyContent = fixture.nativeElement.querySelector('.mat-tab-body-content');
+    const scrollable = fixture.debugElement.query(By.directive(CdkScrollable));
+
+    expect(scrollable).toBeTruthy();
+    expect(scrollable.nativeElement).toBe(tabBodyContent);
   });
 });
 


### PR DESCRIPTION
Since the tab body content can be scrollable and consumers don't have access to the DOM element, we have to mark it as a `CdkScrollable` in order to allow for overlays inside the tabs to reposition.

Fixes #8405.