### PR TITLE
chore: update MatMenu _hovered typing for rxjs 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@webcomponents/custom-elements": "^1.1.0",
     "core-js": "^2.6.1",
     "material-components-web": "^3.0.0",
-    "rxjs": "^6.4.0",
+    "rxjs": "^6.5.2",
     "systemjs": "0.19.43",
     "tsickle": "^0.35.0",
     "tslib": "^1.9.3",

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -255,9 +255,11 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
 
   /** Stream that emits whenever the hovered menu item changes. */
   _hovered(): Observable<MatMenuItem> {
-    return this._directDescendantItems.changes.pipe(
+    // Coerce the `changes` property because Angular types it as `Observable<any>`
+    const itemChanges = this._directDescendantItems.changes as Observable<QueryList<MatMenuItem>>;
+    return itemChanges.pipe(
       startWith(this._directDescendantItems),
-      switchMap(items => merge<MatMenuItem>(...items.map((item: MatMenuItem) => item._hovered)))
+      switchMap(items => merge(...items.map((item: MatMenuItem) => item._hovered)))
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10404,7 +10404,7 @@ rx@4.1.0:
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
   integrity sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=
 
-rxjs@6.4.0, rxjs@^6.4.0:
+rxjs@6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
   integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
@@ -10422,6 +10422,13 @@ rxjs@^6.1.0:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
   integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
+  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Apparently rxjs v7 will have issues in this method, but as of time of
this writing this version is not yet available on npm.