### PR TITLE
docs(table): add note about MatTableDataSource usage

### DIFF
--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -34,6 +34,11 @@ const MAX_SAFE_INTEGER = 9007199254740991;
  * Allows for sort customization by overriding sortingDataAccessor, which defines how data
  * properties are accessed. Also allows for filter customization by overriding filterTermAccessor,
  * which defines how row data is converted to a string for filter matching.
+ *
+ * **Note:** This class is meant to be a simple data source to help you get started. As such
+ * it isn't equipped to handle some more advanced cases like robust i18n support or server-side
+ * interactions. If your app needs to support more advanced use cases, consider implementing your
+ * own `DataSource`.
  */
 export class MatTableDataSource<T> extends DataSource<T> {
   /** Stream that emits when a new data array is set on the data source. */


### PR DESCRIPTION
Adds a note to the `MatTableDataSource` docs to be more explicit about what the intentions behind the data source are.