### PR TITLE
feat: change tslib from direct dependency to peerDependency

### DIFF
--- a/src/cdk-experimental/package.json
+++ b/src/cdk-experimental/package.json
@@ -21,9 +21,7 @@
   "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/cdk": "0.0.0-PLACEHOLDER",
-    "@angular/core": "0.0.0-NG"
-  },
-  "dependencies": {
-    "tslib": "^1.7.1"
+    "@angular/core": "0.0.0-NG",
+    "tslib": "^1.9.0"
   }
 }

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -28,10 +28,8 @@
   "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
-    "@angular/common": "0.0.0-NG"
-  },
-  "dependencies": {
-    "tslib": "^1.7.1"
+    "@angular/common": "0.0.0-NG",
+    "tslib": "^1.9.0"
   },
   "optionalDependencies": {
     "parse5": "^5.0.0"

--- a/src/material-examples/package.json
+++ b/src/material-examples/package.json
@@ -33,9 +33,7 @@
     "@angular/common": "0.0.0-NG",
     "@angular/material": "0.0.0-PLACEHOLDER",
     "@angular/material-experimental": "0.0.0-PLACEHOLDER",
-    "@angular/material-moment-adapter": "0.0.0-PLACEHOLDER"
-  },
-  "dependencies": {
-    "tslib": "^1.7.1"
+    "@angular/material-moment-adapter": "0.0.0-PLACEHOLDER",
+    "tslib": "^1.9.0"
   }
 }

--- a/src/material-experimental/package.json
+++ b/src/material-experimental/package.json
@@ -22,9 +22,7 @@
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
     "@angular/material": "0.0.0-PLACEHOLDER",
-    "material-components-web": "0.0.0-MDC"
-  },
-  "dependencies": {
-    "tslib": "^1.7.1"
+    "material-components-web": "0.0.0-MDC",
+    "tslib": "^1.9.0"
   }
 }

--- a/src/material-moment-adapter/package.json
+++ b/src/material-moment-adapter/package.json
@@ -22,10 +22,8 @@
   "peerDependencies": {
     "@angular/material": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
-    "moment": "^2.18.1"
-  },
-  "dependencies": {
-    "tslib": "^1.7.1"
+    "moment": "^2.18.1",
+    "tslib": "^1.9.0"
   },
   "ng-update": {
     "packageGroup": [

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -30,10 +30,8 @@
     "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",
-    "@angular/forms": "0.0.0-NG"
-  },
-  "dependencies": {
-    "tslib": "^1.7.1"
+    "@angular/forms": "0.0.0-NG",
+    "tslib": "^1.9.0"
   },
   "schematics": "./schematics/collection.json",
   "ng-update": {


### PR DESCRIPTION
BREAKING CHANGE:

We no longer directly have a direct depedency on `tslib`. Instead it is now listed a `peerDependency`.

Users not using the CLI will need to manually install `tslib` via;
```
yarn add tslib
```
or
```
npm install tslib --save
```

Reference: TOOL-836

