### PR TITLE
build: include favicon in dev-app to avoid error

### DIFF
--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -95,6 +95,7 @@ sass_binary(
 dev_server(
     name = "devserver",
     srcs = [
+        "favicon.ico",
         "index.html",
         "system-config.js",
         "system-rxjs-operators.js",


### PR DESCRIPTION
Includes the dev-app favicon in the devserver runfiles, so that
it can be loaded. Currently there is a 404 request to the
favicon.