### PR TITLE
feat(moment-date-adapter): implement strict mode

### DIFF
--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -492,9 +492,9 @@ describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () =
     });
 
     it('should detect invalid strings according to given format', () => {
-      expect(adapter.parse('2017-01-01', 'MM/DD/YYYY')!.isValid()).toEqual(false);
-      expect(adapter.parse('1/2/2017', 'MM/DD/YYYY')!.isValid()).toEqual(false);
-      expect(adapter.parse('Jan 5, 2017', 'MMMM D, YYYY')!.isValid()).toEqual(false);
+      expect(adapter.parse('2017-01-01', 'MM/DD/YYYY')!.isValid()).toBe(false);
+      expect(adapter.parse('1/2/2017', 'MM/DD/YYYY')!.isValid()).toBe(false);
+      expect(adapter.parse('Jan 5, 2017', 'MMMM D, YYYY')!.isValid()).toBe(false);
     });
 
   });

--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -463,4 +463,39 @@ describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () =
     });
   });
 
+  describe('strict mode', () => {
+
+    beforeEach(async(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [MomentDateModule],
+        providers: [
+          {
+            provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+            useValue: {
+              strict: true,
+            },
+          },
+        ]
+      }).compileComponents();
+    }));
+
+    beforeEach(inject([DateAdapter], (d: MomentDateAdapter) => {
+      adapter = d;
+    }));
+
+    it('should detect valid strings according to given format', () => {
+      expect(adapter.parse('1/2/2017', 'D/M/YYYY')!.format('l'))
+        .toEqual(moment([2017,  FEB,  1]).format('l'));
+      expect(adapter.parse('February 1, 2017', 'MMMM D, YYYY')!.format('l'))
+        .toEqual(moment([2017,  FEB,  1]).format('l'));
+    });
+
+    it('should detect invalid strings according to given format', () => {
+      expect(adapter.parse('2017-01-01', 'MM/DD/YYYY')!.isValid()).toEqual(false);
+      expect(adapter.parse('1/2/2017', 'MM/DD/YYYY')!.isValid()).toEqual(false);
+      expect(adapter.parse('Jan 5, 2017', 'MMMM D, YYYY')!.isValid()).toEqual(false);
+    });
+
+  });
 });

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -15,12 +15,19 @@ import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
 // TODO(mmalerba): See if we can clean this up at some point.
 import * as _moment from 'moment';
 // tslint:disable-next-line:no-duplicate-imports
-import {default as _rollupMoment, Moment} from 'moment';
+import {default as _rollupMoment, Moment, MomentFormatSpecification, MomentInput} from 'moment';
 
 const moment = _rollupMoment || _moment;
 
 /** Configurable options for {@see MomentDateAdapter}. */
 export interface MatMomentDateAdapterOptions {
+
+  /**
+   * When enabled, the dates have to match the format exactly.
+   * See https://momentjs.com/guides/#/parsing/strict-mode/.
+   */
+  strict?: boolean;
+
   /**
    * Turns the use of utc dates on or off.
    * Changing this will change how Angular Material components like DatePicker output dates.
@@ -241,7 +248,14 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
   }
 
   /** Creates a Moment instance while respecting the current UTC settings. */
-  private _createMoment(...args: any[]): Moment {
-    return (this._options && this._options.useUtc) ? moment.utc(...args) : moment(...args);
+  private _createMoment(
+    date: MomentInput,
+    format?: MomentFormatSpecification,
+    locale?: string,
+  ): Moment {
+    const strict = this._options ? this._options.strict : undefined;
+    return (this._options && this._options.useUtc)
+      ? moment.utc(date, format, locale, strict)
+      : moment(date, format, locale, strict);
   }
 }

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -33,7 +33,7 @@ export interface MatMomentDateAdapterOptions {
    * Changing this will change how Angular Material components like DatePicker output dates.
    * {@default false}
    */
-  useUtc: boolean;
+  useUtc?: boolean;
 }
 
 /** InjectionToken for moment date adapter to configure options. */
@@ -253,8 +253,9 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     format?: MomentFormatSpecification,
     locale?: string,
   ): Moment {
-    const strict = this._options ? this._options.strict : undefined;
-    return (this._options && this._options.useUtc)
+    const {strict, useUtc}: MatMomentDateAdapterOptions = this._options || {};
+
+    return useUtc
       ? moment.utc(date, format, locale, strict)
       : moment(date, format, locale, strict);
   }

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -257,6 +257,19 @@ By default the `MomentDateAdapter` will creates dates in your time zone specific
 })
 ```
 
+By default the `MomentDateAdapter` will parse dates in a forgiving way. This may result in dates
+being parsed incorrectly. You can change the default behaviour to parse dates strictly by providing
+the `MAT_MOMENT_DATE_ADAPTER_OPTIONS` and setting it to `strict: true`.
+
+```ts
+@NgModule({
+  imports: [MatDatepickerModule, MatMomentDateModule],
+  providers: [
+    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { strict: true } }
+  ]
+})
+```
+
 It is also possible to create your own `DateAdapter` that works with any date format your app
 requires. This is accomplished by subclassing `DateAdapter` and providing your subclass as the
 `DateAdapter` implementation. You will also want to make sure that the `MAT_DATE_FORMATS` provided

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -257,8 +257,10 @@ By default the `MomentDateAdapter` will creates dates in your time zone specific
 })
 ```
 
-By default the `MomentDateAdapter` will parse dates in a forgiving way. This may result in dates
-being parsed incorrectly. You can change the default behaviour to parse dates strictly by providing
+By default the `MomentDateAdapter` will parse dates in a
+[forgiving way](https://momentjs.com/guides/#/parsing/forgiving-mode/). This may result in dates
+being parsed incorrectly. You can change the default behaviour to
+[parse dates strictly](https://momentjs.com/guides/#/parsing/strict-mode/) by providing
 the `MAT_MOMENT_DATE_ADAPTER_OPTIONS` and setting it to `strict: true`.
 
 ```ts

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -252,7 +252,7 @@ By default the `MomentDateAdapter` will creates dates in your time zone specific
 @NgModule({
   imports: [MatDatepickerModule, MatMomentDateModule],
   providers: [
-    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }
+    {provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: {useUtc: true}}
   ]
 })
 ```

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -265,7 +265,7 @@ the `MAT_MOMENT_DATE_ADAPTER_OPTIONS` and setting it to `strict: true`.
 @NgModule({
   imports: [MatDatepickerModule, MatMomentDateModule],
   providers: [
-    { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { strict: true } }
+    {provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: {strict: true}}
   ]
 })
 ```


### PR DESCRIPTION
Moment [supports a strict flag](https://momentjs.com/guides/#/parsing/strict-mode/) which solves a lot of parsing errors. This PR allows setting this flag.

**Why**  
Despite specifying a format, moment is very forgiving in the date strings it perceives as valid. Examples:

| Input          | Format       | Forgiving  | Strict       |
|----------------|--------------|------------|--------------|
| 1/2/2017       | M/D/YYYY     | 2017-01-02 | 2017-01-02   |
| 1/2/2017       | MM/DD/YYYY   | 2017-01-02 | Invalid date |
| 2/1/2017       | MM-DD-YYYY   | 2017-02-01 | Invalid date |
| Januar 1, 2017 | MMMM D, YYYY | 2017-01-01 | Invalid date |
| Jan 1, 2017    | MMMM D, YYYY | 2017-01-01 | Invalid date |
| 2017-1-1       | MMMM D, YYYY | 2017-01-20 | Invalid date |
| 2017/12/24     | MMMM D, YYYY | 2017-01-20 | Invalid date |
| 2017/12/10     | MMM D, YYYY  | 2017-01-20 | Invalid date |

**Note**  
The moment docs state
> In a later release, the parser will default to using strict mode.

This implementation follows the flag's default value in Moment(strict off). When Moment changes their default, the `moment-date-adapter` will follow.