### PR TITLE
feat(datepicker): remove dependency on mat-dialog

### DIFF
--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -31,7 +31,6 @@ ng_module(
         "//src/cdk/portal",
         "//src/material/button",
         "//src/material/core",
-        "//src/material/dialog",
         "//src/material/form-field",
         "//src/material/input",
         "@npm//@angular/animations",

--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -118,7 +118,7 @@ $mat-calendar-weekday-table-font-size: 11px !default;
   }
 
   .mat-datepicker-content-touch {
-    @include _mat-theme-elevation(0, $theme);
+    @include _mat-theme-elevation(24, $theme);
   }
 
   .mat-datepicker-toggle-active {

--- a/src/material/datepicker/datepicker-animations.ts
+++ b/src/material/datepicker/datepicker-animations.ts
@@ -12,6 +12,7 @@ import {
   transition,
   trigger,
   AnimationTriggerMetadata,
+  keyframes,
 } from '@angular/animations';
 
 /**
@@ -24,14 +25,14 @@ export const matDatepickerAnimations: {
 } = {
   /** Transforms the height of the datepicker's calendar. */
   transformPanel: trigger('transformPanel', [
-    state('void', style({
-      opacity: 0,
-      transform: 'scale(1, 0.8)'
-    })),
-    transition('void => enter',  animate('120ms cubic-bezier(0, 0, 0.2, 1)', style({
-      opacity: 1,
-      transform: 'scale(1, 1)'
-    }))),
+    transition('void => enter-popup', animate('120ms cubic-bezier(0, 0, 0.2, 1)', keyframes([
+      style({opacity: 0, transform: 'scale(1, 0.8)'}),
+      style({opacity: 1, transform: 'none'})
+    ]))),
+    transition('void => enter-dialog', animate('150ms cubic-bezier(0, 0, 0.2, 1)', keyframes([
+      style({opacity: 0, transform: 'scale(0.7)'}),
+      style({opacity: 1, transform: 'none'})
+    ]))),
     transition('* => void', animate('100ms linear', style({opacity: 0})))
   ]),
 

--- a/src/material/datepicker/datepicker-module.ts
+++ b/src/material/datepicker/datepicker-module.ts
@@ -12,7 +12,6 @@ import {PortalModule} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
-import {MatDialogModule} from '@angular/material/dialog';
 import {MatCalendar, MatCalendarHeader} from './calendar';
 import {MatCalendarBody} from './calendar-body';
 import {
@@ -32,7 +31,6 @@ import {MatYearView} from './year-view';
   imports: [
     CommonModule,
     MatButtonModule,
-    MatDialogModule,
     OverlayModule,
     A11yModule,
     PortalModule,

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -99,12 +99,12 @@ describe('MatDatepicker', () => {
         testComponent.touch = true;
         fixture.detectChanges();
 
-        expect(document.querySelector('.mat-datepicker-dialog mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
 
         testComponent.datepicker.open();
         fixture.detectChanges();
 
-        expect(document.querySelector('.mat-datepicker-dialog mat-dialog-container'))
+        expect(document.querySelector('.mat-datepicker-dialog'))
             .not.toBeNull();
       });
 
@@ -149,13 +149,13 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
 
         testComponent.datepicker.open();
         fixture.detectChanges();
 
         expect(document.querySelector('.cdk-overlay-pane')).toBeNull();
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
       });
 
       it('disabled datepicker input should open the calendar if datepicker is enabled', () => {
@@ -218,13 +218,14 @@ describe('MatDatepicker', () => {
         testComponent.datepicker.open();
         fixture.detectChanges();
 
-        expect(document.querySelector('mat-dialog-container')).not.toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).not.toBeNull();
 
         testComponent.datepicker.close();
         fixture.detectChanges();
         flush();
+        fixture.detectChanges();
 
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
       }));
 
       it('setting selected via click should update input and close calendar', fakeAsync(() => {
@@ -235,7 +236,7 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
         flush();
 
-        expect(document.querySelector('mat-dialog-container')).not.toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).not.toBeNull();
         expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 1));
 
         let cells = document.querySelectorAll('.mat-calendar-body-cell');
@@ -243,7 +244,7 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
         flush();
 
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
         expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 2));
       }));
 
@@ -256,7 +257,7 @@ describe('MatDatepicker', () => {
           fixture.detectChanges();
           flush();
 
-          expect(document.querySelector('mat-dialog-container')).not.toBeNull();
+          expect(document.querySelector('.mat-datepicker-dialog')).not.toBeNull();
           expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 1));
 
           let calendarBodyEl = document.querySelector('.mat-calendar-body') as HTMLElement;
@@ -268,7 +269,7 @@ describe('MatDatepicker', () => {
           fixture.detectChanges();
           flush();
 
-          expect(document.querySelector('mat-dialog-container')).toBeNull();
+          expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
           expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 2));
         }));
 
@@ -292,7 +293,7 @@ describe('MatDatepicker', () => {
         }
 
         expect(selectedChangedSpy.calls.count()).toEqual(1);
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
         expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 2));
       }));
 
@@ -313,7 +314,7 @@ describe('MatDatepicker', () => {
 
         fixture.whenStable().then(() => {
           expect(selectedChangedSpy.calls.count()).toEqual(0);
-          expect(document.querySelector('mat-dialog-container')).toBeNull();
+          expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
           expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 1));
         });
       });
@@ -903,13 +904,13 @@ describe('MatDatepicker', () => {
       });
 
       it('should open calendar when toggle clicked', () => {
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
 
         let toggle = fixture.debugElement.query(By.css('button'));
         dispatchMouseEvent(toggle.nativeElement, 'click');
         fixture.detectChanges();
 
-        expect(document.querySelector('mat-dialog-container')).not.toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).not.toBeNull();
       });
 
       it('should not open calendar when toggle clicked if datepicker is disabled', () => {
@@ -918,12 +919,12 @@ describe('MatDatepicker', () => {
         const toggle = fixture.debugElement.query(By.css('button')).nativeElement;
 
         expect(toggle.hasAttribute('disabled')).toBe(true);
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
 
         dispatchMouseEvent(toggle, 'click');
         fixture.detectChanges();
 
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
       });
 
       it('should not open calendar when toggle clicked if input is disabled', () => {
@@ -934,12 +935,12 @@ describe('MatDatepicker', () => {
         const toggle = fixture.debugElement.query(By.css('button')).nativeElement;
 
         expect(toggle.hasAttribute('disabled')).toBe(true);
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
 
         dispatchMouseEvent(toggle, 'click');
         fixture.detectChanges();
 
-        expect(document.querySelector('mat-dialog-container')).toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();
       });
 
       it('should set the `button` type on the trigger to prevent form submissions', () => {
@@ -1263,7 +1264,7 @@ describe('MatDatepicker', () => {
         testComponent.datepicker.open();
         fixture.detectChanges();
 
-        expect(document.querySelector('mat-dialog-container')).not.toBeNull();
+        expect(document.querySelector('.mat-datepicker-dialog')).not.toBeNull();
 
         let cells = document.querySelectorAll('.mat-calendar-body-cell');
         expect(cells[0].classList).toContain('mat-calendar-body-disabled');
@@ -1335,7 +1336,7 @@ describe('MatDatepicker', () => {
           testComponent.datepicker.open();
           fixture.detectChanges();
 
-          expect(document.querySelector('mat-dialog-container')).not.toBeNull();
+          expect(document.querySelector('.mat-datepicker-dialog')).not.toBeNull();
 
           const cells = document.querySelectorAll('.mat-calendar-body-cell');
           dispatchMouseEvent(cells[0], 'click');


### PR DESCRIPTION
Reworks the datepicker to remove its dependency to `material/dialog`, avoiding bringing in all of the overhead of the dialog from which the datepicker is using a small fraction.