### PR TITLE
docs(table): TableExpandableRowsExample

### DIFF
--- a/src/material-examples/table-expandable-rows/table-expandable-rows-example.ts
+++ b/src/material-examples/table-expandable-rows/table-expandable-rows-example.ts
@@ -10,7 +10,7 @@ import {animate, state, style, transition, trigger} from '@angular/animations';
   templateUrl: 'table-expandable-rows-example.html',
   animations: [
     trigger('detailExpand', [
-      state('collapsed', style({height: '0px', minHeight: '0', display: 'none'})),
+      state('collapsed', style({height: '0px', minHeight: '0'})),
       state('expanded', style({height: '*'})),
       transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
     ]),


### PR DESCRIPTION
Fix TableExpandableRowsExample for iOS and Edge by removing unnecessary styling rule

Fixes #15596 