### PR TITLE
fix(datepicker): use abbr nodes for week day abbreviations

### DIFF
--- a/src/material/datepicker/calendar.scss
+++ b/src/material/datepicker/calendar.scss
@@ -103,6 +103,11 @@ $mat-calendar-next-icon-transform: translateX(-2px) rotate(45deg);
   padding: 0 0 $mat-calendar-padding 0;
 }
 
+// The browser automatically adds an underline to `abbr` nodes that have a `title`.
+.mat-calendar-table-header abbr {
+  text-decoration: none;
+}
+
 .mat-calendar-table-header-divider {
   position: relative;
   height: $mat-calendar-header-divider-width;

--- a/src/material/datepicker/month-view.html
+++ b/src/material/datepicker/month-view.html
@@ -1,7 +1,9 @@
 <table class="mat-calendar-table" role="presentation">
   <thead class="mat-calendar-table-header">
     <tr>
-      <th scope="col" *ngFor="let day of _weekdays" [attr.aria-label]="day.long">{{day.narrow}}</th>
+      <th scope="col" *ngFor="let day of _weekdays" [attr.aria-label]="day.long">
+        <abbr [attr.title]="day.long">{{day.narrow}}</abbr>
+      </th>
     </tr>
     <tr><th class="mat-calendar-table-header-divider" colspan="7" aria-hidden="true"></th></tr>
   </thead>

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -65,7 +65,7 @@ describe('MatMonthView', () => {
     });
 
     it('has 31 days', () => {
-      let cellEls = monthViewNativeElement.querySelectorAll('.mat-calendar-body-cell')!;
+      let cellEls = monthViewNativeElement.querySelectorAll('.mat-calendar-body-cell');
       expect(cellEls.length).toBe(31);
     });
 
@@ -113,6 +113,16 @@ describe('MatMonthView', () => {
           return header.getAttribute('scope') === 'col';
         })).toBe(true);
         expect(dividerHeader.hasAttribute('scope')).toBe(false);
+      });
+
+      it('should wrap the week day abbreviations in an abbr tag with a title', () => {
+        const abbreviations =
+          Array.from(monthViewNativeElement.querySelectorAll('.mat-calendar-table-header th abbr'));
+
+        expect(abbreviations.length).toBe(7);
+        expect(abbreviations.every(abbreviation => {
+          return !!abbreviation.getAttribute('title');
+        })).toBe(true);
       });
 
       describe('calendar body', () => {


### PR DESCRIPTION
Wraps the week day abbreviations in the calendar header with `abbr` tags and sets the full label as a `title`.

Fixes #16355.