### PR TITLE
fix(radio): clear aria attributes from host node

### DIFF
--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -22,6 +22,7 @@ describe('MatRadio', () => {
         InterleavedRadioGroup,
         TranscludingWrapper,
         RadioButtonWithPredefinedTabindex,
+        RadioButtonWithPredefinedAriaAttributes,
       ]
     });
 
@@ -778,6 +779,18 @@ describe('MatRadio', () => {
       expect(radioButtonEl.getAttribute('tabindex')).toBe('-1');
     });
 
+    it('should remove the aria attributes from the host element', () => {
+      const predefinedFixture = TestBed.createComponent(RadioButtonWithPredefinedAriaAttributes);
+      predefinedFixture.detectChanges();
+
+      const radioButtonEl =
+          predefinedFixture.debugElement.query(By.css('.mat-radio-button'))!.nativeElement;
+
+      expect(radioButtonEl.hasAttribute('aria-label')).toBe(false);
+      expect(radioButtonEl.hasAttribute('aria-describedby')).toBe(false);
+      expect(radioButtonEl.hasAttribute('aria-labelledby')).toBe(false);
+    });
+
   });
 
   describe('group interspersed with other tags', () => {
@@ -991,3 +1004,13 @@ class DefaultRadioButton {}
   template: `<mat-radio-button color="warn"></mat-radio-button>`
 })
 class RadioButtonWithColorBinding {}
+
+
+@Component({
+  template: `
+    <mat-radio-button
+      aria-label="Radio button"
+      aria-describedby="something"
+      aria-labelledby="something-else"></mat-radio-button>`
+})
+class RadioButtonWithPredefinedAriaAttributes {}

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -346,6 +346,9 @@ const _MatRadioButtonMixinBase:
     // Needs to be -1 so the `focus` event still fires.
     '[attr.tabindex]': '-1',
     '[attr.id]': 'id',
+    '[attr.aria-label]': 'null',
+    '[attr.aria-labelledby]': 'null',
+    '[attr.aria-describedby]': 'null',
     // Note: under normal conditions focus shouldn't land on this element, however it may be
     // programmatically set, for example inside of a focus trap, in this case we want to forward
     // the focus to the native element.


### PR DESCRIPTION
If the `aria-*` attributes are set on the host node via static bindings, we can end up with both the host and the input having the same `aria-label` which might be read out by a screen reader. These changes clear the attributes from the host.

Fixes #16913.