### PR TITLE
fix(ng-update): do not report form-field breaking change from v6

### DIFF
--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -15,12 +15,16 @@ import {materialUpgradeData} from './upgrade-data';
 /** List of additional upgrade rules for Angular Material. */
 const upgradeRules = [
   // Misc check rules
-  'check-class-inheritance-misc',
   'check-class-names-misc',
   'check-imports-misc',
   'check-property-names-misc',
   'check-template-misc',
   'update-angular-material-imports',
+
+  // Class inheritance misc V6. NOTE: when adding new
+  // data to this rule, consider adding it to the generic
+  // property-names upgrade data.
+  ['check-class-inheritance-misc', TargetVersion.V6],
 
   // Ripple misc V7
   ['ripple-speed-factor-assignment', TargetVersion.V7],

--- a/src/material/schematics/ng-update/test-cases/misc/class-inheritance.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/misc/class-inheritance.spec.ts
@@ -1,0 +1,20 @@
+import {createTestCaseSetup} from '@angular/cdk/schematics/testing';
+import {migrationCollection} from '../index.spec';
+
+describe('class inheritance misc checks', () => {
+
+  describe('v6 class which extends MatFormFieldControl', () => {
+
+    it('should report if class does not declare "shouldLabelFloat"', async () => {
+      const {removeTempDir, runFixers} = await createTestCaseSetup('migration-v6',
+        migrationCollection, [require.resolve('./class-inheritance_input.ts')]);
+
+      const {logOutput} = await runFixers();
+
+      expect(logOutput).toMatch(/Found class "WithoutLabelProp".*extends "MatFormFieldControl.*must define "shouldLabelFloat"/);
+      expect(logOutput).not.toMatch(/Found class "WithLabelProp".*extends "MatFormFieldControl".*must define "shouldLabelFloat"/);
+
+      removeTempDir();
+    });
+  });
+});

--- a/src/material/schematics/ng-update/test-cases/misc/class-inheritance_input.ts
+++ b/src/material/schematics/ng-update/test-cases/misc/class-inheritance_input.ts
@@ -1,0 +1,10 @@
+import {HostBinding} from '@angular/core';
+import {MatFormFieldControl} from '@angular/material/form-field';
+
+class WithoutLabelProp extends MatFormFieldControl<any> {
+}
+
+class WithLabelProp extends MatFormFieldControl<any> {
+  @HostBinding('class.floating')
+  get shouldLabelFloat() {return true;}
+}

--- a/src/material/schematics/ng-update/upgrade-rules/misc-checks/checkClassInheritanceMiscRule.ts
+++ b/src/material/schematics/ng-update/upgrade-rules/misc-checks/checkClassInheritanceMiscRule.ts
@@ -34,7 +34,7 @@ export class Walker extends ProgramAwareRuleWalker {
     if (baseTypes.includes('MatFormFieldControl')) {
       const hasFloatLabelMember = node.members
           .filter(member => member.name)
-          .find(member => member.name!.getText() === 'shouldFloatLabel');
+          .find(member => member.name!.getText() === 'shouldLabelFloat');
 
       if (!hasFloatLabelMember) {
         this.addFailureAtNode(node, `Found class "${bold(className)}" which extends ` +


### PR DESCRIPTION
The misc rules currently run for every migration, but the one for the
`shouldLabelFloat` was apparently using a wrong check that has
been added back in the days when we pulled out the standalone
migration tool into the material2 repository.

While being at it, we are fixing that invalid check and limit
the misc migration to the V6 upgrade target version.

Fixes #16143