### PR TITLE
fix(material-experimental/mdc-slider): remove theme import from all-theme

### DIFF
--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -84,6 +84,7 @@ sass_binary(
         "external/npm/node_modules",
     ],
     deps = [
+        "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
         "//src/material-experimental/mdc-theming:all_themes",
         "//src/material-experimental/mdc-typography:all_typography",
         "//src/material-experimental/popover-edit:popover_edit_scss_lib",

--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -1,4 +1,5 @@
 @import '../material/core/theming/all-theme';
+@import '../material-experimental/mdc-slider/mdc-slider';
 @import '../material-experimental/mdc-theming/all-theme';
 @import '../material-experimental/mdc-typography/all-typography';
 @import '../material-experimental/popover-edit/popover-edit';
@@ -20,6 +21,7 @@ $candy-app-theme: mat-light-theme($candy-app-primary, $candy-app-accent);
 // Include the default theme styles.
 @include angular-material-theme($candy-app-theme);
 @include angular-material-theme-mdc($candy-app-theme);
+@include mat-slider-theme-mdc($candy-app-theme);
 @include mat-popover-edit-theme($candy-app-theme);
 
 // Define an alternate dark theme.
@@ -35,5 +37,6 @@ $dark-theme: mat-dark-theme($dark-primary, $dark-accent, $dark-warn);
 .demo-unicorn-dark-theme {
   @include angular-material-theme($dark-theme);
   @include angular-material-theme-mdc($dark-theme);
+  @include mat-slider-theme-mdc($dark-theme);
   @include mat-popover-edit-theme($dark-theme);
 }

--- a/src/material-experimental/mdc-theming/BUILD.bazel
+++ b/src/material-experimental/mdc-theming/BUILD.bazel
@@ -16,7 +16,6 @@ sass_library(
         "//src/material-experimental/mdc-progress-bar:mdc_progress_bar_scss_lib",
         "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",
         "//src/material-experimental/mdc-slide-toggle:mdc_slide_toggle_scss_lib",
-        "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
         "//src/material-experimental/mdc-tabs:mdc_tabs_scss_lib",
     ],
 )

--- a/src/material-experimental/mdc-theming/_all-theme.scss
+++ b/src/material-experimental/mdc-theming/_all-theme.scss
@@ -5,7 +5,6 @@
 @import '../mdc-menu/mdc-menu';
 @import '../mdc-radio/mdc-radio';
 @import '../mdc-slide-toggle/mdc-slide-toggle';
-@import '../mdc-slider/mdc-slider';
 @import '../mdc-tabs/mdc-tabs';
 @import '../mdc-progress-bar/mdc-progress-bar';
 
@@ -20,6 +19,7 @@
   @include mat-progress-bar-theme-mdc($theme);
   @include mat-radio-theme-mdc($theme);
   @include mat-slide-toggle-theme-mdc($theme);
-  @include mat-slider-theme-mdc($theme);
+  // TODO(andrewjs): Add this back when MDC syncs their slider code into Google-internal code
+  // @include mat-slider-theme-mdc($theme);
   @include mat-tabs-theme-mdc($theme);
 }

--- a/src/universal-app/BUILD.bazel
+++ b/src/universal-app/BUILD.bazel
@@ -45,6 +45,7 @@ sass_binary(
         "external/npm/node_modules",
     ],
     deps = [
+        "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
         "//src/material-experimental/mdc-theming:all_themes",
         "//src/material-experimental/mdc-typography:all_typography",
         "//src/material/core:theming_scss_lib",

--- a/src/universal-app/theme.scss
+++ b/src/universal-app/theme.scss
@@ -1,4 +1,5 @@
 @import '../material/core/theming/all-theme';
+@import '../material-experimental/mdc-slider/mdc-slider';
 @import '../material-experimental/mdc-theming/all-theme';
 @import '../material-experimental/mdc-typography/all-typography';
 
@@ -18,3 +19,4 @@ $candy-app-theme: mat-light-theme($candy-app-primary, $candy-app-accent);
 // Include the default theme styles.
 @include angular-material-theme($candy-app-theme);
 @include angular-material-theme-mdc($candy-app-theme);
+@include mat-slider-theme-mdc($candy-app-theme);


### PR DESCRIPTION
`angular-material-theme-mdc` is broken internally since it calls slider mixins that are not yet available in Google code.  Removing until slider is fully synced in. For now, manually call the slider mixin for the dev app and universal app.