### PR TITLE
ci: temporarily disable gesture config tests

### DIFF
--- a/src/material/core/gestures/gesture-config.spec.ts
+++ b/src/material/core/gestures/gesture-config.spec.ts
@@ -3,7 +3,13 @@ import {Component} from '@angular/core';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {GestureConfig, MAT_HAMMER_OPTIONS} from './gesture-config';
 
-describe('GestureConfig', () => {
+// TODO(kara): turn these tests back on when Material is using a release
+// of Angular that contains the HammerModule. They need to be turned off
+// for now in order to land https://github.com/angular/angular/pull/32203,
+// which makes Hammer optional (so Material/FW integration tests don't start
+// to fail).
+/* tslint:disable */
+xdescribe('GestureConfig', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ButtonWithLongpressHander],


### PR DESCRIPTION
We need to temporarily disable the gesture tests in order to
land a PR in framework that makes Hammer support optional
(https://github.com/angular/angular/pull/32203). Otherwise,
the Material/FW integration tests will fail because Material
modules haven't yet opted into Hammer.

Unfortunately, we cannot yet fix this properly by adding the
HammerModule to Material because Material is not using a
release that has HammerModule. Once the PR lands and Material
updates to a 9.0.0-next release, we can add the HammerModule
properly and turn these tests back on.