### PR TITLE
build: set up API golden files for testing targets

### DIFF
--- a/tools/public_api_guard/material/autocomplete/testing.d.ts
+++ b/tools/public_api_guard/material/autocomplete/testing.d.ts
@@ -1,0 +1,17 @@
+export interface AutocompleteHarnessFilters extends BaseHarnessFilters {
+    value?: string | RegExp;
+}
+
+export declare class MatAutocompleteHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    enterText(value: string): Promise<void>;
+    focus(): Promise<void>;
+    getOptionGroups(filters?: OptionGroupHarnessFilters): Promise<MatAutocompleteOptionGroupHarness[]>;
+    getOptions(filters?: OptionHarnessFilters): Promise<MatAutocompleteOptionHarness[]>;
+    getValue(): Promise<string>;
+    isDisabled(): Promise<boolean>;
+    isOpen(): Promise<boolean>;
+    selectOption(filters: OptionHarnessFilters): Promise<void>;
+    static hostSelector: string;
+    static with(options?: AutocompleteHarnessFilters): HarnessPredicate<MatAutocompleteHarness>;
+}

--- a/tools/public_api_guard/material/button/testing.d.ts
+++ b/tools/public_api_guard/material/button/testing.d.ts
@@ -1,0 +1,13 @@
+export interface ButtonHarnessFilters extends BaseHarnessFilters {
+    text?: string | RegExp;
+}
+
+export declare class MatButtonHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    click(): Promise<void>;
+    focus(): Promise<void>;
+    getText(): Promise<string>;
+    isDisabled(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: ButtonHarnessFilters): HarnessPredicate<MatButtonHarness>;
+}

--- a/tools/public_api_guard/material/checkbox/testing.d.ts
+++ b/tools/public_api_guard/material/checkbox/testing.d.ts
@@ -1,0 +1,24 @@
+export interface CheckboxHarnessFilters extends BaseHarnessFilters {
+    label?: string | RegExp;
+    name?: string;
+}
+
+export declare class MatCheckboxHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    check(): Promise<void>;
+    focus(): Promise<void>;
+    getAriaLabel(): Promise<string | null>;
+    getAriaLabelledby(): Promise<string | null>;
+    getLabelText(): Promise<string>;
+    getName(): Promise<string | null>;
+    getValue(): Promise<string | null>;
+    isChecked(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    isIndeterminate(): Promise<boolean>;
+    isRequired(): Promise<boolean>;
+    isValid(): Promise<boolean>;
+    toggle(): Promise<void>;
+    uncheck(): Promise<void>;
+    static hostSelector: string;
+    static with(options?: CheckboxHarnessFilters): HarnessPredicate<MatCheckboxHarness>;
+}

--- a/tools/public_api_guard/material/dialog/testing.d.ts
+++ b/tools/public_api_guard/material/dialog/testing.d.ts
@@ -1,0 +1,13 @@
+export interface DialogHarnessFilters extends BaseHarnessFilters {
+}
+
+export declare class MatDialogHarness extends ComponentHarness {
+    close(): Promise<void>;
+    getAriaDescribedby(): Promise<string | null>;
+    getAriaLabel(): Promise<string | null>;
+    getAriaLabelledby(): Promise<string | null>;
+    getId(): Promise<string | null>;
+    getRole(): Promise<DialogRole | null>;
+    static hostSelector: string;
+    static with(options?: DialogHarnessFilters): HarnessPredicate<MatDialogHarness>;
+}

--- a/tools/public_api_guard/material/menu/testing.d.ts
+++ b/tools/public_api_guard/material/menu/testing.d.ts
@@ -1,0 +1,34 @@
+export declare class MatMenuHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    clickItem(filter: Omit<MenuItemHarnessFilters, 'ancestor'>, ...filters: Omit<MenuItemHarnessFilters, 'ancestor'>[]): Promise<void>;
+    close(): Promise<void>;
+    focus(): Promise<void>;
+    getItems(filters?: Omit<MenuItemHarnessFilters, 'ancestor'>): Promise<MatMenuItemHarness[]>;
+    getTriggerText(): Promise<string>;
+    isDisabled(): Promise<boolean>;
+    isOpen(): Promise<boolean>;
+    open(): Promise<void>;
+    static hostSelector: string;
+    static with(options?: MenuHarnessFilters): HarnessPredicate<MatMenuHarness>;
+}
+
+export declare class MatMenuItemHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    click(): Promise<void>;
+    focus(): Promise<void>;
+    getSubmenu(): Promise<MatMenuHarness | null>;
+    getText(): Promise<string>;
+    hasSubmenu(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: MenuItemHarnessFilters): HarnessPredicate<MatMenuItemHarness>;
+}
+
+export interface MenuHarnessFilters extends BaseHarnessFilters {
+    triggerText?: string | RegExp;
+}
+
+export interface MenuItemHarnessFilters extends BaseHarnessFilters {
+    hasSubmenu?: boolean;
+    text?: string | RegExp;
+}

--- a/tools/public_api_guard/material/progress-bar/testing.d.ts
+++ b/tools/public_api_guard/material/progress-bar/testing.d.ts
@@ -1,0 +1,9 @@
+export declare class MatProgressBarHarness extends ComponentHarness {
+    getMode(): Promise<string | null>;
+    getValue(): Promise<number | null>;
+    static hostSelector: string;
+    static with(options?: ProgressBarHarnessFilters): HarnessPredicate<MatProgressBarHarness>;
+}
+
+export interface ProgressBarHarnessFilters extends BaseHarnessFilters {
+}

--- a/tools/public_api_guard/material/progress-spinner/testing.d.ts
+++ b/tools/public_api_guard/material/progress-spinner/testing.d.ts
@@ -1,0 +1,9 @@
+export declare class MatProgressSpinnerHarness extends ComponentHarness {
+    getMode(): Promise<ProgressSpinnerMode>;
+    getValue(): Promise<number | null>;
+    static hostSelector: string;
+    static with(options?: ProgressSpinnerHarnessFilters): HarnessPredicate<MatProgressSpinnerHarness>;
+}
+
+export interface ProgressSpinnerHarnessFilters extends BaseHarnessFilters {
+}

--- a/tools/public_api_guard/material/radio/testing.d.ts
+++ b/tools/public_api_guard/material/radio/testing.d.ts
@@ -1,0 +1,34 @@
+export declare class MatRadioButtonHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    check(): Promise<void>;
+    focus(): Promise<void>;
+    getId(): Promise<string | null>;
+    getLabelText(): Promise<string>;
+    getName(): Promise<string | null>;
+    getValue(): Promise<string | null>;
+    isChecked(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    isRequired(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: RadioButtonHarnessFilters): HarnessPredicate<MatRadioButtonHarness>;
+}
+
+export declare class MatRadioGroupHarness extends ComponentHarness {
+    checkRadioButton(filter?: RadioButtonHarnessFilters): Promise<void>;
+    getCheckedRadioButton(): Promise<MatRadioButtonHarness | null>;
+    getCheckedValue(): Promise<string | null>;
+    getId(): Promise<string | null>;
+    getName(): Promise<string | null>;
+    getRadioButtons(filter?: RadioButtonHarnessFilters): Promise<MatRadioButtonHarness[]>;
+    static hostSelector: string;
+    static with(options?: RadioGroupHarnessFilters): HarnessPredicate<MatRadioGroupHarness>;
+}
+
+export interface RadioButtonHarnessFilters extends BaseHarnessFilters {
+    label?: string | RegExp;
+    name?: string;
+}
+
+export interface RadioGroupHarnessFilters extends BaseHarnessFilters {
+    name?: string;
+}

--- a/tools/public_api_guard/material/sidenav/testing.d.ts
+++ b/tools/public_api_guard/material/sidenav/testing.d.ts
@@ -1,0 +1,17 @@
+export interface DrawerHarnessFilters extends BaseHarnessFilters {
+    position?: 'start' | 'end';
+}
+
+export declare class MatDrawerHarness extends ComponentHarness {
+    getMode(): Promise<'over' | 'push' | 'side'>;
+    getPosition(): Promise<'start' | 'end'>;
+    isOpen(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: DrawerHarnessFilters): HarnessPredicate<MatDrawerHarness>;
+}
+
+export declare class MatSidenavHarness extends MatDrawerHarness {
+    isFixedInViewport(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: DrawerHarnessFilters): HarnessPredicate<MatDrawerHarness>;
+}

--- a/tools/public_api_guard/material/slide-toggle/testing.d.ts
+++ b/tools/public_api_guard/material/slide-toggle/testing.d.ts
@@ -1,0 +1,22 @@
+export declare class MatSlideToggleHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    check(): Promise<void>;
+    focus(): Promise<void>;
+    getAriaLabel(): Promise<string | null>;
+    getAriaLabelledby(): Promise<string | null>;
+    getLabelText(): Promise<string>;
+    getName(): Promise<string | null>;
+    isChecked(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    isRequired(): Promise<boolean>;
+    isValid(): Promise<boolean>;
+    toggle(): Promise<void>;
+    uncheck(): Promise<void>;
+    static hostSelector: string;
+    static with(options?: SlideToggleHarnessFilters): HarnessPredicate<MatSlideToggleHarness>;
+}
+
+export interface SlideToggleHarnessFilters extends BaseHarnessFilters {
+    label?: string | RegExp;
+    name?: string;
+}

--- a/tools/public_api_guard/material/slider/testing.d.ts
+++ b/tools/public_api_guard/material/slider/testing.d.ts
@@ -1,0 +1,18 @@
+export declare class MatSliderHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    focus(): Promise<void>;
+    getDisplayValue(): Promise<string | null>;
+    getId(): Promise<string | null>;
+    getMaxValue(): Promise<number>;
+    getMinValue(): Promise<number>;
+    getOrientation(): Promise<'horizontal' | 'vertical'>;
+    getPercentage(): Promise<number>;
+    getValue(): Promise<number>;
+    isDisabled(): Promise<boolean>;
+    setValue(value: number): Promise<void>;
+    static hostSelector: string;
+    static with(options?: SliderHarnessFilters): HarnessPredicate<MatSliderHarness>;
+}
+
+export interface SliderHarnessFilters extends BaseHarnessFilters {
+}

--- a/tools/public_api_guard/material/snack-bar/testing.d.ts
+++ b/tools/public_api_guard/material/snack-bar/testing.d.ts
@@ -1,0 +1,12 @@
+export declare class MatSnackBarHarness extends ComponentHarness {
+    dismissWithAction(): Promise<void>;
+    getActionDescription(): Promise<string>;
+    getMessage(): Promise<string>;
+    getRole(): Promise<'alert' | 'status' | null>;
+    hasAction(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: SnackBarHarnessFilters): HarnessPredicate<MatSnackBarHarness>;
+}
+
+export interface SnackBarHarnessFilters extends BaseHarnessFilters {
+}

--- a/tools/public_api_guard/material/tabs/testing.d.ts
+++ b/tools/public_api_guard/material/tabs/testing.d.ts
@@ -1,0 +1,28 @@
+export declare class MatTabGroupHarness extends ComponentHarness {
+    getSelectedTab(): Promise<MatTabHarness>;
+    getTabs(filter?: TabHarnessFilters): Promise<MatTabHarness[]>;
+    selectTab(filter?: TabHarnessFilters): Promise<void>;
+    static hostSelector: string;
+    static with(options?: TabGroupHarnessFilters): HarnessPredicate<MatTabGroupHarness>;
+}
+
+export declare class MatTabHarness extends ComponentHarness {
+    getAriaLabel(): Promise<string | null>;
+    getAriaLabelledby(): Promise<string | null>;
+    getHarnessLoaderForContent(): Promise<HarnessLoader>;
+    getLabel(): Promise<string>;
+    getTextContent(): Promise<string>;
+    isDisabled(): Promise<boolean>;
+    isSelected(): Promise<boolean>;
+    select(): Promise<void>;
+    static hostSelector: string;
+    static with(options?: TabHarnessFilters): HarnessPredicate<MatTabHarness>;
+}
+
+export interface TabGroupHarnessFilters extends BaseHarnessFilters {
+    selectedTabLabel?: string | RegExp;
+}
+
+export interface TabHarnessFilters extends BaseHarnessFilters {
+    label?: string | RegExp;
+}


### PR DESCRIPTION
Since the testing targets are now part of the public API, we should have API golden files so we don't introduce breaking changes by accident.