### PR TITLE
fix(drag-n-drop): ignore consecutive touchmove events on drag item on multitouch

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -3233,6 +3233,60 @@ describe('CdkDrag', () => {
                  'Expected target to have dragging class once item has been moved over.');
        }));
   });
+
+  describe('with nested drags', () => {
+    it('should not move draggable container when dragging child (multitouch)', fakeAsync(() => {
+
+      const fixture = createComponent(NestedDragsComponent, [], 10);
+      fixture.detectChanges();
+
+      // First finger drags container (less then threshold)
+      startDraggingViaTouch(fixture, fixture.componentInstance.container.nativeElement);
+      continueDraggingViaTouch(fixture, 2, 0);
+
+      // Second finger drags container
+      startDraggingViaTouch(fixture, fixture.componentInstance.container.nativeElement);
+      continueDraggingViaTouch(fixture, 0, 10);
+      continueDraggingViaTouch(fixture, 0, 20);
+
+      // First finger releases
+      endDraggingViaTouch(fixture, 0, 20);
+      // Second finger releases
+      endDraggingViaTouch(fixture, 0, 10);
+
+      // Container spies worked
+      const containerDragStartedCount =
+          fixture.componentInstance.containerDragStartedSpy.calls.count();
+      const containerDragMovedCount =
+          fixture.componentInstance.containerDragMovedSpy.calls.count();
+      const containerDragReleasedCount =
+          fixture.componentInstance.containerDragReleasedSpy.calls.count();
+
+      expect(containerDragStartedCount).toBeGreaterThan(0);
+      expect(containerDragMovedCount).toBeGreaterThan(0);
+      expect(containerDragReleasedCount).toBeGreaterThan(0);
+
+      // Drag item
+      startDraggingViaTouch(fixture, fixture.componentInstance.item.nativeElement);
+      continueDraggingViaTouch(fixture, 20, 20);
+      continueDraggingViaTouch(fixture, 40, 40);
+      endDraggingViaTouch(fixture, 60, 60);
+
+      // Spies on item worked
+      expect(fixture.componentInstance.itemDragStartedSpy).toHaveBeenCalledTimes(1);
+      expect(fixture.componentInstance.itemDragMovedSpy).toHaveBeenCalledTimes(1);
+      expect(fixture.componentInstance.itemDragReleasedSpy).toHaveBeenCalledTimes(1);
+
+      // Spies on container stay intact
+      expect(fixture.componentInstance.containerDragStartedSpy)
+          .toHaveBeenCalledTimes(containerDragStartedCount);
+      expect(fixture.componentInstance.containerDragMovedSpy)
+          .toHaveBeenCalledTimes(containerDragMovedCount);
+      expect(fixture.componentInstance.containerDragReleasedSpy)
+          .toHaveBeenCalledTimes(containerDragReleasedCount);
+
+    }));
+  });
 });
 
 @Component({
@@ -3771,6 +3825,43 @@ class WrappedDropContainerComponent {
   @Input() items: string[];
 }
 
+@Component({
+  template: `
+    <div style="position: absolute; width: 400px; height: 400px; overflow: hidden;">
+      <div
+        cdkDrag
+        #container
+        class="container"
+        style="position: absolute; width: 200px; height: 200px; overflow: hidden;"
+        (cdkDragStarted)="containerDragStartedSpy($event)"
+        (cdkDragMoved)="containerDragMovedSpy($event)"
+        (cdkDragReleased)="containerDragReleasedSpy($event)"
+      >
+        <div
+          cdkDrag
+          class="item"
+          #item
+          style="position: absolute; width: 50px; height: 50px; overflow: hidden;"
+          (cdkDragStarted)="itemDragStartedSpy($event)"
+          (cdkDragMoved)="itemDragMovedSpy($event)"
+          (cdkDragReleased)="itemDragReleasedSpy($event)"
+        >
+        </div>
+      </div>
+    </div>`
+})
+class NestedDragsComponent {
+  @ViewChild('container', {static: false}) container: ElementRef;
+  @ViewChild('item', {static: false}) item: ElementRef;
+
+  containerDragStartedSpy = jasmine.createSpy('container drag started spy');
+  containerDragMovedSpy = jasmine.createSpy('container drag moved spy');
+  containerDragReleasedSpy = jasmine.createSpy('container drag released spy');
+  itemDragStartedSpy = jasmine.createSpy('item drag started spy');
+  itemDragMovedSpy = jasmine.createSpy('item drag moved spy');
+  itemDragReleasedSpy = jasmine.createSpy('item drag released spy');
+}
+
 /**
  * Drags an element to a position on the page using the mouse.
  * @param fixture Fixture on which to run change detection.
@@ -3815,16 +3906,40 @@ function startDraggingViaMouse(fixture: ComponentFixture<any>,
  */
 function dragElementViaTouch(fixture: ComponentFixture<any>,
     element: Element, x: number, y: number) {
+  startDraggingViaTouch(fixture, element);
+  continueDraggingViaTouch(fixture, x, y);
+  endDraggingViaTouch(fixture, x, y);
+}
 
+/**
+ * @param fixture Fixture on which to run change detection.
+ * @param element Element which is being dragged.
+ */
+function startDraggingViaTouch(fixture: ComponentFixture<any>,
+    element: Element) {
   dispatchTouchEvent(element, 'touchstart');
   fixture.detectChanges();
 
   dispatchTouchEvent(document, 'touchmove');
   fixture.detectChanges();
+}
 
+/**
+ * @param fixture Fixture on which to run change detection.
+ * @param x Position along the x axis to which to drag the element.
+ * @param y Position along the y axis to which to drag the element.
+ */
+function continueDraggingViaTouch(fixture: ComponentFixture<any>, x: number, y: number) {
   dispatchTouchEvent(document, 'touchmove', x, y);
   fixture.detectChanges();
+}
 
+/**
+ * @param fixture Fixture on which to run change detection.
+ * @param x Position along the x axis to which to drag the element.
+ * @param y Position along the y axis to which to drag the element.
+ */
+function endDraggingViaTouch(fixture: ComponentFixture<any>, x: number, y: number) {
   dispatchTouchEvent(document, 'touchend', x, y);
   fixture.detectChanges();
 }

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -3250,9 +3250,9 @@ describe('CdkDrag', () => {
       continueDraggingViaTouch(fixture, 0, 20);
 
       // First finger releases
-      endDraggingViaTouch(fixture, 0, 20);
+      stopDraggingViaTouch(fixture, 0, 20);
       // Second finger releases
-      endDraggingViaTouch(fixture, 0, 10);
+      stopDraggingViaTouch(fixture, 0, 10);
 
       // Container spies worked
       const containerDragStartedCount =
@@ -3270,7 +3270,7 @@ describe('CdkDrag', () => {
       startDraggingViaTouch(fixture, fixture.componentInstance.item.nativeElement);
       continueDraggingViaTouch(fixture, 20, 20);
       continueDraggingViaTouch(fixture, 40, 40);
-      endDraggingViaTouch(fixture, 60, 60);
+      stopDraggingViaTouch(fixture, 60, 60);
 
       // Spies on item worked
       expect(fixture.componentInstance.itemDragStartedSpy).toHaveBeenCalledTimes(1);
@@ -3826,27 +3826,40 @@ class WrappedDropContainerComponent {
 }
 
 @Component({
+  styles: [`
+    :host {
+      height: 400px;
+      width: 400px;
+      position: absolute;
+    }
+    .container {
+      height: 200px;
+      width: 200px;
+      position: absolute;
+    }
+    .item {
+      height: 50px;
+      width: 50px;
+      position: absolute;
+    }
+  `],
   template: `
-    <div style="position: absolute; width: 400px; height: 400px; overflow: hidden;">
+    <div
+      cdkDrag
+      #container
+      class="container"
+      (cdkDragStarted)="containerDragStartedSpy($event)"
+      (cdkDragMoved)="containerDragMovedSpy($event)"
+      (cdkDragReleased)="containerDragReleasedSpy($event)"
+    >
       <div
         cdkDrag
-        #container
-        class="container"
-        style="position: absolute; width: 200px; height: 200px; overflow: hidden;"
-        (cdkDragStarted)="containerDragStartedSpy($event)"
-        (cdkDragMoved)="containerDragMovedSpy($event)"
-        (cdkDragReleased)="containerDragReleasedSpy($event)"
+        class="item"
+        #item
+        (cdkDragStarted)="itemDragStartedSpy($event)"
+        (cdkDragMoved)="itemDragMovedSpy($event)"
+        (cdkDragReleased)="itemDragReleasedSpy($event)"
       >
-        <div
-          cdkDrag
-          class="item"
-          #item
-          style="position: absolute; width: 50px; height: 50px; overflow: hidden;"
-          (cdkDragStarted)="itemDragStartedSpy($event)"
-          (cdkDragMoved)="itemDragMovedSpy($event)"
-          (cdkDragReleased)="itemDragReleasedSpy($event)"
-        >
-        </div>
       </div>
     </div>`
 })
@@ -3908,7 +3921,7 @@ function dragElementViaTouch(fixture: ComponentFixture<any>,
     element: Element, x: number, y: number) {
   startDraggingViaTouch(fixture, element);
   continueDraggingViaTouch(fixture, x, y);
-  endDraggingViaTouch(fixture, x, y);
+  stopDraggingViaTouch(fixture, x, y);
 }
 
 /**
@@ -3939,7 +3952,7 @@ function continueDraggingViaTouch(fixture: ComponentFixture<any>, x: number, y: 
  * @param x Position along the x axis to which to drag the element.
  * @param y Position along the y axis to which to drag the element.
  */
-function endDraggingViaTouch(fixture: ComponentFixture<any>, x: number, y: number) {
+function stopDraggingViaTouch(fixture: ComponentFixture<any>, x: number, y: number) {
   dispatchTouchEvent(document, 'touchend', x, y);
   fixture.detectChanges();
 }

--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -156,6 +156,39 @@ describe('DragDropRegistry', () => {
     pointerMoveSubscription.unsubscribe();
   });
 
+  it('should not emit pointer events on item when drag is over (mutli touch)', () => {
+    const firstItem = testComponent.dragItems.first;
+
+    // First finger down
+    registry.startDragging(firstItem, createTouchEvent('touchstart') as TouchEvent);
+    // Second finger down
+    registry.startDragging(firstItem, createTouchEvent('touchstart') as TouchEvent);
+    // First finger up
+    registry.stopDragging(firstItem);
+
+    // Ensure drag is over - registry is empty
+    expect(registry.isDragging(firstItem)).toBe(false);
+
+    const pointerUpSpy = jasmine.createSpy('pointerUp spy');
+    const pointerMoveSpy = jasmine.createSpy('pointerMove spy');
+
+    const pointerUpSubscription = registry.pointerUp.subscribe(pointerUpSpy);
+    const pointerMoveSubscription = registry.pointerMove.subscribe(pointerMoveSpy);
+
+    // Second finger keeps moving
+    dispatchTouchEvent(document, 'touchmove');
+    expect(pointerMoveSpy).not.toHaveBeenCalled();
+
+    // Second finger up
+    dispatchTouchEvent(document, 'touchend');
+    expect(pointerUpSpy).not.toHaveBeenCalled();
+
+    pointerUpSubscription.unsubscribe();
+    pointerMoveSubscription.unsubscribe();
+
+    registry.ngOnDestroy();
+  });
+
   it('should not throw when trying to register the same container again', () => {
     expect(() => registry.registerDropContainer(testComponent.dropInstances.first)).not.toThrow();
   });

--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -156,7 +156,7 @@ describe('DragDropRegistry', () => {
     pointerMoveSubscription.unsubscribe();
   });
 
-  it('should not emit pointer events on item when drag is over (mutli touch)', () => {
+  it('should not emit pointer events when dragging is over (mutli touch)', () => {
     const firstItem = testComponent.dragItems.first;
 
     // First finger down
@@ -166,7 +166,7 @@ describe('DragDropRegistry', () => {
     // First finger up
     registry.stopDragging(firstItem);
 
-    // Ensure drag is over - registry is empty
+    // Ensure dragging is over - registry is empty
     expect(registry.isDragging(firstItem)).toBe(false);
 
     const pointerUpSpy = jasmine.createSpy('pointerUp spy');
@@ -185,8 +185,6 @@ describe('DragDropRegistry', () => {
 
     pointerUpSubscription.unsubscribe();
     pointerMoveSubscription.unsubscribe();
-
-    registry.ngOnDestroy();
   });
 
   it('should not throw when trying to register the same container again', () => {

--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -112,6 +112,10 @@ export class DragDropRegistry<I, C extends {id: string}> implements OnDestroy {
    * @param event Event that initiated the dragging.
    */
   startDragging(drag: I, event: TouchEvent | MouseEvent) {
+    if (this._activeDragInstances.has(drag)) {
+      return;
+    }
+
     this._activeDragInstances.add(drag);
 
     if (this._activeDragInstances.size === 1) {

--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -112,6 +112,7 @@ export class DragDropRegistry<I, C extends {id: string}> implements OnDestroy {
    * @param event Event that initiated the dragging.
    */
   startDragging(drag: I, event: TouchEvent | MouseEvent) {
+    // Do not process the same drag twice to avoid memory leaks and redundant listeners
     if (this._activeDragInstances.has(drag)) {
       return;
     }

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -689,8 +689,13 @@ export class DragRef<T = any> {
     this._toggleNativeDragInteractions();
     this._hasStartedDragging = this._hasMoved = false;
     this._initialContainer = this._dropContainer!;
+
+    // Avoid multiple subscriptions and memory leaks when multi touch
+    // (isDragging check above isn't enough because of possible temporal and/or dimensional delays)
+    this._removeSubscriptions();
     this._pointerMoveSubscription = this._dragDropRegistry.pointerMove.subscribe(this._pointerMove);
     this._pointerUpSubscription = this._dragDropRegistry.pointerUp.subscribe(this._pointerUp);
+
     this._scrollPosition = this._viewportRuler.getViewportScrollPosition();
 
     if (this._boundaryElement) {


### PR DESCRIPTION
Bumped into an inconsistent behaviour on multitouch. Currently the DragDropRegistry is designed atop of Set, and assumes there could be only one pointer active on item. Which is not true for multitouch devices.  

So there’re two ways to fix it:
1. Teach DragDropRegistry to respect multiple simultaneous pointers on one item.
2. Stick to Set as designed initially, respect only the first pointer on item, and properly ignore all consecutive pointers.

The first way looks much more promising, but requires much more effort and requires attention of core team, I suppose. The second one is not that flexible, but is still more consistent than the current implementation. So this commit implements the second way.