### PR TITLE
refactor: add virtual scroll repeater interface

### DIFF
--- a/src/cdk/scrolling/public-api.ts
+++ b/src/cdk/scrolling/public-api.ts
@@ -14,3 +14,4 @@ export * from './viewport-ruler';
 export * from './virtual-for-of';
 export * from './virtual-scroll-strategy';
 export * from './virtual-scroll-viewport';
+export * from './virtual-scroll-repeater';

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -33,6 +33,7 @@ import {
 import {Observable, Subject, of as observableOf} from 'rxjs';
 import {pairwise, shareReplay, startWith, switchMap, takeUntil} from 'rxjs/operators';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
+import {CdkVirtualScrollRepeater} from './virtual-scroll-repeater';
 
 
 /** The context for an item rendered by `CdkVirtualForOf` */
@@ -74,7 +75,8 @@ function getSize(orientation: 'horizontal' | 'vertical', node: Node): number {
 @Directive({
   selector: '[cdkVirtualFor][cdkVirtualForOf]',
 })
-export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy {
+export class CdkVirtualForOf<T> implements
+ CdkVirtualScrollRepeater<T>, CollectionViewer, DoCheck, OnDestroy {
   /** Emits when the rendered view of the data changes. */
   viewChange = new Subject<ListRange>();
 

--- a/src/cdk/scrolling/virtual-scroll-repeater.ts
+++ b/src/cdk/scrolling/virtual-scroll-repeater.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Observable} from 'rxjs';
+import {ListRange} from '../collections';
+
+/**
+ * An item to be repeated by the VirtualScrollViewport
+ */
+export interface CdkVirtualScrollRepeater<T> {
+  dataStream: Observable<T[] | ReadonlyArray<T>>;
+  measureRangeSize(range: ListRange, orientation: 'horizontal' | 'vertical'): number;
+}

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -27,8 +27,8 @@ import {animationFrameScheduler, asapScheduler, Observable, Subject, Observer} f
 import {auditTime, startWith, takeUntil} from 'rxjs/operators';
 import {ScrollDispatcher} from './scroll-dispatcher';
 import {CdkScrollable, ExtendedScrollToOptions} from './scrollable';
-import {CdkVirtualForOf} from './virtual-for-of';
 import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-strategy';
+import {CdkVirtualScrollRepeater} from './virtual-scroll-repeater';
 
 
 /** Checks if the given ranges are equal. */
@@ -116,7 +116,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   private _viewportSize = 0;
 
   /** the currently attached CdkVirtualForOf. */
-  private _forOf: CdkVirtualForOf<any> | null;
+  private _forOf: CdkVirtualScrollRepeater<any> | null;
 
   /** The last rendered content offset that was set. */
   private _renderedContentOffset = 0;
@@ -184,7 +184,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   }
 
   /** Attaches a `CdkVirtualForOf` to this viewport. */
-  attach(forOf: CdkVirtualForOf<any>) {
+  attach(forOf: CdkVirtualScrollRepeater<any>) {
     if (this._forOf) {
       throw Error('CdkVirtualScrollViewport is already attached.');
     }


### PR DESCRIPTION
taking over for PR #14287 which has gone a while without updates. Includes changes to address comments

> As discussed in #10122

> In order to integrate virtual scroll into mat table we need to decouple CdkVirtualScrollViewport from CdkVirtualForOf

> This modification introduces an adapter between the 2 classes, so users can provide their own version of
~~CdkVirtualScrollAdapter~~ CdkVirtualScrollRepeater

> suggested by @shlomiassaf,

I have created a [stackblitz](https://stackblitz.com/edit/cdk-table-virtual-repeater?file=src/app/app.component.ts) showing an example where this could be used. 