### PR TITLE
fix(slide-toggle): focus ripple not hiding after click/touch

### DIFF
--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -210,7 +210,10 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
     opacity: 0.04;
   }
 
-  .mat-slide-toggle:not(.mat-disabled).cdk-focused & {
+  // As per specifications, the focus ripple should only show up if the slide-toggle has
+  // been focused through keyboard. We cannot account for `cdk-program-focused` because clicking
+  // on the label causes the focus origin to be `program` due to the focus redirection.
+  .mat-slide-toggle:not(.mat-disabled).cdk-keyboard-focused & {
     opacity: 0.12;
   }
 


### PR DESCRIPTION
Similarly to the checkbox (#13295), the persistent ripple should only show up for focus if the slide-toggle has been focused through keyboard.

https://storage.googleapis.com/spec-host-backup/mio-design%2Fassets%2F1w3KOMo81gakKP7JC6yNogxCt-CadYQvx%2Fslidercontrols-1a-v02.mp4