### PR TITLE
refactor(ng-update): run package manager upon migration completion

### DIFF
--- a/src/cdk/schematics/update-tool/migration-rule.ts
+++ b/src/cdk/schematics/update-tool/migration-rule.ts
@@ -19,6 +19,11 @@ export interface MigrationFailure {
   position?: LineAndCharacter;
 }
 
+export type PostMigrationAction = void | {
+  /** Whether the package manager should run upon migration completion. */
+  runPackageManager: boolean;
+};
+
 export class MigrationRule<T> {
   /** List of migration failures that need to be reported. */
   failures: MigrationFailure[] = [];
@@ -92,5 +97,5 @@ export class MigrationRule<T> {
    * migration result of all individual targets. e.g. removing HammerJS if it
    * is not needed in any project target.
    */
-  static globalPostMigration(tree: Tree, context: SchematicContext) {}
+  static globalPostMigration(tree: Tree, context: SchematicContext): PostMigrationAction {}
 }

--- a/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/hammer-gestures-rule.ts
+++ b/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/hammer-gestures-rule.ts
@@ -12,12 +12,12 @@ import {
   Path as DevkitPath
 } from '@angular-devkit/core';
 import {SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
-import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
 import {
   getProjectIndexFiles,
   getProjectMainFile,
   MigrationFailure,
   MigrationRule,
+  PostMigrationAction,
   ResolvedResource,
   TargetVersion
 } from '@angular/cdk/schematics';
@@ -762,11 +762,11 @@ export class HammerGesturesRule extends MigrationRule<null> {
    * on the analysis of the individual targets. For example: we only remove Hammer
    * from the "package.json" if it is not used in *any* project target.
    */
-  static globalPostMigration(tree: Tree, context: SchematicContext) {
+  static globalPostMigration(tree: Tree, context: SchematicContext): PostMigrationAction {
     if (!this.globalUsesHammer && this._removeHammerFromPackageJson(tree)) {
       // Since Hammer has been removed from the workspace "package.json" file,
       // we schedule a node package install task to refresh the lock file.
-      context.addTask(new NodePackageInstallTask({quiet: false}));
+      return {runPackageManager: true};
     }
 
     context.logger.info(chalk.yellow(


### PR DESCRIPTION
We cannot run the package-manager to refresh the lock file
synchronously. This is because the changes made to the
schematic tree are not applied until the actual task
completes. Hence we need to run the task asynchronously
upon migration completion. This ensures that the lock file
is properly updated if something changed the `package.json` file.