### PR TITLE
test: fix a couple of shared harness functions ignoring module parameter

### DIFF
--- a/src/material/dialog/testing/shared.spec.ts
+++ b/src/material/dialog/testing/shared.spec.ts
@@ -7,7 +7,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {MatDialogHarness} from './dialog-harness';
 
-/** Shared tests to run on both the original and MDC-based radio-button's. */
+/** Shared tests to run on both the original and MDC-based dialog's. */
 export function runHarnessTests(
     dialogModule: typeof MatDialogModule, dialogHarness: typeof MatDialogHarness) {
   let fixture: ComponentFixture<DialogHarnessTest>;
@@ -17,7 +17,7 @@ export function runHarnessTests(
   beforeEach(async () => {
     await TestBed
         .configureTestingModule({
-          imports: [MatDialogModule, NoopAnimationsModule],
+          imports: [dialogModule, NoopAnimationsModule],
           declarations: [DialogHarnessTest],
         })
         .compileComponents();

--- a/src/material/progress-spinner/testing/shared.spec.ts
+++ b/src/material/progress-spinner/testing/shared.spec.ts
@@ -2,9 +2,10 @@ import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatProgressSpinnerModule, ProgressSpinnerMode} from '@angular/material/progress-spinner';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatProgressSpinnerHarness} from './progress-spinner-harness';
 
+/** Runs the shared unit tests for the progress spinner test harness. */
 export function runHarnessTests(progressSpinnerModule: typeof MatProgressSpinnerModule,
                                 progressSpinnerHarness: typeof MatProgressSpinnerHarness) {
   let fixture: ComponentFixture<ProgressSpinnerHarnessTest>;
@@ -13,7 +14,7 @@ export function runHarnessTests(progressSpinnerModule: typeof MatProgressSpinner
   beforeEach(async () => {
     await TestBed
         .configureTestingModule({
-          imports: [MatProgressSpinnerModule],
+          imports: [progressSpinnerModule],
           declarations: [ProgressSpinnerHarnessTest],
         })
         .compileComponents();
@@ -37,8 +38,8 @@ export function runHarnessTests(progressSpinnerModule: typeof MatProgressSpinner
 
   it('should get the mode', async () => {
     const [determinate, indeterminate] = await loader.getAllHarnesses(progressSpinnerHarness);
-    expect<ProgressSpinnerMode>(await determinate.getMode()).toBe('determinate');
-    expect<ProgressSpinnerMode>(await indeterminate.getMode()).toBe('indeterminate');
+    expect(await determinate.getMode()).toBe('determinate');
+    expect(await indeterminate.getMode()).toBe('indeterminate');
   });
 }
 


### PR DESCRIPTION
Fixes the shared test functions for the dialog and progress spinner harnesses ignoring their `module` parameter and always using the Material module.