### PR TITLE
style(progress-spinner): move private var to beginning of class

### DIFF
--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -125,6 +125,7 @@ const INDETERMINATE_ANIMATION_TEMPLATE = `
 })
 export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements CanColor {
 
+  private _diameter = BASE_SIZE;
   private _value = 0;
   private _strokeWidth: number;
   private _fallbackAnimation = false;
@@ -151,7 +152,6 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
       this._attachStyleNode();
     }
   }
-  private _diameter = BASE_SIZE;
 
   /** Stroke width of the progress spinner. */
   @Input()


### PR DESCRIPTION
for consistency - private variables should come at beginning of class, not after setter declaration