### PR TITLE
refactor: clean up deprecated uses of combineLatest

### DIFF
--- a/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
+++ b/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
@@ -82,13 +82,13 @@ export class EditEventDispatcher {
   );
 
   /** An observable that emits the row containing focus or an active edit. */
-  readonly editingOrFocused = combineLatest(
+  readonly editingOrFocused = combineLatest([
       this.editing.pipe(
           map(cell => closest(cell, ROW_SELECTOR)),
           this._startWithNull,
       ),
       this.focused.pipe(this._startWithNull),
-  ).pipe(
+  ]).pipe(
       map(([editingRow, focusedRow]) => focusedRow || editingRow),
       this._distinctUntilChanged as MonoTypeOperatorFunction<Element|null>,
       auditTime(FOCUS_DELAY), // Use audit to skip over blur events to the next focused element.
@@ -103,7 +103,7 @@ export class EditEventDispatcher {
   private _currentlyEditing: Element|null = null;
 
   /** The combined set of row hover content states organized by row. */
-  private readonly _hoveredContentStateDistinct = combineLatest(
+  private readonly _hoveredContentStateDistinct = combineLatest([
       this._getFirstRowWithHoverContent(),
       this._getLastRowWithHoverContent(),
       this.editingOrFocused,
@@ -116,7 +116,7 @@ export class EditEventDispatcher {
           ),
           this._startWithNullDistinct,
       ),
-  ).pipe(
+  ]).pipe(
       skip(1), // Skip the initial emission of [null, null, null, null].
       map(computeHoverContentState),
       distinctUntilChanged(areMapEntriesEqual),

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -1396,7 +1396,7 @@ class FakeDataSource extends DataSource<TestData> {
 
   connect(collectionViewer: CollectionViewer) {
     this.isConnected = true;
-    return combineLatest(this._dataChange, collectionViewer.viewChange)
+    return combineLatest([this._dataChange, collectionViewer.viewChange])
       .pipe(map(data => data[0]));
   }
 

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -1010,7 +1010,7 @@ class FakeDataSource extends DataSource<TestData> {
   connect(collectionViewer: CollectionViewer): Observable<TestData[]> {
     this.isConnected = true;
 
-    return combineLatest(this._dataChange, collectionViewer.viewChange).pipe(map(([data]) => {
+    return combineLatest([this._dataChange, collectionViewer.viewChange]).pipe(map(([data]) => {
       this.treeControl.dataNodes = data;
       return data;
     }));

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -384,7 +384,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
 
   /** Combines the center and zoom and the other map options into a single object */
   private _combineOptions(): Observable<google.maps.MapOptions> {
-    return combineLatest(this._options, this._center, this._zoom)
+    return combineLatest([this._options, this._center, this._zoom])
         .pipe(map(([options, center, zoom]) => {
           const combinedOptions: google.maps.MapOptions = {
             ...options,
@@ -406,7 +406,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
 
   private _watchForOptionsChanges(
       optionsChanges: Observable<google.maps.MapOptions>) {
-    combineLatest(this._googleMapChanges, optionsChanges)
+    combineLatest([this._googleMapChanges, optionsChanges])
         .pipe(takeUntil(this._destroy))
         .subscribe(([googleMap, options]) => {
           googleMap.setOptions(options);

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -152,7 +152,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
   }
 
   private _combineOptions(): Observable<google.maps.InfoWindowOptions> {
-    return combineLatest(this._options, this._position).pipe(map(([options, position]) => {
+    return combineLatest([this._options, this._position]).pipe(map(([options, position]) => {
       const combinedOptions: google.maps.InfoWindowOptions = {
         ...options,
         position: position || options.position,

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -330,7 +330,7 @@ export class MapMarker implements OnInit, OnDestroy {
   }
 
   private _combineOptions(): Observable<google.maps.MarkerOptions> {
-    return combineLatest(this._options, this._title, this._position, this._label, this._clickable)
+    return combineLatest([this._options, this._title, this._position, this._label, this._clickable])
         .pipe(map(([options, title, position, label, clickable]) => {
           const combinedOptions: google.maps.MarkerOptions = {
             ...options,

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -228,13 +228,13 @@ export class MatTableDataSource<T> extends DataSource<T> {
         observableOf(null);
     const dataStream = this._data;
     // Watch for base data or filter changes to provide a filtered set of data.
-    const filteredData = combineLatest(dataStream, this._filter)
+    const filteredData = combineLatest([dataStream, this._filter])
       .pipe(map(([data]) => this._filterData(data)));
     // Watch for filtered data or sort changes to provide an ordered set of data.
-    const orderedData = combineLatest(filteredData, sortChange)
+    const orderedData = combineLatest([filteredData, sortChange])
       .pipe(map(([data]) => this._orderData(data)));
     // Watch for ordered data or page changes to provide a paged set of data.
-    const paginatedData = combineLatest(orderedData, pageChange)
+    const paginatedData = combineLatest([orderedData, pageChange])
       .pipe(map(([data]) => this._pageData(data)));
     // Watched for paged data changes and send the result to the table to render.
     this._renderChangesSubscription.unsubscribe();


### PR DESCRIPTION
The signature of `combineLatest` that uses individual parameters has been deprecated. These changes switch to the new recommended way which passes in the observables as an array.