### PR TITLE
docs: overviews should recommend individual entry-points

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -38,7 +38,7 @@ Afterwards you can access the injected data using the `MAT_BOTTOM_SHEET_DATA` in
 
 ```ts
 import {Component, Inject} from '@angular/core';
-import {MAT_BOTTOM_SHEET_DATA} from '@angular/material';
+import {MAT_BOTTOM_SHEET_DATA} from '@angular/material/bottom-sheet';
 
 @Component({
   selector: 'hobbit-sheet',

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -65,7 +65,7 @@ To access the data in your dialog component, you have to use the MAT_DIALOG_DATA
 
 ```ts
 import {Component, Inject} from '@angular/core';
-import {MAT_DIALOG_DATA} from '@angular/material';
+import {MAT_DIALOG_DATA} from '@angular/material/dialog';
 
 @Component({
   selector: 'your-dialog',

--- a/src/material/snack-bar/snack-bar.md
+++ b/src/material/snack-bar/snack-bar.md
@@ -62,7 +62,7 @@ To access the data in your component, you have to use the `MAT_SNACK_BAR_DATA` i
 
 ```ts
 import {Component, Inject} from '@angular/core';
-import {MAT_SNACK_BAR_DATA} from '@angular/material';
+import {MAT_SNACK_BAR_DATA} from '@angular/material/snack-bar';
 
 @Component({
   selector: 'your-snack-bar',


### PR DESCRIPTION
Currently there are still a few overview documents that recommend importing
the entry-point through the primary Material entry-point. This commit updates
these overview documents to refer to the proper individual entry-points.

These are the last usages of the primary entry-point in the components repository. Related to #16495