### PR TITLE
build: publish snapshot scripts incorrectly updating unrelated code

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -95,7 +95,8 @@ publishPackage() {
   # Replace the version in every file recursively with a more specific version that also includes
   # the SHA of the current build job. Normally this "sed" call would just replace the version
   # placeholder, but the version placeholders have been replaced by "npm_package" already.
-  sed -i "s/${buildVersion}/${buildVersionName}/g" $(find . -type f -not -path '*\/.*')
+  escapedVersion=$(echo ${buildVersion} | sed 's/[.[\*^$]/\\&/g')
+  sed -i "s/${escapedVersion}/${buildVersionName}/g" $(find . -type f -not -path '*\/.*')
 
   echo "Updated the build version in every file to include the SHA of the latest commit."
 

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -99,7 +99,8 @@ fi
 # Replace the version in every file recursively with a more specific version that also includes
 # the SHA of the current build job. Normally this "sed" call would just replace the version
 # placeholder, but the version placeholders have been replaced by "npm_package" already.
-sed -i "s/${buildVersion}/${buildVersionName}/g" $(find . -type f -not -path '*\/.*')
+escapedVersion=$(echo ${buildVersion} | sed 's/[.[\*^$]/\\&/g')
+sed -i "s/${escapedVersion}/${buildVersionName}/g" $(find . -type f -not -path '*\/.*')
 
 # Setup the Git configuration
 git config user.name "$commitAuthorName"


### PR DESCRIPTION
I've been wondering for quite some time why a comment in the
cdk drag-drop changes sometimes in the `cdk-builds`.

Apparently it happens because the publish snapshot script used
the current version in the `package.json` as search pattern for
a sed call. This is breaky since the version includes a dot to
separate version segments. These dots are not interpreted as
dots, but rather as a RegExp special character.

Causing unrelated changes to comments that match e.g. `/8.2.0/`

https://github.com/angular/cdk-builds/commit/b3a86279410f3df409e1d1e4638b3b3ed20b8eef#diff-24a5156f00a6496d7fd08504682e8246R1952.