### PR TITLE
fix(material-experimental): typo in harness focus methods

### DIFF
--- a/src/material-experimental/mdc-button/harness/button-harness.spec.ts
+++ b/src/material-experimental/mdc-button/harness/button-harness.spec.ts
@@ -95,7 +95,7 @@ function runTests() {
   it('should focus and blur a button', async () => {
     const button = await loader.getHarness(buttonHarness.with({text: 'Basic button'}));
     expect(getActiveElementId()).not.toBe('basic');
-    await button.foucs();
+    await button.focus();
     expect(getActiveElementId()).toBe('basic');
     await button.blur();
     expect(getActiveElementId()).not.toBe('basic');

--- a/src/material-experimental/mdc-button/harness/button-harness.ts
+++ b/src/material-experimental/mdc-button/harness/button-harness.ts
@@ -56,7 +56,7 @@ export class MatButtonHarness extends ComponentHarness {
   }
 
   /** Focuses the button and returns a void promise that indicates when the action is complete. */
-  async foucs(): Promise<void> {
+  async focus(): Promise<void> {
     return (await this.host()).focus();
   }
 

--- a/src/material-experimental/mdc-button/harness/mdc-button-harness.ts
+++ b/src/material-experimental/mdc-button/harness/mdc-button-harness.ts
@@ -56,7 +56,7 @@ export class MatButtonHarness extends ComponentHarness {
   }
 
   /** Focuses the button and returns a void promise that indicates when the action is complete. */
-  async foucs(): Promise<void> {
+  async focus(): Promise<void> {
     return (await this.host()).focus();
   }
 

--- a/src/material-experimental/mdc-checkbox/harness/checkbox-harness.spec.ts
+++ b/src/material-experimental/mdc-checkbox/harness/checkbox-harness.spec.ts
@@ -128,13 +128,13 @@ function runTests() {
   it('should focus checkbox', async () => {
     const checkbox = await loader.getHarness(checkboxHarness.with({label: 'First'}));
     expect(getActiveElementTagName()).not.toBe('input');
-    await checkbox.foucs();
+    await checkbox.focus();
     expect(getActiveElementTagName()).toBe('input');
   });
 
   it('should blur checkbox', async () => {
     const checkbox = await loader.getHarness(checkboxHarness.with({label: 'First'}));
-    await checkbox.foucs();
+    await checkbox.focus();
     expect(getActiveElementTagName()).toBe('input');
     await checkbox.blur();
     expect(getActiveElementTagName()).not.toBe('input');

--- a/src/material-experimental/mdc-checkbox/harness/checkbox-harness.ts
+++ b/src/material-experimental/mdc-checkbox/harness/checkbox-harness.ts
@@ -89,7 +89,7 @@ export class MatCheckboxHarness extends ComponentHarness {
   }
 
   /** Focuses the checkbox and returns a void promise that indicates when the action is complete. */
-  async foucs(): Promise<void> {
+  async focus(): Promise<void> {
     return (await this._input()).focus();
   }
 

--- a/src/material-experimental/mdc-checkbox/harness/mdc-checkbox-harness.ts
+++ b/src/material-experimental/mdc-checkbox/harness/mdc-checkbox-harness.ts
@@ -89,7 +89,7 @@ export class MatCheckboxHarness extends ComponentHarness {
   }
 
   /** Focuses the checkbox and returns a void promise that indicates when the action is complete. */
-  async foucs(): Promise<void> {
+  async focus(): Promise<void> {
     return (await this._input()).focus();
   }
 

--- a/src/material-experimental/mdc-slide-toggle/harness/mdc-slide-toggle-harness.ts
+++ b/src/material-experimental/mdc-slide-toggle/harness/mdc-slide-toggle-harness.ts
@@ -79,7 +79,7 @@ export class MatSlideToggleHarness extends ComponentHarness {
   }
 
   /** Focuses the slide-toggle and returns a void promise that indicates action completion. */
-  async foucs(): Promise<void> {
+  async focus(): Promise<void> {
     return (await this._input()).focus();
   }
 

--- a/src/material-experimental/mdc-slide-toggle/harness/slide-toggle-harness.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/harness/slide-toggle-harness.spec.ts
@@ -120,13 +120,13 @@ function runTests() {
   it('should focus slide-toggle', async () => {
     const slideToggle = await loader.getHarness(slideToggleHarness.with({label: 'First'}));
     expect(getActiveElementTagName()).not.toBe('input');
-    await slideToggle.foucs();
+    await slideToggle.focus();
     expect(getActiveElementTagName()).toBe('input');
   });
 
   it('should blur slide-toggle', async () => {
     const slideToggle = await loader.getHarness(slideToggleHarness.with({label: 'First'}));
-    await slideToggle.foucs();
+    await slideToggle.focus();
     expect(getActiveElementTagName()).toBe('input');
     await slideToggle.blur();
     expect(getActiveElementTagName()).not.toBe('input');

--- a/src/material-experimental/mdc-slide-toggle/harness/slide-toggle-harness.ts
+++ b/src/material-experimental/mdc-slide-toggle/harness/slide-toggle-harness.ts
@@ -79,7 +79,7 @@ export class MatSlideToggleHarness extends ComponentHarness {
   }
 
   /** Focuses the slide-toggle and returns a void promise that indicates action completion. */
-  async foucs(): Promise<void> {
+  async focus(): Promise<void> {
     return (await this._input()).focus();
   }
 


### PR DESCRIPTION
Fixes a typo for the `focus` method in most of the available
test harnesses. Apparently a single instance of that typo
has spread across all other harnesses due to copy and paste.