### PR TITLE
feat (input) : change required get.

### DIFF
--- a/src/dev-app/input/input-demo.html
+++ b/src/dev-app/input/input-demo.html
@@ -309,11 +309,18 @@
       </mat-form-field>
     </p>
     <p>
-      <mat-checkbox [(ngModel)]="requiredField"> Check to make required:</mat-checkbox>
+      <mat-checkbox [(ngModel)]="requiredField"> Check to make required (Template version):</mat-checkbox>
       <mat-form-field>
         <input matInput
                [required]="requiredField"
                [placeholder]="requiredField ? 'Required field' : 'Not required field'">
+      </mat-form-field>
+    </p>
+    <p>
+      <mat-checkbox [(ngModel)]="requiredField2" (change)="requiredValueChange()"> Check to make required (Reactive form version):</mat-checkbox>
+      <mat-form-field>
+        <input matInput [formControl]="formControlRequired"
+               [placeholder]="requiredField2 ? 'Required field' : 'Not required field'">
       </mat-form-field>
     </p>
     <p>

--- a/src/dev-app/input/input-demo.ts
+++ b/src/dev-app/input/input-demo.ts
@@ -26,13 +26,16 @@ export class InputDemo {
   floatingLabel = 'auto';
   color: boolean;
   requiredField: boolean;
+  requiredField2: boolean;
   hideRequiredMarker: boolean;
   ctrlDisabled = false;
   textareaNgModelValue: string;
   textareaAutosizeEnabled = false;
-  placeholderTestControl = new FormControl('', Validators.required);
+  placeholderTestControl = new FormControl('', [Validators.required]);
+  placeholderTestControlNotRequired = new FormControl('');
 
-  name: string;
+
+    name: string;
   errorMessageExample1: string;
   errorMessageExample2: string;
   errorMessageExample3: string;
@@ -51,6 +54,9 @@ export class InputDemo {
   formControl = new FormControl('hello', Validators.required);
   emailFormControl = new FormControl('', [Validators.required, Validators.pattern(EMAIL_REGEX)]);
   delayedFormControl = new FormControl('');
+
+  formControlRequired = new FormControl('', (this.requiredField2 ? Validators.required : null));
+
   model = 'hello';
   isAutofilled = false;
   customAutofillStyle = true;
@@ -68,6 +74,10 @@ export class InputDemo {
     for (let x = 0; x < n; x++) {
       this.items.push({ value: ++max });
     }
+  }
+
+  requiredValueChange() {
+    this.formControlRequired.setValidators((this.requiredField2 ? Validators.required : null));
   }
 
   customErrorStateMatcher: ErrorStateMatcher = {

--- a/src/lib/input/input.spec.ts
+++ b/src/lib/input/input.spec.ts
@@ -509,6 +509,19 @@ describe('MatInput without forms', () => {
     expect(selectEl.required).toBe(true);
   }));
 
+    it('supports the required attribute as Validators.required for input', fakeAsync(() => {
+        let fixture = createComponent(MatInputRequiredValidatorOnlyTestComponent);
+        fixture.detectChanges();
+
+        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputLabelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+        fixture.detectChanges();
+
+        expect(inputEl.required).toBe(true);
+
+        expect(inputLabelEl.textContent).toMatch(/hello\s+\*/g);
+    }));
+
   it('supports the type attribute as binding', fakeAsync(() => {
     let fixture = createComponent(MatInputWithType);
     fixture.detectChanges();
@@ -1556,10 +1569,10 @@ class MatInputWithDisabled {
 }
 
 @Component({
-  template: `<mat-form-field><input matInput [required]="required"></mat-form-field>`
+    template: `<mat-form-field><input matInput [required]="required"></mat-form-field>`
 })
 class MatInputWithRequired {
-  required: boolean;
+    required: boolean;
 }
 
 @Component({
@@ -1577,6 +1590,15 @@ class MatInputWithType {
 class MatInputPlaceholderRequiredTestComponent {
   hideRequiredMarker: boolean = false;
   disabled: boolean = false;
+}
+
+@Component({
+    template: `<mat-form-field>
+                <input matInput [formControl]="requiredControl" placeholder="hello">
+             </mat-form-field>`
+})
+class MatInputRequiredValidatorOnlyTestComponent {
+    requiredControl = new FormControl('', Validators.required);
 }
 
 @Component({

--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -170,7 +170,20 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
    * @docs-private
    */
   @Input()
-  get required(): boolean { return this._required; }
+  get required(): boolean {
+    if (this._required) {
+      return this._required;
+    }
+
+    // The required attribute is set
+    // when the control return an error from validation with an empty value
+    if (this.ngControl && this.ngControl.control && this.ngControl.control.validator) {
+      const emptyValueControl = Object.assign({}, this.ngControl.control);
+      (emptyValueControl as any).value = null;
+      return 'required' in (this.ngControl.control.validator(emptyValueControl) || {});
+    }
+    return false;
+  }
   set required(value: boolean) { this._required = coerceBooleanProperty(value); }
   protected _required = false;
 


### PR DESCRIPTION
This PR is linked to [issue#2574](https://github.com/angular/material2/issues/2574)

Change required get on input, to allow Angular reactive forms to work with.
The most important point is the * which will be displayed on required input from now
Before this change, we could only set required for a Material input on the template

New unit test and new field in demo.