### PR TITLE
fix(table): not clearing some internal references on destroy

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -447,12 +447,23 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   }
 
   ngOnDestroy() {
-    this._rowOutlet.viewContainer.clear();
-    this._headerRowOutlet.viewContainer.clear();
-    this._footerRowOutlet.viewContainer.clear();
+    [
+      this._rowOutlet.viewContainer,
+      this._headerRowOutlet.viewContainer,
+      this._footerRowOutlet.viewContainer,
+      this._cachedRenderRowsMap,
+      this._customColumnDefs,
+      this._customRowDefs,
+      this._customHeaderRowDefs,
+      this._customFooterRowDefs,
+      this._columnDefsByName
+    ].forEach(def => {
+      def.clear();
+    });
 
-    this._cachedRenderRowsMap.clear();
-
+    this._headerRowDefs = [];
+    this._footerRowDefs = [];
+    this._defaultRowDef = null;
     this._onDestroy.next();
     this._onDestroy.complete();
 


### PR DESCRIPTION
`CdkTable` keeps track of various definitions internally in order to render itself, however some of them weren't being cleared on destroy which could lead to memory leaks. These changes add some extra logic to clear the tracked references.