### PR TITLE
fix(card): disable all animations when using NoopAnimationsModule

### DIFF
--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -1,5 +1,6 @@
 @import '../core/style/variables';
 @import '../core/style/elevation';
+@import '../core/style/noop-animation';
 @import '../../cdk/a11y/a11y';
 
 
@@ -9,6 +10,7 @@ $mat-card-header-size: 40px !default;
 
 .mat-card {
   @include mat-elevation-transition;
+  @include _noop-animation();
   display: block;
   position: relative;
   padding: $mat-card-padding;

--- a/src/material/card/card.ts
+++ b/src/material/card/card.ts
@@ -12,7 +12,10 @@ import {
   ChangeDetectionStrategy,
   Directive,
   Input,
+  Optional,
+  Inject,
 } from '@angular/core';
+import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 
 /**
@@ -156,9 +159,15 @@ export class MatCardAvatar {}
   styleUrls: ['card.css'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {'class': 'mat-card'}
+  host: {
+    'class': 'mat-card',
+    '[class._mat-animation-noopable]': '_animationMode === "NoopAnimations"',
+  }
 })
-export class MatCard {}
+export class MatCard {
+  // @deletion-target 7.0.0 `_animationMode` parameter to be made required.
+  constructor(@Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {}
+}
 
 
 /**

--- a/src/material/card/card.ts
+++ b/src/material/card/card.ts
@@ -165,7 +165,7 @@ export class MatCardAvatar {}
   }
 })
 export class MatCard {
-  // @deletion-target 7.0.0 `_animationMode` parameter to be made required.
+  // @breaking-change 9.0.0 `_animationMode` parameter to be made required.
   constructor(@Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {}
 }
 

--- a/tools/public_api_guard/material/card.d.ts
+++ b/tools/public_api_guard/material/card.d.ts
@@ -1,4 +1,6 @@
 export declare class MatCard {
+    _animationMode?: string | undefined;
+    constructor(_animationMode?: string | undefined);
 }
 
 export declare class MatCardActions {


### PR DESCRIPTION
Fixes the card `box-shadow` transition not being disabled when it's inside something with the `NoopAnimationsModule`.

Relates to #10590.