### PR TITLE
build: fix gulp release output not building

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "postinstall": "node --preserve-symlinks --preserve-symlinks-main tools/bazel/postinstall-patches.js",
-    "build": "gulp build-release-packages",
+    "build": "bash ./scripts/build-packages-dist.sh",
     "bazel:buildifier": "find . -type f \\( -name \"*.bzl\" -or -name WORKSPACE -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs buildifier -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,native-build,native-package,output-group,package-name,package-on-top,redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable,unsorted-dict-items,out-of-order-load",
     "bazel:format-lint": "yarn -s bazel:buildifier --lint=warn --mode=check",
     "dev-app": "ibazel run //src/dev-app:devserver",

--- a/src/material/tsconfig-build.json
+++ b/src/material/tsconfig-build.json
@@ -26,8 +26,6 @@
     "enableIvy": false,
     "annotateForClosureCompiler": true,
     "strictMetadataEmit": true,
-    "flatModuleOutFile": "index.js",
-    "flatModuleId": "@angular/material",
     "skipTemplateCodegen": true,
     "fullTemplateTypeCheck": true
   }

--- a/tools/gulp/packages.ts
+++ b/tools/gulp/packages.ts
@@ -40,5 +40,4 @@ export const allBuildPackages = [
   materialExperimentalPackage,
   momentAdapterPackage,
   googleMapsPackage,
-  examplesPackage
 ];


### PR DESCRIPTION
Even though we do not use the Gulp release output anymore, we should fix
it in case we need to roll-back the Bazel release output migration.

To fix the build, the flat module bundle for the Material primary entry-point has
been removed. We cannot use that anymore since there are no-exports in the
primary entry-point and having `index.ts` as entry-point and flat-module entry-point
the same time causes a NGC metadata bundle stack overflow exception (expected)

Additionally we no longer build the examples with Gulp since that migration was
already successful and the Gulp setup does not work with tertiary entry-points
which are extensively used in the examples package.