### PR TITLE
fix(sort): add missing gesture config

### DIFF
--- a/src/material/sort/sort-module.ts
+++ b/src/material/sort/sort-module.ts
@@ -7,16 +7,21 @@
  */
 
 import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
+import {GestureConfig} from '@angular/material/core';
 import {MatSortHeader} from './sort-header';
 import {MatSort} from './sort';
 import {MAT_SORT_HEADER_INTL_PROVIDER} from './sort-header-intl';
-import {CommonModule} from '@angular/common';
 
 
 @NgModule({
   imports: [CommonModule],
   exports: [MatSort, MatSortHeader],
   declarations: [MatSort, MatSortHeader],
-  providers: [MAT_SORT_HEADER_INTL_PROVIDER]
+  providers: [
+    MAT_SORT_HEADER_INTL_PROVIDER,
+    {provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig},
+  ]
 })
 export class MatSortModule {}


### PR DESCRIPTION
The sort header uses the `longpress` event, however it doesn't import our gesture config. These changes add the config.