### PR TITLE
fix(cdk/overlay): block scroll strategy throwing off scroll behavior feature detection

### DIFF
--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -37,6 +37,7 @@ export function supportsScrollBehavior(): boolean {
     // If we're not in the browser, it can't be supported.
     if (typeof document !== 'object' || !document) {
       scrollBehaviorSupported = false;
+      return scrollBehaviorSupported;
     }
 
     // If the element can have a `scrollBehavior` style, we can be sure that it's supported.


### PR DESCRIPTION
To avoid a scrolling animation when we disable scrollig, we remove and re-set the `scroll-behavior` property on the body without feature checking it. The problem is that since we've set the property to *something*, our `scrollBehaviorSupported` feature check will be thrown off because it checks for `'scrollBehavior' in document.documentElement.style`.

Fixes #17221.