### PR TITLE
build: format mdc-slider build file imports

### DIFF
--- a/src/material-experimental/mdc-slider/BUILD.bazel
+++ b/src/material-experimental/mdc-slider/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
+load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 ng_module(
     name = "mdc-slider",


### PR DESCRIPTION
When the mdc-slider change landed, the PR was not rebased on top
of the latest changes in `master`. Meaning that the buildifier alphabetical
sorting rule was not enabled and the build file now fails the sort rule in
`master`.