### PR TITLE
feat(form-field): allow hideRequiredMarker default value to be configured

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -84,6 +84,7 @@ export type MatFormFieldAppearance = 'legacy' | 'standard' | 'fill' | 'outline';
  */
 export interface MatFormFieldDefaultOptions {
   appearance?: MatFormFieldAppearance;
+  hideRequiredMarker?: boolean;
 }
 
 /**
@@ -280,6 +281,8 @@ export class MatFormField extends _MatFormFieldMixinBase
 
     // Set the default through here so we invoke the setter on the first run.
     this.appearance = (_defaults && _defaults.appearance) ? _defaults.appearance : 'legacy';
+    this._hideRequiredMarker = (_defaults && _defaults.hideRequiredMarker != null) ?
+        _defaults.hideRequiredMarker : false;
   }
 
   /**

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1455,32 +1455,47 @@ describe('MatInput with appearance', () => {
 });
 
 describe('MatFormField default options', () => {
-  it('should be legacy appearance if no default options provided', fakeAsync(() => {
+  it('should be legacy appearance if no default options provided', () => {
     const fixture = createComponent(MatInputWithAppearance);
     fixture.detectChanges();
-    flush();
     expect(fixture.componentInstance.formField.appearance).toBe('legacy');
-  }));
+  });
 
-  it('should be legacy appearance if empty default options provided', fakeAsync(() => {
+  it('should be legacy appearance if empty default options provided', () => {
     const fixture = createComponent(MatInputWithAppearance, [{
       provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {}}
     ]);
 
     fixture.detectChanges();
-    flush();
     expect(fixture.componentInstance.formField.appearance).toBe('legacy');
-  }));
+  });
 
-  it('should be custom default appearance if custom appearance specified in default options',
-      fakeAsync(() => {
-        const fixture = createComponent(MatInputWithAppearance, [{
-          provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {appearance: 'fill'}}
-        ]);
-        fixture.detectChanges();
-        flush();
-        expect(fixture.componentInstance.formField.appearance).toBe('fill');
-      }));
+  it('should be able to change the default appearance', () => {
+    const fixture = createComponent(MatInputWithAppearance, [{
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {appearance: 'fill'}}
+    ]);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.formField.appearance).toBe('fill');
+  });
+
+  it('should default hideRequiredMarker to false', () => {
+    const fixture = createComponent(MatInputWithAppearance, [{
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {}}
+    ]);
+
+    fixture.detectChanges();
+    expect(fixture.componentInstance.formField.hideRequiredMarker).toBe(false);
+  });
+
+  it('should be able to change the default value of hideRequiredMarker', () => {
+    const fixture = createComponent(MatInputWithAppearance, [{
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {hideRequiredMarker: true}}
+    ]);
+
+    fixture.detectChanges();
+    expect(fixture.componentInstance.formField.hideRequiredMarker).toBe(true);
+  });
+
 });
 
 describe('MatInput with textarea autosize', () => {

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -81,6 +81,7 @@ export declare abstract class MatFormFieldControl<T> {
 
 export interface MatFormFieldDefaultOptions {
     appearance?: MatFormFieldAppearance;
+    hideRequiredMarker?: boolean;
 }
 
 export declare class MatFormFieldModule {


### PR DESCRIPTION
Allows for the `hideRequiredMarker` default value to be configured through the `MAT_FORM_FIELD_DEFAULT_OPTIONS` injection token.

Fixes #16243.