### PR TITLE
style(progress-spinner): move private var to beginning of class

### DIFF
--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -124,6 +124,7 @@ const INDETERMINATE_ANIMATION_TEMPLATE = `
   encapsulation: ViewEncapsulation.None,
 })
 export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements CanColor {
+  private _diameter = BASE_SIZE;
   private _value = 0;
   private _strokeWidth: number;
   private _fallbackAnimation = false;
@@ -161,7 +162,6 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
       }
     }
   }
-  private _diameter = BASE_SIZE;
 
   /** Stroke width of the progress spinner. */
   @Input()


### PR DESCRIPTION
for consistency : private vars should come at beginning of the class, not after setter declaration