### PR TITLE
build: publish-release script should run npm login before build

### DIFF
--- a/tools/release/git/git-client.ts
+++ b/tools/release/git/git-client.ts
@@ -7,7 +7,6 @@ import {spawnSync, SpawnSyncReturns} from 'child_process';
  * guaranteed that the working directory is always the target project directory.
  */
 export class GitClient {
-
   constructor(public projectDir: string, public remoteGitUrl: string) {}
 
   /**
@@ -29,9 +28,9 @@ export class GitClient {
 
   /** Gets the commit SHA for the specified remote repository branch. */
   getRemoteCommitSha(branchName: string): string {
-    return this._spawnGitProcess(['ls-remote', this.remoteGitUrl, '-h',
-        `refs/heads/${branchName}`])
-      .stdout.split('\t')[0].trim();
+    return this._spawnGitProcess(['ls-remote', this.remoteGitUrl, '-h', `refs/heads/${branchName}`])
+        .stdout.split('\t')[0]
+        .trim();
   }
 
   /** Gets the latest commit SHA for the specified git reference. */
@@ -83,13 +82,18 @@ export class GitClient {
 
   /** Gets the Git SHA of the specified local tag. */
   getShaOfLocalTag(tagName: string) {
-    return this._spawnGitProcess(['rev-parse', `refs/tags/${tagName}`]).stdout.trim();
+    // We need to use the "^{}" suffix to instruct Git to deference the tag to
+    // the actual commit. See: https://www.git-scm.com/docs/git-rev-parse
+    return this._spawnGitProcess(['rev-parse', `refs/tags/${tagName}^{}`]).stdout.trim();
   }
 
   /** Gets the Git SHA of the specified remote tag. */
   getShaOfRemoteTag(tagName: string): string {
-    return this._spawnGitProcess(['ls-remote', this.remoteGitUrl, '-t', `refs/tags/${tagName}`])
-      .stdout.split('\t')[0].trim();
+    // We need to use the "^{}" suffix to instruct Git to deference the tag to
+    // the actual commit. See: https://www.git-scm.com/docs/git-rev-parse
+    return this._spawnGitProcess(['ls-remote', this.remoteGitUrl, '-t', `refs/tags/${tagName}^{}`])
+        .stdout.split('\t')[0]
+        .trim();
   }
 
   /** Pushes the specified tag to the remote git repository. */
@@ -108,4 +112,3 @@ export class GitClient {
     return this._spawnGitProcess(['remote']).stdout.trim().split('\n');
   }
 }
-

--- a/tools/release/publish-release.ts
+++ b/tools/release/publish-release.ts
@@ -91,6 +91,10 @@ class PublishReleaseTask extends BaseReleaseTask {
       await this._promptStableVersionForNextTag();
     }
 
+    // Ensure that we are authenticated, so that we can run "npm publish" for
+    // each package once the release output is built.
+    this._checkNpmAuthentication();
+
     this._buildReleasePackages();
     console.info(green(`  ✓   Built the release output.`));
 
@@ -98,20 +102,19 @@ class PublishReleaseTask extends BaseReleaseTask {
     checkReleaseOutput(this.releaseOutputPath);
 
     // Extract the release notes for the new version from the changelog file.
-    const {releaseNotes, releaseTitle} = extractReleaseNotes(
+    const extractedReleaseNotes = extractReleaseNotes(
       join(this.projectDir, CHANGELOG_FILE_NAME), newVersionName);
 
-    if (!releaseNotes) {
+    if (!extractedReleaseNotes) {
       console.error(red(`  ✘   Could not find release notes in the changelog.`));
       process.exit(1);
     }
 
+    const {releaseNotes, releaseTitle} = extractedReleaseNotes;
+
     // Create and push the release tag before publishing to NPM.
     this._createReleaseTag(newVersionName, releaseNotes);
     this._pushReleaseTag(newVersionName, upstreamRemote);
-
-    // Ensure that we are authenticated before running "npm publish" for each package.
-    this._checkNpmAuthentication();
 
     // Just in order to double-check that the user is sure to publish to NPM, we want
     // the user to interactively confirm that the script should continue.

--- a/tools/release/stage-release.ts
+++ b/tools/release/stage-release.ts
@@ -76,7 +76,7 @@ class StageReleaseTask extends BaseReleaseTask {
 
     const newVersion = await promptForNewVersion(this.currentVersion);
     const newVersionName = newVersion.format();
-    const needsVersionBump = !newVersion.equalsTo(this.currentVersion);
+    const needsVersionBump = !newVersion.equals(this.currentVersion);
     const stagingBranch = `release-stage/${newVersionName}`;
 
     // After the prompt for the new version, we print a new line because we want the

--- a/tools/release/version-name/parse-version.ts
+++ b/tools/release/version-name/parse-version.ts
@@ -24,7 +24,7 @@ export class Version {
         this.major, this.minor, this.patch, this.prereleaseLabel, this.prereleaseNumber);
   }
 
-  equalsTo(other: Version): boolean {
+  equals(other: Version): boolean {
     return this.major === other.major && this.minor === other.minor && this.patch === other.patch &&
         this.prereleaseLabel === other.prereleaseLabel &&
         this.prereleaseNumber === other.prereleaseNumber;


### PR DESCRIPTION
Building the release packages can take up a lot of time and we
should rather run `npm login` before starting the build because
otherwise if the login fails, the output needs to be rebuilt again.

Additionally this commit fixes that existing local/remote tags are
not properly parsed due to an issue with the Git references that
refer to tags.

Closes #16141