### PR TITLE
fix(menu): mark lazy menu content as dirty before attach

### DIFF
--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -63,7 +63,7 @@ export declare const matMenuAnimations: {
 
 export declare class MatMenuContent implements OnDestroy {
     _attached: Subject<void>;
-    constructor(_template: TemplateRef<any>, _componentFactoryResolver: ComponentFactoryResolver, _appRef: ApplicationRef, _injector: Injector, _viewContainerRef: ViewContainerRef, _document: any);
+    constructor(_template: TemplateRef<any>, _componentFactoryResolver: ComponentFactoryResolver, _appRef: ApplicationRef, _injector: Injector, _viewContainerRef: ViewContainerRef, _document: any, _changeDetectorRef?: ChangeDetectorRef | undefined);
     attach(context?: any): void;
     detach(): void;
     ngOnDestroy(): void;


### PR DESCRIPTION
This fixes a Google presubmit issue where the menu's `@ContentChildren`
aren't updated after attaching lazy `MatMenuContent`.