### PR TITLE
build: dev app not being updated when mdc theme files are changed

### DIFF
--- a/tools/gulp/tasks/development.ts
+++ b/tools/gulp/tasks/development.ts
@@ -146,10 +146,14 @@ task(':watch:devapp', () => {
 
   // Material package watchers.
   watchFilesAndReload([
-    join(materialPackage.sourceDir, '**/!(*-theme.scss)'), `!${materialCoreThemingGlob}`
+    join(materialPackage.sourceDir, '**/!(*-theme.scss)'),
+    join(materialExperimentalPackage.sourceDir, '**/!(*_mdc-*.scss)'),
+    `!${materialCoreThemingGlob}`
   ], ['material:build-no-bundles']);
   watchFilesAndReload([
-    join(materialPackage.sourceDir, '**/*-theme.scss'), materialCoreThemingGlob
+    join(materialPackage.sourceDir, '**/*-theme.scss'),
+    join(materialExperimentalPackage.sourceDir, '**/*_mdc-*.scss'),
+    materialCoreThemingGlob
   ], [':build:devapp:scss']);
 
   // Moment adapter package watchers


### PR DESCRIPTION
Fixes the dev app's CSS not being rebuilt when the MDC theme files are changed.