### PR TITLE
feat(material-experimental/mdc-tabs): add option to fit ink bar to content

### DIFF
--- a/src/dev-app/mdc-tabs/mdc-tabs-demo.html
+++ b/src/dev-app/mdc-tabs/mdc-tabs-demo.html
@@ -91,6 +91,23 @@
     </mat-tab>
   </mat-tab-group>
 
+  <h2>Ink bar fit to content</h2>
+  <button (click)="fitInkBarToContent = !fitInkBarToContent"> Toggle Fit To Content </button>
+  <mat-tab-group [fitInkBarToContent]="fitInkBarToContent">
+    <mat-tab label="First">Content 1</mat-tab>
+    <mat-tab label="Second">Content 2</mat-tab>
+    <mat-tab label="Third">Content 3</mat-tab>
+    <mat-tab label="Fourth" disabled>Content 4</mat-tab>
+  </mat-tab-group>
+
+  <h2>Ink bar fit to content</h2>
+  <nav mat-tab-nav-bar [fitInkBarToContent]="fitInkBarToContent">
+    <a mat-tab-link *ngFor="let link of links"
+       (click)="activeLink = link"
+       [active]="activeLink == link">{{link}}</a>
+    <a mat-tab-link disabled>Disabled Link</a>
+  </nav>
+
   <h2>Lazy tabs</h2>
   <mat-tab-group>
     <mat-tab label="One">

--- a/src/dev-app/mdc-tabs/mdc-tabs-demo.ts
+++ b/src/dev-app/mdc-tabs/mdc-tabs-demo.ts
@@ -15,6 +15,7 @@ import {Component} from '@angular/core';
   styleUrls: ['mdc-tabs-demo.css'],
 })
 export class MdcTabsDemo {
+  fitInkBarToContent = true;
   links = ['First', 'Second', 'Third'];
   lotsOfTabs = new Array(30).fill(0).map((_, index) => `Tab ${index}`);
   activeLink = this.links[0];

--- a/src/material-experimental/mdc-tabs/ink-bar.ts
+++ b/src/material-experimental/mdc-tabs/ink-bar.ts
@@ -66,6 +66,7 @@ export class MatInkBarFoundation {
   private _foundation: MDCTabIndicatorFoundation;
   private _inkBarElement: HTMLElement;
   private _inkBarContentElement: HTMLElement;
+  private _fitToContent = false;
   private _adapter: MDCTabIndicatorAdapter = {
     addClass: className => {
       if (!this._destroyed) {
@@ -88,21 +89,6 @@ export class MatInkBarFoundation {
     }
   };
 
-  /**
-   * Whether the ink bar should be appended to the content, which will cause the ink bar
-   * to match the width of the content rather than the tab host element.
-   */
-  get fitToContent(): boolean { return this._fitToContent; }
-  set fitToContent(fitToContent: boolean) {
-    if (this._fitToContent !== fitToContent) {
-      this._fitToContent = fitToContent;
-      if (this._inkBarElement) {
-        this._appendInkBarElement();
-      }
-    }
-  }
-  private _fitToContent = false;
-
   constructor(private _hostElement: HTMLElement, private _document: Document) {
     this._foundation = new MDCSlidingTabIndicatorFoundation(this._adapter);
   }
@@ -124,7 +110,7 @@ export class MatInkBarFoundation {
 
   /** Initializes the foundation. */
   init() {
-    this._createInkBarElement(this._document);
+    this._createInkBarElement();
     this._foundation.init();
   }
 
@@ -139,10 +125,30 @@ export class MatInkBarFoundation {
     this._destroyed = true;
   }
 
+  /**
+   * Sets whether the ink bar should be appended to the content, which will cause the ink bar
+   * to match the width of the content rather than the tab host element.
+   */
+  setFitToContent(fitToContent: boolean) {
+    if (this._fitToContent !== fitToContent) {
+      this._fitToContent = fitToContent;
+      if (this._inkBarElement) {
+        this._appendInkBarElement();
+      }
+    }
+  }
+
+
+  /**
+   * Gets whether the ink bar should be appended to the content, which will cause the ink bar
+   * to match the width of the content rather than the tab host element.
+   */
+  getFitToContent(): boolean { return this._fitToContent; }
+
   /** Creates and appends the ink bar element. */
-  private _createInkBarElement(document: Document) {
-    this._inkBarElement = document.createElement('span');
-    this._inkBarContentElement = document.createElement('span');
+  private _createInkBarElement() {
+    this._inkBarElement = this._document.createElement('span');
+    this._inkBarContentElement = this._document.createElement('span');
 
     this._inkBarElement.className = 'mdc-tab-indicator';
     this._inkBarContentElement.className = 'mdc-tab-indicator__content' +

--- a/src/material-experimental/mdc-tabs/tab-group.html
+++ b/src/material-experimental/mdc-tabs/tab-group.html
@@ -20,6 +20,7 @@
        [attr.aria-labelledby]="(!tab.ariaLabel && tab.ariaLabelledby) ? tab.ariaLabelledby : null"
        [class.mdc-tab--active]="selectedIndex == i"
        [disabled]="tab.disabled"
+       [fitInkBarToContent]="fitInkBarToContent"
        (click)="_handleClick(tab, tabHeader, i)">
     <span class="mdc-tab__ripple"></span>
 

--- a/src/material-experimental/mdc-tabs/tab-group.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.spec.ts
@@ -677,6 +677,47 @@ describe('nested MatTabGroup with enabled animations', () => {
 });
 
 
+describe('MatTabGroup with ink bar fit to content', () => {
+  let fixture: ComponentFixture<TabGroupWithInkBarFitToContent>;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [MatTabsModule, BrowserAnimationsModule],
+      declarations: [TabGroupWithInkBarFitToContent]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TabGroupWithInkBarFitToContent);
+    fixture.detectChanges();
+  });
+
+  it('should properly nest the ink bar when fit to content', () => {
+    const tabElement = fixture.nativeElement.querySelector('.mdc-tab');
+    const contentElement = tabElement.querySelector('.mdc-tab__content');
+    const indicatorElement = tabElement.querySelector('.mdc-tab-indicator');
+    expect(indicatorElement.parentElement).toBe(contentElement);
+  });
+
+  it('should be able to move the ink bar between content and full', () => {
+    fixture.componentInstance.fitInkBarToContent = false;
+    fixture.detectChanges();
+
+    const tabElement = fixture.nativeElement.querySelector('.mdc-tab');
+    const indicatorElement = tabElement.querySelector('.mdc-tab-indicator');
+    expect(indicatorElement.parentElement).toBe(tabElement);
+
+    fixture.componentInstance.fitInkBarToContent = true;
+    fixture.detectChanges();
+
+    const contentElement = tabElement.querySelector('.mdc-tab__content');
+    expect(indicatorElement.parentElement).toBe(contentElement);
+  });
+});
+
+
 @Component({
   template: `
     <mat-tab-group class="tab-group"
@@ -927,4 +968,17 @@ class TabsWithCustomAnimationDuration {}
 })
 class TabGroupWithIndirectDescendantTabs {
   @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
+}
+
+
+@Component({
+  template: `
+    <mat-tab-group [fitInkBarToContent]="fitInkBarToContent">
+      <mat-tab label="One">Tab one content</mat-tab>
+      <mat-tab label="Two">Tab two content</mat-tab>
+    </mat-tab-group>
+  `,
+})
+class TabGroupWithInkBarFitToContent {
+  fitInkBarToContent = true;
 }

--- a/src/material-experimental/mdc-tabs/tab-group.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.ts
@@ -8,25 +8,27 @@
 
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ContentChildren,
   ElementRef,
+  Inject,
+  Input,
+  Optional,
   QueryList,
   ViewChild,
   ViewEncapsulation,
-  ChangeDetectorRef,
-  Inject,
-  Optional,
 } from '@angular/core';
 import {
   _MatTabGroupBase,
+  MAT_TAB_GROUP,
   MAT_TABS_CONFIG,
   MatTabsConfig,
-  MAT_TAB_GROUP,
 } from '@angular/material/tabs';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MatTab} from './tab';
 import {MatTabHeader} from './tab-header';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
 
 /**
  * Material design tab-group component. Supports basic tab pairs (label + content) and includes
@@ -56,6 +58,12 @@ export class MatTabGroup extends _MatTabGroupBase {
   @ContentChildren(MatTab, {descendants: true}) _allTabs: QueryList<MatTab>;
   @ViewChild('tabBodyWrapper') _tabBodyWrapper: ElementRef;
   @ViewChild('tabHeader') _tabHeader: MatTabHeader;
+
+  /** Whether the ink bar should fit its width to the size of the tab label content. */
+  @Input()
+  get fitInkBarToContent(): boolean { return this._fitInkBarToContent; }
+  set fitInkBarToContent(v: boolean) { this._fitInkBarToContent = coerceBooleanProperty(v); }
+  private _fitInkBarToContent = false;
 
   constructor(elementRef: ElementRef,
               changeDetectorRef: ChangeDetectorRef,

--- a/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
+++ b/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Inject, OnDestroy} from '@angular/core';
+import {Directive, ElementRef, Inject, Input, OnDestroy, OnInit} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {MatTabLabelWrapper as BaseMatTabLabelWrapper} from '@angular/material/tabs';
 import {MatInkBarFoundation, MatInkBarItem} from './ink-bar';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
 
 /**
  * Used in the `mat-tab-group` view to display tab labels.
@@ -23,12 +24,20 @@ import {MatInkBarFoundation, MatInkBarItem} from './ink-bar';
     '[attr.aria-disabled]': '!!disabled',
   }
 })
-export class MatTabLabelWrapper extends BaseMatTabLabelWrapper implements MatInkBarItem, OnDestroy {
-  _foundation: MatInkBarFoundation;
+export class MatTabLabelWrapper extends BaseMatTabLabelWrapper
+    implements MatInkBarItem, OnInit, OnDestroy {
+  _foundation = new MatInkBarFoundation(this.elementRef.nativeElement, this._document);
 
-  constructor(public elementRef: ElementRef, @Inject(DOCUMENT) _document: any) {
+  /** Whether the ink bar should fit its width to the size of the tab label content. */
+  @Input()
+  get fitInkBarToContent(): boolean { return this._foundation.fitToContent; }
+  set fitInkBarToContent(v: boolean) { this._foundation.fitToContent = coerceBooleanProperty(v); }
+
+  constructor(public elementRef: ElementRef, @Inject(DOCUMENT) private _document: any) {
     super(elementRef);
-    this._foundation = new MatInkBarFoundation(elementRef, _document);
+  }
+
+  ngOnInit() {
     this._foundation.init();
   }
 

--- a/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
+++ b/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
@@ -28,15 +28,17 @@ export class MatTabLabelWrapper extends BaseMatTabLabelWrapper
     implements MatInkBarItem, OnInit, OnDestroy {
   private _document: Document;
 
-  _foundation = new MatInkBarFoundation(this.elementRef.nativeElement, this._document);
+  _foundation: MatInkBarFoundation;
 
   /** Whether the ink bar should fit its width to the size of the tab label content. */
   @Input()
-  get fitInkBarToContent(): boolean { return this._foundation.fitToContent; }
-  set fitInkBarToContent(v: boolean) { this._foundation.fitToContent = coerceBooleanProperty(v); }
+  get fitInkBarToContent(): boolean { return this._foundation.getFitToContent(); }
+  set fitInkBarToContent(v: boolean) { this._foundation.setFitToContent(coerceBooleanProperty(v)); }
 
   constructor(public elementRef: ElementRef, @Inject(DOCUMENT) _document: any) {
     super(elementRef);
+    this._document = _document;
+    this._foundation = new MatInkBarFoundation(this.elementRef.nativeElement, this._document);
   }
 
   ngOnInit() {

--- a/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
+++ b/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
@@ -26,6 +26,8 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 })
 export class MatTabLabelWrapper extends BaseMatTabLabelWrapper
     implements MatInkBarItem, OnInit, OnDestroy {
+  private _document: Document;
+
   _foundation = new MatInkBarFoundation(this.elementRef.nativeElement, this._document);
 
   /** Whether the ink bar should fit its width to the size of the tab label content. */
@@ -33,7 +35,7 @@ export class MatTabLabelWrapper extends BaseMatTabLabelWrapper
   get fitInkBarToContent(): boolean { return this._foundation.fitToContent; }
   set fitInkBarToContent(v: boolean) { this._foundation.fitToContent = coerceBooleanProperty(v); }
 
-  constructor(public elementRef: ElementRef, @Inject(DOCUMENT) private _document: any) {
+  constructor(public elementRef: ElementRef, @Inject(DOCUMENT) _document: any) {
     super(elementRef);
   }
 

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -1,5 +1,5 @@
 import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {Component, ViewChild, ViewChildren, QueryList} from '@angular/core';
+import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
 import {dispatchFakeEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
@@ -321,12 +321,46 @@ describe('MatTabNavBar', () => {
         .toBe(true, 'Expected every tab link to have ripples disabled');
     });
   });
+
+  describe('with the ink bar fit to content', () => {
+    let fixture: ComponentFixture<SimpleTabNavBarTestApp>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SimpleTabNavBarTestApp);
+      fixture.componentInstance.fitInkBarToContent = true;
+      fixture.detectChanges();
+    });
+
+    it('should properly nest the ink bar when fit to content', () => {
+      const tabElement = fixture.nativeElement.querySelector('.mdc-tab');
+      const contentElement = tabElement.querySelector('.mdc-tab__content');
+      const indicatorElement = tabElement.querySelector('.mdc-tab-indicator');
+      expect(indicatorElement.parentElement).toBe(contentElement);
+    });
+
+    it('should be able to move the ink bar between content and full', () => {
+      fixture.componentInstance.fitInkBarToContent = false;
+      fixture.detectChanges();
+
+      const tabElement = fixture.nativeElement.querySelector('.mdc-tab');
+      const indicatorElement = tabElement.querySelector('.mdc-tab-indicator');
+      expect(indicatorElement.parentElement).toBe(tabElement);
+
+      fixture.componentInstance.fitInkBarToContent = true;
+      fixture.detectChanges();
+
+      const contentElement = tabElement.querySelector('.mdc-tab__content');
+      expect(indicatorElement.parentElement).toBe(contentElement);
+    });
+  });
 });
 
 @Component({
   selector: 'test-app',
   template: `
-    <nav mat-tab-nav-bar [disableRipple]="disableRippleOnBar">
+    <nav mat-tab-nav-bar
+         [disableRipple]="disableRippleOnBar"
+         [fitInkBarToContent]="fitInkBarToContent">
       <a mat-tab-link
          *ngFor="let tab of tabs; let index = index"
          [active]="activeIndex === index"
@@ -347,6 +381,7 @@ class SimpleTabNavBarTestApp {
   disableRippleOnBar = false;
   disableRippleOnLink = false;
   tabs = [0, 1, 2];
+  fitInkBarToContent = false;
 
   activeIndex = 0;
 }

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -127,7 +127,7 @@ export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnInit
     super(tabNavBar, elementRef, globalRippleOptions, tabIndex, focusMonitor, animationMode);
 
     tabNavBar._fitInkBarToContent.pipe(takeUntil(this._destroyed)).subscribe(fitInkBarToContent => {
-      this._foundation.fitToContent = fitInkBarToContent;
+      this._foundation.setFitToContent(fitInkBarToContent);
     });
   }
 

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -20,7 +20,7 @@ import {
   OnDestroy,
   AfterContentInit,
   NgZone,
-  ChangeDetectorRef,
+  ChangeDetectorRef, OnInit, Input,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
@@ -31,6 +31,9 @@ import {Directionality} from '@angular/cdk/bidi';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {Platform} from '@angular/cdk/platform';
 import {MatInkBar, MatInkBarItem, MatInkBarFoundation} from '../ink-bar';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {BehaviorSubject, Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 
 
 /**
@@ -56,6 +59,12 @@ import {MatInkBar, MatInkBarItem, MatInkBarFoundation} from '../ink-bar';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
+  /** Whether the ink bar should fit its width to the size of the tab label content. */
+  @Input()
+  get fitInkBarToContent(): boolean { return this._fitInkBarToContent.value; }
+  set fitInkBarToContent(v: boolean) { this._fitInkBarToContent.next(coerceBooleanProperty(v)); }
+  _fitInkBarToContent = new BehaviorSubject(false);
+
   @ContentChildren(forwardRef(() => MatTabLink), {descendants: true}) _items: QueryList<MatTabLink>;
   @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
   @ViewChild('tabList', {static: true}) _tabList: ElementRef;
@@ -103,22 +112,32 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
     '[class.mdc-tab--active]': 'active',
   }
 })
-export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnDestroy {
-  _foundation: MatInkBarFoundation;
+export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnInit, OnDestroy {
+  _foundation = new MatInkBarFoundation(this.elementRef.nativeElement, this._document);
+
+  private readonly _destroyed = new Subject<void>();
 
   constructor(
     tabNavBar: MatTabNav,
     elementRef: ElementRef,
     @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS) globalRippleOptions: RippleGlobalOptions|null,
     @Attribute('tabindex') tabIndex: string, focusMonitor: FocusMonitor,
-    @Inject(DOCUMENT) _document: any,
+    @Inject(DOCUMENT) private _document: any,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(tabNavBar, elementRef, globalRippleOptions, tabIndex, focusMonitor, animationMode);
-    this._foundation = new MatInkBarFoundation(elementRef, _document);
+
+    tabNavBar._fitInkBarToContent.pipe(takeUntil(this._destroyed)).subscribe(fitInkBarToContent => {
+      this._foundation.fitToContent = fitInkBarToContent;
+    });
+  }
+
+  ngOnInit() {
     this._foundation.init();
   }
 
   ngOnDestroy() {
+    this._destroyed.next();
+    this._destroyed.complete();
     super.ngOnDestroy();
     this._foundation.destroy();
   }


### PR DESCRIPTION
See material components documentation for an example of the ink bar fitting to the tab label content

https://material-components.github.io/material-components-web-catalog/#/component/tabs