### PR TITLE
fix(tabs): avoid Ivy template type checking errors in tab link

### DIFF
--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -191,6 +191,10 @@ const _MatTabLinkMixinBase:
         mixinTabIndex(mixinDisableRipple(mixinDisabled(MatTabLinkMixinBase)));
 
 /** Base class with all of the `MatTabLink` functionality. */
+@Directive({
+  // TODO(crisbeto): this selector can be removed when we update to Angular 9.0.
+  selector: 'do-not-use-abstract-mat-tab-link-base'
+})
 // tslint:disable-next-line:class-name
 export class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnDestroy, CanDisable,
   CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {

--- a/src/material/tabs/tabs-module.ts
+++ b/src/material/tabs/tabs-module.ts
@@ -20,7 +20,7 @@ import {MatTabGroup, _MatTabGroupBase} from './tab-group';
 import {MatTabHeader, _MatTabHeaderBase} from './tab-header';
 import {MatTabLabel} from './tab-label';
 import {MatTabLabelWrapper} from './tab-label-wrapper';
-import {MatTabLink, MatTabNav, _MatTabNavBase} from './tab-nav-bar/tab-nav-bar';
+import {MatTabLink, MatTabNav, _MatTabNavBase, _MatTabLinkBase} from './tab-nav-bar/tab-nav-bar';
 import {MatPaginatedTabHeader} from './paginated-tab-header';
 
 
@@ -62,6 +62,7 @@ import {MatPaginatedTabHeader} from './paginated-tab-header';
     _MatTabNavBase as any,
     _MatTabBodyBase as any,
     _MatTabHeaderBase as any,
+    _MatTabLinkBase as any,
   ],
 })
 export class MatTabsModule {}


### PR DESCRIPTION
Follow-up from #17228. Adds a directive annotation to the `_MatTabLinkBase` because it was overlooked the last time around.