### PR TITLE
 fix(sort): display mat-sort-header arrow when sorting programmatically

### DIFF
--- a/src/material-examples/material/table/module.ts
+++ b/src/material-examples/material/table/module.ts
@@ -1,12 +1,15 @@
 import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
 import {NgModule} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatIconModule} from '@angular/material/icon';
 import {MatInputModule} from '@angular/material/input';
 import {MatPaginatorModule} from '@angular/material/paginator';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatSelectModule} from '@angular/material/select';
 import {MatSortModule} from '@angular/material/sort';
 import {MatTableModule} from '@angular/material/table';
 import {TableBasicFlexExample} from './table-basic-flex/table-basic-flex-example';
@@ -54,13 +57,16 @@ const EXAMPLES = [
 @NgModule({
   imports: [
     CommonModule,
+    FormsModule,
     MatButtonModule,
     MatButtonToggleModule,
     MatCheckboxModule,
+    MatFormFieldModule,
     MatIconModule,
     MatInputModule,
     MatPaginatorModule,
     MatProgressSpinnerModule,
+    MatSelectModule,
     MatSortModule,
     MatTableModule,
   ],

--- a/src/material-examples/material/table/table-sorting/table-sorting-example.css
+++ b/src/material-examples/material/table/table-sorting/table-sorting-example.css
@@ -5,3 +5,7 @@ table {
 th.mat-sort-header-sorted {
   color: black;
 }
+
+.mat-form-field {
+  margin: 16px 8px;
+}

--- a/src/material-examples/material/table/table-sorting/table-sorting-example.html
+++ b/src/material-examples/material/table/table-sorting/table-sorting-example.html
@@ -1,4 +1,27 @@
-<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+<mat-form-field>
+  <mat-select [(ngModel)]="sortActive" placeholder="Active" (selectionChange)="sortTable()">
+    <mat-option *ngFor="let option of displayedColumns" [value]="option">
+      {{option}}
+    </mat-option>
+  </mat-select>
+</mat-form-field>
+
+<mat-form-field>
+  <mat-select [(ngModel)]="sortDirection" placeholder="Direction" (selectionChange)="sortTable()">
+    <mat-option value="asc">
+      asc
+    </mat-option>
+    <mat-option value="desc">
+      desc
+    </mat-option>
+  </mat-select>
+</mat-form-field>
+
+<table mat-table
+       [dataSource]="dataSource"
+       matSort matSortDisableClear [matSortActive]="sortActive" [matSortDirection]="sortDirection"
+       (matSortChange)="handleSortChange($event)"
+       class="mat-elevation-z8">
 
   <!-- Position Column -->
   <ng-container matColumnDef="position">

--- a/src/material-examples/material/table/table-sorting/table-sorting-example.ts
+++ b/src/material-examples/material/table/table-sorting/table-sorting-example.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {MatSort} from '@angular/material/sort';
+import {Sort, MatSort, MatSortable} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
 
 export interface PeriodicElement {
@@ -31,6 +31,8 @@ const ELEMENT_DATA: PeriodicElement[] = [
   templateUrl: 'table-sorting-example.html',
 })
 export class TableSortingExample implements OnInit {
+  sortActive = 'position';
+  sortDirection = 'asc';
   displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
   dataSource = new MatTableDataSource(ELEMENT_DATA);
 
@@ -38,5 +40,18 @@ export class TableSortingExample implements OnInit {
 
   ngOnInit() {
     this.dataSource.sort = this.sort;
+  }
+
+  sortTable(): void {
+    this.sort.sort(<MatSortable>{
+      id: this.sortActive,
+      start: this.sortDirection,
+      disableClear: true,
+    });
+  }
+
+  handleSortChange(sort: Sort): void {
+    this.sortActive = sort.active;
+    this.sortDirection = sort.direction;
   }
 }

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -188,6 +188,19 @@ describe('MatSort', () => {
       component.expectViewAndDirectionStates(expectedStates);
     });
 
+    it('should be correct when sort has changed programmatically while a header is active', () => {
+      // Sort the first header to set up
+      component.sort('defaultA');
+      expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+      component.expectViewAndDirectionStates(expectedStates);
+
+      // Sort the second header programmatically and verify that the first header animated away
+      component.matSort.sort({id: 'defaultB', start: 'asc', disableClear: false});
+      expectedStates.set('defaultA', {viewState: 'active-to-asc', arrowDirection: 'asc'});
+      expectedStates.set('defaultB', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+      component.expectViewAndDirectionStates(expectedStates);
+    });
+
     it('should be correct when sort has been disabled', () => {
       // Mousing over the first sort should set the view state to hint
       component.disabledColumnSort = true;


### PR DESCRIPTION
Fix mat-sort-header arrow not displaying after sorting programmatically (eg. `matSort.sort()`)

Related to #10242, #12754