### PR TITLE
fix(material/autocomplete): don't handle enter events with modifier keys

### DIFF
--- a/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
@@ -1005,6 +1005,26 @@ describe('MDC-based MatAutocomplete', () => {
       expect(ENTER_EVENT.defaultPrevented).toBe(false, 'Default action should not be prevented.');
     });
 
+    it('should not interfere with the ENTER key when pressing a modifier', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+
+      expect(input.value).toBeFalsy('Expected input to start off blank.');
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to start off open.');
+
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      flush();
+      fixture.detectChanges();
+
+      Object.defineProperty(ENTER_EVENT, 'altKey', {get: () => true});
+      fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+      fixture.detectChanges();
+
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to remain open.');
+      expect(input.value).toBeFalsy('Expected input to remain blank.');
+      expect(ENTER_EVENT.defaultPrevented)
+          .toBe(false, 'Expected the default ENTER action not to have been prevented.');
+    }));
+
     it('should fill the text field, not select an option, when SPACE is entered', () => {
       typeInElement(input, 'New');
       fixture.detectChanges();

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -378,7 +378,7 @@ export abstract class _MatAutocompleteTriggerBase implements ControlValueAccesso
       event.preventDefault();
     }
 
-    if (this.activeOption && keyCode === ENTER && this.panelOpen) {
+    if (this.activeOption && keyCode === ENTER && this.panelOpen && !hasModifierKey(event)) {
       this.activeOption._selectViaInteraction();
       this._resetActiveItem();
       event.preventDefault();

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1000,6 +1000,26 @@ describe('MatAutocomplete', () => {
       expect(ENTER_EVENT.defaultPrevented).toBe(false, 'Default action should not be prevented.');
     });
 
+    it('should not interfere with the ENTER key when pressing a modifier', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+
+      expect(input.value).toBeFalsy('Expected input to start off blank.');
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to start off open.');
+
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      flush();
+      fixture.detectChanges();
+
+      Object.defineProperty(ENTER_EVENT, 'altKey', {get: () => true});
+      fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+      fixture.detectChanges();
+
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to remain open.');
+      expect(input.value).toBeFalsy('Expected input to remain blank.');
+      expect(ENTER_EVENT.defaultPrevented)
+          .toBe(false, 'Expected the default ENTER action not to have been prevented.');
+    }));
+
     it('should fill the text field, not select an option, when SPACE is entered', () => {
       typeInElement(input, 'New');
       fixture.detectChanges();


### PR DESCRIPTION
Doesn't handle `ENTER` key presses and doesn't prevent their default action, if they have a modifier, in order to avoid intefering with any OS-level shortcuts.