### PR TITLE
refactor(popover-edit): remove unnecessary components

### DIFF
--- a/src/cdk-experimental/popover-edit/popover-edit-module.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit-module.ts
@@ -13,8 +13,7 @@ import {
   CdkPopoverEditTabOut,
   CdkRowHoverContent,
   CdkEditable,
-  CdkEditOpen,
-  CdkEditOpenButton
+  CdkEditOpen
 } from './table-directives';
 import {CdkEditControl,
   CdkEditRevert,
@@ -34,7 +33,6 @@ const EXPORTED_DECLARATIONS = [
   CdkEditClose,
   CdkEditable,
   CdkEditOpen,
-  CdkEditOpenButton,
 ];
 
 @NgModule({

--- a/src/cdk-experimental/popover-edit/table-directives.ts
+++ b/src/cdk-experimental/popover-edit/table-directives.ts
@@ -391,33 +391,24 @@ export class CdkRowHoverContent implements AfterViewInit, OnDestroy {
  * element or an ancestor element.
  */
 @Directive({
-  // Specify :not(button) as we only need to add type: button on actual buttons.
-  selector: '[cdkEditOpen]:not(button)',
-  host: {
-    '(click)': 'openEdit($event)',
-  }
+  selector: '[cdkEditOpen]',
+  host: {'(click)': 'openEdit($event)'}
 })
 export class CdkEditOpen {
   constructor(
-      protected readonly elementRef: ElementRef,
-      protected readonly editEventDispatcher: EditEventDispatcher) {}
+      protected readonly elementRef: ElementRef<HTMLElement>,
+      protected readonly editEventDispatcher: EditEventDispatcher) {
+
+    const nativeElement = elementRef.nativeElement;
+
+    // Prevent accidental form submits.
+    if (nativeElement.nodeName === 'BUTTON' && !nativeElement.getAttribute('type')) {
+      nativeElement.setAttribute('type', 'button');
+    }
+  }
 
   openEdit(evt: Event): void {
     this.editEventDispatcher.editing.next(closest(this.elementRef.nativeElement!, CELL_SELECTOR));
     evt.stopPropagation();
   }
 }
-
-/**
- * Opens the closest edit popover to this element, whether it's associated with this exact
- * element or an ancestor element.
- */
-@Directive({
-  // Specify button as we only need to add type: button on actual buttons.
-  selector: 'button[cdkEditOpen]',
-  host: {
-    '(click)': 'openEdit($event)',
-    'type': 'button', // Prevents accidental form submits.
-  }
-})
-export class CdkEditOpenButton extends CdkEditOpen {}

--- a/src/material-experimental/popover-edit/popover-edit-module.ts
+++ b/src/material-experimental/popover-edit/popover-edit-module.ts
@@ -13,8 +13,7 @@ import {
   MatPopoverEdit,
   MatPopoverEditTabOut,
   MatRowHoverContent,
-  MatEditOpen,
-  MatEditOpenButton
+  MatEditOpen
 } from './table-directives';
 import {
   MatEditLens,
@@ -29,8 +28,7 @@ const EXPORTED_DECLARATIONS = [
   MatEditLens,
   MatEditRevert,
   MatEditClose,
-  MatEditOpen,
-  MatEditOpenButton,
+  MatEditOpen
 ];
 
 @NgModule({

--- a/src/material-experimental/popover-edit/table-directives.ts
+++ b/src/material-experimental/popover-edit/table-directives.ts
@@ -10,8 +10,7 @@ import {
   CdkPopoverEdit,
   CdkPopoverEditTabOut,
   CdkRowHoverContent,
-  CdkEditOpen,
-  CdkEditOpenButton,
+  CdkEditOpen
 } from '@angular/cdk-experimental/popover-edit';
 
 const POPOVER_EDIT_HOST_BINDINGS = {
@@ -107,25 +106,8 @@ export class MatRowHoverContent extends CdkRowHoverContent {
  * element or an ancestor element.
  */
 @Directive({
-  // Specify :not(button) as we only need to add type: button on actual buttons.
-  selector: '[matEditOpen]:not(button)',
-  host: {
-    '(click)': 'openEdit($event)',
-  }
+  selector: '[matEditOpen]',
+  host: {'(click)': 'openEdit($event)'}
 })
 export class MatEditOpen extends CdkEditOpen {
 }
-
-/**
- * Opens the closest edit popover to this element, whether it's associated with this exact
- * element or an ancestor element.
- */
-@Directive({
-  // Specify button as we only need to add type: button on actual buttons.
-  selector: 'button[matEditOpen]',
-  host: {
-    '(click)': 'openEdit($event)',
-    'type': 'button', // Prevents accidental form submits.
-  }
-})
-export class MatEditOpenButton extends CdkEditOpenButton {}


### PR DESCRIPTION
Removes a couple of components that are only being used to add a single attribute and are causing a bunch of extra generated code to be added. They aren't really necessary because we can do the same with a few extra lines.

cc @kseamon 