### PR TITLE
build: move edge browser test to saucelabs

### DIFF
--- a/test/browser-providers.js
+++ b/test/browser-providers.js
@@ -19,7 +19,7 @@ const browserConfig = {
   'IE9':               { unitTest: {target: null, }},
   'IE10':              { unitTest: {target: null, }},
   'IE11':              { unitTest: {target: null, }},
-  'Edge':              { unitTest: {target: 'browserstack', }},
+  'Edge':              { unitTest: {target: 'saucelabs', }},
   'Android4.1':        { unitTest: {target: null, }},
   'Android4.2':        { unitTest: {target: null, }},
   'Android4.3':        { unitTest: {target: null, }},


### PR DESCRIPTION
Browserstack Edge is currently very flaky and we don't seem
to be able to fix the flakiness on our end. Recording and debugging
live browserstack instances doesn't seem to help and the behavior
of the browser seems cached. e.g. commit that sets up the MDC
theme for the tests is not reflected in the BrowserStack browser video.

All the test failures are not reproducible locally in Edge, nor do they
reproduce if the tests are executed through BrowserStack from the
local machine (following the CI steps locally).

Since we don't want to spend too much time on it, and Edge runs
extremely slow and flaky on BrowserStack anyway.. we move it
over to Saucelabs.