### PR TITLE
docs: fix typos where "it's" is used instead of "its"

### DIFF
--- a/src/cdk/a11y/key-manager/focus-key-manager.ts
+++ b/src/cdk/a11y/key-manager/focus-key-manager.ts
@@ -12,7 +12,7 @@ import {FocusOrigin} from '../focus-monitor/focus-monitor';
 /**
  * This is the interface for focusable items (used by the FocusKeyManager).
  * Each item must know how to focus itself, whether or not it is currently disabled
- * and be able to supply it's label.
+ * and be able to supply its label.
  */
 export interface FocusableOption extends ListKeyManagerOption {
   /** Focuses the `FocusableOption`. */

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -795,7 +795,7 @@ export class DragRef<T = any> {
     // Drop container that draggable has been moved into.
     let newContainer = this._initialContainer._getSiblingContainerFromPosition(this, x, y);
 
-    // If we couldn't find a new container to move the item into, and the item has left it's
+    // If we couldn't find a new container to move the item into, and the item has left its
     // initial container, check whether the it's over the initial container. This handles the
     // case where two containers are connected one way and the user tries to undo dragging an
     // item into a new container.

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -999,7 +999,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     };
   }
 
-  /** Subtracts the amount that an element is overflowing on an axis from it's length. */
+  /** Subtracts the amount that an element is overflowing on an axis from its length. */
   private _subtractOverflows(length: number, ...overflows: number[]): number {
     return overflows.reduce((currentValue: number, currentOverflow: number) => {
       return currentValue - Math.max(currentOverflow, 0);

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -45,7 +45,7 @@ const SCROLL_SCHEDULER =
     typeof requestAnimationFrame !== 'undefined' ? animationFrameScheduler : asapScheduler;
 
 
-/** A viewport that virtualizes it's scrolling with the help of `CdkVirtualForOf`. */
+/** A viewport that virtualizes its scrolling with the help of `CdkVirtualForOf`. */
 @Component({
   moduleId: module.id,
   selector: 'cdk-virtual-scroll-viewport',

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -217,28 +217,28 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   /**
    * Column definitions that were defined outside of the direct content children of the table.
    * These will be defined when, e.g., creating a wrapper around the cdkTable that has
-   * column definitions as *it's* content child.
+   * column definitions as *its* content child.
    */
   private _customColumnDefs = new Set<CdkColumnDef>();
 
   /**
    * Data row definitions that were defined outside of the direct content children of the table.
    * These will be defined when, e.g., creating a wrapper around the cdkTable that has
-   * built-in data rows as *it's* content child.
+   * built-in data rows as *its* content child.
    */
   private _customRowDefs = new Set<CdkRowDef<T>>();
 
   /**
    * Header row definitions that were defined outside of the direct content children of the table.
    * These will be defined when, e.g., creating a wrapper around the cdkTable that has
-   * built-in header rows as *it's* content child.
+   * built-in header rows as *its* content child.
    */
   private _customHeaderRowDefs = new Set<CdkHeaderRowDef>();
 
   /**
    * Footer row definitions that were defined outside of the direct content children of the table.
    * These will be defined when, e.g., creating a wrapper around the cdkTable that has a
-   * built-in footer row as *it's* content child.
+   * built-in footer row as *its* content child.
    */
   private _customFooterRowDefs = new Set<CdkFooterRowDef>();
 

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -286,7 +286,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     // component will be only marked for check, but no actual change detection runs automatically.
     // Instead of going back into the zone in order to trigger a change detection which causes
     // *all* components to be checked (if explicitly marked or not using OnPush), we only trigger
-    // an explicit change detection for the checkbox view and it's children.
+    // an explicit change detection for the checkbox view and its children.
     this._changeDetectorRef.detectChanges();
   }
 

--- a/src/material/core/datetime/date-adapter.ts
+++ b/src/material/core/datetime/date-adapter.ts
@@ -208,7 +208,7 @@ export abstract class DateAdapter<D> {
    * deserialize should only accept non-ambiguous, locale-independent formats (e.g. a ISO 8601
    * string). The default implementation does not allow any deserialization, it simply checks that
    * the given value is already a valid date object or null. The `<mat-datepicker>` will call this
-   * method on all of it's `@Input()` properties that accept dates. It is therefore possible to
+   * method on all of its `@Input()` properties that accept dates. It is therefore possible to
    * support passing values from your backend directly to these properties by overriding this method
    * to also deserialize the format used by your backend.
    * @param value The value to be deserialized into a date object.

--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -79,7 +79,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
    * will produce `'8/13/1800'`.
    *
    * TODO(mmalerba): drop this variable. It's not being used in the code right now. We're now
-   * getting the string representation of a Date object from it's utc representation. We're keeping
+   * getting the string representation of a Date object from its utc representation. We're keeping
    * it here for sometime, just for precaution, in case we decide to revert some of these changes
    * though.
    */

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -361,7 +361,7 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     // slide-toggle component will be only marked for check, but no actual change detection runs
     // automatically. Instead of going back into the zone in order to trigger a change detection
     // which causes *all* components to be checked (if explicitly marked or not using OnPush),
-    // we only trigger an explicit change detection for the slide-toggle view and it's children.
+    // we only trigger an explicit change detection for the slide-toggle view and its children.
     this._changeDetectorRef.detectChanges();
   }
 }

--- a/tools/dgeni/index.bzl
+++ b/tools/dgeni/index.bzl
@@ -30,7 +30,7 @@ def _dgeni_api_docs(ctx):
     # output should be written to. (e.g. bazel-out/bin/src/docs-content)
     args.add(output_dir_path)
 
-    # Pass each specified entry point and it's corresponding entry points to Dgeni. This will then
+    # Pass each specified entry point and its corresponding entry points to Dgeni. This will then
     # be used to resolve the files that need to be parsed by Dgeni.
     for package_name, entry_points in ctx.attr.entry_points.items():
         args.add(package_name)
@@ -46,7 +46,7 @@ def _dgeni_api_docs(ctx):
 
         # Small workaround that ensures that the "ripple" API doc is properly exposed as an output
         # of the packaging rule. Technically Dgeni should not output the "ripple" directory as
-        # it's own entry-point. TODO(devversion): Support sub API docs for entry-points
+        # its own entry-point. TODO(devversion): Support sub API docs for entry-points
         if package_name == "material":
             expected_outputs += [
                 ctx.actions.declare_file("%s/%s-%s.html" % (output_dir_name, package_name, "ripple")),

--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -57,7 +57,7 @@ task('test:static', [':test:build'], karmaWatchTask({browsers: []}));
 /**
  * Returns a Gulp task that spawns a Karma server and reloads whenever the files change.
  * Note that this doesn't use Karma's built-in file watching. Due to the way our build
- * process is set up, Karma ends up firing it's change detection for every file that is
+ * process is set up, Karma ends up firing its change detection for every file that is
  * written to disk, which causes it to run tests multiple time and makes it hard to follow
  * the console output. This approach runs the Karma server and then depends on the Gulp API
  * to tell Karma when to run the tests.


### PR DESCRIPTION
Follow up of https://github.com/angular/components/pull/16990, where @donroyco asked whether I checked for other occurrences. Here is the answer :)