### PR TITLE
refactor(collections): remove deprecated APIs for 9.0.0

### DIFF
--- a/src/cdk/collections/public-api.ts
+++ b/src/cdk/collections/public-api.ts
@@ -9,7 +9,7 @@
 export * from './array-data-source';
 export * from './collection-viewer';
 export * from './data-source';
-export * from './selection';
+export * from './selection-model';
 export {
   UniqueSelectionDispatcher,
   UniqueSelectionDispatcherListener,

--- a/src/cdk/collections/selection-model.ts
+++ b/src/cdk/collections/selection-model.ts
@@ -36,13 +36,6 @@ export class SelectionModel<T> {
   /** Event emitted when the value has changed. */
   changed: Subject<SelectionChange<T>> = new Subject();
 
-  /**
-   * Event emitted when the value has changed.
-   * @deprecated Use `changed` instead.
-   * @breaking-change 8.0.0 To be changed to `changed`
-   */
-  onChange: Subject<SelectionChange<T>> = this.changed;
-
   constructor(
     private _multiple = false,
     initiallySelectedValues?: T[],

--- a/src/cdk/collections/selection.spec.ts
+++ b/src/cdk/collections/selection.spec.ts
@@ -1,4 +1,4 @@
-import {getMultipleValuesInSingleSelectionError, SelectionModel} from './selection';
+import {getMultipleValuesInSingleSelectionError, SelectionModel} from './selection-model';
 
 
 describe('SelectionModel', () => {

--- a/src/cdk/collections/tree-adapter.ts
+++ b/src/cdk/collections/tree-adapter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SelectionModel} from './selection';
+import {SelectionModel} from './selection-model';
 
 
 /**

--- a/src/cdk/schematics/ng-update/data/property-names.ts
+++ b/src/cdk/schematics/ng-update/data/property-names.ts
@@ -22,14 +22,24 @@ export interface PropertyNameUpgradeData {
 }
 
 export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
-  [TargetVersion.V9]: [{
-    pr: 'https://github.com/angular/components/pull/17084',
-    changes: [{
-      replace: 'boundaryElementSelector',
-      replaceWith: 'boundaryElement',
-      whitelist: {classes: ['CdkDrag']}
-    }]
-  }],
+  [TargetVersion.V9]: [
+    {
+      pr: 'https://github.com/angular/components/pull/17084',
+      changes: [{
+        replace: 'boundaryElementSelector',
+        replaceWith: 'boundaryElement',
+        whitelist: {classes: ['CdkDrag']}
+      }]
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/17302',
+      changes: [{
+        replace: 'onChange',
+        replaceWith: 'changed',
+        whitelist: {classes: ['SelectionModel']}
+      }]
+    }
+  ],
   [TargetVersion.V8]: [],
   [TargetVersion.V7]: [
     {

--- a/src/dev-app/tree/dynamic-tree-demo/dynamic-database.ts
+++ b/src/dev-app/tree/dynamic-tree-demo/dynamic-database.ts
@@ -68,7 +68,7 @@ export class DynamicDataSource {
               private _database: DynamicDatabase) {}
 
   connect(collectionViewer: CollectionViewer): Observable<DynamicFlatNode[]> {
-    this._treeControl.expansionModel.onChange.subscribe(change => {
+    this._treeControl.expansionModel.changed.subscribe(change => {
       if (change.added || change.removed) {
         this.handleTreeControl(change);
       }

--- a/src/material-examples/material/tree/tree-dynamic/tree-dynamic-example.ts
+++ b/src/material-examples/material/tree/tree-dynamic/tree-dynamic-example.ts
@@ -59,7 +59,7 @@ export class DynamicDataSource {
               private _database: DynamicDatabase) {}
 
   connect(collectionViewer: CollectionViewer): Observable<DynamicFlatNode[]> {
-    this._treeControl.expansionModel.onChange.subscribe(change => {
+    this._treeControl.expansionModel.changed.subscribe(change => {
       if ((change as SelectionChange<DynamicFlatNode>).added ||
         (change as SelectionChange<DynamicFlatNode>).removed) {
         this.handleTreeControl(change as SelectionChange<DynamicFlatNode>);

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -400,7 +400,7 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
     }
 
     // Sync external changes to the model back to the options.
-    this.selectedOptions.onChange.pipe(takeUntil(this._destroyed)).subscribe(event => {
+    this.selectedOptions.changed.pipe(takeUntil(this._destroyed)).subscribe(event => {
       if (event.added) {
         for (let item of event.added) {
           item.selected = true;

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -550,7 +550,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   ngAfterContentInit() {
     this._initKeyManager();
 
-    this._selectionModel.onChange.pipe(takeUntil(this._destroy)).subscribe(event => {
+    this._selectionModel.changed.pipe(takeUntil(this._destroy)).subscribe(event => {
       event.added.forEach(option => option.select());
       event.removed.forEach(option => option.deselect());
     });

--- a/src/material/tree/data-source/flat-data-source.ts
+++ b/src/material/tree/data-source/flat-data-source.ts
@@ -149,7 +149,7 @@ export class MatTreeFlatDataSource<T, F> extends DataSource<F> {
   connect(collectionViewer: CollectionViewer): Observable<F[]> {
     const changes = [
       collectionViewer.viewChange,
-      this._treeControl.expansionModel.onChange,
+      this._treeControl.expansionModel.changed,
       this._flattenedData
     ];
     return merge(...changes).pipe(map(() => {

--- a/tools/public_api_guard/cdk/collections.d.ts
+++ b/tools/public_api_guard/cdk/collections.d.ts
@@ -30,7 +30,6 @@ export interface SelectionChange<T> {
 
 export declare class SelectionModel<T> {
     changed: Subject<SelectionChange<T>>;
-    onChange: Subject<SelectionChange<T>>;
     readonly selected: T[];
     constructor(_multiple?: boolean, initiallySelectedValues?: T[], _emitChanges?: boolean);
     clear(): void;


### PR DESCRIPTION
Removes the breaking changes for 9.0 from the `cdk/collections` entry point. Also renames the file with the `SelectionModel` so it's consistent with the class that it contains.

BREAKING CHANGES:
* `SelectionModel.onChange` has been removed. Use `SelectionModel.changed` instead.