### PR TITLE
build: validate bazel rollup globals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,8 +265,16 @@ jobs:
     steps:
       - *checkout_code
       - *restore_cache
+      - *setup_bazel_ci_config
       - *yarn_download
       - *yarn_install
+      - *setup_bazel_binary
+
+      - run:
+          name: Checking rollup globals
+          command: |
+            bazel build //:rollup_globals
+            yarn check-rollup-globals $(bazel info bazel-bin)/rollup_globals.json
 
       - run: ./scripts/circleci/lint-bazel-files.sh
       - run: yarn gulp ci:lint

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
+load("//:rollup-globals.bzl", "ROLLUP_GLOBALS")
+
 exports_files(["LICENSE"])
+
+genrule(
+    name = "rollup_globals",
+    outs = ["rollup_globals.json"],
+    cmd = "echo '%s' > $@" % ROLLUP_GLOBALS,
+)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "format:ts": "git-clang-format HEAD $(git diff HEAD --name-only | grep -v \"\\.d\\.ts\")",
     "format:bazel": "yarn -s bazel:buildifier --lint=fix --mode=fix",
     "format": "yarn -s format:ts && yarn -s format:bazel",
-    "cherry-pick-patch": "ts-node --project tools/cherry-pick-patch/ tools/cherry-pick-patch/cherry-pick-patch.ts"
+    "cherry-pick-patch": "ts-node --project tools/cherry-pick-patch/ tools/cherry-pick-patch/cherry-pick-patch.ts",
+    "check-rollup-globals": "ts-node --project scripts/ scripts/check-rollup-globals.ts"
   },
   "version": "8.2.0",
   "requiredAngularVersion": "^8.0.0 || ^9.0.0-0",

--- a/rollup-globals.bzl
+++ b/rollup-globals.bzl
@@ -7,13 +7,33 @@ load(
     "MATERIAL_EXPERIMENTAL_TESTING_ENTRYPOINTS",
 )
 
-# Base rollup globals for everything in the repo.
+# Base rollup globals for everything in the repo. Note that we want to disable
+# sorting of the globals as we manually group dict entries.
+# buildifier: disable=unsorted-dict-items
 ROLLUP_GLOBALS = {
+    # Framework packages.
+    "@angular/animations": "ng.animations",
+    "@angular/common": "ng.common",
+    "@angular/common/http": "ng.common.http",
+    "@angular/common/http/testing": "ng.common.http.testing",
+    "@angular/common/testing": "ng.common.testing",
+    "@angular/core": "ng.core",
+    "@angular/core/testing": "ng.core.testing",
+    "@angular/forms": "ng.forms",
+    "@angular/platform-browser": "ng.platformBrowser",
+    "@angular/platform-browser-dynamic": "ng.platformBrowserDynamic",
+    "@angular/platform-browser-dynamic/testing": "ng.platformBrowserDynamic.testing",
+    "@angular/platform-browser/animations": "ng.platformBrowser.animations",
+    "@angular/platform-server": "ng.platformServer",
+    "@angular/router": "ng.router",
+
+    # Primary entry-points in the project.
     "@angular/cdk": "ng.cdk",
     "@angular/cdk-experimental": "ng.cdkExperimental",
     "@angular/google-maps": "ng.googleMaps",
     "@angular/material": "ng.material",
     "@angular/material-experimental": "ng.materialExperimental",
+    "@angular/material-moment-adapter": "ng.materialMomentAdapter",
     "@angular/youtube-player": "ng.youtubePlayer",
 
     # MDC Web
@@ -47,7 +67,12 @@ ROLLUP_GLOBALS = {
     "@material/tab-scroller": "mdc.tabScroller",
     "@material/text-field": "mdc.textField",
     "@material/top-app-bar": "mdc.topAppBar",
+
+    # Third-party libraries.
     "moment": "moment",
+    "protractor": "protractor",
+    "rxjs": "rxjs",
+    "rxjs/operators": "rxjs.operators",
     "tslib": "tslib",
 }
 

--- a/scripts/check-rollup-globals.ts
+++ b/scripts/check-rollup-globals.ts
@@ -1,0 +1,73 @@
+/**
+ * Script that goes through each source file that will be included in the
+ * release output and checks if any module imports are not part of the
+ * specified rollup globals file.
+ *
+ * This script is used to validate Bazel rollup globals. We use a genrule to
+ * convert the Starlark rollup globals dict into a JSON file which then can
+ * be passed to this script to ensure that the rollup globals are up-to-date.
+ */
+
+import chalk from 'chalk';
+import {readFileSync} from 'fs';
+import * as minimatch from 'minimatch';
+import {join, relative} from 'path';
+import * as ts from 'typescript';
+
+const projectRoot = join(__dirname, '../');
+const args = process.argv.slice(2);
+
+if (args.length !== 1) {
+  console.error(chalk.red('No rollup globals file has been specified.'));
+  process.exit(1);
+}
+
+const rollupGlobals = JSON.parse(readFileSync(args[0], 'utf8'));
+const configFile = ts.readJsonConfigFile(join(projectRoot, 'tsconfig.json'), ts.sys.readFile);
+const parsedConfig = ts.parseJsonSourceFileConfigFileContent(configFile, ts.sys, projectRoot);
+const filesToCheckGlob = [
+  'src/**/!(*.spec).ts',
+  '!src/+(a11y-demo|e2e-app|universal-app|dev-app)/**/*.ts',
+  '!src/**/schematics/**/*.ts',
+];
+
+const failures = new Map<string, string[]>();
+
+parsedConfig.fileNames.forEach(fileName => {
+  const relativeFileName = relative(projectRoot, fileName);
+  if (!filesToCheckGlob.every(g => minimatch(relativeFileName, g))) {
+    return;
+  }
+
+  const sourceFile =
+      ts.createSourceFile(fileName, readFileSync(fileName, 'utf8'), ts.ScriptTarget.Latest, true);
+
+  const visitNode = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node)) {
+      // Parse out the module name. The first and last characters are the quote marks.
+      const module = node.moduleSpecifier.getText().slice(1, -1);
+      const isExternal = !module.startsWith('.') && !module.startsWith('/');
+
+      // Check whether the module is external and whether it's in our rollup globals.
+      if (isExternal && !rollupGlobals[module]) {
+        failures.set(fileName, (failures.get(fileName) || []).concat(module));
+      }
+    }
+
+    ts.forEachChild(node, visitNode);
+  };
+
+  ts.forEachChild(sourceFile, visitNode);
+});
+
+if (failures.size) {
+  console.error(chalk.red('  ✘   Rollup globals are not up-to-date.'));
+  console.error();
+
+  failures.forEach((missingGlobals, fileName) => {
+    console.error(chalk.yellow(`  ⮑   ${fileName}:`));
+    missingGlobals.forEach(g => console.error(`      - ${g}`));
+  });
+} else {
+  console.info(chalk.green('  ✓   Rollup globals are up-to-date.'));
+}

--- a/src/cdk/config.bzl
+++ b/src/cdk/config.bzl
@@ -17,13 +17,14 @@ CDK_ENTRYPOINTS = [
     "table",
     "text-field",
     "tree",
-
-    # NOTE: "testing" should not be listed here as it will be treated as its own
-    # package that will be included manually in the "ng_package".
+    "testing",
 ]
 
-# List of all entry-point targets of the Angular Material package.
-CDK_TARGETS = ["//src/cdk"] + ["//src/cdk/%s" % ep for ep in CDK_ENTRYPOINTS]
+# List of all entry-point targets of the Angular Material package. Note that
+# we do not want to include "testing" here as it will be treated as a standalone
+# sub-package of the "ng_package".
+CDK_TARGETS = ["//src/cdk"] + \
+              ["//src/cdk/%s" % ep for ep in CDK_ENTRYPOINTS if not ep == "testing"]
 
 # Within the CDK, only a few targets have sass libraries which need to be
 # part of the release package. This list declares all CDK targets with sass

--- a/src/material-experimental/mdc-button/testing/button-harness.ts
+++ b/src/material-experimental/mdc-button/testing/button-harness.ts
@@ -8,7 +8,7 @@
 
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {ButtonHarnessFilters} from '@angular/material/button/testing/button-harness-filters';
+import {ButtonHarnessFilters} from '@angular/material/button/testing';
 
 
 /**

--- a/src/material-experimental/mdc-menu/testing/menu-harness.ts
+++ b/src/material-experimental/mdc-menu/testing/menu-harness.ts
@@ -9,7 +9,7 @@
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {MatMenuItemHarness} from './menu-item-harness';
-import {MenuHarnessFilters} from '@angular/material/menu/testing/menu-harness-filters';
+import {MenuHarnessFilters} from '@angular/material/menu/testing';
 
 /**
  * Harness for interacting with a MDC-based mat-menu in tests.

--- a/src/material-experimental/mdc-menu/testing/menu-item-harness.ts
+++ b/src/material-experimental/mdc-menu/testing/menu-item-harness.ts
@@ -8,7 +8,7 @@
 
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {MenuItemHarnessFilters} from '@angular/material/menu/testing/menu-harness-filters';
+import {MenuItemHarnessFilters} from '@angular/material/menu/testing';
 
 
 /**

--- a/src/material/menu/testing/menu-item-harness.ts
+++ b/src/material/menu/testing/menu-item-harness.ts
@@ -8,7 +8,7 @@
 
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {MenuItemHarnessFilters} from '@angular/material/menu/testing/menu-harness-filters';
+import {MenuItemHarnessFilters} from './menu-harness-filters';
 
 
 /**

--- a/src/material/radio/testing/radio-harness.ts
+++ b/src/material/radio/testing/radio-harness.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {RadioButtonHarnessFilters, RadioGroupHarnessFilters} from '@angular/material/radio/testing/radio-harness-filters';
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {RadioButtonHarnessFilters, RadioGroupHarnessFilters} from './radio-harness-filters';
 
 /**
  * Harness for interacting with a standard mat-radio-group in tests.

--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -136,9 +136,28 @@ export const rollupGlobals = {
 
   // For each Angular Material secondary entry-point, we include a testing
   // tertiary entry-point.
-  ...matSecondaryEntryPoints.reduce((res, entryPoint) => {
-    return {...res, ...generateRollupEntryPoints(`material/${entryPoint}`, ['testing'])};
-  }, []),
+  ...matSecondaryEntryPoints.reduce(
+      (res, entryPoint) => {
+        return {...res, ...generateRollupEntryPoints(`material/${entryPoint}`, ['testing'])};
+      },
+      []),
+
+  // For each Angular Material experimental secondary entry-point, we include a testing
+  // tertiary entry-point.
+  ...materialExperimentalSecondaryEntryPoints.reduce(
+      (res, entryPoint) => {
+        return {
+          ...res,
+          ...generateRollupEntryPoints(`material-experimental/${entryPoint}`, ['testing'])
+        };
+      },
+      []),
+
+  // Manual entry-points which are not detected automatically. Since we do
+  // not use this file for rollup-globals anymore, just as a backup if the Bazel
+  // migrations does not work out, we can add these entries manually for now.
+  '@angular/material-experimental/form-field/testing/control':
+      'ng.materialExperimental.formField.testing.control',
 
   '@angular/cdk/private/testing': 'ng.cdk.private.testing',
   '@angular/cdk/private/testing/e2e': 'ng.cdk.private.testing.e2e',

--- a/tools/package-tools/rollup-globals.ts
+++ b/tools/package-tools/rollup-globals.ts
@@ -134,6 +134,12 @@ export const rollupGlobals = {
   ...rollupYouTubePlayerEntryPoints,
   ...rollupGoogleMapsEntryPoints,
 
+  // For each Angular Material secondary entry-point, we include a testing
+  // tertiary entry-point.
+  ...matSecondaryEntryPoints.reduce((res, entryPoint) => {
+    return {...res, ...generateRollupEntryPoints(`material/${entryPoint}`, ['testing'])};
+  }, []),
+
   '@angular/cdk/private/testing': 'ng.cdk.private.testing',
   '@angular/cdk/private/testing/e2e': 'ng.cdk.private.testing.e2e',
 

--- a/tools/tslint-rules/missingRollupGlobalsRule.ts
+++ b/tools/tslint-rules/missingRollupGlobalsRule.ts
@@ -38,7 +38,7 @@ class Walker extends Lint.RuleWalker {
 
     this._configPath = path.resolve(process.cwd(), configPath);
     this._config = require(this._configPath).rollupGlobals;
-    this._enabled = fileGlobs.some(p => minimatch(relativeFilePath, p));
+    this._enabled = fileGlobs.every(p => minimatch(relativeFilePath, p));
   }
 
   visitImportDeclaration(node: ts.ImportDeclaration) {

--- a/tslint.json
+++ b/tslint.json
@@ -134,7 +134,9 @@
     "missing-rollup-globals": [
       true,
       "./tools/package-tools/rollup-globals.ts",
-      "src/!(a11y-demo|e2e-app|material-examples|universal-app|dev-app)/!(schematics)**/*.ts"
+      "src/**/!(*.spec).ts",
+      "!src/+(a11y-demo|e2e-app|universal-app|dev-app)/**/*.ts",
+      "!src/**/schematics/**/*.ts"
     ],
     "file-name-casing": [true, {
       // Exclude custom lint rule files since they have to always be camel-cased and end


### PR DESCRIPTION
* See individual commits.

**Note**: to reduce too much changes to the gulp build system yet, the rollup globals tslint rule will remain for now.