### PR TITLE
build: do not include material prebuilt theme twice in legacy tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -58,7 +58,7 @@ module.exports = config => {
       // Include a Material theme in the test suite. Also include the MDC theme as
       // karma runs tests for the MDC prototype components as well.
       {
-        pattern: 'dist/packages/**/core/theming/prebuilt/indigo-pink.css',
+        pattern: 'dist/packages/material/core/theming/prebuilt/indigo-pink.css',
         included: true,
         watched: true
       },


### PR DESCRIPTION
Just something I noticed while investigating the MDC slider test failures on Edge BS..

Apparently we include the Angular Material prebuilt theme twice in the
legacy Karma tests. This is because we also generate a second folder
called `esm5` in the package output (for later use in the release
composing step). This folder also contains the prebuilt themes as
a side-effect of copying the assets for esm5 inlining/bundling.

In any case, we should not import the theme using a glob, but rather
use an explicit path (similar to how we do it for the mdc theme).