### PR TITLE
feat(material/radio/testing): polish harness API

### DIFF
--- a/src/material/radio/testing/BUILD.bazel
+++ b/src/material/radio/testing/BUILD.bazel
@@ -26,6 +26,7 @@ ng_test_library(
     deps = [
         ":testing",
         "//src/cdk/platform",
+        "//src/cdk/private/testing",
         "//src/cdk/testing",
         "//src/cdk/testing/testbed",
         "//src/material/radio",

--- a/src/material/radio/testing/radio-harness.ts
+++ b/src/material/radio/testing/radio-harness.ts
@@ -30,8 +30,6 @@ export class MatRadioGroupHarness extends ComponentHarness {
         .addOption('name', options.name, this._checkRadioGroupName);
   }
 
-  private _radioButtons = this.locatorForAll(MatRadioButtonHarness);
-
   /** Gets the name of the radio-group. */
   async getName(): Promise<string|null> {
     const hostName = await this._getGroupNameFromHost();
@@ -59,8 +57,8 @@ export class MatRadioGroupHarness extends ComponentHarness {
     return (await this.host()).getProperty('id');
   }
 
-  /** Gets the selected radio-button in a radio-group. */
-  async getSelectedRadioButton(): Promise<MatRadioButtonHarness|null> {
+  /** Gets the checked radio-button in a radio-group. */
+  async getCheckedRadioButton(): Promise<MatRadioButtonHarness|null> {
     for (let radioButton of await this.getRadioButtons()) {
       if (await radioButton.isChecked()) {
         return radioButton;
@@ -69,18 +67,27 @@ export class MatRadioGroupHarness extends ComponentHarness {
     return null;
   }
 
-  /** Gets the selected value of the radio-group. */
-  async getSelectedValue(): Promise<string|null> {
-    const selectedRadio = await this.getSelectedRadioButton();
-    if (!selectedRadio) {
+  /** Gets the checked value of the radio-group. */
+  async getCheckedValue(): Promise<string|null> {
+    const checkedRadio = await this.getCheckedRadioButton();
+    if (!checkedRadio) {
       return null;
     }
-    return selectedRadio.getValue();
+    return checkedRadio.getValue();
   }
 
   /** Gets all radio buttons which are part of the radio-group. */
-  async getRadioButtons(): Promise<MatRadioButtonHarness[]> {
-    return (await this._radioButtons());
+  async getRadioButtons(filter: RadioButtonHarnessFilters = {}): Promise<MatRadioButtonHarness[]> {
+    return this.locatorForAll(MatRadioButtonHarness.with(filter))();
+  }
+
+  /** Checks a radio button in this group. */
+  async checkRadioButton(filter: RadioButtonHarnessFilters = {}): Promise<void> {
+    const radioButtons = await this.getRadioButtons(filter);
+    if (!radioButtons.length) {
+      throw Error(`Could not find radio button matching ${JSON.stringify(filter)}`);
+    }
+    return radioButtons[0].check();
   }
 
   private async _getGroupNameFromHost() {

--- a/src/material/radio/testing/shared.spec.ts
+++ b/src/material/radio/testing/shared.spec.ts
@@ -1,4 +1,5 @@
 import {Platform} from '@angular/cdk/platform';
+import {expectAsyncError} from '@angular/cdk/private/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
@@ -105,10 +106,10 @@ export function runHarnessTests(radioModule: typeof MatRadioModule,
       expect(await groups[1].getId()).toBe('new-group-name');
     });
 
-    it('should get selected value of radio-group', async () => {
+    it('should get checked value of radio-group', async () => {
       const [firstGroup, secondGroup] = await loader.getAllHarnesses(radioGroupHarness);
-      expect(await firstGroup.getSelectedValue()).toBe('opt2');
-      expect(await secondGroup.getSelectedValue()).toBe(null);
+      expect(await firstGroup.getCheckedValue()).toBe('opt2');
+      expect(await secondGroup.getCheckedValue()).toBe(null);
     });
 
     it('should get radio-button harnesses of radio-group', async () => {
@@ -120,18 +121,36 @@ export function runHarnessTests(radioModule: typeof MatRadioModule,
       expect((await groups[2].getRadioButtons()).length).toBe(2);
     });
 
-    it('should get selected radio-button harnesses of radio-group', async () => {
+    it('should get radio buttons from group with filter', async () => {
+      const group = await loader.getHarness(radioGroupHarness.with({name: 'my-group-1-name'}));
+      expect((await group.getRadioButtons({label: 'opt2'})).length).toBe(1);
+    });
+
+    it('should get checked radio-button harnesses of radio-group', async () => {
       const groups = await loader.getAllHarnesses(radioGroupHarness);
       expect(groups.length).toBe(3);
 
-      const groupOneSelected = await groups[0].getSelectedRadioButton();
-      const groupTwoSelected = await groups[1].getSelectedRadioButton();
-      const groupThreeSelected = await groups[2].getSelectedRadioButton();
+      const groupOneChecked = await groups[0].getCheckedRadioButton();
+      const groupTwoChecked = await groups[1].getCheckedRadioButton();
+      const groupThreeChecked = await groups[2].getCheckedRadioButton();
 
-      expect(groupOneSelected).not.toBeNull();
-      expect(groupTwoSelected).toBeNull();
-      expect(groupThreeSelected).toBeNull();
-      expect(await groupOneSelected!.getId()).toBe('opt2-group-one');
+      expect(groupOneChecked).not.toBeNull();
+      expect(groupTwoChecked).toBeNull();
+      expect(groupThreeChecked).toBeNull();
+      expect(await groupOneChecked!.getId()).toBe('opt2-group-one');
+    });
+
+    it('should check radio button in group', async () => {
+      const group = await loader.getHarness(radioGroupHarness.with({name: 'my-group-1-name'}));
+      expect(await group.getCheckedValue()).toBe('opt2');
+      await group.checkRadioButton({label: 'opt3'});
+      expect(await group.getCheckedValue()).toBe('opt3');
+    });
+
+    it('should throw error when checking invalid radio button', async () => {
+      const group = await loader.getHarness(radioGroupHarness.with({name: 'my-group-1-name'}));
+      await expectAsyncError(() => group.checkRadioButton({label: 'opt4'}),
+          /Error: Could not find radio button matching {"label":"opt4"}/);
     });
   });
 
@@ -222,7 +241,7 @@ export function runHarnessTests(radioModule: typeof MatRadioModule,
       await uncheckedRadio.check();
       expect(await uncheckedRadio.isChecked()).toBe(true);
       // Checked radio state should change since the two radio's
-      // have the same name and only one can be selected.
+      // have the same name and only one can be checked.
       expect(await checkedRadio.isChecked()).toBe(false);
     });
 


### PR DESCRIPTION
- Consistently use "check" rather than "select" in API names
- Add support for passing a filter to `getRadioButtons`
- Add a method on `MatRadioGroupHarness` to check a button in the group