### PR TITLE
feat(slide-toggle): remove Hammer.js dependency

### DIFF
--- a/src/material/slide-toggle/slide-toggle-config.ts
+++ b/src/material/slide-toggle/slide-toggle-config.ts
@@ -12,7 +12,11 @@ import {InjectionToken} from '@angular/core';
 export interface MatSlideToggleDefaultOptions {
   /** Whether toggle action triggers value changes in slide toggle. */
   disableToggleValue?: boolean;
-  /** Whether drag action triggers value changes in slide toggle. */
+  /**
+   * Whether drag action triggers value changes in slide toggle.
+   * @deprecated No longer being used.
+   * @breaking-change 10.0.0
+   */
   disableDragValue?: boolean;
 }
 
@@ -20,5 +24,5 @@ export interface MatSlideToggleDefaultOptions {
 export const MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS =
   new InjectionToken<MatSlideToggleDefaultOptions>('mat-slide-toggle-default-options', {
     providedIn: 'root',
-    factory: () => ({disableToggleValue: false, disableDragValue: false})
+    factory: () => ({disableToggleValue: false})
   });

--- a/src/material/slide-toggle/slide-toggle-module.ts
+++ b/src/material/slide-toggle/slide-toggle-module.ts
@@ -8,8 +8,7 @@
 
 import {ObserversModule} from '@angular/cdk/observers';
 import {NgModule} from '@angular/core';
-import {GestureConfig, MatCommonModule, MatRippleModule} from '@angular/material/core';
-import {HAMMER_GESTURE_CONFIG} from '@angular/platform-browser';
+import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatSlideToggle} from './slide-toggle';
 import {MatSlideToggleRequiredValidator} from './slide-toggle-required-validator';
 
@@ -35,8 +34,5 @@ export class _MatSlideToggleRequiredValidatorModule {
     MatCommonModule
   ],
   declarations: [MatSlideToggle],
-  providers: [
-    {provide: HAMMER_GESTURE_CONFIG, useClass: GestureConfig}
-  ],
 })
 export class MatSlideToggleModule {}

--- a/src/material/slide-toggle/slide-toggle.html
+++ b/src/material/slide-toggle/slide-toggle.html
@@ -16,14 +16,8 @@
            (change)="_onChangeEvent($event)"
            (click)="_onInputClick($event)">
 
-    <div class="mat-slide-toggle-thumb-container"
-         #thumbContainer
-         (slidestart)="_onDragStart()"
-         (slide)="_onDrag($event)"
-         (slideend)="_onDragEnd()">
-
+    <div class="mat-slide-toggle-thumb-container" #thumbContainer>
       <div class="mat-slide-toggle-thumb"></div>
-
       <div class="mat-slide-toggle-ripple" mat-ripple
            [matRippleTrigger]="label"
            [matRippleDisabled]="disableRipple || disabled"
@@ -33,9 +27,7 @@
 
         <div class="mat-ripple-element mat-slide-toggle-persistent-ripple"></div>
       </div>
-
     </div>
-
 
   </div>
 

--- a/src/material/slide-toggle/slide-toggle.md
+++ b/src/material/slide-toggle/slide-toggle.md
@@ -1,27 +1,25 @@
-`<mat-slide-toggle>` is an on/off control that can be toggled via clicking or dragging. 
+`<mat-slide-toggle>` is an on/off control that can be toggled via clicking.
 
 <!-- example(slide-toggle-overview) -->
 
-The slide-toggle behaves similarly to a checkbox, though it does not support an `indeterminate` 
+The slide-toggle behaves similarly to a checkbox, though it does not support an `indeterminate`
 state like `<mat-checkbox>`.
 
-_Note: the sliding behavior for this component requires that HammerJS is loaded on the page._
-
 ### Slide-toggle label
-The slide-toggle label is provided as the content to the `<mat-slide-toggle>` element. 
+The slide-toggle label is provided as the content to the `<mat-slide-toggle>` element.
 
-If you don't want the label to appear next to the slide-toggle, you can use 
-[`aria-label`](https://www.w3.org/TR/wai-aria/states_and_properties#aria-label) or 
-[`aria-labelledby`](https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby) to 
+If you don't want the label to appear next to the slide-toggle, you can use
+[`aria-label`](https://www.w3.org/TR/wai-aria/states_and_properties#aria-label) or
+[`aria-labelledby`](https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby) to
 specify an appropriate label.
 
 ### Use with `@angular/forms`
-`<mat-slide-toggle>` is compatible with `@angular/forms` and supports both `FormsModule` 
+`<mat-slide-toggle>` is compatible with `@angular/forms` and supports both `FormsModule`
 and `ReactiveFormsModule`.
 
 ### Theming
-The color of a `<mat-slide-toggle>` can be changed by using the `color` property. By default, 
-slide-toggles use the theme's accent color. This can be changed to `'primary'` or `'warn'`.  
+The color of a `<mat-slide-toggle>` can be changed by using the `color` property. By default,
+slide-toggles use the theme's accent color. This can be changed to `'primary'` or `'warn'`.
 
 ### Accessibility
 The `<mat-slide-toggle>` uses an internal `<input type="checkbox">` to provide an accessible

--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -1,6 +1,5 @@
 @import '../core/style/variables';
 @import '../core/ripple/ripple';
-@import '../core/style/vendor-prefixes';
 @import '../core/style/list-common';
 @import '../../cdk/a11y/a11y';
 
@@ -22,10 +21,6 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
   line-height: $mat-slide-toggle-height;
   white-space: nowrap;
   outline: none;
-
-  // Disable user selection to ensure that dragging is smooth without grabbing
-  // some elements accidentally.
-  @include user-select(none);
 
   -webkit-tap-highlight-color: transparent;
 
@@ -57,7 +52,6 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
   flex-direction: row;
   align-items: center;
   height: inherit;
-
   cursor: pointer;
 }
 
@@ -92,7 +86,6 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
   margin-right: 0;
 }
 
-// The thumb container is responsible for the dragging functionality.
 // The container includes the visual thumb and the ripple container element.
 .mat-slide-toggle-thumb-container {
   $thumb-bar-vertical-padding: ($mat-slide-toggle-thumb-size - $mat-slide-toggle-bar-height) / 2;
@@ -108,18 +101,6 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
   transform: translate3d(0, 0, 0);
   transition: $swift-linear;
   transition-property: transform;
-
-  @include cursor-grab;
-
-  // Once the thumb container is being dragged around, we remove the transition duration to
-  // make the drag feeling fast and not delayed.
-  &.mat-dragging {
-    transition-duration: 0ms;
-  }
-
-  &:active {
-    @include cursor-grabbing;
-  }
 
   ._mat-animation-noopable & {
     transition: none;

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -32,7 +32,6 @@ import {
   CanColor, CanColorCtor,
   CanDisable, CanDisableCtor,
   CanDisableRipple, CanDisableRippleCtor,
-  HammerInput,
   HasTabIndex, HasTabIndexCtor,
   mixinColor,
   mixinDisabled,
@@ -112,18 +111,6 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   private _required: boolean = false;
   private _checked: boolean = false;
 
-  /** Whether the thumb is currently being dragged. */
-  private _dragging = false;
-
-  /** Previous checked state before drag started. */
-  private _previousChecked: boolean;
-
-  /** Width of the thumb bar of the slide-toggle. */
-  private _thumbBarWidth: number;
-
-  /** Percentage of the thumb while dragging. Percentage as fraction of 100. */
-  private _dragPercentage: number;
-
   /** Reference to the thumb HTMLElement. */
   @ViewChild('thumbContainer', {static: false}) _thumbEl: ElementRef;
 
@@ -164,8 +151,7 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   /**
    * An event will be dispatched each time the slide-toggle input is toggled.
    * This event is always emitted when the user toggles the slide toggle, but this does not mean
-   * the slide toggle's value has changed. The event does not fire when the user drags to change
-   * the slide toggle value.
+   * the slide toggle's value has changed.
    */
   @Output() readonly toggleChange: EventEmitter<void> = new EventEmitter<void>();
 
@@ -174,6 +160,8 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
    * This event is always emitted when the user drags the slide toggle to make a change greater
    * than 50%. It does not mean the slide toggle's value is changed. The event is not emitted when
    * the user toggles the slide toggle to change its value.
+   * @deprecated No longer being used. To be removed.
+   * @breaking-change 10.0.0
    */
   @Output() readonly dragChange: EventEmitter<void> = new EventEmitter<void>();
 
@@ -187,11 +175,15 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
               private _focusMonitor: FocusMonitor,
               private _changeDetectorRef: ChangeDetectorRef,
               @Attribute('tabindex') tabIndex: string,
-              private _ngZone: NgZone,
+                /**
+                 * @deprecated `_ngZone` and `_dir` parameters to be removed.
+                 * @breaking-change 10.0.0
+                 */
+              _ngZone: NgZone,
               @Inject(MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS)
                   public defaults: MatSlideToggleDefaultOptions,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,
-              @Optional() private _dir?: Directionality) {
+              @Optional() _dir?: Directionality) {
     super(elementRef);
     this.tabIndex = parseInt(tabIndex) || 0;
   }
@@ -221,16 +213,12 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     // Otherwise the change event, from the input element, will bubble up and
     // emit its event object to the component's `change` output.
     event.stopPropagation();
+    this.toggleChange.emit();
 
-    if (!this._dragging) {
-      this.toggleChange.emit();
-    }
-    // Releasing the pointer over the `<label>` element while dragging triggers another
-    // click event on the `<label>` element. This means that the checked state of the underlying
-    // input changed unintentionally and needs to be changed back. Or when the slide toggle's config
-    // disabled toggle change event by setting `disableToggleValue: true`, the slide toggle's value
-    // does not change, and the checked state of the underlying input needs to be changed back.
-    if (this._dragging || this.defaults.disableToggleValue) {
+    // When the slide toggle's config disables toggle change event by setting
+    // `disableToggleValue: true`, the slide toggle's value does not change, and the
+    // checked state of the underlying input needs to be changed back.
+    if (this.defaults.disableToggleValue) {
       this._inputElement.nativeElement.checked = this.checked;
       return;
     }
@@ -293,66 +281,6 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   private _emitChangeEvent() {
     this._onChange(this.checked);
     this.change.emit(new MatSlideToggleChange(this, this.checked));
-  }
-
-  /** Retrieves the percentage of thumb from the moved distance. Percentage as fraction of 100. */
-  private _getDragPercentage(distance: number) {
-    let percentage = (distance / this._thumbBarWidth) * 100;
-
-    // When the toggle was initially checked, then we have to start the drag at the end.
-    if (this._previousChecked) {
-      percentage += 100;
-    }
-
-    return Math.max(0, Math.min(percentage, 100));
-  }
-
-  _onDragStart() {
-    if (!this.disabled && !this._dragging) {
-      const thumbEl = this._thumbEl.nativeElement;
-      this._thumbBarWidth = this._thumbBarEl.nativeElement.clientWidth - thumbEl.clientWidth;
-      thumbEl.classList.add('mat-dragging');
-
-      this._previousChecked = this.checked;
-      this._dragging = true;
-    }
-  }
-
-  _onDrag(event: HammerInput) {
-    if (this._dragging) {
-      const direction = this._dir && this._dir.value === 'rtl' ? -1 : 1;
-      this._dragPercentage = this._getDragPercentage(event.deltaX * direction);
-      // Calculate the moved distance based on the thumb bar width.
-      const dragX = (this._dragPercentage / 100) * this._thumbBarWidth * direction;
-      this._thumbEl.nativeElement.style.transform = `translate3d(${dragX}px, 0, 0)`;
-    }
-  }
-
-  _onDragEnd() {
-    if (this._dragging) {
-      const newCheckedValue = this._dragPercentage > 50;
-
-      if (newCheckedValue !== this.checked) {
-        this.dragChange.emit();
-        if (!this.defaults.disableDragValue) {
-          this.checked = newCheckedValue;
-          this._emitChangeEvent();
-        }
-      }
-
-      // The drag should be stopped outside of the current event handler, otherwise the
-      // click event will be fired before it and will revert the drag change.
-      this._ngZone.runOutsideAngular(() => setTimeout(() => {
-        if (this._dragging) {
-          this._dragging = false;
-          this._thumbEl.nativeElement.classList.remove('mat-dragging');
-
-          // Reset the transform because the component will take care
-          // of the thumb position after drag.
-          this._thumbEl.nativeElement.style.transform = '';
-        }
-      }));
-    }
   }
 
   /** Method being called whenever the label text changes. */

--- a/tools/public_api_guard/material/slide-toggle.d.ts
+++ b/tools/public_api_guard/material/slide-toggle.d.ts
@@ -24,11 +24,9 @@ export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements 
     name: string | null;
     required: boolean;
     readonly toggleChange: EventEmitter<void>;
-    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, _ngZone: NgZone, defaults: MatSlideToggleDefaultOptions, _animationMode?: string | undefined, _dir?: Directionality | undefined);
+    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string,
+    _ngZone: NgZone, defaults: MatSlideToggleDefaultOptions, _animationMode?: string | undefined, _dir?: Directionality);
     _onChangeEvent(event: Event): void;
-    _onDrag(event: HammerInput): void;
-    _onDragEnd(): void;
-    _onDragStart(): void;
     _onInputClick(event: Event): void;
     _onLabelTextChange(): void;
     focus(options?: FocusOptions): void;


### PR DESCRIPTION
Removes the slide toggle's dependency on Hammer.js by getting rid of the dragging gestures.