### PR TITLE
refactor(tree): avoid improper query usage

### DIFF
--- a/src/material/tree/outlet.ts
+++ b/src/material/tree/outlet.ts
@@ -18,7 +18,11 @@ import {
  * inside the outlet.
  */
 @Directive({
-  selector: '[matTreeNodeOutlet]'
+  selector: '[matTreeNodeOutlet]',
+  providers: [{
+    provide: CdkTreeNodeOutlet,
+    useExisting: MatTreeNodeOutlet
+  }]
 })
 export class MatTreeNodeOutlet implements CdkTreeNodeOutlet {
   constructor(

--- a/tools/public_api_guard/material/tree.d.ts
+++ b/tools/public_api_guard/material/tree.d.ts
@@ -1,9 +1,10 @@
-export declare class MatNestedTreeNode<T> extends _MatNestedTreeNodeMixinBase<T> implements AfterContentInit, CanDisable, HasTabIndex, OnDestroy {
+export declare class MatNestedTreeNode<T> extends CdkNestedTreeNode<T> implements AfterContentInit, OnDestroy {
     protected _differs: IterableDiffers;
     protected _elementRef: ElementRef<HTMLElement>;
     protected _tree: CdkTree<T>;
+    disabled: any;
     node: T;
-    nodeOutlet: QueryList<MatTreeNodeOutlet>;
+    tabIndex: number;
     constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T>, _differs: IterableDiffers, tabIndex: string);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;


### PR DESCRIPTION
The way things are set up at the moment we have a `CdkNestedTreeNode` which uses a `ContentChildren` to find a `CdkTreeNodeOutlet` so that it knows where to render its content. On top of this we have a `MatNestedTreeNode` which extends `CdkNestedTreeNode` and defines it's own query at the same property, but looking for a `MatTreeNodeOutlet`. With this setup it means that both `CdkNestedTreeNode` and `MatNestedTreeNode` are trying to write to the same `nodeOutlet` property and it's by pure coincidence that it works. This is very fragile and it isn't guaranteed to work in future versions of the framework.

These changes fix the issue by removing the query from the `MatNestedTreeNode` and providing the `MatTreeNodeOutlet` as a `CdkTreeNodeOutlet` so that the query on the `CdkNestedTreeNode` can pick it up.

cc @pkozlowski-opensource 