### PR TITLE
feat(material-experimental/mdc-snackbar): Add skeleton.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,6 +103,7 @@
 /src/material-experimental/mdc-progress-bar/**     @andrewseguin
 # Note to implementer: please repossess
 /src/material-experimental/mdc-radio/**            @mmalerba
+/src/material-experimental/mdc-snackbar/**         @opozo
 /src/material-experimental/mdc-slide-toggle/**     @crisbeto
 /src/material-experimental/mdc-slider/**           @devversion
 /src/material-experimental/mdc-tabs/**             @crisbeto

--- a/src/material-experimental/mdc-snackbar/BUILD.bazel
+++ b/src/material-experimental/mdc-snackbar/BUILD.bazel
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
+load("//:packages.bzl", "CDK_TARGETS", "MATERIAL_TARGETS")
+load("//tools:defaults.bzl", "ng_module")
+
+ng_module(
+    name = "mdc-snackbar",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    assets = [":snackbar_scss"] + glob(["**/*.html"]),
+    module_name = "@angular/material-experimental/mdc-snackbar",
+    deps = [
+        "@npm//material-components-web",
+    ] + CDK_TARGETS + MATERIAL_TARGETS,
+)
+
+sass_library(
+    name = "snackbar_scss_lib",
+    srcs = glob(["**/_*.scss"]),
+    deps = [
+        "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
+        "//src/material/core:core_scss_lib",
+    ],
+)
+
+sass_binary(
+    name = "snackbar_scss",
+    src = "snackbar.scss",
+)

--- a/src/material-experimental/mdc-snackbar/_mdc-snackbar.scss
+++ b/src/material-experimental/mdc-snackbar/_mdc-snackbar.scss
@@ -1,0 +1,5 @@
+@mixin mat-snackbar-theme-mdc($theme) {
+}
+
+@mixin mat-snackbar-typography-mdc($config) {
+}

--- a/src/material-experimental/mdc-snackbar/index.ts
+++ b/src/material-experimental/mdc-snackbar/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-snackbar/module.ts
+++ b/src/material-experimental/mdc-snackbar/module.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatCommonModule} from '@angular/material/core';
+import {MatSnackbar} from './snackbar';
+
+@NgModule({
+  imports: [MatCommonModule, CommonModule],
+  exports: [MatSnackbar, MatCommonModule],
+  declarations: [MatSnackbar],
+})
+export class MatSnackbarModule {
+}

--- a/src/material-experimental/mdc-snackbar/public-api.ts
+++ b/src/material-experimental/mdc-snackbar/public-api.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './snackbar';
+export * from './module';

--- a/src/material-experimental/mdc-snackbar/snackbar.html
+++ b/src/material-experimental/mdc-snackbar/snackbar.html
@@ -1,0 +1,1 @@
+<!-- WIP: MDC-based snackbar -->

--- a/src/material-experimental/mdc-snackbar/snackbar.scss
+++ b/src/material-experimental/mdc-snackbar/snackbar.scss
@@ -1,0 +1,1 @@
+// WIP: MDC-based snackbar

--- a/src/material-experimental/mdc-snackbar/snackbar.ts
+++ b/src/material-experimental/mdc-snackbar/snackbar.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  selector: 'mat-snackbar',
+  templateUrl: 'snackbar.html',
+  styleUrls: ['snackbar.css'],
+  exportAs: 'matSnackbar',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MatSnackbar {
+}

--- a/src/material-experimental/mdc-snackbar/tsconfig-build.json
+++ b/src/material-experimental/mdc-snackbar/tsconfig-build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig-build",
+  "files": [
+    "public-api.ts",
+    "../typings.d.ts"
+  ],
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "strictMetadataEmit": true,
+    "flatModuleOutFile": "index.js",
+    "flatModuleId": "@angular/material-experimental/mdc-snackbar",
+    "skipTemplateCodegen": true,
+    "fullTemplateTypeCheck": true
+  }
+}

--- a/test/karma-system-config.js
+++ b/test/karma-system-config.js
@@ -174,6 +174,8 @@ System.config({
         'dist/packages/material-experimental/mdc-menu/index.js',
     '@angular/material-experimental/mdc-radio':
         'dist/packages/material-experimental/mdc-radio/index.js',
+    '@angular/material-experimental/mdc-snackbar':
+        'dist/packages/material-experimental/mdc-snackbar/index.js',
     '@angular/material-experimental/mdc-slide-toggle':
         'dist/packages/material-experimental/mdc-slide-toggle/index.js',
     '@angular/material-experimental/mdc-slider':


### PR DESCRIPTION
Create snackbar skeleton based on MDC Web