### PR TITLE
build: enable noImplicitReturns compiler option

### DIFF
--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -12,6 +12,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -574,6 +574,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
 
       return verticalFit && horizontalFit;
     }
+    return false;
   }
 
   /**

--- a/src/cdk/schematics/tsconfig.json
+++ b/src/cdk/schematics/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "../../../dist/packages/cdk/schematics",
     "noEmitOnError": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -126,10 +126,8 @@ export class CdkNestedTreeNode<T> extends CdkTreeNode<T> implements AfterContent
   private _getNodeOutlet() {
     const outlets = this.nodeOutlet;
 
-    if (outlets) {
-      // Note that since we use `descendants: true` on the query, we have to ensure
-      // that we don't pick up the outlet of a child node by accident.
-      return outlets.find(outlet => !outlet._node || outlet._node === this);
-    }
+    // Note that since we use `descendants: true` on the query, we have to ensure
+    // that we don't pick up the outlet of a child node by accident.
+    return outlets && outlets.find(outlet => !outlet._node || outlet._node === this);
   }
 }

--- a/src/dev-app/tsconfig-aot.json
+++ b/src/dev-app/tsconfig-aot.json
@@ -9,6 +9,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/src/dev-app/tsconfig-build.json
+++ b/src/dev-app/tsconfig-build.json
@@ -10,6 +10,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitThis": true,
     "lib": ["es6", "es2015", "dom"],

--- a/src/material-examples/tsconfig-build.json
+++ b/src/material-examples/tsconfig-build.json
@@ -10,6 +10,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/src/material-moment-adapter/tsconfig-build.json
+++ b/src/material-moment-adapter/tsconfig-build.json
@@ -10,6 +10,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -188,6 +188,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
       const scale = this.bufferValue / 100;
       return {transform: `scaleX(${scale})`};
     }
+    return undefined;
   }
 
   ngAfterViewInit() {

--- a/src/material/schematics/tsconfig.json
+++ b/src/material/schematics/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "../../../dist/packages/material/schematics",
     "noEmitOnError": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "skipDefaultLibCheck": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,

--- a/src/universal-app/tsconfig-build.json
+++ b/src/universal-app/tsconfig-build.json
@@ -8,6 +8,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/src/universal-app/tsconfig-prerender.json
+++ b/src/universal-app/tsconfig-prerender.json
@@ -7,6 +7,7 @@
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/tools/dgeni/common/decorators.ts
+++ b/tools/dgeni/common/decorators.ts
@@ -49,15 +49,14 @@ export function isPrimaryModuleDoc(doc: any) {
 }
 
 export function getDirectiveSelectors(classDoc: CategorizedClassDoc) {
-  if (!classDoc.directiveMetadata) {
-    return;
-  }
+  if (classDoc.directiveMetadata) {
+    const directiveSelectors: string = classDoc.directiveMetadata.get('selector');
 
-  const directiveSelectors: string = classDoc.directiveMetadata.get('selector');
-
-  if (directiveSelectors) {
-    return directiveSelectors.replace(/[\r\n]/g, '').split(/\s*,\s*/).filter(s => s !== '');
+    if (directiveSelectors) {
+      return directiveSelectors.replace(/[\r\n]/g, '').split(/\s*,\s*/).filter(s => s !== '');
+    }
   }
+  return undefined;
 }
 
 export function hasMemberDecorator(doc: MemberDoc, decoratorName: string) {

--- a/tools/dgeni/common/property-bindings.ts
+++ b/tools/dgeni/common/property-bindings.ts
@@ -50,4 +50,6 @@ function getBindingPropertyData(doc: PropertyMemberDoc, metadata: Map<string, an
       alias: doc.decorators!.find(d => d.name == decoratorName)!.arguments![0]
     };
   }
+
+  return undefined;
 }

--- a/tools/dgeni/tsconfig.json
+++ b/tools/dgeni/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2015", "dom", "es2016.array.include"],
     "moduleResolution": "node",
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitThis": true,
     "noImplicitAny": true,

--- a/tools/gulp/tsconfig.json
+++ b/tools/gulp/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "outDir": "../../dist/tools/gulp",
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitThis": true,
     "noEmitOnError": true,

--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -117,11 +117,11 @@ export class PackageBundler {
       context: 'this',
       external: Object.keys(rollupGlobals),
       input: config.entry,
-      onwarn: (warning: any) => {
+      onwarn: (warning: {message: string, code: string}) => {
         // TODO(jelbourn): figure out *why* rollup warns about certain symbols not being found
         // when those symbols don't appear to be in the input file in the first place.
         if (/but never used/.test(warning.message)) {
-          return false;
+          return;
         }
 
         if (warning.code === 'CIRCULAR_DEPENDENCY') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Turns on the `noImplicitReturns` compiler option and fixes any errors that show up as a result.

Fixes #16669.