### PR TITLE
build: yarn dev-app script should run with ibazel by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "gulp build-release-packages",
     "bazel:buildifier": "find . -type f \\( -name \"*.bzl\" -or -name WORKSPACE -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs buildifier -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,native-build,native-package,output-group,package-name,package-on-top,redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable",
     "bazel:format-lint": "yarn -s bazel:buildifier --lint=warn --mode=check",
-    "dev-app": "bazel run //src/dev-app:devserver",
+    "dev-app": "ibazel run //src/dev-app:devserver",
     "test": "bazel test //src/... --test_tag_filters=-e2e,-browser:firefox-local --build_tag_filters=-browser:firefox-local --build_tests_only",
     "test-firefox": "bazel test //src/... --test_tag_filters=-e2e,-browser:chromium-local --build_tag_filters=-browser:chromium-local --build_tests_only",
     "lint": "gulp lint && yarn -s bazel:format-lint",


### PR DESCRIPTION
* Switches the dev-app script in the `package.json` to use `ibazel` by
default. This aligns with the previous gulp `yarn dev-app` script.