### PR TITLE
feat(paginator): add optional page numbers

### DIFF
--- a/src/dev-app/paginator/paginator-demo.html
+++ b/src/dev-app/paginator/paginator-demo.html
@@ -17,10 +17,15 @@
       <input matInput placeholder="Page Index" type="number" [(ngModel)]="pageIndex">
     </mat-form-field>
 
+    <mat-form-field *ngIf="showPageNumbers">
+      <input matInput placeholder="Count of page numbers" type="number" [(ngModel)]="pageNumberCount">
+    </mat-form-field>
+
     <mat-slide-toggle [(ngModel)]="hidePageSize">Hide page size</mat-slide-toggle>
     <mat-slide-toggle [(ngModel)]="showPageSizeOptions">Show multiple page size options</mat-slide-toggle>
     <mat-slide-toggle [(ngModel)]="showFirstLastButtons">Show first/last buttons</mat-slide-toggle>
     <mat-slide-toggle [(ngModel)]="disabled">Disabled</mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="showPageNumbers">Show Page Numbers</mat-slide-toggle>
   </div>
 
   <mat-paginator #paginator
@@ -31,7 +36,9 @@
                  [showFirstLastButtons]="showFirstLastButtons"
                  [pageSizeOptions]="showPageSizeOptions ? pageSizeOptions : []"
                  [hidePageSize]="hidePageSize"
-                 [pageIndex]="pageIndex">
+                 [pageIndex]="pageIndex"
+                 [showPageNumbers]="showPageNumbers"
+                 [pageNumberCount]="pageNumberCount">
   </mat-paginator>
 
   <div> Output event: {{pageEvent | json}} </div>

--- a/src/dev-app/paginator/paginator-demo.ts
+++ b/src/dev-app/paginator/paginator-demo.ts
@@ -26,6 +26,8 @@ export class PaginatorDemo {
   showPageSizeOptions = true;
   showFirstLastButtons = true;
   disabled = false;
+  showPageNumbers = false;
+  pageNumberCount = 3;
 
   pageEvent: PageEvent;
 

--- a/src/lib/paginator/_paginator-theme.scss
+++ b/src/lib/paginator/_paginator-theme.scss
@@ -27,6 +27,10 @@
     border-top: 2px solid mat-color($foreground, 'icon');
   }
 
+  .mat-paginator-current-page {
+    color: mat-color($foreground, 'text');
+  }
+
   .mat-icon-button[disabled] {
     .mat-paginator-decrement,
     .mat-paginator-increment,

--- a/src/lib/paginator/paginator.html
+++ b/src/lib/paginator/paginator.html
@@ -53,6 +53,29 @@
           <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>
         </svg>
       </button>
+      <div *ngIf="showPageNumbers">
+        <button mat-icon-button type="button"
+                class="mat-paginator-page-button-{{previousPage}} mat-icon-button"
+                *ngFor="let previousPage of previousPageNumbers()"
+                (click)="clickPageNumber(previousPage)"
+                [attr.aria-label]="'Skip to page ' + previousPage">
+                {{ previousPage }}
+        </button>
+        <button mat-icon-button type="button"
+                class="mat-paginator-current-page"
+                aria-disabled="true"
+                attr.aria-label="Current Page">
+                {{ currentPageNumber() }}
+        </button>
+      
+        <button mat-icon-button type="button"
+                class="mat-paginator-page-button-{{nextPage}} mat-icon-button"
+                *ngFor="let nextPage of nextPageNumbers()"
+                (click)="clickPageNumber(nextPage)"
+                [attr.aria-label]="'Skip to page ' + nextPage">
+                {{ nextPage }}
+        </button>
+      </div>
       <button mat-icon-button type="button"
               class="mat-paginator-navigation-next"
               (click)="nextPage()"

--- a/src/lib/paginator/paginator.scss
+++ b/src/lib/paginator/paginator.scss
@@ -99,3 +99,7 @@ $mat-paginator-button-last-increment-icon-margin: 9px;
     transform: rotate(180deg);
   }
 }
+
+.mat-paginator-current-page {
+  font-weight: bold;
+}

--- a/src/lib/paginator/paginator.spec.ts
+++ b/src/lib/paginator/paginator.spec.ts
@@ -413,6 +413,55 @@ describe('MatPaginator', () => {
     expect(getLastButton(fixture).hasAttribute('disabled')).toBe(true);
   });
 
+  it('should be able to go to the clicked page', () => {
+    fixture.componentInstance.showPageNumbers = true;
+    fixture.detectChanges();
+
+    expect(paginator.pageIndex).toBe(0);
+
+    dispatchMouseEvent(getPageNumberButton(fixture), 'click');
+
+    expect(paginator.pageIndex).toBe(2);
+    expect(component.pageEvent).toHaveBeenCalledWith(jasmine.objectContaining({
+      previousPageIndex: 0,
+      pageIndex: 2
+    }));
+  });
+
+  it('should be able to show page numbers', () => {
+    expect(getPageNumberButton(fixture, 2))
+        .toBeNull('Expected page number 2 button to not exist.');
+
+    fixture.componentInstance.showPageNumbers = true;
+    fixture.detectChanges();
+
+    expect(getPageNumberButton(fixture, 2))
+        .toBeTruthy('Expected page number 2 button to exist.');
+
+    expect(getPageNumberButton(fixture))
+        .toBeTruthy('Expected page number 3 button to exist.');
+  });
+
+  it('should know how many page numbers to show', () => {
+    expect(getPageNumberButton(fixture, 2))
+        .toBeNull('Expected page number 2 button to not exist.');
+
+    fixture.componentInstance.showPageNumbers = true;
+    fixture.detectChanges();
+
+    expect(getPageNumberButton(fixture, 5))
+        .toBeFalsy('Should not have 5 page numbers by default');
+
+    fixture.componentInstance.pageNumberCount = 5;
+    fixture.detectChanges();
+
+    expect(getPageNumberButton(fixture, 5))
+        .toBeTruthy('Should have 5 pages');
+
+    expect(getPageNumberButton(fixture, 6))
+        .toBeFalsy('Should not have 6 pages');
+  });
+
 });
 
 function getPreviousButton(fixture: ComponentFixture<any>) {
@@ -431,6 +480,10 @@ function getLastButton(fixture: ComponentFixture<any>) {
     return fixture.nativeElement.querySelector('.mat-paginator-navigation-last');
 }
 
+function getPageNumberButton(fixture: ComponentFixture<any>, pageNumber: number = 3) {
+    return fixture.nativeElement.querySelector(`.mat-paginator-page-button-${pageNumber}`);
+}
+
 @Component({
   template: `
     <mat-paginator [pageIndex]="pageIndex"
@@ -438,6 +491,8 @@ function getLastButton(fixture: ComponentFixture<any>) {
                    [pageSizeOptions]="pageSizeOptions"
                    [hidePageSize]="hidePageSize"
                    [showFirstLastButtons]="showFirstLastButtons"
+                   [showPageNumbers]="showPageNumbers"
+                   [pageNumberCount]="pageNumberCount"
                    [length]="length"
                    [color]="color"
                    [disabled]="disabled"
@@ -451,6 +506,8 @@ class MatPaginatorApp {
   pageSizeOptions = [5, 10, 25, 100];
   hidePageSize = false;
   showFirstLastButtons = false;
+  showPageNumbers = false;
+  pageNumberCount = 3;
   length = 100;
   disabled: boolean;
   pageEvent = jasmine.createSpy('page event');

--- a/tools/public_api_guard/lib/paginator.d.ts
+++ b/tools/public_api_guard/lib/paginator.d.ts
@@ -16,22 +16,28 @@ export declare class MatPaginator extends _MatPaginatorBase implements OnInit, O
     length: number;
     readonly page: EventEmitter<PageEvent>;
     pageIndex: number;
+    pageNumberCount: number;
     pageSize: number;
     pageSizeOptions: number[];
     showFirstLastButtons: boolean;
+    showPageNumbers: boolean;
     constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef);
     _changePageSize(pageSize: number): void;
     _nextButtonsDisabled(): boolean;
     _previousButtonsDisabled(): boolean;
+    clickPageNumber(nextPage: number): void;
+    currentPageNumber(): number;
     firstPage(): void;
     getNumberOfPages(): number;
     hasNextPage(): boolean;
     hasPreviousPage(): boolean;
     lastPage(): void;
     nextPage(): void;
+    nextPageNumbers(): number[];
     ngOnDestroy(): void;
     ngOnInit(): void;
     previousPage(): void;
+    previousPageNumbers(): number[];
 }
 
 export declare class MatPaginatorBase {


### PR DESCRIPTION
Add optional page numbers for displaying navigation on paginator.
Number of visible pages defaults to 3, and is configurable.
Even numbers are rounded up to odd numbers to display equal number
of pages on each side of the current selected page.