### PR TITLE
build: print enabled bazel flags on circleci

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -2,6 +2,10 @@
 # This allows us adding specific configuration flags for builds within CircleCI.
 # See more: https://docs.bazel.build/versions/master/user-manual.html#where-are-the-bazelrc-files
 
+# Print all enabled Bazel flags in CI mode. This makes it easier to debug and reproduce
+# Bazel issues that show up on CircleCI.
+common --announce_rc
+
 # Save downloaded repositories in a location that can be cached by CircleCI. This helps us
 # speeding up the analysis time significantly with Bazel managed node dependencies on the CI.
 build --repository_cache=/home/circleci/bazel_repository_cache


### PR DESCRIPTION
We should print all enabled bazel flags on CircleCI. This can help with debugging and
also makes it easier to reproduce CI-specific failures.