### PR TITLE
fix(material/slide-toggle): fix background opacity when using CSS variable theming

### DIFF
--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -1,7 +1,33 @@
-@import '../core/style/elevation';
-@import '../core/theming/palette';
-@import '../core/theming/theming';
-@import '../core/typography/typography-utils';
+@import "../core/style/elevation";
+@import "../core/theming/palette";
+@import "../core/theming/theming";
+@import "../core/typography/typography-utils";
+
+// If the background color value is not a Sass color,
+// we assume that we've been given a CSS variable.
+// Since we can't perform alpha-blending, nor use any Sass color functions on a CSS variable,
+// we instead remove background color from mat-slide-toggle element itself
+// and utilize the ::before pseudo element by adding background color and opacity to it instead.
+@mixin _mat-slide-toggle-background-opacity($palette, $thumb-checked-hue, $opacity) {
+  $background-color: mat-color($palette, $thumb-checked-hue, $opacity);
+  @if (type-of($background-color) != color) {
+    background-color: unset;
+
+    &::before {
+      position: absolute;
+      content: "";
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      border-radius: 8px;
+      background-color: $background-color;
+      opacity: $opacity;
+    }
+  } @else {
+    background-color: $background-color;
+  }
+}
 
 @mixin _mat-slide-toggle-checked($palette, $thumb-checked-hue) {
   &.mat-checked {
@@ -12,7 +38,7 @@
     .mat-slide-toggle-bar {
       // Opacity is determined from the specs for the selection controls.
       // See: https://material.io/design/components/selection-controls.html#specs
-      background-color: mat-color($palette, $thumb-checked-hue, 0.54);
+      @include _mat-slide-toggle-background-opacity($palette, $thumb-checked-hue, 0.54);
     }
 
     .mat-ripple-element {


### PR DESCRIPTION
Fixes a bug in the Angular Material slide-toggle component where the background color doesn't have opacity when CSS variables are used to make a dynamic theme.

Since we can't perform alpha-blending, nor use any Sass color functions on a CSS variable,
we instead remove the background color from the mat-slide-toggle element itself and utilize the '_::before_' pseudo-element by adding background color and opacity to it instead.

Fixes #[17610](https://github.com/angular/components/issues/17610)