### PR TITLE
fix: annotate a couple base classes with @Directive for Ivy

### DIFF
--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -14,6 +14,8 @@ import {
     EmbeddedViewRef,
     Injector,
     ComponentFactoryResolver,
+    Directive,
+    NgModule,
 } from '@angular/core';
 import {
     throwNullPortalOutletError,
@@ -179,6 +181,13 @@ export type PortalHost = PortalOutlet;
  * Partial implementation of PortalOutlet that handles attaching
  * ComponentPortal and TemplatePortal.
  */
+@Directive({
+  // The @Directive with selector is required here because the CDK is still based on Angular 8.x.
+  // In Angular 9.x, `@Directive()` without any selector is legal (and `BasePortalModule` is not
+  // necessary either).
+  // TODO(alxhub): convert to a selectorless Directive when the CDK upgrades to Angular 9.
+  selector: 'abstract-base-portal-outlet',
+})
 export abstract class BasePortalOutlet implements PortalOutlet {
   /** The portal currently attached to the host. */
   protected _attachedPortal: Portal<any> | null;
@@ -258,6 +267,13 @@ export abstract class BasePortalOutlet implements PortalOutlet {
       this._disposeFn = null;
     }
   }
+}
+
+// TODO(alxhub): remove when `BasePortalOutlet` becomes a selectorless Directive.
+@NgModule({
+  declarations: [BasePortalOutlet as any],
+})
+export class BasePortalOutletModule {
 }
 
 /**

--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -186,7 +186,7 @@ export type PortalHost = PortalOutlet;
   // In Angular 9.x, `@Directive()` without any selector is legal (and `BasePortalModule` is not
   // necessary either).
   // TODO(alxhub): convert to a selectorless Directive when the CDK upgrades to Angular 9.
-  selector: 'abstract-base-portal-outlet',
+  selector: 'do-not-use-abstract-base-portal-outlet',
 })
 export abstract class BasePortalOutlet implements PortalOutlet {
   /** The portal currently attached to the host. */
@@ -273,7 +273,7 @@ export abstract class BasePortalOutlet implements PortalOutlet {
 @NgModule({
   declarations: [BasePortalOutlet as any],
 })
-export class BasePortalOutletModule {
+export class DoNotUseBasePortalOutletModule {
 }
 
 /**

--- a/src/material/form-field/form-field-control.ts
+++ b/src/material/form-field/form-field-control.ts
@@ -17,7 +17,7 @@ import {NgControl} from '@angular/forms';
   // In Angular 9.x, `@Directive()` without any selector is legal (and `MatFormFieldControlModule`
   // is not necessary either).
   // TODO(alxhub): convert to a selectorless Directive when Material upgrades to Angular 9.
-  selector: 'abstract-mat-form-field-control',
+  selector: 'do-not-use-abstract-mat-form-field-control',
 })
 export abstract class MatFormFieldControl<T> {
   /** The value of the control. */
@@ -80,5 +80,5 @@ export abstract class MatFormFieldControl<T> {
 @NgModule({
   declarations: [MatFormFieldControl as any],
 })
-export class MatFormFieldControlModule {
+export class DoNotUseMatFormFieldControlModule {
 }

--- a/src/material/form-field/form-field-control.ts
+++ b/src/material/form-field/form-field-control.ts
@@ -7,10 +7,18 @@
  */
 
 import {Observable} from 'rxjs';
+import {Directive, NgModule} from '@angular/core';
 import {NgControl} from '@angular/forms';
 
 
 /** An interface which allows a control to work inside of a `MatFormField`. */
+@Directive({
+  // The @Directive with selector is required here because Material is still based on Angular 8.x.
+  // In Angular 9.x, `@Directive()` without any selector is legal (and `MatFormFieldControlModule`
+  // is not necessary either).
+  // TODO(alxhub): convert to a selectorless Directive when Material upgrades to Angular 9.
+  selector: 'abstract-mat-form-field-control',
+})
 export abstract class MatFormFieldControl<T> {
   /** The value of the control. */
   value: T | null;
@@ -66,4 +74,11 @@ export abstract class MatFormFieldControl<T> {
 
   /** Handles a click on the control's container. */
   abstract onContainerClick(event: MouseEvent): void;
+}
+
+// TODO(alxhub): remove when `MatFormFieldControl` becomes a selectorless Directive.
+@NgModule({
+  declarations: [MatFormFieldControl as any],
+})
+export class MatFormFieldControlModule {
 }


### PR DESCRIPTION
There are two base classes in Material/CDK which are intended to be extended
by user code: BasePortalHost and MatFormFieldControl.

This commit annotates them with `@Directive`. The best way to do this is to
use `@Directive()` but this is not supported by Angular 8.x, on which
Material and the CDK still depend. Therefore, a workaround is used with a
selector which will never be matched. Modules are also added to satisfy the
View Engine compiler.