### PR TITLE
refactor(mdc-chips): Base isEmptyInput check on chipInput value.

### DIFF
--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -514,9 +514,8 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
 
   /** Returns true if element is an input with no value. */
   private _isEmptyInput(element: HTMLElement): boolean {
-    if (element && element.nodeName.toLowerCase() === 'input') {
-      let input = element as HTMLInputElement;
-      return !input.value;
+    if (element && element.id === this._chipInput!.id) {
+      return this._chipInput.empty;
     }
 
     return false;


### PR DESCRIPTION
Ensures that grids using custom input elements don't break on _isEmptyInput checks. (empty() in chip-input.ts uses the same !input.value logic, so there's no change for existing implementations.)