### PR TITLE
fix(button): content shifting on pointer down in IE

### DIFF
--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -165,6 +165,11 @@
   }
 }
 
+// Prevents the content from shifting on IE when the user has their pointer down.
+.mat-button-wrapper {
+  position: relative;
+}
+
 // Add an outline to make buttons more visible in high contrast mode. Stroked buttons
 // don't need a special look in high-contrast mode, because those already have an outline.
 @include cdk-high-contrast {


### PR DESCRIPTION
By default IE shifts the button's content a few pixels when they've got their pointer down, in order to simulate a button being pressed. These changes reset the behavior, in order to bring it in line with all other browsers.

For reference:
![demo2](https://user-images.githubusercontent.com/4450522/45927143-d81d4d80-bf2e-11e8-8c30-e3434b25bb86.gif)
