### PR TITLE
Remove redundant selector term

### DIFF
--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -63,7 +63,7 @@ $_mat-button-ripple-opacity: 0.1;
     #{$property}: mat-color($warn, $hue);
   }
 
-  &.mat-primary, &.mat-accent, &.mat-warn, &[disabled] {
+  &.mat-primary, &.mat-accent, &.mat-warn {
     &[disabled] {
       $palette: if($property == 'color', $foreground, $background);
       #{$property}: mat-color($palette, disabled-button);


### PR DESCRIPTION
The extra term unnecessarily raises specificity of this selector to e.g. `.mat-flat-button[disabled][disabled]`