### PR TITLE
build: do not run ngc postinstall on schematics

### DIFF
--- a/angular-tsconfig.json
+++ b/angular-tsconfig.json
@@ -18,6 +18,7 @@
   "exclude": [
     "node_modules/@angular/bazel/**",
     "node_modules/@angular/compiler-cli/**",
+    "node_modules/@angular/**/schematics/**",
     "node_modules/@angular/**/testing/**"
   ]
 }


### PR DESCRIPTION
Unblocks https://github.com/angular/angular/pull/31650 as we don't want to post-process the schematic migration code that might have type imports to `@angular/compiler-cli`.

These imports can break due to entry-point issues as https://github.com/angular/angular/issues/29220