### PR TITLE
chore: bazel lint error message printing out wrong fix command

### DIFF
--- a/scripts/circleci/lint-bazel-files.sh
+++ b/scripts/circleci/lint-bazel-files.sh
@@ -7,6 +7,6 @@ YELLOW='\033[0;33m'
 yarn -s bazel:format-lint || {
   echo ""
   echo -e "${RED}Please fix all warnings. Some warnings can" \
-    "be fixed automatically by running: ${YELLOW}yarn bazel:format"
+    "be fixed automatically by running: ${YELLOW}yarn format:bazel"
   exit 1
 }


### PR DESCRIPTION
Fixes the lint failure, that gets logged out if the Bazel linting fails, showing the wrong command that can be used to fix the issue.