### PR TITLE
build: enable coercion-types rule and fix leftover cases

### DIFF
--- a/src/dev-app/example/example.ts
+++ b/src/dev-app/example/example.ts
@@ -71,4 +71,6 @@ export class Example implements OnInit {
     this._elementRef.nativeElement.appendChild(new exampleElementCtor(this._injector));
     this.title = EXAMPLE_COMPONENTS[this.id] ? EXAMPLE_COMPONENTS[this.id].title : '';
   }
+
+  static ngAcceptInputType_showLabel: boolean | string;
 }

--- a/src/material-examples/cdk/stepper/cdk-custom-stepper-without-form/cdk-custom-stepper-without-form-example.ts
+++ b/src/material-examples/cdk/stepper/cdk-custom-stepper-without-form/cdk-custom-stepper-without-form-example.ts
@@ -20,4 +20,10 @@ export class CustomStepper extends CdkStepper {
   onClick(index: number): void {
     this.selectedIndex = index;
   }
+
+  // These properties are required so that the Ivy template type checker in strict mode knows
+  // what kind of values are accepted by the `linear` and `selectedIndex` inputs which
+  // are inherited from `CdkStepper`.
+  static ngAcceptInputType_linear: boolean | string;
+  static ngAcceptInputType_selectedIndex: number | string;
 }

--- a/src/material-examples/material/slider/slider-configurable/slider-configurable-example.html
+++ b/src/material-examples/material/slider/slider-configurable/slider-configurable-example.html
@@ -55,7 +55,7 @@
         [min]="min"
         [step]="step"
         [thumbLabel]="thumbLabel"
-        [tickInterval]="tickInterval"
+        [tickInterval]="getSliderTickInterval()"
         [(ngModel)]="value"
         [vertical]="vertical">
     </mat-slider>

--- a/src/material-examples/material/slider/slider-configurable/slider-configurable-example.ts
+++ b/src/material-examples/material/slider/slider-configurable/slider-configurable-example.ts
@@ -1,4 +1,3 @@
-import {coerceNumberProperty} from '@angular/cdk/coercion';
 import {Component} from '@angular/core';
 
 /**
@@ -20,12 +19,9 @@ export class SliderConfigurableExample {
   thumbLabel = false;
   value = 0;
   vertical = false;
+  tickInterval = 1;
 
-  get tickInterval(): number | 'auto' {
-    return this.showTicks ? (this.autoTicks ? 'auto' : this._tickInterval) : 0;
+  getSliderTickInterval(): number | 'auto' {
+    return this.showTicks ? (this.autoTicks ? 'auto' : this.tickInterval) : 0;
   }
-  set tickInterval(value) {
-    this._tickInterval = coerceNumberProperty(value);
-  }
-  private _tickInterval = 1;
 }

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -290,5 +290,4 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
   static ngAcceptInputType_hidePageSize: boolean | string;
   static ngAcceptInputType_showFirstLastButtons: boolean | string;
   static ngAcceptInputType_disabled: boolean | string;
-
 }

--- a/tools/tslint-rules/coercionTypesRule.ts
+++ b/tools/tslint-rules/coercionTypesRule.ts
@@ -149,8 +149,10 @@ class Walker extends Lint.RuleWalker {
         return prop.name && ts.isIdentifier(prop.name) && prop.name.text === 'selector';
       }) : null;
 
-      return !!selector && ts.isPropertyAssignment(selector) && ts.isIdentifier(selector.name) &&
-             !selector.name.text.startsWith('do-not-use-abstract-');
+      return !!selector && ts.isPropertyAssignment(selector) &&
+        (ts.isStringLiteral(selector.initializer) ||
+         ts.isNoSubstitutionTemplateLiteral(selector.initializer)) &&
+         !selector.initializer.text.startsWith('do-not-use-abstract-');
     }
 
     return false;
@@ -180,7 +182,9 @@ function usesCoercion(setter: ts.SetAccessorDeclaration, coercionFunctions: Set<
       coercionWasUsed = true;
     }
 
-    if (!coercionWasUsed) {
+    // Don't check callback functions since coercion used
+    // inside them most-likely won't need to be declared.
+    if (!coercionWasUsed && !ts.isArrowFunction(node) && !ts.isFunctionExpression(node)) {
       node.forEachChild(walk);
     }
   });

--- a/tslint.json
+++ b/tslint.json
@@ -116,7 +116,7 @@
     "rxjs-imports": true,
     "require-breaking-change-version": true,
     "class-list-signatures": true,
-    "coercion-types": [false, // Disabled until #17528 gets in.
+    "coercion-types": [true,
       ["coerceBooleanProperty", "coerceCssPixelValue", "coerceNumberProperty"],
       {
         "CanDisable": ["disabled"],


### PR DESCRIPTION
Follow-up from #17528 that:
* Turns on the `coercion-types` rule.
* Fixes the rule not detecting abstract directives properly.
* Fixes the rule incorrectly flagging coercion functions used inside of callbacks which are inside of setters.
* Either fixes or works around a final set of failures.