### PR TITLE
fix(material-experimental/mdc-chips): incorrect selector for mdc-chip-avatar

### DIFF
--- a/src/material-experimental/mdc-chips/chip-option.html
+++ b/src/material-experimental/mdc-chips/chip-option.html
@@ -1,7 +1,7 @@
-<ng-content select="[mat-chip-avatar], [matChipAvatar]"></ng-content>
+<ng-content select="mat-chip-avatar, [matChipAvatar]"></ng-content>
 <svg *ngIf="_chipListMultiple" class="mdc-chip__checkmark-svg" viewBox="-2 -3 30 30">
   <path class="mdc-chip__checkmark-path" fill="none" stroke="black"
     d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
 </svg>
 <div class="mdc-chip__text"><ng-content></ng-content></div>
-<ng-content select="[mat-chip-trailing-icon],[matChipRemove],[matChipTrailingIcon]"></ng-content>
+<ng-content select="mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"></ng-content>

--- a/src/material-experimental/mdc-chips/chip-row.html
+++ b/src/material-experimental/mdc-chips/chip-row.html
@@ -1,8 +1,8 @@
 <div role="gridcell">
   <div #chipContent tabindex="-1" class="mat-chip-row-focusable-text-content">
-  	 <ng-content select="[mat-chip-avatar], [matChipAvatar]"></ng-content>
+  	 <ng-content select="mat-chip-avatar, [matChipAvatar]"></ng-content>
   	 <span class="mdc-chip__text"><ng-content></ng-content></span>
-  	 <ng-content select="[mat-chip-trailing-icon],[matChipTrailingIcon]"></ng-content>
+  	 <ng-content select="mat-chip-trailing-icon,[matChipTrailingIcon]"></ng-content>
   </div>
 </div>
 <div role="gridcell" *ngIf="removeIcon">

--- a/src/material-experimental/mdc-chips/chip.html
+++ b/src/material-experimental/mdc-chips/chip.html
@@ -1,3 +1,3 @@
-<ng-content select="[mat-chip-avatar], [matChipAvatar]"></ng-content>
+<ng-content select="mat-chip-avatar, [matChipAvatar]"></ng-content>
 <div class="mdc-chip__text"><ng-content></ng-content></div>
-<ng-content select="[mat-chip-trailing-icon],[matChipRemove],[matChipTrailingIcon]"></ng-content>
+<ng-content select="mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"></ng-content>


### PR DESCRIPTION
The selector for `MatChipAvatar` is: `'mat-chip-avatar, [matChipAvatar]'`

Chips are selecting `[mat-chip-avatar]` instead of `mat-chip-avatar`, causing incorrect styling on the rendered chips