### PR TITLE
feat(typography): align with 2018 material design spec

### DIFF
--- a/src/dev-app/typography/typography-demo.html
+++ b/src/dev-app/typography/typography-demo.html
@@ -36,5 +36,7 @@
       chewbacca ponda solo grievous hutt calrissian lando. Darth mon watto vader chewbacca.
       Lando mace luke yavin darth wookiee c-3po. Moff kessel skywalker yoda c-3po yavin.
     </p>
+    <span class="mat-overline">Overline text</span>
+    <span class="mat-button">Button text</span>
   </div>
 </div>

--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -31,13 +31,13 @@
 
   .mat-card-title {
     font: {
-      size: mat-font-size($config, headline);
-      weight: mat-font-weight($config, title);
+      size: mat-font-size($config, heading-6);
+      weight: mat-font-weight($config, heading-6);
     }
   }
 
   .mat-card-header .mat-card-title {
-    font-size: mat-font-size($config, title);
+    font-size: mat-font-size($config, heading-6);
   }
 
   .mat-card-subtitle,

--- a/src/material/core/typography/_typography-utils.scss
+++ b/src/material/core/typography/_typography-utils.scss
@@ -23,6 +23,16 @@
   @return _mat-get-type-value($config, $level, letter-spacing);
 }
 
+// Gets the text transform for a level inside a typography config.
+@function mat-text-transform($config, $level) {
+  @return _mat-get-type-value($config, $level, text-transform);
+}
+
+// Calculates the letter spacing for a font size using the tracking in Sketch
+@function mat-calc-letter-spacing($tracking, $font-size) {
+  @return ($tracking / $font-size) * 1rem;
+}
+
 // Gets the font-family from a typography config and removes the quotes around it.
 @function mat-font-family($config, $level: null) {
   $font-family: map-get($config, font-family);
@@ -71,4 +81,5 @@
 
   @include mat-typography-font-shorthand($font-size, $font-weight, $line-height, $font-family);
   letter-spacing: mat-letter-spacing($config, $level);
+  text-transform: mat-text-transform($config, $level);
 }

--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -6,14 +6,16 @@
   $line-height: $font-size,
   $font-weight: 400,
   $font-family: null,
-  $letter-spacing: null) {
-
+  $letter-spacing: normal,
+  $text-transform: none
+) {
   @return (
     font-size: $font-size,
     line-height: $line-height,
     font-weight: $font-weight,
     font-family: $font-family,
-    letter-spacing: $letter-spacing
+    letter-spacing: $letter-spacing,
+    text-transform: $text-transform
   );
 }
 
@@ -22,135 +24,171 @@
 // Note: The spec doesn't mention letter spacing. The values here come from
 // eyeballing it until it looked exactly like the spec examples.
 @function mat-typography-config(
-  $font-family:   'Roboto, "Helvetica Neue", sans-serif',
-  $display-4:     mat-typography-level(112px, 112px, 300, $letter-spacing: -0.05em),
-  $display-3:     mat-typography-level(56px, 56px, 400, $letter-spacing: -0.02em),
-  $display-2:     mat-typography-level(45px, 48px, 400, $letter-spacing: -0.005em),
-  $display-1:     mat-typography-level(34px, 40px, 400),
-  $headline:      mat-typography-level(24px, 32px, 400),
-  $title:         mat-typography-level(20px, 32px, 500),
-  $subheading-2:  mat-typography-level(16px, 28px, 400),
-  $subheading-1:  mat-typography-level(15px, 24px, 400),
-  $body-2:        mat-typography-level(14px, 24px, 500),
-  $body-1:        mat-typography-level(14px, 20px, 400),
-  $caption:       mat-typography-level(12px, 20px, 400),
-  $button:        mat-typography-level(14px, 14px, 500),
+  $font-family: 'Roboto, "Helvetica Neue", sans-serif',
+  $display-4: mat-typography-level(112px, 112px, 300, $letter-spacing: -0.05em),
+  $display-3: mat-typography-level(56px, 56px, 400, $letter-spacing: -0.02em),
+  $display-2: mat-typography-level(45px, 48px, 400, $letter-spacing: -0.005em),
+  $display-1: mat-typography-level(34px, 40px, 400),
+  $headline: mat-typography-level(24px, 32px, 400),
+  $title: mat-typography-level(20px, 32px, 500),
+  $subheading-2: mat-typography-level(16px, 28px, 400),
+  $subheading-1: mat-typography-level(15px, 24px, 400),
+  // $body-2: mat-typography-level(14px, 24px, 500),
+  // $body-1: mat-typography-level(14px, 20px, 400),
+  // $caption: mat-typography-level(12px, 20px, 400),
+  // $button: mat-typography-level(14px, 14px, 500),
   // Line-height must be unit-less fraction of the font-size.
-  $input:         mat-typography-level(inherit, 1.125, 400)
+  $input: mat-typography-level(inherit, 1.125, 400),
+  // New typography specs
+  $heading-1: mat-typography-level(
+    96 * 0.0625rem,
+    112 * 0.0625rem,
+    300,
+    $letter-spacing: mat-calc-letter-spacing(-1.5, 96)
+  ),
+  $heading-2: mat-typography-level(
+    60 * 0.0625rem,
+    71 * 0.0625rem,
+    300,
+    $letter-spacing: mat-calc-letter-spacing(-0.5, 60)
+  ),
+  $heading-3: mat-typography-level(48 * 0.0625rem, 57 * 0.0625rem),
+  $heading-4: mat-typography-level(
+    34 * 0.0625rem,
+    40 * 0.0625rem,
+    $letter-spacing: mat-calc-letter-spacing(0.25, 34)
+  ),
+  $heading-5: mat-typography-level(24 * 0.0625rem, 28 * 0.0625rem),
+  $heading-6: mat-typography-level(
+    20 * 0.0625rem,
+    24 * 0.0625rem,
+    500,
+    $letter-spacing: mat-calc-letter-spacing(0.15, 20)
+  ),
+  $subtitle-1: mat-typography-level(
+    16 * 0.0625rem,
+    24 * 0.0625rem,
+    $letter-spacing: mat-calc-letter-spacing(0.15, 16)
+  ),
+  $subtitle-2: mat-typography-level(
+    14 * 0.0625rem,
+    24 * 0.0625rem,
+    500,
+    $letter-spacing: mat-calc-letter-spacing(0.1, 14)
+  ),
+  $body-1: mat-typography-level(
+    16 * 0.0625rem,
+    28 * 0.0625rem,
+    $letter-spacing: mat-calc-letter-spacing(0.44, 16)
+  ),
+  $body-2: mat-typography-level(
+    14 * 0.0625rem,
+    20 * 0.0625rem,
+    $letter-spacing: mat-calc-letter-spacing(0.25, 14)
+  ),
+  $button: mat-typography-level(
+    14 * 0.0625rem,
+    16 * 0.0625rem,
+    500,
+    $letter-spacing: mat-calc-letter-spacing(1.35, 14)
+  ),
+  $caption: mat-typography-level(
+    12 * 0.0625rem,
+    16 * 0.0625rem,
+    $letter-spacing: mat-calc-letter-spacing(0.4, 12)
+  ),
+  $overline: mat-typography-level(
+    10 * 0.0625rem,
+    16 * 0.0625rem,
+    $letter-spacing: mat-calc-letter-spacing(1.5, 10),
+    $text-transform: uppercase
+  )
 ) {
-
   // Declare an initial map with all of the levels.
   $config: (
-    display-4:      $display-4,
-    display-3:      $display-3,
-    display-2:      $display-2,
-    display-1:      $display-1,
-    headline:       $headline,
-    title:          $title,
-    subheading-2:   $subheading-2,
-    subheading-1:   $subheading-1,
-    body-2:         $body-2,
-    body-1:         $body-1,
-    caption:        $caption,
-    button:         $button,
-    input:          $input,
+    display-4: $display-4,
+    display-3: $display-3,
+    display-2: $display-2,
+    display-1: $display-1,
+    headline: $headline,
+    title: $title,
+    subheading-2: $subheading-2,
+    subheading-1: $subheading-1,
+    // body-2:         $body-2,
+      // body-1:         $body-1,
+      // caption:        $caption,
+      // button:         $button,
+      input: $input,
+    // New typography specs
+      heading-1: $heading-1,
+    heading-2: $heading-2,
+    heading-3: $heading-3,
+    heading-4: $heading-4,
+    heading-5: $heading-5,
+    heading-6: $heading-6,
+    subtitle-1: $subtitle-1,
+    subtitle-2: $subtitle-2,
+    body-1: $body-1,
+    body-2: $body-2,
+    button: $button,
+    caption: $caption,
+    overline: $overline
   );
 
   // Loop through the levels and set the `font-family` of the ones that don't have one to the base.
   // Note that Sass can't modify maps in place, which means that we need to merge and re-assign.
   @each $key, $level in $config {
     @if map-get($level, font-family) == null {
-      $new-level: map-merge($level, (font-family: $font-family));
-      $config: map-merge($config, ($key: $new-level));
+      $new-level: map-merge(
+        $level,
+        (
+          font-family: $font-family
+        )
+      );
+      $config: map-merge(
+        $config,
+        (
+          $key: $new-level
+        )
+      );
     }
   }
 
   // Add the base font family to the config.
-  @return map-merge($config, (font-family: $font-family));
+  @return map-merge(
+    $config,
+    (
+      font-family: $font-family
+    )
+  );
 }
 
 // Adds the base typography styles, based on a config.
 @mixin mat-base-typography($config, $selector: '.mat-typography') {
-  .mat-h1, .mat-headline, #{$selector} h1 {
-    @include mat-typography-level-to-styles($config, headline);
-    margin: 0 0 16px;
-  }
-
-  .mat-h2, .mat-title, #{$selector} h2 {
-    @include mat-typography-level-to-styles($config, title);
-    margin: 0 0 16px;
-  }
-
-  .mat-h3, .mat-subheading-2, #{$selector} h3 {
-    @include mat-typography-level-to-styles($config, subheading-2);
-    margin: 0 0 16px;
-  }
-
-  .mat-h4, .mat-subheading-1, #{$selector} h4 {
-    @include mat-typography-level-to-styles($config, subheading-1);
-    margin: 0 0 16px;
-  }
-
-  // Note: the spec doesn't have anything that would correspond to h5 and h6, but we add these for
-  // consistency. The font sizes come from the Chrome user agent styles which have h5 at 0.83em
-  // and h6 at 0.67em.
-  .mat-h5, #{$selector} h5 {
-    @include mat-typography-font-shorthand(
-       // calc is used here to support css variables
-      calc(#{mat-font-size($config, body-1)} * 0.83),
-      mat-font-weight($config, body-1),
-      mat-line-height($config, body-1),
-      mat-font-family($config, body-1)
-    );
-
-    margin: 0 0 12px;
-  }
-
-  .mat-h6, #{$selector} h6 {
-    @include mat-typography-font-shorthand(
-       // calc is used here to support css variables
-      calc(#{mat-font-size($config, body-1)} * 0.67),
-      mat-font-weight($config, body-1),
-      mat-line-height($config, body-1),
-      mat-font-family($config, body-1)
-    );
-
-    margin: 0 0 12px;
-  }
-
-  .mat-body-strong, .mat-body-2 {
-    @include mat-typography-level-to-styles($config, body-2);
-  }
-
-  .mat-body, .mat-body-1, #{$selector} {
-    @include mat-typography-level-to-styles($config, body-1);
-
-    p {
-      margin: 0 0 12px;
+  @each $key, $level in $config {
+    @if $key != 'font-family' {
+      #{$selector} .mat-#{$key},
+      .mat-#{$key} {
+        @include mat-typography-level-to-styles($config, $key);
+        @if $key != 'body-1' or $key != 'body-2' or $key != 'button' or
+          $key != 'caption' or $key != 'overline' {
+          margin: 0 0 16px;
+        }
+      }
+      @if $key == 'heading-1' or $key == 'heading-2' or $key == 'heading-3' or
+        $key == 'heading-4' or $key == 'heading-5' or $key == 'heading-6' {
+        #{$selector} h#{str-slice($key, 9)},
+        .mat-h#{str-slice($key, 9)} {
+          @extend .mat-#{$key};
+        }
+      }
     }
   }
 
-  .mat-small, .mat-caption {
-    @include mat-typography-level-to-styles($config, caption);
-  }
-
-  .mat-display-4, #{$selector} .mat-display-4 {
-    @include mat-typography-level-to-styles($config, display-4);
-    margin: 0 0 56px;
-  }
-
-  .mat-display-3, #{$selector} .mat-display-3 {
-    @include mat-typography-level-to-styles($config, display-3);
-    margin: 0 0 64px;
-  }
-
-  .mat-display-2, #{$selector} .mat-display-2 {
-    @include mat-typography-level-to-styles($config, display-2);
-    margin: 0 0 64px;
-  }
-
-  .mat-display-1, #{$selector} .mat-display-1 {
-    @include mat-typography-level-to-styles($config, display-1);
-    margin: 0 0 64px;
+  #{$selector} {
+    @include mat-typography-level-to-styles($config, body-1);
+    p {
+      margin: 0 0 12px;
+    }
   }
 }

--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -17,6 +17,6 @@
 
 @mixin mat-dialog-typography($config) {
   .mat-dialog-title {
-    @include mat-typography-level-to-styles($config, title);
+    @include mat-typography-level-to-styles($config, heading-6);
   }
 }

--- a/src/material/expansion/_expansion-theme.scss
+++ b/src/material/expansion/_expansion-theme.scss
@@ -58,9 +58,9 @@
 @mixin mat-expansion-panel-typography($config) {
   .mat-expansion-panel-header {
     font: {
-      family: mat-font-family($config, subheading-1);
-      size: mat-font-size($config, subheading-1);
-      weight: mat-font-weight($config, subheading-1);
+      family: mat-font-family($config, subtitle-1);
+      size: mat-font-size($config, subtitle-1);
+      weight: mat-font-weight($config, subtitle-1);
     }
   }
 


### PR DESCRIPTION
* Add support for overline text
* Add specs from type system design document at https://material.io/design/typography/the-type-system.html

Closes #12974

BREAKING CHANGES:

- The following typography CSS classes have been removed and/or replaced with the associating CSS classes:

  | Removed class | Replaced class |
  |---|---|
  | `.mat-body-strong` | No equivalant |
  | `.mat-small` | `.mat-caption` |

(P.S. This will definitely break something in testing)