### PR TITLE
chore: clean up leftover references to private/testing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,7 +70,6 @@
 /src/cdk/coercion/**                               @jelbourn
 /src/cdk/collections/**                            @jelbourn @crisbeto @andrewseguin
 /src/cdk/drag-drop/**                              @crisbeto
-/src/cdk/private/testing/**                        @devversion
 /src/cdk/keycodes/**                               @jelbourn
 /src/cdk/layout/**                                 @jelbourn
 /src/cdk/observers/**                              @jelbourn @crisbeto

--- a/src/cdk/tsconfig-tests.json
+++ b/src/cdk/tsconfig-tests.json
@@ -31,17 +31,12 @@
   "include": [
     // Include the index.ts for each secondary entry-point.
     "./*/index.ts",
-    // Include the "private/testing" internal entry-point.
-    "./private/testing/",
     // Include all spec files of the CDK.
     "**/*.spec.ts"
   ],
   "exclude": [
     "**/schematics/**/*.ts",
     // Exclude end-to-end tests and utilities.
-    "**/*.e2e.spec.ts",
-    // Exclude internal e2e testing utilities. These are not needed by tests
-    // which execute through gulp.
-    "./private/testing/e2e/**"
+    "**/*.e2e.spec.ts"
   ]
 }


### PR DESCRIPTION
Cleans up a few leftover places that are referring to `private/testing` which doesn't exist anymore.