### PR TITLE
fix(material-experimental/mdc-button): add ::after to reflect active styles

### DIFF
--- a/src/material-experimental/mdc-button/_button-base.scss
+++ b/src/material-experimental/mdc-button/_button-base.scss
@@ -3,7 +3,7 @@
 // Adds a `before` pseudo element that acts as an overlay indicator for interaction states
 // such as focus, hover, and active.
 @mixin _mat-button-interactive() {
-  &::before {
+  &::before, &::after {
     content: '';
     pointer-events: none;
     position: absolute;


### PR DESCRIPTION
Looks like MDC uses both `::before` _and_ `::after` to reflect state. They use them in parallel to help reflect the combination of states (e.g. focus + active)