### PR TITLE
fix(schematics): module imports not generated for schematics

### DIFF
--- a/src/cdk/schematics/utils/version-agnostic-typescript.ts
+++ b/src/cdk/schematics/utils/version-agnostic-typescript.ts
@@ -26,13 +26,21 @@ import {SchematicsException} from '@angular-devkit/schematics';
 let ts: typeof typescript;
 
 try {
-  ts = require('@schematics/angular/node_modules/typescript');
+  ts = require('@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript');
 } catch {
+  // Fallback for CLI versions before v8.0.0. The TypeScript dependency has been dropped in
+  // CLI version v8.0.0 but older CLI versions can still run the latest generation schematics.
+  // See: https://github.com/angular/angular-cli/commit/bf1c069f73c8e3d4f0e8d584cbfb47c408c1730b
   try {
-    ts = require('typescript');
+    ts = require('@schematics/angular/node_modules/typescript');
   } catch {
-    throw new SchematicsException('Error: Could not find a TypeScript version for the ' +
-      'schematics. Please report an issue on the Angular Material repository.');
+    try {
+      ts = require('typescript');
+    } catch {
+      throw new SchematicsException(
+          'Error: Could not find a TypeScript version for the ' +
+          'schematics. Please report an issue on the Angular Material repository.');
+    }
   }
 }
 


### PR DESCRIPTION
Currently in some scenarios the CLI project has a different TypeScript version
than the `typescript` version used in the `@schematics/angular` package.

This causes AST parsing & transformations to be broken due to the shifted
values (e.g. in the `SyntaxKind` enum). Previously we solved this by always
using the `typescript` version brought in by the `@schematics/angular` package,
but this no longer works as of v8.0.0 CLI because the `@schematics/angular`
package now vendors `typescript` instead of having an explicit version as
dependency.

https://github.com/angular/angular-cli/commit/bf1c069f73c8e3d4f0e8d584cbfb47c408c1730b