### PR TITLE
build: fix release scripts not all parsing versions properly

### DIFF
--- a/tools/release/version-name/parse-version.ts
+++ b/tools/release/version-name/parse-version.ts
@@ -1,5 +1,5 @@
 /** Regular expression that matches version names and the individual version segments. */
-const versionNameRegex = /^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d)+)?$/;
+const versionNameRegex = /^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d+))?$/;
 
 export class Version {
   constructor(
@@ -44,7 +44,7 @@ export function parseVersionName(version: string): Version|null {
 
   return new Version(
       Number(matches[1]), Number(matches[2]), Number(matches[3]), matches[4] || null,
-      Number(matches[5]) || null);
+      matches[5] !== undefined ? Number(matches[5]) : null);
 }
 
 /** Serializes the specified version into a string. */


### PR DESCRIPTION
Fixes the release scripts not properly parsing versions in the following scenarios:

1) The version has a pre-release version set to `0`. In that case the version pre-release version
  will be ignored.
2) The version has a pre-release version higher than `9`. In that case the Regex for parsing
  the version has an invalid capture group that only matches a single-digit pre-release version.

Thanks to @CaerusKaru for reporting these.