### PR TITLE
perf(ripple): contain layout, paint and style calculations to ripple container

### DIFF
--- a/src/material/core/ripple/_ripple.scss
+++ b/src/material/core/ripple/_ripple.scss
@@ -10,12 +10,18 @@ $mat-ripple-color-opacity: 0.1;
   .mat-ripple {
     overflow: hidden;
 
+    // Limit style recalculations to the ripple container, as much as possible.
+    contain: strict;
+
     // By default, every ripple container should have position: relative in favor of creating an
     // easy API for developers using the MatRipple directive.
     position: relative;
   }
 
   .mat-ripple.mat-ripple-unbounded {
+    // For unbounded ripples we can't contain `paint`,
+    // because it stops `overflow` from working.
+    contain: size layout style;
     overflow: visible;
   }
 


### PR DESCRIPTION
Uses [CSS containment](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) to contain the various layout and style calculations to the ripple container since they're independent of the rest of the page.

For reference, here are a couple of examples with and without containment. The top example is without.

![demo](https://user-images.githubusercontent.com/4450522/45651641-4b0f6a00-bad2-11e8-8d29-cd4c24021510.gif)
![demo2](https://user-images.githubusercontent.com/4450522/45651669-5cf10d00-bad2-11e8-809e-1b519552375d.gif)
