### PR TITLE
fix(form-field): fix animation missing if hint is shown conditionally

### DIFF
--- a/src/lib/form-field/form-field.ts
+++ b/src/lib/form-field/form-field.ts
@@ -344,10 +344,17 @@ export class MatFormField extends _MatFormFieldMixinBase
     return this._hasLabel() || this.appearance === 'legacy' && this._hasPlaceholder();
   }
 
-  /** Determines whether to display hints or errors. */
-  _getDisplayedMessages(): 'error' | 'hint' {
-    return (this._errorChildren && this._errorChildren.length > 0 &&
-        this._control.errorState) ? 'error' : 'hint';
+  /** Determines whether to display hints, errors or none. */
+  _getDisplayedMessages(): 'error' | 'hint' | 'none' {
+    return this.areErrorMessagesVisible() ? 'error' : this.areHintsVisible() ? 'hint' : 'none';
+  }
+
+  private areErrorMessagesVisible(): boolean {
+    return this._errorChildren && this._errorChildren.length > 0 && this._control.errorState;
+  }
+
+  private areHintsVisible(): boolean {
+    return this._hintChildren && this._hintChildren.length > 0 && !this._control.errorState;
   }
 
   /** Animates the placeholder up and locks it in position. */


### PR DESCRIPTION
Fix the bug, which appears when there is a hint with *ngIf statement declared in the form-field. Before the change, variable being animation trigger is set in afterViewInit, so when it appears for the first time animation is defined state. Change introduces new displayMessage value which makes mat-form-field-subscript-wrapper empty in case neither hint nor errors are visible.

Fixes #9747