### PR TITLE
fix(radio): show ripple on programmatic focus

### DIFF
--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -153,7 +153,8 @@ $mat-radio-ripple-radius: 20px;
     opacity: 0.04;
   }
 
-  .mat-radio-button:not(.mat-radio-disabled).cdk-keyboard-focused & {
+  .mat-radio-button:not(.mat-radio-disabled).cdk-keyboard-focused &,
+  .mat-radio-button:not(.mat-radio-disabled).cdk-program-focused & {
     opacity: 0.12;
   }
 


### PR DESCRIPTION
At least Windows/NVDA+JAWS can send focus to mat-radio-button without being detected through the keyboard focused handler. We should still show the same focused style in this case.