### PR TITLE
docs(cdk/platform): remove header in example from TOC

### DIFF
--- a/src/material-examples/cdk/platform/cdk-platform-overview/cdk-platform-overview-example.html
+++ b/src/material-examples/cdk/platform/cdk-platform-overview/cdk-platform-overview-example.html
@@ -1,4 +1,4 @@
-<h3>Platform information:</h3>
+<h2>Platform information:</h2>
 <p>Is Android: {{platform.ANDROID}}</p>
 <p>Is iOS: {{platform.IOS}}</p>
 <p>Is Firefox: {{platform.FIREFOX}}</p>


### PR DESCRIPTION
`h2`s aren't anchored or added to the TOC.

Fixes extra TOC entry here for `Platform Information:` from the example
<img width="1111" alt="Screen Shot 2019-10-28 at 15 59 42" src="https://user-images.githubusercontent.com/3506071/67724336-fb20f900-f99b-11e9-90e5-410e912054e3.png">
