### PR TITLE
fix(form-field): multiple pre/suffix displayed vertically + vertical alignment on Edge

### DIFF
--- a/src/lib/form-field/form-field-legacy.scss
+++ b/src/lib/form-field/form-field-legacy.scss
@@ -15,8 +15,14 @@ $mat-form-field-legacy-underline-height: 1px !default;
     -ms-transform: none;
   }
 
+  .mat-form-field-flex {
+    align-items: baseline;
+  }
+
   .mat-form-field-prefix,
   .mat-form-field-suffix {
+    display: block;
+
     // Allow icons in a prefix or suffix to adapt to the correct size.
     .mat-icon {
       width: 1em;

--- a/src/lib/form-field/form-field.scss
+++ b/src/lib/form-field/form-field.scss
@@ -35,13 +35,15 @@ $mat-form-field-default-infix-width: 180px !default;
 // The underline is outside of it so it can cover all of the elements under this flex container.
 .mat-form-field-flex {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   box-sizing: border-box;
   width: 100%;
 }
 
 .mat-form-field-prefix,
 .mat-form-field-suffix {
+  display: flex;
+  align-items: center;
   white-space: nowrap;
   flex: none;
   position: relative;


### PR DESCRIPTION
Restores a consistent behavior for prefix and suffix with multiple children when appearance is other than legacy.

Also fixes a vertical alignment issue of mat-icon-button as pre/suffix in IE and Edge.
Fixes #14311, #11650, #13094, #13322 & #13592