### PR TITLE
fix(material/menu): use narrower value for aria-haspopup on trigger element

### DIFF
--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -94,7 +94,7 @@ describe('MDC-based MatMenu', () => {
     fixture.detectChanges();
     const triggerElement = fixture.componentInstance.triggerEl.nativeElement;
 
-    expect(triggerElement.getAttribute('aria-haspopup')).toBe('true');
+    expect(triggerElement.getAttribute('aria-haspopup')).toBe('menu');
 
     fixture.componentInstance.trigger.menu = null;
     fixture.detectChanges();
@@ -140,6 +140,14 @@ describe('MDC-based MatMenu', () => {
     tick(500);
 
     expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBeFalsy();
+  }));
+
+  it('should set the correct aria-haspopup value on the trigger element', fakeAsync(() => {
+    const fixture = createComponent(SimpleMenu, [], [FakeIcon]);
+    fixture.detectChanges();
+    const triggerElement = fixture.componentInstance.triggerEl.nativeElement;
+
+    expect(triggerElement.getAttribute('aria-haspopup')).toBe('menu');
   }));
 
   it('should be able to remove the backdrop on repeat openings', fakeAsync(() => {

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -75,7 +75,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({passive: tr
 
 @Directive({
   host: {
-    '[attr.aria-haspopup]': 'menu ? true : null',
+    '[attr.aria-haspopup]': 'menu ? "menu" : null',
     '[attr.aria-expanded]': 'menuOpen || null',
     '[attr.aria-controls]': 'menuOpen ? menu.panelId : null',
     '(click)': '_handleClick($event)',

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -94,7 +94,7 @@ describe('MatMenu', () => {
     fixture.detectChanges();
     const triggerElement = fixture.componentInstance.triggerEl.nativeElement;
 
-    expect(triggerElement.getAttribute('aria-haspopup')).toBe('true');
+    expect(triggerElement.getAttribute('aria-haspopup')).toBe('menu');
 
     fixture.componentInstance.trigger.menu = null;
     fixture.detectChanges();
@@ -140,6 +140,14 @@ describe('MatMenu', () => {
     tick(500);
 
     expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBeFalsy();
+  }));
+
+  it('should set the correct aria-haspopup value on the trigger element', fakeAsync(() => {
+    const fixture = createComponent(SimpleMenu, [], [FakeIcon]);
+    fixture.detectChanges();
+    const triggerElement = fixture.componentInstance.triggerEl.nativeElement;
+
+    expect(triggerElement.getAttribute('aria-haspopup')).toBe('menu');
   }));
 
   it('should be able to remove the backdrop on repeat openings', fakeAsync(() => {


### PR DESCRIPTION
Currently we set `aria-haspopup` correctly on the menu trigger, however [according to the spec](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup) we can narrow the value down so that it indicates what kind of popup will be opened.