### PR TITLE
feat(clipboard): add the ability to specify number of attempts in clipboard directive

### DIFF
--- a/src/cdk/clipboard/clipboard.md
+++ b/src/cdk/clipboard/clipboard.md
@@ -55,3 +55,10 @@ class HeroProfile {
   }
 }
 ```
+
+If you're using the `cdkCopyToClipboard` you can pass in the `cdkCopyToClipboardAttempts` input
+to automatically attempt to copy some text a certain number of times.
+
+```html
+<button [cdkCopyToClipboard]="longText" [cdkCopyToClipboardAttempts]="5">Copy text</button>
+```

--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -6,9 +6,27 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EventEmitter, Input, Output} from '@angular/core';
-
+import {
+  Directive,
+  EventEmitter,
+  Input,
+  Output,
+  NgZone,
+  InjectionToken,
+  Inject,
+  Optional,
+} from '@angular/core';
 import {Clipboard} from './clipboard';
+
+/** Object that can be used to configure the default options for `CdkCopyToClipboard`. */
+export interface CdkCopyToClipboardConfig {
+  /** Default number of attempts to make when copying text to the clipboard. */
+  attempts?: number;
+}
+
+/** Injection token that can be used to provide the default options to `CdkCopyToClipboard`. */
+export const CKD_COPY_TO_CLIPBOARD_CONFIG =
+    new InjectionToken<CdkCopyToClipboardConfig>('CKD_COPY_TO_CLIPBOARD_CONFIG');
 
 /**
  * Provides behavior for a button that when clicked copies content into user's
@@ -25,6 +43,12 @@ export class CdkCopyToClipboard {
   @Input('cdkCopyToClipboard') text: string = '';
 
   /**
+   * How many times to attempt to copy the text. This may be necessary for longer text, because
+   * the browser needs time to fill an intermediate textarea element and copy the content.
+   */
+  @Input('cdkCopyToClipboardAttempts') attempts: number = 1;
+
+  /**
    * Emits when some text is copied to the clipboard. The
    * emitted value indicates whether copying was successful.
    */
@@ -38,10 +62,42 @@ export class CdkCopyToClipboard {
    */
   @Output('copied') _deprecatedCopied = this.copied;
 
-  constructor(private readonly _clipboard: Clipboard) {}
+  constructor(
+    private _clipboard: Clipboard,
+    /**
+     * @deprecated _ngZone parameter to become required.
+     * @breaking-change 10.0.0
+     */
+    private _ngZone?: NgZone,
+    @Optional() @Inject(CKD_COPY_TO_CLIPBOARD_CONFIG) config?: CdkCopyToClipboardConfig) {
+
+    if (config && config.attempts != null) {
+      this.attempts = config.attempts;
+    }
+  }
 
   /** Copies the current text to the clipboard. */
-  copy() {
-    this.copied.emit(this._clipboard.copy(this.text));
+  copy(attempts: number = this.attempts): void {
+    if (attempts > 1) {
+      let remainingAttempts = attempts;
+      const pending = this._clipboard.beginCopy(this.text);
+      const attempt = () => {
+        const successful = pending.copy();
+        if (!successful && --remainingAttempts) {
+          // @breaking-change 10.0.0 Remove null check for `_ngZone`.
+          if (this._ngZone) {
+            this._ngZone.runOutsideAngular(() => setTimeout(attempt));
+          } else {
+            setTimeout(attempt);
+          }
+        } else {
+          pending.destroy();
+          this.copied.emit(successful);
+        }
+      };
+      attempt();
+    } else {
+      this.copied.emit(this._clipboard.copy(this.text));
+    }
   }
 }

--- a/tools/public_api_guard/cdk/clipboard.d.ts
+++ b/tools/public_api_guard/cdk/clipboard.d.ts
@@ -1,12 +1,20 @@
 export declare class CdkCopyToClipboard {
     _deprecatedCopied: EventEmitter<boolean>;
+    attempts: number;
     copied: EventEmitter<boolean>;
     text: string;
-    constructor(_clipboard: Clipboard);
-    copy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkCopyToClipboard, "[cdkCopyToClipboard]", never, { 'text': "cdkCopyToClipboard" }, { 'copied': "cdkCopyToClipboardCopied", '_deprecatedCopied': "copied" }, never>;
+    constructor(_clipboard: Clipboard,
+    _ngZone?: NgZone | undefined, config?: CdkCopyToClipboardConfig);
+    copy(attempts?: number): void;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkCopyToClipboard, "[cdkCopyToClipboard]", never, { 'text': "cdkCopyToClipboard", 'attempts': "cdkCopyToClipboardAttempts" }, { 'copied': "cdkCopyToClipboardCopied", '_deprecatedCopied': "copied" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkCopyToClipboard>;
 }
+
+export interface CdkCopyToClipboardConfig {
+    attempts?: number;
+}
+
+export declare const CKD_COPY_TO_CLIPBOARD_CONFIG: InjectionToken<CdkCopyToClipboardConfig>;
 
 export declare class Clipboard {
     constructor(document: any);


### PR DESCRIPTION
Adds a new input to the `cdkCopyToClipboard` directive which allows consumers to set the number of attempts to try and copy their text. We currently have an example of how to implement attempts in the readme, but this feature makes it more convenient so that consumers don't have to do it on a case-by-case basis.