### PR TITLE
fix(material-experimental/mdc-tabs): markForCheck on ink bar content input setter

### DIFF
--- a/src/material-experimental/mdc-tabs/tab-group.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.ts
@@ -62,7 +62,10 @@ export class MatTabGroup extends _MatTabGroupBase {
   /** Whether the ink bar should fit its width to the size of the tab label content. */
   @Input()
   get fitInkBarToContent(): boolean { return this._fitInkBarToContent; }
-  set fitInkBarToContent(v: boolean) { this._fitInkBarToContent = coerceBooleanProperty(v); }
+  set fitInkBarToContent(v: boolean) {
+    this._fitInkBarToContent = coerceBooleanProperty(v);
+    this._changeDetectorRef.markForCheck();
+  }
   private _fitInkBarToContent = false;
 
   constructor(elementRef: ElementRef,

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -67,7 +67,10 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
   /** Whether the ink bar should fit its width to the size of the tab label content. */
   @Input()
   get fitInkBarToContent(): boolean { return this._fitInkBarToContent.value; }
-  set fitInkBarToContent(v: boolean) { this._fitInkBarToContent.next(coerceBooleanProperty(v)); }
+  set fitInkBarToContent(v: boolean) {
+    this._fitInkBarToContent.next(coerceBooleanProperty(v));
+    this._changeDetectorRef.markForCheck();
+  }
   _fitInkBarToContent = new BehaviorSubject(false);
 
   @ContentChildren(forwardRef(() => MatTabLink), {descendants: true}) _items: QueryList<MatTabLink>;

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -175,7 +175,7 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
   private _groupId: number;
 
   constructor(elementRef: ElementRef,
-              private _changeDetectorRef: ChangeDetectorRef,
+              protected _changeDetectorRef: ChangeDetectorRef,
               @Inject(MAT_TABS_CONFIG) @Optional() defaultConfig?: MatTabsConfig,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
     super(elementRef);

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -30,6 +30,7 @@ export declare abstract class _MatTabBodyBase implements OnInit, OnDestroy {
 export declare abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements AfterContentInit, AfterContentChecked, OnDestroy, CanColor, CanDisableRipple {
     abstract _allTabs: QueryList<MatTab>;
     _animationMode?: string | undefined;
+    protected _changeDetectorRef: ChangeDetectorRef;
     abstract _tabBodyWrapper: ElementRef;
     abstract _tabHeader: MatTabGroupBaseHeader;
     _tabs: QueryList<MatTab>;


### PR DESCRIPTION
The input value is used in the template, so the view must be checked after the setter has been called