### PR TITLE
fix(expansion): incorrect margin for "before" indicator when expanded

### DIFF
--- a/src/material/expansion/expansion-panel-header.scss
+++ b/src/material/expansion/expansion-panel-header.scss
@@ -23,7 +23,11 @@
     flex-direction: row-reverse;
 
     .mat-expansion-indicator {
-      padding: 0 16px 0 0;
+      margin: 0 16px 0 0;
+
+      [dir='rtl'] & {
+        margin: 0 0 0 16px;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes the panel header indicator not being positioned correctly when it's set to the `before` position and the panel is expanded. The issue comes from the fact that we were using `padding` instead of `margin` which changes the center of the rotation.

Also fixes that the `before` position of the indicator doesn't account for RTL.

![Angular_Material_-_Google_Chrome_2019-07-02_06-31-48](https://user-images.githubusercontent.com/4450522/60483594-65e45100-9c96-11e9-9505-3c32ab7ee962.png)
