### PR TITLE
fix(drag-drop): fix drag start delay behavior to allow scrolling (#16224)

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -596,18 +596,28 @@ describe('CdkDrag', () => {
       expect(dragElement.style.transform).toBeFalsy();
     }));
 
-    it('should enable native drag interactions if dragging is disabled', fakeAsync(() => {
+    it('should enable native drag interactions if not dragging', fakeAsync(() => {
       const fixture = createComponent(StandaloneDraggable);
       fixture.detectChanges();
       const dragElement = fixture.componentInstance.dragElement.nativeElement;
       const styles = dragElement.style;
 
-      expect(styles.touchAction || (styles as any).webkitUserDrag).toBe('none');
+      expect(styles.touchAction || (styles as any).webkitUserDrag).toBeFalsy();
+    }));
 
-      fixture.componentInstance.dragInstance.disabled = true;
+    it('should disable native drag interactions if dragging', fakeAsync(() => {
+      const fixture = createComponent(StandaloneDraggable);
       fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+      const styles = dragElement.style;
 
       expect(styles.touchAction || (styles as any).webkitUserDrag).toBeFalsy();
+
+      startDraggingViaMouse(fixture, dragElement);
+      dispatchMouseEvent(document, 'mousemove', 50, 100);
+      fixture.detectChanges();
+
+      expect(styles.touchAction || (styles as any).webkitUserDrag).toBe('none');
     }));
 
     it('should stop propagation for the drag sequence start event', fakeAsync(() => {
@@ -762,7 +772,7 @@ describe('CdkDrag', () => {
       }).toThrowError(/^cdkDrag must be attached to an element node/);
     }));
 
-    it('should allow for the dragging sequence to be delayed', fakeAsync(() => {
+    it('should cancel drag if the mouse moves before the delay is elapsed', fakeAsync(() => {
       // We can't use Jasmine's `clock` because Zone.js interferes with it.
       spyOn(Date, 'now').and.callFake(() => currentTime);
       let currentTime = 0;
@@ -777,13 +787,52 @@ describe('CdkDrag', () => {
       startDraggingViaMouse(fixture, dragElement);
       currentTime += 750;
       dispatchMouseEvent(document, 'mousemove', 50, 100);
+      currentTime += 500;
       fixture.detectChanges();
 
       expect(dragElement.style.transform)
-          .toBeFalsy('Expected element not to be moved if the drag timeout has not passed.');
+          .toBeFalsy('Expected element not to be moved if the mouse moved before the delay.');
+    }));
+
+    it('should enable native drag interactions if mouse moves before the delay', fakeAsync(() => {
+      // We can't use Jasmine's `clock` because Zone.js interferes with it.
+      spyOn(Date, 'now').and.callFake(() => currentTime);
+      let currentTime = 0;
+
+      const fixture = createComponent(StandaloneDraggable);
+      fixture.componentInstance.dragStartDelay = 1000;
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+      const styles = dragElement.style;
+
+      expect(dragElement.style.transform).toBeFalsy('Expected element not to be moved by default.');
+
+      startDraggingViaMouse(fixture, dragElement);
+      currentTime += 750;
+      dispatchMouseEvent(document, 'mousemove', 50, 100);
+      currentTime += 500;
+      fixture.detectChanges();
+
+      expect(styles.touchAction || (styles as any).webkitUserDrag).toBeFalsy();
+    }));
+
+    it('should allow dragging after the drag start delay is elapsed', fakeAsync(() => {
+      // We can't use Jasmine's `clock` because Zone.js interferes with it.
+      spyOn(Date, 'now').and.callFake(() => currentTime);
+      let currentTime = 0;
+
+      const fixture = createComponent(StandaloneDraggable);
+      fixture.componentInstance.dragStartDelay = 500;
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+      expect(dragElement.style.transform).toBeFalsy('Expected element not to be moved by default.');
+
+      dispatchMouseEvent(dragElement, 'mousedown');
+      fixture.detectChanges();
+      currentTime += 750;
 
       // The first `mousemove` here starts the sequence and the second one moves the element.
-      currentTime += 500;
       dispatchMouseEvent(document, 'mousemove', 50, 100);
       dispatchMouseEvent(document, 'mousemove', 50, 100);
       fixture.detectChanges();
@@ -798,22 +847,17 @@ describe('CdkDrag', () => {
       let currentTime = 0;
 
       const fixture = createComponent(StandaloneDraggable);
-      fixture.componentInstance.dragStartDelay = '1000';
+      fixture.componentInstance.dragStartDelay = '500';
       fixture.detectChanges();
       const dragElement = fixture.componentInstance.dragElement.nativeElement;
 
       expect(dragElement.style.transform).toBeFalsy('Expected element not to be moved by default.');
 
-      startDraggingViaMouse(fixture, dragElement);
-      currentTime += 750;
-      dispatchMouseEvent(document, 'mousemove', 50, 100);
+      dispatchMouseEvent(dragElement, 'mousedown');
       fixture.detectChanges();
-
-      expect(dragElement.style.transform)
-          .toBeFalsy('Expected element not to be moved if the drag timeout has not passed.');
+      currentTime += 750;
 
       // The first `mousemove` here starts the sequence and the second one moves the element.
-      currentTime += 500;
       dispatchMouseEvent(document, 'mousemove', 50, 100);
       dispatchMouseEvent(document, 'mousemove', 50, 100);
       fixture.detectChanges();

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -596,6 +596,20 @@ describe('CdkDrag', () => {
       expect(dragElement.style.transform).toBeFalsy();
     }));
 
+    it('should enable native drag interactions if dragging is disabled', fakeAsync(() => {
+      const fixture = createComponent(StandaloneDraggable);
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+      const styles = dragElement.style;
+
+      expect(styles.touchAction || (styles as any).webkitUserDrag).toBeFalsy();
+
+      fixture.componentInstance.dragInstance.disabled = true;
+      fixture.detectChanges();
+
+      expect(styles.touchAction || (styles as any).webkitUserDrag).toBeFalsy();
+    }));
+
     it('should enable native drag interactions if not dragging', fakeAsync(() => {
       const fixture = createComponent(StandaloneDraggable);
       fixture.detectChanges();

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -504,13 +504,13 @@ export class DragRef<T = any> {
       const distanceX = Math.abs(pointerPosition.x - this._pickupPositionOnPage.x);
       const distanceY = Math.abs(pointerPosition.y - this._pickupPositionOnPage.y);
       const isOverThreshold = distanceX + distanceY >= this._config.dragStartThreshold;
-      const isDelayElapsed = (Date.now() >= this._dragStartTime + this.dragStartDelay || 0);
 
       // Only start dragging after the user has moved more than the minimum distance in either
       // direction. Note that this is preferrable over doing something like `skip(minimumDistance)`
       // in the `pointerMove` subscription, because we're not guaranteed to have one move event
       // per pixel of movement (e.g. if the user moves their pointer quickly).
       if (isOverThreshold) {
+        const isDelayElapsed = Date.now() >= this._dragStartTime + (this.dragStartDelay || 0);
         if (!isDelayElapsed) {
           this._endDragSequence(event);
           return;
@@ -585,7 +585,7 @@ export class DragRef<T = any> {
    * Clears subscriptions and stops the dragging sequence.
    * @param event Browser event object that ended the sequence.
    */
-  private _endDragSequence = (event: MouseEvent | TouchEvent) => {
+  private _endDragSequence(event: MouseEvent | TouchEvent) {
     // Note that here we use `isDragging` from the service, rather than from `this`.
     // The difference is that the one from the service reflects whether a dragging sequence
     // has been initiated, whereas the one on `this` includes whether the user has passed

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -504,7 +504,7 @@ export class DragRef<T = any> {
       const distanceX = Math.abs(pointerPosition.x - this._pickupPositionOnPage.x);
       const distanceY = Math.abs(pointerPosition.y - this._pickupPositionOnPage.y);
       const isOverThreshold = distanceX + distanceY >= this._config.dragStartThreshold;
-      const isDelayElapsed = (Date.now() >= this._dragStartTime + (this.dragStartDelay || 0));
+      const isDelayElapsed = (Date.now() >= this._dragStartTime + this.dragStartDelay || 0);
 
       // Only start dragging after the user has moved more than the minimum distance in either
       // direction. Note that this is preferrable over doing something like `skip(minimumDistance)`

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -504,12 +504,18 @@ export class DragRef<T = any> {
       const distanceX = Math.abs(pointerPosition.x - this._pickupPositionOnPage.x);
       const distanceY = Math.abs(pointerPosition.y - this._pickupPositionOnPage.y);
       const isOverThreshold = distanceX + distanceY >= this._config.dragStartThreshold;
+      const isDelayElapsed = (Date.now() >= this._dragStartTime + (this.dragStartDelay || 0));
 
       // Only start dragging after the user has moved more than the minimum distance in either
       // direction. Note that this is preferrable over doing something like `skip(minimumDistance)`
       // in the `pointerMove` subscription, because we're not guaranteed to have one move event
       // per pixel of movement (e.g. if the user moves their pointer quickly).
-      if (isOverThreshold && (Date.now() >= this._dragStartTime + (this.dragStartDelay || 0))) {
+      if (isOverThreshold) {
+        if (!isDelayElapsed) {
+          this._endDragSequence(event);
+          return;
+        }
+
         // Prevent other drag sequences from starting while something in the container is still
         // being dragged. This can happen while we're waiting for the drop animation to finish
         // and can cause errors, because some elements might still be moving around.
@@ -572,6 +578,14 @@ export class DragRef<T = any> {
 
   /** Handler that is invoked when the user lifts their pointer up, after initiating a drag. */
   private _pointerUp = (event: MouseEvent | TouchEvent) => {
+    this._endDragSequence(event);
+  }
+
+  /**
+   * Clears subscriptions and stops the dragging sequence.
+   * @param event Browser event object that ended the sequence.
+   */
+  private _endDragSequence = (event: MouseEvent | TouchEvent) => {
     // Note that here we use `isDragging` from the service, rather than from `this`.
     // The difference is that the one from the service reflects whether a dragging sequence
     // has been initiated, whereas the one on `this` includes whether the user has passed
@@ -623,6 +637,8 @@ export class DragRef<T = any> {
     if (isTouchEvent(event)) {
       this._lastTouchEventTime = Date.now();
     }
+
+    this._toggleNativeDragInteractions();
 
     if (this._dropContainer) {
       const element = this._rootElement;
@@ -686,7 +702,6 @@ export class DragRef<T = any> {
       rootElement.style.webkitTapHighlightColor = 'transparent';
     }
 
-    this._toggleNativeDragInteractions();
     this._hasStartedDragging = this._hasMoved = false;
     this._initialContainer = this._dropContainer!;
 
@@ -999,7 +1014,7 @@ export class DragRef<T = any> {
       return;
     }
 
-    const shouldEnable = this.disabled || this._handles.length > 0;
+    const shouldEnable = this._handles.length > 0 || !this.isDragging();
 
     if (shouldEnable !== this._nativeInteractionsEnabled) {
       this._nativeInteractionsEnabled = shouldEnable;

--- a/src/dev-app/drag-drop/drag-drop-demo-module.ts
+++ b/src/dev-app/drag-drop/drag-drop-demo-module.ts
@@ -12,6 +12,7 @@ import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 import {DragAndDropDemo} from './drag-drop-demo';
@@ -23,6 +24,7 @@ import {DragAndDropDemo} from './drag-drop-demo';
     FormsModule,
     MatFormFieldModule,
     MatIconModule,
+    MatInputModule,
     MatSelectModule,
     RouterModule.forChild([{path: '', component: DragAndDropDemo}]),
   ],

--- a/src/dev-app/drag-drop/drag-drop-demo.html
+++ b/src/dev-app/drag-drop/drag-drop-demo.html
@@ -74,6 +74,6 @@
   <h2>Drag start delay</h2>
 
   <mat-form-field>
-    <input matInput placeholder="Drag start delay" value="100" [(ngModel)]="dragStartDelay">
+    <input matInput placeholder="Drag start delay" value="0" [(ngModel)]="dragStartDelay">
   </mat-form-field>
 </div>

--- a/src/dev-app/drag-drop/drag-drop-demo.html
+++ b/src/dev-app/drag-drop/drag-drop-demo.html
@@ -48,7 +48,7 @@
 
 <div class="demo-list">
   <h2>Free dragging</h2>
-  <div cdkDrag class="demo-free-draggable" [cdkDragLockAxis]="axisLock">Drag me around</div>
+  <div cdkDrag class="demo-free-draggable" [cdkDragLockAxis]="axisLock" [cdkDragStartDelay]="dragStartDelay">Drag me around</div>
 </div>
 
 <div>
@@ -67,5 +67,13 @@
       <mat-option value="x">X axis</mat-option>
       <mat-option value="y">Y axis</mat-option>
     </mat-select>
+  </mat-form-field>
+</div>
+
+<div>
+  <h2>Drag start delay</h2>
+
+  <mat-form-field>
+    <input matInput placeholder="Drag start delay" value="100" [(ngModel)]="dragStartDelay">
   </mat-form-field>
 </div>

--- a/src/dev-app/drag-drop/drag-drop-demo.ts
+++ b/src/dev-app/drag-drop/drag-drop-demo.ts
@@ -21,6 +21,7 @@ import {CdkDragDrop, moveItemInArray, transferArrayItem} from '@angular/cdk/drag
 })
 export class DragAndDropDemo {
   axisLock: 'x' | 'y';
+  dragStartDelay: number = 0;
   todo = [
     'Go out for Lunch',
     'Make a cool app',

--- a/src/dev-app/drag-drop/drag-drop-demo.ts
+++ b/src/dev-app/drag-drop/drag-drop-demo.ts
@@ -21,7 +21,7 @@ import {CdkDragDrop, moveItemInArray, transferArrayItem} from '@angular/cdk/drag
 })
 export class DragAndDropDemo {
   axisLock: 'x' | 'y';
-  dragStartDelay: number = 0;
+  dragStartDelay = 0;
   todo = [
     'Go out for Lunch',
     'Make a cool app',


### PR DESCRIPTION
The current implementation of the drag start delay does not allow scrolling on mobile devices.
Instead, the draggable element gets teleported to the cursor once the delay is elapsed.

In order to handle this use case, we cancel the drag sequence if the cursor moves before
the drag start delay is elapsed and we disable native drag interactions only when the
drag sequence is started instead of when it is initialized.

The drag start delay was also integrated to the drag drop demo.

Fixes #16224