### PR TITLE
chore: switch dev-app to secondary entry-points 

### DIFF
--- a/src/dev-app/autocomplete/autocomplete-demo-module.ts
+++ b/src/dev-app/autocomplete/autocomplete-demo-module.ts
@@ -9,13 +9,11 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {
-  MatAutocompleteModule,
-  MatButtonModule,
-  MatCardModule,
-  MatFormFieldModule,
-  MatInputModule
-} from '@angular/material';
+import {MatAutocompleteModule} from '@angular/material/autocomplete';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
 import {RouterModule} from '@angular/router';
 import {AutocompleteDemo} from './autocomplete-demo';
 

--- a/src/dev-app/badge/badge-demo-module.ts
+++ b/src/dev-app/badge/badge-demo-module.ts
@@ -9,7 +9,9 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatBadgeModule, MatButtonModule, MatIconModule} from '@angular/material';
+import {MatBadgeModule} from '@angular/material/badge';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
 import {RouterModule} from '@angular/router';
 import {BadgeDemo} from './badge-demo';
 

--- a/src/dev-app/baseline/baseline-demo-module.ts
+++ b/src/dev-app/baseline/baseline-demo-module.ts
@@ -8,15 +8,13 @@
 
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {
-  MatCardModule,
-  MatCheckboxModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatRadioModule,
-  MatSelectModule,
-  MatToolbarModule
-} from '@angular/material';
+import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatRadioModule} from '@angular/material/radio';
+import {MatSelectModule} from '@angular/material/select';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {RouterModule} from '@angular/router';
 import {BaselineDemo} from './baseline-demo';
 

--- a/src/dev-app/bottom-sheet/bottom-sheet-demo-module.ts
+++ b/src/dev-app/bottom-sheet/bottom-sheet-demo-module.ts
@@ -9,17 +9,15 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatBottomSheetModule,
-  MatButtonModule,
-  MatCardModule,
-  MatCheckboxModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatInputModule,
-  MatListModule,
-  MatSelectModule
-} from '@angular/material';
+import {MatBottomSheetModule} from '@angular/material/bottom-sheet';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatListModule} from '@angular/material/list';
+import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 import {BottomSheetDemo, ExampleBottomSheet} from './bottom-sheet-demo';
 

--- a/src/dev-app/button-toggle/button-toggle-demo-module.ts
+++ b/src/dev-app/button-toggle/button-toggle-demo-module.ts
@@ -9,7 +9,9 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatButtonToggleModule, MatCheckboxModule, MatIconModule} from '@angular/material';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatIconModule} from '@angular/material/icon';
 import {RouterModule} from '@angular/router';
 import {ButtonToggleDemo} from './button-toggle-demo';
 

--- a/src/dev-app/button/button-demo-module.ts
+++ b/src/dev-app/button/button-demo-module.ts
@@ -7,7 +7,8 @@
  */
 
 import {NgModule} from '@angular/core';
-import {MatButtonModule, MatIconModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
 import {RouterModule} from '@angular/router';
 import {ButtonDemo} from './button-demo';
 

--- a/src/dev-app/card/card-demo-module.ts
+++ b/src/dev-app/card/card-demo-module.ts
@@ -7,12 +7,10 @@
  */
 
 import {NgModule} from '@angular/core';
-import {
-  MatButtonModule,
-  MatCardModule,
-  MatDividerModule,
-  MatProgressBarModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {MatDividerModule} from '@angular/material/divider';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {RouterModule} from '@angular/router';
 import {CardDemo} from './card-demo';
 

--- a/src/dev-app/checkbox/checkbox-demo-module.ts
+++ b/src/dev-app/checkbox/checkbox-demo-module.ts
@@ -9,13 +9,11 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {
-  MatCheckboxModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatPseudoCheckboxModule,
-  MatSelectModule
-} from '@angular/material';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatPseudoCheckboxModule} from '@angular/material/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 import {
   AnimationsNoop,

--- a/src/dev-app/checkbox/checkbox-demo.ts
+++ b/src/dev-app/checkbox/checkbox-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive} from '@angular/core';
-import {MAT_CHECKBOX_CLICK_ACTION} from '@angular/material';
+import {MAT_CHECKBOX_CLICK_ACTION} from '@angular/material/checkbox';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 

--- a/src/dev-app/chips/chips-demo-module.ts
+++ b/src/dev-app/chips/chips-demo-module.ts
@@ -9,15 +9,13 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCardModule,
-  MatCheckboxModule,
-  MatChipsModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatToolbarModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatChipsModule} from '@angular/material/chips';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {RouterModule} from '@angular/router';
 import {ChipsDemo} from './chips-demo';
 

--- a/src/dev-app/chips/chips-demo.ts
+++ b/src/dev-app/chips/chips-demo.ts
@@ -8,7 +8,8 @@
 
 import {COMMA, ENTER} from '@angular/cdk/keycodes';
 import {Component} from '@angular/core';
-import {MatChipInputEvent, ThemePalette} from '@angular/material';
+import {MatChipInputEvent} from '@angular/material/chips';
+import {ThemePalette} from '@angular/material/core';
 
 
 export interface Person {

--- a/src/dev-app/connected-overlay/connected-overlay-demo-module.ts
+++ b/src/dev-app/connected-overlay/connected-overlay-demo-module.ts
@@ -10,7 +10,9 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatButtonModule, MatCheckboxModule, MatRadioModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatRadioModule} from '@angular/material/radio';
 import {RouterModule} from '@angular/router';
 import {ConnectedOverlayDemo} from './connected-overlay-demo';
 

--- a/src/dev-app/datepicker/datepicker-demo-module.ts
+++ b/src/dev-app/datepicker/datepicker-demo-module.ts
@@ -9,16 +9,14 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCheckboxModule,
-  MatDatepickerModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatInputModule,
-  MatNativeDateModule,
-  MatSelectModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatNativeDateModule} from '@angular/material/core';
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 import {CustomHeader, CustomHeaderNgContent, DatepickerDemo} from './datepicker-demo';
 

--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -11,14 +11,17 @@ import {
   ChangeDetectorRef,
   Component,
   Inject,
-  ViewChild,
+  OnDestroy,
   Optional,
-  OnDestroy
+  ViewChild
 } from '@angular/core';
 import {FormControl} from '@angular/forms';
-import {MatCalendar, MatCalendarHeader} from '@angular/material';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, ThemePalette} from '@angular/material/core';
-import {MatDatepickerInputEvent} from '@angular/material/datepicker';
+import {
+  MatCalendar,
+  MatCalendarHeader,
+  MatDatepickerInputEvent
+} from '@angular/material/datepicker';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 

--- a/src/dev-app/dev-app/dev-app-module.ts
+++ b/src/dev-app/dev-app/dev-app-module.ts
@@ -8,16 +8,14 @@
 
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {
-  MatButtonModule,
-  MatIconModule,
-  MatListModule,
-  MatSidenavModule,
-  MatToolbarModule,
-  GestureConfig
-} from '@angular/material';
-import {RouterModule} from '@angular/router';
+import {MatButtonModule} from '@angular/material/button';
+import {GestureConfig} from '@angular/material/core';
+import {MatIconModule} from '@angular/material/icon';
+import {MatListModule} from '@angular/material/list';
+import {MatSidenavModule} from '@angular/material/sidenav';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
+import {RouterModule} from '@angular/router';
 import {DevApp404} from './dev-app-404';
 import {DevAppHome} from './dev-app-home';
 import {DevAppLayout} from './dev-app-layout';

--- a/src/dev-app/dialog/dialog-demo-module.ts
+++ b/src/dev-app/dialog/dialog-demo-module.ts
@@ -8,15 +8,13 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCardModule,
-  MatCheckboxModule,
-  MatDialogModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatSelectModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatDialogModule} from '@angular/material/dialog';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 import {ContentElementDialog, DialogDemo, IFrameDialog, JazzDialog} from './dialog-demo';
 

--- a/src/dev-app/dialog/dialog-demo.ts
+++ b/src/dev-app/dialog/dialog-demo.ts
@@ -8,7 +8,7 @@
 
 import {DOCUMENT} from '@angular/common';
 import {Component, Inject, TemplateRef, ViewChild, ViewEncapsulation} from '@angular/core';
-import {MAT_DIALOG_DATA, MatDialog, MatDialogConfig, MatDialogRef} from '@angular/material';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogConfig, MatDialogRef} from '@angular/material/dialog';
 
 
 const defaultDialogConfig = new MatDialogConfig();

--- a/src/dev-app/drag-drop/drag-drop-demo-module.ts
+++ b/src/dev-app/drag-drop/drag-drop-demo-module.ts
@@ -10,7 +10,9 @@ import {DragDropModule} from '@angular/cdk/drag-drop';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatFormFieldModule, MatIconModule, MatSelectModule} from '@angular/material';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 import {DragAndDropDemo} from './drag-drop-demo';
 

--- a/src/dev-app/drawer/drawer-demo-module.ts
+++ b/src/dev-app/drawer/drawer-demo-module.ts
@@ -7,7 +7,9 @@
  */
 
 import {NgModule} from '@angular/core';
-import {MatButtonModule, MatListModule, MatSidenavModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatListModule} from '@angular/material/list';
+import {MatSidenavModule} from '@angular/material/sidenav';
 import {RouterModule} from '@angular/router';
 import {DrawerDemo} from './drawer-demo';
 

--- a/src/dev-app/example/example-module.ts
+++ b/src/dev-app/example/example-module.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {MatExpansionModule} from '@angular/material';
+import {MatExpansionModule} from '@angular/material/expansion';
 import {ExampleModule as ExampleDataModule} from '@angular/material-examples';
 import {Example} from './example';
 

--- a/src/dev-app/expansion/expansion-demo-module.ts
+++ b/src/dev-app/expansion/expansion-demo-module.ts
@@ -10,15 +10,13 @@ import {CdkAccordionModule} from '@angular/cdk/accordion';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCheckboxModule,
-  MatExpansionModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatRadioModule,
-  MatSlideToggleModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatExpansionModule} from '@angular/material/expansion';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatRadioModule} from '@angular/material/radio';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {RouterModule} from '@angular/router';
 import {ExpansionDemo} from './expansion-demo';
 

--- a/src/dev-app/expansion/expansion-demo.ts
+++ b/src/dev-app/expansion/expansion-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, ViewChild} from '@angular/core';
-import {MatAccordion} from '@angular/material';
+import {MatAccordion} from '@angular/material/expansion';
 
 
 @Component({

--- a/src/dev-app/grid-list/grid-list-demo-module.ts
+++ b/src/dev-app/grid-list/grid-list-demo-module.ts
@@ -9,7 +9,10 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatButtonModule, MatCardModule, MatGridListModule, MatIconModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {MatGridListModule} from '@angular/material/grid-list';
+import {MatIconModule} from '@angular/material/icon';
 import {RouterModule} from '@angular/router';
 import {GridListDemo} from './grid-list-demo';
 

--- a/src/dev-app/icon/icon-demo-module.ts
+++ b/src/dev-app/icon/icon-demo-module.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgModule} from '@angular/core';
-import {MatIconModule} from '@angular/material';
+import {MatIconModule} from '@angular/material/icon';
 import {RouterModule} from '@angular/router';
 import {IconDemo} from './icon-demo';
 

--- a/src/dev-app/icon/icon-demo.ts
+++ b/src/dev-app/icon/icon-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component} from '@angular/core';
-import {MatIconRegistry} from '@angular/material';
+import {MatIconRegistry} from '@angular/material/icon';
 import {DomSanitizer} from '@angular/platform-browser';
 
 

--- a/src/dev-app/input/input-demo-module.ts
+++ b/src/dev-app/input/input-demo-module.ts
@@ -9,18 +9,16 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatButtonToggleModule,
-  MatCardModule,
-  MatCheckboxModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatInputModule,
-  MatSelectModule,
-  MatTabsModule,
-  MatToolbarModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatTabsModule} from '@angular/material/tabs';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {RouterModule} from '@angular/router';
 import {InputDemo} from './input-demo';
 

--- a/src/dev-app/input/input-demo.ts
+++ b/src/dev-app/input/input-demo.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ChangeDetectionStrategy} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
-import {ErrorStateMatcher} from '@angular/material';
+import {ErrorStateMatcher} from '@angular/material/core';
 
 
 let max = 5;

--- a/src/dev-app/list/list-demo-module.ts
+++ b/src/dev-app/list/list-demo-module.ts
@@ -9,7 +9,10 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatButtonModule, MatCheckboxModule, MatIconModule, MatListModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatIconModule} from '@angular/material/icon';
+import {MatListModule} from '@angular/material/list';
 import {RouterModule} from '@angular/router';
 import {ListDemo} from './list-demo';
 

--- a/src/dev-app/live-announcer/live-announcer-demo-module.ts
+++ b/src/dev-app/live-announcer/live-announcer-demo-module.ts
@@ -8,7 +8,7 @@
 
 import {A11yModule} from '@angular/cdk/a11y';
 import {NgModule} from '@angular/core';
-import {MatButtonModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
 import {RouterModule} from '@angular/router';
 import {LiveAnnouncerDemo} from './live-announcer-demo';
 

--- a/src/dev-app/main-module.ts
+++ b/src/dev-app/main-module.ts
@@ -10,7 +10,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {FullscreenOverlayContainer, OverlayContainer} from '@angular/cdk/overlay';
 import {HttpClientModule} from '@angular/common/http';
 import {NgModule} from '@angular/core';
-import {MAT_RIPPLE_GLOBAL_OPTIONS} from '@angular/material';
+import {MAT_RIPPLE_GLOBAL_OPTIONS} from '@angular/material/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterModule} from '@angular/router';

--- a/src/dev-app/mdc-checkbox/mdc-checkbox-demo-module.ts
+++ b/src/dev-app/mdc-checkbox/mdc-checkbox-demo-module.ts
@@ -9,13 +9,11 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {
-  MatFormFieldModule,
-  MatInputModule,
-  MatPseudoCheckboxModule,
-  MatSelectModule
-} from '@angular/material';
 import {MatCheckboxModule} from '@angular/material-experimental/mdc-checkbox';
+import {MatPseudoCheckboxModule} from '@angular/material/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 
 import {

--- a/src/dev-app/mdc-checkbox/mdc-checkbox-demo.ts
+++ b/src/dev-app/mdc-checkbox/mdc-checkbox-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive} from '@angular/core';
-import {MAT_CHECKBOX_CLICK_ACTION} from '@angular/material';
+import {MAT_CHECKBOX_CLICK_ACTION} from '@angular/material/checkbox';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 

--- a/src/dev-app/menu/menu-demo-module.ts
+++ b/src/dev-app/menu/menu-demo-module.ts
@@ -8,13 +8,11 @@
 
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {
-  MatButtonModule,
-  MatDividerModule,
-  MatIconModule,
-  MatMenuModule,
-  MatToolbarModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatDividerModule} from '@angular/material/divider';
+import {MatIconModule} from '@angular/material/icon';
+import {MatMenuModule} from '@angular/material/menu';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {RouterModule} from '@angular/router';
 import {MenuDemo} from './menu-demo';
 

--- a/src/dev-app/paginator/paginator-demo-module.ts
+++ b/src/dev-app/paginator/paginator-demo-module.ts
@@ -9,13 +9,11 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatCardModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatPaginatorModule,
-  MatSlideToggleModule
-} from '@angular/material';
+import {MatCardModule} from '@angular/material/card';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatPaginatorModule} from '@angular/material/paginator';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {RouterModule} from '@angular/router';
 import {PaginatorDemo} from './paginator-demo';
 

--- a/src/dev-app/paginator/paginator-demo.ts
+++ b/src/dev-app/paginator/paginator-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, ViewEncapsulation} from '@angular/core';
-import {PageEvent} from '@angular/material';
+import {PageEvent} from '@angular/material/paginator';
 
 @Component({
   moduleId: module.id,

--- a/src/dev-app/progress-bar/progress-bar-demo-module.ts
+++ b/src/dev-app/progress-bar/progress-bar-demo-module.ts
@@ -8,7 +8,9 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatButtonModule, MatButtonToggleModule, MatProgressBarModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {RouterModule} from '@angular/router';
 import {ProgressBarDemo} from './progress-bar-demo';
 

--- a/src/dev-app/progress-spinner/progress-spinner-demo-module.ts
+++ b/src/dev-app/progress-spinner/progress-spinner-demo-module.ts
@@ -8,12 +8,10 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatButtonToggleModule,
-  MatCheckboxModule,
-  MatProgressSpinnerModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {RouterModule} from '@angular/router';
 import {ProgressSpinnerDemo} from './progress-spinner-demo';
 

--- a/src/dev-app/radio/radio-demo-module.ts
+++ b/src/dev-app/radio/radio-demo-module.ts
@@ -9,7 +9,9 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatButtonModule, MatCheckboxModule, MatRadioModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatRadioModule} from '@angular/material/radio';
 import {RouterModule} from '@angular/router';
 import {RadioDemo} from './radio-demo';
 

--- a/src/dev-app/ripple/ripple-demo-module.ts
+++ b/src/dev-app/ripple/ripple-demo-module.ts
@@ -8,14 +8,12 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCheckboxModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatInputModule,
-  MatRippleModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatRippleModule} from '@angular/material/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
 import {RouterModule} from '@angular/router';
 import {ExampleModule} from '../example/example-module';
 import {RippleDemo} from './ripple-demo';

--- a/src/dev-app/ripple/ripple-demo.ts
+++ b/src/dev-app/ripple/ripple-demo.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, ViewChild} from '@angular/core';
-import {MatRipple} from '@angular/material';
+import {MatRipple} from '@angular/material/core';
 
 
 @Component({

--- a/src/dev-app/ripple/ripple-options.ts
+++ b/src/dev-app/ripple/ripple-options.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injectable} from '@angular/core';
-import {RippleGlobalOptions} from '@angular/material';
+import {RippleGlobalOptions} from '@angular/material/core';
 
 /**
  * Global ripple options for the dev-app. The ripple options are used as a class

--- a/src/dev-app/screen-type/screen-type-demo-module.ts
+++ b/src/dev-app/screen-type/screen-type-demo-module.ts
@@ -9,7 +9,8 @@
 import {LayoutModule} from '@angular/cdk/layout';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {MatGridListModule, MatIconModule} from '@angular/material';
+import {MatGridListModule} from '@angular/material/grid-list';
+import {MatIconModule} from '@angular/material/icon';
 import {RouterModule} from '@angular/router';
 import {ScreenTypeDemo} from './screen-type-demo';
 

--- a/src/dev-app/select/select-demo-module.ts
+++ b/src/dev-app/select/select-demo-module.ts
@@ -9,15 +9,13 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCardModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatInputModule,
-  MatSelectModule,
-  MatToolbarModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {RouterModule} from '@angular/router';
 import {SelectDemo} from './select-demo';
 

--- a/src/dev-app/select/select-demo.ts
+++ b/src/dev-app/select/select-demo.ts
@@ -8,7 +8,8 @@
 
 import {Component} from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
-import {ErrorStateMatcher, MatSelectChange} from '@angular/material';
+import {ErrorStateMatcher} from '@angular/material/core';
+import {MatSelectChange} from '@angular/material/select';
 
 /** Error any time control is invalid */
 export class MyErrorStateMatcher implements ErrorStateMatcher {

--- a/src/dev-app/sidenav/sidenav-demo-module.ts
+++ b/src/dev-app/sidenav/sidenav-demo-module.ts
@@ -9,12 +9,10 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCheckboxModule,
-  MatSidenavModule,
-  MatToolbarModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatSidenavModule} from '@angular/material/sidenav';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {RouterModule} from '@angular/router';
 import {SidenavDemo} from './sidenav-demo';
 

--- a/src/dev-app/slide-toggle/slide-toggle-demo-module.ts
+++ b/src/dev-app/slide-toggle/slide-toggle-demo-module.ts
@@ -8,7 +8,8 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatButtonModule, MatSlideToggleModule} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {RouterModule} from '@angular/router';
 import {SlideToggleDemo} from './slide-toggle-demo';
 

--- a/src/dev-app/slider/slider-demo-module.ts
+++ b/src/dev-app/slider/slider-demo-module.ts
@@ -8,7 +8,8 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {MatSliderModule, MatTabsModule} from '@angular/material';
+import {MatSliderModule} from '@angular/material/slider';
+import {MatTabsModule} from '@angular/material/tabs';
 import {RouterModule} from '@angular/router';
 import {SliderDemo} from './slider-demo';
 

--- a/src/dev-app/snack-bar/snack-bar-demo-module.ts
+++ b/src/dev-app/snack-bar/snack-bar-demo-module.ts
@@ -9,14 +9,12 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCheckboxModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatSelectModule,
-  MatSnackBarModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {RouterModule} from '@angular/router';
 import {SnackBarDemo} from './snack-bar-demo';
 

--- a/src/dev-app/snack-bar/snack-bar-demo.ts
+++ b/src/dev-app/snack-bar/snack-bar-demo.ts
@@ -13,7 +13,7 @@ import {
   MatSnackBarConfig,
   MatSnackBarHorizontalPosition,
   MatSnackBarVerticalPosition,
-} from '@angular/material';
+} from '@angular/material/snack-bar';
 
 
 @Component({

--- a/src/dev-app/stepper/stepper-demo-module.ts
+++ b/src/dev-app/stepper/stepper-demo-module.ts
@@ -9,13 +9,11 @@
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCheckboxModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatStepperModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatStepperModule} from '@angular/material/stepper';
 import {RouterModule} from '@angular/router';
 import {StepperDemo} from './stepper-demo';
 

--- a/src/dev-app/system-config.ts
+++ b/src/dev-app/system-config.ts
@@ -69,7 +69,6 @@ System.config({
     '@angular/platform-browser-dynamic':
         'node:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
 
-    '@angular/material': 'dist/packages/material/index.js',
     '@angular/material-experimental': 'dist/packages/material-experimental/index.js',
     '@angular/material-examples': 'dist/packages/material-examples/index.js',
     '@angular/material-moment-adapter': 'dist/packages/material-moment-adapter/index.js',

--- a/src/dev-app/tabs/tabs-demo-module.ts
+++ b/src/dev-app/tabs/tabs-demo-module.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgModule} from '@angular/core';
-import {MatTabsModule} from '@angular/material';
+import {MatTabsModule} from '@angular/material/tabs';
 import {RouterModule} from '@angular/router';
 import {ExampleModule} from '../example/example-module';
 import {TabsDemo} from './tabs-demo';

--- a/src/dev-app/toolbar/toolbar-demo-module.ts
+++ b/src/dev-app/toolbar/toolbar-demo-module.ts
@@ -7,14 +7,12 @@
  */
 
 import {NgModule} from '@angular/core';
-import {
-  MatButtonModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatInputModule,
-  MatSelectModule,
-  MatToolbarModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {RouterModule} from '@angular/router';
 import {ToolbarDemo} from './toolbar-demo';
 

--- a/src/dev-app/tooltip/tooltip-demo-module.ts
+++ b/src/dev-app/tooltip/tooltip-demo-module.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgModule} from '@angular/core';
-import {MatTooltipModule} from '@angular/material';
+import {MatTooltipModule} from '@angular/material/tooltip';
 import {RouterModule} from '@angular/router';
 import {ExampleModule} from '../example/example-module';
 import {TooltipDemo} from './tooltip-demo';

--- a/src/dev-app/tree/tree-demo-module.ts
+++ b/src/dev-app/tree/tree-demo-module.ts
@@ -9,16 +9,14 @@ import {CdkTreeModule} from '@angular/cdk/tree';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatCheckboxModule,
-  MatExpansionModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatInputModule,
-  MatProgressBarModule,
-  MatTreeModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatExpansionModule} from '@angular/material/expansion';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
+import {MatTreeModule} from '@angular/material/tree';
 import {RouterModule} from '@angular/router';
 
 import {ExampleModule} from '../example/example-module';

--- a/src/dev-app/tsconfig-aot.json
+++ b/src/dev-app/tsconfig-aot.json
@@ -21,7 +21,6 @@
     ],
     "paths": {
       "@angular/material/*": ["../../dist/releases/material/*"],
-      "@angular/material": ["../../dist/releases/material"],
       "@angular/cdk/*": ["../../dist/releases/cdk/*"],
       "@angular/cdk": ["../../dist/releases/cdk"],
       "@angular/material-experimental/*": ["../../dist/releases/material-experimental/*"],

--- a/src/dev-app/tsconfig-build.json
+++ b/src/dev-app/tsconfig-build.json
@@ -28,7 +28,6 @@
     "baseUrl": ".",
     "paths": {
       "@angular/material/*": ["../../dist/packages/material/*"],
-      "@angular/material": ["../../dist/packages/material"],
       "@angular/cdk/*": ["../../dist/packages/cdk/*"],
       "@angular/cdk": ["../../dist/packages/cdk"],
       "@angular/material-experimental/*": ["../../dist/packages/material-experimental/*"],

--- a/src/dev-app/tsconfig.json
+++ b/src/dev-app/tsconfig.json
@@ -9,7 +9,6 @@
     "paths": {
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],
-      "@angular/material": ["../material/public-api.ts"],
       "@angular/material-experimental/*": ["../material-experimental/*"],
       "@angular/material-experimental": ["../material-experimental"],
       "@angular/cdk-experimental/*": ["../cdk-experimental/*"],

--- a/src/dev-app/virtual-scroll/virtual-scroll-demo-module.ts
+++ b/src/dev-app/virtual-scroll/virtual-scroll-demo-module.ts
@@ -11,12 +11,10 @@ import {ScrollingModule} from '@angular/cdk/scrolling';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {
-  MatButtonModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatSelectModule
-} from '@angular/material';
+import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 import {VirtualScrollDemo} from './virtual-scroll-demo';
 

--- a/src/material-examples/BUILD.bazel
+++ b/src/material-examples/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility=["//visibility:public"])
 
-load("//:packages.bzl", "CDK_TARGETS", "CDK_EXPERIMENTAL_TARGETS", "MATERIAL_TARGETS", "MATERIAL_EXPERIMENTAL_TARGETS", "ROLLUP_GLOBALS")
+load("//:packages.bzl", "CDK_TARGETS", "CDK_EXPERIMENTAL_TARGETS", "MATERIAL_PACKAGES", "MATERIAL_EXPERIMENTAL_TARGETS", "ROLLUP_GLOBALS")
 load("//tools:defaults.bzl", "ng_module", "ng_package")
 load("//tools/highlight-files:index.bzl", "highlight_files")
 load("//tools/package-docs-content:index.bzl", "package_docs_content")
@@ -17,7 +17,7 @@ ng_module(
     "@npm//@angular/forms",
     "@npm//moment",
     "//src/material-moment-adapter",
-  ] + CDK_TARGETS + CDK_EXPERIMENTAL_TARGETS + MATERIAL_TARGETS + MATERIAL_EXPERIMENTAL_TARGETS,
+  ] + CDK_TARGETS + CDK_EXPERIMENTAL_TARGETS + MATERIAL_EXPERIMENTAL_TARGETS + ["//src/material/%s" % p for p in MATERIAL_PACKAGES],
   # Specify the tsconfig that is also used by Gulp. We need to explicitly use this tsconfig
   # because in order to import Moment with TypeScript, some specific options need to be set.
   tsconfig = ":tsconfig-build.json",

--- a/src/material-examples/bottom-sheet-overview/bottom-sheet-overview-example.ts
+++ b/src/material-examples/bottom-sheet-overview/bottom-sheet-overview-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatBottomSheet, MatBottomSheetRef} from '@angular/material';
+import {MatBottomSheet, MatBottomSheetRef} from '@angular/material/bottom-sheet';
 
 /**
  * @title Bottom Sheet Overview

--- a/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/material-examples/chips-autocomplete/chips-autocomplete-example.ts
@@ -1,7 +1,8 @@
 import {COMMA, ENTER} from '@angular/cdk/keycodes';
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {FormControl} from '@angular/forms';
-import {MatAutocompleteSelectedEvent, MatChipInputEvent, MatAutocomplete} from '@angular/material';
+import {MatAutocompleteSelectedEvent, MatAutocomplete} from '@angular/material/autocomplete';
+import {MatChipInputEvent} from '@angular/material/chips';
 import {Observable} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
 

--- a/src/material-examples/chips-input/chips-input-example.ts
+++ b/src/material-examples/chips-input/chips-input-example.ts
@@ -1,6 +1,6 @@
 import {COMMA, ENTER} from '@angular/cdk/keycodes';
 import {Component} from '@angular/core';
-import {MatChipInputEvent} from '@angular/material';
+import {MatChipInputEvent} from '@angular/material/chips';
 
 export interface Fruit {
   name: string;

--- a/src/material-examples/datepicker-custom-header/datepicker-custom-header-example.ts
+++ b/src/material-examples/datepicker-custom-header/datepicker-custom-header-example.ts
@@ -5,7 +5,7 @@ import {
   Inject,
   OnDestroy
 } from '@angular/core';
-import {MatCalendar} from '@angular/material';
+import {MatCalendar} from '@angular/material/datepicker';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';

--- a/src/material-examples/dialog-content/dialog-content-example.ts
+++ b/src/material-examples/dialog-content/dialog-content-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatDialog} from '@angular/material';
+import {MatDialog} from '@angular/material/dialog';
 
 /**
  * @title Dialog with header, scrollable content and actions

--- a/src/material-examples/dialog-data/dialog-data-example.ts
+++ b/src/material-examples/dialog-data/dialog-data-example.ts
@@ -1,5 +1,5 @@
 import {Component, Inject} from '@angular/core';
-import {MatDialog, MAT_DIALOG_DATA} from '@angular/material';
+import {MatDialog, MAT_DIALOG_DATA} from '@angular/material/dialog';
 
 export interface DialogData {
   animal: 'panda' | 'unicorn' | 'lion';

--- a/src/material-examples/dialog-elements/dialog-elements-example.ts
+++ b/src/material-examples/dialog-elements/dialog-elements-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatDialog} from '@angular/material';
+import {MatDialog} from '@angular/material/dialog';
 
 /**
  * @title Dialog elements

--- a/src/material-examples/dialog-overview/dialog-overview-example.ts
+++ b/src/material-examples/dialog-overview/dialog-overview-example.ts
@@ -1,5 +1,5 @@
 import {Component, Inject} from '@angular/core';
-import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
+import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material/dialog';
 
 export interface DialogData {
   animal: string;

--- a/src/material-examples/expansion-expand-collapse-all/expansion-expand-collapse-all-example.ts
+++ b/src/material-examples/expansion-expand-collapse-all/expansion-expand-collapse-all-example.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {MatAccordion} from '@angular/material';
+import {MatAccordion} from '@angular/material/expansion';
 
 /**
  * @title Accordion with expand/collapse all toggles

--- a/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/material-examples/form-field-custom-control/form-field-custom-control-example.ts
@@ -2,7 +2,7 @@ import {FocusMonitor} from '@angular/cdk/a11y';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Component, ElementRef, Input, OnDestroy, Optional, Self} from '@angular/core';
 import {FormBuilder, FormGroup, ControlValueAccessor, NgControl} from '@angular/forms';
-import {MatFormFieldControl} from '@angular/material';
+import {MatFormFieldControl} from '@angular/material/form-field';
 import {Subject} from 'rxjs';
 
 /** @title Form field with custom telephone number input control. */

--- a/src/material-examples/icon-svg/icon-svg-example.ts
+++ b/src/material-examples/icon-svg/icon-svg-example.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
-import {MatIconRegistry} from '@angular/material';
+import {MatIconRegistry} from '@angular/material/icon';
 
 /**
  * @title SVG icons

--- a/src/material-examples/material-module.ts
+++ b/src/material-examples/material-module.ts
@@ -1,24 +1,50 @@
-import {NgModule} from '@angular/core';
+import {CdkPopoverEditModule} from '@angular/cdk-experimental/popover-edit';
+import {A11yModule} from '@angular/cdk/a11y';
+import {DragDropModule} from '@angular/cdk/drag-drop';
+import {PortalModule} from '@angular/cdk/portal';
 
 import {ScrollingModule} from '@angular/cdk/scrolling';
-import {A11yModule} from '@angular/cdk/a11y';
-import {CdkPopoverEditModule} from '@angular/cdk-experimental/popover-edit';
+import {CdkStepperModule} from '@angular/cdk/stepper';
 import {CdkTableModule} from '@angular/cdk/table';
 import {CdkTreeModule} from '@angular/cdk/tree';
-import {DragDropModule} from '@angular/cdk/drag-drop';
-import {CdkStepperModule} from '@angular/cdk/stepper';
+import {NgModule} from '@angular/core';
 import {MatPopoverEditModule} from '@angular/material-experimental/popover-edit';
-import {PortalModule} from '@angular/cdk/portal';
-import {
-  MatAutocompleteModule, MatBadgeModule, MatBottomSheetModule, MatButtonModule,
-  MatButtonToggleModule, MatCardModule, MatCheckboxModule, MatChipsModule, MatDatepickerModule,
-  MatDialogModule, MatDividerModule, MatExpansionModule, MatFormFieldModule, MatGridListModule,
-  MatIconModule, MatInputModule, MatListModule, MatMenuModule, MatPaginatorModule,
-  MatProgressBarModule, MatProgressSpinnerModule, MatRadioModule, MatRippleModule, MatSelectModule,
-  MatSidenavModule, MatSliderModule, MatSlideToggleModule, MatSnackBarModule, MatSortModule,
-  MatStepperModule, MatTableModule, MatTabsModule, MatToolbarModule, MatTooltipModule,
-  MatTreeModule, MatNativeDateModule
-} from '@angular/material';
+
+import {MatAutocompleteModule} from '@angular/material/autocomplete';
+import {MatBadgeModule} from '@angular/material/badge';
+import {MatBottomSheetModule} from '@angular/material/bottom-sheet';
+import {MatButtonModule} from '@angular/material/button';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatCardModule} from '@angular/material/card';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatChipsModule} from '@angular/material/chips';
+import {MatNativeDateModule, MatRippleModule} from '@angular/material/core';
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {MatDialogModule} from '@angular/material/dialog';
+import {MatDividerModule} from '@angular/material/divider';
+import {MatExpansionModule} from '@angular/material/expansion';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatGridListModule} from '@angular/material/grid-list';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatListModule} from '@angular/material/list';
+import {MatMenuModule} from '@angular/material/menu';
+import {MatPaginatorModule} from '@angular/material/paginator';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatRadioModule} from '@angular/material/radio';
+import {MatSelectModule} from '@angular/material/select';
+import {MatSidenavModule} from '@angular/material/sidenav';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
+import {MatSliderModule} from '@angular/material/slider';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatSortModule} from '@angular/material/sort';
+import {MatStepperModule} from '@angular/material/stepper';
+import {MatTableModule} from '@angular/material/table';
+import {MatTabsModule} from '@angular/material/tabs';
+import {MatToolbarModule} from '@angular/material/toolbar';
+import {MatTooltipModule} from '@angular/material/tooltip';
+import {MatTreeModule} from '@angular/material/tree';
 
 @NgModule({
   imports: [

--- a/src/material-examples/paginator-configurable/paginator-configurable-example.ts
+++ b/src/material-examples/paginator-configurable/paginator-configurable-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {PageEvent} from '@angular/material';
+import {PageEvent} from '@angular/material/paginator';
 
 /**
  * @title Configurable paginator

--- a/src/material-examples/popover-edit-cell-span-mat-table/popover-edit-cell-span-mat-table-example.ts
+++ b/src/material-examples/popover-edit-cell-span-mat-table/popover-edit-cell-span-mat-table-example.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {DomSanitizer} from '@angular/platform-browser';
 import {NgForm} from '@angular/forms';
-import {MatIconRegistry} from '@angular/material';
+import {MatIconRegistry} from '@angular/material/icon';
 import {BehaviorSubject, Observable} from 'rxjs';
 
 export interface Person {

--- a/src/material-examples/popover-edit-mat-table-flex/popover-edit-mat-table-flex-example.ts
+++ b/src/material-examples/popover-edit-mat-table-flex/popover-edit-mat-table-flex-example.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {DomSanitizer} from '@angular/platform-browser';
 import {NgForm} from '@angular/forms';
-import {MatIconRegistry} from '@angular/material';
+import {MatIconRegistry} from '@angular/material/icon';
 import {BehaviorSubject, Observable} from 'rxjs';
 
 export interface PeriodicElement {

--- a/src/material-examples/popover-edit-mat-table/popover-edit-mat-table-example.ts
+++ b/src/material-examples/popover-edit-mat-table/popover-edit-mat-table-example.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {DomSanitizer} from '@angular/platform-browser';
 import {NgForm} from '@angular/forms';
-import {MatIconRegistry} from '@angular/material';
+import {MatIconRegistry} from '@angular/material/icon';
 import {BehaviorSubject, Observable} from 'rxjs';
 
 export interface PeriodicElement {

--- a/src/material-examples/popover-edit-tab-out-mat-table/popover-edit-tab-out-mat-table-example.ts
+++ b/src/material-examples/popover-edit-tab-out-mat-table/popover-edit-tab-out-mat-table-example.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {DataSource} from '@angular/cdk/collections';
 import {DomSanitizer} from '@angular/platform-browser';
 import {NgForm} from '@angular/forms';
-import {MatIconRegistry} from '@angular/material';
+import {MatIconRegistry} from '@angular/material/icon';
 import {BehaviorSubject, Observable} from 'rxjs';
 
 export interface PeriodicElement {

--- a/src/material-examples/snack-bar-component/snack-bar-component-example.ts
+++ b/src/material-examples/snack-bar-component/snack-bar-component-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatSnackBar} from '@angular/material';
+import {MatSnackBar} from '@angular/material/snack-bar';
 
 /**
  * @title Snack-bar with a custom component

--- a/src/material-examples/snack-bar-overview/snack-bar-overview-example.ts
+++ b/src/material-examples/snack-bar-overview/snack-bar-overview-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatSnackBar} from '@angular/material';
+import {MatSnackBar} from '@angular/material/snack-bar';
 
 /**
  * @title Basic snack-bar

--- a/src/material-examples/snack-bar-position/snack-bar-position-example.ts
+++ b/src/material-examples/snack-bar-position/snack-bar-position-example.ts
@@ -3,7 +3,7 @@ import {
   MatSnackBar,
   MatSnackBarHorizontalPosition,
   MatSnackBarVerticalPosition,
-} from '@angular/material';
+} from '@angular/material/snack-bar';
 
 /**
  * @title Snack-bar with configurable position

--- a/src/material-examples/sort-overview/sort-overview-example.ts
+++ b/src/material-examples/sort-overview/sort-overview-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Sort} from '@angular/material';
+import {Sort} from '@angular/material/sort';
 
 export interface Dessert {
   calories: number;

--- a/src/material-examples/table-filtering/table-filtering-example.ts
+++ b/src/material-examples/table-filtering/table-filtering-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatTableDataSource} from '@angular/material';
+import {MatTableDataSource} from '@angular/material/table';
 
 export interface PeriodicElement {
   name: string;

--- a/src/material-examples/table-http/table-http-example.ts
+++ b/src/material-examples/table-http/table-http-example.ts
@@ -1,6 +1,7 @@
 import {HttpClient} from '@angular/common/http';
 import {Component, ViewChild, AfterViewInit} from '@angular/core';
-import {MatPaginator, MatSort} from '@angular/material';
+import {MatPaginator} from '@angular/material/paginator';
+import {MatSort} from '@angular/material/sort';
 import {merge, Observable, of as observableOf} from 'rxjs';
 import {catchError, map, startWith, switchMap} from 'rxjs/operators';
 

--- a/src/material-examples/table-overview/table-overview-example.ts
+++ b/src/material-examples/table-overview/table-overview-example.ts
@@ -1,5 +1,7 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
+import {MatPaginator} from '@angular/material/paginator';
+import {MatSort} from '@angular/material/sort';
+import {MatTableDataSource} from '@angular/material/table';
 
 export interface UserData {
   id: string;

--- a/src/material-examples/table-pagination/table-pagination-example.ts
+++ b/src/material-examples/table-pagination/table-pagination-example.ts
@@ -1,5 +1,6 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {MatPaginator, MatTableDataSource} from '@angular/material';
+import {MatPaginator} from '@angular/material/paginator';
+import {MatTableDataSource} from '@angular/material/table';
 
 /**
  * @title Table with pagination

--- a/src/material-examples/table-selection/table-selection-example.ts
+++ b/src/material-examples/table-selection/table-selection-example.ts
@@ -1,6 +1,6 @@
 import {SelectionModel} from '@angular/cdk/collections';
 import {Component} from '@angular/core';
-import {MatTableDataSource} from '@angular/material';
+import {MatTableDataSource} from '@angular/material/table';
 
 export interface PeriodicElement {
   name: string;

--- a/src/material-examples/table-sorting/table-sorting-example.ts
+++ b/src/material-examples/table-sorting/table-sorting-example.ts
@@ -1,5 +1,6 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {MatSort, MatTableDataSource} from '@angular/material';
+import {MatSort} from '@angular/material/sort';
+import {MatTableDataSource} from '@angular/material/table';
 
 export interface PeriodicElement {
   name: string;

--- a/src/material-examples/table-sticky-complex-flex/table-sticky-complex-flex-example.ts
+++ b/src/material-examples/table-sticky-complex-flex/table-sticky-complex-flex-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatButtonToggleGroup} from '@angular/material';
+import {MatButtonToggleGroup} from '@angular/material/button-toggle';
 
 /**
  * @title Flex-layout tables with toggle-able sticky headers, footers, and columns

--- a/src/material-examples/table-sticky-complex/table-sticky-complex-example.ts
+++ b/src/material-examples/table-sticky-complex/table-sticky-complex-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatButtonToggleGroup} from '@angular/material';
+import {MatButtonToggleGroup} from '@angular/material/button-toggle';
 
 /**
  * @title Tables with toggle-able sticky headers, footers, and columns

--- a/src/material-examples/table-text-column-advanced/table-text-column-advanced-example.ts
+++ b/src/material-examples/table-text-column-advanced/table-text-column-advanced-example.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {DecimalPipe} from '@angular/common';
-import {MatTableDataSource} from '@angular/material';
+import {MatTableDataSource} from '@angular/material/table';
 
 export interface PeriodicElement {
   name: string;

--- a/src/material-examples/table-wrapped/table-wrapped-example.ts
+++ b/src/material-examples/table-wrapped/table-wrapped-example.ts
@@ -8,14 +8,14 @@ import {
   QueryList,
   ViewChild
 } from '@angular/core';
+import {MatSort} from '@angular/material/sort';
 import {
   MatColumnDef,
   MatHeaderRowDef,
   MatRowDef,
-  MatSort,
   MatTable,
   MatTableDataSource
-} from '@angular/material';
+} from '@angular/material/table';
 
 export interface PeriodicElement {
   name: string;

--- a/src/material-examples/tooltip-auto-hide/tooltip-auto-hide-example.ts
+++ b/src/material-examples/tooltip-auto-hide/tooltip-auto-hide-example.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
-import {TooltipPosition} from '@angular/material';
+import {TooltipPosition} from '@angular/material/tooltip';
 
 /**
  * @title Tooltip that demonstrates auto-hiding when it clips out of its scrolling container.

--- a/src/material-examples/tooltip-modified-defaults/tooltip-modified-defaults-example.ts
+++ b/src/material-examples/tooltip-modified-defaults/tooltip-modified-defaults-example.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltipDefaultOptions} from '@angular/material';
+import {MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltipDefaultOptions} from '@angular/material/tooltip';
 
 /** Custom options the configure the tooltip's default show/hide delays. */
 export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {

--- a/src/material-examples/tooltip-position/tooltip-position-example.ts
+++ b/src/material-examples/tooltip-position/tooltip-position-example.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
-import {TooltipPosition} from '@angular/material';
+import {TooltipPosition} from '@angular/material/tooltip';
 
 /**
  * @title Tooltip with a custom position

--- a/src/material-examples/tsconfig-build.json
+++ b/src/material-examples/tsconfig-build.json
@@ -27,11 +27,10 @@
     "baseUrl": ".",
     "paths": {
       "@angular/material/*": ["../../dist/packages/material/*"],
-      "@angular/material": ["../../dist/packages/material"],
       "@angular/material-experimental/*": ["../../dist/packages/material-experimental/*"],
       "@angular/material-moment-adapter": ["../../dist/packages/material-moment-adapter"],
       "@angular/cdk/*": ["../../dist/packages/cdk/*"],
-      "@angular/cdk-experimental/*": ["../../dist/packages/cdk-experimental/*"],
+      "@angular/cdk-experimental/*": ["../../dist/packages/cdk-experimental/*"]
     }
   },
   "files": [

--- a/src/material-examples/tsconfig.json
+++ b/src/material-examples/tsconfig.json
@@ -10,7 +10,6 @@
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/cdk-experimental/*": ["../cdk-experimental/*"],
       "@angular/material/*": ["../material/*"],
-      "@angular/material": ["../material/public-api.ts"],
       "@angular/material-experimental/*": ["../material-experimental/*"],
       "@angular/material-moment-adapter": ["../material-moment-adapter/public-api.ts"]
     }


### PR DESCRIPTION
Since the primary entry-point @angular/material is now deprecated
with V8, we should no longer use the deprecated entry-point in
our dev-app.

Blocked on #15977 