### PR TITLE
docs: add package ID prefix to h3's ids

### DIFF
--- a/tools/dgeni/templates/entry-point.template.html
+++ b/tools/dgeni/templates/entry-point.template.html
@@ -43,7 +43,7 @@
   </p>
 
   {%- if doc.services.length -%}
-    <h3 id="services" class="docs-header-link docs-api-h3">
+    <h3 id="{$ doc.name $}-services" class="docs-header-link docs-api-h3">
       <span header-link="services"></span>
       Services
     </h3>
@@ -54,7 +54,7 @@
 
 
   {%- if doc.directives.length -%}
-    <h3 id="directives" class="docs-header-link docs-api-h3">
+    <h3 id="{$ doc.name $}-directives" class="docs-header-link docs-api-h3">
       <span header-link="directives"></span>
       Directives
     </h3>
@@ -64,7 +64,7 @@
   {%- endif -%}
 
   {%- if doc.classes.length -%}
-    <h3 id="classes" class="docs-header-link docs-api-h3">
+    <h3 id="{$ doc.name $}-classes" class="docs-header-link docs-api-h3">
       <span header-link="classes"></span>
       Classes
     </h3>
@@ -74,7 +74,7 @@
   {%- endif -%}
 
   {%- if doc.interfaces.length -%}
-    <h3 id="interfaces" class="docs-header-link docs-api-h3">
+    <h3 id="{$ doc.name $}-interfaces" class="docs-header-link docs-api-h3">
       <span header-link="interfaces"></span>
       Interfaces
     </h3>
@@ -84,7 +84,7 @@
   {%- endif -%}
 
   {%- if doc.functions.length -%}
-    <h3 id="functions" class="docs-header-link docs-api-h3">
+    <h3 id="{$ doc.name $}-functions" class="docs-header-link docs-api-h3">
       <span header-link="functions"></span>
       Functions
     </h3>
@@ -98,7 +98,7 @@
   {%- endif -%}
 
   {%- if doc.typeAliases.length -%}
-    <h3 id="type_aliases" class="docs-header-link docs-api-h3">
+    <h3 id="{$ doc.name $}-type_aliases" class="docs-header-link docs-api-h3">
       <span header-link="type_aliases"></span>
       Type aliases
     </h3>
@@ -108,7 +108,7 @@
   {%- endif -%}
 
   {%- if doc.constants.length -%}
-    <h3 id="constants" class="docs-header-link docs-api-h3">
+    <h3 id="{$ doc.name $}-constants" class="docs-header-link docs-api-h3">
       <span header-link="constants"></span>
       Constants
     </h3>


### PR DESCRIPTION
This helps avoid collisions in the table of content's sections like
"Directives" and "Services", since now we may show more than one
package entry point in docs (e.g. button and button-testing).

Note that we chose not to add the prefix to individual
class/constant/interface/etc names because it muddles the URL and
is unlikely that we collide on these values.

e.g
```html
<h3 id="material-button-directives" class="docs-header-link docs-api-h3">
```

```html
<h3 id="material-button-testing-interfaces" class="docs-header-link docs-api-h3">
```

Fixes #17526