### PR TITLE
refactor: don't depend on @Inject for _MatMenuBase DI

### DIFF
--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -445,4 +445,9 @@ export class MatMenu extends _MatMenuBase {}
 })
 // tslint:disable-next-line:class-name
 export class _MatMenu extends MatMenu {
+
+  constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone,
+      @Inject(MAT_MENU_DEFAULT_OPTIONS) defaultOptions: MatMenuDefaultOptions) {
+    super(elementRef, ngZone, defaultOptions);
+  }
 }

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -1,4 +1,5 @@
 export declare class _MatMenu extends MatMenu {
+    constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone, defaultOptions: MatMenuDefaultOptions);
 }
 
 export declare class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit, OnDestroy {


### PR DESCRIPTION
In Ivy, undecorated base classes (like _MatMenuBase) don't have the same
behavior as View Engine; specifically, inheriting the constructor from the
base class will not work in the DI system. Even in View Engine this was
often counter-intuitive - only constructors with DI decorators would be
properly inherited in JIT.

This commit updates _MatMenuBase to not rely on this implementation detail
of Angular, and instead moves the injected constructor onto _MatMenu itself.

Fixes #15937