### PR TITLE
docs: MatMenu api docs are not generated

### DIFF
--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -416,6 +416,7 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
   }
 }
 
+/** @docs-private We show the "_MatMenu" class as "MatMenu" in the docs. */
 export class MatMenu extends _MatMenuBase {}
 
 // Note on the weird inheritance setup: we need three classes, because the MDC-based menu has to
@@ -429,6 +430,7 @@ export class MatMenu extends _MatMenuBase {}
 // * _MatMenu - the actual menu component implementation with the Angular metadata that should
 // be tree shaken away for MDC.
 
+/** @docs-public MatMenu */
 @Component({
   moduleId: module.id,
   selector: 'mat-menu',

--- a/tools/dgeni/bazel-bin.ts
+++ b/tools/dgeni/bazel-bin.ts
@@ -101,9 +101,11 @@ if (require.main === module) {
   // Run the docs generation. The process will be automatically kept alive until Dgeni
   // completed. In case the returned promise has been rejected, we need to manually exit the
   // process with the proper exit code because Dgeni doesn't use native promises which would
-  // automatically cause the error to propagate. The error message will be automatically
-  // printed internally by Dgeni (so we don't want to repeat here)
-  new Dgeni([apiDocsPackage]).generate().catch(() => process.exit(1));
+  // automatically cause the error to propagate.
+  new Dgeni([apiDocsPackage]).generate().catch((e: any) => {
+    console.error(e);
+    process.exit(1);
+  });
 }
 
 

--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -33,7 +33,7 @@ export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLik
   directiveExportAs?: string | null;
   directiveSelectors?: string[];
   directiveMetadata: Map<string, any> | null;
-  extendedDoc: ClassLikeExportDoc | null;
+  extendedDoc: ClassLikeExportDoc | undefined;
 }
 
 /** Extended Dgeni property-member document that includes extracted Angular metadata. */

--- a/tools/dgeni/common/private-docs.ts
+++ b/tools/dgeni/common/private-docs.ts
@@ -1,0 +1,69 @@
+import {ApiDoc} from 'dgeni-packages/typescript/api-doc-types/ApiDoc';
+import {MemberDoc} from 'dgeni-packages/typescript/api-doc-types/MemberDoc';
+
+const INTERNAL_METHODS = [
+  // Lifecycle methods
+  'ngOnInit',
+  'ngOnChanges',
+  'ngDoCheck',
+  'ngAfterContentInit',
+  'ngAfterContentChecked',
+  'ngAfterViewInit',
+  'ngAfterViewChecked',
+  'ngOnDestroy',
+
+  // ControlValueAccessor methods
+  'writeValue',
+  'registerOnChange',
+  'registerOnTouched',
+  'setDisabledState',
+
+  // Don't ever need to document constructors
+  'constructor',
+
+  // tabIndex exists on all elements, no need to document it
+  'tabIndex',
+];
+
+/** Checks whether the given API document is public. */
+export function isPublicDoc(doc: ApiDoc) {
+  if (_isEnforcedPublicDoc(doc)) {
+    return true;
+  }
+  if (_hasDocsPrivateTag(doc) || doc.name.startsWith('_')) {
+    return false;
+  } else if (doc instanceof MemberDoc) {
+    return !_isInternalMember(doc);
+  }
+  return true;
+}
+
+/** Gets the @docs-public tag from the given document if present. */
+export function getDocsPublicTag(doc: any): {tagName: string, description: string}|undefined {
+  const tags = doc.tags && doc.tags.tags;
+  return tags ? tags.find((d: any) => d.tagName == 'docs-public') : undefined;
+}
+
+/** Whether the given method member is listed as an internal member. */
+function _isInternalMember(memberDoc: MemberDoc) {
+  return INTERNAL_METHODS.includes(memberDoc.name);
+}
+
+/** Whether the given doc has a @docs-private tag set. */
+function _hasDocsPrivateTag(doc: any) {
+  const tags = doc.tags && doc.tags.tags;
+  return tags ? tags.find((d: any) => d.tagName == 'docs-private') : false;
+}
+
+/**
+ * Whether the given doc has the @docs-public tag specified and should be enforced as
+ * public document. This allows symbols which are usually private to show up in the docs.
+ *
+ * Additionally symbols with "@docs-public" tag can specify a public name under which the
+ * document should show up in the docs. This is useful for cases where a class needs to be
+ * split up into several base classes to support the MDC prototypes. e.g. "_MatMenu" should
+ * show up in the docs as "MatMenu".
+ */
+function _isEnforcedPublicDoc(doc: any): boolean {
+  return getDocsPublicTag(doc) !== undefined;
+}

--- a/tools/dgeni/docs-package.ts
+++ b/tools/dgeni/docs-package.ts
@@ -78,6 +78,7 @@ apiDocsPackage.config(function(computePathsProcessor: any) {
 apiDocsPackage.config(function(parseTagsProcessor: any) {
   parseTagsProcessor.tagDefinitions = parseTagsProcessor.tagDefinitions.concat([
     {name: 'docs-private'},
+    {name: 'docs-public'},
     {name: 'breaking-change'},
   ]);
 });
@@ -89,7 +90,6 @@ apiDocsPackage.config(function(checkAnchorLinksProcessor: any) {
 
 // Configure the processor for understanding TypeScript.
 apiDocsPackage.config(function(readTypeScriptModules: ReadTypeScriptModules) {
-  readTypeScriptModules.ignoreExportsMatching = [/^_/];
   readTypeScriptModules.hidePrivateMembers = true;
 });
 


### PR DESCRIPTION
Currently the `MatMenu` API docs are not generated because the `MatMenu`
class is no longer treated as directive/component because there is no
decorator w/ directive metadata.

In order to fix this in a flexible way, a new JSdoc tag has been introduced
that allows enforcing the public state of a symbol (with the possibility of
having a public symbol name). This allows us to actually expose the
real `_MatMenu` class w/ directive metadata in the API docs under the
`MatMenu` symbol name.

Fixes #16198