### PR TITLE
fix(material-experimental/mdc-chips): ripple not being clipped in Safari

### DIFF
--- a/src/material-experimental/mdc-chips/chips.scss
+++ b/src/material-experimental/mdc-chips/chips.scss
@@ -11,6 +11,8 @@
   cursor: default;
   // Needed to prevent mat-ripple from escaping the chip
   overflow: hidden;
+  // Required for the ripple to clip properly in Safari.
+  transform: translateZ(0);
 }
 
 // The MDC chip styles related to hover and focus states are intertwined with the MDC ripple styles.


### PR DESCRIPTION
Fixes the ripple inside a `mat-chip` not clipping to the border radius in Safari.