### PR TITLE
fix(datepicker): dateInput being fired on load in IE when input has a placeholder

### DIFF
--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -628,6 +628,7 @@ describe('MatDatepicker', () => {
         expect(inputEl.classList).toContain('ng-pristine');
 
         inputEl.value = '2001-01-01';
+        inputEl.focus();
         dispatchFakeEvent(inputEl, 'input');
         fixture.detectChanges();
 
@@ -1134,6 +1135,7 @@ describe('MatDatepicker', () => {
         expect(testComponent.onDateInput).not.toHaveBeenCalled();
 
         inputEl.value = '2001-01-01';
+        inputEl.focus();
         dispatchFakeEvent(inputEl, 'input');
         fixture.detectChanges();
 
@@ -1186,6 +1188,7 @@ describe('MatDatepicker', () => {
         expect(testComponent.onDateInput).not.toHaveBeenCalled();
 
         inputEl.value = '12/12/2012';
+        inputEl.focus();
         dispatchFakeEvent(inputEl, 'input');
         fixture.detectChanges();
 
@@ -1196,6 +1199,16 @@ describe('MatDatepicker', () => {
 
         expect(testComponent.onDateInput).toHaveBeenCalledTimes(1);
       });
+
+      it('should not dispatch the `dateInput` event if the `input` event is ' +
+        'fired on a non-focused input', () => {
+          expect(testComponent.onDateInput).not.toHaveBeenCalled();
+
+          dispatchFakeEvent(inputEl, 'input');
+          fixture.detectChanges();
+
+          expect(testComponent.onDateInput).not.toHaveBeenCalled();
+        });
 
     });
 


### PR DESCRIPTION
Fixes the `dateInput` event from the datepicker input directive being fired on load, focus and blur, if the input has a placeholder in IE.