### PR TITLE
minor fix for cdk-tree-flat-sample

### DIFF
--- a/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
+++ b/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
@@ -87,7 +87,7 @@ export class CdkTreeFlatExample {
     return null;
   }
 
-  shouldRender(node: ExampleFlatNode) : boolean {
+  shouldRender(node: ExampleFlatNode): boolean {
     const parent = this.getParentNode(node);
     return !parent || (parent.isExpanded && this.shouldRender(parent));
   }

--- a/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
+++ b/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
@@ -87,7 +87,7 @@ export class CdkTreeFlatExample {
     return null;
   }
 
-  shouldRender(node: ExampleFlatNode) {
+  shouldRender(node: ExampleFlatNode) : boolean {
     const parent = this.getParentNode(node);
     return !parent || (parent.isExpanded && this.shouldRender(parent));
   }

--- a/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
+++ b/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
@@ -89,6 +89,6 @@ export class CdkTreeFlatExample {
 
   shouldRender(node: ExampleFlatNode) {
     const parent = this.getParentNode(node);
-    return !parent || parent.isExpanded;
+    return !parent || (parent.isExpanded && this.shouldRender(parent));
   }
 }

--- a/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
+++ b/src/material-examples/cdk-tree-flat/cdk-tree-flat-example.ts
@@ -89,6 +89,6 @@ export class CdkTreeFlatExample {
 
   shouldRender(node: ExampleFlatNode): boolean {
     const parent = this.getParentNode(node);
-    return !parent || (parent.isExpanded && this.shouldRender(parent));
+    return !parent || (this.shouldRender(parent) && !!parent.isExpanded);
   }
 }


### PR DESCRIPTION
current behavior can be seen here: https://material.angular.io/cdk/tree/overview

----parent-node
-----------------child-node
---------------------------grandchild-node

with current example code, when you have an expanded paren-node and expanded child-node( with children), then if you collapse grandparent node, it hides the child-node without hiding grandchild. the grandchild will be hanging of no-where.