### PR TITLE
docs(table): fix incorrect class description

### DIFF
--- a/src/material/table/row.ts
+++ b/src/material/table/row.ts
@@ -54,7 +54,7 @@ export class MatFooterRowDef extends CdkFooterRowDef {
 export class MatRowDef<T> extends CdkRowDef<T> {
 }
 
-/** Footer template container that contains the cell outlet. Adds the right class and role. */
+/** Header template container that contains the cell outlet. Adds the right class and role. */
 @Component({
   moduleId: module.id,
   selector: 'mat-header-row, tr[mat-header-row]',


### PR DESCRIPTION
Fixes an incorrect class description that seems to have been copied verbatim from another class.

Fixes #16456.