### PR TITLE
build: change alpha/beta prerelease options to "next"

### DIFF
--- a/tools/release/prompt/prerelease-labels.ts
+++ b/tools/release/prompt/prerelease-labels.ts
@@ -1,10 +1,8 @@
 import {Version} from '../version-name/parse-version';
 
-/** Inquirer choice for selecting an alpha pre-release label. */
-const ALPHA_CHOICE = {value: 'alpha', name: 'Alpha pre-release'};
 
 /** Inquirer choice for selecting an beta pre-release label. */
-const BETA_CHOICE = {value: 'beta', name: 'Beta pre-release'};
+const NEXT_CHOICE = {value: 'next', name: '"Next"" pre-release'};
 
 /** Inquirer choice for selecting a release candidate label. */
 const RC_CHOICE = {value: 'rc', name: 'Release candidate'};
@@ -17,10 +15,8 @@ export function determineAllowedPrereleaseLabels(version: Version) {
   const {prereleaseLabel} = version;
 
   if (!prereleaseLabel) {
-    return [ALPHA_CHOICE, BETA_CHOICE, RC_CHOICE];
-  } else if (prereleaseLabel === 'alpha') {
-    return [BETA_CHOICE, RC_CHOICE];
-  } else if (prereleaseLabel === 'beta') {
+    return [NEXT_CHOICE, RC_CHOICE];
+  } else if (prereleaseLabel === 'next') {
     return [RC_CHOICE];
   }
 


### PR DESCRIPTION
Angular no longer marks releases as "alpha" or "beta", instead using "next".