### PR TITLE
fix: table sort for array of string and numbers

### DIFF
--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -149,11 +149,15 @@ export class MatTableDataSource<T> extends DataSource<T> {
       // If neither value exists, return 0 (equal).
       let comparatorResult = 0;
       if (valueA != null && valueB != null) {
-        // Check if one value is greater than the other; if equal, comparatorResult should remain 0.
-        if (valueA > valueB) {
-          comparatorResult = 1;
-        } else if (valueA < valueB) {
-          comparatorResult = -1;
+        // if both values are numbers
+        if (typeof valueA === "number" && typeof valueB === "number") {
+          comparatorResult = valueA - valueB;
+          // if both values are string
+        } else if (typeof valueA === "string" && typeof valueB === "string") {
+          comparatorResult = valueA > valueB ? 1 : -1;
+        } else {
+          // if we compare string with number than number must go first
+          comparatorResult = typeof valueA === "string" ? 1 : -1;
         }
       } else if (valueA != null) {
         comparatorResult = 1;

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -150,14 +150,14 @@ export class MatTableDataSource<T> extends DataSource<T> {
       let comparatorResult = 0;
       if (valueA != null && valueB != null) {
         // if both values are numbers
-        if (typeof valueA === "number" && typeof valueB === "number") {
+        if (typeof valueA === 'number' && typeof valueB === 'number') {
           comparatorResult = valueA - valueB;
           // if both values are string
-        } else if (typeof valueA === "string" && typeof valueB === "string") {
+        } else if (typeof valueA === 'string' && typeof valueB === 'string') {
           comparatorResult = valueA > valueB ? 1 : -1;
         } else {
           // if we compare string with number than number must go first
-          comparatorResult = typeof valueA === "string" ? 1 : -1;
+          comparatorResult = typeof valueA === 'string' ? 1 : -1;
         }
       } else if (valueA != null) {
         comparatorResult = 1;
@@ -186,7 +186,7 @@ export class MatTableDataSource<T> extends DataSource<T> {
       // This avoids matches where the values of two columns combined will match the user's query
       // (e.g. `Flute` and `Stop` will match `Test`). The character is intended to be something
       // that has a very low chance of being typed in by somebody in a text field. This one in
-      // particular is "White up-pointing triangle with dot" from
+      // particular is 'White up-pointing triangle with dot' from
       // https://en.wikipedia.org/wiki/List_of_Unicode_characters
       return currentTerm + (data as {[key: string]: any})[key] + '◬';
     }, '').toLowerCase();


### PR DESCRIPTION
MatSort can't sort mixed array (string and numbers) correctly. I add
checking for compare number with string and now all numbers come first.

issue: 16303