### PR TITLE
fix(sidenav): not destroying custom QueryList

### DIFF
--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -848,7 +848,20 @@ describe('MatDrawerContainer', () => {
             .toBe(true);
       }));
 
+    it('should clean up the drawers stream on destroy', fakeAsync(() => {
+      const fixture = TestBed.createComponent(DrawerContainerTwoDrawerTestApp);
+      fixture.detectChanges();
 
+      const spy = jasmine.createSpy('complete spy');
+      const subscription = fixture.componentInstance.drawerContainer._drawers.changes.subscribe({
+        complete: spy
+      });
+
+      fixture.destroy();
+
+      expect(spy).toHaveBeenCalled();
+      subscription.unsubscribe();
+    }));
 });
 
 

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -633,6 +633,7 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
   ngOnDestroy() {
     this._contentMarginChanges.complete();
     this._doCheckSubject.complete();
+    this._drawers.destroy();
     this._destroyed.next();
     this._destroyed.complete();
   }


### PR DESCRIPTION
We maintain a custom `QuestList` called `_drawers` which contains only the drawers that belong to the particular container, however we never destroy it.