### PR TITLE
build: workaround for dev-app livereloading with ibazel

### DIFF
--- a/src/dev-app/index.html
+++ b/src/dev-app/index.html
@@ -24,6 +24,12 @@
 <body>
   <dev-app>Loading...</dev-app>
 </body>
+<!--
+  Sets up the live reloading script from ibazel if present. This is a workaround
+  and will not work if the port changes (in case it is already used).
+  TODO(devversion): replace once https://github.com/bazelbuild/rules_nodejs/issues/1036 is fixed.
+-->
+<script src="http://localhost:35729/livereload.js?snipver=1" async></script>
 <script src="core-js/client/core.js"></script>
 <script src="zone.js/dist/zone.js"></script>
 <script src="hammerjs/hammer.min.js"></script>


### PR DESCRIPTION
Adds a workaround that makes livereloading work most of the time. It won't
work if the default port for the ibazel livereloading script has changed. This
can happen if the port is already used/reserved or if the default port changes
in the `livereload-server` implementation.

Ideally the livereloading script would be served from a canonical location
that always works (regardless of the port). A proposal for this has been
submitted within: https://github.com/bazelbuild/rules_typescript/pull/468