### PR TITLE
build: cleanup material-experimental bazel sass targets

### DIFF
--- a/src/material-experimental/mdc-button/BUILD.bazel
+++ b/src/material-experimental/mdc-button/BUILD.bazel
@@ -44,7 +44,6 @@ sass_library(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 
@@ -55,9 +54,9 @@ sass_binary(
         "external/npm/node_modules",
     ],
     deps = [
+        "//src/cdk/a11y:a11y_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:all_themes",
     ],
 )
 
@@ -70,7 +69,6 @@ sass_binary(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:all_themes",
     ],
 )
 
@@ -83,7 +81,6 @@ sass_binary(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:all_themes",
     ],
 )
 

--- a/src/material-experimental/mdc-card/BUILD.bazel
+++ b/src/material-experimental/mdc-card/BUILD.bazel
@@ -22,7 +22,6 @@ sass_library(
     srcs = glob(["**/_*.scss"]),
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 

--- a/src/material-experimental/mdc-checkbox/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/BUILD.bazel
@@ -46,7 +46,6 @@ sass_library(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 
@@ -59,7 +58,6 @@ sass_binary(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:all_themes",
     ],
 )
 

--- a/src/material-experimental/mdc-chips/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/BUILD.bazel
@@ -28,7 +28,6 @@ sass_library(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 
@@ -41,7 +40,7 @@ sass_binary(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:all_themes",
+        "//src/material/core:core_scss_lib",
     ],
 )
 

--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -43,7 +43,6 @@ sass_library(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 
@@ -55,7 +54,7 @@ sass_binary(
     ],
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:all_themes",
+        "//src/material/core:core_scss_lib",
     ],
 )
 

--- a/src/material-experimental/mdc-radio/BUILD.bazel
+++ b/src/material-experimental/mdc-radio/BUILD.bazel
@@ -22,7 +22,6 @@ sass_library(
     srcs = glob(["**/_*.scss"]),
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 

--- a/src/material-experimental/mdc-sidenav/BUILD.bazel
+++ b/src/material-experimental/mdc-sidenav/BUILD.bazel
@@ -39,7 +39,6 @@ sass_library(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 
@@ -52,7 +51,6 @@ sass_binary(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:all_themes",
     ],
 )
 

--- a/src/material-experimental/mdc-slide-toggle/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/BUILD.bazel
@@ -45,7 +45,6 @@ sass_library(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 

--- a/src/material-experimental/mdc-tabs/BUILD.bazel
+++ b/src/material-experimental/mdc-tabs/BUILD.bazel
@@ -25,7 +25,6 @@ sass_library(
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 
@@ -37,7 +36,6 @@ sass_binary(
     ],
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material/core:all_themes",
     ],
 )
 

--- a/src/material-experimental/popover-edit/BUILD.bazel
+++ b/src/material-experimental/popover-edit/BUILD.bazel
@@ -21,6 +21,7 @@ sass_library(
     name = "popover_edit_scss_lib",
     srcs = glob(["**/_*.scss"]),
     deps = [
+        "//src/cdk/a11y:a11y_scss_lib",
         "//src/material/core:core_scss_lib",
     ],
 )


### PR DESCRIPTION
Cleans up the `material-experimental` bazel sass targets.
We don't want to depend on bazel targets that depend on other
targets which are not used. This negatively affects incrementality.
