### PR TITLE
fix(ng-update): parse cli workspace config as json5

### DIFF
--- a/src/cdk/schematics/ng-update/upgrade-rules/project-tsconfig-paths.spec.ts
+++ b/src/cdk/schematics/ng-update/upgrade-rules/project-tsconfig-paths.spec.ts
@@ -45,4 +45,24 @@ describe('ng-update project-tsconfig-paths', () => {
 
     expect(getProjectTsConfigPaths(testTree)).toEqual(['tsconfig.json']);
   });
+
+  it('should be able to read workspace configuration which is using JSON5 features', () => {
+    testTree.create('/my-build-config.json', '');
+    testTree.create('/angular.json', `{
+      // Comments, unquoted properties or trailing commas are only supported in JSON5.
+      projects: {
+        with_tests: {
+          targets: {
+            build: {
+              options: {
+                tsConfig: './my-build-config.json',
+              }
+            }
+          }
+        }
+      },
+    }`);
+
+    expect(getProjectTsConfigPaths(testTree)).toEqual(['my-build-config.json']);
+  });
 });

--- a/src/cdk/schematics/ng-update/upgrade-rules/project-tsconfig-paths.ts
+++ b/src/cdk/schematics/ng-update/upgrade-rules/project-tsconfig-paths.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {normalize} from '@angular-devkit/core';
+import {JsonParseMode, normalize, parseJson} from '@angular-devkit/core';
 import {Tree} from '@angular-devkit/schematics';
 
 /** Name of the default Angular CLI workspace configuration files. */
@@ -63,7 +63,9 @@ function getWorkspaceConfigGracefully(tree: Tree): any {
   }
 
   try {
-    return JSON.parse(configBuffer.toString());
+    // Parse the workspace file as JSON5 which is also supported for CLI
+    // workspace configurations.
+    return parseJson(configBuffer.toString(), JsonParseMode.Json5);
   } catch {
     return null;
   }


### PR DESCRIPTION
Currently we try to parse CLI workspace configurations gracefully by
using the native `JSON.parse()` method. This means that the CLI workspace
configuration needs to follow the strict JSON specification because otherwise
the migrations would not be able to find TypeScript configurations in the CLI
project where JSON5 workspace configurations are supported.

In order to handle such workspace configurations, we leverage the JSON
parsing logicfrom the `@angular-devkit/core` which is also used by the CLI.