### PR TITLE
refactor(google-maps): Removes reference to GoogleMap from MapMarker

### DIFF
--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -3,7 +3,6 @@ import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {GoogleMapsModule} from '../google-maps-module';
-import {MapMarker} from '../map-marker/map-marker';
 import {
   createMapConstructorSpy,
   createMapSpy,
@@ -240,18 +239,6 @@ describe('GoogleMap', () => {
     expect(mapSpy.addListener).not.toHaveBeenCalledWith('tilt_changed', jasmine.any(Function));
     expect(mapSpy.addListener).not.toHaveBeenCalledWith('zoom_changed', jasmine.any(Function));
   });
-
-  it('calls setMap on child marker components', () => {
-    mapSpy = createMapSpy(DEFAULT_OPTIONS);
-    createMapConstructorSpy(mapSpy).and.callThrough();
-
-    const fixture = TestBed.createComponent(TestApp);
-    const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
-    spyOn(markerComponent, '_setMap').and.callThrough();
-    fixture.detectChanges();
-
-    expect(markerComponent._setMap).toHaveBeenCalledWith(mapSpy);
-  });
 });
 
 @Component({
@@ -264,7 +251,6 @@ describe('GoogleMap', () => {
                          (mapClick)="handleClick($event)"
                          (centerChanged)="handleCenterChanged()"
                          (mapRightclick)="handleRightclick($event)">
-              <map-marker></map-marker>
             </google-map>`,
 })
 class TestApp {

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -21,8 +21,6 @@ import {
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
 import {map, shareReplay, take, takeUntil} from 'rxjs/operators';
 
-import {MapMarker} from '../map-marker/map-marker';
-
 interface GoogleMapsWindow extends Window {
   google?: typeof google;
 }

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -7,10 +7,8 @@
  */
 
 import {
-  AfterContentInit,
   ChangeDetectionStrategy,
   Component,
-  ContentChildren,
   ElementRef,
   EventEmitter,
   Input,
@@ -18,7 +16,6 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  QueryList,
   ViewEncapsulation,
 } from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
@@ -62,7 +59,7 @@ export const DEFAULT_WIDTH = '500px';
   template: '<div class="map-container"></div><ng-content></ng-content>',
   encapsulation: ViewEncapsulation.None,
 })
-export class GoogleMap implements OnChanges, OnInit, AfterContentInit, OnDestroy {
+export class GoogleMap implements OnChanges, OnInit, OnDestroy {
   @Input() height = DEFAULT_HEIGHT;
 
   @Input() width = DEFAULT_WIDTH;
@@ -188,8 +185,6 @@ export class GoogleMap implements OnChanges, OnInit, AfterContentInit, OnDestroy
    */
   @Output() zoomChanged = new EventEmitter<void>();
 
-  @ContentChildren(MapMarker) _markers: QueryList<MapMarker>;
-
   private _mapEl: HTMLElement;
   _googleMap!: UpdatedGoogleMap;
 
@@ -232,13 +227,6 @@ export class GoogleMap implements OnChanges, OnInit, AfterContentInit, OnDestroy
     });
 
     this._watchForOptionsChanges(combinedOptionsChanges);
-  }
-
-  ngAfterContentInit() {
-    for (const marker of this._markers.toArray()) {
-      marker._setMap(this._googleMap);
-    }
-    this._watchForMarkerChanges();
   }
 
   ngOnDestroy() {
@@ -471,15 +459,5 @@ export class GoogleMap implements OnChanges, OnInit, AfterContentInit, OnDestroy
             this.mapClick.emit(event);
           }));
     }
-  }
-
-  private _watchForMarkerChanges() {
-    combineLatest(this._googleMapChanges, this._markers.changes)
-        .pipe(takeUntil(this._destroy))
-        .subscribe(([googleMap, markers]) => {
-          for (let marker of markers) {
-            marker._setMap(googleMap);
-          }
-        });
   }
 }

--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -2,7 +2,10 @@ import {Component} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
+import {DEFAULT_OPTIONS, UpdatedGoogleMap} from '../google-map/google-map';
 import {
+  createMapConstructorSpy,
+  createMapSpy,
   createMarkerConstructorSpy,
   createMarkerSpy,
   TestingWindow
@@ -12,6 +15,8 @@ import {GoogleMapsModule} from '../google-maps-module';
 import {DEFAULT_MARKER_OPTIONS, MapMarker} from './map-marker';
 
 describe('MapMarker', () => {
+  let mapSpy: jasmine.SpyObj<UpdatedGoogleMap>;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [GoogleMapsModule],
@@ -21,6 +26,9 @@ describe('MapMarker', () => {
 
   beforeEach(() => {
     TestBed.compileComponents();
+
+    mapSpy = createMapSpy(DEFAULT_OPTIONS);
+    createMapConstructorSpy(mapSpy).and.callThrough();
   });
 
   afterEach(() => {
@@ -33,9 +41,6 @@ describe('MapMarker', () => {
     const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
 
     const fixture = TestBed.createComponent(TestApp);
-    const fakeMap = {} as unknown as google.maps.Map;
-    const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
-    markerComponent._setMap(fakeMap);
     fixture.detectChanges();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith({
@@ -43,18 +48,17 @@ describe('MapMarker', () => {
       title: undefined,
       label: undefined,
       clickable: undefined,
-      map: fakeMap
+      map: mapSpy,
     });
   });
 
   it('sets marker inputs', () => {
-    const fakeMap = {} as unknown as google.maps.Map;
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
       label: 'marker label',
       clickable: false,
-      map: fakeMap,
+      map: mapSpy,
     };
     const markerSpy = createMarkerSpy(options);
     const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
@@ -64,15 +68,12 @@ describe('MapMarker', () => {
     fixture.componentInstance.title = options.title;
     fixture.componentInstance.label = options.label;
     fixture.componentInstance.clickable = options.clickable;
-    const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
-    markerComponent._setMap(fakeMap);
     fixture.detectChanges();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith(options);
   });
 
   it('sets marker options, ignoring map', () => {
-    const fakeMap = {} as unknown as google.maps.Map;
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -85,15 +86,12 @@ describe('MapMarker', () => {
 
     const fixture = TestBed.createComponent(TestApp);
     fixture.componentInstance.options = options;
-    const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
-    markerComponent._setMap(fakeMap);
     fixture.detectChanges();
 
-    expect(markerConstructorSpy).toHaveBeenCalledWith({...options, map: fakeMap});
+    expect(markerConstructorSpy).toHaveBeenCalledWith({...options, map: mapSpy});
   });
 
   it('gives precedence to specific inputs over options', () => {
-    const fakeMap = {} as unknown as google.maps.Map;
     const options: google.maps.MarkerOptions = {
       position: {lat: 3, lng: 5},
       title: 'marker title',
@@ -107,7 +105,7 @@ describe('MapMarker', () => {
       label: 'updated label',
       clickable: true,
       icon: 'icon name',
-      map: fakeMap,
+      map: mapSpy,
     };
     const markerSpy = createMarkerSpy(options);
     const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
@@ -118,33 +116,9 @@ describe('MapMarker', () => {
     fixture.componentInstance.label = expectedOptions.label;
     fixture.componentInstance.clickable = expectedOptions.clickable;
     fixture.componentInstance.options = options;
-    const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
-    markerComponent._setMap(fakeMap);
     fixture.detectChanges();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith(expectedOptions);
-  });
-
-  it('sets the map on the marker only once', () => {
-    const markerSpy = createMarkerSpy(DEFAULT_MARKER_OPTIONS);
-    const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
-
-    const fixture = TestBed.createComponent(TestApp);
-    const fakeMap = {} as unknown as google.maps.Map;
-    const fakeMap2 = {testValue: 'test'} as unknown as google.maps.Map;
-    const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
-    markerComponent._setMap(fakeMap);
-    markerComponent._setMap(fakeMap2);
-    fixture.detectChanges();
-
-    expect(markerConstructorSpy).toHaveBeenCalledWith({
-      ...DEFAULT_MARKER_OPTIONS,
-      title: undefined,
-      label: undefined,
-      clickable: undefined,
-      map: fakeMap
-    });
-    expect(markerSpy.setOptions).not.toHaveBeenCalled();
   });
 
   it('exposes methods that provide information about the marker', () => {
@@ -152,9 +126,7 @@ describe('MapMarker', () => {
     createMarkerConstructorSpy(markerSpy).and.callThrough();
 
     const fixture = TestBed.createComponent(TestApp);
-    const fakeMap = {} as unknown as google.maps.Map;
     const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
-    markerComponent._setMap(fakeMap);
     fixture.detectChanges();
 
     markerSpy.getAnimation.and.returnValue(null);
@@ -199,9 +171,7 @@ describe('MapMarker', () => {
     createMarkerConstructorSpy(markerSpy).and.callThrough();
 
     const fixture = TestBed.createComponent(TestApp);
-    const fakeMap = {} as unknown as google.maps.Map;
     const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
-    markerComponent._setMap(fakeMap);
     fixture.detectChanges();
 
     expect(markerSpy.addListener)
@@ -234,13 +204,16 @@ describe('MapMarker', () => {
 
 @Component({
   selector: 'test-app',
-  template: `<map-marker [title]="title"
-                         [position]="position"
-                         [label]="label"
-                         [clickable]="clickable"
-                         [options]="options"
-                         (mapClick)="handleClick()"
-                         (positionChanged)="handlePositionChanged()"></map-marker>`,
+  template: `<google-map>
+               <map-marker [title]="title"
+                           [position]="position"
+                           [label]="label"
+                           [clickable]="clickable"
+                           [options]="options"
+                           (mapClick)="handleClick()"
+                           (positionChanged)="handlePositionChanged()">
+               </map-marker>
+             </google-map>`,
 })
 class TestApp {
   title?: string;

--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -171,7 +171,6 @@ describe('MapMarker', () => {
     createMarkerConstructorSpy(markerSpy).and.callThrough();
 
     const fixture = TestBed.createComponent(TestApp);
-    const markerComponent = fixture.debugElement.query(By.directive(MapMarker)).componentInstance;
     fixture.detectChanges();
 
     expect(markerSpy.addListener)

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -68,11 +68,15 @@ export function createMarkerConstructorSpy(markerSpy: jasmine.SpyObj<google.maps
         return markerSpy;
       });
   const testingWindow: TestingWindow = window;
-  testingWindow.google = {
-    maps: {
-      'Marker': markerConstructorSpy,
-    },
-  };
+  if (testingWindow.google && testingWindow.google.maps) {
+    testingWindow.google.maps['Marker'] = markerConstructorSpy;
+  } else {
+    testingWindow.google = {
+      maps: {
+        'Marker': markerConstructorSpy,
+      },
+    };
+  }
   return markerConstructorSpy;
 }
 


### PR DESCRIPTION
Get access to the GoogleMap parent component from a MapMarker through
the constructor instead of calling a "setMap" method on the marker from
the GoogleMap to prevent MapMarker being loaded in all maps.