### PR TITLE
fix(menu): trigger not unsubscribing from panel close stream

### DIFF
--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -201,8 +201,9 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     this._element.nativeElement.removeEventListener('touchstart', this._handleTouchStart,
         passiveEventListenerOptions);
 
-    this._cleanUpSubscriptions();
+    this._menuCloseSubscription.unsubscribe();
     this._closingActionsSubscription.unsubscribe();
+    this._hoverSubscription.unsubscribe();
   }
 
   /** Whether the menu is open. */
@@ -475,12 +476,6 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
         offsetY: -offsetY
       }
     ]);
-  }
-
-  /** Cleans up the active subscriptions. */
-  private _cleanUpSubscriptions(): void {
-    this._closingActionsSubscription.unsubscribe();
-    this._hoverSubscription.unsubscribe();
   }
 
   /** Returns a stream that emits whenever an action that should close the menu occurs. */


### PR DESCRIPTION
Fixes the `matMenuTrigger` not unsubscribing from its `_menuCloseSubscription`. Also removes a pretty simple private method that was only being used once.

Fixes #14094.