### PR TITLE
fix: force tab-body-wrapper to fill parent

### DIFF
--- a/src/lib/tabs/tab-group.scss
+++ b/src/lib/tabs/tab-group.scss
@@ -40,6 +40,8 @@
   position: relative;
   overflow: hidden;
   display: flex;
+  height: 100%;
+  width: 100%;
   transition: height $mat-tab-animation-duration $ease-in-out-curve-function;
 }
 


### PR DESCRIPTION
Fix for #4591

It has been tested with the examples in the documentation, without visible issues.