### PR TITLE
docs: describe dev-env setup for Windows machines

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -2,10 +2,10 @@
 
 1. Make sure you have `node` installed with a version at _least_ 10.0.0 and `yarn` with a version
    of at least 1.10.0. We recommend using `nvm` to manage your node versions.
-2. Make sure the `patch` command is available
-   - On Windows: Install [`MSYS2`](https://www.msys2.org/) by following the described setup.
-     Afterwards you can install the `patch` package by running `pacman -S patch`.
-     Add `C:\msys64\usr\bin` to the `PATH` environment variable.
+2. Material uses Bazel which requires certain Bash and UNIX tools.
+   - On Windows: Follow the [instructions](https://docs.bazel.build/versions/master/install-windows.html#5-optional-install-compilers-and-language-runtimes)
+   to install [`MSYS2`](https://www.msys2.org/) and the listed "Common MSYS2 packages".
+   Afterwards add `C:\msys64\usr\bin` to the `PATH` environment variable.
 3. Run `yarn global add gulp` to install gulp.
 4. Fork the `angular/components` repo on GitHub.
 5. Clone your fork to your machine with `git clone`.

--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -2,12 +2,16 @@
 
 1. Make sure you have `node` installed with a version at _least_ 10.0.0 and `yarn` with a version
    of at least 1.10.0. We recommend using `nvm` to manage your node versions.
-2. Run `yarn global add gulp` to install gulp.
-3. Fork the `angular/components` repo on GitHub.
-4. Clone your fork to your machine with `git clone`.
+2. Make sure the `patch` command is available
+   - On Windows: Install [`MSYS2`](https://www.msys2.org/) by following the described setup.
+     Afterwards you can install the `patch` package by running `pacman -S patch`.
+     Add `C:\msys64\usr\bin` to the `PATH` environment variable.
+3. Run `yarn global add gulp` to install gulp.
+4. Fork the `angular/components` repo on GitHub.
+5. Clone your fork to your machine with `git clone`.
    Recommendation: name your git remotes `upstream` for `angular/components`
    and `<your-username>` for your fork. Also see the [team git shortcuts](https://github.com/angular/components/wiki/Team-git----bash-shortcuts).
-5. From the root of the project, run `yarn`.
+6. From the root of the project, run `yarn`.
 
 
 To build Material in dev mode, run `gulp material:build`.

--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -2,7 +2,7 @@
 
 1. Make sure you have `node` installed with a version at _least_ 10.0.0 and `yarn` with a version
    of at least 1.10.0. We recommend using `nvm` to manage your node versions.
-2. Material uses Bazel which requires certain Bash and UNIX tools.
+2. angular/components uses Bazel which requires certain Bash and UNIX tools.
    - On Windows: Follow the [instructions](https://docs.bazel.build/versions/master/install-windows.html#5-optional-install-compilers-and-language-runtimes)
    to install [`MSYS2`](https://www.msys2.org/) and the listed "Common MSYS2 packages".
    Afterwards add `C:\msys64\usr\bin` to the `PATH` environment variable.
@@ -14,8 +14,8 @@
 6. From the root of the project, run `yarn`.
 
 
-To build Material in dev mode, run `gulp material:build`.
-To build Material in release mode, run `gulp material:build-release`
+To build angular/components in dev mode, run `gulp material:build`.
+To build angular/components in release mode, run `gulp material:build-release`
 
 To bring up a local server, run `yarn dev-app`. This will automatically watch for changes
 and rebuild. The browser should refresh automatically when changes are made.


### PR DESCRIPTION
Windows machines do not have the required `patch` command available.
The added step explains how to install the package on Windows.

Refs #17456