### PR TITLE
build: fix infinite loop in build-release-packages task

### DIFF
--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ModifierKeys} from '@angular/cdk/testing';
 import {ElementDimensions} from './element-dimensions';
+import {ModifierKeys} from './event-objects';
 
 /** An enum of non-text keys that can be used with the `sendKeys` method. */
 // NOTE: This is a separate enum from `@angular/cdk/keycodes` because we don't necessarily want to


### PR DESCRIPTION
Fixes an infinite loop in the `build-release-packages` task because an import from inside a package was referring to itself.