### PR TITLE
perf(cdk/a11y): avoid triggering change detection if there are no subscribers to stream

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -436,11 +436,13 @@ export class FocusMonitor implements OnDestroy {
     }
 
     this._setClasses(element);
-    this._emitOrigin(elementInfo.subject, null);
+    this._emitOrigin(elementInfo, null);
   }
 
-  private _emitOrigin(subject: Subject<FocusOrigin>, origin: FocusOrigin) {
-    this._ngZone.run(() => subject.next(origin));
+  private _emitOrigin(info: MonitoredElementInfo, origin: FocusOrigin) {
+    if (info.subject.observers.length) {
+      this._ngZone.run(() => info.subject.next(origin));
+    }
   }
 
   private _registerGlobalListeners(elementInfo: MonitoredElementInfo) {
@@ -530,7 +532,7 @@ export class FocusMonitor implements OnDestroy {
     elementInfo: MonitoredElementInfo,
   ) {
     this._setClasses(element, origin);
-    this._emitOrigin(elementInfo.subject, origin);
+    this._emitOrigin(elementInfo, origin);
     this._lastFocusOrigin = origin;
   }
 


### PR DESCRIPTION
This is a resubmit of #14964.

Currently we have an `NgZone.run` call on each `focus` and `blur` event of a monitored event in order to bring its subscribers into the `NgZone`, however this means that we're also triggering change detection to any consumers that aren't subscribed to changes (e.g. `mat-button` only cares about the classes being applied). These changes move around some logic so that the `NgZone.run` is only hit if somebody has subscribed to the observable.

**Caretaker note:** this PR had to be reverted before (#15076) because there was an app that depended on the extra change detections. We may have to investigate further before we can merge this in again.
