### PR TITLE
docs(text-field): change AutosizeMinRows to 1

### DIFF
--- a/src/material-examples/text-field-autosize-textarea/text-field-autosize-textarea-example.html
+++ b/src/material-examples/text-field-autosize-textarea/text-field-autosize-textarea-example.html
@@ -15,6 +15,6 @@
   <textarea matInput
             cdkTextareaAutosize
             #autosize="cdkTextareaAutosize"
-            cdkAutosizeMinRows="2"
+            cdkAutosizeMinRows="1"
             cdkAutosizeMaxRows="5"></textarea>
 </mat-form-field>


### PR DESCRIPTION
Change AutosizeMinRows from 2 to 1 so the text-field cdk docs example doesn't look weird at first glance.

Closes #15729