### PR TITLE
feat(cdk/drag-drop): expose native event objects in custom events

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -421,7 +421,10 @@ describe('CdkDrag', () => {
 
       // Assert the event like this, rather than `toHaveBeenCalledWith`, because Jasmine will
       // go into an infinite loop trying to stringify the event, if the test fails.
-      expect(event).toEqual({source: fixture.componentInstance.dragInstance});
+      expect(event).toEqual({
+        source: fixture.componentInstance.dragInstance,
+        event: jasmine.anything(),
+      });
     }));
 
     it('should dispatch an event when the user has stopped dragging', fakeAsync(() => {
@@ -440,6 +443,7 @@ describe('CdkDrag', () => {
         source: fixture.componentInstance.dragInstance,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -454,6 +458,7 @@ describe('CdkDrag', () => {
         source: jasmine.anything(),
         distance: {x: 25, y: 30},
         dropPoint: {x: 25, y: 30},
+        event: jasmine.anything(),
       });
 
       dragElementViaMouse(fixture, fixture.componentInstance.dragElement.nativeElement, 40, 50);
@@ -463,6 +468,7 @@ describe('CdkDrag', () => {
         source: jasmine.anything(),
         distance: {x: 40, y: 50},
         dropPoint: {x: 40, y: 50},
+        event: jasmine.anything(),
       });
     }));
 
@@ -1821,6 +1827,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim())).toEqual([
@@ -1995,6 +2002,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim())).toEqual([
@@ -2071,6 +2079,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim())).toEqual([
@@ -2127,6 +2136,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim())).toEqual([
@@ -2177,6 +2187,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim())).toEqual([
@@ -2225,6 +2236,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -2277,6 +2289,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -2326,6 +2339,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
 
       scrollTo(0, 0);
@@ -4097,6 +4111,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim())).toEqual([
@@ -4581,6 +4596,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -4827,6 +4843,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -4955,6 +4972,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5070,6 +5088,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5101,6 +5120,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5132,6 +5152,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5277,6 +5298,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5420,6 +5442,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5448,6 +5471,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5481,6 +5505,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5527,6 +5552,7 @@ describe('CdkDrag', () => {
           isPointerOverContainer: true,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
           dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+          event: jasmine.anything(),
         });
 
         expect(dropContainers[0].contains(item.element.nativeElement))
@@ -5633,6 +5659,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -5822,6 +5849,7 @@ describe('CdkDrag', () => {
             isPointerOverContainer: false,
             distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
             dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+            event: jasmine.anything(),
           }),
         );
       }),
@@ -6198,6 +6226,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
 
       cleanup();
@@ -6244,6 +6273,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 
@@ -6282,6 +6312,7 @@ describe('CdkDrag', () => {
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
         dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        event: jasmine.anything(),
       });
     }));
 

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -442,23 +442,24 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
   /** Handles the events from the underlying `DragRef`. */
   private _handleEvents(ref: DragRef<CdkDrag<T>>) {
-    ref.started.subscribe(() => {
-      this.started.emit({source: this});
+    ref.started.subscribe(startEvent => {
+      this.started.emit({source: this, event: startEvent.event});
 
       // Since all of these events run outside of change detection,
       // we need to ensure that everything is marked correctly.
       this._changeDetectorRef.markForCheck();
     });
 
-    ref.released.subscribe(() => {
-      this.released.emit({source: this});
+    ref.released.subscribe(releaseEvent => {
+      this.released.emit({source: this, event: releaseEvent.event});
     });
 
-    ref.ended.subscribe(event => {
+    ref.ended.subscribe(endEvent => {
       this.ended.emit({
         source: this,
-        distance: event.distance,
-        dropPoint: event.dropPoint,
+        distance: endEvent.distance,
+        dropPoint: endEvent.dropPoint,
+        event: endEvent.event,
       });
 
       // Since all of these events run outside of change detection,
@@ -466,31 +467,32 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
       this._changeDetectorRef.markForCheck();
     });
 
-    ref.entered.subscribe(event => {
+    ref.entered.subscribe(enterEvent => {
       this.entered.emit({
-        container: event.container.data,
+        container: enterEvent.container.data,
         item: this,
-        currentIndex: event.currentIndex,
+        currentIndex: enterEvent.currentIndex,
       });
     });
 
-    ref.exited.subscribe(event => {
+    ref.exited.subscribe(exitEvent => {
       this.exited.emit({
-        container: event.container.data,
+        container: exitEvent.container.data,
         item: this,
       });
     });
 
-    ref.dropped.subscribe(event => {
+    ref.dropped.subscribe(dropEvent => {
       this.dropped.emit({
-        previousIndex: event.previousIndex,
-        currentIndex: event.currentIndex,
-        previousContainer: event.previousContainer.data,
-        container: event.container.data,
-        isPointerOverContainer: event.isPointerOverContainer,
+        previousIndex: dropEvent.previousIndex,
+        currentIndex: dropEvent.currentIndex,
+        previousContainer: dropEvent.previousContainer.data,
+        container: dropEvent.container.data,
+        isPointerOverContainer: dropEvent.isPointerOverContainer,
         item: this,
-        distance: event.distance,
-        dropPoint: event.dropPoint,
+        distance: dropEvent.distance,
+        dropPoint: dropEvent.dropPoint,
+        event: dropEvent.event,
       });
     });
   }

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -357,16 +357,17 @@ export class CdkDropList<T = any> implements OnDestroy {
       });
     });
 
-    ref.dropped.subscribe(event => {
+    ref.dropped.subscribe(dropEvent => {
       this.dropped.emit({
-        previousIndex: event.previousIndex,
-        currentIndex: event.currentIndex,
-        previousContainer: event.previousContainer.data,
-        container: event.container.data,
-        item: event.item.data,
-        isPointerOverContainer: event.isPointerOverContainer,
-        distance: event.distance,
-        dropPoint: event.dropPoint,
+        previousIndex: dropEvent.previousIndex,
+        currentIndex: dropEvent.currentIndex,
+        previousContainer: dropEvent.previousContainer.data,
+        container: dropEvent.container.data,
+        item: dropEvent.item.data,
+        isPointerOverContainer: dropEvent.isPointerOverContainer,
+        distance: dropEvent.distance,
+        dropPoint: dropEvent.dropPoint,
+        event: dropEvent.event,
       });
 
       // Mark for check since all of these events run outside of change

--- a/src/cdk/drag-drop/drag-events.ts
+++ b/src/cdk/drag-drop/drag-events.ts
@@ -13,12 +13,16 @@ import {CdkDropList} from './directives/drop-list';
 export interface CdkDragStart<T = any> {
   /** Draggable that emitted the event. */
   source: CdkDrag<T>;
+  /** Native event that started the drag sequence. */
+  event: MouseEvent | TouchEvent;
 }
 
 /** Event emitted when the user releases an item, before any animations have started. */
 export interface CdkDragRelease<T = any> {
   /** Draggable that emitted the event. */
   source: CdkDrag<T>;
+  /** Native event that caused the release event. */
+  event: MouseEvent | TouchEvent;
 }
 
 /** Event emitted when the user stops dragging a draggable. */
@@ -29,6 +33,8 @@ export interface CdkDragEnd<T = any> {
   distance: {x: number; y: number};
   /** Position where the pointer was when the item was dropped */
   dropPoint: {x: number; y: number};
+  /** Native event that caused the dragging to stop. */
+  event: MouseEvent | TouchEvent;
 }
 
 /** Event emitted when the user moves an item into a new drop container. */
@@ -70,6 +76,8 @@ export interface CdkDragDrop<T, O = T, I = any> {
   distance: {x: number; y: number};
   /** Position where the pointer was when the item was dropped */
   dropPoint: {x: number; y: number};
+  /** Native event that caused the drop event. */
+  event: MouseEvent | TouchEvent;
 }
 
 /** Event emitted as the user is dragging a draggable item. */

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -305,13 +305,18 @@ export class DragRef<T = any> {
   readonly beforeStarted = new Subject<void>();
 
   /** Emits when the user starts dragging the item. */
-  readonly started = new Subject<{source: DragRef}>();
+  readonly started = new Subject<{source: DragRef; event: MouseEvent | TouchEvent}>();
 
   /** Emits when the user has released a drag item, before any animations have started. */
-  readonly released = new Subject<{source: DragRef}>();
+  readonly released = new Subject<{source: DragRef; event: MouseEvent | TouchEvent}>();
 
   /** Emits when the user stops dragging an item in the container. */
-  readonly ended = new Subject<{source: DragRef; distance: Point; dropPoint: Point}>();
+  readonly ended = new Subject<{
+    source: DragRef;
+    distance: Point;
+    dropPoint: Point;
+    event: MouseEvent | TouchEvent;
+  }>();
 
   /** Emits when the user has moved the item into a new container. */
   readonly entered = new Subject<{container: DropListRef; item: DragRef; currentIndex: number}>();
@@ -329,6 +334,7 @@ export class DragRef<T = any> {
     distance: Point;
     dropPoint: Point;
     isPointerOverContainer: boolean;
+    event: MouseEvent | TouchEvent;
   }>();
 
   /**
@@ -758,7 +764,7 @@ export class DragRef<T = any> {
       return;
     }
 
-    this.released.next({source: this});
+    this.released.next({source: this, event});
 
     if (this._dropContainer) {
       // Stop scrolling immediately, instead of waiting for the animation to finish.
@@ -780,6 +786,7 @@ export class DragRef<T = any> {
           source: this,
           distance: this._getDragDistance(pointerPosition),
           dropPoint: pointerPosition,
+          event,
         });
       });
       this._cleanupCachedDimensions();
@@ -823,12 +830,12 @@ export class DragRef<T = any> {
       toggleVisibility(element, false, dragImportantProperties);
       this._document.body.appendChild(parent.replaceChild(placeholder, element));
       this._getPreviewInsertionPoint(parent, shadowRoot).appendChild(this._preview);
-      this.started.next({source: this}); // Emit before notifying the container.
+      this.started.next({source: this, event}); // Emit before notifying the container.
       dropContainer.start();
       this._initialContainer = dropContainer;
       this._initialIndex = dropContainer.getItemIndex(this);
     } else {
-      this.started.next({source: this});
+      this.started.next({source: this, event});
       this._initialContainer = this._initialIndex = undefined!;
     }
 
@@ -944,7 +951,7 @@ export class DragRef<T = any> {
         pointerPosition.y,
       );
 
-      this.ended.next({source: this, distance, dropPoint: pointerPosition});
+      this.ended.next({source: this, distance, dropPoint: pointerPosition, event});
       this.dropped.next({
         item: this,
         currentIndex,
@@ -954,6 +961,7 @@ export class DragRef<T = any> {
         isPointerOverContainer,
         distance,
         dropPoint: pointerPosition,
+        event,
       });
       container.drop(
         this,

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -138,6 +138,7 @@ export class DropListRef<T = any> {
     isPointerOverContainer: boolean;
     distance: Point;
     dropPoint: Point;
+    event: MouseEvent | TouchEvent;
   }>();
 
   /** Emits as the user is swapping items while actively dragging. */
@@ -357,6 +358,9 @@ export class DropListRef<T = any> {
    * @param isPointerOverContainer Whether the user's pointer was over the
    *    container when the item was dropped.
    * @param distance Distance the user has dragged since the start of the dragging sequence.
+   * @param event Event that triggered the dropping sequence.
+   *
+   * @breaking-change 15.0.0 `previousIndex` and `event` parameters to become required.
    */
   drop(
     item: DragRef,
@@ -366,6 +370,7 @@ export class DropListRef<T = any> {
     isPointerOverContainer: boolean,
     distance: Point,
     dropPoint: Point,
+    event: MouseEvent | TouchEvent = {} as any,
   ): void {
     this._reset();
     this.dropped.next({
@@ -377,6 +382,7 @@ export class DropListRef<T = any> {
       isPointerOverContainer,
       distance,
       dropPoint,
+      event,
     });
   }
 

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -112,6 +112,7 @@ export interface CdkDragDrop<T, O = T, I = any> {
         x: number;
         y: number;
     };
+    event: MouseEvent | TouchEvent;
     isPointerOverContainer: boolean;
     item: CdkDrag<I>;
     previousContainer: CdkDropList<O>;
@@ -128,6 +129,7 @@ export interface CdkDragEnd<T = any> {
         x: number;
         y: number;
     };
+    event: MouseEvent | TouchEvent;
     source: CdkDrag<T>;
 }
 
@@ -207,6 +209,7 @@ export class CdkDragPreview<T = any> {
 
 // @public
 export interface CdkDragRelease<T = any> {
+    event: MouseEvent | TouchEvent;
     source: CdkDrag<T>;
 }
 
@@ -220,6 +223,7 @@ export interface CdkDragSortEvent<T = any, I = T> {
 
 // @public
 export interface CdkDragStart<T = any> {
+    event: MouseEvent | TouchEvent;
     source: CdkDrag<T>;
 }
 
@@ -379,12 +383,14 @@ export class DragRef<T = any> {
         distance: Point;
         dropPoint: Point;
         isPointerOverContainer: boolean;
+        event: MouseEvent | TouchEvent;
     }>;
     enableHandle(handle: HTMLElement): void;
     readonly ended: Subject<{
         source: DragRef;
         distance: Point;
         dropPoint: Point;
+        event: MouseEvent | TouchEvent;
     }>;
     readonly entered: Subject<{
         container: DropListRefInternal;
@@ -417,12 +423,14 @@ export class DragRef<T = any> {
     previewClass: string | string[] | undefined;
     readonly released: Subject<{
         source: DragRef;
+        event: MouseEvent | TouchEvent;
     }>;
     reset(): void;
     setFreeDragPosition(value: Point): this;
     _sortFromLastPointerPosition(): void;
     readonly started: Subject<{
         source: DragRef;
+        event: MouseEvent | TouchEvent;
     }>;
     withBoundaryElement(boundaryElement: ElementRef<HTMLElement> | HTMLElement | null): this;
     withDirection(direction: Direction): this;
@@ -463,7 +471,7 @@ export class DropListRef<T = any> {
     data: T;
     disabled: boolean;
     dispose(): void;
-    drop(item: DragRefInternal, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, dropPoint: Point): void;
+    drop(item: DragRefInternal, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, dropPoint: Point, event?: MouseEvent | TouchEvent): void;
     readonly dropped: Subject<{
         item: DragRefInternal;
         currentIndex: number;
@@ -473,6 +481,7 @@ export class DropListRef<T = any> {
         isPointerOverContainer: boolean;
         distance: Point;
         dropPoint: Point;
+        event: MouseEvent | TouchEvent;
     }>;
     element: HTMLElement | ElementRef<HTMLElement>;
     enter(item: DragRefInternal, pointerX: number, pointerY: number, index?: number): void;


### PR DESCRIPTION
Exposes the native `MouseEvent` and `TouchEvent` objects in the various drag&drop events since they can contain useful information like which keys were pressed while dragging.

Fixes #17032.