### PR TITLE
fix(card): uneven action button margin

### DIFF
--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -7,6 +7,7 @@
 $mat-card-padding: 16px !default;
 $mat-card-border-radius: 4px !default;
 $mat-card-header-size: 40px !default;
+$mat-card-button-margin: 8px !default;
 
 .mat-card {
   @include mat-elevation-transition;
@@ -84,10 +85,8 @@ $mat-card-header-size: 40px !default;
 }
 
 .mat-card-actions {
-  .mat-button,
-  .mat-raised-button,
-  .mat-stroked-button {
-    margin: 0 8px;
+  .mat-button-base {
+    margin: 0 $mat-card-button-margin;
   }
 }
 
@@ -202,14 +201,21 @@ $mat-card-header-size: 40px !default;
 
 // actions panel should always be 8px from sides,
 // so the first button in the actions panel can't add its own margins
-.mat-card-actions {
-  .mat-button,
-  .mat-raised-button,
-  .mat-stroked-button {
-    &:first-child {
-      margin-left: 0;
-      margin-right: 0;
-    }
+.mat-card-actions .mat-button-base:first-child {
+  margin-left: 0;
+
+  [dir='rtl'] & {
+    margin-left: $mat-card-button-margin;
+    margin-right: 0;
+  }
+}
+
+.mat-card-actions .mat-button-base:last-child {
+  margin-right: 0;
+
+  [dir='rtl'] & {
+    margin-right: $mat-card-button-margin;
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
Fixes the margin between the first action button all the other not being even. Also fixes the margin not being reset on the last button when using `align="end"`.

Fixes #13382.

For reference:
![before](https://user-images.githubusercontent.com/4450522/46370302-89d22200-c685-11e8-84c2-7c2130b00139.png)
![after](https://user-images.githubusercontent.com/4450522/46370311-8fc80300-c685-11e8-9f0d-5be1484d749b.png)
