### PR TITLE
fix(paginator): allow screen readers to announce page changes

### DIFF
--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -21,7 +21,7 @@
   </div>
 
   <div class="mat-paginator-range-actions">
-    <div class="mat-paginator-range-label">
+    <div class="mat-paginator-range-label" aria-live="polite">
       {{_intl.getRangeLabel(pageIndex, pageSize, length)}}
     </div>
 


### PR DESCRIPTION
Screen Readers can navigate the paginator but don't announce the
resulting changes occurred. Instead of simply announcing "next page"
this change lets the screen reader announce the page lable, which is
needed for GAR accessibility.