### PR TITLE
build: add API goldens for portal

### DIFF
--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -11,7 +11,7 @@ import {FocusTrapFactory} from '@angular/cdk/a11y';
 import {
   BasePortalOutlet,
   ComponentPortal,
-  PortalHostDirective,
+  CdkPortalOutlet,
   TemplatePortal
 } from '@angular/cdk/portal';
 import {DOCUMENT} from '@angular/common';
@@ -99,7 +99,7 @@ export class CdkDialogContainer extends BasePortalOutlet implements OnDestroy {
   // tslint:disable:no-host-decorator-in-concrete
 
   /** The portal host inside of this container into which the dialog content will be loaded. */
-  @ViewChild(PortalHostDirective, {static: true}) _portalHost: PortalHostDirective;
+  @ViewChild(CdkPortalOutlet, {static: true}) _portalHost: CdkPortalOutlet;
 
   /** A subject emitting before the dialog enters the view. */
   _beforeEnter: Subject<void> = new Subject();

--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -108,3 +108,9 @@ export class DomPortalOutlet extends BasePortalOutlet {
     return (componentRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement;
   }
 }
+
+/**
+ * @deprecated Use `DomPortalOutlet` instead.
+ * @breaking-change 9.0.0
+ */
+export class DomPortalHost extends DomPortalOutlet {}

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -27,7 +27,7 @@ import {BasePortalOutlet, ComponentPortal, Portal, TemplatePortal} from './porta
  * the directive instance itself can be attached to a host, enabling declarative use of portals.
  */
 @Directive({
-  selector: '[cdk-portal], [cdkPortal], [portal]',
+  selector: '[cdkPortal]',
   exportAs: 'cdkPortal',
 })
 export class CdkPortal extends TemplatePortal {
@@ -35,6 +35,20 @@ export class CdkPortal extends TemplatePortal {
     super(templateRef, viewContainerRef);
   }
 }
+
+/**
+ * @deprecated Use `CdkPortal` instead.
+ * @breaking-change 9.0.0
+ */
+@Directive({
+  selector: '[cdk-portal], [portal]',
+  exportAs: 'cdkPortal',
+  providers: [{
+    provide: CdkPortal,
+    useExisting: TemplatePortalDirective
+  }]
+})
+export class TemplatePortalDirective extends CdkPortal {}
 
 /**
  * Possible attached references to the CdkPortalOutlet.
@@ -50,8 +64,8 @@ export type CdkPortalOutletAttachedRef = ComponentRef<any> | EmbeddedViewRef<any
  * `<ng-template [cdkPortalOutlet]="greeting"></ng-template>`
  */
 @Directive({
-  selector: '[cdkPortalOutlet], [cdkPortalHost], [portalHost]',
-  exportAs: 'cdkPortalOutlet, cdkPortalHost',
+  selector: '[cdkPortalOutlet]',
+  exportAs: 'cdkPortalOutlet',
   inputs: ['portal: cdkPortalOutlet']
 })
 export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestroy {
@@ -158,9 +172,24 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
   }
 }
 
+/**
+ * @deprecated Use `CdkPortalOutlet` instead.
+ * @breaking-change 9.0.0
+ */
+@Directive({
+  selector: '[cdkPortalHost], [portalHost]',
+  exportAs: 'cdkPortalHost',
+  inputs: ['portal: cdkPortalHost'],
+  providers: [{
+    provide: CdkPortalOutlet,
+    useExisting: PortalHostDirective
+  }]
+})
+export class PortalHostDirective extends CdkPortalOutlet {}
+
 
 @NgModule({
-  exports: [CdkPortal, CdkPortalOutlet],
-  declarations: [CdkPortal, CdkPortalOutlet],
+  exports: [CdkPortal, CdkPortalOutlet, TemplatePortalDirective, PortalHostDirective],
+  declarations: [CdkPortal, CdkPortalOutlet, TemplatePortalDirective, PortalHostDirective],
 })
 export class PortalModule {}

--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -169,6 +169,11 @@ export interface PortalOutlet {
   hasAttached(): boolean;
 }
 
+/**
+ * @deprecated Use `PortalOutlet` instead.
+ * @breaking-change 9.0.0
+ */
+export type PortalHost = PortalOutlet;
 
 /**
  * Partial implementation of PortalOutlet that handles attaching
@@ -254,3 +259,9 @@ export abstract class BasePortalOutlet implements PortalOutlet {
     }
   }
 }
+
+/**
+ * @deprecated Use `BasePortalOutlet` instead.
+ * @breaking-change 9.0.0
+ */
+export abstract class BasePortalHost extends BasePortalOutlet {}

--- a/src/cdk/portal/public-api.ts
+++ b/src/cdk/portal/public-api.ts
@@ -10,10 +10,3 @@ export * from './portal';
 export * from './dom-portal-outlet';
 export * from './portal-directives';
 export * from './portal-injector';
-
-export {DomPortalOutlet as DomPortalHost} from './dom-portal-outlet';
-export {
-  CdkPortalOutlet as PortalHostDirective,
-  CdkPortal as TemplatePortalDirective,
-} from './portal-directives';
-export {PortalOutlet as PortalHost, BasePortalOutlet as BasePortalHost} from './portal';

--- a/tools/public_api_guard/BUILD.bazel
+++ b/tools/public_api_guard/BUILD.bazel
@@ -2,8 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 load(":generate-guard-tests.bzl", "generate_test_targets")
 
-# TODO(devversion): All entry-points except the CDK portal are currently validated. This is
-# because aliases are not supported by ts-api-guardian. Re-add once we found a solution for that.
-
 # Generate the API guard test targets for each golden file in the current package.
 generate_test_targets(glob(["**/*.d.ts"]))

--- a/tools/public_api_guard/cdk/portal.d.ts
+++ b/tools/public_api_guard/cdk/portal.d.ts
@@ -1,0 +1,96 @@
+export declare abstract class BasePortalHost extends BasePortalOutlet {
+}
+
+export declare abstract class BasePortalOutlet implements PortalOutlet {
+    protected _attachedPortal: Portal<any> | null;
+    attach<T>(portal: ComponentPortal<T>): ComponentRef<T>;
+    attach<T>(portal: TemplatePortal<T>): EmbeddedViewRef<T>;
+    attach(portal: any): any;
+    abstract attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
+    abstract attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C>;
+    detach(): void;
+    dispose(): void;
+    hasAttached(): boolean;
+    setDisposeFn(fn: () => void): void;
+}
+
+export declare class CdkPortal extends TemplatePortal {
+    constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef);
+}
+
+export declare class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestroy {
+    attached: EventEmitter<CdkPortalOutletAttachedRef>;
+    readonly attachedRef: CdkPortalOutletAttachedRef;
+    portal: Portal<any> | null;
+    constructor(_componentFactoryResolver: ComponentFactoryResolver, _viewContainerRef: ViewContainerRef);
+    attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
+    attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C>;
+    ngOnDestroy(): void;
+    ngOnInit(): void;
+}
+
+export declare type CdkPortalOutletAttachedRef = ComponentRef<any> | EmbeddedViewRef<any> | null;
+
+export declare class ComponentPortal<T> extends Portal<ComponentRef<T>> {
+    component: ComponentType<T>;
+    componentFactoryResolver?: ComponentFactoryResolver | null;
+    injector?: Injector | null;
+    viewContainerRef?: ViewContainerRef | null;
+    constructor(component: ComponentType<T>, viewContainerRef?: ViewContainerRef | null, injector?: Injector | null, componentFactoryResolver?: ComponentFactoryResolver | null);
+}
+
+export interface ComponentType<T> {
+    new (...args: any[]): T;
+}
+
+export declare class DomPortalHost extends DomPortalOutlet {
+}
+
+export declare class DomPortalOutlet extends BasePortalOutlet {
+    outletElement: Element;
+    constructor(
+    outletElement: Element, _componentFactoryResolver: ComponentFactoryResolver, _appRef: ApplicationRef, _defaultInjector: Injector);
+    attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
+    attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C>;
+    dispose(): void;
+}
+
+export declare abstract class Portal<T> {
+    readonly isAttached: boolean;
+    attach(host: PortalOutlet): T;
+    detach(): void;
+    setAttachedHost(host: PortalOutlet | null): void;
+}
+
+export declare type PortalHost = PortalOutlet;
+
+export declare class PortalHostDirective extends CdkPortalOutlet {
+}
+
+export declare class PortalInjector implements Injector {
+    constructor(_parentInjector: Injector, _customTokens: WeakMap<any, any>);
+    get(token: any, notFoundValue?: any): any;
+}
+
+export declare class PortalModule {
+}
+
+export interface PortalOutlet {
+    attach(portal: Portal<any>): any;
+    detach(): any;
+    dispose(): void;
+    hasAttached(): boolean;
+}
+
+export declare class TemplatePortal<C = any> extends Portal<EmbeddedViewRef<C>> {
+    context: C | undefined;
+    readonly origin: ElementRef;
+    templateRef: TemplateRef<C>;
+    viewContainerRef: ViewContainerRef;
+    constructor(template: TemplateRef<C>, viewContainerRef: ViewContainerRef, context?: C);
+    attach(host: PortalOutlet, context?: C | undefined): EmbeddedViewRef<C>;
+    detach(): void;
+}
+
+export declare class TemplatePortalDirective extends CdkPortal {
+}


### PR DESCRIPTION
Adds API goldens for the portal package and fixes some compilation errors that showed up when I was trying to generate it.

**Note:** this is another try at #16655 which caused some issues in G3. I've moved a few things around so that the directives don't collide.