### PR TITLE
build: do not generate type definitions without reference to needed global types

### DIFF
--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
+/// <reference types="googlemaps" />
+
 import {
   ChangeDetectionStrategy,
   Component,

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
+/// <reference types="googlemaps" />
+
 import {
   Directive,
   ElementRef,

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
+/// <reference types="googlemaps" />
+
 import {
   ChangeDetectionStrategy,
   Component,

--- a/src/google-maps/tsconfig-build.json
+++ b/src/google-maps/tsconfig-build.json
@@ -11,9 +11,6 @@
     "rootDirs": [
       ".",
       "../../dist/packages/google-maps"
-    ],
-    "types": [
-      "googlemaps"
     ]
   },
   "files": [

--- a/src/google-maps/tsconfig-tests.json
+++ b/src/google-maps/tsconfig-tests.json
@@ -8,9 +8,8 @@
     "module": "commonjs",
     "target": "es5",
     "types": [
-      "jasmine",
-      "googlemaps"
-    ],
+      "jasmine"
+    ]
   },
   "angularCompilerOptions": {
     "strictMetadataEmit": true,

--- a/src/google-maps/tsconfig.json
+++ b/src/google-maps/tsconfig.json
@@ -6,8 +6,7 @@
     "baseUrl": ".",
     "paths": {},
     "types": [
-      "jasmine",
-      "googlemaps"
+      "jasmine"
     ]
   },
   "include": [

--- a/src/youtube-player/tsconfig-build.json
+++ b/src/youtube-player/tsconfig-build.json
@@ -12,7 +12,6 @@
       ".",
       "../../dist/packages/youtube-player"
     ],
-    "types": ["youtube"]
   },
   "files": [
     "public-api.ts",

--- a/src/youtube-player/tsconfig-tests.json
+++ b/src/youtube-player/tsconfig-tests.json
@@ -7,7 +7,7 @@
     "importHelpers": false,
     "module": "commonjs",
     "target": "es5",
-    "types": ["jasmine", "youtube"]
+    "types": ["jasmine"]
   },
   "angularCompilerOptions": {
     "strictMetadataEmit": true,

--- a/src/youtube-player/tsconfig.json
+++ b/src/youtube-player/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "..",
     "baseUrl": ".",
     "paths": {},
-    "types": ["jasmine", "youtube"]
+    "types": ["jasmine"]
   },
   "include": ["*.ts"]
 }

--- a/src/youtube-player/youtube-player.ts
+++ b/src/youtube-player/youtube-player.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
+/// <reference types="youtube" />
+
 import {
   AfterViewInit,
   ChangeDetectionStrategy,


### PR DESCRIPTION
Ensures that we properly generate all type definitions for source files which
rely on global types from third-party type packages.

This is a workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265