### PR TITLE
fix(material/button-toggle): ripples not clipping correctly in safari

### DIFF
--- a/src/material/button-toggle/button-toggle.scss
+++ b/src/material/button-toggle/button-toggle.scss
@@ -19,6 +19,9 @@ $legacy-border-radius: 2px !default;
   border-radius: $legacy-border-radius;
   -webkit-tap-highlight-color: transparent;
 
+  // Fixes the ripples not being clipped to the border radius on Safari.
+  transform: translateZ(0);
+
   @include a11y.high-contrast(active, off) {
     outline: solid 1px;
   }


### PR DESCRIPTION
Fixes the ripples on buttons and button toggles not being clipped to the border radius in Safari.

Relates to #12244.