### PR TITLE
(material-experimental/mdc-checkbox): add disabled class when disabled

### DIFF
--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -60,6 +60,7 @@ export class MatCheckboxChange {
     '[class.mat-accent]': 'color == "accent"',
     '[class.mat-warn]': 'color == "warn"',
     '[class._mat-animation-noopable]': `_animationMode === 'NoopAnimations'`,
+    '[class.mdc-checkbox--disabled]': 'disabled',
     '[id]': 'id',
   },
   providers: [MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR],


### PR DESCRIPTION
Currently the checkbox does not apply MDC's `disabled` styles since the class is not added when disabled.

```css
  .mdc-checkbox--disabled {
    @include mdc-feature-targets($feat-structure) {
      @include mdc-checkbox--disabled_;
    }
  }

  ...

  @mixin mdc-checkbox--disabled_ {
    cursor: default;
    pointer-events: none;
  }
```