### PR TITLE
build: dev-app should use mdc-theming and mdc-typography mixins

### DIFF
--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
-load("//:packages.bzl", "MATERIAL_EXPERIMENTAL_SCSS_LIBS")
 load("//tools:defaults.bzl", "ng_module")
 load("//tools/dev-server:index.bzl", "dev_server")
 
@@ -86,8 +85,11 @@ sass_binary(
         "external/npm/node_modules",
     ],
     deps = [
+        "//src/material-experimental/mdc-theming:all_themes",
+        "//src/material-experimental/mdc-typography:all_typography",
+        "//src/material-experimental/popover-edit:popover_edit_scss_lib",
         "//src/material/core:all_themes",
-    ] + MATERIAL_EXPERIMENTAL_SCSS_LIBS,
+    ],
 )
 
 dev_server(

--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -1,14 +1,6 @@
 @import '../material/core/theming/all-theme';
-@import '../material-experimental/mdc-button/mdc-button';
-@import '../material-experimental/mdc-card/mdc-card';
-@import '../material-experimental/mdc-checkbox/mdc-checkbox';
-@import '../material-experimental/mdc-chips/mdc-chips';
-@import '../material-experimental/mdc-helpers/mdc-helpers';
-@import '../material-experimental/mdc-menu/mdc-menu';
-@import '../material-experimental/mdc-radio/mdc-radio';
-@import '../material-experimental/mdc-slide-toggle/mdc-slide-toggle';
-@import '../material-experimental/mdc-slider/mdc-slider';
-@import '../material-experimental/mdc-tabs/mdc-tabs';
+@import '../material-experimental/mdc-theming/all-theme';
+@import '../material-experimental/mdc-typography/all-typography';
 @import '../material-experimental/popover-edit/popover-edit';
 
 // Plus imports for other components in your app.
@@ -17,17 +9,8 @@
 // have to load a single css file for Angular Material in your app.
 // **Be sure that you only ever include this mixin once!**
 @include mat-core();
-@include mat-button-typography-mdc(mat-typography-config());
-@include mat-icon-button-typography-mdc(mat-typography-config());
-@include mat-fab-typography-mdc(mat-typography-config());
-@include mat-card-typography-mdc(mat-typography-config());
-@include mat-checkbox-typography-mdc(mat-typography-config());
-@include mat-chips-typography-mdc(mat-typography-config());
-@include mat-menu-typography-mdc(mat-typography-config());
-@include mat-radio-typography-mdc(mat-typography-config());
-@include mat-slide-toggle-typography-mdc(mat-typography-config());
-@include mat-slider-typography-mdc(mat-typography-config());
-@include mat-tabs-typography-mdc(mat-typography-config());
+@include angular-material-typography-mdc();
+@include mat-edit-typography(mat-typography-config());
 
 // Define the default theme (same as the example above).
 $candy-app-primary: mat-palette($mat-indigo);
@@ -36,19 +19,9 @@ $candy-app-theme: mat-light-theme($candy-app-primary, $candy-app-accent);
 
 // Include the default theme styles.
 @include angular-material-theme($candy-app-theme);
-@include mat-button-theme-mdc($candy-app-theme);
-@include mat-icon-button-theme-mdc($candy-app-theme);
-@include mat-fab-theme-mdc($candy-app-theme);
-@include mat-card-theme-mdc($candy-app-theme);
-@include mat-checkbox-theme-mdc($candy-app-theme);
-@include mat-chips-theme-mdc($candy-app-theme);
-@include mat-menu-theme-mdc($candy-app-theme);
-@include mat-radio-theme-mdc($candy-app-theme);
-@include mat-slide-toggle-theme-mdc($candy-app-theme);
-@include mat-slider-theme-mdc($candy-app-theme);
-@include mat-tabs-theme-mdc($candy-app-theme);
+@include angular-material-theme-mdc($candy-app-theme);
 @include mat-popover-edit-theme($candy-app-theme);
-@include mat-edit-typography(mat-typography-config());
+
 // Define an alternate dark theme.
 $dark-primary: mat-palette($mat-blue-grey);
 $dark-accent: mat-palette($mat-amber, A200, A100, A400);
@@ -61,16 +34,6 @@ $dark-theme: mat-dark-theme($dark-primary, $dark-accent, $dark-warn);
 // default theme.
 .demo-unicorn-dark-theme {
   @include angular-material-theme($dark-theme);
-  @include mat-button-theme-mdc($dark-theme);
-  @include mat-icon-button-theme-mdc($dark-theme);
-  @include mat-fab-theme-mdc($dark-theme);
-  @include mat-card-theme-mdc($dark-theme);
-  @include mat-checkbox-theme-mdc($dark-theme);
-  @include mat-chips-theme-mdc($dark-theme);
-  @include mat-menu-theme-mdc($dark-theme);
-  @include mat-radio-theme-mdc($dark-theme);
-  @include mat-slide-toggle-theme-mdc($dark-theme);
-  @include mat-slider-theme-mdc($dark-theme);
-  @include mat-tabs-theme-mdc($dark-theme);
+  @include angular-material-theme-mdc($dark-theme);
   @include mat-popover-edit-theme($dark-theme);
 }

--- a/src/material-experimental/mdc-typography/_all-typography.scss
+++ b/src/material-experimental/mdc-typography/_all-typography.scss
@@ -8,6 +8,10 @@
 @import '../mdc-tabs/mdc-tabs';
 
 @mixin angular-material-typography-mdc($config: null) {
+  @if $config == null {
+    $config: mat-typography-config();
+  }
+
   @include mat-button-typography-mdc($config);
   @include mat-fab-typography-mdc($config);
   @include mat-icon-button-typography-mdc($config);


### PR DESCRIPTION
Instead of bringing in all theme and typography mixins manually, the dev-app
should use the mdc-theming and mdc-typography mixins. This ensures that
all themes for prototypes are properly added to the `all_theme` and `all_typography`
files.