### PR TITLE
fix(paginator): allow screenreaders to read meaningful range labels

### DIFF
--- a/src/lib/paginator/paginator-intl.ts
+++ b/src/lib/paginator/paginator-intl.ts
@@ -38,19 +38,41 @@ export class MatPaginatorIntl {
   lastPageLabel: string = 'Last page';
 
   /** A label for the range of items within the current page and the length of the whole list. */
-  getRangeLabel = (page: number, pageSize: number, length: number) => {
-    if (length == 0 || pageSize == 0) { return `0 of ${length}`; }
+  getRangeLabel =
+      (page: number, pageSize: number, length: number) => {
+        if (length == 0 || pageSize == 0) {
+          return `0 of ${length}`;
+        }
+
+        length = Math.max(length, 0);
+
+        const startIndex = page * pageSize;
+
+        // If the start index exceeds the list length, do not try and fix the end index to the end.
+        const endIndex =
+            startIndex < length ? Math.min(startIndex + pageSize, length) : startIndex + pageSize;
+
+        return `${startIndex + 1} - ${endIndex} of ${length}`;
+      }
+
+  /**
+   * Screenreader friendly label for the range of items within the current page and length of the
+   *  whole list.
+   */
+  getReaderRangeLabel = (page: number, pageSize: number, length: number) => {
+    if (length == 0 || pageSize == 0) {
+      return `0 of ${length}`;
+    }
 
     length = Math.max(length, 0);
 
     const startIndex = page * pageSize;
 
     // If the start index exceeds the list length, do not try and fix the end index to the end.
-    const endIndex = startIndex < length ?
-        Math.min(startIndex + pageSize, length) :
-        startIndex + pageSize;
+    const endIndex =
+        startIndex < length ? Math.min(startIndex + pageSize, length) : startIndex + pageSize;
 
-    return `${startIndex + 1} - ${endIndex} of ${length}`;
+    return `${startIndex + 1} through ${endIndex} of ${length}`;
   }
 }
 

--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -23,9 +23,12 @@
       <div *ngIf="_displayedPageSizeOptions.length <= 1">{{pageSize}}</div>
     </div>
 
-    <div class="mat-paginator-range-actions">
-      <div class="mat-paginator-range-label">
+    <div class="mat-paginator-range-actions" aria-live="polite">
+      <div class="mat-paginator-range-label" aria-hidden="true">
         {{_intl.getRangeLabel(pageIndex, pageSize, length)}}
+      </div>
+	    <div class="mat-paginator-reader-only-range-label">
+        {{_intl.getReaderRangeLabel(pageIndex, pageSize, length)}}
       </div>
 
       <button mat-icon-button type="button"

--- a/src/lib/paginator/paginator.md
+++ b/src/lib/paginator/paginator.md
@@ -27,3 +27,4 @@ This will allow you to change the following:
 
 ### Accessibility
 The `aria-label`s for next page, previous page, first page and last page buttons can be set in `MatPaginatorIntl`.
+Screenreader friendly text for the range label can be set in `MatPaginatorIntl` via the `getReaderRangeLabel` method.

--- a/src/lib/paginator/paginator.scss
+++ b/src/lib/paginator/paginator.scss
@@ -86,6 +86,18 @@ $mat-paginator-button-last-increment-icon-margin: 9px;
   margin: $mat-paginator-range-label-margin;
 }
 
+.mat-paginator-reader-only-range-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap; /* added line */
+  border: 0;
+}
+
 .mat-paginator-range-actions {
   display: flex;
   align-items: center;

--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -39,7 +39,7 @@ describe('MatPaginator', () => {
   });
 
   describe('with the default internationalization provider', () => {
-    it('should show the right range text', () => {
+    it('should populate the range label for display', () => {
       const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
 
       // View second page of list of 100, each page contains 10 items.
@@ -83,6 +83,53 @@ describe('MatPaginator', () => {
       component.pageIndex = 2;
       fixture.detectChanges();
       expect(rangeElement.innerText).toBe('11 - 15 of 0');
+    });
+
+    it('should populate a range label only for screen readers', () => {
+      const rangeElement =
+          fixture.nativeElement.querySelector('.mat-paginator-reader-only-range-label');
+
+      // View second page of list of 100, each page contains 10 items.
+      component.length = 100;
+      component.pageSize = 10;
+      component.pageIndex = 1;
+      fixture.detectChanges();
+      expect(rangeElement.innerText).toBe('11 through 20 of 100');
+
+      // View third page of list of 200, each page contains 20 items.
+      component.length = 200;
+      component.pageSize = 20;
+      component.pageIndex = 2;
+      fixture.detectChanges();
+      expect(rangeElement.innerText).toBe('41 through 60 of 200');
+
+      // View first page of list of 0, each page contains 5 items.
+      component.length = 0;
+      component.pageSize = 5;
+      component.pageIndex = 2;
+      fixture.detectChanges();
+      expect(rangeElement.innerText).toBe('0 of 0');
+
+      // View third page of list of 12, each page contains 5 items.
+      component.length = 12;
+      component.pageSize = 5;
+      component.pageIndex = 2;
+      fixture.detectChanges();
+      expect(rangeElement.innerText).toBe('11 through 12 of 12');
+
+      // View third page of list of 10, each page contains 5 items.
+      component.length = 10;
+      component.pageSize = 5;
+      component.pageIndex = 2;
+      fixture.detectChanges();
+      expect(rangeElement.innerText).toBe('11 through 15 of 10');
+
+      // View third page of list of -5, each page contains 5 items.
+      component.length = -5;
+      component.pageSize = 5;
+      component.pageIndex = 2;
+      fixture.detectChanges();
+      expect(rangeElement.innerText).toBe('11 through 15 of 0');
     });
 
     it('should show right aria-labels for select and buttons', () => {

--- a/tools/public_api_guard/lib/paginator.d.ts
+++ b/tools/public_api_guard/lib/paginator.d.ts
@@ -41,6 +41,7 @@ export declare class MatPaginatorIntl {
     readonly changes: Subject<void>;
     firstPageLabel: string;
     getRangeLabel: (page: number, pageSize: number, length: number) => string;
+    getReaderRangeLabel: (page: number, pageSize: number, length: number) => string;
     itemsPerPageLabel: string;
     lastPageLabel: string;
     nextPageLabel: string;


### PR DESCRIPTION
Add aria-live to paginator range labels to allow screen readers to
read updates as they happen. Add an invisible label specifically for
screen readers. Add method to paginator-intl to allow the reader-only
label to be customized.

Similar to PR #11972, but adds screen reader only label to allow what is read to be customized. (otherwise 1-10 of 20 is read as one ten of twenty)