### PR TITLE
build: decorator validation rule skipping property check if next line is disabled

### DIFF
--- a/tools/tslint-rules/validateDecoratorsRule.ts
+++ b/tools/tslint-rules/validateDecoratorsRule.ts
@@ -114,7 +114,8 @@ class Walker extends Lint.RuleWalker {
 
     if (missing.length) {
       // Exit early if any of the properties are missing.
-      this.addFailureAtNode(decorator.parent, 'Missing required properties: ' + missing.join(', '));
+      this.addFailureAtNode(decorator.expression,
+          'Missing required properties: ' + missing.join(', '));
     } else {
       // If all the necessary properties are defined, ensure that
       // they match the pattern and aren't in the forbidden list.


### PR DESCRIPTION
Fixes the decorator validation rule skipping all of the property presence checks if there's a `disable-next-line` inside the object literal. The problem comes from the fact that if the check fails, we report a failure on the entire decorator node. These changes switch to reporting the failure only on the name.