### PR TITLE
 feat(cdk-experimental/testing): add support for matching selector on TestElement

### DIFF
--- a/src/cdk-experimental/testing/component-harness.ts
+++ b/src/cdk-experimental/testing/component-harness.ts
@@ -259,6 +259,10 @@ export interface ComponentHarnessConstructor<T extends ComponentHarness> {
   hostSelector: string;
 }
 
+export interface BaseHarnessFilters {
+  selector?: string;
+}
+
 /**
  * A class used to associate a ComponentHarness class with predicates functions that can be used to
  * filter instances of the class.
@@ -267,7 +271,14 @@ export class HarnessPredicate<T extends ComponentHarness> {
   private _predicates: AsyncPredicate<T>[] = [];
   private _descriptions: string[] = [];
 
-  constructor(public harnessType: ComponentHarnessConstructor<T>) {}
+  constructor(public harnessType: ComponentHarnessConstructor<T>, options: BaseHarnessFilters) {
+    const selector = options.selector;
+    if (selector !== undefined) {
+      this.add(`selector matches "${selector}"`, async item => {
+        return (await item.host()).matchesSelector(selector);
+      });
+    }
+  }
 
   /**
    * Checks if a string matches the given pattern.

--- a/src/cdk-experimental/testing/harness-environment.ts
+++ b/src/cdk-experimental/testing/harness-environment.ts
@@ -23,7 +23,7 @@ function _getErrorForMissingSelector(selector: string): Error {
 function _getErrorForMissingHarness<T extends ComponentHarness>(
     harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): Error {
   const harnessPredicate =
-      harnessType instanceof HarnessPredicate ? harnessType : new HarnessPredicate(harnessType);
+      harnessType instanceof HarnessPredicate ? harnessType : new HarnessPredicate(harnessType, {});
   const {name, hostSelector} = harnessPredicate.harnessType;
   const restrictions = harnessPredicate.getDescription();
   let message = `Expected to find element for ${name} matching selector: "${hostSelector}"`;
@@ -160,7 +160,8 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
   private async _getAllHarnesses<T extends ComponentHarness>(
       harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): Promise<T[]> {
     const harnessPredicate =
-        harnessType instanceof HarnessPredicate ? harnessType : new HarnessPredicate(harnessType);
+        harnessType instanceof HarnessPredicate ?
+            harnessType : new HarnessPredicate(harnessType, {});
     const elements = await this.getAllRawElements(harnessPredicate.harnessType.hostSelector);
     return harnessPredicate.filter(elements.map(
         element => this.createComponentHarness(harnessPredicate.harnessType, element)));

--- a/src/cdk-experimental/testing/protractor/protractor-element.ts
+++ b/src/cdk-experimental/testing/protractor/protractor-element.ts
@@ -142,5 +142,16 @@ export class ProtractorElement implements TestElement {
     return browser.executeScript(`return arguments[0][arguments[1]]`, this.element, name);
   }
 
+  async matchesSelector(selector: string): Promise<boolean> {
+      return browser.executeScript(`
+          return (Element.prototype.matches ||
+                  Element.prototype.matchesSelector ||
+                  Element.prototype.mozMatchesSelector ||
+                  Element.prototype.msMatchesSelector ||
+                  Element.prototype.oMatchesSelector ||
+                  Element.prototype.webkitMatchesSelector).call(arguments[0], arguments[1])
+          `, this.element, selector);
+  }
+
   async forceStabilize(): Promise<void> {}
 }

--- a/src/cdk-experimental/testing/test-element.ts
+++ b/src/cdk-experimental/testing/test-element.ts
@@ -102,6 +102,9 @@ export interface TestElement {
   /** Gets the value of a property of an element. */
   getProperty(name: string): Promise<any>;
 
+  /** Checks whether this element matches the given selector. */
+  matchesSelector(selector: string): Promise<boolean>;
+
   /**
    * Flushes change detection and async tasks.
    * In most cases it should not be necessary to call this. However, there may be some edge cases

--- a/src/cdk-experimental/testing/testbed/unit-test-element.ts
+++ b/src/cdk-experimental/testing/testbed/unit-test-element.ts
@@ -138,6 +138,17 @@ export class UnitTestElement implements TestElement {
     return (this.element as any)[name];
   }
 
+  async matchesSelector(selector: string): Promise<boolean> {
+    await this._stabilize();
+    const elementPrototype = Element.prototype as any;
+    return (elementPrototype['matches'] ||
+            elementPrototype['matchesSelector'] ||
+            elementPrototype['mozMatchesSelector'] ||
+            elementPrototype['msMatchesSelector'] ||
+            elementPrototype['oMatchesSelector'] ||
+            elementPrototype['webkitMatchesSelector']).call(this.element, selector);
+  }
+
   async forceStabilize(): Promise<void> {
     return this._stabilize();
   }

--- a/src/cdk-experimental/testing/tests/harnesses/main-component-harness.ts
+++ b/src/cdk-experimental/testing/tests/harnesses/main-component-harness.ts
@@ -49,6 +49,7 @@ export class MainComponentHarness extends ComponentHarness {
   readonly testLists = this.locatorForAll(SubComponentHarness.with({title: /test/}));
   readonly requiredFourIteamToolsLists =
       this.locatorFor(SubComponentHarness.with({title: 'List of test tools', itemCount: 4}));
+  readonly lastList = this.locatorFor(SubComponentHarness.with({selector: ':last-child'}));
   readonly specaialKey = this.locatorFor('.special-key');
 
   private _testTools = this.locatorFor(SubComponentHarness);

--- a/src/cdk-experimental/testing/tests/harnesses/sub-component-harness.ts
+++ b/src/cdk-experimental/testing/tests/harnesses/sub-component-harness.ts
@@ -6,15 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '../../component-harness';
+import {BaseHarnessFilters, ComponentHarness, HarnessPredicate} from '../../component-harness';
 import {TestElement} from '../../test-element';
+
+export interface SubComponentHarnessFilters extends BaseHarnessFilters {
+  title?: string | RegExp;
+  itemCount?: number;
+}
 
 /** @dynamic */
 export class SubComponentHarness extends ComponentHarness {
   static readonly hostSelector = 'test-sub';
 
-  static with(options: {title?: string | RegExp, itemCount?: number} = {}) {
-    return new HarnessPredicate(SubComponentHarness)
+  static with(options: SubComponentHarnessFilters = {}) {
+    return new HarnessPredicate(SubComponentHarness, options)
         .addOption('title', options.title,
             async (harness, title) =>
                 HarnessPredicate.stringMatches((await harness.title()).text(), title))

--- a/src/cdk-experimental/testing/tests/protractor.e2e.spec.ts
+++ b/src/cdk-experimental/testing/tests/protractor.e2e.spec.ts
@@ -260,6 +260,12 @@ describe('ProtractorHarnessEnvironment', () => {
       await input.sendKeys('Hello');
       expect(await input.getProperty('value')).toBe('Hello');
     });
+
+    it('should check if selector matches', async () => {
+      const button = await harness.button();
+      expect(await button.matchesSelector('button:not(.fake-class)')).toBe(true);
+      expect(await button.matchesSelector('button:disabled')).toBe(false);
+    });
   });
 
   describe('HarnessPredicate', () => {
@@ -291,6 +297,11 @@ describe('ProtractorHarnessEnvironment', () => {
       expect(testLists.length).toBe(2);
       expect(await (await testLists[0].title()).text()).toBe('List of test tools');
       expect(await (await testLists[1].title()).text()).toBe('List of test methods');
+    });
+
+    it('should find subcomponents that match selector', async () => {
+      const lastList = await harness.lastList();
+      expect(await (await lastList.title()).text()).toBe('List of test methods');
     });
 
     it('should error if predicate does not match but a harness is required', async () => {

--- a/src/cdk-experimental/testing/tests/testbed.spec.ts
+++ b/src/cdk-experimental/testing/tests/testbed.spec.ts
@@ -264,7 +264,7 @@ describe('TestbedHarnessEnvironment', () => {
     });
 
     it('should focus and blur element', async () => {
-      let button = await harness.button();
+      const button = await harness.button();
       expect(activeElementText()).not.toBe(await button.text());
       await button.focus();
       expect(activeElementText()).toBe(await button.text());
@@ -276,6 +276,12 @@ describe('TestbedHarnessEnvironment', () => {
       const input = await harness.input();
       await input.sendKeys('Hello');
       expect(await input.getProperty('value')).toBe('Hello');
+    });
+
+    it('should check if selector matches', async () => {
+      const button = await harness.button();
+      expect(await button.matchesSelector('button:not(.fake-class)')).toBe(true);
+      expect(await button.matchesSelector('button:disabled')).toBe(false);
     });
   });
 
@@ -309,6 +315,11 @@ describe('TestbedHarnessEnvironment', () => {
       expect(testLists.length).toBe(2);
       expect(await (await testLists[0].title()).text()).toBe('List of test tools');
       expect(await (await testLists[1].title()).text()).toBe('List of test methods');
+    });
+
+    it('should find subcomponents that match selector', async () => {
+      const lastList = await harness.lastList();
+      expect(await (await lastList.title()).text()).toBe('List of test methods');
     });
 
     it('should error if predicate does not match but a harness is required', async () => {

--- a/src/material-experimental/mdc-button/harness/button-harness-filters.ts
+++ b/src/material-experimental/mdc-button/harness/button-harness-filters.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type ButtonHarnessFilters = {
-  text?: string | RegExp
-};
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
+
+export interface ButtonHarnessFilters extends BaseHarnessFilters {
+  text?: string | RegExp;
+}

--- a/src/material-experimental/mdc-button/harness/button-harness.ts
+++ b/src/material-experimental/mdc-button/harness/button-harness.ts
@@ -30,11 +30,12 @@ export class MatButtonHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a button with specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a button whose host element matches the given selector.
    *   - `text` finds a button with specific text content.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: ButtonHarnessFilters = {}): HarnessPredicate<MatButtonHarness> {
-    return new HarnessPredicate(MatButtonHarness)
+    return new HarnessPredicate(MatButtonHarness, options)
         .addOption('text', options.text,
             (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text));
   }

--- a/src/material-experimental/mdc-button/harness/mdc-button-harness.ts
+++ b/src/material-experimental/mdc-button/harness/mdc-button-harness.ts
@@ -30,11 +30,12 @@ export class MatButtonHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a button with specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a button whose host element matches the given selector.
    *   - `text` finds a button with specific text content.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: ButtonHarnessFilters = {}): HarnessPredicate<MatButtonHarness> {
-    return new HarnessPredicate(MatButtonHarness)
+    return new HarnessPredicate(MatButtonHarness, options)
         .addOption('text', options.text,
             (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text));
   }

--- a/src/material-experimental/mdc-checkbox/harness/checkbox-harness-filters.ts
+++ b/src/material-experimental/mdc-checkbox/harness/checkbox-harness-filters.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type CheckboxHarnessFilters = {
-  label?: string|RegExp;
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
+
+export interface CheckboxHarnessFilters extends BaseHarnessFilters {
+  label?: string | RegExp;
   name?: string;
-};
+}

--- a/src/material-experimental/mdc-checkbox/harness/checkbox-harness.ts
+++ b/src/material-experimental/mdc-checkbox/harness/checkbox-harness.ts
@@ -20,12 +20,13 @@ export class MatCheckboxHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a checkbox with specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a checkbox whose host element matches the given selector.
    *   - `label` finds a checkbox with specific label text.
    *   - `name` finds a checkbox with specific name.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: CheckboxHarnessFilters = {}): HarnessPredicate<MatCheckboxHarness> {
-    return new HarnessPredicate(MatCheckboxHarness)
+    return new HarnessPredicate(MatCheckboxHarness, options)
         .addOption(
             'label', options.label,
             (harness, label) => HarnessPredicate.stringMatches(harness.getLabelText(), label))

--- a/src/material-experimental/mdc-checkbox/harness/mdc-checkbox-harness.ts
+++ b/src/material-experimental/mdc-checkbox/harness/mdc-checkbox-harness.ts
@@ -20,12 +20,13 @@ export class MatCheckboxHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a checkbox with specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a checkbox whose host element matches the given selector.
    *   - `label` finds a checkbox with specific label text.
    *   - `name` finds a checkbox with specific name.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: CheckboxHarnessFilters = {}): HarnessPredicate<MatCheckboxHarness> {
-    return new HarnessPredicate(MatCheckboxHarness)
+    return new HarnessPredicate(MatCheckboxHarness, options)
         .addOption(
             'label', options.label,
             (harness, label) => HarnessPredicate.stringMatches(harness.getLabelText(), label))

--- a/src/material-experimental/mdc-input/harness/input-harness-filters.ts
+++ b/src/material-experimental/mdc-input/harness/input-harness-filters.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type InputHarnessFilters = {
-  id?: string;
-  name?: string;
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
+
+export interface InputHarnessFilters extends BaseHarnessFilters {
   value?: string;
-};
+}

--- a/src/material-experimental/mdc-input/harness/input-harness.spec.ts
+++ b/src/material-experimental/mdc-input/harness/input-harness.spec.ts
@@ -46,12 +46,13 @@ function runTests() {
   });
 
   it('should load input with specific id', async () => {
-    const inputs = await loader.getAllHarnesses(inputHarness.with({id: 'myTextarea'}));
+    const inputs = await loader.getAllHarnesses(inputHarness.with({selector: '#myTextarea'}));
     expect(inputs.length).toBe(1);
   });
 
   it('should load input with specific name', async () => {
-    const inputs = await loader.getAllHarnesses(inputHarness.with({name: 'favorite-food'}));
+    const inputs = await loader.getAllHarnesses(
+        inputHarness.with({selector: '[name="favorite-food"]'}));
     expect(inputs.length).toBe(1);
   });
 
@@ -157,14 +158,14 @@ function runTests() {
   });
 
   it('should be able to focus input', async () => {
-    const input = await loader.getHarness(inputHarness.with({name: 'favorite-food'}));
+    const input = await loader.getHarness(inputHarness.with({selector: '[name="favorite-food"]'}));
     expect(getActiveElementTagName()).not.toBe('input');
     await input.focus();
     expect(getActiveElementTagName()).toBe('input');
   });
 
   it('should be able to blur input', async () => {
-    const input = await loader.getHarness(inputHarness.with({name: 'favorite-food'}));
+    const input = await loader.getHarness(inputHarness.with({selector: '[name="favorite-food"]'}));
     expect(getActiveElementTagName()).not.toBe('input');
     await input.focus();
     expect(getActiveElementTagName()).toBe('input');

--- a/src/material-experimental/mdc-input/harness/input-harness.ts
+++ b/src/material-experimental/mdc-input/harness/input-harness.ts
@@ -26,11 +26,7 @@ export class MatInputHarness extends ComponentHarness {
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: InputHarnessFilters = {}): HarnessPredicate<MatInputHarness> {
-    // TODO(devversion): "name" and "id" can be removed once components#16848 is merged.
-    return new HarnessPredicate(MatInputHarness)
-        .addOption(
-            'name', options.name, async (harness, name) => (await harness.getName()) === name)
-        .addOption('id', options.id, async (harness, id) => (await harness.getId()) === id)
+    return new HarnessPredicate(MatInputHarness, options)
         .addOption(
             'value', options.value, async (harness, value) => (await harness.getValue()) === value);
   }

--- a/src/material-experimental/mdc-menu/harness/mdc-menu-harness.ts
+++ b/src/material-experimental/mdc-menu/harness/mdc-menu-harness.ts
@@ -23,11 +23,12 @@ export class MatMenuHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a menu whose host element matches the given selector.
    *   - `label` finds a menu with specific label text.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: MenuHarnessFilters = {}): HarnessPredicate<MatMenuHarness> {
-    return new HarnessPredicate(MatMenuHarness)
+    return new HarnessPredicate(MatMenuHarness, options)
         .addOption('text', options.triggerText,
             (harness, text) => HarnessPredicate.stringMatches(harness.getTriggerText(), text));
   }

--- a/src/material-experimental/mdc-menu/harness/mdc-menu-item-harness.ts
+++ b/src/material-experimental/mdc-menu/harness/mdc-menu-item-harness.ts
@@ -21,11 +21,12 @@ export class MatMenuItemHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
    * @param options Options for narrowing the search:
-   *   - `label` finds a menu with specific label text.
+   *   - `selector` finds a menu item whose host element matches the given selector.
+   *   - `label` finds a menu item with specific label text.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: MenuItemHarnessFilters = {}): HarnessPredicate<MatMenuItemHarness> {
-    return new HarnessPredicate(MatMenuItemHarness); // TODO: add options here
+    return new HarnessPredicate(MatMenuItemHarness, options); // TODO: add options here
   }
 
   /** Gets a boolean promise indicating if the menu is disabled. */

--- a/src/material-experimental/mdc-menu/harness/menu-harness-filters.ts
+++ b/src/material-experimental/mdc-menu/harness/menu-harness-filters.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type MenuHarnessFilters = {
-  triggerText?: string | RegExp
-};
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
 
-export type MenuItemHarnessFilters = {
-  text?: string | RegExp
-};
+export interface MenuHarnessFilters extends BaseHarnessFilters {
+  triggerText?: string | RegExp;
+}
+
+export interface MenuItemHarnessFilters extends BaseHarnessFilters {
+  text?: string | RegExp;
+}

--- a/src/material-experimental/mdc-menu/harness/menu-harness.ts
+++ b/src/material-experimental/mdc-menu/harness/menu-harness.ts
@@ -23,11 +23,12 @@ export class MatMenuHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a menu whose host element matches the given selector.
    *   - `label` finds a menu with specific label text.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: MenuHarnessFilters = {}): HarnessPredicate<MatMenuHarness> {
-    return new HarnessPredicate(MatMenuHarness)
+    return new HarnessPredicate(MatMenuHarness, options)
         .addOption('text', options.triggerText,
             (harness, text) => HarnessPredicate.stringMatches(harness.getTriggerText(), text));
   }

--- a/src/material-experimental/mdc-menu/harness/menu-item-harness.ts
+++ b/src/material-experimental/mdc-menu/harness/menu-item-harness.ts
@@ -21,11 +21,12 @@ export class MatMenuItemHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
    * @param options Options for narrowing the search:
-   *   - `label` finds a menu with specific label text.
+   *   - `selector` finds a menu item whose host element matches the given selector.
+   *   - `label` finds a menu item with specific label text.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: MenuItemHarnessFilters = {}): HarnessPredicate<MatMenuItemHarness> {
-    return new HarnessPredicate(MatMenuItemHarness); // TODO: add options here
+    return new HarnessPredicate(MatMenuItemHarness, options); // TODO: add options here
   }
 
   /** Gets a boolean promise indicating if the menu is disabled. */

--- a/src/material-experimental/mdc-radio/harness/radio-harness-filters.ts
+++ b/src/material-experimental/mdc-radio/harness/radio-harness-filters.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type RadioGroupHarnessFilters = {
-  id?: string;
-  name?: string;
-};
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
 
-export type RadioButtonHarnessFilters = {
-  label?: string|RegExp,
-  id?: string;
-  name?: string,
-};
+export interface RadioGroupHarnessFilters extends BaseHarnessFilters {
+  name?: string;
+}
+
+export interface RadioButtonHarnessFilters extends BaseHarnessFilters {
+  label?: string | RegExp;
+  name?: string;
+}

--- a/src/material-experimental/mdc-radio/harness/radio-harness.spec.ts
+++ b/src/material-experimental/mdc-radio/harness/radio-harness.spec.ts
@@ -47,7 +47,7 @@ function runRadioGroupTests() {
   });
 
   it('should load radio-group with exact id', async () => {
-    const groups = await loader.getAllHarnesses(radioGroupHarness.with({id: 'my-group-2'}));
+    const groups = await loader.getAllHarnesses(radioGroupHarness.with({selector: '#my-group-2'}));
     expect(groups.length).toBe(1);
   });
 
@@ -169,7 +169,7 @@ function runRadioButtonTests() {
   });
 
   it('should load radio-button with id', async () => {
-    const radios = await loader.getAllHarnesses(radioButtonHarness.with({id: 'opt3'}));
+    const radios = await loader.getAllHarnesses(radioButtonHarness.with({selector: '#opt3'}));
     expect(radios.length).toBe(1);
     expect(await radios[0].getId()).toBe('opt3');
     expect(await radios[0].getLabelText()).toBe('Option #3');
@@ -214,14 +214,14 @@ function runRadioButtonTests() {
   });
 
   it('should focus radio-button', async () => {
-    const radioButton = await loader.getHarness(radioButtonHarness.with({id: 'opt2'}));
+    const radioButton = await loader.getHarness(radioButtonHarness.with({selector: '#opt2'}));
     expect(getActiveElementTagName()).not.toBe('input');
     await radioButton.focus();
     expect(getActiveElementTagName()).toBe('input');
   });
 
   it('should blur radio-button', async () => {
-    const radioButton = await loader.getHarness(radioButtonHarness.with({id: 'opt2'}));
+    const radioButton = await loader.getHarness(radioButtonHarness.with({selector: '#opt2'}));
     await radioButton.focus();
     expect(getActiveElementTagName()).toBe('input');
     await radioButton.blur();
@@ -241,7 +241,7 @@ function runRadioButtonTests() {
     fixture.componentInstance.disableAll = true;
     fixture.detectChanges();
 
-    const radioButton = await loader.getHarness(radioButtonHarness.with({id: 'opt3'}));
+    const radioButton = await loader.getHarness(radioButtonHarness.with({selector: '#opt3'}));
     expect(await radioButton.isChecked()).toBe(false);
     await radioButton.check();
     expect(await radioButton.isChecked()).toBe(false);
@@ -255,7 +255,8 @@ function runRadioButtonTests() {
   });
 
   it('should get required state', async () => {
-    const radioButton = await loader.getHarness(radioButtonHarness.with({id: 'required-radio'}));
+    const radioButton =
+        await loader.getHarness(radioButtonHarness.with({selector: '#required-radio'}));
     expect(await radioButton.isRequired()).toBe(true);
   });
 }

--- a/src/material-experimental/mdc-radio/harness/radio-harness.ts
+++ b/src/material-experimental/mdc-radio/harness/radio-harness.ts
@@ -21,13 +21,12 @@ export class MatRadioGroupHarness extends ComponentHarness {
    * Gets a `HarnessPredicate` that can be used to search for a radio-group with
    * specific attributes.
    * @param options Options for narrowing the search:
-   *   - `id` finds a radio-group with specific id.
+   *   - `selector` finds a radio-group whose host element matches the given selector.
    *   - `name` finds a radio-group with specific name.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: RadioGroupHarnessFilters = {}): HarnessPredicate<MatRadioGroupHarness> {
-    return new HarnessPredicate(MatRadioGroupHarness)
-        .addOption('id', options.id, async (harness, id) => (await harness.getId()) === id)
+    return new HarnessPredicate(MatRadioGroupHarness, options)
         .addOption('name', options.name, this._checkRadioGroupName);
   }
 
@@ -153,19 +152,18 @@ export class MatRadioButtonHarness extends ComponentHarness {
    * Gets a `HarnessPredicate` that can be used to search for a radio-button with
    * specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a radio-button whose host element matches the given selector.
    *   - `label` finds a radio-button with specific label text.
    *   - `name` finds a radio-button with specific name.
-   *   - `id` finds a radio-button with specific id.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: RadioButtonHarnessFilters = {}): HarnessPredicate<MatRadioButtonHarness> {
-    return new HarnessPredicate(MatRadioButtonHarness)
+    return new HarnessPredicate(MatRadioButtonHarness, options)
         .addOption(
             'label', options.label,
             (harness, label) => HarnessPredicate.stringMatches(harness.getLabelText(), label))
         .addOption(
-            'name', options.name, async (harness, name) => (await harness.getName()) === name)
-        .addOption('id', options.id, async (harness, id) => (await harness.getId()) === id);
+            'name', options.name, async (harness, name) => (await harness.getName()) === name);
   }
 
   private _textLabel = this.locatorFor('.mat-radio-label-content');

--- a/src/material-experimental/mdc-select/harness/select-harness-filters.ts
+++ b/src/material-experimental/mdc-select/harness/select-harness-filters.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type SelectHarnessFilters = {
-  id?: string;
-};
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
+
+export interface SelectHarnessFilters extends BaseHarnessFilters {}

--- a/src/material-experimental/mdc-select/harness/select-harness.spec.ts
+++ b/src/material-experimental/mdc-select/harness/select-harness.spec.ts
@@ -69,16 +69,18 @@ function runTests() {
   });
 
   it('should be able to check whether a select is in multi-selection mode', async () => {
-    const singleSelection = await loader.getHarness(harness.with({id: 'single-selection'}));
-    const multipleSelection = await loader.getHarness(harness.with({id: 'multiple-selection'}));
+    const singleSelection = await loader.getHarness(harness.with({selector: '#single-selection'}));
+    const multipleSelection =
+        await loader.getHarness(harness.with({selector: '#multiple-selection'}));
 
     expect(await singleSelection.isMultiple()).toBe(false);
     expect(await multipleSelection.isMultiple()).toBe(true);
   });
 
   it('should get disabled state', async () => {
-    const singleSelection = await loader.getHarness(harness.with({id: 'single-selection'}));
-    const multipleSelection = await loader.getHarness(harness.with({id: 'multiple-selection'}));
+    const singleSelection = await loader.getHarness(harness.with({selector: '#single-selection'}));
+    const multipleSelection =
+        await loader.getHarness(harness.with({selector: '#multiple-selection'}));
 
     expect(await singleSelection.isDisabled()).toBe(false);
     expect(await multipleSelection.isDisabled()).toBe(false);
@@ -91,8 +93,9 @@ function runTests() {
   });
 
   it('should get required state', async () => {
-    const singleSelection = await loader.getHarness(harness.with({id: 'single-selection'}));
-    const multipleSelection = await loader.getHarness(harness.with({id: 'multiple-selection'}));
+    const singleSelection = await loader.getHarness(harness.with({selector: '#single-selection'}));
+    const multipleSelection =
+        await loader.getHarness(harness.with({selector: '#multiple-selection'}));
 
     expect(await singleSelection.isRequired()).toBe(false);
     expect(await multipleSelection.isRequired()).toBe(false);
@@ -105,15 +108,15 @@ function runTests() {
   });
 
   it('should get valid state', async () => {
-    const singleSelection = await loader.getHarness(harness.with({id: 'single-selection'}));
-    const withFormControl = await loader.getHarness(harness.with({id: 'with-form-control'}));
+    const singleSelection = await loader.getHarness(harness.with({selector: '#single-selection'}));
+    const withFormControl = await loader.getHarness(harness.with({selector: '#with-form-control'}));
 
     expect(await singleSelection.isValid()).toBe(true);
     expect(await withFormControl.isValid()).toBe(false);
   });
 
   it('should focus and blur a select', async () => {
-    const select = await loader.getHarness(harness.with({id: 'single-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#single-selection'}));
     expect(getActiveElementId()).not.toBe('single-selection');
     await select.focus();
     expect(getActiveElementId()).toBe('single-selection');
@@ -122,7 +125,7 @@ function runTests() {
   });
 
   it('should be able to open and close a single-selection select', async () => {
-    const select = await loader.getHarness(harness.with({id: 'single-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#single-selection'}));
 
     expect(await select.isOpen()).toBe(false);
 
@@ -134,7 +137,7 @@ function runTests() {
   });
 
   it('should be able to open and close a multi-selection select', async () => {
-    const select = await loader.getHarness(harness.with({id: 'multiple-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#multiple-selection'}));
 
     expect(await select.isOpen()).toBe(false);
 
@@ -146,13 +149,13 @@ function runTests() {
   });
 
   it('should be able to get the select panel', async () => {
-    const select = await loader.getHarness(harness.with({id: 'single-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#single-selection'}));
     await select.open();
     expect(await select.getPanel()).toBeTruthy();
   });
 
   it('should be able to get the select options', async () => {
-    const select = await loader.getHarness(harness.with({id: 'single-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#single-selection'}));
     await select.open();
     const options = await select.getOptions();
 
@@ -161,7 +164,7 @@ function runTests() {
   });
 
   it('should be able to get the select panel groups', async () => {
-    const select = await loader.getHarness(harness.with({id: 'grouped'}));
+    const select = await loader.getHarness(harness.with({selector: '#grouped'}));
     await select.open();
     const groups = await select.getOptionGroups();
     const options = await select.getOptions();
@@ -171,7 +174,7 @@ function runTests() {
   });
 
   it('should be able to get the value text from a single-selection select', async () => {
-    const select = await loader.getHarness(harness.with({id: 'single-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#single-selection'}));
     await select.open();
     const options = await select.getOptions();
 
@@ -181,7 +184,7 @@ function runTests() {
   });
 
   it('should be able to get the value text from a multi-selection select', async () => {
-    const select = await loader.getHarness(harness.with({id: 'multiple-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#multiple-selection'}));
     await select.open();
     const options = await select.getOptions();
 
@@ -192,7 +195,7 @@ function runTests() {
   });
 
   it('should be able to get whether a single-selection select is empty', async () => {
-    const select = await loader.getHarness(harness.with({id: 'single-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#single-selection'}));
 
     expect(await select.isEmpty()).toBe(true);
 
@@ -204,7 +207,7 @@ function runTests() {
   });
 
   it('should be able to get whether a multi-selection select is empty', async () => {
-    const select = await loader.getHarness(harness.with({id: 'multiple-selection'}));
+    const select = await loader.getHarness(harness.with({selector: '#multiple-selection'}));
 
     expect(await select.isEmpty()).toBe(true);
 
@@ -218,7 +221,7 @@ function runTests() {
 
   it('should be able to click an option', async () => {
     const control = fixture.componentInstance.formControl;
-    const select = await loader.getHarness(harness.with({id: 'with-form-control'}));
+    const select = await loader.getHarness(harness.with({selector: '#with-form-control'}));
 
     expect(control.value).toBeFalsy();
 

--- a/src/material-experimental/mdc-select/harness/select-harness.ts
+++ b/src/material-experimental/mdc-select/harness/select-harness.ts
@@ -35,11 +35,7 @@ export class MatSelectHarness extends ComponentHarness {
    * @return `HarnessPredicate` configured with the given options.
    */
   static with(options: SelectHarnessFilters = {}): HarnessPredicate<MatSelectHarness> {
-    return new HarnessPredicate(MatSelectHarness)
-        .addOption('id', options.id, async (harness, id) => {
-          const harnessId = (await harness.host()).getAttribute('id');
-          return (await harnessId) === id;
-        });
+    return new HarnessPredicate(MatSelectHarness, options);
   }
 
   /** Gets a boolean promise indicating if the select is disabled. */

--- a/src/material-experimental/mdc-sidenav/harness/sidenav-harness-filters.ts
+++ b/src/material-experimental/mdc-sidenav/harness/sidenav-harness-filters.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type SidenavHarnessFilters = {
-  id?: string;
-};
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
+
+export interface SidenavHarnessFilters extends BaseHarnessFilters {}

--- a/src/material-experimental/mdc-sidenav/harness/sidenav-harness.ts
+++ b/src/material-experimental/mdc-sidenav/harness/sidenav-harness.ts
@@ -23,11 +23,7 @@ export class MatSidenavHarness extends ComponentHarness {
    * @return `HarnessPredicate` configured with the given options.
    */
   static with(options: SidenavHarnessFilters = {}): HarnessPredicate<MatSidenavHarness> {
-    return new HarnessPredicate(MatSidenavHarness)
-        .addOption('id', options.id, async (harness, id) => {
-          const host = await harness.host();
-          return (await host.getAttribute('id')) === id;
-        });
+    return new HarnessPredicate(MatSidenavHarness, options);
   }
 
   /** Gets whether the sidenav is open. */

--- a/src/material-experimental/mdc-slide-toggle/harness/mdc-slide-toggle-harness.ts
+++ b/src/material-experimental/mdc-slide-toggle/harness/mdc-slide-toggle-harness.ts
@@ -21,11 +21,12 @@ export class MatSlideToggleHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a slide-toggle w/ specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a slide-toggle whose host element matches the given selector.
    *   - `label` finds a slide-toggle with specific label text.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: SlideToggleHarnessFilters = {}): HarnessPredicate<MatSlideToggleHarness> {
-    return new HarnessPredicate(MatSlideToggleHarness)
+    return new HarnessPredicate(MatSlideToggleHarness, options)
         .addOption('label', options.label,
             (harness, label) => HarnessPredicate.stringMatches(harness.getLabelText(), label));
   }

--- a/src/material-experimental/mdc-slide-toggle/harness/slide-toggle-harness-filters.ts
+++ b/src/material-experimental/mdc-slide-toggle/harness/slide-toggle-harness-filters.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export type SlideToggleHarnessFilters = {
-  label?: string | RegExp
-};
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
+
+export interface SlideToggleHarnessFilters extends BaseHarnessFilters {
+  label?: string | RegExp;
+}

--- a/src/material-experimental/mdc-slide-toggle/harness/slide-toggle-harness.ts
+++ b/src/material-experimental/mdc-slide-toggle/harness/slide-toggle-harness.ts
@@ -21,11 +21,12 @@ export class MatSlideToggleHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a slide-toggle w/ specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a slide-toggle whose host element matches the given selector.
    *   - `label` finds a slide-toggle with specific label text.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: SlideToggleHarnessFilters = {}): HarnessPredicate<MatSlideToggleHarness> {
-    return new HarnessPredicate(MatSlideToggleHarness)
+    return new HarnessPredicate(MatSlideToggleHarness, options)
         .addOption('label', options.label,
             (harness, label) => HarnessPredicate.stringMatches(harness.getLabelText(), label));
   }

--- a/src/material-experimental/mdc-slider/harness/slider-harness-filters.ts
+++ b/src/material-experimental/mdc-slider/harness/slider-harness-filters.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
 
-export type SliderHarnessFilters = {
-  id?: string;
-};
+export interface SliderHarnessFilters extends BaseHarnessFilters {}

--- a/src/material-experimental/mdc-slider/harness/slider-harness.spec.ts
+++ b/src/material-experimental/mdc-slider/harness/slider-harness.spec.ts
@@ -43,7 +43,7 @@ function runTests() {
   });
 
   it('should load slider harness by id', async () => {
-    const sliders = await loader.getAllHarnesses(sliderHarness.with({id: 'my-slider'}));
+    const sliders = await loader.getAllHarnesses(sliderHarness.with({selector: '#my-slider'}));
     expect(sliders.length).toBe(1);
   });
 

--- a/src/material-experimental/mdc-slider/harness/slider-harness.ts
+++ b/src/material-experimental/mdc-slider/harness/slider-harness.ts
@@ -21,12 +21,12 @@ export class MatSliderHarness extends ComponentHarness {
    * Gets a `HarnessPredicate` that can be used to search for a mat-slider with
    * specific attributes.
    * @param options Options for narrowing the search:
+   *   - `selector` finds a slider whose host element matches the given selector.
    *   - `id` finds a slider with specific id.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: SliderHarnessFilters = {}): HarnessPredicate<MatSliderHarness> {
-    return new HarnessPredicate(MatSliderHarness)
-        .addOption('id', options.id, async (harness, id) => (await harness.getId()) === id);
+    return new HarnessPredicate(MatSliderHarness, options);
   }
 
   private _textLabel = this.locatorFor('.mat-slider-thumb-label-text');

--- a/src/material-experimental/mdc-tabs/harness/tab-group-harness-filters.ts
+++ b/src/material-experimental/mdc-tabs/harness/tab-group-harness-filters.ts
@@ -5,7 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
 
-export type TabGroupHarnessFilters = {
-  selectedTabLabel?: string|RegExp;
-};
+export interface TabGroupHarnessFilters extends BaseHarnessFilters {
+  selectedTabLabel?: string | RegExp;
+}

--- a/src/material-experimental/mdc-tabs/harness/tab-group-harness.ts
+++ b/src/material-experimental/mdc-tabs/harness/tab-group-harness.ts
@@ -21,12 +21,13 @@ export class MatTabGroupHarness extends ComponentHarness {
    * Gets a `HarnessPredicate` that can be used to search for a radio-button with
    * specific attributes.
    * @param options Options for narrowing the search
+   *   - `selector` finds a tab-group whose host element matches the given selector.
    *   - `selectedTabLabel` finds a tab-group with a selected tab that matches the
    *      specified tab label.
    * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: TabGroupHarnessFilters = {}): HarnessPredicate<MatTabGroupHarness> {
-    return new HarnessPredicate(MatTabGroupHarness)
+    return new HarnessPredicate(MatTabGroupHarness, options)
         .addOption('selectedTabLabel', options.selectedTabLabel, async (harness, label) => {
           const selectedTab = await harness.getSelectedTab();
           return HarnessPredicate.stringMatches(await selectedTab.getLabel(), label);


### PR DESCRIPTION
There were a couple harnesses that had an `id` option which removed. It is now unnecessary since it can be achieved through using the `selector` option.