### PR TITLE
refactor: remove abstract directive selector workaround

### DIFF
--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -61,10 +61,7 @@ interface PeriodicElement {
   weight: number;
 }
 
-@Directive({
-  // TODO(devversion): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-cdk-popover-edit-base-test-component'
-})
+@Directive()
 abstract class BaseTestComponent {
   @ViewChild('table') table: ElementRef;
 

--- a/src/material-experimental/mdc-button/button-base.ts
+++ b/src/material-experimental/mdc-button/button-base.ts
@@ -79,10 +79,7 @@ export const _MatButtonBaseMixin: CanDisableRippleCtor&CanDisableCtor&CanColorCt
     typeof MatButtonMixinCore = mixinColor(mixinDisabled(mixinDisableRipple(MatButtonMixinCore)));
 
 /** Base class for all buttons.  */
-@Directive({
-  // TODO(devversion): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-button-base'
-})
+@Directive()
 export class MatButtonBase extends _MatButtonBaseMixin implements CanDisable, CanColor,
                                                                   CanDisableRipple {
   /** The ripple animation configuration to use for the buttons. */
@@ -154,10 +151,7 @@ export const MAT_ANCHOR_HOST = {
 /**
  * Anchor button base.
  */
-@Directive({
-  // TODO(devversion): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-anchor-base'
-})
+@Directive()
 export class MatAnchorBase extends MatButtonBase {
   tabIndex: number;
 

--- a/src/material-experimental/mdc-button/module.ts
+++ b/src/material-experimental/mdc-button/module.ts
@@ -10,7 +10,6 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatAnchor, MatButton} from './button';
-import {MatAnchorBase, MatButtonBase} from './button-base';
 import {MatFabAnchor, MatFabButton} from './fab';
 import {MatIconAnchor, MatIconButton} from './icon-button';
 
@@ -32,10 +31,6 @@ import {MatIconAnchor, MatIconButton} from './icon-button';
     MatIconButton,
     MatFabAnchor,
     MatFabButton,
-    // TODO(devversion): remove when `MatButtonBase` becomes a selectorless Directive.
-    MatButtonBase,
-    // TODO(devversion): remove when `MatAnchorBase` becomes a selectorless Directive.
-    MatAnchorBase,
   ],
 })
 export class MatButtonModule {

--- a/src/material-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/material-experimental/popover-edit/popover-edit.spec.ts
@@ -59,10 +59,7 @@ interface PeriodicElement {
   weight: number;
 }
 
-@Directive({
-  // TODO(devversion): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-popover-edit-base-test-component'
-})
+@Directive()
 abstract class BaseTestComponent {
   @ViewChild('table') table: ElementRef;
 

--- a/src/material/form-field/form-field-control.ts
+++ b/src/material/form-field/form-field-control.ts
@@ -12,12 +12,7 @@ import {Directive} from '@angular/core';
 
 
 /** An interface which allows a control to work inside of a `MatFormField`. */
-@Directive({
-  // The @Directive with selector is required here because we're still running a lot of things
-  // against ViewEngine where directives without selectors are not allowed.
-  // TODO(crisbeto): convert to a selectorless Directive after we switch to Ivy.
-  selector: 'do-not-use-abstract-mat-form-field-control',
-})
+@Directive()
 export abstract class MatFormFieldControl<T> {
   /** The value of the control. */
   value: T | null;

--- a/src/material/form-field/form-field-module.ts
+++ b/src/material/form-field/form-field-module.ts
@@ -16,8 +16,6 @@ import {MatLabel} from './label';
 import {MatPlaceholder} from './placeholder';
 import {MatPrefix} from './prefix';
 import {MatSuffix} from './suffix';
-import {MatFormFieldControl} from './form-field-control';
-
 
 @NgModule({
   declarations: [
@@ -28,10 +26,6 @@ import {MatFormFieldControl} from './form-field-control';
     MatPlaceholder,
     MatPrefix,
     MatSuffix,
-
-    // TODO(crisbeto): can be removed once `MatFormFieldControl`
-    // is turned into a selector-less directive.
-    MatFormFieldControl as any,
   ],
   imports: [
     CommonModule,

--- a/src/material/menu/menu-module.ts
+++ b/src/material/menu/menu-module.ts
@@ -10,13 +10,10 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
+import {_MatMenu} from './menu';
 import {MatMenuContent} from './menu-content';
-import {_MatMenu, _MatMenuBase, MatMenu} from './menu';
 import {MatMenuItem} from './menu-item';
-import {
-  MatMenuTrigger,
-  MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER,
-} from './menu-trigger';
+import {MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER, MatMenuTrigger} from './menu-trigger';
 
 /**
  * Used by both the current `MatMenuModule` and the MDC `MatMenuModule`
@@ -27,10 +24,6 @@ import {
   declarations: [
     MatMenuTrigger,
     MatMenuContent,
-    // TODO(devversion): remove when `MatMenu` becomes a selectorless Directive.
-    MatMenu,
-    // TODO(devversion): remove when `_MatMenuBase` becomes a selectorless Directive.
-    _MatMenuBase
   ],
   providers: [MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER]
 })

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -93,10 +93,7 @@ const MAT_MENU_BASE_ELEVATION = 4;
 let menuPanelUid = 0;
 
 /** Base class with all of the `MatMenu` functionality. */
-@Directive({
-  // TODO(devversion): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-menu-base'
-})
+@Directive()
 // tslint:disable-next-line:class-name
 export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit,
   OnDestroy {
@@ -454,10 +451,7 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
 }
 
 /** @docs-private We show the "_MatMenu" class as "MatMenu" in the docs. */
-@Directive({
-  // TODO(devversion): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-menu'
-})
+@Directive()
 export class MatMenu extends _MatMenuBase {}
 
 // Note on the weird inheritance setup: we need three classes, because the MDC-based menu has to

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -68,10 +68,7 @@ export type MatPaginatedTabHeaderItem = FocusableOption & {elementRef: ElementRe
  * Base class for a tab header that supported pagination.
  * @docs-private
  */
-@Directive({
-  // TODO(crisbeto): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-paginated-tab-header'
-})
+@Directive()
 export abstract class MatPaginatedTabHeader implements AfterContentChecked, AfterContentInit,
   AfterViewInit, OnDestroy {
   abstract _items: QueryList<MatPaginatedTabHeaderItem>;

--- a/src/material/tabs/tab-body.ts
+++ b/src/material/tabs/tab-body.ts
@@ -102,10 +102,7 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
  * Base class with all of the `MatTabBody` functionality.
  * @docs-private
  */
-@Directive({
-  // TODO(crisbeto): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-tab-body-base'
-})
+@Directive()
 // tslint:disable-next-line:class-name
 export abstract class _MatTabBodyBase implements OnInit, OnDestroy {
   /** Current position of the tab-body in the tab-group. Zero means that the tab is visible. */

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -73,10 +73,7 @@ interface MatTabGroupBaseHeader {
  * Base class with all of the `MatTabGroupBase` functionality.
  * @docs-private
  */
-@Directive({
-  // TODO(crisbeto): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-tab-group-base'
-})
+@Directive()
 // tslint:disable-next-line:class-name
 export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements AfterContentInit,
     AfterContentChecked, OnDestroy, CanColor, CanDisableRipple {

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -38,10 +38,7 @@ import {MatPaginatedTabHeader} from './paginated-tab-header';
  * Base class with all of the `MatTabHeader` functionality.
  * @docs-private
  */
-@Directive({
-  // TODO(crisbeto): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-tab-header-base'
-})
+@Directive()
 // tslint:disable-next-line:class-name
 export abstract class _MatTabHeaderBase extends MatPaginatedTabHeader implements
   AfterContentChecked, AfterContentInit, AfterViewInit, OnDestroy {

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -52,10 +52,7 @@ import {startWith, takeUntil} from 'rxjs/operators';
  * Base class with all of the `MatTabNav` functionality.
  * @docs-private
  */
-@Directive({
-  // TODO(crisbeto): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-tab-nav-base'
-})
+@Directive()
 // tslint:disable-next-line:class-name
 export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements AfterContentChecked,
   AfterContentInit, OnDestroy {
@@ -195,10 +192,7 @@ const _MatTabLinkMixinBase:
         mixinTabIndex(mixinDisableRipple(mixinDisabled(MatTabLinkMixinBase)));
 
 /** Base class with all of the `MatTabLink` functionality. */
-@Directive({
-  // TODO(crisbeto): this selector can be removed when we update to Angular 9.0.
-  selector: 'do-not-use-abstract-mat-tab-link-base'
-})
+@Directive()
 // tslint:disable-next-line:class-name
 export class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnDestroy, CanDisable,
   CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {

--- a/src/material/tabs/tabs-module.ts
+++ b/src/material/tabs/tabs-module.ts
@@ -6,22 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {A11yModule} from '@angular/cdk/a11y';
 import {ObserversModule} from '@angular/cdk/observers';
 import {PortalModule} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {A11yModule} from '@angular/cdk/a11y';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatInkBar} from './ink-bar';
 import {MatTab} from './tab';
-import {MatTabBody, MatTabBodyPortal, _MatTabBodyBase} from './tab-body';
+import {MatTabBody, MatTabBodyPortal} from './tab-body';
 import {MatTabContent} from './tab-content';
-import {MatTabGroup, _MatTabGroupBase} from './tab-group';
-import {MatTabHeader, _MatTabHeaderBase} from './tab-header';
+import {MatTabGroup} from './tab-group';
+import {MatTabHeader} from './tab-header';
 import {MatTabLabel} from './tab-label';
 import {MatTabLabelWrapper} from './tab-label-wrapper';
-import {MatTabLink, MatTabNav, _MatTabNavBase, _MatTabLinkBase} from './tab-nav-bar/tab-nav-bar';
-import {MatPaginatedTabHeader} from './paginated-tab-header';
+import {MatTabLink, MatTabNav} from './tab-nav-bar/tab-nav-bar';
 
 
 @NgModule({
@@ -55,14 +54,6 @@ import {MatPaginatedTabHeader} from './paginated-tab-header';
     MatTabBodyPortal,
     MatTabHeader,
     MatTabContent,
-
-    // TODO(crisbeto): these can be removed once they're turned into selector-less directives.
-    MatPaginatedTabHeader as any,
-    _MatTabGroupBase as any,
-    _MatTabNavBase as any,
-    _MatTabBodyBase as any,
-    _MatTabHeaderBase as any,
-    _MatTabLinkBase as any,
   ],
 })
 export class MatTabsModule {}

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -82,7 +82,7 @@ export declare abstract class MatFormFieldControl<T> {
     value: T | null;
     abstract onContainerClick(event: MouseEvent): void;
     abstract setDescribedByIds(ids: string[]): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatFormFieldControl<any>, "do-not-use-abstract-mat-form-field-control", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatFormFieldControl<any>, never, never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatFormFieldControl<any>>;
 }
 
@@ -93,7 +93,7 @@ export interface MatFormFieldDefaultOptions {
 
 export declare class MatFormFieldModule {
     static ɵinj: i0.ɵɵInjectorDef<MatFormFieldModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatFormFieldModule, [typeof i1.MatError, typeof i2.MatFormField, typeof i3.MatHint, typeof i4.MatLabel, typeof i5.MatPlaceholder, typeof i6.MatPrefix, typeof i7.MatSuffix, typeof i8.MatFormFieldControl], [typeof i9.CommonModule, typeof i10.ObserversModule], [typeof i1.MatError, typeof i2.MatFormField, typeof i3.MatHint, typeof i4.MatLabel, typeof i5.MatPlaceholder, typeof i6.MatPrefix, typeof i7.MatSuffix]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatFormFieldModule, [typeof i1.MatError, typeof i2.MatFormField, typeof i3.MatHint, typeof i4.MatLabel, typeof i5.MatPlaceholder, typeof i6.MatPrefix, typeof i7.MatSuffix], [typeof i8.CommonModule, typeof i9.ObserversModule], [typeof i1.MatError, typeof i2.MatFormField, typeof i3.MatHint, typeof i4.MatLabel, typeof i5.MatPlaceholder, typeof i6.MatPrefix, typeof i7.MatSuffix]>;
 }
 
 export declare class MatHint {

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -45,13 +45,13 @@ export declare class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatM
     resetActiveItem(): void;
     setElevation(depth: number): void;
     setPositionClasses(posX?: MenuPositionX, posY?: MenuPositionY): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatMenuBase, "do-not-use-abstract-mat-menu-base", never, { 'backdropClass': "backdropClass", 'xPosition': "xPosition", 'yPosition': "yPosition", 'overlapTrigger': "overlapTrigger", 'hasBackdrop': "hasBackdrop", 'panelClass': "class", 'classList': "classList" }, { 'closed': "closed", 'close': "close" }, ["lazyContent", "_allItems", "items"]>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatMenuBase, never, never, { 'backdropClass': "backdropClass", 'xPosition': "xPosition", 'yPosition': "yPosition", 'overlapTrigger': "overlapTrigger", 'hasBackdrop': "hasBackdrop", 'panelClass': "class", 'classList': "classList" }, { 'closed': "closed", 'close': "close" }, ["lazyContent", "_allItems", "items"]>;
     static ɵfac: i0.ɵɵFactoryDef<_MatMenuBase>;
 }
 
 export declare class _MatMenuDirectivesModule {
     static ɵinj: i0.ɵɵInjectorDef<_MatMenuDirectivesModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<_MatMenuDirectivesModule, [typeof i1.MatMenuTrigger, typeof i2.MatMenuContent, typeof i3.MatMenu, typeof i3._MatMenuBase], never, [typeof i1.MatMenuTrigger, typeof i2.MatMenuContent, typeof i4.MatCommonModule]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<_MatMenuDirectivesModule, [typeof i1.MatMenuTrigger, typeof i2.MatMenuContent], never, [typeof i1.MatMenuTrigger, typeof i2.MatMenuContent, typeof i3.MatCommonModule]>;
 }
 
 export declare const fadeInItems: AnimationTriggerMetadata;
@@ -63,7 +63,7 @@ export declare const MAT_MENU_PANEL: InjectionToken<MatMenuPanel<any>>;
 export declare const MAT_MENU_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 export declare class MatMenu extends _MatMenuBase {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatMenu, "do-not-use-abstract-mat-menu", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatMenu, never, never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatMenu>;
 }
 
@@ -112,7 +112,7 @@ export declare class MatMenuItem extends _MatMenuItemMixinBase implements Focusa
 
 export declare class MatMenuModule {
     static ɵinj: i0.ɵɵInjectorDef<MatMenuModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatMenuModule, [typeof i3._MatMenu, typeof i5.MatMenuItem], [typeof i6.CommonModule, typeof i4.MatCommonModule, typeof i4.MatRippleModule, typeof i7.OverlayModule, typeof _MatMenuDirectivesModule], [typeof i3._MatMenu, typeof i5.MatMenuItem, typeof _MatMenuDirectivesModule]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatMenuModule, [typeof i4._MatMenu, typeof i5.MatMenuItem], [typeof i6.CommonModule, typeof i3.MatCommonModule, typeof i3.MatRippleModule, typeof i7.OverlayModule, typeof _MatMenuDirectivesModule], [typeof i4._MatMenu, typeof i5.MatMenuItem, typeof _MatMenuDirectivesModule]>;
 }
 
 export interface MatMenuPanel<T = any> {

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -25,7 +25,7 @@ export declare abstract class _MatTabBodyBase implements OnInit, OnDestroy {
     _onTranslateTabStarted(event: AnimationEvent): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabBodyBase, "do-not-use-abstract-mat-tab-body-base", never, { '_content': "content", 'origin': "origin", 'animationDuration': "animationDuration", 'position': "position" }, { '_onCentering': "_onCentering", '_beforeCentering': "_beforeCentering", '_afterLeavingCenter': "_afterLeavingCenter", '_onCentered': "_onCentered" }, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabBodyBase, never, never, { '_content': "content", 'origin': "origin", 'animationDuration': "animationDuration", 'position': "position" }, { '_onCentering': "_onCentering", '_beforeCentering': "_beforeCentering", '_afterLeavingCenter': "_afterLeavingCenter", '_onCentered': "_onCentered" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabBodyBase>;
 }
 
@@ -58,7 +58,7 @@ export declare abstract class _MatTabGroupBase extends _MatTabGroupMixinBase imp
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     realignInkBar(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabGroupBase, "do-not-use-abstract-mat-tab-group-base", never, { 'dynamicHeight': "dynamicHeight", 'selectedIndex': "selectedIndex", 'headerPosition': "headerPosition", 'animationDuration': "animationDuration", 'disablePagination': "disablePagination", 'backgroundColor': "backgroundColor" }, { 'selectedIndexChange': "selectedIndexChange", 'focusChange': "focusChange", 'animationDone': "animationDone", 'selectedTabChange': "selectedTabChange" }, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabGroupBase, never, never, { 'dynamicHeight': "dynamicHeight", 'selectedIndex': "selectedIndex", 'headerPosition': "headerPosition", 'animationDuration': "animationDuration", 'disablePagination': "disablePagination", 'backgroundColor': "backgroundColor" }, { 'selectedIndexChange': "selectedIndexChange", 'focusChange': "focusChange", 'animationDone': "animationDone", 'selectedTabChange': "selectedTabChange" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabGroupBase>;
 }
 
@@ -66,7 +66,7 @@ export declare abstract class _MatTabHeaderBase extends MatPaginatedTabHeader im
     disableRipple: any;
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler, dir: Directionality, ngZone: NgZone, platform: Platform, animationMode?: string);
     protected _itemSelected(event: KeyboardEvent): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabHeaderBase, "do-not-use-abstract-mat-tab-header-base", never, { 'disableRipple': "disableRipple" }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabHeaderBase, never, never, { 'disableRipple': "disableRipple" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabHeaderBase>;
 }
 
@@ -79,7 +79,7 @@ export declare class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnD
     constructor(_tabNavBar: _MatTabNavBase, elementRef: ElementRef, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string, _focusMonitor: FocusMonitor, animationMode?: string);
     focus(): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabLinkBase, "do-not-use-abstract-mat-tab-link-base", never, { 'active': "active" }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabLinkBase, never, never, { 'active': "active" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabLinkBase>;
 }
 
@@ -95,7 +95,7 @@ export declare abstract class _MatTabNavBase extends MatPaginatedTabHeader imple
     protected _itemSelected(): void;
     ngAfterContentInit(): void;
     updateActiveLink(_element?: ElementRef): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabNavBase, "do-not-use-abstract-mat-tab-nav-base", never, { 'backgroundColor': "backgroundColor", 'disableRipple': "disableRipple", 'color': "color" }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabNavBase, never, never, { 'backgroundColor': "backgroundColor", 'disableRipple': "disableRipple", 'color': "color" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabNavBase>;
 }
 
@@ -248,7 +248,7 @@ export interface MatTabsConfig {
 
 export declare class MatTabsModule {
     static ɵinj: i0.ɵɵInjectorDef<MatTabsModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatTabsModule, [typeof i1.MatTabGroup, typeof i2.MatTabLabel, typeof i3.MatTab, typeof i4.MatInkBar, typeof i5.MatTabLabelWrapper, typeof i6.MatTabNav, typeof i6.MatTabLink, typeof i7.MatTabBody, typeof i7.MatTabBodyPortal, typeof i8.MatTabHeader, typeof i9.MatTabContent, typeof i10.MatPaginatedTabHeader, typeof i1._MatTabGroupBase, typeof i6._MatTabNavBase, typeof i7._MatTabBodyBase, typeof i8._MatTabHeaderBase, typeof i6._MatTabLinkBase], [typeof i11.CommonModule, typeof i12.MatCommonModule, typeof i13.PortalModule, typeof i12.MatRippleModule, typeof i14.ObserversModule, typeof i15.A11yModule], [typeof i12.MatCommonModule, typeof i1.MatTabGroup, typeof i2.MatTabLabel, typeof i3.MatTab, typeof i6.MatTabNav, typeof i6.MatTabLink, typeof i9.MatTabContent]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatTabsModule, [typeof i1.MatTabGroup, typeof i2.MatTabLabel, typeof i3.MatTab, typeof i4.MatInkBar, typeof i5.MatTabLabelWrapper, typeof i6.MatTabNav, typeof i6.MatTabLink, typeof i7.MatTabBody, typeof i7.MatTabBodyPortal, typeof i8.MatTabHeader, typeof i9.MatTabContent], [typeof i10.CommonModule, typeof i11.MatCommonModule, typeof i12.PortalModule, typeof i11.MatRippleModule, typeof i13.ObserversModule, typeof i14.A11yModule], [typeof i11.MatCommonModule, typeof i1.MatTabGroup, typeof i2.MatTabLabel, typeof i3.MatTab, typeof i6.MatTabNav, typeof i6.MatTabLink, typeof i9.MatTabContent]>;
 }
 
 export declare type ScrollDirection = 'after' | 'before';


### PR DESCRIPTION
Since we updated the minimum required Angular version, and
updated to Angular `^9.0.0-0`, we can remove the workaround
for abstract directives. Previously we wanted to keep them
with a selector regardless of the installed version, because
we thought that we want to support `^8.0.0` of Angular.