### PR TITLE
fix(form-field): ensure that descendants are picked up in Ivy

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -270,10 +270,10 @@ export class MatFormField extends _MatFormFieldMixinBase
   }
 
   @ContentChild(MatPlaceholder, {static: false}) _placeholderChild: MatPlaceholder;
-  @ContentChildren(MatError) _errorChildren: QueryList<MatError>;
-  @ContentChildren(MatHint) _hintChildren: QueryList<MatHint>;
-  @ContentChildren(MatPrefix) _prefixChildren: QueryList<MatPrefix>;
-  @ContentChildren(MatSuffix) _suffixChildren: QueryList<MatSuffix>;
+  @ContentChildren(MatError, {descendants: true}) _errorChildren: QueryList<MatError>;
+  @ContentChildren(MatHint, {descendants: true}) _hintChildren: QueryList<MatHint>;
+  @ContentChildren(MatPrefix, {descendants: true}) _prefixChildren: QueryList<MatPrefix>;
+  @ContentChildren(MatSuffix, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
 
   constructor(
       public _elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef,


### PR DESCRIPTION
Since there's a slight difference in how `ContentChildren` works in Ivy, these changes add the `descendants` flag explicitly to ensure that we pick up all of the relevant elements. Note that we shouldn't need any extra logic, because nesting form fields is invalid.