### PR TITLE
fix(overlay): error when trying to add/remove empty string class

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -471,7 +471,10 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
 
     coerceArray(cssClasses).forEach(cssClass => {
       // We can't do a spread here, because IE doesn't support setting multiple classes.
-      isAdd ? classList.add(cssClass) : classList.remove(cssClass);
+      // Also trying to add an empty string to a DOMTokenList will throw.
+      if (cssClass) {
+        isAdd ? classList.add(cssClass) : classList.remove(cssClass);
+      }
     });
   }
 

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -418,6 +418,14 @@ describe('Overlay', () => {
     expect(() => overlayRef.addPanelClass('custom-class-two')).not.toThrowError();
   });
 
+  it('should not throw when trying to add or remove and empty string class', () => {
+    const overlayRef = overlay.create();
+    overlayRef.attach(componentPortal);
+
+    expect(() => overlayRef.addPanelClass('')).not.toThrow();
+    expect(() => overlayRef.removePanelClass('')).not.toThrow();
+  });
+
   describe('positioning', () => {
     let config: OverlayConfig;
 


### PR DESCRIPTION
Fixes an error being thrown if an empty string is passed as one of the values to `addPanelClass` or `removePanelClass`.