### PR TITLE
fix(list): list item ripples not being clipped to border radius

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -300,6 +300,13 @@ mat-action-list {
   outline: none;
 }
 
+// Ensures that things like ripples are clipped correctly inside items that can have ripples.
+.mat-nav-list .mat-list-item,
+.mat-action-list .mat-list-item,
+.mat-list-option {
+  overflow: hidden;
+}
+
 @include cdk-high-contrast {
   .mat-selection-list:focus {
     outline-style: dotted;


### PR DESCRIPTION
Fixes the ripples inside the list item not being clipped if the consumer has set a `border-radius`.

Fixes #16124.