### PR TITLE
refactor(popover-edit): remove KeyboardEvent.key usage

### DIFF
--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -1,5 +1,5 @@
 import {DataSource} from '@angular/cdk/collections';
-import {LEFT_ARROW, UP_ARROW, RIGHT_ARROW, DOWN_ARROW, TAB} from '@angular/cdk/keycodes';
+import {LEFT_ARROW, UP_ARROW, RIGHT_ARROW, DOWN_ARROW, TAB, ENTER} from '@angular/cdk/keycodes';
 import {CdkTableModule} from '@angular/cdk/table';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {CommonModule} from '@angular/common';
@@ -118,8 +118,11 @@ abstract class BaseTestComponent {
 
   openLens(rowIndex = 0, cellIndex = 1) {
     this.focusEditCell(rowIndex, cellIndex);
-    this.getEditCell(rowIndex, cellIndex)
-        .dispatchEvent(new KeyboardEvent('keyup', {bubbles: true, key: 'Enter'}));
+    this.getEditCell(rowIndex, cellIndex).dispatchEvent(new KeyboardEvent('keyup', {
+      // Cast to `any`, because `keyCode` is a valid parameter that isn't in the TS typings.
+      bubbles: true,
+      keyCode: ENTER
+    } as any));
     flush();
   }
 
@@ -465,7 +468,7 @@ describe('CDK Popover Edit', () => {
           clearLeftoverTimers();
         }));
 
-        it('opens edit from Enter on focued cell', fakeAsync(() => {
+        it('opens edit from Enter on focused cell', fakeAsync(() => {
           // Uses Enter to open the lens.
           component.openLens();
 

--- a/src/cdk-experimental/popover-edit/table-directives.ts
+++ b/src/cdk-experimental/popover-edit/table-directives.ts
@@ -19,6 +19,7 @@ import {
   ViewContainerRef,
   HostListener,
 } from '@angular/core';
+import {ENTER} from '@angular/cdk/keycodes';
 import {fromEvent, fromEventPattern, merge, ReplaySubject} from 'rxjs';
 import {
   filter,
@@ -85,7 +86,7 @@ export class CdkEditable implements AfterViewInit, OnDestroy {
     const element = this.elementRef.nativeElement!;
 
     const toClosest = (selector: string) =>
-        map((event: UIEvent) => closest(event.target, selector));
+        map((event: Event) => closest(event.target, selector));
 
     this.ngZone.runOutsideAngular(() => {
       // Track mouse movement over the table to hide/show hover content.
@@ -136,7 +137,7 @@ export class CdkEditable implements AfterViewInit, OnDestroy {
 
       fromEvent<KeyboardEvent>(element, 'keyup').pipe(
           takeUntil(this.destroyed),
-          filter(event => event.key === 'Enter'),
+          filter(event => event.keyCode === ENTER),
           toClosest(CELL_SELECTOR),
           ).subscribe(this.editEventDispatcher.editing);
 

--- a/src/material-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/material-experimental/popover-edit/popover-edit.spec.ts
@@ -1,5 +1,5 @@
 import {DataSource} from '@angular/cdk/collections';
-import {LEFT_ARROW, UP_ARROW, RIGHT_ARROW, DOWN_ARROW, TAB} from '@angular/cdk/keycodes';
+import {LEFT_ARROW, UP_ARROW, RIGHT_ARROW, DOWN_ARROW, TAB, ENTER} from '@angular/cdk/keycodes';
 import {MatTableModule} from '@angular/material/table';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing';
 import {CommonModule} from '@angular/common';
@@ -116,8 +116,11 @@ abstract class BaseTestComponent {
 
   openLens(rowIndex = 0, cellIndex = 1) {
     this.focusEditCell(rowIndex, cellIndex);
-    this.getEditCell(rowIndex, cellIndex)
-        .dispatchEvent(new KeyboardEvent('keyup', {bubbles: true, key: 'Enter'}));
+    this.getEditCell(rowIndex, cellIndex).dispatchEvent(new KeyboardEvent('keyup', {
+      // Cast to `any`, because `keyCode` is a valid parameter that isn't in the TS typings.
+      bubbles: true,
+      keyCode: ENTER
+    } as any));
     flush();
   }
 
@@ -402,7 +405,7 @@ describe('Material Popover Edit', () => {
           clearLeftoverTimers();
         }));
 
-        it('opens edit from Enter on focued cell', fakeAsync(() => {
+        it('opens edit from Enter on focused cell', fakeAsync(() => {
           // Uses Enter to open the lens.
           component.openLens();
 


### PR DESCRIPTION
Replaces the use of `KeyboardEvent.key` with `keyCode` for consistency with the rest of the codebase.

cc @kseamon 