### PR TITLE
feat(tabs): support position in tab nav bar

### DIFF
--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -66,7 +66,8 @@ $mat-tab-animation-duration: 500ms !default;
   height: $height;
   transition: $mat-tab-animation-duration $ease-in-out-curve-function;
 
-  .mat-tab-group-inverted-header & {
+  .mat-tab-group-inverted-header &,
+  .mat-tab-nav-bar-inverted & {
     bottom: auto;
     top: 0;
   }

--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -15,12 +15,10 @@
     border-bottom: $header-border;
   }
 
-  .mat-tab-group-inverted-header {
-    .mat-tab-nav-bar,
-    .mat-tab-header {
-      border-top: $header-border;
-      border-bottom: none;
-    }
+  .mat-tab-nav-bar-inverted,
+  .mat-tab-group-inverted-header .mat-tab-header {
+    border-top: $header-border;
+    border-bottom: none;
   }
 
   .mat-tab-label, .mat-tab-link {

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -217,7 +217,7 @@ describe('MatTabNavBar', () => {
   });
 
   it('should support the native tabindex attribute', () => {
-      const fixture = TestBed.createComponent(TabLinkWithNativeTabindexAttr);
+    const fixture = TestBed.createComponent(TabLinkWithNativeTabindexAttr);
     fixture.detectChanges();
 
     const tabLink = fixture.debugElement.query(By.directive(MatTabLink))
@@ -240,6 +240,20 @@ describe('MatTabNavBar', () => {
     fixture.detectChanges();
 
     expect(tabLink.tabIndex).toBe(3, 'Expected the tabIndex to be have been set to 3.');
+  });
+
+  it('should toggle a class, based on its position', () => {
+    const fixture = TestBed.createComponent(SimpleTabNavBarTestApp);
+    fixture.detectChanges();
+
+    const nav = fixture.nativeElement.querySelector('nav');
+
+    expect(nav.classList).not.toContain('mat-tab-nav-bar-inverted');
+
+    fixture.componentInstance.position = 'below';
+    fixture.detectChanges();
+
+    expect(nav.classList).toContain('mat-tab-nav-bar-inverted');
   });
 
   describe('ripples', () => {
@@ -312,7 +326,7 @@ describe('MatTabNavBar', () => {
 @Component({
   selector: 'test-app',
   template: `
-    <nav mat-tab-nav-bar [disableRipple]="disableRippleOnBar">
+    <nav mat-tab-nav-bar [disableRipple]="disableRippleOnBar" [position]="position">
       <a mat-tab-link
          *ngFor="let tab of tabs; let index = index"
          [active]="activeIndex === index"
@@ -331,6 +345,7 @@ class SimpleTabNavBarTestApp {
   disabled = false;
   disableRippleOnBar = false;
   tabs = [0, 1, 2];
+  position = 'above';
 
   activeIndex = 0;
 }

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -68,7 +68,10 @@ const _MatTabNavMixinBase: CanDisableRippleCtor & CanColorCtor & typeof MatTabNa
   inputs: ['color', 'disableRipple'],
   templateUrl: 'tab-nav-bar.html',
   styleUrls: ['tab-nav-bar.css'],
-  host: {'class': 'mat-tab-nav-bar'},
+  host: {
+    'class': 'mat-tab-nav-bar',
+    '[class.mat-tab-nav-bar-inverted]': 'position === "below"',
+  },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -102,6 +105,9 @@ export class MatTabNav extends _MatTabNavMixinBase
     this._backgroundColor = value;
   }
   private _backgroundColor: ThemePalette;
+
+  /** Position of the tab header, in relation to the content. */
+  @Input() position: 'above' | 'below' = 'above';
 
   constructor(elementRef: ElementRef,
               @Optional() private _dir: Directionality,


### PR DESCRIPTION
Adds the `position` input to the `mat-tab-nav-bar` that allows for it to be inverted, if it's position below its content.

Fixes #14191.