### PR TITLE
fix(material-experimental/checkbox): model value not updated through toggle method

### DIFF
--- a/src/material-experimental/mdc-checkbox/checkbox.spec.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.spec.ts
@@ -852,6 +852,17 @@ describe('MatCheckbox', () => {
          expect(checkboxInstance.checked).toBe(false);
          expect(ngModel.valid).toBe(false);
        }));
+
+    it('should update the ngModel value when using the `toggle` method', fakeAsync(() => {
+      const checkbox = fixture.debugElement.query(By.directive(MatCheckbox)).componentInstance;
+
+      expect(fixture.componentInstance.isGood).toBe(false);
+
+      checkbox.toggle();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.isGood).toBe(true);
+    }));
   });
 
   describe('with name attribute', () => {

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -285,6 +285,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
   /** Toggles the `checked` state of the checkbox. */
   toggle() {
     this.checked = !this.checked;
+    this._cvaOnChange(this.checked);
   }
 
   /** Handles blur events on the native input. */


### PR DESCRIPTION
Along the same lines as #11902. When the value of an experimental checkbox is changed through the `toggle` method it wasn't being propagated to the `ControlValueAccessor`.