### PR TITLE
fix(material-experimental/mdc-button): elevate z-index of content

### DIFF
--- a/src/material-experimental/mdc-button/_button-base.scss
+++ b/src/material-experimental/mdc-button/_button-base.scss
@@ -34,6 +34,12 @@
     // smaller. We have special logic for stroked buttons to handle this scenario.
     border-radius: inherit;
   }
+
+  // The content should appear over the state and ripple layers, otherwise they may adversely affect
+  // the accessibility of the text content.
+  .mdc-button__label {
+    z-index: 1;
+  }
 }
 
 // MDC's disabled buttons define a default cursor with pointer-events none. However, they select


### PR DESCRIPTION
This ensures the state and ripple do not affect the text color, e.g. if the ink ripple is purple, the text should remain its color rather than being overlaid with a purple tint