### PR TITLE
build: add blocklist to disable individual tests in the project

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -7,7 +7,10 @@ ts_library(
     name = "angular_test_init",
     testonly = True,
     # This file *must* end with "spec" in order for "karma_web_test_suite" to load it.
-    srcs = ["angular-test-init-spec.ts"],
+    srcs = [
+        "angular-test-init-spec.ts",
+        "test-blocklist.ts",
+    ],
     deps = [
         "@npm//@angular/core",
         "@npm//@angular/platform-browser-dynamic",

--- a/test/angular-test-init-spec.ts
+++ b/test/angular-test-init-spec.ts
@@ -3,6 +3,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
+import {testBlocklist} from './test-blocklist';
 
 /*
  * Common setup / initialization for all unit tests in Angular Material and CDK.
@@ -54,3 +55,16 @@ function patchTestBedToDestroyFixturesAfterEveryTest(testBedInstance: TestBed) {
   // https://github.com/angular/angular/blob/master/packages/core/testing/src/before_each.ts#L25
   afterEach(() => testBedInstance.resetTestingModule());
 }
+
+
+// Filter out any tests explicitly given in the blocklist. The blocklist is empty in the
+// components repository, but the file will be overwritten if the framework repository runs
+// the Angular component test suites against the latest snapshots. This is helpful because
+// sometimes breaking changes that break individual tests land in the framework repository.
+// It should be possible to disable these tests until the component repository migrated the
+// broken tests once the breaking change is released.
+(jasmine.getEnv() as any).configure({
+  specFilter: function(spec: jasmine.Spec) {
+    return !testBlocklist || !testBlocklist[spec.getFullName()];
+  }
+});

--- a/test/test-blocklist.ts
+++ b/test/test-blocklist.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * List of tests that should not run in the Angular component test suites. This should
+ * be empty in the components repository, but the file will be overwritten if the framework
+ * repository runs the Angular component test suites against the latest snapshots. This is
+ * helpful because sometimes breaking changes that break individual tests land in the framework
+ * repository. It should be possible to disable these tests until the component repository
+ * migrated the broken tests.
+ */
+export const testBlocklist: {[testName: string]: Object} = {};


### PR DESCRIPTION
Similarly to what we had in the `ivy-2019` branch for disabling
individual tests, we now need something similar that works with
Bazel. This is necessary because there are still breaking changes
that could land in the framework repository and break individual
tests of the component repository.

Framework now needs a way to disable those specific tests until
the components repository migrated the broken tests (this can
be delayed by weeks since the breaking change is not necessarily
yet released)