### PR TITLE
fix(popover-edit): incorrect spacing for form field inside popover

### DIFF
--- a/src/material-experimental/popover-edit/_popover-edit.scss
+++ b/src/material-experimental/popover-edit/_popover-edit.scss
@@ -105,8 +105,10 @@
     mat-form-field {
       display: block;
 
+      // Clear the top padding, because we don't have a label on it and the reserved space
+      // can throw off the alignment when there isn't a header (see discussion in #17600).
       &:not(.mat-form-field-has-label) .mat-form-field-infix {
-        padding: 0;
+        padding-top: 0;
       }
     }
   }


### PR DESCRIPTION
For some reason the padding on `mat-form-field` was reset inside the popover edit overlay which made it looked weird. From what I can tell, there's no reason to do this so these changes remove the override.

For reference, here's what it looks like at the moment:
![Angular_Material_-_Google_Chrome_2019-11-04_10-30-02](https://user-images.githubusercontent.com/4450522/68111769-42c2fa00-ff33-11e9-9c78-8eab39f50acb.png)
![Angular_Material_-_Google_Chrome_2019-11-04_13-23-00](https://user-images.githubusercontent.com/4450522/68120679-4eb9b680-ff49-11e9-96ce-f0e50a4721e9.png)

