### PR TITLE
build: api-docs can display incorrect module for entry-point

### DIFF
--- a/tools/dgeni/common/decorators.ts
+++ b/tools/dgeni/common/decorators.ts
@@ -42,6 +42,12 @@ export function isDeprecatedDoc(doc: any) {
   return (doc.tags && doc.tags.tags || []).some((tag: any) => tag.tagName === 'deprecated');
 }
 
+/** Whether the given document is annotated with the "@docs-primary-module" jsdoc tag. */
+export function isPrimaryModuleDoc(doc: any) {
+  return (doc.tags && doc.tags.tags || [])
+      .some((tag: any) => tag.tagName === 'docs-primary-module');
+}
+
 export function getDirectiveSelectors(classDoc: CategorizedClassDoc) {
   if (!classDoc.directiveMetadata) {
     return;

--- a/tools/dgeni/docs-package.ts
+++ b/tools/dgeni/docs-package.ts
@@ -79,6 +79,7 @@ apiDocsPackage.config(function(parseTagsProcessor: any) {
   parseTagsProcessor.tagDefinitions = parseTagsProcessor.tagDefinitions.concat([
     {name: 'docs-private'},
     {name: 'docs-public'},
+    {name: 'docs-primary-module'},
     {name: 'breaking-change'},
   ]);
 });


### PR DESCRIPTION
In some cases, an entry-point can export a deprecated NgModule. Currently
if that module is exported after all previous modules, it will show up in the docs
as recommended import. e.g. `import {ScrollDispatchModule} from '@angular/cdk/scrolling';`

This is causing confusion as the non-deprecated module should be used for rendering
the recommended import. This commit ensures that non-deprecated modules are
prioritized over deprecated modules and that specific modules can be explicitly
selected as primary module for an entry-point.

Fixes #16353.