### PR TITLE
refactor: remove calls to deprecated rxjs subscribe signature

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -434,8 +434,7 @@ describe('CdkDrag', () => {
       fixture.detectChanges();
 
       const spy = jasmine.createSpy('move spy');
-      const subscription = fixture.componentInstance.dragInstance.moved
-          .subscribe(undefined, undefined, spy);
+      const subscription = fixture.componentInstance.dragInstance.moved.subscribe({complete: spy});
 
       fixture.destroy();
       expect(spy).toHaveBeenCalled();

--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -143,9 +143,8 @@ describe('DragDropRegistry', () => {
   it('should complete the pointer event streams on destroy', () => {
     const pointerUpSpy = jasmine.createSpy('pointerUp complete spy');
     const pointerMoveSpy = jasmine.createSpy('pointerMove complete spy');
-    const pointerUpSubscription = registry.pointerUp.subscribe(undefined, undefined, pointerUpSpy);
-    const pointerMoveSubscription =
-        registry.pointerMove.subscribe(undefined, undefined, pointerMoveSpy);
+    const pointerUpSubscription = registry.pointerUp.subscribe({complete: pointerUpSpy});
+    const pointerMoveSubscription = registry.pointerMove.subscribe({complete: pointerMoveSpy});
 
     registry.ngOnDestroy();
 

--- a/src/cdk/layout/breakpoints-observer.spec.ts
+++ b/src/cdk/layout/breakpoints-observer.spec.ts
@@ -71,9 +71,9 @@ describe('BreakpointObserver', () => {
 
   it('completes all events when the breakpoint manager is destroyed', fakeAsync(() => {
     const firstTest = jasmine.createSpy('test1');
-    breakpointObserver.observe('test1').subscribe(undefined, undefined, firstTest);
+    breakpointObserver.observe('test1').subscribe({complete: firstTest});
     const secondTest = jasmine.createSpy('test2');
-    breakpointObserver.observe('test2').subscribe(undefined, undefined, secondTest);
+    breakpointObserver.observe('test2').subscribe({complete: secondTest});
 
     flush();
     expect(firstTest).not.toHaveBeenCalled();

--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.spec.ts
@@ -90,7 +90,7 @@ describe('OverlayKeyboardDispatcher', () => {
     const overlayRef = overlay.create();
     const completeSpy = jasmine.createSpy('keydown complete spy');
 
-    overlayRef.keydownEvents().subscribe(undefined, undefined, completeSpy);
+    overlayRef.keydownEvents().subscribe({complete: completeSpy});
 
     overlayRef.dispose();
 

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -261,8 +261,8 @@ describe('Overlay', () => {
     let attachCompleteSpy = jasmine.createSpy('attachCompleteSpy spy');
     let detachCompleteSpy = jasmine.createSpy('detachCompleteSpy spy');
 
-    overlayRef.attachments().subscribe(undefined, undefined, attachCompleteSpy);
-    overlayRef.detachments().subscribe(disposeSpy, undefined, detachCompleteSpy);
+    overlayRef.attachments().subscribe({complete: attachCompleteSpy});
+    overlayRef.detachments().subscribe({next: disposeSpy, complete: detachCompleteSpy});
 
     overlayRef.attach(componentPortal);
     overlayRef.dispose();
@@ -276,8 +276,8 @@ describe('Overlay', () => {
     let overlayRef = overlay.create();
     let callbackOrder: string[] = [];
 
-    overlayRef.attachments().subscribe(undefined, undefined, () => callbackOrder.push('attach'));
-    overlayRef.detachments().subscribe(undefined, undefined, () => callbackOrder.push('detach'));
+    overlayRef.attachments().subscribe({complete: () => callbackOrder.push('attach')});
+    overlayRef.detachments().subscribe({complete: () => callbackOrder.push('detach')});
 
     overlayRef.attach(componentPortal);
     overlayRef.dispose();
@@ -677,7 +677,7 @@ describe('Overlay', () => {
 
       let completeHandler = jasmine.createSpy('backdrop complete handler');
 
-      overlayRef.backdropClick().subscribe(undefined, undefined, completeHandler);
+      overlayRef.backdropClick().subscribe({complete: completeHandler});
       overlayRef.dispose();
 
       expect(completeHandler).toHaveBeenCalled();

--- a/src/cdk/overlay/position/connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.spec.ts
@@ -413,7 +413,7 @@ describe('ConnectedPositionStrategy', () => {
 
       const completeHandler = jasmine.createSpy('complete handler');
 
-      positionStrategy.onPositionChange.subscribe(undefined, undefined, completeHandler);
+      positionStrategy.onPositionChange.subscribe({complete: completeHandler});
       attachOverlay(positionStrategy);
       positionStrategy.dispose();
 

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -93,7 +93,7 @@ describe('ScrollDispatcher', () => {
 
     it('should complete the `scrolled` stream on destroy', () => {
       const completeSpy = jasmine.createSpy('complete spy');
-      const subscription = scroll.scrolled(0).subscribe(undefined, undefined, completeSpy);
+      const subscription = scroll.scrolled(0).subscribe({complete: completeSpy});
 
       scroll.ngOnDestroy();
 
@@ -105,7 +105,7 @@ describe('ScrollDispatcher', () => {
     it('should complete the scrollable stream when it is destroyed', () => {
       const scrollable = fixture.componentInstance.scrollable;
       const spy = jasmine.createSpy('complete spy');
-      const subscription = scrollable.elementScrolled().subscribe(undefined, undefined, spy);
+      const subscription = scrollable.elementScrolled().subscribe({complete: spy});
 
       fixture.destroy();
       expect(spy).toHaveBeenCalled();

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -143,7 +143,7 @@ describe('AutofillMonitor', () => {
     const autofillStream = autofillMonitor.monitor(element);
     const spy = jasmine.createSpy('autofillStream complete');
 
-    autofillStream.subscribe(undefined, undefined, spy);
+    autofillStream.subscribe({complete: spy});
     expect(spy).not.toHaveBeenCalled();
 
     autofillMonitor.stopMonitoring(element);

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -544,7 +544,7 @@ describe('MatChipList', () => {
 
     it('should complete the stateChanges stream on destroy', () => {
       const spy = jasmine.createSpy('stateChanges complete');
-      const subscription = chipListInstance.stateChanges.subscribe(undefined, undefined, spy);
+      const subscription = chipListInstance.stateChanges.subscribe({complete: spy});
 
       fixture.destroy();
       expect(spy).toHaveBeenCalled();

--- a/src/material/core/option/option.spec.ts
+++ b/src/material/core/option/option.spec.ts
@@ -26,7 +26,7 @@ describe('MatOption component', () => {
     const optionInstance: MatOption =
         fixture.debugElement.query(By.directive(MatOption)).componentInstance;
     const completeSpy = jasmine.createSpy('complete spy');
-    const subscription = optionInstance._stateChanges.subscribe(undefined, undefined, completeSpy);
+    const subscription = optionInstance._stateChanges.subscribe({complete: completeSpy});
 
     fixture.destroy();
     expect(completeSpy).toHaveBeenCalled();

--- a/src/material/datepicker/calendar.spec.ts
+++ b/src/material/datepicker/calendar.spec.ts
@@ -148,7 +148,7 @@ describe('MatCalendar', () => {
 
     it('should complete the stateChanges stream', () => {
       const spy = jasmine.createSpy('complete spy');
-      const subscription = calendarInstance.stateChanges.subscribe(undefined, undefined, spy);
+      const subscription = calendarInstance.stateChanges.subscribe({complete: spy});
 
       fixture.destroy();
 

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -294,9 +294,10 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
             // Interrupt if the content got re-attached.
             takeUntil(menu.lazyContent._attached)
           )
-          .subscribe(() => menu.lazyContent!.detach(), undefined, () => {
+          .subscribe({
+            next: () => menu.lazyContent!.detach(),
             // No matter whether the content got re-attached, reset the menu.
-            this._resetMenu();
+            complete: () => this._resetMenu()
           });
       } else {
         this._resetMenu();

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -174,7 +174,7 @@ describe('MatSnackBar', () => {
     expect(overlayContainerElement.childElementCount)
         .toBeGreaterThan(0, 'Expected overlay container element to have at least one child');
 
-    snackBarRef.afterDismissed().subscribe(undefined, undefined, dismissCompleteSpy);
+    snackBarRef.afterDismissed().subscribe({complete: dismissCompleteSpy});
 
     snackBarRef.dismiss();
     viewContainerFixture.detectChanges();  // Run through animations for dismissal
@@ -278,7 +278,7 @@ describe('MatSnackBar', () => {
     let snackBarRef2 = snackBar.open(simpleMessage, undefined, config2);
 
     viewContainerFixture.detectChanges();
-    snackBarRef.afterDismissed().subscribe(undefined, undefined, dismissCompleteSpy);
+    snackBarRef.afterDismissed().subscribe({complete: dismissCompleteSpy});
     flush();
 
     expect(dismissCompleteSpy).toHaveBeenCalled();
@@ -344,8 +344,8 @@ describe('MatSnackBar', () => {
       const snackBarRef = snackBar.open('Some content', 'Dismiss');
       viewContainerFixture.detectChanges();
 
-      snackBarRef.afterDismissed().subscribe(undefined, undefined, dismissCompleteSpy);
-      snackBarRef.onAction().subscribe(undefined, undefined, actionCompleteSpy);
+      snackBarRef.afterDismissed().subscribe({complete: dismissCompleteSpy});
+      snackBarRef.onAction().subscribe({complete: actionCompleteSpy});
 
       let actionButton =
         overlayContainerElement.querySelector('button.mat-button') as HTMLButtonElement;
@@ -365,8 +365,8 @@ describe('MatSnackBar', () => {
     const snackBarRef = snackBar.open('Some content');
     viewContainerFixture.detectChanges();
 
-    snackBarRef.afterDismissed().subscribe(undefined, undefined, dismissCompleteSpy);
-    snackBarRef.onAction().subscribe(undefined, undefined, actionCompleteSpy);
+    snackBarRef.afterDismissed().subscribe({complete: dismissCompleteSpy});
+    snackBarRef.onAction().subscribe({complete: actionCompleteSpy});
 
     snackBarRef.dismissWithAction();
     viewContainerFixture.detectChanges();
@@ -398,7 +398,7 @@ describe('MatSnackBar', () => {
     const snackBarRef = snackBar.open('Some content');
     viewContainerFixture.detectChanges();
 
-    snackBarRef.onAction().subscribe(undefined, undefined, actionCompleteSpy);
+    snackBarRef.onAction().subscribe({complete: actionCompleteSpy});
     snackBarRef.dismiss();
     viewContainerFixture.detectChanges();
     tick();
@@ -531,8 +531,8 @@ describe('MatSnackBar', () => {
       const snackBarRef = snackBar.openFromComponent(BurritosNotification);
       viewContainerFixture.detectChanges();
 
-      snackBarRef.afterDismissed().subscribe(undefined, undefined, dismissCompleteSpy);
-      snackBarRef.onAction().subscribe(undefined, undefined, actionCompleteSpy);
+      snackBarRef.afterDismissed().subscribe({complete: dismissCompleteSpy});
+      snackBarRef.onAction().subscribe({complete: actionCompleteSpy});
 
       snackBarRef.dismissWithAction();
       viewContainerFixture.detectChanges();

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -487,7 +487,7 @@ describe('MatTooltip', () => {
 
       const spy = jasmine.createSpy('complete spy');
       const subscription = tooltipDirective._tooltipInstance!.afterHidden()
-          .subscribe(undefined, undefined, spy);
+          .subscribe({complete: spy});
 
       tooltipDirective.hide(0);
       tick(0);


### PR DESCRIPTION
As of rxjs 6.4.0 the signature of `subscribe` that accepts two falsy values as the first two arguments is deprecated. These changes move us to the correct signature.