### PR TITLE
fix(drag-drop): disabled state not synced on data binding changes

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -3409,6 +3409,36 @@ describe('CdkDrag', () => {
           'Expected outer list to not be dragging.');
     }));
 
+    it('should be able to re-enable a disabled drop list', fakeAsync(() => {
+      const fixture = createComponent(DraggableInDropZone);
+      fixture.detectChanges();
+      const dragItems = fixture.componentInstance.dragItems;
+      const tryDrag = () => {
+        const firstItem = dragItems.first;
+        const thirdItemRect = dragItems.toArray()[2].element.nativeElement.getBoundingClientRect();
+        dragElementViaMouse(fixture, firstItem.element.nativeElement,
+          thirdItemRect.left + 1, thirdItemRect.top + 1);
+        flush();
+        fixture.detectChanges();
+      };
+
+      expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
+          .toEqual(['Zero', 'One', 'Two', 'Three']);
+
+      fixture.componentInstance.dropInstance.disabled = true;
+      fixture.detectChanges();
+      tryDrag();
+
+      expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
+          .toEqual(['Zero', 'One', 'Two', 'Three']);
+
+      fixture.componentInstance.dropInstance.disabled = false;
+      fixture.detectChanges();
+      tryDrag();
+
+      expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
+          .toEqual(['One', 'Two', 'Zero', 'Three']);
+    }));
   });
 
   describe('in a connected drop container', () => {

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -100,7 +100,11 @@ export class CdkDropList<T = any> implements AfterContentInit, OnDestroy {
     return this._disabled || (!!this._group && this._group.disabled);
   }
   set disabled(value: boolean) {
-    this._disabled = coerceBooleanProperty(value);
+    // Usually we sync the directive and ref state right before dragging starts, in order to have
+    // a single point of failure and to avoid having to use setters for everything. `disabled` is
+    // a special case, because it can prevent the `beforeStarted` event from firing, which can lock
+    // the user in a disabled state, so we also need to sync it as it's being set.
+    this._dropListRef.disabled = this._disabled = coerceBooleanProperty(value);
   }
   private _disabled = false;
 
@@ -155,7 +159,7 @@ export class CdkDropList<T = any> implements AfterContentInit, OnDestroy {
       return this.enterPredicate(drag.data, drop.data);
     };
 
-    this._syncInputs(this._dropListRef);
+    this._setupInputSyncSubscription(this._dropListRef);
     this._handleEvents(this._dropListRef);
     CdkDropList._dropLists.push(this);
 
@@ -253,7 +257,7 @@ export class CdkDropList<T = any> implements AfterContentInit, OnDestroy {
   }
 
   /** Syncs the inputs of the CdkDropList with the options of the underlying DropListRef. */
-  private _syncInputs(ref: DropListRef<CdkDropList>) {
+  private _setupInputSyncSubscription(ref: DropListRef<CdkDropList>) {
     if (this._dir) {
       this._dir.change
         .pipe(startWith(this._dir.value), takeUntil(this._destroyed))


### PR DESCRIPTION
Usually we only sync up the drop list ref with the directive right before dragging starts, however if the disabled state is set, it can propagate to the child directives and prevent the user from ever starting a search again. These changes make it so whenever the disable state is set it'll get sync immediately.

Also changes a misleading method name.

Fixes #17325.