### PR TITLE
build: tests should not fail if stylesheets contain quotes

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -197,12 +197,14 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], tags = [], **k
             output_to_bindir = True,
             cmd = """
         files=($(locations %s))
-        css_content=$$(cat $${files[0]})
-        js_template="var cssElement = document.createElement('style'); \
-                    cssElement.type = 'text/css'; \
-                    cssElement.innerHTML = '$$css_content'; \
-                    document.head.appendChild(cssElement);"
-
+        # Escape all double-quotes so that the content can be safely inlined into the
+        # JS template. Note that it needs to be escaped a second time because the string
+        # will be evaluated first in Bash and will then be stored in the JS output.
+        css_content=$$(cat $${files[0]} | sed 's/"/\\\\"/g')
+        js_template='var cssElement = document.createElement("style"); \
+                    cssElement.type = "text/css"; \
+                    cssElement.innerHTML = "'"$$css_content"'"; \
+                    document.head.appendChild(cssElement);'
          echo $$js_template > $@
       """ % css_label,
         )


### PR DESCRIPTION
Currently our workaround that allows us to use stylesheets
in the karma web test suites is not very robust and fails if
stylesheets use single quotes. e.g. `@material/linear-progress`:

https://unpkg.com/browse/@material/linear-progress@3.2.0/_mixins.scss

In order to fix this, we use double-quotes and always escape double-quotes
in the CSS content. This is still a bit hacky, but so is the overall workaround to
make it work.