### PR TITLE
fix(popover-edit): incorrectly caching values for more than one control

### DIFF
--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -27,6 +27,7 @@ const NAME_EDIT_TEMPLATE = `
           [cdkEditControlIgnoreSubmitUnlessValid]="ignoreSubmitUnlessValid"
           [cdkEditControlClickOutBehavior]="clickOutBehavior">
         <input [ngModel]="element.name" name="name" required>
+        <input [ngModel]="element.weight" name="weight">
         <br>
         <button class="submit" type="submit">Confirm</button>
         <button class="revert" cdkEditRevert>Revert</button>
@@ -131,12 +132,16 @@ abstract class BaseTestComponent {
     return document.querySelector('.cdk-overlay-connected-position-bounding-box');
   }
 
-  getInput() {
-    return document.querySelector('input') as HTMLInputElement|null;
+  getNameInput() {
+    return document.querySelector('input[name="name"]') as HTMLInputElement|null;
+  }
+
+  getWeightInput() {
+    return document.querySelector('input[name="weight"]') as HTMLInputElement|null;
   }
 
   lensIsOpen() {
-    return !!this.getInput();
+    return !!this.getNameInput();
   }
 
   getSubmitButton() {
@@ -602,7 +607,7 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
         it('shows a lens with the value from the table', fakeAsync(() => {
           component.openLens();
 
-          expect(component.getInput()!.value).toBe('Hydrogen');
+          expect(component.getNameInput()!.value).toBe('Hydrogen');
           clearLeftoverTimers();
         }));
 
@@ -654,8 +659,8 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
         it('updates the form and submits, closing the lens', fakeAsync(() => {
           component.openLens();
 
-          component.getInput()!.value = 'Hydragon';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = 'Hydragon';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
 
           component.clickSubmitButton();
           fixture.detectChanges();
@@ -667,8 +672,8 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
         it('does not close the lens on submit when form is invalid', fakeAsync(() => {
           component.openLens();
 
-          component.getInput()!.value = '';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = '';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
 
           component.clickSubmitButton();
 
@@ -681,8 +686,8 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
           component.ignoreSubmitUnlessValid = false;
           component.openLens();
 
-          component.getInput()!.value = '';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = '';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
 
           component.clickSubmitButton();
 
@@ -702,8 +707,8 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
         it('closes and reopens a lens with modified value persisted', fakeAsync(() => {
           component.openLens();
 
-          component.getInput()!.value = 'Hydragon';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = 'Hydragon';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
 
           component.clickCloseButton();
           fixture.detectChanges();
@@ -713,46 +718,60 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
 
           component.openLens();
 
-          expect(component.getInput()!.value).toBe('Hydragon');
+          expect(component.getNameInput()!.value).toBe('Hydragon');
           clearLeftoverTimers();
         }));
 
         it('resets the lens to original value', fakeAsync(() => {
           component.openLens();
 
-          component.getInput()!.value = 'Hydragon';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = 'Hydragon';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
 
           component.clickRevertButton();
 
-          expect(component.getInput()!.value).toBe('Hydrogen');
+          expect(component.getNameInput()!.value).toBe('Hydrogen');
           clearLeftoverTimers();
         }));
+
+        it('should not reset the values when clicking revert without making changes',
+          fakeAsync(() => {
+            component.openLens();
+
+            expect(component.getNameInput()!.value).toBe('Hydrogen');
+            expect(component.getWeightInput()!.value).toBe('1.007');
+
+            component.clickRevertButton();
+
+            expect(component.getNameInput()!.value).toBe('Hydrogen');
+            expect(component.getWeightInput()!.value).toBe('1.007');
+            clearLeftoverTimers();
+          }));
 
         it('resets the lens to previously submitted value', fakeAsync(() => {
           component.openLens();
 
-          component.getInput()!.value = 'Hydragon';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = 'Hydragon';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
 
           component.clickSubmitButton();
           fixture.detectChanges();
 
           component.openLens();
 
-          component.getInput()!.value = 'Hydragon X';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = 'Hydragon X';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
 
           component.clickRevertButton();
 
-          expect(component.getInput()!.value).toBe('Hydragon');
+          expect(component.getNameInput()!.value).toBe('Hydragon');
           clearLeftoverTimers();
         }));
 
         it('closes the lens on escape', fakeAsync(() => {
           component.openLens();
 
-          component.getInput()!.dispatchEvent(
+          component.getNameInput()!.dispatchEvent(
               new KeyboardEvent('keyup', {bubbles: true, key: 'Escape'}));
 
           expect(component.lensIsOpen()).toBe(false);
@@ -762,7 +781,7 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
         it('does not close the lens on click within lens', fakeAsync(() => {
           component.openLens();
 
-          component.getInput()!.dispatchEvent(new Event('click', {bubbles: true}));
+          component.getNameInput()!.dispatchEvent(new Event('click', {bubbles: true}));
 
           expect(component.lensIsOpen()).toBe(true);
           clearLeftoverTimers();
@@ -771,8 +790,8 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
         it('closes the lens on outside click', fakeAsync(() => {
           component.openLens();
 
-          component.getInput()!.value = 'Hydragon';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = 'Hydragon';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
           document.body.dispatchEvent(new Event('click', {bubbles: true}));
           fixture.detectChanges();
 
@@ -786,8 +805,8 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
           component.clickOutBehavior = 'submit';
           component.openLens();
 
-          component.getInput()!.value = 'Hydragon';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = 'Hydragon';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
           document.body.dispatchEvent(new Event('click', {bubbles: true}));
           fixture.detectChanges();
 
@@ -801,8 +820,8 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
           component.clickOutBehavior = 'noop';
           component.openLens();
 
-          component.getInput()!.value = 'Hydragon';
-          component.getInput()!.dispatchEvent(new Event('input'));
+          component.getNameInput()!.value = 'Hydragon';
+          component.getNameInput()!.dispatchEvent(new Event('input'));
           document.body.dispatchEvent(new Event('click', {bubbles: true}));
           fixture.detectChanges();
 
@@ -814,7 +833,7 @@ cdkPopoverEditTabOut`, fakeAsync(() => {
         it('sets focus on the first input in the lens', fakeAsync(() => {
           component.openLens();
 
-          expect(document.activeElement).toBe(component.getInput());
+          expect(document.activeElement).toBe(component.getNameInput());
           clearLeftoverTimers();
         }));
 


### PR DESCRIPTION
Currently the edit popover uses the first `valueChange` event to know when to cache the value of its form so that it can revert to it if the user presess the `revert` button. This breaks down if the form has more than one control, because it'll emit a `valueChange` for each control that gets added. These changes fix the issue by using `NgZone` to wait for the form to be initialized.