### PR TITLE
test: rework flaky tests that depend on getComputedStyle

### DIFF
--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -178,13 +178,13 @@ describe('MatDatepicker', () => {
 
         const popup = document.querySelector('.cdk-overlay-pane')!;
         expect(popup).not.toBeNull();
-        expect(parseInt(getComputedStyle(popup).height as string)).not.toBe(0);
+        expect(popup.getBoundingClientRect().height).toBeGreaterThan(0);
 
         testComponent.datepicker.close();
         fixture.detectChanges();
         flush();
 
-        expect(parseInt(getComputedStyle(popup).height as string)).toBe(0);
+        expect(popup.getBoundingClientRect().height).toBe(0);
       }));
 
       it('should close the popup when pressing ESCAPE', fakeAsync(() => {

--- a/src/material/grid-list/grid-list.spec.ts
+++ b/src/material/grid-list/grid-list.spec.ts
@@ -73,9 +73,12 @@ describe('MatGridList', () => {
     const fixture = createComponent(GridListWithUnspecifiedRowHeight);
     fixture.detectChanges();
     const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const inlineStyles = tile.nativeElement.style;
 
     // In ratio mode, heights are set using the padding-top property.
-    expect(getStyle(tile, 'padding-top')).toBe('200px');
+    expect(inlineStyles.paddingTop).toBeTruthy();
+    expect(inlineStyles.height).toBeFalsy();
+    expect(getDimension(tile, 'height')).toBe(200);
   });
 
   it('should use a ratio row height if passed in', () => {
@@ -85,12 +88,18 @@ describe('MatGridList', () => {
     fixture.detectChanges();
 
     const tile = fixture.debugElement.query(By.directive(MatGridTile));
-    expect(getStyle(tile, 'padding-top')).toBe('100px');
+    const inlineStyles = tile.nativeElement.style;
+
+    expect(inlineStyles.paddingTop).toBeTruthy();
+    expect(inlineStyles.height).toBeFalsy();
+    expect(getDimension(tile, 'height')).toBe(100);
 
     fixture.componentInstance.rowHeight = '2:1';
     fixture.detectChanges();
 
-    expect(getStyle(tile, 'padding-top')).toBe('200px');
+    expect(inlineStyles.paddingTop).toBeTruthy();
+    expect(inlineStyles.height).toBeFalsy();
+    expect(getDimension(tile, 'height')).toBe(200);
   });
 
   it('should divide row height evenly in "fit" mode', () => {
@@ -101,13 +110,13 @@ describe('MatGridList', () => {
     const tile = fixture.debugElement.query(By.directive(MatGridTile));
 
     // 149.5 * 2 = 299px + 1px gutter = 300px
-    expect(getStyle(tile, 'height')).toBe('149.5px');
+    expect(getDimension(tile, 'height')).toBe(149.5);
 
     fixture.componentInstance.totalHeight = '200px';
     fixture.detectChanges();
 
     // 99.5 * 2 = 199px + 1px gutter = 200px
-    expect(getStyle(tile, 'height')).toBe('99.5px');
+    expect(getDimension(tile, 'height')).toBe(99.5);
   });
 
   it('should use the fixed row height if passed in', () => {
@@ -117,12 +126,12 @@ describe('MatGridList', () => {
     fixture.detectChanges();
 
     const tile = fixture.debugElement.query(By.directive(MatGridTile));
-    expect(getStyle(tile, 'height')).toBe('100px');
+    expect(getDimension(tile, 'height')).toBe(100);
 
     fixture.componentInstance.rowHeight = '200px';
     fixture.detectChanges();
 
-    expect(getStyle(tile, 'height')).toBe('200px');
+    expect(getDimension(tile, 'height')).toBe(200);
   });
 
   it('should default to pixels if row height units are missing', () => {
@@ -130,7 +139,7 @@ describe('MatGridList', () => {
     fixture.detectChanges();
 
     const tile = fixture.debugElement.query(By.directive(MatGridTile));
-    expect(getStyle(tile, 'height')).toBe('100px');
+    expect(getDimension(tile, 'height')).toBe(100);
   });
 
   it('should default gutter size to 1px', () => {
@@ -140,12 +149,12 @@ describe('MatGridList', () => {
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
     // check horizontal gutter
-    expect(getStyle(tiles[0], 'width')).toBe('99.5px');
+    expect(getDimension(tiles[0], 'width')).toBe(99.5);
     expect(getComputedLeft(tiles[1])).toBe(100.5);
 
     // check vertical gutter
-    expect(getStyle(tiles[0], 'height')).toBe('100px');
-    expect(getStyle(tiles[2], 'top')).toBe('101px');
+    expect(getDimension(tiles[0], 'height')).toBe(100);
+    expect(getDimension(tiles[2], 'top')).toBe(101);
   });
 
   it('should be able to set the gutter size to zero', () => {
@@ -158,12 +167,12 @@ describe('MatGridList', () => {
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
     // check horizontal gutter
-    expect(getStyle(tiles[0], 'width')).toBe('100px');
+    expect(getDimension(tiles[0], 'width')).toBe(100);
     expect(getComputedLeft(tiles[1])).toBe(100);
 
     // check vertical gutter
-    expect(getStyle(tiles[0], 'height')).toBe('100px');
-    expect(getStyle(tiles[2], 'top')).toBe('100px');
+    expect(getDimension(tiles[0], 'height')).toBe(100);
+    expect(getDimension(tiles[2], 'top')).toBe(100);
   });
 
   it('should lay out the tiles correctly for a nested grid list', () => {
@@ -173,9 +182,9 @@ describe('MatGridList', () => {
     const innerTiles = fixture.debugElement.queryAll(
         By.css('mat-grid-tile mat-grid-list mat-grid-tile'));
 
-    expect(getStyle(innerTiles[0], 'top')).toBe('0px');
-    expect(getStyle(innerTiles[1], 'top')).toBe('101px');
-    expect(getStyle(innerTiles[2], 'top')).toBe('202px');
+    expect(getDimension(innerTiles[0], 'top')).toBe(0);
+    expect(getDimension(innerTiles[1], 'top')).toBe(101);
+    expect(getDimension(innerTiles[2], 'top')).toBe(202);
   });
 
   it('should set the gutter size if passed', () => {
@@ -185,12 +194,12 @@ describe('MatGridList', () => {
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
     // check horizontal gutter
-    expect(getStyle(tiles[0], 'width')).toBe('99px');
+    expect(getDimension(tiles[0], 'width')).toBe(99);
     expect(getComputedLeft(tiles[1])).toBe(101);
 
     // check vertical gutter
-    expect(getStyle(tiles[0], 'height')).toBe('100px');
-    expect(getStyle(tiles[2], 'top')).toBe('102px');
+    expect(getDimension(tiles[0], 'height')).toBe(100);
+    expect(getDimension(tiles[2], 'top')).toBe(102);
   });
 
   it('should use pixels if gutter units are missing', () => {
@@ -200,12 +209,12 @@ describe('MatGridList', () => {
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
     // check horizontal gutter
-    expect(getStyle(tiles[0], 'width')).toBe('99px');
+    expect(getDimension(tiles[0], 'width')).toBe(99);
     expect(getComputedLeft(tiles[1])).toBe(101);
 
     // check vertical gutter
-    expect(getStyle(tiles[0], 'height')).toBe('100px');
-    expect(getStyle(tiles[2], 'top')).toBe('102px');
+    expect(getDimension(tiles[0], 'height')).toBe(100);
+    expect(getDimension(tiles[2], 'top')).toBe(102);
   });
 
   it('should allow alternate units for the gutter size', () => {
@@ -217,7 +226,7 @@ describe('MatGridList', () => {
 
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
-    expect(getStyle(tiles[0], 'width')).toBe('90px');
+    expect(getDimension(tiles[0], 'width')).toBe(90);
     expect(getComputedLeft(tiles[1])).toBe(110);
   });
 
@@ -226,7 +235,11 @@ describe('MatGridList', () => {
     fixture.detectChanges();
 
     const list = fixture.debugElement.query(By.directive(MatGridList));
-    expect(getStyle(list, 'padding-bottom')).toBe('201px');
+    const inlineStyles = list.nativeElement.style;
+
+    expect(inlineStyles.paddingBottom).toBeTruthy();
+    expect(inlineStyles.height).toBeFalsy();
+    expect(getDimension(list, 'height')).toBe(201);
   });
 
   it('should set the correct list height in fixed mode', () => {
@@ -234,20 +247,20 @@ describe('MatGridList', () => {
     fixture.detectChanges();
 
     const list = fixture.debugElement.query(By.directive(MatGridList));
-    expect(getStyle(list, 'height')).toBe('201px');
+    expect(getDimension(list, 'height')).toBe(201);
   });
 
   it('should allow adjustment of tile colspan', () => {
     const fixture = createComponent(GridListWithColspanBinding);
-      fixture.componentInstance.colspan = 2;
-      fixture.detectChanges();
+    fixture.componentInstance.colspan = 2;
+    fixture.detectChanges();
 
-      const tile = fixture.debugElement.query(By.directive(MatGridTile));
-      expect(getStyle(tile, 'width')).toBe('199.5px');
+    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    expect(getDimension(tile, 'width')).toBe(199.5);
 
-      fixture.componentInstance.colspan = 3;
-      fixture.detectChanges();
-      expect(getStyle(tile, 'width')).toBe('299.75px');
+    fixture.componentInstance.colspan = 3;
+    fixture.detectChanges();
+    expect(getDimension(tile, 'width')).toBe(299.75);
   });
 
   it('should allow adjustment of tile rowspan', () => {
@@ -257,11 +270,11 @@ describe('MatGridList', () => {
     fixture.detectChanges();
 
     const tile = fixture.debugElement.query(By.directive(MatGridTile));
-    expect(getStyle(tile, 'height')).toBe('201px');
+    expect(getDimension(tile, 'height')).toBe(201);
 
     fixture.componentInstance.rowspan = 3;
     fixture.detectChanges();
-    expect(getStyle(tile, 'height')).toBe('302px');
+    expect(getDimension(tile, 'height')).toBe(302);
   });
 
   it('should lay out tiles correctly for a complex layout', () => {
@@ -277,25 +290,25 @@ describe('MatGridList', () => {
     fixture.detectChanges();
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
-    expect(getStyle(tiles[0], 'width')).toBe('299.75px');
-    expect(getStyle(tiles[0], 'height')).toBe('100px');
+    expect(getDimension(tiles[0], 'width')).toBe(299.75);
+    expect(getDimension(tiles[0], 'height')).toBe(100);
     expect(getComputedLeft(tiles[0])).toBe(0);
-    expect(getStyle(tiles[0], 'top')).toBe('0px');
+    expect(getDimension(tiles[0], 'top')).toBe(0);
 
-    expect(getStyle(tiles[1], 'width')).toBe('99.25px');
-    expect(getStyle(tiles[1], 'height')).toBe('201px');
+    expect(getDimension(tiles[1], 'width')).toBe(99.25);
+    expect(getDimension(tiles[1], 'height')).toBe(201);
     expect(getComputedLeft(tiles[1])).toBe(300.75);
-    expect(getStyle(tiles[1], 'top')).toBe('0px');
+    expect(getDimension(tiles[1], 'top')).toBe(0);
 
-    expect(getStyle(tiles[2], 'width')).toBe('99.25px');
-    expect(getStyle(tiles[2], 'height')).toBe('100px');
+    expect(getDimension(tiles[2], 'width')).toBe(99.25);
+    expect(getDimension(tiles[2], 'height')).toBe(100);
     expect(getComputedLeft(tiles[2])).toBe(0);
-    expect(getStyle(tiles[2], 'top')).toBe('101px');
+    expect(getDimension(tiles[2], 'top')).toBe(101);
 
-    expect(getStyle(tiles[3], 'width')).toBe('199.5px');
-    expect(getStyle(tiles[3], 'height')).toBe('100px');
+    expect(getDimension(tiles[3], 'width')).toBe(199.5);
+    expect(getDimension(tiles[3], 'height')).toBe(100);
     expect(getComputedLeft(tiles[3])).toBe(100.25);
-    expect(getStyle(tiles[3], 'top')).toBe('101px');
+    expect(getDimension(tiles[3], 'top')).toBe(101);
   });
 
   it('should lay out tiles correctly', () => {
@@ -304,30 +317,30 @@ describe('MatGridList', () => {
     fixture.detectChanges();
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
-    expect(getStyle(tiles[0], 'width')).toBe('40px');
-    expect(getStyle(tiles[0], 'height')).toBe('40px');
+    expect(getDimension(tiles[0], 'width')).toBe(40);
+    expect(getDimension(tiles[0], 'height')).toBe(40);
     expect(getComputedLeft(tiles[0])).toBe(0);
-    expect(getStyle(tiles[0], 'top')).toBe('0px');
+    expect(getDimension(tiles[0], 'top')).toBe(0);
 
-    expect(getStyle(tiles[1], 'width')).toBe('20px');
-    expect(getStyle(tiles[1], 'height')).toBe('20px');
+    expect(getDimension(tiles[1], 'width')).toBe(20);
+    expect(getDimension(tiles[1], 'height')).toBe(20);
     expect(getComputedLeft(tiles[1])).toBe(40);
-    expect(getStyle(tiles[1], 'top')).toBe('0px');
+    expect(getDimension(tiles[1], 'top')).toBe(0);
 
-    expect(getStyle(tiles[2], 'width')).toBe('40px');
-    expect(getStyle(tiles[2], 'height')).toBe('40px');
+    expect(getDimension(tiles[2], 'width')).toBe(40);
+    expect(getDimension(tiles[2], 'height')).toBe(40);
     expect(getComputedLeft(tiles[2])).toBe(60);
-    expect(getStyle(tiles[2], 'top')).toBe('0px');
+    expect(getDimension(tiles[2], 'top')).toBe(0);
 
-    expect(getStyle(tiles[3], 'width')).toBe('40px');
-    expect(getStyle(tiles[3], 'height')).toBe('40px');
+    expect(getDimension(tiles[3], 'width')).toBe(40);
+    expect(getDimension(tiles[3], 'height')).toBe(40);
     expect(getComputedLeft(tiles[3])).toBe(0);
-    expect(getStyle(tiles[3], 'top')).toBe('40px');
+    expect(getDimension(tiles[3], 'top')).toBe(40);
 
-    expect(getStyle(tiles[4], 'width')).toBe('40px');
-    expect(getStyle(tiles[4], 'height')).toBe('40px');
+    expect(getDimension(tiles[4], 'width')).toBe(40);
+    expect(getDimension(tiles[4], 'height')).toBe(40);
     expect(getComputedLeft(tiles[4])).toBe(40);
-    expect(getStyle(tiles[4], 'top')).toBe('40px');
+    expect(getDimension(tiles[4], 'top')).toBe(40);
   });
 
   it('should lay out tiles correctly when single cell to be placed at the beginning',
@@ -337,24 +350,24 @@ describe('MatGridList', () => {
     fixture.detectChanges();
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
-    expect(getStyle(tiles[0], 'width')).toBe('40px');
-    expect(getStyle(tiles[0], 'height')).toBe('40px');
+    expect(getDimension(tiles[0], 'width')).toBe(40);
+    expect(getDimension(tiles[0], 'height')).toBe(40);
     expect(getComputedLeft(tiles[0])).toBe(0);
-    expect(getStyle(tiles[0], 'top')).toBe('0px');
+    expect(getDimension(tiles[0], 'top')).toBe(0);
 
-    expect(getStyle(tiles[1], 'width')).toBe('20px');
-    expect(getStyle(tiles[1], 'height')).toBe('40px');
+    expect(getDimension(tiles[1], 'width')).toBe(20);
+    expect(getDimension(tiles[1], 'height')).toBe(40);
     expect(getComputedLeft(tiles[1])).toBe(40);
-    expect(getStyle(tiles[1], 'top')).toBe('0px');
+    expect(getDimension(tiles[1], 'top')).toBe(0);
 
-    expect(getStyle(tiles[2], 'width')).toBe('40px');
-    expect(getStyle(tiles[2], 'height')).toBe('40px');
+    expect(getDimension(tiles[2], 'width')).toBe(40);
+    expect(getDimension(tiles[2], 'height')).toBe(40);
     expect(getComputedLeft(tiles[2])).toBe(60);
-    expect(getStyle(tiles[2], 'top')).toBe('0px');
+    expect(getDimension(tiles[2], 'top')).toBe(0);
 
-    expect(getStyle(tiles[3], 'height')).toBe('20px');
+    expect(getDimension(tiles[3], 'height')).toBe(20);
     expect(getComputedLeft(tiles[3])).toBe(0);
-    expect(getStyle(tiles[3], 'top')).toBe('40px');
+    expect(getDimension(tiles[3], 'top')).toBe(40);
   });
 
   it('should add not add any classes to footers without lines', () => {
@@ -393,17 +406,25 @@ describe('MatGridList', () => {
 
     const list = fixture.debugElement.query(By.directive(MatGridList));
     const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const listInlineStyles = list.nativeElement.style;
+    const tileInlineStyles = tile.nativeElement.style;
 
-    expect(getStyle(tile, 'padding-top')).toBe('100px');
-    expect(getStyle(list, 'padding-bottom')).toBe('100px');
+    expect(getDimension(tile, 'height')).toBe(100);
+    expect(tileInlineStyles.paddingTop).toBeTruthy();
+    expect(tileInlineStyles.height).toBeFalsy();
+
+    expect(getDimension(list, 'height')).toBe(100);
+    expect(listInlineStyles.paddingBottom).toBeTruthy();
+    expect(listInlineStyles.height).toBeFalsy();
 
     fixture.componentInstance.rowHeight = '400px';
     fixture.detectChanges();
 
-    expect(getStyle(tile, 'padding-top')).toBe('0px', 'Expected tile padding to be reset.');
-    expect(getStyle(list, 'padding-bottom')).toBe('0px', 'Expected list padding to be reset.');
-    expect(getStyle(tile, 'top')).toBe('0px');
-    expect(getStyle(tile, 'height')).toBe('400px');
+    expect(tileInlineStyles.paddingTop).toBeFalsy('Expected tile padding to be reset.');
+    expect(listInlineStyles.paddingBottom).toBeFalsy('Expected list padding to be reset.');
+
+    expect(getDimension(tile, 'top')).toBe(0);
+    expect(getDimension(tile, 'height')).toBe(400);
   });
 
   it('should ensure that all tiles are inside the grid when there are no matching gaps', () => {
@@ -438,7 +459,11 @@ describe('MatGridList', () => {
     fixture.detectChanges();
 
     const tile = fixture.debugElement.query(By.directive(MatGridTile));
-    expect(getStyle(tile, 'padding-top')).toBe('200px');
+    const inlineStyles = tile.nativeElement.style;
+
+    expect(inlineStyles.paddingTop).toBeTruthy();
+    expect(inlineStyles.height).toBeFalsy();
+    expect(getDimension(tile, 'height')).toBe(200);
   });
 
   it('should throw if an invalid value is set as the `rowHeight`', () => {
@@ -454,9 +479,19 @@ describe('MatGridList', () => {
 
 });
 
+/** Gets the computed dimension of a DebugElement in pixels. */
+function getDimension(el: DebugElement, dimension: 'width' | 'height' | 'top' | 'left'): number {
+  const nativeElement: HTMLElement = el.nativeElement;
 
-function getStyle(el: DebugElement, prop: string): string {
-  return getComputedStyle(el.nativeElement).getPropertyValue(prop);
+  switch (dimension) {
+    // Note that we use direct measurements, rather than the computed style, because
+    // `getComputedStyle` can be inconsistent between browser and can cause flakes.
+    case 'width': return nativeElement.getBoundingClientRect().width;
+    case 'height': return nativeElement.getBoundingClientRect().height;
+    case 'top': return nativeElement.offsetTop;
+    case 'left': return nativeElement.offsetLeft;
+    default: throw Error(`Unknown dimension ${dimension}.`);
+  }
 }
 
 /** Gets the `left` position of an element. */

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -131,15 +131,15 @@ describe('MatTabNavBar', () => {
         .toBe(true, 'Expected element to no longer be keyboard focusable if disabled.');
     });
 
-    it('should make disabled links unclickable', () => {
+    it('should mark disabled links', () => {
       const tabLinkElement = fixture.debugElement.query(By.css('a')).nativeElement;
 
-      expect(getComputedStyle(tabLinkElement).pointerEvents).not.toBe('none');
+      expect(tabLinkElement.classList).not.toContain('mat-tab-disabled');
 
       fixture.componentInstance.disabled = true;
       fixture.detectChanges();
 
-      expect(getComputedStyle(tabLinkElement).pointerEvents).toBe('none');
+      expect(tabLinkElement.classList).toContain('mat-tab-disabled');
     });
 
     it('should re-align the ink bar when the direction changes', () => {


### PR DESCRIPTION
Currently most of the grid list tests as well as one of tab nav bar test are flaky, because we use `getComputedStyle` for assertions and the return values can be formatted differently depending on the browser. These changes move them to either pick up values directly from the DOM or to measure the element with `getBoundingClientRect`.