### PR TITLE
refactor(google-maps): Remove duplicate module

### DIFF
--- a/src/google-maps/google-maps-module.ts
+++ b/src/google-maps/google-maps-module.ts
@@ -16,7 +16,6 @@ const COMPONENTS = [
   GoogleMap,
   MapInfoWindow,
   MapMarker,
-  MapInfoWindow,
 ];
 
 @NgModule({


### PR DESCRIPTION
Remove duplicate 'MapInfoWindow' from GoogleMapsModule components list.