### PR TITLE
feat(overlay): CoverPositionStrategy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,7 @@
 /src/dev-app/checkbox/**                           @jelbourn @devversion
 /src/dev-app/chips/**                              @jelbourn
 /src/dev-app/connected-overlay/**                  @jelbourn @crisbeto
+/src/dev-app/cover-overlay/**                      @kkseamon @jelbourn
 /src/dev-app/dataset/**                            @andrewseguin
 /src/dev-app/datepicker/**                         @mmalerba
 /src/dev-app/dev-app/**                            @mmalerba

--- a/src/cdk/overlay/position/cover-position-strategy-factory.ts
+++ b/src/cdk/overlay/position/cover-position-strategy-factory.ts
@@ -2,7 +2,7 @@ import {Inject, Injectable} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
-import {OverlayContainer} from '../overlay-container';
+/*import {OverlayContainer} from '../overlay-container';*/
 import {FlexibleConnectedPositionStrategyOrigin} from './flexible-positioning';
 import {CoverPositionStrategy} from './cover-position-strategy';
 
@@ -12,7 +12,7 @@ export class CoverPositionStrategyFactory {
       private _viewportRuler: ViewportRuler,
       @Inject(DOCUMENT) private _document: any,
       private _platform: Platform,
-      private _overlayContainer: OverlayContainer,) {}
+/*      private _overlayContainer: OverlayContainer,*/) {}
   
   create() {
     return this.createWithConnections({});
@@ -28,7 +28,7 @@ export class CoverPositionStrategyFactory {
         this._viewportRuler,
         this._document,
         this._platform,
-        this._overlayContainer,
+/*        this._overlayContainer,*/
         top,
         right,
         bottom,

--- a/src/cdk/overlay/position/cover-position-strategy-factory.ts
+++ b/src/cdk/overlay/position/cover-position-strategy-factory.ts
@@ -1,0 +1,37 @@
+import {Inject, Injectable} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
+import {Platform} from '@angular/cdk/platform';
+import {ViewportRuler} from '@angular/cdk/scrolling';
+import {OverlayContainer} from '../overlay-container';
+import {FlexibleConnectedPositionStrategyOrigin} from './flexible-positioning';
+import {CoverPositionStrategy} from './cover-position-strategy';
+
+@Injectable({providedIn: 'root'})
+export class CoverPositionStrategyFactory {
+  constructor(
+      private _viewportRuler: ViewportRuler,
+      @Inject(DOCUMENT) private _document: any,
+      private _platform: Platform,
+      private _overlayContainer: OverlayContainer,) {}
+  
+  create() {
+    return this.createWithConnections({});
+  }
+  
+  createWithConnections({top, right, left, bottom}: {
+    top?: FlexibleConnectedPositionStrategyOrigin,
+    right?: FlexibleConnectedPositionStrategyOrigin,
+    bottom?: FlexibleConnectedPositionStrategyOrigin,
+    left?: FlexibleConnectedPositionStrategyOrigin
+  }) {
+    return new CoverPositionStrategy(
+        this._viewportRuler,
+        this._document,
+        this._platform,
+        this._overlayContainer,
+        top,
+        right,
+        bottom,
+        left);
+  }
+}

--- a/src/cdk/overlay/position/cover-position-strategy-factory.ts
+++ b/src/cdk/overlay/position/cover-position-strategy-factory.ts
@@ -1,8 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {Inject, Injectable} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
-/*import {OverlayContainer} from '../overlay-container';*/
 import {FlexibleConnectedPositionStrategyOrigin} from './flexible-positioning';
 import {CoverPositionStrategy} from './cover-position-strategy';
 
@@ -11,13 +18,12 @@ export class CoverPositionStrategyFactory {
   constructor(
       private _viewportRuler: ViewportRuler,
       @Inject(DOCUMENT) private _document: any,
-      private _platform: Platform,
-/*      private _overlayContainer: OverlayContainer,*/) {}
-  
+      private _platform: Platform) {}
+
   create() {
     return this.createWithConnections({});
   }
-  
+
   createWithConnections({top, right, left, bottom}: {
     top?: FlexibleConnectedPositionStrategyOrigin,
     right?: FlexibleConnectedPositionStrategyOrigin,
@@ -28,7 +34,6 @@ export class CoverPositionStrategyFactory {
         this._viewportRuler,
         this._document,
         this._platform,
-/*        this._overlayContainer,*/
         top,
         right,
         bottom,

--- a/src/cdk/overlay/position/cover-position-strategy.ts
+++ b/src/cdk/overlay/position/cover-position-strategy.ts
@@ -16,13 +16,13 @@ import {ViewportRuler,/* CdkScrollable,*/ /*ViewportScrollPosition*/} from '@ang
   validateHorizontalPosition,
   validateVerticalPosition,
 } from './connected-position';
-*/import {Observable, Subscription/*, Observer*/} from 'rxjs';
+*/import {/*Observable,*/ Subscription/*, Observer*/} from 'rxjs';
 import {OverlayReference} from '../overlay-reference';
-import {isElementScrolledOutsideView, isElementClippedByScrolling} from './scroll-clip';
-import {coerceCssPixelValue, coerceArray} from '@angular/cdk/coercion';
+/*import {isElementScrolledOutsideView, isElementClippedByScrolling} from './scroll-clip';*/
+import {coerceCssPixelValue/*, coerceArray*/} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
-import {OverlayContainer} from '../overlay-container';
-import {/*clearStyles,*/extendStyles, FlexibleConnectedPositionStrategyOrigin, getOriginRect, Point} from './flexible-positioning';
+/*import {OverlayContainer} from '../overlay-container';*/
+import {clearStyles, extendStyles, FlexibleConnectedPositionStrategyOrigin, getOriginRect, Point} from './flexible-positioning';
 
 /** Class to be added to the overlay bounding box. */
 const boundingBoxClass = 'cdk-overlay-connected-position-bounding-box';
@@ -63,10 +63,10 @@ export class CoverPositionStrategy implements PositionStrategy {
   private _positionLocked = false;
 
   /** Cached origin dimensions */
-  private _originRect: ClientRect;
+/*  private _originRect: ClientRect;*/
 
   /** Cached overlay dimensions */
-  private _overlayRect: ClientRect;
+/*  private _overlayRect: ClientRect;*/
 
   /** Cached viewport dimensions */
   private _viewportRect: ClientRect;
@@ -81,7 +81,7 @@ export class CoverPositionStrategy implements PositionStrategy {
    * The origin element against which the horizontal start of the overlay will be positioned.
    * The start of the overlay will match the start of this element.
    */
-  private _startOrigin: FlexibleConnectedPositionStrategyOrigin;
+  private _startOrigin?: FlexibleConnectedPositionStrategyOrigin;
   
   /**
    * The origin element against which the horizontal end of the overlay will be positioned.
@@ -94,7 +94,7 @@ export class CoverPositionStrategy implements PositionStrategy {
    * The origin element against which the top of the overlay will be positioned.
    * The top of the overlay will match the top of this element.
    */
-  private _topOrigin: FlexibleConnectedPositionStrategyOrigin;
+  private _topOrigin?: FlexibleConnectedPositionStrategyOrigin;
   
   /**
    * The origin element against which the bottom of the overlay will be positioned.
@@ -128,7 +128,7 @@ export class CoverPositionStrategy implements PositionStrategy {
     private _viewportRuler: ViewportRuler,
     private _document: Document,
     private _platform: Platform,
-    private _overlayContainer: OverlayContainer,
+/*    private _overlayContainer: OverlayContainer,*/
     topConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
     endConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
     startConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
@@ -187,8 +187,9 @@ export class CoverPositionStrategy implements PositionStrategy {
     // consumer opted into locking in the position, re-use the old position, in order to
     // prevent the overlay from jumping around.
     if (!this._isInitialRender && this._positionLocked && this._lastPosition) {
-      this.reapplyLastPosition();
-      return;
+      console.log('would reapply');
+/*      this.reapplyLastPosition();*/
+/*      return;*/
     }
 
     this._clearPanelClasses();
@@ -199,11 +200,11 @@ export class CoverPositionStrategy implements PositionStrategy {
     // the overlay relative to the origin.
     // We use the viewport rect to determine whether a position would go off-screen.
     this._viewportRect = this._getNarrowedViewportRect();
-    this._startOriginRect = getOriginRect(this._startOrigin);
+/*    this._startOriginRect = getOriginRect(this._startOrigin);
     this._endOriginRect = getOriginRect(this._endOrigin);
     this._topOriginRect = getOriginRect(this._topOrigin);
-    this._bottomOriginRect = getOriginRect(this._bottomOrigin);    
-    this._overlayRect = this._pane.getBoundingClientRect();
+    this._bottomOriginRect = getOriginRect(this._bottomOrigin);
+*/    /*this._overlayRect = this._pane.getBoundingClientRect();*/
 
     // Compute the preferred position based on the origins.
     const boundingBox = this._calculateBoundingBoxRect();
@@ -227,7 +228,7 @@ export class CoverPositionStrategy implements PositionStrategy {
     // We can't use `_resetBoundingBoxStyles` here, because it resets
     // some properties to zero, rather than removing them.
     if (this._boundingBox) {
-      resetStyles(this._boundingBox.style);
+      clearStyles(this._boundingBox.style);
     }
 
     if (this._pane) {
@@ -248,26 +249,24 @@ export class CoverPositionStrategy implements PositionStrategy {
    * even if a position higher in the "preferred positions" list would now fit. This
    * allows one to re-align the panel without changing the orientation of the panel.
    */
-  reapplyLastPosition(): void {
+  /*reapplyLastPosition(): void {
     if (!this._isDisposed && this._platform.isBrowser) {
       this._originRect = this._getOriginRect();
       this._overlayRect = this._pane.getBoundingClientRect();
       this._viewportRect = this._getNarrowedViewportRect();
 
-      const lastPosition = this._lastPosition;
-
-      this._applyPosition(lastPosition);
+      this._applyPosition(this._lastPosition);
     }
   }
-
+*/
   /**
    * Sets the list of Scrollable containers that host the origin element so that
    * on reposition we can evaluate if it or the overlay has been clipped or outside view. Every
    * Scrollable must be an ancestor element of the strategy's origin element.
    */
-  withScrollableContainers(scrollables: CdkScrollable[]) {
+/*  withScrollableContainers(scrollables: CdkScrollable[]) {
     this.scrollables = scrollables;
-  }
+  }*/
 
   /**
    * Sets a minimum distance the overlay may be positioned to the edge of the viewport.
@@ -357,15 +356,15 @@ export class CoverPositionStrategy implements PositionStrategy {
 
   /** Gets how well an overlay at the given point will fit within the viewport. */
   private _getOverlayAdjustment(overlay: Partial<ClientRect>): Partial<ClientRect> {
-    const top = overlay.top == null ? overlay.bottom - overlay.height : overlay.top;
-    const right = overlay.right == null ? overlay.left + overlay.width : overlay.right;
-    const bottom = overlay.bottom == null ? overlay.top + overlay.height : overlay.bottom;
-    const left = overlay.left == null ? overlay.right - overlay.width : overlay.left;
+    const top = overlay.top == null ? overlay.bottom! - overlay.height! : overlay.top;
+    const right = overlay.right == null ? overlay.left! + overlay.width! : overlay.right;
+    const bottom = overlay.bottom == null ? overlay.top! + overlay.height! : overlay.bottom;
+    const left = overlay.left == null ? overlay.right! - overlay.width! : overlay.left;
 
     return {
       top: 0 - top,
-      right: right - this._viewport.width,
-      bottom: bottom - this._viewport.height,
+      right: right - this._viewportRect.width,
+      bottom: bottom - this._viewportRect.height,
       left: 0 - left,
     };
   }
@@ -376,9 +375,9 @@ export class CoverPositionStrategy implements PositionStrategy {
    * @param point The (x, y) coordinates of the overlat at some position.
    * @param viewport The geometry of the viewport.
    */
-  private _canFitWithFlexibleDimensions(overlay: Partial<ClientRect>, adjustments: ClientRect) {
+/*  private _canFitWithFlexibleDimensions(overlay: Partial<ClientRect>, adjustments: ClientRect) {
     if (!this._hasFlexibleDimensions) return false;
-    
+
     const availableHeight = viewport.bottom - point.y;
     const availableWidth = viewport.right - point.x;
     const minHeight = this._overlayRef.getConfig().minHeight;
@@ -389,8 +388,8 @@ export class CoverPositionStrategy implements PositionStrategy {
 
     return verticalFit && horizontalFit;
   }
-
-  private _adjustBoundingBox(inputOverlay: Partial<ClientRect>, adjustments: ClientRect) {
+*/
+  private _adjustBoundingBox(inputOverlay: Partial<ClientRect>, adjustments: Partial<ClientRect>) {
     const overlayConfig = this._overlayRef.getConfig();
     
     const overlay = {...inputOverlay};
@@ -432,7 +431,7 @@ export class CoverPositionStrategy implements PositionStrategy {
       if (overlay.top != null) {
         overlay.top += pushFromTop;
       } else {
-        overlay.bottom += pushFromTop;
+        overlay.bottom! += pushFromTop;
       }
       this._isPushed = true;
     }
@@ -440,7 +439,7 @@ export class CoverPositionStrategy implements PositionStrategy {
       if (overlay.right != null) {
         overlay.right -= pushFromRight;
       } else {
-        overlay.left -= pushFromRight;
+        overlay.left! -= pushFromRight;
       }
       this._isPushed = true;
     }
@@ -448,7 +447,7 @@ export class CoverPositionStrategy implements PositionStrategy {
       if (overlay.bottom != null) {
         overlay.bottom -= pushFromBottom;
       } else {
-        overlay.top -= pushFromBottom;
+        overlay.top! -= pushFromBottom;
       }
       this._isPushed = true;
     }
@@ -456,22 +455,22 @@ export class CoverPositionStrategy implements PositionStrategy {
       if (overlay.left != null) {
         overlay.left += pushFromLeft;
       } else {
-        overlay.right += pushFromRight;
+        overlay.right! += pushFromRight;
       }
       this._isPushed = true;
     }
     if (shrinkHeight) {
-      overlay.height = Math.max(overlayConfig.minHeight || 0, overlay.height - shrinkHeight);
+      overlay.height = Math.max(overlayConfig.minHeight || 0, overlay.height! - shrinkHeight);
     }
     if (shrinkWidth) {
-      overlay.width = Math.max(overlayConfig.minWidth || 0, overlay.width - shrinkWidth);
+      overlay.width = Math.max(overlayConfig.minWidth || 0, overlay.width! - shrinkWidth);
     }
     
     return overlay;
   }
 
-  private _applyPosition(inputOverlay: Partial<ClientRect>, adjustments: ClientRect) {
-    const overlay = this._getAdjustedOverlay(inputOverlay, adjustments);
+  private _applyPosition(inputOverlay: Partial<ClientRect>, adjustments: Partial<ClientRect>) {
+    const overlay = this._adjustBoundingBox(inputOverlay, adjustments);
 
     this._setOverlayElementStyles(overlay);
     this._setBoundingBoxStyles(overlay);
@@ -587,7 +586,7 @@ export class CoverPositionStrategy implements PositionStrategy {
       }
     }
 
-    this._lastBoundingBoxSize = boundingBoxRect;
+/*    this._lastBoundingBoxSize = boundingBoxRect;*/
 
     extendStyles(this._boundingBox!.style, styles);
   }

--- a/src/cdk/overlay/position/cover-position-strategy.ts
+++ b/src/cdk/overlay/position/cover-position-strategy.ts
@@ -376,26 +376,6 @@ export class CoverPositionStrategy implements PositionStrategy {
     return ret;
   }
 
-  /**
-   * Whether the overlay can fit within the viewport when it may resize either its width or height.
-   * @param fit How well the overlay fits in the viewport at some position.
-   * @param point The (x, y) coordinates of the overlat at some position.
-   * @param viewport The geometry of the viewport.
-   */
-/*  private _canFitWithFlexibleDimensions(overlay: Partial<Rect>, adjustments: Rect) {
-    if (!this._hasFlexibleDimensions) return false;
-
-    const availableHeight = viewport.bottom - point.y;
-    const availableWidth = viewport.right - point.x;
-    const minHeight = this._overlayRef.getConfig().minHeight;
-    const minWidth = this._overlayRef.getConfig().minWidth;
-
-    const verticalFit = adjustments.top + adjustments.bottom <= minHeight || 0;
-    const horizontalFit = adjustments.left + adjustments.right <= minWidth || 0;
-
-    return verticalFit && horizontalFit;
-  }
-*/
   private _adjustBoundingBox(inputOverlay: Partial<Rect>, adjustments: BoundingBox) {
     const overlay = {...inputOverlay};
     let pushFromTop = 0;
@@ -410,7 +390,7 @@ export class CoverPositionStrategy implements PositionStrategy {
         // todo - worry about min-height and min-width?
         // doing it properly would require looking at the viewport to decide
         // what the overlay's actual height is.
-        /*const overlayConfig = this._overlayRef.getConfig();
+/*        const overlayConfig = this._overlayRef.getConfig();
         const minHeight = this._overlayRef.getConfig().minHeight;
         const minWidth = this._overlayRef.getConfig().minWidth;*/
         
@@ -419,6 +399,21 @@ export class CoverPositionStrategy implements PositionStrategy {
         pushFromRight = overlay.right != null && adjustments.right! > 0 ? adjustments.right! : 0;
         pushFromBottom = overlay.bottom != null && adjustments.bottom! > 0 ? adjustments.bottom! : 0;
         pushFromLeft = overlay.left != null && adjustments.left! > 0 ? adjustments.left! : 0;
+        
+/*        shrinkHeight = overlay.height != null ?
+            (adjustments.top! - pushFromTop) + (adjustments.bottom! - pushFromBottom) : 0;
+        shrinkWidth = overlay.width != null ?
+            (adjustments.left! - pushFromLeft) + (adjustments.right! - pushFromRight) : 0;
+
+        const overShrinkHeight = minHeight - (overlay.height - shrinkHeight);
+        if (overShrinkHeight > 0) {
+          if (overlay.top != null) {
+            pushFromTop -= overShrinkHeight;
+          } else {
+            pushFromBottom -= overShrinkHeight;
+          }
+        }*/
+        // todo - also width
       } else {
         // Push only if we can do so without shrinking the overlay.
         pushFromTop = adjustments.top! > 0 && adjustments.bottom! < 0 ?
@@ -431,13 +426,6 @@ export class CoverPositionStrategy implements PositionStrategy {
             Math.min(adjustments.left!, -adjustments.right!) : 0;
       }
     }
-
-/*    if (this._hasFlexibleDimensions) {
-      shrinkHeight = overlay.height != null ?
-          (adjustments.top! - pushFromTop) + (adjustments.bottom! - pushFromBottom) : 0;
-      shrinkWidth = overlay.width != null ?
-          (adjustments.left! - pushFromLeft) + (adjustments.right! - pushFromRight) : 0;
-    }*/
     
     if (pushFromTop) {
       if (overlay.top != null) {
@@ -538,6 +526,8 @@ export class CoverPositionStrategy implements PositionStrategy {
       boundingBox.height = viewport.height - boundingBox.bottom! - this._viewportMargin;
     } else if (boundingBox.bottom == null) {
       boundingBox.height = viewport.height - boundingBox.top + this._viewportMargin;
+    } else {
+      boundingBox.height = viewport.height - boundingBox.bottom - boundingBox.top;
     }
     // todo - we could compute height here based on top vs bottom
 

--- a/src/cdk/overlay/position/cover-position-strategy.ts
+++ b/src/cdk/overlay/position/cover-position-strategy.ts
@@ -1,0 +1,708 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PositionStrategy} from './position-strategy';
+import {ElementRef} from '@angular/core';
+import {ViewportRuler,/* CdkScrollable,*/ /*ViewportScrollPosition*/} from '@angular/cdk/scrolling';
+/*import {
+  ConnectedOverlayPositionChange,
+  ConnectionPositionPair,
+  ScrollingVisibility,
+  validateHorizontalPosition,
+  validateVerticalPosition,
+} from './connected-position';
+*/import {Observable, Subscription/*, Observer*/} from 'rxjs';
+import {OverlayReference} from '../overlay-reference';
+import {isElementScrolledOutsideView, isElementClippedByScrolling} from './scroll-clip';
+import {coerceCssPixelValue, coerceArray} from '@angular/cdk/coercion';
+import {Platform} from '@angular/cdk/platform';
+import {OverlayContainer} from '../overlay-container';
+import {/*clearStyles,*/extendStyles, FlexibleConnectedPositionStrategyOrigin, getOriginRect, Point} from './flexible-positioning';
+
+/** Class to be added to the overlay bounding box. */
+const boundingBoxClass = 'cdk-overlay-connected-position-bounding-box';
+
+/** Possible values that can be set as the origin of a FlexibleConnectedPositionStrategy. */
+export type FlexibleConnectedPositionStrategyOrigin = ElementRef | HTMLElement | Point;
+
+/**
+ * A strategy for positioning overlays. Using this strategy, an overlay is given an
+ * implicit position relative some origin element. The relative position is defined in terms of
+ * a point on the origin element that is connected to a point on the overlay element. For example,
+ * a basic dropdown is connecting the bottom-left corner of the origin to the top-left corner
+ * of the overlay.
+ */
+export class CoverPositionStrategy implements PositionStrategy {
+  /** The overlay to which this strategy is attached. */
+  private _overlayRef: OverlayReference;
+
+  /** Whether we're performing the very first positioning of the overlay. */
+  private _isInitialRender: boolean;
+
+  /** Last size used for the bounding box. Used to avoid resizing the overlay after open. */
+/*  private _lastBoundingBoxSize = {width: 0, height: 0};*/
+
+  /** Whether the overlay was pushed in a previous positioning. */
+  private _isPushed = false;
+
+  /** Whether the overlay can be pushed on-screen on the initial open. */
+  private _canPush = true;
+
+  /** Whether the overlay can grow via flexible width/height after the initial open. */
+  private _growAfterOpen = false;
+
+  /** Whether the overlay's width and height can be constrained to fit within the viewport. */
+  private _hasFlexibleDimensions = true;
+
+  /** Whether the overlay position is locked. */
+  private _positionLocked = false;
+
+  /** Cached origin dimensions */
+  private _originRect: ClientRect;
+
+  /** Cached overlay dimensions */
+  private _overlayRect: ClientRect;
+
+  /** Cached viewport dimensions */
+  private _viewportRect: ClientRect;
+
+  /** Amount of space that must be maintained between the overlay and the edge of the viewport. */
+  private _viewportMargin = 0;
+
+  /** The Scrollable containers used to check scrollable view properties on position change. */
+/*  private scrollables: CdkScrollable[] = [];*/
+  
+  /**
+   * The origin element against which the horizontal start of the overlay will be positioned.
+   * The start of the overlay will match the start of this element.
+   */
+  private _startOrigin: FlexibleConnectedPositionStrategyOrigin;
+  
+  /**
+   * The origin element against which the horizontal end of the overlay will be positioned.
+   * The end of the overlay will match the end of this element.
+   * If absent, the end of _startOrigin will be used.
+   */
+  private _endOrigin?: FlexibleConnectedPositionStrategyOrigin;
+
+  /**
+   * The origin element against which the top of the overlay will be positioned.
+   * The top of the overlay will match the top of this element.
+   */
+  private _topOrigin: FlexibleConnectedPositionStrategyOrigin;
+  
+  /**
+   * The origin element against which the bottom of the overlay will be positioned.
+   * The bottom of the overlay will match the bottom of this element.
+   * If absent, _topOrigin will be used.
+   */
+  private _bottomOrigin?: FlexibleConnectedPositionStrategyOrigin;
+
+  /** The overlay pane element. */
+  private _pane: HTMLElement;
+
+  /** Whether the strategy has been disposed of already. */
+  private _isDisposed: boolean;
+
+  /**
+   * Parent element for the overlay panel used to constrain the overlay panel's size to fit
+   * within the viewport.
+   */
+  private _boundingBox: HTMLElement | null;
+
+  /** The last position to have been calculated as the best fit position. */
+  private _lastPosition: ClientRect | null;
+
+  /** Subscription to viewport size changes. */
+  private _resizeSubscription = Subscription.EMPTY;
+
+  /** Keeps track of the CSS classes that the position strategy has applied on the overlay panel. */
+  private _appliedPanelClasses: string[] = [];
+
+  constructor(
+    private _viewportRuler: ViewportRuler,
+    private _document: Document,
+    private _platform: Platform,
+    private _overlayContainer: OverlayContainer,
+    topConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
+    endConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
+    startConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
+    bottomConnectedTo?: FlexibleConnectedPositionStrategyOrigin,) {
+    this.withTopOrigin(topConnectedTo)
+        .withEndOrigin(endConnectedTo)
+        .withBottomOrigin(bottomConnectedTo)
+        .withStartOrigin(startConnectedTo);
+  }
+
+  /** Attaches this position strategy to an overlay. */
+  attach(overlayRef: OverlayReference): void {
+    if (this._overlayRef && overlayRef !== this._overlayRef) {
+      throw Error('This position strategy is already attached to an overlay');
+    }
+
+    overlayRef.hostElement.classList.add(boundingBoxClass);
+
+    this._overlayRef = overlayRef;
+    this._boundingBox = overlayRef.hostElement;
+    this._pane = overlayRef.overlayElement;
+    this._isDisposed = false;
+    this._isInitialRender = true;
+    this._lastPosition = null;
+    this._resizeSubscription.unsubscribe();
+    this._resizeSubscription = this._viewportRuler.change().subscribe(() => {
+      // When the window is resized, we want to trigger the next reposition as if it
+      // was an initial render, in order for the strategy to pick a new optimal position,
+      // otherwise position locking will cause it to stay at the old one.
+      this._isInitialRender = true;
+      this.apply();
+    });
+  }
+
+  /**
+   * Updates the position of the overlay element, using whichever preferred position relative
+   * to the origin best fits on-screen.
+   *
+   * The selection of a position goes as follows:
+   *  - If any positions fit completely within the viewport as-is,
+   *      choose the first position that does so.
+   *  - If flexible dimensions are enabled and at least one satifies the given minimum width/height,
+   *      choose the position with the greatest available size modified by the positions' weight.
+   *  - If pushing is enabled, take the position that went off-screen the least and push it
+   *      on-screen.
+   *  - If none of the previous criteria were met, use the position that goes off-screen the least.
+   * @docs-private
+   */
+  apply(): void {
+    // We shouldn't do anything if the strategy was disposed or we're on the server.
+    if (this._isDisposed || !this._platform.isBrowser) {
+      return;
+    }
+
+    // If the position has been applied already (e.g. when the overlay was opened) and the
+    // consumer opted into locking in the position, re-use the old position, in order to
+    // prevent the overlay from jumping around.
+    if (!this._isInitialRender && this._positionLocked && this._lastPosition) {
+      this.reapplyLastPosition();
+      return;
+    }
+
+    this._clearPanelClasses();
+    this._resetOverlayElementStyles();
+    this._resetBoundingBoxStyles();
+
+    // We need the bounding rects for the origins and the overlay to determine how to position
+    // the overlay relative to the origin.
+    // We use the viewport rect to determine whether a position would go off-screen.
+    this._viewportRect = this._getNarrowedViewportRect();
+    this._startOriginRect = getOriginRect(this._startOrigin);
+    this._endOriginRect = getOriginRect(this._endOrigin);
+    this._topOriginRect = getOriginRect(this._topOrigin);
+    this._bottomOriginRect = getOriginRect(this._bottomOrigin);    
+    this._overlayRect = this._pane.getBoundingClientRect();
+
+    // Compute the preferred position based on the origins.
+    const boundingBox = this._calculateBoundingBoxRect();
+    const adjustments = this._getOverlayAdjustment(boundingBox);
+
+    this._applyPosition(boundingBox, adjustments);
+  }
+
+  detach() {
+    this._clearPanelClasses();
+    this._lastPosition = null;
+    this._resizeSubscription.unsubscribe();
+  }
+
+  /** Cleanup after the element gets destroyed. */
+  dispose() {
+    if (this._isDisposed) {
+      return;
+    }
+
+    // We can't use `_resetBoundingBoxStyles` here, because it resets
+    // some properties to zero, rather than removing them.
+    if (this._boundingBox) {
+      resetStyles(this._boundingBox.style);
+    }
+
+    if (this._pane) {
+      this._resetOverlayElementStyles();
+    }
+
+    if (this._overlayRef) {
+      this._overlayRef.hostElement.classList.remove(boundingBoxClass);
+    }
+
+    this.detach();
+    this._overlayRef = this._boundingBox = null!;
+    this._isDisposed = true;
+  }
+
+  /**
+   * This re-aligns the overlay element with the trigger in its last calculated position,
+   * even if a position higher in the "preferred positions" list would now fit. This
+   * allows one to re-align the panel without changing the orientation of the panel.
+   */
+  reapplyLastPosition(): void {
+    if (!this._isDisposed && this._platform.isBrowser) {
+      this._originRect = this._getOriginRect();
+      this._overlayRect = this._pane.getBoundingClientRect();
+      this._viewportRect = this._getNarrowedViewportRect();
+
+      const lastPosition = this._lastPosition;
+
+      this._applyPosition(lastPosition);
+    }
+  }
+
+  /**
+   * Sets the list of Scrollable containers that host the origin element so that
+   * on reposition we can evaluate if it or the overlay has been clipped or outside view. Every
+   * Scrollable must be an ancestor element of the strategy's origin element.
+   */
+  withScrollableContainers(scrollables: CdkScrollable[]) {
+    this.scrollables = scrollables;
+  }
+
+  /**
+   * Sets a minimum distance the overlay may be positioned to the edge of the viewport.
+   * @param margin Required margin between the overlay and the viewport edge in pixels.
+   */
+  withViewportMargin(margin: number): this {
+    this._viewportMargin = margin;
+    return this;
+  }
+
+  /** Sets whether the overlay's width and height can be constrained to fit within the viewport. */
+  withFlexibleDimensions(flexibleDimensions = true): this {
+    this._hasFlexibleDimensions = flexibleDimensions;
+    return this;
+  }
+
+  /** Sets whether the overlay can grow after the initial open via flexible width/height. */
+  withGrowAfterOpen(growAfterOpen = true): this {
+    this._growAfterOpen = growAfterOpen;
+    return this;
+  }
+
+  /** Sets whether the overlay can be pushed on-screen if none of the provided positions fit. */
+  withPush(canPush = true): this {
+    this._canPush = canPush;
+    return this;
+  }
+
+  /**
+   * Sets whether the overlay's position should be locked in after it is positioned
+   * initially. When an overlay is locked in, it won't attempt to reposition itself
+   * when the position is re-applied (e.g. when the user scrolls away).
+   * @param isLocked Whether the overlay should locked in.
+   */
+  withLockedPosition(isLocked = true): this {
+    this._positionLocked = isLocked;
+    return this;
+  }
+
+  /**
+   * Sets the origin, relative to which to position horozontal start of the overlay.
+   * Using an element origin is useful for building components that need to be positioned
+   * relatively to a trigger (e.g. dropdown menus or tooltips), whereas using a point can be
+   * used for cases like contextual menus which open relative to the user's pointer.
+   * @param origin Reference to the new origin.
+   */
+  withStartOrigin(origin?: FlexibleConnectedPositionStrategyOrigin): this {
+    this._startOrigin = origin;
+    return this;
+  }
+
+  /**
+   * Sets the origin, relative to which to position horozontal end of the overlay.
+   * Using an element origin is useful for building components that need to be positioned
+   * relatively to a trigger (e.g. dropdown menus or tooltips), whereas using a point can be
+   * used for cases like contextual menus which open relative to the user's pointer.
+   * @param origin Reference to the new origin.
+   */
+  withEndOrigin(origin?: FlexibleConnectedPositionStrategyOrigin): this {
+    this._endOrigin = origin;
+    return this;
+  }
+
+  /**
+   * Sets the origin, relative to which to position top of the overlay.
+   * Using an element origin is useful for building components that need to be positioned
+   * relatively to a trigger (e.g. dropdown menus or tooltips), whereas using a point can be
+   * used for cases like contextual menus which open relative to the user's pointer.
+   * @param origin Reference to the new origin.
+   */
+  withTopOrigin(origin?: FlexibleConnectedPositionStrategyOrigin): this {
+    this._startOrigin = origin;
+    return this;
+  }
+
+  /**
+   * Sets the origin, relative to which to position bottom of the overlay.
+   * Using an element origin is useful for building components that need to be positioned
+   * relatively to a trigger (e.g. dropdown menus or tooltips), whereas using a point can be
+   * used for cases like contextual menus which open relative to the user's pointer.
+   * @param origin Reference to the new origin.
+   */
+  withBottomOrigin(origin?: FlexibleConnectedPositionStrategyOrigin): this {
+    this._endOrigin = origin;
+    return this;
+  }
+
+  /** Gets how well an overlay at the given point will fit within the viewport. */
+  private _getOverlayAdjustment(overlay: Partial<ClientRect>): Partial<ClientRect> {
+    const top = overlay.top == null ? overlay.bottom - overlay.height : overlay.top;
+    const right = overlay.right == null ? overlay.left + overlay.width : overlay.right;
+    const bottom = overlay.bottom == null ? overlay.top + overlay.height : overlay.bottom;
+    const left = overlay.left == null ? overlay.right - overlay.width : overlay.left;
+
+    return {
+      top: 0 - top,
+      right: right - this._viewport.width,
+      bottom: bottom - this._viewport.height,
+      left: 0 - left,
+    };
+  }
+
+  /**
+   * Whether the overlay can fit within the viewport when it may resize either its width or height.
+   * @param fit How well the overlay fits in the viewport at some position.
+   * @param point The (x, y) coordinates of the overlat at some position.
+   * @param viewport The geometry of the viewport.
+   */
+  private _canFitWithFlexibleDimensions(overlay: Partial<ClientRect>, adjustments: ClientRect) {
+    if (!this._hasFlexibleDimensions) return false;
+    
+    const availableHeight = viewport.bottom - point.y;
+    const availableWidth = viewport.right - point.x;
+    const minHeight = this._overlayRef.getConfig().minHeight;
+    const minWidth = this._overlayRef.getConfig().minWidth;
+
+    const verticalFit = adjustments.top + adjustments.bottom <= minHeight || 0;
+    const horizontalFit = adjustments.left + adjustments.right <= minWidth || 0;
+
+    return verticalFit && horizontalFit;
+  }
+
+  private _adjustBoundingBox(inputOverlay: Partial<ClientRect>, adjustments: ClientRect) {
+    const overlayConfig = this._overlayRef.getConfig();
+    
+    const overlay = {...inputOverlay};
+    let pushFromTop = 0;
+    let pushFromRight = 0;
+    let pushFromBottom = 0;
+    let pushFromLeft = 0;
+    let shrinkHeight = 0;
+    let shrinkWidth = 0;
+    
+    if (this._canPush) {
+      if (this._hasFlexibleDimensions) {
+        // Push from all directions (shrinking the resulting overlay is ok).
+        pushFromTop = overlay.top != null && adjustments.top > 0 ? adjustments.top : 0;
+        pushFromRight = overlay.right != null && adjustments.right > 0 ? adjustments.right : 0;
+        pushFromBottom = overlay.bottom != null && adjustments.bottom > 0 ? adjustments.bottom : 0;
+        pushFromLeft = overlay.left != null && adjustments.left > 0 ? adjustments.left : 0;
+      } else {
+        // Push only if we can do so without shrinking the overlay.
+        pushFromTop = adjustments.top > 0 && adjustments.bottom < 0 ?
+            Math.min(adjustments.top, -adjustments.bottom) : 0;
+        pushFromRight = adjustments.right > 0 && adjustments.left < 0 ?
+            Math.min(adjustments.right, -adjustments.left) : 0;
+        pushFromBottom =  adjustments.bottom > 0 && adjustments.top < 0 ?
+            Math.min(adjustments.bottom, -adjustments.top) : 0;
+        pushFromLeft =  adjustments.left > 0 && adjustments.right < 0 ?
+            Math.min(adjustments.left, -adjustments.right) : 0;
+      }
+    }
+    
+    if (this._hasFlexibleDimensions) {
+      shrinkHeight = overlay.height != null ?
+          (adjustments.top - pushFromTop) + (adjustments.bottom - pushFromBottom) : 0;
+      shrinkWidth = overlay.width != null ?
+          (adjustments.left - pushFromLeft) + (adjustments.right - pushFromRight) : 0;
+    }
+    
+    if (pushFromTop) {
+      if (overlay.top != null) {
+        overlay.top += pushFromTop;
+      } else {
+        overlay.bottom += pushFromTop;
+      }
+      this._isPushed = true;
+    }
+    if (pushFromRight) {
+      if (overlay.right != null) {
+        overlay.right -= pushFromRight;
+      } else {
+        overlay.left -= pushFromRight;
+      }
+      this._isPushed = true;
+    }
+    if (pushFromBottom) {
+      if (overlay.bottom != null) {
+        overlay.bottom -= pushFromBottom;
+      } else {
+        overlay.top -= pushFromBottom;
+      }
+      this._isPushed = true;
+    }
+    if (pushFromLeft) {
+      if (overlay.left != null) {
+        overlay.left += pushFromLeft;
+      } else {
+        overlay.right += pushFromRight;
+      }
+      this._isPushed = true;
+    }
+    if (shrinkHeight) {
+      overlay.height = Math.max(overlayConfig.minHeight || 0, overlay.height - shrinkHeight);
+    }
+    if (shrinkWidth) {
+      overlay.width = Math.max(overlayConfig.minWidth || 0, overlay.width - shrinkWidth);
+    }
+    
+    return overlay;
+  }
+
+  private _applyPosition(inputOverlay: Partial<ClientRect>, adjustments: ClientRect) {
+    const overlay = this._getAdjustedOverlay(inputOverlay, adjustments);
+
+    this._setOverlayElementStyles(overlay);
+    this._setBoundingBoxStyles(overlay);
+
+    this._isInitialRender = false;
+  }
+
+  /**
+   * Gets the position and size of the overlay's sizing container.
+   *
+   * This method does no measuring and applies no styles so that we can cheaply compute the
+   * bounds for all positions and choose the best fit based on these results.
+   */
+  private _calculateBoundingBoxRect(): Partial<ClientRect> {
+    const viewport = this._viewportRect;
+    const isRtl = this._isRtl();
+
+    const boundingBox: Partial<ClientRect> = {};
+
+    if (this._topOrigin) {
+      boundingBox.top = getOriginRect(this._topOrigin).top;
+    }
+    if (this._endOrigin) {
+      const endRect = getOriginRect(this._endOrigin);
+      if (isRtl) {
+        boundingBox.left = endRect.left;
+      } else {
+        boundingBox.right = endRect.right;
+      }
+    }
+    if (this._bottomOrigin) {
+      boundingBox.bottom = getOriginRect(this._bottomOrigin).bottom;
+    }
+    if (this._startOrigin) {
+      const startRect = getOriginRect(this._startOrigin);
+      if (isRtl) {
+        boundingBox.right = startRect.right;
+      } else {
+        boundingBox.left = startRect.left;
+      }
+    }
+
+    // Figure out a height if top or bottom is not set.
+    if (boundingBox.top == null && boundingBox.bottom == null) {
+      throw new Error('CoverPositionStrategy: must have a top or bottom origin element');
+    }
+    if (boundingBox.left == null && boundingBox.right == null) {
+      throw new Error('CoverPositionStrategy: must have a start or end origin element');
+    }
+
+    if (boundingBox.top == null) {
+      boundingBox.height = viewport.height - boundingBox.bottom - this._viewportMargin;
+    } else if (boundingBox.bottom == null) {
+      boundingBox.height = viewport.height - boundingBox.top + this._viewportMargin;
+    }
+    
+    if (boundingBox.left == null) {
+      boundingBox.width = viewport.left - boundingBox.right - this._viewportMargin;
+    } else if (boundingBox.right == null) {
+      boundingBox.width = viewport.right - boundingBox.left + this._viewportMargin;
+    }
+
+    return boundingBox;
+  }
+
+  /**
+   * Sets the position and size of the overlay's sizing wrapper. The wrapper is positioned on the
+   * origin's connection point and stetches to the bounds of the viewport.
+   */
+  private _setBoundingBoxStyles(overlay: Partial<ClientRect>): void {
+    const boundingBoxRect = {...overlay};
+    
+    // It's weird if the overlay *grows* while scrolling, so we take the last size into account
+    // when applying a new size.
+    if (!this._isInitialRender && !this._growAfterOpen) {
+      // Todo: figure this out - need to handle that either value could be undefined
+      /*if (boundingBoxRect != null) {
+
+      }
+      boundingBoxRect.height = Math.min(boundingBoxRect.height, this._lastBoundingBoxSize.height);
+      boundingBoxRect.width = Math.min(boundingBoxRect.width, this._lastBoundingBoxSize.width);*/
+    }
+
+    const styles = {} as CSSStyleDeclaration;
+
+    if (this._hasExactPosition()) {
+      styles.top = styles.left = '0';
+      styles.bottom = styles.right = '';
+      styles.width = styles.height = '100%';
+    } else {
+      const maxHeight = this._overlayRef.getConfig().maxHeight;
+      const maxWidth = this._overlayRef.getConfig().maxWidth;
+
+      // todo: do we need to transform empty values to hit screen edges?
+
+      styles.height = coerceCssPixelValue(boundingBoxRect.height);
+      styles.top = coerceCssPixelValue(boundingBoxRect.top);
+      styles.bottom = coerceCssPixelValue(boundingBoxRect.bottom);
+      styles.width = coerceCssPixelValue(boundingBoxRect.width);
+      styles.left = coerceCssPixelValue(boundingBoxRect.left);
+      styles.right = coerceCssPixelValue(boundingBoxRect.right);
+
+      // Push the pane content towards the proper direction.
+      styles.alignItems = boundingBoxRect.top == null ? 'flex-end' : 'flex-start';
+      styles.justifyContent = boundingBoxRect.left == null ? 'flex-end' : 'flex-start';
+
+      if (maxHeight) {
+        styles.maxHeight = coerceCssPixelValue(maxHeight);
+      }
+
+      if (maxWidth) {
+        styles.maxWidth = coerceCssPixelValue(maxWidth);
+      }
+    }
+
+    this._lastBoundingBoxSize = boundingBoxRect;
+
+    extendStyles(this._boundingBox!.style, styles);
+  }
+
+  /** Resets the styles for the bounding box so that a new positioning can be computed. */
+  private _resetBoundingBoxStyles() {
+    extendStyles(this._boundingBox!.style, {
+      top: '0',
+      left: '0',
+      right: '0',
+      bottom: '0',
+      height: '',
+      width: '',
+      alignItems: '',
+      justifyContent: '',
+    } as CSSStyleDeclaration);
+  }
+
+  /** Resets the styles for the overlay pane so that a new positioning can be computed. */
+  private _resetOverlayElementStyles() {
+    extendStyles(this._pane.style, {
+      top: '',
+      left: '',
+      bottom: '',
+      right: '',
+      position: '',
+      transform: '',
+    } as CSSStyleDeclaration);
+  }
+
+  /** Sets positioning styles to the overlay element. */
+  private _setOverlayElementStyles(overlay: Partial<ClientRect>): void {
+    const styles = {} as CSSStyleDeclaration;
+
+    styles.position = 'static';
+
+    if (overlay.top != null && overlay.bottom != null) {
+      styles.height = '100%';
+    }
+    if (overlay.left != null && overlay.right != null) {
+      styles.width = '100%';
+    }
+
+/*    if (this._hasExactPosition()) {
+      const scrollPosition = this._viewportRuler.getViewportScrollPosition();
+      extendStyles(styles, this._getExactOverlayY(position, originPoint, scrollPosition));
+      extendStyles(styles, this._getExactOverlayX(position, originPoint, scrollPosition));
+    } else {
+      styles.position = 'static';
+    }*/
+
+    // If a maxWidth or maxHeight is specified on the overlay, we remove them. We do this because
+    // we need these values to both be set to "100%" for the automatic flexible sizing to work.
+    // The maxHeight and maxWidth are set on the boundingBox in order to enforce the constraint.
+    if (this._hasFlexibleDimensions && this._overlayRef.getConfig().maxHeight) {
+      styles.maxHeight = '';
+    }
+
+    if (this._hasFlexibleDimensions && this._overlayRef.getConfig().maxWidth) {
+      styles.maxWidth = '';
+    }
+
+    extendStyles(this._pane.style, styles);
+  }
+
+  /** Narrows the given viewport rect by the current _viewportMargin. */
+  private _getNarrowedViewportRect(): ClientRect {
+    // We recalculate the viewport rect here ourselves, rather than using the ViewportRuler,
+    // because we want to use the `clientWidth` and `clientHeight` as the base. The difference
+    // being that the client properties don't include the scrollbar, as opposed to `innerWidth`
+    // and `innerHeight` that do. This is necessary, because the overlay container uses
+    // 100% `width` and `height` which don't include the scrollbar either.
+    const width = this._document.documentElement!.clientWidth;
+    const height = this._document.documentElement!.clientHeight;
+    const scrollPosition = this._viewportRuler.getViewportScrollPosition();
+
+    return {
+      top:    scrollPosition.top + this._viewportMargin,
+      left:   scrollPosition.left + this._viewportMargin,
+      right:  scrollPosition.left + width - this._viewportMargin,
+      bottom: scrollPosition.top + height - this._viewportMargin,
+      width:  width  - (2 * this._viewportMargin),
+      height: height - (2 * this._viewportMargin),
+    };
+  }
+
+  /** Whether the we're dealing with an RTL context */
+  private _isRtl() {
+    return this._overlayRef.getDirection() === 'rtl';
+  }
+
+  /** Determines whether the overlay uses exact or flexible positioning. */
+  private _hasExactPosition() {
+    return !this._hasFlexibleDimensions || this._isPushed;
+  }
+
+  /** Adds a single CSS class or an array of classes on the overlay panel. */
+/*  private _addPanelClasses(cssClasses: string | string[]) {
+    if (this._pane) {
+      coerceArray(cssClasses).forEach(cssClass => {
+        if (cssClass !== '' && this._appliedPanelClasses.indexOf(cssClass) === -1) {
+          this._appliedPanelClasses.push(cssClass);
+          this._pane.classList.add(cssClass);
+        }
+      });
+    }
+  }*/
+
+  /** Clears the classes that the position strategy has applied from the overlay panel. */
+  private _clearPanelClasses() {
+    if (this._pane) {
+      this._appliedPanelClasses.forEach(cssClass => {
+        this._pane.classList.remove(cssClass);
+      });
+      this._appliedPanelClasses = [];
+    }
+  }
+}

--- a/src/cdk/overlay/position/cover-position-strategy.ts
+++ b/src/cdk/overlay/position/cover-position-strategy.ts
@@ -22,7 +22,7 @@ import {OverlayReference} from '../overlay-reference';
 import {coerceCssPixelValue/*, coerceArray*/} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
 /*import {OverlayContainer} from '../overlay-container';*/
-import {clearStyles, extendStyles, FlexibleConnectedPositionStrategyOrigin, getOriginRect, Point} from './flexible-positioning';
+import {clearStyles, extendStyles, FlexibleConnectedPositionStrategyOrigin, getOriginRect, Point, Rect} from './flexible-positioning';
 
 /** Class to be added to the overlay bounding box. */
 const boundingBoxClass = 'cdk-overlay-connected-position-bounding-box';
@@ -63,13 +63,13 @@ export class CoverPositionStrategy implements PositionStrategy {
   private _positionLocked = false;
 
   /** Cached origin dimensions */
-/*  private _originRect: ClientRect;*/
+/*  private _originRect: Rect;*/
 
   /** Cached overlay dimensions */
-/*  private _overlayRect: ClientRect;*/
+/*  private _overlayRect: Rect;*/
 
   /** Cached viewport dimensions */
-  private _viewportRect: ClientRect;
+  private _viewportRect: Rect;
 
   /** Amount of space that must be maintained between the overlay and the edge of the viewport. */
   private _viewportMargin = 0;
@@ -116,7 +116,7 @@ export class CoverPositionStrategy implements PositionStrategy {
   private _boundingBox: HTMLElement | null;
 
   /** The last position to have been calculated as the best fit position. */
-  private _lastPosition: ClientRect | null;
+  private _lastPosition: Rect | null;
 
   /** Subscription to viewport size changes. */
   private _resizeSubscription = Subscription.EMPTY;
@@ -131,8 +131,8 @@ export class CoverPositionStrategy implements PositionStrategy {
 /*    private _overlayContainer: OverlayContainer,*/
     topConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
     endConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
-    startConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
-    bottomConnectedTo?: FlexibleConnectedPositionStrategyOrigin,) {
+    bottomConnectedTo?: FlexibleConnectedPositionStrategyOrigin,
+    startConnectedTo?: FlexibleConnectedPositionStrategyOrigin,) {
     this.withTopOrigin(topConnectedTo)
         .withEndOrigin(endConnectedTo)
         .withBottomOrigin(bottomConnectedTo)
@@ -338,7 +338,7 @@ export class CoverPositionStrategy implements PositionStrategy {
    * @param origin Reference to the new origin.
    */
   withTopOrigin(origin?: FlexibleConnectedPositionStrategyOrigin): this {
-    this._startOrigin = origin;
+    this._topOrigin = origin;
     return this;
   }
 
@@ -350,12 +350,12 @@ export class CoverPositionStrategy implements PositionStrategy {
    * @param origin Reference to the new origin.
    */
   withBottomOrigin(origin?: FlexibleConnectedPositionStrategyOrigin): this {
-    this._endOrigin = origin;
+    this._bottomOrigin = origin;
     return this;
   }
 
   /** Gets how well an overlay at the given point will fit within the viewport. */
-  private _getOverlayAdjustment(overlay: Partial<ClientRect>): Partial<ClientRect> {
+  private _getOverlayAdjustment(overlay: Partial<Rect>): Partial<Rect> {
     const top = overlay.top == null ? overlay.bottom! - overlay.height! : overlay.top;
     const right = overlay.right == null ? overlay.left! + overlay.width! : overlay.right;
     const bottom = overlay.bottom == null ? overlay.top! + overlay.height! : overlay.bottom;
@@ -375,7 +375,7 @@ export class CoverPositionStrategy implements PositionStrategy {
    * @param point The (x, y) coordinates of the overlat at some position.
    * @param viewport The geometry of the viewport.
    */
-/*  private _canFitWithFlexibleDimensions(overlay: Partial<ClientRect>, adjustments: ClientRect) {
+/*  private _canFitWithFlexibleDimensions(overlay: Partial<Rect>, adjustments: Rect) {
     if (!this._hasFlexibleDimensions) return false;
 
     const availableHeight = viewport.bottom - point.y;
@@ -389,7 +389,7 @@ export class CoverPositionStrategy implements PositionStrategy {
     return verticalFit && horizontalFit;
   }
 */
-  private _adjustBoundingBox(inputOverlay: Partial<ClientRect>, adjustments: Partial<ClientRect>) {
+  private _adjustBoundingBox(inputOverlay: Partial<Rect>, adjustments: Partial<Rect>) {
     const overlayConfig = this._overlayRef.getConfig();
     
     const overlay = {...inputOverlay};
@@ -403,28 +403,28 @@ export class CoverPositionStrategy implements PositionStrategy {
     if (this._canPush) {
       if (this._hasFlexibleDimensions) {
         // Push from all directions (shrinking the resulting overlay is ok).
-        pushFromTop = overlay.top != null && adjustments.top > 0 ? adjustments.top : 0;
-        pushFromRight = overlay.right != null && adjustments.right > 0 ? adjustments.right : 0;
-        pushFromBottom = overlay.bottom != null && adjustments.bottom > 0 ? adjustments.bottom : 0;
-        pushFromLeft = overlay.left != null && adjustments.left > 0 ? adjustments.left : 0;
+        pushFromTop = overlay.top != null && adjustments.top! > 0 ? adjustments.top! : 0;
+        pushFromRight = overlay.right != null && adjustments.right! > 0 ? adjustments.right! : 0;
+        pushFromBottom = overlay.bottom != null && adjustments.bottom! > 0 ? adjustments.bottom! : 0;
+        pushFromLeft = overlay.left != null && adjustments.left! > 0 ? adjustments.left! : 0;
       } else {
         // Push only if we can do so without shrinking the overlay.
-        pushFromTop = adjustments.top > 0 && adjustments.bottom < 0 ?
-            Math.min(adjustments.top, -adjustments.bottom) : 0;
-        pushFromRight = adjustments.right > 0 && adjustments.left < 0 ?
-            Math.min(adjustments.right, -adjustments.left) : 0;
-        pushFromBottom =  adjustments.bottom > 0 && adjustments.top < 0 ?
-            Math.min(adjustments.bottom, -adjustments.top) : 0;
-        pushFromLeft =  adjustments.left > 0 && adjustments.right < 0 ?
-            Math.min(adjustments.left, -adjustments.right) : 0;
+        pushFromTop = adjustments.top! > 0 && adjustments.bottom! < 0 ?
+            Math.min(adjustments.top!, -adjustments.bottom!) : 0;
+        pushFromRight = adjustments.right! > 0 && adjustments.left! < 0 ?
+            Math.min(adjustments.right!, -adjustments.left!) : 0;
+        pushFromBottom =  adjustments.bottom! > 0 && adjustments.top! < 0 ?
+            Math.min(adjustments.bottom!, -adjustments.top!) : 0;
+        pushFromLeft =  adjustments.left! > 0 && adjustments.right! < 0 ?
+            Math.min(adjustments.left!, -adjustments.right!) : 0;
       }
     }
     
     if (this._hasFlexibleDimensions) {
       shrinkHeight = overlay.height != null ?
-          (adjustments.top - pushFromTop) + (adjustments.bottom - pushFromBottom) : 0;
+          (adjustments.top! - pushFromTop) + (adjustments.bottom! - pushFromBottom) : 0;
       shrinkWidth = overlay.width != null ?
-          (adjustments.left - pushFromLeft) + (adjustments.right - pushFromRight) : 0;
+          (adjustments.left! - pushFromLeft) + (adjustments.right! - pushFromRight) : 0;
     }
     
     if (pushFromTop) {
@@ -469,7 +469,7 @@ export class CoverPositionStrategy implements PositionStrategy {
     return overlay;
   }
 
-  private _applyPosition(inputOverlay: Partial<ClientRect>, adjustments: Partial<ClientRect>) {
+  private _applyPosition(inputOverlay: Partial<Rect>, adjustments: Partial<Rect>) {
     const overlay = this._adjustBoundingBox(inputOverlay, adjustments);
 
     this._setOverlayElementStyles(overlay);
@@ -484,11 +484,11 @@ export class CoverPositionStrategy implements PositionStrategy {
    * This method does no measuring and applies no styles so that we can cheaply compute the
    * bounds for all positions and choose the best fit based on these results.
    */
-  private _calculateBoundingBoxRect(): Partial<ClientRect> {
+  private _calculateBoundingBoxRect(): Partial<Rect> {
     const viewport = this._viewportRect;
     const isRtl = this._isRtl();
 
-    const boundingBox: Partial<ClientRect> = {};
+    const boundingBox: Partial<Rect> = {};
 
     if (this._topOrigin) {
       boundingBox.top = getOriginRect(this._topOrigin).top;
@@ -498,16 +498,16 @@ export class CoverPositionStrategy implements PositionStrategy {
       if (isRtl) {
         boundingBox.left = endRect.left;
       } else {
-        boundingBox.right = endRect.right;
+        boundingBox.right = viewport.left + viewport.right - endRect.right;
       }
     }
     if (this._bottomOrigin) {
-      boundingBox.bottom = getOriginRect(this._bottomOrigin).bottom;
+      boundingBox.bottom = viewport.top + viewport.bottom - getOriginRect(this._bottomOrigin).bottom;
     }
     if (this._startOrigin) {
       const startRect = getOriginRect(this._startOrigin);
       if (isRtl) {
-        boundingBox.right = startRect.right;
+        boundingBox.right = viewport.left + viewport.right - startRect.right;
       } else {
         boundingBox.left = startRect.left;
       }
@@ -522,13 +522,13 @@ export class CoverPositionStrategy implements PositionStrategy {
     }
 
     if (boundingBox.top == null) {
-      boundingBox.height = viewport.height - boundingBox.bottom - this._viewportMargin;
+      boundingBox.height = viewport.height - boundingBox.bottom! - this._viewportMargin;
     } else if (boundingBox.bottom == null) {
       boundingBox.height = viewport.height - boundingBox.top + this._viewportMargin;
     }
     
     if (boundingBox.left == null) {
-      boundingBox.width = viewport.left - boundingBox.right - this._viewportMargin;
+      boundingBox.width = viewport.left - boundingBox.right! - this._viewportMargin;
     } else if (boundingBox.right == null) {
       boundingBox.width = viewport.right - boundingBox.left + this._viewportMargin;
     }
@@ -540,7 +540,7 @@ export class CoverPositionStrategy implements PositionStrategy {
    * Sets the position and size of the overlay's sizing wrapper. The wrapper is positioned on the
    * origin's connection point and stetches to the bounds of the viewport.
    */
-  private _setBoundingBoxStyles(overlay: Partial<ClientRect>): void {
+  private _setBoundingBoxStyles(overlay: Partial<Rect>): void {
     const boundingBoxRect = {...overlay};
     
     // It's weird if the overlay *grows* while scrolling, so we take the last size into account
@@ -618,7 +618,7 @@ export class CoverPositionStrategy implements PositionStrategy {
   }
 
   /** Sets positioning styles to the overlay element. */
-  private _setOverlayElementStyles(overlay: Partial<ClientRect>): void {
+  private _setOverlayElementStyles(overlay: Partial<Rect>): void {
     const styles = {} as CSSStyleDeclaration;
 
     styles.position = 'static';
@@ -653,7 +653,7 @@ export class CoverPositionStrategy implements PositionStrategy {
   }
 
   /** Narrows the given viewport rect by the current _viewportMargin. */
-  private _getNarrowedViewportRect(): ClientRect {
+  private _getNarrowedViewportRect(): Rect {
     // We recalculate the viewport rect here ourselves, rather than using the ViewportRuler,
     // because we want to use the `clientWidth` and `clientHeight` as the base. The difference
     // being that the client properties don't include the scrollbar, as opposed to `innerWidth`

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -295,8 +295,6 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     if (this._canPush) {
       // TODO(jelbourn): after pushing, the opening "direction" of the overlay might not make sense.
       this._isPushed = true;
-      this._applyPosition(fallback!.position, fallback!.originPoint);
-      return;
     }
 
     // All options for getting the overlay within the viewport have been exhausted, so go with the

--- a/src/cdk/overlay/position/flexible-positioning.ts
+++ b/src/cdk/overlay/position/flexible-positioning.ts
@@ -63,7 +63,8 @@ export function getOriginRect(origin: FlexibleConnectedPositionStrategyOrigin): 
 }
 
 /** Shallow-extends a stylesheet object with another stylesheet object. */
-export function extendStyles(dest: CSSStyleDeclaration, source: CSSStyleDeclaration): CSSStyleDeclaration {
+export function extendStyles(
+    dest: CSSStyleDeclaration, source: CSSStyleDeclaration): CSSStyleDeclaration {
   for (let key in source) {
     if (source.hasOwnProperty(key)) {
       dest[key] = source[key];

--- a/src/cdk/overlay/position/flexible-positioning.ts
+++ b/src/cdk/overlay/position/flexible-positioning.ts
@@ -1,4 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {ElementRef} from '@angular/core';
+
+/** Class added to overlay bounding boxes. */
+export const boundingBoxClass = 'cdk-overlay-connected-position-bounding-box';
 
 /** A simple (x, y) coordinate. */
 export interface Point {
@@ -7,20 +18,20 @@ export interface Point {
 }
 
 export interface BoundingBox {
-  top: number,
-  bottom: number,
-  left: number,
-  right: number,
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
 }
 
-export interface Rect extends BoundingBox {
-  height: number,
-  width: number,
+export interface BoundingBoxRect extends BoundingBox {
+  height: number;
+  width: number;
 }
 
 export type FlexibleConnectedPositionStrategyOrigin = ElementRef | HTMLElement | Point;
 
-export function cloneRect(rect: Readonly<Rect>) {
+export function cloneRect(rect: Readonly<BoundingBoxRect>): BoundingBoxRect {
   return {
     top: rect.top,
     bottom: rect.bottom,
@@ -31,7 +42,7 @@ export function cloneRect(rect: Readonly<Rect>) {
   };
 }
 
-export function getOriginRect(origin: FlexibleConnectedPositionStrategyOrigin): Rect {
+export function getOriginRect(origin: FlexibleConnectedPositionStrategyOrigin): BoundingBoxRect {
   if (origin instanceof ElementRef) {
     return cloneRect(origin.nativeElement.getBoundingClientRect());
   }
@@ -62,15 +73,41 @@ export function extendStyles(dest: CSSStyleDeclaration, source: CSSStyleDeclarat
   return dest;
 }
 
-export function clearStyles(dest: CSSStyleDeclaration) {
+const CLEARED_POSITIONS: Readonly<Partial<CSSStyleDeclaration>> = {
+  top: '',
+  left: '',
+  right: '',
+  bottom: '',
+};
+
+const CLEARED_BOUNDING_BOX_PROPERTIES: Readonly<Partial<CSSStyleDeclaration>> = {
+  height: '',
+  width: '',
+  alignItems: '',
+  justifyContent: '',
+};
+
+export function clearBoundingBoxStyles(dest: CSSStyleDeclaration): CSSStyleDeclaration {
   return extendStyles(dest, {
-    top: '',
-    left: '',
-    right: '',
-    bottom: '',
-    height: '',
-    width: '',
-    alignItems: '',
-    justifyContent: '',
+    ...CLEARED_POSITIONS,
+    ...CLEARED_BOUNDING_BOX_PROPERTIES,
+  } as CSSStyleDeclaration);
+}
+
+export function resetBoundingBoxStyles(dest: CSSStyleDeclaration): CSSStyleDeclaration {
+  return extendStyles(dest, {
+    top: '0',
+    left: '0',
+    right: '0',
+    bottom: '0',
+    ...CLEARED_BOUNDING_BOX_PROPERTIES,
+  } as CSSStyleDeclaration);
+}
+
+export function resetOverlayElementStyles(dest: CSSStyleDeclaration): CSSStyleDeclaration {
+  return extendStyles(dest, {
+    ...CLEARED_POSITIONS,
+    position: '',
+    transform: '',
   } as CSSStyleDeclaration);
 }

--- a/src/cdk/overlay/position/flexible-positioning.ts
+++ b/src/cdk/overlay/position/flexible-positioning.ts
@@ -1,0 +1,53 @@
+import {ElementRef} from '@angular/core';
+
+/** A simple (x, y) coordinate. */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export type FlexibleConnectedPositionStrategyOrigin = ElementRef | HTMLElement | Point;
+
+export function getOriginRect(origin: FlexibleConnectedPositionStrategyOrigin): ClientRect {
+  if (origin instanceof ElementRef) {
+    return origin.nativeElement.getBoundingClientRect();
+  }
+
+  if (origin instanceof HTMLElement) {
+    return origin.getBoundingClientRect();
+  }
+
+  // If the origin is a point, return a client rect as if it was a 0x0 element at the point.
+  return {
+    top: origin.y,
+    bottom: origin.y,
+    left: origin.x,
+    right: origin.x,
+    height: 0,
+    width: 0
+  };
+}
+
+/** Shallow-extends a stylesheet object with another stylesheet object. */
+export function extendStyles(dest: CSSStyleDeclaration, source: CSSStyleDeclaration): CSSStyleDeclaration {
+  for (let key in source) {
+    if (source.hasOwnProperty(key)) {
+      dest[key] = source[key];
+    }
+  }
+
+  return dest;
+}
+
+export function clearStyles(dest: CSSStyleDeclaration) {
+  return extendStyles(dest, {
+    top: '',
+    left: '',
+    right: '',
+    bottom: '',
+    height: '',
+    width: '',
+    alignItems: '',
+    justifyContent: '',
+  } as CSSStyleDeclaration);
+}

--- a/src/cdk/overlay/position/flexible-positioning.ts
+++ b/src/cdk/overlay/position/flexible-positioning.ts
@@ -6,15 +6,35 @@ export interface Point {
   y: number;
 }
 
+export interface Rect {
+  top: number,
+  bottom: number,
+  left: number,
+  right: number,
+  height: number,
+  width: number,
+}
+
 export type FlexibleConnectedPositionStrategyOrigin = ElementRef | HTMLElement | Point;
 
-export function getOriginRect(origin: FlexibleConnectedPositionStrategyOrigin): ClientRect {
+export function cloneRect(rect: Readonly<Rect>) {
+  return {
+    top: rect.top,
+    bottom: rect.bottom,
+    left: rect.left,
+    right: rect.right,
+    height: rect.height,
+    width: rect.width,
+  };
+}
+
+export function getOriginRect(origin: FlexibleConnectedPositionStrategyOrigin): Rect {
   if (origin instanceof ElementRef) {
-    return origin.nativeElement.getBoundingClientRect();
+    return cloneRect(origin.nativeElement.getBoundingClientRect());
   }
 
   if (origin instanceof HTMLElement) {
-    return origin.getBoundingClientRect();
+    return cloneRect(origin.getBoundingClientRect());
   }
 
   // If the origin is a point, return a client rect as if it was a 0x0 element at the point.

--- a/src/cdk/overlay/position/flexible-positioning.ts
+++ b/src/cdk/overlay/position/flexible-positioning.ts
@@ -6,11 +6,14 @@ export interface Point {
   y: number;
 }
 
-export interface Rect {
+export interface BoundingBox {
   top: number,
   bottom: number,
   left: number,
   right: number,
+}
+
+export interface Rect extends BoundingBox {
   height: number,
   width: number,
 }

--- a/src/cdk/overlay/position/overlay-position-builder.ts
+++ b/src/cdk/overlay/position/overlay-position-builder.ts
@@ -6,18 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {DOCUMENT} from '@angular/common';
 import {ElementRef, Inject, Injectable, Optional} from '@angular/core';
+
+import {OverlayContainer} from '../overlay-container';
+
 import {OriginConnectionPosition, OverlayConnectionPosition} from './connected-position';
 import {ConnectedPositionStrategy} from './connected-position-strategy';
-import {
-  FlexibleConnectedPositionStrategy,
-  FlexibleConnectedPositionStrategyOrigin,
-} from './flexible-connected-position-strategy';
+import {FlexibleConnectedPositionStrategy} from './flexible-connected-position-strategy';
+import {FlexibleConnectedPositionStrategyOrigin} from './flexible-positioning';
 import {GlobalPositionStrategy} from './global-position-strategy';
-import {Platform} from '@angular/cdk/platform';
-import {OverlayContainer} from '../overlay-container';
 
 
 /** Builder for overlay position strategy. */

--- a/src/cdk/overlay/public-api.ts
+++ b/src/cdk/overlay/public-api.ts
@@ -28,4 +28,6 @@ export {
   ConnectedPosition,
   FlexibleConnectedPositionStrategy,
 } from './position/flexible-connected-position-strategy';
+export {CoverPositionStrategy} from './position/cover-position-strategy';
+export {CoverPositionStrategyFactory} from './position/cover-position-strategy-factory';
 export {VIEWPORT_RULER_PROVIDER} from '@angular/cdk/scrolling';

--- a/src/dev-app/cover-overlay/cover-overlay-demo-module.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo-module.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {OverlayModule} from '@angular/cdk/overlay';
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule, MatCheckboxModule, MatRadioModule} from '@angular/material';
+import {ConnectedOverlayDemo} from './connected-overlay-demo';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatRadioModule,
+    OverlayModule,
+  ],
+  declarations: [CoverOverlayDemo],
+})
+export class CoverOverlayDemoModule {
+}

--- a/src/dev-app/cover-overlay/cover-overlay-demo-module.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo-module.ts
@@ -10,6 +10,7 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {RouterModule} from '@angular/router';
 import {MatButtonModule, MatCheckboxModule, MatRadioModule} from '@angular/material';
 import {ConnectedOverlayDemo} from './connected-overlay-demo';
 
@@ -21,6 +22,7 @@ import {ConnectedOverlayDemo} from './connected-overlay-demo';
     MatCheckboxModule,
     MatRadioModule,
     OverlayModule,
+    RouterModule.forChild([{path: '', component: CoverOverlayDemo}]),
   ],
   declarations: [CoverOverlayDemo],
 })

--- a/src/dev-app/cover-overlay/cover-overlay-demo-module.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo-module.ts
@@ -12,7 +12,7 @@ import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {MatButtonModule, MatCheckboxModule, MatRadioModule} from '@angular/material';
-import {ConnectedOverlayDemo} from './connected-overlay-demo';
+import {CoverOverlayDemo} from './cover-overlay-demo';
 
 @NgModule({
   imports: [

--- a/src/dev-app/cover-overlay/cover-overlay-demo.css
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.css
@@ -2,14 +2,14 @@
   display: flex;
 }
 
-div.position-area {
+div.example-position-area {
   display: inline-block;
   height: 500px;
   position: relative;
   width: 800px;
 }
 
-.origin {
+.example-origin {
   background-color: lightsteelblue;
   height: 50px;
   position: absolute;

--- a/src/dev-app/cover-overlay/cover-overlay-demo.css
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.css
@@ -1,0 +1,12 @@
+.position-area {
+  height: 500px;
+  position: relative;
+  width: 800px;
+}
+
+.origin {
+  background-color: lightsteelblue;
+  height: 50px;
+  position: absolute;
+  width: 100px;
+}

--- a/src/dev-app/cover-overlay/cover-overlay-demo.css
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.css
@@ -1,4 +1,9 @@
-.position-area {
+:host {
+  display: flex;
+}
+
+div.position-area {
+  display: inline-block;
   height: 500px;
   position: relative;
   width: 800px;

--- a/src/dev-app/cover-overlay/cover-overlay-demo.html
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.html
@@ -106,6 +106,10 @@
     <div>
       <mat-checkbox [(ngModel)]="growAfterOpen">Allow grow after open</mat-checkbox>
     </div>
+    
+    <div>
+      <mat-checkbox [(ngModel)]="lockedPosition">Lock position after open</mat-checkbox>
+    </div>
 
     <div>
       <label>

--- a/src/dev-app/cover-overlay/cover-overlay-demo.html
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.html
@@ -1,11 +1,65 @@
 <div class="position-area">
   <div #topOrigin class="origin" [style.left.px]="top.x" [style.top.px]="top.y">Top origin</div>
-  <div #rightOrigin class="origin" [style.left.px]="left.x" [style.top.px]="left.y">Right origin</div>
-  <div #bottomOrigin class="origin" [style.left.px]="left.x" [style.top.px]="left.y">Bottom origin</div>
-  <div leftOrigin class="origin" [style.left.px]="left.x" [style.top.px]="left.y">Left origin</div>
+  <div #rightOrigin class="origin" [style.left.px]="right.x" [style.top.px]="right.y">Right origin</div>
+  <div #bottomOrigin class="origin" [style.left.px]="bottom.x" [style.top.px]="bottom.y">Bottom origin</div>
+  <div #leftOrigin class="origin" [style.left.px]="left.x" [style.top.px]="left.y">Left origin</div>
 </div>
 
 <div class="demo-options mat-typography">
+  <div>
+    <h2>Top origin</h2>
+    <p>
+      <mat-checkbox [(ngModel)]="top.connected">connected</mat-checkbox>
+    </p>
+    <p>
+      <label>
+        x
+        <input type="number" [(ngModel)]="top.x">
+      </label>
+
+      <label>
+        y
+        <input type="number" [(ngModel)]="top.y">
+      </label>
+    </p>
+  </div>
+  
+  <div>
+    <h2>Right origin</h2>
+    <p>
+      <mat-checkbox [(ngModel)]="right.connected">connected</mat-checkbox>
+    </p>
+    <p>
+      <label>
+        x
+        <input type="number" [(ngModel)]="right.x">
+      </label>
+
+      <label>
+        y
+        <input type="number" [(ngModel)]="right.y">
+      </label>
+    </p>
+  </div>
+  
+  <div>
+    <h2>Bottom origin</h2>
+    <p>
+      <mat-checkbox [(ngModel)]="bottom.connected">connected</mat-checkbox>
+    </p>
+    <p>
+      <label>
+        x
+        <input type="number" [(ngModel)]="bottom.x">
+      </label>
+
+      <label>
+        y
+        <input type="number" [(ngModel)]="bottom.y">
+      </label>
+    </p>
+  </div>
+  
   <div>
     <h2>Left origin</h2>
     <p>

--- a/src/dev-app/cover-overlay/cover-overlay-demo.html
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.html
@@ -104,8 +104,14 @@
     </div>
 
     <div>
-      <mat-checkbox [checked]="showBoundingBox" [disabled]="!overlayRef"
-          (click)="toggleShowBoundingBox()">
+      <label>
+        Viewport margin
+        <input type="number" [(ngModel)]="viewportMargin">
+      </label>
+    </div>
+
+    <div>
+      <mat-checkbox [checked]="highlightBoundingBox" (click)="toggleShowBoundingBox()">
         Show bounding box
       </mat-checkbox>
     </div>

--- a/src/dev-app/cover-overlay/cover-overlay-demo.html
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.html
@@ -1,0 +1,72 @@
+<div class="position-area">
+  <div #topOrigin class="origin" [style.left.px]="top.x" [style.top.px]="top.y">Top origin</div>
+  <div #rightOrigin class="origin" [style.left.px]="left.x" [style.top.px]="left.y">Right origin</div>
+  <div #bottomOrigin class="origin" [style.left.px]="left.x" [style.top.px]="left.y">Bottom origin</div>
+  <div leftOrigin class="origin" [style.left.px]="left.x" [style.top.px]="left.y">Left origin</div>
+</div>
+
+<div class="demo-options mat-typography">
+  <div>
+    <h2>Left origin</h2>
+    <p>
+      <mat-checkbox [(ngModel)]="left.connected">connected</mat-checkbox>
+    </p>
+    <p>
+      <label>
+        x
+        <input type="number" [(ngModel)]="left.x">
+      </label>
+
+      <label>
+        y
+        <input type="number" [(ngModel)]="left.y">
+      </label>
+    </p>
+  </div>
+
+  <div>
+    <h2>Options</h2>
+
+    <p>
+      <label>
+        Number of items in the overlay
+        <input type="number" [(ngModel)]="itemCount">
+      </label>
+    </p>
+
+    <p>
+      <label>
+        Item text
+        <input [(ngModel)]="itemText">
+      </label>
+    </p>
+
+    <div>
+      <mat-checkbox [(ngModel)]="isFlexible">Allow flexible dimensions</mat-checkbox>
+    </div>
+
+    <div>
+      <mat-checkbox [(ngModel)]="canPush">Allow push</mat-checkbox>
+    </div>
+
+    <div>
+      <mat-checkbox [checked]="showBoundingBox" [disabled]="!overlayRef"
+          (click)="toggleShowBoundingBox()">
+        Show bounding box
+      </mat-checkbox>
+    </div>
+  </div>
+
+  <div>
+    <button mat-raised-button type="button" (click)="open()" [disabled]="overlayRef">Open</button>
+    <button mat-raised-button type="button" (click)="close()" [disabled]="!overlayRef">Close</button>
+  </div>
+</div>
+
+<ng-template #overlay>
+  <div class="demo-overlay">
+    <div style="overflow: auto;">
+      <ul><li *ngFor="let item of itemArray; index as i">{{itemText}} {{i}}</li></ul>
+    </div>
+  </div>
+</ng-template>

--- a/src/dev-app/cover-overlay/cover-overlay-demo.html
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.html
@@ -1,8 +1,8 @@
-<div class="position-area">
-  <div #topOrigin class="origin" [style.left.px]="top.x" [style.top.px]="top.y">Top origin</div>
-  <div #rightOrigin class="origin" [style.left.px]="right.x" [style.top.px]="right.y">Right origin</div>
-  <div #bottomOrigin class="origin" [style.left.px]="bottom.x" [style.top.px]="bottom.y">Bottom origin</div>
-  <div #leftOrigin class="origin" [style.left.px]="left.x" [style.top.px]="left.y">Left origin</div>
+<div class="example-position-area">
+  <div #topOrigin class="example-origin" [style.left.px]="top.x" [style.top.px]="top.y">Top origin</div>
+  <div #rightOrigin class="example-origin" [style.left.px]="right.x" [style.top.px]="right.y">Right origin</div>
+  <div #bottomOrigin class="example-origin" [style.left.px]="bottom.x" [style.top.px]="bottom.y">Bottom origin</div>
+  <div #leftOrigin class="example-origin" [style.left.px]="left.x" [style.top.px]="left.y">Left origin</div>
 </div>
 
 <div class="demo-options mat-typography">

--- a/src/dev-app/cover-overlay/cover-overlay-demo.html
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.html
@@ -102,6 +102,10 @@
     <div>
       <mat-checkbox [(ngModel)]="canPush">Allow push</mat-checkbox>
     </div>
+    
+    <div>
+      <mat-checkbox [(ngModel)]="growAfterOpen">Allow grow after open</mat-checkbox>
+    </div>
 
     <div>
       <label>

--- a/src/dev-app/cover-overlay/cover-overlay-demo.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.ts
@@ -42,6 +42,7 @@ export class CoverOverlayDemo {
   isFlexible = true;
   canPush = true;
   highlightBoundingBox = true;
+  growAfterOpen = true;
   itemCount = 25;
   itemArray: string[] = [];
   itemText = 'Item with a very very very very very very super duper extremely long name';
@@ -62,13 +63,13 @@ export class CoverOverlayDemo {
         .withFlexibleDimensions(this.isFlexible)
         .withPush(this.canPush)
         .withViewportMargin(10)
-        .withGrowAfterOpen(true);
+        .withGrowAfterOpen(this.growAfterOpen);
 
     this.overlayRef = this.overlay.create({
       positionStrategy,
       scrollStrategy: this.overlay.scrollStrategies.reposition(),
       minWidth: 200,
-      minHeight: 50
+      minHeight: 200,
     });
 
     this.itemArray = Array(this.itemCount);

--- a/src/dev-app/cover-overlay/cover-overlay-demo.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewContainerRef} from '@angular/core';
+import {Component, ElementRef, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {
   CoverPositionStrategyFactory,
   Overlay,
   OverlayRef,
 } from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
-import {Component, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 
 export interface OriginConfig {
   x: number,
@@ -34,7 +33,11 @@ export class CoverOverlayDemo {
   @ViewChild('leftOrigin') leftOrigin: ElementRef;
   @ViewChild('overlay') overlayTemplate: TemplateRef<any>;
 
-  readonly left:  = {x: }
+  readonly top: OriginConfig = {x: 300, y: 20, connected: true};
+  readonly right: OriginConfig = {x: 500, y: 200, connected: true};
+  readonly bottom: OriginConfig = {x: 300, y: 400};
+  readonly left: OriginConfig = {x: 30, y: 200, connected: true};
+  
   isFlexible = true;
   canPush = true;
   showBoundingBox = false;
@@ -48,7 +51,7 @@ export class CoverOverlayDemo {
       readonly overlay: Overlay,
       readonly viewContainerRef: ViewContainerRef) { }
 
-  openWithConfig() {
+  open() {
     const positionStrategy = this.factory.createWithConnections({
       top: this.top.connected ? this.topOrigin : undefined,
       right: this.right.connected ? this.rightOrigin : undefined,

--- a/src/dev-app/cover-overlay/cover-overlay-demo.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.ts
@@ -15,9 +15,9 @@ import {
 import {TemplatePortal} from '@angular/cdk/portal';
 
 export interface OriginConfig {
-  x: number,
-  y: number,
-  connected?: boolean,
+  x: number;
+  y: number;
+  connected?: boolean;
 }
 
 @Component({
@@ -37,33 +37,36 @@ export class CoverOverlayDemo {
   readonly right: OriginConfig = {x: 500, y: 200, connected: true};
   readonly bottom: OriginConfig = {x: 300, y: 400};
   readonly left: OriginConfig = {x: 30, y: 200, connected: true};
-  
-  viewportMargin = 5;
+
+  viewportMargin = 10;
   isFlexible = true;
   canPush = true;
   highlightBoundingBox = true;
   growAfterOpen = true;
+  lockedPosition = false;
   itemCount = 25;
   itemArray: string[] = [];
   itemText = 'Item with a very very very very very very super duper extremely long name';
   overlayRef: OverlayRef | null;
-  
+
   constructor(
       readonly factory: CoverPositionStrategyFactory,
       readonly overlay: Overlay,
       readonly viewContainerRef: ViewContainerRef) { }
 
   open() {
-    const positionStrategy = this.factory.createWithConnections({
-      top: this.top.connected ? this.topOrigin : undefined,
-      right: this.right.connected ? this.rightOrigin : undefined,
-      bottom: this.bottom.connected ? this.bottomOrigin : undefined,
-      left: this.left.connected ? this.leftOrigin : undefined,
-    })
-        .withFlexibleDimensions(this.isFlexible)
-        .withPush(this.canPush)
-        .withViewportMargin(10)
-        .withGrowAfterOpen(this.growAfterOpen);
+    const positionStrategy = this.factory
+                                 .createWithConnections({
+                                   top: this.top.connected ? this.topOrigin : undefined,
+                                   right: this.right.connected ? this.rightOrigin : undefined,
+                                   bottom: this.bottom.connected ? this.bottomOrigin : undefined,
+                                   left: this.left.connected ? this.leftOrigin : undefined,
+                                 })
+                                 .withFlexibleDimensions(this.isFlexible)
+                                 .withPush(this.canPush)
+                                 .withViewportMargin(this.viewportMargin)
+                                 .withGrowAfterOpen(this.growAfterOpen)
+                                 .withLockedPosition(this.lockedPosition);
 
     this.overlayRef = this.overlay.create({
       positionStrategy,
@@ -74,7 +77,7 @@ export class CoverOverlayDemo {
 
     this.itemArray = Array(this.itemCount);
     this.overlayRef.attach(new TemplatePortal(this.overlayTemplate, this.viewContainerRef));
-    
+
     setTimeout(() => {
       this.showBoundingBox();
     }, 0);
@@ -86,7 +89,7 @@ export class CoverOverlayDemo {
       this.overlayRef = null;
     }
   }
-  
+
   showBoundingBox() {
     if (this.highlightBoundingBox) {
       const box = document.querySelector<HTMLElement>('.cdk-overlay-connected-position-bounding-box');
@@ -96,7 +99,7 @@ export class CoverOverlayDemo {
       }
     }
   }
-  
+
   toggleShowBoundingBox() {
     this.highlightBoundingBox = !this.highlightBoundingBox;
     this.showBoundingBox();

--- a/src/dev-app/cover-overlay/cover-overlay-demo.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.ts
@@ -92,7 +92,8 @@ export class CoverOverlayDemo {
 
   showBoundingBox() {
     if (this.highlightBoundingBox) {
-      const box = document.querySelector<HTMLElement>('.cdk-overlay-connected-position-bounding-box');
+      const box =
+          document.querySelector<HTMLElement>('.cdk-overlay-connected-position-bounding-box');
 
       if (box) {
         box.style.background = this.highlightBoundingBox ? 'rgb(255, 69, 0, 0.2)' : '';

--- a/src/dev-app/cover-overlay/cover-overlay-demo.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.ts
@@ -38,12 +38,13 @@ export class CoverOverlayDemo {
   readonly bottom: OriginConfig = {x: 300, y: 400};
   readonly left: OriginConfig = {x: 30, y: 200, connected: true};
   
+  viewportMargin = 5;
   isFlexible = true;
   canPush = true;
-  showBoundingBox = false;
+  highlightBoundingBox = true;
   itemCount = 25;
   itemArray: string[] = [];
-  itemText = 'Item with a long name';
+  itemText = 'Item with a very very very very very very super duper extremely long name';
   overlayRef: OverlayRef | null;
   
   constructor(
@@ -72,22 +73,31 @@ export class CoverOverlayDemo {
 
     this.itemArray = Array(this.itemCount);
     this.overlayRef.attach(new TemplatePortal(this.overlayTemplate, this.viewContainerRef));
+    
+    setTimeout(() => {
+      this.showBoundingBox();
+    }, 0);
   }
 
   close() {
     if (this.overlayRef) {
       this.overlayRef.dispose();
       this.overlayRef = null;
-      this.showBoundingBox = false;
+    }
+  }
+  
+  showBoundingBox() {
+    if (this.highlightBoundingBox) {
+      const box = document.querySelector<HTMLElement>('.cdk-overlay-connected-position-bounding-box');
+
+      if (box) {
+        box.style.background = this.highlightBoundingBox ? 'rgb(255, 69, 0, 0.2)' : '';
+      }
     }
   }
   
   toggleShowBoundingBox() {
-    const box = document.querySelector<HTMLElement>('.cdk-overlay-connected-position-bounding-box');
-
-    if (box) {
-      this.showBoundingBox = !this.showBoundingBox;
-      box.style.background = this.showBoundingBox ? 'rgb(255, 69, 0, 0.2)' : '';
-    }
+    this.highlightBoundingBox = !this.highlightBoundingBox;
+    this.showBoundingBox();
   }
 }

--- a/src/dev-app/cover-overlay/cover-overlay-demo.ts
+++ b/src/dev-app/cover-overlay/cover-overlay-demo.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ViewContainerRef} from '@angular/core';
+import {
+  CoverPositionStrategyFactory,
+  Overlay,
+  OverlayRef,
+} from '@angular/cdk/overlay';
+import {TemplatePortal} from '@angular/cdk/portal';
+import {Component, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+
+export interface OriginConfig {
+  x: number,
+  y: number,
+  connected?: boolean,
+}
+
+@Component({
+  moduleId: module.id,
+  selector: 'cover-overlay-demo',
+  templateUrl: 'cover-overlay-demo.html',
+  styleUrls: ['cover-overlay-demo.css'],
+})
+export class CoverOverlayDemo {
+  @ViewChild('topOrigin') topOrigin: ElementRef;
+  @ViewChild('rightOrigin') rightOrigin: ElementRef;
+  @ViewChild('bottomOrigin') bottomOrigin: ElementRef;
+  @ViewChild('leftOrigin') leftOrigin: ElementRef;
+  @ViewChild('overlay') overlayTemplate: TemplateRef<any>;
+
+  readonly left:  = {x: }
+  isFlexible = true;
+  canPush = true;
+  showBoundingBox = false;
+  itemCount = 25;
+  itemArray: string[] = [];
+  itemText = 'Item with a long name';
+  overlayRef: OverlayRef | null;
+  
+  constructor(
+      readonly factory: CoverPositionStrategyFactory,
+      readonly overlay: Overlay,
+      readonly viewContainerRef: ViewContainerRef) { }
+
+  openWithConfig() {
+    const positionStrategy = this.factory.createWithConnections({
+      top: this.top.connected ? this.topOrigin : undefined,
+      right: this.right.connected ? this.rightOrigin : undefined,
+      bottom: this.bottom.connected ? this.bottomOrigin : undefined,
+      left: this.left.connected ? this.leftOrigin : undefined,
+    })
+        .withFlexibleDimensions(this.isFlexible)
+        .withPush(this.canPush)
+        .withViewportMargin(10)
+        .withGrowAfterOpen(true);
+
+    this.overlayRef = this.overlay.create({
+      positionStrategy,
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      minWidth: 200,
+      minHeight: 50
+    });
+
+    this.itemArray = Array(this.itemCount);
+    this.overlayRef.attach(new TemplatePortal(this.overlayTemplate, this.viewContainerRef));
+  }
+
+  close() {
+    if (this.overlayRef) {
+      this.overlayRef.dispose();
+      this.overlayRef = null;
+      this.showBoundingBox = false;
+    }
+  }
+  
+  toggleShowBoundingBox() {
+    const box = document.querySelector<HTMLElement>('.cdk-overlay-connected-position-bounding-box');
+
+    if (box) {
+      this.showBoundingBox = !this.showBoundingBox;
+      box.style.background = this.showBoundingBox ? 'rgb(255, 69, 0, 0.2)' : '';
+    }
+  }
+}

--- a/src/dev-app/dev-app/routes.ts
+++ b/src/dev-app/dev-app/routes.ts
@@ -85,6 +85,10 @@ export const DEV_APP_ROUTES: Routes = [
     loadChildren: 'connected-overlay/connected-overlay-demo-module#ConnectedOverlayDemoModule'
   },
   {
+    path: 'cover-overlay',
+    loadChildren: 'cover-overlay/cover-overlay-demo-module#CoverOverlayDemoModule'
+  },
+  {
     path: 'virtual-scroll',
     loadChildren: 'virtual-scroll/virtual-scroll-demo-module#VirtualScrollDemoModule'
   },


### PR DESCRIPTION
Adds a new position strategy that allows attaching to the edges of one or more origins while supporting a subset of the functionality in FlexibleConnectedPositionStrategy.

This will be the default positioning strategy for the upcoming MatPopoverEdit.