### PR TITLE
feat(cdk/testing): add `loaderForDocumentRoot` method to `TestbedHarnessEnvironment`

### DIFF
--- a/src/cdk-experimental/testing/testbed/testbed-harness-environment.ts
+++ b/src/cdk-experimental/testing/testbed/testbed-harness-environment.ts
@@ -14,13 +14,18 @@ import {UnitTestElement} from './unit-test-element';
 
 /** A `HarnessEnvironment` implementation for Angular's Testbed. */
 export class TestbedHarnessEnvironment extends HarnessEnvironment<Element> {
-  constructor(rawRootElement: Element, private _fixture: ComponentFixture<unknown>) {
+  protected constructor(rawRootElement: Element, private _fixture: ComponentFixture<unknown>) {
     super(rawRootElement);
   }
 
   /** Creates a `HarnessLoader` rooted at the given fixture's root element. */
   static loader(fixture: ComponentFixture<unknown>): HarnessLoader {
     return new TestbedHarnessEnvironment(fixture.nativeElement, fixture);
+  }
+
+  /** Creates a `HarnessLoader` rooted at the document root element. */
+  static loaderForDocumentRoot(fixture: ComponentFixture<unknown>): HarnessLoader {
+    return new TestbedHarnessEnvironment(document.body, fixture);
   }
 
   /**

--- a/src/material-experimental/mdc-dialog/harness/dialog-harness-filters.ts
+++ b/src/material-experimental/mdc-dialog/harness/dialog-harness-filters.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
- import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
+import {BaseHarnessFilters} from '@angular/cdk-experimental/testing';
 
 export interface DialogHarnessFilters extends BaseHarnessFilters {}

--- a/src/material-experimental/mdc-dialog/harness/dialog-harness.spec.ts
+++ b/src/material-experimental/mdc-dialog/harness/dialog-harness.spec.ts
@@ -22,7 +22,7 @@ describe('MatDialogHarness', () => {
 
       fixture = TestBed.createComponent(DialogHarnessTest);
       fixture.detectChanges();
-      loader = new TestbedHarnessEnvironment(document.body, fixture);
+      loader = TestbedHarnessEnvironment.loaderForDocumentRoot(fixture);
       dialogHarness = MatDialogHarness;
     });
 


### PR DESCRIPTION
This should have been included as part of #16709, but got overlooked
somehow