### PR TITLE
build: allow inspecting test nodejs process w/ bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -87,7 +87,7 @@ build:remote --host_platform=//tools:rbe_platform
 build:remote --platforms=//tools:rbe_platform
 build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
 
- # Setup Build Event Service
+# Setup Build Event Service
 build:remote --bes_backend=buildeventservice.googleapis.com
 build:remote --bes_timeout=30s
 build:remote --bes_results_url="https://source.cloud.google.com/results/invocations/"
@@ -96,7 +96,15 @@ build:remote --bes_results_url="https://source.cloud.google.com/results/invocati
 build:remote --remote_accept_cached=true
 
 ################################
+# --config=debug               #
+################################
+
+# Enable debugging tests with --config=debug
+test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
+
+################################
 # Local Environment Setup      #
+#  Needs to be last statement  #
 ################################
 # Load any settings which are specific to the current user. Needs to be *last* statement
 # in this config, as the user configuration should be able to overwrite flags from this file.


### PR DESCRIPTION
Adds a new `debug` configuration for Bazel that can be used to
open the Chrome Devtools Debugger in order to debug a bazel
test that runs with NodeJS. This is similar to what `angular/angular`
provides.

*Note*: This does not make debugging for web test suites easier. For
web test suites we need to find a better solution. I have something in mind
where developers can run `bazel run` instead of `bazel test` to open the
karma test suite in non-capture mode (allowing easy debugging)