### PR TITLE
fix(mat-tabs): position ink bar relative to tabs

### DIFF
--- a/src/material/tabs/tab-header.html
+++ b/src/material/tabs/tab-header.html
@@ -13,9 +13,11 @@
      (keydown)="_handleKeydown($event)">
   <div class="mat-tab-list" #tabList role="tablist" (cdkObserveContent)="_onContentChanges()">
     <div class="mat-tab-labels">
-      <ng-content></ng-content>
+      <div class="mat-tab-label-group">
+        <ng-content></ng-content>
+        <mat-ink-bar></mat-ink-bar>
+      </div>
     </div>
-    <mat-ink-bar></mat-ink-bar>
   </div>
 </div>
 

--- a/src/material/tabs/tab-header.scss
+++ b/src/material/tabs/tab-header.scss
@@ -95,3 +95,13 @@
     justify-content: flex-end;
   }
 }
+
+.mat-tab-label-group {
+  display: flex;
+  position: relative;
+
+  [mat-stretch-tabs] & {
+    flex-basis: 0;
+    flex-grow: 1;
+  }
+}


### PR DESCRIPTION
This helps to keep the inkbar aligned with the correct tab; however, this does not fix the problem
completely as it is still present when mat-stretch-tabs is used.

Related to (but does not resolve) #6130