### PR TITLE
fix(breakpoint-observer): fix the breakpoint observer emit count and accuracy

### DIFF
--- a/src/cdk/layout/breakpoints-observer.spec.ts
+++ b/src/cdk/layout/breakpoints-observer.spec.ts
@@ -9,10 +9,10 @@
 import {LayoutModule} from './layout-module';
 import {BreakpointObserver, BreakpointState} from './breakpoints-observer';
 import {MediaMatcher} from './media-matcher';
-import {fakeAsync, TestBed, inject, flush} from '@angular/core/testing';
+import {fakeAsync, TestBed, inject, flush, tick} from '@angular/core/testing';
 import {Injectable} from '@angular/core';
 import {Subscription} from 'rxjs';
-import {take} from 'rxjs/operators';
+import {skip, take} from 'rxjs/operators';
 
 describe('BreakpointObserver', () => {
   let breakpointObserver: BreakpointObserver;
@@ -93,10 +93,10 @@ describe('BreakpointObserver', () => {
       queryMatchState = state.matches;
     });
 
-    flush();
+    tick();
     expect(queryMatchState).toBeTruthy();
     mediaMatcher.setMatchesQuery(query, false);
-    flush();
+    tick();
     expect(queryMatchState).toBeFalsy();
   }));
 
@@ -108,15 +108,16 @@ describe('BreakpointObserver', () => {
       breakpointObserver.observe([queryOne, queryTwo]).subscribe((breakpoint: BreakpointState) => {
         state = breakpoint;
       });
+      expect(state.breakpoints).toEqual({[queryOne]: true, [queryTwo]: true});
 
       mediaMatcher.setMatchesQuery(queryOne, false);
       mediaMatcher.setMatchesQuery(queryTwo, false);
-      flush();
+      tick();
       expect(state.breakpoints).toEqual({[queryOne]: false, [queryTwo]: false});
 
       mediaMatcher.setMatchesQuery(queryOne, true);
       mediaMatcher.setMatchesQuery(queryTwo, false);
-      flush();
+      tick();
       expect(state.breakpoints).toEqual({[queryOne]: true, [queryTwo]: false});
   }));
 
@@ -124,6 +125,7 @@ describe('BreakpointObserver', () => {
     const query = '(width: 999px)';
     breakpointObserver.observe(query).subscribe();
     mediaMatcher.setMatchesQuery(query, true);
+    tick();
     expect(breakpointObserver.isMatched(query)).toBeTruthy();
   }));
 
@@ -131,13 +133,29 @@ describe('BreakpointObserver', () => {
     const query = '(width: 999px)';
     breakpointObserver.observe(query).subscribe();
     mediaMatcher.setMatchesQuery(query, false);
+    tick();
     expect(breakpointObserver.isMatched(query)).toBeFalsy();
+  }));
+
+  it('emits one event when multiple queries change', fakeAsync(() => {
+    const observer = jasmine.createSpy('observer');
+    const queryOne = '(width: 700px)';
+    const queryTwo = '(width: 999px)';
+    breakpointObserver.observe([queryOne, queryTwo])
+      .pipe(skip(1))
+      .subscribe(observer);
+
+    mediaMatcher.setMatchesQuery(queryOne, false);
+    mediaMatcher.setMatchesQuery(queryTwo, false);
+
+    tick();
+    expect(observer).toHaveBeenCalledTimes(1);
   }));
 
   it('should not complete other subscribers when preceding subscriber completes', fakeAsync(() => {
     const queryOne = '(width: 700px)';
     const queryTwo = '(width: 999px)';
-    const breakpoint = breakpointObserver.observe([queryOne, queryTwo]);
+    const breakpoint = breakpointObserver.observe([queryOne, queryTwo]).pipe(skip(1));
     const subscriptions: Subscription[] = [];
     let emittedValues: number[] = [];
 
@@ -148,14 +166,14 @@ describe('BreakpointObserver', () => {
 
     mediaMatcher.setMatchesQuery(queryOne, true);
     mediaMatcher.setMatchesQuery(queryTwo, false);
-    flush();
+    tick();
 
     expect(emittedValues).toEqual([1, 2, 3, 4]);
     emittedValues = [];
 
     mediaMatcher.setMatchesQuery(queryOne, false);
     mediaMatcher.setMatchesQuery(queryTwo, true);
-    flush();
+    tick();
 
     expect(emittedValues).toEqual([1, 3, 4]);
 
@@ -172,7 +190,11 @@ export class FakeMediaQueryList {
   /** Toggles the matches state and "emits" a change event. */
   setMatches(matches: boolean) {
     this.matches = matches;
-    this._listeners.forEach(listener => listener(this as any));
+
+    /** Simulate an asynchronous task. */
+    setTimeout(() => {
+      this._listeners.forEach(listener => listener(this as any));
+    });
   }
 
   /** Registers a callback method for change events. */


### PR DESCRIPTION
The breakpoint observer emits multiple and incorrect states when more than one query changes.
Debounce the observer emissions to eliminate the incorrect states and emit once.

References [#10925](https://github.com/angular/components/issues/10925) [#15868](https://github.com/angular/components/issues/15868)

I have reproduced this in Chrome, Firefox, Safari, Edge, and IE. It occurs because the media query API fires an event when a query match changes. The breakpoint observer emits once for each event, updating the state of one query each time. Therefore, the observer may emit multiple times for one change and the reported intermediary states can be incorrect. I have reproduced up to five emissions for a single change.

[https://stackblitz.com/edit/angular-6pmabc](https://stackblitz.com/edit/angular-6pmabc)

> matches: false 
> breakpoints:
> {
>   "(max-width: 599.99px)": false,
>   "(min-width: 600px) and (max-width: 959.99px)": false,
>   "(min-width: 960px) and (max-width: 1279.99px)": false,
>   "(min-width: 1280px) and (max-width: 1919.99px)": false,
>   "(min-width: 1920px)": false
> }
> matches: true 
> breakpoints:
> {
>   "(max-width: 599.99px)": false,
>   "(min-width: 600px) and (max-width: 959.99px)": true,
>   "(min-width: 960px) and (max-width: 1279.99px)": false,
>   "(min-width: 1280px) and (max-width: 1919.99px)": false,
>   "(min-width: 1920px)": false
> }

PR [#11007](https://github.com/angular/components/pull/11007) attempted to resolve this issue. However, the issue still reproduces. My understanding is that the AsapScheduler uses a microtask which fails to debounce the media query events. Using the AsyncScheduler resolves the issue. AsyncScheduler uses a timer, setInterval, that may technically be slower on the first bounce but is more efficient across multiple.