### PR TITLE
Extra classes must be exported for MatTabGroup extending/inheriting

### DIFF
--- a/src/lib/tabs/tabs-module.ts
+++ b/src/lib/tabs/tabs-module.ts
@@ -39,6 +39,9 @@ import {MatTabLink, MatTabNav} from './tab-nav-bar/tab-nav-bar';
     MatTab,
     MatTabNav,
     MatTabLink,
+    MatTabLabelWrapper, 
+    MatTabHeader,
+    MatTabBody
   ],
   declarations: [
     MatTabGroup,


### PR DESCRIPTION
MatTabLabelWrapper, MatTabHeader, MatTabBody - required for extending/inheriting of MatTabGroup, because they are used in MatTabGroup template

See this issue for explaination
https://github.com/angular/material2/issues/9216

Having a static Tabs is not enough. I want to repoduce MDI behaviour where each tab will contain a named router-outlet of links which invoked by other components of application. And ofcource user must be able to close tabs he have opened before. For this i want to add [X] icon to template, but can not inherit because mentioned above classes are not exported