### PR TITLE
chore: fix new typescript errors with 3.5

### DIFF
--- a/src/cdk/a11y/key-manager/list-key-manager.spec.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.spec.ts
@@ -1,13 +1,13 @@
-import {DOWN_ARROW, TAB, UP_ARROW, LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
-import {take} from 'rxjs/operators';
+import {DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, TAB, UP_ARROW} from '@angular/cdk/keycodes';
+import {createKeyboardEvent} from '@angular/cdk/testing';
 import {QueryList} from '@angular/core';
 import {fakeAsync, tick} from '@angular/core/testing';
-import {createKeyboardEvent} from '@angular/cdk/testing';
+import {Subject} from 'rxjs';
+import {take} from 'rxjs/operators';
+import {FocusOrigin} from '../focus-monitor/focus-monitor';
 import {ActiveDescendantKeyManager} from './activedescendant-key-manager';
 import {FocusKeyManager} from './focus-key-manager';
-import {ListKeyManager, ListKeyManagerModifierKey} from './list-key-manager';
-import {FocusOrigin} from '../focus-monitor/focus-monitor';
-import {Subject} from 'rxjs';
+import {ListKeyManager, ListKeyManagerModifierKey, ListKeyManagerOption} from './list-key-manager';
 
 
 class FakeFocusable {
@@ -648,7 +648,8 @@ describe('Key managers', () => {
 
         invalidQueryList.items = [{ disabled: false }];
 
-        const invalidManager = new ListKeyManager(invalidQueryList);
+        const invalidManager =
+            new ListKeyManager(invalidQueryList as QueryList<ListKeyManagerOption>);
 
         expect(() => invalidManager.withTypeAhead()).toThrowError(/must implement/);
       });

--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -61,13 +61,18 @@ export class OverlayConfig {
 
   constructor(config?: OverlayConfig) {
     if (config) {
-      Object.keys(config).forEach(k => {
-        const key = k as keyof OverlayConfig;
-
-        if (typeof config[key] !== 'undefined') {
-          this[key] = config[key];
+      const configKeys = Object.keys(config) as Array<keyof OverlayConfig>;
+      for (const key of configKeys) {
+        if (config[key] !== undefined) {
+          // TypeScript, as of version 3.5, sees the left-hand-side of this expression
+          // as "I don't know *which* key this is, so the only valid value is the intersection
+          // of all the posible values." In this case, that happens to be `undefined`. TypeScript
+          // is not smart enough to see that the right-hand-side is actually an access of the same
+          // exact type with the same exact key, meaning that the value type must be identical.
+          // So we use `any` to work around this.
+          this[key] = config[key] as any;
         }
-      });
+      }
     }
   }
 }

--- a/src/cdk/tree/control/nested-tree-control.ts
+++ b/src/cdk/tree/control/nested-tree-control.ts
@@ -46,9 +46,14 @@ export class NestedTreeControl<T> extends BaseTreeControl<T> {
     if (Array.isArray(childrenNodes)) {
       childrenNodes.forEach((child: T) => this._getDescendants(descendants, child));
     } else if (childrenNodes instanceof Observable) {
-      childrenNodes.pipe(take(1), filter(Boolean)).subscribe(children => {
-        children.forEach((child: T) => this._getDescendants(descendants, child));
-      });
+      // TypeScript as of version 3.5 doesn't seem to treat `Boolean` like a function that
+      // returns a `boolean` specifically in the context of `filter`, so we manually clarify that.
+      childrenNodes.pipe(take(1), filter(Boolean as () => boolean))
+          .subscribe(children => {
+            for (const child of children) {
+              this._getDescendants(descendants, child);
+            }
+          });
     }
   }
 }


### PR DESCRIPTION
Google's TypeScript team is flushing out errors for 3.5. This
commit proactively addresses the three that popped up for us.