### PR TITLE
build: disable runfile creation in bazel_build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,10 @@ jobs:
       - *yarn_install
       - *setup_bazel_binary
 
-      - run: bazel build src/... --build_tag_filters=-docs-package
+      # Build all targets in the project (not only tests). Disable runfile tree creation
+      # as these are only needed for execution of targets and this job just verifies that
+      # targets can be built.
+      - run: bazel build src/... --build_tag_filters=-docs-package --nobuild_runfile_links
 
   # --------------------------------------------------------------------------------------------
   # Job that runs ts-api-guardian against our API goldens in "tools/public_api_guard".


### PR DESCRIPTION
Disables runfile tree creation in the `bazel_build` job. The runfile trees
are only needed for execution of test/binary targets, but this is not the
case for the `bazel_build` job. Runfile trees are not cached and therefore
cause the job to not fully leverage remote caching.

For testing jobs we still get the overhead of creating runfile tree's even if
the test results were part of the remote cache. Seems like a bug/issue that
is tracked on the bazel side: https://github.com/bazelbuild/bazel/issues/6627