### PR TITLE
Avoid unneeded slice+splice in _pageData

### DIFF
--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -266,14 +266,14 @@ export class MatTableDataSource<T> extends DataSource<T> {
   }
 
   /**
-   * Returns a paged splice of the provided data array according to the provided MatPaginator's page
+   * Returns a paged slice of the provided data array according to the provided MatPaginator's page
    * index and length. If there is no paginator provided, returns the data array as provided.
    */
   _pageData(data: T[]): T[] {
     if (!this.paginator) { return data; }
 
     const startIndex = this.paginator.pageIndex * this.paginator.pageSize;
-    return data.slice().splice(startIndex, this.paginator.pageSize);
+    return data.slice(startIndex, startIndex + this.paginator.pageSize);
   }
 
   /**


### PR DESCRIPTION
.slice().splice(index, pageSize) will create an unneeded full copy of the underlying data, and then also mutate it to splice a page. Neither of these operations are needed, and can be particularly slow for larger datasets.
.slice(index, index + indexPageSize) is almost constant time.

In case of a datasource with 1,000,000 rows (big, yes, but not absurdly so), pagination is currently visibly sluggish on my machine. Benchmarks seem to blame this: https://measurethat.net/Benchmarks/ShowResult/62222