### PR TITLE
fix(menu): keyboard controls not respecting DOM order when items are added at a later point

### DIFF
--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -77,7 +77,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase
     private _elementRef: ElementRef<HTMLElement>,
     @Inject(DOCUMENT) document?: any,
     private _focusMonitor?: FocusMonitor,
-    @Inject(MAT_MENU_PANEL) @Optional() private _parentMenu?: MatMenuPanel<MatMenuItem>) {
+    @Inject(MAT_MENU_PANEL) @Optional() public _parentMenu?: MatMenuPanel<MatMenuItem>) {
 
     // @breaking-change 8.0.0 make `_focusMonitor` and `document` required params.
     super();

--- a/src/material/menu/menu-panel.ts
+++ b/src/material/menu/menu-panel.ts
@@ -37,6 +37,16 @@ export interface MatMenuPanel<T = any> {
   lazyContent?: MatMenuContent;
   backdropClass?: string;
   hasBackdrop?: boolean;
+
+  /**
+   * @deprecated To be removed.
+   * @breaking-change 8.0.0
+   */
   addItem?: (item: T) => void;
+
+  /**
+   * @deprecated To be removed.
+   * @breaking-change 8.0.0
+   */
   removeItem?: (item: T) => void;
 }

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -865,6 +865,33 @@ describe('MatMenu', () => {
 
       expect(item.textContent!.trim()).toBe('two');
     }));
+
+    it('should respect the DOM order, rather than insertion order, when moving focus using ' +
+      'the arrow keys', fakeAsync(() => {
+        let fixture = createComponent(SimpleMenuWithRepeater);
+
+        fixture.detectChanges();
+        fixture.componentInstance.trigger.openMenu();
+        fixture.detectChanges();
+        tick(500);
+
+        let menuPanel = document.querySelector('.mat-menu-panel')!;
+        let items = menuPanel.querySelectorAll('.mat-menu-panel [mat-menu-item]');
+
+        expect(document.activeElement).toBe(items[0], 'Expected first item to be focused on open');
+
+        // Add a new item after the first one.
+        fixture.componentInstance.items.splice(1, 0, 'Calzone');
+        fixture.detectChanges();
+
+        items = menuPanel.querySelectorAll('.mat-menu-panel [mat-menu-item]');
+        dispatchKeyboardEvent(menuPanel, 'keydown', DOWN_ARROW);
+        fixture.detectChanges();
+        tick();
+
+        expect(document.activeElement).toBe(items[1], 'Expected second item to be focused');
+        flush();
+      }));
   });
 
   describe('positions', () => {
@@ -2298,7 +2325,6 @@ class LazyMenuWithContext {
 }
 
 
-
 @Component({
   template: `
     <button [matMenuTriggerFor]="one">Toggle menu</button>
@@ -2331,3 +2357,19 @@ class DynamicPanelMenu {
 class MenuWithCheckboxItems {
   @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
 }
+
+
+@Component({
+  template: `
+    <button [matMenuTriggerFor]="menu">Toggle menu</button>
+    <mat-menu #menu="matMenu">
+      <button *ngFor="let item of items" mat-menu-item>{{item}}</button>
+    </mat-menu>
+  `
+})
+class SimpleMenuWithRepeater {
+  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
+  @ViewChild(MatMenu, {static: false}) menu: MatMenu;
+  items = ['Pizza', 'Pasta'];
+}
+

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -3,6 +3,7 @@ export declare class _MatMenu extends MatMenu {
 }
 
 export declare class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit, OnDestroy {
+    _allItems: QueryList<MatMenuItem>;
     _animationDone: Subject<AnimationEvent>;
     _classList: {
         [key: string]: boolean;
@@ -30,12 +31,12 @@ export declare class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatM
     _onAnimationStart(event: AnimationEvent): void;
     _resetAnimation(): void;
     _startAnimation(): void;
-    addItem(item: MatMenuItem): void;
+    addItem(_item: MatMenuItem): void;
     focusFirstItem(origin?: FocusOrigin): void;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    removeItem(item: MatMenuItem): void;
+    removeItem(_item: MatMenuItem): void;
     resetActiveItem(): void;
     setElevation(depth: number): void;
     setPositionClasses(posX?: MenuPositionX, posY?: MenuPositionY): void;
@@ -79,6 +80,7 @@ export interface MatMenuDefaultOptions {
 export declare class MatMenuItem extends _MatMenuItemMixinBase implements FocusableOption, CanDisable, CanDisableRipple, OnDestroy {
     _highlighted: boolean;
     readonly _hovered: Subject<MatMenuItem>;
+    _parentMenu?: MatMenuPanel<MatMenuItem> | undefined;
     _triggersSubmenu: boolean;
     role: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox';
     constructor(_elementRef: ElementRef<HTMLElement>, document?: any, _focusMonitor?: FocusMonitor | undefined, _parentMenu?: MatMenuPanel<MatMenuItem> | undefined);


### PR DESCRIPTION
A while ago we reworked the menu not to pick up the items of other child menus. As a result, we had to use a custom way of registering and de-registering the menu items, however that method ends up adding any newly-created items to the end of the item list. This will throw off the keyboard navigation if an item is inserted in the beginning or the middle of the list. With these changes we switch to picking up the items using `ContentChildren` and filtering out all of the indirect descendants.

Fixes #11652.