### PR TITLE
build: populate release version placeholder properly

### DIFF
--- a/tools/bazel-stamp-vars.js
+++ b/tools/bazel-stamp-vars.js
@@ -12,9 +12,10 @@ const packageJson = require('../package');
 
 const currentCommitSha = getCurrentCommitSha();
 
-// The "BUILD_SCM_VERSION" will be picked up by the "npm_package" and "ng_package" rule
-// in order to replace the "0.0.0-PLACEHOLDER" with a proper version
-console.log(`BUILD_SCM_VERSION ${packageJson.version}-${currentCommitSha.substr(0, 7)}`);
+// The "BUILD_SCM_VERSION" will be picked up by the "npm_package" and "ng_package"
+// rule in order to populate the "0.0.0-PLACEHOLDER". Note that the SHA will be only
+// appended for snapshots builds from within the "publish-build-artifacts.sh" script.
+console.log(`BUILD_SCM_VERSION ${packageJson.version}`);
 console.log(`BUILD_SCM_COMMIT_SHA ${currentCommitSha}`);
 console.log(`BUILD_SCM_BRANCH ${getCurrentBranchName()}`);
 console.log(`BUILD_SCM_USER ${getCurrentGitUser()}`);


### PR DESCRIPTION
Currently we always append the SHA of `HEAD` to the
version placeholder. We only want to append the SHA
of `HEAD` to the version if we are publishing snapshot
build artifacts to the Github build repositories.

This also fixes that the SHA is appended twice to
snapshot builds release output. e.g.

https://github.com/angular/cdk-builds/blob/master/package.json#L3.