### PR TITLE
refactor(ng-generate): do not generate imports to deprecated primary entry-point

### DIFF
--- a/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,13 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import {
-  MatButtonModule,
-  MatCardModule,
-  MatInputModule,
-  MatRadioModule,
-  MatSelectModule,
-} from '@angular/material';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatInputModule } from '@angular/material/input';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/src/material/schematics/ng-generate/address-form/index.ts
+++ b/src/material/schematics/ng-generate/address-form/index.ts
@@ -35,11 +35,11 @@ export default function(options: Schema): Rule {
 function addFormModulesToModule(options: Schema) {
   return (host: Tree) => {
     const modulePath = findModuleFromOptions(host, options)!;
-    addModuleImportToModule(host, modulePath, 'MatInputModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatButtonModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatSelectModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatRadioModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatCardModule', '@angular/material');
+    addModuleImportToModule(host, modulePath, 'MatInputModule', '@angular/material/input');
+    addModuleImportToModule(host, modulePath, 'MatButtonModule', '@angular/material/button');
+    addModuleImportToModule(host, modulePath, 'MatSelectModule', '@angular/material/select');
+    addModuleImportToModule(host, modulePath, 'MatRadioModule', '@angular/material/radio');
+    addModuleImportToModule(host, modulePath, 'MatCardModule', '@angular/material/card');
     addModuleImportToModule(host, modulePath, 'ReactiveFormsModule', '@angular/forms');
     return host;
   };

--- a/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,13 +1,11 @@
 import { LayoutModule } from '@angular/cdk/layout';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  MatButtonModule,
-  MatCardModule,
-  MatGridListModule,
-  MatIconModule,
-  MatMenuModule,
-} from '@angular/material';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/src/material/schematics/ng-generate/dashboard/index.spec.ts
+++ b/src/material/schematics/ng-generate/dashboard/index.spec.ts
@@ -40,9 +40,16 @@ describe('material-dashboard-schematic', () => {
     expect(moduleContent).toContain('MatIconModule');
     expect(moduleContent).toContain('MatButtonModule');
 
-    expect(moduleContent).toContain(
-      `import { MatGridListModule, MatCardModule, MatMenuModule, MatIconModule, MatButtonModule }` +
-      ` from '@angular/material';`);
+    expect(moduleContent)
+      .toContain(`import { MatGridListModule } from '@angular/material/grid-list';`);
+    expect(moduleContent)
+      .toContain(`import { MatCardModule } from '@angular/material/card';`);
+    expect(moduleContent)
+      .toContain(`import { MatMenuModule } from '@angular/material/menu';`);
+    expect(moduleContent)
+      .toContain(`import { MatIconModule } from '@angular/material/icon';`);
+    expect(moduleContent)
+      .toContain(`import { MatButtonModule } from '@angular/material/button';`);
   });
 
   it('should throw if no name has been specified', async () => {

--- a/src/material/schematics/ng-generate/dashboard/index.ts
+++ b/src/material/schematics/ng-generate/dashboard/index.ts
@@ -35,11 +35,11 @@ export default function(options: Schema): Rule {
 function addNavModulesToModule(options: Schema) {
   return (host: Tree) => {
     const modulePath = findModuleFromOptions(host, options)!;
-    addModuleImportToModule(host, modulePath, 'MatGridListModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatCardModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatMenuModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatIconModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatButtonModule', '@angular/material');
+    addModuleImportToModule(host, modulePath, 'MatGridListModule', '@angular/material/grid-list');
+    addModuleImportToModule(host, modulePath, 'MatCardModule', '@angular/material/card');
+    addModuleImportToModule(host, modulePath, 'MatMenuModule', '@angular/material/menu');
+    addModuleImportToModule(host, modulePath, 'MatIconModule', '@angular/material/icon');
+    addModuleImportToModule(host, modulePath, 'MatButtonModule', '@angular/material/button');
     addModuleImportToModule(host, modulePath, 'LayoutModule', '@angular/cdk/layout');
     return host;
   };

--- a/src/material/schematics/ng-generate/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/nav/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,13 +1,11 @@
 import { LayoutModule } from '@angular/cdk/layout';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import {
-  MatButtonModule,
-  MatIconModule,
-  MatListModule,
-  MatSidenavModule,
-  MatToolbarModule,
-} from '@angular/material';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/src/material/schematics/ng-generate/nav/index.spec.ts
+++ b/src/material/schematics/ng-generate/nav/index.spec.ts
@@ -43,10 +43,13 @@ describe('material-nav-schematic', () => {
     expect(moduleContent).toContain('MatListModule');
 
     expect(moduleContent).toContain(`import { LayoutModule } from '@angular/cdk/layout';`);
+    expect(moduleContent).toContain(`import { MatButtonModule } from '@angular/material/button';`);
+    expect(moduleContent).toContain(`import { MatIconModule } from '@angular/material/icon';`);
+    expect(moduleContent).toContain(`import { MatListModule } from '@angular/material/list';`);
     expect(moduleContent)
-        .toContain(
-            `import { MatToolbarModule, MatButtonModule, MatSidenavModule, MatIconModule, ` +
-            `MatListModule } from '@angular/material';`);
+      .toContain(`import { MatToolbarModule } from '@angular/material/toolbar';`);
+    expect(moduleContent)
+      .toContain(`import { MatSidenavModule } from '@angular/material/sidenav';`);
   });
 
   it('should throw if no name has been specified', async () => {

--- a/src/material/schematics/ng-generate/nav/index.ts
+++ b/src/material/schematics/ng-generate/nav/index.ts
@@ -36,11 +36,11 @@ function addNavModulesToModule(options: Schema) {
   return (host: Tree) => {
     const modulePath = findModuleFromOptions(host, options)!;
     addModuleImportToModule(host, modulePath, 'LayoutModule', '@angular/cdk/layout');
-    addModuleImportToModule(host, modulePath, 'MatToolbarModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatButtonModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatSidenavModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatIconModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatListModule', '@angular/material');
+    addModuleImportToModule(host, modulePath, 'MatToolbarModule', '@angular/material/toolbar');
+    addModuleImportToModule(host, modulePath, 'MatButtonModule', '@angular/material/button');
+    addModuleImportToModule(host, modulePath, 'MatSidenavModule', '@angular/material/sidenav');
+    addModuleImportToModule(host, modulePath, 'MatIconModule', '@angular/material/icon');
+    addModuleImportToModule(host, modulePath, 'MatListModule', '@angular/material/list');
     return host;
   };
 }

--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__-datasource.ts.template
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__-datasource.ts.template
@@ -1,5 +1,6 @@
 import { DataSource } from '@angular/cdk/collections';
-import { MatPaginator, MatSort } from '@angular/material';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
 import { map } from 'rxjs/operators';
 import { Observable, of as observableOf, merge } from 'rxjs';
 

--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatPaginatorModule, MatSortModule, MatTableModule } from '@angular/material';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts.template
@@ -1,5 +1,7 @@
 import { AfterViewInit, Component, OnInit, ViewChild<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
-import { MatPaginator, MatSort, MatTable } from '@angular/material';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { MatTable } from '@angular/material/table';
 import { <%= classify(name) %>DataSource, <%= classify(name) %>Item } from './<%= dasherize(name) %>-datasource';
 
 @Component({

--- a/src/material/schematics/ng-generate/table/index.spec.ts
+++ b/src/material/schematics/ng-generate/table/index.spec.ts
@@ -50,8 +50,10 @@ describe('material-table-schematic', () => {
     expect(moduleContent).toContain('MatPaginatorModule');
     expect(moduleContent).toContain('MatSortModule');
 
-    expect(moduleContent).toContain(
-        `import { MatTableModule, MatPaginatorModule, MatSortModule } from '@angular/material';`);
+    expect(moduleContent).toContain(`import { MatTableModule } from '@angular/material/table';`);
+    expect(moduleContent).toContain(`import { MatSortModule } from '@angular/material/sort';`);
+    expect(moduleContent)
+      .toContain(`import { MatPaginatorModule } from '@angular/material/paginator';`);
   });
 
   it('should throw if no name has been specified', async () => {

--- a/src/material/schematics/ng-generate/table/index.ts
+++ b/src/material/schematics/ng-generate/table/index.ts
@@ -35,9 +35,9 @@ export default function(options: Schema): Rule {
 function addTableModulesToModule(options: Schema) {
   return (host: Tree) => {
     const modulePath = findModuleFromOptions(host, options)!;
-    addModuleImportToModule(host, modulePath, 'MatTableModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatPaginatorModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatSortModule', '@angular/material');
+    addModuleImportToModule(host, modulePath, 'MatTableModule', '@angular/material/table');
+    addModuleImportToModule(host, modulePath, 'MatPaginatorModule', '@angular/material/paginator');
+    addModuleImportToModule(host, modulePath, 'MatSortModule', '@angular/material/sort');
     return host;
   };
 }

--- a/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,5 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatButtonModule, MatIconModule, MatTreeModule } from '@angular/material';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTreeModule } from '@angular/material/tree';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 

--- a/src/material/schematics/ng-generate/tree/index.ts
+++ b/src/material/schematics/ng-generate/tree/index.ts
@@ -35,9 +35,9 @@ export default function(options: Schema): Rule {
 function addTreeModulesToModule(options: Schema) {
   return (host: Tree) => {
     const modulePath = findModuleFromOptions(host, options)!;
-    addModuleImportToModule(host, modulePath, 'MatTreeModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatIconModule', '@angular/material');
-    addModuleImportToModule(host, modulePath, 'MatButtonModule', '@angular/material');
+    addModuleImportToModule(host, modulePath, 'MatTreeModule', '@angular/material/tree');
+    addModuleImportToModule(host, modulePath, 'MatIconModule', '@angular/material/icon');
+    addModuleImportToModule(host, modulePath, 'MatButtonModule', '@angular/material/button');
     return host;
   };
 }


### PR DESCRIPTION
Switches all `ng generate` schematics to proper secondary entry-point imports. This is
necessary because as of version 8, imports to the primary entry-point are deprecated.