### PR TITLE
build: fix dev app not working in IE11

### DIFF
--- a/src/dev-app/system-rxjs-operators.js
+++ b/src/dev-app/system-rxjs-operators.js
@@ -14,7 +14,9 @@
 // all rxjs files individually.
 
 if (typeof define === 'function' && define.amd) {
-  define(['exports', 'rxjs'], (exports, rxjs) => {
+  // Note that this needs to be in ES5, because we load it
+  // directly into the browser without transpiling.
+  define(['exports', 'rxjs'], function(exports, rxjs) {
     // Re-export all operators in this AMD module.
     Object.assign(exports, rxjs.operators);
   });


### PR DESCRIPTION
Fixes the dev app throwing a syntax error in IE11 because we were loading a file that has an arrow function.