### PR TITLE
fix(material): fix table generator schematic

### DIFF
--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, OnInit, ViewChild<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
-import { MatPaginator, MatSort } from '@angular/material';
+import { MatPaginator, MatSort, MatTable } from '@angular/material';
 import { <%= classify(name) %>DataSource, <%= classify(name) %>Item } from './<%= dasherize(name) %>-datasource';
 
 @Component({
@@ -16,9 +16,9 @@ import { <%= classify(name) %>DataSource, <%= classify(name) %>Item } from './<%
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })
 export class <%= classify(name) %>Component implements AfterViewInit, OnInit {
-  @ViewChild(MatPaginator) paginator: MatPaginator;
-  @ViewChild(MatSort) sort: MatSort;
-  @ViewChild(MatTable) table: MatTable<<%= classify(name) %>Item>;
+  @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
+  @ViewChild(MatSort, {static: false}) sort: MatSort;
+  @ViewChild(MatTable, {static: false}) table: MatTable<<%= classify(name) %>Item>;
   dataSource: <%= classify(name) %>DataSource;
 
   /** Columns displayed in the table. Columns IDs can be added, removed, or reordered. */


### PR DESCRIPTION
Import `MatTable` (used in `ViewChild` query).

Add `static` option to view queries for future support of Angular version 9.