### PR TITLE
fix(drag-drop): return up-to-date position if getFreeDragPosition is called while dragging

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -850,6 +850,27 @@ describe('CdkDrag', () => {
       expect(dragInstance.getFreeDragPosition()).toEqual({x: 50, y: 100});
     }));
 
+    it('should be able to get the up-to-date position as the user is dragging', fakeAsync(() => {
+      const fixture = createComponent(StandaloneDraggable);
+      fixture.detectChanges();
+
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+      const dragInstance = fixture.componentInstance.dragInstance;
+
+      expect(dragInstance.getFreeDragPosition()).toEqual({x: 0, y: 0});
+
+      startDraggingViaMouse(fixture, dragElement);
+      dispatchMouseEvent(document, 'mousemove', 50, 100);
+      fixture.detectChanges();
+
+      expect(dragInstance.getFreeDragPosition()).toEqual({x: 50, y: 100});
+
+      dispatchMouseEvent(document, 'mousemove', 100, 200);
+      fixture.detectChanges();
+
+      expect(dragInstance.getFreeDragPosition()).toEqual({x: 100, y: 200});
+    }));
+
     it('should react to changes in the free drag position', fakeAsync(() => {
       const fixture = createComponent(StandaloneDraggable);
       fixture.componentInstance.freeDragPosition = {x: 50, y: 100};

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -427,7 +427,8 @@ export class DragRef<T = any> {
    * Gets the current position in pixels the draggable outside of a drop container.
    */
   getFreeDragPosition(): Readonly<Point> {
-    return {x: this._passiveTransform.x, y: this._passiveTransform.y};
+    const position = this.isDragging() ? this._activeTransform : this._passiveTransform;
+    return {x: position.x, y: position.y};
   }
 
   /**


### PR DESCRIPTION
Currently return the passive position when the consumer calls `getFreeDragPosition`, however the it only gets updated once the user has stopped dragging which means that calling it mid-drag will return incorrect values. These changes make it so the active drag position is returned while dragging.