### PR TITLE
fix(datepicker): add focus indication in high contrast mode

### DIFF
--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -76,6 +76,13 @@ $mat-calendar-body-cell-content-size: 100% - $mat-calendar-body-cell-content-mar
   .mat-calendar-body-today {
     outline: dotted 1px;
   }
+
+  .cdk-keyboard-focused .mat-calendar-body-active,
+  .cdk-program-focused .mat-calendar-body-active {
+    & > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
+      outline: dotted 2px;
+    }
+  }
 }
 
 [dir='rtl'] {


### PR DESCRIPTION
Fixes the datepicker calendar not having focus indication in high contrast mode, making it difficult to navigate using the keyboard.