### PR TITLE
build: update mdc version placeholder range

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "version": "9.0.0-next.0",
   "requiredAngularVersion": "^9.0.0-0 || ^10.0.0-0",
-  "requiredMDCVersion": "^4.0.0-alpha.0",
+  "requiredMDCVersion": "^4.0.0-canary.062ade5c0.0",
   "dependencies": {
     "@angular/animations": "^9.0.0-next.12",
     "@angular/common": "^9.0.0-next.12",

--- a/packages.bzl
+++ b/packages.bzl
@@ -2,7 +2,7 @@
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
 ANGULAR_PACKAGE_VERSION = "^9.0.0-0 || ^10.0.0-0"
-MDC_PACKAGE_VERSION = "^4.0.0-alpha.0"
+MDC_PACKAGE_VERSION = "^4.0.0-canary.062ade5c0.0"
 VERSION_PLACEHOLDER_REPLACEMENTS = {
     "0.0.0-MDC": MDC_PACKAGE_VERSION,
     "0.0.0-NG": ANGULAR_PACKAGE_VERSION,


### PR DESCRIPTION
@mmalerba Not sure if there is a more concrete version we can give? but I think just specifying the most explicit lower boundary is the best, since we can guarantee that the components work with that version for sure. Let me know what you prefer 😄 