### PR TITLE
fix(drag-drop): global resize subscription not cleared

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -390,6 +390,7 @@ export class DragRef<T = any> {
     this._handles = [];
     this._disabledHandles.clear();
     this._dropContainer = undefined;
+    this._resizeSubscription.unsubscribe();
     this._boundaryElement = this._rootElement = this._placeholderTemplate =
         this._previewTemplate = this._nextSibling = null!;
   }


### PR DESCRIPTION
Fixes the viewort resize subscription not being removed when the `DragRef` is destroyed.

Fixes #17255.