### PR TITLE
fix(ng-update): do not always use double quotes for generated imports

### DIFF
--- a/src/material/schematics/ng-update/test-cases/misc/material-imports_expected_output.ts
+++ b/src/material/schematics/ng-update/test-cases/misc/material-imports_expected_output.ts
@@ -1,18 +1,18 @@
-import { c as c2 } from "@angular/material/c";
-import { a } from "@angular/material/a";
-import { b } from "@angular/material/b";
-import { c } from "@angular/material/c";
-import { a as a2 } from "@angular/material/a";
+import { c as c2 } from '@angular/material/c';
+import { a } from '@angular/material/a';
+import { b } from '@angular/material/b';
+import { c } from '@angular/material/c';
+import { a as a2 } from '@angular/material/a';
 
 // unsorted
-import { a } from "@angular/material/a";
-import { b } from "@angular/material/b";
-import { c } from "@angular/material/c";
+import { a } from '@angular/material/a';
+import { b } from '@angular/material/b';
+import { c } from '@angular/material/c';
 
-import { /* comment */ a as a3 } from "@angular/material/a";
+import { /* comment */ a as a3 } from '@angular/material/a';
 
 // primary entry-point export
-import { VERSION } from "@angular/material/core";
+import { VERSION } from '@angular/material/core';
 
 // type import
 import { SomeInterface } from "@angular/material/types";

--- a/src/material/schematics/ng-update/test-cases/misc/material-imports_input.ts
+++ b/src/material/schematics/ng-update/test-cases/misc/material-imports_input.ts
@@ -11,4 +11,4 @@ import {/* comment */ a as a3} from '@angular/material';
 import {VERSION} from '@angular/material';
 
 // type import
-import {SomeInterface} from '@angular/material';
+import {SomeInterface} from "@angular/material";


### PR DESCRIPTION
Currently when someone uses single quote import declarations in
their project and the `ng update` migration for Material runs, the
Material imports are rewritten into multiple imports referring to
individual secondary entry-points, but the actual existing quote
style is ignored. This means that the linter can sometimes complain
after the migration has been performed.

Ideally we'd run the tslint fix task after the migration ran in order to
fix all lint rule failures which are specific to the given project, but this
is not a best-practice yet and we need to decide on the CLI-side whether
the CLI should automatically run the fixers after generator/migration
schematics ran. See: https://github.com/angular/angular-cli/issues/14532

Unfortunately we can't do the same thing for the whitespace within
the `NamedImports` declaration because the whitespace for object
literal expressions is hard-coded. See:

https://github.com/microsoft/TypeScript/blob/6a559e37ee0d660fcc94f086a34370e79e94b17a/src/compiler/emitter.ts#L3796-L3797
(`emitObjectLiteralExpression` does not allow configuring the format flags)

Fixes #14532