### PR TITLE
build: ensure to never output files next to sources

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "../dist/dev-infra-scripts",
     "lib": ["es2016"],
     "types": ["node"],
     "strictNullChecks": true

--- a/tools/cherry-pick-patch/tsconfig.json
+++ b/tools/cherry-pick-patch/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "../../dist/tools/cherry-pick-patch",
     "lib": ["es2016"],
     "types": ["node"],
     "strictNullChecks": true

--- a/tools/release/tsconfig.json
+++ b/tools/release/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "../../dist/tools/release",
     "lib": ["es2016"],
     "types": ["node"],
     "strictNullChecks": true


### PR DESCRIPTION
We have a few tsconfig files which are not used by Bazel and therefore
can be run manually/or by IDEs.

In any case, for these TS projects we never want to output the JS
files next to the sources. This would cause the files to show up
in the Git repository tree.

The scenario that someone runs this manually, or that IDEs build
the project somehow is rare, but it's generally good setting the
output directory for these tsconfig files.

Note: we cannot do this for the Bazel tsconfig files as this
would result in warnings from `@bazel/typescript`