### PR TITLE
feat(drag-drop): add support for automatic scrolling

### DIFF
--- a/src/cdk/drag-drop/BUILD.bazel
+++ b/src/cdk/drag-drop/BUILD.bazel
@@ -35,6 +35,7 @@ ng_test_library(
     deps = [
         ":drag-drop",
         "//src/cdk/bidi",
+        "//src/cdk/scrolling",
         "//src/cdk/testing",
         "@npm//@angular/common",
         "@npm//rxjs",

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -129,6 +129,10 @@ export class CdkDropList<T = any> implements CdkDropListContainer, AfterContentI
   @Input('cdkDropListEnterPredicate')
   enterPredicate: (drag: CdkDrag, drop: CdkDropList) => boolean = () => true
 
+  /** Whether to auto-scroll the view when the user moves their pointer close to the edges. */
+  @Input('cdkDropListAutoScrollDisabled')
+  autoScrollDisabled: boolean = false;
+
   /** Emits when the user drops an item inside the container. */
   @Output('cdkDropListDropped')
   dropped: EventEmitter<CdkDragDrop<T, any>> = new EventEmitter<CdkDragDrop<T, any>>();
@@ -298,6 +302,7 @@ export class CdkDropList<T = any> implements CdkDropListContainer, AfterContentI
       ref.disabled = this.disabled;
       ref.lockAxis = this.lockAxis;
       ref.sortingDisabled = this.sortingDisabled;
+      ref.autoScrollDisabled = this.autoScrollDisabled;
       ref
         .connectedTo(siblings.filter(drop => drop && drop !== this).map(list => list._dropListRef))
         .withOrientation(this.orientation);

--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -155,7 +155,7 @@ describe('DragDropRegistry', () => {
     pointerMoveSubscription.unsubscribe();
   });
 
-  it('should not emit pointer events when dragging is over (mutli touch)', () => {
+  it('should not emit pointer events when dragging is over (multi touch)', () => {
     const firstItem = testComponent.dragItems.first;
 
     // First finger down
@@ -211,15 +211,6 @@ describe('DragDropRegistry', () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
-  it('should not prevent the default `wheel` actions when nothing is being dragged', () => {
-    expect(dispatchFakeEvent(document, 'wheel').defaultPrevented).toBe(false);
-  });
-
-  it('should prevent the default `wheel` action when an item is being dragged', () => {
-    registry.startDragging(testComponent.dragItems.first, createMouseEvent('mousedown'));
-    expect(dispatchFakeEvent(document, 'wheel').defaultPrevented).toBe(true);
-  });
-
   it('should not prevent the default `selectstart` actions when nothing is being dragged', () => {
     expect(dispatchFakeEvent(document, 'selectstart').defaultPrevented).toBe(false);
   });
@@ -229,6 +220,26 @@ describe('DragDropRegistry', () => {
     expect(dispatchFakeEvent(document, 'selectstart').defaultPrevented).toBe(true);
   });
 
+  it('should dispatch `scroll` events if the viewport is scrolled while dragging', () => {
+    const spy = jasmine.createSpy('scroll spy');
+    const subscription = registry.scroll.subscribe(spy);
+
+    registry.startDragging(testComponent.dragItems.first, createMouseEvent('mousedown'));
+    dispatchFakeEvent(document, 'scroll');
+
+    expect(spy).toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
+
+  it('should not dispatch `scroll` events when not dragging', () => {
+    const spy = jasmine.createSpy('scroll spy');
+    const subscription = registry.scroll.subscribe(spy);
+
+    dispatchFakeEvent(document, 'scroll');
+
+    expect(spy).not.toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
 
 });
 

--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -56,6 +56,9 @@ export class DragDropRegistry<I, C extends {id: string}> implements OnDestroy {
    */
   readonly pointerUp: Subject<TouchEvent | MouseEvent> = new Subject<TouchEvent | MouseEvent>();
 
+  /** Emits when the viewport has been scrolled while the user is dragging an item. */
+  readonly scroll: Subject<Event> = new Subject<Event>();
+
   constructor(
     private _ngZone: NgZone,
     @Inject(DOCUMENT) _document: any) {
@@ -136,6 +139,9 @@ export class DragDropRegistry<I, C extends {id: string}> implements OnDestroy {
           handler: (e: Event) => this.pointerUp.next(e as TouchEvent | MouseEvent),
           options: true
         })
+        .set('scroll', {
+          handler: (e: Event) => this.scroll.next(e)
+        })
         // Preventing the default action on `mousemove` isn't enough to disable text selection
         // on Safari so we need to prevent the selection event as well. Alternatively this can
         // be done by setting `user-select: none` on the `body`, however it has causes a style
@@ -144,15 +150,6 @@ export class DragDropRegistry<I, C extends {id: string}> implements OnDestroy {
           handler: this._preventDefaultWhileDragging,
           options: activeCapturingEventOptions
         });
-
-      // TODO(crisbeto): prevent mouse wheel scrolling while
-      // dragging until we've set up proper scroll handling.
-      if (!isTouchEvent) {
-        this._globalListeners.set('wheel', {
-          handler: this._preventDefaultWhileDragging,
-          options: activeCapturingEventOptions
-        });
-      }
 
       this._ngZone.runOutsideAngular(() => {
         this._globalListeners.forEach((config, name) => {

--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -47,6 +47,7 @@ export class DragDrop {
    * @param element Element to which to attach the drop list functionality.
    */
   createDropList<T = any>(element: ElementRef<HTMLElement> | HTMLElement): DropListRef<T> {
-    return new DropListRef<T>(element, this._dragDropRegistry, this._document);
+    return new DropListRef<T>(element, this._dragDropRegistry, this._document, this._ngZone,
+        this._viewportRuler);
   }
 }

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -138,6 +138,7 @@ export interface CdkDragStart<T = any> {
 export declare class CdkDropList<T = any> implements CdkDropListContainer, AfterContentInit, OnDestroy {
     _draggables: QueryList<CdkDrag>;
     _dropListRef: DropListRef<CdkDropList<T>>;
+    autoScrollDisabled: boolean;
     connectedTo: (CdkDropList | string)[] | CdkDropList | string;
     data: T;
     disabled: boolean;
@@ -211,6 +212,7 @@ export declare class DragDropRegistry<I, C extends {
 }> implements OnDestroy {
     readonly pointerMove: Subject<TouchEvent | MouseEvent>;
     readonly pointerUp: Subject<TouchEvent | MouseEvent>;
+    readonly scroll: Subject<Event>;
     constructor(_ngZone: NgZone, _document: any);
     getDropContainer(id: string): C | undefined;
     isDragging(drag: I): boolean;
@@ -272,6 +274,7 @@ export declare class DragRef<T = any> {
         source: DragRef<any>;
     }>;
     constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>);
+    _sortFromLastPointerPosition(): void;
     _withDropContainer(container: DropListRef): void;
     disableHandle(handle: HTMLElement): void;
     dispose(): void;
@@ -296,6 +299,7 @@ export interface DragRefConfig {
 }
 
 export declare class DropListRef<T = any> {
+    autoScrollDisabled: boolean;
     beforeStarted: Subject<void>;
     data: T;
     disabled: boolean;
@@ -328,7 +332,8 @@ export declare class DropListRef<T = any> {
         item: DragRef;
     }>;
     sortingDisabled: boolean;
-    constructor(element: ElementRef<HTMLElement> | HTMLElement, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, _document: any);
+    constructor(element: ElementRef<HTMLElement> | HTMLElement, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>, _document: any,
+    _ngZone?: NgZone | undefined, _viewportRuler?: ViewportRuler | undefined);
     _canReceive(item: DragRef, x: number, y: number): boolean;
     _getSiblingContainerFromPosition(item: DragRef, x: number, y: number): DropListRef | undefined;
     _isOverContainer(x: number, y: number): boolean;
@@ -337,7 +342,9 @@ export declare class DropListRef<T = any> {
         y: number;
     }): void;
     _startReceiving(sibling: DropListRef): void;
+    _startScrollingIfNecessary(pointerX: number, pointerY: number): void;
     _stopReceiving(sibling: DropListRef): void;
+    _stopScrolling(): void;
     connectedTo(connectedTo: DropListRef[]): this;
     dispose(): void;
     drop(item: DragRef, currentIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance?: Point): void;


### PR DESCRIPTION
* Adds support for automatically scrolling either the list or the viewport when the user's cursor gets within a certain threshold of the edges (currently within 5% inside and outside).
* Handles changes to the scroll position of both the list and the viewport while the user is dragging. Previously our positioning would break down and we'd emit incorrect data.
* No longer blocks the mouse wheel scrolling while the user is dragging.
* Allows the consumer to opt out of the automatic scrolling.

Fixes #13588.
![list-demo](https://user-images.githubusercontent.com/4450522/60122076-bafb0100-9784-11e9-9f30-3d0d5b44038b.gif)
![viewport-demo](https://user-images.githubusercontent.com/4450522/60122077-bafb0100-9784-11e9-8b23-bf79c4cebb73.gif)

