### PR TITLE
fix(ng-update): do not rely on node-glob for finding rule directories

### DIFF
--- a/src/cdk/schematics/ng-update/upgrade-rules/tslint-config.ts
+++ b/src/cdk/schematics/ng-update/upgrade-rules/tslint-config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {sync as globSync} from 'glob';
+import {join} from 'path';
 import {TargetVersion} from '../target-version';
 import {RuleUpgradeData} from '../upgrade-data';
 
@@ -67,7 +67,18 @@ const baseUpgradeRules: UpgradeRules = [
 ];
 
 /** List of absolute paths that refer to directories that contain the upgrade rules. */
-const ruleDirectories = globSync('./**/', {cwd: __dirname, absolute: true});
+const ruleDirectories = [
+  'attribute-selectors/',
+  'class-inheritance/',
+  'class-names/',
+  'css-selectors/',
+  'element-selectors/',
+  'input-names/',
+  'misc-checks/',
+  'output-names/',
+  'property-names/',
+  'signature-check/',
+].map(relativePath => join(__dirname, relativePath));
 
 /**
  * Creates a TSLint configuration object that can be passed to the schematic `TSLintFixTask`.

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -9,7 +9,7 @@
 import {Rule} from '@angular-devkit/schematics';
 import {createUpgradeRule, TargetVersion, UpgradeTSLintConfig} from '@angular/cdk/schematics';
 import {green, yellow} from 'chalk';
-import {sync as globSync} from 'glob';
+import {join} from 'path';
 
 import {materialUpgradeData} from './upgrade-data';
 
@@ -33,7 +33,11 @@ const upgradeRules = [
 ];
 
 /** List of absolute paths that refer to directories that contain the Material upgrade rules. */
-const ruleDirectories = globSync('upgrade-rules/**/', {cwd: __dirname, absolute: true});
+const ruleDirectories = [
+  'misc-checks/',
+  'misc-ripples-v7/',
+  'package-imports-v8/',
+].map(relativePath => join(__dirname, 'upgrade-rules/', relativePath));
 
 /** TSLint upgrade configuration that will be passed to the CDK ng-update rule. */
 const tslintUpgradeConfig: UpgradeTSLintConfig = {


### PR DESCRIPTION
We currently use `glob` in order to find rule directories automatically. This
has implications because it means that we depend on `glob` that is usually
brought in transitively by other project dependencies. This means that the
glob version is not guaranteed to be working due to previous `glob`
issues on windows.

Related to #16208