### PR TITLE
fix(form-field): remove leading space for asterisk

### DIFF
--- a/src/lib/form-field/form-field.html
+++ b/src/lib/form-field/form-field.html
@@ -52,7 +52,7 @@
           <span
             class="mat-placeholder-required mat-form-field-required-marker"
             aria-hidden="true"
-            *ngIf="!hideRequiredMarker && _control.required && !_control.disabled">&nbsp;*</span>
+            *ngIf="!hideRequiredMarker && _control.required && !_control.disabled">*</span>
         </label>
       </span>
     </div>

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -392,7 +392,7 @@ describe('MatInput without forms', () => {
 
     let el = fixture.debugElement.query(By.css('label'));
     expect(el).not.toBeNull();
-    expect(el.nativeElement.textContent).toMatch(/hello\s+\*/g);
+    expect(el.nativeElement.textContent!.trim()).toBe('hello*');
   }));
 
   it('should hide the required star if input is disabled', () => {
@@ -404,7 +404,7 @@ describe('MatInput without forms', () => {
     const el = fixture.debugElement.query(By.css('label'));
 
     expect(el).not.toBeNull();
-    expect(el.nativeElement.textContent!.trim()).toMatch(/^hello$/);
+    expect(el.nativeElement.textContent!.trim()).toBe('hello');
   });
 
   it('should hide the required star from screen readers', fakeAsync(() => {
@@ -422,12 +422,12 @@ describe('MatInput without forms', () => {
 
     let el = fixture.debugElement.query(By.css('label'));
     expect(el).not.toBeNull();
-    expect(el.nativeElement.textContent).toMatch(/hello\s+\*/g);
+    expect(el.nativeElement.textContent!.trim()).toBe('hello*');
 
     fixture.componentInstance.hideRequiredMarker = true;
     fixture.detectChanges();
 
-    expect(el.nativeElement.textContent).toMatch(/hello/g);
+    expect(el.nativeElement.textContent!.trim()).toBe('hello');
   }));
 
   it('supports the disabled attribute as binding', fakeAsync(() => {


### PR DESCRIPTION
* In order to align with the 2018 Material Design guidelines, the leading space before the required asterisk should be removed.

Based on the specs and by looking at MDC, there should be no leading space. In addition to removing the space, MDC seems to still shift the asterisk by `1px` (potentially to make it look better on higher resolutions; I can notice a little improvement in UX with 4k as well). 



|  0px | 1px  |
|---|---|
| ![image](https://user-images.githubusercontent.com/4987015/44299175-79daca80-a2f1-11e8-9827-e07c80670b3b.png) | ![image](https://user-images.githubusercontent.com/4987015/44299197-a989d280-a2f1-11e8-97c7-827b88394564.png) |


**P2** because it should be merged prioritized for V7 beta. (spec alignment)



Fixes #12721