### PR TITLE
fix(form-field): make outline appearance input field auto fit parent component

### DIFF
--- a/src/material/form-field/form-field-outline.scss
+++ b/src/material/form-field/form-field-outline.scss
@@ -26,6 +26,7 @@ $mat-form-field-outline-subscript-padding:
   // appearances when center-aligned, we also need to add the same amount of margin to the bottom.
   .mat-form-field-wrapper {
     margin: $mat-form-field-outline-label-overlap 0;
+    width: 100%;
   }
 
   .mat-form-field-flex {


### PR DESCRIPTION
the `.mat-form-field-wrapper` element currently would not fit to the parent `mat-form-field` component width in outline appearance.