### PR TITLE
chore: enable noFallthroughCasesInSwitch in the project's tsconfigs

### DIFF
--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -13,6 +13,7 @@
     "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "es2015",
     "moduleResolution": "node",
     "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
Blocked by #16281 as it is the removal of the only fallthrough usage in our library.