### PR TITLE
fix(a11y): unable to clear pending message using clear method

### DIFF
--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -92,6 +92,19 @@ describe('LiveAnnouncer', () => {
       expect(ariaLiveElement.textContent).toBe('Hello there');
     }));
 
+    it('should synchronously clear a message even if not yet displayed', fakeAsync(() => {
+      announcer.announce('Hey Google');
+
+      announcer.clear();
+      expect(ariaLiveElement.textContent).toBeFalsy();
+
+      // This flushes our 100ms timeout for the screenreaders.
+      tick(110);
+
+      // Should not have displayed in the meantime
+      expect(ariaLiveElement.textContent).toBeFalsy();
+    }));
+
     it('should remove the aria-live element from the DOM on destroy', fakeAsync(() => {
       announcer.announce('Hey Google');
 

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -137,6 +137,7 @@ export class LiveAnnouncer implements OnDestroy {
    * through the page landmarks.
    */
   clear() {
+    clearTimeout(this._previousTimeout);
     if (this._liveElement) {
       this._liveElement.textContent = '';
     }


### PR DESCRIPTION
Currently the announcer waits 100ms before announcing, to work around some screenreader issues (apparently). However, when doing ".clear()", it did not kill of any "not yet displayed" announcements.

This is particularly painful when cleaning up unittets, as the announcements would appear after the "liveAnnouncer.clear()" "snackBar.dismiss()" calls in our afterEach.

You’ll notice that in the unittests, you were manually calling "ngOnDestroy()", probably to work around said issue. Just calling ".clear()" is fine now, and will also be fine to clients.