### PR TITLE
refactor(scrolling): remove deprecated APIs for 9.0.0

### DIFF
--- a/src/cdk/overlay/overlay-module.ts
+++ b/src/cdk/overlay/overlay-module.ts
@@ -8,7 +8,7 @@
 
 import {BidiModule} from '@angular/cdk/bidi';
 import {PortalModule} from '@angular/cdk/portal';
-import {ScrollingModule, VIEWPORT_RULER_PROVIDER} from '@angular/cdk/scrolling';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 import {NgModule, Provider} from '@angular/core';
 import {OVERLAY_KEYBOARD_DISPATCHER_PROVIDER} from './keyboard/overlay-keyboard-dispatcher';
 import {Overlay} from './overlay';
@@ -42,7 +42,6 @@ export const OVERLAY_PROVIDERS: Provider[] = [
   Overlay,
   OverlayPositionBuilder,
   OVERLAY_KEYBOARD_DISPATCHER_PROVIDER,
-  VIEWPORT_RULER_PROVIDER,
   OVERLAY_CONTAINER_PROVIDER,
   CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER,
 ];

--- a/src/cdk/overlay/public-api.ts
+++ b/src/cdk/overlay/public-api.ts
@@ -29,4 +29,3 @@ export {
   FlexibleConnectedPositionStrategy,
   FlexibleConnectedPositionStrategyOrigin,
 } from './position/flexible-connected-position-strategy';
-export {VIEWPORT_RULER_PROVIDER} from '@angular/cdk/scrolling';

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -7,14 +7,7 @@
  */
 
 import {Platform} from '@angular/cdk/platform';
-import {
-  ElementRef,
-  Injectable,
-  NgZone,
-  OnDestroy,
-  Optional,
-  SkipSelf,
-} from '@angular/core';
+import {ElementRef, Injectable, NgZone, OnDestroy} from '@angular/core';
 import {fromEvent, of as observableOf, Subject, Subscription, Observable, Observer} from 'rxjs';
 import {auditTime, filter} from 'rxjs/operators';
 import {CdkScrollable} from './scrollable';
@@ -172,18 +165,3 @@ export class ScrollDispatcher implements OnDestroy {
     }
   }
 }
-
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export function SCROLL_DISPATCHER_PROVIDER_FACTORY(
-    parentDispatcher: ScrollDispatcher, ngZone: NgZone, platform: Platform) {
-  return parentDispatcher || new ScrollDispatcher(ngZone, platform);
-}
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export const SCROLL_DISPATCHER_PROVIDER = {
-  // If there is already a ScrollDispatcher available, use that. Otherwise, provide a new one.
-  provide: ScrollDispatcher,
-  deps: [[new Optional(), new SkipSelf(), ScrollDispatcher], NgZone, Platform],
-  useFactory: SCROLL_DISPATCHER_PROVIDER_FACTORY
-};

--- a/src/cdk/scrolling/scrolling-module.ts
+++ b/src/cdk/scrolling/scrolling-module.ts
@@ -31,13 +31,3 @@ import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
   ],
 })
 export class ScrollingModule {}
-
-/**
- * @deprecated ScrollDispatchModule has been renamed to ScrollingModule.
- * @breaking-change 8.0.0 delete this alias
- */
-@NgModule({
-  imports: [ScrollingModule],
-  exports: [ScrollingModule],
-})
-export class ScrollDispatchModule {}

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -7,7 +7,7 @@
  */
 
 import {Platform} from '@angular/cdk/platform';
-import {Injectable, NgZone, OnDestroy, Optional, SkipSelf} from '@angular/core';
+import {Injectable, NgZone, OnDestroy} from '@angular/core';
 import {merge, of as observableOf, fromEvent, Observable, Subscription} from 'rxjs';
 import {auditTime} from 'rxjs/operators';
 
@@ -132,19 +132,3 @@ export class ViewportRuler implements OnDestroy {
         {width: 0, height: 0};
   }
 }
-
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export function VIEWPORT_RULER_PROVIDER_FACTORY(parentRuler: ViewportRuler,
-                                                platform: Platform,
-                                                ngZone: NgZone) {
-  return parentRuler || new ViewportRuler(platform, ngZone);
-}
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export const VIEWPORT_RULER_PROVIDER = {
-  // If there is already a ViewportRuler available, use that. Otherwise, provide a new one.
-  provide: ViewportRuler,
-  deps: [[new Optional(), new SkipSelf(), ViewportRuler], Platform, NgZone],
-  useFactory: VIEWPORT_RULER_PROVIDER_FACTORY
-};

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -135,14 +135,6 @@ export declare class FixedSizeVirtualScrollStrategy implements VirtualScrollStra
     updateItemAndBufferSize(itemSize: number, minBufferPx: number, maxBufferPx: number): void;
 }
 
-export declare const SCROLL_DISPATCHER_PROVIDER: {
-    provide: typeof ScrollDispatcher;
-    deps: (Optional[] | typeof NgZone | typeof Platform)[];
-    useFactory: typeof SCROLL_DISPATCHER_PROVIDER_FACTORY;
-};
-
-export declare function SCROLL_DISPATCHER_PROVIDER_FACTORY(parentDispatcher: ScrollDispatcher, ngZone: NgZone, platform: Platform): ScrollDispatcher;
-
 export declare class ScrollDispatcher implements OnDestroy {
     _globalSubscription: Subscription | null;
     scrollContainers: Map<CdkScrollable, Subscription>;
@@ -155,19 +147,8 @@ export declare class ScrollDispatcher implements OnDestroy {
     scrolled(auditTimeInMs?: number): Observable<CdkScrollable | void>;
 }
 
-export declare class ScrollDispatchModule {
-}
-
 export declare class ScrollingModule {
 }
-
-export declare const VIEWPORT_RULER_PROVIDER: {
-    provide: typeof ViewportRuler;
-    deps: (Optional[] | typeof NgZone | typeof Platform)[];
-    useFactory: typeof VIEWPORT_RULER_PROVIDER_FACTORY;
-};
-
-export declare function VIEWPORT_RULER_PROVIDER_FACTORY(parentRuler: ViewportRuler, platform: Platform, ngZone: NgZone): ViewportRuler;
 
 export declare class ViewportRuler implements OnDestroy {
     constructor(_platform: Platform, ngZone: NgZone);


### PR DESCRIPTION
Cleans up the deprecated APIs from `cdk/scrolling` for 9.0.0.

BREAKING CHANGES:
* `ScrollDispatchModule` has been renamed to `ScrollingModule`.
* `SCROLL_DISPATCHER_PROVIDER_FACTORY` has been removed.
* `SCROLL_DISPATCHER_PROVIDER` has been removed.
* `VIEWPORT_RULER_PROVIDER_FACTORY` has been removed.
* `VIEWPORT_RULER_PROVIDER` has been removed.