### PR TITLE
fix(overlay): disable all animations when using the NoopAnimationsModule

### DIFF
--- a/src/cdk/overlay/_overlay.scss
+++ b/src/cdk/overlay/_overlay.scss
@@ -90,6 +90,13 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     }
   }
 
+  .cdk-overlay-backdrop-transition-disabled {
+    // Reset the transition by overriding, rather than adding
+    // the `transition` conditionally, so we can cover the case
+    // where consumers specified their own transition.
+    transition: none;
+  }
+
   .cdk-overlay-dark-backdrop {
     background: $cdk-overlay-dark-backdrop-background;
   }

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -29,6 +29,7 @@ import {
   ScrollStrategy,
 } from './index';
 import {OverlayReference} from './overlay-reference';
+import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 
 describe('Overlay', () => {
@@ -701,6 +702,64 @@ describe('Overlay', () => {
 
       let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
       expect(backdrop.classList).toContain('cdk-overlay-transparent-backdrop');
+    });
+
+    it('should not disable the backdrop transition if animations are enabled', () => {
+      overlayContainer.ngOnDestroy();
+
+      TestBed
+        .resetTestingModule()
+        .configureTestingModule({
+          imports: [OverlayModule, PortalModule, OverlayTestModule, BrowserAnimationsModule],
+        })
+        .compileComponents();
+
+      inject([Overlay, OverlayContainer], (o: Overlay, oc: OverlayContainer) => {
+        overlay = o;
+        overlayContainer = oc;
+        overlayContainerElement = oc.getContainerElement();
+      })();
+
+      let fixture = TestBed.createComponent(TestComponentWithTemplatePortals);
+      fixture.detectChanges();
+      componentPortal = new ComponentPortal(PizzaMsg, fixture.componentInstance.viewContainerRef);
+      viewContainerFixture = fixture;
+
+      let overlayRef = overlay.create(config);
+      overlayRef.attach(componentPortal);
+      viewContainerFixture.detectChanges();
+
+      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+      expect(backdrop.classList).not.toContain('cdk-overlay-backdrop-transition-disabled');
+    });
+
+    it('should disable the backdrop transition when animations are disabled', () => {
+      overlayContainer.ngOnDestroy();
+
+      TestBed
+        .resetTestingModule()
+        .configureTestingModule({
+          imports: [OverlayModule, PortalModule, OverlayTestModule, NoopAnimationsModule],
+        })
+        .compileComponents();
+
+      inject([Overlay, OverlayContainer], (o: Overlay, oc: OverlayContainer) => {
+        overlay = o;
+        overlayContainer = oc;
+        overlayContainerElement = oc.getContainerElement();
+      })();
+
+      let fixture = TestBed.createComponent(TestComponentWithTemplatePortals);
+      fixture.detectChanges();
+      componentPortal = new ComponentPortal(PizzaMsg, fixture.componentInstance.viewContainerRef);
+      viewContainerFixture = fixture;
+
+      let overlayRef = overlay.create(config);
+      overlayRef.attach(componentPortal);
+      viewContainerFixture.detectChanges();
+
+      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+      expect(backdrop.classList).toContain('cdk-overlay-backdrop-transition-disabled');
     });
 
     it('should apply multiple custom classes to the overlay', () => {

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -24,6 +24,7 @@ import {OverlayContainer} from './overlay-container';
 import {OverlayRef} from './overlay-ref';
 import {OverlayPositionBuilder} from './position/overlay-position-builder';
 import {ScrollStrategyOptions} from './scroll/index';
+import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 
 /** Next overlay unique ID. */
@@ -56,7 +57,12 @@ export class Overlay {
               @Inject(DOCUMENT) private _document: any,
               private _directionality: Directionality,
               // @breaking-change 8.0.0 `_location` parameter to be made required.
-              @Optional() private _location?: Location) { }
+              @Optional() private _location?: Location,
+              /**
+               * @deprecated `animationMode` parameter to be made required.
+               * @breaking-change 8.0.0
+               */
+              @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string) { }
 
   /**
    * Creates an overlay.
@@ -72,7 +78,7 @@ export class Overlay {
     overlayConfig.direction = overlayConfig.direction || this._directionality.value;
 
     return new OverlayRef(portalOutlet, host, pane, overlayConfig, this._ngZone,
-      this._keyboardDispatcher, this._document, this._location);
+      this._keyboardDispatcher, this._document, this._location, this._animationMode);
   }
 
   /**

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -372,13 +372,16 @@ describe('MatDatepicker', () => {
         for (let i = 0; i < 3; i++) {
           testComponent.datepicker.open();
           fixture.detectChanges();
+          flush();
 
           testComponent.datepicker.close();
           fixture.detectChanges();
+          flush();
         }
 
         testComponent.datepicker.open();
         fixture.detectChanges();
+        flush();
 
         const spy = jasmine.createSpy('close event spy');
         const subscription = testComponent.datepicker.closedStream.subscribe(spy);


### PR DESCRIPTION
Disables the CSS-based animations in the overlay when using the `NoopAnimationsModule`.

Relates to #10590.