### PR TITLE
Fix docs api section

### DIFF
--- a/src/cdk/clipboard/clipboard.ts
+++ b/src/cdk/clipboard/clipboard.ts
@@ -13,10 +13,6 @@ import {PendingCopy} from './pending-copy';
 
 /**
  * A service for copying text to the clipboard.
- *
- * Example usage:
- *
- * clipboard.copy("copy this text");
  */
 @Injectable({providedIn: 'root'})
 export class Clipboard {

--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -13,10 +13,6 @@ import {Clipboard} from './clipboard';
 /**
  * Provides behavior for a button that when clicked copies content into user's
  * clipboard.
- *
- * Example usage:
- *
- * `<button copyToClipboard="Content to be copied">Copy me!</button>`
  */
 @Directive({
   selector: '[cdkCopyToClipboard]',

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -26,22 +26,7 @@ import {getTreeControlFunctionsMissingError} from './tree-errors';
  * Nested node is a child of `<cdk-tree>`. It works with nested tree.
  * By using `cdk-nested-tree-node` component in tree node template, children of the parent node will
  * be added in the `cdkTreeNodeOutlet` in tree node template.
- * For example:
- *   ```html
- *   <cdk-nested-tree-node>
- *     {{node.name}}
- *     <ng-template cdkTreeNodeOutlet></ng-template>
- *   </cdk-nested-tree-node>
- *   ```
- * The children of node will be automatically added to `cdkTreeNodeOutlet`, the result dom will be
- * like this:
- *   ```html
- *   <cdk-nested-tree-node>
- *     {{node.name}}
- *      <cdk-nested-tree-node>{{child1.name}}</cdk-nested-tree-node>
- *      <cdk-nested-tree-node>{{child2.name}}</cdk-nested-tree-node>
- *   </cdk-nested-tree-node>
- *   ```
+ * The children of node will be automatically added to `cdkTreeNodeOutlet`.
  */
 @Directive({
   selector: 'cdk-nested-tree-node',


### PR DESCRIPTION
Updates documentation of `tree` and `clipboard` to avoid example usage in API section
as codes are not formatted in that section.

Fixes #17579 