### PR TITLE
feat(material-experimental): add test harness for mdc-slider

### DIFF
--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -87,6 +87,9 @@ export class MatSliderChange {
     '[class.mat-slider-has-ticks]': 'tickInterval !== 0',
     '[class.mdc-slider--display-markers]': 'tickInterval !== 0',
     '[class.mat-slider-thumb-label-showing]': 'thumbLabel',
+    // Class binding which is only used by the test harness as there is no other
+    // way for the harness to detect if mouse coordinates need to be inverted.
+    '[class.mat-slider-invert-mouse-coords]': '_isRtl()',
     '[class.mat-slider-disabled]': 'disabled',
     '[class.mat-primary]': 'color == "primary"',
     '[class.mat-accent]': 'color == "accent"',
@@ -295,7 +298,7 @@ export class MatSlider implements AfterViewInit, OnChanges, OnDestroy, ControlVa
           this._trackMarker.nativeElement.style.setProperty(
               'background', this._getTrackMarkersBackground(min, max, step));
         },
-    isRTL: () => this._dir && this._dir.value === 'rtl',
+    isRTL: () => this._isRtl(),
   };
 
   /** Instance of the MDC slider foundation for this slider. */
@@ -359,9 +362,12 @@ export class MatSlider implements AfterViewInit, OnChanges, OnDestroy, ControlVa
       // These bindings cannot be synced in the foundation, as the foundation is not
       // initialized and they cause DOM globals to be accessed (to move the thumb)
       this._syncStep();
-      this._syncValue();
       this._syncMax();
       this._syncMin();
+
+      // Note that "value" needs to be synced after "max" and "min" because otherwise
+      // the value will be clamped by the MDC foundation implementation.
+      this._syncValue();
     }
 
     this._syncDisabled();
@@ -492,6 +498,11 @@ export class MatSlider implements AfterViewInit, OnChanges, OnDestroy, ControlVa
   /** Syncs the "disabled" input value with the MDC foundation. */
   private _syncDisabled() {
     this._foundation.setDisabled(this.disabled);
+  }
+
+  /** Whether the slider is displayed in RTL-mode. */
+  _isRtl(): boolean {
+    return this._dir && this._dir.value === 'rtl';
   }
 
   /**

--- a/src/material-experimental/mdc-slider/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-slider/testing/BUILD.bazel
@@ -1,0 +1,40 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material-experimental/mdc-slider/testing",
+    deps = [
+        "//src/cdk/coercion",
+        "//src/cdk/testing",
+        "//src/material/slider/testing",
+        "@npm//rxjs",
+        "@npm//zone.js",
+    ],
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":testing",
+        "//src/material-experimental/mdc-slider",
+        "//src/material/slider/testing:harness_tests_lib",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    static_files = [
+        "@npm//:node_modules/@material/slider/dist/mdc.slider.js",
+    ],
+    deps = [
+        ":unit_tests_lib",
+        "//src/material-experimental:mdc_require_config.js",
+    ],
+)

--- a/src/material-experimental/mdc-slider/testing/index.ts
+++ b/src/material-experimental/mdc-slider/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-slider/testing/public-api.ts
+++ b/src/material-experimental/mdc-slider/testing/public-api.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './slider-harness';

--- a/src/material-experimental/mdc-slider/testing/slider-harness.spec.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-harness.spec.ts
@@ -1,0 +1,10 @@
+import {runHarnessTests} from '@angular/material/slider/testing/shared.spec';
+import {MatSliderModule} from '../index';
+import {MatSliderHarness} from './slider-harness';
+
+describe('MDC-based MatSliderHarness', () => {
+  runHarnessTests(MatSliderModule, MatSliderHarness as any, {
+    supportsVertical: false,
+    supportsInvert: false,
+  });
+});

--- a/src/material/slider/testing/slider-harness.spec.ts
+++ b/src/material/slider/testing/slider-harness.spec.ts
@@ -3,5 +3,8 @@ import {runHarnessTests} from '@angular/material/slider/testing/shared.spec';
 import {MatSliderHarness} from './slider-harness';
 
 describe('Non-MDC-based MatSliderHarness', () => {
-  runHarnessTests(MatSliderModule, MatSliderHarness);
+  runHarnessTests(MatSliderModule, MatSliderHarness, {
+    supportsInvert: true,
+    supportsVertical: true,
+  });
 });


### PR DESCRIPTION
* Adds a test harness for the mdc-slider that complies with the
standard Angular Material slider test harness.