### PR TITLE
feat(dialog): allow for custom ComponentFactoryResolver to be passed in

### DIFF
--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ViewContainerRef} from '@angular/core';
+import {ViewContainerRef, ComponentFactoryResolver} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {ScrollStrategy} from '@angular/cdk/overlay';
 
@@ -113,6 +113,9 @@ export class MatDialogConfig<D = any> {
    * the `HashLocationStrategy`).
    */
   closeOnNavigation?: boolean = true;
+
+  /** Alternate `ComponentFactoryResolver` to use when resolving the associated component. */
+  componentFactoryResolver?: ComponentFactoryResolver;
 
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.
 }

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -16,7 +16,8 @@ import {
   NgModule,
   TemplateRef,
   ViewChild,
-  ViewContainerRef
+  ViewContainerRef,
+  ComponentFactoryResolver
 } from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -740,6 +741,19 @@ describe('MatDialog', () => {
     dialog.open(PizzaMsg, {scrollStrategy});
     expect(scrollStrategy.enable).toHaveBeenCalled();
   }));
+
+  it('should be able to pass in an alternate ComponentFactoryResolver',
+    inject([ComponentFactoryResolver], (resolver: ComponentFactoryResolver) => {
+      spyOn(resolver, 'resolveComponentFactory').and.callThrough();
+
+      dialog.open(PizzaMsg, {
+        viewContainerRef: testViewContainerRef,
+        componentFactoryResolver: resolver
+      });
+      viewContainerFixture.detectChanges();
+
+      expect(resolver.resolveComponentFactory).toHaveBeenCalled();
+    }));
 
   describe('passing in data', () => {
     it('should be able to pass in data', () => {

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -223,8 +223,8 @@ export class MatDialog implements OnDestroy {
     const injector = new PortalInjector(userInjector || this._injector, new WeakMap([
       [MatDialogConfig, config]
     ]));
-    const containerPortal =
-        new ComponentPortal(MatDialogContainer, config.viewContainerRef, injector);
+    const containerPortal = new ComponentPortal(MatDialogContainer,
+        config.viewContainerRef, injector, config.componentFactoryResolver);
     const containerRef = overlay.attach<MatDialogContainer>(containerPortal);
 
     return containerRef.instance;

--- a/tools/public_api_guard/material/dialog.d.ts
+++ b/tools/public_api_guard/material/dialog.d.ts
@@ -61,6 +61,7 @@ export declare class MatDialogConfig<D = any> {
     autoFocus?: boolean;
     backdropClass?: string;
     closeOnNavigation?: boolean;
+    componentFactoryResolver?: ComponentFactoryResolver;
     data?: D | null;
     direction?: Direction;
     disableClose?: boolean;


### PR DESCRIPTION
Allows for a different `ComponentFactoryResolver` to be passed in when creating a dialog.

Fixes #16431.