### PR TITLE
fix(dialog): not moving focus to container if autoFocus is disabled and focus was moved from a different component

### DIFF
--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -141,6 +141,11 @@ export class MatDialogContainer extends BasePortalOutlet {
     // wait for the microtask queue to be empty.
     if (this._config.autoFocus) {
       this._focusTrap.focusInitialElementWhenReady();
+    } else {
+      // Otherwise ensure that focus is on the dialog container. It's possible that a different
+      // component tried to move focus while the open animation was running. See:
+      // https://github.com/angular/components/issues/16215
+      this._elementRef.nativeElement.focus();
     }
   }
 


### PR DESCRIPTION
Given an example where we have a `mat-menu` that opens a dialog with `autoFocus = false`, the user's focus will end up on the menu's trigger, rather than the dialog container. This is due to the fact that we move focus to the dialog container immediately when the opening sequence starts and we assume that it's going to stay there. This isn't a problem when `autoFocus` is enabled, because we also try to move focus once the animation is done. These changes add an extra call after the animation finishes to ensure that the container has focus.

**Note:** I wasn't able to capture this properly in a unit test, because we need to be able to flush a `Promise.resolve`, followed by some logic which is then followed by flushing the animations. The problem is that I always ended up flushing the promise and the animations at the same time.

Fixes #16215.