### PR TITLE
feat(material-experimental): add menu test harness skeleton

### DIFF
--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -1,14 +1,17 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 
 ng_module(
     name = "mdc-menu",
     srcs = glob(
         ["**/*.ts"],
-        exclude = ["**/*.spec.ts"],
+        exclude = [
+            "**/*.spec.ts",
+            "harness/**",
+        ],
     ),
     assets = [":menu_scss"] + glob(["**/*.html"]),
     module_name = "@angular/material-experimental/mdc-menu",
@@ -19,6 +22,18 @@ ng_module(
         "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
+    ],
+)
+
+ts_library(
+    name = "harness",
+    srcs = glob(
+        ["harness/**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    deps = [
+        "//src/cdk-experimental/testing",
+        "//src/cdk/coercion",
     ],
 )
 
@@ -51,7 +66,10 @@ ng_test_library(
         exclude = ["**/*.e2e.spec.ts"],
     ),
     deps = [
+        ":harness",
         ":mdc-menu",
+        "//src/cdk-experimental/testing",
+        "//src/cdk-experimental/testing/testbed",
         "//src/cdk/a11y",
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
@@ -60,6 +78,7 @@ ng_test_library(
         "//src/cdk/scrolling",
         "//src/cdk/testing",
         "//src/material/core",
+        "//src/material/menu",
         "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],

--- a/src/material-experimental/mdc-menu/harness/mdc-menu-harness.ts
+++ b/src/material-experimental/mdc-menu/harness/mdc-menu-harness.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk-experimental/testing';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {MatMenuItemHarness} from './mdc-menu-item-harness';
+import {MenuHarnessFilters} from './menu-harness-filters';
+
+
+/**
+ * Harness for interacting with a MDC-based mat-menu in tests.
+ * @dynamic
+ */
+export class MatMenuHarness extends ComponentHarness {
+  static hostSelector = '.mat-menu-trigger';
+
+  // TODO: potentially extend MatButtonHarness
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
+   * @param options Options for narrowing the search:
+   *   - `label` finds a menu with specific label text.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: MenuHarnessFilters = {}): HarnessPredicate<MatMenuHarness> {
+    return new HarnessPredicate(MatMenuHarness)
+        .addOption('text', options.triggerText,
+            (harness, text) => HarnessPredicate.stringMatches(harness.getTriggerText(), text));
+  }
+
+  /** Gets a boolean promise indicating if the menu is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const disabled = (await this.host()).getAttribute('disabled');
+    return coerceBooleanProperty(await disabled);
+  }
+
+  async isOpen(): Promise<boolean> {
+    throw Error('not implemented');
+  }
+
+  async getTriggerText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Focuses the menu and returns a void promise that indicates when the action is complete. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the menu and returns a void promise that indicates when the action is complete. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  async open(): Promise<void> {
+    throw Error('not implemented');
+  }
+
+  async close(): Promise<void> {
+    throw Error('not implemented');
+  }
+
+  async getItems(): Promise<MatMenuItemHarness[]> {
+    throw Error('not implemented');
+  }
+
+  async getItemLabels(): Promise<string[]> {
+    throw Error('not implemented');
+  }
+
+  async getItemByLabel(): Promise<MatMenuItemHarness> {
+    throw Error('not implemented');
+  }
+
+  async getItemByIndex(): Promise<MatMenuItemHarness> {
+    throw Error('not implemented');
+  }
+
+  async getFocusedItem(): Promise<MatMenuItemHarness> {
+    throw Error('not implemented');
+  }
+}

--- a/src/material-experimental/mdc-menu/harness/mdc-menu-item-harness.ts
+++ b/src/material-experimental/mdc-menu/harness/mdc-menu-item-harness.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk-experimental/testing';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {MenuItemHarnessFilters} from './menu-harness-filters';
+
+
+/**
+ * Harness for interacting with a standard mat-menu in tests.
+ * @dynamic
+ */
+export class MatMenuItemHarness extends ComponentHarness {
+  static hostSelector = '.mat-menu-item';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
+   * @param options Options for narrowing the search:
+   *   - `label` finds a menu with specific label text.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: MenuItemHarnessFilters = {}): HarnessPredicate<MatMenuItemHarness> {
+    return new HarnessPredicate(MatMenuItemHarness); // TODO: add options here
+  }
+
+  /** Gets a boolean promise indicating if the menu is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const disabled = (await this.host()).getAttribute('disabled');
+    return coerceBooleanProperty(await disabled);
+  }
+
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Focuses the menu and returns a void promise that indicates when the action is complete. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the menu and returns a void promise that indicates when the action is complete. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+}

--- a/src/material-experimental/mdc-menu/harness/menu-harness-filters.ts
+++ b/src/material-experimental/mdc-menu/harness/menu-harness-filters.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export type MenuHarnessFilters = {
+  triggerText?: string | RegExp
+};
+
+export type MenuItemHarnessFilters = {
+  text?: string | RegExp
+};

--- a/src/material-experimental/mdc-menu/harness/menu-harness.spec.ts
+++ b/src/material-experimental/mdc-menu/harness/menu-harness.spec.ts
@@ -1,0 +1,107 @@
+import {HarnessLoader} from '@angular/cdk-experimental/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatMenuModule} from '@angular/material/menu';
+import {MatMenuModule as MatMdcMenuModule} from '../index';
+import {MatMenuHarness as MatMdcMenuHarness} from './mdc-menu-harness';
+import {MatMenuHarness} from './menu-harness';
+
+let fixture: ComponentFixture<MenuHarnessTest>;
+let loader: HarnessLoader;
+let menuHarness: typeof MatMenuHarness;
+
+describe('MatMenuHarness', () => {
+  describe('non-MDC-based', () => {
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [MatMenuModule],
+        declarations: [MenuHarnessTest],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuHarnessTest);
+      fixture.detectChanges();
+      loader = TestbedHarnessEnvironment.loader(fixture);
+      menuHarness = MatMenuHarness;
+    });
+
+    runTests();
+  });
+
+  describe('MDC-based', () => {
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [MatMdcMenuModule],
+        declarations: [MenuHarnessTest],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuHarnessTest);
+      fixture.detectChanges();
+      loader = TestbedHarnessEnvironment.loader(fixture);
+      // Public APIs are the same as MatMenuHarness, but cast is necessary because of different
+      // private fields.
+      menuHarness = MatMdcMenuHarness as any;
+    });
+
+    runTests();
+  });
+});
+
+/** Shared tests to run on both the original and MDC-based menues. */
+function runTests() {
+  it('should load all menu harnesses', async () => {
+    const menues = await loader.getAllHarnesses(menuHarness);
+    expect(menues.length).toBe(2);
+  });
+
+  it('should load menu with exact text', async () => {
+    const menus = await loader.getAllHarnesses(menuHarness.with({triggerText: 'Settings'}));
+    expect(menus.length).toBe(1);
+    expect(await menus[0].getTriggerText()).toBe('Settings');
+  });
+
+  it('should load menu with regex label match', async () => {
+    const menus = await loader.getAllHarnesses(menuHarness.with({triggerText: /settings/i}));
+    expect(menus.length).toBe(1);
+    expect(await menus[0].getTriggerText()).toBe('Settings');
+  });
+
+  it('should get disabled state', async () => {
+    const [enabledMenu, disabledMenu] = await loader.getAllHarnesses(menuHarness);
+    expect(await enabledMenu.isDisabled()).toBe(false);
+    expect(await disabledMenu.isDisabled()).toBe(true);
+  });
+
+  it('should get menu text', async () => {
+    const [firstMenu, secondMenu] = await loader.getAllHarnesses(menuHarness);
+    expect(await firstMenu.getTriggerText()).toBe('Settings');
+    expect(await secondMenu.getTriggerText()).toBe('Disabled menu');
+  });
+
+  it('should focus and blur a menu', async () => {
+    const menu = await loader.getHarness(menuHarness.with({triggerText: 'Settings'}));
+    expect(getActiveElementId()).not.toBe('settings');
+    await menu.focus();
+    expect(getActiveElementId()).toBe('settings');
+    await menu.blur();
+    expect(getActiveElementId()).not.toBe('settings');
+  });
+}
+
+function getActiveElementId() {
+  return document.activeElement ? document.activeElement.id : '';
+}
+
+@Component({
+  template: `
+      <button type="button" id="settings" [matMenuTriggerFor]="settingsMenu">Settings</button>
+      <button type="button" disabled [matMenuTriggerFor]="settingsMenu">Disabled menu</button>
+
+      <mat-menu #settingsMenu>
+        <menu mat-menu-item>Profile</menu>
+        <menu mat-menu-item>Account</menu>
+      </mat-menu>
+  `
+})
+class MenuHarnessTest { }
+

--- a/src/material-experimental/mdc-menu/harness/menu-harness.ts
+++ b/src/material-experimental/mdc-menu/harness/menu-harness.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk-experimental/testing';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {MenuHarnessFilters} from './menu-harness-filters';
+import {MatMenuItemHarness} from './menu-item-harness';
+
+/**
+ * Harness for interacting with a standard mat-menu in tests.
+ * @dynamic
+ */
+export class MatMenuHarness extends ComponentHarness {
+  static hostSelector = '.mat-menu-trigger';
+
+  // TODO: potentially extend MatButtonHarness
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
+   * @param options Options for narrowing the search:
+   *   - `label` finds a menu with specific label text.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: MenuHarnessFilters = {}): HarnessPredicate<MatMenuHarness> {
+    return new HarnessPredicate(MatMenuHarness)
+        .addOption('text', options.triggerText,
+            (harness, text) => HarnessPredicate.stringMatches(harness.getTriggerText(), text));
+  }
+
+  /** Gets a boolean promise indicating if the menu is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const disabled = (await this.host()).getAttribute('disabled');
+    return coerceBooleanProperty(await disabled);
+  }
+
+  async isOpen(): Promise<boolean> {
+    throw Error('not implemented');
+  }
+
+  async getTriggerText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Focuses the menu and returns a void promise that indicates when the action is complete. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the menu and returns a void promise that indicates when the action is complete. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  async open(): Promise<void> {
+    throw Error('not implemented');
+  }
+
+  async close(): Promise<void> {
+    throw Error('not implemented');
+  }
+
+  async getItems(): Promise<MatMenuItemHarness[]> {
+    throw Error('not implemented');
+  }
+
+  async getItemLabels(): Promise<string[]> {
+    throw Error('not implemented');
+  }
+
+  async getItemByLabel(): Promise<MatMenuItemHarness> {
+    throw Error('not implemented');
+  }
+
+  async getItemByIndex(): Promise<MatMenuItemHarness> {
+    throw Error('not implemented');
+  }
+
+  async getFocusedItem(): Promise<MatMenuItemHarness> {
+    throw Error('not implemented');
+  }
+}

--- a/src/material-experimental/mdc-menu/harness/menu-item-harness.ts
+++ b/src/material-experimental/mdc-menu/harness/menu-item-harness.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk-experimental/testing';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {MenuItemHarnessFilters} from './menu-harness-filters';
+
+
+/**
+ * Harness for interacting with a standard mat-menu in tests.
+ * @dynamic
+ */
+export class MatMenuItemHarness extends ComponentHarness {
+  static hostSelector = '.mat-menu-item';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
+   * @param options Options for narrowing the search:
+   *   - `label` finds a menu with specific label text.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: MenuItemHarnessFilters = {}): HarnessPredicate<MatMenuItemHarness> {
+    return new HarnessPredicate(MatMenuItemHarness); // TODO: add options here
+  }
+
+  /** Gets a boolean promise indicating if the menu is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const disabled = (await this.host()).getAttribute('disabled');
+    return coerceBooleanProperty(await disabled);
+  }
+
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Focuses the menu and returns a void promise that indicates when the action is complete. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the menu and returns a void promise that indicates when the action is complete. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+}

--- a/src/material-experimental/tsconfig.json
+++ b/src/material-experimental/tsconfig.json
@@ -8,6 +8,7 @@
       "@angular/cdk/*": ["../cdk/*"],
       "@angular/material/*": ["../material/*"],
       "@angular/cdk-experimental/*": ["../cdk-experimental/*"],
+      "@angular/material-experimental/*": ["../material-experimental/*"],
       "@material/*": ["../../node_modules/@material/*/index.d.ts"]
     }
   },

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -73,6 +73,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({passive: tr
 @Directive({
   selector: `[mat-menu-trigger-for], [matMenuTriggerFor]`,
   host: {
+    'class': 'mat-menu-trigger',
     'aria-haspopup': 'true',
     '[attr.aria-expanded]': 'menuOpen || null',
     '(mousedown)': '_handleMousedown($event)',


### PR DESCRIPTION
Adds a skeleton for the menu test harness. It currently captures the
basic functionality for the trigger. The functionality for the menu
panel/items will come in a follow-up PR. As part of this, I'm adding a
css class to the menu trigger so that it's findable via DOM.