### PR TITLE
fix(expansion): not adding margin for all button types

### DIFF
--- a/src/material/expansion/expansion-panel.scss
+++ b/src/material/expansion/expansion-panel.scss
@@ -72,7 +72,7 @@
   justify-content: flex-end;
   padding: 16px 8px 16px 24px;
 
-  button.mat-button {
+  button.mat-button-base {
     margin-left: 8px;
 
     [dir='rtl'] & {


### PR DESCRIPTION
Currently the margins for buttons inside the `mat-action-row` is only set up for `mat-button`, however we have other variants like raised and stroked buttons which haven't been accounted for.