### PR TITLE
docs: getting-started guide should not recommend primary entry-point

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -53,7 +53,7 @@ Let's display a slider component in your app and verify that everything works.
 You need to import the `MatSliderModule` that you want to display by adding the following lines to your app.module.ts file.
 
 ```ts
-import { MatSliderModule } from '@angular/material';
+import { MatSliderModule } from '@angular/material/slider';
 …
 @NgModule ({....
   imports: [...,


### PR DESCRIPTION
Currently it looks like the getting-started guide recommends using the
primary entry-point for importing the slider module. Instead we should
use the secondary entry-point to align the guide with the upcoming V9
breaking change.

Also adds a new line to the end of the file.