### PR TITLE
Make checkbox stroke thicker

### DIFF
--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -18,7 +18,7 @@ $_mat-checkbox-ripple-radius: 20px;
 $_mat-checkbox-item-spacing: $mat-toggle-padding;
 
 // The width of the line used to draw the checkmark / mixedmark.
-$_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
+$_mat-checkbox-mark-stroke-size: 2 / 10 * $mat-checkbox-size !default;
 
 
 // Fades in the background of the checkbox when it goes from unchecked -> {checked,indeterminate}.


### PR DESCRIPTION
Updates the checkbox-mark-stroke-size to be thicker to match the GM spec more closely. The current divisor makes the width too small (~2.13px for standard 16px checkbox, while it needs to be closer to 4). Tried setting divisor to 8 but that looks too big given the size of the checkbox. A divisor of 10 puts the standard checkmark width at 3.2px for a 16px checkbox which looked balanced.