### PR TITLE
fix(list): selection list option not picking up indirect descendant lines

### DIFF
--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -40,6 +40,7 @@ describe('MatSelectionList without forms', () => {
           SelectionListWithOnlyOneOption,
           SelectionListWithIndirectChildOptions,
           SelectionListWithSelectedOptionAndValue,
+          SelectionListWithIndirectDescendantLines,
         ],
       });
 
@@ -601,6 +602,14 @@ describe('MatSelectionList without forms', () => {
       const listItemEl = componentFixture.debugElement.query(By.directive(MatListOption))!;
       expect(listItemEl.componentInstance.selected).toBe(true);
       expect(listItemEl.componentInstance.value).toBe(componentFixture.componentInstance.itemValue);
+    });
+
+    it('should pick up indirect descendant lines', () => {
+      const componentFixture = TestBed.createComponent(SelectionListWithIndirectDescendantLines);
+      componentFixture.detectChanges();
+
+      const option = componentFixture.nativeElement.querySelector('mat-list-option');
+      expect(option.classList).toContain('mat-2-line');
     });
 
   });
@@ -1444,4 +1453,19 @@ class SelectionListWithIcon {
 })
 class SelectionListWithIndirectChildOptions {
   @ViewChildren(MatListOption) optionInstances: QueryList<MatListOption>;
+}
+
+// Note the blank `ngSwitch` which we need in order to hit the bug that we're testing.
+@Component({
+  template: `
+  <mat-selection-list>
+    <mat-list-option>
+      <ng-container [ngSwitch]="true">
+        <h3 mat-line>Item</h3>
+        <p mat-line>Item description</p>
+      </ng-container>
+    </mat-list-option>
+  </mat-selection-list>`
+})
+class SelectionListWithIndirectDescendantLines {
 }

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -125,7 +125,7 @@ export class MatListOption extends _MatListOptionMixinBase implements AfterConte
 
   @ContentChild(MatListAvatarCssMatStyler) _avatar: MatListAvatarCssMatStyler;
   @ContentChild(MatListIconCssMatStyler) _icon: MatListIconCssMatStyler;
-  @ContentChildren(MatLine) _lines: QueryList<MatLine>;
+  @ContentChildren(MatLine, {descendants: true}) _lines: QueryList<MatLine>;
 
   /** DOM element containing the item's text. */
   @ViewChild('text') _text: ElementRef;


### PR DESCRIPTION
Fixes `mat-list-option` not picking up `mat-line` instances that aren't direct descendants.