### PR TITLE
fix(list): labels not being set for mat-selection-list

### DIFF
--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -48,6 +48,8 @@ class MatListItemBase {}
 const _MatListItemMixinBase: CanDisableRippleCtor & typeof MatListItemBase =
     mixinDisableRipple(MatListItemBase);
 
+let nextUniqueId = 0;
+
 @Component({
   selector: 'mat-nav-list',
   exportAs: 'matNavList',
@@ -155,9 +157,15 @@ export class MatListIconCssMatStyler {}
  */
 @Directive({
   selector: '[mat-subheader], [matSubheader]',
-  host: {'class': 'mat-subheader'}
+  host: {
+    'class': 'mat-subheader',
+    '[id]': 'id'
+  }
 })
-export class MatListSubheaderCssMatStyler {}
+export class MatListSubheaderCssMatStyler {
+  /** Unique ID for the header. */
+  @Input() id = `mat-subheader-${nextUniqueId++}`;
+}
 
 /** An item within a Material Design list. */
 @Component({

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -1038,6 +1038,51 @@ describe('MatSelectionList without forms', () => {
       });
 
   });
+
+  describe('aria labelling', () => {
+    let fixture: ComponentFixture<SelectionListWithHeader>;
+    let selectionList: DebugElement;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [SelectionListWithHeader]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(SelectionListWithHeader);
+      fixture.detectChanges();
+
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
+    }));
+
+    it('should default aria-labelledby to the id of the header', () => {
+      const header = fixture.nativeElement.querySelector('.mat-subheader');
+
+      expect(header).toBeTruthy();
+      expect(header.id).toBeTruthy();
+      expect(selectionList.nativeElement.getAttribute('aria-labelledby')).toBe(header.id);
+      expect(selectionList.nativeElement.hasAttribute('aria-label')).toBe(false);
+    });
+
+    it('should allow the consumer to set another aria-labelledby', () => {
+      fixture.componentInstance.ariaLabelledby = 'custom-labelled-by';
+      fixture.detectChanges();
+
+      expect(selectionList.nativeElement.getAttribute('aria-labelledby'))
+          .toBe('custom-labelled-by');
+    });
+
+    it('should clear aria-labelledby if the list has an aria-label', () => {
+      const listElement: HTMLElement = selectionList.nativeElement;
+
+      fixture.componentInstance.ariaLabel = 'Your email';
+      fixture.detectChanges();
+
+      expect(listElement.getAttribute('aria-label')).toBe('Your email');
+      expect(listElement.hasAttribute('aria-labelledby')).toBe(false);
+    });
+  });
+
 });
 
 describe('MatSelectionList with forms', () => {
@@ -1664,4 +1709,19 @@ class SelectionListWithIndirectChildOptions {
   </mat-selection-list>`
 })
 class SelectionListWithIndirectDescendantLines {
+}
+
+
+@Component({
+  template: `
+    <mat-selection-list [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby">
+      <h3 mat-subheader>Email</h3>
+      <mat-list-option>Inbox</mat-list-option>
+      <mat-list-option>Spam</mat-list-option>
+    </mat-selection-list>
+  `
+})
+class SelectionListWithHeader {
+  ariaLabel?: string;
+  ariaLabelledby?: string;
 }

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -55,7 +55,11 @@ import {
 import {Subject} from 'rxjs';
 import {startWith, takeUntil} from 'rxjs/operators';
 
-import {MatListAvatarCssMatStyler, MatListIconCssMatStyler} from './list';
+import {
+  MatListAvatarCssMatStyler,
+  MatListIconCssMatStyler,
+  MatListSubheaderCssMatStyler,
+} from './list';
 
 
 /** @docs-private */
@@ -330,6 +334,8 @@ export class MatListOption extends _MatListOptionMixinBase implements AfterConte
     '[attr.aria-multiselectable]': 'multiple',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.tabindex]': '_tabIndex',
+    '[attr.aria-label]': 'ariaLabel || null',
+    '[attr.aria-labelledby]': '_getAriaLabelledby()',
   },
   template: '<ng-content></ng-content>',
   styleUrls: ['list.css'],
@@ -347,6 +353,10 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
 
   /** The option components contained within this selection-list. */
   @ContentChildren(MatListOption, {descendants: true}) options: QueryList<MatListOption>;
+
+  /** Reference to the first header in the list. */
+  @ContentChild(MatListSubheaderCssMatStyler, {static: false})
+  _header?: MatListSubheaderCssMatStyler;
 
   /** Emits a change event whenever the selected state of an option changes. */
   @Output() readonly selectionChange: EventEmitter<MatSelectionListChange> =
@@ -398,6 +408,12 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
       this.selectedOptions = new SelectionModel(this._multiple, this.selectedOptions.selected);
     }
   }
+
+  /** Aria label of the list. */
+  @Input('aria-label') ariaLabel: string = '';
+
+  /** Input that can be used to specify the `aria-labelledby` attribute. */
+  @Input('aria-labelledby') ariaLabelledby: string = '';
 
   /** The currently selected options. */
   selectedOptions = new SelectionModel<MatListOption>(this._multiple);
@@ -618,6 +634,15 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
   /** Implemented as part of ControlValueAccessor. */
   registerOnTouched(fn: () => void): void {
     this._onTouched = fn;
+  }
+
+  /** Gets the value for the `aria-labelledby` attribute. */
+  _getAriaLabelledby() {
+    if (this.ariaLabel || !this._header) {
+      return null;
+    }
+
+    return this.ariaLabelledby || this._header.id;
   }
 
   /** Sets the selected options based on the specified values. */

--- a/tools/public_api_guard/material/list.d.ts
+++ b/tools/public_api_guard/material/list.d.ts
@@ -82,7 +82,8 @@ export declare class MatListOption extends _MatListOptionMixinBase implements Af
 }
 
 export declare class MatListSubheaderCssMatStyler {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatListSubheaderCssMatStyler, "[mat-subheader], [matSubheader]", never, {}, {}, never>;
+    id: string;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatListSubheaderCssMatStyler, "[mat-subheader], [matSubheader]", never, { "id": "id"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatListSubheaderCssMatStyler, never>;
 }
 
@@ -97,10 +98,13 @@ export declare class MatNavList extends _MatListMixinBase implements CanDisable,
 }
 
 export declare class MatSelectionList extends _MatSelectionListMixinBase implements CanDisableRipple, AfterContentInit, ControlValueAccessor, OnDestroy, OnChanges {
+    _header?: MatListSubheaderCssMatStyler;
     _keyManager: FocusKeyManager<MatListOption>;
     _onTouched: () => void;
     _tabIndex: number;
     _value: string[] | null;
+    ariaLabel: string;
+    ariaLabelledby: string;
     color: ThemePalette;
     compareWith: (o1: any, o2: any) => boolean;
     get disabled(): boolean;
@@ -113,6 +117,7 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
     tabIndex: number;
     constructor(_element: ElementRef<HTMLElement>, tabIndex: string, _changeDetector: ChangeDetectorRef);
     _emitChangeEvent(option: MatListOption): void;
+    _getAriaLabelledby(): string | null;
     _keydown(event: KeyboardEvent): void;
     _onFocus(): void;
     _removeOptionFromList(option: MatListOption): MatListOption | null;
@@ -131,7 +136,7 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_multiple: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSelectionList, "mat-selection-list", ["matSelectionList"], { "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "color": "color"; "compareWith": "compareWith"; "disabled": "disabled"; "multiple": "multiple"; }, { "selectionChange": "selectionChange"; }, ["options"], ["*"]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSelectionList, "mat-selection-list", ["matSelectionList"], { "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "color": "color"; "compareWith": "compareWith"; "disabled": "disabled"; "multiple": "multiple"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; }, { "selectionChange": "selectionChange"; }, ["_header", "options"], ["*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatSelectionList, [null, { attribute: "tabindex"; }, null]>;
 }
 


### PR DESCRIPTION
Currently when the user's focus lands on a `mat-selection-list`, screen readers will read out only "List", unless the consumer set an `aria-label` explicitly. These changes automatically set an `aria-labelledby` to the list's header, unless the consumer set a custom `aria-label` or `aria-labelledby`.