### PR TITLE
fix(cdk/active-descendant-key-manager): emit change event after setting active styles

### DIFF
--- a/src/cdk/a11y/key-manager/activedescendant-key-manager.ts
+++ b/src/cdk/a11y/key-manager/activedescendant-key-manager.ts
@@ -40,12 +40,17 @@ export class ActiveDescendantKeyManager<T> extends ListKeyManager<Highlightable 
   setActiveItem(item: T): void;
 
   setActiveItem(index: any): void {
+    const previousIndex = this.activeItemIndex;
+
     if (this.activeItem) {
       this.activeItem.setInactiveStyles();
     }
-    super.setActiveItem(index);
+    super.updateActiveItem(index);
     if (this.activeItem) {
       this.activeItem.setActiveStyles();
+    }
+    if (previousIndex !== this.activeItemIndex) {
+      this.change.next(this.activeItemIndex);
     }
   }
 

--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -265,7 +265,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
   }
 
   /** Index of the currently active item. */
-  get activeItemIndex(): number | null {
+  get activeItemIndex(): number {
     return this._activeItemIndex;
   }
 

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -107,7 +107,7 @@ export declare function isFakeMousedownFromScreenReader(event: MouseEvent): bool
 
 export declare class ListKeyManager<T extends ListKeyManagerOption> {
     readonly activeItem: T | null;
-    readonly activeItemIndex: number | null;
+    readonly activeItemIndex: number;
     change: Subject<number>;
     tabOut: Subject<void>;
     constructor(_items: QueryList<T> | T[]);

--- a/tools/public_api_guard/cdk/stepper.d.ts
+++ b/tools/public_api_guard/cdk/stepper.d.ts
@@ -46,7 +46,7 @@ export declare class CdkStepper implements AfterViewInit, OnDestroy {
     readonly steps: QueryList<CdkStep>;
     constructor(_dir: Directionality, _changeDetectorRef: ChangeDetectorRef, _elementRef?: ElementRef<HTMLElement> | undefined, _document?: any);
     _getAnimationDirection(index: number): StepContentPositionState;
-    _getFocusIndex(): number | null;
+    _getFocusIndex(): number;
     _getIndicatorType(index: number, state?: StepState): StepState;
     _getStepContentId(i: number): string;
     _getStepLabelId(i: number): string;


### PR DESCRIPTION
Before this change, the "change" event was triggered before the active styles have been set and it was impossible to subscribe to this event and handle items with updated styles (e.g. call change detection). This change fixes it.