### PR TITLE
_updateElementSize should not fail if pane is disposed.

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -359,6 +359,10 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
 
   /** Updates the size of the overlay element based on the overlay config. */
   private _updateElementSize() {
+    if (!this._pane) {
+      return;
+    }
+
     const style = this._pane.style;
 
     style.width = coerceCssPixelValue(this._config.width);


### PR DESCRIPTION
Note that this._pane will be set to null if the OverlayRef.dispose is called()

This could happen due to variety of reasons.