### PR TITLE
fix(tabs): tabs with background overriding ripple color for all descendants

### DIFF
--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -120,7 +120,8 @@
 
   // Set ripples color to be the contrast color of the new background. Otherwise the ripple
   // color will be based on the app background color.
-  .mat-ripple-element {
+  .mat-tab-header .mat-ripple-element,
+  .mat-tab-links .mat-ripple-element {
     background-color: mat-color($background-color, default-contrast, 0.12);
   }
 }


### PR DESCRIPTION
When a tab group has a background color we need to change its ripple color so it doesn't blend in with the background, however the current selector is too broad which means that it also targets all the ripples inside the tabs content. These changes narrow down the selector to avoid the issue.