### PR TITLE
fix(cdk/a11y): FocusMonitor emits rogue values in IE 11

### DIFF
--- a/src/cdk/a11y/a11y.md
+++ b/src/cdk/a11y/a11y.md
@@ -133,6 +133,8 @@ indicate how the element was focused.
 Note: currently the `FocusMonitor` emits on the observable _outside_ of the Angular zone. Therefore
 if you `markForCheck` in the subscription you must put yourself back in the Angular zone.
 
+Note: for browser compatibility reasons, the actual DOM events listened for by the `FocusMonitor` are `focusin` and `focusout`.
+
 ```ts
 focusMonitor.monitor(el).subscribe(origin => this.ngZone.run(() => /* ... */ ));
 ```

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -179,18 +179,20 @@ export class FocusMonitor implements OnDestroy {
     this._elementInfo.set(nativeElement, info);
     this._incrementMonitoredElementCount();
 
-    // Start listening. We need to listen in capture phase since focus events don't bubble.
-    let focusListener = (event: FocusEvent) => this._onFocus(event, nativeElement);
-    let blurListener = (event: FocusEvent) => this._onBlur(event, nativeElement);
+    // Start listening. We need to listen in capture phase since focus events don't bubble
+    // Casting from `Event` to `FocusEvent` to work around bug with typescript dom typings
+    // TODO correct typing after typescript upgrade
+    let focusListener = (event: Event) => this._onFocus(event as FocusEvent, nativeElement);
+    let blurListener = (event: Event) => this._onBlur(event as FocusEvent, nativeElement);
     this._ngZone.runOutsideAngular(() => {
-      nativeElement.addEventListener('focus', focusListener, true);
-      nativeElement.addEventListener('blur', blurListener, true);
+      nativeElement.addEventListener('focusin', focusListener, true);
+      nativeElement.addEventListener('focusout', blurListener, true);
     });
 
     // Create an unlisten function for later.
     info.unlisten = () => {
-      nativeElement.removeEventListener('focus', focusListener, true);
-      nativeElement.removeEventListener('blur', blurListener, true);
+      nativeElement.removeEventListener('focusin', focusListener, true);
+      nativeElement.removeEventListener('focusout', blurListener, true);
     };
 
     return info.subject.asObservable();

--- a/src/cdk/testing/testbed/fake-events/element-focus.ts
+++ b/src/cdk/testing/testbed/fake-events/element-focus.ts
@@ -23,11 +23,16 @@ function triggerFocusChange(element: HTMLElement, event: 'focus' | 'blur') {
  * Patches an elements focus and blur methods to emit events consistently and predictably.
  * This is necessary, because some browsers, like IE11, will call the focus handlers asynchronously,
  * while others won't fire them at all if the browser window is not focused.
- * @docs-private
  */
 export function patchElementFocus(element: HTMLElement) {
-  element.focus = () => dispatchFakeEvent(element, 'focus');
-  element.blur = () => dispatchFakeEvent(element, 'blur');
+    element.focus = () => {
+        dispatchFakeEvent(element, 'focus');
+        dispatchFakeEvent(element, 'focusin');
+    };
+    element.blur = () => {
+        dispatchFakeEvent(element, 'blur');
+        dispatchFakeEvent(element, 'focusout');
+    };
 }
 
 /** @docs-private */

--- a/src/dev-app/focus-origin/focus-origin-demo-module.ts
+++ b/src/dev-app/focus-origin/focus-origin-demo-module.ts
@@ -10,9 +10,11 @@ import {A11yModule} from '@angular/cdk/a11y';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {FocusOriginDemo} from './focus-origin-demo';
+import {CommonModule} from '@angular/common';
 
 @NgModule({
   imports: [
+    CommonModule,
     A11yModule,
     RouterModule.forChild([{path: '', component: FocusOriginDemo}]),
   ],

--- a/src/dev-app/focus-origin/focus-origin-demo.html
+++ b/src/dev-app/focus-origin/focus-origin-demo.html
@@ -24,3 +24,12 @@
   <p>Parent div should get same focus origin as button when button is focused:</p>
   <button class="demo-focusable" cdkMonitorElementFocus>focus me</button>
 </div>
+
+<div #c class="demo-monitor">
+  <p>Monitored, including children, via `monitor`; each value is listed below</p>
+  <button>1</button>
+  <button>2</button>
+  <ol>
+    <li *ngFor="let event of containerEvents">{{event}}</li>
+  </ol>
+</div>

--- a/src/dev-app/focus-origin/focus-origin-demo.ts
+++ b/src/dev-app/focus-origin/focus-origin-demo.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {FocusMonitor} from '@angular/cdk/a11y';
+import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
 
 
 @Component({
@@ -15,6 +15,22 @@ import {FocusMonitor} from '@angular/cdk/a11y';
   templateUrl: 'focus-origin-demo.html',
   styleUrls: ['focus-origin-demo.css'],
 })
-export class FocusOriginDemo {
-  constructor(public fom: FocusMonitor) {}
+export class FocusOriginDemo implements OnInit, OnDestroy  {
+  containerEvents: FocusOrigin[] = [];
+
+  @ViewChild('c', {static: true}) container: ElementRef<HTMLElement>;
+
+  constructor(public fom: FocusMonitor) {
+  }
+
+  ngOnInit(): void {
+    this.fom.monitor(this.container, true)
+      .subscribe((value: FocusOrigin) => {
+        this.containerEvents.push(value);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.fom.stopMonitoring(this.container);
+  }
 }

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -948,6 +948,7 @@ describe('MatCheckbox', () => {
       // If the input element loses focus, the control should remain dirty but should
       // also turn touched.
       dispatchFakeEvent(inputElement, 'blur');
+      dispatchFakeEvent(inputElement, 'focusout');
       fixture.detectChanges();
       flushMicrotasks();
 
@@ -972,6 +973,7 @@ describe('MatCheckbox', () => {
       expect(checkboxNativeElement.classList).not.toContain('ng-touched');
 
       dispatchFakeEvent(inputElement, 'blur');
+      dispatchFakeEvent(inputElement, 'focusout');
       fixture.detectChanges();
       flushMicrotasks();
       fixture.detectChanges();

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -485,6 +485,7 @@ describe('MatRadio', () => {
       // Blur the input element in order to verify that the ng-touched state has been set to true.
       // The touched state should be only set to true after the form control has been blurred.
       dispatchFakeEvent(innerRadios[2].nativeElement, 'blur');
+      dispatchFakeEvent(innerRadios[2].nativeElement, 'focusout');
 
       expect(groupNgModel.valid).toBe(true);
       expect(groupNgModel.pristine).toBe(false);

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -587,6 +587,7 @@ describe('MatSlideToggle with forms', () => {
       // Once the input element loses focus, the control should remain dirty but should
       // also turn touched.
       dispatchFakeEvent(inputElement, 'blur');
+      dispatchFakeEvent(inputElement, 'focusout');
       fixture.detectChanges();
       flushMicrotasks();
 
@@ -625,6 +626,7 @@ describe('MatSlideToggle with forms', () => {
       // Once the input element loses focus, the control should remain dirty but should
       // also turn touched.
       dispatchFakeEvent(inputElement, 'blur');
+      dispatchFakeEvent(inputElement, 'focusout');
       fixture.detectChanges();
       flushMicrotasks();
 

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -143,6 +143,7 @@ describe('MatSlider', () => {
       sliderInstance._isActive = true;
 
       dispatchFakeEvent(sliderNativeElement, 'blur');
+      dispatchFakeEvent(sliderNativeElement, 'focusout');
       fixture.detectChanges();
 
       expect(sliderInstance._isActive).toBe(false);
@@ -156,6 +157,7 @@ describe('MatSlider', () => {
       expect(sliderInstance._thumbGap).toBe(10);
 
       dispatchFakeEvent(sliderNativeElement, 'blur');
+      dispatchFakeEvent(sliderNativeElement, 'focusout');
       fixture.detectChanges();
 
       expect(sliderInstance._thumbGap).toBe(7);


### PR DESCRIPTION
Fixes #15517.

Not ready to merge just yet, but I wanted to get this up and get any feedback in case I haven't fully understood the potential impact.

- [x] Fully update documentation
- [x] Rebase and squash

TLDR of the issue:

> When you monitor a parent element with `checkChildren` set to `true`, internally the focus monitor listens for both `focus` and `blur` events on the parent element. When focus shifts from child element 1 to child element 2, the `blur` event on child element 1 is captured first. The design is that this `blur` event does not result in a `null` value on the subject, because the focus monitor will see that the [event's `relatedTarget`](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget) (the element that's about to take the focus) is also a child of our parent element, [and take no further action](https://github.com/angular/components/blob/2d976a92429ed37a89bfa9ee74b479b48c7ac40d/src/cdk/a11y/focus-monitor/focus-monitor.ts#L375).
> 
> However, IE does not set the `relatedTarget` on `focus` or `blur` events, so the focus monitor can't know that focus is not leaving the parent element, and so we get a `null` value on the subject.

The solution here is to listen for the `focusin` and `focusout` events instead, where IE _does_ set the `relatedTarget` correctly (along with all other browsers). Other than this, there are some differences between the two sets of events:

- `focusin` and `focusout` support bubbling, where `focus` and `blur` do not - I don't think this makes any difference for our use case, as we are explicitly using capture mode anyway
- `focusin` and `focusout` fire _after_ their counterparts `focus` and `blur` - it's theoretically possible the some users may be relying on an order of events, but given there's no documentation that spells out when the focus monitor emits in relation to, say, model changes, I don't think it should be considered a breaking change

(I've not been able to run the full test suite on Windows due to #16632, and linting on Windows is a non-starter because of line breaks, so I'll be testing properly on my Mac later)