### PR TITLE
fix(material/radio): clear names from host nodes

### DIFF
--- a/src/material/legacy-radio/radio.spec.ts
+++ b/src/material/legacy-radio/radio.spec.ts
@@ -68,6 +68,11 @@ describe('MatRadio', () => {
       }
     });
 
+    it('should clear the name attribute from the radio group host node', () => {
+      expect(groupInstance.name).toBeTruthy();
+      expect(groupDebugElement.nativeElement.getAttribute('name')).toBeFalsy();
+    });
+
     it('should coerce the disabled binding on the radio group', () => {
       (groupInstance as any).disabled = '';
       fixture.detectChanges();

--- a/src/material/legacy-radio/radio.ts
+++ b/src/material/legacy-radio/radio.ts
@@ -87,6 +87,7 @@ export class MatLegacyRadioGroup extends _MatRadioGroupBase<MatLegacyRadioButton
     '[attr.aria-label]': 'null',
     '[attr.aria-labelledby]': 'null',
     '[attr.aria-describedby]': 'null',
+    '[attr.name]': 'null',
     // Note: under normal conditions focus shouldn't land on this element, however it may be
     // programmatically set, for example inside of a focus trap, in this case we want to forward
     // the focus to the native element.

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -76,6 +76,11 @@ describe('MDC-based MatRadio', () => {
       }
     });
 
+    it('should clear the name attribute from the radio group host node', () => {
+      expect(groupInstance.name).toBeTruthy();
+      expect(groupDebugElement.nativeElement.getAttribute('name')).toBeFalsy();
+    });
+
     it('should coerce the disabled binding on the radio group', () => {
       (groupInstance as any).disabled = '';
       fixture.detectChanges();
@@ -820,6 +825,10 @@ describe('MDC-based MatRadio', () => {
 
     it('should default the radio color to `accent`', () => {
       expect(seasonRadioInstances.every(radio => radio.color === 'accent')).toBe(true);
+    });
+
+    it('should clear the name attribute from the radio host node', () => {
+      expect(radioDebugElements.every(el => !el.nativeElement.getAttribute('name'))).toBe(true);
     });
   });
 

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -685,6 +685,7 @@ export class MatRadioGroup extends _MatRadioGroupBase<MatRadioButton> {
     '[attr.aria-label]': 'null',
     '[attr.aria-labelledby]': 'null',
     '[attr.aria-describedby]': 'null',
+    '[attr.name]': 'null',
     // Note: under normal conditions focus shouldn't land on this element, however it may be
     // programmatically set, for example inside of a focus trap, in this case we want to forward
     // the focus to the native element.


### PR DESCRIPTION
Along the same lines as #15368. Clears the `name` from the host node of the radio button and radio group, because they end up being forwarded to the underlying `input` and can cause double results when using something like `getElementsByName`.