### PR TITLE
fix(google-maps): Fix issues with google maps inputs

### DIFF
--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -116,7 +116,8 @@ describe('GoogleMap', () => {
     fixture.componentInstance.zoom = 12;
     fixture.detectChanges();
 
-    expect(mapSpy.setOptions).toHaveBeenCalledWith({center: {lat: 8, lng: 9}, zoom: 12});
+    expect(mapSpy.setCenter).toHaveBeenCalledWith({lat: 8, lng: 9});
+    expect(mapSpy.setZoom).toHaveBeenCalledWith(12);
   });
 
   it('sets map options', () => {

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -36,7 +36,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
   }
 
   @Input()
-  set position(position: google.maps.LatLngLiteral) {
+  set position(position: google.maps.LatLngLiteral|google.maps.LatLng) {
     this._position.next(position);
   }
 
@@ -74,7 +74,8 @@ export class MapInfoWindow implements OnInit, OnDestroy {
   @Output() zindexChanged = new EventEmitter<void>();
 
   private readonly _options = new BehaviorSubject<google.maps.InfoWindowOptions>({});
-  private readonly _position = new BehaviorSubject<google.maps.LatLngLiteral|undefined>(undefined);
+  private readonly _position =
+      new BehaviorSubject<google.maps.LatLngLiteral|google.maps.LatLng|undefined>(undefined);
 
   private readonly _listeners: google.maps.MapsEventListener[] = [];
 

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -22,9 +22,9 @@ export interface TestingWindow extends Window {
 /** Creates a jasmine.SpyObj for a google.maps.Map. */
 export function createMapSpy(options: google.maps.MapOptions): jasmine.SpyObj<UpdatedGoogleMap> {
   const mapSpy = jasmine.createSpyObj('google.maps.Map', [
-    'setOptions', 'setMap', 'addListener', 'fitBounds', 'panBy', 'panTo', 'panToBounds',
-    'getBounds', 'getCenter', 'getClickableIcons', 'getHeading', 'getMapTypeId', 'getProjection',
-    'getStreetView', 'getTilt', 'getZoom'
+    'setOptions', 'setCenter', 'setZoom', 'setMap', 'addListener', 'fitBounds', 'panBy', 'panTo',
+    'panToBounds', 'getBounds', 'getCenter', 'getClickableIcons', 'getHeading', 'getMapTypeId',
+    'getProjection', 'getStreetView', 'getTilt', 'getZoom'
   ]);
   mapSpy.addListener.and.returnValue({remove: () => {}});
   return mapSpy;


### PR DESCRIPTION
Allow LatLng to be an allowable input type in addition to LatLngLiteral.
Decouple individual inputs from the main "options", to prevent manual
user inputs from causing unpredictable behavior in conjunction with
programmatic changes.