### PR TITLE
refactor: debugElement.query is nullable

### DIFF
--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -574,7 +574,7 @@ describe('Dialog', () => {
   it('should set the proper animation states', () => {
     let dialogRef = dialog.openFromComponent(PizzaMsg, { viewContainerRef: testViewContainerRef });
     let dialogContainer: CdkDialogContainer =
-        viewContainerFixture.debugElement.query(By.directive(CdkDialogContainer)).componentInstance;
+        viewContainerFixture.debugElement.query(By.directive(CdkDialogContainer))!.componentInstance;
 
     expect(dialogContainer._state).toBe('enter');
 

--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -574,7 +574,8 @@ describe('Dialog', () => {
   it('should set the proper animation states', () => {
     let dialogRef = dialog.openFromComponent(PizzaMsg, { viewContainerRef: testViewContainerRef });
     let dialogContainer: CdkDialogContainer =
-        viewContainerFixture.debugElement.query(By.directive(CdkDialogContainer))!.componentInstance;
+        viewContainerFixture.debugElement.query(By.directive(CdkDialogContainer))!
+        .componentInstance;
 
     expect(dialogContainer._state).toBe('enter');
 

--- a/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
@@ -31,7 +31,7 @@ describe('FocusMonitor', () => {
     fixture = TestBed.createComponent(PlainButton);
     fixture.detectChanges();
 
-    buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
+    buttonElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
     focusMonitor = fm;
 
     changeHandler = jasmine.createSpy('focus origin change handler');
@@ -264,7 +264,7 @@ describe('cdkMonitorFocus', () => {
       fixture.detectChanges();
 
       spyOn(fixture.componentInstance, 'focusChanged');
-      buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
+      buttonElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
       patchElementFocus(buttonElement);
     });
 
@@ -362,8 +362,8 @@ describe('cdkMonitorFocus', () => {
       fixture = TestBed.createComponent(ComplexComponentWithMonitorElementFocus);
       fixture.detectChanges();
 
-      parentElement = fixture.debugElement.query(By.css('div')).nativeElement;
-      childElement = fixture.debugElement.query(By.css('button')).nativeElement;
+      parentElement = fixture.debugElement.query(By.css('div'))!.nativeElement;
+      childElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
       patchElementFocus(parentElement);
       patchElementFocus(childElement);
@@ -395,8 +395,8 @@ describe('cdkMonitorFocus', () => {
       fixture = TestBed.createComponent(ComplexComponentWithMonitorSubtreeFocus);
       fixture.detectChanges();
 
-      parentElement = fixture.debugElement.query(By.css('div')).nativeElement;
-      childElement = fixture.debugElement.query(By.css('button')).nativeElement;
+      parentElement = fixture.debugElement.query(By.css('div'))!.nativeElement;
+      childElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
       patchElementFocus(parentElement);
       patchElementFocus(childElement);
@@ -431,8 +431,8 @@ describe('cdkMonitorFocus', () => {
           TestBed.createComponent(ComplexComponentWithMonitorSubtreeFocusAndMonitorElementFocus);
       fixture.detectChanges();
 
-      parentElement = fixture.debugElement.query(By.css('div')).nativeElement;
-      childElement = fixture.debugElement.query(By.css('button')).nativeElement;
+      parentElement = fixture.debugElement.query(By.css('div'))!.nativeElement;
+      childElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
       patchElementFocus(parentElement);
       patchElementFocus(childElement);

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -35,7 +35,7 @@ describe('LiveAnnouncer', () => {
     });
 
     it('should correctly update the announce text', fakeAsync(() => {
-      let buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
+      let buttonElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
       buttonElement.click();
 
       // This flushes our 100ms timeout for the screenreaders.

--- a/src/cdk/accordion/accordion-item.spec.ts
+++ b/src/cdk/accordion/accordion-item.spec.ts
@@ -27,7 +27,7 @@ describe('CdkAccordionItem', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(SingleItem);
       item = fixture.debugElement
-        .query(By.directive(CdkAccordionItem))
+        .query(By.directive(CdkAccordionItem))!
         .injector.get<CdkAccordionItem>(CdkAccordionItem);
     });
 

--- a/src/cdk/bidi/directionality.spec.ts
+++ b/src/cdk/bidi/directionality.spec.ts
@@ -75,7 +75,7 @@ describe('Directionality', () => {
     it('should provide itself as Directionality', () => {
       const fixture = TestBed.createComponent(ElementWithDir);
       const injectedDirectionality =
-        fixture.debugElement.query(By.directive(InjectsDirectionality)).componentInstance.dir;
+        fixture.debugElement.query(By.directive(InjectsDirectionality))!.componentInstance.dir;
 
       fixture.detectChanges();
 
@@ -85,7 +85,7 @@ describe('Directionality', () => {
     it('should emit a change event when the value changes', fakeAsync(() => {
       const fixture = TestBed.createComponent(ElementWithDir);
       const injectedDirectionality =
-        fixture.debugElement.query(By.directive(InjectsDirectionality)).componentInstance.dir;
+        fixture.debugElement.query(By.directive(InjectsDirectionality))!.componentInstance.dir;
 
       fixture.detectChanges();
 
@@ -108,7 +108,7 @@ describe('Directionality', () => {
     it('should complete the change stream on destroy', fakeAsync(() => {
       const fixture = TestBed.createComponent(ElementWithDir);
       const dir =
-        fixture.debugElement.query(By.directive(InjectsDirectionality)).componentInstance.dir;
+        fixture.debugElement.query(By.directive(InjectsDirectionality))!.componentInstance.dir;
       const spy = jasmine.createSpy('complete spy');
       const subscription = dir.change.subscribe(undefined, undefined, spy);
 

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -294,7 +294,7 @@ describe('Overlay directives', () => {
     });
 
     it('should set the offsetY', () => {
-      const trigger = fixture.debugElement.query(By.css('button')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('button'))!.nativeElement;
       trigger.style.position = 'absolute';
       trigger.style.top = '30px';
       trigger.style.height = '20px';

--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -37,7 +37,7 @@ describe('CdkTextareaAutosize', () => {
 
     textarea = fixture.nativeElement.querySelector('textarea');
     autosize = fixture.debugElement.query(
-        By.directive(CdkTextareaAutosize)).injector.get<CdkTextareaAutosize>(CdkTextareaAutosize);
+        By.directive(CdkTextareaAutosize))!.injector.get<CdkTextareaAutosize>(CdkTextareaAutosize);
   });
 
   it('should resize the textarea based on its content', () => {
@@ -173,7 +173,7 @@ describe('CdkTextareaAutosize', () => {
     // detection should be triggered after a multiline content is set.
     fixture = TestBed.createComponent(AutosizeTextAreaWithContent);
     textarea = fixture.nativeElement.querySelector('textarea');
-    autosize = fixture.debugElement.query(By.css('textarea'))
+    autosize = fixture.debugElement.query(By.css('textarea'))!
         .injector.get<CdkTextareaAutosize>(CdkTextareaAutosize);
 
     fixture.componentInstance.content = `
@@ -239,7 +239,7 @@ describe('CdkTextareaAutosize', () => {
   it('should not trigger a resize when it is disabled', fakeAsync(() => {
     const fixtureWithoutAutosize = TestBed.createComponent(AutosizeTextareaWithoutAutosize);
     textarea = fixtureWithoutAutosize.nativeElement.querySelector('textarea');
-    autosize = fixtureWithoutAutosize.debugElement.query(By.css('textarea'))
+    autosize = fixtureWithoutAutosize.debugElement.query(By.css('textarea'))!
         .injector.get<CdkTextareaAutosize>(CdkTextareaAutosize);
 
     fixtureWithoutAutosize.detectChanges();

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -48,7 +48,7 @@ describe('GoogleMap', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
 
-    const container = fixture.debugElement.query(By.css('div'));
+    const container = fixture.debugElement.query(By.css('div'))!;
     expect(container.nativeElement.style.height).toBe(DEFAULT_HEIGHT);
     expect(container.nativeElement.style.width).toBe(DEFAULT_WIDTH);
     expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, DEFAULT_OPTIONS);
@@ -63,7 +63,7 @@ describe('GoogleMap', () => {
     fixture.componentInstance.width = '400px';
     fixture.detectChanges();
 
-    const container = fixture.debugElement.query(By.css('div'));
+    const container = fixture.debugElement.query(By.css('div'))!;
     expect(container.nativeElement.style.height).toBe('750px');
     expect(container.nativeElement.style.width).toBe('400px');
     expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, DEFAULT_OPTIONS);
@@ -86,7 +86,7 @@ describe('GoogleMap', () => {
     fixture.componentInstance.zoom = options.zoom;
     fixture.detectChanges();
 
-    const container = fixture.debugElement.query(By.css('div'));
+    const container = fixture.debugElement.query(By.css('div'))!;
     expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, options);
 
     fixture.componentInstance.center = {lat: 8, lng: 9};
@@ -105,7 +105,7 @@ describe('GoogleMap', () => {
     fixture.componentInstance.options = options;
     fixture.detectChanges();
 
-    const container = fixture.debugElement.query(By.css('div'));
+    const container = fixture.debugElement.query(By.css('div'))!;
     expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, options);
 
     fixture.componentInstance.options = {...options, heading: 170};
@@ -126,7 +126,7 @@ describe('GoogleMap', () => {
     fixture.componentInstance.options = inputOptions;
     fixture.detectChanges();
 
-    const container = fixture.debugElement.query(By.css('div'));
+    const container = fixture.debugElement.query(By.css('div'))!;
     expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, correctedOptions);
   });
 });

--- a/src/material-experimental/mdc-checkbox/checkbox.spec.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.spec.ts
@@ -698,7 +698,8 @@ describe('MatCheckbox', () => {
          fixture.detectChanges();
 
          const checkbox =
-             fixture.debugElement.query(By.directive(MatCheckbox))!.componentInstance as MatCheckbox;
+             fixture.debugElement.query(By.directive(MatCheckbox))!
+             .componentInstance as MatCheckbox;
 
          expect(checkbox.tabIndex)
              .toBe(5, 'Expected tabIndex property to have been set based on the native attribute');

--- a/src/material-experimental/mdc-checkbox/checkbox.spec.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.spec.ts
@@ -44,7 +44,7 @@ describe('MatCheckbox', () => {
       fixture = createComponent(SingleCheckbox);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
@@ -480,7 +480,7 @@ describe('MatCheckbox', () => {
         fixture = createComponent(SingleCheckbox);
         fixture.detectChanges();
 
-        checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+        checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
         checkboxNativeElement = checkboxDebugElement.nativeElement;
         checkboxInstance = checkboxDebugElement.componentInstance;
         testComponent = fixture.debugElement.componentInstance;
@@ -512,7 +512,7 @@ describe('MatCheckbox', () => {
         fixture = createComponent(SingleCheckbox);
         fixture.detectChanges();
 
-        checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+        checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
         checkboxNativeElement = checkboxDebugElement.nativeElement;
         checkboxInstance = checkboxDebugElement.componentInstance;
         testComponent = fixture.debugElement.componentInstance;
@@ -564,7 +564,7 @@ describe('MatCheckbox', () => {
       fixture = createComponent(CheckboxWithChangeEvent);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
@@ -614,7 +614,7 @@ describe('MatCheckbox', () => {
 
     it('should use the provided aria-label', fakeAsync(() => {
          fixture = createComponent(CheckboxWithAriaLabel);
-         checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+         checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
          checkboxNativeElement = checkboxDebugElement.nativeElement;
          inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -638,7 +638,7 @@ describe('MatCheckbox', () => {
 
     it('should use the provided aria-labelledby', fakeAsync(() => {
          fixture = createComponent(CheckboxWithAriaLabelledby);
-         checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+         checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
          checkboxNativeElement = checkboxDebugElement.nativeElement;
          inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -648,7 +648,7 @@ describe('MatCheckbox', () => {
 
     it('should not assign aria-labelledby if none is provided', fakeAsync(() => {
          fixture = createComponent(SingleCheckbox);
-         checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+         checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
          checkboxNativeElement = checkboxDebugElement.nativeElement;
          inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -668,7 +668,7 @@ describe('MatCheckbox', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
     });
@@ -698,7 +698,7 @@ describe('MatCheckbox', () => {
          fixture.detectChanges();
 
          const checkbox =
-             fixture.debugElement.query(By.directive(MatCheckbox)).componentInstance as MatCheckbox;
+             fixture.debugElement.query(By.directive(MatCheckbox))!.componentInstance as MatCheckbox;
 
          expect(checkbox.tabIndex)
              .toBe(5, 'Expected tabIndex property to have been set based on the native attribute');
@@ -708,7 +708,7 @@ describe('MatCheckbox', () => {
          fixture = createComponent(CheckboxWithTabindexAttr);
          fixture.detectChanges();
 
-         const checkbox = fixture.debugElement.query(By.directive(MatCheckbox)).nativeElement;
+         const checkbox = fixture.debugElement.query(By.directive(MatCheckbox))!.nativeElement;
          expect(checkbox.getAttribute('tabindex')).toBeFalsy();
        }));
   });
@@ -743,7 +743,7 @@ describe('MatCheckbox', () => {
       fixture.componentInstance.isRequired = false;
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
@@ -785,7 +785,7 @@ describe('MatCheckbox', () => {
          fixture = createComponent(CheckboxWithNgModelAndOnPush);
          fixture.detectChanges();
 
-         checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+         checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
          checkboxNativeElement = checkboxDebugElement.nativeElement;
          checkboxInstance = checkboxDebugElement.componentInstance;
          inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
@@ -860,7 +860,7 @@ describe('MatCheckbox', () => {
     });
 
     it('should forward name value to input element', fakeAsync(() => {
-         let checkboxElement = fixture.debugElement.query(By.directive(MatCheckbox));
+         let checkboxElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
          let inputElement = <HTMLInputElement>checkboxElement.nativeElement.querySelector('input');
 
          expect(inputElement.getAttribute('name')).toBe('test-name');
@@ -877,7 +877,7 @@ describe('MatCheckbox', () => {
       fixture = createComponent(CheckboxWithFormControl);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
       inputElement = <HTMLInputElement>checkboxDebugElement.nativeElement.querySelector('input');
@@ -905,8 +905,8 @@ describe('MatCheckbox', () => {
 
     beforeEach(() => {
       fixture = createComponent(CheckboxWithoutLabel);
-      const checkboxDebugEl = fixture.debugElement.query(By.directive(MatCheckbox));
-      checkboxInnerContainer = checkboxDebugEl.query(By.css('.mdc-form-field')).nativeElement;
+      const checkboxDebugEl = fixture.debugElement.query(By.directive(MatCheckbox))!;
+      checkboxInnerContainer = checkboxDebugEl.query(By.css('.mdc-form-field'))!.nativeElement;
     });
 
     it('should not add the "name" attribute if it is not passed in', fakeAsync(() => {

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -850,7 +850,8 @@ describe('MatChipGrid', () => {
     });
 
     it('sets the aria-describedby to reference errors when in error state', () => {
-      let hintId = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
+      let hintId =
+          fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
       let describedBy = chipGridEl.getAttribute('aria-describedby');
 
       expect(hintId).toBeTruthy('hint should be shown');

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -213,7 +213,7 @@ describe('MatChipGrid', () => {
             fixture = createComponent(StandardChipGridWithAnimations, [], BrowserAnimationsModule);
             fixture.detectChanges();
 
-            chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid));
+            chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid))!;
             chipGridNativeElement = chipGridDebugElement.nativeElement;
             chipGridInstance = chipGridDebugElement.componentInstance;
             testComponent = fixture.debugElement.componentInstance;
@@ -240,7 +240,7 @@ describe('MatChipGrid', () => {
           fixture = createComponent(ChipGridWithRemove);
           fixture.detectChanges();
 
-          chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid));
+          chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid))!;
           chipGridInstance = chipGridDebugElement.componentInstance;
           chipGridNativeElement = chipGridDebugElement.nativeElement;
           chips = chipGridInstance._chips;
@@ -535,7 +535,7 @@ describe('MatChipGrid', () => {
       fixture = createComponent(ChipGridWithRemove);
       fixture.detectChanges();
 
-      chipGrid = fixture.debugElement.query(By.directive(MatChipGrid)).componentInstance;
+      chipGrid = fixture.debugElement.query(By.directive(MatChipGrid))!.componentInstance;
       chipElements = fixture.debugElement.queryAll(By.directive(MatChipRow));
       chipRemoveDebugElements = fixture.debugElement.queryAll(By.directive(MatChipRemove));
       chips = chipGrid._chips;
@@ -622,7 +622,7 @@ describe('MatChipGrid', () => {
       expect(fixture.componentInstance.control.touched)
         .toBe(false, 'Expected the control to start off as untouched.');
 
-      const nativeChipGrid = fixture.debugElement.query(By.css('mat-chip-grid')).nativeElement;
+      const nativeChipGrid = fixture.debugElement.query(By.css('mat-chip-grid'))!.nativeElement;
       dispatchFakeEvent(nativeChipGrid, 'blur');
       tick();
 
@@ -635,7 +635,7 @@ describe('MatChipGrid', () => {
         .toBe(false, 'Expected the control to start off as untouched.');
 
       fixture.componentInstance.control.disable();
-      const nativeChipGrid = fixture.debugElement.query(By.css('mat-chip-grid')).nativeElement;
+      const nativeChipGrid = fixture.debugElement.query(By.css('mat-chip-grid'))!.nativeElement;
       dispatchFakeEvent(nativeChipGrid, 'blur');
       tick();
 
@@ -675,14 +675,14 @@ describe('MatChipGrid', () => {
     });
 
     it('should set an asterisk after the placeholder if the control is required', () => {
-      let requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'));
+      let requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!;
       expect(requiredMarker)
         .toBeNull(`Expected placeholder not to have an asterisk, as control was not required.`);
 
       fixture.componentInstance.isRequired = true;
       fixture.detectChanges();
 
-      requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'));
+      requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!;
       expect(requiredMarker)
         .not.toBeNull(`Expected placeholder to have an asterisk, as control was required.`);
     });
@@ -763,8 +763,8 @@ describe('MatChipGrid', () => {
       fixture = createComponent(ChipGridWithFormErrorMessages);
       fixture.detectChanges();
       errorTestComponent = fixture.componentInstance;
-      containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
-      chipGridEl = fixture.debugElement.query(By.css('mat-chip-grid')).nativeElement;
+      containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+      chipGridEl = fixture.debugElement.query(By.css('mat-chip-grid'))!.nativeElement;
     });
 
     it('should not show any errors if the user has not interacted', () => {
@@ -800,7 +800,7 @@ describe('MatChipGrid', () => {
         .toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
 
-      dispatchFakeEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('form'))!.nativeElement, 'submit');
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {
@@ -850,7 +850,7 @@ describe('MatChipGrid', () => {
     });
 
     it('sets the aria-describedby to reference errors when in error state', () => {
-      let hintId = fixture.debugElement.query(By.css('.mat-hint')).nativeElement.getAttribute('id');
+      let hintId = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
       let describedBy = chipGridEl.getAttribute('aria-describedby');
 
       expect(hintId).toBeTruthy('hint should be shown');
@@ -900,7 +900,7 @@ describe('MatChipGrid', () => {
     }]);
     fixture.detectChanges();
 
-    chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid));
+    chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid))!;
     chipGridNativeElement = chipGridDebugElement.nativeElement;
     chipGridInstance = chipGridDebugElement.componentInstance;
     testComponent = fixture.debugElement.componentInstance;
@@ -911,7 +911,7 @@ describe('MatChipGrid', () => {
     fixture = createComponent(FormFieldChipGrid);
     fixture.detectChanges();
 
-    chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid));
+    chipGridDebugElement = fixture.debugElement.query(By.directive(MatChipGrid))!;
     chipGridNativeElement = chipGridDebugElement.nativeElement;
     chipGridInstance = chipGridDebugElement.componentInstance;
     testComponent = fixture.debugElement.componentInstance;

--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -48,7 +48,7 @@ describe('MatChipInput', () => {
     testChipInput = fixture.debugElement.componentInstance;
     fixture.detectChanges();
 
-    inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput));
+    inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput))!;
     chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
     inputNativeElement = inputDebugElement.nativeElement;
   }));
@@ -215,7 +215,7 @@ describe('MatChipInput', () => {
       testChipInput = fixture.debugElement.componentInstance;
       fixture.detectChanges();
 
-      inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput));
+      inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput))!;
       chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
       inputNativeElement = inputDebugElement.nativeElement;
 

--- a/src/material-experimental/mdc-chips/chip-listbox.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.spec.ts
@@ -99,7 +99,7 @@ describe('MatChipListbox', () => {
       beforeEach(() => {
         fixture = createComponent(SelectedChipListbox);
         fixture.detectChanges();
-        chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox));
+        chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox))!;
         chipListboxNativeElement = chipListboxDebugElement.nativeElement;
       });
 
@@ -451,7 +451,7 @@ describe('MatChipListbox', () => {
         nativeChips = fixture.debugElement.queryAll(By.css('mat-chip-option'))
             .map((chip) => chip.nativeElement);
 
-        chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox));
+        chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox))!;
         chipListboxInstance = chipListboxDebugElement.componentInstance;
         chips = chipListboxInstance._chips;
 
@@ -595,7 +595,7 @@ describe('MatChipListbox', () => {
             .toBe(false, 'Expected the control to start off as untouched.');
 
           const nativeChipListbox = fixture.debugElement.query(
-            By.css('mat-chip-listbox')).nativeElement;
+            By.css('mat-chip-listbox'))!.nativeElement;
           dispatchFakeEvent(nativeChipListbox, 'blur');
           tick();
 
@@ -609,7 +609,7 @@ describe('MatChipListbox', () => {
 
           fixture.componentInstance.control.disable();
           const nativeChipListbox = fixture.debugElement.query(
-            By.css('mat-chip-listbox')).nativeElement;
+            By.css('mat-chip-listbox'))!.nativeElement;
           dispatchFakeEvent(nativeChipListbox, 'blur');
           tick();
 
@@ -776,7 +776,7 @@ describe('MatChipListbox', () => {
     }]);
     fixture.detectChanges();
 
-    chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox));
+    chipListboxDebugElement = fixture.debugElement.query(By.directive(MatChipListbox))!;
     chipListboxNativeElement = chipListboxDebugElement.nativeElement;
     chipListboxInstance = chipListboxDebugElement.componentInstance;
     testComponent = fixture.debugElement.componentInstance;

--- a/src/material-experimental/mdc-chips/chip-option.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-option.spec.ts
@@ -48,7 +48,7 @@ describe('Option Chips', () => {
       fixture = TestBed.createComponent(SingleChip);
       fixture.detectChanges();
 
-      chipDebugElement = fixture.debugElement.query(By.directive(MatChipOption));
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChipOption))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChipOption>(MatChipOption);
       testComponent = fixture.debugElement.componentInstance;

--- a/src/material-experimental/mdc-chips/chip-remove.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-remove.spec.ts
@@ -26,7 +26,7 @@ describe('Chip Remove', () => {
     testChip = fixture.debugElement.componentInstance;
     fixture.detectChanges();
 
-    chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+    chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
     chipNativeElement = chipDebugElement.nativeElement;
   }));
 

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -42,7 +42,7 @@ describe('Row Chips', () => {
       fixture = TestBed.createComponent(SingleChip);
       fixture.detectChanges();
 
-      chipDebugElement = fixture.debugElement.query(By.directive(MatChipRow));
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChipRow))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChipRow>(MatChipRow);
       testComponent = fixture.debugElement.componentInstance;

--- a/src/material-experimental/mdc-chips/chip-set.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-set.spec.ts
@@ -26,7 +26,7 @@ describe('MatChipSet', () => {
         fixture = TestBed.createComponent(BasicChipSet);
         fixture.detectChanges();
 
-        chipSetDebugElement = fixture.debugElement.query(By.directive(MatChipSet));
+        chipSetDebugElement = fixture.debugElement.query(By.directive(MatChipSet))!;
         chipSetNativeElement = chipSetDebugElement.nativeElement;
         chipSetInstance = chipSetDebugElement.componentInstance;
         chips = chipSetInstance._chips;

--- a/src/material-experimental/mdc-chips/chip.spec.ts
+++ b/src/material-experimental/mdc-chips/chip.spec.ts
@@ -40,7 +40,7 @@ describe('Chips', () => {
       fixture = TestBed.createComponent(BasicChip);
       fixture.detectChanges();
 
-      chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
 
@@ -63,7 +63,7 @@ describe('Chips', () => {
       fixture = TestBed.createComponent(SingleChip);
       fixture.detectChanges();
 
-      chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
       testComponent = fixture.debugElement.componentInstance;

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -427,7 +427,7 @@ describe('MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
 
-    const menuEl = fixture.debugElement.query(By.css('mat-menu')).nativeElement;
+    const menuEl = fixture.debugElement.query(By.css('mat-menu'))!.nativeElement;
     const panel = overlayContainerElement.querySelector('.mat-mdc-menu-panel')!;
 
     expect(menuEl.classList).not.toContain('custom-one');
@@ -1224,8 +1224,8 @@ describe('MatMenu', () => {
       fixture.componentInstance.trigger.openMenu();
       fixture.detectChanges();
 
-      const item = fixture.debugElement.query(By.css('.mat-mdc-menu-item'));
-      const ripple = item.query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
+      const item = fixture.debugElement.query(By.css('.mat-mdc-menu-item'))!;
+      const ripple = item.query(By.css('.mat-ripple'))!.injector.get<MatRipple>(MatRipple);
 
       expect(ripple.disabled).toBe(false);
     });
@@ -1238,7 +1238,7 @@ describe('MatMenu', () => {
       fixture.detectChanges();
 
       const items = fixture.debugElement.queryAll(By.css('.mat-mdc-menu-item'));
-      const ripple = items[1].query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
+      const ripple = items[1].query(By.css('.mat-ripple'))!.injector.get<MatRipple>(MatRipple);
 
       expect(ripple.disabled).toBe(true);
     });
@@ -1252,7 +1252,7 @@ describe('MatMenu', () => {
 
       // The third menu item in the `SimpleMenu` component has ripples disabled.
       const items = fixture.debugElement.queryAll(By.css('.mat-mdc-menu-item'));
-      const ripple = items[2].query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
+      const ripple = items[2].query(By.css('.mat-ripple'))!.injector.get<MatRipple>(MatRipple);
 
       expect(ripple.disabled).toBe(true);
     });
@@ -1483,7 +1483,7 @@ describe('MatMenu', () => {
       expect(overlay.querySelectorAll('.mat-mdc-menu-panel').length)
           .toBe(1, 'Expected one open menu');
 
-      const item = fixture.debugElement.query(By.directive(MatMenuItem));
+      const item = fixture.debugElement.query(By.directive(MatMenuItem))!;
 
       item.componentInstance.disabled = true;
       fixture.detectChanges();

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
@@ -43,13 +43,13 @@ describe('MatSlideToggle without forms', () => {
       // Initialize the slide-toggle component, by triggering the first change detection cycle.
       fixture.detectChanges();
 
-      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
+      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'))!;
 
       testComponent = fixture.debugElement.componentInstance;
       slideToggle = slideToggleDebug.componentInstance;
       slideToggleElement = slideToggleDebug.nativeElement;
-      inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-      labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+      inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      labelElement = fixture.debugElement.query(By.css('label'))!.nativeElement;
     }));
 
     it('should apply class based on color attribute', () => {
@@ -313,7 +313,7 @@ describe('MatSlideToggle without forms', () => {
       fixture.detectChanges();
 
       const slideToggle = fixture.debugElement
-        .query(By.directive(MatSlideToggle)).componentInstance as MatSlideToggle;
+        .query(By.directive(MatSlideToggle))!.componentInstance as MatSlideToggle;
 
       expect(slideToggle.tabIndex)
         .toBe(5, 'Expected tabIndex property to have been set based on the native attribute');
@@ -324,7 +324,7 @@ describe('MatSlideToggle without forms', () => {
 
       fixture.detectChanges();
 
-      const slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle)).nativeElement;
+      const slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle))!.nativeElement;
       expect(slideToggle.hasAttribute('tabindex')).toBe(false);
     }));
 
@@ -334,7 +334,7 @@ describe('MatSlideToggle without forms', () => {
       fixture.componentInstance.disabled = true;
       fixture.detectChanges();
 
-      const slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle)).nativeElement;
+      const slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle))!.nativeElement;
       expect(slideToggle.hasAttribute('tabindex')).toBe(false);
     }));
   });
@@ -354,11 +354,11 @@ describe('MatSlideToggle without forms', () => {
       fixture.detectChanges();
 
       const testComponent = fixture.debugElement.componentInstance;
-      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
+      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'))!;
 
       const slideToggle = slideToggleDebug.componentInstance;
-      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-      const labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+      const inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      const labelElement = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
       expect(testComponent.toggleTriggered).toBe(0);
       expect(testComponent.dragTriggered).toBe(0);
@@ -411,14 +411,14 @@ describe('MatSlideToggle with forms', () => {
       fixture = TestBed.createComponent(SlideToggleWithModel);
       fixture.detectChanges();
 
-      const slideToggleDebug = fixture.debugElement.query(By.directive(MatSlideToggle));
+      const slideToggleDebug = fixture.debugElement.query(By.directive(MatSlideToggle))!;
 
       testComponent = fixture.debugElement.componentInstance;
       slideToggle = slideToggleDebug.componentInstance;
       slideToggleElement = slideToggleDebug.nativeElement;
       slideToggleModel = slideToggleDebug.injector.get<NgModel>(NgModel);
-      inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-      labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+      inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      labelElement = fixture.debugElement.query(By.css('label'))!.nativeElement;
     }));
 
     it('should be initially set to ng-pristine', () => {
@@ -524,8 +524,8 @@ describe('MatSlideToggle with forms', () => {
 
     it('should update checked state on click if control is checked initially', fakeAsync(() => {
       fixture = TestBed.createComponent(SlideToggleWithModel);
-      slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle)).componentInstance;
-      labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+      slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle))!.componentInstance;
+      labelElement = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
       fixture.componentInstance.modelValue = true;
       fixture.detectChanges();
@@ -554,7 +554,7 @@ describe('MatSlideToggle with forms', () => {
       fixture.componentInstance.modelValue = true;
       fixture.detectChanges();
 
-      const debugElement = fixture.debugElement.query(By.directive(MatSlideToggle));
+      const debugElement = fixture.debugElement.query(By.directive(MatSlideToggle))!;
       const modelInstance = debugElement.injector.get<NgModel>(NgModel);
 
       // Flush the microtasks because the forms module updates the model state asynchronously.
@@ -566,7 +566,7 @@ describe('MatSlideToggle with forms', () => {
     it('should set the model value when toggling via the `toggle` method', fakeAsync(() => {
       expect(testComponent.modelValue).toBe(false);
 
-      fixture.debugElement.query(By.directive(MatSlideToggle)).componentInstance.toggle();
+      fixture.debugElement.query(By.directive(MatSlideToggle))!.componentInstance.toggle();
       fixture.detectChanges();
       flushMicrotasks();
 
@@ -588,8 +588,8 @@ describe('MatSlideToggle with forms', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle)).componentInstance;
-      inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+      slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle))!.componentInstance;
+      inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
     });
 
     it('should toggle the disabled state', () => {
@@ -622,8 +622,8 @@ describe('MatSlideToggle with forms', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
-      inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+      buttonElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
+      inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
     }));
 
     it('should prevent the form from submit when being required', () => {
@@ -683,7 +683,7 @@ describe('MatSlideToggle with forms', () => {
       const fixture = TestBed.createComponent(SlideToggleWithModelAndChangeEvent);
       fixture.detectChanges();
 
-      const labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+      const labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
       spyOn(fixture.componentInstance, 'onChange').and.callFake(() => {
         expect(fixture.componentInstance.checked)

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -102,7 +102,7 @@ describe('MatAutocomplete', () => {
     beforeEach(() => {
       fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
-      input = fixture.debugElement.query(By.css('input')).nativeElement;
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
     });
 
     it('should open the panel when the input is focused', () => {
@@ -394,7 +394,7 @@ describe('MatAutocomplete', () => {
       spyOn(inputContainer, '_animateAndLockLabel');
       expect(inputContainer._animateAndLockLabel).not.toHaveBeenCalled();
 
-      dispatchFakeEvent(fixture.debugElement.query(By.css('input')).nativeElement, 'focusin');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('input'))!.nativeElement, 'focusin');
       expect(inputContainer._animateAndLockLabel).toHaveBeenCalled();
     });
 
@@ -521,7 +521,7 @@ describe('MatAutocomplete', () => {
   it('should not close the panel when clicking on the input', fakeAsync(() => {
        const fixture = createComponent(SimpleAutocomplete);
        fixture.detectChanges();
-       const input = fixture.debugElement.query(By.css('input')).nativeElement;
+       const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
        dispatchFakeEvent(input, 'focusin');
        fixture.detectChanges();
@@ -545,7 +545,7 @@ describe('MatAutocomplete', () => {
 
        const fixture = createComponent(SimpleAutocompleteShadowDom);
        fixture.detectChanges();
-       const input = fixture.debugElement.query(By.css('input')).nativeElement;
+       const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
        dispatchFakeEvent(input, 'focusin');
        fixture.detectChanges();
@@ -628,7 +628,7 @@ describe('MatAutocomplete', () => {
       fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
 
-      input = fixture.debugElement.query(By.css('input')).nativeElement;
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
     });
 
     it('should update control value as user types with input value', () => {
@@ -755,7 +755,7 @@ describe('MatAutocomplete', () => {
 
     it('should disable input in view when disabled programmatically', () => {
       const formFieldElement =
-          fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+          fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
 
       expect(input.disabled)
           .toBe(false, `Expected input to start out enabled in view.`);
@@ -853,7 +853,7 @@ describe('MatAutocomplete', () => {
       fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
 
-      input = fixture.debugElement.query(By.css('input')).nativeElement;
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
       DOWN_ARROW_EVENT = createKeyboardEvent('keydown', DOWN_ARROW);
       UP_ARROW_EVENT = createKeyboardEvent('keydown', UP_ARROW);
       ENTER_EVENT = createKeyboardEvent('keydown', ENTER);
@@ -1333,7 +1333,7 @@ describe('MatAutocomplete', () => {
       fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
 
-      input = fixture.debugElement.query(By.css('input')).nativeElement;
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
     });
 
     it('should set role of input to combobox', () => {
@@ -1345,7 +1345,7 @@ describe('MatAutocomplete', () => {
       fixture.componentInstance.trigger.openPanel();
       fixture.detectChanges();
 
-      const panel = fixture.debugElement.query(By.css('.mat-autocomplete-panel')).nativeElement;
+      const panel = fixture.debugElement.query(By.css('.mat-autocomplete-panel'))!.nativeElement;
 
       expect(panel.getAttribute('role'))
           .toEqual('listbox', 'Expected role of the panel to be listbox.');
@@ -1418,7 +1418,7 @@ describe('MatAutocomplete', () => {
       fixture.componentInstance.trigger.openPanel();
       fixture.detectChanges();
 
-      const panel = fixture.debugElement.query(By.css('.mat-autocomplete-panel')).nativeElement;
+      const panel = fixture.debugElement.query(By.css('.mat-autocomplete-panel'))!.nativeElement;
 
       expect(input.getAttribute('aria-owns'))
           .toBe(panel.getAttribute('id'), 'Expected aria-owns to match attached autocomplete.');
@@ -1464,7 +1464,7 @@ describe('MatAutocomplete', () => {
     it('should use below positioning by default', fakeAsync(() => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       fixture.componentInstance.trigger.openPanel();
       fixture.detectChanges();
@@ -1490,7 +1490,7 @@ describe('MatAutocomplete', () => {
 
       fixture.detectChanges();
 
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
       spacer.style.height = '1000px';
       document.body.appendChild(spacer);
 
@@ -1515,7 +1515,7 @@ describe('MatAutocomplete', () => {
     it('should fall back to above position if panel cannot fit below', fakeAsync(() => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the autocomplete trigger down so it won't have room to open "below"
       inputReference.style.bottom = '0';
@@ -1540,8 +1540,8 @@ describe('MatAutocomplete', () => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
 
-      let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the element down so it has a little bit of space, but not enough to render.
       inputReference.style.bottom = '10px';
@@ -1581,8 +1581,8 @@ describe('MatAutocomplete', () => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
 
-      let input = fixture.debugElement.query(By.css('input')).nativeElement;
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the autocomplete trigger down so it won't have room to open "below"
       inputReference.style.bottom = '0';
@@ -1611,8 +1611,8 @@ describe('MatAutocomplete', () => {
       fixture.componentInstance.filteredStates = fixture.componentInstance.states.slice();
       fixture.detectChanges();
 
-      let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the element down so it has a little bit of space, but not enough to render.
       inputReference.style.bottom = '75px';
@@ -1659,7 +1659,7 @@ describe('MatAutocomplete', () => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.componentInstance.position = 'below';
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the autocomplete trigger down so it won't have room to open below.
       inputReference.style.bottom = '0';
@@ -1684,7 +1684,7 @@ describe('MatAutocomplete', () => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.componentInstance.position = 'above';
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the autocomplete trigger up so it won't have room to open above.
       inputReference.style.top = '0';
@@ -1708,7 +1708,7 @@ describe('MatAutocomplete', () => {
     it('should handle the position being changed after the first open', fakeAsync(() => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex')).nativeElement;
+      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
       let openPanel = () => {
         fixture.componentInstance.trigger.openPanel();
         fixture.detectChanges();
@@ -1888,7 +1888,7 @@ describe('MatAutocomplete', () => {
     }));
 
     it('should reposition the panel when the amount of options changes', fakeAsync(() => {
-      let formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+      let formField = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
       let inputReference = formField.querySelector('.mat-form-field-flex');
       let input = inputReference.querySelector('input');
 
@@ -1933,7 +1933,7 @@ describe('MatAutocomplete', () => {
       fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
 
-      input = fixture.debugElement.query(By.css('input')).nativeElement;
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
       fixture.componentInstance.trigger.openPanel();
       fixture.detectChanges();
@@ -2004,7 +2004,7 @@ describe('MatAutocomplete', () => {
     });
 
     it('should not throw when clicking outside', fakeAsync(() => {
-      dispatchFakeEvent(fixture.debugElement.query(By.css('input')).nativeElement, 'focus');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('input'))!.nativeElement, 'focus');
       fixture.detectChanges();
       flush();
 
@@ -2019,7 +2019,7 @@ describe('MatAutocomplete', () => {
         const fixture = createComponent(AutocompleteWithoutForms);
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
         typeInElement(input, 'd');
         fixture.detectChanges();
 
@@ -2033,7 +2033,7 @@ describe('MatAutocomplete', () => {
       const fixture = createComponent(AutocompleteWithNgModel);
       fixture.detectChanges();
 
-      expect(fixture.debugElement.query(By.css('input')).nativeElement.value).toBe('');
+      expect(fixture.debugElement.query(By.css('input'))!.nativeElement.value).toBe('');
     });
 
     it('should display the number when the selected option is the number zero', fakeAsync(() => {
@@ -2043,14 +2043,14 @@ describe('MatAutocomplete', () => {
       fixture.detectChanges();
       tick();
 
-      expect(fixture.debugElement.query(By.css('input')).nativeElement.value).toBe('0');
+      expect(fixture.debugElement.query(By.css('input'))!.nativeElement.value).toBe('0');
     }));
 
     it('should work when input is wrapped in ngIf', () => {
       const fixture = createComponent(NgIfAutocomplete);
       fixture.detectChanges();
 
-      dispatchFakeEvent(fixture.debugElement.query(By.css('input')).nativeElement, 'focusin');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('input'))!.nativeElement, 'focusin');
       fixture.detectChanges();
 
       expect(fixture.componentInstance.trigger.panelOpen)
@@ -2072,7 +2072,7 @@ describe('MatAutocomplete', () => {
       fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
       fixture.detectChanges();
 
-      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
       typeInElement(input, 'o');
       fixture.detectChanges();
 
@@ -2187,7 +2187,7 @@ describe('MatAutocomplete', () => {
     it('should handle autocomplete being attached to number inputs', fakeAsync(() => {
       const fixture = createComponent(AutocompleteWithNumberInputAndNgModel);
       fixture.detectChanges();
-      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
       typeInElement(input, '1337');
       fixture.detectChanges();
@@ -2232,7 +2232,7 @@ describe('MatAutocomplete', () => {
     widthFixture.detectChanges();
 
     const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
-    const input = widthFixture.debugElement.query(By.css('input')).nativeElement;
+    const input = widthFixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(300);
 
@@ -2251,7 +2251,7 @@ describe('MatAutocomplete', () => {
     fixture.detectChanges();
 
     const trigger = fixture.componentInstance.trigger;
-    const input = fixture.debugElement.query(By.css('input')).nativeElement;
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     input.focus();
     fixture.detectChanges();
@@ -2347,7 +2347,7 @@ describe('MatAutocomplete', () => {
       let fixture = createComponent(AutocompleteWithOnPushDelay);
 
       fixture.detectChanges();
-      dispatchFakeEvent(fixture.debugElement.query(By.css('input')).nativeElement, 'focusin');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('input'))!.nativeElement, 'focusin');
       tick(1000);
 
       fixture.detectChanges();
@@ -2460,7 +2460,7 @@ describe('MatAutocomplete', () => {
   it('should be able to re-type the same value when it is reset while open', fakeAsync(() => {
     const fixture = createComponent(SimpleAutocomplete);
     fixture.detectChanges();
-    const input = fixture.debugElement.query(By.css('input')).nativeElement;
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
     const formControl = fixture.componentInstance.stateCtrl;
 
     typeInElement(input, 'Cal');

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1464,7 +1464,8 @@ describe('MatAutocomplete', () => {
     it('should use below positioning by default', fakeAsync(() => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       fixture.componentInstance.trigger.openPanel();
       fixture.detectChanges();
@@ -1490,7 +1491,8 @@ describe('MatAutocomplete', () => {
 
       fixture.detectChanges();
 
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
       spacer.style.height = '1000px';
       document.body.appendChild(spacer);
 
@@ -1515,7 +1517,8 @@ describe('MatAutocomplete', () => {
     it('should fall back to above position if panel cannot fit below', fakeAsync(() => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the autocomplete trigger down so it won't have room to open "below"
       inputReference.style.bottom = '0';
@@ -1541,7 +1544,8 @@ describe('MatAutocomplete', () => {
       fixture.detectChanges();
 
       let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the element down so it has a little bit of space, but not enough to render.
       inputReference.style.bottom = '10px';
@@ -1582,7 +1586,8 @@ describe('MatAutocomplete', () => {
       fixture.detectChanges();
 
       let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the autocomplete trigger down so it won't have room to open "below"
       inputReference.style.bottom = '0';
@@ -1612,7 +1617,8 @@ describe('MatAutocomplete', () => {
       fixture.detectChanges();
 
       let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the element down so it has a little bit of space, but not enough to render.
       inputReference.style.bottom = '75px';
@@ -1659,7 +1665,8 @@ describe('MatAutocomplete', () => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.componentInstance.position = 'below';
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the autocomplete trigger down so it won't have room to open below.
       inputReference.style.bottom = '0';
@@ -1684,7 +1691,8 @@ describe('MatAutocomplete', () => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.componentInstance.position = 'above';
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
 
       // Push the autocomplete trigger up so it won't have room to open above.
       inputReference.style.top = '0';
@@ -1708,7 +1716,8 @@ describe('MatAutocomplete', () => {
     it('should handle the position being changed after the first open', fakeAsync(() => {
       let fixture = createComponent(SimpleAutocomplete);
       fixture.detectChanges();
-      let inputReference = fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mat-form-field-flex'))!.nativeElement;
       let openPanel = () => {
         fixture.componentInstance.trigger.openPanel();
         fixture.detectChanges();

--- a/src/material/badge/badge.spec.ts
+++ b/src/material/badge/badge.spec.ts
@@ -22,7 +22,7 @@ describe('MatBadge', () => {
     testComponent = fixture.debugElement.componentInstance;
     fixture.detectChanges();
 
-    badgeDebugElement = fixture.debugElement.query(By.directive(MatBadge));
+    badgeDebugElement = fixture.debugElement.query(By.directive(MatBadge))!;
     badgeNativeElement = badgeDebugElement.nativeElement;
   }));
 

--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -562,7 +562,8 @@ describe('MatButtonToggle without forms', () => {
     });
 
     it('should check a button toggle upon interaction with underlying native checkbox', () => {
-      let nativeCheckboxButton = buttonToggleDebugElements[0].query(By.css('button'))!.nativeElement;
+      let nativeCheckboxButton =
+          buttonToggleDebugElements[0].query(By.css('button'))!.nativeElement;
 
       nativeCheckboxButton.click();
       fixture.detectChanges();

--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -37,7 +37,7 @@ describe('MatButtonToggle with forms', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup))!;
       groupInstance = groupDebugElement.injector.get<MatButtonToggleGroup>(MatButtonToggleGroup);
     }));
 
@@ -86,14 +86,14 @@ describe('MatButtonToggle with forms', () => {
       fixture.detectChanges();
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup))!;
       groupInstance = groupDebugElement.injector.get<MatButtonToggleGroup>(MatButtonToggleGroup);
       groupNgModel = groupDebugElement.injector.get<NgModel>(NgModel);
 
       buttonToggleDebugElements = fixture.debugElement.queryAll(By.directive(MatButtonToggle));
       buttonToggleInstances = buttonToggleDebugElements.map(debugEl => debugEl.componentInstance);
       innerButtons = buttonToggleDebugElements.map(
-        debugEl => debugEl.query(By.css('button')).nativeElement);
+        debugEl => debugEl.query(By.css('button'))!.nativeElement);
 
       fixture.detectChanges();
     }));
@@ -274,7 +274,7 @@ describe('MatButtonToggle without forms', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup))!;
       groupNativeElement = groupDebugElement.nativeElement;
       groupInstance = groupDebugElement.injector.get<MatButtonToggleGroup>(MatButtonToggleGroup);
 
@@ -478,7 +478,7 @@ describe('MatButtonToggle without forms', () => {
     it('should not fire an initial change event', () => {
       let fixture = TestBed.createComponent(ButtonToggleGroupWithInitialValue);
       let testComponent = fixture.debugElement.componentInstance;
-      let groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
+      let groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup))!;
       let groupInstance: MatButtonToggleGroup = groupDebugElement.injector
           .get<MatButtonToggleGroup>(MatButtonToggleGroup);
 
@@ -515,7 +515,7 @@ describe('MatButtonToggle without forms', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatButtonToggleGroup))!;
       groupNativeElement = groupDebugElement.nativeElement;
       groupInstance = groupDebugElement.injector.get<MatButtonToggleGroup>(MatButtonToggleGroup);
 
@@ -538,7 +538,7 @@ describe('MatButtonToggle without forms', () => {
     it('should check a button toggle when clicked', () => {
       expect(buttonToggleInstances.every(buttonToggle => !buttonToggle.checked)).toBe(true);
 
-      let nativeCheckboxLabel = buttonToggleDebugElements[0].query(By.css('button')).nativeElement;
+      let nativeCheckboxLabel = buttonToggleDebugElements[0].query(By.css('button'))!.nativeElement;
 
       nativeCheckboxLabel.click();
 
@@ -562,7 +562,7 @@ describe('MatButtonToggle without forms', () => {
     });
 
     it('should check a button toggle upon interaction with underlying native checkbox', () => {
-      let nativeCheckboxButton = buttonToggleDebugElements[0].query(By.css('button')).nativeElement;
+      let nativeCheckboxButton = buttonToggleDebugElements[0].query(By.css('button'))!.nativeElement;
 
       nativeCheckboxButton.click();
       fixture.detectChanges();
@@ -643,10 +643,10 @@ describe('MatButtonToggle without forms', () => {
       fixture = TestBed.createComponent(StandaloneButtonToggle);
       fixture.detectChanges();
 
-      buttonToggleDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
+      buttonToggleDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle))!;
       buttonToggleNativeElement = buttonToggleDebugElement.nativeElement;
       buttonToggleLabelElement = fixture.debugElement
-          .query(By.css('.mat-button-toggle-label-content')).nativeElement;
+          .query(By.css('.mat-button-toggle-label-content'))!.nativeElement;
       buttonToggleInstance = buttonToggleDebugElement.componentInstance;
       buttonToggleButtonElement =
           buttonToggleNativeElement.querySelector('button')! as HTMLButtonElement;
@@ -688,7 +688,7 @@ describe('MatButtonToggle without forms', () => {
     }));
 
     it('should focus on underlying input element when focus() is called', () => {
-      let nativeButton = buttonToggleDebugElement.query(By.css('button')).nativeElement;
+      let nativeButton = buttonToggleDebugElement.query(By.css('button'))!.nativeElement;
       expect(document.activeElement).not.toBe(nativeButton);
 
       buttonToggleInstance.focus();
@@ -717,7 +717,7 @@ describe('MatButtonToggle without forms', () => {
   describe('aria-label handling ', () => {
     it('should not set the aria-label attribute if none is provided', () => {
       let fixture = TestBed.createComponent(StandaloneButtonToggle);
-      let checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
+      let checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle))!;
       let checkboxNativeElement = checkboxDebugElement.nativeElement;
       let buttonElement = checkboxNativeElement.querySelector('button') as HTMLButtonElement;
 
@@ -727,7 +727,7 @@ describe('MatButtonToggle without forms', () => {
 
     it('should use the provided aria-label', () => {
       let fixture = TestBed.createComponent(ButtonToggleWithAriaLabel);
-      let checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
+      let checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle))!;
       let checkboxNativeElement = checkboxDebugElement.nativeElement;
       let buttonElement = checkboxNativeElement.querySelector('button') as HTMLButtonElement;
 
@@ -743,7 +743,7 @@ describe('MatButtonToggle without forms', () => {
 
     it('should use the provided aria-labelledby', () => {
       let fixture = TestBed.createComponent(ButtonToggleWithAriaLabelledby);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       buttonElement = checkboxNativeElement.querySelector('button') as HTMLButtonElement;
 
@@ -753,7 +753,7 @@ describe('MatButtonToggle without forms', () => {
 
     it('should not assign aria-labelledby if none is provided', () => {
       let fixture = TestBed.createComponent(StandaloneButtonToggle);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatButtonToggle))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       buttonElement = checkboxNativeElement.querySelector('button') as HTMLButtonElement;
 
@@ -853,7 +853,7 @@ describe('MatButtonToggle without forms', () => {
     // `fixture.detectChanges` immediately, but getting a hold of the instance via the
     // DebugElement and setting the value ourselves.
     expect(() => {
-      const toggle = fixture.debugElement.query(By.css('mat-button-toggle')).componentInstance;
+      const toggle = fixture.debugElement.query(By.css('mat-button-toggle'))!.componentInstance;
       toggle.checked = true;
       fixture.detectChanges();
     }).not.toThrow();

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -21,8 +21,8 @@ describe('MatButton', () => {
     let fixture = TestBed.createComponent(TestApp);
 
     let testComponent = fixture.debugElement.componentInstance;
-    let buttonDebugElement = fixture.debugElement.query(By.css('button'));
-    let aDebugElement = fixture.debugElement.query(By.css('a'));
+    let buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
+    let aDebugElement = fixture.debugElement.query(By.css('a'))!;
 
     testComponent.buttonColor = 'primary';
     fixture.detectChanges();
@@ -45,14 +45,14 @@ describe('MatButton', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
 
-    const button = fixture.debugElement.query(By.directive(MatButton)).componentInstance;
+    const button = fixture.debugElement.query(By.directive(MatButton))!.componentInstance;
     expect(button.ripple).toBeTruthy();
   });
 
   it('should not clear previous defined classes', () => {
     let fixture = TestBed.createComponent(TestApp);
     let testComponent = fixture.debugElement.componentInstance;
-    let buttonDebugElement = fixture.debugElement.query(By.css('button'));
+    let buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
 
     buttonDebugElement.nativeElement.classList.add('custom-class');
 
@@ -73,7 +73,7 @@ describe('MatButton', () => {
   describe('button[mat-fab]', () => {
     it('should have accent palette by default', () => {
       const fixture = TestBed.createComponent(TestApp);
-      const fabButtonDebugEl = fixture.debugElement.query(By.css('button[mat-fab]'));
+      const fabButtonDebugEl = fixture.debugElement.query(By.css('button[mat-fab]'))!;
 
       fixture.detectChanges();
 
@@ -85,7 +85,7 @@ describe('MatButton', () => {
   describe('button[mat-mini-fab]', () => {
     it('should have accent palette by default', () => {
       const fixture = TestBed.createComponent(TestApp);
-      const miniFabButtonDebugEl = fixture.debugElement.query(By.css('button[mat-mini-fab]'));
+      const miniFabButtonDebugEl = fixture.debugElement.query(By.css('button[mat-mini-fab]'))!;
 
       fixture.detectChanges();
 
@@ -99,7 +99,7 @@ describe('MatButton', () => {
     it('should handle a click on the button', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let buttonDebugElement = fixture.debugElement.query(By.css('button'));
+      let buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
 
       buttonDebugElement.nativeElement.click();
       expect(testComponent.clickCount).toBe(1);
@@ -108,7 +108,7 @@ describe('MatButton', () => {
     it('should not increment if disabled', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let buttonDebugElement = fixture.debugElement.query(By.css('button'));
+      let buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
 
       testComponent.isDisabled = true;
       fixture.detectChanges();
@@ -135,7 +135,7 @@ describe('MatButton', () => {
     it('should not redirect if disabled', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let buttonDebugElement = fixture.debugElement.query(By.css('a'));
+      let buttonDebugElement = fixture.debugElement.query(By.css('a'))!;
 
       testComponent.isDisabled = true;
       fixture.detectChanges();
@@ -146,7 +146,7 @@ describe('MatButton', () => {
     it('should remove tabindex if disabled', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let buttonDebugElement = fixture.debugElement.query(By.css('a'));
+      let buttonDebugElement = fixture.debugElement.query(By.css('a'))!;
       expect(buttonDebugElement.nativeElement.getAttribute('tabIndex')).toBe(null);
 
       testComponent.isDisabled = true;
@@ -157,7 +157,7 @@ describe('MatButton', () => {
     it('should add aria-disabled attribute if disabled', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let buttonDebugElement = fixture.debugElement.query(By.css('a'));
+      let buttonDebugElement = fixture.debugElement.query(By.css('a'))!;
       fixture.detectChanges();
       expect(buttonDebugElement.nativeElement.getAttribute('aria-disabled')).toBe('false');
 
@@ -169,7 +169,7 @@ describe('MatButton', () => {
     it('should not add aria-disabled attribute if disabled is false', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let buttonDebugElement = fixture.debugElement.query(By.css('a'));
+      let buttonDebugElement = fixture.debugElement.query(By.css('a'))!;
       fixture.detectChanges();
       expect(buttonDebugElement.nativeElement.getAttribute('aria-disabled'))
         .toBe('false', 'Expect aria-disabled="false"');
@@ -187,7 +187,7 @@ describe('MatButton', () => {
     it('should be able to set a custom tabindex', () => {
       let fixture = TestBed.createComponent(TestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let buttonElement = fixture.debugElement.query(By.css('a')).nativeElement;
+      let buttonElement = fixture.debugElement.query(By.css('a'))!.nativeElement;
 
       fixture.componentInstance.tabIndex = 3;
       fixture.detectChanges();
@@ -220,12 +220,12 @@ describe('MatButton', () => {
 
       testComponent = fixture.componentInstance;
 
-      buttonDebugElement = fixture.debugElement.query(By.css('button[mat-button]'));
-      buttonRippleDebugElement = buttonDebugElement.query(By.directive(MatRipple));
+      buttonDebugElement = fixture.debugElement.query(By.css('button[mat-button]'))!;
+      buttonRippleDebugElement = buttonDebugElement.query(By.directive(MatRipple))!;
       buttonRippleInstance = buttonRippleDebugElement.injector.get<MatRipple>(MatRipple);
 
-      anchorDebugElement = fixture.debugElement.query(By.css('a[mat-button]'));
-      anchorRippleDebugElement = anchorDebugElement.query(By.directive(MatRipple));
+      anchorDebugElement = fixture.debugElement.query(By.css('a[mat-button]'))!;
+      anchorRippleDebugElement = anchorDebugElement.query(By.directive(MatRipple))!;
       anchorRippleInstance = anchorRippleDebugElement.injector.get<MatRipple>(MatRipple);
     });
 

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -38,7 +38,7 @@ describe('MatCheckbox', () => {
       fixture = createComponent(SingleCheckbox);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
@@ -547,7 +547,7 @@ describe('MatCheckbox', () => {
         fixture = createComponent(SingleCheckbox);
         fixture.detectChanges();
 
-        checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+        checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
         checkboxNativeElement = checkboxDebugElement.nativeElement;
         checkboxInstance = checkboxDebugElement.componentInstance;
         testComponent = fixture.debugElement.componentInstance;
@@ -584,7 +584,7 @@ describe('MatCheckbox', () => {
         fixture = createComponent(SingleCheckbox);
         fixture.detectChanges();
 
-        checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+        checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
         checkboxNativeElement = checkboxDebugElement.nativeElement;
         checkboxInstance = checkboxDebugElement.componentInstance;
         testComponent = fixture.debugElement.componentInstance;
@@ -648,7 +648,7 @@ describe('MatCheckbox', () => {
       fixture = createComponent(CheckboxWithChangeEvent);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
@@ -696,7 +696,7 @@ describe('MatCheckbox', () => {
 
     it('should use the provided aria-label', () => {
       fixture = createComponent(CheckboxWithAriaLabel);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -719,7 +719,7 @@ describe('MatCheckbox', () => {
 
     it('should use the provided aria-labelledby', () => {
       fixture = createComponent(CheckboxWithAriaLabelledby);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -729,7 +729,7 @@ describe('MatCheckbox', () => {
 
     it('should not assign aria-labelledby if none is provided', () => {
       fixture = createComponent(SingleCheckbox);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
 
@@ -749,7 +749,7 @@ describe('MatCheckbox', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
     });
@@ -779,7 +779,7 @@ describe('MatCheckbox', () => {
       fixture.detectChanges();
 
       const checkbox = fixture.debugElement
-        .query(By.directive(MatCheckbox)).componentInstance as MatCheckbox;
+        .query(By.directive(MatCheckbox))!.componentInstance as MatCheckbox;
 
       expect(checkbox.tabIndex)
         .toBe(5, 'Expected tabIndex property to have been set based on the native attribute');
@@ -789,7 +789,7 @@ describe('MatCheckbox', () => {
       fixture = createComponent(CheckboxWithTabindexAttr);
       fixture.detectChanges();
 
-      const checkbox = fixture.debugElement.query(By.directive(MatCheckbox)).nativeElement;
+      const checkbox = fixture.debugElement.query(By.directive(MatCheckbox))!.nativeElement;
       expect(checkbox.getAttribute('tabindex')).toBeFalsy();
     });
   });
@@ -803,7 +803,7 @@ describe('MatCheckbox', () => {
       fixture = createComponent(CheckboxUsingViewChild);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       testComponent = fixture.debugElement.componentInstance;
     });
@@ -880,7 +880,7 @@ describe('MatCheckbox', () => {
       fixture.componentInstance.isRequired = false;
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
@@ -920,7 +920,7 @@ describe('MatCheckbox', () => {
       fixture.destroy();
       TestBed.resetTestingModule();
       fixture = createComponent(CheckboxWithNgModelAndOnPush);
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
       checkboxInstance = checkboxDebugElement.componentInstance;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
@@ -993,7 +993,7 @@ describe('MatCheckbox', () => {
     });
 
     it('should forward name value to input element', () => {
-      let checkboxElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      let checkboxElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       let inputElement = <HTMLInputElement> checkboxElement.nativeElement.querySelector('input');
 
       expect(inputElement.getAttribute('name')).toBe('test-name');
@@ -1010,7 +1010,7 @@ describe('MatCheckbox', () => {
       fixture = createComponent(CheckboxWithFormControl);
       fixture.detectChanges();
 
-      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox));
+      checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxInstance = checkboxDebugElement.componentInstance;
       testComponent = fixture.debugElement.componentInstance;
       inputElement = <HTMLInputElement>checkboxDebugElement.nativeElement.querySelector('input');
@@ -1040,11 +1040,11 @@ describe('MatCheckbox', () => {
     beforeEach(() => {
       fixture = createComponent(CheckboxWithoutLabel);
 
-      const checkboxDebugEl = fixture.debugElement.query(By.directive(MatCheckbox));
+      const checkboxDebugEl = fixture.debugElement.query(By.directive(MatCheckbox))!;
 
       testComponent = fixture.componentInstance;
       checkboxInnerContainer = checkboxDebugEl
-        .query(By.css('.mat-checkbox-inner-container')).nativeElement;
+        .query(By.css('.mat-checkbox-inner-container'))!.nativeElement;
     });
 
     it('should remove margin for checkbox without a label', () => {
@@ -1092,7 +1092,7 @@ describe('MatCheckbox', () => {
 
       fixture = createComponent(CheckboxWithoutLabel);
       checkboxInnerContainer = fixture.debugElement
-        .query(By.css('.mat-checkbox-inner-container')).nativeElement;
+        .query(By.css('.mat-checkbox-inner-container'))!.nativeElement;
 
       fixture.detectChanges();
 
@@ -1142,7 +1142,7 @@ describe('MatCheckbox', () => {
       fixture.detectChanges();
 
       const checkboxInnerContainer = fixture.debugElement
-        .query(By.css('.mat-checkbox-inner-container')).nativeElement;
+        .query(By.css('.mat-checkbox-inner-container'))!.nativeElement;
 
       // Do not run the change detection for the fixture manually because we want to verify
       // that the checkbox properly toggles the margin class even if the observe content output

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -44,7 +44,7 @@ describe('MatChipInput', () => {
     testChipInput = fixture.debugElement.componentInstance;
     fixture.detectChanges();
 
-    inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput));
+    inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput))!;
     chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
     inputNativeElement = inputDebugElement.nativeElement;
   }));
@@ -211,7 +211,7 @@ describe('MatChipInput', () => {
       testChipInput = fixture.debugElement.componentInstance;
       fixture.detectChanges();
 
-      inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput));
+      inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput))!;
       chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
       inputNativeElement = inputDebugElement.nativeElement;
 

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -1251,7 +1251,8 @@ describe('MatChipList', () => {
     });
 
     it('sets the aria-describedby to reference errors when in error state', () => {
-      let hintId = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
+      let hintId =
+          fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
       let describedBy = chipListEl.getAttribute('aria-describedby');
 
       expect(hintId).toBeTruthy('hint should be shown');

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -109,7 +109,7 @@ describe('MatChipList', () => {
       beforeEach(() => {
         fixture = createComponent(SelectedChipList);
         fixture.detectChanges();
-        chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList));
+        chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList))!;
         chipListNativeElement = chipListDebugElement.nativeElement;
       });
 
@@ -247,7 +247,7 @@ describe('MatChipList', () => {
             fixture = createComponent(StandardChipListWithAnimations, [], BrowserAnimationsModule);
             fixture.detectChanges();
 
-            chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList));
+            chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList))!;
             chipListNativeElement = chipListDebugElement.nativeElement;
             chipListInstance = chipListDebugElement.componentInstance;
             testComponent = fixture.debugElement.componentInstance;
@@ -572,7 +572,7 @@ describe('MatChipList', () => {
       fixture = createComponent(ChipListWithRemove);
       fixture.detectChanges();
 
-      chipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
+      chipList = fixture.debugElement.query(By.directive(MatChipList))!.componentInstance;
       chipRemoveDebugElements = fixture.debugElement.queryAll(By.directive(MatChipRemove));
       chips = chipList.chips;
     });
@@ -598,12 +598,12 @@ describe('MatChipList', () => {
       fixture = createComponent(BasicChipList);
       fixture.detectChanges();
 
-      formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+      formField = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
       nativeChips = fixture.debugElement.queryAll(By.css('mat-chip'))
           .map((chip) => chip.nativeElement);
 
 
-      chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList));
+      chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList))!;
       chipListInstance = chipListDebugElement.componentInstance;
       chips = chipListInstance.chips;
 
@@ -750,7 +750,7 @@ describe('MatChipList', () => {
         expect(fixture.componentInstance.control.touched)
           .toBe(false, 'Expected the control to start off as untouched.');
 
-        const nativeChipList = fixture.debugElement.query(By.css('.mat-chip-list')).nativeElement;
+        const nativeChipList = fixture.debugElement.query(By.css('.mat-chip-list'))!.nativeElement;
         dispatchFakeEvent(nativeChipList, 'blur');
 
         expect(fixture.componentInstance.control.touched)
@@ -762,7 +762,7 @@ describe('MatChipList', () => {
           .toBe(false, 'Expected the control to start off as untouched.');
 
         fixture.componentInstance.control.disable();
-        const nativeChipList = fixture.debugElement.query(By.css('.mat-chip-list')).nativeElement;
+        const nativeChipList = fixture.debugElement.query(By.css('.mat-chip-list'))!.nativeElement;
         dispatchFakeEvent(nativeChipList, 'blur');
 
         expect(fixture.componentInstance.control.touched)
@@ -792,14 +792,14 @@ describe('MatChipList', () => {
 
 
       it('should set an asterisk after the placeholder if the control is required', () => {
-        let requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'));
+        let requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!;
         expect(requiredMarker)
           .toBeNull(`Expected placeholder not to have an asterisk, as control was not required.`);
 
         fixture.componentInstance.isRequired = true;
         fixture.detectChanges();
 
-        requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'));
+        requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!;
         expect(requiredMarker)
           .not.toBeNull(`Expected placeholder to have an asterisk, as control was required.`);
       });
@@ -1011,7 +1011,7 @@ describe('MatChipList', () => {
       expect(fixture.componentInstance.control.touched)
         .toBe(false, 'Expected the control to start off as untouched.');
 
-      const nativeChipList = fixture.debugElement.query(By.css('.mat-chip-list')).nativeElement;
+      const nativeChipList = fixture.debugElement.query(By.css('.mat-chip-list'))!.nativeElement;
 
       dispatchFakeEvent(nativeChipList, 'blur');
       tick();
@@ -1025,7 +1025,7 @@ describe('MatChipList', () => {
         .toBe(false, 'Expected the control to start off as untouched.');
 
       fixture.componentInstance.control.disable();
-      const nativeChipList = fixture.debugElement.query(By.css('.mat-chip-list')).nativeElement;
+      const nativeChipList = fixture.debugElement.query(By.css('.mat-chip-list'))!.nativeElement;
       dispatchFakeEvent(nativeChipList, 'blur');
 
       expect(fixture.componentInstance.control.touched)
@@ -1055,14 +1055,14 @@ describe('MatChipList', () => {
 
 
     it('should set an asterisk after the placeholder if the control is required', () => {
-      let requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'));
+      let requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!;
       expect(requiredMarker)
         .toBeNull(`Expected placeholder not to have an asterisk, as control was not required.`);
 
       fixture.componentInstance.isRequired = true;
       fixture.detectChanges();
 
-      requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'));
+      requiredMarker = fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!;
       expect(requiredMarker)
         .not.toBeNull(`Expected placeholder to have an asterisk, as control was required.`);
     });
@@ -1109,7 +1109,7 @@ describe('MatChipList', () => {
 
     describe('keyboard behavior', () => {
       beforeEach(() => {
-        chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList));
+        chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList))!;
         chipListInstance = chipListDebugElement.componentInstance;
         chips = chipListInstance.chips;
         manager = fixture.componentInstance.chipList._keyManager;
@@ -1164,8 +1164,8 @@ describe('MatChipList', () => {
       fixture = createComponent(ChipListWithFormErrorMessages);
       fixture.detectChanges();
       errorTestComponent = fixture.componentInstance;
-      containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
-      chipListEl = fixture.debugElement.query(By.css('mat-chip-list')).nativeElement;
+      containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+      chipListEl = fixture.debugElement.query(By.css('mat-chip-list'))!.nativeElement;
     });
 
     it('should not show any errors if the user has not interacted', () => {
@@ -1201,7 +1201,7 @@ describe('MatChipList', () => {
         .toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
 
-      dispatchFakeEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('form'))!.nativeElement, 'submit');
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {
@@ -1251,7 +1251,7 @@ describe('MatChipList', () => {
     });
 
     it('sets the aria-describedby to reference errors when in error state', () => {
-      let hintId = fixture.debugElement.query(By.css('.mat-hint')).nativeElement.getAttribute('id');
+      let hintId = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
       let describedBy = chipListEl.getAttribute('aria-describedby');
 
       expect(hintId).toBeTruthy('hint should be shown');
@@ -1301,7 +1301,7 @@ describe('MatChipList', () => {
     }]);
     fixture.detectChanges();
 
-    chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList));
+    chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList))!;
     chipListNativeElement = chipListDebugElement.nativeElement;
     chipListInstance = chipListDebugElement.componentInstance;
     testComponent = fixture.debugElement.componentInstance;
@@ -1312,7 +1312,7 @@ describe('MatChipList', () => {
     fixture = createComponent(FormFieldChipList);
     fixture.detectChanges();
 
-    chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList));
+    chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList))!;
     chipListNativeElement = chipListDebugElement.nativeElement;
     chipListInstance = chipListDebugElement.componentInstance;
     testComponent = fixture.debugElement.componentInstance;

--- a/src/material/chips/chip-remove.spec.ts
+++ b/src/material/chips/chip-remove.spec.ts
@@ -25,7 +25,7 @@ describe('Chip Remove', () => {
     testChip = fixture.debugElement.componentInstance;
     fixture.detectChanges();
 
-    chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+    chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
     chipNativeElement = chipDebugElement.nativeElement;
   }));
 

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -41,7 +41,7 @@ describe('Chips', () => {
       fixture = TestBed.createComponent(BasicChip);
       fixture.detectChanges();
 
-      chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
 
@@ -65,7 +65,7 @@ describe('Chips', () => {
       fixture = TestBed.createComponent(SingleChip);
       fixture.detectChanges();
 
-      chipDebugElement = fixture.debugElement.query(By.directive(MatChip));
+      chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
       testComponent = fixture.debugElement.componentInstance;

--- a/src/material/core/option/option.spec.ts
+++ b/src/material/core/option/option.spec.ts
@@ -24,7 +24,7 @@ describe('MatOption component', () => {
     fixture.detectChanges();
 
     const optionInstance: MatOption =
-        fixture.debugElement.query(By.directive(MatOption)).componentInstance;
+        fixture.debugElement.query(By.directive(MatOption))!.componentInstance;
     const completeSpy = jasmine.createSpy('complete spy');
     const subscription = optionInstance._stateChanges.subscribe({complete: completeSpy});
 
@@ -38,7 +38,7 @@ describe('MatOption component', () => {
     fixture.detectChanges();
 
     const optionInstance: MatOption =
-        fixture.debugElement.query(By.directive(MatOption)).componentInstance;
+        fixture.debugElement.query(By.directive(MatOption))!.componentInstance;
 
     optionInstance.select();
     expect(optionInstance.selected).toBe(true);
@@ -60,7 +60,7 @@ describe('MatOption component', () => {
     fixture.detectChanges();
 
     const optionInstance: MatOption =
-        fixture.debugElement.query(By.directive(MatOption)).componentInstance;
+        fixture.debugElement.query(By.directive(MatOption))!.componentInstance;
 
     optionInstance.deselect();
     expect(optionInstance.selected).toBe(false);
@@ -83,7 +83,7 @@ describe('MatOption component', () => {
     fixture.componentInstance.id = 'custom-option';
     fixture.detectChanges();
 
-    const optionInstance = fixture.debugElement.query(By.directive(MatOption)).componentInstance;
+    const optionInstance = fixture.debugElement.query(By.directive(MatOption))!.componentInstance;
 
     expect(optionInstance.id).toBe('custom-option');
   });
@@ -92,7 +92,7 @@ describe('MatOption component', () => {
     const fixture = TestBed.createComponent(BasicOption);
     fixture.detectChanges();
 
-    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption));
+    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption))!;
     const optionNativeElement: HTMLElement = optionDebugElement.nativeElement;
     const optionInstance: MatOption = optionDebugElement.componentInstance;
     const spy = jasmine.createSpy('selection change spy');
@@ -110,7 +110,7 @@ describe('MatOption component', () => {
     const fixture = TestBed.createComponent(BasicOption);
     fixture.detectChanges();
 
-    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption));
+    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption))!;
     const optionNativeElement: HTMLElement = optionDebugElement.nativeElement;
     const optionInstance: MatOption = optionDebugElement.componentInstance;
     const spy = jasmine.createSpy('selection change spy');
@@ -128,7 +128,7 @@ describe('MatOption component', () => {
     const fixture = TestBed.createComponent(BasicOption);
     fixture.detectChanges();
 
-    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption));
+    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption))!;
     const optionNativeElement: HTMLElement = optionDebugElement.nativeElement;
     const optionInstance: MatOption = optionDebugElement.componentInstance;
     const spy = jasmine.createSpy('selection change spy');
@@ -157,7 +157,7 @@ describe('MatOption component', () => {
       fixture = TestBed.createComponent(BasicOption);
       fixture.detectChanges();
 
-      optionDebugElement = fixture.debugElement.query(By.directive(MatOption));
+      optionDebugElement = fixture.debugElement.query(By.directive(MatOption))!;
       optionNativeElement = optionDebugElement.nativeElement;
       optionInstance = optionDebugElement.componentInstance;
     });

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -36,7 +36,7 @@ describe('MatCalendarBody', () => {
       fixture = TestBed.createComponent(StandardCalendarBody);
       fixture.detectChanges();
 
-      const calendarBodyDebugElement = fixture.debugElement.query(By.directive(MatCalendarBody));
+      const calendarBodyDebugElement = fixture.debugElement.query(By.directive(MatCalendarBody))!;
       calendarBodyNativeElement = calendarBodyDebugElement.nativeElement;
       testComponent = fixture.componentInstance;
 

--- a/src/material/datepicker/calendar-header.spec.ts
+++ b/src/material/datepicker/calendar-header.spec.ts
@@ -43,7 +43,7 @@ describe('MatCalendarHeader', () => {
       fixture = TestBed.createComponent(StandardCalendar);
       fixture.detectChanges();
 
-      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar));
+      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar))!;
       calendarElement = calendarDebugElement.nativeElement;
       periodButton = calendarElement.querySelector('.mat-calendar-period-button') as HTMLElement;
       prevButton = calendarElement.querySelector('.mat-calendar-previous-button') as HTMLElement;
@@ -164,7 +164,7 @@ describe('MatCalendarHeader', () => {
       fixture = TestBed.createComponent(CalendarWithMinMaxDate);
       fixture.detectChanges();
 
-      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar));
+      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar))!;
       calendarElement = calendarDebugElement.nativeElement;
       periodButton =
         calendarElement.querySelector('.mat-calendar-period-button') as HTMLButtonElement;
@@ -218,7 +218,7 @@ describe('MatCalendarHeader', () => {
       fixture = TestBed.createComponent(CalendarWithMinMaxDate);
       fixture.detectChanges();
 
-      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar));
+      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar))!;
       calendarElement = calendarDebugElement.nativeElement;
       periodButton =
         calendarElement.querySelector('.mat-calendar-period-button') as HTMLButtonElement;
@@ -271,7 +271,7 @@ describe('MatCalendarHeader', () => {
       fixture = TestBed.createComponent(CalendarWithMinMaxDate);
       fixture.detectChanges();
 
-      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar));
+      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar))!;
       calendarElement = calendarDebugElement.nativeElement;
       periodButton =
         calendarElement.querySelector('.mat-calendar-period-button') as HTMLButtonElement;

--- a/src/material/datepicker/calendar.spec.ts
+++ b/src/material/datepicker/calendar.spec.ts
@@ -52,7 +52,7 @@ describe('MatCalendar', () => {
       fixture = TestBed.createComponent(StandardCalendar);
       fixture.detectChanges();
 
-      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar));
+      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar))!;
       calendarElement = calendarDebugElement.nativeElement;
       periodButton = calendarElement.querySelector('.mat-calendar-period-button') as HTMLElement;
 
@@ -294,7 +294,7 @@ describe('MatCalendar', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(CalendarWithMinMax);
 
-      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar));
+      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar))!;
       calendarElement = calendarDebugElement.nativeElement;
       calendarInstance = calendarDebugElement.componentInstance;
       testComponent = fixture.componentInstance;
@@ -450,7 +450,7 @@ describe('MatCalendar', () => {
       const dynamicFixture = TestBed.createComponent(CalendarWithSelectableMinDate);
       dynamicFixture.detectChanges();
 
-      const calendarDebugElement = dynamicFixture.debugElement.query(By.directive(MatCalendar));
+      const calendarDebugElement = dynamicFixture.debugElement.query(By.directive(MatCalendar))!;
       const disabledClass = 'mat-calendar-body-disabled';
       calendarElement = calendarDebugElement.nativeElement;
       calendarInstance = calendarDebugElement.componentInstance;
@@ -486,7 +486,7 @@ describe('MatCalendar', () => {
       fixture = TestBed.createComponent(CalendarWithDateFilter);
       fixture.detectChanges();
 
-      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar));
+      let calendarDebugElement = fixture.debugElement.query(By.directive(MatCalendar))!;
       calendarElement = calendarDebugElement.nativeElement;
       calendarInstance = calendarDebugElement.componentInstance;
       testComponent = fixture.componentInstance;

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -329,7 +329,7 @@ describe('MatDatepicker', () => {
       });
 
       it('input should aria-owns calendar after opened in non-touch mode', fakeAsync(() => {
-        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(inputEl.getAttribute('aria-owns')).toBeNull();
 
         testComponent.datepicker.open();
@@ -348,7 +348,7 @@ describe('MatDatepicker', () => {
         testComponent.touch = true;
         fixture.detectChanges();
 
-        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(inputEl.getAttribute('aria-owns')).toBeNull();
 
         testComponent.datepicker.open();
@@ -718,7 +718,7 @@ describe('MatDatepicker', () => {
       }));
 
       it('should mark input dirty after input event', () => {
-        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         expect(inputEl.classList).toContain('ng-pristine');
 
@@ -730,7 +730,7 @@ describe('MatDatepicker', () => {
       });
 
       it('should mark input dirty after date selected', fakeAsync(() => {
-        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         expect(inputEl.classList).toContain('ng-pristine');
 
@@ -743,7 +743,7 @@ describe('MatDatepicker', () => {
       }));
 
       it('should not mark dirty after model change', fakeAsync(() => {
-        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         expect(inputEl.classList).toContain('ng-pristine');
 
@@ -756,7 +756,7 @@ describe('MatDatepicker', () => {
       }));
 
       it('should mark input touched on blur', () => {
-        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         expect(inputEl.classList).toContain('ng-untouched');
 
@@ -778,7 +778,7 @@ describe('MatDatepicker', () => {
           return;
         }
 
-        const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         inputEl.value = '2001-01-01';
         dispatchFakeEvent(inputEl, 'input');
@@ -791,7 +791,7 @@ describe('MatDatepicker', () => {
       });
 
       it('should not reformat invalid dates on blur', () => {
-        const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         inputEl.value = 'very-valid-date';
         dispatchFakeEvent(inputEl, 'input');
@@ -804,7 +804,7 @@ describe('MatDatepicker', () => {
       });
 
       it('should mark input touched on calendar selection', fakeAsync(() => {
-        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         expect(inputEl.classList).toContain('ng-untouched');
 
@@ -858,7 +858,7 @@ describe('MatDatepicker', () => {
       });
 
       it('should disable input when form control disabled', () => {
-        let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         expect(inputEl.disabled).toBe(false);
 
@@ -896,7 +896,7 @@ describe('MatDatepicker', () => {
       }));
 
       it('should set `aria-haspopup` on the toggle button', () => {
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
 
         expect(button).toBeTruthy();
         expect(button.nativeElement.getAttribute('aria-haspopup')).toBe('dialog');
@@ -905,7 +905,7 @@ describe('MatDatepicker', () => {
       it('should open calendar when toggle clicked', () => {
         expect(document.querySelector('mat-dialog-container')).toBeNull();
 
-        let toggle = fixture.debugElement.query(By.css('button'));
+        let toggle = fixture.debugElement.query(By.css('button'))!;
         dispatchMouseEvent(toggle.nativeElement, 'click');
         fixture.detectChanges();
 
@@ -915,7 +915,7 @@ describe('MatDatepicker', () => {
       it('should not open calendar when toggle clicked if datepicker is disabled', () => {
         testComponent.datepicker.disabled = true;
         fixture.detectChanges();
-        const toggle = fixture.debugElement.query(By.css('button')).nativeElement;
+        const toggle = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
         expect(toggle.hasAttribute('disabled')).toBe(true);
         expect(document.querySelector('mat-dialog-container')).toBeNull();
@@ -931,7 +931,7 @@ describe('MatDatepicker', () => {
 
         testComponent.input.disabled = true;
         fixture.detectChanges();
-        const toggle = fixture.debugElement.query(By.css('button')).nativeElement;
+        const toggle = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
         expect(toggle.hasAttribute('disabled')).toBe(true);
         expect(document.querySelector('mat-dialog-container')).toBeNull();
@@ -943,7 +943,7 @@ describe('MatDatepicker', () => {
       });
 
       it('should set the `button` type on the trigger to prevent form submissions', () => {
-        let toggle = fixture.debugElement.query(By.css('button')).nativeElement;
+        let toggle = fixture.debugElement.query(By.css('button'))!.nativeElement;
         expect(toggle.getAttribute('type')).toBe('button');
       });
 
@@ -953,7 +953,7 @@ describe('MatDatepicker', () => {
       });
 
       it('should restore focus to the toggle after the calendar is closed', () => {
-        let toggle = fixture.debugElement.query(By.css('button')).nativeElement;
+        let toggle = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
         fixture.componentInstance.touchUI = false;
         fixture.detectChanges();
@@ -978,7 +978,7 @@ describe('MatDatepicker', () => {
 
       it('should re-render when the i18n labels change',
         inject([MatDatepickerIntl], (intl: MatDatepickerIntl) => {
-          const toggle = fixture.debugElement.query(By.css('button')).nativeElement;
+          const toggle = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
           intl.openCalendarLabel = 'Open the calendar, perhaps?';
           intl.changes.next();
@@ -988,7 +988,7 @@ describe('MatDatepicker', () => {
         }));
 
       it('should toggle the active state of the datepicker toggle', fakeAsync(() => {
-        const toggle = fixture.debugElement.query(By.css('mat-datepicker-toggle')).nativeElement;
+        const toggle = fixture.debugElement.query(By.css('mat-datepicker-toggle'))!.nativeElement;
 
         expect(toggle.classList).not.toContain('mat-datepicker-toggle-active');
 
@@ -1146,7 +1146,7 @@ describe('MatDatepicker', () => {
         flush();
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('input')).nativeElement.classList)
+        expect(fixture.debugElement.query(By.css('input'))!.nativeElement.classList)
             .toContain('ng-invalid');
       }));
 
@@ -1157,7 +1157,7 @@ describe('MatDatepicker', () => {
 
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('input')).nativeElement.classList)
+        expect(fixture.debugElement.query(By.css('input'))!.nativeElement.classList)
             .toContain('ng-invalid');
       }));
 
@@ -1167,7 +1167,7 @@ describe('MatDatepicker', () => {
         flush();
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('input')).nativeElement.classList)
+        expect(fixture.debugElement.query(By.css('input'))!.nativeElement.classList)
             .not.toContain('ng-invalid');
       }));
 
@@ -1177,7 +1177,7 @@ describe('MatDatepicker', () => {
         flush();
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('input')).nativeElement.classList)
+        expect(fixture.debugElement.query(By.css('input'))!.nativeElement.classList)
             .not.toContain('ng-invalid');
       }));
 
@@ -1187,12 +1187,12 @@ describe('MatDatepicker', () => {
         flush();
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('input')).nativeElement.classList)
+        expect(fixture.debugElement.query(By.css('input'))!.nativeElement.classList)
             .not.toContain('ng-invalid');
       }));
 
       it('should update validity when switching between null and invalid', fakeAsync(() => {
-        const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         inputEl.value = '';
         dispatchFakeEvent(inputEl, 'input');
 
@@ -1245,7 +1245,7 @@ describe('MatDatepicker', () => {
         flush();
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('input')).nativeElement.classList)
+        expect(fixture.debugElement.query(By.css('input'))!.nativeElement.classList)
             .toContain('ng-invalid');
 
         testComponent.date = new Date(2017, JAN, 2);
@@ -1253,7 +1253,7 @@ describe('MatDatepicker', () => {
         flush();
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('input')).nativeElement.classList)
+        expect(fixture.debugElement.query(By.css('input'))!.nativeElement.classList)
             .not.toContain('ng-invalid');
       }));
 
@@ -1281,7 +1281,7 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         testComponent = fixture.componentInstance;
-        inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         spyOn(testComponent, 'onChange');
         spyOn(testComponent, 'onInput');
@@ -1431,7 +1431,7 @@ describe('MatDatepicker', () => {
         fixture = createComponent(DatepickerOpeningOnFocus, [MatNativeDateModule]);
         fixture.detectChanges();
         testComponent = fixture.componentInstance;
-        input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input = fixture.debugElement.query(By.css('input'))!.nativeElement;
       }));
 
       it('should not reopen if the browser fires the focus event asynchronously', fakeAsync(() => {
@@ -1580,7 +1580,7 @@ describe('MatDatepicker', () => {
       fixture = createComponent(StandardDatepicker, [MatNativeDateModule]);
       fixture.detectChanges();
       testComponent = fixture.componentInstance;
-      input = fixture.debugElement.query(By.css('input')).nativeElement;
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
       input.style.position = 'fixed';
     }));
 

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -54,7 +54,7 @@ describe('MatMonthView', () => {
       fixture = TestBed.createComponent(StandardMonthView);
       fixture.detectChanges();
 
-      let monthViewDebugElement = fixture.debugElement.query(By.directive(MatMonthView));
+      let monthViewDebugElement = fixture.debugElement.query(By.directive(MatMonthView))!;
       monthViewNativeElement = monthViewDebugElement.nativeElement;
       testComponent = fixture.componentInstance;
     });
@@ -287,7 +287,7 @@ describe('MatMonthView', () => {
       fixture = TestBed.createComponent(MonthViewWithDateFilter);
       fixture.detectChanges();
 
-      let monthViewDebugElement = fixture.debugElement.query(By.directive(MatMonthView));
+      let monthViewDebugElement = fixture.debugElement.query(By.directive(MatMonthView))!;
       monthViewNativeElement = monthViewDebugElement.nativeElement;
     });
 
@@ -306,7 +306,7 @@ describe('MatMonthView', () => {
       fixture = TestBed.createComponent(MonthViewWithDateClass);
       fixture.detectChanges();
 
-      let monthViewDebugElement = fixture.debugElement.query(By.directive(MatMonthView));
+      let monthViewDebugElement = fixture.debugElement.query(By.directive(MatMonthView))!;
       monthViewNativeElement = monthViewDebugElement.nativeElement;
     });
 

--- a/src/material/datepicker/multi-year-view.spec.ts
+++ b/src/material/datepicker/multi-year-view.spec.ts
@@ -52,7 +52,7 @@ describe('MatMultiYearView', () => {
       fixture = TestBed.createComponent(StandardMultiYearView);
       fixture.detectChanges();
 
-      let multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView));
+      let multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView))!;
       multiYearViewNativeElement = multiYearViewDebugElement.nativeElement;
       testComponent = fixture.componentInstance;
     });
@@ -238,7 +238,7 @@ describe('MatMultiYearView', () => {
       fixture = TestBed.createComponent(MultiYearViewWithDateFilter);
       fixture.detectChanges();
 
-      const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView));
+      const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView))!;
       multiYearViewNativeElement = multiYearViewDebugElement.nativeElement;
     });
 
@@ -257,7 +257,7 @@ describe('MatMultiYearView', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(MultiYearViewWithMinMaxDate);
 
-      const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView));
+      const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView))!;
       multiYearViewNativeElement = multiYearViewDebugElement.nativeElement;
       testComponent = fixture.componentInstance;
     });
@@ -280,7 +280,7 @@ describe('MatMultiYearView', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(MultiYearViewWithMinMaxDate);
 
-      const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView));
+      const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView))!;
       multiYearViewNativeElement = multiYearViewDebugElement.nativeElement;
       testComponent = fixture.componentInstance;
     });
@@ -303,7 +303,7 @@ describe('MatMultiYearView', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(MultiYearViewWithMinMaxDate);
 
-      const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView));
+      const multiYearViewDebugElement = fixture.debugElement.query(By.directive(MatMultiYearView))!;
       multiYearViewNativeElement = multiYearViewDebugElement.nativeElement;
       testComponent = fixture.componentInstance;
     });

--- a/src/material/datepicker/year-view.spec.ts
+++ b/src/material/datepicker/year-view.spec.ts
@@ -51,7 +51,7 @@ describe('MatYearView', () => {
       fixture = TestBed.createComponent(StandardYearView);
       fixture.detectChanges();
 
-      let yearViewDebugElement = fixture.debugElement.query(By.directive(MatYearView));
+      let yearViewDebugElement = fixture.debugElement.query(By.directive(MatYearView))!;
       yearViewNativeElement = yearViewDebugElement.nativeElement;
       testComponent = fixture.componentInstance;
     });
@@ -304,7 +304,7 @@ describe('MatYearView', () => {
       fixture = TestBed.createComponent(YearViewWithDateFilter);
       fixture.detectChanges();
 
-      const yearViewDebugElement = fixture.debugElement.query(By.directive(MatYearView));
+      const yearViewDebugElement = fixture.debugElement.query(By.directive(MatYearView))!;
       yearViewNativeElement = yearViewDebugElement.nativeElement;
     });
 

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -630,7 +630,8 @@ describe('MatDialog', () => {
   it('should set the proper animation states', () => {
     let dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
     let dialogContainer: MatDialogContainer =
-        viewContainerFixture.debugElement.query(By.directive(MatDialogContainer))!.componentInstance;
+        viewContainerFixture.debugElement.query(By.directive(MatDialogContainer))!
+        .componentInstance;
 
     expect(dialogContainer._state).toBe('enter');
 

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -630,7 +630,7 @@ describe('MatDialog', () => {
   it('should set the proper animation states', () => {
     let dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
     let dialogContainer: MatDialogContainer =
-        viewContainerFixture.debugElement.query(By.directive(MatDialogContainer)).componentInstance;
+        viewContainerFixture.debugElement.query(By.directive(MatDialogContainer))!.componentInstance;
 
     expect(dialogContainer._state).toBe('enter');
 

--- a/src/material/divider/divider.spec.ts
+++ b/src/material/divider/divider.spec.ts
@@ -22,7 +22,7 @@ describe('MatDivider', () => {
     fixture.componentInstance.vertical = true;
     fixture.detectChanges();
 
-    const divider = fixture.debugElement.query(By.css('mat-divider'));
+    const divider = fixture.debugElement.query(By.css('mat-divider'))!;
     expect(divider.nativeElement.classList).toContain('mat-divider');
     expect(divider.nativeElement.classList).toContain('mat-divider-vertical');
   });
@@ -31,7 +31,7 @@ describe('MatDivider', () => {
     fixture.componentInstance.vertical = false;
     fixture.detectChanges();
 
-    const divider = fixture.debugElement.query(By.css('mat-divider'));
+    const divider = fixture.debugElement.query(By.css('mat-divider'))!;
     expect(divider.nativeElement.classList).toContain('mat-divider');
     expect(divider.nativeElement.classList).not.toContain('mat-divider-vertical');
     expect(divider.nativeElement.classList).toContain('mat-divider-horizontal');
@@ -41,7 +41,7 @@ describe('MatDivider', () => {
     fixture.componentInstance.inset = true;
     fixture.detectChanges();
 
-    const divider = fixture.debugElement.query(By.css('mat-divider'));
+    const divider = fixture.debugElement.query(By.css('mat-divider'))!;
     expect(divider.nativeElement.classList).toContain('mat-divider');
     expect(divider.nativeElement.classList).toContain('mat-divider-inset');
   });
@@ -51,7 +51,7 @@ describe('MatDivider', () => {
     fixture.componentInstance.inset = true;
     fixture.detectChanges();
 
-    const divider = fixture.debugElement.query(By.css('mat-divider'));
+    const divider = fixture.debugElement.query(By.css('mat-divider'))!;
     expect(divider.nativeElement.classList).toContain('mat-divider');
     expect(divider.nativeElement.classList).toContain('mat-divider-inset');
     expect(divider.nativeElement.classList).toContain('mat-divider-vertical');
@@ -60,7 +60,7 @@ describe('MatDivider', () => {
   it('should add aria roles properly', () => {
     fixture.detectChanges();
 
-    const divider = fixture.debugElement.query(By.css('mat-divider'));
+    const divider = fixture.debugElement.query(By.css('mat-divider'))!;
     expect(divider.nativeElement.getAttribute('role')).toBe('separator');
   });
 });

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -124,7 +124,7 @@ describe('MatAccordion', () => {
 
   it('should update the expansion panel if hideToggle changed', () => {
     const fixture = TestBed.createComponent(AccordionWithHideToggle);
-    const panel = fixture.debugElement.query(By.directive(MatExpansionPanel));
+    const panel = fixture.debugElement.query(By.directive(MatExpansionPanel))!;
 
     fixture.detectChanges();
 
@@ -140,7 +140,7 @@ describe('MatAccordion', () => {
 
   it('should update the expansion panel if togglePosition changed', () => {
     const fixture = TestBed.createComponent(AccordionWithTogglePosition);
-    const panel = fixture.debugElement.query(By.directive(MatExpansionPanel));
+    const panel = fixture.debugElement.query(By.directive(MatExpansionPanel))!;
 
     fixture.detectChanges();
 

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -48,7 +48,7 @@ describe('MatExpansionPanel', () => {
   it('should be able to render panel content lazily', fakeAsync(() => {
     const fixture = TestBed.createComponent(LazyPanelWithContent);
     const content = fixture.debugElement.query(
-      By.css('.mat-expansion-panel-content')).nativeElement;
+      By.css('.mat-expansion-panel-content'))!.nativeElement;
     fixture.detectChanges();
 
     expect(content.textContent.trim()).toBe('', 'Expected content element to be empty.');
@@ -63,7 +63,7 @@ describe('MatExpansionPanel', () => {
   it('should render the content for a lazy-loaded panel that is opened on init', fakeAsync(() => {
     const fixture = TestBed.createComponent(LazyPanelOpenOnLoad);
     const content = fixture.debugElement.query(
-      By.css('.mat-expansion-panel-content')).nativeElement;
+      By.css('.mat-expansion-panel-content'))!.nativeElement;
     fixture.detectChanges();
 
     expect(content.textContent.trim())
@@ -171,7 +171,7 @@ describe('MatExpansionPanel', () => {
     fixture.detectChanges();
     tick(250);
 
-    const button = fixture.debugElement.query(By.css('button')).nativeElement;
+    const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
     button.focus();
     expect(document.activeElement).toBe(button, 'Expected button to start off focusable.');
@@ -191,8 +191,8 @@ describe('MatExpansionPanel', () => {
     fixture.detectChanges();
     tick(250);
 
-    const button = fixture.debugElement.query(By.css('button')).nativeElement;
-    const header = fixture.debugElement.query(By.css('mat-expansion-panel-header')).nativeElement;
+    const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
+    const header = fixture.debugElement.query(By.css('mat-expansion-panel-header'))!.nativeElement;
 
     button.focus();
     expect(document.activeElement).toBe(button, 'Expected button to start off focusable.');
@@ -208,7 +208,7 @@ describe('MatExpansionPanel', () => {
     const fixture = TestBed.createComponent(PanelWithCustomMargin);
     fixture.detectChanges();
 
-    const panel = fixture.debugElement.query(By.css('mat-expansion-panel'));
+    const panel = fixture.debugElement.query(By.css('mat-expansion-panel'))!;
     let styles = getComputedStyle(panel.nativeElement);
 
     expect(panel.componentInstance._hasSpacing()).toBe(false);
@@ -232,7 +232,7 @@ describe('MatExpansionPanel', () => {
 
   it('should be able to hide the toggle', () => {
     const fixture = TestBed.createComponent(PanelWithContent);
-    const header = fixture.debugElement.query(By.css('.mat-expansion-panel-header')).nativeElement;
+    const header = fixture.debugElement.query(By.css('.mat-expansion-panel-header'))!.nativeElement;
 
     fixture.detectChanges();
 
@@ -253,7 +253,7 @@ describe('MatExpansionPanel', () => {
       fixture.detectChanges();
       tick(250);
 
-      const arrow = fixture.debugElement.query(By.css('.mat-expansion-indicator')).nativeElement;
+      const arrow = fixture.debugElement.query(By.css('.mat-expansion-indicator'))!.nativeElement;
 
       expect(arrow.style.transform).toBe('rotate(0deg)', 'Expected no rotation.');
 
@@ -276,7 +276,7 @@ describe('MatExpansionPanel', () => {
 
   it('should support two-way binding of the `expanded` property', () => {
     const fixture = TestBed.createComponent(PanelWithTwoWayBinding);
-    const header = fixture.debugElement.query(By.css('mat-expansion-panel-header')).nativeElement;
+    const header = fixture.debugElement.query(By.css('mat-expansion-panel-header'))!.nativeElement;
 
     fixture.detectChanges();
     expect(fixture.componentInstance.expanded).toBe(false);
@@ -333,8 +333,8 @@ describe('MatExpansionPanel', () => {
     const fixture = TestBed.createComponent(PanelWithTwoWayBinding);
     fixture.detectChanges();
 
-    const panel = fixture.debugElement.query(By.directive(MatExpansionPanel));
-    const header = fixture.debugElement.query(By.directive(MatExpansionPanelHeader));
+    const panel = fixture.debugElement.query(By.directive(MatExpansionPanel))!;
+    const header = fixture.debugElement.query(By.directive(MatExpansionPanelHeader))!;
 
     expect(panel.componentInstance.hideToggle).toBe(true);
     expect(header.componentInstance.expandedHeight).toBe('10px');
@@ -349,8 +349,8 @@ describe('MatExpansionPanel', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(PanelWithContent);
       fixture.detectChanges();
-      panel = fixture.debugElement.query(By.css('mat-expansion-panel')).nativeElement;
-      header = fixture.debugElement.query(By.css('mat-expansion-panel-header')).nativeElement;
+      panel = fixture.debugElement.query(By.css('mat-expansion-panel'))!.nativeElement;
+      header = fixture.debugElement.query(By.css('mat-expansion-panel-header'))!.nativeElement;
     });
 
     it('should toggle the aria-disabled attribute on the header', () => {

--- a/src/material/grid-list/grid-list.spec.ts
+++ b/src/material/grid-list/grid-list.spec.ts
@@ -52,7 +52,7 @@ describe('MatGridList', () => {
 
   it('should not throw when setting the `rowHeight` programmatically before init', () => {
     const fixture = createComponent(GridListWithUnspecifiedRowHeight);
-    const gridList = fixture.debugElement.query(By.directive(MatGridList));
+    const gridList = fixture.debugElement.query(By.directive(MatGridList))!;
 
     expect(() => {
       // Set the row height twice so the tile styler is initialized.
@@ -64,7 +64,7 @@ describe('MatGridList', () => {
 
   it('should preserve value when zero is set as row height', () => {
     const fixture = createComponent(GridListWithUnspecifiedRowHeight);
-    const gridList = fixture.debugElement.query(By.directive(MatGridList)).componentInstance;
+    const gridList = fixture.debugElement.query(By.directive(MatGridList))!.componentInstance;
 
     gridList.rowHeight = 0;
     expect(gridList.rowHeight).toBe('0');
@@ -92,7 +92,7 @@ describe('MatGridList', () => {
     }
 
     fixture.detectChanges();
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     const inlineStyles = tile.nativeElement.style;
 
     // In ratio mode, heights are set using the padding-top property.
@@ -111,7 +111,7 @@ describe('MatGridList', () => {
     fixture.componentInstance.rowHeight = '4:1';
     fixture.detectChanges();
 
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     const inlineStyles = tile.nativeElement.style;
 
     expect(inlineStyles.paddingTop).toBeTruthy();
@@ -135,7 +135,7 @@ describe('MatGridList', () => {
 
     fixture.componentInstance.totalHeight = '300px';
     fixture.detectChanges();
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
 
     // 149.5 * 2 = 299px + 1px gutter = 300px
     expect(getDimension(tile, 'height')).toBe(149.5);
@@ -157,7 +157,7 @@ describe('MatGridList', () => {
     fixture.componentInstance.rowHeight = '100px';
     fixture.detectChanges();
 
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     expect(getDimension(tile, 'height')).toBe(100);
 
     fixture.componentInstance.rowHeight = '200px';
@@ -174,7 +174,7 @@ describe('MatGridList', () => {
     }
 
     fixture.detectChanges();
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     expect(getDimension(tile, 'height')).toBe(100);
   });
 
@@ -199,7 +199,7 @@ describe('MatGridList', () => {
 
   it('should be able to set the gutter size to zero', () => {
     const fixture = createComponent(GridListWithUnspecifiedGutterSize);
-    const gridList = fixture.debugElement.query(By.directive(MatGridList));
+    const gridList = fixture.debugElement.query(By.directive(MatGridList))!;
 
     if (disableComputedStyleTests) {
       return;
@@ -275,7 +275,7 @@ describe('MatGridList', () => {
 
   it('should allow alternate units for the gutter size', () => {
     const fixture = createComponent(GridListWithUnspecifiedGutterSize);
-    const gridList = fixture.debugElement.query(By.directive(MatGridList));
+    const gridList = fixture.debugElement.query(By.directive(MatGridList))!;
 
     if (disableComputedStyleTests) {
       return;
@@ -298,7 +298,7 @@ describe('MatGridList', () => {
     }
 
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.directive(MatGridList));
+    const list = fixture.debugElement.query(By.directive(MatGridList))!;
     const inlineStyles = list.nativeElement.style;
 
     expect(inlineStyles.paddingBottom).toBeTruthy();
@@ -314,7 +314,7 @@ describe('MatGridList', () => {
     }
 
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.directive(MatGridList));
+    const list = fixture.debugElement.query(By.directive(MatGridList))!;
     expect(getDimension(list, 'height')).toBe(201);
   });
 
@@ -328,7 +328,7 @@ describe('MatGridList', () => {
     fixture.componentInstance.colspan = 2;
     fixture.detectChanges();
 
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     expect(getDimension(tile, 'width')).toBe(199.5);
 
     fixture.componentInstance.colspan = 3;
@@ -346,7 +346,7 @@ describe('MatGridList', () => {
     fixture.componentInstance.rowspan = 2;
     fixture.detectChanges();
 
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     expect(getDimension(tile, 'height')).toBe(201);
 
     fixture.componentInstance.rowspan = 3;
@@ -463,7 +463,7 @@ describe('MatGridList', () => {
     const fixture = createComponent(GridListWithFootersWithoutLines);
     fixture.detectChanges();
 
-    const footer = fixture.debugElement.query(By.directive(MatGridTileText));
+    const footer = fixture.debugElement.query(By.directive(MatGridTileText))!;
     expect(footer.nativeElement.classList.contains('mat-2-line')).toBe(false);
   });
 
@@ -471,7 +471,7 @@ describe('MatGridList', () => {
     const fixture = createComponent(GridListWithFooterContainingTwoLines);
     fixture.detectChanges();
 
-    const footer = fixture.debugElement.query(By.directive(MatGridTileText));
+    const footer = fixture.debugElement.query(By.directive(MatGridTileText))!;
     expect(footer.nativeElement.classList.contains('mat-2-line')).toBe(true);
   });
 
@@ -481,7 +481,7 @@ describe('MatGridList', () => {
     fixture.componentInstance.rowHeight = '4:1';
     fixture.detectChanges();
 
-    const firstTile = fixture.debugElement.query(By.directive(MatGridTile)).nativeElement;
+    const firstTile = fixture.debugElement.query(By.directive(MatGridTile))!.nativeElement;
 
     expect(firstTile.style.marginTop).toBe('0px');
     expect(firstTile.style.left).toBe('0px');
@@ -497,8 +497,8 @@ describe('MatGridList', () => {
     fixture.componentInstance.rowHeight = '4:1';
     fixture.detectChanges();
 
-    const list = fixture.debugElement.query(By.directive(MatGridList));
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const list = fixture.debugElement.query(By.directive(MatGridList))!;
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     const listInlineStyles = list.nativeElement.style;
     const tileInlineStyles = tile.nativeElement.style;
 
@@ -531,7 +531,7 @@ describe('MatGridList', () => {
 
   it('should default to LTR if empty directionality is given', () => {
     const fixture = createComponent(GridListWithEmptyDirectionality);
-    const tile: HTMLElement = fixture.debugElement.query(By.css('mat-grid-tile')).nativeElement;
+    const tile: HTMLElement = fixture.debugElement.query(By.css('mat-grid-tile'))!.nativeElement;
     fixture.detectChanges();
 
     expect(tile.style.left).toBe('0px');
@@ -540,7 +540,7 @@ describe('MatGridList', () => {
 
   it('should set `right` styles for RTL', () => {
     const fixture = createComponent(GridListWithRtl);
-    const tile: HTMLElement = fixture.debugElement.query(By.css('mat-grid-tile')).nativeElement;
+    const tile: HTMLElement = fixture.debugElement.query(By.css('mat-grid-tile'))!.nativeElement;
     fixture.detectChanges();
 
     expect(tile.style.left).toBe('');
@@ -555,7 +555,7 @@ describe('MatGridList', () => {
     }
 
     fixture.detectChanges();
-    const tile = fixture.debugElement.query(By.directive(MatGridTile));
+    const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     const inlineStyles = tile.nativeElement.style;
 
     expect(inlineStyles.paddingTop).toBeTruthy();
@@ -565,7 +565,7 @@ describe('MatGridList', () => {
 
   it('should throw if an invalid value is set as the `rowHeight`', () => {
     const fixture = createComponent(GridListWithUnspecifiedRowHeight);
-    const gridList = fixture.debugElement.query(By.directive(MatGridList));
+    const gridList = fixture.debugElement.query(By.directive(MatGridList))!;
 
     expect(() => {
       // Note the semicolon at the end which will be an invalid value on some browsers (see #13252).

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -52,7 +52,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputWithId);
     fixture.detectChanges();
 
-    let formField = fixture.debugElement.query(By.directive(MatFormField))
+    let formField = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
     expect(formField.floatLabel).toBe('auto',
         'Expected MatInput to set floatingLabel to auto by default.');
@@ -64,7 +64,7 @@ describe('MatInput without forms', () => {
     }]);
     fixture.detectChanges();
 
-    let formField = fixture.debugElement.query(By.directive(MatFormField))
+    let formField = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
     expect(formField.floatLabel).toBe('always',
       'Expected MatInput to set floatingLabel to always from global option.');
@@ -77,7 +77,7 @@ describe('MatInput without forms', () => {
       let fixture = createComponent(MatInputDateTestController);
       fixture.detectChanges();
 
-      let el = fixture.debugElement.query(By.css('label')).nativeElement;
+      let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
       expect(el).not.toBeNull();
       expect(el.classList.contains('mat-form-field-empty')).toBe(false);
     }
@@ -91,7 +91,7 @@ describe('MatInput without forms', () => {
       let fixture = createComponent(MatInputDateTestController);
       fixture.detectChanges();
 
-      let el = fixture.debugElement.query(By.css('label')).nativeElement;
+      let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
       expect(el).not.toBeNull();
       expect(el.classList.contains('mat-form-field-empty')).toBe(true);
     }
@@ -101,7 +101,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label')).nativeElement;
+    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
     expect(el).not.toBeNull();
     expect(el.classList.contains('mat-form-field-empty')).toBe(true);
   }));
@@ -110,7 +110,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputPasswordTestController);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label')).nativeElement;
+    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
     expect(el).not.toBeNull();
     expect(el.classList.contains('mat-form-field-empty')).toBe(true);
   }));
@@ -119,7 +119,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputNumberTestController);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label')).nativeElement;
+    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
     expect(el).not.toBeNull();
     expect(el.classList.contains('mat-form-field-empty')).toBe(true);
   }));
@@ -128,8 +128,8 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'));
-    let el = fixture.debugElement.query(By.css('label')).nativeElement;
+    let inputEl = fixture.debugElement.query(By.css('input'))!;
+    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
     expect(el).not.toBeNull();
     expect(el.classList.contains('mat-form-field-empty')).toBe(true, 'should be empty');
 
@@ -138,7 +138,7 @@ describe('MatInput without forms', () => {
     inputEl.triggerEventHandler('input', {target: inputEl.nativeElement});
     fixture.detectChanges();
 
-    el = fixture.debugElement.query(By.css('label')).nativeElement;
+    el = fixture.debugElement.query(By.css('label'))!.nativeElement;
     expect(el.classList.contains('mat-form-field-empty')).toBe(false, 'should not be empty');
   }));
 
@@ -146,8 +146,8 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputWithStaticLabel);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'));
-    let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+    let inputEl = fixture.debugElement.query(By.css('input'))!;
+    let labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
     expect(labelEl.classList).toContain('mat-form-field-empty');
     expect(labelEl.classList).not.toContain('mat-form-field-float');
@@ -165,7 +165,7 @@ describe('MatInput without forms', () => {
   it('should not be empty when the value set before view init', fakeAsync(() => {
     let fixture = createComponent(MatInputWithValueBinding);
     fixture.detectChanges();
-    let labelEl = fixture.debugElement.query(By.css('.mat-form-field-label')).nativeElement;
+    let labelEl = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
 
     expect(labelEl.classList).not.toContain('mat-form-field-empty');
 
@@ -180,9 +180,9 @@ describe('MatInput without forms', () => {
     fixture.detectChanges();
 
     const inputElement: HTMLInputElement =
-        fixture.debugElement.query(By.css('input')).nativeElement;
+        fixture.debugElement.query(By.css('input'))!.nativeElement;
     const labelElement: HTMLInputElement =
-        fixture.debugElement.query(By.css('label')).nativeElement;
+        fixture.debugElement.query(By.css('label'))!.nativeElement;
 
     expect(inputElement.id).toBeTruthy();
     expect(inputElement.id).toEqual(labelElement.getAttribute('for')!);
@@ -193,9 +193,9 @@ describe('MatInput without forms', () => {
     fixture.detectChanges();
 
     const inputElement: HTMLInputElement =
-        fixture.debugElement.query(By.css('input')).nativeElement;
+        fixture.debugElement.query(By.css('input'))!.nativeElement;
     const labelElement: HTMLInputElement =
-        fixture.debugElement.query(By.css('label')).nativeElement;
+        fixture.debugElement.query(By.css('label'))!.nativeElement;
 
     expect(labelElement.getAttribute('aria-owns')).toBe(inputElement.id);
   }));
@@ -205,7 +205,7 @@ describe('MatInput without forms', () => {
     fixture.detectChanges();
 
     const inputElement: HTMLInputElement =
-        fixture.debugElement.query(By.css('input')).nativeElement;
+        fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(inputElement.getAttribute('aria-required'))
         .toBe('false', 'Expected aria-required to reflect required state of false');
@@ -222,9 +222,9 @@ describe('MatInput without forms', () => {
     fixture.detectChanges();
 
     const inputElement: HTMLInputElement =
-        fixture.debugElement.query(By.css('input')).nativeElement;
+        fixture.debugElement.query(By.css('input'))!.nativeElement;
     const labelElement: HTMLInputElement =
-        fixture.debugElement.query(By.css('label')).nativeElement;
+        fixture.debugElement.query(By.css('label'))!.nativeElement;
 
     expect(inputElement.id).toBe('test-id');
     expect(labelElement.getAttribute('for')).toBe('test-id');
@@ -320,7 +320,7 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
 
-    let hint = fixture.debugElement.query(By.css('.mat-hint')).nativeElement;
+    let hint = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement;
 
     expect(hint.getAttribute('id')).toBeTruthy();
   }));
@@ -330,12 +330,12 @@ describe('MatInput without forms', () => {
     fixture.detectChanges();
 
     // In this case, we should have an empty <mat-hint>.
-    let el = fixture.debugElement.query(By.css('mat-hint')).nativeElement;
+    let el = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
     expect(el.textContent).toBeFalsy();
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
-    el = fixture.debugElement.query(By.css('mat-hint')).nativeElement;
+    el = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
     expect(el.textContent).toBe('label');
   }));
 
@@ -345,7 +345,7 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
 
-    let hint = fixture.debugElement.query(By.css('mat-hint')).nativeElement;
+    let hint = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
 
     expect(hint.getAttribute('id')).toBeTruthy();
   }));
@@ -354,7 +354,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputPlaceholderAttrTestComponent);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(fixture.debugElement.query(By.css('label'))).toBeNull();
     expect(inputEl.placeholder).toBe('');
@@ -362,7 +362,7 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.placeholder = 'Other placeholder';
     fixture.detectChanges();
 
-    let labelEl = fixture.debugElement.query(By.css('label'));
+    let labelEl = fixture.debugElement.query(By.css('label'))!;
 
     expect(inputEl.placeholder).toBe('Other placeholder');
     expect(labelEl).not.toBeNull();
@@ -373,14 +373,14 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputPlaceholderElementTestComponent);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'));
+    let el = fixture.debugElement.query(By.css('label'))!;
     expect(el).not.toBeNull();
     expect(el.nativeElement.textContent).toMatch('Default Placeholder');
 
     fixture.componentInstance.placeholder = 'Other placeholder';
     fixture.detectChanges();
 
-    el = fixture.debugElement.query(By.css('label'));
+    el = fixture.debugElement.query(By.css('label'))!;
     expect(el).not.toBeNull();
     expect(el.nativeElement.textContent).toBe('Other placeholder');
   }));
@@ -389,7 +389,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'));
+    let el = fixture.debugElement.query(By.css('label'))!;
     expect(el).not.toBeNull();
     expect(el.nativeElement.textContent).toBe('hello *');
   }));
@@ -400,7 +400,7 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.disabled = true;
     fixture.detectChanges();
 
-    const el = fixture.debugElement.query(By.css('label'));
+    const el = fixture.debugElement.query(By.css('label'))!;
 
     expect(el).not.toBeNull();
     expect(el.nativeElement.textContent).toBe('hello');
@@ -410,7 +410,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('.mat-form-field-required-marker')).nativeElement;
+    let el = fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!.nativeElement;
 
     expect(el.getAttribute('aria-hidden')).toBe('true');
   }));
@@ -419,7 +419,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'));
+    let el = fixture.debugElement.query(By.css('label'))!;
     expect(el).not.toBeNull();
     expect(el.nativeElement.textContent).toBe('hello *');
 
@@ -434,8 +434,8 @@ describe('MatInput without forms', () => {
     fixture.detectChanges();
 
     const formFieldEl =
-        fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
-    const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
+    const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(formFieldEl.classList.contains('mat-form-field-disabled'))
         .toBe(false, `Expected form field not to start out disabled.`);
@@ -454,8 +454,8 @@ describe('MatInput without forms', () => {
     fixture.detectChanges();
 
     const formFieldEl =
-        fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
-    const selectEl = fixture.debugElement.query(By.css('select')).nativeElement;
+        fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
+    const selectEl = fixture.debugElement.query(By.css('select'))!.nativeElement;
 
     expect(formFieldEl.classList.contains('mat-form-field-disabled'))
         .toBe(false, `Expected form field not to start out disabled.`);
@@ -473,7 +473,7 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputSelect);
     fixture.detectChanges();
 
-    const formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+    const formField = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
 
     expect(formField.classList).toContain('mat-form-field-type-mat-native-select');
   }));
@@ -482,7 +482,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputWithRequired);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(inputEl.required).toBe(false);
 
@@ -496,7 +496,7 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputSelect);
     fixture.detectChanges();
 
-    const selectEl = fixture.debugElement.query(By.css('select')).nativeElement;
+    const selectEl = fixture.debugElement.query(By.css('select'))!.nativeElement;
 
     expect(selectEl.required).toBe(false);
 
@@ -510,7 +510,7 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputWithType);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(inputEl.type).toBe('text');
 
@@ -542,8 +542,8 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
 
-    let hint = fixture.debugElement.query(By.css('.mat-hint')).nativeElement;
-    let input = fixture.debugElement.query(By.css('input')).nativeElement;
+    let hint = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement;
+    let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(input.getAttribute('aria-describedby')).toBe(hint.getAttribute('id'));
   }));
@@ -554,8 +554,8 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
 
-    let hint = fixture.debugElement.query(By.css('.mat-hint')).nativeElement;
-    let input = fixture.debugElement.query(By.css('input')).nativeElement;
+    let hint = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement;
+    let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(input.getAttribute('aria-describedby')).toBe(hint.getAttribute('id'));
   }));
@@ -567,7 +567,7 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.endId = 'end';
     fixture.detectChanges();
 
-    let input = fixture.debugElement.query(By.css('input')).nativeElement;
+    let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(input.getAttribute('aria-describedby')).toBe('start end');
   }));
@@ -578,9 +578,9 @@ describe('MatInput without forms', () => {
 
       fixture.detectChanges();
 
-      let hintLabel = fixture.debugElement.query(By.css('.mat-hint:not(.mat-right)')).nativeElement;
-      let endLabel = fixture.debugElement.query(By.css('.mat-hint.mat-right')).nativeElement;
-      let input = fixture.debugElement.query(By.css('input')).nativeElement;
+      let hintLabel = fixture.debugElement.query(By.css('.mat-hint:not(.mat-right)'))!.nativeElement;
+      let endLabel = fixture.debugElement.query(By.css('.mat-hint.mat-right'))!.nativeElement;
+      let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
       let ariaValue = input.getAttribute('aria-describedby');
 
       expect(ariaValue).toBe(`${hintLabel.getAttribute('id')} ${endLabel.getAttribute('id')}`);
@@ -590,8 +590,8 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputWithDynamicLabel);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-    let formFieldEl = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    let formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
 
     expect(formFieldEl.classList).toContain('mat-form-field-can-float');
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
@@ -616,8 +616,8 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputWithDynamicLabel);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-    let formFieldEl = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    let formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
 
     expect(formFieldEl.classList).toContain('mat-form-field-can-float');
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
@@ -638,7 +638,7 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputSelect);
     fixture.detectChanges();
 
-    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
   }));
 
@@ -646,7 +646,7 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputSelect);
     fixture.detectChanges();
 
-    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
     const selectEl: HTMLSelectElement = formFieldEl.querySelector('select');
 
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
@@ -662,7 +662,7 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputSelectWithNoLabelNoValue);
     fixture.detectChanges();
 
-    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
     expect(formFieldEl.classList).not.toContain('mat-form-field-should-float');
   }));
 
@@ -671,7 +671,7 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputSelectWithLabel);
     fixture.detectChanges();
 
-    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
   }));
 
@@ -680,7 +680,7 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputSelectWithInnerHtml);
     fixture.detectChanges();
 
-    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))
+    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!
         .nativeElement;
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
   }));
@@ -696,8 +696,8 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.shouldFloat = 'never';
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-    let labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    let labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
     expect(labelEl.classList).toContain('mat-form-field-empty');
     expect(labelEl.classList).not.toContain('mat-form-field-float');
@@ -717,7 +717,7 @@ describe('MatInput without forms', () => {
 
     fixture.detectChanges();
 
-    const formField = fixture.debugElement.query(By.directive(MatFormField));
+    const formField = fixture.debugElement.query(By.directive(MatFormField))!;
     const containerInstance = formField.componentInstance as MatFormField;
     const label = formField.nativeElement.querySelector('.mat-form-field-label');
 
@@ -747,8 +747,8 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputWithPrefixAndSuffix);
     fixture.detectChanges();
 
-    const prefixEl = fixture.debugElement.query(By.css('.mat-form-field-prefix'));
-    const suffixEl = fixture.debugElement.query(By.css('.mat-form-field-suffix'));
+    const prefixEl = fixture.debugElement.query(By.css('.mat-form-field-prefix'))!;
+    const suffixEl = fixture.debugElement.query(By.css('.mat-form-field-suffix'))!;
 
     expect(prefixEl).not.toBeNull();
     expect(suffixEl).not.toBeNull();
@@ -761,7 +761,7 @@ describe('MatInput without forms', () => {
     fixture.detectChanges();
 
     let component = fixture.componentInstance;
-    let label = fixture.debugElement.query(By.css('.mat-form-field-label')).nativeElement;
+    let label = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
 
     expect(label.classList).toContain('mat-form-field-empty', 'Input initially empty');
 
@@ -775,9 +775,9 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
-    let input = fixture.debugElement.query(By.directive(MatInput))
+    let input = fixture.debugElement.query(By.directive(MatInput))!
       .injector.get<MatInput>(MatInput);
-    let container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+    let container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
     // Call the focus handler directly to avoid flakyness where
     // browsers don't focus elements if the window is minimized.
@@ -792,9 +792,9 @@ describe('MatInput without forms', () => {
       const fixture = createComponent(MatInputTextTestController);
       fixture.detectChanges();
 
-      const input = fixture.debugElement.query(By.directive(MatInput))
+      const input = fixture.debugElement.query(By.directive(MatInput))!
           .injector.get<MatInput>(MatInput);
-      const container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+      const container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
       // Call the focus handler directly to avoid flakyness where
       // browsers don't focus elements if the window is minimized.
@@ -813,9 +813,9 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
-    let inputContainer = fixture.debugElement.query(By.directive(MatFormField))
+    let inputContainer = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
-    let label = fixture.debugElement.query(By.css('.mat-form-field-label')).nativeElement;
+    let label = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
 
     expect(inputContainer.floatLabel).toBe('auto');
 
@@ -838,8 +838,8 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputWithReadonlyInput);
     fixture.detectChanges();
 
-    let input = fixture.debugElement.query(By.directive(MatInput)).injector.get<MatInput>(MatInput);
-    let container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+    let input = fixture.debugElement.query(By.directive(MatInput))!.injector.get<MatInput>(MatInput);
+    let container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
     // Call the focus handler directly to avoid flakyness where
     // browsers don't focus elements if the window is minimized.
@@ -854,9 +854,9 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputWithReadonlyInput);
     fixture.detectChanges();
 
-    const inputDebugElement = fixture.debugElement.query(By.directive(MatInput));
+    const inputDebugElement = fixture.debugElement.query(By.directive(MatInput))!;
     const input = inputDebugElement.injector.get<MatInput>(MatInput);
-    const container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+    const container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
     fixture.componentInstance.isReadonly = false;
     fixture.detectChanges();
@@ -883,9 +883,9 @@ describe('MatInput without forms', () => {
     const fixture = createComponent(MatInputWithLabelAndPlaceholder);
     fixture.detectChanges();
 
-    const container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
-    const label = fixture.debugElement.query(By.css('.mat-form-field-label')).nativeElement;
-    const input = fixture.debugElement.query(By.css('input')).nativeElement;
+    const container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+    const label = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(container.classList).toContain('mat-form-field-hide-placeholder');
     expect(container.classList).not.toContain('mat-form-field-should-float');
@@ -905,7 +905,7 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.floatLabel = 'always';
     fixture.detectChanges();
 
-    const container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+    const container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
     expect(container.classList).not.toContain('mat-form-field-hide-placeholder');
   });
@@ -913,7 +913,7 @@ describe('MatInput without forms', () => {
   it('should not add the `placeholder` attribute if there is no placeholder', () => {
     const fixture = createComponent(MatInputWithoutPlaceholder);
     fixture.detectChanges();
-    const input = fixture.debugElement.query(By.css('input')).nativeElement;
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(input.hasAttribute('placeholder')).toBe(false);
   });
@@ -924,8 +924,8 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.floatLabel = 'never';
     fixture.detectChanges();
 
-    const container = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
-    const input = fixture.debugElement.query(By.css('input')).nativeElement;
+    const container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(container.classList).toContain('mat-form-field-hide-placeholder');
     expect(container.classList).not.toContain('mat-form-field-should-float');
@@ -940,7 +940,7 @@ describe('MatInput without forms', () => {
   it('should not add the native select class if the control is not a native select', () => {
     const fixture = createComponent(MatInputWithId);
     fixture.detectChanges();
-    const formField = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+    const formField = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
     expect(formField.classList).not.toContain('mat-form-field-type-mat-native-select');
   });
@@ -949,7 +949,7 @@ describe('MatInput without forms', () => {
     'the element is empty with a custom accessor', fakeAsync(() => {
       let fixture = createComponent(MatInputWithCustomAccessor, [], [], [CustomMatInputAccessor]);
       fixture.detectChanges();
-      let label = fixture.debugElement.query(By.css('label')).nativeElement;
+      let label = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
       expect(label.classList).toContain('mat-form-field-empty');
 
@@ -972,8 +972,8 @@ describe('MatInput with forms', () => {
       fixture = createComponent(MatInputWithFormErrorMessages);
       fixture.detectChanges();
       testComponent = fixture.componentInstance;
-      containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
-      inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+      containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+      inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
     }));
 
     it('should not show any errors if the user has not interacted', fakeAsync(() => {
@@ -1004,7 +1004,7 @@ describe('MatInput with forms', () => {
       expect(testComponent.formControl.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
 
-      dispatchFakeEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('form'))!.nativeElement, 'submit')!;
       fixture.detectChanges();
       flush();
 
@@ -1026,8 +1026,8 @@ describe('MatInput with forms', () => {
 
       groupFixture.detectChanges();
       component = groupFixture.componentInstance;
-      containerEl = groupFixture.debugElement.query(By.css('mat-form-field')).nativeElement;
-      inputEl = groupFixture.debugElement.query(By.css('input')).nativeElement;
+      containerEl = groupFixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+      inputEl = groupFixture.debugElement.query(By.css('input'))!.nativeElement;
 
       expect(component.formGroup.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
@@ -1036,7 +1036,7 @@ describe('MatInput with forms', () => {
       expect(component.formGroupDirective.submitted)
         .toBe(false, 'Expected form not to have been submitted');
 
-      dispatchFakeEvent(groupFixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+      dispatchFakeEvent(groupFixture.debugElement.query(By.css('form'))!.nativeElement, 'submit');
       groupFixture.detectChanges();
       flush();
 
@@ -1097,7 +1097,7 @@ describe('MatInput with forms', () => {
     }));
 
     it('sets the aria-describedby to reference errors when in error state', fakeAsync(() => {
-      let hintId = fixture.debugElement.query(By.css('.mat-hint')).nativeElement.getAttribute('id');
+      let hintId = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
       let describedBy = inputEl.getAttribute('aria-describedby');
 
       expect(hintId).toBeTruthy('hint should be shown');
@@ -1122,7 +1122,7 @@ describe('MatInput with forms', () => {
       fixture.detectChanges();
 
       let component = fixture.componentInstance;
-      let containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+      let containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
       const control = component.formGroup.get('name')!;
 
@@ -1150,7 +1150,7 @@ describe('MatInput with forms', () => {
 
       fixture.detectChanges();
 
-      let containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+      let containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
       let testComponent = fixture.componentInstance;
 
       // Expect the control to still be untouched but the error to show due to the global setting
@@ -1164,7 +1164,7 @@ describe('MatInput with forms', () => {
       }]);
       fixture.detectChanges();
 
-      let containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+      let containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
       let testComponent = fixture.componentInstance;
 
       expect(testComponent.formControl.invalid).toBe(true, 'Expected form control to be invalid');
@@ -1188,7 +1188,7 @@ describe('MatInput with forms', () => {
     let fixture = createComponent(MatInputWithFormControl);
     fixture.detectChanges();
 
-    let input = fixture.debugElement.query(By.directive(MatInput))
+    let input = fixture.debugElement.query(By.directive(MatInput))!
       .injector.get<MatInput>(MatInput);
 
     expect(input.value).toBeFalsy();
@@ -1203,8 +1203,8 @@ describe('MatInput with forms', () => {
     fixture.detectChanges();
 
     const formFieldEl =
-        fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
-    const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
+    const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(formFieldEl.classList)
       .not.toContain('mat-form-field-disabled', `Expected form field not to start out disabled.`);
@@ -1225,7 +1225,7 @@ describe('MatInput with forms', () => {
 
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label')).nativeElement;
+    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
     expect(el).not.toBeNull();
     expect(el.classList.contains('mat-form-field-empty')).toBe(false);
   }));
@@ -1234,7 +1234,7 @@ describe('MatInput with forms', () => {
     const fixture = createComponent(MatInputWithFormControl);
     fixture.detectChanges();
 
-    const el = fixture.debugElement.query(By.css('label')).nativeElement;
+    const el = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
     expect(el.classList).toContain('mat-form-field-empty');
 
@@ -1256,7 +1256,7 @@ describe('MatInput with appearance', () => {
     fixture = createComponent(MatInputWithAppearance);
     fixture.detectChanges();
     testComponent = fixture.componentInstance;
-    containerEl = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+    containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
   }));
 
   it('legacy appearance should promote placeholder to label', fakeAsync(() => {

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -578,7 +578,8 @@ describe('MatInput without forms', () => {
 
       fixture.detectChanges();
 
-      let hintLabel = fixture.debugElement.query(By.css('.mat-hint:not(.mat-right)'))!.nativeElement;
+      let hintLabel =
+          fixture.debugElement.query(By.css('.mat-hint:not(.mat-right)'))!.nativeElement;
       let endLabel = fixture.debugElement.query(By.css('.mat-hint.mat-right'))!.nativeElement;
       let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
       let ariaValue = input.getAttribute('aria-describedby');
@@ -838,7 +839,8 @@ describe('MatInput without forms', () => {
     let fixture = createComponent(MatInputWithReadonlyInput);
     fixture.detectChanges();
 
-    let input = fixture.debugElement.query(By.directive(MatInput))!.injector.get<MatInput>(MatInput);
+    let input =
+        fixture.debugElement.query(By.directive(MatInput))!.injector.get<MatInput>(MatInput);
     let container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
     // Call the focus handler directly to avoid flakyness where
@@ -1097,7 +1099,8 @@ describe('MatInput with forms', () => {
     }));
 
     it('sets the aria-describedby to reference errors when in error state', fakeAsync(() => {
-      let hintId = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
+      let hintId =
+          fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
       let describedBy = inputEl.getAttribute('aria-describedby');
 
       expect(hintId).toBeTruthy('hint should be shown');

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1004,7 +1004,7 @@ describe('MatInput with forms', () => {
       expect(testComponent.formControl.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
 
-      dispatchFakeEvent(fixture.debugElement.query(By.css('form'))!.nativeElement, 'submit')!;
+      dispatchFakeEvent(fixture.debugElement.query(By.css('form'))!.nativeElement, 'submit');
       fixture.detectChanges();
       flush();
 

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -25,7 +25,7 @@ describe('MatList', () => {
 
   it('should not apply any additional class to a list without lines', () => {
     const fixture = TestBed.createComponent(ListWithOneItem);
-    const listItem = fixture.debugElement.query(By.css('mat-list-item'));
+    const listItem = fixture.debugElement.query(By.css('mat-list-item'))!;
     fixture.detectChanges();
     expect(listItem.nativeElement.className).toBe('mat-list-item');
   });
@@ -79,7 +79,7 @@ describe('MatList', () => {
     fixture.debugElement.componentInstance.showThirdLine = false;
     fixture.detectChanges();
 
-    const listItem = fixture.debugElement.children[0].query(By.css('mat-list-item'));
+    const listItem = fixture.debugElement.children[0].query(By.css('mat-list-item'))!;
     expect(listItem.nativeElement.classList.length).toBe(2);
     expect(listItem.nativeElement.classList).toContain('mat-2-line');
     expect(listItem.nativeElement.classList).toContain('mat-list-item');
@@ -94,7 +94,7 @@ describe('MatList', () => {
     fixture.detectChanges();
 
     const list = fixture.debugElement.children[0];
-    const listItem = fixture.debugElement.children[0].query(By.css('mat-list-item'));
+    const listItem = fixture.debugElement.children[0].query(By.css('mat-list-item'))!;
     expect(list.nativeElement.getAttribute('role')).toBeNull('Expect mat-list no role');
     expect(listItem.nativeElement.getAttribute('role')).toBeNull('Expect mat-list-item no role');
   });
@@ -167,7 +167,7 @@ describe('MatList', () => {
     const fixture = TestBed.createComponent(ActionListWithoutType);
     fixture.detectChanges();
 
-    const listItemEl = fixture.debugElement.query(By.css('.mat-list-item'));
+    const listItemEl = fixture.debugElement.query(By.css('.mat-list-item'))!;
     expect(listItemEl.nativeElement.getAttribute('type')).toBe('button');
   });
 
@@ -175,7 +175,7 @@ describe('MatList', () => {
     const fixture = TestBed.createComponent(ActionListWithType);
     fixture.detectChanges();
 
-    const listItemEl = fixture.debugElement.query(By.css('.mat-list-item'));
+    const listItemEl = fixture.debugElement.query(By.css('.mat-list-item'))!;
     expect(listItemEl.nativeElement.getAttribute('type')).toBe('submit');
   });
 

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -51,7 +51,7 @@ describe('MatSelectionList without forms', () => {
       fixture.detectChanges();
 
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption));
-      selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
     }));
 
     it('should be able to set a value on a list option', () => {
@@ -538,7 +538,7 @@ describe('MatSelectionList without forms', () => {
       const descendatsFixture = TestBed.createComponent(SelectionListWithIndirectChildOptions);
       descendatsFixture.detectChanges();
       listOptions = descendatsFixture.debugElement.queryAll(By.directive(MatListOption));
-      selectionList = descendatsFixture.debugElement.query(By.directive(MatSelectionList));
+      selectionList = descendatsFixture.debugElement.query(By.directive(MatSelectionList))!;
       const list: MatSelectionList = selectionList.componentInstance;
 
       expect(list.options.toArray().every(option => option.selected)).toBe(false);
@@ -594,8 +594,8 @@ describe('MatSelectionList without forms', () => {
 
     beforeEach(async(() => {
       fixture = TestBed.createComponent(SelectionListWithSelectedOption);
-      listItemEl = fixture.debugElement.query(By.directive(MatListOption));
-      selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
+      listItemEl = fixture.debugElement.query(By.directive(MatListOption))!;
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
       fixture.detectChanges();
     }));
 
@@ -622,7 +622,7 @@ describe('MatSelectionList without forms', () => {
 
     it('should properly handle native tabindex attribute', () => {
       const fixture = TestBed.createComponent(SelectionListWithTabindexAttr);
-      const selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
+      const selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
 
       expect(selectionList.componentInstance.tabIndex)
         .toBe(5, 'Expected the selection-list tabindex to be set to the attribute value.');
@@ -630,7 +630,7 @@ describe('MatSelectionList without forms', () => {
 
     it('should support changing the tabIndex through binding', () => {
       const fixture = TestBed.createComponent(SelectionListWithTabindexBinding);
-      const selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
+      const selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
 
       expect(selectionList.componentInstance.tabIndex)
         .toBe(0, 'Expected the tabIndex to be set to "0" by default.');
@@ -666,7 +666,7 @@ describe('MatSelectionList without forms', () => {
     beforeEach(async(() => {
       fixture = TestBed.createComponent(SelectionListWithDisabledOption);
 
-      const listOptionDebug = fixture.debugElement.query(By.directive(MatListOption));
+      const listOptionDebug = fixture.debugElement.query(By.directive(MatListOption))!;
 
       listOption = listOptionDebug.componentInstance;
       listOptionEl = listOptionDebug.nativeElement;
@@ -717,7 +717,7 @@ describe('MatSelectionList without forms', () => {
     beforeEach(async(() => {
       fixture = TestBed.createComponent(SelectionListWithListDisabled);
       listOption = fixture.debugElement.queryAll(By.directive(MatListOption));
-      selectionList = fixture.debugElement.query(By.directive(MatSelectionList));
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
       fixture.detectChanges();
     }));
 
@@ -739,7 +739,7 @@ describe('MatSelectionList without forms', () => {
       // property of the selection list has been updated, the ripple directive can be used.
       // Inspecting the host classes of the options doesn't work because those update as part
       // of the parent template (of the selection-list).
-      const listOptionRipple = listOption[2].query(By.directive(MatRipple))
+      const listOptionRipple = listOption[2].query(By.directive(MatRipple))!
           .injector.get<MatRipple>(MatRipple);
 
       expect(listOptionRipple.disabled)
@@ -776,7 +776,7 @@ describe('MatSelectionList without forms', () => {
     }));
 
     it('should be able to customize checkbox position', () => {
-      let listItemContent = fixture.debugElement.query(By.css('.mat-list-item-content'));
+      let listItemContent = fixture.debugElement.query(By.css('.mat-list-item-content'))!;
       expect(listItemContent.nativeElement.classList).toContain('mat-list-item-content-reverse');
     });
   });
@@ -838,7 +838,7 @@ describe('MatSelectionList with forms', () => {
       fixture = TestBed.createComponent(SelectionListWithModel);
       fixture.detectChanges();
 
-      selectionListDebug = fixture.debugElement.query(By.directive(MatSelectionList));
+      selectionListDebug = fixture.debugElement.query(By.directive(MatSelectionList))!;
       ngModel = selectionListDebug.injector.get<NgModel>(NgModel);
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
         .map(optionDebugEl => optionDebugEl.componentInstance);
@@ -901,7 +901,7 @@ describe('MatSelectionList with forms', () => {
       fixture.detectChanges();
 
       ngModel =
-        fixture.debugElement.query(By.directive(MatSelectionList)).injector.get<NgModel>(NgModel);
+        fixture.debugElement.query(By.directive(MatSelectionList))!.injector.get<NgModel>(NgModel);
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
         .map(optionDebugEl => optionDebugEl.componentInstance);
 
@@ -995,7 +995,7 @@ describe('MatSelectionList with forms', () => {
       fixture = TestBed.createComponent(SelectionListWithFormControl);
       fixture.detectChanges();
 
-      selectionList = fixture.debugElement.query(By.directive(MatSelectionList)).componentInstance;
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!.componentInstance;
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
         .map(optionDebugEl => optionDebugEl.componentInstance);
     });

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -429,7 +429,7 @@ describe('MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
 
-    const menuEl = fixture.debugElement.query(By.css('mat-menu')).nativeElement;
+    const menuEl = fixture.debugElement.query(By.css('mat-menu'))!.nativeElement;
     const panel = overlayContainerElement.querySelector('.mat-menu-panel')!;
 
     expect(menuEl.classList).not.toContain('custom-one');
@@ -1242,8 +1242,8 @@ describe('MatMenu', () => {
       fixture.componentInstance.trigger.openMenu();
       fixture.detectChanges();
 
-      const item = fixture.debugElement.query(By.css('.mat-menu-item'));
-      const ripple = item.query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
+      const item = fixture.debugElement.query(By.css('.mat-menu-item'))!;
+      const ripple = item.query(By.css('.mat-ripple'))!.injector.get<MatRipple>(MatRipple);
 
       expect(ripple.disabled).toBe(false);
     });
@@ -1256,7 +1256,7 @@ describe('MatMenu', () => {
       fixture.detectChanges();
 
       const items = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
-      const ripple = items[1].query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
+      const ripple = items[1].query(By.css('.mat-ripple'))!.injector.get<MatRipple>(MatRipple);
 
       expect(ripple.disabled).toBe(true);
     });
@@ -1270,7 +1270,7 @@ describe('MatMenu', () => {
 
       // The third menu item in the `SimpleMenu` component has ripples disabled.
       const items = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
-      const ripple = items[2].query(By.css('.mat-ripple')).injector.get<MatRipple>(MatRipple);
+      const ripple = items[2].query(By.css('.mat-ripple'))!.injector.get<MatRipple>(MatRipple);
 
       expect(ripple.disabled).toBe(true);
     });
@@ -1497,7 +1497,7 @@ describe('MatMenu', () => {
       expect(overlay.querySelectorAll('.mat-menu-panel').length)
           .toBe(1, 'Expected one open menu');
 
-      const item = fixture.debugElement.query(By.directive(MatMenuItem));
+      const item = fixture.debugElement.query(By.directive(MatMenuItem))!;
 
       item.componentInstance.disabled = true;
       fixture.detectChanges();

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -391,7 +391,8 @@ describe('MatPaginator', () => {
   });
 
   it('should be able to disable all the controls in the paginator via the binding', () => {
-    const select: MatSelect = fixture.debugElement.query(By.directive(MatSelect))!.componentInstance;
+    const select: MatSelect =
+        fixture.debugElement.query(By.directive(MatSelect))!.componentInstance;
 
     fixture.componentInstance.pageIndex = 1;
     fixture.componentInstance.showFirstLastButtons = true;

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -391,7 +391,7 @@ describe('MatPaginator', () => {
   });
 
   it('should be able to disable all the controls in the paginator via the binding', () => {
-    const select: MatSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance;
+    const select: MatSelect = fixture.debugElement.query(By.directive(MatSelect))!.componentInstance;
 
     fixture.componentInstance.pageIndex = 1;
     fixture.componentInstance.showFirstLastButtons = true;

--- a/src/material/progress-bar/progress-bar.spec.ts
+++ b/src/material/progress-bar/progress-bar.spec.ts
@@ -31,14 +31,14 @@ describe('MatProgressBar', () => {
       it('should apply a mode of "determinate" if no mode is provided.', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
-        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
         expect(progressElement.componentInstance.mode).toBe('determinate');
       });
 
       it('should define default values for value and bufferValue attributes', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
-        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
         expect(progressElement.componentInstance.value).toBe(0);
         expect(progressElement.componentInstance.bufferValue).toBe(0);
       });
@@ -47,7 +47,7 @@ describe('MatProgressBar', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
 
-        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
         const progressComponent = progressElement.componentInstance;
 
         progressComponent.value = 50;
@@ -73,7 +73,7 @@ describe('MatProgressBar', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
 
-        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
         const progressComponent = progressElement.componentInstance;
 
         expect(progressComponent._primaryTransform()).toEqual({transform: 'scaleX(0)'});
@@ -103,7 +103,7 @@ describe('MatProgressBar', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
 
-        const rect = fixture.debugElement.query(By.css('rect')).nativeElement;
+        const rect = fixture.debugElement.query(By.css('rect'))!.nativeElement;
         expect(rect.getAttribute('fill')).toMatch(/^url\(['"]?\/fake-path#.*['"]?\)$/);
       });
 
@@ -113,7 +113,7 @@ describe('MatProgressBar', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
 
-        const rect = fixture.debugElement.query(By.css('rect')).nativeElement;
+        const rect = fixture.debugElement.query(By.css('rect'))!.nativeElement;
         expect(rect.getAttribute('fill')).not.toContain('#anchor#');
       });
 
@@ -121,7 +121,7 @@ describe('MatProgressBar', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
 
-        const svg = fixture.debugElement.query(By.css('svg')).nativeElement;
+        const svg = fixture.debugElement.query(By.css('svg'))!.nativeElement;
         expect(svg.getAttribute('focusable')).toBe('false');
       });
 
@@ -129,7 +129,7 @@ describe('MatProgressBar', () => {
         let fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
 
-        let rect = fixture.debugElement.query(By.css('rect')).nativeElement;
+        let rect = fixture.debugElement.query(By.css('rect'))!.nativeElement;
         expect(rect.getAttribute('fill')).toMatch(/^url\(['"]?\/fake-path#.*['"]?\)$/);
 
         fixture.destroy();
@@ -137,7 +137,7 @@ describe('MatProgressBar', () => {
 
         fixture = TestBed.createComponent(BasicProgressBar);
         fixture.detectChanges();
-        rect = fixture.debugElement.query(By.css('rect')).nativeElement;
+        rect = fixture.debugElement.query(By.css('rect'))!.nativeElement;
 
         expect(rect.getAttribute('fill')).toMatch(/^url\(['"]?\/another-fake-path#.*['"]?\)$/);
       });
@@ -146,7 +146,7 @@ describe('MatProgressBar', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
 
-        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
         const progressComponent = progressElement.componentInstance;
 
         progressComponent.mode = 'determinate';
@@ -167,7 +167,7 @@ describe('MatProgressBar', () => {
         const fixture = createComponent(BasicProgressBar);
         fixture.detectChanges();
 
-        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
         const progressComponent = progressElement.componentInstance;
 
         progressComponent.mode = 'determinate';
@@ -194,9 +194,9 @@ describe('MatProgressBar', () => {
       beforeEach(() => {
         fixture = createComponent(BasicProgressBar);
 
-        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
         progressComponent = progressElement.componentInstance;
-        primaryValueBar = progressElement.query(By.css('.mat-progress-bar-primary'));
+        primaryValueBar = progressElement.query(By.css('.mat-progress-bar-primary'))!;
       });
 
       it('should trigger output event on primary value bar animation end', () => {
@@ -220,9 +220,9 @@ describe('MatProgressBar', () => {
       beforeEach(() => {
         fixture = createComponent(BufferProgressBar);
 
-        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+        const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
         progressComponent = progressElement.componentInstance;
-        primaryValueBar = progressElement.query(By.css('.mat-progress-bar-primary'));
+        primaryValueBar = progressElement.query(By.css('.mat-progress-bar-primary'))!;
       });
 
       it('should bind on transitionend eventListener on primaryBarValue', () => {
@@ -268,9 +268,9 @@ describe('MatProgressBar', () => {
 
     beforeEach(async(() => {
       fixture = createComponent(BasicProgressBar, [MatProgressBarModule, NoopAnimationsModule]);
-      const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'));
+      const progressElement = fixture.debugElement.query(By.css('mat-progress-bar'))!;
       progressComponent = progressElement.componentInstance;
-      primaryValueBar = progressElement.query(By.css('.mat-progress-bar-primary'));
+      primaryValueBar = progressElement.query(By.css('.mat-progress-bar-primary'))!;
     }));
 
     it('should not bind transition end listener', () => {

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -33,7 +33,7 @@ describe('MatProgressSpinner', () => {
     let fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     expect(progressElement.componentInstance.mode).toBe('determinate');
   });
 
@@ -41,7 +41,7 @@ describe('MatProgressSpinner', () => {
     let fixture = TestBed.createComponent(IndeterminateProgressSpinner);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     expect(progressElement.componentInstance.mode).toBe('indeterminate');
   });
 
@@ -49,13 +49,13 @@ describe('MatProgressSpinner', () => {
     let fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     expect(progressElement.componentInstance.value).toBe(0);
   });
 
   it('should set the value to 0 when the mode is set to indeterminate', () => {
     let fixture = TestBed.createComponent(ProgressSpinnerWithValueAndBoundMode);
-    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     fixture.componentInstance.mode = 'determinate';
     fixture.detectChanges();
 
@@ -67,7 +67,7 @@ describe('MatProgressSpinner', () => {
 
   it('should retain the value if it updates while indeterminate', () => {
     let fixture = TestBed.createComponent(ProgressSpinnerWithValueAndBoundMode);
-    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
 
     fixture.componentInstance.mode = 'determinate';
     fixture.detectChanges();
@@ -108,7 +108,7 @@ describe('MatProgressSpinner', () => {
     let fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     let progressComponent = progressElement.componentInstance;
 
     progressComponent.value = 50;
@@ -129,7 +129,7 @@ describe('MatProgressSpinner', () => {
 
   it('should default to a stroke width that is 10% of the diameter', () => {
     const fixture = TestBed.createComponent(ProgressSpinnerCustomDiameter);
-    const spinner = fixture.debugElement.query(By.directive(MatProgressSpinner));
+    const spinner = fixture.debugElement.query(By.directive(MatProgressSpinner))!;
 
     fixture.componentInstance.diameter = 67;
     fixture.detectChanges();
@@ -139,7 +139,7 @@ describe('MatProgressSpinner', () => {
 
   it('should allow a custom diameter', () => {
     const fixture = TestBed.createComponent(ProgressSpinnerCustomDiameter);
-    const spinner = fixture.debugElement.query(By.css('mat-progress-spinner')).nativeElement;
+    const spinner = fixture.debugElement.query(By.css('mat-progress-spinner'))!.nativeElement;
     const svgElement = fixture.nativeElement.querySelector('svg');
 
     fixture.componentInstance.diameter = 32;
@@ -227,7 +227,7 @@ describe('MatProgressSpinner', () => {
     let fixture = TestBed.createComponent(SpinnerWithColor);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('mat-spinner'));
+    let progressElement = fixture.debugElement.query(By.css('mat-spinner'))!;
 
     expect(progressElement.nativeElement.classList).toContain('mat-primary');
 
@@ -242,7 +242,7 @@ describe('MatProgressSpinner', () => {
     let fixture = TestBed.createComponent(ProgressSpinnerWithColor);
     fixture.detectChanges();
 
-    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    let progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
 
     expect(progressElement.nativeElement.classList).toContain('mat-primary');
 
@@ -263,7 +263,7 @@ describe('MatProgressSpinner', () => {
 
   it('should handle the number inputs being passed in as strings', () => {
     const fixture = TestBed.createComponent(ProgressSpinnerWithStringValues);
-    const spinner = fixture.debugElement.query(By.directive(MatProgressSpinner));
+    const spinner = fixture.debugElement.query(By.directive(MatProgressSpinner))!;
     const svgElement = spinner.nativeElement.querySelector('svg');
 
     fixture.detectChanges();
@@ -281,7 +281,7 @@ describe('MatProgressSpinner', () => {
 
   it('should update the element size when changed dynamically', () => {
     let fixture = TestBed.createComponent(BasicProgressSpinner);
-    let spinner = fixture.debugElement.query(By.directive(MatProgressSpinner));
+    let spinner = fixture.debugElement.query(By.directive(MatProgressSpinner))!;
     spinner.componentInstance.diameter = 32;
     fixture.detectChanges();
     expect(spinner.nativeElement.style.width).toBe('32px');
@@ -304,7 +304,7 @@ describe('MatProgressSpinner', () => {
     const fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
 
-    const progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    const progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     expect(progressElement.componentInstance.diameter).toBe(23);
   });
 
@@ -324,13 +324,13 @@ describe('MatProgressSpinner', () => {
     const fixture = TestBed.createComponent(BasicProgressSpinner);
     fixture.detectChanges();
 
-    const progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    const progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     expect(progressElement.componentInstance.strokeWidth).toBe(7);
   });
 
   it('should set `aria-valuenow` to the current value in determinate mode', () => {
     const fixture = TestBed.createComponent(ProgressSpinnerWithValueAndBoundMode);
-    const progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    const progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     fixture.componentInstance.mode = 'determinate';
     fixture.componentInstance.value = 37;
     fixture.detectChanges();
@@ -340,7 +340,7 @@ describe('MatProgressSpinner', () => {
 
   it('should clear `aria-valuenow` in indeterminate mode', () => {
     const fixture = TestBed.createComponent(ProgressSpinnerWithValueAndBoundMode);
-    const progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'));
+    const progressElement = fixture.debugElement.query(By.css('mat-progress-spinner'))!;
     fixture.componentInstance.mode = 'determinate';
     fixture.componentInstance.value = 89;
     fixture.detectChanges();
@@ -363,7 +363,7 @@ describe('MatProgressSpinner', () => {
     fixture.componentInstance.diameter = 27;
     fixture.detectChanges();
 
-    const spinner = fixture.debugElement.query(By.css('mat-progress-spinner')).nativeElement;
+    const spinner = fixture.debugElement.query(By.css('mat-progress-spinner'))!.nativeElement;
     const shadowRoot = _getShadowRoot(spinner, document) as HTMLElement;
 
     expect(shadowRoot.querySelector('style[mat-spinner-animation="27"]')).toBeTruthy();
@@ -384,7 +384,7 @@ describe('MatProgressSpinner', () => {
     fixture.componentInstance.diameter = 39;
     fixture.detectChanges();
 
-    const spinner = fixture.debugElement.query(By.css('mat-progress-spinner')).nativeElement;
+    const spinner = fixture.debugElement.query(By.css('mat-progress-spinner'))!.nativeElement;
     const shadowRoot = _getShadowRoot(spinner, document) as HTMLElement;
 
     expect(shadowRoot.querySelectorAll('style[mat-spinner-animation="39"]').length).toBe(1);

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -45,7 +45,7 @@ describe('MatRadio', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup))!;
       groupInstance = groupDebugElement.injector.get<MatRadioGroup>(MatRadioGroup);
 
       radioDebugElements = fixture.debugElement.queryAll(By.directive(MatRadioButton));
@@ -53,9 +53,9 @@ describe('MatRadio', () => {
       radioInstances = radioDebugElements.map(debugEl => debugEl.componentInstance);
 
       radioLabelElements = radioDebugElements
-        .map(debugEl => debugEl.query(By.css('label')).nativeElement);
+        .map(debugEl => debugEl.query(By.css('label'))!.nativeElement);
       radioInputElements = radioDebugElements
-        .map(debugEl => debugEl.query(By.css('input')).nativeElement);
+        .map(debugEl => debugEl.query(By.css('input'))!.nativeElement);
     }));
 
     it('should set individual radio names based on the group name', () => {
@@ -405,7 +405,7 @@ describe('MatRadio', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup))!;
       groupInstance = groupDebugElement.injector.get<MatRadioGroup>(MatRadioGroup);
       groupNgModel = groupDebugElement.injector.get<NgModel>(NgModel);
 
@@ -414,7 +414,7 @@ describe('MatRadio', () => {
       innerRadios = fixture.debugElement.queryAll(By.css('input[type="radio"]'));
 
       radioLabelElements = radioDebugElements
-        .map(debugEl => debugEl.query(By.css('label')).nativeElement);
+        .map(debugEl => debugEl.query(By.css('label'))!.nativeElement);
     });
 
     it('should set individual radio names based on the group name', () => {
@@ -532,7 +532,7 @@ describe('MatRadio', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup))!;
       groupInstance = groupDebugElement.injector.get<MatRadioGroup>(MatRadioGroup);
     });
 
@@ -562,7 +562,7 @@ describe('MatRadio', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      const radioDebugElement = fixture.debugElement.query(By.directive(MatRadioButton));
+      const radioDebugElement = fixture.debugElement.query(By.directive(MatRadioButton))!;
       radioInstance = radioDebugElement.injector.get<MatRadioButton>(MatRadioButton);
       radioNativeElement = radioDebugElement.nativeElement.querySelector('input');
     });
@@ -743,8 +743,8 @@ describe('MatRadio', () => {
     });
 
     it('should forward focus to native input', () => {
-      let radioButtonEl = fixture.debugElement.query(By.css('.mat-radio-button')).nativeElement;
-      let inputEl = fixture.debugElement.query(By.css('.mat-radio-input')).nativeElement;
+      let radioButtonEl = fixture.debugElement.query(By.css('.mat-radio-button'))!.nativeElement;
+      let inputEl = fixture.debugElement.query(By.css('.mat-radio-input'))!.nativeElement;
 
       radioButtonEl.focus();
       // Focus events don't always fire in tests, so we need to fake it.
@@ -756,7 +756,7 @@ describe('MatRadio', () => {
 
     it('should allow specifying an explicit tabindex for a single radio-button', () => {
       const radioButtonInput = fixture.debugElement
-        .query(By.css('.mat-radio-button input')).nativeElement as HTMLInputElement;
+        .query(By.css('.mat-radio-button input'))!.nativeElement as HTMLInputElement;
 
       expect(radioButtonInput.tabIndex)
         .toBe(0, 'Expected the tabindex to be set to "0" by default.');
@@ -773,7 +773,7 @@ describe('MatRadio', () => {
       predefinedFixture.detectChanges();
 
       const radioButtonEl =
-          predefinedFixture.debugElement.query(By.css('.mat-radio-button')).nativeElement;
+          predefinedFixture.debugElement.query(By.css('.mat-radio-button'))!.nativeElement;
 
       expect(radioButtonEl.getAttribute('tabindex')).toBe('-1');
     });
@@ -791,7 +791,7 @@ describe('MatRadio', () => {
       fixture = TestBed.createComponent(InterleavedRadioGroup);
       fixture.detectChanges();
 
-      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup));
+      groupDebugElement = fixture.debugElement.query(By.directive(MatRadioGroup))!;
       groupInstance = groupDebugElement.injector.get<MatRadioGroup>(MatRadioGroup);
       radioDebugElements = fixture.debugElement.queryAll(By.directive(MatRadioButton));
       radioInstances = radioDebugElements.map(debugEl => debugEl.componentInstance);
@@ -822,7 +822,7 @@ describe('MatRadioDefaultOverrides', () => {
         TestBed.createComponent(DefaultRadioButton);
       fixture.detectChanges();
       const radioDebugElement: DebugElement =
-        fixture.debugElement.query(By.directive(MatRadioButton));
+        fixture.debugElement.query(By.directive(MatRadioButton))!;
       expect(
         radioDebugElement.nativeElement.classList
       ).toContain('mat-primary');
@@ -832,7 +832,7 @@ describe('MatRadioDefaultOverrides', () => {
         TestBed.createComponent(RadioButtonWithColorBinding);
       fixture.detectChanges();
       const radioDebugElement: DebugElement =
-        fixture.debugElement.query(By.directive(MatRadioButton));
+        fixture.debugElement.query(By.directive(MatRadioButton))!;
       expect(
         radioDebugElement.nativeElement.classList
       ).not.toContain('mat-primary');

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -139,7 +139,7 @@ describe('MatSelect', () => {
         beforeEach(fakeAsync(() => {
           fixture = TestBed.createComponent(BasicSelect);
           fixture.detectChanges();
-          select = fixture.debugElement.query(By.css('mat-select')).nativeElement;
+          select = fixture.debugElement.query(By.css('mat-select'))!.nativeElement;
         }));
 
         it('should set the role of the select to listbox', fakeAsync(() => {
@@ -239,7 +239,7 @@ describe('MatSelect', () => {
 
           const labelFixture = TestBed.createComponent(SelectWithFormFieldLabel);
           labelFixture.detectChanges();
-          select = labelFixture.debugElement.query(By.css('mat-select')).nativeElement;
+          select = labelFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
           expect(select.getAttribute('aria-labelledby')).toBeTruthy();
           expect(select.getAttribute('aria-labelledby'))
@@ -252,7 +252,7 @@ describe('MatSelect', () => {
           const labelFixture = TestBed.createComponent(SelectWithFormFieldLabel);
           labelFixture.componentInstance.placeholder = 'Thing selector';
           labelFixture.detectChanges();
-          select = labelFixture.debugElement.query(By.css('mat-select')).nativeElement;
+          select = labelFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
           expect(select.getAttribute('aria-labelledby')).toBeFalsy();
         });
@@ -262,7 +262,7 @@ describe('MatSelect', () => {
 
           const labelFixture = TestBed.createComponent(SelectWithChangeEvent);
           labelFixture.detectChanges();
-          select = labelFixture.debugElement.query(By.css('mat-select')).nativeElement;
+          select = labelFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
           expect(select.getAttribute('aria-labelledby')).toBeFalsy();
         });
@@ -513,7 +513,7 @@ describe('MatSelect', () => {
             const instance = multiFixture.componentInstance;
 
             multiFixture.detectChanges();
-            select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+            select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
             const initialValue = instance.control.value;
 
@@ -534,7 +534,7 @@ describe('MatSelect', () => {
             const instance = multiFixture.componentInstance;
 
             multiFixture.detectChanges();
-            select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+            select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
             const initialValue = instance.control.value;
 
@@ -554,7 +554,7 @@ describe('MatSelect', () => {
           const instance = multiFixture.componentInstance;
 
           multiFixture.detectChanges();
-          select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+          select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
           const initialValue = instance.control.value;
 
@@ -599,7 +599,7 @@ describe('MatSelect', () => {
           const multiFixture = TestBed.createComponent(MultiSelect);
 
           multiFixture.detectChanges();
-          select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+          select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
           multiFixture.componentInstance.select.open();
           multiFixture.detectChanges();
 
@@ -649,7 +649,7 @@ describe('MatSelect', () => {
           const multiFixture = TestBed.createComponent(MultiSelect);
 
           multiFixture.detectChanges();
-          select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+          select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
           expect(multiFixture.componentInstance.select.panelOpen)
               .toBe(false, 'Expected panel to be closed initially.');
@@ -669,7 +669,7 @@ describe('MatSelect', () => {
             Object.defineProperty(event, 'shiftKey', {get: () => true});
 
             multiFixture.detectChanges();
-            select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+            select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
             multiFixture.componentInstance.select.open();
             multiFixture.detectChanges();
@@ -697,7 +697,7 @@ describe('MatSelect', () => {
             Object.defineProperty(event, 'shiftKey', {get: () => true});
 
             multiFixture.detectChanges();
-            select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+            select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
             multiFixture.componentInstance.select.open();
             multiFixture.detectChanges();
@@ -766,7 +766,7 @@ describe('MatSelect', () => {
         // Having `aria-hidden` on the trigger avoids issues where
         // screen readers read out the wrong amount of options.
         it('should set aria-hidden on the trigger element', fakeAsync(() => {
-          const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+          const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
           expect(trigger.getAttribute('aria-hidden'))
               .toBe('true', 'Expected aria-hidden to be true when the select is open.');
@@ -778,7 +778,7 @@ describe('MatSelect', () => {
           const multiFixture = TestBed.createComponent(MultiSelect);
 
           multiFixture.detectChanges();
-          select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+          select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
           expect(select.getAttribute('aria-multiselectable')).toBe('true');
         }));
@@ -791,7 +791,7 @@ describe('MatSelect', () => {
           fixture.componentInstance.control.setValue('chips-4');
           fixture.detectChanges();
 
-          const host = fixture.debugElement.query(By.css('mat-select')).nativeElement;
+          const host = fixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
           expect(host.hasAttribute('aria-activedescendant'))
               .toBe(false, 'Expected no aria-activedescendant on init.');
@@ -814,7 +814,7 @@ describe('MatSelect', () => {
         }));
 
         it('should set aria-activedescendant based on the focused option', fakeAsync(() => {
-          const host = fixture.debugElement.query(By.css('mat-select')).nativeElement;
+          const host = fixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
           fixture.componentInstance.select.open();
           fixture.detectChanges();
@@ -839,7 +839,7 @@ describe('MatSelect', () => {
 
         it('should not change the aria-activedescendant using the horizontal arrow keys',
           fakeAsync(() => {
-            const host = fixture.debugElement.query(By.css('mat-select')).nativeElement;
+            const host = fixture.debugElement.query(By.css('mat-select'))!.nativeElement;
 
             fixture.componentInstance.select.open();
             fixture.detectChanges();
@@ -865,7 +865,7 @@ describe('MatSelect', () => {
             const instance = multiFixture.componentInstance;
 
             multiFixture.detectChanges();
-            select = multiFixture.debugElement.query(By.css('mat-select')).nativeElement;
+            select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
             instance.select.open();
             multiFixture.detectChanges();
 
@@ -890,7 +890,7 @@ describe('MatSelect', () => {
         beforeEach(fakeAsync(() => {
           fixture = TestBed.createComponent(BasicSelect);
           fixture.detectChanges();
-          trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+          trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
           trigger.click();
           fixture.detectChanges();
 
@@ -927,7 +927,7 @@ describe('MatSelect', () => {
           const multiFixture = TestBed.createComponent(MultiSelect);
           multiFixture.detectChanges();
 
-          trigger = multiFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+          trigger = multiFixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
           trigger.click();
           multiFixture.detectChanges();
 
@@ -980,7 +980,7 @@ describe('MatSelect', () => {
         beforeEach(fakeAsync(() => {
           fixture = TestBed.createComponent(SelectWithGroups);
           fixture.detectChanges();
-          trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+          trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
           trigger.click();
           fixture.detectChanges();
           groups =
@@ -1013,7 +1013,7 @@ describe('MatSelect', () => {
       beforeEach(fakeAsync(() => {
         fixture = TestBed.createComponent(BasicSelect);
         fixture.detectChanges();
-        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
       }));
 
       it('should not throw when attempting to open too early', () => {
@@ -1250,7 +1250,7 @@ describe('MatSelect', () => {
 
         const groupFixture = TestBed.createComponent(SelectWithGroupsAndNgContainer);
         groupFixture.detectChanges();
-        trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
         trigger.click();
         groupFixture.detectChanges();
 
@@ -1287,8 +1287,8 @@ describe('MatSelect', () => {
       beforeEach(fakeAsync(() => {
         fixture = TestBed.createComponent(BasicSelect);
         fixture.detectChanges();
-        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-        formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+        trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
+        formField = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
       }));
 
       it('should not float label if no option is selected', fakeAsync(() => {
@@ -1438,7 +1438,7 @@ describe('MatSelect', () => {
         fixture.detectChanges();
         flush();
 
-        const value = fixture.debugElement.query(By.css('.mat-select-value')).nativeElement;
+        const value = fixture.debugElement.query(By.css('.mat-select-value'))!.nativeElement;
 
         expect(formField.classList.contains('mat-form-field-should-float'))
             .toBe(true, 'Label should be floating');
@@ -1509,7 +1509,7 @@ describe('MatSelect', () => {
 
         const groupFixture = TestBed.createComponent(SelectWithGroups);
         groupFixture.detectChanges();
-        groupFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+        groupFixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement.click();
         groupFixture.detectChanges();
 
         const disabledGroup = overlayContainerElement.querySelectorAll('mat-optgroup')[1];
@@ -1558,7 +1558,7 @@ describe('MatSelect', () => {
           }).not.toThrow();
 
           fixture.detectChanges();
-          trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+          trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
           trigger.click();
           fixture.detectChanges();
@@ -1613,18 +1613,18 @@ describe('MatSelect', () => {
       beforeEach(fakeAsync(() => {
         fixture = TestBed.createComponent(BasicSelect);
         fixture.detectChanges();
-        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
       }));
 
       it('should take an initial view value with reactive forms', fakeAsync(() => {
         fixture.componentInstance.control = new FormControl('pizza-1');
         fixture.detectChanges();
 
-        const value = fixture.debugElement.query(By.css('.mat-select-value'));
+        const value = fixture.debugElement.query(By.css('.mat-select-value'))!;
         expect(value.nativeElement.textContent)
             .toContain('Pizza', `Expected trigger to be populated by the control's initial value.`);
 
-        trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
         trigger.click();
         fixture.detectChanges();
         flush();
@@ -1637,13 +1637,13 @@ describe('MatSelect', () => {
       }));
 
       it('should set the view value from the form', fakeAsync(() => {
-        let value = fixture.debugElement.query(By.css('.mat-select-value'));
+        let value = fixture.debugElement.query(By.css('.mat-select-value'))!;
         expect(value.nativeElement.textContent.trim()).toBe('Food');
 
         fixture.componentInstance.control.setValue('pizza-1');
         fixture.detectChanges();
 
-        value = fixture.debugElement.query(By.css('.mat-select-value'));
+        value = fixture.debugElement.query(By.css('.mat-select-value'))!;
         expect(value.nativeElement.textContent)
             .toContain('Pizza', `Expected trigger to be populated by the control's new value.`);
 
@@ -1681,7 +1681,7 @@ describe('MatSelect', () => {
         fixture.componentInstance.control.setValue('gibberish');
         fixture.detectChanges();
 
-        const value = fixture.debugElement.query(By.css('.mat-select-value'));
+        const value = fixture.debugElement.query(By.css('.mat-select-value'))!;
         expect(value.nativeElement.textContent.trim())
             .toBe('Food', `Expected trigger to show the placeholder.`);
         expect(trigger.textContent)
@@ -1705,7 +1705,7 @@ describe('MatSelect', () => {
         fixture.componentInstance.control.reset();
         fixture.detectChanges();
 
-        const value = fixture.debugElement.query(By.css('.mat-select-value'));
+        const value = fixture.debugElement.query(By.css('.mat-select-value'))!;
         expect(value.nativeElement.textContent.trim())
             .toBe('Food', `Expected trigger to show the placeholder.`);
         expect(trigger.textContent)
@@ -1825,7 +1825,7 @@ describe('MatSelect', () => {
         fixture.componentInstance.control.disable();
         fixture.detectChanges();
         let trigger =
-            fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+            fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
         expect(getComputedStyle(trigger).getPropertyValue('cursor'))
             .toEqual('default', `Expected cursor to be default arrow on disabled control.`);
 
@@ -1859,7 +1859,7 @@ describe('MatSelect', () => {
       beforeEach(fakeAsync(() => {
         fixture = TestBed.createComponent(BasicSelect);
         fixture.detectChanges();
-        formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+        formField = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
       }));
 
       it('should float the label when the panel is open and unselected', fakeAsync(() => {
@@ -1903,7 +1903,7 @@ describe('MatSelect', () => {
         flush();
         fixture.detectChanges();
 
-        host = fixture.debugElement.query(By.css('mat-select')).nativeElement;
+        host = fixture.debugElement.query(By.css('mat-select'))!.nativeElement;
         panel = overlayContainerElement.querySelector('.mat-select-panel')! as HTMLElement;
       }));
 
@@ -1951,7 +1951,7 @@ describe('MatSelect', () => {
         groupFixture.detectChanges();
         flush();
 
-        host = groupFixture.debugElement.query(By.css('mat-select')).nativeElement;
+        host = groupFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
         panel = overlayContainerElement.querySelector('.mat-select-panel')! as HTMLElement;
 
         for (let i = 0; i < 5; i++) {
@@ -2034,7 +2034,7 @@ describe('MatSelect', () => {
       fixture = TestBed.createComponent(SelectWithChangeEvent);
       fixture.detectChanges();
 
-      trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
     }));
 
     it('should emit an event when the selected option has changed', fakeAsync(() => {
@@ -2059,7 +2059,7 @@ describe('MatSelect', () => {
     }));
 
     it('should only emit one event when pressing arrow keys on closed select', fakeAsync(() => {
-      const select = fixture.debugElement.query(By.css('mat-select')).nativeElement;
+      const select = fixture.debugElement.query(By.css('mat-select'))!.nativeElement;
       dispatchKeyboardEvent(select, 'keydown', DOWN_ARROW);
 
       expect(fixture.componentInstance.changeListener).toHaveBeenCalledTimes(1);
@@ -2081,7 +2081,7 @@ describe('MatSelect', () => {
 
       fixture.detectChanges();
       const trigger =
-          fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+          fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
       expect(getComputedStyle(trigger).getPropertyValue('cursor'))
           .toEqual('default', `Expected cursor to be default arrow on disabled control.`);
 
@@ -2121,14 +2121,14 @@ describe('MatSelect', () => {
       fixture.componentInstance.isShowing = true;
       fixture.detectChanges();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
       trigger.style.width = '300px';
 
       trigger.click();
       fixture.detectChanges();
       flush();
 
-      const value = fixture.debugElement.query(By.css('.mat-select-value'));
+      const value = fixture.debugElement.query(By.css('.mat-select-value'))!;
       expect(value.nativeElement.textContent)
           .toContain('Pizza', `Expected trigger to be populated by the control's initial value.`);
 
@@ -2188,7 +2188,7 @@ describe('MatSelect', () => {
       }));
 
       it('should remove aria-owns when the options are not visible', fakeAsync(() => {
-        const select = fixture.debugElement.query(By.css('mat-select'));
+        const select = fixture.debugElement.query(By.css('mat-select'))!;
 
         expect(select.nativeElement.hasAttribute('aria-owns'))
             .toBe(true, 'Expected select to have aria-owns while open.');
@@ -2238,7 +2238,7 @@ describe('MatSelect', () => {
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(FloatLabelSelect);
       fixture.detectChanges();
-      formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+      formField = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
     }));
 
     it('should be able to disable the floating label', fakeAsync(() => {
@@ -2288,7 +2288,7 @@ describe('MatSelect', () => {
       fixture = TestBed.createComponent(FloatLabelSelect);
       fixture.componentInstance.floatLabel = null;
       fixture.detectChanges();
-      formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+      formField = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
 
       expect(formField.classList.contains('mat-form-field-can-float'))
           .toBe(true, 'Label should be able to float');
@@ -2319,7 +2319,7 @@ describe('MatSelect', () => {
       const fixture = TestBed.createComponent(SelectWithPlainTabindex);
       fixture.detectChanges();
 
-      const select = fixture.debugElement.query(By.css('mat-select')).nativeElement;
+      const select = fixture.debugElement.query(By.css('mat-select'))!.nativeElement;
       expect(select.getAttribute('tabindex')).toBe('5');
     }));
   });
@@ -2331,7 +2331,7 @@ describe('MatSelect', () => {
       const fixture = TestBed.createComponent(SelectWithPlainTabindex);
       fixture.detectChanges();
 
-      const debugElement = fixture.debugElement.query(By.directive(MatSelect));
+      const debugElement = fixture.debugElement.query(By.directive(MatSelect))!;
       const select = debugElement.componentInstance;
 
       const spy = jasmine.createSpy('stateChanges complete');
@@ -2350,7 +2350,7 @@ describe('MatSelect', () => {
       const fixture = TestBed.createComponent(BasicSelectInitiallyHidden);
       fixture.detectChanges();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
       trigger.style.width = '200px';
       fixture.componentInstance.isVisible = true;
       fixture.detectChanges();
@@ -2371,7 +2371,7 @@ describe('MatSelect', () => {
       const fixture = TestBed.createComponent(BasicSelectNoPlaceholder);
 
       fixture.detectChanges();
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
       trigger.click();
       fixture.detectChanges();
@@ -2515,7 +2515,7 @@ describe('MatSelect', () => {
       fixture = TestBed.createComponent(SelectInsideFormGroup);
       fixture.detectChanges();
       testComponent = fixture.componentInstance;
-      select = fixture.debugElement.query(By.css('mat-select')).nativeElement;
+      select = fixture.debugElement.query(By.css('mat-select'))!.nativeElement;
     }));
 
     it('should not set the invalid class on a clean select', fakeAsync(() => {
@@ -2566,7 +2566,7 @@ describe('MatSelect', () => {
       expect(select.getAttribute('aria-invalid'))
           .toBe('false', 'Expected aria-invalid to be set to false.');
 
-      dispatchFakeEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('form'))!.nativeElement, 'submit');
       fixture.detectChanges();
 
       expect(select.classList)
@@ -2580,7 +2580,7 @@ describe('MatSelect', () => {
 
       expect(debugEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error messages');
 
-      dispatchFakeEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+      dispatchFakeEvent(fixture.debugElement.query(By.css('form'))!.nativeElement, 'submit');
       fixture.detectChanges();
 
       expect(debugEl.querySelectorAll('mat-error').length).toBe(1, 'Expected one error message');
@@ -2657,7 +2657,7 @@ describe('MatSelect', () => {
       flush();
       fixture.detectChanges();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
       expect(trigger.textContent).toContain('Pizza');
       expect(fixture.componentInstance.options.toArray()[1].selected).toBe(true);
@@ -2688,7 +2688,7 @@ describe('MatSelect', () => {
       const fixture = TestBed.createComponent(FalsyValueSelect);
 
       fixture.detectChanges();
-      fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+      fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement.click();
       fixture.componentInstance.control.setValue(0);
       fixture.detectChanges();
       flush();
@@ -2712,7 +2712,7 @@ describe('MatSelect', () => {
       fixture.detectChanges();
       flush();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
       fixture.detectChanges();
 
@@ -2722,7 +2722,7 @@ describe('MatSelect', () => {
     it('should update the trigger based on the value', fakeAsync(() => {
       const fixture = TestBed.createComponent(BasicSelectOnPush);
       fixture.detectChanges();
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
       fixture.componentInstance.control.setValue('pizza-1');
       fixture.detectChanges();
@@ -2746,7 +2746,7 @@ describe('MatSelect', () => {
       fixture.componentInstance.control.setValue('pizza-1');
       fixture.detectChanges();
 
-      const label = fixture.debugElement.query(By.css('.mat-select-value')).nativeElement;
+      const label = fixture.debugElement.query(By.css('.mat-select-value'))!.nativeElement;
 
       expect(label.textContent).toContain('azziP',
           'Expected the displayed text to be "Pizza" in reverse.');
@@ -2764,8 +2764,8 @@ describe('MatSelect', () => {
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(ResetValuesSelect);
       fixture.detectChanges();
-      trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-      formField = fixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
+      trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
+      formField = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
 
       trigger.click();
       fixture.detectChanges();
@@ -2861,7 +2861,7 @@ describe('MatSelect', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.selectedFood).toBeFalsy();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
       trigger.click();
       fixture.detectChanges();
@@ -2895,7 +2895,7 @@ describe('MatSelect', () => {
       fixture.componentInstance.selectedFood = 'sandwich-2';
       fixture.detectChanges();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
       expect(trigger.textContent).toContain('Sandwich');
 
       trigger.click();
@@ -2913,7 +2913,7 @@ describe('MatSelect', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.selectedFood).toBeFalsy();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
       trigger.click();
       fixture.detectChanges();
@@ -2940,7 +2940,7 @@ describe('MatSelect', () => {
       fixture.detectChanges();
       flush();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
       fixture.detectChanges();
       expect(trigger.textContent).toContain('Pizza');
 
@@ -2959,7 +2959,7 @@ describe('MatSelect', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.selectedFoods).toBeFalsy();
 
-      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      const trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
       trigger.click();
       fixture.detectChanges();
@@ -2993,7 +2993,7 @@ describe('MatSelect', () => {
       const fixture = TestBed.createComponent(BasicSelectWithoutForms);
 
       fixture.detectChanges();
-      fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+      fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement.click();
       fixture.detectChanges();
       flush();
 
@@ -3011,7 +3011,7 @@ describe('MatSelect', () => {
       const select = fixture.debugElement.nativeElement.querySelector('mat-select');
 
       fixture.detectChanges();
-      fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+      fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement.click();
       fixture.detectChanges();
       flush();
 
@@ -3035,7 +3035,7 @@ describe('MatSelect', () => {
 
       expect(instance.selectedFood).toBeFalsy();
 
-      fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+      fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement.click();
       fixture.detectChanges();
       flush();
 
@@ -3060,7 +3060,7 @@ describe('MatSelect', () => {
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(SelectWithoutOptionCentering);
       fixture.detectChanges();
-      trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
     }));
 
     it('should not align the active option with the trigger if centering is disabled',
@@ -3098,8 +3098,8 @@ describe('MatSelect', () => {
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(BasicSelect);
       fixture.detectChanges();
-      trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-      formField = fixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+      trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
+      formField = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
     }));
 
     /**
@@ -3238,8 +3238,8 @@ describe('MatSelect', () => {
 
         let groupFixture = TestBed.createComponent(SelectWithGroups);
         groupFixture.detectChanges();
-        trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-        formField = groupFixture.debugElement.query(By.css('mat-form-field')).nativeElement;
+        trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
+        formField = groupFixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
         formField.style.position = 'fixed';
         formField.style.top = '200px';
@@ -3764,8 +3764,8 @@ describe('MatSelect', () => {
       beforeEach(fakeAsync(() => {
         multiFixture = TestBed.createComponent(MultiSelect);
         multiFixture.detectChanges();
-        formField = multiFixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
-        trigger = multiFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        formField = multiFixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
+        trigger = multiFixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
         formField.style.position = 'fixed';
         formField.style.left = '60px';
@@ -3809,8 +3809,8 @@ describe('MatSelect', () => {
       beforeEach(fakeAsync(() => {
         groupFixture = TestBed.createComponent(SelectWithGroups);
         groupFixture.detectChanges();
-        formField = groupFixture.debugElement.query(By.css('.mat-form-field')).nativeElement;
-        trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+        formField = groupFixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
+        trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
 
         formField.style.position = 'fixed';
         formField.style.left = '60px';
@@ -3916,7 +3916,7 @@ describe('MatSelect', () => {
       testInstance = fixture.componentInstance;
       fixture.detectChanges();
 
-      trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+      trigger = fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
     }));
 
     it('should be able to select multiple values', fakeAsync(() => {

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -45,9 +45,9 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
 
       const testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      const container = fixture.debugElement.query(By.css('mat-drawer-container')).nativeElement;
+      const container = fixture.debugElement.query(By.css('mat-drawer-container'))!.nativeElement;
 
-      fixture.debugElement.query(By.css('.open')).nativeElement.click();
+      fixture.debugElement.query(By.css('.open'))!.nativeElement.click();
       fixture.detectChanges();
 
       expect(testComponent.openCount).toBe(0);
@@ -68,14 +68,14 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
 
       const testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      const container = fixture.debugElement.query(By.css('mat-drawer-container')).nativeElement;
+      const container = fixture.debugElement.query(By.css('mat-drawer-container'))!.nativeElement;
 
-      fixture.debugElement.query(By.css('.open')).nativeElement.click();
+      fixture.debugElement.query(By.css('.open'))!.nativeElement.click();
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
 
-      fixture.debugElement.query(By.css('.close')).nativeElement.click();
+      fixture.debugElement.query(By.css('.close'))!.nativeElement.click();
       fixture.detectChanges();
 
       expect(testComponent.closeCount).toBe(0);
@@ -95,7 +95,7 @@ describe('MatDrawer', () => {
       const fixture = TestBed.createComponent(BasicTestApp);
       fixture.detectChanges();
       const drawer: MatDrawer =
-          fixture.debugElement.query(By.directive(MatDrawer)).componentInstance;
+          fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
 
       drawer.open().then(result => expect(result).toBe('open'));
       fixture.detectChanges();
@@ -106,7 +106,7 @@ describe('MatDrawer', () => {
     it('should resolve the close method promise with the new state of the drawer', fakeAsync(() => {
       const fixture = TestBed.createComponent(BasicTestApp);
       fixture.detectChanges();
-      const drawer = fixture.debugElement.query(By.directive(MatDrawer));
+      const drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
       const drawerInstance: MatDrawer = drawer.componentInstance;
 
       drawerInstance.open();
@@ -125,14 +125,14 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
 
       const testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      fixture.debugElement.query(By.css('.open')).nativeElement.click();
+      fixture.debugElement.query(By.css('.open'))!.nativeElement.click();
       fixture.detectChanges();
 
       expect(testComponent.openCount).toBe(0);
       expect(testComponent.closeCount).toBe(0);
 
       tick();
-      fixture.debugElement.query(By.css('.close')).nativeElement.click();
+      fixture.debugElement.query(By.css('.close'))!.nativeElement.click();
       fixture.detectChanges();
 
       flush();
@@ -155,7 +155,7 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
 
       let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      let openButtonElement = fixture.debugElement.query(By.css('.open')).nativeElement;
+      let openButtonElement = fixture.debugElement.query(By.css('.open'))!.nativeElement;
 
       openButtonElement.click();
       fixture.detectChanges();
@@ -163,7 +163,7 @@ describe('MatDrawer', () => {
 
       expect(testComponent.backdropClickedCount).toBe(0);
 
-      fixture.debugElement.query(By.css('.mat-drawer-backdrop')).nativeElement.click();
+      fixture.debugElement.query(By.css('.mat-drawer-backdrop'))!.nativeElement.click();
       fixture.detectChanges();
       flush();
 
@@ -173,7 +173,7 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
       flush();
 
-      fixture.debugElement.query(By.css('.close')).nativeElement.click();
+      fixture.debugElement.query(By.css('.close'))!.nativeElement.click();
       fixture.detectChanges();
       flush();
 
@@ -186,7 +186,7 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
 
       let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer));
+      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
 
       drawer.componentInstance.open();
       fixture.detectChanges();
@@ -212,7 +212,7 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
 
       let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer));
+      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
 
       drawer.componentInstance.open();
       fixture.detectChanges();
@@ -244,7 +244,7 @@ describe('MatDrawer', () => {
     it('should not close by pressing escape when disableClose is set', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer));
+      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
 
       drawer.componentInstance.disableClose = true;
       drawer.componentInstance.open();
@@ -262,14 +262,14 @@ describe('MatDrawer', () => {
     it('should not close by clicking on the backdrop when disableClose is set', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
       let testComponent = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer)).componentInstance;
+      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
 
       drawer.disableClose = true;
       drawer.open();
       fixture.detectChanges();
       tick();
 
-      fixture.debugElement.query(By.css('.mat-drawer-backdrop')).nativeElement.click();
+      fixture.debugElement.query(By.css('.mat-drawer-backdrop'))!.nativeElement.click();
       fixture.detectChanges();
       tick();
 
@@ -282,7 +282,7 @@ describe('MatDrawer', () => {
 
       fixture.detectChanges();
 
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer)).componentInstance;
+      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
       let openButton = fixture.componentInstance.openButton.nativeElement;
       let drawerButton = fixture.componentInstance.drawerButton.nativeElement;
 
@@ -303,7 +303,7 @@ describe('MatDrawer', () => {
     it('should not restore focus on close if focus is outside drawer', fakeAsync(() => {
       let fixture = TestBed.createComponent(BasicTestApp);
       let drawer: MatDrawer = fixture.debugElement
-          .query(By.directive(MatDrawer)).componentInstance;
+          .query(By.directive(MatDrawer))!.componentInstance;
       fixture.detectChanges();
 
       let openButton = fixture.componentInstance.openButton.nativeElement;
@@ -331,7 +331,7 @@ describe('MatDrawer', () => {
 
       fixture.detectChanges();
 
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer)).componentInstance;
+      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
 
       expect((drawer as MatDrawer).opened).toBe(false);
     });
@@ -341,7 +341,7 @@ describe('MatDrawer', () => {
 
       fixture.detectChanges();
 
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer)).componentInstance;
+      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
 
       expect((drawer as MatDrawer).opened).toBe(true);
     });
@@ -350,7 +350,7 @@ describe('MatDrawer', () => {
       const fixture = TestBed.createComponent(BasicTestApp);
       fixture.detectChanges();
 
-      const drawerEl = fixture.debugElement.query(By.css('mat-drawer')).nativeElement;
+      const drawerEl = fixture.debugElement.query(By.css('mat-drawer'))!.nativeElement;
       expect(drawerEl.hasAttribute('align'))
           .toBe(false, 'Expected drawer not to have a native align attribute.');
     });
@@ -389,7 +389,7 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
 
       let drawer: MatDrawer = fixture.debugElement
-          .query(By.directive(MatDrawer)).componentInstance;
+          .query(By.directive(MatDrawer))!.componentInstance;
 
       drawer.open();
       fixture.detectChanges();
@@ -441,9 +441,9 @@ describe('MatDrawer', () => {
       fixture = TestBed.createComponent(DrawerWithFocusableElements);
       fixture.detectChanges();
       testComponent = fixture.debugElement.componentInstance;
-      drawer = fixture.debugElement.query(By.directive(MatDrawer)).componentInstance;
-      firstFocusableElement = fixture.debugElement.query(By.css('.input1')).nativeElement;
-      lastFocusableElement = fixture.debugElement.query(By.css('.input2')).nativeElement;
+      drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
+      firstFocusableElement = fixture.debugElement.query(By.css('.input1'))!.nativeElement;
+      lastFocusableElement = fixture.debugElement.query(By.css('.input2'))!.nativeElement;
       lastFocusableElement.focus();
     });
 
@@ -487,7 +487,7 @@ describe('MatDrawer', () => {
       fixture.destroy();
 
       const nonFocusableFixture = TestBed.createComponent(DrawerWithoutFocusableElements);
-      const drawerEl = nonFocusableFixture.debugElement.query(By.directive(MatDrawer));
+      const drawerEl = nonFocusableFixture.debugElement.query(By.directive(MatDrawer))!;
       nonFocusableFixture.detectChanges();
 
       drawerEl.componentInstance.open();

--- a/src/material/sidenav/sidenav.spec.ts
+++ b/src/material/sidenav/sidenav.spec.ts
@@ -20,7 +20,7 @@ describe('MatSidenav', () => {
     fixture = TestBed.createComponent(SidenavWithFixedPosition);
     fixture.detectChanges();
 
-    sidenavEl = fixture.debugElement.query(By.directive(MatSidenav)).nativeElement;
+    sidenavEl = fixture.debugElement.query(By.directive(MatSidenav))!.nativeElement;
   }));
 
   it('should be fixed position when in fixed mode', () => {

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -70,13 +70,13 @@ describe('MatSlideToggle without forms', () => {
       // Initialize the slide-toggle component, by triggering the first change detection cycle.
       fixture.detectChanges();
 
-      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
+      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'))!;
 
       testComponent = fixture.debugElement.componentInstance;
       slideToggle = slideToggleDebug.componentInstance;
       slideToggleElement = slideToggleDebug.nativeElement;
-      inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-      labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+      inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      labelElement = fixture.debugElement.query(By.css('label'))!.nativeElement;
     }));
 
     it('should apply class based on color attribute', () => {
@@ -362,7 +362,7 @@ describe('MatSlideToggle without forms', () => {
       fixture.detectChanges();
 
       const slideToggle = fixture.debugElement
-        .query(By.directive(MatSlideToggle)).componentInstance as MatSlideToggle;
+        .query(By.directive(MatSlideToggle))!.componentInstance as MatSlideToggle;
 
       expect(slideToggle.tabIndex)
         .toBe(5, 'Expected tabIndex property to have been set based on the native attribute');
@@ -373,7 +373,7 @@ describe('MatSlideToggle without forms', () => {
 
       fixture.detectChanges();
 
-      const slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle)).nativeElement;
+      const slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle))!.nativeElement;
       expect(slideToggle.getAttribute('tabindex')).toBe('-1');
     }));
 
@@ -383,7 +383,7 @@ describe('MatSlideToggle without forms', () => {
       fixture.componentInstance.disabled = true;
       fixture.detectChanges();
 
-      const slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle)).nativeElement;
+      const slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle))!.nativeElement;
       expect(slideToggle.hasAttribute('tabindex')).toBe(false);
     }));
   });
@@ -407,11 +407,11 @@ describe('MatSlideToggle without forms', () => {
       fixture.detectChanges();
 
       const testComponent = fixture.debugElement.componentInstance;
-      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
+      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'))!;
 
       const slideToggle = slideToggleDebug.componentInstance;
-      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-      const labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+      const inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      const labelElement = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
       expect(testComponent.toggleTriggered).toBe(0);
       expect(testComponent.dragTriggered).toBe(0);
@@ -450,9 +450,9 @@ describe('MatSlideToggle without forms', () => {
       fixture.detectChanges();
 
       const testComponent = fixture.debugElement.componentInstance;
-      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
+      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'))!;
       const thumbContainerDebug = slideToggleDebug
-        .query(By.css('.mat-slide-toggle-thumb-container'));
+        .query(By.css('.mat-slide-toggle-thumb-container'))!;
 
       const slideThumbContainer = thumbContainerDebug.nativeElement;
       const slideToggle = slideToggleDebug.componentInstance;
@@ -496,9 +496,9 @@ describe('MatSlideToggle without forms', () => {
       fixture = TestBed.createComponent(SlideToggleBasic);
       fixture.detectChanges();
 
-      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'));
+      const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'))!;
       const thumbContainerDebug = slideToggleDebug
-          .query(By.css('.mat-slide-toggle-thumb-container'));
+          .query(By.css('.mat-slide-toggle-thumb-container'))!;
 
       testComponent = fixture.debugElement.componentInstance;
       slideToggle = slideToggleDebug.componentInstance;
@@ -707,11 +707,11 @@ describe('MatSlideToggle without forms', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(SlideToggleWithoutLabel);
 
-      const slideToggleDebugEl = fixture.debugElement.query(By.directive(MatSlideToggle));
+      const slideToggleDebugEl = fixture.debugElement.query(By.directive(MatSlideToggle))!;
 
       testComponent = fixture.componentInstance;
       slideToggleBarElement = slideToggleDebugEl
-          .query(By.css('.mat-slide-toggle-bar')).nativeElement;
+          .query(By.css('.mat-slide-toggle-bar'))!.nativeElement;
     });
 
     it('should remove margin for slide-toggle without a label', () => {
@@ -752,7 +752,7 @@ describe('MatSlideToggle without forms', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(SlideToggleProjectedLabel);
       slideToggleBarElement = fixture.debugElement
-        .query(By.css('.mat-slide-toggle-bar')).nativeElement;
+        .query(By.css('.mat-slide-toggle-bar'))!.nativeElement;
 
       fixture.detectChanges();
     });
@@ -800,14 +800,14 @@ describe('MatSlideToggle with forms', () => {
       fixture = TestBed.createComponent(SlideToggleWithModel);
       fixture.detectChanges();
 
-      const slideToggleDebug = fixture.debugElement.query(By.directive(MatSlideToggle));
+      const slideToggleDebug = fixture.debugElement.query(By.directive(MatSlideToggle))!;
 
       testComponent = fixture.debugElement.componentInstance;
       slideToggle = slideToggleDebug.componentInstance;
       slideToggleElement = slideToggleDebug.nativeElement;
       slideToggleModel = slideToggleDebug.injector.get<NgModel>(NgModel);
-      inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-      labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+      inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      labelElement = fixture.debugElement.query(By.css('label'))!.nativeElement;
     }));
 
     it('should be initially set to ng-pristine', () => {
@@ -915,8 +915,8 @@ describe('MatSlideToggle with forms', () => {
 
     it('should update checked state on click if control is checked initially', fakeAsync(() => {
       fixture = TestBed.createComponent(SlideToggleWithModel);
-      slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle)).componentInstance;
-      labelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+      slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle))!.componentInstance;
+      labelElement = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
       fixture.componentInstance.modelValue = true;
       fixture.detectChanges();
@@ -945,7 +945,7 @@ describe('MatSlideToggle with forms', () => {
       fixture.componentInstance.modelValue = true;
       fixture.detectChanges();
 
-      const debugElement = fixture.debugElement.query(By.directive(MatSlideToggle));
+      const debugElement = fixture.debugElement.query(By.directive(MatSlideToggle))!;
       const modelInstance = debugElement.injector.get<NgModel>(NgModel);
 
       // Flush the microtasks because the forms module updates the model state asynchronously.
@@ -957,7 +957,7 @@ describe('MatSlideToggle with forms', () => {
     it('should set the model value when toggling via the `toggle` method', fakeAsync(() => {
       expect(testComponent.modelValue).toBe(false);
 
-      fixture.debugElement.query(By.directive(MatSlideToggle)).componentInstance.toggle();
+      fixture.debugElement.query(By.directive(MatSlideToggle))!.componentInstance.toggle();
       fixture.detectChanges();
       flushMicrotasks();
 
@@ -979,8 +979,8 @@ describe('MatSlideToggle with forms', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle)).componentInstance;
-      inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+      slideToggle = fixture.debugElement.query(By.directive(MatSlideToggle))!.componentInstance;
+      inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
     });
 
     it('should toggle the disabled state', () => {
@@ -1013,8 +1013,8 @@ describe('MatSlideToggle with forms', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
-      inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+      buttonElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
+      inputElement = fixture.debugElement.query(By.css('input'))!.nativeElement;
     }));
 
     it('should prevent the form from submit when being required', () => {
@@ -1074,7 +1074,7 @@ describe('MatSlideToggle with forms', () => {
       const fixture = TestBed.createComponent(SlideToggleWithModelAndChangeEvent);
       fixture.detectChanges();
 
-      const labelEl = fixture.debugElement.query(By.css('label')).nativeElement;
+      const labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
       spyOn(fixture.componentInstance, 'onChange').and.callFake(() => {
         expect(fixture.componentInstance.checked)

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -54,7 +54,7 @@ describe('MatSlider', () => {
       fixture = createComponent(StandardSlider);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
 
@@ -235,7 +235,7 @@ describe('MatSlider', () => {
       fixture = createComponent(DisabledSlider);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
@@ -311,7 +311,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithMinAndMax);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       testComponent = fixture.debugElement.componentInstance;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
@@ -405,7 +405,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithValue);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
     });
@@ -442,7 +442,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithStep);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
@@ -536,7 +536,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithAutoTickInterval);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       ticksContainerElement =
           <HTMLElement>sliderNativeElement.querySelector('.mat-slider-ticks-container');
@@ -566,7 +566,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithSetTickInterval);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       ticksContainerElement =
           <HTMLElement>sliderNativeElement.querySelector('.mat-slider-ticks-container');
@@ -608,7 +608,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithThumbLabel);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
       thumbLabelTextElement = sliderNativeElement.querySelector('.mat-slider-thumb-label-text')!;
@@ -648,7 +648,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithCustomThumbLabelFormatting);
       fixture.detectChanges();
 
-      const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       const sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
       thumbLabelTextElement = sliderNativeElement.querySelector('.mat-slider-thumb-label-text')!;
@@ -685,7 +685,7 @@ describe('MatSlider', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
@@ -716,7 +716,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithValueSmallerThanMin);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
@@ -744,7 +744,7 @@ describe('MatSlider', () => {
       fixture = createComponent(SliderWithValueGreaterThanMax);
       fixture.detectChanges();
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.componentInstance;
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
@@ -775,7 +775,7 @@ describe('MatSlider', () => {
       spyOn(testComponent, 'onChange');
       spyOn(testComponent, 'onInput');
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
     });
 
@@ -846,7 +846,7 @@ describe('MatSlider', () => {
       spyOn(testComponent, 'onInput');
       spyOn(testComponent, 'onChange');
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
     });
 
@@ -894,7 +894,7 @@ describe('MatSlider', () => {
       spyOn(testComponent, 'onInput');
       spyOn(testComponent, 'onChange');
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
     });
@@ -1050,7 +1050,7 @@ describe('MatSlider', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
       sliderNativeElement = sliderDebugElement.nativeElement;
     });
@@ -1191,7 +1191,7 @@ describe('MatSlider', () => {
       fixture.detectChanges();
 
       testComponent = fixture.debugElement.componentInstance;
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
       sliderNativeElement = sliderDebugElement.nativeElement;
       trackFillElement = <HTMLElement>sliderNativeElement.querySelector('.mat-slider-track-fill');
@@ -1246,7 +1246,7 @@ describe('MatSlider', () => {
       const fixture = createComponent(SliderWithTabIndexBinding);
       fixture.detectChanges();
 
-      const slider = fixture.debugElement.query(By.directive(MatSlider)).componentInstance;
+      const slider = fixture.debugElement.query(By.directive(MatSlider))!.componentInstance;
 
       expect(slider.tabIndex).toBe(0, 'Expected the tabIndex to be set to 0 by default.');
 
@@ -1260,7 +1260,7 @@ describe('MatSlider', () => {
       const fixture = createComponent(SliderWithNativeTabindexAttr);
       fixture.detectChanges();
 
-      const slider = fixture.debugElement.query(By.directive(MatSlider)).componentInstance;
+      const slider = fixture.debugElement.query(By.directive(MatSlider))!.componentInstance;
 
       expect(slider.tabIndex)
         .toBe(5, 'Expected the tabIndex to be set to the value of the native attribute.');
@@ -1279,7 +1279,7 @@ describe('MatSlider', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
     });
 
@@ -1341,7 +1341,7 @@ describe('MatSlider', () => {
 
       testComponent = fixture.debugElement.componentInstance;
 
-      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
     });
@@ -1438,7 +1438,7 @@ describe('MatSlider', () => {
       fixture.detectChanges();
 
       testComponent = fixture.componentInstance;
-      let sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
+      let sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
     });
 

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -373,7 +373,7 @@ describe('MatSort', () => {
 
   it('should re-render when the i18n labels have changed',
     inject([MatSortHeaderIntl], (intl: MatSortHeaderIntl) => {
-      const header = fixture.debugElement.query(By.directive(MatSortHeader)).nativeElement;
+      const header = fixture.debugElement.query(By.directive(MatSortHeader))!.nativeElement;
       const button = header.querySelector('.mat-sort-header-button');
 
       intl.sortButtonLabel = () => 'Sort all of the things';

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -62,13 +62,13 @@ describe('MatStepper', () => {
 
     it('should default to the first step', () => {
       let stepperComponent = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
+          .query(By.css('mat-vertical-stepper'))!.componentInstance;
       expect(stepperComponent.selectedIndex).toBe(0);
     });
 
     it('should throw when a negative `selectedIndex` is assigned', () => {
       const stepperComponent: MatVerticalStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
+          .query(By.css('mat-vertical-stepper'))!.componentInstance;
 
       expect(() => {
         stepperComponent.selectedIndex = -10;
@@ -78,7 +78,7 @@ describe('MatStepper', () => {
 
     it('should throw when an out-of-bounds `selectedIndex` is assigned', () => {
       const stepperComponent: MatVerticalStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
+          .query(By.css('mat-vertical-stepper'))!.componentInstance;
 
       expect(() => {
         stepperComponent.selectedIndex = 1337;
@@ -88,7 +88,7 @@ describe('MatStepper', () => {
 
     it('should change selected index on header click', () => {
       let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
       expect(stepperComponent.selected instanceof MatStep).toBe(true);
@@ -111,13 +111,13 @@ describe('MatStepper', () => {
     });
 
     it('should set the "tablist" role on stepper', () => {
-      let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper')).nativeElement;
+      let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('role')).toBe('tablist');
     });
 
     it('should set aria-expanded of content correctly', () => {
       let stepContents = fixture.debugElement.queryAll(By.css(`.mat-vertical-stepper-content`));
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let firstStepContentEl = stepContents[0].nativeElement;
       expect(firstStepContentEl.getAttribute('aria-expanded')).toBe('true');
 
@@ -130,7 +130,7 @@ describe('MatStepper', () => {
     });
 
     it('should display the correct label', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let selectedLabel = fixture.nativeElement.querySelector('[aria-selected="true"]');
       expect(selectedLabel.textContent).toMatch('Step 1');
 
@@ -148,7 +148,7 @@ describe('MatStepper', () => {
     });
 
     it('should go to next available step when the next button is clicked', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
 
@@ -175,12 +175,12 @@ describe('MatStepper', () => {
     });
 
     it('should set the next stepper button type to "submit"', () => {
-      const button = fixture.debugElement.query(By.directive(MatStepperNext)).nativeElement;
+      const button = fixture.debugElement.query(By.directive(MatStepperNext))!.nativeElement;
       expect(button.type).toBe('submit', `Expected the button to have "submit" set as type.`);
     });
 
     it('should go to previous available step when the previous button is clicked', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
 
@@ -208,12 +208,12 @@ describe('MatStepper', () => {
     });
 
     it('should set the previous stepper button type to "button"', () => {
-      const button = fixture.debugElement.query(By.directive(MatStepperPrevious)).nativeElement;
+      const button = fixture.debugElement.query(By.directive(MatStepperPrevious))!.nativeElement;
       expect(button.type).toBe('button', `Expected the button to have "button" set as type.`);
     });
 
     it('should set the correct step position for animation', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent._getAnimationDirection(0)).toBe('current');
       expect(stepperComponent._getAnimationDirection(1)).toBe('next');
@@ -235,7 +235,7 @@ describe('MatStepper', () => {
     });
 
     it('should not set focus on header of selected step if header is not clicked', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let stepHeaderEl = fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
@@ -248,7 +248,7 @@ describe('MatStepper', () => {
     });
 
     it('should focus next step header if focus is inside the stepper', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let stepHeaderEl = fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
@@ -262,7 +262,7 @@ describe('MatStepper', () => {
     });
 
     it('should only be able to return to a previous step if it is editable', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       stepperComponent.selectedIndex = 1;
       stepperComponent.steps.toArray()[0].editable = false;
@@ -281,7 +281,7 @@ describe('MatStepper', () => {
     });
 
     it('should set create icon if step is editable and completed', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       expect(stepperComponent._getIndicatorType(0)).toBe('number');
@@ -293,7 +293,7 @@ describe('MatStepper', () => {
     });
 
     it('should set done icon if step is not editable and is completed', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       expect(stepperComponent._getIndicatorType(0)).toBe('number');
@@ -305,7 +305,7 @@ describe('MatStepper', () => {
     });
 
     it('should emit an event when the enter animation is done', fakeAsync(() => {
-      let stepper = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepper = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let selectionChangeSpy = jasmine.createSpy('selectionChange spy');
       let animationDoneSpy = jasmine.createSpy('animationDone spy');
       let selectionChangeSubscription = stepper.selectionChange.subscribe(selectionChangeSpy);
@@ -336,7 +336,7 @@ describe('MatStepper', () => {
 
     it('should adjust the index when removing a step before the current one', () => {
       const stepperComponent: MatVerticalStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
+          .query(By.css('mat-vertical-stepper'))!.componentInstance;
 
       stepperComponent.selectedIndex = 2;
       fixture.detectChanges();
@@ -364,7 +364,7 @@ describe('MatStepper', () => {
 
     it('should set the proper tabindex', () => {
       let stepContents = fixture.debugElement.queryAll(By.css(`.mat-vertical-stepper-content`));
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let firstStepContentEl = stepContents[0].nativeElement;
       let secondStepContentEl = stepContents[1].nativeElement;
 
@@ -384,7 +384,7 @@ describe('MatStepper', () => {
     it('should not throw', () => {
       const fixture = createComponent(SimpleMatVerticalStepperApp);
       const stepperComponent: MatVerticalStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
+          .query(By.css('mat-vertical-stepper'))!.componentInstance;
 
       expect(() => stepperComponent.selected).not.toThrow();
     });
@@ -394,7 +394,7 @@ describe('MatStepper', () => {
     it('should not throw', () => {
       const fixture = createComponent(SimpleMatVerticalStepperApp);
       const stepperComponent: MatVerticalStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
+          .query(By.css('mat-vertical-stepper'))!.componentInstance;
 
       expect(() => stepperComponent.selected = null!).not.toThrow();
       expect(stepperComponent.selectedIndex).toBe(-1);
@@ -435,7 +435,7 @@ describe('MatStepper', () => {
     });
 
     it('should allow for the `edit` icon to be overridden', () => {
-      const stepperDebugElement = fixture.debugElement.query(By.directive(MatStepper));
+      const stepperDebugElement = fixture.debugElement.query(By.directive(MatStepper))!;
       const stepperComponent: MatStepper = stepperDebugElement.componentInstance;
 
       stepperComponent.steps.toArray()[0].editable = true;
@@ -448,7 +448,7 @@ describe('MatStepper', () => {
     });
 
     it('should allow for the `done` icon to be overridden', () => {
-      const stepperDebugElement = fixture.debugElement.query(By.directive(MatStepper));
+      const stepperDebugElement = fixture.debugElement.query(By.directive(MatStepper))!;
       const stepperComponent: MatStepper = stepperDebugElement.componentInstance;
 
       stepperComponent.steps.toArray()[0].editable = false;
@@ -461,7 +461,7 @@ describe('MatStepper', () => {
     });
 
     it('should allow for the `number` icon to be overridden with context', () => {
-      const stepperDebugElement = fixture.debugElement.query(By.directive(MatStepper));
+      const stepperDebugElement = fixture.debugElement.query(By.directive(MatStepper))!;
       const headers = stepperDebugElement.nativeElement.querySelectorAll('mat-step-header');
 
       expect(headers[2].textContent).toContain('III');
@@ -478,7 +478,7 @@ describe('MatStepper', () => {
     });
 
     it('should reverse animation in RTL mode', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent._getAnimationDirection(0)).toBe('current');
       expect(stepperComponent._getAnimationDirection(1)).toBe('previous');
@@ -511,7 +511,7 @@ describe('MatStepper', () => {
 
       testComponent = fixture.componentInstance;
       stepperComponent = fixture.debugElement
-          .query(By.css('mat-vertical-stepper')).componentInstance;
+          .query(By.css('mat-vertical-stepper'))!.componentInstance;
     });
 
     it('should have true linear attribute', () => {
@@ -728,7 +728,7 @@ describe('MatStepper', () => {
       preselectedFixture = createComponent(SimplePreselectedMatHorizontalStepperApp);
       preselectedFixture.detectChanges();
       stepper = preselectedFixture.debugElement
-          .query(By.directive(MatHorizontalStepper)).componentInstance;
+          .query(By.directive(MatHorizontalStepper))!.componentInstance;
     });
 
     it('should not throw', () => {
@@ -752,7 +752,7 @@ describe('MatStepper', () => {
     });
     it('should not move to the next step if the current one is not completed ', () => {
       const stepper: MatHorizontalStepper = noStepControlFixture.debugElement
-          .query(By.directive(MatHorizontalStepper)).componentInstance;
+          .query(By.directive(MatHorizontalStepper))!.componentInstance;
 
       const headers = noStepControlFixture.debugElement
           .queryAll(By.css('.mat-horizontal-stepper-header'));
@@ -779,7 +779,7 @@ describe('MatStepper', () => {
         expect(controlAndBindingFixture.componentInstance.steps[0].completed).toBe(false);
 
         const stepper: MatHorizontalStepper = controlAndBindingFixture.debugElement
-            .query(By.directive(MatHorizontalStepper)).componentInstance;
+            .query(By.directive(MatHorizontalStepper))!.componentInstance;
 
         const headers = controlAndBindingFixture.debugElement
             .queryAll(By.css('.mat-horizontal-stepper-header'));
@@ -798,7 +798,7 @@ describe('MatStepper', () => {
       let fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
-      let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper')).nativeElement;
+      let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('aria-orientation')).toBe('vertical');
     });
 
@@ -833,7 +833,7 @@ describe('MatStepper', () => {
 
       const stepHeaders = fixture.debugElement.queryAll(By.directive(MatStepHeader));
       const headerRipples = stepHeaders.map(headerDebugEl =>
-        headerDebugEl.query(By.directive(MatRipple)).injector.get(MatRipple));
+        headerDebugEl.query(By.directive(MatRipple))!.injector.get(MatRipple));
 
       expect(headerRipples.every(ripple => ripple.disabled)).toBe(false);
 
@@ -849,7 +849,7 @@ describe('MatStepper', () => {
       let fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
-      let stepperEl = fixture.debugElement.query(By.css('mat-horizontal-stepper')).nativeElement;
+      let stepperEl = fixture.debugElement.query(By.css('mat-horizontal-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('aria-orientation')).toBe('horizontal');
     });
 
@@ -890,7 +890,7 @@ describe('MatStepper', () => {
 
       const stepHeaders = fixture.debugElement.queryAll(By.directive(MatStepHeader));
       const headerRipples = stepHeaders.map(headerDebugEl =>
-          headerDebugEl.query(By.directive(MatRipple)).injector.get(MatRipple));
+          headerDebugEl.query(By.directive(MatRipple))!.injector.get(MatRipple));
 
       expect(headerRipples.every(ripple => ripple.disabled)).toBe(false);
 
@@ -912,7 +912,7 @@ describe('MatStepper', () => {
 
       testComponent = fixture.componentInstance;
       stepper = fixture.debugElement
-          .query(By.css('mat-horizontal-stepper')).componentInstance;
+          .query(By.css('mat-horizontal-stepper'))!.componentInstance;
     });
 
     it('must be visited if not optional', () => {
@@ -993,7 +993,7 @@ describe('MatStepper', () => {
       );
       fixture.detectChanges();
       stepper = fixture.debugElement
-          .query(By.css('mat-horizontal-stepper')).componentInstance;
+          .query(By.css('mat-horizontal-stepper'))!.componentInstance;
     });
 
     it('should show error state', () => {
@@ -1041,7 +1041,7 @@ describe('MatStepper', () => {
       );
       fixture.detectChanges();
       stepper = fixture.debugElement
-          .query(By.css('mat-horizontal-stepper')).componentInstance;
+          .query(By.css('mat-horizontal-stepper'))!.componentInstance;
     });
 
     it('should show done state when step is completed and its not the current step', () => {
@@ -1070,7 +1070,7 @@ describe('MatStepper', () => {
 function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
                                           stepHeaders: DebugElement[],
                                           orientation: StepperOrientation) {
-  let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+  let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
   let nextKey = orientation === 'vertical' ? DOWN_ARROW : RIGHT_ARROW;
   let prevKey = orientation === 'vertical' ? UP_ARROW : LEFT_ARROW;
 
@@ -1141,7 +1141,7 @@ function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
 /** Asserts that arrow key direction works correctly in RTL mode. */
 function assertArrowKeyInteractionInRtl(fixture: ComponentFixture<any>,
                                         stepHeaders: DebugElement[]) {
-  let stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+  let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
   expect(stepperComponent._getFocusIndex()).toBe(0);
 
@@ -1163,7 +1163,7 @@ function assertSelectKeyWithModifierInteraction(fixture: ComponentFixture<any>,
                                                 stepHeaders: DebugElement[],
                                                 orientation: StepperOrientation,
                                                 selectionKey: number) {
-  const stepperComponent = fixture.debugElement.query(By.directive(MatStepper)).componentInstance;
+  const stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
   const modifiers = ['altKey', 'shiftKey', 'ctrlKey', 'metaKey'];
 
   expect(stepperComponent._getFocusIndex()).toBe(0);

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -88,7 +88,8 @@ describe('MatStepper', () => {
 
     it('should change selected index on header click', () => {
       let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
       expect(stepperComponent.selected instanceof MatStep).toBe(true);
@@ -117,7 +118,8 @@ describe('MatStepper', () => {
 
     it('should set aria-expanded of content correctly', () => {
       let stepContents = fixture.debugElement.queryAll(By.css(`.mat-vertical-stepper-content`));
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let firstStepContentEl = stepContents[0].nativeElement;
       expect(firstStepContentEl.getAttribute('aria-expanded')).toBe('true');
 
@@ -130,7 +132,8 @@ describe('MatStepper', () => {
     });
 
     it('should display the correct label', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let selectedLabel = fixture.nativeElement.querySelector('[aria-selected="true"]');
       expect(selectedLabel.textContent).toMatch('Step 1');
 
@@ -148,7 +151,8 @@ describe('MatStepper', () => {
     });
 
     it('should go to next available step when the next button is clicked', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
 
@@ -180,7 +184,8 @@ describe('MatStepper', () => {
     });
 
     it('should go to previous available step when the previous button is clicked', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
 
@@ -213,7 +218,8 @@ describe('MatStepper', () => {
     });
 
     it('should set the correct step position for animation', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent._getAnimationDirection(0)).toBe('current');
       expect(stepperComponent._getAnimationDirection(1)).toBe('next');
@@ -235,7 +241,8 @@ describe('MatStepper', () => {
     });
 
     it('should not set focus on header of selected step if header is not clicked', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let stepHeaderEl = fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
@@ -248,7 +255,8 @@ describe('MatStepper', () => {
     });
 
     it('should focus next step header if focus is inside the stepper', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let stepHeaderEl = fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
@@ -262,7 +270,8 @@ describe('MatStepper', () => {
     });
 
     it('should only be able to return to a previous step if it is editable', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       stepperComponent.selectedIndex = 1;
       stepperComponent.steps.toArray()[0].editable = false;
@@ -281,7 +290,8 @@ describe('MatStepper', () => {
     });
 
     it('should set create icon if step is editable and completed', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       expect(stepperComponent._getIndicatorType(0)).toBe('number');
@@ -293,7 +303,8 @@ describe('MatStepper', () => {
     });
 
     it('should set done icon if step is not editable and is completed', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       expect(stepperComponent._getIndicatorType(0)).toBe('number');
@@ -364,7 +375,8 @@ describe('MatStepper', () => {
 
     it('should set the proper tabindex', () => {
       let stepContents = fixture.debugElement.queryAll(By.css(`.mat-vertical-stepper-content`));
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let firstStepContentEl = stepContents[0].nativeElement;
       let secondStepContentEl = stepContents[1].nativeElement;
 
@@ -478,7 +490,8 @@ describe('MatStepper', () => {
     });
 
     it('should reverse animation in RTL mode', () => {
-      let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      let stepperComponent =
+          fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent._getAnimationDirection(0)).toBe('current');
       expect(stepperComponent._getAnimationDirection(1)).toBe('previous');

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -99,7 +99,7 @@ describe('MatTabGroup', () => {
 
     it('should change tabs based on selectedIndex', fakeAsync(() => {
       let component = fixture.componentInstance;
-      let tabComponent = fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
+      let tabComponent = fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
 
       spyOn(component, 'handleSelection').and.callThrough();
 
@@ -117,7 +117,7 @@ describe('MatTabGroup', () => {
     it('should update tab positions when selected index is changed', () => {
       fixture.detectChanges();
       const component: MatTabGroup =
-          fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
+          fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
       const tabs: MatTab[] = component._tabs.toArray();
 
       expect(tabs[0].position).toBeLessThan(0);
@@ -142,7 +142,7 @@ describe('MatTabGroup', () => {
     it('should clamp the selected index to the size of the number of tabs', () => {
       fixture.detectChanges();
       const component: MatTabGroup =
-          fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
+          fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
 
       // Set the index to be negative, expect first tab selected
       fixture.componentInstance.selectedIndex = -1;
@@ -259,7 +259,7 @@ describe('MatTabGroup', () => {
 
       const tabLabels = fixture.debugElement.queryAll(By.css('.mat-tab-label'));
       const tabLabelContainer = fixture.debugElement
-        .query(By.css('.mat-tab-label-container')).nativeElement as HTMLElement;
+        .query(By.css('.mat-tab-label-container'))!.nativeElement as HTMLElement;
 
       expect(fixture.componentInstance.handleFocus).toHaveBeenCalledTimes(0);
 
@@ -365,7 +365,7 @@ describe('MatTabGroup', () => {
     it('should be able to add a new tab, select it, and have correct origin position',
       fakeAsync(() => {
         const component: MatTabGroup =
-            fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
+            fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
 
         let tabs: MatTab[] = component._tabs.toArray();
         expect(tabs[0].origin).toBe(null);
@@ -397,7 +397,7 @@ describe('MatTabGroup', () => {
 
     it('should update selected index if the last tab removed while selected', fakeAsync(() => {
       const component: MatTabGroup =
-          fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
+          fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
 
       const numberOfTabs = component._tabs.length;
       fixture.componentInstance.selectedIndex = numberOfTabs - 1;
@@ -416,7 +416,7 @@ describe('MatTabGroup', () => {
     it('should maintain the selected tab if a new tab is added', () => {
       fixture.detectChanges();
       const component: MatTabGroup =
-          fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
+          fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
 
       fixture.componentInstance.selectedIndex = 1;
       fixture.detectChanges();
@@ -436,7 +436,7 @@ describe('MatTabGroup', () => {
       fixture.detectChanges();
 
       const component: MatTabGroup =
-          fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
+          fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
 
       // Remove the first tab that is right before the selected one.
       fixture.componentInstance.tabs.splice(0, 1);
@@ -451,7 +451,7 @@ describe('MatTabGroup', () => {
     it('should be able to select a new tab after creation', fakeAsync(() => {
       fixture.detectChanges();
       const component: MatTabGroup =
-        fixture.debugElement.query(By.css('mat-tab-group')).componentInstance;
+        fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
 
       fixture.componentInstance.tabs.push({label: 'Last tab', content: 'at the end'});
       fixture.componentInstance.selectedIndex = 3;
@@ -507,7 +507,7 @@ describe('MatTabGroup', () => {
       tick();
 
       tabGroup =
-          fixture.debugElement.query(By.directive(MatTabGroup)).componentInstance as MatTabGroup;
+          fixture.debugElement.query(By.directive(MatTabGroup))!.componentInstance as MatTabGroup;
     }));
 
     it('should support a tab-group with the simple api', fakeAsync(() => {
@@ -546,7 +546,7 @@ describe('MatTabGroup', () => {
     }));
 
     it('should support setting the header position', () => {
-      let tabGroupNode = fixture.debugElement.query(By.css('mat-tab-group')).nativeElement;
+      let tabGroupNode = fixture.debugElement.query(By.css('mat-tab-group'))!.nativeElement;
 
       expect(tabGroupNode.classList).not.toContain('mat-tab-group-inverted-header');
 
@@ -569,7 +569,7 @@ describe('MatTabGroup', () => {
       tick();
       fixture.detectChanges();
 
-      const child = fixture.debugElement.query(By.css('.child'));
+      const child = fixture.debugElement.query(By.css('.child'))!;
       expect(child.nativeElement).toBeDefined();
     }));
   });
@@ -596,15 +596,15 @@ describe('MatTabGroup', () => {
     fixture.detectChanges();
 
     let tabComponent: MatTabGroup = fixture.debugElement
-        .query(By.css('mat-tab-group')).componentInstance;
+        .query(By.css('mat-tab-group'))!.componentInstance;
     expect(tabComponent.selectedIndex).toBe(expectedIndex);
 
     let tabLabelElement = fixture.debugElement
-        .query(By.css(`.mat-tab-label:nth-of-type(${expectedIndex + 1})`)).nativeElement;
+        .query(By.css(`.mat-tab-label:nth-of-type(${expectedIndex + 1})`))!.nativeElement;
     expect(tabLabelElement.classList.contains('mat-tab-label-active')).toBe(true);
 
     let tabContentElement = fixture.debugElement
-        .query(By.css(`mat-tab-body:nth-of-type(${expectedIndex + 1})`)).nativeElement;
+        .query(By.css(`mat-tab-body:nth-of-type(${expectedIndex + 1})`))!.nativeElement;
     expect(tabContentElement.classList.contains('mat-tab-body-active')).toBe(true);
   }
 

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -268,7 +268,7 @@ describe('MatTabHeader', () => {
 
         expect(appComponent.tabHeader._showPaginationControls).toBe(true);
 
-        const buttonAfter = fixture.debugElement.query(By.css('.mat-tab-header-pagination-after'));
+        const buttonAfter = fixture.debugElement.query(By.css('.mat-tab-header-pagination-after'))!;
 
         expect(fixture.nativeElement.querySelectorAll('.mat-ripple-element').length)
           .toBe(0, 'Expected no ripple to show up initially.');
@@ -287,7 +287,7 @@ describe('MatTabHeader', () => {
 
         expect(appComponent.tabHeader._showPaginationControls).toBe(true);
 
-        const buttonAfter = fixture.debugElement.query(By.css('.mat-tab-header-pagination-after'));
+        const buttonAfter = fixture.debugElement.query(By.css('.mat-tab-header-pagination-after'))!;
 
         expect(fixture.nativeElement.querySelectorAll('.mat-ripple-element').length)
           .toBe(0, 'Expected no ripple to show up initially.');

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -132,7 +132,7 @@ describe('MatTabNavBar', () => {
     });
 
     it('should mark disabled links', () => {
-      const tabLinkElement = fixture.debugElement.query(By.css('a')).nativeElement;
+      const tabLinkElement = fixture.debugElement.query(By.css('a'))!.nativeElement;
 
       expect(tabLinkElement.classList).not.toContain('mat-tab-disabled');
 
@@ -231,7 +231,7 @@ describe('MatTabNavBar', () => {
       const fixture = TestBed.createComponent(TabLinkWithNativeTabindexAttr);
     fixture.detectChanges();
 
-    const tabLink = fixture.debugElement.query(By.directive(MatTabLink))
+    const tabLink = fixture.debugElement.query(By.directive(MatTabLink))!
         .injector.get<MatTabLink>(MatTabLink);
 
     expect(tabLink.tabIndex)
@@ -242,7 +242,7 @@ describe('MatTabNavBar', () => {
     const fixture = TestBed.createComponent(TabLinkWithTabIndexBinding);
     fixture.detectChanges();
 
-    const tabLink = fixture.debugElement.query(By.directive(MatTabLink))
+    const tabLink = fixture.debugElement.query(By.directive(MatTabLink))!
         .injector.get<MatTabLink>(MatTabLink);
 
     expect(tabLink.tabIndex).toBe(0, 'Expected the tabIndex to be set to 0 by default.');
@@ -311,7 +311,7 @@ describe('MatTabNavBar', () => {
     });
 
     it('should be able to disable ripples on an individual tab link', () => {
-      const tabLinkDebug = fixture.debugElement.query(By.css('a'));
+      const tabLinkDebug = fixture.debugElement.query(By.css('a'))!;
       const tabLinkElement = tabLinkDebug.nativeElement;
       const tabLinkInstance = tabLinkDebug.injector.get<MatTabLink>(MatTabLink);
 

--- a/src/material/toolbar/toolbar.spec.ts
+++ b/src/material/toolbar/toolbar.spec.ts
@@ -22,7 +22,7 @@ describe('MatToolbar', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(ToolbarSingleRow);
       testComponent = fixture.debugElement.componentInstance;
-      toolbarElement = fixture.debugElement.query(By.css('.mat-toolbar')).nativeElement;
+      toolbarElement = fixture.debugElement.query(By.css('.mat-toolbar'))!.nativeElement;
     });
 
     it('should apply class based on color attribute', () => {

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -97,7 +97,7 @@ describe('MatTooltip', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
-      buttonDebugElement = fixture.debugElement.query(By.css('button'));
+      buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
       buttonElement = <HTMLButtonElement> buttonDebugElement.nativeElement;
       tooltipDirective = buttonDebugElement.injector.get<MatTooltip>(MatTooltip);
     });
@@ -186,7 +186,7 @@ describe('MatTooltip', () => {
 
       fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
-      tooltipDirective = fixture.debugElement.query(By.css('button'))
+      tooltipDirective = fixture.debugElement.query(By.css('button'))!
           .injector.get<MatTooltip>(MatTooltip);
 
       tooltipDirective.show();
@@ -221,7 +221,7 @@ describe('MatTooltip', () => {
 
       const newFixture = TestBed.createComponent(TooltipDemoWithoutPositionBinding);
       newFixture.detectChanges();
-      tooltipDirective = newFixture.debugElement.query(By.css('button'))
+      tooltipDirective = newFixture.debugElement.query(By.css('button'))!
           .injector.get<MatTooltip>(MatTooltip);
 
       tooltipDirective.show();
@@ -728,7 +728,7 @@ describe('MatTooltip', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(BasicTooltipDemo);
       fixture.detectChanges();
-      tooltip = fixture.debugElement.query(By.css('button')).injector.get<MatTooltip>(MatTooltip);
+      tooltip = fixture.debugElement.query(By.css('button'))!.injector.get<MatTooltip>(MatTooltip);
     });
 
     it('should set a fallback origin position by inverting the main origin position', () => {
@@ -776,7 +776,7 @@ describe('MatTooltip', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(ScrollableTooltipDemo);
       fixture.detectChanges();
-      buttonDebugElement = fixture.debugElement.query(By.css('button'));
+      buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
       tooltipDirective = buttonDebugElement.injector.get<MatTooltip>(MatTooltip);
     });
 
@@ -836,7 +836,7 @@ describe('MatTooltip', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(OnPushTooltipDemo);
       fixture.detectChanges();
-      buttonDebugElement = fixture.debugElement.query(By.css('button'));
+      buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
       buttonElement = <HTMLButtonElement> buttonDebugElement.nativeElement;
       tooltipDirective = buttonDebugElement.injector.get<MatTooltip>(MatTooltip);
     });


### PR DESCRIPTION
This is a necessary step to pass CI for https://github.com/angular/angular/pull/32365

`DebugElement.query` can return `null` in fact but its type definition doesn't include it.