### PR TITLE
fix(list): remove hover indication from disabled items

### DIFF
--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -29,8 +29,10 @@
   .mat-list-option,
   .mat-nav-list .mat-list-item,
   .mat-action-list .mat-list-item {
-    &:hover, &:focus {
-      background: mat-color($background, 'hover');
+    &:not(.mat-list-item-disabled) {
+      &:hover, &:focus {
+        background: mat-color($background, 'hover');
+      }
     }
   }
 }

--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -308,8 +308,10 @@ mat-action-list {
   .mat-list-option,
   .mat-nav-list .mat-list-item,
   mat-action-list .mat-list-item {
-    &:hover, &:focus {
-      outline: dotted 1px;
+    &:not(.mat-list-item-disabled) {
+      &:hover, &:focus {
+        outline: dotted 1px;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes the hover indication still showing up for disabled list items.