### PR TITLE
feat(material-experimental/button): anchor disabled state

### DIFF
--- a/src/dev-app/mdc-button/mdc-button-demo.html
+++ b/src/dev-app/mdc-button/mdc-button-demo.html
@@ -12,6 +12,18 @@
       <mat-icon>check</mat-icon>
     </button>
   </section>
+  <section>
+    <button mat-button disabled>normal</button>
+    <button mat-raised-button disabled>raised</button>
+    <button mat-stroked-button disabled>stroked</button>
+    <button mat-flat-button disabled>flat</button>
+    <button mat-fab disabled>
+      <mat-icon>check</mat-icon>
+    </button>
+    <button mat-mini-fab disabled>
+      <mat-icon>check</mat-icon>
+    </button>
+  </section>
 
   <h4 class="demo-section-header">Anchors</h4>
   <section>
@@ -23,6 +35,18 @@
       <mat-icon>check</mat-icon>
     </a>
     <a href="//www.google.com" mat-mini-fab>
+      <mat-icon>check</mat-icon>
+    </a>
+  </section>
+  <section>
+    <a href="//www.google.com" disabled mat-button color="primary">SEARCH</a>
+    <a href="//www.google.com" disabled mat-raised-button>SEARCH</a>
+    <a href="//www.google.com" disabled mat-stroked-button color="primary">SEARCH</a>
+    <a href="//www.google.com" disabled mat-flat-button>SEARCH</a>
+    <a href="//www.google.com" disabled mat-fab>
+      <mat-icon>check</mat-icon>
+    </a>
+    <a href="//www.google.com" disabled mat-mini-fab>
       <mat-icon>check</mat-icon>
     </a>
   </section>

--- a/src/material-experimental/mdc-button/_button-base.scss
+++ b/src/material-experimental/mdc-button/_button-base.scss
@@ -16,6 +16,9 @@
 
 // MDC's disabled buttons define a default cursor with pointer-events none. However, they select
 // :disabled for this, which does not affect anchor tags.
+// TODO(andrewseguin): Discuss with the MDC team about a mixin we can call for applying this style,
+// and note that having pointer-events may have unintended side-effects, e.g. allowing the user
+// to click the target underneath the button.
 @mixin _mat-button-disabled() {
   &[disabled] {
     cursor: default;

--- a/src/material-experimental/mdc-button/_button-base.scss
+++ b/src/material-experimental/mdc-button/_button-base.scss
@@ -13,3 +13,12 @@
     @content;
   }
 }
+
+// MDC's disabled buttons define a default cursor with pointer-events none. However, they select
+// :disabled for this, which does not affect anchor tags.
+@mixin _mat-button-disabled() {
+  &[disabled] {
+    cursor: default;
+    pointer-events: none;
+  }
+}

--- a/src/material-experimental/mdc-button/_mdc-button.scss
+++ b/src/material-experimental/mdc-button/_mdc-button.scss
@@ -15,6 +15,8 @@
 // MDC adds theme color by using :not(:disabled), so just using [disabled] once will not
 // override this, neither will it apply to anchor tags. This needs to override the
 // previously set theme color, so it must be ordered after the theme styles.
+// TODO(andrewseguin): Discuss with the MDC team to see if we can avoid the :not(:disabled) by
+// manually styling disabled buttons with a [disabled] selector.
 @mixin _mat-button-apply-disabled-style() {
   &[disabled][disabled] {
     @content;
@@ -22,7 +24,9 @@
 }
 
 // Applies the disabled theme background color for raised buttons. Value is taken from
-// mixin `mdc-button--filled`
+// mixin `mdc-button--filled`.
+// TODO(andrewseguin): Discuss with the MDC team about providing a variable for the 0.12 value
+// or otherwise have a mixin we can call to apply this style for both button and anchors.
 @mixin _mat-button-disabled-background() {
   @include mdc-theme-prop(background-color, rgba(mdc-theme-prop-value(on-surface), 0.12));
 }

--- a/src/material-experimental/mdc-button/_mdc-button.scss
+++ b/src/material-experimental/mdc-button/_mdc-button.scss
@@ -1,8 +1,22 @@
 @import '@material/button/mixins';
+@import '@material/button/variables';
 @import '@material/fab/mixins';
 @import '@material/ripple/mixins';
 @import '@material/icon-button/mixins';
 @import '../mdc-helpers/mdc-helpers';
+
+// Applies the disabled theme color to the text color.
+@mixin _mat-button-disabled-color() {
+  @include mdc-theme-prop(color,
+      mdc-theme-ink-color-for-fill_(disabled, $mdc-theme-background));
+}
+
+// Applies the disabled theme background color for raised buttons. Value is taken from
+// mixin `mdc-button--filled`
+@mixin _mat-button-disabled-background() {
+  @include mdc-theme-prop(background-color, rgba(mdc-theme-prop-value(on-surface), 0.12));
+}
+
 
 @mixin mat-button-theme-mdc($theme) {
   @include mat-using-mdc-theme($theme) {
@@ -39,6 +53,10 @@
         @include mdc-button-ink-color(on-error, $query: $mat-theme-styles-query);
         @include mdc-states-base-color(on-error, $query: $mat-theme-styles-query);
       }
+
+      &[disabled][disabled] {
+        @include _mat-button-disabled-background();
+      }
     }
 
     .mat-mdc-outlined-button {
@@ -48,6 +66,26 @@
 
       &.mat-warn {
         @include mdc-button-outline-color(error, $query: $mat-theme-styles-query);
+      }
+
+      &[disabled][disabled] {
+        @include mdc-theme-prop(border-color,
+            mdc-theme-ink-color-for-fill_(disabled, $mdc-theme-background));
+      }
+    }
+
+    .mat-mdc-raised-button {
+      &[disabled][disabled] {
+        @include mdc-elevation(0, $query: $mat-theme-styles-query);
+      }
+    }
+
+    // MDC adds theme color by using :not(:disabled), so just using [disabled] once will not
+    // override this and also will not apply to anchor tags. This needs to override the
+    // previously set theme color, so it must be ordered after the theme styles.
+    .mat-mdc-button, .mat-mdc-raised-button, .mat-mdc-unelevated-button, .mat-mdc-outlined-button {
+      &[disabled][disabled] {
+        @include _mat-button-disabled-color();
       }
     }
 
@@ -78,6 +116,12 @@
         @include mdc-fab-container-color(error, $query: $mat-theme-styles-query);
         @include mdc-fab-ink-color(on-error, $query: $mat-theme-styles-query);
       }
+
+      &[disabled][disabled] {
+        @include _mat-button-disabled-color();
+        @include _mat-button-disabled-background();
+        @include mdc-elevation(0, $query: $mat-theme-styles-query);
+      }
     }
 
     @include mdc-fab-without-ripple($query: $mat-theme-styles-query);
@@ -105,6 +149,10 @@
       &.mat-warn {
         @include mdc-states-base-color(error, $query: $mat-theme-styles-query);
         @include mdc-icon-button-ink-color(error, $query: $mat-theme-styles-query);
+      }
+
+      &[disabled][disabled] {
+        @include _mat-button-disabled-color();
       }
     }
 

--- a/src/material-experimental/mdc-button/_mdc-button.scss
+++ b/src/material-experimental/mdc-button/_mdc-button.scss
@@ -11,6 +11,16 @@
       mdc-theme-ink-color-for-fill_(disabled, $mdc-theme-background));
 }
 
+// Wraps the content style in a selector for the disabled state.
+// MDC adds theme color by using :not(:disabled), so just using [disabled] once will not
+// override this, neither will it apply to anchor tags. This needs to override the
+// previously set theme color, so it must be ordered after the theme styles.
+@mixin _mat-button-apply-disabled-style() {
+  &[disabled][disabled] {
+    @content;
+  }
+}
+
 // Applies the disabled theme background color for raised buttons. Value is taken from
 // mixin `mdc-button--filled`
 @mixin _mat-button-disabled-background() {
@@ -54,7 +64,7 @@
         @include mdc-states-base-color(on-error, $query: $mat-theme-styles-query);
       }
 
-      &[disabled][disabled] {
+      @include _mat-button-apply-disabled-style() {
         @include _mat-button-disabled-background();
       }
     }
@@ -68,23 +78,20 @@
         @include mdc-button-outline-color(error, $query: $mat-theme-styles-query);
       }
 
-      &[disabled][disabled] {
+      @include _mat-button-apply-disabled-style() {
         @include mdc-theme-prop(border-color,
             mdc-theme-ink-color-for-fill_(disabled, $mdc-theme-background));
       }
     }
 
     .mat-mdc-raised-button {
-      &[disabled][disabled] {
+      @include _mat-button-apply-disabled-style() {
         @include mdc-elevation(0, $query: $mat-theme-styles-query);
       }
     }
 
-    // MDC adds theme color by using :not(:disabled), so just using [disabled] once will not
-    // override this and also will not apply to anchor tags. This needs to override the
-    // previously set theme color, so it must be ordered after the theme styles.
     .mat-mdc-button, .mat-mdc-raised-button, .mat-mdc-unelevated-button, .mat-mdc-outlined-button {
-      &[disabled][disabled] {
+      @include _mat-button-apply-disabled-style() {
         @include _mat-button-disabled-color();
       }
     }
@@ -117,7 +124,7 @@
         @include mdc-fab-ink-color(on-error, $query: $mat-theme-styles-query);
       }
 
-      &[disabled][disabled] {
+      @include _mat-button-apply-disabled-style() {
         @include _mat-button-disabled-color();
         @include _mat-button-disabled-background();
         @include mdc-elevation(0, $query: $mat-theme-styles-query);
@@ -151,7 +158,7 @@
         @include mdc-icon-button-ink-color(error, $query: $mat-theme-styles-query);
       }
 
-      &[disabled][disabled] {
+      @include _mat-button-apply-disabled-style() {
         @include _mat-button-disabled-color();
       }
     }

--- a/src/material-experimental/mdc-button/button-base.ts
+++ b/src/material-experimental/mdc-button/button-base.ts
@@ -122,7 +122,9 @@ export const MAT_ANCHOR_INPUTS = ['disabled', 'disableRipple', 'color', 'tabInde
 
 /** Shared host configuration for buttons using the `<a>` tag. */
 export const MAT_ANCHOR_HOST = {
-  ...MAT_BUTTON_HOST,
+  '[attr.disabled]': 'disabled || null',
+  '[class._mat-animation-noopable]': '_animationMode === "NoopAnimations"',
+
   // Note that we ignore the user-specified tabindex when it's disabled for
   // consistency with the `mat-button` applied on native buttons where even
   // though they have an index, they're not tabbable.

--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -16,5 +16,5 @@
   }
 
   @include _mat-button-interactive();
+  @include _mat-button-disabled();
 }
-

--- a/src/material-experimental/mdc-button/fab.scss
+++ b/src/material-experimental/mdc-button/fab.scss
@@ -8,15 +8,7 @@
 
 .mat-mdc-fab, .mat-mdc-mini-fab {
   @include _mat-button-interactive();
-
-  // Spec does not define disabled FAB buttons but Angular Material does support it.
-  &:disabled {
-    background-color: rgba(mdc-theme-prop-value(on-surface), 0.12);
-    color: $mdc-button-disabled-ink-color;
-    cursor: default;
-    pointer-events: none;
-    box-shadow: none;
-  }
+  @include _mat-button-disabled();
 }
 
 .mat-mdc-fab, .mat-mdc-mini-fab {

--- a/src/material-experimental/mdc-button/icon-button.scss
+++ b/src/material-experimental/mdc-button/icon-button.scss
@@ -12,4 +12,5 @@
   // Border radius is inherited by ripple to know its shape. Set to 50% so the ripple is round.
   border-radius: 50%;
 
+  @include _mat-button-disabled();
 }


### PR DESCRIPTION
Manually style buttons as disabled:
 - MDC does not apply disabled style to anchor buttons
 - MDC does not apply the right styles for the dark theme