### PR TITLE
feat(material/dialog): update dialog subjects to be AsyncSubjects

### DIFF
--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -9,7 +9,7 @@
 import {ESCAPE, hasModifierKey} from '@angular/cdk/keycodes';
 import {GlobalPositionStrategy, OverlayRef} from '@angular/cdk/overlay';
 import {Location} from '@angular/common';
-import {Observable, Subject} from 'rxjs';
+import {AsyncSubject, Observable} from 'rxjs';
 import {filter, take} from 'rxjs/operators';
 import {DialogPosition} from './dialog-config';
 import {MatDialogContainer} from './dialog-container';
@@ -34,13 +34,13 @@ export class MatDialogRef<T, R = any> {
   disableClose: boolean | undefined = this._containerInstance._config.disableClose;
 
   /** Subject for notifying the user that the dialog has finished opening. */
-  private readonly _afterOpened = new Subject<void>();
+  private readonly _afterOpened = new AsyncSubject<void>();
 
   /** Subject for notifying the user that the dialog has finished closing. */
-  private readonly _afterClosed = new Subject<R | undefined>();
+  private readonly _afterClosed = new AsyncSubject<R | undefined>();
 
   /** Subject for notifying the user that the dialog has started closing. */
-  private readonly _beforeClosed = new Subject<R | undefined>();
+  private readonly _beforeClosed = new AsyncSubject<R | undefined>();
 
   /** Result to be passed to afterClosed. */
   private _result: R | undefined;

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -207,6 +207,22 @@ describe('MatDialog', () => {
     expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
   }));
 
+  it('should close a dialog and get back a result even if no subscription is made until' +
+       'after the dialog closes', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
+    const afterCloseCallback = jasmine.createSpy('afterClose callback');
+    const afterClosedObservable = dialogRef.afterClosed();
+
+    dialogRef.close('Charmander');
+    viewContainerFixture.detectChanges();
+    flush();
+
+    afterClosedObservable.subscribe(afterCloseCallback);
+
+    expect(afterCloseCallback).toHaveBeenCalledWith('Charmander');
+    expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
+  }));
+
   it('should dispatch the beforeClose and afterClose events when the ' +
     'overlay is detached externally', fakeAsync(inject([Overlay], (overlay: Overlay) => {
       const dialogRef = dialog.open(PizzaMsg, {


### PR DESCRIPTION
AsyncSubjects have the advantage over other types of Subjects that any subscription made after the subject is marked as complete is still provided with the value.
Specifically for dialogs, this allows the consumer to delay subscribing to the afterClosed observable and still get the result from their dialog.