### PR TITLE
build: re-enable release output validation for source maps

### DIFF
--- a/tools/release/release-output/output-validations.ts
+++ b/tools/release/release-output/output-validations.ts
@@ -25,9 +25,7 @@ export function checkReleaseBundle(bundlePath: string): string[] {
   const failures: string[] = [];
 
   if (inlineStylesSourcemapRegex.exec(bundleContent) !== null) {
-    // TODO(devversion): check if we can omit the invalid source-map references
-    // for built components. For now this check is temporarily disabled.
-    // failures.push('Found sourcemap references in component styles.');
+    failures.push('Found sourcemap references in component styles.');
   }
 
   if (externalReferencesRegex.exec(bundleContent) !== null) {


### PR DESCRIPTION
Since we landed 230fd2f6ac2b0647c6c577583d407ea22da522d8, we should be able to
re-enable our output validation check that ensures that there are no source map
references in inlined styles.