### PR TITLE
fix(drag-drop): unable to drop into connected sibling that was scrolled into view

### DIFF
--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -254,14 +254,7 @@ export class DropListRef<T = any> {
 
     // @breaking-change 9.0.0 Remove check for _viewportRuler once it's marked as a required param.
     if (this._viewportRuler) {
-      this._viewportScrollPosition = this._viewportRuler.getViewportScrollPosition();
-      this._viewportScrollSubscription = this._dragDropRegistry.scroll.subscribe(() => {
-        if (this.isDragging()) {
-          const newPosition = this._viewportRuler!.getViewportScrollPosition();
-          this._updateAfterScroll(this._viewportScrollPosition, newPosition.top, newPosition.left,
-                                  this._clientRect);
-        }
-      });
+      this._listenToScrollEvents();
     }
   }
 
@@ -854,6 +847,7 @@ export class DropListRef<T = any> {
     if (!activeSiblings.has(sibling)) {
       activeSiblings.add(sibling);
       this._cacheOwnPosition();
+      this._listenToScrollEvents();
     }
   }
 
@@ -863,6 +857,24 @@ export class DropListRef<T = any> {
    */
   _stopReceiving(sibling: DropListRef) {
     this._activeSiblings.delete(sibling);
+    this._viewportScrollSubscription.unsubscribe();
+  }
+
+  /**
+   * Starts listening to scroll events on the viewport.
+   * Used for updating the internal state of the list.
+   */
+  private _listenToScrollEvents() {
+    this._viewportScrollPosition = this._viewportRuler!.getViewportScrollPosition();
+    this._viewportScrollSubscription = this._dragDropRegistry.scroll.subscribe(() => {
+      if (this.isDragging()) {
+        const newPosition = this._viewportRuler!.getViewportScrollPosition();
+        this._updateAfterScroll(this._viewportScrollPosition, newPosition.top, newPosition.left,
+                                this._clientRect);
+      } else if (this.isReceiving()) {
+        this._cacheOwnPosition();
+      }
+    });
   }
 }
 


### PR DESCRIPTION
In the scenario where two drop lists are connected and one of them is scrolled out of view, even if the user scrolls it into view, the list won't accept the dragged item until the user starts a new drag sequence. The issue comes from the fact that we only update the cached dimensions of the list in which we're currently dragging, but not the ones that it's connected to. These changes fix the issue by also updating the dimensions of all connected lists.