### PR TITLE
style(input): increase line-height for input

### DIFF
--- a/src/lib/core/typography/_typography.scss
+++ b/src/lib/core/typography/_typography.scss
@@ -34,7 +34,7 @@
   $caption:       mat-typography-level(12px, 20px, 400),
   $button:        mat-typography-level(14px, 14px, 500),
   // Line-height must be unit-less fraction of the font-size.
-  $input:         mat-typography-level(inherit, 1.125, 400)
+  $input:         mat-typography-level(inherit, 1.25, 400)
 ) {
 
   // Declare an initial map with all of the levels.

--- a/src/lib/select/select.spec.ts
+++ b/src/lib/select/select.spec.ts
@@ -2771,7 +2771,7 @@ describe('MatSelect', () => {
       const options = overlayPane.querySelectorAll('mat-option');
       const optionTop = options[index].getBoundingClientRect().top;
       const triggerFontSize = parseInt(window.getComputedStyle(trigger)['font-size']);
-      const triggerLineHeightEm = 1.125;
+      const triggerLineHeightEm = 1.25;
 
       // Extra trigger height beyond the font size caused by the fact that the line-height is
       // greater than 1em.
@@ -2932,7 +2932,7 @@ describe('MatSelect', () => {
             const selectItemHeight = 48;
             const selectedIndex = 4;
             const fontSize = 16;
-            const lineHeightEm = 1.125;
+            const lineHeightEm = 1.25;
             const expectedExtraScroll = 5;
 
             // Trigger element height.
@@ -2986,7 +2986,7 @@ describe('MatSelect', () => {
             const selectItemHeight = 48;
             const selectedIndex = 4;
             const fontSize = 16;
-            const lineHeightEm = 1.125;
+            const lineHeightEm = 1.25;
             const expectedExtraScroll = 5;
 
             // Trigger element height.
@@ -3515,7 +3515,7 @@ describe('MatSelect', () => {
 
         const menuItemHeight = 48;
         const triggerFontSize = 16;
-        const triggerLineHeightEm = 1.125;
+        const triggerLineHeightEm = 1.25;
         const triggerHeight = triggerFontSize * triggerLineHeightEm;
 
         trigger.click();


### PR DESCRIPTION
Fix cropping issue for mat-input fields, previous line-height was to small for the used font.

Closes #9738