### PR TITLE
docs(chips): fix autocomplete-chips example with addonblur enabled

### DIFF
--- a/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
@@ -36,7 +36,7 @@ export class ChipsAutocompleteExample {
   add(event: MatChipInputEvent): void {
     // Add fruit only when MatAutocomplete is not open
     // To make sure this does not conflict with OptionSelected Event
-    if(!this.matAutocomplete.isOpen) {
+    if (!this.matAutocomplete.isOpen) {
       const input = event.input;
       const value = event.value;
 


### PR DESCRIPTION
Existing example did not work with addOnBlur enabled, this fix allows us to use both addOnBlur and selected methods together