### PR TITLE
test: fix flaky slide-toggle test with pending timer task

### DIFF
--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -389,7 +389,7 @@ describe('MatSlideToggle without forms', () => {
   });
 
   describe('custom action configuration', () => {
-    it('should not change value on click when click action is noop', fakeAsync(() => {
+    it('should not change value on click when click action is noop', () => {
       TestBed
         .resetTestingModule()
         .configureTestingModule({
@@ -430,7 +430,7 @@ describe('MatSlideToggle without forms', () => {
       expect(slideToggle.checked).toBe(false, 'Expect slide toggle value not changed');
       expect(testComponent.toggleTriggered).toBe(2, 'Expect toggle twice');
       expect(testComponent.dragTriggered).toBe(0);
-    }));
+    });
 
     it('should not change value on dragging when drag action is noop', fakeAsync(() => {
       TestBed


### PR DESCRIPTION
One of the slide-toggle tests has become quite flaky the
last days and after debugging ZoneJS it turns out that
this is related to the `(focus)` event from the `FocusMonitor`
and we can safely improve the stability of the test by removing
the `fakeAsync` which isn't needed anyway.

For reference: Other tests asserting the `click` event on
the slide-toggle native element also have a `tick()`
specified but we don't need to wait for pending timers
anyway.. so we can just remove `fakeAsync .