### PR TITLE
build: do generate invalid semver versions for snapshot builds

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -38,7 +38,12 @@ publishPackage() {
   commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
   commitMessage=$(git log --oneline -n 1)
 
-  buildVersionName="${buildVersion}-${commitSha}"
+  # Note that we cannot store the commit SHA in its own version segment
+  # as it will not comply with the semver specification. For example:
+  # 1.0.0-00abcdef will break since the SHA starts with zeros. To fix this,
+  # we create a new version segment with the following format: "1.0.0-sha-00abcdef".
+  # See issue: https://jubianchi.github.io/semver-check/#/^8.0.0/8.2.2-0462599
+  buildVersionName="${buildVersion}-sha-${commitSha}"
   buildTagName="${branchName}-${commitSha}"
   buildCommitMessage="${branchName} - ${commitMessage}"
 
@@ -89,7 +94,7 @@ publishPackage() {
 
   # Replace the version in every file recursively with a more specific version that also includes
   # the SHA of the current build job. Normally this "sed" call would just replace the version
-  # placeholder, but the version placeholders have been replaced by the release task already.
+  # placeholder, but the version placeholders have been replaced by "npm_package" already.
   sed -i "s/${buildVersion}/${buildVersionName}/g" $(find . -type f -not -path '*\/.*')
 
   echo "Updated the build version in every file to include the SHA of the latest commit."

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -42,7 +42,12 @@ commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
 commitMessage=$(git log --oneline -n 1)
 commitTag="${buildVersion}-${commitSha}"
 
-buildVersionName="${buildVersion}-${commitSha}"
+# Note that we cannot store the commit SHA in its own version segment
+# as it will not comply with the semver specification. For example:
+# 1.0.0-00abcdef will break since the SHA starts with zeros. To fix this,
+# we create a new version segment with the following format: "1.0.0-sha-00abcdef".
+# See issue: https://jubianchi.github.io/semver-check/#/^8.0.0/8.2.2-0462599
+buildVersionName="${buildVersion}-sha-${commitSha}"
 buildTagName="${branchName}-${commitSha}"
 buildCommitMessage="${branchName} - ${commitMessage}"
 
@@ -85,6 +90,11 @@ if [[ $(git ls-remote origin "refs/tags/${buildTagName}") ]]; then
   echo "Skipping publish of docs-content because tag is already published. Exiting.."
   exit 0
 fi
+
+# Replace the version in every file recursively with a more specific version that also includes
+# the SHA of the current build job. Normally this "sed" call would just replace the version
+# placeholder, but the version placeholders have been replaced by "npm_package" already.
+sed -i "s/${buildVersion}/${buildVersionName}/g" $(find . -type f -not -path '*\/.*')
 
 # Setup the Git configuration
 git config user.name "$commitAuthorName"


### PR DESCRIPTION
Apparently there is a long-standing issue in the snapshot builds
where we generate invalid versions if the snapshot SHA starts with
zero's. In order to fix this, we need to ensure that the commit SHA is
part of a version segment that starts with text (i.e. `-sha-{val}`).

This happens rarely, but it should be a good idea to fix this.

**Note**: I guess this should also go into the patch branch for the `8.2.x` docs-content.

Fixes #17264