### PR TITLE
build: re-enable disabled gesture config test

### DIFF
--- a/src/material/core/gestures/gesture-config.spec.ts
+++ b/src/material/core/gestures/gesture-config.spec.ts
@@ -3,13 +3,7 @@ import {Component} from '@angular/core';
 import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
 import {GestureConfig, MAT_HAMMER_OPTIONS} from './gesture-config';
 
-// TODO(kara): turn these tests back on when Material is using a release
-// of Angular that contains the HammerModule. They need to be turned off
-// for now in order to land https://github.com/angular/angular/pull/32203,
-// which makes Hammer optional (so Material/FW integration tests don't start
-// to fail).
-/* tslint:disable */
-xdescribe('GestureConfig', () => {
+describe('GestureConfig', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ButtonWithLongpressHander],


### PR DESCRIPTION
eaf70ca2a0600757041633976b29ab5a95d08296 temporarily disabled the gesture config tests because the blocklist
didn't work. Now that the blocklist works on the framework side, we can
re-enable this test again.

Once this PR lands, we can update the SHA on the framework repo and
add the gesture tests to the blocklist.

cc. @kara 