### PR TITLE
fix(overlay): add panelClass from position to the overlay

### DIFF
--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -391,6 +391,23 @@ describe('Overlay directives', () => {
       expect(Math.floor(overlayRect.left)).toBe(Math.floor(triggerRect.left) + 20);
     });
 
+    it('should take the offset from the position', () => {
+      fixture.componentInstance.positionOverrides = [{
+        originX: 'start',
+        originY: 'top',
+        overlayX: 'start',
+        overlayY: 'top',
+        panelClass: 'custom-class'
+      }];
+
+      fixture.componentInstance.isOpen = true;
+      fixture.detectChanges();
+
+      const panel = getPaneElement();
+      expect(panel.classList).toContain('custom-class');
+      expect(panel.classList).toContain('cdk-test-panel-class');
+    });
+
     it('should be able to set the viewport margin', () => {
       expect(fixture.componentInstance.connectedOverlayDirective.viewportMargin).not.toBe(10);
 

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -326,7 +326,8 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
       overlayX: currentPosition.overlayX,
       overlayY: currentPosition.overlayY,
       offsetX: currentPosition.offsetX || this.offsetX,
-      offsetY: currentPosition.offsetY || this.offsetY
+      offsetY: currentPosition.offsetY || this.offsetY,
+      panelClass: currentPosition.panelClass || undefined,
     }));
 
     return positionStrategy


### PR DESCRIPTION
CdkConnectedOverlay directive was ignoring panelClass from
cdkConnectedOverlayPositions. This change adds support to add panelClass
from positions to the overlay.