### PR TITLE
fix(material/slide-toggle): handle background provided as a css variable

### DIFF
--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -9,10 +9,16 @@
       background-color: mat-color($palette, $thumb-checked-hue);
     }
 
-    .mat-slide-toggle-bar {
+    .mat-slide-toggle-bar::before {
       // Opacity is determined from the specs for the selection controls.
       // See: https://material.io/design/components/selection-controls.html#specs
-      background-color: mat-color($palette, $thumb-checked-hue, 0.54);
+      $opacity: 0.54;
+      $color: mat-color($palette, $thumb-checked-hue, 0.54);
+      background-color: $color;
+
+      @if (type-of($color) != color) {
+        opacity: $opacity;
+      }
     }
 
     .mat-ripple-element {
@@ -67,7 +73,7 @@
     background-color: mat-color($mat-grey, $thumb-unchecked-hue);
   }
 
-  .mat-slide-toggle-bar {
+  .mat-slide-toggle-bar::before {
     background-color: $bar-unchecked-color;
   }
 }

--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -131,8 +131,22 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
   // Prevent shrinking of the bar container. It can happen that the content is long enough to
   // shrink the bar and the thumb.
   flex-shrink: 0;
-
   border-radius: $mat-slide-toggle-bar-border-radius;
+
+  // Used to provide the background color for the toggle bar. We need a separate (pseudo) element
+  // for this, because we need to fall back to using `rgb` and `opacity` for the background if
+  // the theme has some values that are provided as CSS variables. We can't set the background
+  // and an opacity directly on the `.mat-slide-toggle-bar`, because it has other elements that
+  // the opacity shouldn't apply to (e.g. the thumb).
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-radius: inherit;
+  }
 }
 
 // The slide toggle shows a visually hidden input inside of the component, which is used


### PR DESCRIPTION
Currently we apply an opacity to the background of the slide toggle via `rgba` which won't work if the theme uses CSS variables. These changes set up a fallback that uses `opacity` instead.