### PR TITLE
refactor(ng-update): do not visit external stylesheets multiple times

### DIFF
--- a/src/cdk/schematics/BUILD.bazel
+++ b/src/cdk/schematics/BUILD.bazel
@@ -89,5 +89,5 @@ filegroup(
     srcs = glob([
         "ng-update/test-cases/**/*_input.ts",
         "ng-update/test-cases/**/*_expected_output.ts",
-    ]),
+    ]) + ["ng-update/test-cases/misc/global-stylesheets-test.scss"],
 )

--- a/src/cdk/schematics/ng-update/test-cases/misc/global-stylesheets-test.scss
+++ b/src/cdk/schematics/ng-update/test-cases/misc/global-stylesheets-test.scss
@@ -1,0 +1,3 @@
+[cdkPortalHost] {
+  color: red;
+}

--- a/src/cdk/schematics/ng-update/test-cases/misc/global-stylesheets.spec.ts
+++ b/src/cdk/schematics/ng-update/test-cases/misc/global-stylesheets.spec.ts
@@ -1,0 +1,27 @@
+import {createTestCaseSetup} from '../../../testing';
+import {migrationCollection} from '../index.spec';
+import {readFileSync} from 'fs';
+
+describe('global stylesheets migration', () => {
+
+  it('should not check stylesheet twice if referenced in component', async () => {
+    const {runFixers, writeFile, removeTempDir, appTree} = await createTestCaseSetup(
+      'migration-v6', migrationCollection, [require.resolve('./global-stylesheets_input.ts')]);
+
+    const testStylesheetPath = 'projects/cdk-testing/src/test-cases/global-stylesheets-test.scss';
+
+    // Copy the test stylesheets file into the test CLI application. That way it will
+    // be picked up by the update-tool.
+    writeFile(testStylesheetPath,
+        readFileSync(require.resolve('./global-stylesheets-test.scss'), 'utf8'));
+
+    await runFixers();
+
+    // if the external stylesheet would have been checked multiple times, the migrated
+    // stylesheet would not match the expected output.
+    expect(appTree.readContent(testStylesheetPath))
+        .toBe(`[cdkPortalOutlet] {\n  color: red;\n}\n`);
+
+    removeTempDir();
+  });
+});

--- a/src/cdk/schematics/ng-update/test-cases/misc/global-stylesheets_input.ts
+++ b/src/cdk/schematics/ng-update/test-cases/misc/global-stylesheets_input.ts
@@ -1,0 +1,7 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: 'hello',
+  styleUrls: ['./global-stylesheets-test.scss'],
+})
+export class MyTestComp {}


### PR DESCRIPTION
Besides stylesheets which are referenced in components, we also visit
stylesheets which are not referenced by a component. This has been done
at some point to capture global stylesheets.

Right now we accidentally visit external stylesheets multiple times. This can
result in broken stylesheets.

Also this commit does some path manipulation cleanup.