### PR TITLE
test(paginator): fix setting paginator pageIndex

### DIFF
--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -164,7 +164,7 @@ describe('MatPaginator', () => {
   });
 
   it('should not allow a negative pageIndex', () => {
-    paginator.pageSize = -42;
+    paginator.pageIndex = -42;
     expect(paginator.pageIndex).toBeGreaterThanOrEqual(0);
   });
 


### PR DESCRIPTION
The negative `pageIndex` test, `it('should not allow a negative pageIndex')`, was incorrectly setting the `pageSize` as a negative number, which is already tested in the above `it('should not allow a negative pageSize')`. This fixes that presumably copy and paste issue by setting the `pageIndex` instead.