### PR TITLE
build: fill in missing MATERIAL_EXPERIMENTAL_PACKAGES

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "ngc -p angular-tsconfig.json",
     "build": "gulp build-release-packages",
     "dev-app": "gulp serve:devapp",
-    "test": "gulp test",
+    "test": "bazel test //src/...",
     "lint": "gulp lint",
     "e2e": "bazel test //e2e/...",
     "deploy": "gulp deploy:devapp",

--- a/packages.bzl
+++ b/packages.bzl
@@ -79,6 +79,14 @@ MATERIAL_SCSS_LIBS = [
 ]
 
 MATERIAL_EXPERIMENTAL_PACKAGES = [
+  "mdc-button",
+  "mdc-card",
+  "mdc-checkbox",
+  "mdc-chips",
+  "mdc-helpers",
+  "mdc-menu",
+  "mdc-radio",
+  "mdc-slide-toggle",
   "popover-edit",
 ]
 

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -44,13 +44,5 @@ sass_binary(
   ],
   deps = [
     "//src/material/core:all_themes",
-    "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-    "//src/material-experimental/mdc-button:button_scss_lib",
-    "//src/material-experimental/mdc-card:card_scss_lib",
-    "//src/material-experimental/mdc-checkbox:checkbox_scss_lib",
-    "//src/material-experimental/mdc-chips:chips_scss_lib",
-    "//src/material-experimental/mdc-menu:menu_scss_lib",
-    "//src/material-experimental/mdc-radio:radio_scss_lib",
-    "//src/material-experimental/mdc-slide-toggle:slide_toggle_scss_lib",
   ] + MATERIAL_EXPERIMENTAL_SCSS_LIBS
 )

--- a/src/e2e-app/BUILD.bazel
+++ b/src/e2e-app/BUILD.bazel
@@ -58,13 +58,13 @@ sass_binary(
   deps = [
     "//src/material/core:all_themes",
     "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-    "//src/material-experimental/mdc-button:button_scss_lib",
-    "//src/material-experimental/mdc-card:card_scss_lib",
-    "//src/material-experimental/mdc-checkbox:checkbox_scss_lib",
-    "//src/material-experimental/mdc-chips:chips_scss_lib",
-    "//src/material-experimental/mdc-menu:menu_scss_lib",
-    "//src/material-experimental/mdc-radio:radio_scss_lib",
-    "//src/material-experimental/mdc-slide-toggle:slide_toggle_scss_lib",
+    "//src/material-experimental/mdc-button:mdc_button_scss_lib",
+    "//src/material-experimental/mdc-card:mdc_card_scss_lib",
+    "//src/material-experimental/mdc-checkbox:mdc_checkbox_scss_lib",
+    "//src/material-experimental/mdc-chips:mdc_chips_scss_lib",
+    "//src/material-experimental/mdc-menu:mdc_menu_scss_lib",
+    "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",
+    "//src/material-experimental/mdc-slide-toggle:mdc_slide_toggle_scss_lib",
   ]
 )
 

--- a/src/material-experimental/mdc-button/BUILD.bazel
+++ b/src/material-experimental/mdc-button/BUILD.bazel
@@ -17,7 +17,7 @@ ng_module(
 )
 
 sass_library(
-    name = "button_scss_lib",
+    name = "mdc_button_scss_lib",
     srcs = glob(["**/_*.scss"]),
     deps = [
         "//src/material/core:core_scss_lib",

--- a/src/material-experimental/mdc-card/BUILD.bazel
+++ b/src/material-experimental/mdc-card/BUILD.bazel
@@ -15,7 +15,7 @@ ng_module(
 )
 
 sass_library(
-  name = "card_scss_lib",
+  name = "mdc_card_scss_lib",
   srcs = glob(["**/_*.scss"]),
   deps = [
     "//src/material/core:core_scss_lib",

--- a/src/material-experimental/mdc-checkbox/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/BUILD.bazel
@@ -22,7 +22,7 @@ ng_module(
 )
 
 sass_library(
-  name = "checkbox_scss_lib",
+  name = "mdc_checkbox_scss_lib",
   srcs = glob(["**/_*.scss"]),
   deps = [
     "//src/material/core:core_scss_lib",
@@ -38,8 +38,8 @@ sass_binary(
     "external/npm/node_modules",
   ],
   deps = [
-    ":checkbox_scss_lib",
     "//src/material/core:all_themes",
+    "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
     "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
   ]
 )

--- a/src/material-experimental/mdc-chips/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/BUILD.bazel
@@ -17,7 +17,7 @@ ng_module(
 )
 
 sass_library(
-  name = "chips_scss_lib",
+  name = "mdc_chips_scss_lib",
   srcs = glob(["**/_*.scss"]),
   deps = [
     "//src/material/core:core_scss_lib",

--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -20,7 +20,7 @@ ng_module(
 )
 
 sass_library(
-  name = "menu_scss_lib",
+  name = "mdc_menu_scss_lib",
   srcs = glob(["**/_*.scss"]),
   deps = [
     "//src/material/core:core_scss_lib",
@@ -36,7 +36,6 @@ sass_binary(
     "external/npm/node_modules",
   ],
   deps = [
-    ":menu_scss_lib",
     "//src/material/core:all_themes",
     "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
   ]

--- a/src/material-experimental/mdc-radio/BUILD.bazel
+++ b/src/material-experimental/mdc-radio/BUILD.bazel
@@ -15,7 +15,7 @@ ng_module(
 )
 
 sass_library(
-  name = "radio_scss_lib",
+  name = "mdc_radio_scss_lib",
   srcs = glob(["**/_*.scss"]),
   deps = [
     "//src/material/core:core_scss_lib",

--- a/src/material-experimental/mdc-slide-toggle/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/BUILD.bazel
@@ -20,7 +20,7 @@ ng_module(
 )
 
 sass_library(
-  name = "slide_toggle_scss_lib",
+  name = "mdc_slide_toggle_scss_lib",
   srcs = glob(["**/_*.scss"]),
   deps = [
     "//src/material/core:core_scss_lib",
@@ -36,7 +36,7 @@ sass_binary(
     "external/npm/node_modules",
   ],
   deps = [
-    ":slide_toggle_scss_lib",
+    "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
     "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
   ]
 )


### PR DESCRIPTION
I noticed that the MDC components were missing from MATERIAL_EXPERIMENTAL_PACKAGES. This PR fixes it and does some related cleanup