### PR TITLE
build: ensure dependencies are properly locked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then ./scripts/install-angular-snapshot.sh --only-save; fi
 
 install:
-  - yarn install --frozen-lockfile --non-interactive
+  - ./scripts/ci/travis-install.sh
 
 before_script:
   - mkdir -p $LOGS_DIR

--- a/scripts/ci/travis-install.sh
+++ b/scripts/ci/travis-install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Script that installs the project node module dependencies within Travis. The script also ensures that the cached
+# node modules are in sync with the lock file and also checks that if the lock file is in sync with the
+# project `package.json` file.
+
+# Go to the project root directory
+cd $(dirname $0)/../..
+
+# Yarn's integrity check command throws in the following scenarios:
+#   1) Cached node modules are not in sync with lock file
+#   2) Lock file is not in sync with `package.json`
+
+# In case the integrity check passes, we just use the cached/locked node modules. If it fails, we want to purge the
+# node modules and run Yarn with `--frozen-lockfile`. Running with a frozen lockfile ensures that outdated/cached node
+# modules will be refreshed to **match** the actual lock file. Otherwise, if the `package.json` does not match with
+# the lock file, Yarn automatically throws an error due to the `--frozen-lockfile` option.
+if ! (yarn check --integrity &> /dev/null); then
+  echo "Cached node modules are not in sync. Purging and refreshing..."
+  rm -rf ./node_modules/
+  yarn install --frozen-lockfile --non-interactive
+else
+  echo "Cached node modules have been checked and are in sync with the lock file."
+fi


### PR DESCRIPTION
* Since we lock our dependencies in the `yarn.lock` file, we need to enforce that the lock file is in sync with the `package.json` file (similar as in angular/angular)
* Since we cache the dependenices & the yarn cache within Travis, it can happen that the node modules are stale (there is no checksum mechanism in Travis). In that case we need to purge the node modules and re-install (similar as in angular/angular)

---

* https://github.com/angular/angular/blob/master/scripts/ci/install.sh#L40
* https://github.com/angular/angular/blob/master/tools/npm/check-node-modules.js

Fixes jobs like that: https://travis-ci.org/angular/material2/jobs/438268744