### PR TITLE
build: fine-grain examples for dev-app pages

### DIFF
--- a/src/dev-app/popover-edit/BUILD.bazel
+++ b/src/dev-app/popover-edit/BUILD.bazel
@@ -7,7 +7,8 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     deps = [
         "//src/dev-app/example",
-        "//src/material-examples:examples",
+        "//src/material-examples/cdk-experimental/popover-edit",
+        "//src/material-examples/material-experimental/popover-edit",
         "@npm//@angular/forms",
         "@npm//@angular/router",
     ],

--- a/src/dev-app/popover-edit/popover-edit-demo-module.ts
+++ b/src/dev-app/popover-edit/popover-edit-demo-module.ts
@@ -8,13 +8,19 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {
+  CdkPopoverEditExamplesModule
+} from '@angular/material-examples/cdk-experimental/popover-edit/module';
+import {
+  PopoverEditExamplesModule
+} from '@angular/material-examples/material-experimental/popover-edit/module';
 import {RouterModule} from '@angular/router';
-import {ExampleModule} from '../example/example-module';
 import {PopoverEditDemo} from './popover-edit-demo';
 
 @NgModule({
   imports: [
-    ExampleModule,
+    CdkPopoverEditExamplesModule,
+    PopoverEditExamplesModule,
     FormsModule,
     RouterModule.forChild([{path: '', component: PopoverEditDemo}]),
   ],

--- a/src/dev-app/popover-edit/popover-edit-demo.ts
+++ b/src/dev-app/popover-edit/popover-edit-demo.ts
@@ -7,15 +7,30 @@
  */
 
 import {Component} from '@angular/core';
-import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
-
 
 @Component({
   moduleId: module.id,
-  template: '<material-example-list [ids]="examples"></material-example-list>',
+  template: `
+    <h3>CDK popover-edit with cdk-table</h3>
+    <cdk-popover-edit-cdk-table-example></cdk-popover-edit-cdk-table-example>
+    <h3>CDK popover-edit with cdk-table flex</h3>
+    <cdk-popover-edit-cdk-table-flex-example></cdk-popover-edit-cdk-table-flex-example>
+    <h3>CDK popover-edit with vanilla table</h3>
+    <cdk-popover-edit-cell-span-vanilla-table-example>
+    </cdk-popover-edit-cell-span-vanilla-table-example>
+    <h3>CDK popover-edit with vanilla table and tab out</h3>
+    <cdk-popover-edit-tab-out-vanilla-table-example>
+    </cdk-popover-edit-tab-out-vanilla-table-example>
+    <h3>CDK popover-edit with vanilla table</h3>
+    <cdk-popover-edit-vanilla-table-example></cdk-popover-edit-vanilla-table-example>
+    <h3>Material popover-edit with mat-table and cell span</h3>
+    <popover-edit-cell-span-mat-table-example></popover-edit-cell-span-mat-table-example>
+    <h3>Material popover-edit with mat-table</h3>
+    <popover-edit-mat-table-example></popover-edit-mat-table-example>
+    <h3>Material popover-edit with mat-table flex</h3>
+    <popover-edit-mat-table-flex-example></popover-edit-mat-table-flex-example>
+    <h3>Material popover-edit with mat</h3>
+    <popover-edit-tab-out-mat-table-example></popover-edit-tab-out-mat-table-example>
+  `,
 })
-export class PopoverEditDemo {
-  examples = Object.keys(EXAMPLE_COMPONENTS)
-      .filter(example => example.startsWith('popover-edit-') ||
-          example.startsWith('cdk-popover-edit-'));
-}
+export class PopoverEditDemo {}

--- a/src/dev-app/ripple/BUILD.bazel
+++ b/src/dev-app/ripple/BUILD.bazel
@@ -11,6 +11,7 @@ ng_module(
     ],
     deps = [
         "//src/dev-app/example",
+        "//src/material-examples/material/core",
         "//src/material/button",
         "//src/material/checkbox",
         "//src/material/icon",

--- a/src/dev-app/ripple/ripple-demo-module.ts
+++ b/src/dev-app/ripple/ripple-demo-module.ts
@@ -8,17 +8,17 @@
 
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {CoreExamplesModule} from '@angular/material-examples/material/core/module';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatIconModule} from '@angular/material/icon';
 import {MatInputModule} from '@angular/material/input';
 import {RouterModule} from '@angular/router';
-import {ExampleModule} from '../example/example-module';
 import {RippleDemo} from './ripple-demo';
 
 @NgModule({
   imports: [
-    ExampleModule,
+    CoreExamplesModule,
     FormsModule,
     MatButtonModule,
     MatCheckboxModule,

--- a/src/dev-app/ripple/ripple-demo.html
+++ b/src/dev-app/ripple/ripple-demo.html
@@ -13,5 +13,6 @@
 
   <hr>
 
-  <material-example id="ripple-overview"></material-example>
+  <h3>Ripple overview example</h3>
+  <ripple-overview-example></ripple-overview-example>
 </div>

--- a/src/dev-app/table/BUILD.bazel
+++ b/src/dev-app/table/BUILD.bazel
@@ -5,9 +5,11 @@ load("//tools:defaults.bzl", "ng_module")
 ng_module(
     name = "table",
     srcs = glob(["**/*.ts"]),
+    assets = ["table-demo.html"],
     deps = [
         "//src/dev-app/example",
-        "//src/material-examples:examples",
+        "//src/material-examples/cdk/table",
+        "//src/material-examples/material/table",
         "@npm//@angular/router",
     ],
 )

--- a/src/dev-app/table/table-demo-module.ts
+++ b/src/dev-app/table/table-demo-module.ts
@@ -8,12 +8,14 @@
 
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
-import {ExampleModule} from '../example/example-module';
+import {CdkTableExamplesModule} from '@angular/material-examples/cdk/table/module';
+import {TableExamplesModule} from '@angular/material-examples/material/table/module';
 import {TableDemo} from './table-demo';
 
 @NgModule({
   imports: [
-    ExampleModule,
+    CdkTableExamplesModule,
+    TableExamplesModule,
     RouterModule.forChild([{path: '', component: TableDemo}]),
   ],
   declarations: [TableDemo],

--- a/src/dev-app/table/table-demo.html
+++ b/src/dev-app/table/table-demo.html
@@ -1,0 +1,68 @@
+<h3>Cdk table basic</h3>
+<cdk-table-basic-example></cdk-table-basic-example>
+
+<h3>Cdk table basic flex</h3>
+<cdk-table-basic-flex-example></cdk-table-basic-flex-example>
+
+<h3>Table basic</h3>
+<table-basic-example></table-basic-example>
+
+<h3>Table basic flex</h3>
+<table-basic-flex-example></table-basic-flex-example>
+
+<h3>Table dynamic columns</h3>
+<table-dynamic-columns-example></table-dynamic-columns-example>
+
+<h3>Table expandable rows</h3>
+<table-expandable-rows-example></table-expandable-rows-example>
+
+<h3>Table filtering</h3>
+<table-filtering-example></table-filtering-example>
+
+<h3>Table footer row</h3>
+<table-footer-row-example></table-footer-row-example>
+
+<h3>Table with http</h3>
+<table-http-example></table-http-example>
+
+<h3>Table with multiple headers and footers</h3>
+<table-multiple-header-footer-example></table-multiple-header-footer-example>
+
+<h3>Table overview</h3>
+<table-overview-example></table-overview-example>
+
+<h3>Table row context</h3>
+<table-row-context-example></table-row-context-example>
+
+<h3>Table with pagination</h3>
+<table-pagination-example></table-pagination-example>
+
+<h3>Table with selection</h3>
+<table-selection-example></table-selection-example>
+
+<h3>Table with sorting</h3>
+<table-sorting-example></table-sorting-example>
+
+<h3>Table with sticky columns</h3>
+<table-sticky-columns-example></table-sticky-columns-example>
+
+<h3>Table with sticky headers, footers and columns</h3>
+<table-sticky-complex-example></table-sticky-complex-example>
+
+<h3>Table flex with sticky headers, footers and columns</h3>
+<table-sticky-complex-flex-example></table-sticky-complex-flex-example>
+
+<h3>Table with sticky footer</h3>
+<table-sticky-footer-example></table-sticky-footer-example>
+
+<h3>Table with sticky header</h3>
+<table-sticky-header-example></table-sticky-header-example>
+
+<h3>Table with mat-text-column</h3>
+<table-text-column-example></table-text-column-example>
+
+<h3>Table with mat-text-column advanced</h3>
+<table-text-column-advanced-example></table-text-column-advanced-example>
+
+<h3>Table wrapped in reusable component</h3>
+<table-wrapped-example></table-wrapped-example>

--- a/src/dev-app/table/table-demo.ts
+++ b/src/dev-app/table/table-demo.ts
@@ -7,14 +7,9 @@
  */
 
 import {Component} from '@angular/core';
-import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
-
 
 @Component({
   moduleId: module.id,
-  template: '<material-example-list [ids]="examples"></material-example-list>',
+  templateUrl: './table-demo.html',
 })
-export class TableDemo {
-  examples = Object.keys(EXAMPLE_COMPONENTS)
-      .filter(example => example.startsWith('table-') || example.startsWith('cdk-table-'));
-}
+export class TableDemo {}

--- a/src/dev-app/tabs/BUILD.bazel
+++ b/src/dev-app/tabs/BUILD.bazel
@@ -8,7 +8,7 @@ ng_module(
     assets = ["tabs-demo.html"],
     deps = [
         "//src/dev-app/example",
-        "//src/material-examples:examples",
+        "//src/material-examples/material/tabs",
         "//src/material/tabs",
         "@npm//@angular/router",
     ],

--- a/src/dev-app/tabs/tabs-demo-module.ts
+++ b/src/dev-app/tabs/tabs-demo-module.ts
@@ -9,12 +9,12 @@
 import {NgModule} from '@angular/core';
 import {MatTabsModule} from '@angular/material/tabs';
 import {RouterModule} from '@angular/router';
-import {ExampleModule} from '../example/example-module';
+import {TabGroupExamplesModule} from '@angular/material-examples/material/tabs/module';
 import {TabsDemo} from './tabs-demo';
 
 @NgModule({
   imports: [
-    ExampleModule,
+    TabGroupExamplesModule,
     MatTabsModule,
     RouterModule.forChild([{path: '', component: TabsDemo}]),
   ],

--- a/src/dev-app/tabs/tabs-demo.html
+++ b/src/dev-app/tabs/tabs-demo.html
@@ -1,1 +1,22 @@
-<material-example-list [ids]="examples"></material-example-list>
+<h3>Tab group alignment</h3>
+<tab-group-align-example></tab-group-align-example>
+<h3>Tab group animations</h3>
+<tab-group-animations-example></tab-group-animations-example>
+<h3>Tab group async</h3>
+<tab-group-async-example></tab-group-async-example>
+<h3>Tab group basic</h3>
+<tab-group-basic-example></tab-group-basic-example>
+<h3>Tab group with custom label</h3>
+<tab-group-custom-label-example></tab-group-custom-label-example>
+<h3>Tab group dynamic</h3>
+<tab-group-dynamic-example></tab-group-dynamic-example>
+<h3>Tab group with dynamic height</h3>
+<tab-group-dynamic-height-example></tab-group-dynamic-height-example>
+<h3>Tab group with lazy loaded content</h3>
+<tab-group-lazy-loaded-example></tab-group-lazy-loaded-example>
+<h3>Tab group stretched</h3>
+<tab-group-stretched-example></tab-group-stretched-example>
+<h3>Tab group theming</h3>
+<tab-group-theme-example></tab-group-theme-example>
+<h3>Tab Navigation Bar basic</h3>
+<tab-nav-bar-basic-example></tab-nav-bar-basic-example>

--- a/src/dev-app/tabs/tabs-demo.ts
+++ b/src/dev-app/tabs/tabs-demo.ts
@@ -7,13 +7,10 @@
  */
 
 import {Component} from '@angular/core';
-import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
 
 @Component({
   moduleId: module.id,
   selector: 'tabs-demo',
   templateUrl: 'tabs-demo.html',
 })
-export class TabsDemo {
-  examples = Object.keys(EXAMPLE_COMPONENTS).filter(example => example.startsWith('tab-'));
-}
+export class TabsDemo {}

--- a/src/dev-app/tooltip/BUILD.bazel
+++ b/src/dev-app/tooltip/BUILD.bazel
@@ -8,7 +8,7 @@ ng_module(
     assets = ["tooltip-demo.html"],
     deps = [
         "//src/dev-app/example",
-        "//src/material-examples:examples",
+        "//src/material-examples/material/tooltip",
         "@npm//@angular/router",
     ],
 )

--- a/src/dev-app/tooltip/tooltip-demo-module.ts
+++ b/src/dev-app/tooltip/tooltip-demo-module.ts
@@ -8,12 +8,12 @@
 
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
-import {ExampleModule} from '../example/example-module';
+import {TooltipExamplesModule} from '@angular/material-examples/material/tooltip/module';
 import {TooltipDemo} from './tooltip-demo';
 
 @NgModule({
   imports: [
-    ExampleModule,
+    TooltipExamplesModule,
     RouterModule.forChild([{path: '', component: TooltipDemo}]),
   ],
   declarations: [TooltipDemo],

--- a/src/dev-app/tooltip/tooltip-demo.html
+++ b/src/dev-app/tooltip/tooltip-demo.html
@@ -1,1 +1,26 @@
-<material-example-list [ids]="examples" expandAll></material-example-list>
+<h3>Tooltip auto hide</h3>
+<tooltip-auto-hide-example></tooltip-auto-hide-example>
+
+<h3>Tooltip custom class</h3>
+<tooltip-custom-class-example></tooltip-custom-class-example>
+
+<h3>Tooltip with delay</h3>
+<tooltip-delay-example></tooltip-delay-example>
+
+<h3>Tooltip disabled</h3>
+<tooltip-disabled-example></tooltip-disabled-example>
+
+<h3>Tooltip manual</h3>
+<tooltip-manual-example></tooltip-manual-example>
+
+<h3>Tooltip message</h3>
+<tooltip-message-example></tooltip-message-example>
+
+<h3>Tooltip modified defaults</h3>
+<tooltip-modified-defaults-example></tooltip-modified-defaults-example>
+
+<h3>Tooltip overview</h3>
+<tooltip-overview-example></tooltip-overview-example>
+
+<h3>Tooltip positioning</h3>
+<tooltip-position-example></tooltip-position-example>

--- a/src/dev-app/tooltip/tooltip-demo.ts
+++ b/src/dev-app/tooltip/tooltip-demo.ts
@@ -6,13 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Component} from '@angular/core';
-import {EXAMPLE_COMPONENTS} from '@angular/material-examples';
 
 @Component({
   moduleId: module.id,
   selector: 'tooltip-demo',
   templateUrl: 'tooltip-demo.html',
 })
-export class TooltipDemo {
-  examples = Object.keys(EXAMPLE_COMPONENTS).filter(example => example.startsWith('tooltip-'));
-}
+export class TooltipDemo {}

--- a/src/dev-app/tree/BUILD.bazel
+++ b/src/dev-app/tree/BUILD.bazel
@@ -16,7 +16,8 @@ ng_module(
     ],
     deps = [
         "//src/cdk/tree",
-        "//src/dev-app/example",
+        "//src/material-examples/cdk/tree",
+        "//src/material-examples/material/tree",
         "//src/material/button",
         "//src/material/checkbox",
         "//src/material/expansion",

--- a/src/dev-app/tree/tree-demo-module.ts
+++ b/src/dev-app/tree/tree-demo-module.ts
@@ -18,8 +18,8 @@ import {MatInputModule} from '@angular/material/input';
 import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {MatTreeModule} from '@angular/material/tree';
 import {RouterModule} from '@angular/router';
-
-import {ExampleModule} from '../example/example-module';
+import {CdkTreeExamplesModule} from '@angular/material-examples/cdk/tree/module';
+import {TreeExamplesModule} from '@angular/material-examples/material/tree/module';
 
 import {ChecklistNestedTreeDemo} from './checklist-tree-demo/checklist-nested-tree-demo';
 import {ChecklistTreeDemo} from './checklist-tree-demo/checklist-tree-demo';
@@ -30,8 +30,10 @@ import {TreeDemo} from './tree-demo';
 @NgModule({
   imports: [
     CdkTreeModule,
+    CdkTreeExamplesModule,
     CommonModule,
     FormsModule,
+    TreeExamplesModule,
     MatButtonModule,
     MatExpansionModule,
     MatCheckboxModule,
@@ -40,7 +42,6 @@ import {TreeDemo} from './tree-demo';
     MatInputModule,
     MatTreeModule,
     MatProgressBarModule,
-    ExampleModule,
     RouterModule.forChild([{path: '', component: TreeDemo}]),
   ],
   declarations:

--- a/src/dev-app/tree/tree-demo.html
+++ b/src/dev-app/tree/tree-demo.html
@@ -1,19 +1,19 @@
 <mat-accordion class="demo-tree-container">
   <mat-expansion-panel>
     <mat-expansion-panel-header>Flat tree</mat-expansion-panel-header>
-    <material-example id="tree-flat-overview"></material-example>
+    <tree-flat-overview-example></tree-flat-overview-example>
   </mat-expansion-panel>
   <mat-expansion-panel>
     <mat-expansion-panel-header>CDK Flat tree</mat-expansion-panel-header>
-    <material-example id="cdk-tree-flat"></material-example>
+    <cdk-tree-flat-example></cdk-tree-flat-example>
   </mat-expansion-panel>
   <mat-expansion-panel>
     <mat-expansion-panel-header>Nested tree</mat-expansion-panel-header>
-    <material-example id="tree-nested-overview"></material-example>
+    <tree-nested-overview-example></tree-nested-overview-example>
   </mat-expansion-panel>
   <mat-expansion-panel>
     <mat-expansion-panel-header>CDK Nested tree</mat-expansion-panel-header>
-    <material-example id="cdk-tree-nested"></material-example>
+    <cdk-tree-nested-example></cdk-tree-nested-example>
   </mat-expansion-panel>
 
   <mat-expansion-panel>

--- a/src/dev-app/tsconfig.json
+++ b/src/dev-app/tsconfig.json
@@ -15,7 +15,8 @@
       "@angular/cdk-experimental": ["../cdk-experimental"],
       "@angular/material-moment-adapter": ["../material-moment-adapter/public-api.ts"],
       "@angular/google-maps": ["../google-maps"],
-      "@angular/material-examples": ["../../dist/packages/material-examples"]
+      "@angular/material-examples": ["../material-examples"],
+      "@angular/material-examples/*": ["../material-examples/*"]
     }
   },
   "include": ["./**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
       "@angular/cdk-experimental/*": ["./src/cdk-experimental/*"],
       "@angular/cdk-experimental": ["./src/cdk-experimental"],
       "@angular/material-moment-adapter": ["./src/material-moment-adapter"],
-      "@angular/material-examples": ["./src/packages/material-examples"]
+      "@angular/material-examples": ["./src/packages/material-examples"],
+      "@angular/material-examples/*": ["./src/packages/material-examples/*"]
     }
   },
   "include": [


### PR DESCRIPTION
We should not use the kitchen-sink `ExampleModule`
for showing a subset of examples in a dev-app page.

This slows down the loading page significantly since
each example is loaded. Instead we should use fine-grained
examples which will be lazy-loaded.

This opens up the possibility to speed up the dev-app
turnaround overall. i.e. by dropping the dependency
on the kitchen-sink `ExampleModule` eventually.