### PR TITLE
testing(color): fix test of the mixinColor which could never fail

### DIFF
--- a/src/lib/core/common-behaviors/color.spec.ts
+++ b/src/lib/core/common-behaviors/color.spec.ts
@@ -7,13 +7,8 @@ describe('MixinColor', () => {
     const classWithColor = mixinColor(TestClass);
     const instance = new classWithColor();
 
-    expect(instance.color)
-        .toBeFalsy('Expected the mixed-into class to have a color property');
-
-    instance.color = 'accent';
-
-    expect(instance.color)
-        .toBe('accent', 'Expected the mixed-into class to have an updated color property');
+    expect('color' in instance)
+        .toBeTruthy('Expected the mixed-into class to have a color property');
   });
 
   it('should remove old color classes if new color is set', () => {


### PR DESCRIPTION
While reviewing the tests of the mixinColor, I noticed two things:

1. One of the tests could never fail given the circumstances in the test
2. One of the tests never really tested the actual intent of the mixin.

If my understanding is correct, the test I updated for `mixinColor` exists to test that applying the `mixinColor` to a class allows that class to meet the constraints of `CanColor`. Previously, this test didn't actually test anything other than that javsacript objects work as intended. This test now covers the described case properly.