### PR TITLE
fix(card): better scaling for avatar image

### DIFF
--- a/src/lib/card/card.scss
+++ b/src/lib/card/card.scss
@@ -105,6 +105,10 @@ $mat-card-header-size: 40px !default;
   width: $mat-card-header-size;
   border-radius: 50%;
   flex-shrink: 0;
+
+  // Makes `<img>` tags behave like `background-size: cover`. Not supported
+  // in IE, but we're using it as a progressive enhancement.
+  object-fit: cover;
 }
 
 // TITLE-GROUP STYLES


### PR DESCRIPTION
Avoids the image getting squashed or losing its ratio, if it's dimensions are different from the card avatar.