### PR TITLE
fix(material-experimental): add mdc-slider to mdc-theming and mdc-typography

### DIFF
--- a/src/material-experimental/mdc-theming/BUILD.bazel
+++ b/src/material-experimental/mdc-theming/BUILD.bazel
@@ -15,6 +15,7 @@ sass_library(
         "//src/material-experimental/mdc-menu:mdc_menu_scss_lib",
         "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",
         "//src/material-experimental/mdc-slide-toggle:mdc_slide_toggle_scss_lib",
+        "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
         "//src/material-experimental/mdc-tabs:mdc_tabs_scss_lib",
     ],
 )

--- a/src/material-experimental/mdc-theming/_all-theme.scss
+++ b/src/material-experimental/mdc-theming/_all-theme.scss
@@ -5,6 +5,7 @@
 @import '../mdc-menu/mdc-menu';
 @import '../mdc-radio/mdc-radio';
 @import '../mdc-slide-toggle/mdc-slide-toggle';
+@import '../mdc-slider/mdc-slider';
 @import '../mdc-tabs/mdc-tabs';
 
 @mixin angular-material-theme-mdc($theme) {
@@ -17,5 +18,6 @@
   @include mat-menu-theme-mdc($theme);
   @include mat-radio-theme-mdc($theme);
   @include mat-slide-toggle-theme-mdc($theme);
+  @include mat-slider-theme-mdc($theme);
   @include mat-tabs-theme-mdc($theme);
 }

--- a/src/material-experimental/mdc-typography/BUILD.bazel
+++ b/src/material-experimental/mdc-typography/BUILD.bazel
@@ -15,6 +15,7 @@ sass_library(
         "//src/material-experimental/mdc-menu:mdc_menu_scss_lib",
         "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",
         "//src/material-experimental/mdc-slide-toggle:mdc_slide_toggle_scss_lib",
+        "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
         "//src/material-experimental/mdc-tabs:mdc_tabs_scss_lib",
     ],
 )

--- a/src/material-experimental/mdc-typography/_all-typography.scss
+++ b/src/material-experimental/mdc-typography/_all-typography.scss
@@ -5,6 +5,7 @@
 @import '../mdc-menu/mdc-menu';
 @import '../mdc-radio/mdc-radio';
 @import '../mdc-slide-toggle/mdc-slide-toggle';
+@import '../mdc-slider/mdc-slider';
 @import '../mdc-tabs/mdc-tabs';
 
 @mixin angular-material-typography-mdc($config: null) {
@@ -17,5 +18,6 @@
   @include mat-menu-typography-mdc($config);
   @include mat-radio-typography-mdc($config);
   @include mat-slide-toggle-typography-mdc($config);
+  @include mat-slider-typography-mdc($config);
   @include mat-tabs-typography-mdc($config);
 }


### PR DESCRIPTION
Follow-up to the initial implementation of the mdc-slider prototype. This commit
adds the mdc-slider theme and typography to the `mdc-theming` and `mdc-typography`
entry-points, so that consumers don't need to include the slider styles separately.