### PR TITLE
fix(tabs): active tab label is fully opaque

### DIFF
--- a/src/lib/tabs/_tabs-common.scss
+++ b/src/lib/tabs/_tabs-common.scss
@@ -20,10 +20,10 @@ $mat-tab-animation-duration: 500ms !default;
 
   &:focus {
     outline: none;
+  }
 
-    &:not(.mat-tab-disabled) {
-      opacity: 1;
-    }
+  &.mat-tab-label-active {
+    opacity: 1;
   }
 
   &.mat-tab-disabled {


### PR DESCRIPTION
Ensures that the active tab label has full opacity even when not focused.

Fixes #10061.