### PR TITLE
fix(tabs): only use aria-current on active links

### DIFF
--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -80,13 +80,13 @@ describe('MatTabNavBar', () => {
 
       tabLink1.nativeElement.click();
       fixture.detectChanges();
-      expect(tabLinkElements[0].getAttribute('aria-current')).toEqual('true');
-      expect(tabLinkElements[1].getAttribute('aria-current')).toEqual('false');
+      expect(tabLinkElements[0].getAttribute('aria-current')).toEqual('page');
+      expect(tabLinkElements[1].hasAttribute('aria-current')).toEqual(false);
 
       tabLink2.nativeElement.click();
       fixture.detectChanges();
-      expect(tabLinkElements[0].getAttribute('aria-current')).toEqual('false');
-      expect(tabLinkElements[1].getAttribute('aria-current')).toEqual('true');
+      expect(tabLinkElements[0].hasAttribute('aria-current')).toEqual(false);
+      expect(tabLinkElements[1].getAttribute('aria-current')).toEqual('page');
     });
 
     it('should add the disabled class if disabled', () => {

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -168,7 +168,7 @@ const _MatTabLinkMixinBase:
   inputs: ['disabled', 'disableRipple', 'tabIndex'],
   host: {
     'class': 'mat-tab-link',
-    '[attr.aria-current]': 'active',
+    '[attr.aria-current]': 'active ? "page" : null',
     '[attr.aria-disabled]': 'disabled',
     '[attr.tabIndex]': 'tabIndex',
     '[class.mat-tab-disabled]': 'disabled',


### PR DESCRIPTION
We previously set `aria-current` to either "true" or "false" for each
`matTabLink`. This change now only applies the attribute to the active
tab, omitting it for inactive tabs. Additionally, instead of setting
true, we now set the attribute to "page", which specifically indicates
that the item is a link that refers to the current page.

Fixes #16557