### PR TITLE
build: avoid bazel analysis cache discarding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,7 @@ build --symlink_prefix=/
 build --watchfs
 
 # Turn off legacy external runfiles
+build --nolegacy_external_runfiles
 run --nolegacy_external_runfiles
 test --nolegacy_external_runfiles
 


### PR DESCRIPTION
It looks like Bazel sometimes discards the analysis cache
when switching between testing/running and plain building.

This is because b3a00376cd4d156a81b7b8c70548259977cc6a5a introduced a flag for disabling
legacy bazel behavior. This flag has been only applied to "run"
and "test", but not for "build". This means that we accidentally
switch the environment, and Bazel discards the analysis cache

```
INFO: Build option --legacy_external_runfiles has changed, discarding analysis cache.
```