### PR TITLE
fix(expansion-panel): title text not centered with taller description

### DIFF
--- a/src/material/expansion/expansion-panel-header.scss
+++ b/src/material/expansion/expansion-panel-header.scss
@@ -44,6 +44,7 @@
   display: flex;
   flex-grow: 1;
   margin-right: 16px;
+  align-items: center;
 
   [dir='rtl'] & {
     margin-right: 0;


### PR DESCRIPTION
Fixes the expansion panel's title not being centered vertically if the description is taller.

For reference from the docs:
![expansion_panel__angular_material_-_google_chrome_2018-07-11_22-03-06](https://user-images.githubusercontent.com/4450522/42596682-d1b2835a-8556-11e8-9a71-7cf18f352254.png)
