### PR TITLE
build: update rules sass version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,6 +44,7 @@ build:release --workspace_status_command="node ./tools/bazel-stamp-vars.js"
 # running as daemons, and cache SourceFile AST's to reduce parse time.
 build --strategy=TypeScriptCompile=worker
 build --strategy=AngularTemplateCompile=worker
+build --strategy=SassCompiler=worker
 
 ################################
 # Temporary Settings for Ivy   #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,9 +12,11 @@ http_archive(
 # Add sass rules
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "4f05239080175a3f4efa8982d2b7775892d656bb47e8cf56914d5f9441fb5ea6",
-    strip_prefix = "rules_sass-86ca977cf2a8ed481859f83a286e164d07335116",
-    url = "https://github.com/bazelbuild/rules_sass/archive/86ca977cf2a8ed481859f83a286e164d07335116.zip",
+    sha256 = "ad08e8c82aa1f48b72dc295cb83bba33f514cdf24cc7b0e21e9353f20f0dc147",
+    strip_prefix = "rules_sass-5d1b26f8cd12c5d75dd359f9291090b341e8fd52",
+    # We need to use a version that includes SHA 5d1b26f8cd12c5d75dd359f9291090b341e8fd52 of
+    # the "rules_sass" repository as it adds support for workers.
+    url = "https://github.com/bazelbuild/rules_sass/archive/5d1b26f8cd12c5d75dd359f9291090b341e8fd52.zip",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")


### PR DESCRIPTION
Updates the version of `rules_sass` and enables worker
compilation. Sass compilation actions were generally a
pain-point within the current Bazel pipeline, but the
workers fix this bottleneck.