### PR TITLE
fix(input): placeholder being read out twice by some screen readers

### DIFF
--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -1,8 +1,8 @@
 cdk/drag-drop/all-directives: 154096
 cdk/drag-drop/basic: 151353
 material-experimental/mdc-chips/basic: 147607
-material-experimental/mdc-form-field/advanced: 220897
-material-experimental/mdc-form-field/basic: 220060
+material-experimental/mdc-form-field/advanced: 251959
+material-experimental/mdc-form-field/basic: 251127
 material/autocomplete/without-optgroup: 210028
 material/button-toggle/standalone: 119486
 material/chips/basic: 162776

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -250,7 +250,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
    * @docs-private
    */
   get empty(): boolean {
-    return (!this._chipInput || this._chipInput.empty) && this.chips.length === 0;
+    return (!this._chipInput || this._chipInput.empty) && (!this.chips || this.chips.length === 0);
   }
 
   /**
@@ -801,7 +801,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
 
   /** Checks whether any of the chips is focused. */
   private _hasFocusedChip() {
-    return this.chips.some(chip => chip._hasFocus);
+    return this.chips && this.chips.some(chip => chip._hasFocus);
   }
 
   /** Syncs the list's state with the individual chips. */

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -411,7 +411,8 @@ export class MatFormField extends _MatFormFieldMixinBase
   }
 
   _shouldLabelFloat() {
-    return this._canLabelFloat && (this._control.shouldLabelFloat || this._shouldAlwaysFloat);
+    return this._canLabelFloat &&
+        ((this._control && this._control.shouldLabelFloat) || this._shouldAlwaysFloat);
   }
 
   _hideControlPlaceholder() {

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -367,20 +367,29 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputPlaceholderAttrTestComponent);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
-
     expect(fixture.debugElement.query(By.css('label'))).toBeNull();
-    expect(inputEl.placeholder).toBe('');
 
     fixture.componentInstance.placeholder = 'Other placeholder';
     fixture.detectChanges();
 
     let labelEl = fixture.debugElement.query(By.css('label'))!;
 
-    expect(inputEl.placeholder).toBe('Other placeholder');
     expect(labelEl).not.toBeNull();
     expect(labelEl.nativeElement.textContent).toBe('Other placeholder');
   }));
+
+  it('should not render the native placeholder when its value is mirrored in the label',
+    fakeAsync(() => {
+      const fixture = createComponent(MatInputPlaceholderAttrTestComponent);
+      fixture.componentInstance.placeholder = 'Enter a name';
+      fixture.detectChanges();
+
+      const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+      const labelEl = fixture.debugElement.query(By.css('label'));
+
+      expect(inputEl.hasAttribute('placeholder')).toBe(false);
+      expect(labelEl.nativeElement.textContent).toContain('Enter a name');
+    }));
 
   it('supports placeholder element', fakeAsync(() => {
     let fixture = createComponent(MatInputPlaceholderElementTestComponent);
@@ -911,8 +920,8 @@ describe('MatInput without forms', () => {
 
     expect(container.classList).toContain('mat-form-field-hide-placeholder');
     expect(container.classList).not.toContain('mat-form-field-should-float');
-    expect(label.textContent).toBe('Label');
-    expect(input.getAttribute('placeholder')).toBe('Placeholder');
+    expect(label.textContent.trim()).toBe('Label');
+    expect(input.hasAttribute('placeholder')).toBe(false);
 
     input.value = 'Value';
     fixture.detectChanges();
@@ -980,6 +989,12 @@ describe('MatInput without forms', () => {
 
       expect(label.classList).not.toContain('mat-form-field-empty');
     }));
+
+  it('should not throw when there is a default ngIf on the label element', fakeAsync(() => {
+    expect(() => {
+      createComponent(MatInputWithDefaultNgIf).detectChanges();
+    }).not.toThrow();
+  }));
 
 });
 
@@ -2221,3 +2236,18 @@ class CustomMatInputAccessor {
   set value(_value: any) {}
   private _value = null;
 }
+
+
+// Note that the DOM structure is slightly weird, but it's
+// testing a specific g3 issue. See the discussion on #10466.
+@Component({
+  template: `
+    <mat-form-field appearance="outline">
+      <mat-label *ngIf="true">My Label</mat-label>
+      <ng-container *ngIf="true">
+        <input matInput>
+      </ng-container>
+    </mat-form-field>
+  `
+})
+class MatInputWithDefaultNgIf {}

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -71,8 +71,12 @@ export class MatInputHarness extends MatFormFieldControlHarness {
 
   /** Gets the placeholder of the input. */
   async getPlaceholder(): Promise<string> {
-    // The "placeholder" property of the native input is never undefined.
-    return (await (await this.host()).getProperty('placeholder'))!;
+    const host = await this.host();
+    const [nativePlaceholder, fallback] = await Promise.all([
+      host.getProperty('placeholder'),
+      host.getAttribute('data-placeholder')
+    ]);
+    return nativePlaceholder || fallback || '';
   }
 
   /** Gets the id of the input. */

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -40,9 +40,10 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     get value(): string;
     set value(value: string);
     constructor(_elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>, _platform: Platform,
-    ngControl: NgControl, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone);
+    ngControl: NgControl, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined);
     protected _dirtyCheckNativeValue(): void;
     _focusChanged(isFocused: boolean): void;
+    _getPlaceholderAttribute(): string | undefined;
     protected _isBadInput(): boolean;
     protected _isNeverEmpty(): boolean;
     _onInput(): void;
@@ -59,7 +60,7 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     static ngAcceptInputType_required: BooleanInput;
     static ngAcceptInputType_value: any;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatInput, "input[matInput], textarea[matInput], select[matNativeControl],      input[matNativeControl], textarea[matNativeControl]", ["matInput"], { "disabled": "disabled"; "id": "id"; "placeholder": "placeholder"; "required": "required"; "type": "type"; "errorStateMatcher": "errorStateMatcher"; "value": "value"; "readonly": "readonly"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatInput, [null, null, { optional: true; self: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatInput, [null, null, { optional: true; self: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }, null, null, { optional: true; }]>;
 }
 
 export declare class MatInputModule {


### PR DESCRIPTION
Currently we hide the native placeholder using CSS while we mirror its value in the form field label, however because the value is still in the DOM, some screen readers will read it out twice: once for the label and once for the attribute. These changes remove the attribute from the DOM if it isn't supposed to be shown.

Fixes #9721.