### PR TITLE
fix:(tabs) add call for rechecking tab scroll distance

### DIFF
--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -604,6 +604,34 @@ describe('MatTabHeader', () => {
       expect(tabHeaderElement.classList).toContain(enabledClass);
     });
 
+    it('should scroll to last tab', async(() => {
+      const tabs = [
+        {label: 'tab one'},
+        {label: 'tab one'},
+        {label: 'tab one'},
+        {label: 'tab one'},
+        {label: 'tab one'},
+        {label: 'tab one'},
+        {label: 'tab one'},
+        {label: 'tab one'},
+      ];
+
+      fixture = TestBed.createComponent(SimpleTabHeaderApp);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      component.tabs = tabs;
+      component.selectedIndex = tabs.length - 1;
+      fixture.detectChanges();
+
+      fixture.whenRenderingDone()
+        .then(() => {
+          expect(component.tabHeader._disableScrollAfter).toBeTruthy();
+          expect(component.tabHeader.scrollDistance)
+            .toEqual(component.tabHeader._getMaxScrollDistance());
+        });
+    }));
+
   });
 });
 

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -238,6 +238,7 @@ export class MatTabHeader extends _MatTabHeaderMixinBase
     const dirChange = this._dir ? this._dir.change : observableOf(null);
     const resize = this._viewportRuler.change(150);
     const realign = () => {
+      this._scrollToLabel(this._selectedIndex);
       this.updatePagination();
       this._alignInkBarToSelectedTab();
     };


### PR DESCRIPTION
Add call to scroll the tabs header after initialising header pagination, to accurately calculate the scroll distance.

Fixes #12889