### PR TITLE
build: run mdc prototype tests with bazel

### DIFF
--- a/src/material-experimental/BUILD.bazel
+++ b/src/material-experimental/BUILD.bazel
@@ -4,6 +4,8 @@ load("@io_bazel_rules_sass//:defs.bzl", "sass_library")
 load("//tools:defaults.bzl", "ng_module", "ng_package")
 load("//:packages.bzl", "ROLLUP_GLOBALS")
 
+exports_files(["mdc_require_config.js"])
+
 ng_module(
   name = "material-experimental",
   srcs = glob(["*.ts"], exclude=["**/*.spec.ts"]),

--- a/src/material-experimental/mdc-checkbox/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
   name = "mdc-checkbox",
@@ -42,4 +42,24 @@ sass_binary(
     "//src/material/core:all_themes",
     "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
   ]
+)
+
+ng_test_library(
+  name = "checkbox_tests_lib",
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":mdc-checkbox",
+    "@npm//@angular/platform-browser",
+    "@npm//@angular/forms",
+    "//src/cdk/testing",
+  ]
+)
+
+ng_web_test_suite(
+  name = "unit_tests",
+  static_files = ["@npm//node_modules/@material/checkbox:dist/mdc.checkbox.js"],
+  deps = [
+    "//src/material-experimental:mdc_require_config.js",
+    ":checkbox_tests_lib",
+  ],
 )

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -120,6 +120,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
   }
   set checked(checked) {
     this._checked = coerceBooleanProperty(checked);
+    this._changeDetectorRef.markForCheck();
   }
   private _checked = false;
 
@@ -135,6 +136,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
   }
   set indeterminate(indeterminate) {
     this._indeterminate = coerceBooleanProperty(indeterminate);
+    this._changeDetectorRef.markForCheck();
   }
   private _indeterminate = false;
 
@@ -156,6 +158,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
   }
   set required(required) {
     this._required = coerceBooleanProperty(required);
+    this._changeDetectorRef.markForCheck();
   }
   private _required = false;
 

--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
   name = "mdc-menu",
@@ -40,4 +40,28 @@ sass_binary(
     "//src/material/core:all_themes",
     "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
   ]
+)
+
+ng_test_library(
+  name = "menu_tests_lib",
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":mdc-menu",
+    "@npm//@angular/platform-browser",
+    "@npm//rxjs",
+    "//src/cdk/a11y",
+    "//src/cdk/bidi",
+    "//src/cdk/overlay",
+    "//src/cdk/keycodes",
+    "//src/cdk/scrolling",
+    "//src/cdk/testing",
+    "//src/material/core",
+  ]
+)
+
+ng_web_test_suite(
+  name = "unit_tests",
+  deps = [
+    ":menu_tests_lib",
+  ],
 )

--- a/src/material-experimental/mdc-menu/menu.ts
+++ b/src/material-experimental/mdc-menu/menu.ts
@@ -6,13 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Component, ViewEncapsulation, Provider} from '@angular/core';
 import {Overlay, ScrollStrategy} from '@angular/cdk/overlay';
 import {
-  MatMenu as BaseMatMenu,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Inject,
+  NgZone,
+  Provider,
+  ViewEncapsulation
+} from '@angular/core';
+import {
+  MAT_MENU_DEFAULT_OPTIONS,
   MAT_MENU_PANEL,
-  matMenuAnimations,
   MAT_MENU_SCROLL_STRATEGY,
+  MatMenu as BaseMatMenu,
+  matMenuAnimations,
+  MatMenuDefaultOptions,
 } from '@angular/material/menu';
 
 /** @docs-private */
@@ -45,6 +55,13 @@ export const MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER: Provider = {
   ]
 })
 export class MatMenu extends BaseMatMenu {
+
+  constructor(_elementRef: ElementRef<HTMLElement>,
+              _ngZone: NgZone,
+              @Inject(MAT_MENU_DEFAULT_OPTIONS) _defaultOptions: MatMenuDefaultOptions) {
+    super(_elementRef, _ngZone, _defaultOptions);
+  }
+
   setElevation(_depth: number) {
     // TODO(crisbeto): MDC's styles come with elevation already and we haven't mapped our mixins
     // to theirs. Disable the elevation stacking for now until everything has been mapped.

--- a/src/material-experimental/mdc-slide-toggle/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility=["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library", "sass_binary")
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
   name = "mdc-slide-toggle",
@@ -39,4 +39,25 @@ sass_binary(
     ":slide_toggle_scss_lib",
     "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
   ]
+)
+
+ng_test_library(
+  name = "slide_toggle_tests_lib",
+  srcs = glob(["**/*.spec.ts"]),
+  deps = [
+    ":mdc-slide-toggle",
+    "@npm//@angular/platform-browser",
+    "@npm//@angular/forms",
+    "//src/cdk/bidi",
+    "//src/cdk/testing",
+  ]
+)
+
+ng_web_test_suite(
+  name = "unit_tests",
+  static_files = ["@npm//node_modules/@material/switch:dist/mdc.switch.js"],
+  deps = [
+    "//src/material-experimental:mdc_require_config.js",
+    ":slide_toggle_tests_lib",
+  ],
 )

--- a/src/material-experimental/mdc_require_config.js
+++ b/src/material-experimental/mdc_require_config.js
@@ -1,0 +1,37 @@
+// Require.js is being used by the karma bazel rules and needs to be configured to properly
+// load AMD modules which are not explicitly named in their output bundle.
+require.config({
+  paths: {
+    '@material/animation': '/base/npm/node_modules/@material/animation/dist/mdc.animation',
+    '@material/auto-init': '/base/npm/node_modules/@material/auto-init/dist/mdc.autoInit',
+    '@material/base': '/base/npm/node_modules/@material/base/dist/mdc.base',
+    '@material/checkbox': '/base/npm/node_modules/@material/checkbox/dist/mdc.checkbox',
+    '@material/chips': '/base/npm/node_modules/@material/chips/dist/mdc.chips',
+    '@material/dialog': '/base/npm/node_modules/@material/dialog/dist/mdc.dialog',
+    '@material/dom': '/base/npm/node_modules/@material/dom/dist/mdc.dom',
+    '@material/drawer': '/base/npm/node_modules/@material/drawer/dist/mdc.drawer',
+    '@material/floating-label': '/base/npm/node_modules/@material/floating-label/dist/mdc.floatingLabel',
+    '@material/form-field': '/base/npm/node_modules/@material/form-field/dist/mdc.formField',
+    '@material/grid-list': '/base/npm/node_modules/@material/grid-list/dist/mdc.gridList',
+    '@material/icon-button': '/base/npm/node_modules/@material/icon-button/dist/mdc.iconButton',
+    '@material/line-ripple': '/base/npm/node_modules/@material/line-ripple/dist/mdc.lineRipple',
+    '@material/linear-progress': '/base/npm/node_modules/@material/linear-progress/dist/mdc.linearProgress',
+    '@material/list': '/base/npm/node_modules/@material/list/dist/mdc.list',
+    '@material/menu': '/base/npm/node_modules/@material/menu/dist/mdc.menu',
+    '@material/menu-surface': '/base/npm/node_modules/@material/menu-surface/dist/mdc.menuSurface',
+    '@material/notched-outline': '/base/npm/node_modules/@material/notched-outline/dist/mdc.notchedOutline',
+    '@material/radio': '/base/npm/node_modules/@material/radio/dist/mdc.radio',
+    '@material/ripple': '/base/npm/node_modules/@material/ripple/dist/mdc.ripple',
+    '@material/select': '/base/npm/node_modules/@material/select/dist/mdc.select',
+    '@material/slider': '/base/npm/node_modules/@material/slider/dist/mdc.slider',
+    '@material/snackbar': '/base/npm/node_modules/@material/snackbar/dist/mdc.snackbar',
+    '@material/switch': '/base/npm/node_modules/@material/switch/dist/mdc.switch',
+    '@material/tab': '/base/npm/node_modules/@material/tab/dist/mdc.tab',
+    '@material/tab-bar': '/base/npm/node_modules/@material/tab-bar/dist/mdc.tabBar',
+    '@material/tab-indicator': '/base/npm/node_modules/@material/tab-indicator/dist/mdc.tabIndicator',
+    '@material/tab-scroller': '/base/npm/node_modules/@material/tab-scroller/dist/mdc.tabScroller',
+    '@material/text-field': '/base/npm/node_modules/@material/textfield/dist/mdc.textField',
+    '@material/toolbar': '/base/npm/node_modules/@material/toolbar/dist/mdc.toolbar',
+    '@material/top-app-bar': '/base/npm/node_modules/@material/top-app-bar/dist/mdc.topAppBar',
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,19 @@
     "skipLibCheck": true,
     "target": "es2015",
     "lib": ["es5", "es2015", "dom"],
-    "types": ["jasmine"]
+    "types": ["jasmine"],
+    "baseUrl": ".",
+    "paths": {
+      "@angular/cdk": ["./src/cdk"],
+      "@angular/cdk/*": ["./src/cdk/*"],
+      "@angular/material/*": ["./src/material/*"],
+      "@angular/material-experimental/*": ["./src/material-experimental/*"],
+      "@angular/material-experimental": ["./src/material-experimental"],
+      "@angular/cdk-experimental/*": ["./src/cdk-experimental/*"],
+      "@angular/cdk-experimental": ["./src/cdk-experimental"],
+      "@angular/material-moment-adapter": ["./src/material-moment-adapter"],
+      "@angular/material-examples": ["./src/packages/material-examples"]
+    }
   },
   "include": [
     "src/**/*.ts",
@@ -33,6 +45,12 @@
 
     // IDEs should not type-check the different node_modules directories of the different packages.
     // This would cause the IDEs to be slower and also linters would check the node_modules.
-    "node_modules/"
+    "node_modules/",
+
+    // Exclude schematic template files and test cases which aren't valid TS files.
+    "src/material/schematics/ng-generate/*/files/**/*",
+    "src/cdk/schematics/ng-generate/*/files/**/*",
+    "src/cdk/schematics/ng-update/test-cases/**/*",
+    "src/material/schematics/ng-update/test-cases/**/*"
   ]
 }


### PR DESCRIPTION
Sets up the MDC prototype entry-points to run tests with Bazel. This
allows us to run tests for these components against Ivy.