### PR TITLE
datepicker: emit new dateSelection on all date selections

### DIFF
--- a/src/lib/datepicker/datepicker-content.html
+++ b/src/lib/datepicker/datepicker-content.html
@@ -12,5 +12,5 @@
     (selectedChange)="datepicker._select($event)"
     (yearSelected)="datepicker._selectYear($event)"
     (monthSelected)="datepicker._selectMonth($event)"
-    (_userSelection)="datepicker.close()">
+    (_userSelection)="datepicker._userSelection()">
 </mat-calendar>

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -247,9 +247,13 @@ describe('MatDatepicker', () => {
         }));
 
       it('clicking the currently selected date should close the calendar ' +
-         'without firing selectedChanged', fakeAsync(() => {
+         'without firing selectedChanged but should fire userSelection ' +
+         'on every call', fakeAsync(() => {
         const selectedChangedSpy =
             spyOn(testComponent.datepicker._selectedChanged, 'next').and.callThrough();
+
+        const userSelectionSpy =
+            spyOn(testComponent.datepicker.userSelection, 'emit').and.callThrough();
 
         for (let changeCount = 1; changeCount < 3; changeCount++) {
           const currentDay = changeCount;
@@ -265,6 +269,7 @@ describe('MatDatepicker', () => {
           flush();
         }
 
+        expect(userSelectionSpy.calls.count()).toEqual(2);
         expect(selectedChangedSpy.calls.count()).toEqual(1);
         expect(document.querySelector('mat-dialog-container')).toBeNull();
         expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 2));

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -209,6 +209,9 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
   /** Emits when the datepicker has been closed. */
   @Output('closed') closedStream: EventEmitter<void> = new EventEmitter<void>();
 
+  /** Emits when any date is selected */
+  @Output('userSelection') userSelection: EventEmitter<void> = new EventEmitter<void>();
+
 
   /** Whether the calendar is open. */
   @Input()
@@ -296,6 +299,12 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
     if (!this._dateAdapter.sameDate(oldValue, this._selected)) {
       this._selectedChanged.next(date);
     }
+  }
+
+  /** Emits userSelection and closes datepicker */
+  _userSelection(): void {
+    this.close();
+    this.userSelection.emit();
   }
 
   /** Emits the selected year in multiyear view */


### PR DESCRIPTION
In the datepicker there are no subscriptions available to developers when they click on the date already selected. I have added the EventEmitter `userSelection` which emits void on every date selection, whether it changes or not.