### PR TITLE
fix(tabs): align active tab styles with spec

### DIFF
--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -8,6 +8,7 @@ $mat-tab-animation-duration: 500ms !default;
 
 // Mixin styles for labels that are contained within the tab header.
 @mixin tab-label {
+  @include user-select(none);
   height: $mat-tab-bar-height;
   padding: 0 24px;
   cursor: pointer;
@@ -38,6 +39,10 @@ $mat-tab-animation-duration: 500ms !default;
     @include cdk-high-contrast {
       opacity: 0.5;
     }
+  }
+
+  &.mat-tab-label-active {
+    opacity: 1;
   }
 
   .mat-tab-label-content {

--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -58,10 +58,12 @@
       &.mat-#{$name} {
         @include _mat-tab-label-focus($color);
         @include _mat-ink-bar($color);
+        @include _mat-tab-label-active($color);
 
         // Override ink bar when background color is the same
         &.mat-background-#{$name} {
           @include _mat-ink-bar($color, default-contrast);
+          @include _mat-tab-label-active($color, default-contrast);
         }
       }
     }
@@ -90,6 +92,16 @@
       &:not(.mat-tab-disabled) {
         background-color: mat-color($tab-focus-color, lighter, 0.3);
       }
+    }
+  }
+}
+
+@mixin _mat-tab-label-active($color, $hue: default) {
+  .mat-tab-label-active {
+    color: mat-color($color, $hue);
+
+    .mat-ripple-element {
+      background-color: mat-color($color, $hue, 0.1);
     }
   }
 }


### PR DESCRIPTION
Fixes the styling for active tabs not being aligned with the spec. According to the spec, they're supposed to have the current color, however in our case they retain the default text color. These changes also align the ripple colors.

Fixes #2058.

For reference, here's what the spec looks like:
![mio-design_assets_1xbnadj-1y46fsn4un5ak5-f2vtolldil_tabs-spec-scrollable](https://user-images.githubusercontent.com/4450522/50399878-4b7f6700-078b-11e9-813c-37dc7a10b8d8.png)

These are our tabs:
![tabs__angular_material_-_google_chrome_2018-12-24_14-47-33](https://user-images.githubusercontent.com/4450522/50399885-56d29280-078b-11e9-9566-adce1e219a7b.png)

And this is after the changes:
![angular_material_-_google_chrome_2018-12-24_14-47-49](https://user-images.githubusercontent.com/4450522/50399888-5e923700-078b-11e9-99d0-57db5e20d45c.png)
