### PR TITLE
feat(google-maps): add input options for google Map component

### DIFF
--- a/src/dev-app/google-map/google-map-demo.html
+++ b/src/dev-app/google-map/google-map-demo.html
@@ -1,1 +1,5 @@
-<google-map *ngIf="isReady"></google-map>
+<google-map *ngIf="isReady"
+            height="400px"
+            width="750px"
+            [center]="center"
+            [zoom]="zoom"></google-map>

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -18,6 +18,9 @@ import {HttpClient} from '@angular/common/http';
 export class GoogleMapDemo {
   isReady = false;
 
+  center = {lat: 24, lng: 12};
+  zoom = 4;
+
   constructor(httpClient: HttpClient) {
     httpClient.jsonp('https://maps.googleapis.com/maps/api/js?', 'callback')
       .subscribe(() => {

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -2,22 +2,18 @@ import {Component} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
-import {createMapConstructorSpy, createMapSpy} from './testing/fake-google-map-utils';
-import {GoogleMapModule} from './index';
-
-const DEFAULT_OPTIONS: google.maps.MapOptions = {
-  center: {lat: 37.421995, lng: -122.084092},
-  zoom: 17,
-};
+import {DEFAULT_HEIGHT, DEFAULT_OPTIONS, DEFAULT_WIDTH, GoogleMapModule} from './index';
+import {
+  createMapConstructorSpy,
+  createMapSpy,
+  TestingWindow
+} from './testing/fake-google-map-utils';
 
 describe('GoogleMap', () => {
   let mapConstructorSpy: jasmine.Spy;
   let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
   beforeEach(async(() => {
-    mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy);
-
     TestBed.configureTestingModule({
       imports: [GoogleMapModule],
       declarations: [TestApp],
@@ -28,17 +24,137 @@ describe('GoogleMap', () => {
     TestBed.compileComponents();
   });
 
+  afterEach(() => {
+    const testingWindow: TestingWindow = window;
+    delete testingWindow.google;
+  });
+
+  it('throws an error is the Google Maps JavaScript API was not loaded', () => {
+    mapSpy = createMapSpy(DEFAULT_OPTIONS);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy, false);
+
+    expect(() => TestBed.createComponent(TestApp))
+        .toThrow(new Error(
+            'Namespace google not found, cannot construct embedded google ' +
+            'map. Please install the Google Maps JavaScript API: ' +
+            'https://developers.google.com/maps/documentation/javascript/' +
+            'tutorial#Loading_the_Maps_API'));
+  });
+
   it('initializes a Google map', () => {
+    mapSpy = createMapSpy(DEFAULT_OPTIONS);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
+
     const fixture = TestBed.createComponent(TestApp);
-    const container = fixture.debugElement.query(By.css('div'));
     fixture.detectChanges();
 
+    const container = fixture.debugElement.query(By.css('div'));
+    expect(container.nativeElement.style.height).toBe(DEFAULT_HEIGHT);
+    expect(container.nativeElement.style.width).toBe(DEFAULT_WIDTH);
     expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, DEFAULT_OPTIONS);
+  });
+
+  it('sets height and width of the map', () => {
+    mapSpy = createMapSpy(DEFAULT_OPTIONS);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.componentInstance.height = '750px';
+    fixture.componentInstance.width = '400px';
+    fixture.detectChanges();
+
+    const container = fixture.debugElement.query(By.css('div'));
+    expect(container.nativeElement.style.height).toBe('750px');
+    expect(container.nativeElement.style.width).toBe('400px');
+    expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, DEFAULT_OPTIONS);
+
+    fixture.componentInstance.height = '650px';
+    fixture.componentInstance.width = '350px';
+    fixture.detectChanges();
+
+    expect(container.nativeElement.style.height).toBe('650px');
+    expect(container.nativeElement.style.width).toBe('350px');
+  });
+
+  it('sets center and zoom of the map', () => {
+    const options = {center: {lat: 3, lng: 5}, zoom: 7};
+    mapSpy = createMapSpy(options);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.componentInstance.center = options.center;
+    fixture.componentInstance.zoom = options.zoom;
+    fixture.detectChanges();
+
+    const container = fixture.debugElement.query(By.css('div'));
+    expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, options);
+
+    fixture.componentInstance.center = {lat: 8, lng: 9};
+    fixture.componentInstance.zoom = 12;
+    fixture.detectChanges();
+
+    expect(mapSpy.setOptions).toHaveBeenCalledWith({center: {lat: 8, lng: 9}, zoom: 12});
+  });
+
+  it('sets map options', () => {
+    const options = {center: {lat: 3, lng: 5}, zoom: 7, draggable: false};
+    mapSpy = createMapSpy(options);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.componentInstance.options = options;
+    fixture.detectChanges();
+
+    const container = fixture.debugElement.query(By.css('div'));
+    expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, options);
+
+    fixture.componentInstance.options = {...options, heading: 170};
+    fixture.detectChanges();
+
+    expect(mapSpy.setOptions).toHaveBeenCalledWith({...options, heading: 170});
+  });
+
+  it('gives precedence to center and zoom over options', () => {
+    const inputOptions = {center: {lat: 3, lng: 5}, zoom: 7, heading: 170};
+    const correctedOptions = {center: {lat: 12, lng: 15}, zoom: 5, heading: 170};
+    mapSpy = createMapSpy(correctedOptions);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.componentInstance.center = correctedOptions.center;
+    fixture.componentInstance.zoom = correctedOptions.zoom;
+    fixture.componentInstance.options = inputOptions;
+    fixture.detectChanges();
+
+    const container = fixture.debugElement.query(By.css('div'));
+    expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, correctedOptions);
+  });
+
+  it('does not initialize the map if inputs are not configure correctly', () => {
+    const options = {};
+    mapSpy = createMapSpy(options);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.componentInstance.options = options;
+    fixture.detectChanges();
+
+    expect(mapConstructorSpy).not.toHaveBeenCalled();
   });
 });
 
 @Component({
   selector: 'test-app',
-  template: `<google-map></google-map>`,
+  template: `<google-map [height]="height"
+                         [width]="width"
+                         [center]="center"
+                         [zoom]="zoom"
+                         [options]="options"></google-map>`,
 })
-class TestApp {}
+class TestApp {
+  height?: string;
+  width?: string;
+  center?: google.maps.LatLngLiteral;
+  zoom?: number;
+  options?: google.maps.MapOptions;
+}

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -129,18 +129,6 @@ describe('GoogleMap', () => {
     const container = fixture.debugElement.query(By.css('div'));
     expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, correctedOptions);
   });
-
-  it('does not initialize the map if inputs are not configure correctly', () => {
-    const options = {};
-    mapSpy = createMapSpy(options);
-    mapConstructorSpy = createMapConstructorSpy(mapSpy);
-
-    const fixture = TestBed.createComponent(TestApp);
-    fixture.componentInstance.options = options;
-    fixture.detectChanges();
-
-    expect(mapConstructorSpy).not.toHaveBeenCalled();
-  });
 });
 
 @Component({

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   Input,
+  OnChanges,
   OnDestroy,
   OnInit,
 } from '@angular/core';
@@ -34,16 +35,10 @@ export const DEFAULT_WIDTH = '500px';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<div class="map-container"></div>',
 })
-export class GoogleMap implements OnInit, OnDestroy {
-  @Input()
-  set height(height: string) {
-    this._height.next(height || DEFAULT_HEIGHT);
-  }
+export class GoogleMap implements OnChanges, OnInit, OnDestroy {
+  @Input() height = DEFAULT_HEIGHT;
 
-  @Input()
-  set width(width: string) {
-    this._width.next(width || DEFAULT_WIDTH);
-  }
+  @Input() width = DEFAULT_WIDTH;
 
   @Input()
   set center(center: google.maps.LatLngLiteral) {
@@ -60,8 +55,8 @@ export class GoogleMap implements OnInit, OnDestroy {
 
   // TODO(mbehrlich): Add event handlers, properties, and methods.
 
-  private readonly _height = new BehaviorSubject<string>(DEFAULT_HEIGHT);
-  private readonly _width = new BehaviorSubject<string>(DEFAULT_WIDTH);
+  private _mapEl?: HTMLElement;
+
   private readonly _options = new BehaviorSubject<google.maps.MapOptions>(DEFAULT_OPTIONS);
   private readonly _center = new BehaviorSubject<google.maps.LatLngLiteral|undefined>(undefined);
   private readonly _zoom = new BehaviorSubject<number|undefined>(undefined);
@@ -79,40 +74,54 @@ export class GoogleMap implements OnInit, OnDestroy {
     }
   }
 
+  ngOnChanges() {
+    this._setSize();
+  }
+
   ngOnInit() {
-    const mapEl = this._elementRef.nativeElement.querySelector('.map-container');
+    this._mapEl = this._elementRef.nativeElement.querySelector('.map-container')!;
+    this._setSize();
 
-    // Combines the center and zoom and the other map options into a single
-    // object
-    const combinedOptionsChanges: Observable<google.maps.MapOptions> =
-        combineLatest(this._options, this._center, this._zoom)
-            .pipe(map(([options, center, zoom]) => {
-              const combinedOptions: google.maps.MapOptions = {
-                ...options,
-                center: center || options.center,
-                zoom: zoom !== undefined ? zoom : options.zoom,
-              };
-              return combinedOptions;
-            }));
+    const combinedOptionsChanges = this._combineOptions();
 
-    // Initializes the Google Map
-    const googleMapChanges =
-        combinedOptionsChanges.pipe(take(1), map(options => new google.maps.Map(mapEl, options)));
+    const googleMapChanges = this._initializeMap(combinedOptionsChanges);
     googleMapChanges.subscribe();
 
-    // Watches for updates to any options
-    combineLatest(googleMapChanges, combinedOptionsChanges)
+    this._watchForOptionsChanges(googleMapChanges, combinedOptionsChanges);
+  }
+
+  private _setSize() {
+    if (this._mapEl) {
+      this._mapEl.style.height = this.height || DEFAULT_HEIGHT;
+      this._mapEl.style.width = this.width || DEFAULT_WIDTH;
+    }
+  }
+
+  /** Combines the center and zoom and the other map options into a single object */
+  private _combineOptions(): Observable<google.maps.MapOptions> {
+    return combineLatest(this._options, this._center, this._zoom)
+        .pipe(map(([options, center, zoom]) => {
+          const combinedOptions: google.maps.MapOptions = {
+            ...options,
+            center: center || options.center,
+            zoom: zoom !== undefined ? zoom : options.zoom,
+          };
+          return combinedOptions;
+        }));
+  }
+
+  private _initializeMap(optionsChanges: Observable<google.maps.MapOptions>):
+      Observable<google.maps.Map> {
+    return optionsChanges.pipe(take(1), map(options => new google.maps.Map(this._mapEl!, options)));
+  }
+
+  private _watchForOptionsChanges(
+      googleMapChanges: Observable<google.maps.Map>,
+      optionsChanges: Observable<google.maps.MapOptions>) {
+    combineLatest(googleMapChanges, optionsChanges)
         .pipe(takeUntil(this._destroy))
         .subscribe(([googleMap, options]) => {
           googleMap.setOptions(options);
-        });
-
-    // Watches for updates to the size of the container element
-    combineLatest(this._height, this._width)
-        .pipe(takeUntil(this._destroy))
-        .subscribe(([height, width]) => {
-          mapEl.style.height = height;
-          mapEl.style.width = width;
         });
   }
 

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -3,9 +3,26 @@ import {
   Component,
   ElementRef,
   Input,
+  OnDestroy,
   OnInit,
 } from '@angular/core';
-import {ReplaySubject} from 'rxjs';
+import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
+import {map, take, takeUntil} from 'rxjs/operators';
+
+interface GoogleMapsWindow extends Window {
+  google?: typeof google;
+}
+
+/** default options set to the Googleplex */
+export const DEFAULT_OPTIONS: google.maps.MapOptions = {
+  center: {lat: 37.421995, lng: -122.084092},
+  zoom: 17,
+};
+
+/** Arbitrarily chose default height for the map element */
+export const DEFAULT_HEIGHT = '500px';
+/** Arbitrarily chose default width for the map element */
+export const DEFAULT_WIDTH = '500px';
 
 /**
  * Angular component that renders a Google Map via the Google Maps JavaScript
@@ -17,28 +34,93 @@ import {ReplaySubject} from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<div class="map-container"></div>',
 })
-export class GoogleMap implements OnInit {
-  // Arbitrarily chosen default size
-  @Input() height = '500px';
-  @Input() width = '500px';
+export class GoogleMap implements OnInit, OnDestroy {
+  @Input()
+  set height(height: string) {
+    this._height$.next(height || DEFAULT_HEIGHT);
+  }
 
-  // TODO(mbehrlich): add options, handlers, properties, and methods.
+  @Input()
+  set width(width: string) {
+    this._width$.next(width || DEFAULT_WIDTH);
+  }
 
-  private readonly _map$ = new ReplaySubject<google.maps.Map>(1);
+  @Input()
+  set center(center: google.maps.LatLngLiteral) {
+    this._center$.next(center);
+  }
+  @Input()
+  set zoom(zoom: number) {
+    this._zoom$.next(zoom);
+  }
+  @Input()
+  set options(options: google.maps.MapOptions) {
+    this._options$.next(options || DEFAULT_OPTIONS);
+  }
 
-  constructor(private readonly _elementRef: ElementRef) {}
+  // TODO(mbehrlich): Add event handlers, properties, and methods.
+
+  private readonly _height$ = new BehaviorSubject<string>(DEFAULT_HEIGHT);
+  private readonly _width$ = new BehaviorSubject<string>(DEFAULT_WIDTH);
+  private readonly _options$ = new BehaviorSubject<google.maps.MapOptions>(DEFAULT_OPTIONS);
+  private readonly _center$ = new BehaviorSubject<google.maps.LatLngLiteral|undefined>(undefined);
+  private readonly _zoom$ = new BehaviorSubject<number|undefined>(undefined);
+
+  private readonly _destroy$ = new Subject<void>();
+
+  constructor(private readonly _elementRef: ElementRef) {
+    const googleMapsWindow: GoogleMapsWindow = window;
+    if (!googleMapsWindow.google) {
+      throw new Error(
+          'Namespace google not found, cannot construct embedded google ' +
+          'map. Please install the Google Maps JavaScript API: ' +
+          'https://developers.google.com/maps/documentation/javascript/' +
+          'tutorial#Loading_the_Maps_API');
+    }
+  }
 
   ngOnInit() {
-    // default options set to the Googleplex
-    const options: google.maps.MapOptions = {
-      center: {lat: 37.421995, lng: -122.084092},
-      zoom: 17,
-    };
-
     const mapEl = this._elementRef.nativeElement.querySelector('.map-container');
-    mapEl.style.height = this.height;
-    mapEl.style.width = this.width;
-    const map = new google.maps.Map(mapEl, options);
-    this._map$.next(map);
+
+    const combinedOptions$: Observable<google.maps.MapOptions> =
+        combineLatest(this._options$, this._center$, this._zoom$)
+            .pipe(map(([options, center, zoom]) => {
+              const combinedOptions: google.maps.MapOptions = {
+                ...options,
+                center: center || options.center,
+                zoom: zoom !== undefined ? zoom : options.zoom,
+              };
+              if (!combinedOptions.center || !combinedOptions.center.lat ||
+                  !combinedOptions.center.lng || !combinedOptions.zoom) {
+                throw new Error(
+                    'The MapOptions object is not configured correctly. ' +
+                    'See the Google Maps JavaScript API: ' +
+                    'https://developers.google.com/maps/documentation/javascript/' +
+                    'reference/map#MapOptions');
+              }
+              return combinedOptions;
+            }));
+    const googleMap$ =
+        combinedOptions$.pipe(take(1), map(options => new google.maps.Map(mapEl, options)));
+
+    googleMap$.subscribe();
+
+    combineLatest(googleMap$, combinedOptions$)
+        .pipe(takeUntil(this._destroy$))
+        .subscribe(([googleMap, options]) => {
+          googleMap.setOptions(options);
+        });
+
+    combineLatest(this._height$, this._width$)
+        .pipe(takeUntil(this._destroy$))
+        .subscribe(([height, width]) => {
+          mapEl.style.height = height;
+          mapEl.style.width = width;
+        });
+  }
+
+  ngOnDestroy() {
+    this._destroy$.next();
+    this._destroy$.complete();
   }
 }

--- a/src/google-maps/google-map/testing/fake-google-map-utils.ts
+++ b/src/google-maps/google-map/testing/fake-google-map-utils.ts
@@ -1,28 +1,31 @@
-declare global {
-  interface Window {
-    google?: {
-      maps: {
-        Map: jasmine.Spy;
-      };
+/** Window interface for testing */
+export interface TestingWindow extends Window {
+  google?: {
+    maps: {
+      Map: jasmine.Spy;
     };
-  }
+  };
 }
 
 /** Creates a jasmine.SpyObj for a google.maps.Map. */
 export function createMapSpy(options: google.maps.MapOptions): jasmine.SpyObj<google.maps.Map> {
-  return jasmine.createSpyObj('Map', ['getDiv']);
+  return jasmine.createSpyObj('google.maps.Map', ['setOptions']);
 }
 
 /** Creates a jasmine.Spy to watch for the constructor of a google.maps.Map. */
-export function createMapConstructorSpy(mapSpy: jasmine.SpyObj<google.maps.Map>): jasmine.Spy {
+export function createMapConstructorSpy(
+    mapSpy: jasmine.SpyObj<google.maps.Map>, apiLoaded = true): jasmine.Spy {
   const mapConstructorSpy =
       jasmine.createSpy('Map constructor', (_el: Element, _options: google.maps.MapOptions) => {
         return mapSpy;
       });
-  window.google = {
-    maps: {
-      'Map': mapConstructorSpy,
-    }
-  };
+  const testingWindow: TestingWindow = window;
+  if (apiLoaded) {
+    testingWindow.google = {
+      maps: {
+        'Map': mapConstructorSpy,
+      }
+    };
+  }
   return mapConstructorSpy;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2958,15 +2958,6 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
-cliui@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
-  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
-  dependencies:
-    string-width "^3.1.0"
-    strip-ansi "^5.2.0"
-    wrap-ansi "^5.1.0"
-
 clone-regexp@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-2.2.0.tgz#7d65e00885cd8796405c35a737e7a86b7429e36f"
@@ -11184,15 +11175,6 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.0.0"
 
-string-width@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
 string-width@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
@@ -11273,7 +11255,7 @@ strip-ansi@^5.0.0:
   dependencies:
     ansi-regex "^4.0.0"
 
-strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -12648,15 +12630,6 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
-  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
-  dependencies:
-    ansi-styles "^3.2.0"
-    string-width "^3.0.0"
-    strip-ansi "^5.0.0"
-
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -12795,14 +12768,6 @@ yargs-parser@^13.0.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
-  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^4.1.0, yargs-parser@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
@@ -12915,22 +12880,6 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
-
-yargs@^13.3.0:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
-  integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
-  dependencies:
-    cliui "^5.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^13.1.1"
 
 yargs@^3.32.0:
   version "3.32.0"


### PR DESCRIPTION
Add inputs to configure Google Map, including the main options, as well
as center and zoom. Allow resizing the height and width of the
component. Add errors for not loading the API and using malformed
inputs.