### PR TITLE
build: run custom tslint rules on new packages

### DIFF
--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -11,6 +19,7 @@ import {
   OnInit,
   Output,
   QueryList,
+  ViewEncapsulation,
 } from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
 import {map, shareReplay, take, takeUntil} from 'rxjs/operators';
@@ -47,9 +56,11 @@ export const DEFAULT_WIDTH = '500px';
  * @see https://developers.google.com/maps/documentation/javascript/reference/
  */
 @Component({
+  moduleId: module.id,
   selector: 'google-map',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<div class="map-container"></div><ng-content></ng-content>',
+  encapsulation: ViewEncapsulation.None,
 })
 export class GoogleMap implements OnChanges, OnInit, AfterContentInit, OnDestroy {
   @Input() height = DEFAULT_HEIGHT;

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {
   ChangeDetectionStrategy,
   Component,
@@ -5,7 +13,8 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Output
+  Output,
+  ViewEncapsulation
 } from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, ReplaySubject, Subject} from 'rxjs';
 import {map, takeUntil} from 'rxjs/operators';
@@ -23,9 +32,11 @@ export const DEFAULT_MARKER_OPTIONS = {
  * @see developers.google.com/maps/documentation/javascript/reference/marker
  */
 @Component({
+  moduleId: module.id,
   selector: 'map-marker',
   template: '<ng-content></ng-content>',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
 })
 export class MapMarker implements OnInit, OnDestroy {
   @Input()

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {UpdatedGoogleMap} from '../google-map/index';
 
 /** Window interface for testing */

--- a/src/youtube-player/fake-youtube-player.ts
+++ b/src/youtube-player/fake-youtube-player.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 // A re-creation of YT.PlayerState since enum values cannot be bound to the window
 // object.
 const playerState = {

--- a/src/youtube-player/index.ts
+++ b/src/youtube-player/index.ts
@@ -1,1 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export * from './public-api';

--- a/src/youtube-player/public-api.ts
+++ b/src/youtube-player/public-api.ts
@@ -1,2 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 export * from './youtube-module';
 export {YouTubePlayer} from './youtube-player';

--- a/src/youtube-player/tsconfig-build.json
+++ b/src/youtube-player/tsconfig-build.json
@@ -1,6 +1,6 @@
-// TypeScript config file that is used to compile the Material package through Gulp. As the
-// long term goal is to switch to Bazel, and we already want to run tests with Bazel, we need to
-// ensure the TypeScript build options are the same for Gulp and Bazel. We achieve this by
+// TypeScript config file that is used to compile the "youtube-player" package through Gulp. As
+// the long term goal is to switch to Bazel, and we already want to run tests with Bazel, we need
+// to ensure the TypeScript build options are the same for Gulp and Bazel. We achieve this by
 // extending the generic Bazel build tsconfig which will be used for each entry-point.
 {
   "extends": "../bazel-tsconfig-build.json",
@@ -15,7 +15,8 @@
     "types": ["youtube"]
   },
   "files": [
-    "public-api.ts"
+    "public-api.ts",
+    "typings.d.ts"
   ],
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,

--- a/src/youtube-player/typings.d.ts
+++ b/src/youtube-player/typings.d.ts
@@ -1,0 +1,1 @@
+declare var module: {id: string};

--- a/src/youtube-player/youtube-module.ts
+++ b/src/youtube-player/youtube-module.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 

--- a/src/youtube-player/youtube-player.ts
+++ b/src/youtube-player/youtube-player.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -7,37 +15,38 @@ import {
   Input,
   NgZone,
   OnDestroy,
+  OnInit,
   Output,
   ViewChild,
-  OnInit,
+  ViewEncapsulation,
 } from '@angular/core';
 
 import {
   combineLatest,
-  of as observableOf,
-  Observable,
   ConnectableObservable,
-  pipe,
-  MonoTypeOperatorFunction,
   merge,
+  MonoTypeOperatorFunction,
+  Observable,
+  of as observableOf,
   OperatorFunction,
+  pipe,
   Subject,
 } from 'rxjs';
 
 import {
   combineLatest as combineLatestOp,
-  map,
-  scan,
-  withLatestFrom,
-  flatMap,
-  filter,
-  startWith,
-  publish,
-  first,
   distinctUntilChanged,
-  takeUntil,
-  take,
+  filter,
+  first,
+  flatMap,
+  map,
+  publish,
+  scan,
   skipWhile,
+  startWith,
+  take,
+  takeUntil,
+  withLatestFrom,
 } from 'rxjs/operators';
 
 declare global {
@@ -66,8 +75,10 @@ type UninitializedPlayer = Pick<Player, 'videoId' | 'destroy' | 'addEventListene
  * @see https://developers.google.com/youtube/iframe_api_reference
  */
 @Component({
+  moduleId: module.id,
   selector: 'youtube-player',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   // This div is *replaced* by the YouTube player embed.
   template: '<div #youtube_container></div>',
 })

--- a/tslint.json
+++ b/tslint.json
@@ -126,15 +126,15 @@
         "!host": "\\[class\\]"
       },
       "NgModule": "^(?!\\s*$).+"
-    }, "src/+(material|cdk|material-experimental|cdk-experimental)/**/!(*.spec).ts"],
+    }, "src/!(a11y-demo|e2e-app|material-examples|universal-app|dev-app)/**/!(*.spec).ts"],
     "require-license-banner": [
       true,
-      "src/+(material|cdk|material-experimental|cdk-experimental|dev-app)/**/!(*.spec).ts"
+      "src/!(a11y-demo|e2e-app|material-examples|universal-app)/**/!(*.spec).ts"
     ],
     "missing-rollup-globals": [
       true,
       "./tools/package-tools/rollup-globals.ts",
-      "src/+(material|cdk|material-examples|material-experimental|cdk-experimental)/!(schematics)**/*.ts"
+      "src/!(a11y-demo|e2e-app|material-examples|universal-app|dev-app)/!(schematics)**/*.ts"
     ],
     "file-name-casing": [true, {
       // Exclude custom lint rule files since they have to always be camel-cased and end


### PR DESCRIPTION
Apparently we didn't run the custom tslint rules for the new packages
that have been merged (`youtube-player` and `google-maps`). This is
because we have a whitelist of packages we want to run these custom
lint rules against.

It should be actually the other way around where we only specify the folders
we _don't_ want to lint against. That way, new folders are automatically linted
and we need to explicitly exclude them if we don't want to run for those.

**Note**: Marked as target minor because it will not merge safely into the patch branch (as youtube-player is not part of that branch).