### PR TITLE
Edge nested sticky fix for flex-style table

### DIFF
--- a/src/cdk/table/edge-nested-sticky-fix.ts
+++ b/src/cdk/table/edge-nested-sticky-fix.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Workaround for nested sticky problem in Edge.
+ * Remove this and the code part on sticky-styler when Edge nested sticky columns are fixed.
+ * See https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18940617/
+ * @docs-private
+ */
+// TODO missing tests
+export class EdgeNestedStickyFix {
+  isBrowserEdge = typeof CSS !== 'undefined' && CSS.supports('(-ms-ime-align:auto)');
+  // This is initialized when found undefined the first time, before being used
+  private scrollingContext!: HTMLElement;
+  private stickyRowWrappers: HTMLElement[] = [];
+  private lastKnownHorizontalScroll = 0;
+  private lastKnownVerticalScroll = 0;
+
+  /**
+   * Uses the fix to manage a sticky row.
+   *
+   * @param row The row to manage
+   * @param isSticky Its stickyness status
+   * @param position Where the row is positioned
+   * @param stickyHeight The offset the row should have if it's sticky
+   * @memberof EdgeNestedStickyFix
+   */
+  useEdgeFix(
+    row: HTMLElement,
+    isSticky: boolean,
+    position: 'top' | 'bottom',
+    stickyHeight: number
+  ) {
+    // First time we get the scrollContext, we initialize the wrokaround
+    if (this.scrollingContext === undefined) {
+    // Being this the first time we enter stickRows method, we know no rows
+    //  are wrapped. If the current row was, the method searching for the
+    //  scrolling context would stop to the wrapper instead of the one we need
+    this.initializeHorizontalScrollPropagation(row);
+    }
+
+    if (!isSticky) {
+      this.unstickRow(row);
+      return;
+    }
+
+    this.stickRow(row, position, stickyHeight);
+  }
+
+  private unstickRow(row: HTMLElement) {
+    // Check if the row was wrapped and, if so, we unwrap it
+    if (this.isRowWrapped(row)) {
+        this.unwrapStickyRow(row);
+    }
+  }
+
+  private stickRow(row: HTMLElement, position: 'top' | 'bottom', stickyHeight: number) {
+    // If the row isn't wrapped, we wrap it up and get the wrapper reference
+    const wrapper = this.isRowWrapped(row)
+      ? this.getRowWrapper(row)
+      : this.wrapStickyRow(row);
+
+    const scrollRect = this.scrollingContext.getBoundingClientRect();
+    const positionValue = position === 'top'
+    ? scrollRect.top + stickyHeight
+    : window.document.body.clientHeight
+        - scrollRect.bottom
+        + stickyHeight
+        + (scrollRect.height - this.scrollingContext.clientHeight);
+
+    // Updates wrapper position rules
+    wrapper.style[position] = `${positionValue}px`;
+    wrapper.style.left = `${scrollRect.left}px`;
+  }
+
+  private initializeHorizontalScrollPropagation(row: HTMLElement) {
+    this.scrollingContext = this.getScrollingContext(row);
+    this.lastKnownVerticalScroll = this.scrollingContext.getBoundingClientRect().top;
+
+    // We use passive listeners to keep the scroll animation smooth
+    this.scrollingContext.addEventListener('scroll', () => {
+      if (this.scrollingContext.scrollLeft === this.lastKnownHorizontalScroll) {
+        return;
+      }
+      window.requestAnimationFrame(this.propagateHorizontalScroll.bind(this));
+    }, { passive: true });
+
+    // TODO memory leak?
+    // Capture all scroll events on the page using the third parameter and a document-level listener
+    window.document.addEventListener('scroll', event => {
+      if (event.target === this.scrollingContext
+        || !(event.target as HTMLElement).contains(this.scrollingContext)) {
+        return;
+      }
+
+      // TODO eats up 1px or so every time it fires
+      // TODO animation lags behind the scroll
+      this.updateStickyRowsPosition();
+    }, { passive: true });
+
+    // TODO resize breaks positioning, must recalculate/update them
+    window.addEventListener('resize', this.updateStickyRowsWidth.bind(this), { passive: true });
+  }
+
+  private unwrapStickyRow(row: HTMLElement) {
+    const wrapper = row.parentElement!;
+    // Removes placeholder
+    wrapper.previousElementSibling!.remove();
+    // Takes out the row
+    wrapper.parentNode!.insertBefore(row, wrapper);
+    // Removes the wrapper from the keep-scroll-in-sync array
+    const wrapperIndex = this.stickyRowWrappers!.findIndex(element => wrapper === element);
+    this.stickyRowWrappers!.splice(wrapperIndex, 1);
+    // Removes wrapper
+    wrapper.remove();
+    // Reset row width
+    row.style.width = '';
+  }
+
+  private wrapStickyRow(row: HTMLElement) {
+    const rowWidth = row.clientWidth;
+
+    const wrapper = window.document.createElement('div');
+    wrapper.classList.add('mat-edge-sticky-row-wrapper');
+
+    // We delegate to the next frame to be sure not to have some kind of race-condition
+    //  which would give us a wrong wrapper width
+    // Es. when the scrolling element is loaded async and displayed under a expandable panel
+    //  See 'table-sticky-complex-flex' example
+    window.requestAnimationFrame(this.updateStickyRowsWidth.bind(this));
+
+    // Insert wrapper
+    row.parentNode!.insertBefore(wrapper, row);
+    // Put in the row
+    wrapper.appendChild(row);
+    // Insert placeholder
+    wrapper.parentNode!.insertBefore(row.cloneNode(), wrapper);
+    // Set expected row width
+    row.style.width = `${rowWidth}px`;
+
+    // Initial sync of scroll position
+    // Ths must be after all DOM manipulations have been done or it won't work
+    wrapper.scrollLeft = this.scrollingContext.scrollLeft;
+
+    // Register the wrapper to be in sync with scrolling context horizontal offset
+    this.stickyRowWrappers.push(wrapper);
+
+    return wrapper;
+  }
+
+  private isRowWrapped(row: HTMLElement) {
+    return this.getRowWrapper(row).classList.contains('mat-edge-sticky-row-wrapper');
+  }
+
+  private getRowWrapper(row: HTMLElement) {
+    return row.parentElement!;
+  }
+
+  private getScrollingContext(scrolledElement: HTMLElement) {
+    // If a scrolling context is marked by the developer, we use it
+    // This can be useful when using libraries that manage scrolling in a not native way,
+    //  like ngx-perfect-scrollbar, effectively breaking our normal scrolling context research
+    const markedScrollingContext = scrolledElement.closest('.cdk-scrolling-context');
+    if (markedScrollingContext !== null) {
+      return markedScrollingContext as HTMLElement;
+    }
+
+    // Find the nearest scrolling element ancestor
+    do {
+      scrolledElement = scrolledElement.parentElement!;
+    } while (scrolledElement.offsetWidth === scrolledElement.scrollWidth
+      || scrolledElement.parentElement === null);
+    return scrolledElement.parentElement!;
+  }
+
+  private propagateHorizontalScroll() {
+    // Forces reflow only 1 time
+    this.lastKnownHorizontalScroll = this.scrollingContext.scrollLeft;
+
+    this.stickyRowWrappers!.forEach(wrapper => {
+      wrapper.scrollLeft = this.lastKnownHorizontalScroll;
+    });
+  }
+
+  private updateStickyRowsPosition() {
+    const scrollRect = this.scrollingContext.getBoundingClientRect();
+    const scrollDelta = this.lastKnownVerticalScroll - scrollRect.top;
+
+    this.stickyRowWrappers!.forEach(({style: wrapperStyle}) => {
+      // Define in which position the row is pinned
+      const position = wrapperStyle.top ? 'top' : 'bottom';
+      const newPosition = `${parseInt(wrapperStyle[position]!, 10)
+        + scrollDelta * (position === 'top' ? -1 : 1)}px`;
+
+      // Updates wrapper positioning rules
+      wrapperStyle[position] = newPosition;
+      wrapperStyle.left = `${scrollRect.left}px`;
+    });
+
+    this.lastKnownVerticalScroll = scrollRect.top;
+  }
+
+  private updateStickyRowsWidth() {
+    // We must use clientWidth to avoid counting in the possible scrollbar width
+    const scrollingContextWidth = this.scrollingContext.clientWidth;
+
+    this.stickyRowWrappers!.forEach(wrapper => {
+      wrapper.style.width = `${scrollingContextWidth}px`;
+    });
+  }
+}

--- a/src/lib/table/table.scss
+++ b/src/lib/table/table.scss
@@ -66,6 +66,15 @@ mat-cell, mat-header-cell, mat-footer-cell {
   min-height: inherit;
 }
 
+.mat-edge-sticky-row-wrapper {
+  background-color: inherit;
+  overflow: hidden;
+  position: fixed;
+  // Without this, wrappers sometimes go out-of-sync with the position they must reach
+  transition: top 1ms, bottom 1ms;
+  z-index: 100;
+}
+
 /**
  * Native HTML table structure
  */


### PR DESCRIPTION
Fixes #13665

Still has problems, but I'll like to get some feedback.
I used `table-sticky-complex-flex` as a basis for my tests.
I tried to group up almost all the workaround code into a separated file, this should help when the issue on Edge is fixed and the workaround should be removed quickly.

Known problems:
- there are no tests yet, I don't actually know how to fake "being on Edge" given that tests are run on Chrome Headless (I could run the fix on Chrome and check it works there, but results are not consistent on Edge)
- must re-calculate sticky rows position when on resize
- there's some lag between the scroll action and sticky rows movement and I don't really know how to get it better, for me it's fine like this if no one can help me on this
- position updates "eat" away 1px at a time for some unknown reason, so after a bit sticky rows are not in sync anymore with the table, cannot understand why...
- there is a possible memory leak with the scroll on `document` and resize on `window` listeners, but I don't know when/where/how to remove them: sticky-styler doesn't have a `destroy` method (yet)
- it's more a "fixed in place" than an actual "sticky" behaviour (activate row2 and deactivate row1 to understand what I'm talking about) but I think it's enough until Edge just fixes the issue