### PR TITLE
feat(overlay): add option to provide a custom element container for the…

### DIFF
--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -60,7 +60,8 @@ export class OverlayConfig {
   disposeOnNavigation?: boolean = false;
 
   /**
-   * The element on which the overlay will be attached to. The default element is the document body.
+   * The element on which the overlay will be attached to. 
+   * The default containing element is the document body.
    */
   container?: HTMLElement;
 

--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -60,7 +60,7 @@ export class OverlayConfig {
   disposeOnNavigation?: boolean = false;
 
   /**
-   * The element on which the overlay will be attached to. 
+   * The element on which the overlay will be attached to.
    * The default containing element is the document body.
    */
   container?: HTMLElement;

--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -59,6 +59,11 @@ export class OverlayConfig {
    */
   disposeOnNavigation?: boolean = false;
 
+  /**
+   * The element on which the overlay will be attached to. The default element is the document body.
+   */
+  container?: HTMLElement;
+
   constructor(config?: OverlayConfig) {
     if (config) {
       Object.keys(config).forEach(k => {

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -647,13 +647,11 @@ describe('Overlay', () => {
       const mockDiv = document.createElement('div');
       mockDiv.setAttribute('data-test', 'test');
 
-      const getContainer = jasmine.createSpy('getContainer spy');
       const overlayRef = overlay.create({container: mockDiv});
 
       expect(overlayContainer.getContainerElement).not.toHaveBeenCalled();
       expect(overlayRef.hostElement).toBe(mockDiv);
     });
-
   });
 
   describe('backdrop', () => {

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -648,9 +648,10 @@ describe('Overlay', () => {
       mockDiv.setAttribute('data-test', 'test');
 
       const overlayRef = overlay.create({container: mockDiv});
+      const spy = spyOn(overlayContainer, 'getContainerElement');
 
-      expect(overlayContainer.getContainerElement).not.toHaveBeenCalled();
-      expect(overlayRef.hostElement).toBe(mockDiv);
+      expect(spy).not.toHaveBeenCalled();
+      expect(overlayRef.hostElement.parentElement).toBe(mockDiv);
     });
   });
 

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -643,6 +643,17 @@ describe('Overlay', () => {
       expect(style.maxHeight).toBeFalsy();
     });
 
+    it('should not user the default container when a custom container element is provided', () => {
+      const mockDiv = document.createElement('div');
+      mockDiv.setAttribute('data-test', 'test');
+
+      const getContainer = jasmine.createSpy('getContainer spy');
+      const overlayRef = overlay.create({container: mockDiv});
+
+      expect(overlayContainer.getContainerElement).not.toHaveBeenCalled();
+      expect(overlayRef.hostElement).toBe(mockDiv);
+    });
+
   });
 
   describe('backdrop', () => {

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -64,7 +64,7 @@ export class Overlay {
    * @returns Reference to the created overlay.
    */
   create(config?: OverlayConfig): OverlayRef {
-    const host = this._createHostElement();
+    const host = this._createHostElement(config && config.container);
     const pane = this._createPaneElement(host);
     const portalOutlet = this._createPortalOutlet(pane);
     const overlayConfig = new OverlayConfig(config);
@@ -103,9 +103,11 @@ export class Overlay {
    * and can be used for advanced positioning.
    * @returns Newly-create host element.
    */
-  private _createHostElement(): HTMLElement {
+  private _createHostElement(containerElement?: HTMLElement): HTMLElement {
+    const container = containerElement ? containerElement :
+      this._overlayContainer.getContainerElement();
     const host = this._document.createElement('div');
-    this._overlayContainer.getContainerElement().appendChild(host);
+    container.appendChild(host);
     return host;
   }
 

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -186,7 +186,6 @@ export declare class OverlayConfig {
     positionStrategy?: PositionStrategy;
     scrollStrategy?: ScrollStrategy;
     width?: number | string;
-    container?: HTMLElement;
     constructor(config?: OverlayConfig);
 }
 

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -186,6 +186,7 @@ export declare class OverlayConfig {
     positionStrategy?: PositionStrategy;
     scrollStrategy?: ScrollStrategy;
     width?: number | string;
+    container?: HTMLElement;
     constructor(config?: OverlayConfig);
 }
 

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -174,7 +174,7 @@ export declare const OVERLAY_PROVIDERS: Provider[];
 
 export declare class OverlayConfig {
     backdropClass?: string | string[];
-    container: HTMLElement;
+    container?: HTMLElement;
     direction?: Direction | Directionality;
     disposeOnNavigation?: boolean;
     hasBackdrop?: boolean;

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -174,6 +174,7 @@ export declare const OVERLAY_PROVIDERS: Provider[];
 
 export declare class OverlayConfig {
     backdropClass?: string | string[];
+    container: HTMLElement;
     direction?: Direction | Directionality;
     disposeOnNavigation?: boolean;
     hasBackdrop?: boolean;


### PR DESCRIPTION
add option to provide a custom element container for the overlay to be attached to. By default the overlay is attached to the document, but there are cases when the container should be different. One such example is to have a dialog element (the native dialog), overlays that are attached to the body appearing behind the dialog. Attaching the overlay to the dialog will fix the issue.

resolves #15571 