### PR TITLE
build: enable strict null checks for release scripts

### DIFF
--- a/tools/release/base-release-task.ts
+++ b/tools/release/base-release-task.ts
@@ -46,6 +46,7 @@ export class BaseReleaseTask {
     }
 
     console.log(green(`  ✓   Switched to the "${italic(defaultPublishBranch)}" branch.`));
+    return defaultPublishBranch;
   }
 
   /** Verifies that the local branch is up to date with the given publish branch. */

--- a/tools/release/npm/npm-client.ts
+++ b/tools/release/npm/npm-client.ts
@@ -41,6 +41,7 @@ export function npmPublish(packagePath: string, distTag: string): string | null 
   if (result.status !== 0) {
     return result.stderr.toString();
   }
+  return null;
 }
 
 /** Log out of npm. */

--- a/tools/release/prompt/new-version-prompt.ts
+++ b/tools/release/prompt/new-version-prompt.ts
@@ -63,7 +63,7 @@ export async function promptForNewVersion(currentVersion: Version): Promise<Vers
     type: 'list',
     name: 'prereleaseLabel',
     message: 'Please select a pre-release label:',
-    choices: allowedPrereleaseChoices,
+    choices: allowedPrereleaseChoices!,
     when: ({isPrerelease, proposedVersion}) =>
       // Only prompt for selecting a pre-release label if the current release is a pre-release,
       // or the existing pre-release label should be changed.
@@ -75,7 +75,7 @@ export async function promptForNewVersion(currentVersion: Version): Promise<Vers
   // prompt answers.
   const newVersion = answers.proposedVersion === 'new-prerelease-label' ?
       currentVersion.clone() :
-      parseVersionName(answers.proposedVersion);
+      parseVersionName(answers.proposedVersion)!;
 
   if (answers.prereleaseLabel) {
     newVersion.prereleaseLabel = answers.prereleaseLabel;

--- a/tools/release/publish-release.ts
+++ b/tools/release/publish-release.ts
@@ -53,13 +53,15 @@ class PublishReleaseTask extends BaseReleaseTask {
     this.releaseOutputPath = join(projectDir, 'dist/releases');
 
     this.packageJson = JSON.parse(readFileSync(this.packageJsonPath, 'utf-8'));
-    this.currentVersion = parseVersionName(this.packageJson.version);
 
-    if (!this.currentVersion) {
+    const parsedVersion = parseVersionName(this.packageJson.version);
+    if (!parsedVersion) {
       console.error(red(`Cannot parse current version in ${italic('package.json')}. Please ` +
         `make sure "${this.packageJson.version}" is a valid Semver version.`));
       process.exit(1);
+      return;
     }
+    this.currentVersion = parsedVersion;
   }
 
   async run() {
@@ -108,6 +110,7 @@ class PublishReleaseTask extends BaseReleaseTask {
     if (!extractedReleaseNotes) {
       console.error(red(`  ✘   Could not find release notes in the changelog.`));
       process.exit(1);
+      return;
     }
 
     const {releaseNotes, releaseTitle} = extractedReleaseNotes;

--- a/tools/release/release-output/output-validations.ts
+++ b/tools/release/release-output/output-validations.ts
@@ -37,7 +37,7 @@ export function checkReleaseBundle(bundlePath: string): string[] {
 export function checkTypeDefinitionFile(filePath: string): string[] {
   const baseDir = dirname(filePath);
   const fileContent = readFileSync(filePath, 'utf8');
-  const failures = [];
+  const failures: string[] = [];
 
   const sourceFile = ts.createSourceFile(filePath, fileContent, ts.ScriptTarget.Latest, true);
   const nodeQueue = [...sourceFile.getChildren()];

--- a/tools/release/tsconfig.json
+++ b/tools/release/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2016"],
-    "types": ["node"]
+    "types": ["node"],
+    "strictNullChecks": true
   }
 }

--- a/tools/release/version-name/create-version.ts
+++ b/tools/release/version-name/create-version.ts
@@ -11,7 +11,7 @@ export function createNewVersion(currentVersion: Version, releaseType: ReleaseTy
   const newVersion = currentVersion.clone();
 
   if (releaseType === 'bump-prerelease') {
-    newVersion.prereleaseNumber++;
+    newVersion.prereleaseNumber!++;
   } else {
     // For all other release types, the pre-release label and number should be removed
     // because the new version is not another pre-release.

--- a/tools/release/version-name/publish-branches.ts
+++ b/tools/release/version-name/publish-branches.ts
@@ -13,9 +13,9 @@ export function getAllowedPublishBranches(version: Version): string[] {
     // branch than "master". This can happen if major changes have been merged into "master"
     // and non-major changes are cherry-picked into a separate branch (e.g. 7.x)
     return ['master', `${version.major}.x`];
-  } else if (versionType === 'patch') {
-    return [`${version.major}.${version.minor}.x`];
   }
+
+  return [`${version.major}.${version.minor}.x`];
 }
 
 /** Determines the type of the specified Semver version. */


### PR DESCRIPTION
* Enables strict null checks for the release scripts
* Fixes a bug where the publish branch is not properly computed due to a missing return statement.