### PR TITLE
fix(cdk/virtual-scroll): fix subpixel rounding errors on hdpi screens

### DIFF
--- a/src/cdk/scrolling/virtual-scroll-viewport.html
+++ b/src/cdk/scrolling/virtual-scroll-viewport.html
@@ -10,5 +10,4 @@
   so that the scrollbar captures the size of the entire data set.
 -->
 <div class="cdk-virtual-scroll-spacer"
-     [style.width]="orientation == 'horizontal' ? _totalContentSize + 'px' : ''"
-     [style.height]="orientation == 'vertical' ? _totalContentSize + 'px' : ''"></div>
+     [style.width]="_totalContentWidth" [style.height]="_totalContentHeight"></div>

--- a/src/cdk/scrolling/virtual-scroll-viewport.html
+++ b/src/cdk/scrolling/virtual-scroll-viewport.html
@@ -9,4 +9,6 @@
   Spacer used to force the scrolling container to the correct size for the *total* number of items
   so that the scrollbar captures the size of the entire data set.
 -->
-<div class="cdk-virtual-scroll-spacer" [style.transform]="_totalContentSizeTransform"></div>
+<div class="cdk-virtual-scroll-spacer"
+     [style.width]="orientation == 'horizontal' ? _totalContentSize + 'px' : ''"
+     [style.height]="orientation == 'vertical' ? _totalContentSize + 'px' : ''"></div>

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -71,7 +71,17 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   private _renderedRangeSubject = new Subject<ListRange>();
 
   /** The direction the viewport scrolls. */
-  @Input() orientation: 'horizontal' | 'vertical' = 'vertical';
+  @Input()
+  get orientation() {
+    return this._orientation;
+  }
+  set orientation(orientation: 'horizontal' | 'vertical') {
+    if (this._orientation !== orientation) {
+      this._orientation = orientation;
+      this._calculateSpacerSize();
+    }
+  }
+  private _orientation: 'horizontal' | 'vertical' = 'vertical';
 
   // Note: we don't use the typical EventEmitter here because we need to subscribe to the scroll
   // strategy lazily (i.e. only if the user is actually listening to the events). We do this because
@@ -92,7 +102,13 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   /**
    * The total size of all content (in pixels), including content that is not currently rendered.
    */
-  _totalContentSize = 0;
+  private _totalContentSize = 0;
+
+  /** A string representing the `style.width` property value to be used for the spacer element. */
+  _totalContentWidth = '';
+
+  /** A string representing the `style.height` property value to be used for the spacer element. */
+  _totalContentHeight = '';
 
   /**
    * The CSS transform applied to the rendered subset of items so that they appear within the bounds
@@ -232,6 +248,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   setTotalContentSize(size: number) {
     if (this._totalContentSize !== size) {
       this._totalContentSize = size;
+      this._calculateSpacerSize();
       this._markChangeDetectionNeeded();
     }
   }
@@ -389,5 +406,13 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     for (const fn of runAfterChangeDetection) {
       fn();
     }
+  }
+
+  /** Calculates the `style.width` and `style.height` for the spacer element. */
+  private _calculateSpacerSize() {
+    this._totalContentHeight =
+        this.orientation === 'horizontal' ? '' : `${this._totalContentSize}px`;
+    this._totalContentWidth =
+        this.orientation === 'horizontal' ? `${this._totalContentSize}px` : '';
   }
 }

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -90,15 +90,9 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   renderedRangeStream: Observable<ListRange> = this._renderedRangeSubject.asObservable();
 
   /**
-   * The transform used to scale the spacer to the same size as all content, including content that
-   * is not currently rendered.
-   */
-  _totalContentSizeTransform = '';
-
-  /**
    * The total size of all content (in pixels), including content that is not currently rendered.
    */
-  private _totalContentSize = 0;
+  _totalContentSize = 0;
 
   /**
    * The CSS transform applied to the rendered subset of items so that they appear within the bounds
@@ -238,8 +232,6 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   setTotalContentSize(size: number) {
     if (this._totalContentSize !== size) {
       this._totalContentSize = size;
-      const axis = this.orientation == 'horizontal' ? 'X' : 'Y';
-      this._totalContentSizeTransform = `scale${axis}(${this._totalContentSize})`;
       this._markChangeDetectionNeeded();
     }
   }

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -90,7 +90,7 @@ export declare type CdkVirtualForOfContext<T> = {
 
 export declare class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, OnDestroy {
     _contentWrapper: ElementRef<HTMLElement>;
-    _totalContentSizeTransform: string;
+    _totalContentSize: number;
     elementRef: ElementRef<HTMLElement>;
     orientation: 'horizontal' | 'vertical';
     renderedRangeStream: Observable<ListRange>;

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -90,7 +90,8 @@ export declare type CdkVirtualForOfContext<T> = {
 
 export declare class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, OnDestroy {
     _contentWrapper: ElementRef<HTMLElement>;
-    _totalContentSize: number;
+    _totalContentHeight: string;
+    _totalContentWidth: string;
     elementRef: ElementRef<HTMLElement>;
     orientation: 'horizontal' | 'vertical';
     renderedRangeStream: Observable<ListRange>;


### PR DESCRIPTION
Using `transform` appears to cause rounding errors that can accumulate and
become significant after scrolling through a large number of items.
Switching to `width` / `height` corrects this.