### PR TITLE
fix(menu): prevent menu from collapsing to less than one item

### DIFF
--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -13,6 +13,10 @@ $mat-menu-submenu-indicator-size: 10px !default;
   border-radius: $mat-menu-border-radius;
   outline: 0;
 
+  // Give the menu a minimum height so that the user can't
+  // collapse it to zero when they scroll away.
+  min-height: $mat-menu-item-height + $mat-menu-vertical-padding * 2;
+
   // Prevent users from interacting with the panel while it's animating. Note that
   // people won't be able to click through it, because the overlay pane will catch the click.
   // This fixes the following issues:


### PR DESCRIPTION
Currently we allow the menu it's height to collapse so that it becomes scrollable if it won't fit in the viewport, however this has the side effect that the user can make the menu go to zero height when they scroll away. These changes give the menu a minimum height so it doesn't happen.