### PR TITLE
fix(material/chips): fix ripple element opacity when using CSS variable theming

### DIFF
--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -15,6 +15,20 @@ $mat-chip-remove-font-size: 18px;
   }
 }
 
+
+// Applies the background color for a ripple element.
+// If the color value provided is not a Sass color, 
+// we assume that we've been given a CSS variable. 
+// Since we can't perform alpha-blending on a CSS variable,
+// we instead add the opacity directly to the ripple element.
+@mixin _mat-chips-ripple-background($palette, $default-contrast, $opacity) {
+  $background-color: mat-color($palette, $default-contrast, $opacity);
+  background-color: $background-color;
+  @if (type-of($background-color) != color) {
+    opacity: $opacity;
+  }
+}
+
 @mixin mat-chips-theme-color($palette) {
   @include mat-chips-color(mat-color($palette, default-contrast), mat-color($palette));
 

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -17,8 +17,8 @@ $mat-chip-remove-font-size: 18px;
 
 
 // Applies the background color for a ripple element.
-// If the color value provided is not a Sass color, 
-// we assume that we've been given a CSS variable. 
+// If the color value provided is not a Sass color,
+// we assume that we've been given a CSS variable.
 // Since we can't perform alpha-blending on a CSS variable,
 // we instead add the opacity directly to the ripple element.
 @mixin _mat-chips-ripple-background($palette, $default-contrast, $opacity) {

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -33,15 +33,7 @@ $mat-chip-remove-font-size: 18px;
   @include mat-chips-color(mat-color($palette, default-contrast), mat-color($palette));
 
   .mat-ripple-element {
-    $ripple-opacity: 0.1;
-    $ripple-color: mat-color($palette, default-contrast, $ripple-opacity);
-    background-color: $ripple-color;
-
-    // If the ripple color is a CSS variable, `mat-color` will
-    // return a solid color so we have to apply the opacity separately.
-    @if (type-of($ripple-color) != color) {
-      opacity: $ripple-opacity;
-    }
+   @include _mat-chips-ripple-background($palette, default-contrast, 0.1);
   }
 }
 


### PR DESCRIPTION
Fixes a bug in the Angular Material `chips` component where ripple element doesn't have opacity when CSS variables are used to make a dynamic theme

Fixes #17577 