### PR TITLE
build: update ibazel to latest version w/ windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@angular/upgrade": "^8.0.1",
     "@bazel/bazel": "0.26.1",
     "@bazel/buildifier": "^0.25.1",
-    "@bazel/ibazel": "^0.9.0",
+    "@bazel/ibazel": "^0.10.3",
     "@bazel/jasmine": "0.31.1",
     "@bazel/karma": "0.31.1",
     "@bazel/typescript": "0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,10 +324,10 @@
     "@bazel/buildifier-linux_x64" "0.25.1"
     "@bazel/buildifier-win32_x64" "0.25.1"
 
-"@bazel/ibazel@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.9.0.tgz#fd60023acd36313d304cc2f8c2e181b88b5445cd"
-  integrity sha512-E31cefDcdJsx/oii6p/gqKZXSVw0kEg1O73DD2McFcSvnf/p1GYWcQtVgdRQmlviBEytJkJgdX8rtThitRvcow==
+"@bazel/ibazel@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.10.3.tgz#2e2b8a1d3e885946eac41db2b1aa6801fb319887"
+  integrity sha512-v1nXbMTHVlMM4z4uWp6XiRoHAyUlYggF1SOboLLWRp0+D22kWixqArWqnozLw2mOtnxr97BdLjluWiho6A8Hjg==
 
 "@bazel/jasmine@0.31.1":
   version "0.31.1"


### PR DESCRIPTION
Updates `ibazel` to the latest version. This version comes with long
awaited windows support that is now also usable in the components
repository (based on manual testing). In follow-ups we should work
towards switching away from `gulp test` to `ibazel`. Though we need to
ensure that common workflows like debugging are still possible.

Fixes #16405