### PR TITLE
refactor(select): remove deprecated APIs for 9.0.0

### DIFF
--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -14,6 +14,12 @@ import {ConstructorChecksUpgradeData, TargetVersion, VersionChanges} from '@angu
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V9]: [
+    {
+      pr: 'https://github.com/angular/components/pull/17230',
+      changes: ['MatSelect']
+    }
+  ],
   [TargetVersion.V8]: [
     {
       pr: 'https://github.com/angular/components/pull/15647',

--- a/src/material/select/select-animations.ts
+++ b/src/material/select/select-animations.ts
@@ -27,7 +27,6 @@ import {
 export const matSelectAnimations: {
   readonly transformPanelWrap: AnimationTriggerMetadata;
   readonly transformPanel: AnimationTriggerMetadata;
-  readonly fadeInContent: AnimationTriggerMetadata;
 } = {
   /**
    * This animation ensures the select's overlay panel animation (transformPanel) is called when
@@ -66,35 +65,5 @@ export const matSelectAnimations: {
     })),
     transition('void => *', animate('120ms cubic-bezier(0, 0, 0.2, 1)')),
     transition('* => void', animate('100ms 25ms linear', style({opacity: 0})))
-  ]),
-
-  /**
-   * This animation fades in the background color and text content of the
-   * select's options. It is time delayed to occur 100ms after the overlay
-   * panel has transformed in.
-   * @deprecated Not used anymore. To be removed.
-   * @breaking-change 8.0.0
-   */
-  fadeInContent: trigger('fadeInContent', [
-    state('showing', style({opacity: 1})),
-    transition('void => showing', [
-      style({opacity: 0}),
-      animate('150ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)')
-    ])
   ])
 };
-
-
-/**
- * @deprecated
- * @breaking-change 8.0.0
- * @docs-private
- */
-export const transformPanel = matSelectAnimations.transformPanel;
-
-/**
- * @deprecated
- * @breaking-change 8.0.0
- * @docs-private
- */
-export const fadeInContent = matSelectAnimations.fadeInContent;

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -321,13 +321,6 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   get focused(): boolean {
     return this._focused || this._panelOpen;
   }
-  /**
-   * @deprecated Setter to be removed as this property is intended to be readonly.
-   * @breaking-change 8.0.0
-   */
-  set focused(value: boolean) {
-    this._focused = value;
-  }
   private _focused = false;
 
   /** A name for this control that can be used by `mat-form-field`. */
@@ -495,11 +488,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     @Self() @Optional() public ngControl: NgControl,
     @Attribute('tabindex') tabIndex: string,
     @Inject(MAT_SELECT_SCROLL_STRATEGY) scrollStrategyFactory: any,
-    /**
-     * @deprecated _liveAnnouncer to be turned into a required parameter.
-     * @breaking-change 8.0.0
-     */
-    private _liveAnnouncer?: LiveAnnouncer) {
+    private _liveAnnouncer: LiveAnnouncer) {
     super(elementRef, _defaultErrorStateMatcher, _parentForm,
           _parentFormGroup, ngControl);
 
@@ -739,8 +728,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       const selectedOption = this.selected;
 
       // Since the value has changed, we need to announce it ourselves.
-      // @breaking-change 8.0.0 remove null check for _liveAnnouncer.
-      if (this._liveAnnouncer && selectedOption && previouslySelectedOption !== selectedOption) {
+      if (selectedOption && previouslySelectedOption !== selectedOption) {
         // We set a duration on the live announcement, because we want the live element to be
         // cleared after a while so that users can't navigate to it using the arrow keys.
         this._liveAnnouncer.announce((selectedOption as MatOption).viewValue, 10000);

--- a/tools/public_api_guard/material/select.d.ts
+++ b/tools/public_api_guard/material/select.d.ts
@@ -1,5 +1,3 @@
-export declare const fadeInContent: AnimationTriggerMetadata;
-
 export declare const MAT_SELECT_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 export declare const MAT_SELECT_SCROLL_STRATEGY_PROVIDER: {
@@ -39,7 +37,7 @@ export declare class MatSelect extends _MatSelectMixinBase implements AfterConte
     disableOptionCentering: boolean;
     readonly empty: boolean;
     errorStateMatcher: ErrorStateMatcher;
-    focused: boolean;
+    readonly focused: boolean;
     id: string;
     multiple: boolean;
     ngControl: NgControl;
@@ -64,8 +62,7 @@ export declare class MatSelect extends _MatSelectMixinBase implements AfterConte
     typeaheadDebounceInterval: number;
     value: any;
     readonly valueChange: EventEmitter<any>;
-    constructor(_viewportRuler: ViewportRuler, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, _defaultErrorStateMatcher: ErrorStateMatcher, elementRef: ElementRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any,
-    _liveAnnouncer?: LiveAnnouncer | undefined);
+    constructor(_viewportRuler: ViewportRuler, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, _defaultErrorStateMatcher: ErrorStateMatcher, elementRef: ElementRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any, _liveAnnouncer: LiveAnnouncer);
     _calculateOverlayScroll(selectedIndex: number, scrollBuffer: number, maxScroll: number): number;
     _getAriaActiveDescendant(): string | null;
     _getAriaLabel(): string | null;
@@ -96,7 +93,6 @@ export declare class MatSelect extends _MatSelectMixinBase implements AfterConte
 export declare const matSelectAnimations: {
     readonly transformPanelWrap: AnimationTriggerMetadata;
     readonly transformPanel: AnimationTriggerMetadata;
-    readonly fadeInContent: AnimationTriggerMetadata;
 };
 
 export declare class MatSelectChange {
@@ -124,5 +120,3 @@ export declare const SELECT_PANEL_MAX_HEIGHT = 256;
 export declare const SELECT_PANEL_PADDING_X = 16;
 
 export declare const SELECT_PANEL_VIEWPORT_PADDING = 8;
-
-export declare const transformPanel: AnimationTriggerMetadata;


### PR DESCRIPTION
BREAKING CHANGES:
* `MatSelect.focused` is now a readonly property.
* `_liveAnnouncer` constructor parameter is now required.
* `transformPanel` constant has been removed. Use `matSelectAnimations.transformPanel`.
* `matSelectAnimations.fadeInContent` has been removed.