### PR TITLE
feat(slide-toggle/checkbox): Custom true false value

### DIFF
--- a/src/dev-app/checkbox/checkbox-demo.html
+++ b/src/dev-app/checkbox/checkbox-demo.html
@@ -7,7 +7,9 @@
                 (change)="isIndeterminate = false"
                 [indeterminate]="isIndeterminate"
                 [disabled]="isDisabled"
-                [labelPosition]="labelPosition">
+                [labelPosition]="labelPosition"
+                [trueValue]="customTrueValue"
+                [falseValue]="customFalseValue">
     Do you want to <em>foobar</em> the <em>bazquux</em>?
 
   </mat-checkbox> - <strong>{{printResult()}}</strong>

--- a/src/dev-app/checkbox/checkbox-demo.ts
+++ b/src/dev-app/checkbox/checkbox-demo.ts
@@ -93,8 +93,11 @@ export class MatCheckboxDemoNestedChecklist {
   styleUrls: ['checkbox-demo.css'],
 })
 export class CheckboxDemo {
+
+  customTrueValue: string = 'Yes!!';
+  customFalseValue: string = 'No!!';
   isIndeterminate: boolean = false;
-  isChecked: boolean = false;
+  isChecked: string = this.customTrueValue;
   isDisabled: boolean = false;
   labelPosition: string = 'after';
   useAlternativeColor: boolean = false;
@@ -117,7 +120,7 @@ export class CheckboxDemo {
     if (this.isIndeterminate) {
       return 'Maybe!';
     }
-    return this.isChecked ? 'Yes!' : 'No!';
+    return this.isChecked;
   }
 
   checkboxColor() {

--- a/src/dev-app/slide-toggle/slide-toggle-demo.html
+++ b/src/dev-app/slide-toggle/slide-toggle-demo.html
@@ -3,6 +3,7 @@
   <mat-slide-toggle color="primary" [(ngModel)]="firstToggle">
     Default Slide Toggle
   </mat-slide-toggle>
+  <p>Default Slide Toggle: <em>{{firstToggle}}</em></p>
 
   <mat-slide-toggle [(ngModel)]="firstToggle" disabled>
     Disabled Slide Toggle
@@ -11,6 +12,11 @@
   <mat-slide-toggle [disabled]="firstToggle">
     Disable Bound
   </mat-slide-toggle>
+  
+  <mat-slide-toggle color="primary" [(ngModel)]="secondToggle" [trueValue]="customTrueValue" [falseValue]="customFalseValue">
+    Slide Toggle with Value
+  </mat-slide-toggle>
+  <p>Slide Toggle with Value: <em>{{secondToggle}}</em></p>
 
   <p>Example where the slide toggle is required inside of a form.</p>
 

--- a/src/dev-app/slide-toggle/slide-toggle-demo.ts
+++ b/src/dev-app/slide-toggle/slide-toggle-demo.ts
@@ -16,7 +16,11 @@ import {Component} from '@angular/core';
   styleUrls: ['slide-toggle-demo.css'],
 })
 export class SlideToggleDemo {
+
   firstToggle: boolean;
+  customTrueValue: string = 'Yes!!';
+  customFalseValue: string = 'No!!';
+  secondToggle: string = this.customTrueValue;
 
   onFormSubmit() {
     alert(`You submitted the form.`);

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -77,10 +77,14 @@ export enum TransitionCheckState {
 
 /** Change event object emitted by MatCheckbox. */
 export class MatCheckboxChange {
-  /** The source MatCheckbox of the event. */
-  source: MatCheckbox;
-  /** The new `checked` value of the checkbox. */
-  checked: boolean;
+  constructor(
+    /** The source MatCheckbox of the event. */
+    public source: MatCheckbox,
+    /** The new `checked` value of the checkbox. */
+    public checked: boolean,
+    /** The new alias `value` of the MatSlideToggle. */
+    public value: any
+  ) { }
 }
 
 // Boilerplate for applying mixins to MatCheckbox.
@@ -169,6 +173,10 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
 
   /** The value attribute of the native input element */
   @Input() value: string;
+
+  /** Values to override default true/false outputs */
+  @Input() trueValue: any = true;
+  @Input() falseValue: any = false;
 
   /** The native `<input type="checkbox">` element */
   @ViewChild('input', {static: false}) _inputElement: ElementRef<HTMLInputElement>;
@@ -291,7 +299,13 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
 
   // Implemented as part of ControlValueAccessor.
   writeValue(value: any) {
-    this.checked = !!value;
+    if (value === this.trueValue) {
+      this.checked = true;
+    } else if (value === this.falseValue) {
+      this.checked = false;
+    } else {
+      this.checked = !!value;
+    }
   }
 
   // Implemented as part of ControlValueAccessor.
@@ -342,13 +356,15 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     }
   }
 
-  private _emitChangeEvent() {
-    const event = new MatCheckboxChange();
-    event.source = this;
-    event.checked = this.checked;
+  /** Computes checked value based on selection. Defaults to true/false */
+  private getCheckedValue(): any {
+    return this.checked ? this.trueValue : this.falseValue;
+  }
 
-    this._controlValueAccessorChangeFn(this.checked);
-    this.change.emit(event);
+  private _emitChangeEvent() {
+    const outputValue = this.getCheckedValue();
+    this._controlValueAccessorChangeFn(outputValue);
+    this.change.emit(new MatCheckboxChange(this, this.checked, outputValue));
   }
 
   /** Toggles the `checked` state of the checkbox. */

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -357,12 +357,12 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   }
 
   /** Computes checked value based on selection. Defaults to true/false */
-  private getCheckedValue(): any {
+  private _getCheckedValue(): any {
     return this.checked ? this.trueValue : this.falseValue;
   }
 
   private _emitChangeEvent() {
-    const outputValue = this.getCheckedValue();
+    const outputValue = this._getCheckedValue();
     this._controlValueAccessorChangeFn(outputValue);
     this.change.emit(new MatCheckboxChange(this, this.checked, outputValue));
   }

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -61,7 +61,10 @@ export class MatSlideToggleChange {
     /** The source MatSlideToggle of the event. */
     public source: MatSlideToggle,
     /** The new `checked` value of the MatSlideToggle. */
-    public checked: boolean) { }
+    public checked: boolean,
+    /** The new alias `value` of the MatSlideToggle. */
+    public value: any
+  ) { }
 }
 
 // Boilerplate for applying mixins to MatSlideToggle.
@@ -157,6 +160,11 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     this._checked = coerceBooleanProperty(value);
     this._changeDetectorRef.markForCheck();
   }
+
+  /** Values to override default true/false outputs */
+  @Input() trueValue: any = true;
+  @Input() falseValue: any = false;
+
   /** An event will be dispatched each time the slide-toggle changes its value. */
   @Output() readonly change: EventEmitter<MatSlideToggleChange> =
       new EventEmitter<MatSlideToggleChange>();
@@ -257,7 +265,13 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
 
   /** Implemented as part of ControlValueAccessor. */
   writeValue(value: any): void {
-    this.checked = !!value;
+    if (value === this.trueValue) {
+      this.checked = true;
+    } else if (value === this.falseValue) {
+      this.checked = false;
+    } else {
+      this.checked = !!value;
+    }
   }
 
   /** Implemented as part of ControlValueAccessor. */
@@ -281,18 +295,24 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     this._focusMonitor.focusVia(this._inputElement, 'keyboard');
   }
 
+  /** Computes checked value based on selection. Defaults to true/false */
+  private getCheckedValue(): any {
+    return this.checked ? this.trueValue : this.falseValue;
+  }
+
   /** Toggles the checked state of the slide-toggle. */
   toggle(): void {
     this.checked = !this.checked;
-    this._onChange(this.checked);
+    this._onChange(this.getCheckedValue());
   }
 
   /**
    * Emits a change event on the `change` output. Also notifies the FormControl about the change.
    */
   private _emitChangeEvent() {
-    this._onChange(this.checked);
-    this.change.emit(new MatSlideToggleChange(this, this.checked));
+    const outputValue = this.getCheckedValue();
+    this._onChange(outputValue);
+    this.change.emit(new MatSlideToggleChange(this, this.checked, outputValue));
   }
 
   /** Retrieves the percentage of thumb from the moved distance. Percentage as fraction of 100. */

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -296,21 +296,21 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   }
 
   /** Computes checked value based on selection. Defaults to true/false */
-  private getCheckedValue(): any {
+  private _getCheckedValue(): any {
     return this.checked ? this.trueValue : this.falseValue;
   }
 
   /** Toggles the checked state of the slide-toggle. */
   toggle(): void {
     this.checked = !this.checked;
-    this._onChange(this.getCheckedValue());
+    this._onChange(this._getCheckedValue());
   }
 
   /**
    * Emits a change event on the `change` output. Also notifies the FormControl about the change.
    */
   private _emitChangeEvent() {
-    const outputValue = this.getCheckedValue();
+    const outputValue = this._getCheckedValue();
     this._onChange(outputValue);
     this.change.emit(new MatSlideToggleChange(this, this.checked, outputValue));
   }


### PR DESCRIPTION
**Use Case**
The default behaviour of slide-toggle/checkbox outputs Boolean true/false. The need for mapping the Boolean value to custom object needs to be handled outside the material component.

**Motivation**
Feature [ngTrueValue & ngFalseValue](https://docs.angularjs.org/api/ng/input/input[checkbox]) from AngularJS

**Change**
Added input attributes `trueValue` & `falseValue` for providing custom value.
The customised values will emit on ngModel/FormControl.
Emitted event will have additional field `value` holding this value.
Allows user to abstract logic that maps Boolean to custom value & vice versa.