### PR TITLE
feat(tooltip): remove Hammer.js dependency

### DIFF
--- a/src/material/tooltip/BUILD.bazel
+++ b/src/material/tooltip/BUILD.bazel
@@ -31,7 +31,6 @@ ng_module(
         "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],
 )

--- a/src/material/tooltip/tooltip-module.ts
+++ b/src/material/tooltip/tooltip-module.ts
@@ -10,8 +10,7 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {A11yModule} from '@angular/cdk/a11y';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {GestureConfig, MatCommonModule} from '@angular/material/core';
-import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
+import {MatCommonModule} from '@angular/material/core';
 import {
   MatTooltip,
   TooltipComponent,
@@ -28,9 +27,6 @@ import {
   exports: [MatTooltip, TooltipComponent, MatCommonModule],
   declarations: [MatTooltip, TooltipComponent],
   entryComponents: [TooltipComponent],
-  providers: [
-    MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER,
-    {provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig},
-  ]
+  providers: [MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER]
 })
 export class MatTooltipModule {}

--- a/src/material/tooltip/tooltip.md
+++ b/src/material/tooltip/tooltip.md
@@ -25,16 +25,14 @@ the positions `before` and `after` should be used instead of `left` and `right`,
 ### Showing and hiding
 
 By default, the tooltip will be immediately shown when the user's mouse hovers over the tooltip's
-trigger element and immediately hides when the user's mouse leaves. 
+trigger element and immediately hides when the user's mouse leaves.
 
 On mobile, the tooltip is displayed when the user longpresses the element and hides after a
-delay of 1500ms. The longpress behavior requires HammerJS to be loaded on the page. To learn more
-about adding HammerJS to your app, check out the Gesture Support section of the Getting Started 
-guide.
+delay of 1500ms.
 
 #### Show and hide delays
 
-To add a delay before showing or hiding the tooltip, you can use the inputs `matTooltipShowDelay` 
+To add a delay before showing or hiding the tooltip, you can use the inputs `matTooltipShowDelay`
 and `matTooltipHideDelay` to provide a delay time in milliseconds.
 
 The following example has a tooltip that waits one second to display after the user
@@ -58,7 +56,7 @@ which both accept a number in milliseconds to delay before applying the display 
 
 #### Disabling the tooltip from showing
 
-To completely disable a tooltip, set `matTooltipDisabled`. While disabled, a tooltip will never be 
+To completely disable a tooltip, set `matTooltipDisabled`. While disabled, a tooltip will never be
 shown.
 
 ### Accessibility

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -38,6 +38,7 @@ import {
   SCROLL_THROTTLE_MS,
   TOOLTIP_PANEL_CLASS,
   MAT_TOOLTIP_DEFAULT_OPTIONS,
+  TooltipTouchGestures,
 } from './index';
 
 
@@ -883,33 +884,175 @@ describe('MatTooltip', () => {
     }));
   });
 
-  describe('special cases', () => {
-
-    it('should clear the `user-select` when a tooltip is set on a text field', () => {
-      const fixture = TestBed.createComponent(TooltipOnTextFields);
-      const instance = fixture.componentInstance;
-
-      fixture.detectChanges();
-
-      expect(instance.input.nativeElement.style.userSelect).toBeFalsy();
-      expect(instance.input.nativeElement.style.webkitUserSelect).toBeFalsy();
-      expect(instance.input.nativeElement.style.msUserSelect).toBeFalsy();
-
-      expect(instance.textarea.nativeElement.style.userSelect).toBeFalsy();
-      expect(instance.textarea.nativeElement.style.webkitUserSelect).toBeFalsy();
-      expect(instance.textarea.nativeElement.style.msUserSelect).toBeFalsy();
+  describe('touch gestures', () => {
+    beforeEach(() => {
+      platform.ANDROID = true;
     });
 
-    it('should clear the `-webkit-user-drag` on draggable elements', () => {
-      const fixture = TestBed.createComponent(TooltipOnDraggableElement);
+    it('should have a delay when showing on touchstart', fakeAsync(() => {
+      const fixture = TestBed.createComponent(BasicTooltipDemo);
+      fixture.detectChanges();
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
 
+      dispatchFakeEvent(button, 'touchstart');
+      fixture.detectChanges();
+      tick(250); // Halfway through the delay.
+
+      assertTooltipInstance(fixture.componentInstance.tooltip, false);
+
+      tick(250); // Finish the delay.
+      fixture.detectChanges();
+      tick(500); // Finish the animation.
+
+      assertTooltipInstance(fixture.componentInstance.tooltip, true);
+    }));
+
+    it('should be able to disable opening on touch', fakeAsync(() => {
+      const fixture = TestBed.createComponent(BasicTooltipDemo);
+      fixture.componentInstance.touchGestures = 'off';
+      fixture.detectChanges();
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+
+      dispatchFakeEvent(button, 'touchstart');
+      fixture.detectChanges();
+      tick(500); // Finish the delay.
+      fixture.detectChanges();
+      tick(500); // Finish the animation.
+
+      assertTooltipInstance(fixture.componentInstance.tooltip, false);
+    }));
+
+    it('should not prevent the default action on touchstart', () => {
+      const fixture = TestBed.createComponent(BasicTooltipDemo);
+      fixture.detectChanges();
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      const event = dispatchFakeEvent(button, 'touchstart');
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('should close on touchend with a delay', fakeAsync(() => {
+      const fixture = TestBed.createComponent(BasicTooltipDemo);
+      fixture.detectChanges();
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+
+      dispatchFakeEvent(button, 'touchstart');
+      fixture.detectChanges();
+      tick(500); // Finish the open delay.
+      fixture.detectChanges();
+      tick(500); // Finish the animation.
+      assertTooltipInstance(fixture.componentInstance.tooltip, true);
+
+      dispatchFakeEvent(button, 'touchend');
+      fixture.detectChanges();
+      tick(1000); // 2/3 through the delay
+      assertTooltipInstance(fixture.componentInstance.tooltip, true);
+
+      tick(500); // Finish the delay.
+      fixture.detectChanges();
+      tick(500); // Finish the exit animation.
+
+      assertTooltipInstance(fixture.componentInstance.tooltip, false);
+    }));
+
+    it('should close on touchcancel with a delay', fakeAsync(() => {
+      const fixture = TestBed.createComponent(BasicTooltipDemo);
+      fixture.detectChanges();
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+
+      dispatchFakeEvent(button, 'touchstart');
+      fixture.detectChanges();
+      tick(500); // Finish the open delay.
+      fixture.detectChanges();
+      tick(500); // Finish the animation.
+      assertTooltipInstance(fixture.componentInstance.tooltip, true);
+
+      dispatchFakeEvent(button, 'touchcancel');
+      fixture.detectChanges();
+      tick(1000); // 2/3 through the delay
+      assertTooltipInstance(fixture.componentInstance.tooltip, true);
+
+      tick(500); // Finish the delay.
+      fixture.detectChanges();
+      tick(500); // Finish the exit animation.
+
+      assertTooltipInstance(fixture.componentInstance.tooltip, false);
+    }));
+
+    it('should disable native touch interactions', () => {
+      const fixture = TestBed.createComponent(BasicTooltipDemo);
+      fixture.detectChanges();
+
+      const styles = fixture.nativeElement.querySelector('button').style;
+      expect(styles.touchAction || (styles as any).webkitUserDrag).toBe('none');
+    });
+
+    it('should allow native touch interactions if touch gestures are turned off', () => {
+      const fixture = TestBed.createComponent(BasicTooltipDemo);
+      fixture.componentInstance.touchGestures = 'off';
+      fixture.detectChanges();
+
+      const styles = fixture.nativeElement.querySelector('button').style;
+      expect(styles.touchAction || (styles as any).webkitUserDrag).toBeFalsy();
+    });
+
+    it('should allow text selection on inputs when gestures are set to auto', () => {
+      const fixture = TestBed.createComponent(TooltipOnTextFields);
+      fixture.detectChanges();
+
+      const inputStyle = fixture.componentInstance.input.nativeElement.style;
+      const textareaStyle = fixture.componentInstance.textarea.nativeElement.style;
+
+      expect(inputStyle.userSelect).toBeFalsy();
+      expect(inputStyle.webkitUserSelect).toBeFalsy();
+      expect(inputStyle.msUserSelect).toBeFalsy();
+      expect((inputStyle as any).MozUserSelect).toBeFalsy();
+
+      expect(textareaStyle.userSelect).toBeFalsy();
+      expect(textareaStyle.webkitUserSelect).toBeFalsy();
+      expect(textareaStyle.msUserSelect).toBeFalsy();
+      expect((textareaStyle as any).MozUserSelect).toBeFalsy();
+    });
+
+    it('should disable text selection on inputs when gestures are set to on', () => {
+      const fixture = TestBed.createComponent(TooltipOnTextFields);
+      fixture.componentInstance.touchGestures = 'on';
+      fixture.detectChanges();
+
+      const inputStyle = fixture.componentInstance.input.nativeElement.style;
+      const inputUserSelect = inputStyle.userSelect || inputStyle.webkitUserSelect ||
+                              inputStyle.msUserSelect || (inputStyle as any).MozUserSelect;
+      const textareaStyle = fixture.componentInstance.textarea.nativeElement.style;
+      const textareaUserSelect = textareaStyle.userSelect || textareaStyle.webkitUserSelect ||
+                                 textareaStyle.msUserSelect || (textareaStyle as any).MozUserSelect;
+
+      expect(inputUserSelect).toBe('none');
+      expect(textareaUserSelect).toBe('none');
+    });
+
+    it('should allow native dragging on draggable elements when gestures are set to auto', () => {
+      const fixture = TestBed.createComponent(TooltipOnDraggableElement);
       fixture.detectChanges();
 
       expect(fixture.componentInstance.button.nativeElement.style.webkitUserDrag).toBeFalsy();
     });
 
+    it('should disable native dragging on draggable elements when gestures are set to on', () => {
+      const fixture = TestBed.createComponent(TooltipOnDraggableElement);
+      fixture.componentInstance.touchGestures = 'on';
+      fixture.detectChanges();
+
+      const styles = fixture.componentInstance.button.nativeElement.style;
+
+      if ('webkitUserDrag' in styles) {
+        expect(styles.webkitUserDrag).toBe('none');
+      }
+    });
+
     it('should not open on `mouseenter` on iOS', () => {
       platform.IOS = true;
+      platform.ANDROID = false;
 
       const fixture = TestBed.createComponent(BasicTooltipDemo);
 
@@ -922,6 +1065,7 @@ describe('MatTooltip', () => {
 
     it('should not open on `mouseenter` on Android', () => {
       platform.ANDROID = true;
+      platform.IOS = false;
 
       const fixture = TestBed.createComponent(BasicTooltipDemo);
 
@@ -931,7 +1075,6 @@ describe('MatTooltip', () => {
 
       assertTooltipInstance(fixture.componentInstance.tooltip, false);
     });
-
   });
 
 });
@@ -943,7 +1086,8 @@ describe('MatTooltip', () => {
             *ngIf="showButton"
             [matTooltip]="message"
             [matTooltipPosition]="position"
-            [matTooltipClass]="{'custom-one': showTooltipClass, 'custom-two': showTooltipClass }">
+            [matTooltipClass]="{'custom-one': showTooltipClass, 'custom-two': showTooltipClass }"
+            [matTooltipTouchGestures]="touchGestures">
       Button
     </button>`
 })
@@ -952,6 +1096,7 @@ class BasicTooltipDemo {
   message: any = initialTooltipMessage;
   showButton: boolean = true;
   showTooltipClass = false;
+  touchGestures: TooltipTouchGestures = 'auto';
   @ViewChild(MatTooltip, {static: false}) tooltip: MatTooltip;
   @ViewChild('button', {static: false}) button: ElementRef<HTMLButtonElement>;
 }
@@ -1023,31 +1168,33 @@ class DynamicTooltipsDemo {
   template: `
     <input
       #input
-      style="user-select: none; -webkit-user-select: none"
-      matTooltip="Something">
+      matTooltip="Something"
+      [matTooltipTouchGestures]="touchGestures">
 
     <textarea
       #textarea
-      style="user-select: none; -webkit-user-select: none"
-      matTooltip="Another thing"></textarea>
+      matTooltip="Another thing"
+      [matTooltipTouchGestures]="touchGestures"></textarea>
   `,
 })
 class TooltipOnTextFields {
   @ViewChild('input', {static: false}) input: ElementRef<HTMLInputElement>;
   @ViewChild('textarea', {static: false}) textarea: ElementRef<HTMLTextAreaElement>;
+  touchGestures: TooltipTouchGestures = 'auto';
 }
 
 @Component({
   template: `
     <button
       #button
-      style="-webkit-user-drag: none;"
       draggable="true"
-      matTooltip="Drag me"></button>
+      matTooltip="Drag me"
+      [matTooltipTouchGestures]="touchGestures"></button>
   `,
 })
 class TooltipOnDraggableElement {
   @ViewChild('button', {static: false}) button: ElementRef;
+  touchGestures: TooltipTouchGestures = 'auto';
 }
 
 @Component({

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -21,7 +21,7 @@ import {
   ScrollStrategy,
   VerticalConnectionPos,
 } from '@angular/cdk/overlay';
-import {Platform} from '@angular/cdk/platform';
+import {Platform, normalizePassiveListenerOptions} from '@angular/cdk/platform';
 import {ComponentPortal} from '@angular/cdk/portal';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
@@ -40,20 +40,38 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import {HAMMER_LOADER, HammerLoader} from '@angular/platform-browser';
 import {Observable, Subject} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
 
 import {matTooltipAnimations} from './tooltip-animations';
 
 
+/** Possible positions for a tooltip. */
 export type TooltipPosition = 'left' | 'right' | 'above' | 'below' | 'before' | 'after';
+
+/**
+ * Options for how the tooltip trigger should handle touch gestures.
+ * See `MatTooltip.touchGestures` for more information.
+ */
+export type TooltipTouchGestures = 'auto' | 'on' | 'off';
+
+/** Possible visibility states of a tooltip. */
+export type TooltipVisibility = 'initial' | 'visible' | 'hidden';
 
 /** Time in ms to throttle repositioning after scroll events. */
 export const SCROLL_THROTTLE_MS = 20;
 
 /** CSS class that will be attached to the overlay panel. */
 export const TOOLTIP_PANEL_CLASS = 'mat-tooltip-panel';
+
+/** Options used to bind passive event listeners. */
+const passiveListenerOptions = normalizePassiveListenerOptions({passive: true});
+
+/**
+ * Time between the user putting the pointer on a tooltip
+ * trigger and the long press event being fired.
+ */
+const LONGPRESS_DELAY = 500;
 
 /**
  * Creates an error to be thrown if the user supplied an invalid tooltip position.
@@ -84,6 +102,7 @@ export interface MatTooltipDefaultOptions {
   showDelay: number;
   hideDelay: number;
   touchendHideDelay: number;
+  touchGestures?: TooltipTouchGestures;
   position?: TooltipPosition;
 }
 
@@ -113,9 +132,7 @@ export function MAT_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): MatTooltipDefaultOptions 
   selector: '[matTooltip]',
   exportAs: 'matTooltip',
   host: {
-    '(longpress)': 'show()',
     '(keydown)': '_handleKeydown($event)',
-    '(touchend)': '_handleTouchend()',
   },
 })
 export class MatTooltip implements OnDestroy, OnInit {
@@ -165,7 +182,21 @@ export class MatTooltip implements OnDestroy, OnInit {
   /** The default delay in ms before hiding the tooltip after hide is called */
   @Input('matTooltipHideDelay') hideDelay = this._defaultOptions.hideDelay;
 
-  private _message = '';
+  /**
+   * How touch gestures should be handled by the tooltip. On touch devices the tooltip directive
+   * uses a long press gesture to show and hide, however it can conflict with the native browser
+   * gestures. To work around the conflict, Angular Material disables native gestures on the
+   * trigger, but that might not be desirable on particular elements (e.g. inputs and draggable
+   * elements). The different values for this option configure the touch event handling as follows:
+   * - `auto` - Enables touch gestures for all elements, but tries to avoid conflicts with native
+   *   browser gestures on particular elements. In particular, it allows text selection on inputs
+   *   and textareas, and preserves the native browser dragging on elements marked as `draggable`.
+   * - `on` - Enables touch gestures for all elements and disables native
+   *   browser gestures with no exceptions.
+   * - `off` - Disables touch gestures. Note that this will prevent the tooltip from
+   *   showing on touch devices.
+   */
+  @Input('matTooltipTouchGestures') touchGestures: TooltipTouchGestures = 'auto';
 
   /** The message to be displayed in the tooltip */
   @Input('matTooltip')
@@ -183,6 +214,7 @@ export class MatTooltip implements OnDestroy, OnInit {
       this._ariaDescriber.describe(this._elementRef.nativeElement, this.message);
     }
   }
+  private _message = '';
 
   /** Classes to be passed to the tooltip. Supports the same syntax as `ngClass`. */
   @Input('matTooltipClass')
@@ -194,7 +226,11 @@ export class MatTooltip implements OnDestroy, OnInit {
     }
   }
 
-  private _manualListeners = new Map<string, EventListenerOrEventListenerObject>();
+  /** Manually-bound passive event listeners. */
+  private _passiveListeners = new Map<string, EventListenerOrEventListenerObject>();
+
+  /** Timer started at the last `touchstart` event. */
+  private _touchstartTimeout: number;
 
   /** Emits when the component is destroyed. */
   private readonly _destroyed = new Subject<void>();
@@ -205,85 +241,68 @@ export class MatTooltip implements OnDestroy, OnInit {
     private _scrollDispatcher: ScrollDispatcher,
     private _viewContainerRef: ViewContainerRef,
     private _ngZone: NgZone,
-    platform: Platform,
+    private _platform: Platform,
     private _ariaDescriber: AriaDescriber,
     private _focusMonitor: FocusMonitor,
     @Inject(MAT_TOOLTIP_SCROLL_STRATEGY) scrollStrategy: any,
     @Optional() private _dir: Directionality,
     @Optional() @Inject(MAT_TOOLTIP_DEFAULT_OPTIONS)
       private _defaultOptions: MatTooltipDefaultOptions,
-    @Optional() @Inject(HAMMER_LOADER) hammerLoader?: HammerLoader) {
+      /**
+       * @deprecated _hammerLoader parameter to be removed.
+       * @breaking-change 9.0.0
+       */
+      // Note that we need to give Angular something to inject here so it doesn't throw.
+      @Inject(ElementRef) _hammerLoader?: any) {
 
     this._scrollStrategy = scrollStrategy;
-    const element: HTMLElement = _elementRef.nativeElement;
-    const hasGestures = typeof window === 'undefined' || (window as any).Hammer || hammerLoader;
 
-    // The mouse events shouldn't be bound on mobile devices, because they can prevent the
-    // first tap from firing its click event or can cause the tooltip to open for clicks.
-    if (!platform.IOS && !platform.ANDROID) {
-      this._manualListeners
-        .set('mouseenter', () => this.show())
-        .set('mouseleave', () => this.hide());
-    } else if (!hasGestures) {
-      // If Hammerjs isn't loaded, fall back to showing on `touchstart`, otherwise
-      // there's no way for the user to trigger the tooltip on a touch device.
-      this._manualListeners.set('touchstart', () => this.show());
-    }
-
-    this._manualListeners.forEach((listener, event) => element.addEventListener(event, listener));
-
-    _focusMonitor.monitor(_elementRef).pipe(takeUntil(this._destroyed)).subscribe(origin => {
-      // Note that the focus monitor runs outside the Angular zone.
-      if (!origin) {
-        _ngZone.run(() => this.hide(0));
-      } else if (origin === 'keyboard') {
-        _ngZone.run(() => this.show());
+    if (_defaultOptions) {
+      if (_defaultOptions.position) {
+        this.position = _defaultOptions.position;
       }
-    });
 
-    if (_defaultOptions && _defaultOptions.position) {
-      this.position = _defaultOptions.position;
+      if (_defaultOptions.touchGestures) {
+        this.touchGestures = _defaultOptions.touchGestures;
+      }
     }
+
+    _focusMonitor.monitor(_elementRef)
+      .pipe(takeUntil(this._destroyed))
+      .subscribe(origin => {
+        // Note that the focus monitor runs outside the Angular zone.
+        if (!origin) {
+          _ngZone.run(() => this.hide(0));
+        } else if (origin === 'keyboard') {
+          _ngZone.run(() => this.show());
+        }
+    });
   }
 
   /**
    * Setup styling-specific things
    */
   ngOnInit() {
-    const element = this._elementRef.nativeElement;
-    const elementStyle = element.style as CSSStyleDeclaration & {webkitUserDrag: string};
-
-    if (element.nodeName === 'INPUT' || element.nodeName === 'TEXTAREA') {
-      // When we bind a gesture event on an element (in this case `longpress`), HammerJS
-      // will add some inline styles by default, including `user-select: none`. This is
-      // problematic on iOS and in Safari, because it will prevent users from typing in inputs.
-      // Since `user-select: none` is not needed for the `longpress` event and can cause unexpected
-      // behavior for text fields, we always clear the `user-select` to avoid such issues.
-      elementStyle.webkitUserSelect = elementStyle.userSelect = elementStyle.msUserSelect = '';
-    }
-
-    // Hammer applies `-webkit-user-drag: none` on all elements by default,
-    // which breaks the native drag&drop. If the consumer explicitly made
-    // the element draggable, clear the `-webkit-user-drag`.
-    if (element.draggable && elementStyle.webkitUserDrag === 'none') {
-      elementStyle.webkitUserDrag = '';
-    }
+    // This needs to happen in `ngOnInit` so the initial values for all inputs have been set.
+    this._setupPointerEvents();
   }
 
   /**
    * Dispose the tooltip when destroyed.
    */
   ngOnDestroy() {
+    clearTimeout(this._touchstartTimeout);
+
     if (this._overlayRef) {
       this._overlayRef.dispose();
       this._tooltipInstance = null;
     }
 
     // Clean up the event listeners set in the constructor
-    this._manualListeners.forEach((listener, event) => {
-      this._elementRef.nativeElement.removeEventListener(event, listener);
+    this._passiveListeners.forEach((listener, event) => {
+      this._elementRef.nativeElement.removeEventListener(event, listener, passiveListenerOptions);
     });
-    this._manualListeners.clear();
+    this._passiveListeners.clear();
 
     this._destroyed.next();
     this._destroyed.complete();
@@ -336,11 +355,6 @@ export class MatTooltip implements OnDestroy, OnInit {
       e.stopPropagation();
       this.hide(0);
     }
-  }
-
-  /** Handles the touchend events on the host element. */
-  _handleTouchend() {
-    this.hide(this._defaultOptions.touchendHideDelay);
   }
 
   /** Create the overlay config and position strategy */
@@ -518,9 +532,63 @@ export class MatTooltip implements OnDestroy, OnInit {
 
     return {x, y};
   }
-}
 
-export type TooltipVisibility = 'initial' | 'visible' | 'hidden';
+  /** Binds the pointer events to the tooltip trigger. */
+  private _setupPointerEvents() {
+    // The mouse events shouldn't be bound on mobile devices, because they can prevent the
+    // first tap from firing its click event or can cause the tooltip to open for clicks.
+    if (!this._platform.IOS && !this._platform.ANDROID) {
+      this._passiveListeners
+        .set('mouseenter', () => this.show())
+        .set('mouseleave', () => this.hide());
+    } else if (this.touchGestures !== 'off') {
+      this._disableNativeGesturesIfNecessary();
+      const touchendListener = () => {
+        clearTimeout(this._touchstartTimeout);
+        this.hide(this._defaultOptions.touchendHideDelay);
+      };
+
+      this._passiveListeners
+        .set('touchend', touchendListener)
+        .set('touchcancel', touchendListener)
+        .set('touchstart', () => {
+          // Note that it's important that we don't `preventDefault` here,
+          // because it can prevent click events from firing on the element.
+          clearTimeout(this._touchstartTimeout);
+          this._touchstartTimeout = setTimeout(() => this.show(), LONGPRESS_DELAY);
+        });
+    }
+
+    this._passiveListeners.forEach((listener, event) => {
+      this._elementRef.nativeElement.addEventListener(event, listener, passiveListenerOptions);
+    });
+  }
+
+  /** Disables the native browser gestures, based on how the tooltip has been configured. */
+  private _disableNativeGesturesIfNecessary() {
+    const element = this._elementRef.nativeElement;
+    const style = element.style;
+    const gestures = this.touchGestures;
+
+    if (gestures !== 'off') {
+      // If gestures are set to `auto`, we don't disable text selection on inputs and
+      // textareas, because it prevents the user from typing into them on iOS Safari.
+      if (gestures === 'on' || (element.nodeName !== 'INPUT' && element.nodeName !== 'TEXTAREA')) {
+        style.userSelect = style.msUserSelect = style.webkitUserSelect =
+            (style as any).MozUserSelect = 'none';
+      }
+
+      // If we have `auto` gestures and the element uses native HTML dragging,
+      // we don't set `-webkit-user-drag` because it prevents the native behavior.
+      if (gestures === 'on' || !element.draggable) {
+        (style as any).webkitUserDrag = 'none';
+      }
+
+      style.touchAction = 'none';
+      style.webkitTapHighlightColor = 'transparent';
+    }
+  }
+}
 
 /**
  * Internal component that wraps the tooltip's content.

--- a/tools/public_api_guard/material/tooltip.d.ts
+++ b/tools/public_api_guard/material/tooltip.d.ts
@@ -25,7 +25,9 @@ export declare class MatTooltip implements OnDestroy, OnInit {
     tooltipClass: string | string[] | Set<string> | {
         [key: string]: any;
     };
-    constructor(_overlay: Overlay, _elementRef: ElementRef<HTMLElement>, _scrollDispatcher: ScrollDispatcher, _viewContainerRef: ViewContainerRef, _ngZone: NgZone, platform: Platform, _ariaDescriber: AriaDescriber, _focusMonitor: FocusMonitor, scrollStrategy: any, _dir: Directionality, _defaultOptions: MatTooltipDefaultOptions, hammerLoader?: HammerLoader);
+    touchGestures: TooltipTouchGestures;
+    constructor(_overlay: Overlay, _elementRef: ElementRef<HTMLElement>, _scrollDispatcher: ScrollDispatcher, _viewContainerRef: ViewContainerRef, _ngZone: NgZone, _platform: Platform, _ariaDescriber: AriaDescriber, _focusMonitor: FocusMonitor, scrollStrategy: any, _dir: Directionality, _defaultOptions: MatTooltipDefaultOptions,
+    _hammerLoader?: any);
     _getOrigin(): {
         main: OriginConnectionPosition;
         fallback: OriginConnectionPosition;
@@ -35,7 +37,6 @@ export declare class MatTooltip implements OnDestroy, OnInit {
         fallback: OverlayConnectionPosition;
     };
     _handleKeydown(e: KeyboardEvent): void;
-    _handleTouchend(): void;
     _isTooltipVisible(): boolean;
     hide(delay?: number): void;
     ngOnDestroy(): void;
@@ -52,6 +53,7 @@ export interface MatTooltipDefaultOptions {
     hideDelay: number;
     position?: TooltipPosition;
     showDelay: number;
+    touchGestures?: TooltipTouchGestures;
     touchendHideDelay: number;
 }
 
@@ -84,5 +86,7 @@ export declare class TooltipComponent implements OnDestroy {
 }
 
 export declare type TooltipPosition = 'left' | 'right' | 'above' | 'below' | 'before' | 'after';
+
+export declare type TooltipTouchGestures = 'auto' | 'on' | 'off';
 
 export declare type TooltipVisibility = 'initial' | 'visible' | 'hidden';


### PR DESCRIPTION
Reworks the tooltip to remove its dependency on Hammer.js. Also adds an option to disable touch gestures so that text selection doesn't have to be disabled on the trigger.

Fixes #16850.