### PR TITLE
fix(bottom-sheet): not moving focus to container if autoFocus is disabled and focus was moved while animating

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -180,15 +180,27 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
     }
   }
 
-
   /** Moves the focus inside the focus trap. */
   private _trapFocus() {
+    const element = this._elementRef.nativeElement;
+
     if (!this._focusTrap) {
-      this._focusTrap = this._focusTrapFactory.create(this._elementRef.nativeElement);
+      this._focusTrap = this._focusTrapFactory.create(element);
     }
 
     if (this.bottomSheetConfig.autoFocus) {
       this._focusTrap.focusInitialElementWhenReady();
+    } else {
+      const activeElement = this._document.activeElement;
+
+      // Otherwise ensure that focus is on the container. It's possible that a different
+      // component tried to move focus while the open animation was running. See:
+      // https://github.com/angular/components/issues/16215. Note that we only want to do this
+      // if the focus isn't inside the bottom sheet already, because it's possible that the
+      // consumer turned off `autoFocus` in order to move focus themselves.
+      if (activeElement !== element && !element.contains(activeElement)) {
+        element.focus();
+      }
     }
   }
 


### PR DESCRIPTION
These changes incorporate #16297 and #16221 into the bottom sheet since it follows a similar focus capturing behavior to `MatDialogContainer`. They ensure that focus is on the bottom sheet container when the animation is over, because it could've moved while we were animating. It also has an extra check to ensure that we don't move focus unnecessarily if the consumer decided to move focus themselves somewhere within the bottom sheet.

**Note:** does not include a unit test, because we need to be able to flush a `Promise.resolve` and an animation in a specific sequence, however the testing utilities flush them all at the same time.