### PR TITLE
fix(expansion-panel): header animating on init when using non-default height

### DIFF
--- a/tools/public_api_guard/material/expansion.d.ts
+++ b/tools/public_api_guard/material/expansion.d.ts
@@ -70,11 +70,13 @@ export declare class MatExpansionPanelDescription {
 }
 
 export declare class MatExpansionPanelHeader implements OnDestroy, FocusableOption {
+    _animationsDisabled: boolean;
     collapsedHeight: string;
     readonly disabled: any;
     expandedHeight: string;
     panel: MatExpansionPanel;
     constructor(panel: MatExpansionPanel, _element: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, defaultOptions?: MatExpansionPanelDefaultOptions);
+    _animationStarted(): void;
     _getExpandedState(): string;
     _getPanelId(): string;
     _isExpanded(): boolean;


### PR DESCRIPTION
Works around the expansion panel header animating on init, if its header is different from the default one. The original issue comes from the code introduced in #13088, but we can't remove that code, because it's there to work around a bug in Angular.

Fixes #16067.