### PR TITLE
fix(popover-edit): rework host listeners to account for changes in Ivy

### DIFF
--- a/src/cdk-experimental/popover-edit/table-directives.ts
+++ b/src/cdk-experimental/popover-edit/table-directives.ts
@@ -17,6 +17,7 @@ import {
   OnDestroy,
   TemplateRef,
   ViewContainerRef,
+  HostListener,
 } from '@angular/core';
 import {fromEvent, merge, ReplaySubject} from 'rxjs';
 import {debounceTime, filter, map, mapTo, startWith, takeUntil} from 'rxjs/operators';
@@ -393,7 +394,6 @@ export class CdkRowHoverContent implements AfterViewInit, OnDestroy {
  */
 @Directive({
   selector: '[cdkEditOpen]',
-  host: {'(click)': 'openEdit($event)'}
 })
 export class CdkEditOpen {
   constructor(
@@ -408,6 +408,11 @@ export class CdkEditOpen {
     }
   }
 
+  // In Ivy the `host` metadata will be merged, whereas in ViewEngine it is overridden. In order
+  // to avoid double event listeners, we need to use `HostListener`. Once Ivy is the default, we
+  // can move this back into `host`.
+  // tslint:disable:no-host-decorator-in-concrete
+  @HostListener('click', ['$event'])
   openEdit(evt: Event): void {
     this.editEventDispatcher.editing.next(closest(this.elementRef.nativeElement!, CELL_SELECTOR));
     evt.stopPropagation();

--- a/src/material-experimental/popover-edit/lens-directives.ts
+++ b/src/material-experimental/popover-edit/lens-directives.ts
@@ -24,11 +24,6 @@ import {
 @Directive({
   selector: 'form[matEditLens]',
   host: {
-    '(ngSubmit)': 'handleFormSubmit()',
-    '(keydown.enter)': 'editRef.trackEnterPressForClose(true)',
-    '(keyup.enter)': 'editRef.trackEnterPressForClose(false)',
-    '(keyup.escape)': 'close()',
-    '(document:click)': 'handlePossibleClickOut($event)',
     'class': 'mat-edit-lens',
   },
   inputs: [
@@ -46,7 +41,6 @@ export class MatEditLens<FormValue> extends CdkEditControl<FormValue> {
 @Directive({
   selector: 'button[matEditRevert]',
   host: {
-    '(click)': 'revertEdit()',
     'type': 'button', // Prevents accidental form submits.
   }
 })
@@ -57,7 +51,6 @@ export class MatEditRevert<FormValue> extends CdkEditRevert<FormValue> {
 @Directive({
   selector: 'button[matEditClose]',
   host: {
-    '(click)': 'closeEdit()',
     'type': 'button', // Prevents accidental form submits.
   }
 })

--- a/src/material-experimental/popover-edit/table-directives.ts
+++ b/src/material-experimental/popover-edit/table-directives.ts
@@ -107,7 +107,6 @@ export class MatRowHoverContent extends CdkRowHoverContent {
  */
 @Directive({
   selector: '[matEditOpen]',
-  host: {'(click)': 'openEdit($event)'}
 })
 export class MatEditOpen extends CdkEditOpen {
 }


### PR DESCRIPTION
Switches all of the inherited event listeners in `popover-edit` to use `@HostListener`. In Ivy the `host` objects are merged when inheriting, whereas in ViewEngine they are overwritten. This means that with the current setup we'll end up with double event listeners once Ivy lands.