### PR TITLE
fix(snack-bar): too tall under some circumstances in Safari

### DIFF
--- a/src/material/snack-bar/simple-snack-bar.scss
+++ b/src/material/snack-bar/simple-snack-bar.scss
@@ -14,7 +14,6 @@ $mat-snack-bar-button-vertical-margin:
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 100%;
   line-height: $mat-snack-bar-line-height;
   opacity: 1;
 }


### PR DESCRIPTION
Fixes the snack bar stretching to 100% of the viewport height in some cases in Safari.

Fixes #16605.