### PR TITLE
fix(radio): missing focus indication in high contrast mode

### DIFF
--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -61,6 +61,16 @@ $mat-radio-ripple-radius: 20px;
   ._mat-animation-noopable & {
     transition: none;
   }
+
+  // Note that this creates a square box around the circle, however it's consistent with
+  // how IE/Edge treat native radio buttons in high contrast mode. We can't turn the border
+  // into a dotted one, because it's too thick which causes the circles to look off.
+  @include cdk-high-contrast {
+    .mat-radio-button.cdk-keyboard-focused & {
+      outline: dotted 1px;
+    }
+  }
+
 }
 
 // The inner circle for the radio, shown when checked.


### PR DESCRIPTION
Currently we use ripples for focus indication on radio buttons, however they're hidden in high contrast mode. These changes add an outline as a fallback.

Also fixes the focus indication showing up for mouse focus.