### PR TITLE
build: remove workaround for ivy test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,13 +403,9 @@ jobs:
       - *yarn_install
       - *setup_bazel_binary
 
-      # Setup Angular ivy snapshots built with ngtsc but locked to a specific tag. We
-      # cannot determine the tag automatically based on the Angular version specified in
-      # the "package.json" because the SHA is not known for the given release. Nor can
-      # we use ngcc to apply the ivy switches because ngcc currently does not handle the
-      # UMD format which is used by Bazel when running tests. UMD processing is in
-      # progress and tracked with FW-85.
-      - run: node ./scripts/circleci/setup-angular-snapshots.js --tag 9.0.0-next.0-ivy-aot+3122f3415
+      # Setup ngcc to make the Angular packages compatible with ngtsc (i.e. creating
+      # directive and component definitions as static class members).
+      - run: node ./scripts/circleci/setup-ivy-ngcc.js
       # Disable type checking when building with Ivy. This is necessary because
       # type checking is not complete yet and can incorrectly break compilation.
       # Issue is tracked with FW-1004.

--- a/scripts/circleci/setup-ivy-ngcc.js
+++ b/scripts/circleci/setup-ivy-ngcc.js
@@ -1,0 +1,30 @@
+/**
+ * Script that sets up Ivy ngcc to postprocess installed node modules. The script achieves
+ * this by updating the "postinstall" script in the "package.json". This is necessary because
+ * Bazel manages its own version of the node modules and needs to run ivy-ngcc on its own when
+ * installing dependencies.
+ */
+
+const {green} = require('chalk');
+const {writeFileSync} = require('fs');
+const {join} = require('path');
+
+const projectDir = join(__dirname, '../../');
+const packageJsonPath = join(projectDir, 'package.json');
+const packageJson = require(packageJsonPath);
+
+const postInstallCommand = `ivy-ngcc --properties main module`;
+
+if (!packageJson['scripts']) {
+  packageJson['scripts'] = {};
+}
+
+if (!packageJson.scripts.postinstall) {
+  packageJson.scripts.postinstall = postInstallCommand;
+} else {
+  packageJson.scripts.postinstall += ` && ${postInstallCommand}`;
+}
+
+writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+console.log(green('Successfully set up Ivy ngcc in the "package.json".'));


### PR DESCRIPTION
We currently have a workaround in the `ivy_test` job
in place because initially when we created the job, ngcc
did not support the `umd` format. This is now fixed and
we should be able to use ngcc to make the Angular packages
compatible with ngtsc.

We don't want to continue pulling a specific version from the
github build repositories, but rather want to test against the
current ivy version of the installed angular packages.

Testing against snapshots is covered by the `ivy_snapshot_test` job.