### PR TITLE
feat(overlay): support custom navigation event signals for auto dispose

### DIFF
--- a/src/cdk/overlay/navigation-signal.ts
+++ b/src/cdk/overlay/navigation-signal.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectFlags, InjectionToken, inject} from '@angular/core';
+import {Location} from '@angular/common';
+import {SubscriptionLike, Subscription} from 'rxjs';
+
+/** Stream that signals whenever a navigation event has occurred. */
+export interface NavigationSignal {
+  subscribe(onNext: () => void): SubscriptionLike;
+}
+
+/** @docs-private */
+export function defaultNavigationSignalFactory(): NavigationSignal {
+  return inject(Location, InjectFlags.Optional) || {
+    subscribe: () => Subscription.EMPTY
+  };
+}
+
+/** Injection token that can be used to configure the stream that signals the navigation events. */
+export const NAVIGATION_SIGNAL = new InjectionToken<NavigationSignal>('NAVIGATION_SIGNAL', {
+  providedIn: 'root',
+  factory: defaultNavigationSignalFactory
+});

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -8,7 +8,7 @@
 
 import {Directionality} from '@angular/cdk/bidi';
 import {DomPortalOutlet} from '@angular/cdk/portal';
-import {DOCUMENT, Location} from '@angular/common';
+import {DOCUMENT} from '@angular/common';
 import {
   ApplicationRef,
   ComponentFactoryResolver,
@@ -19,6 +19,7 @@ import {
   Optional,
 } from '@angular/core';
 import {OverlayKeyboardDispatcher} from './keyboard/overlay-keyboard-dispatcher';
+import {NAVIGATION_SIGNAL, NavigationSignal} from './navigation-signal';
 import {OverlayConfig} from './overlay-config';
 import {OverlayContainer} from './overlay-container';
 import {OverlayRef} from './overlay-ref';
@@ -55,8 +56,9 @@ export class Overlay {
               private _ngZone: NgZone,
               @Inject(DOCUMENT) private _document: any,
               private _directionality: Directionality,
-              // @breaking-change 8.0.0 `_location` parameter to be made required.
-              @Optional() private _location?: Location) { }
+              // @breaking-change 8.0.0 `_navigationSignal` parameter to be made required.
+              @Inject(NAVIGATION_SIGNAL) @Optional()
+              private _navigationSignal?: NavigationSignal) { }
 
   /**
    * Creates an overlay.
@@ -72,7 +74,7 @@ export class Overlay {
     overlayConfig.direction = overlayConfig.direction || this._directionality.value;
 
     return new OverlayRef(portalOutlet, host, pane, overlayConfig, this._ngZone,
-      this._keyboardDispatcher, this._document, this._location);
+      this._keyboardDispatcher, this._document, this._navigationSignal);
   }
 
   /**

--- a/src/cdk/overlay/public-api.ts
+++ b/src/cdk/overlay/public-api.ts
@@ -14,6 +14,7 @@ export {Overlay} from './overlay';
 export {OverlayContainer} from './overlay-container';
 export {CdkOverlayOrigin, CdkConnectedOverlay} from './overlay-directives';
 export {FullscreenOverlayContainer} from './fullscreen-overlay-container';
+export {NAVIGATION_SIGNAL, NavigationSignal} from './navigation-signal';
 export {OverlayRef, OverlaySizeConfig} from './overlay-ref';
 export {ViewportRuler} from '@angular/cdk/scrolling';
 export {ComponentType} from '@angular/cdk/portal';


### PR DESCRIPTION
Currently when overlays are opened with the `disposeOnNavigation` option set to `true` they only
close automatically when the user uses the browser history back / forward functions. However, when
the `@angular/router` module is used, clicking an element with a `[navigationLink]` directive will
not cause the overlay to be closed. This can be explained by the fact that this behavior is
implemented using the `Location` service from `@angular/common`. Unfortunately that service only
emits a signal whenever a `popstate` event occurs. This feature replaces the `Location` dependency
for a more abstract `NavigationSignal`, allowing consumers of the overlay module to specify their
own custom stream of navigation events, e.g. based on the `Router.event` stream. When no such stream
is specified (via the `NAVIGATION_SIGNAL` injection token) then `Location` is used as default.