### PR TITLE
refactor(mdc-chips): Make MatChipTextControl publically available.

### DIFF
--- a/src/material-experimental/mdc-chips/public-api.ts
+++ b/src/material-experimental/mdc-chips/public-api.ts
@@ -16,3 +16,4 @@ export * from './module';
 export * from './chip-input';
 export * from './chip-default-options';
 export * from './chip-icons';
+export * from './chip-text-control';


### PR DESCRIPTION
Make the MatChipTextControl class available for implementation by other classes, so input fields other than input elements - eg. custom divs - can be used with mat-chip-grid (which currently assumes a matChipInputFor <input> is provided).