### PR TITLE
fix(tooltip): leaking TooltipComponent references

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -37,7 +37,6 @@ import {
   OnDestroy,
   OnInit,
   Optional,
-  ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
 import {Observable, Subject} from 'rxjs';
@@ -244,7 +243,6 @@ export class MatTooltip implements OnDestroy, OnInit {
     private _overlay: Overlay,
     private _elementRef: ElementRef<HTMLElement>,
     private _scrollDispatcher: ScrollDispatcher,
-    private _viewContainerRef: ViewContainerRef,
     private _ngZone: NgZone,
     private _platform: Platform,
     private _ariaDescriber: AriaDescriber,
@@ -333,7 +331,8 @@ export class MatTooltip implements OnDestroy, OnInit {
     const overlayRef = this._createOverlay();
 
     this._detach();
-    this._portal = this._portal || new ComponentPortal(TooltipComponent, this._viewContainerRef);
+    overlayRef.setDirection(this._dir ? this._dir.value : 'ltr');
+    this._portal = this._portal || new ComponentPortal(TooltipComponent);
     this._tooltipInstance = overlayRef.attach(this._portal).instance;
     this._tooltipInstance.afterHidden()
       .pipe(takeUntil(this._destroyed))

--- a/tools/public_api_guard/material/tooltip.d.ts
+++ b/tools/public_api_guard/material/tooltip.d.ts
@@ -32,7 +32,7 @@ export declare class MatTooltip implements OnDestroy, OnInit {
         [key: string]: any;
     });
     touchGestures: TooltipTouchGestures;
-    constructor(_overlay: Overlay, _elementRef: ElementRef<HTMLElement>, _scrollDispatcher: ScrollDispatcher, _viewContainerRef: ViewContainerRef, _ngZone: NgZone, _platform: Platform, _ariaDescriber: AriaDescriber, _focusMonitor: FocusMonitor, scrollStrategy: any, _dir: Directionality, _defaultOptions: MatTooltipDefaultOptions,
+    constructor(_overlay: Overlay, _elementRef: ElementRef<HTMLElement>, _scrollDispatcher: ScrollDispatcher, _ngZone: NgZone, _platform: Platform, _ariaDescriber: AriaDescriber, _focusMonitor: FocusMonitor, scrollStrategy: any, _dir: Directionality, _defaultOptions: MatTooltipDefaultOptions,
     _hammerLoader?: any);
     _getOrigin(): {
         main: OriginConnectionPosition;


### PR DESCRIPTION
Fixes references to each of the `TooltipComponent` instances (one per opened tooltip) created by `MatTooltip` not being cleaned up on close. The issue comes from the fact that we're passing in the `ViewContainerRef` which ends up retaining the references until it is destroyed, which is problematic, because the tooltip could be attached to a very long-lived view container (e.g. inside an app's navigation). In this case we can get away with not passing in the view container, because the tooltip component is internal and we manipulate it directly through the tooltip trigger anyway.