### PR TITLE
test(material-experimental/chips) Port unit tests for mdc chips

### DIFF
--- a/src/material-experimental/mdc-chips/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/BUILD.bazel
@@ -1,8 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
-load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
     name = "mdc-chips",
@@ -15,6 +14,7 @@ ng_module(
     deps = [
         "//src/material/core",
         "//src/material/form-field",
+        "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/forms",
@@ -45,18 +45,36 @@ sass_binary(
     ],
 )
 
-ng_e2e_test_library(
-    name = "e2e_test_sources",
-    srcs = glob(["**/*.e2e.spec.ts"]),
+ng_test_library(
+    name = "chips_tests_lib",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["**/*.e2e.spec.ts"],
+    ),
     deps = [
-        "//src/cdk/testing/e2e",
+        ":mdc-chips",
+        "//src/cdk/a11y",
+        "//src/cdk/bidi",
+        "//src/cdk/keycodes",
+        "//src/cdk/platform",
+        "//src/cdk/testing",
+        "//src/material/core",
+        "//src/material/form-field",
+        "//src/material/input",
+        "@npm//@angular/animations",
+        "@npm//@angular/common",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+        "@npm//material-components-web",
+        "@npm//rxjs",
     ],
 )
 
-e2e_test_suite(
-    name = "e2e_tests",
+ng_web_test_suite(
+    name = "unit_tests",
+    static_files = ["@npm//:node_modules/@material/chips/dist/mdc.chips.js"],
     deps = [
-        ":e2e_test_sources",
-        "//src/cdk/testing/e2e",
+        ":chips_tests_lib",
+        "//src/material-experimental:mdc_require_config.js",
     ],
 )

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -1,0 +1,1098 @@
+import {animate, style, transition, trigger} from '@angular/animations';
+import {Directionality, Direction} from '@angular/cdk/bidi';
+import {
+  BACKSPACE,
+  DELETE,
+  ENTER,
+  LEFT_ARROW,
+  RIGHT_ARROW,
+  SPACE,
+  TAB
+} from '@angular/cdk/keycodes';
+import {
+  createFakeEvent,
+  createKeyboardEvent,
+  dispatchFakeEvent,
+  dispatchKeyboardEvent,
+  dispatchMouseEvent,
+  MockNgZone,
+  typeInElement,
+} from '@angular/cdk/testing';
+import {
+  Component,
+  DebugElement,
+  NgZone,
+  Provider,
+  QueryList,
+  Type,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
+import {fakeAsync, ComponentFixture, TestBed, tick} from '@angular/core/testing';
+import {FormControl, FormsModule, NgForm, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {By} from '@angular/platform-browser';
+import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Subject} from 'rxjs';
+import {GridFocusKeyManager} from './grid-focus-key-manager';
+import {
+  MatChipEvent,
+  MatChipGrid,
+  MatChipInputEvent,
+  MatChipRemove,
+  MatChipRow,
+  MatChipsModule
+} from './index';
+
+
+describe('MatChipGrid', () => {
+  let fixture: ComponentFixture<any>;
+  let chipGridDebugElement: DebugElement;
+  let chipGridNativeElement: HTMLElement;
+  let chipGridInstance: MatChipGrid;
+  let chips: QueryList<MatChipRow>;
+  let manager: GridFocusKeyManager;
+  let zone: MockNgZone;
+  let testComponent: StandardChipGrid;
+  let dirChange: Subject<Direction>;
+
+  describe('StandardChipGrid', () => {
+    describe('basic behaviors', () => {
+      beforeEach(() => {
+        setupStandardGrid();
+      });
+
+      it('should add the `mat-mdc-chip-set` class', () => {
+        expect(chipGridNativeElement.classList).toContain('mat-mdc-chip-set');
+      });
+
+      it('should toggle the chips disabled state based on whether it is disabled', () => {
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+
+        chipGridInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+
+        chipGridInstance.disabled = false;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+      });
+
+      it('should disable a chip that is added after the list became disabled', fakeAsync(() => {
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+
+        chipGridInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+
+        fixture.componentInstance.chips.push(5, 6);
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+      }));
+    });
+
+    describe('focus behaviors', () => {
+      beforeEach(() => {
+        setupStandardGrid();
+        manager = chipGridInstance._keyManager;
+      });
+
+      it('should focus the first chip on focus', () => {
+        chipGridInstance.focus();
+        fixture.detectChanges();
+
+        expect(manager.activeRowIndex).toBe(0);
+        expect(manager.activeColumnIndex).toBe(0);
+      });
+
+      it('should watch for chip focus', () => {
+        let array = chips.toArray();
+        let lastIndex = array.length - 1;
+        let lastItem = array[lastIndex];
+
+        lastItem.focus();
+        fixture.detectChanges();
+
+        expect(manager.activeRowIndex).toBe(lastIndex);
+      });
+
+      it('should not be able to become focused when disabled', () => {
+        expect(chipGridInstance.focused).toBe(false, 'Expected grid to not be focused.');
+
+        chipGridInstance.disabled = true;
+        fixture.detectChanges();
+
+        chipGridInstance.focus();
+        fixture.detectChanges();
+
+        expect(chipGridInstance.focused).toBe(false, 'Expected grid to continue not to be focused');
+      });
+
+      it('should remove the tabindex from the grid if it is disabled', () => {
+        expect(chipGridNativeElement.getAttribute('tabindex')).toBe('0');
+
+        chipGridInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(chipGridNativeElement.getAttribute('tabindex')).toBe('-1');
+      });
+
+      describe('on chip destroy', () => {
+        it('should focus the next item', () => {
+          let array = chips.toArray();
+          let midItem = array[2];
+
+          // Focus the middle item
+          midItem.focus();
+
+          // Destroy the middle item
+          testComponent.chips.splice(2, 1);
+          fixture.detectChanges();
+
+          // It focuses the 4th item (now at index 2)
+          expect(manager.activeRowIndex).toEqual(2);
+        });
+
+        it('should focus the previous item', () => {
+          let array = chips.toArray();
+          let lastIndex = array.length - 1;
+          let lastItem = array[lastIndex];
+
+          // Focus the last item
+          lastItem.focus();
+
+          // Destroy the last item
+          testComponent.chips.pop();
+          fixture.detectChanges();
+
+          // It focuses the next-to-last item
+          expect(manager.activeRowIndex).toEqual(lastIndex - 1);
+        });
+
+        it('should not focus if chip grid is not focused', fakeAsync(() => {
+          let array = chips.toArray();
+          let midItem = array[2];
+
+          // Focus and blur the middle item
+          midItem.focus();
+          midItem._focusout();
+          tick();
+          zone.simulateZoneExit();
+
+          // Destroy the middle item
+          testComponent.chips.splice(2, 1);
+          fixture.detectChanges();
+
+          // Should not have focus
+          expect(chipGridInstance._keyManager.activeRowIndex).toEqual(-1);
+        }));
+
+        it('should focus the grid if the last focused item is removed', () => {
+          testComponent.chips = [0];
+
+          spyOn(chipGridInstance, 'focus');
+          chips.last.focus();
+
+          testComponent.chips.pop();
+          fixture.detectChanges();
+
+          expect(chipGridInstance.focus).toHaveBeenCalled();
+        });
+
+        it('should move focus to the last chip when the focused chip was deleted inside a' +
+          'component with animations', fakeAsync(() => {
+            fixture.destroy();
+            TestBed.resetTestingModule();
+            fixture = createComponent(StandardChipGridWithAnimations, [], BrowserAnimationsModule);
+            fixture.detectChanges();
+
+            chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid));
+            chipGridNativeElement = chipGridDebugElement.nativeElement;
+            chipGridInstance = chipGridDebugElement.componentInstance;
+            testComponent = fixture.debugElement.componentInstance;
+            chips = chipGridInstance._chips;
+
+            chips.last.focus();
+            fixture.detectChanges();
+
+            expect(chipGridInstance._keyManager.activeRowIndex).toBe(chips.length - 1);
+
+            dispatchKeyboardEvent(chips.last._elementRef.nativeElement, 'keydown', BACKSPACE);
+            fixture.detectChanges();
+            tick(500);
+
+            expect(chipGridInstance._keyManager.activeRowIndex).toBe(chips.length - 1);
+            expect(chipGridInstance._keyManager.activeColumnIndex).toBe(0);
+        }));
+      });
+    });
+
+    describe('keyboard behavior', () => {
+      describe('LTR (default)', () => {
+        beforeEach(() => {
+          fixture = createComponent(ChipGridWithRemove);
+          fixture.detectChanges();
+
+          chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid));
+          chipGridInstance = chipGridDebugElement.componentInstance;
+          chipGridNativeElement = chipGridDebugElement.nativeElement;
+          chips = chipGridInstance._chips;
+          manager = chipGridInstance._keyManager;
+        });
+
+        it('should focus previous column when press LEFT ARROW', () => {
+          let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
+          let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
+
+          let LEFT_EVENT = createKeyboardEvent('keydown', LEFT_ARROW, lastNativeChip);
+          let array = chips.toArray();
+          let lastRowIndex = array.length - 1;
+          let lastChip = array[lastRowIndex];
+
+          // Focus the first column of the last chip in the array
+          lastChip.focus();
+          expect(manager.activeRowIndex).toEqual(lastRowIndex);
+          expect(manager.activeColumnIndex).toEqual(0);
+
+          // Press the LEFT arrow
+          chipGridInstance._keydown(LEFT_EVENT);
+          chipGridInstance._blur(); // Simulate focus leaving the list and going to the chip.
+          fixture.detectChanges();
+
+          // It focuses the last column of the previous chip
+          expect(manager.activeRowIndex).toEqual(lastRowIndex - 1);
+          expect(manager.activeColumnIndex).toEqual(1);
+        });
+
+        it('should focus next column when press RIGHT ARROW', () => {
+          let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
+          let firstNativeChip = nativeChips[0] as HTMLElement;
+
+          let RIGHT_EVENT: KeyboardEvent =
+            createKeyboardEvent('keydown', RIGHT_ARROW, firstNativeChip);
+          let array = chips.toArray();
+          let firstItem = array[0];
+
+          // Focus the first column of the first chip in the array
+          firstItem.focus();
+          expect(manager.activeRowIndex).toEqual(0);
+          expect(manager.activeColumnIndex).toEqual(0);
+
+          // Press the RIGHT arrow
+          chipGridInstance._keydown(RIGHT_EVENT);
+          chipGridInstance._blur(); // Simulate focus leaving the list and going to the chip.
+          fixture.detectChanges();
+
+          // It focuses the next column of the chip
+          expect(manager.activeRowIndex).toEqual(0);
+          expect(manager.activeColumnIndex).toEqual(1);
+        });
+
+        it('should not handle arrow key events from non-chip elements', () => {
+          const event: KeyboardEvent =
+              createKeyboardEvent('keydown', RIGHT_ARROW, chipGridNativeElement);
+          const initialActiveIndex = manager.activeRowIndex;
+
+          chipGridInstance._keydown(event);
+          fixture.detectChanges();
+
+          expect(manager.activeRowIndex)
+              .toBe(initialActiveIndex, 'Expected focused item not to have changed.');
+        });
+      });
+
+      describe('RTL', () => {
+        beforeEach(() => {
+          setupStandardGrid('rtl');
+          manager = chipGridInstance._keyManager;
+        });
+
+        it('should focus previous column when press RIGHT ARROW', () => {
+          let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
+          let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
+
+          let RIGHT_EVENT: KeyboardEvent =
+              createKeyboardEvent('keydown', RIGHT_ARROW, lastNativeChip);
+          let array = chips.toArray();
+          let lastRowIndex = array.length - 1;
+          let lastItem = array[lastRowIndex];
+
+          // Focus the first column of the last chip in the array
+          lastItem.focus();
+          expect(manager.activeRowIndex).toEqual(lastRowIndex);
+          expect(manager.activeColumnIndex).toEqual(0);
+
+
+          // Press the RIGHT arrow
+          chipGridInstance._keydown(RIGHT_EVENT);
+          chipGridInstance._blur(); // Simulate focus leaving the list and going to the chip.
+          fixture.detectChanges();
+
+          // It focuses the last column of the previous chip
+          expect(manager.activeRowIndex).toEqual(lastRowIndex - 1);
+          expect(manager.activeColumnIndex).toEqual(0);
+        });
+
+        it('should focus next column when press LEFT ARROW', () => {
+          let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
+          let firstNativeChip = nativeChips[0] as HTMLElement;
+
+          let LEFT_EVENT: KeyboardEvent =
+              createKeyboardEvent('keydown', LEFT_ARROW, firstNativeChip);
+          let array = chips.toArray();
+          let firstItem = array[0];
+
+          // Focus the first column of the first chip in the array
+          firstItem.focus();
+          expect(manager.activeRowIndex).toEqual(0);
+          expect(manager.activeColumnIndex).toEqual(0);
+
+
+          // Press the LEFT arrow
+          chipGridInstance._keydown(LEFT_EVENT);
+          chipGridInstance._blur(); // Simulate focus leaving the list and going to the chip.
+          fixture.detectChanges();
+
+          // It focuses the next column of the chip
+          expect(manager.activeRowIndex).toEqual(1);
+          expect(manager.activeColumnIndex).toEqual(0);
+        });
+
+        it('should allow focus to escape when tabbing away', fakeAsync(() => {
+          let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
+          let firstNativeChip = nativeChips[0] as HTMLElement;
+
+          chipGridInstance._keydown(createKeyboardEvent('keydown', TAB, firstNativeChip));
+
+          expect(chipGridInstance.tabIndex)
+            .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
+
+          tick();
+
+          expect(chipGridInstance.tabIndex).toBe(0, 'Expected tabIndex to be reset back to 0');
+        }));
+
+        it(`should use user defined tabIndex`, fakeAsync(() => {
+          chipGridInstance.tabIndex = 4;
+
+          fixture.detectChanges();
+
+          expect(chipGridInstance.tabIndex)
+            .toBe(4, 'Expected tabIndex to be set to user defined value 4.');
+
+          let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
+          let firstNativeChip = nativeChips[0] as HTMLElement;
+
+          chipGridInstance._keydown(createKeyboardEvent('keydown', TAB, firstNativeChip));
+
+          expect(chipGridInstance.tabIndex)
+            .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
+
+          tick();
+
+          expect(chipGridInstance.tabIndex).toBe(4, 'Expected tabIndex to be reset back to 4');
+        }));
+      });
+
+      it('should account for the direction changing', () => {
+        setupStandardGrid();
+        manager = chipGridInstance._keyManager;
+
+        let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
+        let firstNativeChip = nativeChips[0] as HTMLElement;
+
+        let RIGHT_EVENT: KeyboardEvent =
+          createKeyboardEvent('keydown', RIGHT_ARROW, firstNativeChip);
+        let array = chips.toArray();
+        let firstItem = array[0];
+
+        firstItem.focus();
+        expect(manager.activeRowIndex).toBe(0);
+        expect(manager.activeColumnIndex).toBe(0);
+
+        chipGridInstance._keydown(RIGHT_EVENT);
+        chipGridInstance._blur();
+        fixture.detectChanges();
+
+        expect(manager.activeRowIndex).toBe(1);
+        expect(manager.activeColumnIndex).toBe(0);
+
+        dirChange.next('rtl');
+        fixture.detectChanges();
+
+        chipGridInstance._keydown(RIGHT_EVENT);
+        chipGridInstance._blur();
+        fixture.detectChanges();
+
+        expect(manager.activeRowIndex).toBe(0);
+        expect(manager.activeColumnIndex).toBe(0);
+      });
+    });
+  });
+
+  describe('FormFieldChipGrid', () => {
+    beforeEach(() => {
+      setupInputGrid();
+    });
+
+    describe('keyboard behavior', () => {
+      beforeEach(() => {
+        manager = chipGridInstance._keyManager;
+      });
+
+      it('should maintain focus if the active chip is deleted', () => {
+        const secondChip = fixture.nativeElement.querySelectorAll('.mat-mdc-chip')[1];
+
+        secondChip.focus();
+        fixture.detectChanges();
+
+        expect(chipGridInstance._chips.toArray().findIndex(chip => chip._hasFocus)).toBe(1);
+
+        dispatchKeyboardEvent(secondChip, 'keydown', DELETE);
+        fixture.detectChanges();
+
+        expect(chipGridInstance._chips.toArray().findIndex(chip => chip._hasFocus)).toBe(1);
+      });
+
+      describe('when the input has focus', () => {
+
+        it('should not focus the last chip when press DELETE', () => {
+          let nativeInput = fixture.nativeElement.querySelector('input');
+          let DELETE_EVENT: KeyboardEvent =
+              createKeyboardEvent('keydown', DELETE, nativeInput);
+
+          // Focus the input
+          nativeInput.focus();
+          expect(manager.activeRowIndex).toBe(-1);
+          expect(manager.activeColumnIndex).toBe(-1);
+
+          // Press the DELETE key
+          chipGridInstance._keydown(DELETE_EVENT);
+          fixture.detectChanges();
+
+          // It doesn't focus the last chip
+          expect(manager.activeRowIndex).toEqual(-1);
+          expect(manager.activeColumnIndex).toBe(-1);
+        });
+
+        it('should focus the last chip when press BACKSPACE', () => {
+          let nativeInput = fixture.nativeElement.querySelector('input');
+          let BACKSPACE_EVENT: KeyboardEvent =
+              createKeyboardEvent('keydown', BACKSPACE, nativeInput);
+
+          // Focus the input
+          nativeInput.focus();
+          expect(manager.activeRowIndex).toBe(-1);
+          expect(manager.activeColumnIndex).toBe(-1);
+
+          // Press the BACKSPACE key
+          chipGridInstance._keydown(BACKSPACE_EVENT);
+          fixture.detectChanges();
+
+          // It focuses the last chip
+          expect(manager.activeRowIndex).toEqual(chips.length - 1);
+          expect(manager.activeColumnIndex).toBe(0);
+        });
+      });
+    });
+
+    it('should complete the stateChanges stream on destroy', () => {
+      const spy = jasmine.createSpy('stateChanges complete');
+      const subscription = chipGridInstance.stateChanges.subscribe({complete: spy});
+
+      fixture.destroy();
+      expect(spy).toHaveBeenCalled();
+      subscription.unsubscribe();
+    });
+
+    it('should point the label id to the chip input', () => {
+      const label = fixture.nativeElement.querySelector('label');
+      const input = fixture.nativeElement.querySelector('input');
+
+      fixture.detectChanges();
+
+      expect(label.getAttribute('for')).toBeTruthy();
+      expect(label.getAttribute('for')).toBe(input.getAttribute('id'));
+      expect(label.getAttribute('aria-owns')).toBe(input.getAttribute('id'));
+    });
+  });
+
+  describe('with chip remove', () => {
+    let chipGrid: MatChipGrid;
+    let chipElements: DebugElement[];
+    let chipRemoveDebugElements: DebugElement[];
+
+    beforeEach(() => {
+      fixture = createComponent(ChipGridWithRemove);
+      fixture.detectChanges();
+
+      chipGrid = fixture.debugElement.query(By.directive(MatChipGrid)).componentInstance;
+      chipElements = fixture.debugElement.queryAll(By.directive(MatChipRow));
+      chipRemoveDebugElements = fixture.debugElement.queryAll(By.directive(MatChipRemove));
+      chips = chipGrid._chips;
+    });
+
+    it('should properly focus next item if chip is removed through click', () => {
+      chips.toArray()[2].focus();
+
+      // Destroy the third focused chip by dispatching a bubbling click event on the
+      // associated chip remove element.
+      dispatchMouseEvent(chipRemoveDebugElements[2].nativeElement, 'click');
+      fixture.detectChanges();
+
+      const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+      chipElements[2].nativeElement.dispatchEvent(fakeEvent);
+
+      fixture.detectChanges();
+
+      expect(chips.toArray()[2].value).not.toBe(2, 'Expected the third chip to be removed.');
+      expect(chipGrid._keyManager.activeRowIndex).toBe(2);
+    });
+  });
+
+  describe('chip grid with chip input', () => {
+    let nativeChips: HTMLElement[];
+
+    beforeEach(() => {
+      fixture = createComponent(InputChipGrid);
+      fixture.detectChanges();
+
+      nativeChips = fixture.debugElement.queryAll(By.css('mat-chip-row'))
+        .map((chip) => chip.nativeElement);
+    });
+
+    it('should take an initial view value with reactive forms', () => {
+      fixture.componentInstance.control = new FormControl('[pizza-1]');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.chipGrid.value).toEqual('[pizza-1]');
+    });
+
+    it('should set the view value from the form', () => {
+      const chipGrid = fixture.componentInstance.chipGrid;
+
+      expect(chipGrid.value).toBeFalsy('Expect chip grid to have no initial value');
+
+      fixture.componentInstance.control.setValue('[pizza-1]');
+      fixture.detectChanges();
+
+      expect(chipGrid.value).toEqual('[pizza-1]');
+    });
+
+    it('should update the form value when the view changes', fakeAsync(() => {
+      expect(fixture.componentInstance.control.value)
+        .toEqual(null, `Expected the control's value to be empty initially.`);
+
+      const nativeInput = fixture.nativeElement.querySelector('input');
+      // tick();
+      nativeInput.focus();
+
+      typeInElement('123', nativeInput);
+      fixture.detectChanges();
+      dispatchKeyboardEvent(nativeInput, 'keydown', ENTER);
+      fixture.detectChanges();
+      tick();
+
+      dispatchFakeEvent(nativeInput, 'blur');
+      tick();
+
+      expect(fixture.componentInstance.control.value).toContain('123-8');
+    }));
+
+    it('should clear the value when the control is reset', () => {
+      fixture.componentInstance.control.setValue('pizza-1');
+      fixture.detectChanges();
+
+      fixture.componentInstance.control.reset();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.chipGrid.value).toEqual(null);
+    });
+
+    it('should set the control to touched when the chip grid is touched', fakeAsync(() => {
+      expect(fixture.componentInstance.control.touched)
+        .toBe(false, 'Expected the control to start off as untouched.');
+
+      const nativeChipGrid = fixture.debugElement.query(By.css('mat-chip-grid')).nativeElement;
+      dispatchFakeEvent(nativeChipGrid, 'blur');
+      tick();
+
+      expect(fixture.componentInstance.control.touched)
+        .toBe(true, 'Expected the control to be touched.');
+    }));
+
+    it('should not set touched when a disabled chip grid is touched', fakeAsync(() => {
+      expect(fixture.componentInstance.control.touched)
+        .toBe(false, 'Expected the control to start off as untouched.');
+
+      fixture.componentInstance.control.disable();
+      const nativeChipGrid = fixture.debugElement.query(By.css('mat-chip-grid')).nativeElement;
+      dispatchFakeEvent(nativeChipGrid, 'blur');
+      tick();
+
+      expect(fixture.componentInstance.control.touched)
+        .toBe(false, 'Expected the control to stay untouched.');
+    }));
+
+    it('should set the control to dirty when the chip grid\'s value changes in the DOM',
+      fakeAsync(() => {
+      expect(fixture.componentInstance.control.dirty)
+          .toEqual(false, `Expected control to start out pristine.`);
+
+      const nativeInput = fixture.nativeElement.querySelector('input');
+      nativeInput.focus();
+
+      typeInElement('123', nativeInput);
+      fixture.detectChanges();
+      dispatchKeyboardEvent(nativeInput, 'keydown', ENTER);
+      fixture.detectChanges();
+      tick();
+
+      dispatchFakeEvent(nativeInput, 'blur');
+      tick();
+
+      expect(fixture.componentInstance.control.dirty)
+          .toEqual(true, `Expected control to be dirty after value was changed by user.`);
+    }));
+
+    it('should not set the control to dirty when the value changes programmatically', () => {
+      expect(fixture.componentInstance.control.dirty)
+        .toEqual(false, `Expected control to start out pristine.`);
+
+      fixture.componentInstance.control.setValue(['pizza-1']);
+
+      expect(fixture.componentInstance.control.dirty)
+        .toEqual(false, `Expected control to stay pristine after programmatic change.`);
+    });
+
+    it('should set an asterisk after the placeholder if the control is required', () => {
+      let requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'));
+      expect(requiredMarker)
+        .toBeNull(`Expected placeholder not to have an asterisk, as control was not required.`);
+
+      fixture.componentInstance.isRequired = true;
+      fixture.detectChanges();
+
+      requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'));
+      expect(requiredMarker)
+        .not.toBeNull(`Expected placeholder to have an asterisk, as control was required.`);
+    });
+
+    it('should blur the form field when the active chip is blurred', fakeAsync(() => {
+      const formField: HTMLElement = fixture.nativeElement.querySelector('.mat-form-field');
+
+      dispatchFakeEvent(nativeChips[0], 'focusin');
+      fixture.detectChanges();
+
+      expect(formField.classList).toContain('mat-focused');
+
+      dispatchFakeEvent(nativeChips[0], 'focusout');
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+      tick();
+      expect(formField.classList).not.toContain('mat-focused');
+    }));
+
+    it('should keep focus on the input after adding the first chip', fakeAsync(() => {
+      const nativeInput = fixture.nativeElement.querySelector('input');
+      const chipEls = Array.from<HTMLElement>(
+          fixture.nativeElement.querySelectorAll('mat-chip-row')).reverse();
+
+      // Remove the chips via backspace to simulate the user removing them.
+      chipEls.forEach(chip => {
+        chip.focus();
+        dispatchKeyboardEvent(chip, 'keydown', BACKSPACE);
+        fixture.detectChanges();
+        const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+        chip.dispatchEvent(fakeEvent);
+        fixture.detectChanges();
+        tick();
+      });
+
+      nativeInput.focus();
+      expect(fixture.componentInstance.foods).toEqual([], 'Expected all chips to be removed.');
+      expect(document.activeElement).toBe(nativeInput, 'Expected input to be focused.');
+
+      typeInElement('123', nativeInput);
+      fixture.detectChanges();
+      dispatchKeyboardEvent(nativeInput, 'keydown', ENTER);
+      fixture.detectChanges();
+      tick();
+
+      expect(document.activeElement).toBe(nativeInput, 'Expected input to remain focused.');
+    }));
+
+    it('should set aria-invalid if the form field is invalid', fakeAsync(() => {
+      fixture.componentInstance.control = new FormControl(undefined, [Validators.required]);
+      fixture.detectChanges();
+
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+
+      typeInElement('123', input);
+      fixture.detectChanges();
+      dispatchKeyboardEvent(input, 'keydown', ENTER);
+      fixture.detectChanges();
+      tick();
+
+      dispatchFakeEvent(input, 'blur');
+      tick();
+
+      fixture.detectChanges();
+      expect(input.getAttribute('aria-invalid')).toBe('false');
+    }));
+  });
+
+  describe('error messages', () => {
+    let errorTestComponent: ChipGridWithFormErrorMessages;
+    let containerEl: HTMLElement;
+    let chipGridEl: HTMLElement;
+
+    beforeEach(() => {
+      fixture = createComponent(ChipGridWithFormErrorMessages);
+      fixture.detectChanges();
+      errorTestComponent = fixture.componentInstance;
+      containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+      chipGridEl = fixture.debugElement.query(By.css('mat-chip-grid')).nativeElement;
+    });
+
+    it('should not show any errors if the user has not interacted', () => {
+      expect(errorTestComponent.formControl.untouched)
+        .toBe(true, 'Expected untouched form control');
+      expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
+      expect(chipGridEl.getAttribute('aria-invalid'))
+        .toBe('false', 'Expected aria-invalid to be set to "false".');
+    });
+
+    it('should display an error message when the grid is touched and invalid', fakeAsync(() => {
+      expect(errorTestComponent.formControl.invalid)
+        .toBe(true, 'Expected form control to be invalid');
+      expect(containerEl.querySelectorAll('mat-error').length)
+        .toBe(0, 'Expected no error message');
+
+      errorTestComponent.formControl.markAsTouched();
+      fixture.detectChanges();
+      tick();
+
+      expect(containerEl.classList)
+        .toContain('mat-form-field-invalid', 'Expected container to have the invalid CSS class.');
+      expect(containerEl.querySelectorAll('mat-error').length)
+        .toBe(1, 'Expected one error message to have been rendered.');
+      expect(chipGridEl.getAttribute('aria-invalid'))
+        .toBe('true', 'Expected aria-invalid to be set to "true".');
+    }));
+
+    it('should display an error message when the parent form is submitted', fakeAsync(() => {
+      expect(errorTestComponent.form.submitted)
+        .toBe(false, 'Expected form not to have been submitted');
+      expect(errorTestComponent.formControl.invalid)
+        .toBe(true, 'Expected form control to be invalid');
+      expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
+
+      dispatchFakeEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        expect(errorTestComponent.form.submitted)
+          .toBe(true, 'Expected form to have been submitted');
+        expect(containerEl.classList)
+          .toContain('mat-form-field-invalid', 'Expected container to have the invalid CSS class.');
+        expect(containerEl.querySelectorAll('mat-error').length)
+          .toBe(1, 'Expected one error message to have been rendered.');
+        expect(chipGridEl.getAttribute('aria-invalid'))
+          .toBe('true', 'Expected aria-invalid to be set to "true".');
+      });
+    }));
+
+    it('should hide the errors and show the hints once the chip grid becomes valid',
+        fakeAsync(() => {
+      errorTestComponent.formControl.markAsTouched();
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        expect(containerEl.classList)
+          .toContain('mat-form-field-invalid', 'Expected container to have the invalid CSS class.');
+        expect(containerEl.querySelectorAll('mat-error').length)
+          .toBe(1, 'Expected one error message to have been rendered.');
+        expect(containerEl.querySelectorAll('mat-hint').length)
+          .toBe(0, 'Expected no hints to be shown.');
+
+        errorTestComponent.formControl.setValue('something');
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+          expect(containerEl.classList).not.toContain('mat-form-field-invalid',
+            'Expected container not to have the invalid class when valid.');
+          expect(containerEl.querySelectorAll('mat-error').length)
+            .toBe(0, 'Expected no error messages when the input is valid.');
+          expect(containerEl.querySelectorAll('mat-hint').length)
+            .toBe(1, 'Expected one hint to be shown once the input is valid.');
+        });
+      });
+    }));
+
+    it('should set the proper role on the error messages', () => {
+      errorTestComponent.formControl.markAsTouched();
+      fixture.detectChanges();
+
+      expect(containerEl.querySelector('mat-error')!.getAttribute('role')).toBe('alert');
+    });
+
+    it('sets the aria-describedby to reference errors when in error state', () => {
+      let hintId = fixture.debugElement.query(By.css('.mat-hint')).nativeElement.getAttribute('id');
+      let describedBy = chipGridEl.getAttribute('aria-describedby');
+
+      expect(hintId).toBeTruthy('hint should be shown');
+      expect(describedBy).toBe(hintId);
+
+      fixture.componentInstance.formControl.markAsTouched();
+      fixture.detectChanges();
+
+      let errorIds = fixture.debugElement.queryAll(By.css('.mat-error'))
+        .map(el => el.nativeElement.getAttribute('id')).join(' ');
+      describedBy = chipGridEl.getAttribute('aria-describedby');
+
+      expect(errorIds).toBeTruthy('errors should be shown');
+      expect(describedBy).toBe(errorIds);
+    });
+  });
+
+  function createComponent<T>(component: Type<T>, providers: Provider[] = [], animationsModule:
+      Type<NoopAnimationsModule> | Type<BrowserAnimationsModule> = NoopAnimationsModule):
+          ComponentFixture<T> {
+    TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        MatChipsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        animationsModule,
+      ],
+      declarations: [component],
+      providers: [
+        {provide: NgZone, useFactory: () => zone = new MockNgZone()},
+        ...providers
+      ]
+    }).compileComponents();
+
+    return TestBed.createComponent<T>(component);
+  }
+
+  function setupStandardGrid(direction: Direction = 'ltr') {
+    dirChange = new Subject();
+    fixture = createComponent(StandardChipGrid, [{
+      provide: Directionality, useFactory: () => ({
+        value: direction.toLowerCase(),
+        change: dirChange
+      })
+    }]);
+    fixture.detectChanges();
+
+    chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid));
+    chipGridNativeElement = chipGridDebugElement.nativeElement;
+    chipGridInstance = chipGridDebugElement.componentInstance;
+    testComponent = fixture.debugElement.componentInstance;
+    chips = chipGridInstance._chips;
+  }
+
+  function setupInputGrid() {
+    fixture = createComponent(FormFieldChipGrid);
+    fixture.detectChanges();
+
+    chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid));
+    chipGridNativeElement = chipGridDebugElement.nativeElement;
+    chipGridInstance = chipGridDebugElement.componentInstance;
+    testComponent = fixture.debugElement.componentInstance;
+    chips = chipGridInstance._chips;
+  }
+});
+
+@Component({
+  template: `
+    <mat-chip-grid [tabIndex]="tabIndex" #chipGrid>
+      <mat-chip-row *ngFor="let i of chips">
+        {{name}} {{i + 1}}
+      </mat-chip-row>
+    </mat-chip-grid>
+    <input name="test" [matChipInputFor]="chipGrid"/>`
+})
+class StandardChipGrid {
+  name: string = 'Test';
+  tabIndex: number = 0;
+  chips = [0, 1, 2, 3, 4];
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-label>Add a chip</mat-label>
+      <mat-chip-grid #chipGrid>
+        <mat-chip-row *ngFor="let chip of chips" (removed)="remove(chip)">{{chip}}</mat-chip-row>
+      </mat-chip-grid>
+      <input name="test" [matChipInputFor]="chipGrid"/>
+    </mat-form-field>
+  `
+})
+class FormFieldChipGrid {
+  chips = ['Chip 0', 'Chip 1', 'Chip 2'];
+
+  remove(chip: string) {
+    const index = this.chips.indexOf(chip);
+
+    if (index > -1) {
+      this.chips.splice(index, 1);
+    }
+  }
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-chip-grid #chipGrid
+                    placeholder="Food" [formControl]="control" [required]="isRequired">
+        <mat-chip-row *ngFor="let food of foods" [value]="food.value" (removed)="remove(food)">
+          {{ food.viewValue }}
+        </mat-chip-row>
+      </mat-chip-grid>
+      <input placeholder="New food..."
+          [matChipInputFor]="chipGrid"
+          [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+          [matChipInputAddOnBlur]="addOnBlur"
+          (matChipInputTokenEnd)="add($event)"/>
+    </mat-form-field>
+  `
+})
+class InputChipGrid {
+  foods: any[] = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+    {value: 'tacos-2', viewValue: 'Tacos', disabled: true},
+    {value: 'sandwich-3', viewValue: 'Sandwich'},
+    {value: 'chips-4', viewValue: 'Chips'},
+    {value: 'eggs-5', viewValue: 'Eggs'},
+    {value: 'pasta-6', viewValue: 'Pasta'},
+    {value: 'sushi-7', viewValue: 'Sushi'},
+  ];
+  control = new FormControl();
+
+  separatorKeyCodes = [ENTER, SPACE];
+  addOnBlur: boolean = true;
+  isRequired: boolean;
+
+  add(event: MatChipInputEvent): void {
+    let input = event.input;
+    let value = event.value;
+
+    // Add our foods
+    if ((value || '').trim()) {
+      this.foods.push({
+        value: `${value.trim().toLowerCase()}-${this.foods.length}`,
+        viewValue: value.trim()
+      });
+    }
+
+    // Reset the input value
+    if (input) {
+      input.value = '';
+    }
+  }
+
+  remove(food: any): void {
+    const index = this.foods.indexOf(food);
+
+    if (index > -1) {
+      this.foods.splice(index, 1);
+    }
+  }
+
+  @ViewChild(MatChipGrid, {static: false}) chipGrid: MatChipGrid;
+  @ViewChildren(MatChipRow) chips: QueryList<MatChipRow>;
+}
+
+@Component({
+  template: `
+<form #form="ngForm" novalidate>
+  <mat-form-field>
+    <mat-chip-grid #chipGrid [formControl]="formControl">
+      <mat-chip-row *ngFor="let food of foods" [value]="food.value">
+      {{food.viewValue}}
+      </mat-chip-row>
+    </mat-chip-grid>
+    <input name="test" [matChipInputFor]="chipGrid"/>
+    <mat-hint>Please select a chip, or type to add a new chip</mat-hint>
+    <mat-error>Should have value</mat-error>
+  </mat-form-field>
+</form>
+  `
+})
+class ChipGridWithFormErrorMessages {
+  foods: any[] = [
+    {value: 0, viewValue: 'Steak'},
+    {value: 1, viewValue: 'Pizza'},
+    {value: 2, viewValue: 'Pasta'},
+  ];
+  @ViewChildren(MatChipRow) chips: QueryList<MatChipRow>;
+
+  @ViewChild('form', {static: false}) form: NgForm;
+  formControl = new FormControl('', Validators.required);
+}
+
+@Component({
+  template: `
+    <mat-chip-grid #chipGrid>
+      <mat-chip-row *ngFor="let i of numbers" (removed)="remove(i)">{{i}}</mat-chip-row>
+      <input name="test" [matChipInputFor]="chipGrid"/>
+    </mat-chip-grid>`,
+  animations: [
+    // For the case we're testing this animation doesn't
+    // have to be used anywhere, it just has to be defined.
+    trigger('dummyAnimation', [
+      transition(':leave', [
+        style({opacity: 0}),
+        animate('500ms', style({opacity: 1}))
+      ])
+    ])
+  ]
+})
+class StandardChipGridWithAnimations {
+  numbers = [0, 1, 2, 3, 4];
+
+  remove(item: number): void {
+    const index = this.numbers.indexOf(item);
+
+    if (index > -1) {
+      this.numbers.splice(index, 1);
+    }
+  }
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-chip-grid #chipGrid>
+        <mat-chip-row [value]="i" (removed)="removeChip($event)" *ngFor="let i of chips">
+          Chip {{i + 1}}
+          <span matChipRemove>Remove</span>
+        </mat-chip-row>
+      </mat-chip-grid>
+      <input name="test" [matChipInputFor]="chipGrid"/>
+    </mat-form-field>
+  `
+})
+class ChipGridWithRemove {
+  chips = [0, 1, 2, 3, 4];
+
+  removeChip(event: MatChipEvent) {
+    this.chips.splice(event.chip.value, 1);
+  }
+}

--- a/src/material-experimental/mdc-chips/chip-icons.ts
+++ b/src/material-experimental/mdc-chips/chip-icons.ts
@@ -93,7 +93,7 @@ const _MatChipRemoveMixinBase:
   selector: '[matChipRemove]',
   inputs: ['disabled', 'tabIndex'],
   host: {
-    'class': 'mat-mdc-chip-trailing-icon mdc-chip__icon mdc-chip__icon--trailing',
+    'class': 'mat-chip-remove mat-mdc-chip-trailing-icon mdc-chip__icon mdc-chip__icon--trailing',
     '[tabIndex]': 'tabIndex',
     'role': 'button',
     '(click)': 'interaction.next($event)',

--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -1,0 +1,264 @@
+import {Directionality} from '@angular/cdk/bidi';
+import {ENTER, COMMA, TAB} from '@angular/cdk/keycodes';
+import {PlatformModule} from '@angular/cdk/platform';
+import {createKeyboardEvent, dispatchKeyboardEvent, dispatchEvent} from '@angular/cdk/testing';
+import {Component, DebugElement, ViewChild} from '@angular/core';
+import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {Subject} from 'rxjs';
+import {
+  MAT_CHIPS_DEFAULT_OPTIONS,
+  MatChipInput,
+  MatChipInputEvent,
+  MatChipGrid,
+  MatChipsDefaultOptions,
+  MatChipsModule
+} from './index';
+
+
+describe('MatChipInput', () => {
+  let fixture: ComponentFixture<any>;
+  let testChipInput: TestChipInput;
+  let inputDebugElement: DebugElement;
+  let inputNativeElement: HTMLElement;
+  let chipInputDirective: MatChipInput;
+  let dir = 'ltr';
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [PlatformModule, MatChipsModule, MatFormFieldModule, NoopAnimationsModule],
+      declarations: [TestChipInput],
+      providers: [{
+        provide: Directionality, useFactory: () => {
+          return {
+            value: dir.toLowerCase(),
+            change: new Subject()
+          };
+        }
+      }]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(TestChipInput);
+    testChipInput = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+
+    inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput));
+    chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
+    inputNativeElement = inputDebugElement.nativeElement;
+  }));
+
+  describe('basic behavior', () => {
+    it('emits the (chipEnd) on enter keyup', () => {
+      let ENTER_EVENT = createKeyboardEvent('keydown', ENTER, inputNativeElement);
+
+      spyOn(testChipInput, 'add');
+
+      chipInputDirective._keydown(ENTER_EVENT);
+      expect(testChipInput.add).toHaveBeenCalled();
+    });
+
+    it('should have a default id', () => {
+      expect(inputNativeElement.getAttribute('id')).toBeTruthy();
+    });
+
+    it('should allow binding to the `placeholder` input', () => {
+      expect(inputNativeElement.hasAttribute('placeholder')).toBe(false);
+
+      testChipInput.placeholder = 'bound placeholder';
+      fixture.detectChanges();
+
+      expect(inputNativeElement.getAttribute('placeholder')).toBe('bound placeholder');
+    });
+
+    it('should propagate the dynamic `placeholder` value to the form field', () => {
+      fixture.componentInstance.placeholder = 'add a chip';
+      fixture.detectChanges();
+
+      const label: HTMLElement = fixture.nativeElement.querySelector('.mat-form-field-label');
+
+      expect(label).toBeTruthy();
+      expect(label.textContent).toContain('add a chip');
+
+      fixture.componentInstance.placeholder = 'or don\'t';
+      fixture.detectChanges();
+
+      expect(label.textContent).toContain('or don\'t');
+    });
+
+    it('should become disabled if the chip list is disabled', () => {
+      expect(inputNativeElement.hasAttribute('disabled')).toBe(false);
+      expect(chipInputDirective.disabled).toBe(false);
+
+      fixture.componentInstance.chipGridInstance.disabled = true;
+      fixture.detectChanges();
+
+      expect(inputNativeElement.getAttribute('disabled')).toBe('true');
+      expect(chipInputDirective.disabled).toBe(true);
+    });
+
+    it('should allow focus to escape when tabbing forwards', fakeAsync(() => {
+      const gridElement: HTMLElement = fixture.nativeElement.querySelector('mat-chip-grid');
+
+      expect(gridElement.getAttribute('tabindex')).toBe('0');
+
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', TAB, inputNativeElement);
+      fixture.detectChanges();
+
+      expect(gridElement.getAttribute('tabindex'))
+        .toBe('-1', 'Expected tabIndex to be set to -1 temporarily.');
+
+      tick();
+      fixture.detectChanges();
+
+      expect(gridElement.getAttribute('tabindex'))
+        .toBe('0', 'Expected tabIndex to be reset back to 0');
+    }));
+
+    it('should not allow focus to escape when tabbing backwards', fakeAsync(() => {
+      const gridElement: HTMLElement = fixture.nativeElement.querySelector('mat-chip-grid');
+      const event = createKeyboardEvent('keydown', TAB, inputNativeElement);
+      Object.defineProperty(event, 'shiftKey', {get: () => true});
+
+      expect(gridElement.getAttribute('tabindex')).toBe('0');
+
+      dispatchEvent(inputNativeElement, event);
+      fixture.detectChanges();
+
+      expect(gridElement.getAttribute('tabindex')).toBe('0', 'Expected tabindex to remain 0');
+
+      tick();
+      fixture.detectChanges();
+
+      expect(gridElement.getAttribute('tabindex')).toBe('0', 'Expected tabindex to remain 0');
+    }));
+
+  });
+
+  describe('[addOnBlur]', () => {
+    it('allows (chipEnd) when true', () => {
+      spyOn(testChipInput, 'add');
+
+      testChipInput.addOnBlur = true;
+      fixture.detectChanges();
+
+      chipInputDirective._blur();
+      expect(testChipInput.add).toHaveBeenCalled();
+    });
+
+    it('disallows (chipEnd) when false', () => {
+      spyOn(testChipInput, 'add');
+
+      testChipInput.addOnBlur = false;
+      fixture.detectChanges();
+
+      chipInputDirective._blur();
+      expect(testChipInput.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('[separatorKeyCodes]', () => {
+    it('does not emit (chipEnd) when a non-separator key is pressed', () => {
+      let ENTER_EVENT = createKeyboardEvent('keydown', ENTER, inputNativeElement);
+      spyOn(testChipInput, 'add');
+
+      chipInputDirective.separatorKeyCodes = [COMMA];
+      fixture.detectChanges();
+
+      chipInputDirective._keydown(ENTER_EVENT);
+      expect(testChipInput.add).not.toHaveBeenCalled();
+    });
+
+    it('emits (chipEnd) when a custom separator keys is pressed', () => {
+      let COMMA_EVENT = createKeyboardEvent('keydown', COMMA, inputNativeElement);
+      spyOn(testChipInput, 'add');
+
+      chipInputDirective.separatorKeyCodes = [COMMA];
+      fixture.detectChanges();
+
+      chipInputDirective._keydown(COMMA_EVENT);
+      expect(testChipInput.add).toHaveBeenCalled();
+    });
+
+    it('emits accepts the custom separator keys in a Set', () => {
+      let COMMA_EVENT = createKeyboardEvent('keydown', COMMA, inputNativeElement);
+      spyOn(testChipInput, 'add');
+
+      chipInputDirective.separatorKeyCodes = new Set([COMMA]);
+      fixture.detectChanges();
+
+      chipInputDirective._keydown(COMMA_EVENT);
+      expect(testChipInput.add).toHaveBeenCalled();
+    });
+
+    it('emits (chipEnd) when the separator keys are configured globally', () => {
+      fixture.destroy();
+
+      TestBed
+        .resetTestingModule()
+        .configureTestingModule({
+          imports: [MatChipsModule, MatFormFieldModule, PlatformModule, NoopAnimationsModule],
+          declarations: [TestChipInput],
+          providers: [{
+            provide: MAT_CHIPS_DEFAULT_OPTIONS,
+            useValue: ({separatorKeyCodes: [COMMA]} as MatChipsDefaultOptions)
+          }]
+        })
+        .compileComponents();
+
+      fixture = TestBed.createComponent(TestChipInput);
+      testChipInput = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+
+      inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput));
+      chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
+      inputNativeElement = inputDebugElement.nativeElement;
+
+      spyOn(testChipInput, 'add');
+      fixture.detectChanges();
+
+      chipInputDirective._keydown(createKeyboardEvent('keydown', COMMA, inputNativeElement));
+      expect(testChipInput.add).toHaveBeenCalled();
+    });
+
+    it('should not emit the chipEnd event if a separator is pressed with a modifier key', () => {
+      const ENTER_EVENT = createKeyboardEvent('keydown', ENTER, inputNativeElement);
+      Object.defineProperty(ENTER_EVENT, 'shiftKey', {get: () => true});
+      spyOn(testChipInput, 'add');
+
+      chipInputDirective.separatorKeyCodes = [ENTER];
+      fixture.detectChanges();
+
+      chipInputDirective._keydown(ENTER_EVENT);
+      expect(testChipInput.add).not.toHaveBeenCalled();
+    });
+
+  });
+});
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-chip-grid #chipGrid>
+        <mat-chip-row>Hello</mat-chip-row>
+        <input matInput [matChipInputFor]="chipGrid"
+                  [matChipInputAddOnBlur]="addOnBlur"
+                  (matChipInputTokenEnd)="add($event)"
+                  [placeholder]="placeholder" />
+      </mat-chip-grid>
+    </mat-form-field>
+  `
+})
+class TestChipInput {
+  @ViewChild(MatChipGrid, {static: false}) chipGridInstance: MatChipGrid;
+  addOnBlur: boolean = false;
+  placeholder = '';
+
+  add(_: MatChipInputEvent) {
+  }
+}

--- a/src/material-experimental/mdc-chips/chip-input.ts
+++ b/src/material-experimental/mdc-chips/chip-input.ts
@@ -171,4 +171,3 @@ export class MatChipInput implements MatChipTextControl, OnChanges {
     return Array.isArray(separators) ? separators.indexOf(keyCode) > -1 : separators.has(keyCode);
   }
 }
-

--- a/src/material-experimental/mdc-chips/chip-listbox.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.spec.ts
@@ -1,0 +1,900 @@
+import {FocusKeyManager} from '@angular/cdk/a11y';
+import {Directionality, Direction} from '@angular/cdk/bidi';
+import {
+  END,
+  HOME,
+  LEFT_ARROW,
+  RIGHT_ARROW,
+  SPACE,
+  TAB,
+} from '@angular/cdk/keycodes';
+import {
+  createKeyboardEvent,
+  dispatchFakeEvent,
+  dispatchKeyboardEvent,
+  MockNgZone,
+} from '@angular/cdk/testing';
+import {
+  Component,
+  DebugElement,
+  NgZone,
+  Provider,
+  QueryList,
+  Type,
+  ViewChild,
+  ViewChildren
+} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {By} from '@angular/platform-browser';
+import {Subject} from 'rxjs';
+import {MatChip, MatChipListbox, MatChipOption, MatChipsModule} from './index';
+
+
+describe('MatChipListbox', () => {
+  let fixture: ComponentFixture<any>;
+  let chipListboxDebugElement: DebugElement;
+  let chipListboxNativeElement: HTMLElement;
+  let chipListboxInstance: MatChipListbox;
+  let testComponent: StandardChipListbox;
+  let chips: QueryList<MatChipOption>;
+  let manager: FocusKeyManager<MatChip>;
+  let zone: MockNgZone;
+  let dirChange: Subject<Direction>;
+
+  describe('StandardChipList', () => {
+    describe('basic behaviors', () => {
+
+      beforeEach(() => {
+        setupStandardListbox();
+      });
+
+      it('should add the `mat-mdc-chip-set` class', () => {
+        expect(chipListboxNativeElement.classList).toContain('mat-mdc-chip-set');
+      });
+
+      it('should not have the aria-selected attribute when it is not selectable', fakeAsync(() => {
+        testComponent.selectable = false;
+        fixture.detectChanges();
+        tick();
+
+        const chipsValid = chips.toArray().every(chip =>
+            !chip.selectable && !chip._elementRef.nativeElement.hasAttribute('aria-selected'));
+
+        expect(chipsValid).toBe(true);
+      }));
+
+      it('should toggle the chips disabled state based on whether it is disabled', () => {
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+
+        chipListboxInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+
+        chipListboxInstance.disabled = false;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+      });
+
+      it('should disable a chip that is added after the listbox became disabled', fakeAsync(() => {
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+
+        chipListboxInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+
+        fixture.componentInstance.chips.push(5, 6);
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+      }));
+    });
+
+    describe('with selected chips', () => {
+      beforeEach(() => {
+        fixture = createComponent(SelectedChipListbox);
+        fixture.detectChanges();
+        chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox));
+        chipListboxNativeElement = chipListboxDebugElement.nativeElement;
+      });
+
+      it('should not override chips selected', () => {
+        const instanceChips = fixture.componentInstance.chips.toArray();
+
+        expect(instanceChips[0].selected).toBe(true, 'Expected first option to be selected.');
+        expect(instanceChips[1].selected).toBe(false, 'Expected second option to be not selected.');
+        expect(instanceChips[2].selected).toBe(true, 'Expected third option to be selected.');
+      });
+
+      it('should have role listbox', () => {
+        expect(chipListboxNativeElement.getAttribute('role')).toBe('listbox');
+      });
+
+      it('should not have role when empty', () => {
+        fixture.componentInstance.foods = [];
+        fixture.detectChanges();
+
+        expect(chipListboxNativeElement.getAttribute('role')).toBeNull('Expect no role attribute');
+      });
+    });
+
+    describe('focus behaviors', () => {
+
+      beforeEach(() => {
+        setupStandardListbox();
+        manager = chipListboxInstance._keyManager;
+      });
+
+      it('should focus the first chip on focus', () => {
+        chipListboxInstance.focus();
+        fixture.detectChanges();
+
+        expect(manager.activeItemIndex).toBe(0);
+      });
+
+      it('should watch for chip focus', () => {
+        let array = chips.toArray();
+        let lastIndex = array.length - 1;
+        let lastItem = array[lastIndex];
+
+        lastItem.focus();
+        fixture.detectChanges();
+
+        expect(manager.activeItemIndex).toBe(lastIndex);
+      });
+
+      it('should not be able to become focused when disabled', () => {
+        expect(chipListboxInstance.focused).toBe(false, 'Expected listbox to not be focused.');
+
+        chipListboxInstance.disabled = true;
+        fixture.detectChanges();
+
+        chipListboxInstance.focus();
+        fixture.detectChanges();
+
+        expect(chipListboxInstance.focused).toBe(false,
+          'Expected listbox to continue not to be focused');
+      });
+
+      it('should remove the tabindex from the listbox if it is disabled', () => {
+        expect(chipListboxNativeElement.getAttribute('tabindex')).toBe('0');
+
+        chipListboxInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(chipListboxNativeElement.getAttribute('tabindex')).toBe('-1');
+      });
+
+      describe('on chip destroy', () => {
+
+        it('should focus the next item', () => {
+          let array = chips.toArray();
+          let midItem = array[2];
+
+          // Focus the middle item
+          midItem.focus();
+
+          // Destroy the middle item
+          testComponent.chips.splice(2, 1);
+          fixture.detectChanges();
+
+          // It focuses the 4th item (now at index 2)
+          expect(manager.activeItemIndex).toEqual(2);
+        });
+
+        it('should focus the previous item', () => {
+          let array = chips.toArray();
+          let lastIndex = array.length - 1;
+          let lastItem = array[lastIndex];
+
+          // Focus the last item
+          lastItem.focus();
+
+          // Destroy the last item
+          testComponent.chips.pop();
+          fixture.detectChanges();
+          // It focuses the next-to-last item
+          expect(manager.activeItemIndex).toEqual(lastIndex - 1);
+        });
+
+        it('should not focus if chip listbox is not focused', () => {
+          let array = chips.toArray();
+          let midItem = array[2];
+
+          // Focus and blur the middle item
+          midItem.focus();
+          midItem._blur();
+          zone.simulateZoneExit();
+
+          // Destroy the middle item
+          testComponent.chips.splice(2, 1);
+          fixture.detectChanges();
+
+          // Should not have focus
+          expect(chipListboxInstance._keyManager.activeItemIndex).toEqual(-1);
+        });
+
+        it('should focus the listbox if the last focused item is removed', () => {
+          testComponent.chips = [0];
+          fixture.detectChanges();
+
+          spyOn(chipListboxInstance, 'focus');
+          chips.last.focus();
+
+          testComponent.chips.pop();
+          fixture.detectChanges();
+
+          expect(chipListboxInstance.focus).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('keyboard behavior', () => {
+      describe('LTR (default)', () => {
+        beforeEach(() => {
+          setupStandardListbox();
+          manager = chipListboxInstance._keyManager;
+        });
+
+        it('should focus previous item when press LEFT ARROW', () => {
+          let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
+          let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
+
+          let LEFT_EVENT = createKeyboardEvent('keydown', LEFT_ARROW, lastNativeChip);
+          let array = chips.toArray();
+          let lastIndex = array.length - 1;
+          let lastItem = array[lastIndex];
+
+          // Focus the last item in the array
+          lastItem.focus();
+          expect(manager.activeItemIndex).toEqual(lastIndex);
+
+          // Press the LEFT arrow
+          chipListboxInstance._keydown(LEFT_EVENT);
+          chipListboxInstance._blur(); // Simulate focus leaving the listbox and going to the chip.
+          fixture.detectChanges();
+
+          // It focuses the next-to-last item
+          expect(manager.activeItemIndex).toEqual(lastIndex - 1);
+        });
+
+        it('should focus next item when press RIGHT ARROW', () => {
+          let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
+          let firstNativeChip = nativeChips[0] as HTMLElement;
+
+          let RIGHT_EVENT: KeyboardEvent =
+            createKeyboardEvent('keydown', RIGHT_ARROW, firstNativeChip);
+          let array = chips.toArray();
+          let firstItem = array[0];
+
+          // Focus the last item in the array
+          firstItem.focus();
+          expect(manager.activeItemIndex).toEqual(0);
+
+          // Press the RIGHT arrow
+          chipListboxInstance._keydown(RIGHT_EVENT);
+          chipListboxInstance._blur(); // Simulate focus leaving the listbox and going to the chip.
+          fixture.detectChanges();
+
+          // It focuses the next-to-last item
+          expect(manager.activeItemIndex).toEqual(1);
+        });
+
+        it('should not handle arrow key events from non-chip elements', () => {
+          const event: KeyboardEvent =
+              createKeyboardEvent('keydown', RIGHT_ARROW, chipListboxNativeElement);
+          const initialActiveIndex = manager.activeItemIndex;
+
+          chipListboxInstance._keydown(event);
+          fixture.detectChanges();
+
+          expect(manager.activeItemIndex)
+              .toBe(initialActiveIndex, 'Expected focused item not to have changed.');
+        });
+
+        it('should focus the first item when pressing HOME', () => {
+          const nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
+          const lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
+          const HOME_EVENT = createKeyboardEvent('keydown', HOME, lastNativeChip);
+          const array = chips.toArray();
+          const lastItem = array[array.length - 1];
+
+          lastItem.focus();
+          expect(manager.activeItemIndex).toBe(array.length - 1);
+
+          chipListboxInstance._keydown(HOME_EVENT);
+          fixture.detectChanges();
+
+          expect(manager.activeItemIndex).toBe(0);
+          expect(HOME_EVENT.defaultPrevented).toBe(true);
+        });
+
+        it('should focus the last item when pressing END', () => {
+          const nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
+          const END_EVENT = createKeyboardEvent('keydown', END, nativeChips[0]);
+
+          expect(manager.activeItemIndex).toBe(-1);
+
+          chipListboxInstance._keydown(END_EVENT);
+          fixture.detectChanges();
+
+          expect(manager.activeItemIndex).toBe(chips.length - 1);
+          expect(END_EVENT.defaultPrevented).toBe(true);
+        });
+      });
+
+      describe('RTL', () => {
+        beforeEach(() => {
+          setupStandardListbox('rtl');
+          manager = chipListboxInstance._keyManager;
+        });
+
+        it('should focus previous item when press RIGHT ARROW', () => {
+          let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
+          let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
+
+          let RIGHT_EVENT: KeyboardEvent =
+              createKeyboardEvent('keydown', RIGHT_ARROW, lastNativeChip);
+          let array = chips.toArray();
+          let lastIndex = array.length - 1;
+          let lastItem = array[lastIndex];
+
+          // Focus the last item in the array
+          lastItem.focus();
+          expect(manager.activeItemIndex).toEqual(lastIndex);
+
+          // Press the RIGHT arrow
+          chipListboxInstance._keydown(RIGHT_EVENT);
+          chipListboxInstance._blur(); // Simulate focus leaving the listbox and going to the chip.
+          fixture.detectChanges();
+
+          // It focuses the next-to-last item
+          expect(manager.activeItemIndex).toEqual(lastIndex - 1);
+        });
+
+        it('should focus next item when press LEFT ARROW', () => {
+          let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
+          let firstNativeChip = nativeChips[0] as HTMLElement;
+
+          let LEFT_EVENT: KeyboardEvent =
+              createKeyboardEvent('keydown', LEFT_ARROW, firstNativeChip);
+          let array = chips.toArray();
+          let firstItem = array[0];
+
+          // Focus the last item in the array
+          firstItem.focus();
+          expect(manager.activeItemIndex).toEqual(0);
+
+          // Press the LEFT arrow
+          chipListboxInstance._keydown(LEFT_EVENT);
+          chipListboxInstance._blur(); // Simulate focus leaving the listbox and going to the chip.
+          fixture.detectChanges();
+
+          // It focuses the next-to-last item
+          expect(manager.activeItemIndex).toEqual(1);
+        });
+
+        it('should allow focus to escape when tabbing away', fakeAsync(() => {
+          chipListboxInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
+
+          expect(chipListboxInstance.tabIndex)
+            .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
+
+          tick();
+
+          expect(chipListboxInstance.tabIndex).toBe(0, 'Expected tabIndex to be reset back to 0');
+        }));
+
+        it(`should use user defined tabIndex`, fakeAsync(() => {
+          chipListboxInstance.tabIndex = 4;
+
+          fixture.detectChanges();
+
+          expect(chipListboxInstance.tabIndex)
+            .toBe(4, 'Expected tabIndex to be set to user defined value 4.');
+
+          chipListboxInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
+
+          expect(chipListboxInstance.tabIndex)
+            .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
+
+          tick();
+
+          expect(chipListboxInstance.tabIndex).toBe(4, 'Expected tabIndex to be reset back to 4');
+        }));
+      });
+
+      it('should account for the direction changing', () => {
+        setupStandardListbox();
+        manager = chipListboxInstance._keyManager;
+
+        let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
+        let firstNativeChip = nativeChips[0] as HTMLElement;
+
+        let RIGHT_EVENT: KeyboardEvent =
+          createKeyboardEvent('keydown', RIGHT_ARROW, firstNativeChip);
+        let array = chips.toArray();
+        let firstItem = array[0];
+
+        firstItem.focus();
+        expect(manager.activeItemIndex).toBe(0);
+
+        chipListboxInstance._keydown(RIGHT_EVENT);
+        chipListboxInstance._blur();
+        fixture.detectChanges();
+
+        expect(manager.activeItemIndex).toBe(1);
+
+        dirChange.next('rtl');
+        fixture.detectChanges();
+
+        chipListboxInstance._keydown(RIGHT_EVENT);
+        chipListboxInstance._blur();
+        fixture.detectChanges();
+
+        expect(manager.activeItemIndex).toBe(0);
+      });
+    });
+
+    describe('selection logic', () => {
+      let nativeChips: HTMLElement[];
+
+      beforeEach(() => {
+        fixture = createComponent(BasicChipListbox);
+        fixture.detectChanges();
+
+        nativeChips = fixture.debugElement.queryAll(By.css('mat-chip-option'))
+            .map((chip) => chip.nativeElement);
+
+        chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox));
+        chipListboxInstance = chipListboxDebugElement.componentInstance;
+        chips = chipListboxInstance._chips;
+
+      });
+
+      it('should remove selection if chip has been removed', fakeAsync(() => {
+        const instanceChips = fixture.componentInstance.chips;
+        const chipListbox = fixture.componentInstance.chipListbox;
+        const firstChip = nativeChips[0];
+        dispatchKeyboardEvent(firstChip, 'keydown', SPACE);
+        fixture.detectChanges();
+
+        expect(instanceChips.first.selected).toBe(true, 'Expected first option to be selected.');
+        expect(chipListbox.selected).toBe(chips.first, 'Expected first option to be selected.');
+
+        fixture.componentInstance.foods = [];
+        fixture.detectChanges();
+        tick();
+
+        expect(chipListbox.selected)
+          .toBe(undefined, 'Expected selection to be removed when option no longer exists.');
+      }));
+
+
+      it('should select an option that was added after initialization', () => {
+        fixture.componentInstance.foods.push({viewValue: 'Potatoes', value: 'potatoes-8'});
+        fixture.detectChanges();
+
+        nativeChips = fixture.debugElement.queryAll(By.css('mat-chip-option'))
+          .map((chip) => chip.nativeElement);
+        const lastChip = nativeChips[8];
+        dispatchKeyboardEvent(lastChip, 'keydown', SPACE);
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.chipListbox.value)
+          .toContain('potatoes-8', 'Expect value contain the value of the last option');
+        expect(fixture.componentInstance.chips.last.selected)
+          .toBeTruthy('Expect last option selected');
+      });
+
+      it('should not select disabled chips', () => {
+        const array = chips.toArray();
+        const disabledChip = nativeChips[2];
+        dispatchKeyboardEvent(disabledChip, 'keydown', SPACE);
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.chipListbox.value)
+          .toBeUndefined('Expect value to be undefined');
+        expect(array[2].selected).toBeFalsy('Expect disabled chip not selected');
+        expect(fixture.componentInstance.chipListbox.selected)
+          .toBeUndefined('Expect no selected chips');
+      });
+    });
+
+    describe('chip list with chip input', () => {
+      let nativeChips: HTMLElement[];
+
+      describe('single selection', () => {
+        beforeEach(() => {
+          fixture = createComponent(BasicChipListbox);
+          fixture.detectChanges();
+
+          nativeChips = fixture.debugElement.queryAll(By.css('mat-chip-option'))
+            .map((chip) => chip.nativeElement);
+          chips = fixture.componentInstance.chips;
+        });
+
+        it('should take an initial view value with reactive forms', fakeAsync(() => {
+          fixture.componentInstance.control = new FormControl('pizza-1');
+          fixture.detectChanges();
+          tick();
+          const array = chips.toArray();
+
+          expect(array[1].selected).toBeTruthy('Expect pizza-1 chip to be selected');
+
+          dispatchKeyboardEvent(nativeChips[1], 'keydown', SPACE);
+          fixture.detectChanges();
+
+          expect(array[1].selected).toBeFalsy(
+            'Expect chip to be not selected after toggle selected');
+        }));
+
+        it('should set the view value from the form', () => {
+          const chipListbox = fixture.componentInstance.chipListbox;
+          const array = chips.toArray();
+
+          expect(chipListbox.value).toBeFalsy('Expect chip listbox to have no initial value');
+
+          fixture.componentInstance.control.setValue('pizza-1');
+          fixture.detectChanges();
+
+          expect(array[1].selected).toBeTruthy('Expect chip to be selected');
+        });
+
+        it('should update the form value when the view changes', fakeAsync(() => {
+          expect(fixture.componentInstance.control.value)
+            .toEqual(null, `Expected the control's value to be empty initially.`);
+
+          dispatchKeyboardEvent(nativeChips[0], 'keydown', SPACE);
+          fixture.detectChanges();
+
+          tick();
+
+          expect(fixture.componentInstance.control.value)
+            .toEqual('steak-0', `Expected control's value to be set to the new option.`);
+        }));
+
+        it('should clear the selection when a nonexistent option value is selected', () => {
+          const array = chips.toArray();
+
+          fixture.componentInstance.control.setValue('pizza-1');
+          fixture.detectChanges();
+
+          expect(array[1].selected)
+            .toBeTruthy(`Expected chip with the value to be selected.`);
+
+          fixture.componentInstance.control.setValue('gibberish');
+
+          fixture.detectChanges();
+
+          expect(array[1].selected)
+            .toBeFalsy(`Expected chip with the old value not to be selected.`);
+        });
+
+
+        it('should clear the selection when the control is reset', () => {
+          const array = chips.toArray();
+
+          fixture.componentInstance.control.setValue('pizza-1');
+          fixture.detectChanges();
+
+          fixture.componentInstance.control.reset();
+          fixture.detectChanges();
+
+          expect(array[1].selected)
+            .toBeFalsy(`Expected chip with the old value not to be selected.`);
+        });
+
+        it('should set the control to touched when the chip listbox is touched', fakeAsync(() => {
+          expect(fixture.componentInstance.control.touched)
+            .toBe(false, 'Expected the control to start off as untouched.');
+
+          const nativeChipListbox = fixture.debugElement.query(
+            By.css('mat-chip-listbox')).nativeElement;
+          dispatchFakeEvent(nativeChipListbox, 'blur');
+          tick();
+
+          expect(fixture.componentInstance.control.touched)
+            .toBe(true, 'Expected the control to be touched.');
+        }));
+
+        it('should not set touched when a disabled chip listbox is touched', fakeAsync(() => {
+          expect(fixture.componentInstance.control.touched)
+            .toBe(false, 'Expected the control to start off as untouched.');
+
+          fixture.componentInstance.control.disable();
+          const nativeChipListbox = fixture.debugElement.query(
+            By.css('mat-chip-listbox')).nativeElement;
+          dispatchFakeEvent(nativeChipListbox, 'blur');
+          tick();
+
+          expect(fixture.componentInstance.control.touched)
+            .toBe(false, 'Expected the control to stay untouched.');
+        }));
+
+        it('should set the control to dirty when the chip listbox\'s value changes in the DOM',
+          () => {
+          expect(fixture.componentInstance.control.dirty)
+            .toEqual(false, `Expected control to start out pristine.`);
+
+          dispatchKeyboardEvent(nativeChips[1], 'keydown', SPACE);
+          fixture.detectChanges();
+
+          expect(fixture.componentInstance.control.dirty)
+            .toEqual(true, `Expected control to be dirty after value was changed by user.`);
+        });
+
+        it('should not set the control to dirty when the value changes programmatically', () => {
+          expect(fixture.componentInstance.control.dirty)
+            .toEqual(false, `Expected control to start out pristine.`);
+
+          fixture.componentInstance.control.setValue('pizza-1');
+
+          expect(fixture.componentInstance.control.dirty)
+            .toEqual(false, `Expected control to stay pristine after programmatic change.`);
+        });
+
+        it('should be able to programmatically select a falsy option', () => {
+          fixture.destroy();
+          TestBed.resetTestingModule();
+
+          const falsyFixture = createComponent(FalsyValueChipListbox);
+          falsyFixture.detectChanges();
+
+          falsyFixture.componentInstance.control.setValue([0]);
+          falsyFixture.detectChanges();
+          falsyFixture.detectChanges();
+
+          expect(falsyFixture.componentInstance.chips.first.selected)
+            .toBe(true, 'Expected first option to be selected');
+        });
+
+        it('should not focus the active chip when the value is set programmatically', () => {
+          const chipArray = fixture.componentInstance.chips.toArray();
+
+          spyOn(chipArray[4], 'focus').and.callThrough();
+
+          fixture.componentInstance.control.setValue('chips-4');
+          fixture.detectChanges();
+
+          expect(chipArray[4].focus).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('multiple selection', () => {
+        beforeEach(() => {
+          fixture = createComponent(MultiSelectionChipListbox);
+          fixture.detectChanges();
+
+          nativeChips = fixture.debugElement.queryAll(By.css('mat-chip-option'))
+            .map((chip) => chip.nativeElement);
+          chips = fixture.componentInstance.chips;
+        });
+
+        it('should take an initial view value with reactive forms', () => {
+          fixture.componentInstance.control = new FormControl(['pizza-1']);
+          fixture.detectChanges();
+
+          const array = chips.toArray();
+
+          expect(array[1].selected).toBeTruthy('Expect pizza-1 chip to be selected');
+
+          dispatchKeyboardEvent(nativeChips[1], 'keydown', SPACE);
+          fixture.detectChanges();
+
+          expect(array[1].selected).toBeFalsy(
+            'Expect chip to be not selected after toggle selected');
+        });
+
+        it('should set the view value from the form', () => {
+          const chipListbox = fixture.componentInstance.chipListbox;
+          const array = chips.toArray();
+
+          expect(chipListbox.value).toBeFalsy('Expect chip listbox to have no initial value');
+
+          fixture.componentInstance.control.setValue(['pizza-1']);
+          fixture.detectChanges();
+
+          expect(array[1].selected).toBeTruthy('Expect chip to be selected');
+        });
+
+        it('should update the form value when the view changes', () => {
+
+          expect(fixture.componentInstance.control.value)
+            .toEqual(null, `Expected the control's value to be empty initially.`);
+
+          dispatchKeyboardEvent(nativeChips[0], 'keydown', SPACE);
+          fixture.detectChanges();
+
+          expect(fixture.componentInstance.control.value)
+            .toEqual(['steak-0'], `Expected control's value to be set to the new option.`);
+        });
+
+        it('should clear the selection when a nonexistent option value is selected', () => {
+          const array = chips.toArray();
+
+          fixture.componentInstance.control.setValue(['pizza-1']);
+          fixture.detectChanges();
+
+          expect(array[1].selected)
+            .toBeTruthy(`Expected chip with the value to be selected.`);
+
+          fixture.componentInstance.control.setValue(['gibberish']);
+
+          fixture.detectChanges();
+
+          expect(array[1].selected)
+            .toBeFalsy(`Expected chip with the old value not to be selected.`);
+        });
+
+        it('should clear the selection when the control is reset', () => {
+          const array = chips.toArray();
+
+          fixture.componentInstance.control.setValue(['pizza-1']);
+          fixture.detectChanges();
+
+          fixture.componentInstance.control.reset();
+          fixture.detectChanges();
+
+          expect(array[1].selected)
+            .toBeFalsy(`Expected chip with the old value not to be selected.`);
+        });
+      });
+    });
+  });
+
+  function createComponent<T>(component: Type<T>, providers: Provider[] = []):
+        ComponentFixture<T> {
+    TestBed.configureTestingModule({
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        MatChipsModule,
+      ],
+      declarations: [component],
+      providers: [
+        {provide: NgZone, useFactory: () => zone = new MockNgZone()},
+        ...providers
+      ]
+    }).compileComponents();
+
+    return TestBed.createComponent<T>(component);
+  }
+
+  function setupStandardListbox(direction: Direction = 'ltr') {
+    dirChange = new Subject();
+    fixture = createComponent(StandardChipListbox, [{
+      provide: Directionality, useFactory: () => ({
+        value: direction.toLowerCase(),
+        change: dirChange
+      })
+    }]);
+    fixture.detectChanges();
+
+    chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox));
+    chipListboxNativeElement = chipListboxDebugElement.nativeElement;
+    chipListboxInstance = chipListboxDebugElement.componentInstance;
+    testComponent = fixture.debugElement.componentInstance;
+    chips = chipListboxInstance._chips;
+  }
+});
+
+@Component({
+  template: `
+    <mat-chip-listbox [tabIndex]="tabIndex" [selectable]="selectable">
+      <mat-chip-option *ngFor="let i of chips" (select)="chipSelect(i)"
+        (deselect)="chipDeselect(i)">
+        {{name}} {{i + 1}}
+      </mat-chip-option>
+    </mat-chip-listbox>`
+})
+class StandardChipListbox {
+  name: string = 'Test';
+  selectable: boolean = true;
+  chipSelect: (index?: number) => void = () => {};
+  chipDeselect: (index?: number) => void = () => {};
+  tabIndex: number = 0;
+  chips = [0, 1, 2, 3, 4];
+}
+
+@Component({
+  template: `
+      <mat-chip-listbox [formControl]="control" [required]="isRequired"
+        [tabIndex]="tabIndexOverride" [selectable]="selectable">
+        <mat-chip-option *ngFor="let food of foods" [value]="food.value" [disabled]="food.disabled">
+          {{ food.viewValue }}
+        </mat-chip-option>
+      </mat-chip-listbox>
+  `
+})
+class BasicChipListbox {
+  foods: any[] = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+    {value: 'tacos-2', viewValue: 'Tacos', disabled: true},
+    {value: 'sandwich-3', viewValue: 'Sandwich'},
+    {value: 'chips-4', viewValue: 'Chips'},
+    {value: 'eggs-5', viewValue: 'Eggs'},
+    {value: 'pasta-6', viewValue: 'Pasta'},
+    {value: 'sushi-7', viewValue: 'Sushi'},
+  ];
+  control = new FormControl();
+  isRequired: boolean;
+  tabIndexOverride: number;
+  selectable: boolean;
+
+  @ViewChild(MatChipListbox, {static: false}) chipListbox: MatChipListbox;
+  @ViewChildren(MatChipOption) chips: QueryList<MatChipOption>;
+}
+
+@Component({
+  template: `
+      <mat-chip-listbox [multiple]="true" [formControl]="control"
+        [required]="isRequired"
+        [tabIndex]="tabIndexOverride" [selectable]="selectable">
+        <mat-chip-option *ngFor="let food of foods" [value]="food.value" [disabled]="food.disabled">
+          {{ food.viewValue }}
+        </mat-chip-option>
+      </mat-chip-listbox>
+  `
+})
+class MultiSelectionChipListbox {
+  foods: any[] = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+    {value: 'tacos-2', viewValue: 'Tacos', disabled: true},
+    {value: 'sandwich-3', viewValue: 'Sandwich'},
+    {value: 'chips-4', viewValue: 'Chips'},
+    {value: 'eggs-5', viewValue: 'Eggs'},
+    {value: 'pasta-6', viewValue: 'Pasta'},
+    {value: 'sushi-7', viewValue: 'Sushi'},
+  ];
+  control = new FormControl();
+  isRequired: boolean;
+  tabIndexOverride: number;
+  selectable: boolean;
+
+  @ViewChild(MatChipListbox, {static: false}) chipListbox: MatChipListbox;
+  @ViewChildren(MatChipOption) chips: QueryList<MatChipOption>;
+}
+
+@Component({
+  template: `
+      <mat-chip-listbox [formControl]="control">
+        <mat-chip-option *ngFor="let food of foods" [value]="food.value">
+          {{ food.viewValue }}
+        </mat-chip-option>
+      </mat-chip-listbox>
+  `
+})
+class FalsyValueChipListbox {
+  foods: any[] = [
+    {value: 0, viewValue: 'Steak'},
+    {value: 1, viewValue: 'Pizza'},
+  ];
+  control = new FormControl();
+  @ViewChildren(MatChipOption) chips: QueryList<MatChipOption>;
+}
+
+@Component({
+  template: `
+    <mat-chip-listbox>
+        <mat-chip-option *ngFor="let food of foods" [value]="food.value" [selected]="food.selected">
+            {{ food.viewValue }}
+        </mat-chip-option>
+    </mat-chip-listbox>
+  `
+})
+class SelectedChipListbox {
+  foods: any[] = [
+    {value: 0, viewValue: 'Steak', selected: true},
+    {value: 1, viewValue: 'Pizza', selected: false},
+    {value: 2, viewValue: 'Pasta', selected: true},
+  ];
+  @ViewChildren(MatChipOption) chips: QueryList<MatChipOption>;
+}

--- a/src/material-experimental/mdc-chips/chip-option.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-option.spec.ts
@@ -1,0 +1,306 @@
+import {Directionality} from '@angular/cdk/bidi';
+import {SPACE} from '@angular/cdk/keycodes';
+import {createKeyboardEvent, dispatchFakeEvent} from '@angular/cdk/testing';
+import {Component, DebugElement, ViewChild} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
+import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
+import {By} from '@angular/platform-browser';
+import {Subject} from 'rxjs';
+import {
+  MatChipEvent,
+  MatChipListbox,
+  MatChipOption,
+  MatChipSelectionChange,
+  MatChipsModule,
+} from './index';
+
+
+describe('Option Chips', () => {
+  let fixture: ComponentFixture<any>;
+  let chipDebugElement: DebugElement;
+  let chipNativeElement: HTMLElement;
+  let chipInstance: MatChipOption;
+  let globalRippleOptions: RippleGlobalOptions;
+
+  let dir = 'ltr';
+
+  beforeEach(async(() => {
+    globalRippleOptions = {};
+    TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [SingleChip],
+      providers: [
+        {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useFactory: () => globalRippleOptions},
+        {provide: Directionality, useFactory: () => ({
+          value: dir,
+          change: new Subject()
+        })},
+      ]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  describe('MatChipOption', () => {
+    let testComponent: SingleChip;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SingleChip);
+      fixture.detectChanges();
+
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChipOption));
+      chipNativeElement = chipDebugElement.nativeElement;
+      chipInstance = chipDebugElement.injector.get<MatChipOption>(MatChipOption);
+      testComponent = fixture.debugElement.componentInstance;
+
+      document.body.appendChild(chipNativeElement);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(chipNativeElement);
+    });
+
+    describe('basic behaviors', () => {
+
+      it('adds the `mat-chip` class', () => {
+        expect(chipNativeElement.classList).toContain('mat-mdc-chip');
+      });
+
+      it('emits focus only once for multiple clicks', () => {
+        let counter = 0;
+        chipInstance._onFocus.subscribe(() => {
+          counter ++ ;
+        });
+
+        chipNativeElement.focus();
+        chipNativeElement.focus();
+        fixture.detectChanges();
+
+        expect(counter).toBe(1);
+      });
+
+      it('emits destroy on destruction', () => {
+        spyOn(testComponent, 'chipDestroy').and.callThrough();
+
+        // Force a destroy callback
+        testComponent.shouldShow = false;
+        fixture.detectChanges();
+
+        expect(testComponent.chipDestroy).toHaveBeenCalledTimes(1);
+      });
+
+      it('allows color customization', () => {
+        expect(chipNativeElement.classList).toContain('mat-primary');
+
+        testComponent.color = 'warn';
+        fixture.detectChanges();
+
+        expect(chipNativeElement.classList).not.toContain('mat-primary');
+        expect(chipNativeElement.classList).toContain('mat-warn');
+      });
+
+      it('allows selection', () => {
+        spyOn(testComponent, 'chipSelectionChange');
+        expect(chipNativeElement.classList).not.toContain('mat-mdc-chip-selected');
+
+        testComponent.selected = true;
+        fixture.detectChanges();
+
+        expect(chipNativeElement.classList).toContain('mat-mdc-chip-selected');
+        expect(testComponent.chipSelectionChange)
+            .toHaveBeenCalledWith({source: chipInstance, isUserInput: false, selected: true});
+      });
+
+      it('should not prevent the default click action', () => {
+        const event = dispatchFakeEvent(chipNativeElement, 'click');
+        fixture.detectChanges();
+
+        expect(event.defaultPrevented).toBe(false);
+      });
+
+      it('should prevent the default click action when the chip is disabled', () => {
+        chipInstance.disabled = true;
+        fixture.detectChanges();
+
+        const event = dispatchFakeEvent(chipNativeElement, 'click');
+        fixture.detectChanges();
+
+        expect(event.defaultPrevented).toBe(true);
+      });
+
+      it('should not dispatch `selectionChange` event when deselecting a non-selected chip', () => {
+        chipInstance.deselect();
+
+        const spy = jasmine.createSpy('selectionChange spy');
+        const subscription = chipInstance.selectionChange.subscribe(spy);
+
+        chipInstance.deselect();
+
+        expect(spy).not.toHaveBeenCalled();
+        subscription.unsubscribe();
+      });
+
+      it('should not dispatch `selectionChange` event when selecting a selected chip', () => {
+        chipInstance.select();
+
+        const spy = jasmine.createSpy('selectionChange spy');
+        const subscription = chipInstance.selectionChange.subscribe(spy);
+
+        chipInstance.select();
+
+        expect(spy).not.toHaveBeenCalled();
+        subscription.unsubscribe();
+      });
+
+      it('should not dispatch `selectionChange` event when selecting a selected chip via ' +
+        'user interaction', () => {
+          chipInstance.select();
+
+          const spy = jasmine.createSpy('selectionChange spy');
+          const subscription = chipInstance.selectionChange.subscribe(spy);
+
+          chipInstance.selectViaInteraction();
+
+          expect(spy).not.toHaveBeenCalled();
+          subscription.unsubscribe();
+        });
+
+      it('should not dispatch `selectionChange` through setter if the value did not change', () => {
+        chipInstance.selected = false;
+
+        const spy = jasmine.createSpy('selectionChange spy');
+        const subscription = chipInstance.selectionChange.subscribe(spy);
+
+        chipInstance.selected = false;
+
+        expect(spy).not.toHaveBeenCalled();
+        subscription.unsubscribe();
+      });
+    });
+
+    describe('keyboard behavior', () => {
+
+      describe('when selectable is true', () => {
+        beforeEach(() => {
+          testComponent.selectable = true;
+          fixture.detectChanges();
+        });
+
+        it('should selects/deselects the currently focused chip on SPACE', () => {
+          const SPACE_EVENT: KeyboardEvent = createKeyboardEvent('keydown', SPACE) as KeyboardEvent;
+          const CHIP_SELECTED_EVENT: MatChipSelectionChange = {
+            source: chipInstance,
+            isUserInput: true,
+            selected: true
+          };
+
+          const CHIP_DESELECTED_EVENT: MatChipSelectionChange = {
+            source: chipInstance,
+            isUserInput: true,
+            selected: false
+          };
+
+          spyOn(testComponent, 'chipSelectionChange');
+
+          // Use the spacebar to select the chip
+          chipInstance._keydown(SPACE_EVENT);
+          fixture.detectChanges();
+
+          expect(chipInstance.selected).toBeTruthy();
+          expect(testComponent.chipSelectionChange).toHaveBeenCalledTimes(1);
+          expect(testComponent.chipSelectionChange).toHaveBeenCalledWith(CHIP_SELECTED_EVENT);
+
+          // Use the spacebar to deselect the chip
+          chipInstance._keydown(SPACE_EVENT);
+          fixture.detectChanges();
+
+          expect(chipInstance.selected).toBeFalsy();
+          expect(testComponent.chipSelectionChange).toHaveBeenCalledTimes(2);
+          expect(testComponent.chipSelectionChange).toHaveBeenCalledWith(CHIP_DESELECTED_EVENT);
+        });
+
+        it('should have correct aria-selected in single selection mode', () => {
+          expect(chipNativeElement.hasAttribute('aria-selected')).toBe(false);
+
+          testComponent.selected = true;
+          fixture.detectChanges();
+
+          expect(chipNativeElement.getAttribute('aria-selected')).toBe('true');
+        });
+
+        it('should have the correct aria-selected in multi-selection mode', fakeAsync(() => {
+          testComponent.chipList.multiple = true;
+          flush();
+          fixture.detectChanges();
+          expect(chipNativeElement.getAttribute('aria-selected')).toBe('false');
+
+          testComponent.selected = true;
+          fixture.detectChanges();
+
+          expect(chipNativeElement.getAttribute('aria-selected')).toBe('true');
+        }));
+
+      });
+
+      describe('when selectable is false', () => {
+        beforeEach(() => {
+          testComponent.selectable = false;
+          fixture.detectChanges();
+        });
+
+        it('SPACE ignores selection', () => {
+          const SPACE_EVENT: KeyboardEvent = createKeyboardEvent('keydown', SPACE) as KeyboardEvent;
+
+          spyOn(testComponent, 'chipSelectionChange');
+
+          // Use the spacebar to attempt to select the chip
+          chipInstance._keydown(SPACE_EVENT);
+          fixture.detectChanges();
+
+          expect(chipInstance.selected).toBeFalsy();
+          expect(testComponent.chipSelectionChange).not.toHaveBeenCalled();
+        });
+
+        it('should not have the aria-selected attribute', () => {
+          expect(chipNativeElement.hasAttribute('aria-selected')).toBe(false);
+        });
+      });
+
+      it('should update the aria-label for disabled chips', () => {
+        expect(chipNativeElement.getAttribute('aria-disabled')).toBe('false');
+
+        testComponent.disabled = true;
+        fixture.detectChanges();
+
+        expect(chipNativeElement.getAttribute('aria-disabled')).toBe('true');
+      });
+    });
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip-listbox>
+      <div *ngIf="shouldShow">
+        <mat-chip-option [selectable]="selectable"
+                 [color]="color" [selected]="selected" [disabled]="disabled"
+                 (focus)="chipFocus($event)" (destroyed)="chipDestroy($event)"
+                 (selectionChange)="chipSelectionChange($event)">
+          {{name}}
+        </mat-chip-option>
+      </div>
+    </mat-chip-listbox>`
+})
+class SingleChip {
+  @ViewChild(MatChipListbox, {static: false}) chipList: MatChipListbox;
+  disabled: boolean = false;
+  name: string = 'Test';
+  color: string = 'primary';
+  selected: boolean = false;
+  selectable: boolean = true;
+  shouldShow: boolean = true;
+
+  chipFocus: (event?: MatChipEvent) => void = () => {};
+  chipDestroy: (event?: MatChipEvent) => void = () => {};
+  chipSelectionChange: (event?: MatChipSelectionChange) => void = () => {};
+}

--- a/src/material-experimental/mdc-chips/chip-remove.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-remove.spec.ts
@@ -1,0 +1,97 @@
+import {createFakeEvent} from '@angular/cdk/testing';
+import {Component, DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChip, MatChipsModule} from './index';
+
+describe('Chip Remove', () => {
+  let fixture: ComponentFixture<TestChip>;
+  let testChip: TestChip;
+  let chipDebugElement: DebugElement;
+  let chipNativeElement: HTMLElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [
+        TestChip
+      ]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(TestChip);
+    testChip = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+
+    chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+    chipNativeElement = chipDebugElement.nativeElement;
+  }));
+
+  describe('basic behavior', () => {
+    it('should apply the `mat-chip-remove` CSS class', () => {
+      let buttonElement = chipNativeElement.querySelector('button')!;
+
+      expect(buttonElement.classList).toContain('mat-chip-remove');
+    });
+
+    it('should start MDC exit animation on click', () => {
+      let buttonElement = chipNativeElement.querySelector('button')!;
+
+      testChip.removable = true;
+      fixture.detectChanges();
+
+      buttonElement.click();
+      fixture.detectChanges();
+
+      expect(chipNativeElement.classList.contains('mdc-chip--exit')).toBe(true);
+    });
+
+    it ('should emit (removed) event when exit animation is complete', () => {
+      let buttonElement = chipNativeElement.querySelector('button')!;
+
+      testChip.removable = true;
+      fixture.detectChanges();
+
+      spyOn(testChip, 'didRemove');
+      buttonElement.click();
+      fixture.detectChanges();
+
+      const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+      chipNativeElement.dispatchEvent(fakeEvent);
+
+      expect(testChip.didRemove).toHaveBeenCalled();
+    });
+
+    it('should not start MDC exit animation if parent chip is disabled', () => {
+      let buttonElement = chipNativeElement.querySelector('button')!;
+
+      testChip.removable = true;
+      testChip.disabled = true;
+      fixture.detectChanges();
+
+      buttonElement.click();
+      fixture.detectChanges();
+
+      expect(chipNativeElement.classList.contains('mdc-chip--exit')).toBe(false);
+    });
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip
+      [removable]="removable"
+      [disabled]="disabled"
+      (removed)="didRemove()"><button matChipRemove></button></mat-chip>
+  `
+})
+class TestChip {
+  removable: boolean;
+  disabled = false;
+
+  didRemove() {}
+}
+

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -1,0 +1,242 @@
+import {Directionality} from '@angular/cdk/bidi';
+import {BACKSPACE, DELETE} from '@angular/cdk/keycodes';
+import {createKeyboardEvent, createFakeEvent, dispatchFakeEvent} from '@angular/cdk/testing';
+import {Component, DebugElement, ViewChild} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
+import {By} from '@angular/platform-browser';
+import {Subject} from 'rxjs';
+import {MatChipEvent, MatChipGrid, MatChipRow, MatChipsModule} from './index';
+
+
+describe('Row Chips', () => {
+  let fixture: ComponentFixture<any>;
+  let chipDebugElement: DebugElement;
+  let chipNativeElement: HTMLElement;
+  let chipInstance: MatChipRow;
+  let globalRippleOptions: RippleGlobalOptions;
+
+  let dir = 'ltr';
+
+  beforeEach(async(() => {
+    globalRippleOptions = {};
+    TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [SingleChip],
+      providers: [
+        {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useFactory: () => globalRippleOptions},
+        {provide: Directionality, useFactory: () => ({
+          value: dir,
+          change: new Subject()
+        })},
+      ]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  describe('MatChipRow', () => {
+    let testComponent: SingleChip;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SingleChip);
+      fixture.detectChanges();
+
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChipRow));
+      chipNativeElement = chipDebugElement.nativeElement;
+      chipInstance = chipDebugElement.injector.get<MatChipRow>(MatChipRow);
+      testComponent = fixture.debugElement.componentInstance;
+
+      document.body.appendChild(chipNativeElement);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(chipNativeElement);
+    });
+
+    describe('basic behaviors', () => {
+
+      it('adds the `mat-mdc-chip` class', () => {
+        expect(chipNativeElement.classList).toContain('mat-mdc-chip');
+      });
+
+      it('does not add the `mat-basic-chip` class', () => {
+        expect(chipNativeElement.classList).not.toContain('mat-basic-chip');
+      });
+
+      it('emits destroy on destruction', () => {
+        spyOn(testComponent, 'chipDestroy').and.callThrough();
+
+        // Force a destroy callback
+        testComponent.shouldShow = false;
+        fixture.detectChanges();
+
+        expect(testComponent.chipDestroy).toHaveBeenCalledTimes(1);
+      });
+
+      it('allows color customization', () => {
+        expect(chipNativeElement.classList).toContain('mat-primary');
+
+        testComponent.color = 'warn';
+        fixture.detectChanges();
+
+        expect(chipNativeElement.classList).not.toContain('mat-primary');
+        expect(chipNativeElement.classList).toContain('mat-warn');
+      });
+
+      it('allows removal', () => {
+        spyOn(testComponent, 'chipRemove');
+
+        chipInstance.remove();
+        fixture.detectChanges();
+
+        const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+        chipNativeElement.dispatchEvent(fakeEvent);
+
+        expect(testComponent.chipRemove).toHaveBeenCalledWith({chip: chipInstance});
+      });
+
+      it('should prevent the default click action', () => {
+        const event = dispatchFakeEvent(chipNativeElement, 'mousedown');
+        fixture.detectChanges();
+
+        expect(event.defaultPrevented).toBe(true);
+      });
+    });
+
+    describe('keyboard behavior', () => {
+      describe('when removable is true', () => {
+        beforeEach(() => {
+          testComponent.removable = true;
+          fixture.detectChanges();
+        });
+
+        it('DELETE emits the (removed) event', () => {
+          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE) as KeyboardEvent;
+
+          spyOn(testComponent, 'chipRemove');
+
+          chipInstance._keydown(DELETE_EVENT);
+          fixture.detectChanges();
+
+          const fakeEvent = Object.assign(createFakeEvent('transitionend'),
+            {propertyName: 'width'});
+          chipNativeElement.dispatchEvent(fakeEvent);
+
+          expect(testComponent.chipRemove).toHaveBeenCalled();
+        });
+
+        it('BACKSPACE emits the (removed) event', () => {
+          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE) as KeyboardEvent;
+
+          spyOn(testComponent, 'chipRemove');
+
+          chipInstance._keydown(BACKSPACE_EVENT);
+          fixture.detectChanges();
+
+          const fakeEvent = Object.assign(createFakeEvent('transitionend'),
+            {propertyName: 'width'});
+          chipNativeElement.dispatchEvent(fakeEvent);
+
+          expect(testComponent.chipRemove).toHaveBeenCalled();
+        });
+      });
+
+      describe('when removable is false', () => {
+        beforeEach(() => {
+          testComponent.removable = false;
+          fixture.detectChanges();
+        });
+
+        it('DELETE does not emit the (removed) event', () => {
+          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE) as KeyboardEvent;
+
+          spyOn(testComponent, 'chipRemove');
+
+          chipInstance._keydown(DELETE_EVENT);
+          fixture.detectChanges();
+
+          const fakeEvent = Object.assign(createFakeEvent('transitionend'),
+            {propertyName: 'width'});
+          chipNativeElement.dispatchEvent(fakeEvent);
+
+          expect(testComponent.chipRemove).not.toHaveBeenCalled();
+        });
+
+        it('BACKSPACE does not emit the (removed) event', () => {
+          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE) as KeyboardEvent;
+
+          spyOn(testComponent, 'chipRemove');
+
+          // Use the delete to remove the chip
+          chipInstance._keydown(BACKSPACE_EVENT);
+          fixture.detectChanges();
+
+          const fakeEvent = Object.assign(createFakeEvent('transitionend'),
+            {propertyName: 'width'});
+          chipNativeElement.dispatchEvent(fakeEvent);
+
+          expect(testComponent.chipRemove).not.toHaveBeenCalled();
+        });
+      });
+
+      it('should update the aria-label for disabled chips', () => {
+        expect(chipNativeElement.getAttribute('aria-disabled')).toBe('false');
+
+        testComponent.disabled = true;
+        fixture.detectChanges();
+
+        expect(chipNativeElement.getAttribute('aria-disabled')).toBe('true');
+      });
+
+      describe('focus management', () => {
+        it('sends focus to first grid cell on click', () => {
+          dispatchFakeEvent(chipNativeElement, 'click');
+          fixture.detectChanges();
+
+          expect(document.activeElement!.classList.contains('mat-chip-row-focusable-text-content'));
+        });
+
+        it('emits focus only once for multiple focus() calls', () => {
+          let counter = 0;
+          chipInstance._onFocus.subscribe(() => {
+            counter ++ ;
+          });
+
+          chipInstance.focus();
+          chipInstance.focus();
+          fixture.detectChanges();
+
+          expect(counter).toBe(1);
+        });
+      });
+    });
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip-grid #chipGrid>
+      <div *ngIf="shouldShow">
+        <mat-chip-row [removable]="removable"
+                 [color]="color" [disabled]="disabled"
+                 (focus)="chipFocus($event)" (destroyed)="chipDestroy($event)"
+                 (removed)="chipRemove($event)">
+          {{name}}
+        </mat-chip-row>
+        <input matInput [matChipInputFor]="chipGrid">
+      </div>
+    </mat-chip-grid>`
+})
+class SingleChip {
+  @ViewChild(MatChipGrid, {static: false}) chipList: MatChipGrid;
+  disabled: boolean = false;
+  name: string = 'Test';
+  color: string = 'primary';
+  removable: boolean = true;
+  shouldShow: boolean = true;
+
+  chipFocus: (event?: MatChipEvent) => void = () => {};
+  chipDestroy: (event?: MatChipEvent) => void = () => {};
+  chipRemove: (event?: MatChipEvent) => void = () => {};
+}

--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -40,7 +40,7 @@ import {GridKeyManagerRow, NAVIGATION_KEYS} from './grid-key-manager';
     '[attr.disabled]': 'disabled || null',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[tabIndex]': 'tabIndex',
-    '(click)': '_click($event)',
+    '(mousedown)': '_mousedown($event)',
     '(keydown)': '_keydown($event)',
     '(transitionend)': '_chipFoundation.handleTransitionEnd($event)',
     '(focusin)': '_focusin()',
@@ -93,9 +93,11 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
       return;
     }
 
+    if (!this._hasFocusInternal) {
+      this._onFocus.next({chip: this});
+    }
+
     this.chipContent.nativeElement.focus();
-    this._hasFocusInternal = true;
-    this._onFocus.next({chip: this});
   }
 
   /**
@@ -119,13 +121,12 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
   }
 
   /** Sends focus to the first gridcell when the user clicks anywhere inside the chip. */
-  _click(event: MouseEvent) {
-    if (this.disabled) {
-      event.preventDefault();
-    } else {
+  _mousedown(event: MouseEvent) {
+    if (!this.disabled) {
       this.focus();
-      event.stopPropagation();
     }
+
+    event.preventDefault();
   }
 
   /** Handles custom key presses. */

--- a/src/material-experimental/mdc-chips/chip-set.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-set.spec.ts
@@ -1,0 +1,88 @@
+import {Component, DebugElement, QueryList} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {MatChip, MatChipSet, MatChipsModule} from './index';
+
+
+describe('MatChipSet', () => {
+  let fixture: ComponentFixture<any>;
+  let chipSetDebugElement: DebugElement;
+  let chipSetNativeElement: HTMLElement;
+  let chipSetInstance: MatChipSet;
+  let chips: QueryList<MatChip>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [BasicChipSet],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  describe('BasicChipSet', () => {
+    describe('basic behaviors', () => {
+      beforeEach(() => {
+        fixture = TestBed.createComponent(BasicChipSet);
+        fixture.detectChanges();
+
+        chipSetDebugElement = fixture.debugElement.query(By.directive(MatChipSet));
+        chipSetNativeElement = chipSetDebugElement.nativeElement;
+        chipSetInstance = chipSetDebugElement.componentInstance;
+        chips = chipSetInstance._chips;
+      });
+
+      it('should add the `mat-mdc-chip-set` class', () => {
+        expect(chipSetNativeElement.classList).toContain('mat-mdc-chip-set');
+      });
+
+      it('should toggle the chips disabled state based on whether it is disabled', () => {
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+
+        chipSetInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+
+        chipSetInstance.disabled = false;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+      });
+
+      it('should disable a chip that is added after the set became disabled', fakeAsync(() => {
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(false);
+
+        chipSetInstance.disabled = true;
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+
+        fixture.componentInstance.chips.push(5, 6);
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        expect(chips.toArray().every(chip => chip.disabled)).toBe(true);
+      }));
+
+      it('should have role presentation', () => {
+        expect(chipSetNativeElement.getAttribute('role')).toBe('presentation');
+      });
+    });
+  });
+});
+
+@Component({
+  template: `
+      <mat-chip-set>
+        <mat-chip *ngFor="let i of chips">
+          {{name}} {{i + 1}}
+        </mat-chip>
+      </mat-chip-set>
+  `
+})
+class BasicChipSet {
+  name: string = 'Test';
+  chips = [0, 1, 2, 3, 4];
+}

--- a/src/material-experimental/mdc-chips/chip.spec.ts
+++ b/src/material-experimental/mdc-chips/chip.spec.ts
@@ -1,0 +1,171 @@
+import {Directionality} from '@angular/cdk/bidi';
+import {createFakeEvent} from '@angular/cdk/testing';
+import {Component, DebugElement, ViewChild} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
+import {By} from '@angular/platform-browser';
+import {Subject} from 'rxjs';
+import {MatChip, MatChipEvent, MatChipSet, MatChipsModule} from './index';
+
+
+describe('Chips', () => {
+  let fixture: ComponentFixture<any>;
+  let chipDebugElement: DebugElement;
+  let chipNativeElement: HTMLElement;
+  let chipInstance: MatChip;
+  let globalRippleOptions: RippleGlobalOptions;
+
+  let dir = 'ltr';
+
+  beforeEach(async(() => {
+    globalRippleOptions = {};
+    TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [BasicChip, SingleChip],
+      providers: [
+        {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useFactory: () => globalRippleOptions},
+        {provide: Directionality, useFactory: () => ({
+          value: dir,
+          change: new Subject()
+        })},
+      ]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  describe('MatBasicChip', () => {
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(BasicChip);
+      fixture.detectChanges();
+
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+      chipNativeElement = chipDebugElement.nativeElement;
+      chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
+
+      document.body.appendChild(chipNativeElement);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(chipNativeElement);
+    });
+
+    it('adds the `mat-mdc-basic-chip` class', () => {
+      expect(chipNativeElement.classList).toContain('mat-mdc-basic-chip');
+    });
+  });
+
+  describe('MatChip', () => {
+    let testComponent: SingleChip;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SingleChip);
+      fixture.detectChanges();
+
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+      chipNativeElement = chipDebugElement.nativeElement;
+      chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
+      testComponent = fixture.debugElement.componentInstance;
+
+      document.body.appendChild(chipNativeElement);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(chipNativeElement);
+    });
+
+    it('adds the `mat-chip` class', () => {
+      expect(chipNativeElement.classList).toContain('mat-mdc-chip');
+    });
+
+    it('does not add the `mat-basic-chip` class', () => {
+      expect(chipNativeElement.classList).not.toContain('mat-mdc-basic-chip');
+    });
+
+    it('emits destroy on destruction', () => {
+      spyOn(testComponent, 'chipDestroy').and.callThrough();
+
+      // Force a destroy callback
+      testComponent.shouldShow = false;
+      fixture.detectChanges();
+
+      expect(testComponent.chipDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows color customization', () => {
+      expect(chipNativeElement.classList).toContain('mat-primary');
+
+      testComponent.color = 'warn';
+      fixture.detectChanges();
+
+      expect(chipNativeElement.classList).not.toContain('mat-primary');
+      expect(chipNativeElement.classList).toContain('mat-warn');
+    });
+
+    it('allows removal', () => {
+      spyOn(testComponent, 'chipRemove');
+
+      chipInstance.remove();
+      fixture.detectChanges();
+
+      const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+      chipNativeElement.dispatchEvent(fakeEvent);
+
+      expect(testComponent.chipRemove).toHaveBeenCalledWith({chip: chipInstance});
+    });
+
+    it('should be able to disable ripples through ripple global options at runtime', () => {
+      expect(chipInstance.rippleDisabled).toBe(false, 'Expected chip ripples to be enabled.');
+
+      globalRippleOptions.disabled = true;
+
+      expect(chipInstance.rippleDisabled).toBe(true, 'Expected chip ripples to be disabled.');
+    });
+
+    it('should update the aria-label for disabled chips', () => {
+      expect(chipNativeElement.getAttribute('aria-disabled')).toBe('false');
+
+      testComponent.disabled = true;
+      fixture.detectChanges();
+
+      expect(chipNativeElement.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('should not be focusable', () => {
+      expect(chipNativeElement.getAttribute('tabindex')).toBeFalsy();
+    });
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip-set>
+      <div *ngIf="shouldShow">
+        <mat-chip [removable]="removable"
+                 [color]="color" [disabled]="disabled"
+                 (focus)="chipFocus($event)" (destroyed)="chipDestroy($event)"
+                 (removed)="chipRemove($event)">
+          {{name}}
+        </mat-chip>
+      </div>
+    </mat-chip-set>`
+})
+class SingleChip {
+  @ViewChild(MatChipSet, {static: false}) chipList: MatChipSet;
+  disabled: boolean = false;
+  name: string = 'Test';
+  color: string = 'primary';
+  removable: boolean = true;
+  shouldShow: boolean = true;
+
+  chipFocus: (event?: MatChipEvent) => void = () => {};
+  chipDestroy: (event?: MatChipEvent) => void = () => {};
+  chipRemove: (event?: MatChipEvent) => void = () => {};
+}
+
+@Component({
+  template: `<mat-basic-chip>{{name}}</mat-basic-chip>`
+})
+class BasicChip {
+}

--- a/src/material-experimental/mdc-chips/chips.e2e.spec.ts
+++ b/src/material-experimental/mdc-chips/chips.e2e.spec.ts
@@ -1,1 +1,0 @@
-// TODO: copy tests from existing mat-chip-list, update as necessary to fix.

--- a/src/material-experimental/mdc-chips/chips.scss
+++ b/src/material-experimental/mdc-chips/chips.scss
@@ -1,8 +1,10 @@
 @import '@material/chips/mixins';
+@import '../../material/core/style/noop-animation';
 @import '../mdc-helpers/mdc-helpers';
 
 @include mdc-chip-without-ripple($query: $mat-base-styles-query);
 @include mdc-chip-set-core-styles($query: $mat-base-styles-query);
+@include _noop-animation;
 
 
 // The MDC chip styles related to hover and focus states are intertwined with the MDC ripple styles.

--- a/src/material-experimental/mdc-chips/chips.spec.ts
+++ b/src/material-experimental/mdc-chips/chips.spec.ts
@@ -1,1 +1,0 @@
-// TODO: copy tests from existing mat-chip-list, update as necessary to fix.


### PR DESCRIPTION
Ported existing unit tests as follows:
- Copied `chip-remove.spec`.
- Copied `chip-input.spec` and changed its test component template to use grid/row.
- Copied `chip-list.spec` basic tests to `chip-set.spec`.
- Copied `chip-list.spec` to `chip-listbox.spec` and removed form-field integration, mat-chip-remove integration, and related keyboard shortcuts.
- Copied `chip-list.spec` to `chip-grid.spec` and removed the selection behavior. Updated keyboard tests to reflect that it is using `GridFocusKeyManager`, which has both an active row and an active column. Updated some of the form tests where the value was being changed via selection to change the value in a different way, like by adding a chip.
- Copied `chip.spec` basic tests to `chip.spec`.
- Copied `chip.spec` to `chip-option.spec` and removed logic related to user removal of the chip.
- Copied `chip.spec` to `chip-row.spec` and removed selection logic.

Also updated component code to fix bugs/missing features that were caught by the unit tests:
- Added missing `ControlValueAccessor` method `setDisabledState` to mat-chip-listbox and mat-chip-grid
- Stopped overwriting user-defined tab index in mat-chip-listbox and mat-chip-grid.
- Removed role from empty mat-chip-listbox and mat-chip-grid.
- Added a new subscription in mat-chip-set to chip destroyed events, and moved the logic that updates the `lastDestroyedChipIndex` out of the removed subscription into the new destroyed subscription.
- Replaced `_optionChip` and `_rowChips` `ViewChildren` in mat-chip-listbox and mat-chip-grid with just overriding `_chips`, to fix bugs where the `_chips.changes` subscription was trying to do things with `_optionChips`/`_rowChips` but those QueryLists were still out of date.
- Added `placeholder` setter to mat-chip-grid.
- Added `value` setter to mat-chip-listbox.
- Added injected `animationMode` to mat-chip and its subcomponents.
- Updated `rippleConfig` to be injected into mat-chip and its subcomponents.
- Switched click handler to mousedown handler in mat-chip-row.
- Added mat-chip-remove class to remove icon.