### PR TITLE
refactor(drag-drop): add current index to entered event

### DIFF
--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -355,7 +355,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     ref.entered.subscribe(event => {
       this.entered.emit({
         container: event.container.data,
-        item: this
+        item: this,
+        currentIndex: event.currentIndex
       });
     });
 

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -313,7 +313,8 @@ export class CdkDropList<T = any> implements CdkDropListContainer, AfterContentI
     ref.entered.subscribe(event => {
       this.entered.emit({
         container: this,
-        item: event.item.data
+        item: event.item.data,
+        currentIndex: event.currentIndex
       });
     });
 

--- a/src/cdk/drag-drop/drag-events.ts
+++ b/src/cdk/drag-drop/drag-events.ts
@@ -33,6 +33,8 @@ export interface CdkDragEnter<T = any, I = T> {
   container: CdkDropList<T>;
   /** Item that was removed from the container. */
   item: CdkDrag<I>;
+  /** Index at which the item has entered the container. */
+  currentIndex: number;
 }
 
 /**

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -236,7 +236,7 @@ export class DragRef<T = any> {
   ended = new Subject<{source: DragRef}>();
 
   /** Emits when the user has moved the item into a new container. */
-  entered = new Subject<{container: DropListRef, item: DragRef}>();
+  entered = new Subject<{container: DropListRef, item: DragRef, currentIndex: number}>();
 
   /** Emits when the user removes the item its container by dragging it into another container. */
   exited = new Subject<{container: DropListRef, item: DragRef}>();
@@ -772,9 +772,13 @@ export class DragRef<T = any> {
         this.exited.next({item: this, container: this._dropContainer!});
         this._dropContainer!.exit(this);
         // Notify the new container that the item has entered.
-        this.entered.next({item: this, container: newContainer!});
         this._dropContainer = newContainer!;
         this._dropContainer.enter(this, x, y);
+        this.entered.next({
+          item: this,
+          container: newContainer!,
+          currentIndex: newContainer!.getItemIndex(this)
+        });
       });
     }
 

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -81,7 +81,7 @@ export class DropListRef<T = any> {
   /**
    * Emits when the user has moved a new drag item into this container.
    */
-  entered = new Subject<{item: DragRef, container: DropListRef}>();
+  entered = new Subject<{item: DragRef, container: DropListRef, currentIndex: number}>();
 
   /**
    * Emits when the user removes an item from the container
@@ -189,7 +189,6 @@ export class DropListRef<T = any> {
    * @param pointerY Position of the item along the Y axis.
    */
   enter(item: DragRef, pointerX: number, pointerY: number): void {
-    this.entered.next({item, container: this});
     this.start();
 
     // If sorting is disabled, we want the item to return to its starting
@@ -237,6 +236,7 @@ export class DropListRef<T = any> {
     // Note that the positions were already cached when we called `start` above,
     // but we need to refresh them since the amount of items has changed.
     this._cacheItemPositions();
+    this.entered.next({item, container: this, currentIndex: this.getItemIndex(item)});
   }
 
   /**

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -64,6 +64,7 @@ export interface CdkDragEnd<T = any> {
 
 export interface CdkDragEnter<T = any, I = T> {
     container: CdkDropList<T>;
+    currentIndex: number;
     item: CdkDrag<I>;
 }
 
@@ -229,6 +230,7 @@ export declare class DragRef<T = any> {
     entered: Subject<{
         container: DropListRef;
         item: DragRef<any>;
+        currentIndex: number;
     }>;
     exited: Subject<{
         container: DropListRef;
@@ -294,6 +296,7 @@ export declare class DropListRef<T = any> {
     entered: Subject<{
         item: DragRef;
         container: DropListRef<any>;
+        currentIndex: number;
     }>;
     exited: Subject<{
         item: DragRef;


### PR DESCRIPTION
Adds the index at which the item entered a new container to the `entered` events.

Fixes #15924.