### PR TITLE
fix(material/input): label floating state not updated when using text binding inside textarea

### DIFF
--- a/scripts/check-mdc-tests-config.ts
+++ b/scripts/check-mdc-tests-config.ts
@@ -79,7 +79,8 @@ export const config = {
       'should be legacy appearance if empty default options provided',
       'should not calculate wrong content height due to long placeholders',
       'should work in a tab',
-      'should work in a step'
+      'should work in a step',
+      'should float the label when the text comes into textarea via text binding'
     ],
     'mdc-list': [
       // TODO: these tests need to be double-checked for missing functionality.

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -672,6 +672,16 @@ describe('MatInput without forms', () => {
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
   }));
 
+  it('should float the label when the text comes into textarea via text binding', fakeAsync(() => {
+    const fixture = createComponent(MatInputWithTextareaTextBindingOnPush);
+    fixture.detectChanges();
+
+    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+
+    expect(formFieldEl.classList).toContain('mat-form-field-can-float');
+    expect(formFieldEl.classList).toContain('mat-form-field-should-float');
+  }));
+
   it('should always float the label when floatLabel is set to true', fakeAsync(() => {
     let fixture = createComponent(MatInputWithDynamicLabel);
     fixture.detectChanges();
@@ -2302,6 +2312,17 @@ class MatInputWithCustomAccessor {}
     </mat-form-field>`
 })
 class MatInputSelectWithoutOptions {}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <mat-form-field>
+      <textarea matInput placeholder="Type something" readonly>{{text}}</textarea>
+    </mat-form-field>`
+})
+class MatInputWithTextareaTextBindingOnPush {
+  text = 'Hello there';
+}
 
 
 /** Custom component that never has a value. Used for testing the `MAT_INPUT_VALUE_ACCESSOR`. */

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -4,7 +4,7 @@ export declare const MAT_INPUT_VALUE_ACCESSOR: InjectionToken<{
     value: any;
 }>;
 
-export declare class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck, CanUpdateErrorState {
+export declare class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges, OnDestroy, DoCheck, AfterViewInit, CanUpdateErrorState {
     protected _disabled: boolean;
     protected _elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
     protected _id: string;
@@ -40,8 +40,9 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     get value(): string;
     set value(value: string);
     constructor(_elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>, _platform: Platform,
-    ngControl: NgControl, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined);
-    protected _dirtyCheckNativeValue(): void;
+    ngControl: NgControl, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined,
+    _changeDetectorRef?: ChangeDetectorRef | undefined);
+    protected _dirtyCheckNativeValue(): boolean;
     _focusChanged(isFocused: boolean): void;
     protected _isBadInput(): boolean;
     protected _isNeverEmpty(): boolean;
@@ -59,7 +60,7 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     static ngAcceptInputType_required: BooleanInput;
     static ngAcceptInputType_value: any;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatInput, "input[matInput], textarea[matInput], select[matNativeControl],      input[matNativeControl], textarea[matNativeControl]", ["matInput"], { "disabled": "disabled"; "id": "id"; "placeholder": "placeholder"; "required": "required"; "type": "type"; "errorStateMatcher": "errorStateMatcher"; "userAriaDescribedBy": "aria-describedby"; "value": "value"; "readonly": "readonly"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatInput, [null, null, { optional: true; self: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatInput, [null, null, { optional: true; self: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }, null, null, { optional: true; }, null]>;
 }
 
 export declare class MatInputModule {


### PR DESCRIPTION
Fixes the state that tells the form field whether the label should float not being up-to-date if the consumer is using a `textarea` with a text binding (e.g. `<textarea matInput>{{someValue}}</textarea>`). This causes a "changed after checked" error with regular change detection and the label to be hidden incorrectly with `OnPush` change detection.

Fixes #12070.