### PR TITLE
docs(drag-drop): expose DragRef and DragListRef to docs

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -66,7 +66,6 @@ interface DragHelperTemplate<T = any> {
 
 /**
  * Reference to a draggable item. Used to manipulate or dispose of the item.
- * @docs-private
  */
 export class DragRef<T = any> {
   /** Element displayed next to the user's pointer while the element is dragged. */

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -69,7 +69,6 @@ export interface DropListRefInternal extends DropListRef {}
 
 /**
  * Reference to a drop list. Used to manipulate or dispose of the container.
- * @docs-private
  */
 export class DropListRef<T = any> {
   /** Element that the drop list is attached to. */


### PR DESCRIPTION
DragRef is returned by `createDrag` and has public API items that are not showing up on the documentation site.

https://material.angular.io/cdk/drag-drop/api#DragDrop
![image](https://user-images.githubusercontent.com/4655972/66871701-31a94d80-ef72-11e9-82c2-0a90a0e043dd.png)
