### PR TITLE
fix(datepicker): double role definition on calendar cell

### DIFF
--- a/src/material/datepicker/calendar-body.html
+++ b/src/material/datepicker/calendar-body.html
@@ -40,7 +40,6 @@
       (click)="_cellClicked(item)"
       [style.width]="_cellWidth"
       [style.paddingTop]="_cellPadding"
-      role="button"
       [style.paddingBottom]="_cellPadding">
       <div class="mat-calendar-body-cell-content"
         [class.mat-calendar-body-selected]="selectedValue === item.value"


### PR DESCRIPTION
Fixes the calendar cells having two `role` attributes.

Fixes #17280.