### PR TITLE
build: add mdc prebuilt theme to karma legacy tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -55,9 +55,15 @@ module.exports = config => {
       {pattern: 'test/karma-system-config.js', included: true, watched: false},
       {pattern: 'test/karma-test-shim.js', included: true, watched: false},
 
-      // Include a Material theme in the test suite.
+      // Include a Material theme in the test suite. Also include the MDC theme as
+      // karma runs tests for the MDC prototype components as well.
       {
         pattern: 'dist/packages/**/core/theming/prebuilt/indigo-pink.css',
+        included: true,
+        watched: true
+      },
+      {
+        pattern: 'dist/packages/material-experimental/mdc-theming/prebuilt/indigo-pink.css',
         included: true,
         watched: true
       },


### PR DESCRIPTION
Adds the MDC prebuilt theme to the karma legacy tests. This is
consistent with what we did for the Bazel tests. It can cause
unexpected differences and confusion when debugging tests in
both Bazel and the legacy job (different visual output).