### PR TITLE
build: generate changelog for google-maps package

### DIFF
--- a/tools/release/changelog.ts
+++ b/tools/release/changelog.ts
@@ -27,7 +27,7 @@ const orderedChangelogPackages = [
 ];
 
 /** List of packages which are excluded in the changelog. */
-const excludedChangelogPackages = ['google-maps'];
+const excludedChangelogPackages = [];
 
 /** Prompts for a changelog release name and prepends the new changelog. */
 export async function promptAndGenerateChangelog(changelogPath: string) {


### PR DESCRIPTION
We previously disabled the changelog generation for the `google-maps`
package. Now that we released it, we should enable the changelog generation
for future changes.