### PR TITLE
build: add more linting around async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "ts-api-guardian": "^0.4.6",
     "ts-node": "^3.0.4",
     "tsconfig-paths": "^2.3.0",
-    "tslint": "^5.18.0",
+    "tslint": "^5.19.0",
     "tsutils": "^3.0.0",
     "typescript": "3.5.3",
     "uglify-js": "^2.8.14"

--- a/src/cdk-experimental/testing/tests/protractor.e2e.spec.ts
+++ b/src/cdk-experimental/testing/tests/protractor.e2e.spec.ts
@@ -12,11 +12,11 @@ describe('ProtractorHarnessEnvironment', () => {
   describe('HarnessLoader', () => {
     let loader: HarnessLoader;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       loader = ProtractorHarnessEnvironment.loader();
     });
 
-    it('should create HarnessLoader', async () => {
+    it('should create HarnessLoader', () => {
       expect(loader).not.toBeNull();
     });
 

--- a/src/cdk-experimental/testing/tests/testbed.spec.ts
+++ b/src/cdk-experimental/testing/tests/testbed.spec.ts
@@ -21,11 +21,11 @@ describe('TestbedHarnessEnvironment', () => {
   describe('HarnessLoader', () => {
     let loader: HarnessLoader;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       loader = TestbedHarnessEnvironment.loader(fixture);
     });
 
-    it('should create HarnessLoader from fixture', async () => {
+    it('should create HarnessLoader from fixture', () => {
       expect(loader).not.toBeNull();
     });
 

--- a/src/material-experimental/mdc-chips/harness/chip-grid-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-grid-harness.spec.ts
@@ -34,7 +34,7 @@ describe('MatChipGridHarness', () => {
   it('should get the chip input harness', async () => {
     const harnesses = await loader.getAllHarnesses(MatChipGridHarness);
     const input = await harnesses[0].getTextInput();
-    expect(await input).not.toBe(null);
+    expect(input).not.toBe(null);
   });
 });
 

--- a/src/material-experimental/mdc-chips/harness/chip-listbox-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/harness/chip-listbox-harness.spec.ts
@@ -30,11 +30,11 @@ describe('MatChipListboxHarness', () => {
     expect ((await harnesses[0].getOptions()).length).toBe(4);
   });
 
-  describe('should get selection', async () => {
+  describe('should get selection', () => {
     it('with no selected options', async () => {
       const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
       const selectedOption = await harnesses[0].getSelected();
-      expect(await selectedOption.length).toBe(0);
+      expect(selectedOption.length).toBe(0);
     });
 
     it('with a single selected option', async () => {
@@ -43,7 +43,7 @@ describe('MatChipListboxHarness', () => {
 
       const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
       const selectedOption = await harnesses[0].getSelected();
-      expect(await selectedOption.length).toBe(1);
+      expect(selectedOption.length).toBe(1);
       expect(await selectedOption[0].getText()).toContain('Blue');
     });
 
@@ -55,7 +55,7 @@ describe('MatChipListboxHarness', () => {
 
       const harnesses = (await loader.getAllHarnesses(MatChipListboxHarness));
       const selectedOption = await harnesses[0].getSelected();
-      expect(await selectedOption.length).toBe(2);
+      expect(selectedOption.length).toBe(2);
       expect(await selectedOption[0].getText()).toContain('Blue');
       expect(await selectedOption[1].getText()).toContain('Green');
     });

--- a/src/material/icon/icon.spec.ts
+++ b/src/material/icon/icon.spec.ts
@@ -936,7 +936,7 @@ describe('MatIcon without HttpClientModule', () => {
     sanitizer = ds;
   }));
 
-  it('should throw an error when trying to load a remote icon', async() => {
+  it('should throw an error when trying to load a remote icon', () => {
     const expectedError = wrappedErrorMessage(getMatIconNoHttpProviderError());
 
     expect(() => {

--- a/tslint.json
+++ b/tslint.json
@@ -81,10 +81,11 @@
     ],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.
     "linebreak-style": [true, "LF"],
-    // Namespaces are no allowed, because of Closure compiler.
+    // Namespaces are not allowed, because of Closure compiler.
     "no-namespace": true,
     "jsdoc-format": [true, "check-multiline-start"],
     "no-duplicate-imports": true,
+    "await-promise": true,
 
     // Codelyzer
     "template-banana-in-box": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11847,10 +11847,10 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint@^5.18.0:
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.18.0.tgz#f61a6ddcf372344ac5e41708095bbf043a147ac6"
-  integrity sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==
+tslint@^5.19.0:
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.19.0.tgz#a2cbd4a7699386da823f6b499b8394d6c47bb968"
+  integrity sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"


### PR DESCRIPTION
Given that we'll be using async/await a lot more because of the test harnesses, these changes enable the `await-promise` rule which ensures that the value that is being `await`-ed is a promise.