### PR TITLE
fix(a11y): focus monitor not identifying touch focus inside shadow root

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -117,7 +117,11 @@ export class FocusMonitor implements OnDestroy {
     if (this._touchTimeoutId != null) {
       clearTimeout(this._touchTimeoutId);
     }
-    this._lastTouchTarget = event.target;
+
+    // Since this listener is bound on the `document` level, any events coming from the shadow DOM
+    // will have their `target` set to the shadow root. If available, use `composedPath` to
+    // figure out the event target.
+    this._lastTouchTarget = event.composedPath ? event.composedPath()[0] : event.target;
     this._touchTimeoutId = setTimeout(() => this._lastTouchTarget = null, TOUCH_BUFFER_MS);
   }
 


### PR DESCRIPTION
`FocusMonitor` uses a `touchstart` listener on the `document` to identify when an element was focused via touch. The problem is that if an element is inside the shadow DOM, the `event.target` will be set to the shadow root. These changes use `composedPath` to get the event target which accounts for the shadow DOM.

**Note:** I was unable to write a test that captures the error, because our fake touch events weren't behaving similarly to the ones the browser dispatches from the shadow DOM.