### PR TITLE
build: bump required angular version for upcoming v9 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "check-rollup-globals": "ts-node --project scripts/ scripts/check-rollup-globals.ts"
   },
   "version": "9.0.0-next.0",
-  "requiredAngularVersion": "^8.0.0 || ^9.0.0-0",
+  "requiredAngularVersion": "^9.0.0-0 || ^10.0.0-0",
   "requiredMDCVersion": "^4.0.0-alpha.0",
   "dependencies": {
     "@angular/animations": "^9.0.0-next.10",

--- a/packages.bzl
+++ b/packages.bzl
@@ -1,7 +1,7 @@
 # Each individual package uses a placeholder for the version of Angular to ensure they're
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
-ANGULAR_PACKAGE_VERSION = "^8.0.0 || ^9.0.0-0"
+ANGULAR_PACKAGE_VERSION = "^9.0.0-0 || ^10.0.0-0"
 MDC_PACKAGE_VERSION = "^4.0.0-alpha.0"
 VERSION_PLACEHOLDER_REPLACEMENTS = {
     "0.0.0-MDC": MDC_PACKAGE_VERSION,


### PR DESCRIPTION
Bumps the required Angular version for the upcoming v9
release.