### PR TITLE
refactor(media-queries): update to css level 4 syntax

### DIFF
--- a/src/cdk/layout/breakpoints.ts
+++ b/src/cdk/layout/breakpoints.ts
@@ -8,24 +8,24 @@
 // PascalCase is being used as Breakpoints is used like an enum.
 // tslint:disable-next-line:variable-name
 export const Breakpoints = {
-  XSmall: '(max-width: 599.99px)',
-  Small: '(min-width: 600px) and (max-width: 959.99px)',
-  Medium: '(min-width: 960px) and (max-width: 1279.99px)',
-  Large: '(min-width: 1280px) and (max-width: 1919.99px)',
-  XLarge: '(min-width: 1920px)',
+  XSmall: '(width <= 599.99px)',
+  Small: '(600px <= width <= 959.99px)',
+  Medium: '(960px <= width <= 1279.99px)',
+  Large: '(1280px <= width <= 1919.99px)',
+  XLarge: '(width => 1920px)',
 
-  Handset: '(max-width: 599.99px) and (orientation: portrait), ' +
-           '(max-width: 959.99px) and (orientation: landscape)',
-  Tablet: '(min-width: 600px) and (max-width: 839.99px) and (orientation: portrait), ' +
-          '(min-width: 960px) and (max-width: 1279.99px) and (orientation: landscape)',
-  Web: '(min-width: 840px) and (orientation: portrait), ' +
-       '(min-width: 1280px) and (orientation: landscape)',
+  Handset: '(width <= 599.99px) and (orientation: portrait), ' +
+           '(width <= 959.99px) and (orientation: landscape)',
+  Tablet: '(600px <= width <= 839.99px) and (orientation: portrait), ' +
+          '(960px <= width <= 1279.99px) and (orientation: landscape)',
+  Web: '(width => 840px) and (orientation: portrait), ' +
+       '(width => 1280px) and (orientation: landscape)',
 
-  HandsetPortrait: '(max-width: 599.99px) and (orientation: portrait)',
-  TabletPortrait: '(min-width: 600px) and (max-width: 839.99px) and (orientation: portrait)',
-  WebPortrait: '(min-width: 840px) and (orientation: portrait)',
+  HandsetPortrait: '(width <= 599.99px) and (orientation: portrait)',
+  TabletPortrait: '(600px <= width <= 839.00px) and (orientation: portrait)',
+  WebPortrait: '(width => 840px) and (orientation: portrait)',
 
-  HandsetLandscape: '(max-width: 959.99px) and (orientation: landscape)',
-  TabletLandscape: '(min-width: 960px) and (max-width: 1279.99px) and (orientation: landscape)',
-  WebLandscape: '(min-width: 1280px) and (orientation: landscape)',
+  HandsetLandscape: '(width <= 959.99px) and (orientation: landscape)',
+  TabletLandscape: '(960px <= width <= 1279.99px) and (orientation: landscape)',
+  WebLandscape: '(width => 1280px) and (orientation: landscape)',
 };


### PR DESCRIPTION
This updates the syntax of CSS Media Queries used to Level 4. It is intended to be simpler to write and to understand.