### PR TITLE
refactor(a11y): remove deprecated APIs for 9.0.0

### DIFF
--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -7,14 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {
-  Inject,
-  Injectable,
-  InjectionToken,
-  OnDestroy,
-  Optional,
-  SkipSelf,
-} from '@angular/core';
+import {Inject, Injectable, OnDestroy} from '@angular/core';
 import {addAriaReferencedId, getAriaReferenceIds, removeAriaReferencedId} from './aria-reference';
 
 
@@ -256,20 +249,3 @@ export class AriaDescriber implements OnDestroy {
     return element.nodeType === this._document.ELEMENT_NODE;
   }
 }
-
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export function ARIA_DESCRIBER_PROVIDER_FACTORY(parentDispatcher: AriaDescriber, _document: any) {
-  return parentDispatcher || new AriaDescriber(_document);
-}
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export const ARIA_DESCRIBER_PROVIDER = {
-  // If there is already an AriaDescriber available, use that. Otherwise, provide a new one.
-  provide: AriaDescriber,
-  deps: [
-    [new Optional(), new SkipSelf(), AriaDescriber],
-    DOCUMENT as InjectionToken<any>
-  ],
-  useFactory: ARIA_DESCRIBER_PROVIDER_FACTORY
-};

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -14,9 +14,7 @@ import {
   Injectable,
   NgZone,
   OnDestroy,
-  Optional,
   Output,
-  SkipSelf,
 } from '@angular/core';
 import {Observable, of as observableOf, Subject, Subscription} from 'rxjs';
 import {coerceElement} from '@angular/cdk/coercion';
@@ -454,17 +452,3 @@ export class CdkMonitorFocus implements OnDestroy {
     this._monitorSubscription.unsubscribe();
   }
 }
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export function FOCUS_MONITOR_PROVIDER_FACTORY(
-    parentDispatcher: FocusMonitor, ngZone: NgZone, platform: Platform) {
-  return parentDispatcher || new FocusMonitor(ngZone, platform);
-}
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export const FOCUS_MONITOR_PROVIDER = {
-  // If there is already a FocusMonitor available, use that. Otherwise, provide a new one.
-  provide: FocusMonitor,
-  deps: [[new Optional(), new SkipSelf(), FocusMonitor], NgZone, Platform],
-  useFactory: FOCUS_MONITOR_PROVIDER_FACTORY
-};

--- a/src/cdk/a11y/key-manager/list-key-manager.spec.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.spec.ts
@@ -868,7 +868,7 @@ describe('Key managers', () => {
 
       keyManager.updateActiveItem(1);
       expect(keyManager.activeItemIndex)
-          .toBe(1, `Expected activeItemIndex to update after calling updateActiveItemIndex().`);
+          .toBe(1, `Expected activeItemIndex to update after calling updateActiveItem().`);
       expect(itemList.items[1].focus).not.toHaveBeenCalledTimes(1);
     });
 

--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -318,16 +318,6 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
   }
 
   /**
-   * Allows setting of the activeItemIndex without any other effects.
-   * @param index The new activeItemIndex.
-   * @deprecated Use `updateActiveItem` instead.
-   * @breaking-change 8.0.0
-   */
-  updateActiveItemIndex(index: number): void {
-    this.updateActiveItem(index);
-  }
-
-  /**
    * This method sets the active item, given a list of items and the delta between the
    * currently active item and the new active item. It will calculate differently
    * depending on whether wrap mode is turned on.

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -17,8 +17,6 @@ import {
   NgZone,
   OnDestroy,
   Optional,
-  Provider,
-  SkipSelf,
 } from '@angular/core';
 import {Subscription} from 'rxjs';
 import {
@@ -226,24 +224,3 @@ export class CdkAriaLive implements OnDestroy {
     }
   }
 }
-
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export function LIVE_ANNOUNCER_PROVIDER_FACTORY(
-    parentAnnouncer: LiveAnnouncer, liveElement: any, _document: any, ngZone: NgZone) {
-  return parentAnnouncer || new LiveAnnouncer(liveElement, ngZone, _document);
-}
-
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export const LIVE_ANNOUNCER_PROVIDER: Provider = {
-  // If there is already a LiveAnnouncer available, use that. Otherwise, provide a new one.
-  provide: LiveAnnouncer,
-  deps: [
-    [new Optional(), new SkipSelf(), LiveAnnouncer],
-    [new Optional(), new Inject(LIVE_ANNOUNCER_ELEMENT_TOKEN)],
-    DOCUMENT,
-    NgZone,
-  ],
-  useFactory: LIVE_ANNOUNCER_PROVIDER_FACTORY
-};

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -342,7 +342,7 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
         .pipe(startWith(this._layoutDirection()), takeUntil(this._destroyed))
         .subscribe(direction => this._keyManager.withHorizontalOrientation(direction));
 
-    this._keyManager.updateActiveItemIndex(this._selectedIndex);
+    this._keyManager.updateActiveItem(this._selectedIndex);
 
     this.steps.changes.pipe(takeUntil(this._destroyed)).subscribe(() => {
       if (!this.selected) {
@@ -456,7 +456,7 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
     // (e.g. checking whether focus is inside the active step), because we don't have a
     // reference to the elements that are rendering out the content.
     this._containsFocus() ? this._keyManager.setActiveItem(newIndex) :
-                            this._keyManager.updateActiveItemIndex(newIndex);
+                            this._keyManager.updateActiveItem(newIndex);
 
     this._selectedIndex = newIndex;
     this._stateChanged();

--- a/src/material-experimental/mdc-chips/chip-listbox.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.ts
@@ -513,7 +513,7 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
       let chipIndex: number = this._chips.toArray().indexOf(event.chip as MatChipOption);
 
       if (this._isValidIndex(chipIndex)) {
-        this._keyManager.updateActiveItemIndex(chipIndex);
+        this._keyManager.updateActiveItem(chipIndex);
       }
     });
   }

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -756,7 +756,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
       let chipIndex: number = this.chips.toArray().indexOf(event.chip);
 
       if (this._isValidIndex(chipIndex)) {
-        this._keyManager.updateActiveItemIndex(chipIndex);
+        this._keyManager.updateActiveItem(chipIndex);
       }
       this.stateChanges.next();
     });

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -1141,7 +1141,7 @@ function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
 
   // When the focus is on the last step and right arrow key is pressed, the focus should cycle
   // through to the first step.
-  stepperComponent._keyManager.updateActiveItemIndex(2);
+  stepperComponent._keyManager.updateActiveItem(2);
   stepHeaderEl = stepHeaders[2].nativeElement;
   dispatchKeyboardEvent(stepHeaderEl, 'keydown', nextKey);
   fixture.detectChanges();

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -126,7 +126,7 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
       this._selectedIndex = value;
 
       if (this._keyManager) {
-        this._keyManager.updateActiveItemIndex(value);
+        this._keyManager.updateActiveItem(value);
       }
     }
   }

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -6,14 +6,6 @@ export declare class ActiveDescendantKeyManager<T> extends ListKeyManager<Highli
     setActiveItem(item: T): void;
 }
 
-export declare const ARIA_DESCRIBER_PROVIDER: {
-    provide: typeof AriaDescriber;
-    deps: (Optional[] | InjectionToken<any>)[];
-    useFactory: typeof ARIA_DESCRIBER_PROVIDER_FACTORY;
-};
-
-export declare function ARIA_DESCRIBER_PROVIDER_FACTORY(parentDispatcher: AriaDescriber, _document: any): AriaDescriber;
-
 export declare class AriaDescriber implements OnDestroy {
     constructor(_document: any);
     describe(hostElement: Element, message: string | HTMLElement): void;
@@ -48,14 +40,6 @@ export declare class CdkTrapFocus implements OnDestroy, AfterContentInit, DoChec
     ngDoCheck(): void;
     ngOnDestroy(): void;
 }
-
-export declare const FOCUS_MONITOR_PROVIDER: {
-    provide: typeof FocusMonitor;
-    deps: (Optional[] | typeof NgZone | typeof Platform)[];
-    useFactory: typeof FOCUS_MONITOR_PROVIDER_FACTORY;
-};
-
-export declare function FOCUS_MONITOR_PROVIDER_FACTORY(parentDispatcher: FocusMonitor, ngZone: NgZone, platform: Platform): FocusMonitor;
 
 export interface FocusableOption extends ListKeyManagerOption {
     focus(origin?: FocusOrigin): void;
@@ -137,7 +121,6 @@ export declare class ListKeyManager<T extends ListKeyManagerOption> {
     skipPredicate(predicate: (item: T) => boolean): this;
     updateActiveItem(item: T): void;
     updateActiveItem(index: number): void;
-    updateActiveItemIndex(index: number): void;
     withAllowedModifierKeys(keys: ListKeyManagerModifierKey[]): this;
     withHorizontalOrientation(direction: 'ltr' | 'rtl' | null): this;
     withTypeAhead(debounceInterval?: number): this;
@@ -157,10 +140,6 @@ export declare const LIVE_ANNOUNCER_DEFAULT_OPTIONS: InjectionToken<LiveAnnounce
 export declare const LIVE_ANNOUNCER_ELEMENT_TOKEN: InjectionToken<HTMLElement | null>;
 
 export declare function LIVE_ANNOUNCER_ELEMENT_TOKEN_FACTORY(): null;
-
-export declare const LIVE_ANNOUNCER_PROVIDER: Provider;
-
-export declare function LIVE_ANNOUNCER_PROVIDER_FACTORY(parentAnnouncer: LiveAnnouncer, liveElement: any, _document: any, ngZone: NgZone): LiveAnnouncer;
 
 export declare class LiveAnnouncer implements OnDestroy {
     constructor(elementToken: any, _ngZone: NgZone, _document: any, _defaultOptions?: LiveAnnouncerDefaultOptions | undefined);


### PR DESCRIPTION
Cleans up the deprecated APIs for v9 from the `cdk/a11y` package.

BREAKING CHANGES:
* `ListKeyManager.updateActiveItemIndex` has been removed. Use `ListKeyManager.updateActiveItem` instead.
* `ARIA_DESCRIBER_PROVIDER_FACTORY` has been removed.
* `ARIA_DESCRIBER_PROVIDER` has been removed.
* `FOCUS_MONITOR_PROVIDER_FACTORY` has been removed.
* `FOCUS_MONITOR_PROVIDER` has been removed.
* `LIVE_ANNOUNCER_PROVIDER_FACTORY` has been removed.
* `LIVE_ANNOUNCER_PROVIDER` has been removed.