### PR TITLE
style(button-toggle-demo): missing space in attributes

### DIFF
--- a/src/dev-app/button-toggle/button-toggle-demo.html
+++ b/src/dev-app/button-toggle/button-toggle-demo.html
@@ -10,7 +10,7 @@
 
 <section>
   <mat-button-toggle-group name="alignment" [vertical]="isVertical">
-    <mat-button-toggle value="left"[disabled]="isDisabled">
+    <mat-button-toggle value="left" [disabled]="isDisabled">
       <mat-icon>format_align_left</mat-icon>
     </mat-button-toggle>
     <mat-button-toggle value="center" [disabled]="isDisabled">


### PR DESCRIPTION
This fixes obvious typo in a demo page markup.

Thanks!