### PR TITLE
build: run tests against latest Microsoft Edge version

### DIFF
--- a/test/karma-browsers.json
+++ b/test/karma-browsers.json
@@ -243,7 +243,7 @@
   "BROWSERSTACK_EDGE": {
     "base": "BrowserStack",
     "browser": "Edge",
-    "browser_version": "17.0",
+    "browser_version": "18.0",
     "os": "Windows",
     "os_version": "10"
   },


### PR DESCRIPTION
Updates the Microsoft Edge version that is used by BrowserStack. We recently
hit a lot of flakes with `getComputedStyle` which sometimes didn't return the
[resolved value](https://drafts.csswg.org/cssom/#resolved-values) for requested CSS properties in the grid-list tests.

I tried looking for bug reports in the Edge issue tracker, also tried reproducing the grid-list test flakes locally.. but wasn't able to reproduce these. It could be a broken version in BrowserStack that causes
the flaky value resolution w/ `getComputedStyle`. I didn't find anything odd in the tests itself as these execute properly in other browsers and the grid tile elements are rendered (added to DOM)