### PR TITLE
refactor: switch output event event classes to interfaces

### DIFF
--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -7,7 +7,6 @@ import {ESCAPE} from '@angular/cdk/keycodes';
 import {CdkConnectedOverlay, OverlayModule, CdkOverlayOrigin} from './index';
 import {OverlayContainer} from './overlay-container';
 import {ConnectedPositionStrategy} from './position/connected-position-strategy';
-import {ConnectedOverlayPositionChange} from './position/connected-position';
 
 
 describe('Overlay directives', () => {
@@ -272,11 +271,6 @@ describe('Overlay directives', () => {
       fixture.detectChanges();
 
       expect(fixture.componentInstance.positionChangeHandler).toHaveBeenCalled();
-
-      const latestCall = fixture.componentInstance.positionChangeHandler.calls.mostRecent();
-
-      expect(latestCall.args[0] instanceof ConnectedOverlayPositionChange)
-          .toBe(true, `Expected directive to emit an instance of ConnectedOverlayPositionChange.`);
     });
 
     it('should emit attach and detach appropriately', () => {

--- a/src/cdk/overlay/position/connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.spec.ts
@@ -366,11 +366,7 @@ describe('ConnectedPositionStrategy', () => {
       strategy.attach(fakeOverlayRef(overlayElement));
       strategy.apply();
 
-      const latestCall = positionChangeHandler.calls.mostRecent();
-
       expect(positionChangeHandler).toHaveBeenCalled();
-      expect(latestCall.args[0] instanceof ConnectedOverlayPositionChange)
-          .toBe(true, `Expected strategy to emit an instance of ConnectedOverlayPositionChange.`);
 
       // If the strategy is re-applied and the initial position would now fit,
       // the position change event should be emitted again.

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -423,9 +423,10 @@ export class ConnectedPositionStrategy implements PositionStrategy {
     element.style[horizontalStyleProperty] = `${x}px`;
 
     // Notify that the position has been changed along with its change properties.
-    const scrollableViewProperties = this._getScrollVisibility(element);
-    const positionChange = new ConnectedOverlayPositionChange(pos, scrollableViewProperties);
-    this._onPositionChange.next(positionChange);
+    this._onPositionChange.next({
+      connectionPair: pos,
+      scrollableViewProperties: this._getScrollVisibility(element)
+    });
   }
 
   /**

--- a/src/cdk/overlay/position/connected-position.ts
+++ b/src/cdk/overlay/position/connected-position.ts
@@ -7,7 +7,6 @@
  */
 
 /** Horizontal dimension of a connection point on the perimeter of the origin or overlay element. */
-import {Optional} from '@angular/core';
 export type HorizontalConnectionPos = 'start' | 'center' | 'end';
 
 /** Vertical dimension of a connection point on the perimeter of the origin or overlay element. */
@@ -83,10 +82,10 @@ export class ScrollingVisibility {
 }
 
 /** The change event emitted by the strategy when a fallback position is used. */
-export class ConnectedOverlayPositionChange {
-  constructor(
-      /** The position used as a result of this change. */
-      public connectionPair: ConnectionPositionPair,
-      /** @docs-private */
-      @Optional() public scrollableViewProperties: ScrollingVisibility) {}
+export interface ConnectedOverlayPositionChange {
+  /** The position used as a result of this change. */
+  connectionPair: ConnectionPositionPair;
+
+  /** @docs-private */
+  scrollableViewProperties: ScrollingVisibility;
 }

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -47,7 +47,7 @@ export type StepContentPositionState = 'previous' | 'current' | 'next';
 export type StepperOrientation = 'horizontal' | 'vertical';
 
 /** Change event emitted on selection changes. */
-export class StepperSelectionEvent {
+export interface StepperSelectionEvent {
   /** Index of the step now selected. */
   selectedIndex: number;
 

--- a/src/lib/autocomplete/autocomplete.ts
+++ b/src/lib/autocomplete/autocomplete.ts
@@ -37,12 +37,12 @@ import {ActiveDescendantKeyManager} from '@angular/cdk/a11y';
 let _uniqueAutocompleteIdCounter = 0;
 
 /** Event object that is emitted when an autocomplete option is selected */
-export class MatAutocompleteSelectedEvent {
-  constructor(
-    /** Reference to the autocomplete panel that emitted the event. */
-    public source: MatAutocomplete,
-    /** Option that was selected. */
-    public option: MatOption) { }
+export interface MatAutocompleteSelectedEvent {
+  /** Reference to the autocomplete panel that emitted the event. */
+  source: MatAutocomplete;
+
+  /** Option that was selected. */
+  option: MatOption;
 }
 
 // Boilerplate for applying mixins to MatAutocomplete.
@@ -153,8 +153,7 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
 
   /** Emits the `select` event. */
   _emitSelectEvent(option: MatOption): void {
-    const event = new MatAutocompleteSelectedEvent(this, option);
-    this.optionSelected.emit(event);
+    this.optionSelected.emit({source: this, option});
   }
 }
 

--- a/src/lib/button-toggle/button-toggle.ts
+++ b/src/lib/button-toggle/button-toggle.ts
@@ -52,7 +52,7 @@ export const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any = {
 let _uniqueIdCounter = 0;
 
 /** Change event object emitted by MatButtonToggle. */
-export class MatButtonToggleChange {
+export interface MatButtonToggleChange {
   /** The MatButtonToggle that emits the event. */
   source: MatButtonToggle | null;
   /** The value assigned to the MatButtonToggle. */
@@ -190,9 +190,7 @@ export class MatButtonToggleGroup extends _MatButtonToggleGroupMixinBase
 
   /** Dispatch change event with current selection and group value. */
   _emitChangeEvent(): void {
-    let event = new MatButtonToggleChange();
-    event.source = this._selected;
-    event.value = this._value;
+    const event: MatButtonToggleChange = {source: this._selected, value: this._value};
     this._controlValueAccessorChangeFn(event.value);
     this.change.emit(event);
   }
@@ -467,10 +465,7 @@ export class MatButtonToggle implements OnInit, OnDestroy {
 
   /** Dispatch change event with current value. */
   private _emitChangeEvent(): void {
-    let event = new MatButtonToggleChange();
-    event.source = this;
-    event.value = this._value;
-    this.change.emit(event);
+    this.change.emit({source: this, value: this._value});
   }
 
   // Unregister buttonToggleDispatcherListener on destroy

--- a/src/lib/checkbox/checkbox.ts
+++ b/src/lib/checkbox/checkbox.ts
@@ -72,7 +72,7 @@ export enum TransitionCheckState {
 }
 
 /** Change event object emitted by MatCheckbox. */
-export class MatCheckboxChange {
+export interface MatCheckboxChange {
   /** The source MatCheckbox of the event. */
   source: MatCheckbox;
   /** The new `checked` value of the checkbox. */
@@ -335,12 +335,8 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   }
 
   private _emitChangeEvent() {
-    let event = new MatCheckboxChange();
-    event.source = this;
-    event.checked = this.checked;
-
     this._controlValueAccessorChangeFn(this.checked);
-    this.change.emit(event);
+    this.change.emit({source: this, checked: this.checked});
   }
 
   /** Function is called whenever the focus changes for the input element. */

--- a/src/lib/chips/chip-input.ts
+++ b/src/lib/chips/chip-input.ts
@@ -66,8 +66,7 @@ export class MatChipInput {
   @Input('matChipInputSeparatorKeyCodes') separatorKeyCodes: number[] = [ENTER];
 
   /** Emitted when a chip is to be added. */
-  @Output('matChipInputTokenEnd')
-  chipEnd = new EventEmitter<MatChipInputEvent>();
+  @Output('matChipInputTokenEnd') chipEnd = new EventEmitter<MatChipInputEvent>();
 
   /** The input's placeholder text. */
   @Input() placeholder: string = '';

--- a/src/lib/chips/chip-list.ts
+++ b/src/lib/chips/chip-list.ts
@@ -59,12 +59,11 @@ export const _MatChipListMixinBase = mixinErrorState(MatChipListBase);
 let nextUniqueId = 0;
 
 /** Change event object that is emitted when the chip list value has changed. */
-export class MatChipListChange {
-  constructor(
-    /** Chip list that emitted the event. */
-    public source: MatChipList,
-    /** Value of the chip list when the event was emitted. */
-    public value: any) { }
+export interface MatChipListChange {
+  /** Chip list that emitted the event. */
+  source: MatChipList;
+  /** Value of the chip list when the event was emitted. */
+  value: any;
 }
 
 
@@ -648,7 +647,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
       valueToEmit = this.selected ? this.selected.value : fallbackValue;
     }
     this._value = valueToEmit;
-    this.change.emit(new MatChipListChange(this, valueToEmit));
+    this.change.emit({source: this, value: valueToEmit});
     this.valueChange.emit(valueToEmit);
     this._onChange(valueToEmit);
     this._changeDetectorRef.markForCheck();

--- a/src/lib/chips/chip.ts
+++ b/src/lib/chips/chip.ts
@@ -28,14 +28,13 @@ export interface MatChipEvent {
 }
 
 /** Event object emitted by MatChip when selected or deselected. */
-export class MatChipSelectionChange {
-  constructor(
-    /** Reference to the chip that emitted the event. */
-    public source: MatChip,
-    /** Whether the chip that emitted the event is selected. */
-    public selected: boolean,
-    /** Whether the selection change was a result of a user interaction. */
-    public isUserInput = false) { }
+export interface MatChipSelectionChange {
+  /** Reference to the chip that emitted the event. */
+  source: MatChip;
+  /** Whether the chip that emitted the event is selected. */
+  selected: boolean;
+  /** Whether the selection change was a result of a user interaction. */
+  isUserInput: boolean;
 }
 
 

--- a/src/lib/core/option/option.ts
+++ b/src/lib/core/option/option.ts
@@ -31,12 +31,11 @@ import {MatOptgroup} from './optgroup';
 let _uniqueIdCounter = 0;
 
 /** Event object emitted by MatOption when selected or deselected. */
-export class MatOptionSelectionChange {
-  constructor(
-    /** Reference to the option that emitted the event. */
-    public source: MatOption,
-    /** Whether the change in the option's value was a result of a user action. */
-    public isUserInput = false) { }
+export interface MatOptionSelectionChange {
+  /** Reference to the option that emitted the event. */
+  source: MatOption;
+  /** Whether the change in the option's value was a result of a user action. */
+  isUserInput: boolean;
 }
 
 /**
@@ -221,7 +220,7 @@ export class MatOption {
 
   /** Emits the selection change event. */
   private _emitSelectionChangeEvent(isUserInput = false): void {
-    this.onSelectionChange.emit(new MatOptionSelectionChange(this, isUserInput));
+    this.onSelectionChange.emit({source: this, isUserInput});
   }
 
   /**

--- a/src/lib/datepicker/datepicker-input.ts
+++ b/src/lib/datepicker/datepicker-input.ts
@@ -57,17 +57,13 @@ export const MAT_DATEPICKER_VALIDATORS: any = {
  * input or change event because the event may have been triggered by the user clicking on the
  * calendar popup. For consistency, we always use MatDatepickerInputEvent instead.
  */
-export class MatDatepickerInputEvent<D> {
+export interface MatDatepickerInputEvent<D> {
   /** The new value for the target datepicker input. */
   value: D | null;
-
-  constructor(
-    /** Reference to the datepicker input component that emitted the event. */
-    public target: MatDatepickerInput<D>,
-    /** Reference to the native input element associated with the datepicker input. */
-    public targetElement: HTMLElement) {
-    this.value = this.target.value;
-  }
+  /** Reference to the datepicker input component that emitted the event. */
+  target: MatDatepickerInput<D>;
+  /** Reference to the native input element associated with the datepicker input. */
+  targetElement: HTMLElement;
 }
 
 
@@ -250,8 +246,10 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
             this.value = selected;
             this._cvaOnChange(selected);
             this._onTouched();
-            this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-            this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+
+            const event = this._getChangeEvent();
+            this.dateInput.emit(event);
+            this.dateChange.emit(event);
           });
     }
   }
@@ -321,11 +319,11 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
     this._value = date;
     this._cvaOnChange(date);
     this._valueChange.emit(date);
-    this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+    this.dateInput.emit(this._getChangeEvent());
   }
 
   _onChange() {
-    this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+    this.dateChange.emit(this._getChangeEvent());
   }
 
   /**
@@ -334,5 +332,16 @@ export class MatDatepickerInput<D> implements AfterContentInit, ControlValueAcce
    */
   private _getValidDateOrNull(obj: any): D | null {
     return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
+  }
+
+  /**
+   * Creates a change event object that can be emitted to the consumer.
+   */
+  private _getChangeEvent(): MatDatepickerInputEvent<D> {
+    return {
+      value: this.value,
+      target: this,
+      targetElement: this._elementRef.nativeElement
+    };
   }
 }

--- a/src/lib/list/selection-list.ts
+++ b/src/lib/list/selection-list.ts
@@ -63,21 +63,19 @@ export const MAT_SELECTION_LIST_VALUE_ACCESSOR: any = {
  * Change event object emitted by MatListOption whenever the selected state changes.
  * @deprecated Use the `MatSelectionListChange` event on the selection list instead.
  */
-export class MatListOptionChange {
-  constructor(
-    /** Reference to the list option that changed. */
-    public source: MatListOption,
-    /** The new selected state of the option. */
-    public selected: boolean) {}
+export interface MatListOptionChange {
+  /** Reference to the list option that changed. */
+  source: MatListOption;
+  /** The new selected state of the option. */
+  selected: boolean;
 }
 
 /** Change event that is being fired whenever the selected state of an option changes. */
-export class MatSelectionListChange {
-  constructor(
-    /** Reference to the selection list that emitted the event. */
-    public source: MatSelectionList,
-    /** Reference to the option that has been changed. */
-    public option: MatListOption) {}
+export interface MatSelectionListChange {
+  /** Reference to the selection list that emitted the event. */
+  source: MatSelectionList;
+  /** Reference to the option that has been changed. */
+  option: MatListOption;
 }
 
 /**
@@ -261,7 +259,7 @@ export class MatListOption extends _MatListOptionMixinBase
   /** Emits a selectionChange event for this option. */
   _emitDeprecatedChangeEvent() {
     // TODO: the `selectionChange` event on the option is deprecated. Remove that in the future.
-    this.selectionChange.emit(new MatListOptionChange(this, this.selected));
+    this.selectionChange.emit({source: this, selected: this.selected});
   }
 }
 
@@ -394,7 +392,7 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements Focu
 
   /** Emits a change event if the selected state of an option changed. */
   _emitChangeEvent(option: MatListOption) {
-    this.selectionChange.emit(new MatSelectionListChange(this, option));
+    this.selectionChange.emit({source: this, option});
   }
 
   /** Implemented as part of ControlValueAccessor. */

--- a/src/lib/paginator/paginator.ts
+++ b/src/lib/paginator/paginator.ts
@@ -28,7 +28,7 @@ const DEFAULT_PAGE_SIZE = 50;
  * Change event object that is emitted when the user selects a
  * different page size or navigates to another page.
  */
-export class PageEvent {
+export interface PageEvent {
   /** The current page index. */
   pageIndex: number;
 

--- a/src/lib/radio/radio.ts
+++ b/src/lib/radio/radio.ts
@@ -57,7 +57,7 @@ export const MAT_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any = {
 };
 
 /** Change event object emitted by MatRadio and MatRadioGroup. */
-export class MatRadioChange {
+export interface MatRadioChange {
   /** The MatRadioButton that emits the change event. */
   source: MatRadioButton | null;
   /** The value of the MatRadioButton. */
@@ -262,10 +262,10 @@ export class MatRadioGroup extends _MatRadioGroupMixinBase
   /** Dispatch change event with current selection and group value. */
   _emitChangeEvent(): void {
     if (this._isInitialized) {
-      const event = new MatRadioChange();
-      event.source = this._selected;
-      event.value = this._value;
-      this.change.emit(event);
+      this.change.emit({
+        source: this._selected,
+        value: this._value
+      });
     }
   }
 
@@ -551,10 +551,10 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
 
   /** Dispatch change event with current value. */
   private _emitChangeEvent(): void {
-    const event = new MatRadioChange();
-    event.source = this;
-    event.value = this._value;
-    this.change.emit(event);
+    this.change.emit({
+      source: this,
+      value: this._value
+    });
   }
 
   _isRippleDisabled() {

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -43,7 +43,6 @@ import {
   FloatLabelType,
   MAT_LABEL_GLOBAL_OPTIONS,
   MatOption,
-  MatOptionSelectionChange,
 } from '@angular/material/core';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
@@ -1108,7 +1107,10 @@ describe('MatSelect', () => {
         fixture.detectChanges();
         flush();
 
-        expect(spy).toHaveBeenCalledWith(jasmine.any(MatOptionSelectionChange));
+        expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({
+          source: fixture.componentInstance.options.first,
+          isUserInput: true
+        }));
 
         subscription.unsubscribe();
       }));
@@ -1138,7 +1140,10 @@ describe('MatSelect', () => {
           fixture.detectChanges();
           flush();
 
-          expect(spy).toHaveBeenCalledWith(jasmine.any(MatOptionSelectionChange));
+          expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({
+            source: fixture.componentInstance.options.first,
+            isUserInput: true
+          }));
 
           subscription!.unsubscribe();
         }));

--- a/src/lib/select/select.ts
+++ b/src/lib/select/select.ts
@@ -139,12 +139,11 @@ export const MAT_SELECT_SCROLL_STRATEGY_PROVIDER = {
 };
 
 /** Change event object that is emitted when the select value has changed. */
-export class MatSelectChange {
-  constructor(
-    /** Reference to the select that emitted the change event. */
-    public source: MatSelect,
-    /** Current value of the select that emitted the event. */
-    public value: any) { }
+export interface MatSelectChange {
+  /** Reference to the select that emitted the change event. */
+  source: MatSelect;
+  /** Current value of the select that emitted the event. */
+  value: any;
 }
 
 // Boilerplate for applying mixins to MatSelect.
@@ -909,7 +908,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     this._value = valueToEmit;
     this.valueChange.emit(valueToEmit);
     this._onChange(valueToEmit);
-    this.selectionChange.emit(new MatSelectChange(this, valueToEmit));
+    this.selectionChange.emit({source: this, value: valueToEmit});
     this._changeDetectorRef.markForCheck();
   }
 

--- a/src/lib/slide-toggle/slide-toggle.ts
+++ b/src/lib/slide-toggle/slide-toggle.ts
@@ -51,7 +51,7 @@ export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
 };
 
 /** Change event object emitted by a MatSlideToggle. */
-export class MatSlideToggleChange {
+export interface MatSlideToggleChange {
   source: MatSlideToggle;
   checked: boolean;
 }
@@ -250,9 +250,7 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
    * Emits a change event on the `change` output. Also notifies the FormControl about the change.
    */
   private _emitChangeEvent() {
-    let event = new MatSlideToggleChange();
-    event.source = this;
-    event.checked = this.checked;
+    const event: MatSlideToggleChange = {source: this, checked: this.checked};
     this.onChange(this.checked);
     this.change.emit(event);
   }

--- a/src/lib/slider/slider.ts
+++ b/src/lib/slider/slider.ts
@@ -73,10 +73,9 @@ export const MAT_SLIDER_VALUE_ACCESSOR: any = {
 };
 
 /** A simple change event emitted by the MatSlider component. */
-export class MatSliderChange {
+export interface MatSliderChange {
   /** The MatSlider that changed. */
   source: MatSlider;
-
   /** The new value of the source slider. */
   value: number | null;
 }
@@ -624,12 +623,12 @@ export class MatSlider extends _MatSliderMixinBase
   /** Emits a change event if the current value is different from the last emitted value. */
   private _emitChangeEvent() {
     this._controlValueAccessorChangeFn(this.value);
-    this.change.emit(this._createChangeEvent());
+    this.change.emit({source: this, value: this.value});
   }
 
   /** Emits an input event when the current value is different from the last emitted value. */
   private _emitInputEvent() {
-    this.input.emit(this._createChangeEvent());
+    this.input.emit({source: this, value: this.value});
   }
 
   /** Updates the amount of space between ticks as a percentage of the width of the slider. */
@@ -647,16 +646,6 @@ export class MatSlider extends _MatSliderMixinBase
     } else {
       this._tickIntervalPercent = this.tickInterval * this.step / (this.max - this.min);
     }
-  }
-
-  /** Creates a slider change object from the specified value. */
-  private _createChangeEvent(value = this.value): MatSliderChange {
-    let event = new MatSliderChange();
-
-    event.source = this;
-    event.value = value;
-
-    return event;
   }
 
   /** Calculates the percentage of the slider that a value is. */

--- a/src/lib/tabs/tab-group.ts
+++ b/src/lib/tabs/tab-group.ts
@@ -40,7 +40,7 @@ import {
 let nextId = 0;
 
 /** A simple change event emitted on focus or selection changes. */
-export class MatTabChangeEvent {
+export interface MatTabChangeEvent {
   /** Index of the currently-selected tab. */
   index: number;
   /** Reference to the currently-selected tab. */
@@ -58,7 +58,7 @@ export class MatTabGroupBase {
 export const _MatTabGroupMixinBase = mixinColor(mixinDisableRipple(MatTabGroupBase), 'primary');
 
 /**
- * Material design tab-group component.  Supports basic tab pairs (label + content) and includes
+ * Material design tab-group component. Supports basic tab pairs (label + content) and includes
  * animated ink-bar, keyboard navigation, and screen reader.
  * See: https://www.google.com/design/spec/components/tabs.html
  */
@@ -225,12 +225,13 @@ export class MatTabGroup extends _MatTabGroupMixinBase implements AfterContentIn
   }
 
   private _createChangeEvent(index: number): MatTabChangeEvent {
-    const event = new MatTabChangeEvent;
-    event.index = index;
+    let tab;
+
     if (this._tabs && this._tabs.length) {
-      event.tab = this._tabs.toArray()[index];
+      tab = this._tabs.toArray()[index];
     }
-    return event;
+
+    return {index, tab};
   }
 
   /**


### PR DESCRIPTION
Converts the various event classes that we emit through `@Output` into interfaces in order to generate less compiled code and potentially less objects to garbage collect.