### PR TITLE
docs(platform): remove comment from API docs

### DIFF
--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -30,12 +30,10 @@ try {
  */
 @Injectable({providedIn: 'root'})
 export class Platform {
-  /**
-   * Whether the Angular application is being rendered in the browser.
-   * We want to use the Angular platform check because if the Document is shimmed
-   * without the navigator, the following checks will fail. This is preferred because
-   * sometimes the Document may be shimmed without the user's knowledge or intention
-   */
+  // We want to use the Angular platform check because if the Document is shimmed
+  // without the navigator, the following checks will fail. This is preferred because
+  // sometimes the Document may be shimmed without the user's knowledge or intention
+  /** Whether the Angular application is being rendered in the browser. */
   isBrowser: boolean = this._platformId ?
       isPlatformBrowser(this._platformId) : typeof document === 'object' && !!document;
 
@@ -45,14 +43,14 @@ export class Platform {
   /** Whether the current rendering engine is Microsoft Trident. */
   TRIDENT: boolean = this.isBrowser && /(msie|trident)/i.test(navigator.userAgent);
 
-  /** Whether the current rendering engine is Blink. */
   // EdgeHTML and Trident mock Blink specific things and need to be excluded from this check.
+  /** Whether the current rendering engine is Blink. */
   BLINK: boolean = this.isBrowser && (!!((window as any).chrome || hasV8BreakIterator) &&
       typeof CSS !== 'undefined' && !this.EDGE && !this.TRIDENT);
 
-  /** Whether the current rendering engine is WebKit. */
   // Webkit is part of the userAgent in EdgeHTML, Blink and Trident. Therefore we need to
   // ensure that Webkit runs standalone and is not used as another engine's base.
+  /** Whether the current rendering engine is WebKit. */
   WEBKIT: boolean = this.isBrowser &&
       /AppleWebKit/i.test(navigator.userAgent) && !this.BLINK && !this.EDGE && !this.TRIDENT;
 
@@ -60,27 +58,26 @@ export class Platform {
   IOS: boolean = this.isBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) &&
       !('MSStream' in window);
 
-  /** Whether the current browser is Firefox. */
   // It's difficult to detect the plain Gecko engine, because most of the browsers identify
   // them self as Gecko-like browsers and modify the userAgent's according to that.
   // Since we only cover one explicit Firefox case, we can simply check for Firefox
   // instead of having an unstable check for Gecko.
+  /** Whether the current browser is Firefox. */
   FIREFOX: boolean = this.isBrowser && /(firefox|minefield)/i.test(navigator.userAgent);
 
   /** Whether the current platform is Android. */
   // Trident on mobile adds the android platform to the userAgent to trick detections.
   ANDROID: boolean = this.isBrowser && /android/i.test(navigator.userAgent) && !this.TRIDENT;
 
-  /** Whether the current browser is Safari. */
   // Safari browsers will include the Safari keyword in their userAgent. Some browsers may fake
   // this and just place the Safari keyword in the userAgent. To be more safe about Safari every
   // Safari browser should also use Webkit as its layout engine.
+  /** Whether the current browser is Safari. */
   SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
 
   /**
    * @breaking-change 8.0.0 remove optional decorator
    */
-  constructor(@Optional() @Inject(PLATFORM_ID) private _platformId?: Object) {
-}
+  constructor(@Optional() @Inject(PLATFORM_ID) private _platformId?: Object) {}
 }
 


### PR DESCRIPTION
Removes a comment, that was providing context about why the code works a certain way, from the API docs that show up on material.angular.io.