### PR TITLE
refactor(dialog): allow matDialogClose on non-button nodes

### DIFF
--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -25,7 +25,7 @@ let dialogElementUid = 0;
  * Button that will close the current dialog.
  */
 @Directive({
-  selector: `button[mat-dialog-close], button[matDialogClose]`,
+  selector: '[mat-dialog-close], [matDialogClose]',
   exportAs: 'matDialogClose',
   host: {
     '(click)': 'dialogRef.close(dialogResult)',


### PR DESCRIPTION
Loosens up the selector on `MatDialogClose` so that it can be added on everything, not just buttons.

Fixes #16597.