### PR TITLE
fix(overlay): content not becoming scrollable inside flexible overlay on IE11

### DIFF
--- a/src/cdk/overlay/_overlay.scss
+++ b/src/cdk/overlay/_overlay.scss
@@ -61,6 +61,10 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     display: flex;
     max-width: 100%;
     max-height: 100%;
+
+    // Needs to be set specifically on the pane for
+    // the content to become scrollable on IE11.
+    overflow: auto;
   }
 
   .cdk-overlay-backdrop {

--- a/src/dev-app/connected-overlay/connected-overlay-demo.html
+++ b/src/dev-app/connected-overlay/connected-overlay-demo.html
@@ -105,8 +105,6 @@
 
 <ng-template #overlay>
   <div class="demo-overlay-connected-overlay">
-    <div style="overflow: auto;">
-      <ul><li *ngFor="let item of itemArray; index as i">{{itemText}} {{i}}</li></ul>
-    </div>
+    <ul><li *ngFor="let item of itemArray; index as i">{{itemText}} {{i}}</li></ul>
   </div>
 </ng-template>


### PR DESCRIPTION
Fixes flexible overlays not becoming scrollable when they hit the edge of the viewport on IE11.