### PR TITLE
fix(select): optionSelectionChanges not emitting when the list of options changes

### DIFF
--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -1552,6 +1552,36 @@ describe('MatSelect', () => {
           subscription!.unsubscribe();
         }));
 
+      it('should emit to `optionSelectionChanges` after the list of options has changed',
+        fakeAsync(() => {
+          let spy = jasmine.createSpy('option selection spy');
+          let subscription = fixture.componentInstance.select.optionSelectionChanges.subscribe(spy);
+          let selectFirstOption = () => {
+            trigger.click();
+            fixture.detectChanges();
+            flush();
+
+            const option = overlayContainerElement.querySelector('mat-option') as HTMLElement;
+            option.click();
+            fixture.detectChanges();
+            flush();
+          };
+
+          fixture.componentInstance.foods = [{value: 'salad-8', viewValue: 'Salad'}];
+          fixture.detectChanges();
+          selectFirstOption();
+
+          expect(spy).toHaveBeenCalledTimes(1);
+
+          fixture.componentInstance.foods = [{value: 'fruit-9', viewValue: 'Fruit'}];
+          fixture.detectChanges();
+          selectFirstOption();
+
+          expect(spy).toHaveBeenCalledTimes(2);
+
+          subscription!.unsubscribe();
+        }));
+
     });
 
     describe('forms integration', () => {

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -443,8 +443,13 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
 
   /** Combined stream of all of the child options' change events. */
   readonly optionSelectionChanges: Observable<MatOptionSelectionChange> = defer(() => {
-    if (this.options) {
-      return merge(...this.options.map(option => option.onSelectionChange));
+    const options = this.options;
+
+    if (options) {
+      return options.changes.pipe(
+        startWith(options),
+        switchMap(() => merge(...options.map(option => option.onSelectionChange)))
+      );
     }
 
     return this._ngZone.onStable


### PR DESCRIPTION
Along the same lines as #14813. Fixes `MatSelect.optionSelectionChanges` not emitting if the list options changes.