### PR TITLE
fix(material/checkbox): clear name from host node

### DIFF
--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -959,6 +959,12 @@ describe('MDC-based MatCheckbox', () => {
 
       expect(inputElement.getAttribute('name')).toBe('test-name');
     }));
+
+    it('should clear the name attribute from the host node', () => {
+      const checkboxElement = fixture.debugElement.query(By.directive(MatCheckbox));
+
+      expect(checkboxElement.nativeElement.getAttribute('name')).toBeFalsy();
+    });
   });
 
   describe('with form control', () => {

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -92,6 +92,7 @@ const defaults = MAT_CHECKBOX_DEFAULT_OPTIONS_FACTORY();
     '[attr.tabindex]': 'null',
     '[attr.aria-label]': 'null',
     '[attr.aria-labelledby]': 'null',
+    '[attr.name]': 'null',
     '[class._mat-animation-noopable]': `_animationMode === 'NoopAnimations'`,
     '[class.mdc-checkbox--disabled]': 'disabled',
     '[id]': 'id',


### PR DESCRIPTION
Currently we forward the name attribute from the host node to the underlying input, however we leave the name on the host node intact. This can throw off functions like `document.getElementsByName` or the `By.name` Protractor selector.