### PR TITLE
fix(slider-toggle): Fixes incorrect font size for content label

### DIFF
--- a/src/lib/slide-toggle/_slide-toggle-theme.scss
+++ b/src/lib/slide-toggle/_slide-toggle-theme.scss
@@ -90,6 +90,6 @@
 
 @mixin mat-slide-toggle-typography($config) {
   .mat-slide-toggle-content {
-    @include mat-typography-level-to-styles($config, body-1);
+    @include mat-typography-level-to-styles($config, input);
   }
 }


### PR DESCRIPTION
Fixes #10552. 
This corrects the font size from `14px` to `16px` for the slider-toggle content label.

*Before*: 
<img width="460" alt="screen shot 2018-04-02 at 1 54 16 pm" src="https://user-images.githubusercontent.com/14265337/38208002-9912373e-367d-11e8-92f6-f59390fee42c.png">

*After*: 
<img width="297" alt="screen shot 2018-04-02 at 1 55 47 pm" src="https://user-images.githubusercontent.com/14265337/38208005-9ae18592-367d-11e8-9c88-97b2a89eea24.png">