### PR TITLE
build: enable buildifier "unsorted-dict-items" and "out-of-order-load" rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "postinstall": "ngc -p angular-tsconfig.json",
     "build": "gulp build-release-packages",
-    "bazel:buildifier": "find . -type f \\( -name \"*.bzl\" -or -name WORKSPACE -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs buildifier -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,native-build,native-package,output-group,package-name,package-on-top,redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable",
+    "bazel:buildifier": "find . -type f \\( -name \"*.bzl\" -or -name WORKSPACE -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs buildifier -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,native-build,native-package,output-group,package-name,package-on-top,redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable,unsorted-dict-items,out-of-order-load",
     "bazel:format-lint": "yarn -s bazel:buildifier --lint=warn --mode=check",
     "dev-app": "bazel run //src/dev-app:devserver",
     "test": "bazel test //src/... --test_tag_filters=-e2e,-browser:firefox-local --build_tag_filters=-browser:firefox-local --build_tests_only",

--- a/packages.bzl
+++ b/packages.bzl
@@ -115,20 +115,20 @@ MATERIAL_EXPERIMENTAL_SCSS_LIBS = [
 ANGULAR_PACKAGE_VERSION = "^8.0.0 || ^9.0.0-0"
 MDC_PACKAGE_VERSION = "^1.1.0"
 VERSION_PLACEHOLDER_REPLACEMENTS = {
-    "0.0.0-NG": ANGULAR_PACKAGE_VERSION,
     "0.0.0-MDC": MDC_PACKAGE_VERSION,
+    "0.0.0-NG": ANGULAR_PACKAGE_VERSION,
 }
 
 # Base rollup globals for everything in the repo.
 ROLLUP_GLOBALS = {
-    "tslib": "tslib",
-    "moment": "moment",
     "@angular/cdk": "ng.cdk",
     "@angular/cdk-experimental": "ng.cdkExperimental",
+    "@angular/google-maps": "ng.googleMaps",
     "@angular/material": "ng.material",
     "@angular/material-experimental": "ng.materialExperimental",
     "@angular/youtube-player": "ng.youtubePlayer",
-    "@angular/google-maps": "ng.googleMaps",
+    "moment": "moment",
+    "tslib": "tslib",
 }
 
 # Rollup globals for cdk subpackages in the form of, e.g., {"@angular/cdk/table": "ng.cdk.table"}

--- a/src/cdk-experimental/BUILD.bazel
+++ b/src/cdk-experimental/BUILD.bazel
@@ -1,12 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_package")
 load(
     "//:packages.bzl",
     "CDK_EXPERIMENTAL_PACKAGES",
     "CDK_EXPERIMENTAL_TARGETS",
     "ROLLUP_GLOBALS",
 )
+load("//tools:defaults.bzl", "ng_module", "ng_package")
 
 ng_module(
     name = "cdk-experimental",

--- a/src/cdk-experimental/scrolling/BUILD.bazel
+++ b/src/cdk-experimental/scrolling/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
     name = "scrolling",

--- a/src/cdk-experimental/testing/BUILD.bazel
+++ b/src/cdk-experimental/testing/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_web_test_suite")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_module", "ng_web_test_suite")
 
 ng_module(
     name = "testing",

--- a/src/e2e-app/BUILD.bazel
+++ b/src/e2e-app/BUILD.bazel
@@ -2,8 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@npm_bazel_typescript//:defs.bzl", "ts_devserver")
-load("//tools:defaults.bzl", "ng_module")
 load("//:packages.bzl", "ANGULAR_LIBRARY_UMDS")
+load("//tools:defaults.bzl", "ng_module")
 
 exports_files([
     "protractor.conf.js",

--- a/src/material-examples/BUILD.bazel
+++ b/src/material-examples/BUILD.bazel
@@ -82,20 +82,20 @@ package_docs_content(
         # in the documentation.
         "//guides": "guides",
 
-        # For the live-examples in our docs, we want to package the highlighted files
-        # into the docs content. These will be used to show the source code for examples.
-        ":highlighted-source-files": "examples-highlighted",
+        # Package the overviews for "@angular/material" and "@angular/cdk" into the docs content
+        "//src/cdk:overviews": "overviews/cdk",
+        "//src/material:overviews": "overviews/material",
+
+        # Package the API docs for the Material and CDK package into the docs-content
+        "//src:api-docs": "api-docs",
 
         # In order to be able to run examples in StackBlitz, we also want to package the
         # plain source files into the docs-content.
         ":example-source-files": "examples-source",
 
-        # Package the overviews for "@angular/material" and "@angular/cdk" into the docs content
-        "//src/material:overviews": "overviews/material",
-        "//src/cdk:overviews": "overviews/cdk",
-
-        # Package the API docs for the Material and CDK package into the docs-content
-        "//src:api-docs": "api-docs",
+        # For the live-examples in our docs, we want to package the highlighted files
+        # into the docs content. These will be used to show the source code for examples.
+        ":highlighted-source-files": "examples-highlighted",
     },
     tags = ["docs-package"],
 )

--- a/src/material-experimental/BUILD.bazel
+++ b/src/material-experimental/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_package")
 load("//:packages.bzl", "ROLLUP_GLOBALS")
+load("//tools:defaults.bzl", "ng_module", "ng_package")
 
 exports_files(["mdc_require_config.js"])
 

--- a/src/material-experimental/mdc-button/BUILD.bazel
+++ b/src/material-experimental/mdc-button/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 ng_module(
     name = "mdc-button",

--- a/src/material-experimental/mdc-card/BUILD.bazel
+++ b/src/material-experimental/mdc-card/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
 
 ng_module(
     name = "mdc-card",

--- a/src/material-experimental/mdc-checkbox/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 ng_module(
     name = "mdc-checkbox",

--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 ng_module(
     name = "mdc-menu",

--- a/src/material-experimental/mdc-radio/BUILD.bazel
+++ b/src/material-experimental/mdc-radio/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_web_test_suite")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_web_test_suite")
 
 ng_module(
     name = "mdc-radio",

--- a/src/material-experimental/mdc-select/BUILD.bazel
+++ b/src/material-experimental/mdc-select/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 ng_module(
     name = "mdc-select",

--- a/src/material-experimental/mdc-sidenav/BUILD.bazel
+++ b/src/material-experimental/mdc-sidenav/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 ng_module(
     name = "mdc-sidenav",

--- a/src/material-experimental/mdc-slide-toggle/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 ng_module(
     name = "mdc-slide-toggle",

--- a/src/material-experimental/mdc-tabs/BUILD.bazel
+++ b/src/material-experimental/mdc-tabs/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module")
 
 ng_module(
     name = "mdc-tabs",

--- a/src/material-moment-adapter/BUILD.bazel
+++ b/src/material-moment-adapter/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_package", "ng_test_library", "ng_web_test_suite")
 load("//:packages.bzl", "ROLLUP_GLOBALS")
+load("//tools:defaults.bzl", "ng_module", "ng_package", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
     name = "material-moment-adapter",

--- a/src/material/BUILD.bazel
+++ b/src/material/BUILD.bazel
@@ -1,7 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:sass_bundle.bzl", "sass_bundle")
-load("//tools:defaults.bzl", "ng_module", "ng_package")
 load(
     "//:packages.bzl",
     "MATERIAL_PACKAGES",
@@ -9,6 +7,8 @@ load(
     "MATERIAL_TARGETS",
     "ROLLUP_GLOBALS",
 )
+load("//tools:defaults.bzl", "ng_module", "ng_package")
+load("//tools:sass_bundle.bzl", "sass_bundle")
 
 # Root "@angular/material" entry-point.
 ng_module(

--- a/src/material/card/BUILD.bazel
+++ b/src/material/card/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "markdown_to_html", "ng_e2e_test_library", "ng_module")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "markdown_to_html", "ng_e2e_test_library", "ng_module")
 
 ng_module(
     name = "card",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "sass_bundle_lib",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -2,10 +2,10 @@
 
 load("@npm_angular_bazel//:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package", _protractor_web_test_suite = "protractor_web_test_suite")
 load("@npm_bazel_jasmine//:index.bzl", _jasmine_node_test = "jasmine_node_test")
-load("@npm_bazel_typescript//:defs.bzl", _ts_library = "ts_library")
 load("@npm_bazel_karma//:defs.bzl", _karma_web_test_suite = "karma_web_test_suite")
-load("//tools/markdown-to-html:index.bzl", _markdown_to_html = "markdown_to_html")
+load("@npm_bazel_typescript//:defs.bzl", _ts_library = "ts_library")
 load("//:packages.bzl", "ANGULAR_LIBRARY_UMDS", "VERSION_PLACEHOLDER_REPLACEMENTS")
+load("//tools/markdown-to-html:index.bzl", _markdown_to_html = "markdown_to_html")
 
 _DEFAULT_TSCONFIG_BUILD = "//src:bazel-tsconfig-build.json"
 _DEFAULT_TSCONFIG_TEST = "//src:tsconfig-test"

--- a/tools/dgeni/index.bzl
+++ b/tools/dgeni/index.bzl
@@ -82,18 +82,18 @@ dgeni_api_docs = rule(
         # { "cdk": ["a11y", "platform", "bidi"] }.
         "entry_points": attr.string_list_dict(mandatory = True),
 
-        # Dgeni document templates that should be be available as inputs to the
-        # Bazel action. Dgeni tries to resolve templates from the execroot, so they
-        # need to be available in the sandbox.
-        "_dgeni_templates": attr.label(
-            default = Label("//tools/dgeni/templates"),
-        ),
-
         # NodeJS binary target that runs Dgeni and parses the passed command arguments.
         "_dgeni_bin": attr.label(
             default = Label("//tools/dgeni"),
             executable = True,
             cfg = "host",
+        ),
+
+        # Dgeni document templates that should be be available as inputs to the
+        # Bazel action. Dgeni tries to resolve templates from the execroot, so they
+        # need to be available in the sandbox.
+        "_dgeni_templates": attr.label(
+            default = Label("//tools/dgeni/templates"),
         ),
     },
 )

--- a/tools/sass_bundle.bzl
+++ b/tools/sass_bundle.bzl
@@ -50,16 +50,16 @@ sass_bundle = rule(
         # the nodejs_binary runs.
         "srcs": attr.label_list(allow_files = True),
 
+        # The scss entry-point. Note that this uses a label and not a string
+        # in order to make bazel aware that this file is a *dependency* of the
+        # rule (and will thus be available to the nodejs_binary in the sandbox).
+        "entry_point": attr.label(mandatory = True, allow_single_file = True),
+
         # The name of the file to be output from this rule. The rule will fail if
         # the nodejs_binary does not produce this output file. By using
         # `attr.output()`, we can omit the separate `outputs` declaration a more
         # complicated rule would need.
         "output_name": attr.output(),
-
-        # The scss entry-point. Note that this uses a label and not a string
-        # in order to make bazel aware that this file is a *dependency* of the
-        # rule (and will thus be available to the nodejs_binary in the sandbox).
-        "entry_point": attr.label(mandatory = True, allow_single_file = True),
 
         # The executable (bundler) for this rule (private).
         "_sass_bundle": attr.label(


### PR DESCRIPTION
Enables the `unsorted-dict-items` rule to enforce that dependencies and more are
sorted alphabetically. Additionally enforces that load statements in build files are
sorted. Enabling these two rules improves overall health in bazel build files and
makes these consistent.