### PR TITLE
build: reintroduce static query rule

### DIFF
--- a/tools/tslint-rules/staticQueryRule.ts
+++ b/tools/tslint-rules/staticQueryRule.ts
@@ -1,0 +1,39 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+
+/**
+ * Rule which enforces that all queries are explicitly marked as static or non-static.
+ * TODO(crisbeto): we can remove this once we don't support 8.0.0 anymore.
+ */
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+  }
+}
+
+class Walker extends Lint.RuleWalker {
+  visitPropertyDeclaration(node: ts.PropertyDeclaration) {
+    const childQueryDecorator = node.decorators && node.decorators.find(decorator => {
+      const expression = (decorator.expression as ts.CallExpression);
+      const name = expression && expression.expression.getText();
+      return name === 'ViewChild' || name === 'ContentChild';
+    });
+
+    if (childQueryDecorator) {
+      const options = (childQueryDecorator.expression as ts.CallExpression).arguments[1];
+
+      if (!options || !ts.isObjectLiteralExpression(options) ||
+          !this._getObjectProperty(options, 'static')) {
+        this.addFailureAtNode(childQueryDecorator,
+                              'Queries have to explicitly set the `static` option.');
+      }
+    }
+
+    super.visitPropertyDeclaration(node);
+  }
+
+  /** Gets the node of an object property by name. */
+  private _getObjectProperty(node: ts.ObjectLiteralExpression, name: string) {
+    return node.properties.find(property => (property.name as ts.Identifier).getText() === name);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -106,6 +106,7 @@
     "ng-on-changes-property-access": true,
     "rxjs-imports": true,
     "require-breaking-change-version": true,
+    "static-query": true,
     "no-host-decorator-in-concrete": [
       true,
       "HostBinding",


### PR DESCRIPTION
While we support Angular 8 we need to keep the static query rule around to enforce that we specify the query timing.