### PR TITLE
refactor(sort): state should be determined and provided by container

### DIFF
--- a/src/material/sort/sort-container.ts
+++ b/src/material/sort/sort-container.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '@angular/core';
+import {Subject} from 'rxjs';
+import {MatSortable} from './sortable';
+
+/** Injection token for the MatSortContainer. */
+export const MAT_SORT_CONTAINER = new InjectionToken<MatSortContainer<any>>('MatSortContainer');
+
+/** Container that is responsible for the state management of a set of registered Sortables. */
+export interface MatSortContainer<T> {
+  /**
+   * Stream that emits when the state has changed for any Sortable in the set of
+   * Sortables, e.g. the active Sortable has changed.
+   */
+  stateChanges: Subject<void>;
+
+  /** Registers a sortable to the set of managed Sortables. */
+  register(sortable: MatSortable): void;
+
+  /** Deregisters a sortable to the set of managed Sortables. */
+  deregister(sortable: MatSortable): void;
+
+  /** Performs the sort action for this sortable with relation to this sort container. */
+  sort(sortable: MatSortable): void;
+
+  /** Provides the current state of the sortable. */
+  getSortableState(sortable: MatSortable): T;
+}

--- a/src/material/sort/sort-module.ts
+++ b/src/material/sort/sort-module.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
-import {MatSortHeader} from './sort-header';
-import {MatSort} from './sort';
-import {MAT_SORT_HEADER_INTL_PROVIDER} from './sort-header-intl';
 import {CommonModule} from '@angular/common';
-
+import {NgModule} from '@angular/core';
+import {MatSort} from './sort';
+import {MatSortHeader} from './sort-header';
+import {MAT_SORT_HEADER_INTL_PROVIDER} from './sort-header-intl';
 
 @NgModule({
   imports: [CommonModule],
@@ -19,4 +18,5 @@ import {CommonModule} from '@angular/common';
   declarations: [MatSort, MatSortHeader],
   providers: [MAT_SORT_HEADER_INTL_PROVIDER]
 })
-export class MatSortModule {}
+export class MatSortModule {
+}

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -354,6 +354,65 @@ describe('MatSort', () => {
     expect(header._showIndicatorHint).toBeFalsy();
   });
 
+  describe('sortable state', () => {
+    it('should represent the right active and directions when cycling sort', () => {
+      const matSort = fixture.componentInstance.matSort;
+      const sortable = matSort.sortables.get('defaultA')!;
+
+      expect(matSort.getSortableState(sortable)).toEqual({
+        active: '',
+        isSorted: false,
+        isDisabled: false,
+        direction: '',
+        nextDirection: 'asc'
+      });
+
+      // Should expect it to be sorted with 'asc' direction
+      matSort.sort(sortable);
+      expect(matSort.getSortableState(sortable)).toEqual({
+        active: sortable.id,
+        isSorted: true,
+        isDisabled: false,
+        direction: 'asc',
+        nextDirection: 'desc'
+      });
+
+      // Should expect it to be sorted with 'desc' direction
+      matSort.sort(sortable);
+      expect(matSort.getSortableState(sortable)).toEqual({
+        active: sortable.id,
+        isSorted: true,
+        isDisabled: false,
+        direction: 'desc',
+        nextDirection: ''
+      });
+
+      // Should expect it to no longer be sorted
+      matSort.sort(sortable);
+      expect(matSort.getSortableState(sortable)).toEqual({
+        active: sortable.id,
+        isSorted: false,
+        isDisabled: false,
+        direction: '',
+        nextDirection: 'asc'
+      });
+    });
+
+    it('should be disabled if sort container or sortable is disabled', () => {
+      const matSort = fixture.componentInstance.matSort;
+      const sortable = matSort.sortables.get('defaultA')!;
+
+      sortable.disabled = true;
+      expect(matSort.getSortableState(sortable).isDisabled).toBe(true);
+
+      sortable.disabled = false;
+      expect(matSort.getSortableState(sortable).isDisabled).toBe(false);
+
+      matSort.disabled = true;
+      expect(matSort.getSortableState(sortable).isDisabled).toBe(true);
+    });
+  });
+
   it('should apply the aria-sort label to the header when sorted', () => {
     const sortHeaderElement = fixture.nativeElement.querySelector('#defaultA');
     expect(sortHeaderElement.getAttribute('aria-sort')).toBe(null);

--- a/src/material/sort/sortable.ts
+++ b/src/material/sort/sortable.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {SortDirection} from './sort-direction';
+
+/**
+ * Interface for a directive that triggers sort state changes and is contained by a `SortContainer`.
+ */
+export interface MatSortable {
+  /** The id of the sortable being sorted. */
+  id: string;
+
+  /** Starting sort direction. */
+  start: 'asc'|'desc';
+
+  /** Whether to disable clearing the sorting state. */
+  disableClear: boolean;
+
+  /** Whether the sortable is disabled. */
+  disabled: boolean;
+}
+
+/** Interface for the current state of a sortable, which is determined by its `SortContainer`. */
+export interface SortableState {
+  /** Whether this sortable is currently sorted. */
+  isSorted: boolean;
+
+  /** Whether this sortable is disabled. */
+  isDisabled: boolean;
+
+  /** The direction that this sortable is oriented if sorted, otherwise an empty string.  */
+  direction: SortDirection;
+
+  /** The sort direction that will be next if this sortable is triggered again. */
+  nextDirection: SortDirection;
+}

--- a/tools/public_api_guard/material/sort.d.ts
+++ b/tools/public_api_guard/material/sort.d.ts
@@ -13,27 +13,22 @@ export declare const MAT_SORT_HEADER_INTL_PROVIDER: {
 
 export declare function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl): MatSortHeaderIntl;
 
-export declare class MatSort extends _MatSortMixinBase implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit {
-    readonly _stateChanges: Subject<void>;
+export declare class MatSort extends _MatSortMixinBase implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit, MatSortContainer<MatSortSortableState> {
     active: string;
     direction: SortDirection;
     disableClear: boolean;
     readonly sortChange: EventEmitter<Sort>;
     sortables: Map<string, MatSortable>;
     start: 'asc' | 'desc';
+    readonly stateChanges: Subject<void>;
     deregister(sortable: MatSortable): void;
     getNextSortDirection(sortable: MatSortable): SortDirection;
+    getSortableState(sortable: MatSortable): MatSortSortableState;
     ngOnChanges(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
     register(sortable: MatSortable): void;
     sort(sortable: MatSortable): void;
-}
-
-export interface MatSortable {
-    disableClear: boolean;
-    id: string;
-    start: 'asc' | 'desc';
 }
 
 export declare const matSortAnimations: {
@@ -51,13 +46,13 @@ export declare class MatSortHeader extends _MatSortHeaderMixinBase implements Ca
     _disableViewStateAnimation: boolean;
     _intl: MatSortHeaderIntl;
     _showIndicatorHint: boolean;
-    _sort: MatSort;
     _viewState: ArrowViewStateTransition;
     arrowPosition: 'before' | 'after';
     disableClear: boolean;
     id: string;
+    protected sortContainer: MatSortContainer<SortableState>;
     start: 'asc' | 'desc';
-    constructor(_intl: MatSortHeaderIntl, changeDetectorRef: ChangeDetectorRef, _sort: MatSort, _columnDef: MatSortHeaderColumnDef);
+    constructor(_intl: MatSortHeaderIntl, changeDetectorRef: ChangeDetectorRef, _columnDef: MatSortHeaderColumnDef, sortContainer: MatSortContainer<SortableState>);
     _getAriaSortAttribute(): "ascending" | "descending" | null;
     _getArrowDirectionState(): string;
     _getArrowViewState(): string;
@@ -78,6 +73,10 @@ export declare class MatSortHeaderIntl {
 }
 
 export declare class MatSortModule {
+}
+
+export interface MatSortSortableState extends SortableState {
+    active: string;
 }
 
 export interface Sort {


### PR DESCRIPTION
Refactors `MatSort` and `MatSortHeader` so that they are not tightly coupled. 

Currently, the sort header determines its state by accessing properties from the `MatSort` such as `active` and `direction` to determine if it is sorted. This means that `MatSort `cannot be replaced by something like a multi-sort container.

This change changes the interaction so that the `MatSortHeader` requests its state from the container and there is a simple contract that the container needs to follow to be replaced.

Note that this is the first of three phases needed to get us towards having a `MatMultiSort`. The conversation can be found here #13538. Thanks to @relair for making the foundation for this feature