### PR TITLE
DatePicker: update names of weekdays in month view on init

### DIFF
--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -151,19 +151,6 @@ export class MatMonthView<D> implements AfterContentInit {
     this._init();
   }
 
-  /** Initializes the weekdays. */
-  _initWeekdays() {
-    const firstDayOfWeek = this._dateAdapter.getFirstDayOfWeek();
-    const narrowWeekdays = this._dateAdapter.getDayOfWeekNames('narrow');
-    const longWeekdays = this._dateAdapter.getDayOfWeekNames('long');
-
-    // Rotate the labels for days of the week based on the configured first day of the week.
-    let weekdays = longWeekdays.map((long, i) => {
-      return {long, narrow: narrowWeekdays[i]};
-    });
-    this._weekdays = weekdays.slice(firstDayOfWeek).concat(weekdays.slice(0, firstDayOfWeek));
-  }
-
   /** Handles when a new date is selected. */
   _dateSelected(date: number) {
     if (this._selectedDate != date) {
@@ -256,7 +243,6 @@ export class MatMonthView<D> implements AfterContentInit {
          this._dateAdapter.getFirstDayOfWeek()) % DAYS_PER_WEEK;
 
     this._initWeekdays();
-
     this._createWeekCells();
     this._changeDetectorRef.markForCheck();
   }
@@ -264,6 +250,19 @@ export class MatMonthView<D> implements AfterContentInit {
   /** Focuses the active cell after the microtask queue is empty. */
   _focusActiveCell() {
     this._matCalendarBody._focusActiveCell();
+  }
+
+  /** Initializes the weekdays. */
+  private _initWeekdays() {
+    const firstDayOfWeek = this._dateAdapter.getFirstDayOfWeek();
+    const narrowWeekdays = this._dateAdapter.getDayOfWeekNames('narrow');
+    const longWeekdays = this._dateAdapter.getDayOfWeekNames('long');
+
+    // Rotate the labels for days of the week based on the configured first day of the week.
+    let weekdays = longWeekdays.map((long, i) => {
+        return {long, narrow: narrowWeekdays[i]};
+    });
+    this._weekdays = weekdays.slice(firstDayOfWeek).concat(weekdays.slice(0, firstDayOfWeek));
   }
 
   /** Creates MatCalendarCells for the dates in this month. */

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -144,6 +144,15 @@ export class MatMonthView<D> implements AfterContentInit {
       throw createMissingDateImplError('MAT_DATE_FORMATS');
     }
 
+    this._activeDate = this._dateAdapter.today();
+  }
+
+  ngAfterContentInit() {
+    this._init();
+  }
+
+  /** Initializes the weekdays. */
+  _initWeekdays() {
     const firstDayOfWeek = this._dateAdapter.getFirstDayOfWeek();
     const narrowWeekdays = this._dateAdapter.getDayOfWeekNames('narrow');
     const longWeekdays = this._dateAdapter.getDayOfWeekNames('long');
@@ -153,12 +162,6 @@ export class MatMonthView<D> implements AfterContentInit {
       return {long, narrow: narrowWeekdays[i]};
     });
     this._weekdays = weekdays.slice(firstDayOfWeek).concat(weekdays.slice(0, firstDayOfWeek));
-
-    this._activeDate = this._dateAdapter.today();
-  }
-
-  ngAfterContentInit() {
-    this._init();
   }
 
   /** Handles when a new date is selected. */
@@ -251,6 +254,8 @@ export class MatMonthView<D> implements AfterContentInit {
     this._firstWeekOffset =
         (DAYS_PER_WEEK + this._dateAdapter.getDayOfWeek(firstOfMonth) -
          this._dateAdapter.getFirstDayOfWeek()) % DAYS_PER_WEEK;
+
+    this._initWeekdays();
 
     this._createWeekCells();
     this._changeDetectorRef.markForCheck();


### PR DESCRIPTION
This PR puts the initialization of weekdays in a method that's called on init of the month view. 

This is needed to update the month view correctly after a conversion to another calendar (https://github.com/dhlab-basel/JDNConvertibleCalendarDateAdapter/pull/15#discussion_r307621426).  