### PR TITLE
fix(datepicker): Add an invisible button at datepicker's calendar #14379

### DIFF
--- a/src/lib/datepicker/datepicker-content.html
+++ b/src/lib/datepicker/datepicker-content.html
@@ -1,17 +1,12 @@
-<mat-calendar cdkTrapFocus
-    [id]="datepicker.id"
-    [ngClass]="datepicker.panelClass"
-    [startAt]="datepicker.startAt"
-    [startView]="datepicker.startView"
-    [minDate]="datepicker._minDate"
-    [maxDate]="datepicker._maxDate"
-    [dateFilter]="datepicker._dateFilter"
-    [headerComponent]="datepicker.calendarHeaderComponent"
-    [selected]="datepicker._selected"
-    [dateClass]="datepicker.dateClass"
-    [@fadeInCalendar]="'enter'"
-    (selectedChange)="datepicker.select($event)"
-    (yearSelected)="datepicker._selectYear($event)"
-    (monthSelected)="datepicker._selectMonth($event)"
-    (_userSelection)="datepicker.close()">
-</mat-calendar>
+<div cdkTrapFocus>
+    <mat-calendar [id]="datepicker.id" [ngClass]="datepicker.panelClass" [startAt]="datepicker.startAt" [startView]="datepicker.startView"
+        [minDate]="datepicker._minDate" [maxDate]="datepicker._maxDate" [dateFilter]="datepicker._dateFilter"
+        [headerComponent]="datepicker.calendarHeaderComponent" [selected]="datepicker._selected" [dateClass]="datepicker.dateClass"
+        [@fadeInCalendar]="'enter'" (selectedChange)="datepicker.select($event)" (yearSelected)="datepicker._selectYear($event)"
+        (monthSelected)="datepicker._selectMonth($event)" (_userSelection)="datepicker.close()" height="100px">
+    </mat-calendar>
+    <div *ngIf="datepicker.touchUi">
+        <button type="button" [class.cdk-visually-hidden]="true" class="mat-datepicker-close-area"
+         [attr.aria-label]="datepicker.closeAreaLabel" disableRipple (click)="datepicker.close()"></button>
+    </div>
+</div>

--- a/src/lib/datepicker/datepicker-content.scss
+++ b/src/lib/datepicker/datepicker-content.scss
@@ -49,6 +49,10 @@ $mat-datepicker-touch-max-height: 788px;
   }
 }
 
+.mat-datepicker-close-area {
+  margin-top: 10px;
+}
+
 @media all and (orientation: landscape) {
   .mat-datepicker-content-touch .mat-calendar {
     width: $mat-datepicker-touch-landscape-width;

--- a/src/lib/datepicker/datepicker-intl.ts
+++ b/src/lib/datepicker/datepicker-intl.ts
@@ -48,4 +48,7 @@ export class MatDatepickerIntl {
 
   /** A label for the 'switch to year view' button (used by screen readers). */
   switchToMultiYearViewLabel: string = 'Choose month and year';
+
+  /** Calendar close button text */
+  closeAreaLabel: string = 'Close calendar';
 }

--- a/src/lib/datepicker/datepicker.spec.ts
+++ b/src/lib/datepicker/datepicker.spec.ts
@@ -479,6 +479,23 @@ describe('MatDatepicker', () => {
         expect(event.defaultPrevented).toBe(false);
       }));
 
+      it('Should close the calednar via close button', fakeAsync(() => {
+        testComponent.datepicker.touchUi = true;
+        testComponent.datepicker.open();
+        expect(testComponent.datepicker.opened).toBe(true, 'Datepicker should be opened.');
+        fixture.detectChanges();
+
+        const closeArea = fixture.debugElement.query(By.css('.mat-datepicker-close-area'));
+        expect(closeArea.nativeElement.getAttribute('aria-label')).toBe('Close calendar');
+
+        const closeButton = document.querySelector('.mat-datepicker-close-area') as HTMLElement;
+        closeButton.click();
+        fixture.detectChanges();
+        flush();
+
+        expect(testComponent.datepicker.opened).toBe(false, 'DatePicker should be closed.');
+      }));
+
     });
 
     describe('datepicker with too many inputs', () => {

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -51,6 +51,7 @@ import {matDatepickerAnimations} from './datepicker-animations';
 import {createMissingDateImplError} from './datepicker-errors';
 import {MatDatepickerInput} from './datepicker-input';
 import {MatCalendarCellCssClasses} from './calendar-body';
+import { MatDatepickerIntl } from './datepicker-intl';
 
 /** Used to generate a unique ID for each datepicker instance. */
 let datepickerUid = 0;
@@ -237,6 +238,9 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
   set _selected(value: D | null) { this._validSelected = value; }
   private _validSelected: D | null = null;
 
+  /** Close area text */
+  get closeAreaLabel(): string { return this._intl.closeAreaLabel; }
+
   /** The minimum selectable date. */
   get _minDate(): D | null {
     return this._datepickerInput && this._datepickerInput.min;
@@ -282,6 +286,7 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
               private _overlay: Overlay,
               private _ngZone: NgZone,
               private _viewContainerRef: ViewContainerRef,
+              private _intl: MatDatepickerIntl,
               @Inject(MAT_DATEPICKER_SCROLL_STRATEGY) scrollStrategy: any,
               @Optional() private _dateAdapter: DateAdapter<D>,
               @Optional() private _dir: Directionality,

--- a/src/material-examples/tooltip-manual/tooltip-manual-example.html
+++ b/src/material-examples/tooltip-manual/tooltip-manual-example.html
@@ -2,21 +2,23 @@
   <span> Mouse over to </span>
   <button mat-button
           (mouseenter)="tooltip.show()"
-          (keyup.enter)="tooltip.show()"
+          (focus)="tooltip.show()"
+          (focusout)="tooltip.hide()"
           aria-label="Button that progamatically shows a tooltip on another button"
           class="example-action-button">
     show
   </button>
   <button mat-button
           (mouseenter)="tooltip.hide()"
-          (keyup.enter)="tooltip.hide()"
+          (focus)="tooltip.hide()"
           aria-label="Button that progamatically hides a tooltip on another button"
           class="example-action-button">
     hide
   </button>
   <button mat-button
           (mouseenter)="tooltip.toggle()"
-          (keyup.enter)="tooltip.toggle()"
+          (focus)="tooltip.toggle()"
+          (focusout)="tooltip.hide()"
           aria-label="Button that progamatically toggles a tooltip on another button to show/hide"
           class="example-action-button">
     toggle show/hide

--- a/src/material-examples/tooltip-manual/tooltip-manual-example.html
+++ b/src/material-examples/tooltip-manual/tooltip-manual-example.html
@@ -2,18 +2,21 @@
   <span> Mouse over to </span>
   <button mat-button
           (mouseenter)="tooltip.show()"
+          (keyup.enter)="tooltip.show()"
           aria-label="Button that progamatically shows a tooltip on another button"
           class="example-action-button">
     show
   </button>
   <button mat-button
           (mouseenter)="tooltip.hide()"
+          (keyup.enter)="tooltip.hide()"
           aria-label="Button that progamatically hides a tooltip on another button"
           class="example-action-button">
     hide
   </button>
   <button mat-button
           (mouseenter)="tooltip.toggle()"
+          (keyup.enter)="tooltip.toggle()"
           aria-label="Button that progamatically toggles a tooltip on another button to show/hide"
           class="example-action-button">
     toggle show/hide


### PR DESCRIPTION
#14379

Add an invisible button at datepicker's calendar, when touchUi is enabled. It's an accessibility improvement for touch devices with screen readers.