### PR TITLE
fix(progress-spinner): non-default diameter indeterminate animation not working inside Shadow DOM

### DIFF
--- a/src/material/progress-spinner/BUILD.bazel
+++ b/src/material/progress-spinner/BUILD.bazel
@@ -50,6 +50,7 @@ ng_test_library(
     ),
     deps = [
         ":progress-spinner",
+        "//src/cdk/platform",
         "@npm//@angular/platform-browser",
     ],
 )

--- a/src/material/progress-spinner/public-api.ts
+++ b/src/material/progress-spinner/public-api.ts
@@ -7,5 +7,11 @@
  */
 
 export * from './progress-spinner-module';
-export * from './progress-spinner';
-
+export {
+  MatProgressSpinner,
+  MatSpinner,
+  MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS,
+  ProgressSpinnerMode,
+  MatProgressSpinnerDefaultOptions,
+  MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY,
+} from './progress-spinner';


### PR DESCRIPTION
Fixes animating a progress spinner with a non-default diameter in indeterminate mode not working if the element is inside of a shadow root. The issue is that we always add the `style` tag with the animation to the `document.head` which doesn't pierce through the Shadow DOM.

Also adds a some more test coverage for the `style` tag insertion logic.

Fixes #16172.