### PR TITLE
docs: fix typo in code comment

### DIFF
--- a/src/cdk/stepper/stepper-button.ts
+++ b/src/cdk/stepper/stepper-button.ts
@@ -25,7 +25,7 @@ export class CdkStepperNext {
 
   // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
   // In Ivy the `host` bindings will be merged when this class is extended, whereas in
-  // ViewEngine they're overwritte.
+  // ViewEngine they're overwritten.
   // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
   // tslint:disable-next-line:no-host-decorator-in-concrete
   @HostListener('click')
@@ -49,7 +49,7 @@ export class CdkStepperPrevious {
 
   // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
   // In Ivy the `host` bindings will be merged when this class is extended, whereas in
-  // ViewEngine they're overwritte.
+  // ViewEngine they're overwritten.
   // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
   // tslint:disable-next-line:no-host-decorator-in-concrete
   @HostListener('click')

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -130,7 +130,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase
   /** Prevents the default element actions if it is disabled. */
   // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
   // In Ivy the `host` bindings will be merged when this class is extended, whereas in
-  // ViewEngine they're overwritte.
+  // ViewEngine they're overwritten.
   // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
   // tslint:disable-next-line:no-host-decorator-in-concrete
   @HostListener('click', ['$event'])
@@ -144,7 +144,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase
   /** Emits to the hover stream. */
   // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
   // In Ivy the `host` bindings will be merged when this class is extended, whereas in
-  // ViewEngine they're overwritte.
+  // ViewEngine they're overwritten.
   // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
   // tslint:disable-next-line:no-host-decorator-in-concrete
   @HostListener('mouseenter')

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -421,7 +421,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
 
   // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
   // In Ivy the `host` bindings will be merged when this class is extended, whereas in
-  // ViewEngine they're overwritte.
+  // ViewEngine they're overwritten.
   // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
   // tslint:disable-next-line:no-host-decorator-in-concrete
   @HostListener('@transform.start', ['$event'])
@@ -431,7 +431,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
 
   // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
   // In Ivy the `host` bindings will be merged when this class is extended, whereas in
-  // ViewEngine they're overwritte.
+  // ViewEngine they're overwritten.
   // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
   // tslint:disable-next-line:no-host-decorator-in-concrete
   @HostListener('@transform.done', ['$event'])


### PR DESCRIPTION
- stepper-button
- menu-item
- drawer

ViewEngine they're overwritte. ==> ViewEngine they're overwritten.