### PR TITLE
refactor(sidenav): expose api to update content margins

### DIFF
--- a/tools/public_api_guard/material/sidenav.d.ts
+++ b/tools/public_api_guard/material/sidenav.d.ts
@@ -63,6 +63,7 @@ export declare class MatDrawerContainer implements AfterContentInit, DoCheck, On
     ngDoCheck(): void;
     ngOnDestroy(): void;
     open(): void;
+    updateContentMargins(): void;
 }
 
 export declare class MatDrawerContent extends CdkScrollable implements AfterContentInit {


### PR DESCRIPTION
Exposes an API so that consumers can trigger an update of the content margins manually. This allows the sidenav to handle some cases that might not have accounted for.

Fixes #15777.