### PR TITLE
docs(dialog): add note about passing data to a template dialog

### DIFF
--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -76,6 +76,15 @@ export class YourDialog {
 }
 ```
 
+Note that if you're using a template dialog (one that was opened with a `TemplateRef`), the data
+will be available implicitly in the template:
+
+```html
+<ng-template let-data>
+  Hello, {{data.name}}
+</ng-template>
+```
+
 <!-- example(dialog-data) -->
 
 ### Dialog content


### PR DESCRIPTION
Based on the discussion in #16665, these changes add a note to the dialog docs about how to access the `data` inside a template dialog.