### PR TITLE
fix(chips): default selectable state not passed to individual chips on init

### DIFF
--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -701,6 +701,23 @@ describe('MatChipList', () => {
         .toBeUndefined('Expect no selected chips');
     });
 
+    it('should propagate the list `selectable` state to the individual chips on init',
+      fakeAsync(() => {
+        fixture.destroy();
+        TestBed.resetTestingModule();
+
+        const selectableFixture = createComponent(ChipListSelectableDisabled);
+        selectableFixture.detectChanges();
+        tick();
+
+        const selectableComponent = selectableFixture.componentInstance;
+
+        expect(selectableComponent.chipList.selectable)
+            .toBe(false, 'Expected chip list not to be selectable.');
+        expect(selectableComponent.chips.toArray().every(chip => !chip.selectable))
+            .toBe(true, 'Expected none of the chips to be selectable');
+      }));
+
   });
 
   describe('forms integration', () => {
@@ -1674,7 +1691,6 @@ class ChipListWithRemove {
   }
 }
 
-
 @Component({
   template: `
     <mat-form-field>
@@ -1716,4 +1732,23 @@ class ChipListInsideDynamicFormGroup {
       control: {value: [], disabled: isDisabled}
     });
   }
+}
+
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-chip-list [selectable]="false">
+        <mat-chip *ngFor="let food of foods" [value]="food.value">{{ food.viewValue }}</mat-chip>
+      </mat-chip-list>
+    </mat-form-field>
+  `
+})
+class ChipListSelectableDisabled {
+  foods: any[] = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+  ];
+  @ViewChild(MatChipList, {static: false}) chipList: MatChipList;
+  @ViewChildren(MatChip) chips: QueryList<MatChip>;
 }

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -284,7 +284,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     this._selectable = coerceBooleanProperty(value);
 
     if (this.chips) {
-      this.chips.forEach(chip => chip.chipListSelectable = this._selectable);
+      this._syncSelectableState();
     }
   }
   protected _selectable: boolean = true;
@@ -365,13 +365,15 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
 
     // When the list changes, re-subscribe
     this.chips.changes.pipe(startWith(null), takeUntil(this._destroyed)).subscribe(() => {
-      if (this.disabled) {
-        // Since this happens after the content has been
-        // checked, we need to defer it to the next tick.
-        Promise.resolve().then(() => {
+      // Since this happens after the content has been
+      // checked, we need to defer it to the next tick.
+      Promise.resolve().then(() => {
+        if (this.disabled) {
           this._syncChipsState();
-        });
-      }
+        }
+
+        this._syncSelectableState();
+      });
 
       this._resetChips();
 
@@ -812,6 +814,11 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
         chip._chipListMultiple = this.multiple;
       });
     }
+  }
+
+  /** Syncs the chip list's `selected` state with the chips. */
+  private _syncSelectableState() {
+    this.chips.forEach(chip => chip.chipListSelectable = this._selectable);
   }
 
   static ngAcceptInputType_multiple: BooleanInput;


### PR DESCRIPTION
Fixes the default `selectable` state from the chip list not being passed to the individual chips on init.

Fixes #14397.