### PR TITLE
build: re-enable cronjob snapshot test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,9 +488,7 @@ workflows:
       # is no easy way to detect whether a job runs inside of a cronjob or specific
       # workflow. See: https://circleci.com/ideas/?idea=CCI-I-295
       - snapshot_tests_local_browsers
-      # TODO(devversion): Renable once we are able to update to the version of angular 
-      # and bazel build rules which corrects our errors.
-      # - ivy_snapshot_test_cronjob
+      - ivy_snapshot_test_cronjob
     triggers:
       - schedule:
           cron: "0 * * * *"


### PR DESCRIPTION
* Re-enables the cronjob snapshot test since we updated to Angular 8.0.1 (#16305). This was intended to also fix this issue and we should be able to re-enable this.