### PR TITLE
chore: fix various examples missing button module

### DIFF
--- a/src/material-examples/cdk/tree/BUILD.bazel
+++ b/src/material-examples/cdk/tree/BUILD.bazel
@@ -11,6 +11,7 @@ ng_module(
     ]),
     deps = [
         "//src/cdk/tree",
+        "//src/material/button",
         "//src/material/icon",
     ],
 )

--- a/src/material-examples/cdk/tree/module.ts
+++ b/src/material-examples/cdk/tree/module.ts
@@ -1,5 +1,6 @@
 import {CdkTreeModule} from '@angular/cdk/tree';
 import {NgModule} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {CdkTreeFlatExample} from './cdk-tree-flat/cdk-tree-flat-example';
 import {CdkTreeNestedExample} from './cdk-tree-nested/cdk-tree-nested-example';
@@ -12,6 +13,7 @@ const EXAMPLES = [
 @NgModule({
   imports: [
     CdkTreeModule,
+    MatButtonModule,
     MatIconModule,
   ],
   declarations: EXAMPLES,

--- a/src/material-examples/material/badge/BUILD.bazel
+++ b/src/material-examples/material/badge/BUILD.bazel
@@ -11,6 +11,7 @@ ng_module(
     ]),
     deps = [
         "//src/material/badge",
+        "//src/material/button",
         "//src/material/icon",
     ],
 )

--- a/src/material-examples/material/badge/module.ts
+++ b/src/material-examples/material/badge/module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from '@angular/core';
 import {MatBadgeModule} from '@angular/material/badge';
+import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {BadgeOverviewExample} from './badge-overview/badge-overview-example';
 
@@ -10,6 +11,7 @@ const EXAMPLES = [
 @NgModule({
   imports: [
     MatBadgeModule,
+    MatButtonModule,
     MatIconModule,
   ],
   declarations: EXAMPLES,

--- a/src/material-examples/material/bottom-sheet/BUILD.bazel
+++ b/src/material-examples/material/bottom-sheet/BUILD.bazel
@@ -11,6 +11,7 @@ ng_module(
     ]),
     deps = [
         "//src/material/bottom-sheet",
+        "//src/material/button",
         "//src/material/list",
     ],
 )

--- a/src/material-examples/material/bottom-sheet/module.ts
+++ b/src/material-examples/material/bottom-sheet/module.ts
@@ -1,5 +1,6 @@
 import {NgModule} from '@angular/core';
 import {MatBottomSheetModule} from '@angular/material/bottom-sheet';
+import {MatButtonModule} from '@angular/material/button';
 import {MatListModule} from '@angular/material/list';
 import {
   BottomSheetOverviewExample,
@@ -14,6 +15,7 @@ const EXAMPLES = [
 @NgModule({
   imports: [
     MatBottomSheetModule,
+    MatButtonModule,
     MatListModule,
   ],
   declarations: EXAMPLES,

--- a/src/material-examples/material/expansion/BUILD.bazel
+++ b/src/material-examples/material/expansion/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
         "**/*.css",
     ]),
     deps = [
+        "//src/material/button",
         "//src/material/datepicker",
         "//src/material/expansion",
         "//src/material/icon",

--- a/src/material-examples/material/expansion/module.ts
+++ b/src/material-examples/material/expansion/module.ts
@@ -1,4 +1,5 @@
 import {NgModule} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {MatIconModule} from '@angular/material/icon';
@@ -17,6 +18,7 @@ const EXAMPLES = [
 
 @NgModule({
   imports: [
+    MatButtonModule,
     MatDatepickerModule,
     MatExpansionModule,
     MatIconModule,


### PR DESCRIPTION
Looks like a few examples were missing the `MatButtonModule` after
the restructuring of the examples. I've noticed these while manually
testing the Bazel release output in the docs app.