### PR TITLE
refactor(checkbox): remove unused host binding for required validator

### DIFF
--- a/src/material/checkbox/checkbox-required-validator.ts
+++ b/src/material/checkbox/checkbox-required-validator.ts
@@ -31,6 +31,5 @@ export const MAT_CHECKBOX_REQUIRED_VALIDATOR: Provider = {
   selector: `mat-checkbox[required][formControlName],
              mat-checkbox[required][formControl], mat-checkbox[required][ngModel]`,
   providers: [MAT_CHECKBOX_REQUIRED_VALIDATOR],
-  host: {'[attr.required]': 'required ? "" : null'}
 })
 export class MatCheckboxRequiredValidator extends CheckboxRequiredValidator {}


### PR DESCRIPTION
Currently the `mat-checkbox` required validator defines a host binding
that adds the "required" attribute to the `mat-checkbox` host element.

This is not necessary as the `required` attribute should be only added
to the underlying input element (which is handled as part of the checkbox
template).

This unnecessary host binding seems to have been added by
accident since the `CheckboxRequiredValidator` from `@angular/forms`
has the same host binding. Through the difference is that the
`CheckboxRequiredValidator` from `@angular/forms` is guaranteed
to have native input elements as host element.