### PR TITLE
build: fine-grain dependencies for mdc prototypes

### DIFF
--- a/src/material-experimental/mdc-button/BUILD.bazel
+++ b/src/material-experimental/mdc-button/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
 load("//tools:defaults.bzl", "ng_module")
-load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
 
 ng_module(
     name = "mdc-button",
@@ -12,7 +11,9 @@ ng_module(
     deps = [
         "@npm//@angular/animations",
         "@npm//material-components-web",
-    ] + CDK_TARGETS + MATERIAL_TARGETS,
+        "//src/cdk/platform",
+        "//src/material/core",
+    ],
 )
 
 sass_library(

--- a/src/material-experimental/mdc-card/BUILD.bazel
+++ b/src/material-experimental/mdc-card/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
-load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
 
 ng_module(
   name = "mdc-card",
@@ -11,7 +10,8 @@ ng_module(
   assets = [":card_scss"] + glob(["**/*.html"]),
   deps = [
     "@npm//material-components-web",
-  ] + CDK_TARGETS + MATERIAL_TARGETS,
+    "//src/material/core",
+  ],
 )
 
 sass_library(

--- a/src/material-experimental/mdc-checkbox/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
-load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
 
 ng_module(
   name = "mdc-checkbox",
@@ -15,7 +14,11 @@ ng_module(
     "@npm//@angular/core",
     "@npm//@angular/forms",
     "@npm//material-components-web",
-  ] + CDK_TARGETS + MATERIAL_TARGETS,
+    "//src/cdk/coercion",
+    "//src/cdk/platform",
+    "//src/material/core",
+    "//src/material/checkbox",
+  ],
 )
 
 sass_library(

--- a/src/material-experimental/mdc-chips/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
-load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
 
 ng_module(
   name = "mdc-chips",
@@ -13,7 +12,8 @@ ng_module(
     "@npm//@angular/common",
     "@npm//@angular/core",
     "@npm//material-components-web",
-  ] + CDK_TARGETS + MATERIAL_TARGETS,
+    "//src/material/core",
+  ],
 )
 
 sass_library(

--- a/src/material-experimental/mdc-helpers/BUILD.bazel
+++ b/src/material-experimental/mdc-helpers/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library")
 load("//tools:defaults.bzl", "ng_module")
-load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
 
 ng_module(
   name = "mdc-helpers",
@@ -11,7 +10,7 @@ ng_module(
   assets = glob(["**/*.html"]),
   deps = [
     "@npm//@angular/core",
-  ] + CDK_TARGETS + MATERIAL_TARGETS,
+  ],
 )
 
 # Add all MDC Sass files that we depend on here. After updating MDC dependencies, use the following

--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
-load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
 
 ng_module(
   name = "mdc-menu",
@@ -14,7 +13,10 @@ ng_module(
     "@npm//@angular/common",
     "@npm//@angular/core",
     "@npm//material-components-web",
-  ] + CDK_TARGETS + MATERIAL_TARGETS,
+    "//src/cdk/overlay",
+    "//src/material/menu",
+    "//src/material/core",
+  ],
 )
 
 sass_library(

--- a/src/material-experimental/mdc-radio/BUILD.bazel
+++ b/src/material-experimental/mdc-radio/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
-load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
 
 ng_module(
   name = "mdc-radio",
@@ -11,7 +10,8 @@ ng_module(
   assets = [":radio_scss"] + glob(["**/*.html"]),
   deps = [
     "@npm//material-components-web",
-  ] + CDK_TARGETS + MATERIAL_TARGETS,
+    "//src/material/core",
+  ],
 )
 
 sass_library(

--- a/src/material-experimental/mdc-slide-toggle/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
-load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
 
 ng_module(
   name = "mdc-slide-toggle",
@@ -15,7 +14,9 @@ ng_module(
     "@npm//@angular/forms",
     "@npm//@angular/animations",
     "@npm//material-components-web",
-  ] + CDK_TARGETS + MATERIAL_TARGETS,
+    "//src/cdk/coercion",
+    "//src/material/core",
+  ],
 )
 
 sass_library(


### PR DESCRIPTION
Currently all mdc prototype secondary entry-points specify
all CDK and Material Bazel targets as dependencies. This
causes significant slower builds and also doesn't follow the
fine-grained dependency pattern.

Fine-grained dependencies have various benefits over
coarced dependencies. We should consider putting
this into a Bazel guide somewhere inside the repository
at some point.