### PR TITLE
refactor(material/dialog): use type overload for open method

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet.ts
+++ b/src/material/bottom-sheet/bottom-sheet.ts
@@ -60,8 +60,21 @@ export class MatBottomSheet implements OnDestroy {
       @Optional() @Inject(MAT_BOTTOM_SHEET_DEFAULT_OPTIONS)
           private _defaultOptions?: MatBottomSheetConfig) {}
 
+  /**
+   * Opens a bottom sheet containing the given component.
+   * @param component Type of the component to load into the bottom sheet.
+   * @param config Extra configuration options.
+   * @returns Reference to the newly-opened bottom sheet.
+   */
   open<T, D = any, R = any>(component: ComponentType<T>,
                    config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
+
+  /**
+   * Opens a bottom sheet containing the given template.
+   * @param template TemplateRef to instantiate as the bottom sheet content.
+   * @param config Extra configuration options.
+   * @returns Reference to the newly-opened bottom sheet.
+   */
   open<T, D = any, R = any>(template: TemplateRef<T>,
                    config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
 

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -116,14 +116,27 @@ export abstract class _MatDialogBase<C extends _MatDialogContainerBase> implemen
 
   /**
    * Opens a modal dialog containing the given component.
-   * @param componentOrTemplateRef Type of the component to load into the dialog,
-   *     or a TemplateRef to instantiate as the dialog content.
+   * @param component Type of the component to load into the dialog.
    * @param config Extra configuration options.
    * @returns Reference to the newly-opened dialog.
    */
-  open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-          config?: MatDialogConfig<D>): MatDialogRef<T, R> {
+  open<T, D = any, R = any>(component: ComponentType<T>,
+                            config?: MatDialogConfig<D>): MatDialogRef<T, R>;
 
+  /**
+   * Opens a modal dialog containing the given template.
+   * @param template TemplateRef to instantiate as the dialog content.
+   * @param config Extra configuration options.
+   * @returns Reference to the newly-opened dialog.
+   */
+  open<T, D = any, R = any>(template: TemplateRef<T>,
+                            config?: MatDialogConfig<D>): MatDialogRef<T, R>;
+
+  open<T, D = any, R = any>(template: ComponentType<T> | TemplateRef<T>,
+                            config?: MatDialogConfig<D>): MatDialogRef<T, R>;
+
+  open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
+                            config?: MatDialogConfig<D>): MatDialogRef<T, R> {
     config = _applyConfigDefaults(config, this._defaultOptions || new MatDialogConfig());
 
     if (config.id && this.getDialogById(config.id) &&

--- a/tools/public_api_guard/material/dialog.d.ts
+++ b/tools/public_api_guard/material/dialog.d.ts
@@ -9,7 +9,9 @@ export declare abstract class _MatDialogBase<C extends _MatDialogContainerBase> 
     closeAll(): void;
     getDialogById(id: string): MatDialogRef<any> | undefined;
     ngOnDestroy(): void;
-    open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>, config?: MatDialogConfig<D>): MatDialogRef<T, R>;
+    open<T, D = any, R = any>(component: ComponentType<T>, config?: MatDialogConfig<D>): MatDialogRef<T, R>;
+    open<T, D = any, R = any>(template: TemplateRef<T>, config?: MatDialogConfig<D>): MatDialogRef<T, R>;
+    open<T, D = any, R = any>(template: ComponentType<T> | TemplateRef<T>, config?: MatDialogConfig<D>): MatDialogRef<T, R>;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatDialogBase<any>, never, never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatDialogBase<any>, never>;
 }


### PR DESCRIPTION
* Reworks the `MatDialog.open` method to use overloads, rather than the single signature that has `componentOrTemplateRef: ComponentType<T> | TemplateRef<T>`. This makes the separation clearer and looks nicer in autocompletion.
* Adds docs for the `MatBottomSheet.open` method.