### PR TITLE
fix(table): nested objects can be sorted in columns.

### DIFF
--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -101,7 +101,7 @@ export class MatTableDataSource<T> extends DataSource<T> {
    * Data accessor function that is used for accessing data properties for sorting through
    * the default sortData function.
    * This default function assumes that the sort header IDs (which defaults to the column name)
-   * matches the data's properties (e.g. column Xyz represents data['Xyz']. Furthermore , column 
+   * matches the data's properties (e.g. column Xyz represents data['Xyz']. Furthermore , column
    * Abc.Xyz represents data['Abc']['Xyz']). May be set to a custom function for different behavior.
    * @param data Data object that is being accessed.
    * @param sortHeaderId The name of the column that represents the data.

--- a/src/lib/table/table-data-source.ts
+++ b/src/lib/table/table-data-source.ts
@@ -101,14 +101,15 @@ export class MatTableDataSource<T> extends DataSource<T> {
    * Data accessor function that is used for accessing data properties for sorting through
    * the default sortData function.
    * This default function assumes that the sort header IDs (which defaults to the column name)
-   * matches the data's properties (e.g. column Xyz represents data['Xyz']).
-   * May be set to a custom function for different behavior.
+   * matches the data's properties (e.g. column Xyz represents data['Xyz']. Furthermore , column 
+   * Abc.Xyz represents data['Abc']['Xyz']). May be set to a custom function for different behavior.
    * @param data Data object that is being accessed.
    * @param sortHeaderId The name of the column that represents the data.
    */
   sortingDataAccessor: ((data: T, sortHeaderId: string) => string|number) =
       (data: T, sortHeaderId: string): string|number => {
-    const value = (data as {[key: string]: any})[sortHeaderId];
+    const value = sortHeaderId.split('.').reduce((obj, key) =>
+       (obj && obj[key] !== 'undefined') ? obj[key] : undefined, data as { [key: string]: any });
 
     if (_isNumberValue(value)) {
       const numberValue = Number(value);


### PR DESCRIPTION
I fix #14763 , overriding the "sortingDataAccessor" to sort the column when using objects in the data.