### PR TITLE
fix(datepicker): wait for exit animation to finish before detaching content

### DIFF
--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -140,6 +140,29 @@ describe('MatDatepicker', () => {
         testComponent.opened = false;
         fixture.detectChanges();
         flush();
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
+
+        expect(document.querySelector('.mat-datepicker-content')).toBeNull();
+      }));
+
+      it('should wait for the animation to finish before removing the content', fakeAsync(() => {
+        testComponent.datepicker.open();
+        fixture.detectChanges();
+        flush();
+
+        expect(document.querySelector('.mat-datepicker-content')).not.toBeNull();
+
+        testComponent.datepicker.close();
+        fixture.detectChanges();
+        flush();
+
+        expect(document.querySelector('.mat-datepicker-content')).not.toBeNull();
+
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
 
         expect(document.querySelector('.mat-datepicker-content')).toBeNull();
       }));
@@ -178,13 +201,16 @@ describe('MatDatepicker', () => {
 
         const popup = document.querySelector('.cdk-overlay-pane')!;
         expect(popup).not.toBeNull();
-        expect(parseInt(getComputedStyle(popup).height as string)).not.toBe(0);
+        expect(parseInt(getComputedStyle(popup).height || '0')).not.toBe(0);
 
         testComponent.datepicker.close();
         fixture.detectChanges();
         flush();
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
 
-        expect(parseInt(getComputedStyle(popup).height as string)).toBe(0);
+        expect(parseInt(getComputedStyle(popup).height || '0')).toBeFalsy();
       }));
 
       it('should close the popup when pressing ESCAPE', fakeAsync(() => {
@@ -1092,9 +1118,13 @@ describe('MatDatepicker', () => {
         testComponent.datepicker.close();
         fixture.detectChanges();
         flush();
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
 
         testComponent.formField.color = 'warn';
         testComponent.datepicker.open();
+        fixture.detectChanges();
 
         contentEl = document.querySelector('.mat-datepicker-content')!;
         fixture.detectChanges();

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -139,11 +139,15 @@ export declare const matDatepickerAnimations: {
 };
 
 export declare class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase implements AfterViewInit, CanColor {
+    _animationDone: Subject<AnimationEvent>;
+    _animationState: 'enter' | 'void';
     _calendar: MatCalendar<D>;
     _isAbove: boolean;
     datepicker: MatDatepicker<D>;
-    constructor(elementRef: ElementRef);
+    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef);
+    _startExitAnimation(): Subject<AnimationEvent>;
     ngAfterViewInit(): void;
+    ngOnDestroy(): void;
 }
 
 export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {


### PR DESCRIPTION
This is something I ran into while working on aligning the datepicker with the most-recent Material design spec. Since #9639 we use a portal outlet to render the calendar header. The portal outlet directive will detach in `ngOnDestroy` and it won't wait for the parent animation to finish, which ends up shifting the entire calendar up while it's animating away. The only reason that this isn't visible at the moment is because the current animation isn't configured correctly, which causes it to go to `opacity: 0` immediately.

For reference:
![demo](https://user-images.githubusercontent.com/4450522/43419812-52a14a60-9442-11e8-9272-139fe285dcac.gif)
