### PR TITLE
build: max-line-length check not catching all cases

### DIFF
--- a/src/material-examples/cdk-experimental/popover-edit/module.ts
+++ b/src/material-examples/cdk-experimental/popover-edit/module.ts
@@ -3,11 +3,22 @@ import {CdkTableModule} from '@angular/cdk/table';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-import {CdkPopoverEditCdkTableFlexExample} from './cdk-popover-edit-cdk-table-flex/cdk-popover-edit-cdk-table-flex-example';
-import {CdkPopoverEditCdkTableExample} from './cdk-popover-edit-cdk-table/cdk-popover-edit-cdk-table-example';
-import {CdkPopoverEditCellSpanVanillaTableExample} from './cdk-popover-edit-cell-span-vanilla-table/cdk-popover-edit-cell-span-vanilla-table-example';
-import {CdkPopoverEditTabOutVanillaTableExample} from './cdk-popover-edit-tab-out-vanilla-table/cdk-popover-edit-tab-out-vanilla-table-example';
-import {CdkPopoverEditVanillaTableExample} from './cdk-popover-edit-vanilla-table/cdk-popover-edit-vanilla-table-example';
+import {
+  CdkPopoverEditCdkTableFlexExample
+} from './cdk-popover-edit-cdk-table-flex/cdk-popover-edit-cdk-table-flex-example';
+import {
+  CdkPopoverEditCdkTableExample
+} from './cdk-popover-edit-cdk-table/cdk-popover-edit-cdk-table-example';
+import {
+  CdkPopoverEditCellSpanVanillaTableExample
+  // tslint:disable-next-line:max-line-length
+} from './cdk-popover-edit-cell-span-vanilla-table/cdk-popover-edit-cell-span-vanilla-table-example';
+import {
+  CdkPopoverEditTabOutVanillaTableExample
+} from './cdk-popover-edit-tab-out-vanilla-table/cdk-popover-edit-tab-out-vanilla-table-example';
+import {
+  CdkPopoverEditVanillaTableExample
+} from './cdk-popover-edit-vanilla-table/cdk-popover-edit-vanilla-table-example';
 
 export {
   CdkPopoverEditCdkTableFlexExample,

--- a/src/material-experimental/select/testing/shared.spec.ts
+++ b/src/material-experimental/select/testing/shared.spec.ts
@@ -47,7 +47,9 @@ export function runHarnessTests(
   });
 
   it('should be able to check whether a select is in multi-selection mode', async () => {
-    const singleSelection = await loader.getHarness(selectHarness.with({selector: '#single-selection'}));
+    const singleSelection = await loader.getHarness(selectHarness.with({
+      selector: '#single-selection'
+    }));
     const multipleSelection =
         await loader.getHarness(selectHarness.with({selector: '#multiple-selection'}));
 
@@ -56,7 +58,9 @@ export function runHarnessTests(
   });
 
   it('should get disabled state', async () => {
-    const singleSelection = await loader.getHarness(selectHarness.with({selector: '#single-selection'}));
+    const singleSelection = await loader.getHarness(selectHarness.with({
+      selector: '#single-selection'
+    }));
     const multipleSelection =
         await loader.getHarness(selectHarness.with({selector: '#multiple-selection'}));
 
@@ -71,7 +75,9 @@ export function runHarnessTests(
   });
 
   it('should get required state', async () => {
-    const singleSelection = await loader.getHarness(selectHarness.with({selector: '#single-selection'}));
+    const singleSelection = await loader.getHarness(selectHarness.with({
+      selector: '#single-selection'
+    }));
     const multipleSelection =
         await loader.getHarness(selectHarness.with({selector: '#multiple-selection'}));
 
@@ -86,8 +92,12 @@ export function runHarnessTests(
   });
 
   it('should get valid state', async () => {
-    const singleSelection = await loader.getHarness(selectHarness.with({selector: '#single-selection'}));
-    const withFormControl = await loader.getHarness(selectHarness.with({selector: '#with-form-control'}));
+    const singleSelection = await loader.getHarness(selectHarness.with({
+      selector: '#single-selection'
+    }));
+    const withFormControl = await loader.getHarness(selectHarness.with({
+      selector: '#with-form-control'
+    }));
 
     expect(await singleSelection.isValid()).toBe(true);
     expect(await withFormControl.isValid()).toBe(false);

--- a/tools/release/base-release-task.ts
+++ b/tools/release/base-release-task.ts
@@ -57,8 +57,8 @@ export class BaseReleaseTask {
 
     // Check if the current branch is in sync with the remote branch.
     if (upstreamCommitSha !== localCommitSha) {
-      console.error(chalk.red(`  ✘ The current branch is not in sync with the remote branch. Please ` +
-        `make sure your local branch "${chalk.italic(publishBranch)}" is up to date.`));
+      console.error(chalk.red(`  ✘ The current branch is not in sync with the remote branch. ` +
+        `Please make sure your local branch "${chalk.italic(publishBranch)}" is up to date.`));
       process.exit(1);
     }
   }

--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,12 @@
     "node_modules/codelyzer"
   ],
   "rules": {
-    "max-line-length": [true, 100],
+    "max-line-length": [true, {
+        "limit": 100,
+        "check-strings": true,
+        "check-regex": true
+      }
+    ],
     // Disable this flag because of SHA tslint#48b0c597f9257712c7d1f04b55ed0aa60e333f6a
     // TSLint now shows warnings if types for properties are inferred. This rule needs to be
     // disabled because all properties need to have explicit types set to work for Dgeni.


### PR DESCRIPTION
In tslint 5.19.0 they added a separate option that determines whether strings should be checked and it seems to have been defaulted to `false` (https://github.com/palantir/tslint/pull/4798). As a result we ended up with a few places where the limit was being violated.

These changes explicitly enable checking of strings and fix the failures that we had accumulated.