### PR TITLE
build: run e2e tests with chrome headless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       - *restore_cache
       - *yarn_install
 
-      - run: xvfb-run -a --server-args='-screen 0, 1024x768x16' yarn gulp ci:e2e
+      - run: yarn gulp ci:e2e
 
       - *save_cache
 

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -36,6 +36,10 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
 
+    chromeOptions: {
+      args: [ '--headless', '--window-size=1024,768']
+    },
+
     // Enables concurrent testing in the Webdriver. Currently runs three e2e files in parallel.
     shardTestFiles: true,
     maxInstances: 5,


### PR DESCRIPTION
* Since the fullscreen e2e tests have been removed, we can now use Chrome Headless for e2e testing.