### PR TITLE
chore: fix menu harness tests

### DIFF
--- a/src/material-experimental/mdc-autocomplete/harness/autocomplete-harness.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/harness/autocomplete-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk-experimental/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, Type} from '@angular/core';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {OverlayContainer} from '@angular/cdk/overlay';
@@ -16,18 +16,8 @@ let overlayContainer: OverlayContainer;
 describe('MatAutocompleteHarness', () => {
   describe('non-MDC-based', () => {
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [MatAutocompleteModule],
-        declarations: [AutocompleteHarnessTest],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(AutocompleteHarnessTest);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
+      await prepareTests(MatAutocompleteModule, AutocompleteHarnessTest);
       harness = MatAutocompleteHarness;
-      inject([OverlayContainer], (oc: OverlayContainer) => {
-        overlayContainer = oc;
-      })();
     });
 
     runTests();
@@ -35,14 +25,7 @@ describe('MatAutocompleteHarness', () => {
 
   describe('MDC-based', () => {
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [MatMdcAutocompleteModule],
-        declarations: [AutocompleteHarnessTest],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(AutocompleteHarnessTest);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
+      await prepareTests(MatMdcAutocompleteModule, AutocompleteHarnessTest);
       // Public APIs are the same as MatAutocompleteHarness, but cast
       // is necessary because of different private fields.
       harness = MatMdcAutocompleteHarness as any;
@@ -53,11 +36,27 @@ describe('MatAutocompleteHarness', () => {
   });
 });
 
+/** Shared test setup logic. */
+async function prepareTests(moduleType: Type<any>, fixtureType: Type<any>) {
+  await TestBed.configureTestingModule({
+    imports: [moduleType],
+    declarations: [fixtureType],
+  }).compileComponents();
+
+  fixture = TestBed.createComponent(fixtureType);
+  fixture.detectChanges();
+  loader = TestbedHarnessEnvironment.loader(fixture);
+  inject([OverlayContainer], (oc: OverlayContainer) => {
+    overlayContainer = oc;
+  })();
+}
+
 /** Shared tests to run on both the original and MDC-based autocomplete. */
 function runTests() {
   afterEach(() => {
     // Angular won't call this for us so we need to do it ourselves to avoid leaks.
     overlayContainer.ngOnDestroy();
+    overlayContainer = null!;
   });
 
   it('should load all autocomplete harnesses', async () => {

--- a/src/material-experimental/mdc-menu/harness/menu-harness.spec.ts
+++ b/src/material-experimental/mdc-menu/harness/menu-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk-experimental/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, Type} from '@angular/core';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {MatMenuModule} from '@angular/material/menu';
 import {OverlayContainer} from '@angular/cdk/overlay';
@@ -16,18 +16,8 @@ let overlayContainer: OverlayContainer;
 describe('MatMenuHarness', () => {
   describe('non-MDC-based', () => {
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [MatMenuModule],
-        declarations: [MenuHarnessTest],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(MenuHarnessTest);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
+      await prepareTests(MatMenuModule, MenuHarnessTest);
       menuHarness = MatMenuHarness;
-      inject([OverlayContainer], (oc: OverlayContainer) => {
-        overlayContainer = oc;
-      })();
     });
 
     runTests();
@@ -35,14 +25,7 @@ describe('MatMenuHarness', () => {
 
   describe('MDC-based', () => {
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [MatMdcMenuModule],
-        declarations: [MenuHarnessTest],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(MenuHarnessTest);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
+      await prepareTests(MatMdcMenuModule, MenuHarnessTest);
       // Public APIs are the same as MatMenuHarness, but cast is necessary because of different
       // private fields.
       menuHarness = MatMdcMenuHarness as any;
@@ -52,11 +35,27 @@ describe('MatMenuHarness', () => {
   });
 });
 
+/** Shared test setup logic. */
+async function prepareTests(moduleType: Type<any>, fixtureType: Type<any>) {
+  await TestBed.configureTestingModule({
+    imports: [moduleType],
+    declarations: [fixtureType],
+  }).compileComponents();
+
+  fixture = TestBed.createComponent(fixtureType);
+  fixture.detectChanges();
+  loader = TestbedHarnessEnvironment.loader(fixture);
+  inject([OverlayContainer], (oc: OverlayContainer) => {
+    overlayContainer = oc;
+  })();
+}
+
 /** Shared tests to run on both the original and MDC-based menues. */
 function runTests() {
   afterEach(() => {
     // Angular won't call this for us so we need to do it ourselves to avoid leaks.
     overlayContainer.ngOnDestroy();
+    overlayContainer = null!;
   });
 
   it('should load all menu harnesses', async () => {

--- a/src/material-experimental/mdc-select/harness/select-harness.spec.ts
+++ b/src/material-experimental/mdc-select/harness/select-harness.spec.ts
@@ -1,6 +1,6 @@
 import {HarnessLoader} from '@angular/cdk-experimental/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk-experimental/testing/testbed';
-import {Component} from '@angular/core';
+import {Component, Type} from '@angular/core';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ReactiveFormsModule, FormControl, Validators} from '@angular/forms';
@@ -19,23 +19,8 @@ let overlayContainer: OverlayContainer;
 describe('MatSelectHarness', () => {
   describe('non-MDC-based', () => {
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [
-          MatSelectModule,
-          MatFormFieldModule,
-          NoopAnimationsModule,
-          ReactiveFormsModule,
-        ],
-        declarations: [SelectHarnessTest],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(SelectHarnessTest);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
+      await prepareTests(MatSelectModule, SelectHarnessTest);
       harness = MatSelectHarness;
-      inject([OverlayContainer], (oc: OverlayContainer) => {
-        overlayContainer = oc;
-      })();
     });
 
     runTests();
@@ -43,19 +28,7 @@ describe('MatSelectHarness', () => {
 
   describe('MDC-based', () => {
     beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [
-          MatMdcSelectModule,
-          MatFormFieldModule,
-          NoopAnimationsModule,
-          ReactiveFormsModule,
-        ],
-        declarations: [SelectHarnessTest],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(SelectHarnessTest);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
+      await prepareTests(MatMdcSelectModule, SelectHarnessTest);
       // Public APIs are the same as MatSelectHarness, but cast
       // is necessary because of different private fields.
       harness = MatMdcSelectHarness as any;
@@ -66,11 +39,34 @@ describe('MatSelectHarness', () => {
   });
 });
 
+/** Shared test setup logic. */
+async function prepareTests(moduleType: Type<any>, fixtureType: Type<any>) {
+  await TestBed.configureTestingModule({
+    imports: [
+      moduleType,
+      MatFormFieldModule,
+      NoopAnimationsModule,
+      ReactiveFormsModule,
+    ],
+    declarations: [fixtureType],
+  }).compileComponents();
+
+  fixture = TestBed.createComponent(fixtureType);
+  fixture.detectChanges();
+  loader = TestbedHarnessEnvironment.loader(fixture);
+  inject([OverlayContainer], (oc: OverlayContainer) => {
+    overlayContainer = oc;
+  })();
+}
+
+
+
 /** Shared tests to run on both the original and MDC-based select. */
 function runTests() {
   afterEach(() => {
     // Angular won't call this for us so we need to do it ourselves to avoid leaks.
     overlayContainer.ngOnDestroy();
+    overlayContainer = null!;
   });
 
   it('should load all select harnesses', async () => {


### PR DESCRIPTION
Fixes a failure that wasn't caught by the CI in #17007 for some reason. We were only injecting the overlay container for one kind of test harness.