### PR TITLE
build: fix snapshot local browsers cronjob test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,11 +367,12 @@ jobs:
     - *checkout_code
     - *restore_cache
     - *yarn_download
+    - *yarn_install
 
     - run: node ./scripts/circleci/setup-angular-snapshots.js --tag master
-      # Install yarn dependencies after the package.json has been updated. Note that
-      # we can't use frozen-lockfile since the setup snapshots script does not update
-      # the lock file.
+      # We need to re-run yarn install in order to pull the Angular snapshot builds. Note
+      # that we can't use the "--frozen-lockfile" option since the setup snapshots script does
+      # not update the lock file.
     - run: yarn install --non-interactive
     - run: ./scripts/circleci/run-local-browser-tests.sh
 
@@ -485,6 +486,7 @@ workflows:
   # Lint workflow. As we want to lint in one job, this is a workflow with just one job.
   lint:
     jobs:
+      - snapshot_tests_local_browsers
       - lint:
           filters: *ignore_presubmit_branch_filter
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,6 @@ workflows:
   # Lint workflow. As we want to lint in one job, this is a workflow with just one job.
   lint:
     jobs:
-      - snapshot_tests_local_browsers
       - lint:
           filters: *ignore_presubmit_branch_filter
 


### PR DESCRIPTION
The `snapshot_tests_local_browsers` job currently seems
to fail because in order to run the setup snapshots script,
we already need to have the `node_modules` installed. This
means that we need to run Yarn twice for the cronjob. Though
this shouldn't have any performance implications because
we recently updated Yarn to a version that is able to
properly cache/restore the `node_modules`.