### PR TITLE
fix(dialog): default dialog actions alignment to end

### DIFF
--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -53,8 +53,12 @@ $mat-dialog-button-margin: 8px !default;
   // Pull the actions down to avoid their padding stacking with the dialog's padding.
   margin-bottom: -$mat-dialog-padding;
 
-  &[align='end'] {
+  &, &[align='end'] {
     justify-content: flex-end;
+  }
+
+  &[align='start'] {
+    justify-content: flex-start;
   }
 
   &[align='center'] {


### PR DESCRIPTION
Switches to defaulting the alignment for `mat-dialog-actions` to the `end`, rather than the `start`.

Fixes #13618.