### PR TITLE
perf(drag-drop): use narrower check for touch events

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -1103,7 +1103,10 @@ function removeElement(element: HTMLElement | null) {
 
 /** Determines whether an event is a touch event. */
 function isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent {
-  return event.type.startsWith('touch');
+  // This function is called for every pixel that the user has dragged so we need it to be
+  // as fast as possible. Since we only bind mouse events and touch events, we can assume
+  // that if the event's name starts with `t`, it's a touch event.
+  return event.type[0] === 't';
 }
 
 /** Gets the element into which the drag preview should be inserted. */


### PR DESCRIPTION
We use the `isTouchEvent` any time we need to normalize something between touch and mouse events which happens for every pixel that the user has dragged. These changes switch to using direct comparison, rather than `startsWith`, which should be slightly faster since there's a narrow set of touch event types.