### PR TITLE
feat(material-experimental): option to filter tab-group harness by selected tab label

### DIFF
--- a/src/material-experimental/mdc-tabs/harness/tab-group-harness-filters.ts
+++ b/src/material-experimental/mdc-tabs/harness/tab-group-harness-filters.ts
@@ -6,4 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type TabGroupHarnessFilters = {};
+export type TabGroupHarnessFilters = {
+  selectedTabLabel?: string|RegExp;
+};

--- a/src/material-experimental/mdc-tabs/harness/tab-group-harness.spec.ts
+++ b/src/material-experimental/mdc-tabs/harness/tab-group-harness.spec.ts
@@ -43,6 +43,20 @@ function runTests() {
     expect(tabGroups.length).toBe(1);
   });
 
+  it('should load harness for tab-group with selected tab label', async () => {
+    const tabGroups = await loader.getAllHarnesses(tabGroupHarness.with({
+      selectedTabLabel: 'First',
+    }));
+    expect(tabGroups.length).toBe(1);
+  });
+
+  it('should load harness for tab-group with matching tab label regex', async () => {
+    const tabGroups = await loader.getAllHarnesses(tabGroupHarness.with({
+      selectedTabLabel: /f.*st/i,
+    }));
+    expect(tabGroups.length).toBe(1);
+  });
+
   it('should be able to get tabs of tab-group', async () => {
     const tabGroup = await loader.getHarness(tabGroupHarness);
     const tabs = await tabGroup.getTabs();

--- a/src/material-experimental/mdc-tabs/harness/tab-group-harness.ts
+++ b/src/material-experimental/mdc-tabs/harness/tab-group-harness.ts
@@ -21,10 +21,16 @@ export class MatTabGroupHarness extends ComponentHarness {
    * Gets a `HarnessPredicate` that can be used to search for a radio-button with
    * specific attributes.
    * @param options Options for narrowing the search
+   *   - `selectedTabLabel` finds a tab-group with a selected tab that matches the
+   *      specified tab label.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: TabGroupHarnessFilters = {}): HarnessPredicate<MatTabGroupHarness> {
-    return new HarnessPredicate(MatTabGroupHarness);
+    return new HarnessPredicate(MatTabGroupHarness)
+        .addOption('selectedTabLabel', options.selectedTabLabel, async (harness, label) => {
+          const selectedTab = await harness.getSelectedTab();
+          return HarnessPredicate.stringMatches(await selectedTab.getLabel(), label);
+        });
   }
 
   private _tabs = this.locatorForAll(MatTabHarness);
@@ -39,12 +45,10 @@ export class MatTabGroupHarness extends ComponentHarness {
     const tabs = await this.getTabs();
     const isSelected = await Promise.all(tabs.map(t => t.isSelected()));
     for (let i = 0; i < tabs.length; i++) {
-      if  (isSelected[i]) {
+      if (isSelected[i]) {
         return tabs[i];
       }
     }
     throw new Error('No selected tab could be found.');
   }
 }
-
-


### PR DESCRIPTION
Follow-up that addresses feedback from the original tab-group
harness PR. See: https://github.com/angular/components/pull/16728#discussion_r314819393