### PR TITLE
fix(material-experimental/popover-edit): inconsistent theme naming

### DIFF
--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -44,7 +44,7 @@ $candy-app-theme: mat-light-theme($candy-app-primary, $candy-app-accent);
 @include mat-radio-theme-mdc($candy-app-theme);
 @include mat-slide-toggle-theme-mdc($candy-app-theme);
 @include mat-tabs-theme-mdc($candy-app-theme);
-@include mat-edit-theme($candy-app-theme);
+@include mat-popover-edit-theme($candy-app-theme);
 @include mat-edit-typography(mat-typography-config());
 // Define an alternate dark theme.
 $dark-primary: mat-palette($mat-blue-grey);
@@ -68,5 +68,5 @@ $dark-theme: mat-dark-theme($dark-primary, $dark-accent, $dark-warn);
   @include mat-radio-theme-mdc($dark-theme);
   @include mat-slide-toggle-theme-mdc($dark-theme);
   @include mat-tabs-theme-mdc($dark-theme);
-  @include mat-edit-theme($dark-theme);
+  @include mat-popover-edit-theme($dark-theme);
 }

--- a/src/material-experimental/popover-edit/_popover-edit.scss
+++ b/src/material-experimental/popover-edit/_popover-edit.scss
@@ -9,11 +9,10 @@
   @return linear-gradient($direction, rgba($background-color, 0), $background-color 8px);
 }
 
-@mixin mat-edit-theme($theme) {
+@mixin mat-popover-edit-theme($theme) {
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
   $primary: map-get($theme, primary);
-
   $background-color: mat-color($background, 'card');
 
   .mat-row-hover-content-host-cell {


### PR DESCRIPTION
The naming scheme we follow for the theme mixins is `mat-{{entry point name}}-theme`, however the `popover-edit` entry point doesn't follow it. These changes make it consistent.