### PR TITLE
chore: change karma "ChromeHeadlessLocal" to "ChromeHeadless"

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -74,7 +74,7 @@ module.exports = (config) => {
     browserNoActivityTimeout: 300000,
     captureTimeout: 180000,
 
-    browsers: ['ChromeHeadlessLocal'],
+    browsers: ['ChromeHeadless'],
     singleRun: false,
 
     // Try Websocket for a faster transmission first. Fallback to polling if necessary.


### PR DESCRIPTION
`ChromeHeadlessLocal` doesn't seem to exist any more