### PR TITLE
build: remove es2015 workaround

### DIFF
--- a/src/lib/input/autosize.ts
+++ b/src/lib/input/autosize.ts
@@ -43,7 +43,3 @@ export class MatTextareaAutosize extends CdkTextareaAutosize {
   get matTextareaAutosize(): boolean { return this.enabled; }
   set matTextareaAutosize(value: boolean) { this.enabled = value; }
 }
-
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatTextareaAutosize as any)['ctorParameters'] = () =>
-    (CdkTextareaAutosize as any)['ctorParameters'];

--- a/src/lib/stepper/step-label.ts
+++ b/src/lib/stepper/step-label.ts
@@ -13,6 +13,3 @@ import {CdkStepLabel} from '@angular/cdk/stepper';
   selector: '[matStepLabel]',
 })
 export class MatStepLabel extends CdkStepLabel {}
-
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatStepLabel as any)['ctorParameters'] = () => (CdkStepLabel as any)['ctorParameters'];

--- a/src/lib/stepper/stepper-button.ts
+++ b/src/lib/stepper/stepper-button.ts
@@ -33,8 +33,3 @@ export class MatStepperNext extends CdkStepperNext {}
   providers: [{provide: CdkStepper, useExisting: MatStepper}]
 })
 export class MatStepperPrevious extends CdkStepperPrevious {}
-
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatStepperNext as any)['ctorParameters'] = () => (CdkStepperNext as any)['ctorParameters'];
-(MatStepperPrevious as any)['ctorParameters'] = () =>
-    (CdkStepperPrevious as any)['ctorParameters'];

--- a/src/lib/stepper/stepper.ts
+++ b/src/lib/stepper/stepper.ts
@@ -123,9 +123,6 @@ export class MatStepper extends CdkStepper implements AfterContentInit {
   }
 }
 
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatStepper as any)['ctorParameters'] = () => (CdkStepper as any)['ctorParameters'];
-
 @Component({
   moduleId: module.id,
   selector: 'mat-horizontal-stepper',

--- a/src/lib/table/cell.ts
+++ b/src/lib/table/cell.ts
@@ -45,11 +45,6 @@ export class MatHeaderCellDef extends CdkHeaderCellDef {}
 })
 export class MatFooterCellDef extends CdkFooterCellDef {}
 
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatCellDef as any)['ctorParameters'] = () => (CdkCellDef as any)['ctorParameters'];
-(MatHeaderCellDef as any)['ctorParameters'] = () => (CdkHeaderCellDef as any)['ctorParameters'];
-(MatFooterCellDef as any)['ctorParameters'] = () => (MatFooterCellDef as any)['ctorParameters'];
-
 /**
  * Column definition for the mat-table.
  * Defines a set of cells available for a table column.

--- a/src/lib/table/row.ts
+++ b/src/lib/table/row.ts
@@ -54,11 +54,6 @@ export class MatFooterRowDef extends CdkFooterRowDef {}
 })
 export class MatRowDef<T> extends CdkRowDef<T> {}
 
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatHeaderRowDef as any)['ctorParameters'] = () => (CdkHeaderRowDef as any)['ctorParameters'];
-(MatFooterRowDef as any)['ctorParameters'] = () => (CdkFooterRowDef as any)['ctorParameters'];
-(MatRowDef as any)['ctorParameters'] = () => (CdkRowDef as any)['ctorParameters'];
-
 /** Footer template container that contains the cell outlet. Adds the right class and role. */
 @Component({
   moduleId: module.id,

--- a/src/lib/table/table.ts
+++ b/src/lib/table/table.ts
@@ -28,6 +28,3 @@ export class MatTable<T> extends CdkTable<T> {
   /** Overrides the sticky CSS class set by the `CdkTable`. */
   protected stickyCssClass = 'mat-table-sticky';
 }
-
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatTable as any)['ctorParameters'] = () => (CdkTable as any)['ctorParameters'];

--- a/src/lib/tabs/tab-label.ts
+++ b/src/lib/tabs/tab-label.ts
@@ -14,6 +14,3 @@ import {CdkPortal} from '@angular/cdk/portal';
   selector: '[mat-tab-label], [matTabLabel]',
 })
 export class MatTabLabel extends CdkPortal {}
-
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatTabLabel as any)['ctorParameters'] = () => (CdkPortal as any)['ctorParameters'];

--- a/src/lib/tree/node.ts
+++ b/src/lib/tree/node.ts
@@ -76,9 +76,6 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
   @Input('matTreeNode') data: T;
 }
 
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatTreeNodeDef as any)['ctorParameters'] = () => (CdkTreeNodeDef as any)['ctorParameters'];
-
 /**
  * Wrapper for the CdkTree nested node with Material design styles.
  */

--- a/src/lib/tree/padding.ts
+++ b/src/lib/tree/padding.ts
@@ -23,7 +23,3 @@ export class MatTreeNodePadding<T> extends CdkTreeNodePadding<T> {
   /** The indent for each level. Default number 40px from material design menu sub-menu spec. */
   @Input('matTreeNodePaddingIndent') indent: number;
 }
-
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatTreeNodePadding as any)['ctorParameters'] = () =>
-    (CdkTreeNodePadding as any)['ctorParameters'];

--- a/src/lib/tree/toggle.ts
+++ b/src/lib/tree/toggle.ts
@@ -22,6 +22,3 @@ import {Directive, Input} from '@angular/core';
 export class MatTreeNodeToggle<T> extends CdkTreeNodeToggle<T> {
   @Input('matTreeNodeToggleRecursive') recursive: boolean = false;
 }
-
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatTreeNodeToggle as any)['ctorParameters'] = () => (CdkTreeNodeToggle as any)['ctorParameters'];

--- a/src/lib/tree/tree.ts
+++ b/src/lib/tree/tree.ts
@@ -31,6 +31,3 @@ export class MatTree<T> extends CdkTree<T> {
   // Outlets within the tree's template where the dataNodes will be inserted.
   @ViewChild(MatTreeNodeOutlet) _nodeOutlet: MatTreeNodeOutlet;
 }
-
-// TODO(devversion): workaround for https://github.com/angular/material2/issues/12760
-(MatTree as any)['ctorParameters'] = () => (CdkTree as any)['ctorParameters'];


### PR DESCRIPTION
With two commits (2adced10c8815579b4174e4386d72c2f5d6b316a and a22a9fa3d737b423206e26b3afea8c556270238c), we recently tried to add a workaround for an Angular bug that causes Angular Material to not work w/ ES2015.

The workaround technically worked but had to be partially reverted because Google Closure compiler was no longer able to remove unused classes (due to a function with side-effects that modified the actual component metadata). 

Since the workaround (in the state it is right now) is not helping at all and a fix will land with Angular `v7.1.0` (https://github.com/angular/angular/commit/95743e3a64b61a6223b7755d6c9931dcb245979f), we are removing the workaround **completely**.

Closes #12760