### PR TITLE
feat(sort): remove hammer dependency

### DIFF
--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -76,7 +76,6 @@ interface MatSortHeaderColumnDef {
   host: {
     '(click)': '_handleClick()',
     '(mouseenter)': '_setIndicatorHintVisible(true)',
-    '(longpress)': '_setIndicatorHintVisible(true)',
     '(mouseleave)': '_setIndicatorHintVisible(false)',
     '[attr.aria-sort]': '_getAriaSortAttribute()',
     '[class.mat-sort-header-disabled]': '_isDisabled()',


### PR DESCRIPTION
These changes remove the dependency on Hammer.js from the `matSortHeader`. I decided to remove the `longpress` gesture, rather than implement it with vanilla JS, because it doesn't look like it's worth the trouble. The gesture was meant to show the hover indication if the user holds their pointer on the header, however the touch area is so small that it's most likely that the user won't be able to see the hover indication anyway, because it'll be under their finger. Furthermore, there's nothing indicating to the user that they can long press this element.