### PR TITLE
fix(scrolling): ensure that there is only one resize listener per instance

### DIFF
--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -8,9 +8,9 @@
 
 import {Platform} from '@angular/cdk/platform';
 import {Injectable, NgZone, OnDestroy, Optional, Inject} from '@angular/core';
-import {merge, of as observableOf, fromEvent, Observable, Subscription} from 'rxjs';
-import {auditTime} from 'rxjs/operators';
 import {DOCUMENT} from '@angular/common';
+import {merge, of as observableOf, fromEvent, Observable, Subscription} from 'rxjs';
+import {auditTime, share} from 'rxjs/operators';
 
 /** Time in ms to throttle the resize events by default. */
 export const DEFAULT_RESIZE_TIME = 20;
@@ -49,7 +49,8 @@ export class ViewportRuler implements OnDestroy {
       const window = this._getWindow();
 
       this._change = _platform.isBrowser ?
-          merge(fromEvent(window, 'resize'), fromEvent(window, 'orientationchange')) :
+          // Add `share` here to ensure that we only have one listener per page.
+          merge(fromEvent(window, 'resize'), fromEvent(window, 'orientationchange')).pipe(share()) :
           observableOf();
 
       // Note that we need to do the subscription inside `runOutsideAngular`


### PR DESCRIPTION
One of the use cases for the `ViewportRuler` is to subscribe to viewport size changes and to ensure that there is only one listener per page. We do this by maintaining a single observable and passing it around, however doing so doesn't guarantee that the same event listener will be reused. This can be verified by running `window.eventListeners('resize')` and looking at the number of listeners.

We didn't catch this earlier, because using the native `getEventListeners(window).resize` yields a single listener, but that seems to be due to Zone.js coalescing the listeners.

These changes ensure that we only have one listener by adding a `share` to the observable.