### PR TITLE
#16289: prevent tab switching

### DIFF
--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -65,6 +65,21 @@ describe('MatTabGroup', () => {
       checkSelectedIndex(2, fixture);
     });
 
+    it('should not change selected index when canActivate return false', fakeAsync(() => {
+      let component = fixture.componentInstance;
+      component.selectedIndex = 0;
+      component.canActivate = () => false;
+
+      fixture.detectChanges();
+
+      let tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
+      tabLabel.nativeElement.click();
+      fixture.detectChanges();
+      tick();
+
+      expect(component.selectedIndex).toBe(0);
+    }));
+
     it('should support two-way binding for selectedIndex', fakeAsync(() => {
       let component = fixture.componentInstance;
       component.selectedIndex = 0;
@@ -680,6 +695,7 @@ describe('nested MatTabGroup with enabled animations', () => {
     <mat-tab-group class="tab-group"
         [(selectedIndex)]="selectedIndex"
         [headerPosition]="headerPosition"
+        [canActivate]="canActivate"
         [disableRipple]="disableRipple"
         (animationDone)="animationDone()"
         (focusChange)="handleFocus($event)"
@@ -702,6 +718,7 @@ describe('nested MatTabGroup with enabled animations', () => {
 class SimpleTabsTestApp {
   @ViewChildren(MatTab) tabs: QueryList<MatTab>;
   selectedIndex: number = 1;
+  canActivate: Function = () => true;
   focusEvent: any;
   selectEvent: any;
   disableRipple: boolean = false;

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -142,6 +142,11 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
   @Input()
   disablePagination: boolean;
 
+  /**
+   * a pass down function that determine if tab can be switch, by default it will return true.
+   */
+  @Input() canActivate: Function = () => true;
+
   /** Background color of the tab group. */
   @Input()
   get backgroundColor(): ThemePalette { return this._backgroundColor; }
@@ -367,7 +372,7 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
 
   /** Handle click events, setting new selected index if appropriate. */
   _handleClick(tab: MatTab, tabHeader: MatTabGroupBaseHeader, index: number) {
-    if (!tab.disabled) {
+    if (!tab.disabled && this.canActivate()) {
       this.selectedIndex = tabHeader.focusIndex = index;
     }
   }

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -44,6 +44,7 @@ export declare abstract class _MatTabGroupBase extends _MatTabGroupMixinBase imp
     readonly focusChange: EventEmitter<MatTabChangeEvent>;
     headerPosition: MatTabHeaderPosition;
     selectedIndex: number | null;
+    canActivate: Function;
     readonly selectedIndexChange: EventEmitter<number>;
     readonly selectedTabChange: EventEmitter<MatTabChangeEvent>;
     constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, defaultConfig?: MatTabsConfig, _animationMode?: string | undefined);


### PR DESCRIPTION
feat(material/tab): prevent tab switching

Add a new input param function to tab group component.
This feature allow user to prevent tab switching base on the return value of the function.

Fixes #16289