### PR TITLE
feat(menu): add the ability to set a custom offset

### DIFF
--- a/src/lib/menu/menu-directive.ts
+++ b/src/lib/menu/menu-directive.ts
@@ -8,7 +8,7 @@
 
 import {FocusKeyManager, FocusOrigin} from '@angular/cdk/a11y';
 import {Direction} from '@angular/cdk/bidi';
-import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
 import {
   ESCAPE,
   LEFT_ARROW,
@@ -111,6 +111,8 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
   private _keyManager: FocusKeyManager<MatMenuItem>;
   private _xPosition: MenuPositionX = this._defaultOptions.xPosition;
   private _yPosition: MenuPositionY = this._defaultOptions.yPosition;
+  private _xOffset: number;
+  private _yOffset: number;
   private _previousElevation: string;
 
   /** Menu items inside the current menu. */
@@ -163,6 +165,20 @@ export class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnI
     }
     this._yPosition = value;
     this.setPositionClasses();
+  }
+
+  /** Offset of the menu along the X axis. */
+  @Input()
+  get xOffset(): number { return this._xOffset; }
+  set xOffset(value: number) {
+    this._xOffset = coerceNumberProperty(value);
+  }
+
+  /** Offset of the menu along the Y axis. */
+  @Input()
+  get yOffset(): number { return this._yOffset; }
+  set yOffset(value: number) {
+    this._yOffset = coerceNumberProperty(value);
   }
 
   /** @docs-private */

--- a/src/lib/menu/menu-panel.ts
+++ b/src/lib/menu/menu-panel.ts
@@ -39,4 +39,6 @@ export interface MatMenuPanel<T = any> {
   hasBackdrop?: boolean;
   addItem?: (item: T) => void;
   removeItem?: (item: T) => void;
+  xOffset?: number;
+  yOffset?: number;
 }

--- a/src/lib/menu/menu-trigger.ts
+++ b/src/lib/menu/menu-trigger.ts
@@ -444,27 +444,38 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
 
     let [originY, originFallbackY] = [overlayY, overlayFallbackY];
     let [overlayX, overlayFallbackX] = [originX, originFallbackX];
-    let offsetY = 0;
+    let offsetY: number;
+    let offsetX = this.menu.xOffset || 0;
 
     if (this.triggersSubmenu()) {
       // When the menu is a sub-menu, it should always align itself
       // to the edges of the trigger, instead of overlapping it.
       overlayFallbackX = originX = this.menu.xPosition === 'before' ? 'start' : 'end';
       originFallbackX = overlayX = originX === 'end' ? 'start' : 'end';
-      offsetY = overlayY === 'bottom' ? MENU_PANEL_TOP_PADDING : -MENU_PANEL_TOP_PADDING;
-    } else if (!this.menu.overlapTrigger) {
+    } if (!this.menu.overlapTrigger) {
       originY = overlayY === 'top' ? 'bottom' : 'top';
       originFallbackY = overlayFallbackY === 'top' ? 'bottom' : 'top';
     }
 
+    if (this.menu.yOffset == null) {
+      if (this.triggersSubmenu()) {
+        offsetY = overlayY === 'bottom' ? MENU_PANEL_TOP_PADDING : -MENU_PANEL_TOP_PADDING;
+      } else {
+        offsetY = 0;
+      }
+    } else {
+      offsetY = this.menu.yOffset;
+    }
+
     positionStrategy.withPositions([
-      {originX, originY, overlayX, overlayY, offsetY},
-      {originX: originFallbackX, originY, overlayX: overlayFallbackX, overlayY, offsetY},
+      {originX, originY, overlayX, overlayY, offsetX, offsetY},
+      {originX: originFallbackX, originY, overlayX: overlayFallbackX, overlayY, offsetX, offsetY},
       {
         originX,
         originY: originFallbackY,
         overlayX,
         overlayY: overlayFallbackY,
+        offsetX,
         offsetY: -offsetY
       },
       {
@@ -472,6 +483,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
         originY: originFallbackY,
         overlayX: overlayFallbackX,
         overlayY: overlayFallbackY,
+        offsetX,
         offsetY: -offsetY
       }
     ]);

--- a/src/lib/menu/menu.spec.ts
+++ b/src/lib/menu/menu.spec.ts
@@ -1201,6 +1201,47 @@ describe('MatMenu', () => {
     });
   });
 
+  describe('offsets', () => {
+    let fixture: ComponentFixture<SimpleMenu>;
+    let trigger: HTMLElement;
+
+    beforeEach(() => {
+      fixture = createComponent(SimpleMenu, [], [FakeIcon]);
+      fixture.detectChanges();
+      trigger = fixture.componentInstance.triggerEl.nativeElement;
+      trigger.style.position = 'fixed';
+      trigger.style.top = trigger.style.left = '200px';
+    });
+
+    it('should be able to set an offset along the x axis', () => {
+      fixture.componentInstance.xOffset = 50;
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openMenu();
+      fixture.detectChanges();
+
+      const panel = overlayContainerElement.querySelector('.mat-menu-panel') as HTMLElement;
+      const triggerRect = trigger.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+
+      expect(Math.floor(panelRect.left)).toBe(Math.floor(triggerRect.left) + 50);
+    });
+
+    it('should be able to set an offset along the y axis', () => {
+      fixture.componentInstance.yOffset = 50;
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openMenu();
+      fixture.detectChanges();
+
+      const panel = overlayContainerElement.querySelector('.mat-menu-panel') as HTMLElement;
+      const triggerRect = trigger.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+
+      expect(Math.floor(panelRect.top)).toBe(Math.floor(triggerRect.top) + 50);
+    });
+  });
+
   describe('close event', () => {
     let fixture: ComponentFixture<SimpleMenu>;
 
@@ -2005,7 +2046,9 @@ describe('MatMenu default overrides', () => {
       #menu="matMenu"
       [class]="panelClass"
       (closed)="closeCallback($event)"
-      [backdropClass]="backdropClass">
+      [backdropClass]="backdropClass"
+      [xOffset]="xOffset"
+      [yOffset]="yOffset">
 
       <button mat-menu-item> Item </button>
       <button mat-menu-item disabled> Disabled </button>
@@ -2027,6 +2070,8 @@ class SimpleMenu {
   backdropClass: string;
   panelClass: string;
   restoreFocus = true;
+  xOffset: number;
+  yOffset: number;
 }
 
 @Component({

--- a/tools/public_api_guard/lib/menu.d.ts
+++ b/tools/public_api_guard/lib/menu.d.ts
@@ -23,7 +23,9 @@ export declare class MatMenu implements AfterContentInit, MatMenuPanel<MatMenuIt
     panelClass: string;
     parentMenu: MatMenuPanel | undefined;
     templateRef: TemplateRef<any>;
+    xOffset: number;
     xPosition: MenuPositionX;
+    yOffset: number;
     yPosition: MenuPositionY;
     constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _defaultOptions: MatMenuDefaultOptions);
     _handleKeydown(event: KeyboardEvent): void;
@@ -96,7 +98,9 @@ export interface MatMenuPanel<T = any> {
     resetActiveItem: () => void;
     setPositionClasses?: (x: MenuPositionX, y: MenuPositionY) => void;
     templateRef: TemplateRef<any>;
+    xOffset?: number;
     xPosition: MenuPositionX;
+    yOffset?: number;
     yPosition: MenuPositionY;
     setElevation?(depth: number): void;
 }


### PR DESCRIPTION
Adds the `xOffset` and `yOffset` properties that allow consumers to set a custom offset on the menu panel.

Fixes #1672.