### PR TITLE
build: member naming rule not catching private readonly

### DIFF
--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -86,8 +86,8 @@ export class MapInfoWindow implements OnInit, OnDestroy {
 
   private _infoWindow?: google.maps.InfoWindow;
 
-  constructor(private readonly googleMap: GoogleMap, private _elementRef: ElementRef<HTMLElement>) {
-  }
+  constructor(private readonly _googleMap: GoogleMap,
+              private _elementRef: ElementRef<HTMLElement>) {}
 
   ngOnInit() {
     this._combineOptions().pipe(takeUntil(this._destroy)).subscribe(options => {
@@ -149,9 +149,9 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    */
   open(anchor?: MapMarker) {
     const marker = anchor ? anchor._marker : undefined;
-    if (this.googleMap._googleMap) {
+    if (this._googleMap._googleMap) {
       this._elementRef.nativeElement.style.display = '';
-      this._infoWindow!.open(this.googleMap._googleMap, marker);
+      this._infoWindow!.open(this._googleMap._googleMap, marker);
     }
   }
 

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -210,14 +210,14 @@ export class MapMarker implements OnInit, OnDestroy {
 
   _marker?: google.maps.Marker;
 
-  constructor(private readonly googleMap: GoogleMap) {}
+  constructor(private readonly _googleMap: GoogleMap) {}
 
   ngOnInit() {
     const combinedOptionsChanges = this._combineOptions();
 
     combinedOptionsChanges.pipe(take(1)).subscribe(options => {
       this._marker = new google.maps.Marker(options);
-      this._marker.setMap(this.googleMap._googleMap);
+      this._marker.setMap(this._googleMap._googleMap);
       this._initializeEventHandlers();
     });
 
@@ -344,7 +344,7 @@ export class MapMarker implements OnInit, OnDestroy {
             position: position || options.position,
             label: label || options.label,
             clickable: clickable !== undefined ? clickable : options.clickable,
-            map: this.googleMap._googleMap || null,
+            map: this._googleMap._googleMap || null,
           };
           return combinedOptions;
         }));

--- a/tools/tslint-rules/memberNamingRule.ts
+++ b/tools/tslint-rules/memberNamingRule.ts
@@ -57,13 +57,13 @@ class Walker extends Lint.RuleWalker {
       // Check class members that were declared via the constructor
       // (e.g. `constructor(private _something: number)`. These nodes don't
       // show up under `ClassDeclaration.members`.
-      if (tsutils.hasModifier(modifiers, ts.SyntaxKind.ReadonlyKeyword) ||
-          tsutils.hasModifier(modifiers, ts.SyntaxKind.PublicKeyword)) {
-        this._validateNode(param, 'public');
-      } else if (tsutils.hasModifier(modifiers, ts.SyntaxKind.PrivateKeyword)) {
+      if (tsutils.hasModifier(modifiers, ts.SyntaxKind.PrivateKeyword)) {
         this._validateNode(param, 'private');
       } else if (tsutils.hasModifier(modifiers, ts.SyntaxKind.ProtectedKeyword)) {
         this._validateNode(param, 'protected');
+      } else if (tsutils.hasModifier(modifiers, ts.SyntaxKind.ReadonlyKeyword) ||
+                 tsutils.hasModifier(modifiers, ts.SyntaxKind.PublicKeyword)) {
+        this._validateNode(param, 'public');
       }
     });
 


### PR DESCRIPTION
Fixes the rule that validates member naming not picking up class properties declared through the constructor as `private readonly` (e.g. `constructor(private readonly something: any)`.