### PR TITLE
fix(datepicker): change overlay position strategy so the calendar is kept on-screen

### DIFF
--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -445,7 +445,7 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
       .withTransformOriginOn('.mat-datepicker-content')
       .withFlexibleDimensions(false)
       .withViewportMargin(8)
-      .withPush(true)
+      .withLockedPosition()
       .withPositions([
         {
           originX: 'start',


### PR DESCRIPTION
Fixes #6965.