### PR TITLE
refactor(dialog,bottom-sheet): remove extra generic for return type

### DIFF
--- a/src/material-examples/dialog-overview/dialog-overview-example.ts
+++ b/src/material-examples/dialog-overview/dialog-overview-example.ts
@@ -22,10 +22,11 @@ export class DialogOverviewExample {
   constructor(public dialog: MatDialog) {}
 
   openDialog(): void {
-    const dialogRef = this.dialog.open(DialogOverviewExampleDialog, {
-      width: '250px',
-      data: {name: this.name, animal: this.animal}
-    });
+    const dialogRef: MatDialogRef<DialogOverviewExampleDialog> =
+      this.dialog.open(DialogOverviewExampleDialog, {
+        width: '250px',
+        data: {name: this.name, animal: this.animal}
+      });
 
     dialogRef.afterClosed().subscribe(result => {
       console.log('The dialog was closed');

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -383,7 +383,7 @@ describe('MatBottomSheet', () => {
   }));
 
   it('should be able to pass a result back to the dismissed stream', fakeAsync(() => {
-    const bottomSheetRef = bottomSheet.open<PizzaMsg, any, number>(PizzaMsg);
+    const bottomSheetRef = bottomSheet.open<PizzaMsg>(PizzaMsg);
     const spy = jasmine.createSpy('afterDismissed spy');
 
     bottomSheetRef.afterDismissed().subscribe(spy);

--- a/src/material/bottom-sheet/bottom-sheet.ts
+++ b/src/material/bottom-sheet/bottom-sheet.ts
@@ -61,19 +61,19 @@ export class MatBottomSheet implements OnDestroy {
       @Optional() @Inject(MAT_BOTTOM_SHEET_DEFAULT_OPTIONS)
           private _defaultOptions?: MatBottomSheetConfig) {}
 
-  open<T, D = any, R = any>(component: ComponentType<T>,
-                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
-  open<T, D = any, R = any>(template: TemplateRef<T>,
-                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
+  open<T, D = any>(component: ComponentType<T>,
+                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, {}>;
+  open<T, D = any>(template: TemplateRef<T>,
+                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, {}>;
 
-  open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R> {
+  open<T, D = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
+                   config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, {}> {
 
     const _config =
         _applyConfigDefaults(this._defaultOptions || new MatBottomSheetConfig(), config);
     const overlayRef = this._createOverlay(_config);
     const container = this._attachContainer(overlayRef, _config);
-    const ref = new MatBottomSheetRef<T, R>(container, overlayRef, this._location);
+    const ref = new MatBottomSheetRef<T>(container, overlayRef, this._location);
 
     if (componentOrTemplateRef instanceof TemplateRef) {
       container.attachTemplatePortal(new TemplatePortal<T>(componentOrTemplateRef, null!, {

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -125,8 +125,8 @@ export class MatDialog implements OnDestroy {
    * @param config Extra configuration options.
    * @returns Reference to the newly-opened dialog.
    */
-  open<T, D = any, R = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
-          config?: MatDialogConfig<D>): MatDialogRef<T, R> {
+  open<T, D = any>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
+                   config?: MatDialogConfig<D>): MatDialogRef<T, {}> {
 
     config = _applyConfigDefaults(config, this._defaultOptions || new MatDialogConfig());
 
@@ -136,10 +136,10 @@ export class MatDialog implements OnDestroy {
 
     const overlayRef = this._createOverlay(config);
     const dialogContainer = this._attachDialogContainer(overlayRef, config);
-    const dialogRef = this._attachDialogContent<T, R>(componentOrTemplateRef,
-                                                      dialogContainer,
-                                                      overlayRef,
-                                                      config);
+    const dialogRef = this._attachDialogContent<T>(componentOrTemplateRef,
+                                                   dialogContainer,
+                                                   overlayRef,
+                                                   config);
 
     // If this is the first dialog that we're opening, hide all the non-overlay content.
     if (!this.openDialogs.length) {
@@ -239,16 +239,15 @@ export class MatDialog implements OnDestroy {
    * @param config The dialog configuration.
    * @returns A promise resolving to the MatDialogRef that should be returned to the user.
    */
-  private _attachDialogContent<T, R>(
+  private _attachDialogContent<T>(
       componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
       dialogContainer: MatDialogContainer,
       overlayRef: OverlayRef,
-      config: MatDialogConfig): MatDialogRef<T, R> {
+      config: MatDialogConfig): MatDialogRef<T> {
 
     // Create a reference to the dialog we're creating in order to give the user a handle
     // to modify and close it.
-    const dialogRef =
-        new MatDialogRef<T, R>(overlayRef, dialogContainer, this._location, config.id);
+    const dialogRef = new MatDialogRef<T>(overlayRef, dialogContainer, this._location, config.id);
 
     // When the dialog backdrop is clicked, we want to close it.
     if (config.hasBackdrop) {
@@ -347,20 +346,21 @@ export class MatDialog implements OnDestroy {
     const overlayContainer = this._overlayContainer.getContainerElement();
 
     // Ensure that the overlay container is attached to the DOM.
-    if (overlayContainer.parentElement) {
-      const siblings = overlayContainer.parentElement.children;
+    if (!overlayContainer.parentElement) {
+      return;
+    }
 
-      for (let i = siblings.length - 1; i > -1; i--) {
-        let sibling = siblings[i];
+    const siblings = overlayContainer.parentElement.children;
 
-        if (sibling !== overlayContainer &&
+    for (let i = siblings.length - 1; i > -1; i--) {
+      let sibling = siblings[i];
+
+      if (sibling !== overlayContainer &&
           sibling.nodeName !== 'SCRIPT' &&
           sibling.nodeName !== 'STYLE' &&
           !sibling.hasAttribute('aria-live')) {
-
-          this._ariaHiddenElements.set(sibling, sibling.getAttribute('aria-hidden'));
-          sibling.setAttribute('aria-hidden', 'true');
-        }
+        this._ariaHiddenElements.set(sibling, sibling.getAttribute('aria-hidden'));
+        sibling.setAttribute('aria-hidden', 'true');
       }
     }
   }


### PR DESCRIPTION
Removes the `R` generic, because it always ends up as `any` in the result subscriptions.

Fixes #12898.