### PR TITLE
ci: move to latest lock-closed commit for github action

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -9,7 +9,7 @@ jobs:
   lock_closed:
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@14ebea5
+      - uses: angular/dev-infra/github-actions/lock-closed@7f7ef07
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}
-          locks-per-execution: 250
+          locks-per-execution: 100


### PR DESCRIPTION
Moving to 100 locks per run as the latest commit of the lock-closed github action only allows for 100 per run.

Previously, the action was only performing 100 locks per run anyway, this is simply updating our config to match 