### PR TITLE
feat(Dialog): don't override type attribute if set on mat-dialog-close

### DIFF
--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -30,12 +30,15 @@ let dialogElementUid = 0;
   host: {
     '(click)': 'dialogRef.close(dialogResult)',
     '[attr.aria-label]': 'ariaLabel || null',
-    'type': 'button', // Prevents accidental form submits.
+    '[attr.type]': 'buttonType',
   }
 })
 export class MatDialogClose implements OnInit, OnChanges {
   /** Screenreader label for the button. */
   @Input('aria-label') ariaLabel: string;
+
+  /** Default to "button" to prevents accidental form submits. */
+  @Input('type') buttonType: 'submit' | 'button' = 'button';
 
   /** Dialog close input. */
   @Input('mat-dialog-close') dialogResult: any;

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -30,7 +30,7 @@ let dialogElementUid = 0;
   host: {
     '(click)': 'dialogRef.close(dialogResult)',
     '[attr.aria-label]': 'ariaLabel || null',
-    '[attr.type]': 'buttonType',
+    '[attr.type]': 'type',
   }
 })
 export class MatDialogClose implements OnInit, OnChanges {
@@ -38,7 +38,7 @@ export class MatDialogClose implements OnInit, OnChanges {
   @Input('aria-label') ariaLabel: string;
 
   /** Default to "button" to prevents accidental form submits. */
-  @Input('type') buttonType: 'submit' | 'button' = 'button';
+  @Input() type: 'submit' | 'button' | 'reset' = 'button';
 
   /** Dialog close input. */
   @Input('mat-dialog-close') dialogResult: any;

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -1204,10 +1204,16 @@ describe('MatDialog', () => {
         expect(button.getAttribute('aria-label')).toBe('Best close button ever');
       }));
 
-      it('should override the "type" attribute of the close button', () => {
+      it('should set the "type" attribute of the close button if not set manually', () => {
         let button = overlayContainerElement.querySelector('button[mat-dialog-close]')!;
 
         expect(button.getAttribute('type')).toBe('button');
+      });
+
+      it('should not override type attribute of the close button if set manually', () => {
+        let button = overlayContainerElement.querySelector('button.with-submit')!;
+
+        expect(button.getAttribute('type')).toBe('submit');
       });
 
       it('should return the [mat-dialog-close] result when clicking the close button',
@@ -1557,6 +1563,7 @@ class PizzaMsg {
         aria-label="Best close button ever"
         [mat-dialog-close]="true"></button>
       <div mat-dialog-close>Should not close</div>
+      <button class="with-submit" type="submit" mat-dialog-close>Should have submit</button>
     </mat-dialog-actions>
   `
 })

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -1582,6 +1582,7 @@ class ContentElementDialog {}
           aria-label="Best close button ever"
           [mat-dialog-close]="true"></button>
         <div mat-dialog-close>Should not close</div>
+        <button class="with-submit" type="submit" mat-dialog-close>Should have submit</button>
       </mat-dialog-actions>
     </ng-template>
   `

--- a/tools/public_api_guard/material/dialog.d.ts
+++ b/tools/public_api_guard/material/dialog.d.ts
@@ -49,6 +49,7 @@ export declare class MatDialogClose implements OnInit, OnChanges {
     ariaLabel: string;
     dialogRef: MatDialogRef<any>;
     dialogResult: any;
+    type: 'submit' | 'button' | 'reset';
     constructor(dialogRef: MatDialogRef<any>, _elementRef: ElementRef<HTMLElement>, _dialog: MatDialog);
     ngOnChanges(changes: SimpleChanges): void;
     ngOnInit(): void;


### PR DESCRIPTION
only default the type attribute on mat-dialog-close if it isn't set

#16909