### PR TITLE
build: use bazel automatic execution strategy selection

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,16 +36,6 @@ test --test_output=errors
 # See https://docs.bazel.build/versions/master/user-manual.html#flag--workspace_status_command
 build:release --workspace_status_command="node ./tools/bazel-stamp-vars.js"
 
-###############################
-# Typescript / Angular / Sass #
-###############################
-
-# Make compilation fast, by keeping a few copies of the compilers
-# running as daemons, and cache SourceFile AST's to reduce parse time.
-build --strategy=TypeScriptCompile=worker
-build --strategy=AngularTemplateCompile=worker
-build --strategy=SassCompiler=worker
-
 ################################
 # Temporary Settings for Ivy   #
 ################################
@@ -62,12 +52,7 @@ build --define=compile=legacy
 build:remote --remote_instance_name=projects/internal-200822/instances/default_instance
 build:remote --project_id=internal-200822
 
-# Setup the build strategy for various types of actions. Mixing "local" and "remote"
-# can cause unexpected results and we want to run everything remotely if possible.
-build:remote --spawn_strategy=remote,local
-build:remote --strategy=Javac=remote
-build:remote --strategy=Closure=remote
-build:remote --strategy=Genrule=remote
+# Needed due to: https://github.com/bazelbuild/bazel/issues/7254
 build:remote --define=EXECUTOR=remote
 
 # Setup the remote build execution servers.

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,5 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@npm_bazel_typescript//:index.bzl", "ts_config")
 load("//:packages.bzl", "CDK_PACKAGES", "MATERIAL_PACKAGES")
 load("//tools:defaults.bzl", "ts_library")
 load("//tools/dgeni:index.bzl", "dgeni_api_docs")
@@ -19,6 +20,12 @@ exports_files([
 ts_library(
     name = "module-typings",
     srcs = [":module-typings.d.ts"],
+)
+
+ts_config(
+    name = "tsconfig-test",
+    src = "bazel-tsconfig-test.json",
+    deps = ["bazel-tsconfig-build.json"],
 )
 
 dgeni_api_docs(

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -8,7 +8,7 @@ load("//tools/markdown-to-html:index.bzl", _markdown_to_html = "markdown_to_html
 load("//:packages.bzl", "ANGULAR_LIBRARY_UMDS", "VERSION_PLACEHOLDER_REPLACEMENTS")
 
 _DEFAULT_TSCONFIG_BUILD = "//src:bazel-tsconfig-build.json"
-_DEFAULT_TSCONFIG_TEST = "//src:bazel-tsconfig-test.json"
+_DEFAULT_TSCONFIG_TEST = "//src:tsconfig-test"
 
 # Whether Angular type checking should be enabled or not. Enabled by
 # default but will be overwritten when running snapshots tests with Ivy


### PR DESCRIPTION
* Switches our bazel setup to use the new bazel automatic strategy selection. https://blog.bazel.build/2019/06/19/list-strategy.html

Related to CI performance with Bazel: We currently get a lot of overhead for actions not running on remote as they cause runfile tree's to be created even though we don't need these (as test results are cached / or we just build). This seems like a bug/issue on the bazel-side: bazelbuild/bazel#6627