### PR TITLE
fix(mdc chips) Fix matChipRemove Expression has changed error

### DIFF
--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -70,9 +70,13 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
     super.ngAfterContentInit();
 
     if (this.removeIcon) {
-      // removeIcon has tabIndex 0 for regular chips, but should only be focusable by
-      // the GridFocusKeyManager for row chips.
-      this.removeIcon.tabIndex = -1;
+      // Defer setting the value in order to avoid the "Expression
+      // has changed after it was checked" errors from Angular.
+      setTimeout(() => {
+        // removeIcon has tabIndex 0 for regular chips, but should only be focusable by
+        // the GridFocusKeyManager for row chips.
+        this.removeIcon.tabIndex = -1;
+      });
     }
   }
 


### PR DESCRIPTION
This line works fine with mat-icon, but was causing errors in a
unit test environment when matChipRemove was on a button element.

Defer the tab index update to avoid the errors.