### PR TITLE
build: google maps dev app not working in Edge and IE

### DIFF
--- a/src/dev-app/google-map/google-map-demo-module.ts
+++ b/src/dev-app/google-map/google-map-demo-module.ts
@@ -7,7 +7,6 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {HttpClientJsonpModule, HttpClientModule} from '@angular/common/http';
 import {NgModule} from '@angular/core';
 import {GoogleMapsModule} from '@angular/google-maps';
 import {RouterModule} from '@angular/router';
@@ -18,8 +17,6 @@ import {GoogleMapDemo} from './google-map-demo';
   imports: [
     CommonModule,
     GoogleMapsModule,
-    HttpClientJsonpModule,
-    HttpClientModule,
     RouterModule.forChild([{path: '', component: GoogleMapDemo}]),
   ],
   declarations: [GoogleMapDemo],

--- a/src/dev-app/google-map/google-map-demo.html
+++ b/src/dev-app/google-map/google-map-demo.html
@@ -1,5 +1,4 @@
-<google-map *ngIf="isReady"
-            height="400px"
+<google-map height="400px"
             width="750px"
             [center]="center"
             [zoom]="zoom"

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpClient} from '@angular/common/http';
 import {Component, ViewChild} from '@angular/core';
 import {MapInfoWindow, MapMarker} from '@angular/google-maps';
 
@@ -19,21 +18,12 @@ import {MapInfoWindow, MapMarker} from '@angular/google-maps';
 export class GoogleMapDemo {
   @ViewChild(MapInfoWindow, {static: false}) infoWindow: MapInfoWindow;
 
-  isReady = false;
-
   center = {lat: 24, lng: 12};
   markerOptions = {draggable: false};
   markerPositions: google.maps.LatLngLiteral[] = [];
   infoWindowPosition: google.maps.LatLngLiteral;
   zoom = 4;
   display?: google.maps.LatLngLiteral;
-
-  constructor(httpClient: HttpClient) {
-    httpClient.jsonp('https://maps.googleapis.com/maps/api/js?', 'callback')
-      .subscribe(() => {
-        this.isReady = true;
-      });
-  }
 
   handleClick(event: google.maps.MouseEvent) {
     this.markerPositions.push(event.latLng.toJSON());

--- a/src/dev-app/index.html
+++ b/src/dev-app/index.html
@@ -30,6 +30,7 @@
 <script src="systemjs/dist/system.js"></script>
 <script src="system-config.js"></script>
 <script src="https://www.youtube.com/iframe_api"></script>
+<script src="https://maps.googleapis.com/maps/api/js"></script>
 <script>
   // Workaround until https://github.com/angular/components/issues/13883 has been addressed.
   var module = {id: ''};


### PR DESCRIPTION
It seems like loading the Google Maps API through JSNOP wasn't working under IE and Edge in the dev app. These changes switch to loading the API through a `script` tag instead.