### PR TITLE
fix(table): error in Ivy for coerced multiTemplateDataRows

### DIFF
--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -727,6 +727,14 @@ describe('CdkTable', () => {
              ['', '5', '6'],
            ]);
          });
+
+      it('should not throw when multiTemplateDataRows is coerced from a static value', () => {
+        expect(() => {
+          setupTableTestApp(CoercedMultiTemplateDataRows);
+          fixture.detectChanges();
+        }).not.toThrow();
+      });
+
     });
   });
 
@@ -1623,6 +1631,59 @@ class WhenRowCdkTableApp {
     this.columnsForIsIndex1Row = indexColumns;
     this.columnsForHasC3Row = indexColumns;
   }
+}
+
+@Component({
+  template: `
+    <cdk-table [dataSource]="dataSource" multiTemplateDataRows>
+      <ng-container cdkColumnDef="column_a">
+        <cdk-header-cell *cdkHeaderCellDef> Column A</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.a}}</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="column_b">
+        <cdk-header-cell *cdkHeaderCellDef> Column B</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.b}}</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="column_c">
+        <cdk-header-cell *cdkHeaderCellDef> Column C</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let row"> {{row.c}}</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="index1Column">
+        <cdk-header-cell *cdkHeaderCellDef> Column C</cdk-header-cell>
+        <cdk-cell *cdkCellDef> index_1_special_row</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="c3Column">
+        <cdk-header-cell *cdkHeaderCellDef> Column C</cdk-header-cell>
+        <cdk-cell *cdkCellDef> c3_special_row</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="index">
+        <cdk-header-cell *cdkHeaderCellDef> Index</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let index = index"> {{index}}</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="dataIndex">
+        <cdk-header-cell *cdkHeaderCellDef> Data Index</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let dataIndex = dataIndex"> {{dataIndex}}</cdk-cell>
+      </ng-container>
+
+      <ng-container cdkColumnDef="renderIndex">
+        <cdk-header-cell *cdkHeaderCellDef> Render Index</cdk-header-cell>
+        <cdk-cell *cdkCellDef="let renderIndex = renderIndex"> {{renderIndex}}</cdk-cell>
+      </ng-container>
+
+      <cdk-header-row *cdkHeaderRowDef="columnsToRender"></cdk-header-row>
+      <cdk-row *cdkRowDef="let row; columns: columnsToRender"></cdk-row>
+      <cdk-row *cdkRowDef="let row; columns: columnsForIsIndex1Row; when: isIndex1"></cdk-row>
+      <cdk-row *cdkRowDef="let row; columns: columnsForHasC3Row; when: hasC3"></cdk-row>
+    </cdk-table>
+  `
+})
+class CoercedMultiTemplateDataRows extends WhenRowCdkTableApp {
 }
 
 @Component({

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -346,7 +346,10 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   }
   set multiTemplateDataRows(v: boolean) {
     this._multiTemplateDataRows = coerceBooleanProperty(v);
-    if (this._rowOutlet.viewContainer.length) {
+
+    // In Ivy if this value is set via a static attribute (e.g. <table multiTemplateDataRows>),
+    // this setter will be invoked before the row outlet has been defined hence the null check.
+    if (this._rowOutlet && this._rowOutlet.viewContainer.length) {
       this._forceRenderDataRows();
     }
   }


### PR DESCRIPTION
Fixes an error that is thrown by the table in Ivy, if `multiTemplateDataRows` is set as a static attribute. The timing for setters of static attributes is slightly different in Ivy, which means that we need an extra null check.

Fixes #16044.