### PR TITLE
fix(progress-spinner): animation node inserted into wrong style root when using ngIf with ShadowDom encapsulation

### DIFF
--- a/src/material/progress-spinner/BUILD.bazel
+++ b/src/material/progress-spinner/BUILD.bazel
@@ -51,6 +51,7 @@ ng_test_library(
     deps = [
         ":progress-spinner",
         "//src/cdk/platform",
+        "@npm//@angular/common",
         "@npm//@angular/platform-browser",
     ],
 )

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -1,7 +1,8 @@
 import {TestBed, async, inject} from '@angular/core/testing';
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component, ViewEncapsulation, ViewChild, ElementRef} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {Platform} from '@angular/cdk/platform';
+import {CommonModule} from '@angular/common';
 import {_getShadowRoot} from './progress-spinner';
 import {
   MatProgressSpinnerModule,
@@ -14,7 +15,7 @@ describe('MatProgressSpinner', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MatProgressSpinnerModule],
+      imports: [MatProgressSpinnerModule, CommonModule],
       declarations: [
         BasicProgressSpinner,
         IndeterminateProgressSpinner,
@@ -25,6 +26,7 @@ describe('MatProgressSpinner', () => {
         SpinnerWithColor,
         ProgressSpinnerWithStringValues,
         IndeterminateSpinnerInShadowDom,
+        IndeterminateSpinnerInShadowDomWithNgIf,
       ],
     }).compileComponents();
   }));
@@ -404,6 +406,28 @@ describe('MatProgressSpinner', () => {
     expect(shadowRoot.querySelectorAll('style[mat-spinner-animation="61"]').length).toBe(1);
   });
 
+  it('should add the indeterminate animation style tag to the Shadow root if the element is ' +
+    'inside an ngIf', () => {
+      // The test is only relevant in browsers that support Shadow DOM.
+      if (!supportsShadowDom) {
+        return;
+      }
+
+      const fixture = TestBed.createComponent(IndeterminateSpinnerInShadowDomWithNgIf);
+      fixture.componentInstance.diameter = 27;
+      fixture.detectChanges();
+
+      const spinner = fixture.componentInstance.spinner.nativeElement;
+      const shadowRoot = _getShadowRoot(spinner, document) as HTMLElement;
+
+      expect(shadowRoot.querySelector('style[mat-spinner-animation="27"]')).toBeTruthy();
+
+      fixture.componentInstance.diameter = 15;
+      fixture.detectChanges();
+
+      expect(shadowRoot.querySelector('style[mat-spinner-animation="27"]')).toBeTruthy();
+    });
+
 });
 
 
@@ -454,3 +478,19 @@ class ProgressSpinnerWithStringValues { }
 class IndeterminateSpinnerInShadowDom {
   diameter: number;
 }
+
+@Component({
+  template: `
+    <div *ngIf="true">
+      <mat-progress-spinner mode="indeterminate" [diameter]="diameter"></mat-progress-spinner>
+    </div>
+  `,
+  encapsulation: ViewEncapsulation.ShadowDom,
+})
+class IndeterminateSpinnerInShadowDomWithNgIf {
+  @ViewChild(MatProgressSpinner, {read: ElementRef, static: false})
+  spinner: ElementRef<HTMLElement>;
+
+  diameter: number;
+}
+

--- a/tools/public_api_guard/material/progress-spinner.d.ts
+++ b/tools/public_api_guard/material/progress-spinner.d.ts
@@ -2,7 +2,7 @@ export declare const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatPro
 
 export declare function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinnerDefaultOptions;
 
-export declare class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements CanColor {
+export declare class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements OnInit, CanColor {
     readonly _circleRadius: number;
     readonly _circleStrokeWidth: number;
     _elementRef: ElementRef<HTMLElement>;
@@ -15,6 +15,7 @@ export declare class MatProgressSpinner extends _MatProgressSpinnerMixinBase imp
     strokeWidth: number;
     value: number;
     constructor(_elementRef: ElementRef<HTMLElement>, platform: Platform, _document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
+    ngOnInit(): void;
 }
 
 export interface MatProgressSpinnerDefaultOptions {


### PR DESCRIPTION
If the progress spinner is inside the shadow DOM, we attach the `style` tag with the animation to the shadow root, however since we do the insertion inside the constructor, the spinner might not have been moved into the shadow root yet. These changes move the logic into `ngOnInit` which fires late enough for the node to be in the correct place.