### PR TITLE
fix(drag-drop): drop list ref sorting disabled by default

### DIFF
--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -90,7 +90,7 @@ export class DropListRef<T = any> {
   disabled: boolean = false;
 
   /** Whether sorting items within the list is disabled. */
-  sortingDisabled: boolean = true;
+  sortingDisabled: boolean = false;
 
   /** Locks the position of the draggable elements inside the container along the specified axis. */
   lockAxis: 'x' | 'y';


### PR DESCRIPTION
It looks like something I overlooked when I first implemented the `sortingDisabled` flag. Currently it's set to `true` by default which means that sorting won't work unless users opt into it.

Fixes #16961.