### PR TITLE
build: update jasmine types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@types/gulp-util": "^3.0.34",
     "@types/hammerjs": "^2.0.35",
     "@types/inquirer": "^0.0.43",
-    "@types/jasmine": "^3.0.0",
+    "@types/jasmine": "^3.4.0",
     "@types/marked": "^0.4.2",
     "@types/merge2": "^0.3.30",
     "@types/minimist": "^1.2.0",

--- a/src/cdk/a11y/aria-describer/aria-reference.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-reference.spec.ts
@@ -46,7 +46,8 @@ describe('AriaReference', () => {
   it('should not add the same reference id if it already exists', () => {
     addAriaReferencedId(testElement!, 'aria-describedby', 'reference_1');
     addAriaReferencedId(testElement!, 'aria-describedby', 'reference_1');
-    expect(['reference_1']);
+    expect(getAriaReferenceIds(testElement!, 'aria-describedby'))
+        .toEqual(['reference_1']);
   });
 
   it('should retrieve ids that are deliminated by extra whitespace', () => {

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -749,7 +749,7 @@ describe('CdkTable', () => {
 
     function expectNoStickyStyles(elements: any[]) {
       elements.forEach(element => {
-        expect(element.classList.contains('cdk-table-sticky'));
+        expect(element.classList.contains('cdk-table-sticky')).toBe(false);
         expect(element.style.position).toBe('');
         expect(element.style.zIndex || '0').toBe('0');
         ['top', 'bottom', 'left', 'right'].forEach(d => {

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -190,11 +190,12 @@ describe('Row Chips', () => {
       });
 
       describe('focus management', () => {
-        it('sends focus to first grid cell on click', () => {
-          dispatchFakeEvent(chipNativeElement, 'click');
+        it('sends focus to first grid cell on mousedown', () => {
+          dispatchFakeEvent(chipNativeElement, 'mousedown');
           fixture.detectChanges();
 
-          expect(document.activeElement!.classList.contains('mat-chip-row-focusable-text-content'));
+          expect(document.activeElement!.classList.contains('mat-chip-row-focusable-text-content'))
+              .toBe(true);
         });
 
         it('emits focus only once for multiple focus() calls', () => {

--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -377,7 +377,7 @@ describe('MatButtonToggle without forms', () => {
       fixture.detectChanges();
 
       expect(buttonToggleInstances[0].checked).toBe(true);
-      expect(groupInstance.value);
+      expect(groupInstance.value).toBe('test1');
     });
 
     it('should change the vertical state', () => {

--- a/src/material/core/gestures/gesture-config.spec.ts
+++ b/src/material/core/gestures/gesture-config.spec.ts
@@ -18,7 +18,7 @@ xdescribe('GestureConfig', () => {
   }));
 
   it('should instantiate HammerJS', () => {
-    spyOn(window, 'Hammer' as any).and.callThrough();
+    spyOn(window as any, 'Hammer').and.callThrough();
 
     const fixture = TestBed.createComponent(ButtonWithLongpressHander);
     fixture.detectChanges();
@@ -38,7 +38,7 @@ xdescribe('GestureConfig', () => {
       })
       .compileComponents();
 
-    spyOn(window, 'Hammer' as any).and.callThrough();
+    spyOn(window as any, 'Hammer').and.callThrough();
 
     const fixture = TestBed.createComponent(ButtonWithLongpressHander);
     fixture.detectChanges();

--- a/src/material/datepicker/year-view.spec.ts
+++ b/src/material/datepicker/year-view.spec.ts
@@ -108,7 +108,7 @@ describe('MatYearView', () => {
       testComponent.date = new Date(2017, JUL, 31);
       fixture.detectChanges();
 
-      expect(testComponent.yearView._monthSelected(JUN));
+      testComponent.yearView._monthSelected(JUN);
       fixture.detectChanges();
 
       expect(testComponent.selected).toEqual(new Date(2017, JUN, 30));

--- a/src/youtube-player/fake-youtube-player.ts
+++ b/src/youtube-player/fake-youtube-player.ts
@@ -45,7 +45,7 @@ export function createFakeYtNamespace(): FakeYtNamespace {
 
       for (const [event, callback] of playerSpy.addEventListener.calls.allArgs()) {
         if (event === name) {
-          callback(arg);
+          callback(arg as YT.PlayerEvent);
         }
       }
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,10 +1260,10 @@
     "@types/rx" "*"
     "@types/through" "*"
 
-"@types/jasmine@^3.0.0":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.3.1.tgz#b6c4f356013364e98b583647c7b3b6de6fccd2cc"
-  integrity sha512-JnKB+cEIFuQZXizZP6N0zxma+JlvowkjefWuL61otVmXN7Ebbs4ka3IbDVIz1pc+TCiT00q925jANz3gQJ9qXw==
+"@types/jasmine@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.4.0.tgz#018c56db42400c092aae47de21f710b7f04e4b06"
+  integrity sha512-6pUnBg6DuSB55xnxJ5+gW9JOkFrPsXkYAuqqEE8oyrpgDiPQ+TZ+1Zt4S+CHcRJcxyNYXeIXG4vHSzdF6y9Uvw==
 
 "@types/jju@~1.4.0":
   version "1.4.1"


### PR DESCRIPTION
Updates the jasmine types to the latest version. Unfortunately the update
didn't bring in the types for the `jasmine.Env.configure` method for #16833,
but it's still a good thing to update as it helps tsetse catch more incomplete
test expectations.