### PR TITLE
feat: add coercion for string arrays

### DIFF
--- a/src/cdk/coercion/public-api.ts
+++ b/src/cdk/coercion/public-api.ts
@@ -11,3 +11,4 @@ export * from './number-property';
 export * from './array';
 export * from './css-pixel-value';
 export * from './element';
+export * from './string-array';

--- a/src/cdk/coercion/string-array.spec.ts
+++ b/src/cdk/coercion/string-array.spec.ts
@@ -1,0 +1,28 @@
+import {coerceStringArray} from '@angular/cdk/coercion/string-array';
+
+describe('coerceStringArray', () => {
+    it('should split a string', () => {
+        expect(coerceStringArray('x,y, z,1')).toEqual(['x', 'y', 'z', '1']);
+    });
+
+    it('should map values to string in an array', () => {
+        expect(coerceStringArray(['x', 1, true, null, undefined, ['arr', 'ay'], { data: false }]))
+            .toEqual(['x', '1', 'true', 'null', 'undefined', 'arr,ay', '[object Object]']);
+    });
+
+    it('should trim values and remove empty values', () => {
+        expect(coerceStringArray(',  x,  ,, ')).toEqual(['x']);
+    });
+
+    it('should map non-string values to string', () => {
+        expect(coerceStringArray(0)).toEqual(['0']);
+    });
+
+    it('should return an empty array for null', () => {
+        expect(coerceStringArray(null)).toEqual([]);
+    });
+
+    it('should return an empty array for undefined', () => {
+        expect(coerceStringArray(undefined)).toEqual([]);
+    });
+});

--- a/src/cdk/coercion/string-array.ts
+++ b/src/cdk/coercion/string-array.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Coerces a value to an array of strings. */
+export function coerceStringArray(value: any, separator: string | RegExp = ','): string[] {
+    if (value == null) {
+        return [];
+    }
+    const stringArray = Array.isArray(value) ?
+        value.map(item => `${item}`) :
+        value.toString().split(separator);
+    return stringArray
+        .map((item: string) => item.trim())
+        .filter((item: string) => item.length > 0);
+}
+


### PR DESCRIPTION
Adds a utility function to coerce string arrays. This has been very useful for CSS class lists or defining columns for a CDK table.

Handling of `null` and `undefined` (and objects) may be up for discussion. Currently they are mapped via [string interpolation](https://github.com/JanMalch/components/blob/feat/coerce-string-array/src/cdk/coercion/string-array.ts#L15) and [not filtered](https://github.com/JanMalch/components/blob/feat/coerce-string-array/src/cdk/coercion/string-array.spec.ts#L10).

(If this is not just a "small" feature, I'm happy to open up a new issue.)