### PR TITLE
fix(material/expansion): panel appearing as open when parent is animating away

### DIFF
--- a/src/material/expansion/expansion-animations.ts
+++ b/src/material/expansion/expansion-animations.ts
@@ -53,9 +53,11 @@ export const matExpansionAnimations: {
   ]),
   /** Animation that expands and collapses the panel content. */
   bodyExpansion: trigger('bodyExpansion', [
+    // Note: we also have `void` here as a fallback, because Angular will reset the
+    // state back to void when the element is being removed. See #11765.
     state('collapsed, void', style({height: '0px', visibility: 'hidden'})),
     state('expanded', style({height: '*', visibility: 'visible'})),
-    transition('expanded <=> collapsed, void => collapsed',
-      animate(EXPANSION_PANEL_ANIMATION_TIMING)),
+    transition('expanded <=> collapsed, expanded <=> void, void => collapsed',
+        animate(EXPANSION_PANEL_ANIMATION_TIMING)),
   ])
 };


### PR DESCRIPTION
Fixes an issue where the expansion panel will appear as if it is open, if the element is part of a component that is animating away. The issue comes from the fact that Angular resets the animation state to `void` which we don't have in the animation definitions.

Fixes #11765.