### PR TITLE
docs(chips): chips autocomplete demo separator key codes not working correctly

### DIFF
--- a/src/material-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
+++ b/src/material-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
@@ -15,7 +15,6 @@
       [matAutocomplete]="auto"
       [matChipInputFor]="chipList"
       [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-      [matChipInputAddOnBlur]="addOnBlur"
       (matChipInputTokenEnd)="add($event)">
   </mat-chip-list>
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">

--- a/src/material-examples/material/chips/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/material-examples/material/chips/chips-autocomplete/chips-autocomplete-example.ts
@@ -18,7 +18,6 @@ export class ChipsAutocompleteExample {
   visible = true;
   selectable = true;
   removable = true;
-  addOnBlur = true;
   separatorKeysCodes: number[] = [ENTER, COMMA];
   fruitCtrl = new FormControl();
   filteredFruits: Observable<string[]>;
@@ -35,24 +34,20 @@ export class ChipsAutocompleteExample {
   }
 
   add(event: MatChipInputEvent): void {
-    // Add fruit only when MatAutocomplete is not open
-    // To make sure this does not conflict with OptionSelected Event
-    if (!this.matAutocomplete.isOpen) {
-      const input = event.input;
-      const value = event.value;
+    const input = event.input;
+    const value = event.value;
 
-      // Add our fruit
-      if ((value || '').trim()) {
-        this.fruits.push(value.trim());
-      }
-
-      // Reset the input value
-      if (input) {
-        input.value = '';
-      }
-
-      this.fruitCtrl.setValue(null);
+    // Add our fruit
+    if ((value || '').trim()) {
+      this.fruits.push(value.trim());
     }
+
+    // Reset the input value
+    if (input) {
+      input.value = '';
+    }
+
+    this.fruitCtrl.setValue(null);
   }
 
   remove(fruit: string): void {


### PR DESCRIPTION
In #12971 `addOnBlur` was added to the chips autocomplete example, however it ended up breaking pressing the separator keys while the autocomplete is open. These changes remove the `addOnBlur` since having an autocomplete and adding chips on blur inherrently doesn't work together, because clicking on the autocomplete will blur the input. We could technically hack around it with a timeout, but that'll make the demo more confusing.

Fixes #17448.