### PR TITLE
feat(material-experimental/mdc-button): use MDC classnames in CSS

### DIFF
--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -6,7 +6,7 @@
 
 $_mat-button-ripple-opacity: 0.1;
 
-.mat-mdc-button {
+.mat-mdc-button, .mat-mdc-unelevated-button, .mat-mdc-raised-button, .mat-mdc-outlined-button {
   // The ripple element is created from the RippleRenderer rather than the MDC ripple, so it is
   // necessary to provide the color and opacity styling manually.
   .mat-ripple-element {

--- a/src/material-experimental/mdc-button/fab.scss
+++ b/src/material-experimental/mdc-button/fab.scss
@@ -5,7 +5,7 @@
 
 $_mat-button-ripple-opacity: 0.1;
 
-.mat-mdc-button {
+.mat-mdc-fab, .mat-mdc-mini-fab {
   // The ripple element is created from the RippleRenderer rather than the MDC ripple, so it is
   // necessary to provide the color and opacity styling manually.
   .mat-ripple-element {

--- a/src/material-experimental/mdc-button/icon-button.scss
+++ b/src/material-experimental/mdc-button/icon-button.scss
@@ -5,7 +5,7 @@
 
 $_mat-button-ripple-opacity: 0.1;
 
-.mat-mdc-button {
+.mat-mdc-icon-button {
   // The ripple element is created from the RippleRenderer rather than the MDC ripple, so it is
   // necessary to provide the color and opacity styling manually.
   .mat-ripple-element {


### PR DESCRIPTION
Alternatively we can use the `mat-mdc-` prefix for the component names but that would be more verbose without any additional gain