### PR TITLE
fix(dialog): don't move focus to dialog container if focus is already inside the dialog

### DIFF
--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -132,20 +132,28 @@ export class MatDialogContainer extends BasePortalOutlet {
 
   /** Moves the focus inside the focus trap. */
   private _trapFocus() {
+    const element = this._elementRef.nativeElement;
+
     if (!this._focusTrap) {
-      this._focusTrap = this._focusTrapFactory.create(this._elementRef.nativeElement);
+      this._focusTrap = this._focusTrapFactory.create(element);
     }
 
-    // If were to attempt to focus immediately, then the content of the dialog would not yet be
+    // If we were to attempt to focus immediately, then the content of the dialog would not yet be
     // ready in instances where change detection has to run first. To deal with this, we simply
     // wait for the microtask queue to be empty.
     if (this._config.autoFocus) {
       this._focusTrap.focusInitialElementWhenReady();
     } else {
+      const activeElement = this._document.activeElement;
+
       // Otherwise ensure that focus is on the dialog container. It's possible that a different
       // component tried to move focus while the open animation was running. See:
-      // https://github.com/angular/components/issues/16215
-      this._elementRef.nativeElement.focus();
+      // https://github.com/angular/components/issues/16215. Note that we only want to do this
+      // if the focus isn't inside the dialog already, because it's possible that the consumer
+      // turned off `autoFocus` in order to move focus themselves.
+      if (activeElement !== element && !element.contains(activeElement)) {
+        element.focus();
+      }
     }
   }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/angular/components/pull/16221. What we hadn't accounted for in the aforementioned PR is that the consumer may have turned off `autoFocus` so that they can handle it themselves and with our changes focus would be reset back to the container. These changes add an extra check which will ensure that focus is only moved if it's not inside the dialog already.

**Note:** I haven't written a test for this for the same reason as #16221: in order to capture the behavior properly, we need to be able to flush a `Promise.resolve` and the animations in a specific sequence, whereas the tests flush them all together.