### PR TITLE
fix(select): changed after checked error if selected option label changes

### DIFF
--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -1541,8 +1541,24 @@ describe('MatSelect', () => {
 
         fixture.componentInstance.foods[1].viewValue = 'Calzone';
         fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
 
         expect(trigger.textContent!.trim()).toBe('Calzone');
+      }));
+
+      it('should update the trigger value if the text in the DOM changes', fakeAsync(() => {
+        fixture.componentInstance.control.setValue('pizza-1');
+        fixture.detectChanges();
+
+        expect(trigger.textContent!.trim()).toBe('Pizza');
+
+        fixture.componentInstance.options.toArray()[1]._getHostElement().textContent = 'changed';
+        fixture.checkNoChanges();
+        tick();
+        fixture.detectChanges();
+
+        expect(trigger.textContent!.trim()).toBe('changed');
       }));
 
       it('should not select disabled options', fakeAsync(() => {
@@ -4479,6 +4495,7 @@ describe('MatSelect', () => {
         [typeaheadDebounceInterval]="typeaheadDebounceInterval">
         <mat-option *ngFor="let food of foods" [value]="food.value" [disabled]="food.disabled">
           {{ food.viewValue }}
+          <span class="extra-content">{{extraOptionContent}}</span>
         </mat-option>
       </mat-select>
     </mat-form-field>
@@ -4506,6 +4523,7 @@ class BasicSelect {
   panelClass = ['custom-one', 'custom-two'];
   disableRipple: boolean;
   typeaheadDebounceInterval: number;
+  extraOptionContent: string;
 
   @ViewChild(MatSelect, {static: true}) select: MatSelect;
   @ViewChildren(MatOption) options: QueryList<MatOption>;

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -85,7 +85,7 @@ import {
   mixinTabIndex,
 } from '@angular/material/core';
 import {MAT_FORM_FIELD, MatFormField, MatFormFieldControl} from '@angular/material/form-field';
-import {defer, merge, Observable, Subject} from 'rxjs';
+import {defer, merge, Observable, Subject, asapScheduler} from 'rxjs';
 import {
   distinctUntilChanged,
   filter,
@@ -94,6 +94,7 @@ import {
   switchMap,
   take,
   takeUntil,
+  delay,
 } from 'rxjs/operators';
 import {matSelectAnimations} from './select-animations';
 import {
@@ -973,7 +974,11 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     // Listen to changes in the internal state of the options and react accordingly.
     // Handles cases like the labels of the selected options changing.
     merge(...this.options.map(option => option._stateChanges))
-      .pipe(takeUntil(changedOrDestroyed))
+      // The `delay` is necessary, because the option's label can change in the DOM as a
+      // result of an expression being re-evaluated which in turn will change the select's
+      // trigger value and cause a "changed after checked error". We use the `asapScheduler`
+      // so that `fakeAsync` tests don't start failing as a result.
+      .pipe(delay(0, asapScheduler), takeUntil(changedOrDestroyed))
       .subscribe(() => {
         this._changeDetectorRef.markForCheck();
         this.stateChanges.next();


### PR DESCRIPTION
Fixes a "changed after checked" error being thrown by `mat-select`, if the label of the selected `mat-option` changes.

Also fixes that the trigger value doesn't get updated until the next change detection.

Fixes #14793.