### PR TITLE
fix(radio): Allow multiple radios with equal values (#11368)

### DIFF
--- a/src/demo-app/radio/radio-demo.html
+++ b/src/demo-app/radio/radio-demo.html
@@ -13,6 +13,15 @@
   <mat-radio-button name="group2" color="warn">Warn</mat-radio-button>
 </section>
 
+<h1>Multiple same Values Example</h1>
+<section class="demo-section">
+  <mat-radio-group [value]="'foo'">
+    <mat-radio-button [value]="val" *ngFor="let val of ['foo','bar','baz','foo']">
+      {{val}}
+    </mat-radio-button>
+  </mat-radio-group>
+</section>
+
 <h1>Dynamic Example</h1>
 <section class="demo-section">
   <div>


### PR DESCRIPTION
This allows multiple `<mat-radio-button>` with equal values within a `<mat-radio-group>`.
This is achieved by checking the actual selected property of the `<mat-radio-group>` instead
of checking the value.

This logic needed to be extended the pre-selection algorithms, too. Also we needed to check
not to select multiple radios in the init process.

This change does not contain any breaking changes and existing tests pass without adjustment.

Fixes #11368