### PR TITLE
fix(chips): unable to tab out of chip list with input on firefox

### DIFF
--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -8,7 +8,7 @@
 
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Directive, ElementRef, EventEmitter, Inject, Input, OnChanges, Output} from '@angular/core';
-import {hasModifierKey} from '@angular/cdk/keycodes';
+import {hasModifierKey, TAB} from '@angular/cdk/keycodes';
 import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
 import {MatChipList} from './chip-list';
 import {MatChipTextControl} from './chip-text-control';
@@ -109,6 +109,12 @@ export class MatChipInput implements MatChipTextControl, OnChanges {
 
   /** Utility method to make host definition/tests more clear. */
   _keydown(event?: KeyboardEvent) {
+    // Allow the user's focus to escape when they're tabbing forward. Note that we don't
+    // want to do this when going backwards, because focus should go back to the first chip.
+    if (event && event.keyCode === TAB && !hasModifierKey(event, 'shiftKey')) {
+      this._chipList._allowFocusEscape();
+    }
+
     this._emitChipEnd(event);
   }
 

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -356,14 +356,8 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
         .subscribe(dir => this._keyManager.withHorizontalOrientation(dir));
     }
 
-    // Prevents the chip list from capturing focus and redirecting
-    // it back to the first chip when the user tabs out.
     this._keyManager.tabOut.pipe(takeUntil(this._destroyed)).subscribe(() => {
-      this._tabIndex = -1;
-      setTimeout(() => {
-        this._tabIndex = this._userTabIndex || 0;
-        this._changeDetectorRef.markForCheck();
-      });
+      this._allowFocusEscape();
     });
 
     // When the list changes, re-subscribe
@@ -678,6 +672,22 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     this._onTouched();
     this._changeDetectorRef.markForCheck();
     this.stateChanges.next();
+  }
+
+  /**
+   * Removes the `tabindex` from the chip list and resets it back afterwards, allowing the
+   * user to tab out of it. This prevents the list from capturing focus and redirecting
+   * it back to the first chip, creating a focus trap, if it user tries to tab away.
+   */
+  _allowFocusEscape() {
+    if (this._tabIndex !== -1) {
+      this._tabIndex = -1;
+
+      setTimeout(() => {
+        this._tabIndex = this._userTabIndex || 0;
+        this._changeDetectorRef.markForCheck();
+      });
+    }
   }
 
   private _resetChips() {

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -117,6 +117,7 @@ export declare class MatChipList extends _MatChipListMixinBase implements MatFor
     readonly valueChange: EventEmitter<any>;
     constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher,
     ngControl: NgControl);
+    _allowFocusEscape(): void;
     _blur(): void;
     _focusInput(): void;
     _keydown(event: KeyboardEvent): void;


### PR DESCRIPTION
Fixes user focus being wrapped back to the first chip, when trying to tab out of a chip list that has an input, on Firefox.

**Note:** the Browserstack failure seems to unrelated.

Fixes #15011.