### PR TITLE
fix(drag-drop): unable to drop into connected sibling after scrolling into view via the parent

### DIFF
--- a/src/cdk/drag-drop/drag-drop-registry.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.ts
@@ -136,7 +136,10 @@ export class DragDropRegistry<I, C> implements OnDestroy {
           options: true
         })
         .set('scroll', {
-          handler: (e: Event) => this.scroll.next(e)
+          handler: (e: Event) => this.scroll.next(e),
+          // Use capturing so that we pick up scroll changes in any scrollable nodes that aren't
+          // the document. See https://github.com/angular/components/issues/17144.
+          options: true
         })
         // Preventing the default action on `mousemove` isn't enough to disable text selection
         // on Safari so we need to prevent the selection event as well. Alternatively this can


### PR DESCRIPTION
In #16681 we added some logic that updates the cached dimensions if the document is scrolled while dragging, however it didn't account for any scrollable parent nodes that might've been scrolled. These changes switch the event listener to use capturing so that we can pick up all of the elements being scrolled.

**Note:** this was tricky to reproduce in a test, but I've added more context in a comment with a reference to the issue that it fixes.

Fixes #17144.