### PR TITLE
fix(dialog): causing error when closing dialog on old browsers

### DIFF
--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -113,11 +113,11 @@ export class MatDialogRef<T, R = any> {
       // The logic that disposes of the overlay depends on the exit animation completing, however
       // it isn't guaranteed if the parent view is destroyed while it's running. Add a fallback
       // timeout which will clean everything up if the animation hasn't fired within the specified
-      // amount of time plus 100ms. We don't need to run this outside the NgZone, because for the
+      // amount of time plus 300ms. We don't need to run this outside the NgZone, because for the
       // vast majority of cases the timeout will have been cleared before it has the chance to fire.
       this._closeFallbackTimeout = setTimeout(() => {
         this._overlayRef.dispose();
-      }, event.totalTime + 100);
+      }, event.totalTime + 300);
     });
 
     this._containerInstance._startExitAnimation();


### PR DESCRIPTION
When fix on #16309 has released on @angular/material@8.0.2, some old browsers are emitting error when closing dialogs.

Error message: `ERROR DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is no longer a child of this node. Perhaps it was moved in a 'blur' event handler?(…)`

Adding timeout for destroying dialog is right, but maybe providing more time will be great.