### PR TITLE
fix(expansion): prevent animation parameters from being renamed by closure

### DIFF
--- a/src/material/expansion/expansion-animations.ts
+++ b/src/material/expansion/expansion-animations.ts
@@ -20,6 +20,12 @@ import {
 /** Time and timing curve for expansion panel animations. */
 export const EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,0.2,1)';
 
+// We need to declare these as constants in order to prevent Closure compiler from renaming
+// the animation parameters below. They need to be exported so that TS doesn't throw an error
+// about them being unused.
+export declare const collapsedHeight: string;
+export declare const expandedHeight: string;
+
 /**
  * Animations used by the Material expansion panel.
  *

--- a/src/material/expansion/public-api.ts
+++ b/src/material/expansion/public-api.ts
@@ -12,4 +12,4 @@ export * from './accordion-base';
 export * from './expansion-panel';
 export * from './expansion-panel-header';
 export * from './expansion-panel-content';
-export * from './expansion-animations';
+export {EXPANSION_PANEL_ANIMATION_TIMING, matExpansionAnimations} from './expansion-animations';


### PR DESCRIPTION
Pulls the parameters for the `expansionHeight` animation in order to avoid having them be minified by Closure.

Fixes #15305.