### PR TITLE
fix(dialog): DOM nodes not cleaned up if view container is destroyed mid-animation

### DIFF
--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -194,6 +194,17 @@ describe('MatDialog', () => {
     expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
   }));
 
+  it('should dispose of dialog if view container is destroyed while animating', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
+
+    dialogRef.close();
+    viewContainerFixture.detectChanges();
+    viewContainerFixture.destroy();
+    flush();
+
+    expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
+  }));
+
   it('should dispatch the beforeClose and afterClose events when the ' +
     'overlay is detached externally', fakeAsync(inject([Overlay], (overlay: Overlay) => {
       const dialogRef = dialog.open(PizzaMsg, {
@@ -1064,6 +1075,7 @@ describe('MatDialog', () => {
 
       document.body.removeChild(button);
       document.body.removeChild(input);
+      flush();
     }));
 
     it('should move focus to the container if there are no focusable elements in the dialog',


### PR DESCRIPTION
Currently the dialog's cleanup logic is tied to its exit animation completing. This usually isn't a problem since by default the dialog is attached to the application ref, however if the consumer has set a `viewContainerRef` and that ref is destroyed mid-animation, the exit animation event will never fire. These changes add a timeout as a fallback in case the animation doesn't finish in the specified time.

Fixes #16284.