### PR TITLE
allow clearing row definitions (table, header, footer)

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -536,6 +536,11 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     this._customRowDefs.delete(rowDef);
   }
 
+  /** Removes all row definitions that was not included as part of the content children. */
+  clearRowDef() {
+    this._customRowDefs.clear();
+  }
+
   /** Adds a header row definition that was not included as part of the content children. */
   addHeaderRowDef(headerRowDef: CdkHeaderRowDef) {
     this._customHeaderRowDefs.add(headerRowDef);
@@ -548,6 +553,12 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     this._headerRowDefChanged = true;
   }
 
+  /** Removes all header row definitions that was not included as part of the content children. */
+  clearHeaderRowDef() {
+    this._customHeaderRowDefs.clear();
+    this._headerRowDefChanged = true;
+  }
+
   /** Adds a footer row definition that was not included as part of the content children. */
   addFooterRowDef(footerRowDef: CdkFooterRowDef) {
     this._customFooterRowDefs.add(footerRowDef);
@@ -557,6 +568,12 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   /** Removes a footer row definition that was not included as part of the content children. */
   removeFooterRowDef(footerRowDef: CdkFooterRowDef) {
     this._customFooterRowDefs.delete(footerRowDef);
+    this._footerRowDefChanged = true;
+  }
+
+  /** Removes all footer row definitions that was not included as part of the content children. */
+  clearFooterRowDef() {
+    this._customFooterRowDefs.clear();
     this._footerRowDefChanged = true;
   }
 


### PR DESCRIPTION
Currently, CDK table allows adding and removing row definitions for table rows, header rows and footer rows.

Because there is no access to the `Set` that holds each of them they are not easily removed in bulk.

Furthermore, to manage a definition set, the developer needs to maintain it's own copy of the current `Set` so he can remove defintiions when required.

For example, if I have a `QueryList` (`@ViewChildren`) of row definitions that are defined **outside** of the `cdk-table` I will need to insert them manually using the methods provided by `CdkTable`.

If my list has changed I will need to a reference to the old list so I can clear it before adding item from the changed list.
If not, I will not be able to call removeRowDef with the proper reference (its not longer in my list).

With the ability to clear the list this is easy.