### PR TITLE
build: do not show inherited protected members in api docs

### DIFF
--- a/tools/dgeni/processors/merge-inherited-properties.ts
+++ b/tools/dgeni/processors/merge-inherited-properties.ts
@@ -20,7 +20,12 @@ export class MergeInheritedProperties implements Processor {
     // Note that we need to get check all base documents. We cannot assume
     // that directive base documents already have merged inherited members.
     getInheritedDocsOfClass(doc).forEach(d => {
-      d.members.forEach(member => this._addMemberDocIfNotPresent(doc, member));
+      d.members.forEach(member => {
+        // only add inherited class members which are not "protected" or "private".
+        if (member.accessibility === 'public') {
+          this._addMemberDocIfNotPresent(doc, member);
+        }
+      });
     });
   }
 


### PR DESCRIPTION
As per discussion in the team meeting, we do not want to show
the API documentation of inherited protected members.

The protected members should be only displayed in the API
doc of the class that _declares_ these.