### PR TITLE
build: fix docs not displaying inherited members properly

### DIFF
--- a/tools/dgeni/processors/docs-private-filter.ts
+++ b/tools/dgeni/processors/docs-private-filter.ts
@@ -9,6 +9,7 @@ import {getDocsPublicTag, isPublicDoc} from '../common/private-docs';
 export class DocsPrivateFilter implements Processor {
   name = 'docs-private-filter';
   $runBefore = ['categorizer'];
+  $runAfter = ['merge-inherited-properties'];
 
   $process(docs: DocCollection) {
     return docs.filter(doc => {


### PR DESCRIPTION
Recently due to the MDC prototypes, we have multiple layers of inheritance. Apparently
our current docs tooling sometimes does not display inherited members which are coming
from implicitly inherited class-like documents.

For example: see how the `MatTabLink` docs broke when the MDC prototype
landed: https://github.com/angular/material2-docs-content/commit/338929159e4263e952e5df6a37f1ac3a9ca15885