### PR TITLE
chore: temporarily disable ivy_snapshot_test_cronjob on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,9 @@ workflows:
       # is no easy way to detect whether a job runs inside of a cronjob or specific
       # workflow. See: https://circleci.com/ideas/?idea=CCI-I-295
       - snapshot_tests_local_browsers
-      - ivy_snapshot_test_cronjob
+      # TODO(devversion): Renable once we are able to update to the version of angular 
+      # and bazel build rules which corrects our errors.
+      # - ivy_snapshot_test_cronjob
     triggers:
       - schedule:
           cron: "0 * * * *"


### PR DESCRIPTION
@devversion I think we should just disable this until you are able to update to the new version and we can reenable it.