### PR TITLE
fix(progress-bar): account for query params when prefixing references

### DIFF
--- a/src/lib/progress-bar/progress-bar.ts
+++ b/src/lib/progress-bar/progress-bar.ts
@@ -66,11 +66,12 @@ export interface MatProgressBarLocation {
 /** @docs-private */
 export function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation {
   const _document = inject(DOCUMENT);
+  const _location = _document ? _document.location : null;
 
   return {
-    // Note that this needs to be a function, because Angular will only instantiate
-    // this provider once, but we want the current location on each call.
-    getPathname: () => (_document && _document.location && _document.location.pathname) || ''
+    // Note that this needs to be a function, rather than a property, because Angular
+    // will only resolve it once, but we want the current path on each call.
+    getPathname: () => _location ? (_location.pathname + _location.search) : ''
   };
 }
 


### PR DESCRIPTION
Fixes the progress bar not accounting for URL query params when it prefixes its SVG references.

Related to #13930.