### PR TITLE
fix(tabs): no longer use OnPush

### DIFF
--- a/src/material/tabs/tab-body.ts
+++ b/src/material/tabs/tab-body.ts
@@ -251,7 +251,8 @@ export abstract class _MatTabBodyBase implements OnInit, OnDestroy {
   templateUrl: 'tab-body.html',
   styleUrls: ['tab-body.css'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   animations: [matTabsAnimations.translateTab],
   host: {
     'class': 'mat-tab-body',

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -360,7 +360,8 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
   templateUrl: 'tab-group.html',
   styleUrls: ['tab-group.css'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   inputs: ['color', 'disableRipple'],
   host: {
     'class': 'mat-tab-group',

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -83,7 +83,8 @@ export abstract class _MatTabHeaderBase extends MatPaginatedTabHeader implements
   inputs: ['selectedIndex'],
   outputs: ['selectFocusedIndex', 'indexFocused'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   host: {
     'class': 'mat-tab-header',
     '[class.mat-tab-header-pagination-controls-enabled]': '_showPaginationControls',

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -160,7 +160,8 @@ export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements Af
     '[class.mat-warn]': 'color === "warn"',
   },
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class MatTabNav extends _MatTabNavBase {
   @ContentChildren(forwardRef(() => MatTabLink), {descendants: true}) _items: QueryList<MatTabLink>;

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -38,7 +38,8 @@ const _MatTabMixinBase: CanDisableCtor & typeof MatTabBase =
   selector: 'mat-tab',
   templateUrl: 'tab.html',
   inputs: ['disabled'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
   exportAs: 'matTab',
 })

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -45,7 +45,18 @@ const _MatTabMixinBase: CanDisableCtor & typeof MatTabBase =
 })
 export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnChanges, OnDestroy {
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
-  @ContentChild(MatTabLabel, {static: false}) templateLabel: MatTabLabel;
+  @ContentChild(MatTabLabel, {static: false})
+  get templateLabel(): MatTabLabel { return this._templateLabel; }
+  set templateLabel(value: MatTabLabel) {
+    // Only update the templateLabel via query if there is actually
+    // a MatTabLabel found. This works around an issue where a user may have
+    // manually set `templateLabel` during creation mode, which would then get clobbered
+    // by `undefined` when this query resolves.
+    if (value) {
+      this._templateLabel = value;
+    }
+  }
+  private _templateLabel: MatTabLabel;
 
   /**
    * Template provided in the tab content that will be used if present, used to enable lazy-loading


### PR DESCRIPTION
This resolves an issue with ivy where the template content would be
checked out of sync with the tab view. See #15440 for additional
context.