### PR TITLE
feat(dialog): theming support for dialog titles

### DIFF
--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -145,7 +145,7 @@ export class JazzDialog {
     }
   `],
   template: `
-    <h2 mat-dialog-title>Neptune</h2>
+    <h2 color="primary" mat-dialog-title>Neptune</h2>
 
     <mat-dialog-content>
       <img src="https://upload.wikimedia.org/wikipedia/commons/5/56/Neptune_Full.jpg"/>

--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -7,11 +7,31 @@
 @mixin mat-dialog-theme($theme) {
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
 
   .mat-dialog-container {
     @include _mat-theme-elevation(24, $theme);
     background: mat-color($background, dialog);
     color: mat-color($foreground, text);
+  }
+
+  .mat-dialog-title {
+    &.mat-primary {
+      background: mat-color($primary);
+      color: mat-color($primary, default-contrast);
+    }
+
+    &.mat-accent {
+      background: mat-color($accent);
+      color: mat-color($accent, default-contrast);
+    }
+
+    &.mat-warn {
+      background: mat-color($warn);
+      color: mat-color($warn, default-contrast);
+    }
   }
 }
 

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/core';
 import {MatDialog} from './dialog';
 import {MatDialogRef} from './dialog-ref';
+import {CanColor, mixinColor} from '@angular/material/core';
 
 /** Counter used to generate unique IDs for dialog elements. */
 let dialogElementUid = 0;
@@ -67,24 +68,35 @@ export class MatDialogClose implements OnInit, OnChanges {
   }
 }
 
+// Boilerplate for applying mixins to MatDialogTitle.
+/** @docs-private */
+export class MatDialogTitleBase {
+  constructor(public _elementRef: ElementRef) {}
+}
+export const _MatDialogTitleMixinBase = mixinColor(MatDialogTitleBase);
+
 /**
  * Title of a dialog element. Stays fixed to the top of the dialog when scrolling.
  */
 @Directive({
   selector: '[mat-dialog-title], [matDialogTitle]',
   exportAs: 'matDialogTitle',
+  inputs: ['color'],
   host: {
     'class': 'mat-dialog-title',
     '[id]': 'id',
   },
 })
-export class MatDialogTitle implements OnInit {
+export class MatDialogTitle extends _MatDialogTitleMixinBase implements OnInit, CanColor {
   @Input() id = `mat-dialog-title-${dialogElementUid++}`;
 
   constructor(
     @Optional() private _dialogRef: MatDialogRef<any>,
-    private _elementRef: ElementRef<HTMLElement>,
-    private _dialog: MatDialog) {}
+    elementRef: ElementRef<HTMLElement>,
+    private _dialog: MatDialog) {
+
+    super(elementRef);
+  }
 
   ngOnInit() {
     if (!this._dialogRef) {

--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -36,10 +36,20 @@ $mat-dialog-button-margin: 8px !default;
   max-height: $mat-dialog-max-height;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+
+  // We the content is preceeded by a title that has a color, we have to add some
+  // extra padding so the user's content isn't flush against the title.
+  .mat-dialog-title.mat-primary + &,
+  .mat-dialog-title.mat-accent + &,
+  .mat-dialog-title.mat-warn + & {
+    padding-top: $mat-dialog-padding;
+  }
 }
 
 .mat-dialog-title {
-  margin: 0 0 20px;
+  $inverted-padding: $mat-dialog-padding * -1;
+  margin: $inverted-padding $inverted-padding 0 $inverted-padding;
+  padding: $mat-dialog-padding;
   display: block;
 }
 


### PR DESCRIPTION
Adds support for adding a theme color to the `mat-dialog-title`.