### PR TITLE
build: bump to latest MDC version and fix error in master

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/youtube": "^0.0.38",
     "@webcomponents/custom-elements": "^1.1.0",
     "core-js": "^2.6.1",
-    "material-components-web": "^4.0.0-canary.e851d4f40.0",
+    "material-components-web": "^4.0.0-canary.062ade5c0.0",
     "rxjs": "^6.5.3",
     "systemjs": "0.19.43",
     "tsickle": "^0.35.0",

--- a/src/material-experimental/mdc-progress-bar/progress-bar.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.ts
@@ -82,12 +82,18 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements AfterVie
     addClass: (className: string) => this._rootElement.classList.add(className),
     getBuffer: () => this._bufferBar,
     getPrimaryBar: () => this._primaryBar,
+    // TODO(crisbeto): remove the ` as MDCLinearProgressAdapter` below once this is released:
+    // tslint:disable-next-line:max-line-length
+    // https://github.com/material-components/material-components-web/commit/062ade5c052cf00cefeee6e8e0acf7d16c4ce338
+    // We add `forceLayout` before the code requiring it is in the canary
+    // release so that our cronjob that runs against master doesn't fail.
+    forceLayout: () => this._platform.isBrowser && this._rootElement.offsetWidth,
     hasClass: (className: string) => this._rootElement.classList.contains(className),
     removeClass: (className: string) => this._rootElement.classList.remove(className),
     setStyle: (el: HTMLElement, styleProperty: string, value: string) => {
       (el.style as any)[styleProperty] = value;
     }
-  };
+  } as MDCLinearProgressAdapter;
 
   /** Flag that indicates whether NoopAnimations mode is set to true. */
   _isNoopAnimation = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7996,7 +7996,7 @@ matchdep@^2.0.0:
     resolve "^1.4.0"
     stack-trace "0.0.10"
 
-material-components-web@^4.0.0-canary.e851d4f40.0:
+material-components-web@^4.0.0-canary.062ade5c0.0:
   version "4.0.0-canary.e851d4f40.0"
   resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-4.0.0-canary.e851d4f40.0.tgz#a3c0539eca3a78498056ba4268115ab332c29658"
   integrity sha512-QNv/KGq3zYdxqNrWJu9ksryEGHIzy0LWoNixR/4gaqV5Cick/b74+7u/qni81ZGib7A10Y8iYVo3kPASPnceVw==


### PR DESCRIPTION
Bumps to the latest canary version of MDC and fixes an error that shows up in master. Note that the updates to the `MDCLinearProgressAdapter` interface haven't landed yet, but our CI is failing because it runs against unreleased MDC code.