### PR TITLE
test: menu test flaky due to missing animation flush

### DIFF
--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -796,6 +796,7 @@ describe('MatMenu', () => {
     fixture.detectChanges();
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
+    tick(500);
 
     expect(document.activeElement).toBe(overlayContainerElement.querySelector('.mat-menu-panel'));
   }));


### PR DESCRIPTION
One recently added test for the `menu` seems to miss a `tick`
to flush the animation. This causes the `FakeAsyncTestZone`
to report a pending timer on test completion.

See: https://app.circleci.com/jobs/github/angular/angular/514744