### PR TITLE
fix(drag-drop): connected drop zones not working inside shadow root

### DIFF
--- a/src/cdk/drag-drop/BUILD.bazel
+++ b/src/cdk/drag-drop/BUILD.bazel
@@ -35,6 +35,7 @@ ng_test_library(
     deps = [
         ":drag-drop",
         "//src/cdk/bidi",
+        "//src/cdk/platform",
         "//src/cdk/scrolling",
         "//src/cdk/testing",
         "@npm//@angular/common",

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -24,6 +24,7 @@ import {
 import {TestBed, ComponentFixture, fakeAsync, flush, tick} from '@angular/core/testing';
 import {DOCUMENT} from '@angular/common';
 import {ViewportRuler} from '@angular/cdk/scrolling';
+import {_supportsShadowDom} from '@angular/cdk/platform';
 import {of as observableOf} from 'rxjs';
 
 import {DragDropModule} from '../drag-drop-module';
@@ -4010,6 +4011,39 @@ describe('CdkDrag', () => {
       cleanup();
     }));
 
+    it('should be able to drop into a new container inside the Shadow DOM', fakeAsync(() => {
+      // This test is only relevant for Shadow DOM-supporting browsers.
+      if (!_supportsShadowDom()) {
+        return;
+      }
+
+      const fixture = createComponent(ConnectedDropZonesInsideShadowRoot);
+      fixture.detectChanges();
+
+      const groups = fixture.componentInstance.groupedDragItems;
+      const item = groups[0][1];
+      const targetRect = groups[1][2].element.nativeElement.getBoundingClientRect();
+
+      dragElementViaMouse(fixture, item.element.nativeElement,
+        targetRect.left + 1, targetRect.top + 1);
+      flush();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.droppedSpy).toHaveBeenCalledTimes(1);
+
+      const event = fixture.componentInstance.droppedSpy.calls.mostRecent().args[0];
+
+      expect(event).toEqual({
+        previousIndex: 1,
+        currentIndex: 3,
+        item,
+        container: fixture.componentInstance.dropInstances.toArray()[1],
+        previousContainer: fixture.componentInstance.dropInstances.first,
+        isPointerOverContainer: true,
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+      });
+    }));
+
   });
 
   describe('with nested drags', () => {
@@ -4389,65 +4423,68 @@ class DraggableInDropZoneWithCustomPlaceholder {
   renderPlaceholder = true;
 }
 
+const CONNECTED_DROP_ZONES_STYLES = [`
+  .cdk-drop-list {
+    display: block;
+    width: 100px;
+    min-height: ${ITEM_HEIGHT}px;
+    background: hotpink;
+  }
+
+  .cdk-drag {
+    display: block;
+    height: ${ITEM_HEIGHT}px;
+    background: red;
+  }
+`];
+
+const CONNECTED_DROP_ZONES_TEMPLATE = `
+  <div
+    cdkDropList
+    #todoZone="cdkDropList"
+    [cdkDropListData]="todo"
+    [cdkDropListConnectedTo]="[doneZone]"
+    (cdkDropListDropped)="droppedSpy($event)"
+    (cdkDropListEntered)="enteredSpy($event)">
+    <div
+      [cdkDragData]="item"
+      (cdkDragEntered)="itemEnteredSpy($event)"
+      *ngFor="let item of todo"
+      cdkDrag>{{item}}</div>
+  </div>
+
+  <div
+    cdkDropList
+    #doneZone="cdkDropList"
+    [cdkDropListData]="done"
+    [cdkDropListConnectedTo]="[todoZone]"
+    (cdkDropListDropped)="droppedSpy($event)"
+    (cdkDropListEntered)="enteredSpy($event)">
+    <div
+      [cdkDragData]="item"
+      (cdkDragEntered)="itemEnteredSpy($event)"
+      *ngFor="let item of done"
+      cdkDrag>{{item}}</div>
+  </div>
+
+  <div
+    cdkDropList
+    #extraZone="cdkDropList"
+    [cdkDropListData]="extra"
+    (cdkDropListDropped)="droppedSpy($event)"
+    (cdkDropListEntered)="enteredSpy($event)">
+    <div
+      [cdkDragData]="item"
+      (cdkDragEntered)="itemEnteredSpy($event)"
+      *ngFor="let item of extra"
+      cdkDrag>{{item}}</div>
+  </div>
+`;
 
 @Component({
   encapsulation: ViewEncapsulation.None,
-  styles: [`
-    .cdk-drop-list {
-      display: block;
-      width: 100px;
-      min-height: ${ITEM_HEIGHT}px;
-      background: hotpink;
-    }
-
-    .cdk-drag {
-      display: block;
-      height: ${ITEM_HEIGHT}px;
-      background: red;
-    }
-  `],
-  template: `
-    <div
-      cdkDropList
-      #todoZone="cdkDropList"
-      [cdkDropListData]="todo"
-      [cdkDropListConnectedTo]="[doneZone]"
-      (cdkDropListDropped)="droppedSpy($event)"
-      (cdkDropListEntered)="enteredSpy($event)">
-      <div
-        [cdkDragData]="item"
-        (cdkDragEntered)="itemEnteredSpy($event)"
-        *ngFor="let item of todo"
-        cdkDrag>{{item}}</div>
-    </div>
-
-    <div
-      cdkDropList
-      #doneZone="cdkDropList"
-      [cdkDropListData]="done"
-      [cdkDropListConnectedTo]="[todoZone]"
-      (cdkDropListDropped)="droppedSpy($event)"
-      (cdkDropListEntered)="enteredSpy($event)">
-      <div
-        [cdkDragData]="item"
-        (cdkDragEntered)="itemEnteredSpy($event)"
-        *ngFor="let item of done"
-        cdkDrag>{{item}}</div>
-    </div>
-
-    <div
-      cdkDropList
-      #extraZone="cdkDropList"
-      [cdkDropListData]="extra"
-      (cdkDropListDropped)="droppedSpy($event)"
-      (cdkDropListEntered)="enteredSpy($event)">
-      <div
-        [cdkDragData]="item"
-        (cdkDragEntered)="itemEnteredSpy($event)"
-        *ngFor="let item of extra"
-        cdkDrag>{{item}}</div>
-    </div>
-  `
+  styles: CONNECTED_DROP_ZONES_STYLES,
+  template: CONNECTED_DROP_ZONES_TEMPLATE
 })
 class ConnectedDropZones implements AfterViewInit {
   @ViewChildren(CdkDrag) rawDragItems: QueryList<CdkDrag>;
@@ -4471,6 +4508,15 @@ class ConnectedDropZones implements AfterViewInit {
     });
   }
 }
+
+@Component({
+  encapsulation: ViewEncapsulation.ShadowDom,
+  styles: CONNECTED_DROP_ZONES_STYLES,
+  template: CONNECTED_DROP_ZONES_TEMPLATE
+})
+class ConnectedDropZonesInsideShadowRoot extends ConnectedDropZones {
+}
+
 
 @Component({
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
Fixes not being able to drop into a connected drop list when using `ShadowDom` view encapsulation. The issue comes from the fact that we use `elementFromPoint` to figure out whether the user's pointer is over a drop list. When the element is inside a shadow root, calling `elementFromPoint` on the `document` will return the shadow root.

These changes fix the issue by calling `elementFromPoint` from the shadow root instead.

Fixes #16898.