### PR TITLE
refactor(tabs): remove duplicate styling

### DIFF
--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -11,24 +11,6 @@
   }
 }
 
-// Wraps each tab label
-.mat-tab-label {
-  @include tab-label;
-  position: relative;
-}
-
-@media ($mat-xsmall) {
-  .mat-tab-label {
-    padding: 0 12px;
-  }
-}
-
-@media ($mat-small) {
-  .mat-tab-label {
-    padding: 0 12px;
-  }
-}
-
 // Note that we only want to target direct descendant tabs.
 .mat-tab-group[mat-stretch-tabs] > .mat-tab-header .mat-tab-label {
   flex-basis: 0;

--- a/src/lib/tabs/tab-header.scss
+++ b/src/lib/tabs/tab-header.scss
@@ -13,9 +13,16 @@
   position: relative;
 }
 
+@media ($mat-small) {
+  .mat-tab-label {
+    padding: 0 12px;
+  }
+}
+
 @media ($mat-xsmall) {
   .mat-tab-label {
     min-width: 72px;
+    padding: 0 12px;
   }
 }
 


### PR DESCRIPTION
* Removes some styling for the `.mat-tab-label` being repeated across multiple files.
* Removes some, what appears to be, left over debugging CSS from the tabs demo.

For reference:
![angular_material_-_google_chrome_2018-03-10_18-55-25](https://user-images.githubusercontent.com/4450522/37248087-47528744-2496-11e8-863e-6ea1bba4417a.png)
