### PR TITLE
build: set up remote-http-caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,6 +44,20 @@ build:release --workspace_status_command="node ./tools/bazel-stamp-vars.js"
 # does not generate factory files which are needed for AOT.
 build --define=compile=legacy
 
+#######################
+# Remote HTTP Caching #
+#######################
+build --remote_http_cache=https://storage.googleapis.com/angular-team-cache
+build --remote_accept_cached=true
+build --remote_upload_local_results=false
+
+######################################
+# Remote HTTP Caching writes support #
+# Turn on these settings with        #
+#  --config=-http-caching            #
+######################################
+build:remote-http-caching --remote_upload_local_results=true
+
 ################################
 # Remote Execution Setup       #
 ################################


### PR DESCRIPTION
Adds bazel configuration to use read remote http caching during builds.

Adds --remote-http-caching flag to also write to http cache during builds