### PR TITLE
build: ensure no permission errors thrown in packages-dist script

### DIFF
--- a/scripts/build-packages-dist.sh
+++ b/scripts/build-packages-dist.sh
@@ -44,7 +44,13 @@ dirs=`echo "$targets" | sed -e 's/\/\/src\/\(.*\):npm_package/\1/'`
 # do this to ensure that the version placeholders are properly populated.
 for pkg in ${dirs}; do
   pkg_dir="${bazel_bin_path}/src/${pkg}/npm_package"
-  rm -Rf ${pkg_dir}
+  if [[ -d ${pkg_dir} ]]; then
+    # Make all directories in the previous package output writable. Bazel by default
+    # makes tree artifacts and file outputs readonly. This causes permission errors
+    # when deleting the folder. To avoid these errors, we make all files writable.
+    chmod -R u+w ${pkg_dir}
+    rm -Rf ${pkg_dir}
+  fi
 done
 
 # Walk through each release package target and build it.


### PR DESCRIPTION
Bazel by default makes output files or tree artifacts readonly. This
means that the packages-dist script fails in case release output
has been built previously. This has only an effect in non-windows
environments.

We can reasonably fix this by making the folder/files writable
before trying to delete them. This is similar to what Bazel
internally does when deleting outputs of previous builds.

see:
https://github.com/bazelbuild/bazel/blob/07924e8260a447b69b18e8248203e1089b46962a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java#L1251