### PR TITLE
fix(material/list): Do not rely on input binding order

### DIFF
--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -39,6 +39,7 @@ describe('MatSelectionList without forms', () => {
           SelectionListWithListDisabled,
           SelectionListWithOnlyOneOption,
           SelectionListWithIndirectChildOptions,
+          SelectionListWithSelectedOptionAndValue,
         ],
       });
 
@@ -593,6 +594,14 @@ describe('MatSelectionList without forms', () => {
         expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
             .toBe(0, 'Expected no ripples after list ripples are disabled.');
       }));
+
+    it('can bind both selected and value at the same time', () => {
+      const componentFixture = TestBed.createComponent(SelectionListWithSelectedOptionAndValue);
+      componentFixture.detectChanges();
+      const listItemEl = componentFixture.debugElement.query(By.directive(MatListOption))!;
+      expect(listItemEl.componentInstance.selected).toBe(true);
+      expect(listItemEl.componentInstance.value).toBe(componentFixture.componentInstance.itemValue);
+    });
 
   });
 
@@ -1190,18 +1199,6 @@ describe('MatSelectionList with forms', () => {
       expect(testComponent.compareWith).toHaveBeenCalled();
       expect(testComponent.optionInstances.toArray()[1].selected).toBe(true);
     }));
-  });
-
-  it('can bind both selected and value at the same time', () => {
-    const fixture =
-        TestBed
-            .configureTestingModule(
-                {imports: [MatListModule], declarations: [SelectionListWithSelectedOptionAndValue]})
-            .createComponent(SelectionListWithSelectedOptionAndValue);
-    fixture.detectChanges();
-    const listItemEl = fixture.debugElement.query(By.directive(MatListOption))!;
-    expect(listItemEl.componentInstance.selected).toBe(true);
-    expect(listItemEl.componentInstance.value).toBe(fixture.componentInstance.itemValue);
   });
 });
 

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -1191,6 +1191,18 @@ describe('MatSelectionList with forms', () => {
       expect(testComponent.optionInstances.toArray()[1].selected).toBe(true);
     }));
   });
+
+  it('can bind both selected and value at the same time', () => {
+    const fixture =
+        TestBed
+            .configureTestingModule(
+                {imports: [MatListModule], declarations: [SelectionListWithSelectedOptionAndValue]})
+            .createComponent(SelectionListWithSelectedOptionAndValue);
+    fixture.detectChanges();
+    const listItemEl = fixture.debugElement.query(By.directive(MatListOption))!;
+    expect(listItemEl.componentInstance.selected).toBe(true);
+    expect(listItemEl.componentInstance.value).toBe(fixture.componentInstance.itemValue);
+  });
 });
 
 
@@ -1275,6 +1287,16 @@ class SelectionListWithDisabledOption {
     <mat-list-option [selected]="true">Item</mat-list-option>
   </mat-selection-list>`})
 class SelectionListWithSelectedOption {
+}
+
+@Component({
+  template: `
+  <mat-selection-list>
+    <mat-list-option [selected]="true" [value]="itemValue">Item</mat-list-option>
+  </mat-selection-list>`
+})
+class SelectionListWithSelectedOptionAndValue {
+  itemValue = 'item1';
 }
 
 @Component({template: `

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -10,14 +10,14 @@ import {FocusableOption, FocusKeyManager} from '@angular/cdk/a11y';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {SelectionModel} from '@angular/cdk/collections';
 import {
-  SPACE,
-  ENTER,
-  HOME,
-  END,
-  UP_ARROW,
-  DOWN_ARROW,
   A,
+  DOWN_ARROW,
+  END,
+  ENTER,
   hasModifierKey,
+  HOME,
+  SPACE,
+  UP_ARROW,
 } from '@angular/cdk/keycodes';
 import {
   AfterContentInit,
@@ -32,25 +32,27 @@ import {
   forwardRef,
   Inject,
   Input,
+  OnChanges,
   OnDestroy,
   OnInit,
   Output,
   QueryList,
+  SimpleChanges,
   ViewChild,
   ViewEncapsulation,
-  SimpleChanges,
-  OnChanges,
 } from '@angular/core';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
-  CanDisableRipple, CanDisableRippleCtor,
+  CanDisableRipple,
+  CanDisableRippleCtor,
   MatLine,
-  setLines,
   mixinDisableRipple,
+  setLines,
   ThemePalette,
 } from '@angular/material/core';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+
 import {MatListAvatarCssMatStyler, MatListIconCssMatStyler} from './list';
 
 
@@ -114,9 +116,10 @@ export class MatSelectionListChange {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatListOption extends _MatListOptionMixinBase
-    implements AfterContentInit, OnDestroy, OnInit, FocusableOption, CanDisableRipple {
-
+export class MatListOption extends _MatListOptionMixinBase implements AfterContentInit, OnChanges,
+                                                                      OnDestroy, OnInit,
+                                                                      FocusableOption,
+                                                                      CanDisableRipple {
   private _selected = false;
   private _disabled = false;
   private _hasFocus = false;
@@ -137,11 +140,16 @@ export class MatListOption extends _MatListOptionMixinBase
   set color(newValue: ThemePalette) { this._color = newValue; }
   private _color: ThemePalette;
 
+  /**
+   * This is set to true after the first OnChanges cycle so we don't clear the value of `selected`
+   * in the first cycle.
+   */
+  private _inputsInitialized = false;
   /** Value of the option */
   @Input()
   get value(): any { return this._value; }
   set value(newValue: any) {
-    if (this.selected && newValue !== this.value) {
+    if (this.selected && newValue !== this.value && this._inputsInitialized) {
       this.selected = false;
     }
 
@@ -200,6 +208,10 @@ export class MatListOption extends _MatListOptionMixinBase
         this._changeDetector.markForCheck();
       }
     });
+  }
+
+  ngOnChanges() {
+    this._inputsInitialized = true;
   }
 
   ngAfterContentInit() {

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -116,9 +116,8 @@ export class MatSelectionListChange {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatListOption extends _MatListOptionMixinBase implements AfterContentInit, OnChanges,
-                                                                      OnDestroy, OnInit,
-                                                                      FocusableOption,
+export class MatListOption extends _MatListOptionMixinBase implements AfterContentInit, OnDestroy,
+                                                                      OnInit, FocusableOption,
                                                                       CanDisableRipple {
   private _selected = false;
   private _disabled = false;
@@ -208,9 +207,6 @@ export class MatListOption extends _MatListOptionMixinBase implements AfterConte
         this._changeDetector.markForCheck();
       }
     });
-  }
-
-  ngOnChanges() {
     this._inputsInitialized = true;
   }
 


### PR DESCRIPTION
This change ensures that setting `value` does not clear the `selected`
input until after the first change detection cycle. Ivy sets inputs
based on the order they appear in the templates.

Fixes #17500