### PR TITLE
feat(material-experimental): add test harness for radio-group

### DIFF
--- a/src/material-experimental/mdc-radio/harness/radio-harness-filters.ts
+++ b/src/material-experimental/mdc-radio/harness/radio-harness-filters.ts
@@ -6,6 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export type RadioGroupHarnessFilters = {
+  id?: string;
+  name?: string;
+};
+
 export type RadioButtonHarnessFilters = {
   label?: string|RegExp,
   id?: string;

--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -21,6 +21,7 @@
         [disabled]="disabled"
         [tabIndex]="tabIndex"
         [attr.name]="name"
+        [attr.value]="value"
         [required]="required"
         [attr.aria-label]="ariaLabel"
         [attr.aria-labelledby]="ariaLabelledby"

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -657,6 +657,11 @@ describe('MatRadio', () => {
       expect(radioInstance.required).toBe(true);
     });
 
+    it('should add value attribute to the underlying input element', () => {
+      expect(fruitRadioNativeInputs[0].getAttribute('value')).toBe('banana');
+      expect(fruitRadioNativeInputs[1].getAttribute('value')).toBe('raspberry');
+    });
+
     it('should add aria-label attribute to the underlying input element if defined', () => {
       expect(fruitRadioNativeInputs[0].getAttribute('aria-label')).toBe('Banana');
     });


### PR DESCRIPTION
Follow-up for 583af19e9cc6fb37e1e4d32fe2abcf9700d12fff. This PR introduces a new test
harness for the `mat-radio-group` implementation.

Note that we can't provide harness methods for getting the selected
value because the selected value or the value of a radio-button are
part of the component-internal state (no way to determine from DOM)