### PR TITLE
build: mark all e2e test suites as flaky within bazel

### DIFF
--- a/src/cdk-experimental/scrolling/BUILD.bazel
+++ b/src/cdk-experimental/scrolling/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "protractor_web_test_suite")
 
 ng_module(
     name = "scrolling",

--- a/src/cdk-experimental/testing/BUILD.bazel
+++ b/src/cdk-experimental/testing/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_web_test_suite")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
+load("//tools:defaults.bzl", "ng_module", "ng_web_test_suite", "protractor_web_test_suite")
 
 ng_module(
     name = "testing",

--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material-experimental/mdc-button/BUILD.bazel
+++ b/src/material-experimental/mdc-button/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "protractor_web_test_suite")
 
 ng_module(
     name = "mdc-button",

--- a/src/material-experimental/mdc-card/BUILD.bazel
+++ b/src/material-experimental/mdc-card/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "protractor_web_test_suite")
 
 ng_module(
     name = "mdc-card",

--- a/src/material-experimental/mdc-checkbox/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "protractor_web_test_suite", "ts_library")
 
 ng_module(
     name = "mdc-checkbox",

--- a/src/material-experimental/mdc-chips/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "protractor_web_test_suite")
 
 ng_module(
     name = "mdc-chips",

--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "protractor_web_test_suite")
 
 ng_module(
     name = "mdc-menu",

--- a/src/material-experimental/mdc-radio/BUILD.bazel
+++ b/src/material-experimental/mdc-radio/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "protractor_web_test_suite")
 
 ng_module(
     name = "mdc-radio",

--- a/src/material-experimental/mdc-slide-toggle/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "protractor_web_test_suite")
 
 ng_module(
     name = "mdc-slide-toggle",

--- a/src/material-experimental/mdc-tabs/BUILD.bazel
+++ b/src/material-experimental/mdc-tabs/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "protractor_web_test_suite")
 
 ng_module(
     name = "mdc-tabs",

--- a/src/material/button-toggle/BUILD.bazel
+++ b/src/material/button-toggle/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/button/BUILD.bazel
+++ b/src/material/button/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/card/BUILD.bazel
+++ b/src/material/card/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "markdown_to_html", "ng_e2e_test_library", "ng_module")
+load("//tools:defaults.bzl", "markdown_to_html", "ng_e2e_test_library", "ng_module", "protractor_web_test_suite")
 
 ng_module(
     name = "card",

--- a/src/material/checkbox/BUILD.bazel
+++ b/src/material/checkbox/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/dialog/BUILD.bazel
+++ b/src/material/dialog/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/expansion/BUILD.bazel
+++ b/src/material/expansion/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/grid-list/BUILD.bazel
+++ b/src/material/grid-list/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/icon/BUILD.bazel
+++ b/src/material/icon/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/input/BUILD.bazel
+++ b/src/material/input/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/list/BUILD.bazel
+++ b/src/material/list/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/menu/BUILD.bazel
+++ b/src/material/menu/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/progress-bar/BUILD.bazel
+++ b/src/material/progress-bar/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/progress-spinner/BUILD.bazel
+++ b/src/material/progress-spinner/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/radio/BUILD.bazel
+++ b/src/material/radio/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/sidenav/BUILD.bazel
+++ b/src/material/sidenav/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/slide-toggle/BUILD.bazel
+++ b/src/material/slide-toggle/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/stepper/BUILD.bazel
+++ b/src/material/stepper/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/tabs/BUILD.bazel
+++ b/src/material/tabs/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/src/material/toolbar/BUILD.bazel
+++ b/src/material/toolbar/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("@npm_angular_bazel//:index.bzl", "protractor_web_test_suite")
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +8,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "protractor_web_test_suite",
 )
 
 ng_module(

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,6 +1,6 @@
 # Re-export of Bazel rules with repository-wide defaults
 
-load("@npm_angular_bazel//:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
+load("@npm_angular_bazel//:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package", _protractor_web_test_suite = "protractor_web_test_suite")
 load("@npm_bazel_jasmine//:index.bzl", _jasmine_node_test = "jasmine_node_test")
 load("@npm_bazel_typescript//:defs.bzl", _ts_library = "ts_library")
 load("@npm_bazel_karma//:defs.bzl", _ts_web_test_suite = "ts_web_test_suite")
@@ -119,6 +119,15 @@ def ts_web_test_suite(deps = [], srcs = [], **kwargs):
         srcs = [
             "@npm//node_modules/tslib:tslib.js",
         ] + ANGULAR_LIBRARY_UMDS + srcs,
+        **kwargs
+    )
+
+# Protractor web test targets are flaky by default as the browser can sometimes
+# crash (e.g. due to too much concurrency). Passing the "flaky" flag ensures that
+# Bazel detects flaky tests and re-runs these a second time in case of a flake.
+def protractor_web_test_suite(flaky = True, **kwargs):
+    _protractor_web_test_suite(
+        flaky = flaky,
         **kwargs
     )
 


### PR DESCRIPTION
Marks all e2e test suites as flaky with Bazel's `flaky` rule
attribute. This should improve CI stability as e2e tests can
sometimes fail due to browser crashes, port collisions.

For example: https://circleci.com/gh/angular/components/59829