### PR TITLE
Revert "refactor: mark injectable refs with `@Injectable`"

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/material/bottom-sheet/bottom-sheet-ref.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Location} from '@angular/common';
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {OverlayRef} from '@angular/cdk/overlay';
-import {Location} from '@angular/common';
-import {Injectable} from '@angular/core';
 import {merge, Observable, Subject} from 'rxjs';
 import {filter, take} from 'rxjs/operators';
 import {MatBottomSheetContainer} from './bottom-sheet-container';
 
 
-/** Reference to a bottom sheet dispatched from the bottom sheet service. */
-@Injectable()
+/**
+ * Reference to a bottom sheet dispatched from the bottom sheet service.
+ */
 export class MatBottomSheetRef<T = any, R = any> {
   /** Instance of the component making up the content of the bottom sheet. */
   instance: T;

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -9,7 +9,6 @@
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {GlobalPositionStrategy, OverlayRef} from '@angular/cdk/overlay';
 import {Location} from '@angular/common';
-import {Injectable} from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 import {filter, take} from 'rxjs/operators';
 import {DialogPosition} from './dialog-config';
@@ -21,8 +20,9 @@ import {MatDialogContainer} from './dialog-container';
 // Counter for unique dialog ids.
 let uniqueId = 0;
 
-/** Reference to a dialog opened via the MatDialog service. */
-@Injectable()
+/**
+ * Reference to a dialog opened via the MatDialog service.
+ */
 export class MatDialogRef<T, R = any> {
   /** The instance of component opened into the dialog. */
   componentInstance: T;

--- a/src/material/snack-bar/snack-bar-ref.ts
+++ b/src/material/snack-bar/snack-bar-ref.ts
@@ -7,7 +7,6 @@
  */
 
 import {OverlayRef} from '@angular/cdk/overlay';
-import {Injectable} from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 import {MatSnackBarContainer} from './snack-bar-container';
 
@@ -18,8 +17,9 @@ export interface MatSnackBarDismiss {
   dismissedByAction: boolean;
 }
 
-/** Reference to a snack bar dispatched from the snack bar service. */
-@Injectable()
+/**
+ * Reference to a snack bar dispatched from the snack bar service.
+ */
 export class MatSnackBarRef<T> {
   /** The instance of the component making up the content of the snack bar. */
   instance: T;


### PR DESCRIPTION
Reverts angular/components#15584

Caused warnings while building:
```
Warning: Can't resolve all parameters for MatDialogRef in .../components/dist/packages/material/dialog/dialog-ref.d.ts: ([object Object], [object Object], [object Object], ?). This will become an error in Angular v6.x
```