### PR TITLE
build: remove ng_package entry-point workaround

### DIFF
--- a/src/cdk/coercion/BUILD.bazel
+++ b/src/cdk/coercion/BUILD.bazel
@@ -1,14 +1,17 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ng_module", "ts_library")
+load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ts_library")
 
-ng_module(
+ts_library(
     name = "coercion",
     srcs = glob(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
     module_name = "@angular/cdk/coercion",
+    deps = [
+        "@npm//@angular/core",
+    ],
 )
 
 ts_library(

--- a/src/cdk/keycodes/BUILD.bazel
+++ b/src/cdk/keycodes/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ng_module", "ts_library")
+load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ts_library")
 
-ng_module(
+ts_library(
     name = "keycodes",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material-experimental/input/testing/BUILD.bazel
+++ b/src/material-experimental/input/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material-experimental/mdc-button/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-button/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material-experimental/mdc-checkbox/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material-experimental/mdc-chips/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material-experimental/mdc-menu/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material-experimental/mdc-slide-toggle/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material-experimental/select/testing/BUILD.bazel
+++ b/src/material-experimental/select/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/autocomplete/testing/BUILD.bazel
+++ b/src/material/autocomplete/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/button/testing/BUILD.bazel
+++ b/src/material/button/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/checkbox/testing/BUILD.bazel
+++ b/src/material/checkbox/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/dialog/testing/BUILD.bazel
+++ b/src/material/dialog/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/menu/testing/BUILD.bazel
+++ b/src/material/menu/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/progress-bar/testing/BUILD.bazel
+++ b/src/material/progress-bar/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/progress-spinner/testing/BUILD.bazel
+++ b/src/material/progress-spinner/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/radio/testing/BUILD.bazel
+++ b/src/material/radio/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/sidenav/testing/BUILD.bazel
+++ b/src/material/sidenav/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/slide-toggle/testing/BUILD.bazel
+++ b/src/material/slide-toggle/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/slider/testing/BUILD.bazel
+++ b/src/material/slider/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/snack-bar/testing/BUILD.bazel
+++ b/src/material/snack-bar/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],

--- a/src/material/tabs/testing/BUILD.bazel
+++ b/src/material/tabs/testing/BUILD.bazel
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
-ng_module(
+ts_library(
     name = "testing",
     srcs = glob(
         ["**/*.ts"],


### PR DESCRIPTION
We recently had to switch all `ts_library` entry
points to use `ng_module` because the `ng_package`
rule did not properly handle `ts_library` targets
as entry-points.

https://github.com/angular/angular/commit/217db9b216970a400c96a57e2dcd640cc16a8721 fixed this issue upstream and we can
now use `ts_library` instead of `ng_module` for vanilla TS entry-points.