### PR TITLE
build: remove module id references for components in release output

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,6 +49,7 @@ yarn_install(
         "//:tools/bazel/flat_module_factory_resolution.patch",
         "//:tools/bazel/manifest_externs_hermeticity.patch",
         "//:tools/bazel/postinstall-patches.js",
+        "//:tools/bazel/remove-module-id.patch",
         "//:tools/bazel/rollup_windows_arguments.patch",
         "//:tools/npm/check-npm.js",
     ],

--- a/tools/bazel/postinstall-patches.js
+++ b/tools/bazel/postinstall-patches.js
@@ -112,6 +112,9 @@ searchAndReplace(/angular_compiler_options = {/, `$&
         "strictAttributeTypes": False,
         "strictDomEventTypes": False,`, 'node_modules/@angular/bazel/src/ng_module.bzl');
 
+// Workaround until https://github.com/angular/angular/pull/33621 has been fixed.
+shelljs.cat(path.join(__dirname, './remove-module-id.patch')).exec('patch -p0');
+
 /**
  * Reads the specified file and replaces matches of the search expression
  * with the given replacement. Throws if no changes were made.

--- a/tools/bazel/remove-module-id.patch
+++ b/tools/bazel/remove-module-id.patch
@@ -1,0 +1,24 @@
+diff --git node_modules/@angular/compiler-cli/src/transformers/inline_resources.js node_modules/@angular/compiler-cli/src/transformers/inline_resources.js
+index 993aedc..e877a94 100644
+--- node_modules/@angular/compiler-cli/src/transformers/inline_resources.js
++++ node_modules/@angular/compiler-cli/src/transformers/inline_resources.js
+@@ -78,6 +78,9 @@
+                 arg['styles'] = styles;
+                 delete arg['styleUrls'];
+             }
++            if (arg['moduleId']) {
++                delete arg['moduleId'];
++            }
+             return arg;
+         };
+         return InlineResourcesMetadataTransformer;
+@@ -271,6 +274,9 @@
+                     var template = loader.get(prop.initializer.text);
+                     newProperties.push(ts.updatePropertyAssignment(prop, ts.createIdentifier('template'), ts.createLiteral(template)));
+                     break;
++                case 'moduleId':
++                    // we don't want to add "moduleId" to the new object.
++                    break;
+                 default:
+                     newProperties.push(prop);
+             }


### PR DESCRIPTION
Currently when building the libary with Gulp, we manually inline
resources and remove the `moduleId` properties. This is actually
why https://github.com/angular/components/issues/13883 never came up until Bazel was a thing.

Since we now release with Bazel and rely on the official resource
inlining from `@angular/compiler-cli` we no longer have control to
omit the `moduleId` properties. Technically since resources are
inlined, the `moduleId` is unnecessary and can cause unexpected
behavior. So this could be considered a bug in compiler-cli.

Possible fix: https://github.com/angular/angular/pull/33621.

For now though, since it's unlikely that this is fixed upstream
in RC phase, we manually patch the NGC resource inlining transform
to also remove the `moduleId` property.

Keeping `moduleId` can cause errors in the UMD bundles like:

```
ReferenceError: module is not defined
    at eval (http://localhost:9876/base/node_modules/@angular/material/bundles/material-core.umd.js:1528:35)
```