### PR TITLE
fix(button): fix typo in comment

### DIFF
--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -10,7 +10,7 @@
   }
 }
 
-// Only flat and stroked buttons (not raised, FABs or icon buttons) have a hover style.
+// Only normal and stroked buttons (not raised, FABs or icon buttons) have a hover style.
 // Use the same visual treatment for hover as for focus.
 .mat-button:hover,
 .mat-stroked-button:hover {

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -10,7 +10,7 @@
   }
 }
 
-// Only normal and stroked buttons (not raised, FABs or icon buttons) have a hover style.
+// Only basic and stroked buttons (not raised, FABs or icon buttons) have a hover style.
 // Use the same visual treatment for hover as for focus.
 .mat-button:hover,
 .mat-stroked-button:hover {


### PR DESCRIPTION
according to the implement actually the hover is applied to the basic and stroked button, flat is not included