### PR TITLE
fix(chips): remove button not accessible via keyboard

### DIFF
--- a/src/material/chips/chip-remove.spec.ts
+++ b/src/material/chips/chip-remove.spec.ts
@@ -2,6 +2,8 @@ import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChip, MatChipsModule} from './index';
+import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing';
+import {ENTER} from '@angular/cdk/keycodes';
 
 describe('Chip Remove', () => {
   let fixture: ComponentFixture<TestChip>;
@@ -41,13 +43,52 @@ describe('Chip Remove', () => {
 
       testChip.removable = true;
       fixture.detectChanges();
-
-      spyOn(testChip, 'didRemove');
-
       buttonElement.click();
+
+      expect(testChip.didRemove).toHaveBeenCalled();
+    });
+
+    it('should become focusable when the chip is focused', () => {
+      const removeElement = chipNativeElement.querySelector('a')!;
+
+      expect(removeElement.getAttribute('tabindex')).toBe('-1');
+
+      dispatchFakeEvent(chipNativeElement, 'focus');
+      fixture.detectChanges();
+
+      expect(removeElement.getAttribute('tabindex')).toBe('0');
+
+      dispatchFakeEvent(chipNativeElement, 'blur');
+      fixture.detectChanges();
+
+      expect(removeElement.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('should not overwrite the tabindex if it was set by the consumer', () => {
+      const removeElement = chipNativeElement.querySelector('a')!;
+
+      fixture.componentInstance.chipRemoveTabindex = 3;
+      fixture.detectChanges();
+
+      expect(removeElement.getAttribute('tabindex')).toBe('3');
+
+      dispatchFakeEvent(chipNativeElement, 'focus');
+      fixture.detectChanges();
+
+      expect(removeElement.getAttribute('tabindex')).toBe('3');
+    });
+
+    it('should remove the chip when pressing enter', () => {
+      const hrefElement = chipNativeElement.querySelector('a')!;
+
+      testChip.removable = true;
+      fixture.detectChanges();
+
+      const event = dispatchKeyboardEvent(hrefElement, 'keydown', ENTER);
       fixture.detectChanges();
 
       expect(testChip.didRemove).toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(true);
     });
 
     it('should not remove if parent chip is disabled', () => {
@@ -77,8 +118,8 @@ describe('Chip Remove', () => {
   `
 })
 class TestChip {
+  chipRemoveTabindex: number;
   removable: boolean;
   disabled = false;
-
-  didRemove() {}
+  didRemove = jasmine.createSpy('remove spy');
 }

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -8,7 +8,7 @@
 
 import {FocusableOption} from '@angular/cdk/a11y';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {BACKSPACE, DELETE, SPACE} from '@angular/cdk/keycodes';
+import {BACKSPACE, DELETE, SPACE, ENTER} from '@angular/cdk/keycodes';
 import {Platform} from '@angular/cdk/platform';
 import {
   ContentChild,
@@ -393,12 +393,18 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
 @Directive({
   selector: '[matChipRemove]',
   host: {
+    '[attr.tabindex]': 'tabIndex == null ? (_parentChip._hasFocus ? 0 : -1) : tabIndex',
     'class': 'mat-chip-remove mat-chip-trailing-icon',
     '(click)': '_handleClick($event)',
+    '(keydown)': '_handleKeydown($event)',
   }
 })
 export class MatChipRemove {
-  constructor(protected _parentChip: MatChip) {}
+  /** Tabindex for the remove icon. */
+  @Input() tabIndex: number;
+
+  constructor(public _parentChip: MatChip) {
+  }
 
   /** Calls the parent chip's public `remove()` method if applicable. */
   _handleClick(event: Event): void {
@@ -414,5 +420,15 @@ export class MatChipRemove {
     // the parent click listener of the `MatChip` would prevent propagation, but it can happen
     // that the chip is being removed before the event bubbles up.
     event.stopPropagation();
+  }
+
+  /** Handles key events on the chip remove button. */
+  _handleKeydown(event: KeyboardEvent) {
+    // Since the element might not be a button, we have to handle key events ourselves.
+    if (event.keyCode === ENTER && this._parentChip.removable) {
+      event.preventDefault();
+      event.stopPropagation();
+      this._parentChip.remove();
+    }
   }
 }


### PR DESCRIPTION
* Fixes the user not being able to reach the chip remove button using the keyboard. Now the button will become tabbable once the chip around it is focused.
* Fixes the remove button not doing anything on enter key presses.

Fixes #11896.