### PR TITLE
build: generate metadata for cdk keycodes entry-point

### DIFF
--- a/src/cdk/keycodes/BUILD.bazel
+++ b/src/cdk/keycodes/BUILD.bazel
@@ -1,8 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ts_library")
+load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ng_module", "ts_library")
 
-ts_library(
+# We need to use "ng_module" here since we want metadata to be generated for keycode
+# constants. This is necessary because some of these constants are statically used in
+# component/directive metadata (e.g. chips) and NGC needs to be able to evaluate these
+# at compile time.
+ng_module(
     name = "keycodes",
     srcs = glob(
         ["**/*.ts"],


### PR DESCRIPTION
We need to use "ng_module" for building the `keycodes` entry-point since we
want metadata to be generated for keycode constants. This is necessary
because some of these constants are statically used in component/directive
metadata (e.g. chips) and NGC needs to be able to evaluate these at compile time.