### PR TITLE
fix(tabs): not picking up indirect descendant tabs in ivy

### DIFF
--- a/src/material-experimental/mdc-tabs/public-api.ts
+++ b/src/material-experimental/mdc-tabs/public-api.ts
@@ -27,4 +27,5 @@ export {
   MatTabHeaderPosition,
   MatTabsConfig,
   MAT_TABS_CONFIG,
+  MAT_TAB_GROUP,
 } from '@angular/material/tabs';

--- a/src/material-experimental/mdc-tabs/tab-group.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.spec.ts
@@ -23,6 +23,8 @@ describe('MatTabGroup', () => {
         TemplateTabs,
         TabGroupWithAriaInputs,
         TabGroupWithIsActiveBinding,
+        NestedTabs,
+        TabGroupWithIndirectDescendantTabs,
       ],
     });
 
@@ -589,6 +591,34 @@ describe('MatTabGroup', () => {
     }));
   });
 
+  describe('nested tabs', () => {
+    it('should not pick up the tabs from descendant tab groups', fakeAsync(() => {
+      const fixture = TestBed.createComponent(NestedTabs);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const groups = fixture.componentInstance.groups.toArray();
+
+      expect(groups.length).toBe(2);
+      expect(groups[0]._tabs.map((tab: MatTab) => tab.textLabel))
+          .toEqual(['One', 'Two']);
+      expect(groups[1]._tabs.map((tab: MatTab) => tab.textLabel))
+        .toEqual(['Inner tab one', 'Inner tab two']);
+    }));
+
+    it('should pick up indirect descendant tabs', fakeAsync(() => {
+      const fixture = TestBed.createComponent(TabGroupWithIndirectDescendantTabs);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const tabs = fixture.componentInstance.tabGroup._tabs;
+      expect(tabs.map((tab: MatTab) => tab.textLabel)).toEqual(['One', 'Two']);
+    }));
+  });
+
+
   /**
    * Checks that the `selectedIndex` has been updated; checks that the label and body have their
    * respective `active` classes
@@ -825,7 +855,9 @@ class TabGroupWithSimpleApi {
     </mat-tab-group>
   `,
 })
-class NestedTabs {}
+class NestedTabs {
+  @ViewChildren(MatTabGroup) groups: QueryList<MatTabGroup>;
+}
 
 @Component({
   selector: 'template-tabs',
@@ -881,3 +913,18 @@ class TabGroupWithIsActiveBinding {
   `,
 })
 class TabsWithCustomAnimationDuration {}
+
+
+@Component({
+  template: `
+    <mat-tab-group>
+      <ng-container [ngSwitch]="true">
+        <mat-tab label="One">Tab one content</mat-tab>
+        <mat-tab label="Two">Tab two content</mat-tab>
+      </ng-container>
+    </mat-tab-group>
+  `,
+})
+class TabGroupWithIndirectDescendantTabs {
+  @ViewChild(MatTabGroup, {static: false}) tabGroup: MatTabGroup;
+}

--- a/src/material-experimental/mdc-tabs/tab-group.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.ts
@@ -18,7 +18,12 @@ import {
   Inject,
   Optional,
 } from '@angular/core';
-import {_MatTabGroupBase, MAT_TABS_CONFIG, MatTabsConfig} from '@angular/material/tabs';
+import {
+  _MatTabGroupBase,
+  MAT_TABS_CONFIG,
+  MatTabsConfig,
+  MAT_TAB_GROUP,
+} from '@angular/material/tabs';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MatTab} from './tab';
 import {MatTabHeader} from './tab-header';
@@ -37,6 +42,10 @@ import {MatTabHeader} from './tab-header';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   inputs: ['color', 'disableRipple'],
+  providers: [{
+    provide: MAT_TAB_GROUP,
+    useExisting: MatTabGroup
+  }],
   host: {
     'class': 'mat-mdc-tab-group',
     '[class.mat-mdc-tab-group-dynamic-height]': 'dynamicHeight',
@@ -44,7 +53,7 @@ import {MatTabHeader} from './tab-header';
   },
 })
 export class MatTabGroup extends _MatTabGroupBase {
-  @ContentChildren(MatTab) _tabs: QueryList<MatTab>;
+  @ContentChildren(MatTab, {descendants: true}) _allTabs: QueryList<MatTab>;
   @ViewChild('tabBodyWrapper', {static: false}) _tabBodyWrapper: ElementRef;
   @ViewChild('tabHeader', {static: false}) _tabHeader: MatTabHeader;
 

--- a/src/material/tabs/public-api.ts
+++ b/src/material/tabs/public-api.ts
@@ -18,7 +18,7 @@ export {
 } from './tab-body';
 export {MatTabHeader, _MatTabHeaderBase} from './tab-header';
 export {MatTabLabelWrapper} from './tab-label-wrapper';
-export {MatTab} from './tab';
+export {MatTab, MAT_TAB_GROUP} from './tab';
 export {MatTabLabel} from './tab-label';
 export {MatTabNav, MatTabLink, _MatTabNavBase, _MatTabLinkBase} from './tab-nav-bar/index';
 export {MatTabContent} from './tab-content';

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -23,6 +23,8 @@ describe('MatTabGroup', () => {
         TemplateTabs,
         TabGroupWithAriaInputs,
         TabGroupWithIsActiveBinding,
+        NestedTabs,
+        TabGroupWithIndirectDescendantTabs,
       ],
     });
 
@@ -588,6 +590,33 @@ describe('MatTabGroup', () => {
     }));
   });
 
+  describe('nested tabs', () => {
+    it('should not pick up the tabs from descendant tab groups', fakeAsync(() => {
+      const fixture = TestBed.createComponent(NestedTabs);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const groups = fixture.componentInstance.groups.toArray();
+
+      expect(groups.length).toBe(2);
+      expect(groups[0]._tabs.map((tab: MatTab) => tab.textLabel))
+          .toEqual(['One', 'Two']);
+      expect(groups[1]._tabs.map((tab: MatTab) => tab.textLabel))
+        .toEqual(['Inner tab one', 'Inner tab two']);
+    }));
+
+    it('should pick up indirect descendant tabs', fakeAsync(() => {
+      const fixture = TestBed.createComponent(TabGroupWithIndirectDescendantTabs);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const tabs = fixture.componentInstance.tabGroup._tabs;
+      expect(tabs.map((tab: MatTab) => tab.textLabel)).toEqual(['One', 'Two']);
+    }));
+  });
+
   /**
    * Checks that the `selectedIndex` has been updated; checks that the label and body have their
    * respective `active` classes
@@ -824,7 +853,9 @@ class TabGroupWithSimpleApi {
     </mat-tab-group>
   `,
 })
-class NestedTabs {}
+class NestedTabs {
+  @ViewChildren(MatTabGroup) groups: QueryList<MatTabGroup>;
+}
 
 @Component({
   selector: 'template-tabs',
@@ -880,3 +911,18 @@ class TabGroupWithIsActiveBinding {
   `,
 })
 class TabsWithCustomAnimationDuration {}
+
+
+@Component({
+  template: `
+    <mat-tab-group>
+      <ng-container [ngSwitch]="true">
+        <mat-tab label="One">Tab one content</mat-tab>
+        <mat-tab label="Two">Tab two content</mat-tab>
+      </ng-container>
+    </mat-tab-group>
+  `,
+})
+class TabGroupWithIndirectDescendantTabs {
+  @ViewChild(MatTabGroup, {static: false}) tabGroup: MatTabGroup;
+}

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -20,6 +20,9 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
+  InjectionToken,
+  Inject,
+  Optional,
 } from '@angular/core';
 import {CanDisable, CanDisableCtor, mixinDisabled} from '@angular/material/core';
 import {Subject} from 'rxjs';
@@ -32,6 +35,12 @@ import {MatTabLabel} from './tab-label';
 class MatTabBase {}
 const _MatTabMixinBase: CanDisableCtor & typeof MatTabBase =
     mixinDisabled(MatTabBase);
+
+/**
+ * Used to provide a tab group to a tab without causing a circular dependency.
+ * @docs-private
+ */
+export const MAT_TAB_GROUP = new InjectionToken<any>('MAT_TAB_GROUP');
 
 @Component({
   moduleId: module.id,
@@ -107,7 +116,13 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
    */
   isActive = false;
 
-  constructor(private _viewContainerRef: ViewContainerRef) {
+  constructor(
+    private _viewContainerRef: ViewContainerRef,
+    /**
+     * @deprecated `_closestTabGroup` parameter to become required.
+     * @breaking-change 10.0.0
+     */
+    @Optional() @Inject(MAT_TAB_GROUP) public _closestTabGroup?: any) {
     super();
   }
 

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -28,10 +28,11 @@ export declare abstract class _MatTabBodyBase implements OnInit, OnDestroy {
 }
 
 export declare abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements AfterContentInit, AfterContentChecked, OnDestroy, CanColor, CanDisableRipple {
+    abstract _allTabs: QueryList<MatTab>;
     _animationMode?: string | undefined;
     abstract _tabBodyWrapper: ElementRef;
     abstract _tabHeader: MatTabGroupBaseHeader;
-    abstract _tabs: QueryList<MatTab>;
+    _tabs: QueryList<MatTab>;
     readonly animationDone: EventEmitter<void>;
     animationDuration: string;
     backgroundColor: ThemePalette;
@@ -86,6 +87,8 @@ export declare abstract class _MatTabNavBase extends MatPaginatedTabHeader imple
     updateActiveLink(_element?: ElementRef): void;
 }
 
+export declare const MAT_TAB_GROUP: InjectionToken<any>;
+
 export declare const MAT_TABS_CONFIG: InjectionToken<MatTabsConfig>;
 
 export declare class MatInkBar {
@@ -97,6 +100,7 @@ export declare class MatInkBar {
 }
 
 export declare class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnChanges, OnDestroy {
+    _closestTabGroup?: any;
     _explicitContent: TemplateRef<any>;
     _implicitContent: TemplateRef<any>;
     readonly _stateChanges: Subject<void>;
@@ -108,7 +112,8 @@ export declare class MatTab extends _MatTabMixinBase implements OnInit, CanDisab
     position: number | null;
     templateLabel: MatTabLabel;
     textLabel: string;
-    constructor(_viewContainerRef: ViewContainerRef);
+    constructor(_viewContainerRef: ViewContainerRef,
+    _closestTabGroup?: any);
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
@@ -140,9 +145,9 @@ export declare class MatTabContent {
 }
 
 export declare class MatTabGroup extends _MatTabGroupBase {
+    _allTabs: QueryList<MatTab>;
     _tabBodyWrapper: ElementRef;
     _tabHeader: MatTabGroupBaseHeader;
-    _tabs: QueryList<MatTab>;
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, defaultConfig?: MatTabsConfig, animationMode?: string);
 }
 


### PR DESCRIPTION
In ViewEngine `ContentChildren` would pick up indirect descendant items, as long as another directive wasn't matched along the way. This allowed for tabs to be wrapped inside something like an `ng-container`. With Ivy `ContentChildren` is a little more strict and it only works on direct descendants.

These changes turn on `descendants` so that we continue supporting the existing use cases from ViewEngine. Note that it needs a bit of extra logic in order to ensure that nested tab groups continue to work as expected.

Fixes #17336.