### PR TITLE
build: switch test targets to karma_web_test_suite

### DIFF
--- a/src/cdk/coercion/BUILD.bazel
+++ b/src/cdk/coercion/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "markdown_to_html", "ts_library", "ts_web_test_suite")
+load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ts_library")
 
 ts_library(
     name = "coercion",
@@ -28,7 +28,7 @@ ts_library(
     ],
 )
 
-ts_web_test_suite(
+karma_web_test_suite(
     name = "unit_tests",
     deps = [":unit_test_sources"],
 )

--- a/src/cdk/keycodes/BUILD.bazel
+++ b/src/cdk/keycodes/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "markdown_to_html", "ts_library", "ts_web_test_suite")
+load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ts_library")
 
 ts_library(
     name = "keycodes",
@@ -25,7 +25,7 @@ ts_library(
     ],
 )
 
-ts_web_test_suite(
+karma_web_test_suite(
     name = "unit_tests",
     deps = [":unit_test_sources"],
 )

--- a/src/material-moment-adapter/BUILD.bazel
+++ b/src/material-moment-adapter/BUILD.bazel
@@ -38,7 +38,7 @@ ng_test_library(
 ng_web_test_suite(
     name = "unit_tests",
     # We need to load Moment statically since it is not a named AMD module and needs to
-    # be manually configured through "require.js" which is used by "ts_web_test_suite".
+    # be manually configured through "require.js" which is used by "karma_web_test_suite".
     static_files = [
         "@npm//moment",
     ],

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -6,7 +6,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "angular_test_init",
     testonly = True,
-    # This file *must* end with "spec" in order for ts_web_test to load it.
+    # This file *must* end with "spec" in order for "karma_web_test_suite" to load it.
     srcs = ["angular-test-init-spec.ts"],
     deps = [
         "@npm//@angular/core",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -3,7 +3,7 @@
 load("@npm_angular_bazel//:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package", _protractor_web_test_suite = "protractor_web_test_suite")
 load("@npm_bazel_jasmine//:index.bzl", _jasmine_node_test = "jasmine_node_test")
 load("@npm_bazel_typescript//:defs.bzl", _ts_library = "ts_library")
-load("@npm_bazel_karma//:defs.bzl", _ts_web_test_suite = "ts_web_test_suite")
+load("@npm_bazel_karma//:defs.bzl", _karma_web_test_suite = "karma_web_test_suite")
 load("//tools/markdown-to-html:index.bzl", _markdown_to_html = "markdown_to_html")
 load("//:packages.bzl", "ANGULAR_LIBRARY_UMDS", "VERSION_PLACEHOLDER_REPLACEMENTS")
 
@@ -108,8 +108,8 @@ def ng_e2e_test_library(deps = [], tsconfig = None, **kwargs):
         **kwargs
     )
 
-def ts_web_test_suite(deps = [], srcs = [], **kwargs):
-    _ts_web_test_suite(
+def karma_web_test_suite(deps = [], srcs = [], **kwargs):
+    _karma_web_test_suite(
         deps = ["//tools/rxjs:rxjs_umd_modules"] + deps,
         # Required for running the compiled ng modules that use TypeScript import helpers.
         # TODO(jelbourn): remove UMDs from here once we don't have to manually include them
@@ -141,7 +141,7 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], **kwargs):
     # Workaround for https://github.com/bazelbuild/rules_typescript/issues/301
     # Since some of our tests depend on CSS files which are not part of the `ng_module` rule,
     # we need to somehow load static CSS files within Karma (e.g. overlay prebuilt). Those styles
-    # are required for successful test runs. Since the `ts_web_test_suite` rule currently only
+    # are required for successful test runs. Since the `karma_web_test_suite` rule currently only
     # allows JS files to be included and served within Karma, we need to create a JS file that
     # loads the given CSS file.
     for css_label in static_css:
@@ -165,7 +165,7 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], **kwargs):
       """ % css_label,
         )
 
-    ts_web_test_suite(
+    karma_web_test_suite(
         # Depend on our custom test initialization script. This needs to be the first dependency.
         deps = [
             "//test:angular_test_init",


### PR DESCRIPTION
Switches all `ts_web_test_suite` targets to the new
`karma_web_test_suite` rule. `ts_web_test_suite` is
based on the `karma_web_test_suite` rule but does not
allow developers to have a custom karma configuration.

In order to be able to provide a custom karma configuration
for setting up Saucelabs and Browserstack, we switch all
targets over to the `karma_web_test_suite` rule.

See: https://github.com/bazelbuild/rules_typescript/pull/363.

@josephperrott I don't think we want to provide a custom karma configuration for all targets right now. Only the target that runs on Saucelabs should provide the custom karma configuration. We prospectively will have targets that combine multiple tests to avoid rate and browser limits.

Ideally even then, we would not need to specify a custom karma configuration as the default karma configuration for Bazel has an integrated mechanism for using saucelabs. see:

https://github.com/bazelbuild/rules_nodejs/blob/master/packages/karma/src/karma.conf.js#L311