### PR TITLE
feat(material-experimental/mdc-chips): add harness skeleton

### DIFF
--- a/src/material-experimental/mdc-chips/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/BUILD.bazel
@@ -1,13 +1,16 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 ng_module(
     name = "mdc-chips",
     srcs = glob(
         ["**/*.ts"],
-        exclude = ["**/*.spec.ts"],
+        exclude = [
+            "**/*.spec.ts",
+            "harness/**",
+        ],
     ),
     assets = [":chips_scss"] + glob(["**/*.html"]),
     module_name = "@angular/material-experimental/mdc-chips",
@@ -20,6 +23,17 @@ ng_module(
         "@npm//@angular/forms",
         "@npm//@material/chips",
         "@npm//@material/ripple",
+    ],
+)
+
+ts_library(
+    name = "harness",
+    srcs = glob(
+        ["harness/**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    deps = [
+        "//src/cdk-experimental/testing",
     ],
 )
 
@@ -52,7 +66,10 @@ ng_test_library(
         exclude = ["**/*.e2e.spec.ts"],
     ),
     deps = [
+        ":harness",
         ":mdc-chips",
+        "//src/cdk-experimental/testing",
+        "//src/cdk-experimental/testing/testbed",
         "//src/cdk/a11y",
         "//src/cdk/bidi",
         "//src/cdk/keycodes",

--- a/src/material-experimental/mdc-chips/harness/chip-grid-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-grid-harness.spec.ts
@@ -1,0 +1,52 @@
+import {HarnessLoader} from '@angular/cdk-experimental/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChipsModule} from '../index';
+import {MatChipGridHarness} from './chip-grid-harness';
+
+let fixture: ComponentFixture<ChipGridHarnessTest>;
+let loader: HarnessLoader;
+
+describe('MatChipGridHarness', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [ChipGridHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipGridHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should get correct number of grid harnesses', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipGridHarness);
+    expect(harnesses.length).toBe(1);
+  });
+
+  it('should get correct number of rows', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipGridHarness);
+    const rows = await harnesses[0].getRows();
+    expect(rows.length).toBe(3);
+  });
+
+  it('should get the chip input harness', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipGridHarness);
+    const input = await harnesses[0].getInput();
+    expect(await input).not.toBe(null);
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip-grid #grid>
+      <mat-chip-row> Chip A </mat-chip-row>
+      <mat-chip-row> Chip B </mat-chip-row>
+      <mat-chip-row> Chip C </mat-chip-row>
+      <input [matChipInputFor]="grid" />
+    </mat-chip-grid>
+  `
+})
+class ChipGridHarnessTest {}
+

--- a/src/material-experimental/mdc-chips/harness/chip-grid-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-grid-harness.spec.ts
@@ -33,7 +33,7 @@ describe('MatChipGridHarness', () => {
 
   it('should get the chip input harness', async () => {
     const harnesses = await loader.getAllHarnesses(MatChipGridHarness);
-    const input = await harnesses[0].getInput();
+    const input = await harnesses[0].getTextInput();
     expect(await input).not.toBe(null);
   });
 });

--- a/src/material-experimental/mdc-chips/harness/chip-grid-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-grid-harness.ts
@@ -25,8 +25,8 @@ export class MatChipGridHarness extends ComponentHarness {
     return await this._rows();
   }
 
-  /** Gets promise of the chip input harness. */
-  async getInput(): Promise<MatChipInputHarness|null> {
+  /** Gets promise of the chip text input harness. */
+  async getTextInput(): Promise<MatChipInputHarness|null> {
     return await this._input();
   }
 }

--- a/src/material-experimental/mdc-chips/harness/chip-grid-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-grid-harness.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness} from '@angular/cdk-experimental/testing';
+import {MatChipRowHarness} from './chip-row-harness';
+import {MatChipInputHarness} from './chip-input';
+
+/**
+ * Harness for interacting with a mat-chip-grid in tests.
+ * @dynamic
+ */
+export class MatChipGridHarness extends ComponentHarness {
+  static hostSelector = 'mat-chip-grid';
+
+  private _rows = this.locatorForAll(MatChipRowHarness);
+  private _input = this.locatorFor(MatChipInputHarness);
+
+  /** Gets promise of the harnesses for the chip rows. */
+  async getRows(): Promise<MatChipRowHarness[]> {
+    return await this._rows();
+  }
+
+  /** Gets promise of the chip input harness. */
+  async getInput(): Promise<MatChipInputHarness|null> {
+    return await this._input();
+  }
+}

--- a/src/material-experimental/mdc-chips/harness/chip-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-harness.spec.ts
@@ -31,12 +31,6 @@ describe('MatChipHarness', () => {
     expect(await harnesses[1].getText()).toBe('Chip');
     expect(await harnesses[2].getText()).toBe('Disabled Chip');
   });
-
-  it('should get the disabled state', async () => {
-    const harnesses = await loader.getAllHarnesses(MatChipHarness);
-    expect(await harnesses[0].isDisabled()).toBe(false);
-    expect(await harnesses[2].isDisabled()).toBe(true);
-  });
 });
 
 @Component({

--- a/src/material-experimental/mdc-chips/harness/chip-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-harness.spec.ts
@@ -1,0 +1,50 @@
+import {HarnessLoader} from '@angular/cdk-experimental/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChipsModule} from '../index';
+import {MatChipHarness} from './chip-harness';
+
+let fixture: ComponentFixture<ChipHarnessTest>;
+let loader: HarnessLoader;
+
+describe('MatChipHarness', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [ChipHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should get correct number of chip harnesses', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipHarness);
+    expect(harnesses.length).toBe(3);
+  });
+
+  it('should get the chip text content', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipHarness);
+    expect(await harnesses[0].getTextContent()).toBe('Basic Chip');
+    expect(await harnesses[1].getTextContent()).toBe('Chip');
+    expect(await harnesses[2].getTextContent()).toBe('Disabled Chip');
+  });
+
+  it('should get the disabled state', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipHarness);
+    expect(await harnesses[0].isDisabled()).toBe(false);
+    expect(await harnesses[2].isDisabled()).toBe(true);
+  });
+});
+
+@Component({
+  template: `
+    <mat-basic-chip> Basic Chip </mat-basic-chip>
+    <mat-chip> Chip </mat-chip>
+    <mat-chip disabled> Disabled Chip </mat-chip>
+  `
+})
+class ChipHarnessTest {}
+

--- a/src/material-experimental/mdc-chips/harness/chip-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-harness.spec.ts
@@ -27,9 +27,9 @@ describe('MatChipHarness', () => {
 
   it('should get the chip text content', async () => {
     const harnesses = await loader.getAllHarnesses(MatChipHarness);
-    expect(await harnesses[0].getTextContent()).toBe('Basic Chip');
-    expect(await harnesses[1].getTextContent()).toBe('Chip');
-    expect(await harnesses[2].getTextContent()).toBe('Disabled Chip');
+    expect(await harnesses[0].getText()).toBe('Basic Chip');
+    expect(await harnesses[1].getText()).toBe('Chip');
+    expect(await harnesses[2].getText()).toBe('Disabled Chip');
   });
 
   it('should get the disabled state', async () => {

--- a/src/material-experimental/mdc-chips/harness/chip-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-harness.ts
@@ -16,13 +16,12 @@ export class MatChipHarness extends ComponentHarness {
   static hostSelector = 'mat-basic-chip, mat-chip';
 
   /** Gets a promise for the text content the option. */
-  async getTextContent(): Promise<string> {
+  async getText(): Promise<string> {
     return (await this.host()).text();
   }
 
   /** Gets a promise for the disabled state. */
   async isDisabled(): Promise<boolean> {
-    const ariaSelected = (await this.host()).getAttribute('aria-disabled');
-    return await ariaSelected === 'true';
+    return await ((await this.host()).getAttribute('aria-disabled')) === 'true';
   }
 }

--- a/src/material-experimental/mdc-chips/harness/chip-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-harness.ts
@@ -19,9 +19,4 @@ export class MatChipHarness extends ComponentHarness {
   async getText(): Promise<string> {
     return (await this.host()).text();
   }
-
-  /** Gets a promise for the disabled state. */
-  async isDisabled(): Promise<boolean> {
-    return await ((await this.host()).getAttribute('aria-disabled')) === 'true';
-  }
 }

--- a/src/material-experimental/mdc-chips/harness/chip-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-harness.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness} from '@angular/cdk-experimental/testing';
+
+/**
+ * Harness for interacting with a mat-chip in tests.
+ * @dynamic
+ */
+export class MatChipHarness extends ComponentHarness {
+  static hostSelector = 'mat-basic-chip, mat-chip';
+
+  /** Gets a promise for the text content the option. */
+  async getTextContent(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Gets a promise for the disabled state. */
+  async isDisabled(): Promise<boolean> {
+    const ariaSelected = (await this.host()).getAttribute('aria-disabled');
+    return await ariaSelected === 'true';
+  }
+}

--- a/src/material-experimental/mdc-chips/harness/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-input.spec.ts
@@ -1,0 +1,47 @@
+import {HarnessLoader} from '@angular/cdk-experimental/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChipsModule} from '../index';
+import {MatChipInputHarness} from './chip-input';
+
+let fixture: ComponentFixture<ChipInputHarnessTest>;
+let loader: HarnessLoader;
+
+describe('MatChipInputHarness', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [ChipInputHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipInputHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should get correct number of chip input harnesses', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipInputHarness);
+    expect(harnesses.length).toBe(2);
+  });
+
+  it('should get the disabled state', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipInputHarness);
+    expect(await harnesses[0].isDisabled()).toBe(false);
+    expect(await harnesses[1].isDisabled()).toBe(true);
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip-grid #grid1>
+      <input [matChipInputFor]="grid1" />
+    </mat-chip-grid>
+
+    <mat-chip-grid #grid2>
+      <input [matChipInputFor]="grid2" disabled />
+    </mat-chip-grid>
+  `
+})
+class ChipInputHarnessTest {}
+

--- a/src/material-experimental/mdc-chips/harness/chip-input.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-input.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness} from '@angular/cdk-experimental/testing';
+
+/**
+ * Harness for interacting with a grid's chip input in tests.
+ * @dynamic
+ */
+export class MatChipInputHarness extends ComponentHarness {
+  static hostSelector = 'input.mat-mdc-chip-input';
+
+  /** Gets a promise for the disabled state. */
+  async isDisabled(): Promise<boolean> {
+    const ariaSelected = (await this.host()).getAttribute('disabled');
+    return await ariaSelected === 'true';
+  }
+
+  /** Gets a promise for the placeholder text. */
+  async getPlaceholder(): Promise<string|null> {
+    return (await this.host()).getAttribute('placeholder');
+  }
+}

--- a/src/material-experimental/mdc-chips/harness/chip-input.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-input.ts
@@ -13,12 +13,11 @@ import {ComponentHarness} from '@angular/cdk-experimental/testing';
  * @dynamic
  */
 export class MatChipInputHarness extends ComponentHarness {
-  static hostSelector = 'input.mat-mdc-chip-input';
+  static hostSelector = '.mat-mdc-chip-input';
 
   /** Gets a promise for the disabled state. */
   async isDisabled(): Promise<boolean> {
-    const ariaSelected = (await this.host()).getAttribute('disabled');
-    return await ariaSelected === 'true';
+    return await ((await this.host()).getAttribute('disabled')) === 'true';
   }
 
   /** Gets a promise for the placeholder text. */

--- a/src/material-experimental/mdc-chips/harness/chip-listbox-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-listbox-harness.spec.ts
@@ -1,0 +1,88 @@
+import {HarnessLoader} from '@angular/cdk-experimental/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChipsModule} from '../index';
+import {MatChipListboxHarness} from './chip-listbox-harness';
+
+let fixture: ComponentFixture<ChipListboxHarnessTest>;
+let loader: HarnessLoader;
+
+describe('MatChipListboxHarness', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [ChipListboxHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipListboxHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should get correct number of listbox harnesses', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
+    expect(harnesses.length).toBe(1);
+  });
+
+  it('should get the number of options', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
+    expect ((await harnesses[0].getOptions()).length).toBe(4);
+  });
+
+  describe('should get selection', async () => {
+    it('with no selected options', async () => {
+      const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
+      const selectedOption = await harnesses[0].getSelected();
+      expect(await selectedOption.length).toBe(0);
+    });
+
+    it('with a single selected option', async () => {
+      fixture.componentInstance.options[0].selected = true;
+      fixture.detectChanges();
+
+      const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
+      const selectedOption = await harnesses[0].getSelected();
+      expect(await selectedOption.length).toBe(1);
+      expect(await selectedOption[0].getTextContent()).toContain('Blue');
+    });
+
+    it('with multiple selected options', async () => {
+      fixture.componentInstance.enableMultipleSelection = true;
+      fixture.componentInstance.options[0].selected = true;
+      fixture.componentInstance.options[1].selected = true;
+      fixture.detectChanges();
+
+      const harnesses = (await loader.getAllHarnesses(MatChipListboxHarness));
+      const selectedOption = await harnesses[0].getSelected();
+      expect(await selectedOption.length).toBe(2);
+      expect(await selectedOption[0].getTextContent()).toContain('Blue');
+      expect(await selectedOption[1].getTextContent()).toContain('Green');
+    });
+  });
+});
+
+interface ExampleOption {
+  selected: boolean;
+  text: string;
+}
+
+@Component({
+  template: `
+    <mat-chip-listbox [multiple]="enableMultipleSelection">
+      <mat-chip-option *ngFor="let option of options" [selected]="option.selected">
+        {{option.text}}
+      </mat-chip-option>
+    </mat-chip-listbox>
+  `
+})
+class ChipListboxHarnessTest {
+  enableMultipleSelection = false;
+  options: ExampleOption[] = [
+    {text: 'Blue', selected: false},
+    {text: 'Green', selected: false},
+    {text: 'Red', selected: false},
+    {text: 'Yellow', selected: false},
+  ];
+}
+

--- a/src/material-experimental/mdc-chips/harness/chip-listbox-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-listbox-harness.spec.ts
@@ -44,7 +44,7 @@ describe('MatChipListboxHarness', () => {
       const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
       const selectedOption = await harnesses[0].getSelected();
       expect(await selectedOption.length).toBe(1);
-      expect(await selectedOption[0].getTextContent()).toContain('Blue');
+      expect(await selectedOption[0].getText()).toContain('Blue');
     });
 
     it('with multiple selected options', async () => {
@@ -56,8 +56,8 @@ describe('MatChipListboxHarness', () => {
       const harnesses = (await loader.getAllHarnesses(MatChipListboxHarness));
       const selectedOption = await harnesses[0].getSelected();
       expect(await selectedOption.length).toBe(2);
-      expect(await selectedOption[0].getTextContent()).toContain('Blue');
-      expect(await selectedOption[1].getTextContent()).toContain('Green');
+      expect(await selectedOption[0].getText()).toContain('Blue');
+      expect(await selectedOption[1].getText()).toContain('Green');
     });
   });
 });

--- a/src/material-experimental/mdc-chips/harness/chip-listbox-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-listbox-harness.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness} from '@angular/cdk-experimental/testing';
+import {MatChipOptionHarness} from './chip-option-harness';
+
+/**
+ * Harness for interacting with a mat-chip-listbox in tests.
+ * @dynamic
+ */
+export class MatChipListboxHarness extends ComponentHarness {
+  static hostSelector = 'mat-chip-listbox';
+
+  private _options = this.locatorForAll(MatChipOptionHarness);
+
+  /** Gets promise of the harnesses for the chip options in the listbox. */
+  async getOptions(): Promise<MatChipOptionHarness[]> {
+    return await this._options();
+  }
+
+  /** Gets promise of the selected options. */
+  async getSelected(): Promise<MatChipOptionHarness[]> {
+    const options = await this._options();
+    return Promise.all(options.map(o => o.isSelected())).then(isSelectedStates => {
+      const selectedOptions: MatChipOptionHarness[] = [];
+      isSelectedStates.forEach((isSelectedOption, index) => {
+        if (isSelectedOption) {
+          selectedOptions.push(options[index]);
+        }
+      });
+      return selectedOptions;
+    });
+  }
+}

--- a/src/material-experimental/mdc-chips/harness/chip-option-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-option-harness.spec.ts
@@ -1,0 +1,46 @@
+import {HarnessLoader} from '@angular/cdk-experimental/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChipsModule} from '../index';
+import {MatChipOptionHarness} from './chip-option-harness';
+
+let fixture: ComponentFixture<ChipOptionHarnessTest>;
+let loader: HarnessLoader;
+
+describe('MatChipOptionHarness', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [ChipOptionHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipOptionHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should get correct number of chip harnesses', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipOptionHarness);
+    expect(harnesses.length).toBe(3);
+  });
+
+  it('should get whether the chip is selected', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipOptionHarness);
+    expect(await harnesses[0].isSelected()).toBe(false);
+    expect(await harnesses[1].isSelected()).toBe(false);
+    expect(await harnesses[2].isSelected()).toBe(true);
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip-listbox>
+      <mat-basic-chip-option> Basic Chip Option </mat-basic-chip-option>
+      <mat-chip-option> Chip Option </mat-chip-option>
+      <mat-chip-option selected> Selected Chip Option </mat-chip-option>
+    </mat-chip-listbox>
+  `
+})
+class ChipOptionHarnessTest {}
+

--- a/src/material-experimental/mdc-chips/harness/chip-option-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-option-harness.spec.ts
@@ -22,7 +22,7 @@ describe('MatChipOptionHarness', () => {
 
   it('should get correct number of chip harnesses', async () => {
     const harnesses = await loader.getAllHarnesses(MatChipOptionHarness);
-    expect(harnesses.length).toBe(3);
+    expect(harnesses.length).toBe(4);
   });
 
   it('should get whether the chip is selected', async () => {
@@ -30,6 +30,12 @@ describe('MatChipOptionHarness', () => {
     expect(await harnesses[0].isSelected()).toBe(false);
     expect(await harnesses[1].isSelected()).toBe(false);
     expect(await harnesses[2].isSelected()).toBe(true);
+  });
+
+  it('should get the disabled state', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipOptionHarness);
+    expect(await harnesses[0].isDisabled()).toBe(false);
+    expect(await harnesses[3].isDisabled()).toBe(true);
   });
 });
 
@@ -39,6 +45,7 @@ describe('MatChipOptionHarness', () => {
       <mat-basic-chip-option> Basic Chip Option </mat-basic-chip-option>
       <mat-chip-option> Chip Option </mat-chip-option>
       <mat-chip-option selected> Selected Chip Option </mat-chip-option>
+      <mat-chip-option disabled> Chip Option </mat-chip-option>
     </mat-chip-listbox>
   `
 })

--- a/src/material-experimental/mdc-chips/harness/chip-option-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-option-harness.ts
@@ -15,8 +15,13 @@ import {MatChipHarness} from './chip-harness';
 export class MatChipOptionHarness extends MatChipHarness {
   static hostSelector = 'mat-basic-chip-option, mat-chip-option';
 
+  /** Gets a promise for the selected state. */
   async isSelected(): Promise<boolean> {
-    const ariaSelected = (await this.host()).getAttribute('aria-selected');
-    return await ariaSelected === 'true';
+    return await ((await this.host()).getAttribute('aria-selected')) === 'true';
+  }
+
+  /** Gets a promise for the disabled state. */
+  async isDisabled(): Promise<boolean> {
+    return await ((await this.host()).getAttribute('aria-disabled')) === 'true';
   }
 }

--- a/src/material-experimental/mdc-chips/harness/chip-option-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-option-harness.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MatChipHarness} from './chip-harness';
+
+/**
+ * Harness for interacting with a mat-chip-option in tests.
+ * @dynamic
+ */
+export class MatChipOptionHarness extends MatChipHarness {
+  static hostSelector = 'mat-basic-chip-option, mat-chip-option';
+
+  async isSelected(): Promise<boolean> {
+    const ariaSelected = (await this.host()).getAttribute('aria-selected');
+    return await ariaSelected === 'true';
+  }
+}

--- a/src/material-experimental/mdc-chips/harness/chip-row-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-row-harness.spec.ts
@@ -1,0 +1,39 @@
+import {HarnessLoader} from '@angular/cdk-experimental/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChipsModule} from '../index';
+import {MatChipRowHarness} from './chip-row-harness';
+
+let fixture: ComponentFixture<ChipRowHarnessTest>;
+let loader: HarnessLoader;
+
+describe('MatChipRowHarness', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [ChipRowHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipRowHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should get correct number of chip harnesses', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipRowHarness);
+    expect(harnesses.length).toBe(2);
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip-grid #grid>
+      <mat-basic-chip-row> Basic Chip Row </mat-basic-chip-row>
+      <mat-chip-row> Chip Row </mat-chip-row>
+      <input [matChipInputFor]="grid" />
+    </mat-chip-grid>
+  `
+})
+class ChipRowHarnessTest {}
+

--- a/src/material-experimental/mdc-chips/harness/chip-row-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-row-harness.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MatChipHarness} from './chip-harness';
+
+/**
+ * Harness for interacting with a mat-chip-row in tests.
+ * @dynamic
+ */
+export class MatChipRowHarness extends MatChipHarness {
+  static hostSelector = 'mat-chip-row, mat-basic-chip-row';
+}

--- a/src/material-experimental/mdc-chips/harness/chip-set-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-set-harness.spec.ts
@@ -1,0 +1,45 @@
+import {HarnessLoader} from '@angular/cdk-experimental/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChipsModule} from '../index';
+import {MatChipSetHarness} from './chip-set-harness';
+
+let fixture: ComponentFixture<ChipSetHarnessTest>;
+let loader: HarnessLoader;
+
+describe('MatChipSetHarness', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [ChipSetHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipSetHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should get correct number of set harnesses', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipSetHarness);
+    expect(harnesses.length).toBe(1);
+  });
+
+  it('should get correct number of chips', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipSetHarness);
+    const chips = await harnesses[0].getChips();
+    expect(chips.length).toBe(3);
+  });
+});
+
+@Component({
+  template: `
+    <mat-chip-set>
+      <mat-chip> Chip A </mat-chip>
+      <mat-chip> Chip B </mat-chip>
+      <mat-chip> Chip C </mat-chip>
+    </mat-chip-set>
+  `
+})
+class ChipSetHarnessTest {}
+

--- a/src/material-experimental/mdc-chips/harness/chip-set-harness.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-set-harness.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness} from '@angular/cdk-experimental/testing';
+import {MatChipHarness} from './chip-harness';
+
+/**
+ * Harness for interacting with a mat-chip-set in tests.
+ * @dynamic
+ */
+export class MatChipSetHarness extends ComponentHarness {
+  static hostSelector = 'mat-chip-set';
+
+  private _chips = this.locatorForAll(MatChipHarness);
+
+  /** Gets promise of the harnesses for the chips. */
+  async getChips(): Promise<MatChipHarness[]> {
+    return await this._chips();
+  }
+}


### PR DESCRIPTION
Covers the skeleton work for harnesses for the grid + rows + input, listbox + options, and set + chips. 