### PR TITLE
refactor: ensure hammer migration properly sets up gesture config in app module

### DIFF
--- a/src/cdk/schematics/update-tool/index.ts
+++ b/src/cdk/schematics/update-tool/index.ts
@@ -122,8 +122,8 @@ export function runMigrationRules<T>(
   if (ruleFailures.length) {
     ruleFailures.forEach(({filePath, message, position}) => {
       const normalizedFilePath = normalize(getProjectRelativePath(filePath));
-      const lineAndCharacter = `${position.line + 1}:${position.character + 1}`;
-      logger.warn(`${normalizedFilePath}@${lineAndCharacter} - ${message}`);
+      const lineAndCharacter = position ? `@${position.line + 1}:${position.character + 1}` : '';
+      logger.warn(`${normalizedFilePath}${lineAndCharacter} - ${message}`);
     });
   }
 

--- a/src/cdk/schematics/update-tool/migration-rule.ts
+++ b/src/cdk/schematics/update-tool/migration-rule.ts
@@ -16,7 +16,7 @@ import {LineAndCharacter} from './utils/line-mappings';
 export interface MigrationFailure {
   filePath: string;
   message: string;
-  position: LineAndCharacter;
+  position?: LineAndCharacter;
 }
 
 export class MigrationRule<T> {

--- a/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/find-main-module.ts
+++ b/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/find-main-module.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+/**
+ * Finds the main Angular module within the specified source file. The first module
+ * that is part of the "bootstrapModule" expression is returned.
+ */
+export function findMainModuleExpression(mainSourceFile: ts.SourceFile): ts.Expression|null {
+  let foundModule: ts.Expression|null = null;
+  const visitNode = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && node.arguments.length &&
+        ts.isPropertyAccessExpression(node.expression) && ts.isIdentifier(node.expression.name) &&
+        node.expression.name.text === 'bootstrapModule') {
+      foundModule = node.arguments[0]!;
+    } else {
+      ts.forEachChild(node, visitNode);
+    }
+  };
+
+  ts.forEachChild(mainSourceFile, visitNode);
+
+  return foundModule;
+}


### PR DESCRIPTION
Currently the HammerJS v9 migration relies on a few utilities from
`@schematics/angular`. Apparently these are not reliable enough for
our migration use-case, so we cannot use them.

This came up when testing the migration with more possible
scenarios in the docs app. Currently the migration is unable
to set up the gesture config (if hammer is used) in the app
module if the bootstrap module call imports it through multiple
layers of files. We can fix this, make the logic more robust and
make the code less verbose by simply using the type checker to
resolve the file that contains the app module references in a
bootstrap call (that way we do not need to deal with import resolution).