### PR TITLE
refactor(platform-browser): Hoist functions to workaround optimizatio…

### DIFF
--- a/src/material/core/common-behaviors/common-module.ts
+++ b/src/material/core/common-behaviors/common-module.ts
@@ -17,17 +17,16 @@ import {VERSION as CDK_VERSION} from '@angular/cdk';
 // re-exports all secondary entry-points
 const VERSION = new Version('0.0.0-PLACEHOLDER');
 
+/** @docs-private */
+export function MATERIAL_SANITY_CHECKS_FACTORY(): boolean {
+  return true;
+}
 
 /** Injection token that configures whether the Material sanity checks are enabled. */
 export const MATERIAL_SANITY_CHECKS = new InjectionToken<boolean>('mat-sanity-checks', {
   providedIn: 'root',
   factory: MATERIAL_SANITY_CHECKS_FACTORY,
 });
-
-/** @docs-private */
-export function MATERIAL_SANITY_CHECKS_FACTORY(): boolean {
-  return true;
-}
 
 /**
  * Module that captures anything that should be loaded and/or run for *all* Angular Material


### PR DESCRIPTION
…n bug

Technically, function definitions can live anywhere because they are
hoisted. However, in this case Closure optimizations break when exported
function definitions are referred in another static object that is
exported.

The bad pattern is:
```
exports const obj = {f};
export function f() {...}
```

which turns to the following in Closure's module system:
```
goog.module('m');

exports.obj = {f};

function f() {...}
exports.f = f;
```

which badly optimizes to (note module objects are collapsed)

```
var b = a; var a = function() {...};  // now b is undefined.
```

This is an optimizer bug and should be fixed in Closure, but in the
meantime this change is a noop and will unblock other changes we want to
make.