### PR TITLE
fix(drag-drop): unable to stop dragging after quick double click

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -159,6 +159,29 @@ describe('CdkDrag', () => {
           expect(dragElement.style.transform).toBeFalsy();
         }));
 
+      it('should be able to stop dragging after a double click', fakeAsync(() => {
+        const fixture = createComponent(StandaloneDraggable, [], 5);
+        fixture.detectChanges();
+        const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+        expect(dragElement.style.transform).toBeFalsy();
+
+        dispatchMouseEvent(dragElement, 'mousedown');
+        fixture.detectChanges();
+        dispatchMouseEvent(document, 'mouseup');
+        fixture.detectChanges();
+        dispatchMouseEvent(dragElement, 'mousedown');
+        fixture.detectChanges();
+        dispatchMouseEvent(document, 'mouseup');
+        fixture.detectChanges();
+
+        dragElementViaMouse(fixture, dragElement, 50, 50);
+        dispatchMouseEvent(document, 'mousemove', 100, 100);
+        fixture.detectChanges();
+
+        expect(dragElement.style.transform).toBeFalsy();
+      }));
+
       it('should preserve the previous `transform` value', fakeAsync(() => {
         const fixture = createComponent(StandaloneDraggable);
         fixture.detectChanges();

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -495,7 +495,11 @@ export class DragRef<T = any> {
 
   /** Handler that is invoked when the user lifts their pointer up, after initiating a drag. */
   private _pointerUp = (event: MouseEvent | TouchEvent) => {
-    if (!this.isDragging()) {
+    // Note that here we use `isDragging` from the service, rather than from `this`.
+    // The difference is that the one from the service reflects whether a dragging sequence
+    // has been initiated, whereas the one on `this` includes whether the user has passed
+    // the minimum dragging threshold.
+    if (!this._dragDropRegistry.isDragging(this)) {
       return;
     }
 


### PR DESCRIPTION
Seems to be something that regressed while we were doing the recent refactor. When starting a drag after a quick double-click sequence, the user can't stop dragging.