### PR TITLE
chore: update "material2" to "components"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# Configuration file for https://circleci.com/gh/angular/material2
+# Configuration file for https://circleci.com/gh/angular/components
 
 # Note: YAML anchors allow an object to be re-used, reducing duplication.
 # The ampersand declares an alias for an object, then later the `<<: *name`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,13 +70,13 @@ chances of your issue being dealt with quickly:
 * **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
     causing the problem (line of code or commit)
 
-You can file new issues by providing the above information [here](https://github.com/angular/material2/issues/new).
+You can file new issues by providing the above information [here](https://github.com/angular/components/issues/new).
 
 
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-* Search [GitHub](https://github.com/angular/material2/pulls) for an open or closed PR
+* Search [GitHub](https://github.com/angular/components/pulls) for an open or closed PR
   that relates to your submission. You don't want to duplicate effort.
 * Please sign our [Contributor License Agreement (CLA)](#cla) before sending PRs.
   We cannot accept code without this.
@@ -106,7 +106,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git push my-fork my-fix-branch
     ```
 
-* In GitHub, send a pull request to `material2:master`.
+* In GitHub, send a pull request to `components:master`.
 * If we suggest changes then:
   * Make the required updates.
   * Re-run the Angular Material test suites to ensure tests are still passing.
@@ -239,9 +239,9 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 [coc]: https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/preview
 [corporate-cla]: http://code.google.com/legal/corporate-cla-v1.0.html
-[dev-doc]: https://github.com/angular/material2/blob/master/DEV_ENVIRONMENT.md
-[github]: https://github.com/angular/material2
-[gitter]: https://gitter.im/angular/material2
+[dev-doc]: https://github.com/angular/components/blob/master/DEV_ENVIRONMENT.md
+[github]: https://github.com/angular/components
+[gitter]: https://gitter.im/angular/components
 [individual-cla]: http://code.google.com/legal/individual-cla-v1.0.html
 [js-style-guide]: https://google.github.io/styleguide/jsguide.html
 [codepen]: http://codepen.io/

--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -3,10 +3,10 @@
 1. Make sure you have `node` installed with a version at _least_ 10.0.0 and `yarn` with a version
    of at least 1.10.0. We recommend using `nvm` to manage your node versions.
 2. Run `yarn global add gulp` to install gulp.
-3. Fork the `angular/material2` repo on GitHub.
+3. Fork the `angular/components` repo on GitHub.
 4. Clone your fork to your machine with `git clone`.
-   Recommendation: name your git remotes `upstream` for `angular/material2`
-   and `<your-username>` for your fork. Also see the [team git shortcuts](https://github.com/angular/material2/wiki/Team-git----bash-shortcuts).
+   Recommendation: name your git remotes `upstream` for `angular/components`
+   and `<your-username>` for your fork. Also see the [team git shortcuts](https://github.com/angular/components/wiki/Team-git----bash-shortcuts).
 5. From the root of the project, run `yarn`.
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Components and Material Design for Angular
 [![npm version](https://badge.fury.io/js/%40angular%2Fmaterial.svg)](https://www.npmjs.com/package/%40angular%2Fmaterial)
-[![Build status](https://circleci.com/gh/angular/material2.svg?style=svg)](https://circleci.com/gh/angular/material2)
-[![Gitter](https://badges.gitter.im/angular/material2.svg)](https://gitter.im/angular/material2?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Build status](https://circleci.com/gh/angular/components.svg?style=svg)](https://circleci.com/gh/angular/components)
+[![Gitter](https://badges.gitter.im/angular/components.svg)](https://gitter.im/angular/material2?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 This is the home for the Angular team's UI components built for and with Angular.
 These include Material Design components and the Angular Component Development Kit (CDK).
@@ -9,7 +9,7 @@ These include Material Design components and the Angular Component Development K
 #### Quick links
 [Documentation, demos, and guides][aio] |
 [Google group](https://groups.google.com/forum/#!forum/angular-material2) |
-[Contributing](https://github.com/angular/material2/blob/master/CONTRIBUTING.md) |
+[Contributing](https://github.com/angular/components/blob/master/CONTRIBUTING.md) |
 [StackBlitz Template](https://goo.gl/wwnhMV)
 
 ### Getting started
@@ -17,18 +17,18 @@ These include Material Design components and the Angular Component Development K
 See our [Getting Started Guide][getting-started]
 if you're building your first project with Angular Material.
 
-Check out our [directory of design documents](https://github.com/angular/material2/wiki/Design-doc-directory)
+Check out our [directory of design documents](https://github.com/angular/components/wiki/Design-doc-directory)
 for more insight into our process.
 
-If you'd like to contribute, you must follow our [contributing guidelines](https://github.com/angular/material2/blob/master/CONTRIBUTING.md).
+If you'd like to contribute, you must follow our [contributing guidelines](https://github.com/angular/components/blob/master/CONTRIBUTING.md).
 You can look through the GitHub issues (which should be up-to-date on who is working on which features
 and which pieces are blocked) and make a comment.
 
-Please see our [`help wanted`](https://github.com/angular/material2/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+Please see our [`help wanted`](https://github.com/angular/components/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 label for a list of issues where we could use help from the community.
 
 #### High level stuff planned for Q1 → Q2 2019 (January - June):
-* Most of the Angular Material team is on loan to the framework team
+* Most of the Angular Components team is on loan to the framework team
   helping with [Ivy](https://blog.angular.io/a-plan-for-version-8-0-and-ivy-b3318dfc19f7).
   We've been using the Angular CDK and Angular Material tests to validate code paths as well
   as helping debug issues in switching Google applications to the new rendering pipeline.
@@ -103,7 +103,7 @@ label for a list of issues where we could use help from the community.
 [16]: https://material.angular.io/components/slider/overview
 [17]: https://material.angular.io/components/menu/overview
 [18]: https://material.angular.io/components/tooltip/overview
-[19]: https://github.com/angular/material2/blob/master/src/material/core/ripple/ripple.md
+[19]: https://github.com/angular/components/blob/master/src/material/core/ripple/ripple.md
 [20]: https://material.angular.io/guide/theming
 [21]: https://material.angular.io/components/snack-bar/overview
 [22]: https://material.angular.io/components/dialog/overview

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -185,7 +185,7 @@ export class UnicornCandyAppModule {
 ```
 
 #### Theming only certain components
-The `angular-material-theme` mixin will output styles for [all components in the library](https://github.com/angular/material2/blob/master/src/material/core/theming/_all-theme.scss).
+The `angular-material-theme` mixin will output styles for [all components in the library](https://github.com/angular/components/blob/master/src/material/core/theming/_all-theme.scss).
 If you are only using a subset of the components (or if you want to change the theme for specific
 components), you can include component-specific theme mixins. You also will need to include
 the `mat-core-theme` mixin as well, which contains theme-specific styles for common behaviors

--- a/guides/typography.md
+++ b/guides/typography.md
@@ -101,7 +101,7 @@ If you're using Material's theming, you can also pass in your typography config 
 ```
 
 For more details about the typography functions and default config, see the
-[source](https://github.com/angular/material2/blob/master/src/material/core/typography/_typography.scss).
+[source](https://github.com/angular/components/blob/master/src/material/core/typography/_typography.scss).
 
 
 ### Material typography in your custom CSS

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "material2-srcs",
+  "name": "components-srcs",
   "description": "Material Design components for Angular",
-  "homepage": "https://github.com/angular/material2",
-  "bugs": "https://github.com/angular/material2/issues",
+  "homepage": "https://github.com/angular/components",
+  "bugs": "https://github.com/angular/components/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/material2.git"
+    "url": "https://github.com/angular/components.git"
   },
   "license": "MIT",
   "engines": {

--- a/scripts/caretaking/write-presubmit-scheduler.js
+++ b/scripts/caretaking/write-presubmit-scheduler.js
@@ -8,7 +8,7 @@ const github = new GitHubApi();
 
 /** CONFIGURATION: change these things if you want to tweak how the runs are made. */
 
-/** Path to the local material2. By default based on the location of this script. */
+/** Path to the local components repo. By default based on the location of this script. */
 const localRepo = path.resolve(__dirname, '..', '..');
 
 /** Where to write the output from the presubmit script. */
@@ -32,7 +32,7 @@ const githubSearchOptions = {
   // Use the maximum of allowed items per Github API query. 100 pull requests should be
   // enough to continuously run presubmits through night.
   per_page: 100,
-  q: 'repo:angular/material2 is:open type:pr label:"pr: merge ready" -label:"pr: merge safe"',
+  q: 'repo:angular/components is:open type:pr label:"pr: merge ready" -label:"pr: merge safe"',
 };
 
 /** END OF CONFIGURATION. */

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -27,7 +27,7 @@ docsContentPath="${projectPath}/tmp/material2-docs-content"
 examplesPackagePath="$(bazel info bazel-bin)/src/material-examples/npm_package"
 
 # Git clone URL for the material2-docs-content repository.
-docsContentRepoUrl="https://github.com/angular/material2-docs-content"
+docsContentRepoUrl="https://github.com/angular/components-docs-content"
 
 # Current version of Angular Material from the package.json file
 buildVersion=$(node -pe "require('./package.json').version")

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 Angular Material
 =======
 
-The sources for this package are in the main [Angular Material](https://github.com/angular/material2) repo. Please file issues and pull requests against that repo.
+The sources for this package are in the main [Angular Material](https://github.com/angular/components) repo. Please file issues and pull requests against that repo.
 
 License: MIT

--- a/src/cdk-experimental/package.json
+++ b/src/cdk-experimental/package.json
@@ -8,13 +8,13 @@
   "typings": "./cdk-experimental.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/material2.git"
+    "url": "https://github.com/angular/components.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/angular/material2/issues"
+    "url": "https://github.com/angular/components/issues"
   },
-  "homepage": "https://github.com/angular/material2#readme",
+  "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG"

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -8,7 +8,7 @@
   "typings": "./cdk.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/material2.git"
+    "url": "https://github.com/angular/components.git"
   },
   "keywords": [
     "angular",
@@ -19,9 +19,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/angular/material2/issues"
+    "url": "https://github.com/angular/components/issues"
   },
-  "homepage": "https://github.com/angular/material2#readme",
+  "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG"

--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -17,7 +17,7 @@ let hasV8BreakIterator: boolean;
 // cause IE to throw. These cases are tied to particular versions of Windows and can happen if
 // the consumer is providing a polyfilled `Map`. See:
 // https://github.com/Microsoft/ChakraCore/issues/3189
-// https://github.com/angular/material2/issues/15687
+// https://github.com/angular/components/issues/15687
 try {
   hasV8BreakIterator = (typeof Intl !== 'undefined' && (Intl as any).v8BreakIterator);
 } catch {

--- a/src/cdk/schematics/ng-update/data/attribute-selectors.ts
+++ b/src/cdk/schematics/ng-update/data/attribute-selectors.ts
@@ -19,7 +19,7 @@ export interface AttributeSelectorUpgradeData {
 export const attributeSelectors: VersionChanges<AttributeSelectorUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10257',
+      pr: 'https://github.com/angular/components/pull/10257',
       changes: [
         {
           replace: 'cdkPortalHost',

--- a/src/cdk/schematics/ng-update/data/class-names.ts
+++ b/src/cdk/schematics/ng-update/data/class-names.ts
@@ -19,7 +19,7 @@ export interface ClassNameUpgradeData {
 export const classNames: VersionChanges<ClassNameUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10161',
+      pr: 'https://github.com/angular/components/pull/10161',
       changes: [
         {
           replace: 'ConnectedOverlayDirective',
@@ -33,7 +33,7 @@ export const classNames: VersionChanges<ClassNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10267',
+      pr: 'https://github.com/angular/components/pull/10267',
       changes: [
         {
           replace: 'ObserveContent',
@@ -43,7 +43,7 @@ export const classNames: VersionChanges<ClassNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10325',
+      pr: 'https://github.com/angular/components/pull/10325',
       changes: [
         {
           replace: 'FocusTrapDirective',

--- a/src/cdk/schematics/ng-update/data/constructor-checks.ts
+++ b/src/cdk/schematics/ng-update/data/constructor-checks.ts
@@ -19,7 +19,7 @@ export type ConstructorChecksUpgradeData = string;
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
   [TargetVersion.V8]: [
     {
-      pr: 'https://github.com/angular/material2/pull/15647',
+      pr: 'https://github.com/angular/components/pull/15647',
       changes: [
         'CdkDrag', 'CdkDropList', 'ConnectedPositionStrategy', 'FlexibleConnectedPositionStrategy',
         'OverlayPositionBuilder', 'CdkTable'

--- a/src/cdk/schematics/ng-update/data/input-names.ts
+++ b/src/cdk/schematics/ng-update/data/input-names.ts
@@ -26,7 +26,7 @@ export interface InputNameUpgradeData {
 export const inputNames: VersionChanges<InputNameUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10161',
+      pr: 'https://github.com/angular/components/pull/10161',
       changes: [
         {
           replace: 'origin',

--- a/src/cdk/schematics/ng-update/data/method-call-checks.ts
+++ b/src/cdk/schematics/ng-update/data/method-call-checks.ts
@@ -21,7 +21,7 @@ export interface MethodCallUpgradeData {
 export const methodCallChecks: VersionChanges<MethodCallUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10325',
+      pr: 'https://github.com/angular/components/pull/10325',
       changes: [
         {
           className: 'FocusMonitor',

--- a/src/cdk/schematics/ng-update/data/property-names.ts
+++ b/src/cdk/schematics/ng-update/data/property-names.ts
@@ -24,7 +24,7 @@ export interface PropertyNameUpgradeData {
 export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
   [TargetVersion.V7]: [
     {
-      pr: 'https://github.com/angular/material2/pull/8286',
+      pr: 'https://github.com/angular/components/pull/8286',
       changes: [
         {
           replace: 'onChange',
@@ -37,7 +37,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/12927',
+      pr: 'https://github.com/angular/components/pull/12927',
       changes: [
         {
           replace: 'flexibleDiemsions',
@@ -52,7 +52,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
 
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10161',
+      pr: 'https://github.com/angular/components/pull/10161',
       changes: [
         {
           replace: '_deprecatedOrigin',
@@ -142,7 +142,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10257',
+      pr: 'https://github.com/angular/components/pull/10257',
       changes: [
         {
           replace: '_deprecatedPortal',

--- a/src/cdk/schematics/ng-update/update-schematic.md
+++ b/src/cdk/schematics/ng-update/update-schematic.md
@@ -98,7 +98,7 @@ because the non-separated upgrade data would just include: _`onChange` => `onVal
 Also besides separating the upgrade data based on the target version, we split the upgrade data
 based on the type of code that is affected by these migrations:  
   
-* See here: [src/material/schematics/update/material/data](https://github.com/angular/material2/tree/master/src/material/schematics/update/material/data)  
+* See here: [src/material/schematics/update/material/data](https://github.com/angular/components/tree/master/src/material/schematics/update/material/data)  
   
 ### Adding upgrade data
   

--- a/src/cdk/schematics/ng-update/upgrade-rules/signature-check/constructorSignatureCheckRule.ts
+++ b/src/cdk/schematics/ng-update/upgrade-rules/signature-check/constructorSignatureCheckRule.ts
@@ -33,7 +33,7 @@ export class Rule extends Rules.TypedRule {
   applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
     // Note that the data for this rule is not distinguished based on the target version because
     // we don't keep track of the new signature and don't want to update incrementally.
-    // See: https://github.com/angular/material2/pull/12970#issuecomment-418337566
+    // See: https://github.com/angular/components/pull/12970#issuecomment-418337566
     const data = getAllChanges<ConstructorChecksUpgradeData>
         (this.getOptions().ruleArguments[1].constructorChecks);
     return this.applyWithFunction(sourceFile, visitSourceFile, data, program);

--- a/src/cdk/schematics/utils/build-component.ts
+++ b/src/cdk/schematics/utils/build-component.ts
@@ -210,7 +210,7 @@ export function buildComponent(options: ComponentOptions,
     // In case the specified style extension is not part of the supported CSS supersets,
     // we generate the stylesheets with the "css" extension. This ensures that we don't
     // accidentally generate invalid stylesheets (e.g. drag-drop-comp.styl) which will
-    // break the Angular CLI project. See: https://github.com/angular/material2/issues/15164
+    // break the Angular CLI project. See: https://github.com/angular/components/issues/15164
     if (!supportedCssExtensions.includes(options.style!)) {
       // TODO: Cast is necessary as we can't use the Style enum which has been introduced
       // within CLI v7.3.0-rc.0. This would break the schematic for older CLI versions.

--- a/src/dev-app/dev-app/dev-app-module.ts
+++ b/src/dev-app/dev-app/dev-app-module.ts
@@ -36,7 +36,7 @@ import {DevAppLayout} from './dev-app-layout';
   exports: [DevAppLayout],
 
   // We need to pass this in here, because the gesture config currently doesn't for lazy-loaded
-  // modules. See https://github.com/angular/material2/issues/4595#issuecomment-416641018.
+  // modules. See https://github.com/angular/components/issues/4595#issuecomment-416641018.
   providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}]
 })
 export class DevAppModule {

--- a/src/e2e-app/devserver-configure.js
+++ b/src/e2e-app/devserver-configure.js
@@ -39,5 +39,5 @@ require.config({
   }
 });
 
-// Workaround until https://github.com/angular/material2/issues/13883 has been addressed.
+// Workaround until https://github.com/angular/components/issues/13883 has been addressed.
 var module = {id: ''};

--- a/src/e2e-app/e2e-app/e2e-app-module.ts
+++ b/src/e2e-app/e2e-app/e2e-app-module.ts
@@ -23,7 +23,7 @@ import {E2eAppLayout, Home} from './e2e-app-layout';
   exports: [E2eAppLayout],
 
   // We need to pass this in here, because the gesture config currently doesn't for lazy-loaded
-  // modules. See https://github.com/angular/material2/issues/4595#issuecomment-416641018.
+  // modules. See https://github.com/angular/components/issues/4595#issuecomment-416641018.
   providers: [{provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}]
 })
 export class E2eAppModule {

--- a/src/material-examples/package.json
+++ b/src/material-examples/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/material2.git"
+    "url": "https://github.com/angular/components.git"
   },
   "keywords": [
     "angular",
@@ -19,9 +19,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/angular/material2/issues"
+    "url": "https://github.com/angular/components/issues"
   },
-  "homepage": "https://github.com/angular/material2#readme",
+  "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",

--- a/src/material-examples/table-http/table-http-example.ts
+++ b/src/material-examples/table-http/table-http-example.ts
@@ -77,7 +77,7 @@ export class ExampleHttpDatabase {
   getRepoIssues(sort: string, order: string, page: number): Observable<GithubApi> {
     const href = 'https://api.github.com/search/issues';
     const requestUrl =
-        `${href}?q=repo:angular/material2&sort=${sort}&order=${order}&page=${page + 1}`;
+        `${href}?q=repo:angular/components&sort=${sort}&order=${order}&page=${page + 1}`;
 
     return this.http.get<GithubApi>(requestUrl);
   }

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -341,7 +341,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
       this.indeterminate = false;
       // tslint:disable:max-line-length
       // We use `Promise.resolve().then` to ensure the same timing as the original `MatCheckbox`:
-      // https://github.com/angular/material2/blob/309d5644aa610ee083c56a823ce7c422988730e8/src/lib/checkbox/checkbox.ts#L381
+      // https://github.com/angular/components/blob/309d5644aa610ee083c56a823ce7c422988730e8/src/lib/checkbox/checkbox.ts#L381
       // tslint:enable:max-line-length
       Promise.resolve().then(() => this.indeterminateChange.next(this.indeterminate));
     } else {

--- a/src/material-experimental/package.json
+++ b/src/material-experimental/package.json
@@ -8,13 +8,13 @@
   "typings": "./material-experimental.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/material2.git"
+    "url": "https://github.com/angular/components.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/angular/material2/issues"
+    "url": "https://github.com/angular/components/issues"
   },
-  "homepage": "https://github.com/angular/material2#readme",
+  "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
     "@angular/material": "0.0.0-PLACEHOLDER",

--- a/src/material-moment-adapter/package.json
+++ b/src/material-moment-adapter/package.json
@@ -8,13 +8,13 @@
   "typings": "./material-moment-adapter.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/material2.git"
+    "url": "https://github.com/angular/components.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/angular/material2/issues"
+    "url": "https://github.com/angular/components/issues"
   },
-  "homepage": "https://github.com/angular/material2#readme",
+  "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/material": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",

--- a/src/material/button-toggle/button-toggle.scss
+++ b/src/material/button-toggle/button-toggle.scss
@@ -74,7 +74,7 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   // overlay for `.cdk-program-focused` because mouse clicks on the <label> element would be always
   // treated as programmatic focus. Note that it needs the extra `:not` in order to have more
   // specificity than the `:hover` above.
-  // TODO(paul): support `program` as well. See https://github.com/angular/material2/issues/9889
+  // TODO(paul): support `program` as well. See https://github.com/angular/components/issues/9889
   &.cdk-keyboard-focused:not(.mat-button-toggle-disabled) .mat-button-toggle-focus-overlay {
     opacity: 0.12;
 

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -52,7 +52,7 @@
   // child element cannot expand to the same boundaries as the parent element with a border.
   // In order to work around this issue by *not* hiding overflow, we adjust the child elements
   // to fully cover the actual button element. This means that the border-radius would be correct
-  // then. See: https://github.com/angular/material2/issues/13738
+  // then. See: https://github.com/angular/components/issues/13738
   .mat-button-ripple.mat-ripple, .mat-button-focus-overlay {
     top: -$mat-stroked-button-border-width;
     left: -$mat-stroked-button-border-width;

--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -137,7 +137,7 @@ $mat-card-header-size: 40px !default;
 
 // This should normally also extend the `%mat-card-title-img`, but in order to avoid breaking
 // changes, we need to keep the horizontal margin reversion for now.
-// See: https://github.com/angular/material2/issues/12203
+// See: https://github.com/angular/components/issues/12203
 .mat-card-xl-image {
   width: 240px;
   height: 240px;

--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -18,7 +18,7 @@ let SUPPORTS_INTL_API: boolean;
 // cause IE to throw. These cases are tied to particular versions of Windows and can happen if
 // the consumer is providing a polyfilled `Map`. See:
 // https://github.com/Microsoft/ChakraCore/issues/3189
-// https://github.com/angular/material2/issues/15687
+// https://github.com/angular/components/issues/15687
 try {
   SUPPORTS_INTL_API = typeof Intl != 'undefined';
 } catch {

--- a/src/material/form-field/form-field-input.scss
+++ b/src/material/form-field/form-field-input.scss
@@ -92,7 +92,7 @@
 
     &:-ms-input-placeholder {
       // fix IE11 not able to focus programmatically with css style -ms-user-select: none
-      // see https://github.com/angular/material2/issues/15093
+      // see https://github.com/angular/components/issues/15093
       -ms-user-select: text;
     }
 
@@ -113,7 +113,7 @@
 
       // Overwrite browser specific CSS properties that can overwrite the `color` property.
       // Some developers seem to use this approach to easily overwrite the placeholder and
-      // label color. See: https://github.com/angular/material2/issues/12074
+      // label color. See: https://github.com/angular/components/issues/12074
       -webkit-text-fill-color: transparent;
 
       // Remove the transition to prevent the placeholder

--- a/src/material/form-field/form-field-legacy.scss
+++ b/src/material/form-field/form-field-legacy.scss
@@ -50,7 +50,7 @@ $mat-form-field-legacy-underline-height: 1px !default;
     height: $height;
 
     // In some browsers like Microsoft Edge, the `scaleX` transform causes overflow that exceeds
-    // the desired form-field ripple height. See: angular/material2#6351
+    // the desired form-field ripple height. See: angular/components#6351
     overflow: hidden;
 
     @include cdk-high-contrast {

--- a/src/material/form-field/form-field-outline.scss
+++ b/src/material/form-field/form-field-outline.scss
@@ -82,7 +82,7 @@ $mat-form-field-outline-subscript-padding:
 
   .mat-form-field-outline-gap {
     // hack for Chrome's treatment of borders with non-integer (scaled) widths
-    // refer to https://github.com/angular/material2/issues/10710
+    // refer to https://github.com/angular/components/issues/10710
     border-radius: 0.000001px;
 
     border: $mat-form-field-outline-width solid currentColor;

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -411,7 +411,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   onContainerClick() {
     // Do not re-focus the input element if the element is already focused. Otherwise it can happen
     // that someone clicks on a time input and the cursor resets to the "hours" field while the
-    // "minutes" field was actually clicked. See: https://github.com/angular/material2/issues/12849
+    // "minutes" field was actually clicked. See: https://github.com/angular/components/issues/12849
     if (!this.focused) {
       this.focus();
     }

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -8,7 +8,7 @@
   "typings": "./material.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/material2.git"
+    "url": "https://github.com/angular/components.git"
   },
   "keywords": [
     "angular",
@@ -18,9 +18,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/angular/material2/issues"
+    "url": "https://github.com/angular/components/issues"
   },
-  "homepage": "https://github.com/angular/material2#readme",
+  "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/animations": "0.0.0-NG",
     "@angular/cdk": "0.0.0-PLACEHOLDER",

--- a/src/material/progress-spinner/progress-spinner.scss
+++ b/src/material/progress-spinner/progress-spinner.scss
@@ -79,7 +79,7 @@ $_mat-progress-spinner-default-circumference: $pi * $_mat-progress-spinner-defau
     // .0001 percentage difference is necessary in order to avoid unwanted animation frames
     // for example because the animation duration is 4 seconds, .1% accounts to 4ms
     // which are enough to see the flicker described in
-    // https://github.com/angular/material2/issues/8984
+    // https://github.com/angular/components/issues/8984
     //
     // NOTE: this is replaced by js for any diameter other that 100
     0%      { stroke-dashoffset: $start;  transform: rotate(0); }

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -74,7 +74,7 @@ export function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinn
 // .0001 percentage difference is necessary in order to avoid unwanted animation frames
 // for example because the animation duration is 4 seconds, .1% accounts to 4ms
 // which are enough to see the flicker described in
-// https://github.com/angular/material2/issues/8984
+// https://github.com/angular/components/issues/8984
 const INDETERMINATE_ANIMATION_TEMPLATE = `
  @keyframes mat-progress-spinner-stroke-rotate-DIAMETER {
     0%      { stroke-dashoffset: START_VALUE;  transform: rotate(0); }

--- a/src/material/schematics/ng-add/theming/theming.ts
+++ b/src/material/schematics/ng-add/theming/theming.ts
@@ -157,7 +157,7 @@ function validateDefaultTargetBuilder(project: WorkspaceProject, targetName: 'bu
   // used. In case the builder has been changed for the "build" target, we throw an error and
   // exit because setting up a theme is a primary goal of `ng-add`. Otherwise if just the "test"
   // builder has been changed, we warn because a theme is not mandatory for running tests
-  // with Material. See: https://github.com/angular/material2/issues/14176
+  // with Material. See: https://github.com/angular/components/issues/14176
   if (!isDefaultBuilder && targetName === 'build') {
     throw new SchematicsException(`Your project is not using the default builders for ` +
       `"${targetName}". The Angular Material schematics cannot add a theme to the workspace ` +

--- a/src/material/schematics/ng-update/data/class-names.ts
+++ b/src/material/schematics/ng-update/data/class-names.ts
@@ -11,7 +11,7 @@ import {ClassNameUpgradeData, TargetVersion, VersionChanges} from '@angular/cdk/
 export const classNames: VersionChanges<ClassNameUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10291',
+      pr: 'https://github.com/angular/components/pull/10291',
       changes: [
         {
           replace: 'FloatPlaceholderType',

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -16,73 +16,73 @@ import {ConstructorChecksUpgradeData, TargetVersion, VersionChanges} from '@angu
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
   [TargetVersion.V8]: [
     {
-      pr: 'https://github.com/angular/material2/pull/15647',
+      pr: 'https://github.com/angular/components/pull/15647',
       changes: ['MatFormField', 'MatTabLink', 'MatVerticalStepper']
     },
     {
-      pr: 'https://github.com/angular/material2/pull/15757',
+      pr: 'https://github.com/angular/components/pull/15757',
       changes: ['MatBadge']
     },
     {
-      pr: 'https://github.com/angular/material2/issues/15734',
+      pr: 'https://github.com/angular/components/issues/15734',
       changes: ['MatButton', 'MatAnchor']
     },
     {
-      pr: 'https://github.com/angular/material2/pull/15761',
+      pr: 'https://github.com/angular/components/pull/15761',
       changes: ['MatSpinner', 'MatProgressSpinner']
     },
     {
-      pr: 'https://github.com/angular/material2/pull/15723',
+      pr: 'https://github.com/angular/components/pull/15723',
       changes: ['MatList', 'MatListItem']
     },
     {
-      pr: 'https://github.com/angular/material2/pull/15722',
+      pr: 'https://github.com/angular/components/pull/15722',
       changes: ['MatExpansionPanel']
     },
     {
-      pr: 'https://github.com/angular/material2/pull/15737',
+      pr: 'https://github.com/angular/components/pull/15737',
       changes: ['MatTabHeader', 'MatTabBody']
     },
     {
-      pr: 'https://github.com/angular/material2/pull/15806',
+      pr: 'https://github.com/angular/components/pull/15806',
       changes: ['MatSlideToggle']
     },
     {
-      pr: 'https://github.com/angular/material2/pull/15773',
+      pr: 'https://github.com/angular/components/pull/15773',
       changes: ['MatDrawerContainer']
     }
   ],
 
   [TargetVersion.V7]: [
     {
-      pr: 'https://github.com/angular/material2/pull/11706',
+      pr: 'https://github.com/angular/components/pull/11706',
       changes: ['MatDrawerContent'],
     },
     {
-      pr: 'https://github.com/angular/material2/pull/11706',
+      pr: 'https://github.com/angular/components/pull/11706',
       changes: ['MatSidenavContent']
     }
   ],
 
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/9190',
+      pr: 'https://github.com/angular/components/pull/9190',
       changes: ['NativeDateAdapter'],
     },
     {
-      pr: 'https://github.com/angular/material2/pull/10319',
+      pr: 'https://github.com/angular/components/pull/10319',
       changes: ['MatAutocomplete'],
     },
     {
-      pr: 'https://github.com/angular/material2/pull/10344',
+      pr: 'https://github.com/angular/components/pull/10344',
       changes: ['MatTooltip'],
     },
     {
-      pr: 'https://github.com/angular/material2/pull/10389',
+      pr: 'https://github.com/angular/components/pull/10389',
       changes: ['MatIconRegistry'],
     },
     {
-      pr: 'https://github.com/angular/material2/pull/9775',
+      pr: 'https://github.com/angular/components/pull/9775',
       changes: ['MatCalendar'],
     },
   ]

--- a/src/material/schematics/ng-update/data/css-selectors.ts
+++ b/src/material/schematics/ng-update/data/css-selectors.ts
@@ -27,7 +27,7 @@ export interface MaterialCssSelectorData {
 export const cssSelectors: VersionChanges<MaterialCssSelectorData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10296',
+      pr: 'https://github.com/angular/components/pull/10296',
       changes: [
         {
           replace: '.mat-form-field-placeholder',
@@ -95,7 +95,7 @@ export const cssSelectors: VersionChanges<MaterialCssSelectorData> = {
     // TODO(devversion): this shouldn't be here because it's not a CSS selector. Move into misc
     // rule.
     {
-      pr: 'https://github.com/angular/material2/pull/10430',
+      pr: 'https://github.com/angular/components/pull/10430',
       changes: [
         {
           replace: '$mat-font-family',

--- a/src/material/schematics/ng-update/data/element-selectors.ts
+++ b/src/material/schematics/ng-update/data/element-selectors.ts
@@ -11,7 +11,7 @@ import {ElementSelectorUpgradeData, TargetVersion, VersionChanges} from '@angula
 export const elementSelectors: VersionChanges<ElementSelectorUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10297',
+      pr: 'https://github.com/angular/components/pull/10297',
       changes: [
         {
           replace: 'mat-input-container',

--- a/src/material/schematics/ng-update/data/input-names.ts
+++ b/src/material/schematics/ng-update/data/input-names.ts
@@ -11,7 +11,7 @@ import {InputNameUpgradeData, TargetVersion, VersionChanges} from '@angular/cdk/
 export const inputNames: VersionChanges<InputNameUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10218',
+      pr: 'https://github.com/angular/components/pull/10218',
       changes: [
         {
           replace: 'align',
@@ -24,7 +24,7 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10279',
+      pr: 'https://github.com/angular/components/pull/10279',
       changes: [
         {
           replace: 'align',
@@ -37,7 +37,7 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10294',
+      pr: 'https://github.com/angular/components/pull/10294',
       changes: [
         {
           replace: 'dividerColor',
@@ -57,7 +57,7 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10309',
+      pr: 'https://github.com/angular/components/pull/10309',
       changes: [
         {
           replace: 'mat-dynamic-height',
@@ -70,7 +70,7 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10342',
+      pr: 'https://github.com/angular/components/pull/10342',
       changes: [
         {
           replace: 'align',
@@ -83,7 +83,7 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10344',
+      pr: 'https://github.com/angular/components/pull/10344',
       changes: [
         {
           replace: 'tooltip-position',
@@ -96,7 +96,7 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10373',
+      pr: 'https://github.com/angular/components/pull/10373',
       changes: [
         {
           replace: 'thumb-label',

--- a/src/material/schematics/ng-update/data/output-names.ts
+++ b/src/material/schematics/ng-update/data/output-names.ts
@@ -11,7 +11,7 @@ import {OutputNameUpgradeData, TargetVersion, VersionChanges} from '@angular/cdk
 export const outputNames: VersionChanges<OutputNameUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10163',
+      pr: 'https://github.com/angular/components/pull/10163',
       changes: [
         {
           replace: 'change',
@@ -38,7 +38,7 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10279',
+      pr: 'https://github.com/angular/components/pull/10279',
       changes: [
         {
           replace: 'align-changed',
@@ -65,7 +65,7 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10309',
+      pr: 'https://github.com/angular/components/pull/10309',
       changes: [
         {
           replace: 'selectChange',
@@ -78,7 +78,7 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10311',
+      pr: 'https://github.com/angular/components/pull/10311',
       changes: [
         {
           replace: 'remove',

--- a/src/material/schematics/ng-update/data/property-names.ts
+++ b/src/material/schematics/ng-update/data/property-names.ts
@@ -11,7 +11,7 @@ import {PropertyNameUpgradeData, TargetVersion, VersionChanges} from '@angular/c
 export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
   [TargetVersion.V6]: [
     {
-      pr: 'https://github.com/angular/material2/pull/10163',
+      pr: 'https://github.com/angular/components/pull/10163',
       changes: [
         {
           replace: 'change',
@@ -38,7 +38,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10218',
+      pr: 'https://github.com/angular/components/pull/10218',
       changes: [
         {
           replace: 'align',
@@ -51,7 +51,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10253',
+      pr: 'https://github.com/angular/components/pull/10253',
       changes: [
         {
           replace: 'extraClasses',
@@ -64,7 +64,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10279',
+      pr: 'https://github.com/angular/components/pull/10279',
       changes: [
         {
           replace: 'align',
@@ -98,7 +98,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10293',
+      pr: 'https://github.com/angular/components/pull/10293',
       changes: [
         {
           replace: 'shouldPlaceholderFloat',
@@ -111,7 +111,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10294',
+      pr: 'https://github.com/angular/components/pull/10294',
       changes: [
         {
           replace: 'dividerColor',
@@ -131,7 +131,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10309',
+      pr: 'https://github.com/angular/components/pull/10309',
       changes: [
         {
           replace: 'selectChange',
@@ -151,7 +151,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10311',
+      pr: 'https://github.com/angular/components/pull/10311',
       changes: [
         {
           replace: 'destroy',
@@ -171,7 +171,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10342',
+      pr: 'https://github.com/angular/components/pull/10342',
       changes: [
         {
           replace: 'align',
@@ -184,7 +184,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10344',
+      pr: 'https://github.com/angular/components/pull/10344',
       changes: [
         {
           replace: '_positionDeprecated',
@@ -197,7 +197,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     },
 
     {
-      pr: 'https://github.com/angular/material2/pull/10373',
+      pr: 'https://github.com/angular/components/pull/10373',
       changes: [
         {
           replace: '_thumbLabelDeprecated',

--- a/src/material/schematics/ng-update/upgrade-rules/misc-checks/checkImportsMiscRule.ts
+++ b/src/material/schematics/ng-update/upgrade-rules/misc-checks/checkImportsMiscRule.ts
@@ -39,7 +39,7 @@ export class Walker extends ProgramAwareRuleWalker {
 
   /**
    * Checks for named imports that refer to the deleted animation constants.
-   * https://github.com/angular/material2/commit/9f3bf274c4f15f0b0fbd8ab7dbf1a453076e66d9
+   * https://github.com/angular/components/commit/9f3bf274c4f15f0b0fbd8ab7dbf1a453076e66d9
    */
   private _checkAnimationConstants(namedImports: ts.NamedImports) {
     namedImports.elements.filter(element => ts.isIdentifier(element.name)).forEach(element => {

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -389,7 +389,7 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     // Don't use `translate3d` here because we don't want to create a new layer. A new layer
     // seems to cause flickering and overflow in Internet Explorer. For example, the ink bar
     // and ripples will exceed the boundaries of the visible tab bar.
-    // See: https://github.com/angular/material2/issues/10276
+    // See: https://github.com/angular/components/issues/10276
     // We round the `transform` here, because transforms with sub-pixel precision cause some
     // browsers to blur the content of the element.
     this._tabList.nativeElement.style.transform = `translateX(${Math.round(translateX)}px)`;

--- a/tools/release/publish-release.ts
+++ b/tools/release/publish-release.ts
@@ -311,6 +311,6 @@ class PublishReleaseTask extends BaseReleaseTask {
 
 /** Entry-point for the create release script. */
 if (require.main === module) {
-  new PublishReleaseTask(join(__dirname, '../../'), 'angular', 'material2').run();
+  new PublishReleaseTask(join(__dirname, '../../'), 'angular', 'components').run();
 }
 

--- a/tools/release/release-output/output-validations.ts
+++ b/tools/release/release-output/output-validations.ts
@@ -32,7 +32,7 @@ export function checkReleaseBundle(bundlePath: string): string[] {
  * Checks the specified TypeScript definition file by ensuring it does not contain invalid
  * dynamic import statements. There can be invalid type imports paths because we compose the
  * release package by moving things in a desired output structure. See Angular package format
- * specification and https://github.com/angular/material2/pull/12876
+ * specification and https://github.com/angular/components/pull/12876
  */
 export function checkTypeDefinitionFile(filePath: string): string[] {
   const baseDir = dirname(filePath);

--- a/tools/release/stage-release.ts
+++ b/tools/release/stage-release.ts
@@ -164,6 +164,6 @@ class StageReleaseTask extends BaseReleaseTask {
 
 /** Entry-point for the release staging script. */
 if (require.main === module) {
-  new StageReleaseTask(join(__dirname, '../../'), 'angular', 'material2').run();
+  new StageReleaseTask(join(__dirname, '../../'), 'angular', 'components').run();
 }
 


### PR DESCRIPTION
This should capture things that reference the GitHub repository.
There are many other places we use "material2" that we can clean up in
subsequent changes.