### PR TITLE
refactor: allow coercion inputs to work with async pipe

### DIFF
--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -464,6 +464,6 @@ export class CdkAutoSizeVirtualScroll implements OnChanges {
     this._scrollStrategy.updateBufferSize(this.minBufferPx, this.maxBufferPx);
   }
 
-  static ngAcceptInputType_minBufferPx: number | string;
-  static ngAcceptInputType_maxBufferPx: number | string;
+  static ngAcceptInputType_minBufferPx: number | string | null | undefined;
+  static ngAcceptInputType_maxBufferPx: number | string | null | undefined;
 }

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -419,6 +419,6 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit, DoCheck {
     }
   }
 
-  static ngAcceptInputType_enabled: boolean | string;
-  static ngAcceptInputType_autoCapture: boolean | string;
+  static ngAcceptInputType_enabled: boolean | string | null | undefined;
+  static ngAcceptInputType_autoCapture: boolean | string | null | undefined;
 }

--- a/src/cdk/accordion/accordion-item.ts
+++ b/src/cdk/accordion/accordion-item.ts
@@ -153,6 +153,6 @@ export class CdkAccordionItem implements OnDestroy {
     });
   }
 
-  static ngAcceptInputType_expanded: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_expanded: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/cdk/accordion/accordion.ts
+++ b/src/cdk/accordion/accordion.ts
@@ -60,5 +60,5 @@ export class CdkAccordion implements OnDestroy, OnChanges {
     }
   }
 
-  static ngAcceptInputType_multi: boolean | string;
+  static ngAcceptInputType_multi: boolean | string | null | undefined;
 }

--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -47,5 +47,5 @@ export class CdkDragHandle implements OnDestroy {
     this._stateChanges.complete();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -409,7 +409,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     });
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }
 
 /** Gets the closest ancestor of an element that matches a selector. */

--- a/src/cdk/drag-drop/directives/drop-list-group.ts
+++ b/src/cdk/drag-drop/directives/drop-list-group.ts
@@ -35,5 +35,5 @@ export class CdkDropListGroup<T> implements OnDestroy {
     this._items.clear();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -328,7 +328,7 @@ export class CdkDropList<T = any> implements AfterContentInit, OnDestroy {
     });
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_sortingDisabled: boolean | string;
-  static ngAcceptInputType_autoScrollDisabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_sortingDisabled: boolean | string | null | undefined;
+  static ngAcceptInputType_autoScrollDisabled: boolean | string | null | undefined;
 }

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -194,8 +194,8 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_debounce: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_debounce: boolean | string | null | undefined;
 }
 
 

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -384,11 +384,11 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
     this._backdropSubscription.unsubscribe();
   }
 
-  static ngAcceptInputType_hasBackdrop: boolean | string;
-  static ngAcceptInputType_lockPosition: boolean | string;
-  static ngAcceptInputType_flexibleDimensions: boolean | string;
-  static ngAcceptInputType_growAfterOpen: boolean | string;
-  static ngAcceptInputType_push: boolean | string;
+  static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
+  static ngAcceptInputType_lockPosition: boolean | string | null | undefined;
+  static ngAcceptInputType_flexibleDimensions: boolean | string | null | undefined;
+  static ngAcceptInputType_growAfterOpen: boolean | string | null | undefined;
+  static ngAcceptInputType_push: boolean | string | null | undefined;
 }
 
 

--- a/src/cdk/scrolling/fixed-size-virtual-scroll.ts
+++ b/src/cdk/scrolling/fixed-size-virtual-scroll.ts
@@ -204,7 +204,7 @@ export class CdkFixedSizeVirtualScroll implements OnChanges {
     this._scrollStrategy.updateItemAndBufferSize(this.itemSize, this.minBufferPx, this.maxBufferPx);
   }
 
-  static ngAcceptInputType_itemSize: string | number;
-  static ngAcceptInputType_minBufferPx: string | number;
-  static ngAcceptInputType_maxBufferPx: string | number;
+  static ngAcceptInputType_itemSize: string | number | null | undefined;
+  static ngAcceptInputType_minBufferPx: string | number | null | undefined;
+  static ngAcceptInputType_maxBufferPx: string | number | null | undefined;
 }

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -231,10 +231,10 @@ export class CdkStep implements OnChanges {
     this._stepper._stateChanged();
   }
 
-  static ngAcceptInputType_editable: boolean | string;
-  static ngAcceptInputType_hasError: boolean | string;
-  static ngAcceptInputType_optional: boolean | string;
-  static ngAcceptInputType_completed: boolean | string;
+  static ngAcceptInputType_editable: boolean | string | null | undefined;
+  static ngAcceptInputType_hasError: boolean | string | null | undefined;
+  static ngAcceptInputType_optional: boolean | string | null | undefined;
+  static ngAcceptInputType_completed: boolean | string | null | undefined;
 }
 
 @Directive({
@@ -524,12 +524,12 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
     return stepperElement === focusedElement || stepperElement.contains(focusedElement);
   }
 
-  static ngAcceptInputType_editable: boolean | string;
-  static ngAcceptInputType_optional: boolean | string;
-  static ngAcceptInputType_completed: boolean | string;
-  static ngAcceptInputType_hasError: boolean | string;
-  static ngAcceptInputType_linear: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_editable: boolean | string | null | undefined;
+  static ngAcceptInputType_optional: boolean | string | null | undefined;
+  static ngAcceptInputType_completed: boolean | string | null | undefined;
+  static ngAcceptInputType_hasError: boolean | string | null | undefined;
+  static ngAcceptInputType_linear: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }
 
 

--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -108,8 +108,8 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
    */
   cssClassFriendlyName: string;
 
-  static ngAcceptInputType_sticky: boolean | string;
-  static ngAcceptInputType_stickyEnd: boolean | string;
+  static ngAcceptInputType_sticky: boolean | string | null | undefined;
+  static ngAcceptInputType_stickyEnd: boolean | string | null | undefined;
 }
 
 /** Base class for the cells. Adds a CSS classname that identifies the column it renders in. */

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -100,7 +100,7 @@ export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, O
     super.ngOnChanges(changes);
   }
 
-  static ngAcceptInputType_sticky: boolean | string;
+  static ngAcceptInputType_sticky: boolean | string | null | undefined;
 }
 
 // Boilerplate for applying mixins to CdkFooterRowDef.
@@ -128,7 +128,7 @@ export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, O
     super.ngOnChanges(changes);
   }
 
-  static ngAcceptInputType_sticky: boolean | string;
+  static ngAcceptInputType_sticky: boolean | string | null | undefined;
 }
 
 /**

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -1077,7 +1077,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
         });
   }
 
-  static ngAcceptInputType_multiTemplateDataRows: boolean | string;
+  static ngAcceptInputType_multiTemplateDataRows: boolean | string | null | undefined;
 }
 
 /** Utility function that gets a merged list of the entries in a QueryList and values of a Set. */

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -273,7 +273,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     }
   }
 
-  static ngAcceptInputType_minRows: number | string;
-  static ngAcceptInputType_maxRows: number | string;
-  static ngAcceptInputType_enabled: boolean | string;
+  static ngAcceptInputType_minRows: number | string | null | undefined;
+  static ngAcceptInputType_maxRows: number | string | null | undefined;
+  static ngAcceptInputType_enabled: boolean | string | null | undefined;
 }

--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -110,5 +110,5 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
     }
   }
 
-  static ngAcceptInputType_level: number | string;
+  static ngAcceptInputType_level: number | string | null | undefined;
 }

--- a/src/cdk/tree/toggle.ts
+++ b/src/cdk/tree/toggle.ts
@@ -39,5 +39,5 @@ export class CdkTreeNodeToggle<T> {
     event.stopPropagation();
   }
 
-  static ngAcceptInputType_recursive: boolean | string;
+  static ngAcceptInputType_recursive: boolean | string | null | undefined;
 }

--- a/src/components-examples/cdk/stepper/cdk-custom-stepper-without-form/cdk-custom-stepper-without-form-example.ts
+++ b/src/components-examples/cdk/stepper/cdk-custom-stepper-without-form/cdk-custom-stepper-without-form-example.ts
@@ -24,6 +24,6 @@ export class CustomStepper extends CdkStepper {
   // These properties are required so that the Ivy template type checker in strict mode knows
   // what kind of values are accepted by the `linear` and `selectedIndex` inputs which
   // are inherited from `CdkStepper`.
-  static ngAcceptInputType_linear: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_linear: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }

--- a/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
@@ -150,6 +150,6 @@ export class MyTelInput implements ControlValueAccessor, MatFormFieldControl<MyT
     this.onChange(this.parts.value);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
 }

--- a/src/dev-app/example/example-list.ts
+++ b/src/dev-app/example/example-list.ts
@@ -66,5 +66,5 @@ export class ExampleList {
 
   exampleComponents = EXAMPLE_COMPONENTS;
 
-  static ngAcceptInputType_expandAll: boolean | string;
+  static ngAcceptInputType_expandAll: boolean | string | null | undefined;
 }

--- a/src/dev-app/example/example.ts
+++ b/src/dev-app/example/example.ts
@@ -72,5 +72,5 @@ export class Example implements OnInit {
     this.title = EXAMPLE_COMPONENTS[this.id] ? EXAMPLE_COMPONENTS[this.id].title : '';
   }
 
-  static ngAcceptInputType_showLabel: boolean | string;
+  static ngAcceptInputType_showLabel: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-button/button.ts
+++ b/src/material-experimental/mdc-button/button.ts
@@ -56,8 +56,8 @@ export class MatButton extends MatButtonBase {
     super(elementRef, platform, ngZone, animationMode);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 
 /**
@@ -87,6 +87,6 @@ export class MatAnchor extends MatAnchorBase {
     super(elementRef, platform, ngZone, animationMode);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-button/fab.ts
+++ b/src/material-experimental/mdc-button/fab.ts
@@ -55,8 +55,8 @@ export class MatFabButton extends MatButtonBase {
     super(elementRef, platform, ngZone, animationMode);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 
 
@@ -87,6 +87,6 @@ export class MatFabAnchor extends MatAnchor {
     super(elementRef, platform, ngZone, animationMode);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-button/icon-button.ts
+++ b/src/material-experimental/mdc-button/icon-button.ts
@@ -52,8 +52,8 @@ export class MatIconButton extends MatButtonBase {
     super(elementRef, platform, ngZone, animationMode);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 
 /**
@@ -81,6 +81,6 @@ export class MatIconAnchor extends MatAnchorBase {
     super(elementRef, platform, ngZone, animationMode);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -370,9 +370,9 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
     this._changeDetectorRef.markForCheck();
   }
 
-  static ngAcceptInputType_checked: boolean | string;
-  static ngAcceptInputType_indeterminate: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_checked: boolean | string | null | undefined;
+  static ngAcceptInputType_indeterminate: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -520,6 +520,6 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     return false;
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-chips/chip-icons.ts
+++ b/src/material-experimental/mdc-chips/chip-icons.ts
@@ -121,5 +121,5 @@ export class MatChipRemove extends _MatChipRemoveMixinBase implements CanDisable
     super(_elementRef);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-chips/chip-input.ts
+++ b/src/material-experimental/mdc-chips/chip-input.ts
@@ -171,6 +171,6 @@ export class MatChipInput implements MatChipTextControl, OnChanges {
     return Array.isArray(separators) ? separators.indexOf(keyCode) > -1 : separators.has(keyCode);
   }
 
-  static ngAcceptInputType_addOnBlur: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_addOnBlur: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-chips/chip-listbox.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.ts
@@ -554,9 +554,9 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
     this._lastDestroyedChipIndex = null;
   }
 
-  static ngAcceptInputType_multiple: boolean | string;
-  static ngAcceptInputType_selectable: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_multiple: boolean | string | null | undefined;
+  static ngAcceptInputType_selectable: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }
 

--- a/src/material-experimental/mdc-chips/chip-option.ts
+++ b/src/material-experimental/mdc-chips/chip-option.ts
@@ -226,10 +226,10 @@ export class MatChipOption extends MatChip {
     }
   }
 
-  static ngAcceptInputType_selectable: boolean | string;
-  static ngAcceptInputType_selected: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_removable: boolean | string;
-  static ngAcceptInputType_highlighted: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_selectable: boolean | string | null | undefined;
+  static ngAcceptInputType_selected: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_removable: boolean | string | null | undefined;
+  static ngAcceptInputType_highlighted: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -150,8 +150,8 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_removable: boolean | string;
-  static ngAcceptInputType_highlighted: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_removable: boolean | string | null | undefined;
+  static ngAcceptInputType_highlighted: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-chips/chip-set.ts
+++ b/src/material-experimental/mdc-chips/chip-set.ts
@@ -304,6 +304,6 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterContentInit
     return false;
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }
 

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -389,8 +389,8 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_removable: boolean | string;
-  static ngAcceptInputType_highlighted: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_removable: boolean | string | null | undefined;
+  static ngAcceptInputType_highlighted: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-menu/menu-item.ts
+++ b/src/material-experimental/mdc-menu/menu-item.ts
@@ -34,6 +34,6 @@ import {MatMenuItem as BaseMatMenuItem} from '@angular/material/menu';
   ]
 })
 export class MatMenuItem extends BaseMatMenuItem {
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-menu/menu.ts
+++ b/src/material-experimental/mdc-menu/menu.ts
@@ -71,6 +71,6 @@ export class MatMenu extends BaseMatMenu {
     // - should not increase the elevation if the user specified a custom one
   }
 
-  static ngAcceptInputType_overlapTrigger: boolean | string;
-  static ngAcceptInputType_hasBackdrop: boolean | string;
+  static ngAcceptInputType_overlapTrigger: boolean | string | null | undefined;
+  static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -80,5 +80,5 @@ export class MatRadioButton implements AfterViewInit, OnDestroy {
     this._changeDetectorRef.markForCheck();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
@@ -312,9 +312,9 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
     this._changeDetectorRef.markForCheck();
   }
 
-  static ngAcceptInputType_tabIndex: number | string;
-  static ngAcceptInputType_required: boolean | string;
-  static ngAcceptInputType_checked: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_tabIndex: number | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+  static ngAcceptInputType_checked: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -542,11 +542,11 @@ export class MatSlider implements AfterViewInit, OnChanges, OnDestroy, ControlVa
     this._syncValue();
   }
 
-  static ngAcceptInputType_min: number | string;
-  static ngAcceptInputType_max: number | string;
-  static ngAcceptInputType_value: number | string;
-  static ngAcceptInputType_step: number | string;
-  static ngAcceptInputType_tickInterval: number | string;
-  static ngAcceptInputType_thumbLabel: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_min: number | string | null | undefined;
+  static ngAcceptInputType_max: number | string | null | undefined;
+  static ngAcceptInputType_value: number | string | null | undefined;
+  static ngAcceptInputType_step: number | string | null | undefined;
+  static ngAcceptInputType_tickInterval: number | string | null | undefined;
+  static ngAcceptInputType_thumbLabel: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-tabs/tab-group.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.ts
@@ -73,9 +73,9 @@ export class MatTabGroup extends _MatTabGroupBase {
         defaultConfig.fitInkBarToContent : false;
   }
 
-  static ngAcceptInputType_fitInkBarToContent: boolean | string;
-  static ngAcceptInputType_dynamicHeight: boolean | string;
-  static ngAcceptInputType_animationDuration: number | string;
-  static ngAcceptInputType_selectedIndex: number | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_fitInkBarToContent: boolean | string | null | undefined;
+  static ngAcceptInputType_dynamicHeight: boolean | string | null | undefined;
+  static ngAcceptInputType_animationDuration: number | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-tabs/tab-header.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.ts
@@ -73,6 +73,6 @@ export class MatTabHeader extends _MatTabHeaderBase implements AfterContentInit 
     super.ngAfterContentInit();
   }
 
-  static ngAcceptInputType_disableRipple: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }

--- a/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
+++ b/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
@@ -54,6 +54,6 @@ export class MatTabLabelWrapper extends BaseMatTabLabelWrapper
     this.elementRef.nativeElement.focus();
   }
 
-  static ngAcceptInputType_fitInkBarToContent: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_fitInkBarToContent: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -99,9 +99,9 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
     super.ngAfterContentInit();
   }
 
-  static ngAcceptInputType_fitInkBarToContent: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_fitInkBarToContent: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }
 
 /**
@@ -154,6 +154,6 @@ export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnInit
     this._foundation.destroy();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material-experimental/mdc-tabs/tab.ts
+++ b/src/material-experimental/mdc-tabs/tab.ts
@@ -39,5 +39,5 @@ export class MatTab extends BaseMatTab {
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
   @ContentChild(MatTabLabel) templateLabel: MatTabLabel;
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -759,5 +759,5 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
     return !element.readOnly && !element.disabled && !this._autocompleteDisabled;
   }
 
-  static ngAcceptInputType_autocompleteDisabled: boolean | string;
+  static ngAcceptInputType_autocompleteDisabled: boolean | string | null | undefined;
 }

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -221,7 +221,7 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
     classList['mat-autocomplete-hidden'] = !this.showPanel;
   }
 
-  static ngAcceptInputType_autoActiveFirstOption: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_autoActiveFirstOption: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -270,7 +270,7 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_hidden: boolean | string;
-  static ngAcceptInputType_overlap: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_hidden: boolean | string | null | undefined;
+  static ngAcceptInputType_overlap: boolean | string | null | undefined;
 }

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -369,9 +369,9 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
     this.valueChange.emit(this.value);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_multiple: boolean | string;
-  static ngAcceptInputType_vertical: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_multiple: boolean | string | null | undefined;
+  static ngAcceptInputType_vertical: boolean | string | null | undefined;
 }
 
 // Boilerplate for applying mixins to the MatButtonToggle class.
@@ -560,9 +560,9 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
     this._changeDetectorRef.markForCheck();
   }
 
-  static ngAcceptInputType_checked: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_vertical: boolean | string;
-  static ngAcceptInputType_multiple: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_checked: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_vertical: boolean | string | null | undefined;
+  static ngAcceptInputType_multiple: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -135,8 +135,8 @@ export class MatButton extends _MatButtonMixinBase
     return attributes.some(attribute => this._getHostElement().hasAttribute(attribute));
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 
 /**
@@ -181,6 +181,6 @@ export class MatAnchor extends MatButton {
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -470,7 +470,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
     return `mat-checkbox-anim-${animSuffix}`;
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -171,6 +171,6 @@ export class MatChipInput implements MatChipTextControl, OnChanges {
     return Array.isArray(separators) ? separators.indexOf(keyCode) > -1 : separators.has(keyCode);
   }
 
-  static ngAcceptInputType_addOnBlur: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_addOnBlur: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -810,8 +810,8 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     }
   }
 
-  static ngAcceptInputType_multiple: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_selectable: boolean | string;
+  static ngAcceptInputType_multiple: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_selectable: boolean | string | null | undefined;
 }

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -389,11 +389,11 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     }
   }
 
-  static ngAcceptInputType_selected: boolean | string;
-  static ngAcceptInputType_selectable: boolean | string;
-  static ngAcceptInputType_removable: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_selected: boolean | string | null | undefined;
+  static ngAcceptInputType_selectable: boolean | string | null | undefined;
+  static ngAcceptInputType_removable: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 
 

--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -45,5 +45,5 @@ export class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
   /** Unique id for the underlying label. */
   _labelId: string = `mat-optgroup-label-${_uniqueOptgroupIdCounter++}`;
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -267,7 +267,7 @@ export class MatOption implements FocusableOption, AfterViewChecked, OnDestroy {
     this.onSelectionChange.emit(new MatOptionSelectionChange(this, isUserInput));
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }
 
 /**

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -367,7 +367,7 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
     return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 
   // Accept `any` to avoid conflicts with other directives on `<input>` that
   // may accept different types.

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -132,5 +132,5 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
     ).subscribe(() => this._changeDetectorRef.markForCheck());
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/datepicker/datepicker.ts
+++ b/src/material/datepicker/datepicker.ts
@@ -521,6 +521,6 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_touchUi: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_touchUi: boolean | string | null | undefined;
 }

--- a/src/material/divider/divider.ts
+++ b/src/material/divider/divider.ts
@@ -37,6 +37,6 @@ export class MatDivider {
   set inset(value: boolean) { this._inset = coerceBooleanProperty(value); }
   private _inset: boolean = false;
 
-  static ngAcceptInputType_vertical: boolean | string;
-  static ngAcceptInputType_inset: boolean | string;
+  static ngAcceptInputType_vertical: boolean | string | null | undefined;
+  static ngAcceptInputType_inset: boolean | string | null | undefined;
 }

--- a/src/material/expansion/accordion.ts
+++ b/src/material/expansion/accordion.ts
@@ -87,6 +87,6 @@ export class MatAccordion extends CdkAccordion implements MatAccordionBase, Afte
     this._keyManager.updateActiveItem(header);
   }
 
-  static ngAcceptInputType_hideToggle: boolean | string;
-  static ngAcceptInputType_multi: boolean | string;
+  static ngAcceptInputType_hideToggle: boolean | string | null | undefined;
+  static ngAcceptInputType_multi: boolean | string | null | undefined;
 }

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -229,9 +229,9 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
     return false;
   }
 
-  static ngAcceptInputType_hideToggle: boolean | string;
-  static ngAcceptInputType_expanded: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_hideToggle: boolean | string | null | undefined;
+  static ngAcceptInputType_expanded: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }
 
 @Directive({

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -598,5 +598,5 @@ export class MatFormField extends _MatFormFieldMixinBase
     return document.documentElement!.contains(element);
   }
 
-  static ngAcceptInputType_hideRequiredMarker: boolean | string;
+  static ngAcceptInputType_hideRequiredMarker: boolean | string | null | undefined;
 }

--- a/src/material/grid-list/grid-list.ts
+++ b/src/material/grid-list/grid-list.ts
@@ -170,5 +170,5 @@ export class MatGridList implements MatGridListBase, OnInit, AfterContentChecked
     }
   }
 
-  static ngAcceptInputType_cols: number | string;
+  static ngAcceptInputType_cols: number | string | null | undefined;
 }

--- a/src/material/grid-list/grid-tile.ts
+++ b/src/material/grid-list/grid-tile.ts
@@ -60,8 +60,8 @@ export class MatGridTile {
     (this._element.nativeElement.style as any)[property] = value;
   }
 
-  static ngAcceptInputType_rowspan: number | string;
-  static ngAcceptInputType_colspan: number | string;
+  static ngAcceptInputType_rowspan: number | string | null | undefined;
+  static ngAcceptInputType_colspan: number | string | null | undefined;
 }
 
 @Component({

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -419,5 +419,5 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Aft
     }
   }
 
-  static ngAcceptInputType_inline: boolean | string;
+  static ngAcceptInputType_inline: boolean | string | null | undefined;
 }

--- a/src/material/input/autosize.ts
+++ b/src/material/input/autosize.ts
@@ -43,7 +43,7 @@ export class MatTextareaAutosize extends CdkTextareaAutosize {
   get matTextareaAutosize(): boolean { return this.enabled; }
   set matTextareaAutosize(value: boolean) { this.enabled = value; }
 
-  static ngAcceptInputType_minRows: number | string;
-  static ngAcceptInputType_maxRows: number | string;
-  static ngAcceptInputType_enabled: boolean | string;
+  static ngAcceptInputType_minRows: number | string | null | undefined;
+  static ngAcceptInputType_maxRows: number | string | null | undefined;
+  static ngAcceptInputType_enabled: boolean | string | null | undefined;
 }

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -417,9 +417,9 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_readonly: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_readonly: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
 
   // Accept `any` to avoid conflicts with other directives on `<input>` that may
   // accept different types.

--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -69,7 +69,7 @@ export class MatNavList extends _MatListMixinBase implements CanDisableRipple, O
     this._stateChanges.complete();
   }
 
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 
 @Component({
@@ -118,7 +118,7 @@ export class MatList extends _MatListMixinBase implements CanDisableRipple, OnCh
     this._stateChanges.complete();
   }
 
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 
 /**
@@ -221,5 +221,5 @@ export class MatListItem extends _MatListItemMixinBase implements AfterContentIn
     return this._element.nativeElement;
   }
 
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -305,9 +305,9 @@ export class MatListOption extends _MatListOptionMixinBase implements AfterConte
     this._changeDetector.markForCheck();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_selected: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_selected: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }
 
 
@@ -640,6 +640,6 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -173,6 +173,6 @@ export class MatMenuItem extends _MatMenuItemMixinBase
     return output.trim();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -496,6 +496,6 @@ export class _MatMenu extends MatMenu {
     super(elementRef, ngZone, defaultOptions);
   }
 
-  static ngAcceptInputType_overlapTrigger: boolean | string;
-  static ngAcceptInputType_hasBackdrop: boolean | string;
+  static ngAcceptInputType_overlapTrigger: boolean | string | null | undefined;
+  static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
 }

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -283,10 +283,10 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
     });
   }
 
-  static ngAcceptInputType_pageIndex: number | string;
-  static ngAcceptInputType_length: number | string;
-  static ngAcceptInputType_pageSize: number | string;
-  static ngAcceptInputType_hidePageSize: boolean | string;
-  static ngAcceptInputType_showFirstLastButtons: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_pageIndex: number | string | null | undefined;
+  static ngAcceptInputType_length: number | string | null | undefined;
+  static ngAcceptInputType_pageSize: number | string | null | undefined;
+  static ngAcceptInputType_hidePageSize: boolean | string | null | undefined;
+  static ngAcceptInputType_showFirstLastButtons: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -219,7 +219,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
     }
   }
 
-  static ngAcceptInputType_value: number | string;
+  static ngAcceptInputType_value: number | string | null | undefined;
 }
 
 /** Clamps a value to be between two numbers, by default 0 and 100. */

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -295,9 +295,9 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
         .replace(/DIAMETER/g, `${this.diameter}`);
   }
 
-  static ngAcceptInputType_diameter: number | string;
-  static ngAcceptInputType_strokeWidth: number | string;
-  static ngAcceptInputType_value: number | string;
+  static ngAcceptInputType_diameter: number | string | null | undefined;
+  static ngAcceptInputType_strokeWidth: number | string | null | undefined;
+  static ngAcceptInputType_value: number | string | null | undefined;
 }
 
 
@@ -333,9 +333,9 @@ export class MatSpinner extends MatProgressSpinner {
     this.mode = 'indeterminate';
   }
 
-  static ngAcceptInputType_diameter: number | string;
-  static ngAcceptInputType_strokeWidth: number | string;
-  static ngAcceptInputType_value: number | string;
+  static ngAcceptInputType_diameter: number | string | null | undefined;
+  static ngAcceptInputType_strokeWidth: number | string | null | undefined;
+  static ngAcceptInputType_value: number | string | null | undefined;
 }
 
 

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -307,8 +307,8 @@ export class MatRadioGroup implements AfterContentInit, ControlValueAccessor {
     this._changeDetector.markForCheck();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
 }
 
 // Boilerplate for applying mixins to MatRadioButton.
@@ -597,8 +597,8 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
     }
   }
 
-  static ngAcceptInputType_checked: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_required: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_checked: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -1339,10 +1339,10 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     return this._panelOpen || !this.empty;
   }
 
-  static ngAcceptInputType_required: boolean | string;
-  static ngAcceptInputType_multiple: boolean | string;
-  static ngAcceptInputType_disableOptionCentering: boolean | string;
-  static ngAcceptInputType_typeaheadDebounceInterval: number | string;
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+  static ngAcceptInputType_multiple: boolean | string | null | undefined;
+  static ngAcceptInputType_disableOptionCentering: boolean | string | null | undefined;
+  static ngAcceptInputType_typeaheadDebounceInterval: number | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -452,9 +452,9 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
     this._animationEnd.next(event);
   }
 
-  static ngAcceptInputType_disableClose: boolean | string;
-  static ngAcceptInputType_autoFocus: boolean | string;
-  static ngAcceptInputType_opened: boolean | string;
+  static ngAcceptInputType_disableClose: boolean | string | null | undefined;
+  static ngAcceptInputType_autoFocus: boolean | string | null | undefined;
+  static ngAcceptInputType_opened: boolean | string | null | undefined;
 }
 
 
@@ -831,6 +831,6 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
     return drawer != null && drawer.opened;
   }
 
-  static ngAcceptInputType_autosize: boolean | string;
-  static ngAcceptInputType_hasBackdrop: boolean | string;
+  static ngAcceptInputType_autosize: boolean | string | null | undefined;
+  static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
 }

--- a/src/material/sidenav/sidenav.ts
+++ b/src/material/sidenav/sidenav.ts
@@ -96,12 +96,12 @@ export class MatSidenav extends MatDrawer {
   set fixedBottomGap(value) { this._fixedBottomGap = coerceNumberProperty(value); }
   private _fixedBottomGap = 0;
 
-  static ngAcceptInputType_fixedInViewport: boolean | string;
-  static ngAcceptInputType_fixedTopGap: number | string;
-  static ngAcceptInputType_fixedBottomGap: number | string;
-  static ngAcceptInputType_disableClose: boolean | string;
-  static ngAcceptInputType_autoFocus: boolean | string;
-  static ngAcceptInputType_opened: boolean | string;
+  static ngAcceptInputType_fixedInViewport: boolean | string | null | undefined;
+  static ngAcceptInputType_fixedTopGap: number | string | null | undefined;
+  static ngAcceptInputType_fixedBottomGap: number | string | null | undefined;
+  static ngAcceptInputType_disableClose: boolean | string | null | undefined;
+  static ngAcceptInputType_autoFocus: boolean | string | null | undefined;
+  static ngAcceptInputType_opened: boolean | string | null | undefined;
 }
 
 
@@ -132,6 +132,6 @@ export class MatSidenavContainer extends MatDrawerContainer {
 
   @ContentChild(MatSidenavContent) _content: MatSidenavContent;
 
-  static ngAcceptInputType_autosize: boolean | string;
-  static ngAcceptInputType_hasBackdrop: boolean | string;
+  static ngAcceptInputType_autosize: boolean | string | null | undefined;
+  static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
 }

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -294,8 +294,8 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
     this._changeDetectorRef.detectChanges();
   }
 
-  static ngAcceptInputType_required: boolean | string;
-  static ngAcceptInputType_checked: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+  static ngAcceptInputType_checked: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -849,15 +849,15 @@ export class MatSlider extends _MatSliderMixinBase
     this.disabled = isDisabled;
   }
 
-  static ngAcceptInputType_invert: boolean | string;
-  static ngAcceptInputType_max: number | string;
-  static ngAcceptInputType_min: number | string;
-  static ngAcceptInputType_step: number | string;
-  static ngAcceptInputType_thumbLabel: boolean | string;
-  static ngAcceptInputType_tickInterval: number | string;
-  static ngAcceptInputType_value: number | string | null;
-  static ngAcceptInputType_vertical: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_invert: boolean | string | null | undefined;
+  static ngAcceptInputType_max: number | string | null | undefined;
+  static ngAcceptInputType_min: number | string | null | undefined;
+  static ngAcceptInputType_step: number | string | null | undefined;
+  static ngAcceptInputType_thumbLabel: boolean | string | null | undefined;
+  static ngAcceptInputType_tickInterval: number | string | null | undefined;
+  static ngAcceptInputType_value: number | string | null | undefined;
+  static ngAcceptInputType_vertical: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }
 
 /** Returns whether an event is a touch event. */

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -293,6 +293,6 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
     return !this._isDisabled() || this._isSorted();
   }
 
-  static ngAcceptInputType_disableClear: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disableClear: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -167,8 +167,8 @@ export class MatSort extends _MatSortMixinBase
     this._stateChanges.complete();
   }
 
-  static ngAcceptInputType_disableClear: boolean | string;
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disableClear: boolean | string | null | undefined;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }
 
 /** Returns the sort direction cycle to use given the provided parameters of order and clear. */

--- a/src/material/stepper/stepper.ts
+++ b/src/material/stepper/stepper.ts
@@ -81,10 +81,10 @@ export class MatStep extends CdkStep implements ErrorStateMatcher {
     return originalErrorState || customErrorState;
   }
 
-  static ngAcceptInputType_editable: boolean | string;
-  static ngAcceptInputType_hasError: boolean | string;
-  static ngAcceptInputType_optional: boolean | string;
-  static ngAcceptInputType_completed: boolean | string;
+  static ngAcceptInputType_editable: boolean | string | null | undefined;
+  static ngAcceptInputType_hasError: boolean | string | null | undefined;
+  static ngAcceptInputType_optional: boolean | string | null | undefined;
+  static ngAcceptInputType_completed: boolean | string | null | undefined;
 }
 
 
@@ -134,12 +134,12 @@ export class MatStepper extends CdkStepper implements AfterContentInit {
     });
   }
 
-  static ngAcceptInputType_editable: boolean | string;
-  static ngAcceptInputType_optional: boolean | string;
-  static ngAcceptInputType_completed: boolean | string;
-  static ngAcceptInputType_hasError: boolean | string;
-  static ngAcceptInputType_linear: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_editable: boolean | string | null | undefined;
+  static ngAcceptInputType_optional: boolean | string | null | undefined;
+  static ngAcceptInputType_completed: boolean | string | null | undefined;
+  static ngAcceptInputType_hasError: boolean | string | null | undefined;
+  static ngAcceptInputType_linear: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }
 
 @Component({
@@ -168,12 +168,12 @@ export class MatHorizontalStepper extends MatStepper {
   @Input()
   labelPosition: 'bottom' | 'end' = 'end';
 
-  static ngAcceptInputType_editable: boolean | string;
-  static ngAcceptInputType_optional: boolean | string;
-  static ngAcceptInputType_completed: boolean | string;
-  static ngAcceptInputType_hasError: boolean | string;
-  static ngAcceptInputType_linear: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_editable: boolean | string | null | undefined;
+  static ngAcceptInputType_optional: boolean | string | null | undefined;
+  static ngAcceptInputType_completed: boolean | string | null | undefined;
+  static ngAcceptInputType_hasError: boolean | string | null | undefined;
+  static ngAcceptInputType_linear: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }
 
 @Component({
@@ -206,10 +206,10 @@ export class MatVerticalStepper extends MatStepper {
     this._orientation = 'vertical';
   }
 
-  static ngAcceptInputType_editable: boolean | string;
-  static ngAcceptInputType_optional: boolean | string;
-  static ngAcceptInputType_completed: boolean | string;
-  static ngAcceptInputType_hasError: boolean | string;
-  static ngAcceptInputType_linear: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_editable: boolean | string | null | undefined;
+  static ngAcceptInputType_optional: boolean | string | null | undefined;
+  static ngAcceptInputType_completed: boolean | string | null | undefined;
+  static ngAcceptInputType_hasError: boolean | string | null | undefined;
+  static ngAcceptInputType_linear: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }

--- a/src/material/table/cell.ts
+++ b/src/material/table/cell.ts
@@ -61,8 +61,8 @@ export class MatColumnDef extends CdkColumnDef {
   /** Unique name for this column. */
   @Input('matColumnDef') name: string;
 
-  static ngAcceptInputType_sticky: boolean | string;
-  static ngAcceptInputType_stickyEnd: boolean | string;
+  static ngAcceptInputType_sticky: boolean | string | null | undefined;
+  static ngAcceptInputType_stickyEnd: boolean | string | null | undefined;
 }
 
 /** Header cell template container that adds the right classes and role. */

--- a/src/material/table/row.ts
+++ b/src/material/table/row.ts
@@ -27,7 +27,7 @@ import {ChangeDetectionStrategy, Component, Directive, ViewEncapsulation} from '
   inputs: ['columns: matHeaderRowDef', 'sticky: matHeaderRowDefSticky'],
 })
 export class MatHeaderRowDef extends CdkHeaderRowDef {
-  static ngAcceptInputType_sticky: boolean | string;
+  static ngAcceptInputType_sticky: boolean | string | null | undefined;
 }
 
 /**
@@ -40,7 +40,7 @@ export class MatHeaderRowDef extends CdkHeaderRowDef {
   inputs: ['columns: matFooterRowDef', 'sticky: matFooterRowDefSticky'],
 })
 export class MatFooterRowDef extends CdkFooterRowDef {
-  static ngAcceptInputType_sticky: boolean | string;
+  static ngAcceptInputType_sticky: boolean | string | null | undefined;
 }
 
 /**

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -30,5 +30,5 @@ export class MatTable<T> extends CdkTable<T> {
   /** Overrides the sticky CSS class set by the `CdkTable`. */
   protected stickyCssClass = 'mat-table-sticky';
 
-  static ngAcceptInputType_multiTemplateDataRows: boolean | string;
+  static ngAcceptInputType_multiTemplateDataRows: boolean | string | null | undefined;
 }

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -417,8 +417,8 @@ export class MatTabGroup extends _MatTabGroupBase {
     super(elementRef, changeDetectorRef, defaultConfig, animationMode);
   }
 
-  static ngAcceptInputType_dynamicHeight: boolean | string;
-  static ngAcceptInputType_animationDuration: number | string;
-  static ngAcceptInputType_selectedIndex: number | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_dynamicHeight: boolean | string | null | undefined;
+  static ngAcceptInputType_animationDuration: number | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -109,6 +109,6 @@ export class MatTabHeader extends _MatTabHeaderBase {
     super(elementRef, changeDetectorRef, viewportRuler, dir, ngZone, platform, animationMode);
   }
 
-  static ngAcceptInputType_disableRipple: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }

--- a/src/material/tabs/tab-label-wrapper.ts
+++ b/src/material/tabs/tab-label-wrapper.ts
@@ -46,5 +46,5 @@ export class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase implements 
     return this.elementRef.nativeElement.offsetWidth;
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -183,8 +183,8 @@ export class MatTabNav extends _MatTabNavBase {
     super(elementRef, dir, ngZone, changeDetectorRef, viewportRuler, platform, animationMode);
   }
 
-  static ngAcceptInputType_disableRipple: boolean | string;
-  static ngAcceptInputType_selectedIndex: number | string;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }
 
 // Boilerplate for applying mixins to MatTabLink.
@@ -295,6 +295,6 @@ export class MatTabLink extends _MatTabLinkBase implements OnDestroy {
     this._tabLinkRipple._removeTriggerEvents();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_disableRipple: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
 }

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -140,5 +140,5 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
         this._explicitContent || this._implicitContent, this._viewContainerRef);
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -604,9 +604,9 @@ export class MatTooltip implements OnDestroy, OnInit {
     }
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
-  static ngAcceptInputType_hideDelay: number | string;
-  static ngAcceptInputType_showDelay: number | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_hideDelay: number | string | null | undefined;
+  static ngAcceptInputType_showDelay: number | string | null | undefined;
 }
 
 /**

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -62,7 +62,7 @@ export class MatTreeNode<T> extends _MatTreeNodeMixinBase<T>
     this.tabIndex = Number(tabIndex) || 0;
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }
 
 /**
@@ -134,5 +134,5 @@ export class MatNestedTreeNode<T> extends CdkNestedTreeNode<T> implements AfterC
     super.ngOnDestroy();
   }
 
-  static ngAcceptInputType_disabled: boolean | string;
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
 }

--- a/src/material/tree/padding.ts
+++ b/src/material/tree/padding.ts
@@ -23,5 +23,5 @@ export class MatTreeNodePadding<T> extends CdkTreeNodePadding<T> {
   /** The indent for each level. Default number 40px from material design menu sub-menu spec. */
   @Input('matTreeNodePaddingIndent') indent: number;
 
-  static ngAcceptInputType_level: number | string;
+  static ngAcceptInputType_level: number | string | null | undefined;
 }

--- a/src/material/tree/toggle.ts
+++ b/src/material/tree/toggle.ts
@@ -19,5 +19,5 @@ import {Directive, Input} from '@angular/core';
 export class MatTreeNodeToggle<T> extends CdkTreeNodeToggle<T> {
   @Input('matTreeNodeToggleRecursive') recursive: boolean = false;
 
-  static ngAcceptInputType_recursive: boolean | string;
+  static ngAcceptInputType_recursive: boolean | string | null | undefined;
 }

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -47,8 +47,8 @@ export declare class CdkTrapFocus implements OnDestroy, AfterContentInit, DoChec
     ngAfterContentInit(): void;
     ngDoCheck(): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_autoCapture: boolean | string;
-    static ngAcceptInputType_enabled: boolean | string;
+    static ngAcceptInputType_autoCapture: boolean | string | null | undefined;
+    static ngAcceptInputType_enabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkTrapFocus, "[cdkTrapFocus]", ["cdkTrapFocus"], { 'enabled': "cdkTrapFocus", 'autoCapture': "cdkTrapFocusAutoCapture" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkTrapFocus>;
 }

--- a/tools/public_api_guard/cdk/accordion.d.ts
+++ b/tools/public_api_guard/cdk/accordion.d.ts
@@ -7,7 +7,7 @@ export declare class CdkAccordion implements OnDestroy, OnChanges {
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     openAll(): void;
-    static ngAcceptInputType_multi: boolean | string;
+    static ngAcceptInputType_multi: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkAccordion, "cdk-accordion, [cdkAccordion]", ["cdkAccordion"], { 'multi': "multi" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkAccordion>;
 }
@@ -27,8 +27,8 @@ export declare class CdkAccordionItem implements OnDestroy {
     ngOnDestroy(): void;
     open(): void;
     toggle(): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_expanded: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_expanded: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkAccordionItem, "cdk-accordion-item, [cdkAccordionItem]", ["cdkAccordionItem"], { 'expanded': "expanded", 'disabled': "disabled" }, { 'closed': "closed", 'opened': "opened", 'destroyed': "destroyed", 'expandedChange': "expandedChange" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkAccordionItem>;
 }

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -46,7 +46,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     reset(): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { 'data': "cdkDragData", 'lockAxis': "cdkDragLockAxis", 'rootElementSelector': "cdkDragRootElement", 'boundaryElement': "cdkDragBoundary", 'dragStartDelay': "cdkDragStartDelay", 'freeDragPosition': "cdkDragFreeDragPosition", 'disabled': "cdkDragDisabled", 'constrainPosition': "cdkDragConstrainPosition", 'previewClass': "cdkDragPreviewClass" }, { 'started': "cdkDragStarted", 'released': "cdkDragReleased", 'ended': "cdkDragEnded", 'entered': "cdkDragEntered", 'exited': "cdkDragExited", 'dropped': "cdkDragDropped", 'moved': "cdkDragMoved" }, ["_previewTemplate", "_placeholderTemplate", "_handles"]>;
     static ɵfac: i0.ɵɵFactoryDef<CdkDrag<any>>;
 }
@@ -90,7 +90,7 @@ export declare class CdkDragHandle implements OnDestroy {
     element: ElementRef<HTMLElement>;
     constructor(element: ElementRef<HTMLElement>, parentDrag?: any);
     ngOnDestroy(): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDragHandle, "[cdkDragHandle]", never, { 'disabled': "cdkDragHandleDisabled" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkDragHandle>;
 }
@@ -169,9 +169,9 @@ export declare class CdkDropList<T = any> implements AfterContentInit, OnDestroy
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     start(): void;
-    static ngAcceptInputType_autoScrollDisabled: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_sortingDisabled: boolean | string;
+    static ngAcceptInputType_autoScrollDisabled: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_sortingDisabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { 'connectedTo': "cdkDropListConnectedTo", 'data': "cdkDropListData", 'orientation': "cdkDropListOrientation", 'id': "id", 'lockAxis': "cdkDropListLockAxis", 'disabled': "cdkDropListDisabled", 'sortingDisabled': "cdkDropListSortingDisabled", 'enterPredicate': "cdkDropListEnterPredicate", 'autoScrollDisabled': "cdkDropListAutoScrollDisabled" }, { 'dropped': "cdkDropListDropped", 'entered': "cdkDropListEntered", 'exited': "cdkDropListExited", 'sorted': "cdkDropListSorted" }, ["_draggables"]>;
     static ɵfac: i0.ɵɵFactoryDef<CdkDropList<any>>;
 }
@@ -180,7 +180,7 @@ export declare class CdkDropListGroup<T> implements OnDestroy {
     readonly _items: Set<T>;
     disabled: boolean;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDropListGroup<any>, "[cdkDropListGroup]", ["cdkDropListGroup"], { 'disabled': "cdkDropListGroupDisabled" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkDropListGroup<any>>;
 }

--- a/tools/public_api_guard/cdk/observers.d.ts
+++ b/tools/public_api_guard/cdk/observers.d.ts
@@ -5,8 +5,8 @@ export declare class CdkObserveContent implements AfterContentInit, OnDestroy {
     constructor(_contentObserver: ContentObserver, _elementRef: ElementRef<HTMLElement>, _ngZone: NgZone);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_debounce: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_debounce: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkObserveContent, "[cdkObserveContent]", ["cdkObserveContent"], { 'disabled': "cdkObserveContentDisabled", 'debounce': "debounce" }, { 'event': "cdkObserveContent" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkObserveContent>;
 }

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -34,11 +34,11 @@ export declare class CdkConnectedOverlay implements OnDestroy, OnChanges {
     constructor(_overlay: Overlay, templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef, scrollStrategyFactory: any, _dir: Directionality);
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_flexibleDimensions: boolean | string;
-    static ngAcceptInputType_growAfterOpen: boolean | string;
-    static ngAcceptInputType_hasBackdrop: boolean | string;
-    static ngAcceptInputType_lockPosition: boolean | string;
-    static ngAcceptInputType_push: boolean | string;
+    static ngAcceptInputType_flexibleDimensions: boolean | string | null | undefined;
+    static ngAcceptInputType_growAfterOpen: boolean | string | null | undefined;
+    static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
+    static ngAcceptInputType_lockPosition: boolean | string | null | undefined;
+    static ngAcceptInputType_push: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkConnectedOverlay, "[cdk-connected-overlay], [connected-overlay], [cdkConnectedOverlay]", ["cdkConnectedOverlay"], { 'origin': "cdkConnectedOverlayOrigin", 'positions': "cdkConnectedOverlayPositions", 'offsetX': "cdkConnectedOverlayOffsetX", 'offsetY': "cdkConnectedOverlayOffsetY", 'width': "cdkConnectedOverlayWidth", 'height': "cdkConnectedOverlayHeight", 'minWidth': "cdkConnectedOverlayMinWidth", 'minHeight': "cdkConnectedOverlayMinHeight", 'backdropClass': "cdkConnectedOverlayBackdropClass", 'panelClass': "cdkConnectedOverlayPanelClass", 'viewportMargin': "cdkConnectedOverlayViewportMargin", 'scrollStrategy': "cdkConnectedOverlayScrollStrategy", 'open': "cdkConnectedOverlayOpen", 'hasBackdrop': "cdkConnectedOverlayHasBackdrop", 'lockPosition': "cdkConnectedOverlayLockPosition", 'flexibleDimensions': "cdkConnectedOverlayFlexibleDimensions", 'growAfterOpen': "cdkConnectedOverlayGrowAfterOpen", 'push': "cdkConnectedOverlayPush" }, { 'backdropClick': "backdropClick", 'positionChange': "positionChange", 'attach': "attach", 'detach': "detach", 'overlayKeydown': "overlayKeydown" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkConnectedOverlay>;
 }

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -43,9 +43,9 @@ export declare class CdkFixedSizeVirtualScroll implements OnChanges {
     maxBufferPx: number;
     minBufferPx: number;
     ngOnChanges(): void;
-    static ngAcceptInputType_itemSize: string | number;
-    static ngAcceptInputType_maxBufferPx: string | number;
-    static ngAcceptInputType_minBufferPx: string | number;
+    static ngAcceptInputType_itemSize: string | number | null | undefined;
+    static ngAcceptInputType_maxBufferPx: string | number | null | undefined;
+    static ngAcceptInputType_minBufferPx: string | number | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkFixedSizeVirtualScroll, "cdk-virtual-scroll-viewport[itemSize]", never, { 'itemSize': "itemSize", 'minBufferPx': "minBufferPx", 'maxBufferPx': "maxBufferPx" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkFixedSizeVirtualScroll>;
 }

--- a/tools/public_api_guard/cdk/stepper.d.ts
+++ b/tools/public_api_guard/cdk/stepper.d.ts
@@ -19,10 +19,10 @@ export declare class CdkStep implements OnChanges {
     ngOnChanges(): void;
     reset(): void;
     select(): void;
-    static ngAcceptInputType_completed: boolean | string;
-    static ngAcceptInputType_editable: boolean | string;
-    static ngAcceptInputType_hasError: boolean | string;
-    static ngAcceptInputType_optional: boolean | string;
+    static ngAcceptInputType_completed: boolean | string | null | undefined;
+    static ngAcceptInputType_editable: boolean | string | null | undefined;
+    static ngAcceptInputType_hasError: boolean | string | null | undefined;
+    static ngAcceptInputType_optional: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<CdkStep, "cdk-step", ["cdkStep"], { 'stepControl': "stepControl", 'label': "label", 'errorMessage': "errorMessage", 'ariaLabel': "aria-label", 'ariaLabelledby': "aria-labelledby", 'state': "state", 'editable': "editable", 'optional': "optional", 'completed': "completed", 'hasError': "hasError" }, {}, ["stepLabel"]>;
     static ɵfac: i0.ɵɵFactoryDef<CdkStep>;
 }
@@ -67,12 +67,12 @@ export declare class CdkStepper implements AfterViewInit, OnDestroy {
     ngOnDestroy(): void;
     previous(): void;
     reset(): void;
-    static ngAcceptInputType_completed: boolean | string;
-    static ngAcceptInputType_editable: boolean | string;
-    static ngAcceptInputType_hasError: boolean | string;
-    static ngAcceptInputType_linear: boolean | string;
-    static ngAcceptInputType_optional: boolean | string;
-    static ngAcceptInputType_selectedIndex: number | string;
+    static ngAcceptInputType_completed: boolean | string | null | undefined;
+    static ngAcceptInputType_editable: boolean | string | null | undefined;
+    static ngAcceptInputType_hasError: boolean | string | null | undefined;
+    static ngAcceptInputType_linear: boolean | string | null | undefined;
+    static ngAcceptInputType_optional: boolean | string | null | undefined;
+    static ngAcceptInputType_selectedIndex: number | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkStepper, "[cdkStepper]", ["cdkStepper"], { 'linear': "linear", 'selectedIndex': "selectedIndex", 'selected': "selected" }, { 'selectionChange': "selectionChange" }, ["_steps", "_stepHeader"]>;
     static ɵfac: i0.ɵɵFactoryDef<CdkStepper>;
 }

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -81,8 +81,8 @@ export declare class CdkColumnDef extends _CdkColumnDefBase implements CanStick 
     headerCell: CdkHeaderCellDef;
     name: string;
     stickyEnd: boolean;
-    static ngAcceptInputType_sticky: boolean | string;
-    static ngAcceptInputType_stickyEnd: boolean | string;
+    static ngAcceptInputType_sticky: boolean | string | null | undefined;
+    static ngAcceptInputType_stickyEnd: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkColumnDef, "[cdkColumnDef]", never, { 'sticky': "sticky", 'name': "cdkColumnDef", 'stickyEnd': "stickyEnd" }, {}, ["cell", "headerCell", "footerCell"]>;
     static ɵfac: i0.ɵɵFactoryDef<CdkColumnDef>;
 }
@@ -108,7 +108,7 @@ export declare class CdkFooterRow {
 export declare class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, OnChanges {
     constructor(template: TemplateRef<any>, _differs: IterableDiffers);
     ngOnChanges(changes: SimpleChanges): void;
-    static ngAcceptInputType_sticky: boolean | string;
+    static ngAcceptInputType_sticky: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkFooterRowDef, "[cdkFooterRowDef]", never, { 'columns': "cdkFooterRowDef", 'sticky': "cdkFooterRowDefSticky" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkFooterRowDef>;
 }
@@ -134,7 +134,7 @@ export declare class CdkHeaderRow {
 export declare class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, OnChanges {
     constructor(template: TemplateRef<any>, _differs: IterableDiffers);
     ngOnChanges(changes: SimpleChanges): void;
-    static ngAcceptInputType_sticky: boolean | string;
+    static ngAcceptInputType_sticky: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkHeaderRowDef, "[cdkHeaderRowDef]", never, { 'columns': "cdkHeaderRowDef", 'sticky': "cdkHeaderRowDefSticky" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkHeaderRowDef>;
 }
@@ -193,7 +193,7 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
     updateStickyColumnStyles(): void;
     updateStickyFooterRowStyles(): void;
     updateStickyHeaderRowStyles(): void;
-    static ngAcceptInputType_multiTemplateDataRows: boolean | string;
+    static ngAcceptInputType_multiTemplateDataRows: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<CdkTable<any>, "cdk-table, table[cdk-table]", ["cdkTable"], { 'trackBy': "trackBy", 'dataSource': "dataSource", 'multiTemplateDataRows': "multiTemplateDataRows" }, {}, ["_contentColumnDefs", "_contentRowDefs", "_contentHeaderRowDefs", "_contentFooterRowDefs"]>;
     static ɵfac: i0.ɵɵFactoryDef<CdkTable<any>>;
 }

--- a/tools/public_api_guard/cdk/text-field.d.ts
+++ b/tools/public_api_guard/cdk/text-field.d.ts
@@ -36,9 +36,9 @@ export declare class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDe
     ngOnDestroy(): void;
     reset(): void;
     resizeToFitContent(force?: boolean): void;
-    static ngAcceptInputType_enabled: boolean | string;
-    static ngAcceptInputType_maxRows: number | string;
-    static ngAcceptInputType_minRows: number | string;
+    static ngAcceptInputType_enabled: boolean | string | null | undefined;
+    static ngAcceptInputType_maxRows: number | string | null | undefined;
+    static ngAcceptInputType_minRows: number | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkTextareaAutosize, "textarea[cdkTextareaAutosize]", ["cdkTextareaAutosize"], { 'minRows': "cdkAutosizeMinRows", 'maxRows': "cdkAutosizeMaxRows", 'enabled': "cdkTextareaAutosize" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkTextareaAutosize>;
 }

--- a/tools/public_api_guard/cdk/tree.d.ts
+++ b/tools/public_api_guard/cdk/tree.d.ts
@@ -113,7 +113,7 @@ export declare class CdkTreeNodePadding<T> implements OnDestroy {
     _paddingIndent(): string | null;
     _setPadding(forceChange?: boolean): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_level: number | string;
+    static ngAcceptInputType_level: number | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkTreeNodePadding<any>, "[cdkTreeNodePadding]", never, { 'level': "cdkTreeNodePadding", 'indent': "cdkTreeNodePaddingIndent" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkTreeNodePadding<any>>;
 }
@@ -125,7 +125,7 @@ export declare class CdkTreeNodeToggle<T> {
     recursive: boolean;
     constructor(_tree: CdkTree<T>, _treeNode: CdkTreeNode<T>);
     _toggle(event: Event): void;
-    static ngAcceptInputType_recursive: boolean | string;
+    static ngAcceptInputType_recursive: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkTreeNodeToggle<any>, "[cdkTreeNodeToggle]", never, { 'recursive': "cdkTreeNodeToggleRecursive" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkTreeNodeToggle<any>>;
 }

--- a/tools/public_api_guard/material/autocomplete.d.ts
+++ b/tools/public_api_guard/material/autocomplete.d.ts
@@ -46,8 +46,8 @@ export declare class MatAutocomplete extends _MatAutocompleteMixinBase implement
     _setScrollTop(scrollTop: number): void;
     _setVisibility(): void;
     ngAfterContentInit(): void;
-    static ngAcceptInputType_autoActiveFirstOption: boolean | string;
-    static ngAcceptInputType_disableRipple: boolean | string;
+    static ngAcceptInputType_autoActiveFirstOption: boolean | string | null | undefined;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { 'disableRipple': "disableRipple", 'displayWith': "displayWith", 'autoActiveFirstOption': "autoActiveFirstOption", 'panelWidth': "panelWidth", 'classList': "class" }, { 'optionSelected': "optionSelected", 'opened': "opened", 'closed': "closed" }, ["options", "optionGroups"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatAutocomplete>;
 }
@@ -103,7 +103,7 @@ export declare class MatAutocompleteTrigger implements ControlValueAccessor, Aft
     setDisabledState(isDisabled: boolean): void;
     updatePosition(): void;
     writeValue(value: any): void;
-    static ngAcceptInputType_autocompleteDisabled: boolean | string;
+    static ngAcceptInputType_autocompleteDisabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatAutocompleteTrigger, "input[matAutocomplete], textarea[matAutocomplete]", ["matAutocompleteTrigger"], { 'autocomplete': "matAutocomplete", 'position': "matAutocompletePosition", 'connectedTo': "matAutocompleteConnectedTo", 'autocompleteAttribute': "autocomplete", 'autocompleteDisabled': "matAutocompleteDisabled" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatAutocompleteTrigger>;
 }

--- a/tools/public_api_guard/material/badge.d.ts
+++ b/tools/public_api_guard/material/badge.d.ts
@@ -14,9 +14,9 @@ export declare class MatBadge extends _MatBadgeMixinBase implements OnDestroy, O
     isAfter(): boolean;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_hidden: boolean | string;
-    static ngAcceptInputType_overlap: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_hidden: boolean | string | null | undefined;
+    static ngAcceptInputType_overlap: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatBadge, "[matBadge]", never, { 'disabled': "matBadgeDisabled", 'color': "matBadgeColor", 'overlap': "matBadgeOverlap", 'position': "matBadgePosition", 'content': "matBadge", 'description': "matBadgeDescription", 'size': "matBadgeSize", 'hidden': "matBadgeHidden" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatBadge>;
 }

--- a/tools/public_api_guard/material/button-toggle.d.ts
+++ b/tools/public_api_guard/material/button-toggle.d.ts
@@ -23,11 +23,11 @@ export declare class MatButtonToggle extends _MatButtonToggleMixinBase implement
     focus(options?: FocusOptions): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ngAcceptInputType_checked: boolean | string;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_multiple: boolean | string;
-    static ngAcceptInputType_vertical: boolean | string;
+    static ngAcceptInputType_checked: boolean | string | null | undefined;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_multiple: boolean | string | null | undefined;
+    static ngAcceptInputType_vertical: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatButtonToggle, "mat-button-toggle", ["matButtonToggle"], { 'disableRipple': "disableRipple", 'ariaLabel': "aria-label", 'ariaLabelledby': "aria-labelledby", 'id': "id", 'name': "name", 'value': "value", 'tabIndex': "tabIndex", 'appearance': "appearance", 'checked': "checked", 'disabled': "disabled" }, { 'change': "change" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatButtonToggle>;
 }
@@ -70,9 +70,9 @@ export declare class MatButtonToggleGroup implements ControlValueAccessor, OnIni
     registerOnTouched(fn: any): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_multiple: boolean | string;
-    static ngAcceptInputType_vertical: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_multiple: boolean | string | null | undefined;
+    static ngAcceptInputType_vertical: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatButtonToggleGroup, "mat-button-toggle-group", ["matButtonToggleGroup"], { 'appearance': "appearance", 'name': "name", 'vertical': "vertical", 'value': "value", 'multiple': "multiple", 'disabled': "disabled" }, { 'valueChange': "valueChange", 'change': "change" }, ["_buttonToggles"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatButtonToggleGroup>;
 }

--- a/tools/public_api_guard/material/button.d.ts
+++ b/tools/public_api_guard/material/button.d.ts
@@ -2,8 +2,8 @@ export declare class MatAnchor extends MatButton {
     tabIndex: number;
     constructor(focusMonitor: FocusMonitor, elementRef: ElementRef, animationMode: string);
     _haltDisabledEvents(event: Event): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAnchor, "a[mat-button], a[mat-raised-button], a[mat-icon-button], a[mat-fab],             a[mat-mini-fab], a[mat-stroked-button], a[mat-flat-button]", ["matButton", "matAnchor"], { 'disabled': "disabled", 'disableRipple': "disableRipple", 'color': "color", 'tabIndex': "tabIndex" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatAnchor>;
 }
@@ -19,8 +19,8 @@ export declare class MatButton extends _MatButtonMixinBase implements OnDestroy,
     _isRippleDisabled(): boolean;
     focus(origin?: FocusOrigin, options?: FocusOptions): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatButton, "button[mat-button], button[mat-raised-button], button[mat-icon-button],             button[mat-fab], button[mat-mini-fab], button[mat-stroked-button],             button[mat-flat-button]", ["matButton"], { 'disabled': "disabled", 'disableRipple': "disableRipple", 'color': "color" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatButton>;
 }

--- a/tools/public_api_guard/material/checkbox.d.ts
+++ b/tools/public_api_guard/material/checkbox.d.ts
@@ -46,9 +46,9 @@ export declare class MatCheckbox extends _MatCheckboxMixinBase implements Contro
     setDisabledState(isDisabled: boolean): void;
     toggle(): void;
     writeValue(value: any): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_required: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_required: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatCheckbox, "mat-checkbox", ["matCheckbox"], { 'disableRipple': "disableRipple", 'color': "color", 'tabIndex': "tabIndex", 'ariaLabel': "aria-label", 'ariaLabelledby': "aria-labelledby", 'id': "id", 'required': "required", 'labelPosition': "labelPosition", 'name': "name", 'value': "value", 'checked': "checked", 'disabled': "disabled", 'indeterminate': "indeterminate" }, { 'change': "change", 'indeterminateChange': "indeterminateChange" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatCheckbox>;
 }

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -37,11 +37,11 @@ export declare class MatChip extends _MatChipMixinBase implements FocusableOptio
     select(): void;
     selectViaInteraction(): void;
     toggleSelected(isUserInput?: boolean): boolean;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_removable: boolean | string;
-    static ngAcceptInputType_selectable: boolean | string;
-    static ngAcceptInputType_selected: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_removable: boolean | string | null | undefined;
+    static ngAcceptInputType_selectable: boolean | string | null | undefined;
+    static ngAcceptInputType_selected: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatChip, "mat-basic-chip, [mat-basic-chip], mat-chip, [mat-chip]", ["matChip"], { 'color': "color", 'disabled': "disabled", 'disableRipple': "disableRipple", 'selected': "selected", 'value': "value", 'selectable': "selectable", 'removable': "removable" }, { 'selectionChange': "selectionChange", 'destroyed': "destroyed", 'removed': "removed" }, ["avatar", "trailingIcon", "removeIcon"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatChip>;
 }
@@ -77,8 +77,8 @@ export declare class MatChipInput implements MatChipTextControl, OnChanges {
     _onInput(): void;
     focus(options?: FocusOptions): void;
     ngOnChanges(): void;
-    static ngAcceptInputType_addOnBlur: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_addOnBlur: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatChipInput, "input[matChipInputFor]", ["matChipInput", "matChipInputFor"], { 'chipList': "matChipInputFor", 'addOnBlur': "matChipInputAddOnBlur", 'separatorKeyCodes': "matChipInputSeparatorKeyCodes", 'placeholder': "placeholder", 'id': "id", 'disabled': "disabled" }, { 'chipEnd': "matChipInputTokenEnd" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatChipInput>;
 }
@@ -151,10 +151,10 @@ export declare class MatChipList extends _MatChipListMixinBase implements MatFor
     setDescribedByIds(ids: string[]): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_multiple: boolean | string;
-    static ngAcceptInputType_required: boolean | string;
-    static ngAcceptInputType_selectable: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_multiple: boolean | string | null | undefined;
+    static ngAcceptInputType_required: boolean | string | null | undefined;
+    static ngAcceptInputType_selectable: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatChipList, "mat-chip-list", ["matChipList"], { 'errorStateMatcher': "errorStateMatcher", 'multiple': "multiple", 'compareWith': "compareWith", 'value': "value", 'required': "required", 'placeholder': "placeholder", 'disabled': "disabled", 'ariaOrientation': "aria-orientation", 'selectable': "selectable", 'tabIndex': "tabIndex" }, { 'change': "change", 'valueChange': "valueChange" }, ["chips"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatChipList>;
 }

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -242,7 +242,7 @@ export declare class MatNativeDateModule {
 export declare class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
     _labelId: string;
     label: string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatOptgroup, "mat-optgroup", ["matOptgroup"], { 'disabled': "disabled", 'label': "label" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatOptgroup>;
 }
@@ -273,7 +273,7 @@ export declare class MatOption implements FocusableOption, AfterViewChecked, OnD
     select(): void;
     setActiveStyles(): void;
     setInactiveStyles(): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatOption, "mat-option", ["matOption"], { 'value': "value", 'id': "id", 'disabled': "disabled" }, { 'onSelectionChange': "onSelectionChange" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatOption>;
 }

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -133,8 +133,8 @@ export declare class MatDatepicker<D> implements OnDestroy, CanColor {
     ngOnDestroy(): void;
     open(): void;
     select(date: D): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_touchUi: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_touchUi: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDatepicker<any>, "mat-datepicker", ["matDatepicker"], { 'calendarHeaderComponent': "calendarHeaderComponent", 'startAt': "startAt", 'startView': "startView", 'color': "color", 'touchUi': "touchUi", 'disabled': "disabled", 'panelClass': "panelClass", 'dateClass': "dateClass", 'opened': "opened" }, { 'yearSelected': "yearSelected", 'monthSelected': "monthSelected", 'openedStream': "opened", 'closedStream': "closed" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepicker<any>>;
 }
@@ -184,7 +184,7 @@ export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDe
     setDisabledState(isDisabled: boolean): void;
     validate(c: AbstractControl): ValidationErrors | null;
     writeValue(value: D): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ngAcceptInputType_value: any;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerInput<any>, "input[matDatepicker]", ["matDatepickerInput"], { 'matDatepicker': "matDatepicker", 'matDatepickerFilter': "matDatepickerFilter", 'value': "value", 'min': "min", 'max': "max", 'disabled': "disabled" }, { 'dateChange': "dateChange", 'dateInput': "dateInput" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerInput<any>>;
@@ -234,7 +234,7 @@ export declare class MatDatepickerToggle<D> implements AfterContentInit, OnChang
     ngAfterContentInit(): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDatepickerToggle<any>, "mat-datepicker-toggle", ["matDatepickerToggle"], { 'datepicker': "for", 'tabIndex': "tabIndex", 'disabled': "disabled", 'disableRipple': "disableRipple" }, {}, ["_customIcon"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerToggle<any>>;
 }

--- a/tools/public_api_guard/material/divider.d.ts
+++ b/tools/public_api_guard/material/divider.d.ts
@@ -1,8 +1,8 @@
 export declare class MatDivider {
     inset: boolean;
     vertical: boolean;
-    static ngAcceptInputType_inset: boolean | string;
-    static ngAcceptInputType_vertical: boolean | string;
+    static ngAcceptInputType_inset: boolean | string | null | undefined;
+    static ngAcceptInputType_vertical: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDivider, "mat-divider", never, { 'vertical': "vertical", 'inset': "inset" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDivider>;
 }

--- a/tools/public_api_guard/material/expansion.d.ts
+++ b/tools/public_api_guard/material/expansion.d.ts
@@ -12,8 +12,8 @@ export declare class MatAccordion extends CdkAccordion implements MatAccordionBa
     _handleHeaderFocus(header: MatExpansionPanelHeader): void;
     _handleHeaderKeydown(event: KeyboardEvent): void;
     ngAfterContentInit(): void;
-    static ngAcceptInputType_hideToggle: boolean | string;
-    static ngAcceptInputType_multi: boolean | string;
+    static ngAcceptInputType_hideToggle: boolean | string | null | undefined;
+    static ngAcceptInputType_multi: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatAccordion, "mat-accordion", ["matAccordion"], { 'multi': "multi", 'hideToggle': "hideToggle", 'displayMode': "displayMode", 'togglePosition': "togglePosition" }, {}, ["_headers"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatAccordion>;
 }
@@ -61,9 +61,9 @@ export declare class MatExpansionPanel extends CdkAccordionItem implements After
     ngAfterContentInit(): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_expanded: boolean | string;
-    static ngAcceptInputType_hideToggle: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_expanded: boolean | string | null | undefined;
+    static ngAcceptInputType_hideToggle: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatExpansionPanel, "mat-expansion-panel", ["matExpansionPanel"], { 'disabled': "disabled", 'expanded': "expanded", 'hideToggle': "hideToggle", 'togglePosition': "togglePosition" }, { 'opened': "opened", 'closed': "closed", 'expandedChange': "expandedChange", 'afterExpand': "afterExpand", 'afterCollapse': "afterCollapse" }, ["_lazyContent"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatExpansionPanel>;
 }

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -55,7 +55,7 @@ export declare class MatFormField extends _MatFormFieldMixinBase implements Afte
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     updateOutlineGap(): void;
-    static ngAcceptInputType_hideRequiredMarker: boolean | string;
+    static ngAcceptInputType_hideRequiredMarker: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatFormField, "mat-form-field", ["matFormField"], { 'color': "color", 'appearance': "appearance", 'hideRequiredMarker': "hideRequiredMarker", 'hintLabel': "hintLabel", 'floatLabel': "floatLabel" }, {}, ["_controlNonStatic", "_controlStatic", "_labelChildNonStatic", "_labelChildStatic", "_placeholderChild", "_errorChildren", "_hintChildren", "_prefixChildren", "_suffixChildren"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatFormField>;
 }

--- a/tools/public_api_guard/material/grid-list.d.ts
+++ b/tools/public_api_guard/material/grid-list.d.ts
@@ -12,7 +12,7 @@ export declare class MatGridList implements MatGridListBase, OnInit, AfterConten
     _setListStyle(style: [string, string | null] | null): void;
     ngAfterContentChecked(): void;
     ngOnInit(): void;
-    static ngAcceptInputType_cols: number | string;
+    static ngAcceptInputType_cols: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatGridList, "mat-grid-list", ["matGridList"], { 'cols': "cols", 'gutterSize': "gutterSize", 'rowHeight': "rowHeight" }, {}, ["_tiles"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatGridList>;
 }
@@ -30,8 +30,8 @@ export declare class MatGridTile {
     rowspan: number;
     constructor(_element: ElementRef<HTMLElement>, _gridList?: MatGridListBase | undefined);
     _setStyle(property: string, value: any): void;
-    static ngAcceptInputType_colspan: number | string;
-    static ngAcceptInputType_rowspan: number | string;
+    static ngAcceptInputType_colspan: number | string | null | undefined;
+    static ngAcceptInputType_rowspan: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatGridTile, "mat-grid-tile", ["matGridTile"], { 'rowspan': "rowspan", 'colspan': "colspan" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatGridTile>;
 }

--- a/tools/public_api_guard/material/icon.d.ts
+++ b/tools/public_api_guard/material/icon.d.ts
@@ -33,7 +33,7 @@ export declare class MatIcon extends _MatIconMixinBase implements OnChanges, OnI
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ngAcceptInputType_inline: boolean | string;
+    static ngAcceptInputType_inline: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatIcon, "mat-icon", ["matIcon"], { 'color': "color", 'inline': "inline", 'svgIcon': "svgIcon", 'fontSet': "fontSet", 'fontIcon': "fontIcon" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatIcon>;
 }

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -48,9 +48,9 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     ngOnInit(): void;
     onContainerClick(): void;
     setDescribedByIds(ids: string[]): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_readonly: boolean | string;
-    static ngAcceptInputType_required: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_readonly: boolean | string | null | undefined;
+    static ngAcceptInputType_required: boolean | string | null | undefined;
     static ngAcceptInputType_value: any;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatInput, "input[matInput], textarea[matInput], select[matNativeControl],      input[matNativeControl], textarea[matNativeControl]", ["matInput"], { 'disabled': "disabled", 'id': "id", 'placeholder': "placeholder", 'required': "required", 'type': "type", 'errorStateMatcher': "errorStateMatcher", 'value': "value", 'readonly': "readonly" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatInput>;
@@ -66,9 +66,9 @@ export declare class MatTextareaAutosize extends CdkTextareaAutosize {
     matAutosizeMaxRows: number;
     matAutosizeMinRows: number;
     matTextareaAutosize: boolean;
-    static ngAcceptInputType_enabled: boolean | string;
-    static ngAcceptInputType_maxRows: number | string;
-    static ngAcceptInputType_minRows: number | string;
+    static ngAcceptInputType_enabled: boolean | string | null | undefined;
+    static ngAcceptInputType_maxRows: number | string | null | undefined;
+    static ngAcceptInputType_minRows: number | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTextareaAutosize, "textarea[mat-autosize], textarea[matTextareaAutosize]", ["matTextareaAutosize"], { 'cdkAutosizeMinRows': "cdkAutosizeMinRows", 'cdkAutosizeMaxRows': "cdkAutosizeMaxRows", 'matAutosizeMinRows': "matAutosizeMinRows", 'matAutosizeMaxRows': "matAutosizeMaxRows", 'matAutosize': "mat-autosize", 'matTextareaAutosize': "matTextareaAutosize" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTextareaAutosize>;
 }

--- a/tools/public_api_guard/material/list.d.ts
+++ b/tools/public_api_guard/material/list.d.ts
@@ -6,7 +6,7 @@ export declare class MatList extends _MatListMixinBase implements CanDisableRipp
     _getListType(): 'list' | 'action-list' | null;
     ngOnChanges(): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatList, "mat-list, mat-action-list", ["matList"], { 'disableRipple': "disableRipple" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatList>;
 }
@@ -30,7 +30,7 @@ export declare class MatListItem extends _MatListItemMixinBase implements AfterC
     _isRippleDisabled(): boolean;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatListItem, "mat-list-item, a[mat-list-item], button[mat-list-item]", ["matListItem"], { 'disableRipple': "disableRipple" }, {}, ["_avatar", "_icon", "_lines"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatListItem>;
 }
@@ -66,9 +66,9 @@ export declare class MatListOption extends _MatListOptionMixinBase implements Af
     ngOnDestroy(): void;
     ngOnInit(): void;
     toggle(): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_selected: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_selected: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatListOption, "mat-list-option", ["matListOption"], { 'disableRipple': "disableRipple", 'checkboxPosition': "checkboxPosition", 'color': "color", 'value': "value", 'disabled': "disabled", 'selected': "selected" }, {}, ["_avatar", "_icon", "_lines"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatListOption>;
 }
@@ -82,7 +82,7 @@ export declare class MatNavList extends _MatListMixinBase implements CanDisableR
     _stateChanges: Subject<void>;
     ngOnChanges(): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatNavList, "mat-nav-list", ["matNavList"], { 'disableRipple': "disableRipple" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatNavList>;
 }
@@ -114,8 +114,8 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
     selectAll(): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(values: string[]): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSelectionList, "mat-selection-list", ["matSelectionList"], { 'disableRipple': "disableRipple", 'tabIndex': "tabIndex", 'color': "color", 'compareWith': "compareWith", 'disabled': "disabled" }, { 'selectionChange': "selectionChange" }, ["options"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatSelectionList>;
 }

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -1,7 +1,7 @@
 export declare class _MatMenu extends MatMenu {
     constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone, defaultOptions: MatMenuDefaultOptions);
-    static ngAcceptInputType_hasBackdrop: boolean | string;
-    static ngAcceptInputType_overlapTrigger: boolean | string;
+    static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
+    static ngAcceptInputType_overlapTrigger: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<_MatMenu, "mat-menu", ["matMenu"], {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatMenu>;
 }
@@ -104,8 +104,8 @@ export declare class MatMenuItem extends _MatMenuItemMixinBase implements Focusa
     focus(origin?: FocusOrigin, options?: FocusOptions): void;
     getLabel(): string;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatMenuItem, "[mat-menu-item]", ["matMenuItem"], { 'disabled': "disabled", 'disableRipple': "disableRipple", 'role': "role" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatMenuItem>;
 }

--- a/tools/public_api_guard/material/paginator.d.ts
+++ b/tools/public_api_guard/material/paginator.d.ts
@@ -30,12 +30,12 @@ export declare class MatPaginator extends _MatPaginatorBase implements OnInit, O
     ngOnDestroy(): void;
     ngOnInit(): void;
     previousPage(): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_hidePageSize: boolean | string;
-    static ngAcceptInputType_length: number | string;
-    static ngAcceptInputType_pageIndex: number | string;
-    static ngAcceptInputType_pageSize: number | string;
-    static ngAcceptInputType_showFirstLastButtons: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_hidePageSize: boolean | string | null | undefined;
+    static ngAcceptInputType_length: number | string | null | undefined;
+    static ngAcceptInputType_pageIndex: number | string | null | undefined;
+    static ngAcceptInputType_pageSize: number | string | null | undefined;
+    static ngAcceptInputType_showFirstLastButtons: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatPaginator, "mat-paginator", ["matPaginator"], { 'disabled': "disabled", 'color': "color", 'pageIndex': "pageIndex", 'length': "length", 'pageSize': "pageSize", 'pageSizeOptions': "pageSizeOptions", 'hidePageSize': "hidePageSize", 'showFirstLastButtons': "showFirstLastButtons" }, { 'page': "page" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatPaginator>;
 }

--- a/tools/public_api_guard/material/progress-bar.d.ts
+++ b/tools/public_api_guard/material/progress-bar.d.ts
@@ -23,7 +23,7 @@ export declare class MatProgressBar extends _MatProgressBarMixinBase implements 
     };
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_value: number | string;
+    static ngAcceptInputType_value: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatProgressBar, "mat-progress-bar", ["matProgressBar"], { 'color': "color", 'value': "value", 'bufferValue': "bufferValue", 'mode': "mode" }, { 'animationEnd': "animationEnd" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatProgressBar>;
 }

--- a/tools/public_api_guard/material/progress-spinner.d.ts
+++ b/tools/public_api_guard/material/progress-spinner.d.ts
@@ -16,9 +16,9 @@ export declare class MatProgressSpinner extends _MatProgressSpinnerMixinBase imp
     value: number;
     constructor(_elementRef: ElementRef<HTMLElement>, platform: Platform, _document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
     ngOnInit(): void;
-    static ngAcceptInputType_diameter: number | string;
-    static ngAcceptInputType_strokeWidth: number | string;
-    static ngAcceptInputType_value: number | string;
+    static ngAcceptInputType_diameter: number | string | null | undefined;
+    static ngAcceptInputType_strokeWidth: number | string | null | undefined;
+    static ngAcceptInputType_value: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatProgressSpinner, "mat-progress-spinner", ["matProgressSpinner"], { 'color': "color", 'diameter': "diameter", 'strokeWidth': "strokeWidth", 'mode': "mode", 'value': "value" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatProgressSpinner>;
 }
@@ -31,9 +31,9 @@ export interface MatProgressSpinnerDefaultOptions {
 
 export declare class MatSpinner extends MatProgressSpinner {
     constructor(elementRef: ElementRef<HTMLElement>, platform: Platform, document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
-    static ngAcceptInputType_diameter: number | string;
-    static ngAcceptInputType_strokeWidth: number | string;
-    static ngAcceptInputType_value: number | string;
+    static ngAcceptInputType_diameter: number | string | null | undefined;
+    static ngAcceptInputType_strokeWidth: number | string | null | undefined;
+    static ngAcceptInputType_value: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSpinner, "mat-spinner", never, { 'color': "color" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatSpinner>;
 }

--- a/tools/public_api_guard/material/radio.d.ts
+++ b/tools/public_api_guard/material/radio.d.ts
@@ -30,10 +30,10 @@ export declare class MatRadioButton extends _MatRadioButtonMixinBase implements 
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ngAcceptInputType_checked: boolean | string;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_required: boolean | string;
+    static ngAcceptInputType_checked: boolean | string | null | undefined;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_required: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatRadioButton, "mat-radio-button", ["matRadioButton"], { 'disableRipple': "disableRipple", 'tabIndex': "tabIndex", 'id': "id", 'name': "name", 'ariaLabel': "aria-label", 'ariaLabelledby': "aria-labelledby", 'ariaDescribedby': "aria-describedby", 'checked': "checked", 'value': "value", 'labelPosition': "labelPosition", 'disabled': "disabled", 'required': "required", 'color': "color" }, { 'change': "change" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatRadioButton>;
 }
@@ -72,8 +72,8 @@ export declare class MatRadioGroup implements AfterContentInit, ControlValueAcce
     registerOnTouched(fn: any): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_required: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_required: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatRadioGroup, "mat-radio-group", ["matRadioGroup"], { 'color': "color", 'name': "name", 'labelPosition': "labelPosition", 'value': "value", 'selected': "selected", 'disabled': "disabled", 'required': "required" }, { 'change': "change" }, ["_radios"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatRadioGroup>;
 }

--- a/tools/public_api_guard/material/select.d.ts
+++ b/tools/public_api_guard/material/select.d.ts
@@ -83,12 +83,12 @@ export declare class MatSelect extends _MatSelectMixinBase implements AfterConte
     setDisabledState(isDisabled: boolean): void;
     toggle(): void;
     writeValue(value: any): void;
-    static ngAcceptInputType_disableOptionCentering: boolean | string;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_multiple: boolean | string;
-    static ngAcceptInputType_required: boolean | string;
-    static ngAcceptInputType_typeaheadDebounceInterval: number | string;
+    static ngAcceptInputType_disableOptionCentering: boolean | string | null | undefined;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_multiple: boolean | string | null | undefined;
+    static ngAcceptInputType_required: boolean | string | null | undefined;
+    static ngAcceptInputType_typeaheadDebounceInterval: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSelect, "mat-select", ["matSelect"], { 'disabled': "disabled", 'disableRipple': "disableRipple", 'tabIndex': "tabIndex", 'panelClass': "panelClass", 'placeholder': "placeholder", 'required': "required", 'multiple': "multiple", 'disableOptionCentering': "disableOptionCentering", 'compareWith': "compareWith", 'value': "value", 'ariaLabel': "aria-label", 'ariaLabelledby': "aria-labelledby", 'errorStateMatcher': "errorStateMatcher", 'typeaheadDebounceInterval': "typeaheadDebounceInterval", 'sortComparator': "sortComparator", 'id': "id" }, { 'openedChange': "openedChange", '_openedStream': "opened", '_closedStream': "closed", 'selectionChange': "selectionChange", 'valueChange': "valueChange" }, ["customTrigger", "options", "optionGroups"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatSelect>;
 }

--- a/tools/public_api_guard/material/sidenav.d.ts
+++ b/tools/public_api_guard/material/sidenav.d.ts
@@ -31,9 +31,9 @@ export declare class MatDrawer implements AfterContentInit, AfterContentChecked,
     ngOnDestroy(): void;
     open(openedVia?: FocusOrigin): Promise<MatDrawerToggleResult>;
     toggle(isOpen?: boolean, openedVia?: FocusOrigin): Promise<MatDrawerToggleResult>;
-    static ngAcceptInputType_autoFocus: boolean | string;
-    static ngAcceptInputType_disableClose: boolean | string;
-    static ngAcceptInputType_opened: boolean | string;
+    static ngAcceptInputType_autoFocus: boolean | string | null | undefined;
+    static ngAcceptInputType_disableClose: boolean | string | null | undefined;
+    static ngAcceptInputType_opened: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDrawer, "mat-drawer", ["matDrawer"], { 'position': "position", 'mode': "mode", 'disableClose': "disableClose", 'autoFocus': "autoFocus", 'opened': "opened" }, { 'openedChange': "openedChange", '_openedStream': "opened", 'openedStart': "openedStart", '_closedStream': "closed", 'closedStart': "closedStart", 'onPositionChanged': "positionChanged" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDrawer>;
 }
@@ -72,8 +72,8 @@ export declare class MatDrawerContainer implements AfterContentInit, DoCheck, On
     ngOnDestroy(): void;
     open(): void;
     updateContentMargins(): void;
-    static ngAcceptInputType_autosize: boolean | string;
-    static ngAcceptInputType_hasBackdrop: boolean | string;
+    static ngAcceptInputType_autosize: boolean | string | null | undefined;
+    static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDrawerContainer, "mat-drawer-container", ["matDrawerContainer"], { 'autosize': "autosize", 'hasBackdrop': "hasBackdrop" }, { 'backdropClick': "backdropClick" }, ["_content", "_allDrawers"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatDrawerContainer>;
 }
@@ -94,12 +94,12 @@ export declare class MatSidenav extends MatDrawer {
     fixedBottomGap: number;
     fixedInViewport: boolean;
     fixedTopGap: number;
-    static ngAcceptInputType_autoFocus: boolean | string;
-    static ngAcceptInputType_disableClose: boolean | string;
-    static ngAcceptInputType_fixedBottomGap: number | string;
-    static ngAcceptInputType_fixedInViewport: boolean | string;
-    static ngAcceptInputType_fixedTopGap: number | string;
-    static ngAcceptInputType_opened: boolean | string;
+    static ngAcceptInputType_autoFocus: boolean | string | null | undefined;
+    static ngAcceptInputType_disableClose: boolean | string | null | undefined;
+    static ngAcceptInputType_fixedBottomGap: number | string | null | undefined;
+    static ngAcceptInputType_fixedInViewport: boolean | string | null | undefined;
+    static ngAcceptInputType_fixedTopGap: number | string | null | undefined;
+    static ngAcceptInputType_opened: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSidenav, "mat-sidenav", ["matSidenav"], { 'fixedInViewport': "fixedInViewport", 'fixedTopGap': "fixedTopGap", 'fixedBottomGap': "fixedBottomGap" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatSidenav>;
 }
@@ -107,8 +107,8 @@ export declare class MatSidenav extends MatDrawer {
 export declare class MatSidenavContainer extends MatDrawerContainer {
     _allDrawers: QueryList<MatSidenav>;
     _content: MatSidenavContent;
-    static ngAcceptInputType_autosize: boolean | string;
-    static ngAcceptInputType_hasBackdrop: boolean | string;
+    static ngAcceptInputType_autosize: boolean | string | null | undefined;
+    static ngAcceptInputType_hasBackdrop: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSidenavContainer, "mat-sidenav-container", ["matSidenavContainer"], {}, {}, ["_content", "_allDrawers"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatSidenavContainer>;
 }

--- a/tools/public_api_guard/material/slide-toggle.d.ts
+++ b/tools/public_api_guard/material/slide-toggle.d.ts
@@ -39,10 +39,10 @@ export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements 
     setDisabledState(isDisabled: boolean): void;
     toggle(): void;
     writeValue(value: any): void;
-    static ngAcceptInputType_checked: boolean | string;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_required: boolean | string;
+    static ngAcceptInputType_checked: boolean | string | null | undefined;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_required: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSlideToggle, "mat-slide-toggle", ["matSlideToggle"], { 'disabled': "disabled", 'disableRipple': "disableRipple", 'color': "color", 'tabIndex': "tabIndex", 'name': "name", 'id': "id", 'labelPosition': "labelPosition", 'ariaLabel': "aria-label", 'ariaLabelledby': "aria-labelledby", 'required': "required", 'checked': "checked" }, { 'change': "change", 'toggleChange': "toggleChange", 'dragChange': "dragChange" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatSlideToggle>;
 }

--- a/tools/public_api_guard/material/slider.d.ts
+++ b/tools/public_api_guard/material/slider.d.ts
@@ -52,15 +52,15 @@ export declare class MatSlider extends _MatSliderMixinBase implements ControlVal
     registerOnTouched(fn: any): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_invert: boolean | string;
-    static ngAcceptInputType_max: number | string;
-    static ngAcceptInputType_min: number | string;
-    static ngAcceptInputType_step: number | string;
-    static ngAcceptInputType_thumbLabel: boolean | string;
-    static ngAcceptInputType_tickInterval: number | string;
-    static ngAcceptInputType_value: number | string | null;
-    static ngAcceptInputType_vertical: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_invert: boolean | string | null | undefined;
+    static ngAcceptInputType_max: number | string | null | undefined;
+    static ngAcceptInputType_min: number | string | null | undefined;
+    static ngAcceptInputType_step: number | string | null | undefined;
+    static ngAcceptInputType_thumbLabel: boolean | string | null | undefined;
+    static ngAcceptInputType_tickInterval: number | string | null | undefined;
+    static ngAcceptInputType_value: number | string | null | undefined;
+    static ngAcceptInputType_vertical: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSlider, "mat-slider", ["matSlider"], { 'disabled': "disabled", 'color': "color", 'tabIndex': "tabIndex", 'invert': "invert", 'max': "max", 'min': "min", 'step': "step", 'thumbLabel': "thumbLabel", 'tickInterval': "tickInterval", 'value': "value", 'displayWith': "displayWith", 'vertical': "vertical" }, { 'change': "change", 'input': "input", 'valueChange': "valueChange" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatSlider>;
 }

--- a/tools/public_api_guard/material/sort.d.ts
+++ b/tools/public_api_guard/material/sort.d.ts
@@ -28,8 +28,8 @@ export declare class MatSort extends _MatSortMixinBase implements CanDisable, Ha
     ngOnInit(): void;
     register(sortable: MatSortable): void;
     sort(sortable: MatSortable): void;
-    static ngAcceptInputType_disableClear: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disableClear: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatSort, "[matSort]", ["matSort"], { 'disabled': "matSortDisabled", 'active': "matSortActive", 'start': "matSortStart", 'direction': "matSortDirection", 'disableClear': "matSortDisableClear" }, { 'sortChange': "matSortChange" }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatSort>;
 }
@@ -74,8 +74,8 @@ export declare class MatSortHeader extends _MatSortHeaderMixinBase implements Ca
     _updateArrowDirection(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ngAcceptInputType_disableClear: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disableClear: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSortHeader, "[mat-sort-header]", ["matSortHeader"], { 'disabled': "disabled", 'id': "mat-sort-header", 'arrowPosition': "arrowPosition", 'start': "start", 'disableClear': "disableClear" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatSortHeader>;
 }

--- a/tools/public_api_guard/material/stepper.d.ts
+++ b/tools/public_api_guard/material/stepper.d.ts
@@ -8,12 +8,12 @@ export declare function MAT_STEPPER_INTL_PROVIDER_FACTORY(parentIntl: MatStepper
 
 export declare class MatHorizontalStepper extends MatStepper {
     labelPosition: 'bottom' | 'end';
-    static ngAcceptInputType_completed: boolean | string;
-    static ngAcceptInputType_editable: boolean | string;
-    static ngAcceptInputType_hasError: boolean | string;
-    static ngAcceptInputType_linear: boolean | string;
-    static ngAcceptInputType_optional: boolean | string;
-    static ngAcceptInputType_selectedIndex: number | string;
+    static ngAcceptInputType_completed: boolean | string | null | undefined;
+    static ngAcceptInputType_editable: boolean | string | null | undefined;
+    static ngAcceptInputType_hasError: boolean | string | null | undefined;
+    static ngAcceptInputType_linear: boolean | string | null | undefined;
+    static ngAcceptInputType_optional: boolean | string | null | undefined;
+    static ngAcceptInputType_selectedIndex: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatHorizontalStepper, "mat-horizontal-stepper", ["matHorizontalStepper"], { 'selectedIndex': "selectedIndex", 'labelPosition': "labelPosition" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatHorizontalStepper>;
 }
@@ -22,10 +22,10 @@ export declare class MatStep extends CdkStep implements ErrorStateMatcher {
     stepLabel: MatStepLabel;
     constructor(stepper: MatStepper, _errorStateMatcher: ErrorStateMatcher, stepperOptions?: StepperOptions);
     isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean;
-    static ngAcceptInputType_completed: boolean | string;
-    static ngAcceptInputType_editable: boolean | string;
-    static ngAcceptInputType_hasError: boolean | string;
-    static ngAcceptInputType_optional: boolean | string;
+    static ngAcceptInputType_completed: boolean | string | null | undefined;
+    static ngAcceptInputType_editable: boolean | string | null | undefined;
+    static ngAcceptInputType_hasError: boolean | string | null | undefined;
+    static ngAcceptInputType_optional: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatStep, "mat-step", ["matStep"], {}, {}, ["stepLabel"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatStep>;
 }
@@ -71,12 +71,12 @@ export declare class MatStepper extends CdkStepper implements AfterContentInit {
     readonly animationDone: EventEmitter<void>;
     disableRipple: boolean;
     ngAfterContentInit(): void;
-    static ngAcceptInputType_completed: boolean | string;
-    static ngAcceptInputType_editable: boolean | string;
-    static ngAcceptInputType_hasError: boolean | string;
-    static ngAcceptInputType_linear: boolean | string;
-    static ngAcceptInputType_optional: boolean | string;
-    static ngAcceptInputType_selectedIndex: number | string;
+    static ngAcceptInputType_completed: boolean | string | null | undefined;
+    static ngAcceptInputType_editable: boolean | string | null | undefined;
+    static ngAcceptInputType_hasError: boolean | string | null | undefined;
+    static ngAcceptInputType_linear: boolean | string | null | undefined;
+    static ngAcceptInputType_optional: boolean | string | null | undefined;
+    static ngAcceptInputType_selectedIndex: number | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStepper, "[matStepper]", never, { 'disableRipple': "disableRipple" }, { 'animationDone': "animationDone" }, ["_steps", "_icons"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatStepper>;
 }
@@ -124,12 +124,12 @@ export declare class MatStepperPrevious extends CdkStepperPrevious {
 
 export declare class MatVerticalStepper extends MatStepper {
     constructor(dir: Directionality, changeDetectorRef: ChangeDetectorRef, elementRef?: ElementRef<HTMLElement>, _document?: any);
-    static ngAcceptInputType_completed: boolean | string;
-    static ngAcceptInputType_editable: boolean | string;
-    static ngAcceptInputType_hasError: boolean | string;
-    static ngAcceptInputType_linear: boolean | string;
-    static ngAcceptInputType_optional: boolean | string;
-    static ngAcceptInputType_selectedIndex: number | string;
+    static ngAcceptInputType_completed: boolean | string | null | undefined;
+    static ngAcceptInputType_editable: boolean | string | null | undefined;
+    static ngAcceptInputType_hasError: boolean | string | null | undefined;
+    static ngAcceptInputType_linear: boolean | string | null | undefined;
+    static ngAcceptInputType_optional: boolean | string | null | undefined;
+    static ngAcceptInputType_selectedIndex: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatVerticalStepper, "mat-vertical-stepper", ["matVerticalStepper"], { 'selectedIndex': "selectedIndex" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatVerticalStepper>;
 }

--- a/tools/public_api_guard/material/table.d.ts
+++ b/tools/public_api_guard/material/table.d.ts
@@ -11,8 +11,8 @@ export declare class MatCellDef extends CdkCellDef {
 
 export declare class MatColumnDef extends CdkColumnDef {
     name: string;
-    static ngAcceptInputType_sticky: boolean | string;
-    static ngAcceptInputType_stickyEnd: boolean | string;
+    static ngAcceptInputType_sticky: boolean | string | null | undefined;
+    static ngAcceptInputType_stickyEnd: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatColumnDef, "[matColumnDef]", never, { 'sticky': "sticky", 'name': "matColumnDef" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatColumnDef>;
 }
@@ -34,7 +34,7 @@ export declare class MatFooterRow extends CdkFooterRow {
 }
 
 export declare class MatFooterRowDef extends CdkFooterRowDef {
-    static ngAcceptInputType_sticky: boolean | string;
+    static ngAcceptInputType_sticky: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatFooterRowDef, "[matFooterRowDef]", never, { 'columns': "matFooterRowDef", 'sticky': "matFooterRowDefSticky" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatFooterRowDef>;
 }
@@ -56,7 +56,7 @@ export declare class MatHeaderRow extends CdkHeaderRow {
 }
 
 export declare class MatHeaderRowDef extends CdkHeaderRowDef {
-    static ngAcceptInputType_sticky: boolean | string;
+    static ngAcceptInputType_sticky: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatHeaderRowDef, "[matHeaderRowDef]", never, { 'columns': "matHeaderRowDef", 'sticky': "matHeaderRowDefSticky" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatHeaderRowDef>;
 }
@@ -73,7 +73,7 @@ export declare class MatRowDef<T> extends CdkRowDef<T> {
 
 export declare class MatTable<T> extends CdkTable<T> {
     protected stickyCssClass: string;
-    static ngAcceptInputType_multiTemplateDataRows: boolean | string;
+    static ngAcceptInputType_multiTemplateDataRows: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTable<any>, "mat-table, table[mat-table]", ["matTable"], {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTable<any>>;
 }

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -131,7 +131,7 @@ export declare class MatTab extends _MatTabMixinBase implements OnInit, CanDisab
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTab, "mat-tab", ["matTab"], { 'disabled': "disabled", 'textLabel': "label", 'ariaLabel': "aria-label", 'ariaLabelledby': "aria-labelledby" }, {}, ["templateLabel", "_explicitContent"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatTab>;
 }
@@ -172,10 +172,10 @@ export declare class MatTabGroup extends _MatTabGroupBase {
     _tabBodyWrapper: ElementRef;
     _tabHeader: MatTabGroupBaseHeader;
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, defaultConfig?: MatTabsConfig, animationMode?: string);
-    static ngAcceptInputType_animationDuration: number | string;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_dynamicHeight: boolean | string;
-    static ngAcceptInputType_selectedIndex: number | string;
+    static ngAcceptInputType_animationDuration: number | string | null | undefined;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_dynamicHeight: boolean | string | null | undefined;
+    static ngAcceptInputType_selectedIndex: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTabGroup, "mat-tab-group", ["matTabGroup"], { 'color': "color", 'disableRipple': "disableRipple" }, {}, ["_allTabs"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabGroup>;
 }
@@ -188,8 +188,8 @@ export declare class MatTabHeader extends _MatTabHeaderBase {
     _tabList: ElementRef;
     _tabListContainer: ElementRef;
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler, dir: Directionality, ngZone: NgZone, platform: Platform, animationMode?: string);
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_selectedIndex: number | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_selectedIndex: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTabHeader, "mat-tab-header", never, { 'selectedIndex': "selectedIndex" }, { 'selectFocusedIndex': "selectFocusedIndex", 'indexFocused': "indexFocused" }, ["_items"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabHeader>;
 }
@@ -207,7 +207,7 @@ export declare class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase imp
     focus(): void;
     getOffsetLeft(): number;
     getOffsetWidth(): number;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTabLabelWrapper, "[matTabLabelWrapper]", never, { 'disabled': "disabled" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabLabelWrapper>;
 }
@@ -215,8 +215,8 @@ export declare class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase imp
 export declare class MatTabLink extends _MatTabLinkBase implements OnDestroy {
     constructor(tabNavBar: MatTabNav, elementRef: ElementRef, ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string, focusMonitor: FocusMonitor, animationMode?: string);
     ngOnDestroy(): void;
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTabLink, "[mat-tab-link], [matTabLink]", ["matTabLink"], { 'disabled': "disabled", 'disableRipple': "disableRipple", 'tabIndex': "tabIndex" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabLink>;
 }
@@ -230,8 +230,8 @@ export declare class MatTabNav extends _MatTabNavBase {
     _tabListContainer: ElementRef;
     constructor(elementRef: ElementRef, dir: Directionality, ngZone: NgZone, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler,
     platform?: Platform, animationMode?: string);
-    static ngAcceptInputType_disableRipple: boolean | string;
-    static ngAcceptInputType_selectedIndex: number | string;
+    static ngAcceptInputType_disableRipple: boolean | string | null | undefined;
+    static ngAcceptInputType_selectedIndex: number | string | null | undefined;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTabNav, "[mat-tab-nav-bar]", ["matTabNavBar", "matTabNav"], { 'color': "color" }, {}, ["_items"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabNav>;
 }

--- a/tools/public_api_guard/material/tooltip.d.ts
+++ b/tools/public_api_guard/material/tooltip.d.ts
@@ -42,9 +42,9 @@ export declare class MatTooltip implements OnDestroy, OnInit {
     ngOnInit(): void;
     show(delay?: number): void;
     toggle(): void;
-    static ngAcceptInputType_disabled: boolean | string;
-    static ngAcceptInputType_hideDelay: number | string;
-    static ngAcceptInputType_showDelay: number | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
+    static ngAcceptInputType_hideDelay: number | string | null | undefined;
+    static ngAcceptInputType_showDelay: number | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTooltip, "[matTooltip]", ["matTooltip"], { 'position': "matTooltipPosition", 'disabled': "matTooltipDisabled", 'showDelay': "matTooltipShowDelay", 'hideDelay': "matTooltipHideDelay", 'touchGestures': "matTooltipTouchGestures", 'message': "matTooltip", 'tooltipClass': "matTooltipClass" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTooltip>;
 }

--- a/tools/public_api_guard/material/tree.d.ts
+++ b/tools/public_api_guard/material/tree.d.ts
@@ -8,7 +8,7 @@ export declare class MatNestedTreeNode<T> extends CdkNestedTreeNode<T> implement
     constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T>, _differs: IterableDiffers, tabIndex: string);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatNestedTreeNode<any>, "mat-nested-tree-node", ["matNestedTreeNode"], { 'node': "matNestedTreeNode", 'disabled': "disabled", 'tabIndex': "tabIndex" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatNestedTreeNode<any>>;
 }
@@ -58,7 +58,7 @@ export declare class MatTreeNode<T> extends _MatTreeNodeMixinBase<T> implements 
     protected _tree: CdkTree<T>;
     role: 'treeitem' | 'group';
     constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T>, tabIndex: string);
-    static ngAcceptInputType_disabled: boolean | string;
+    static ngAcceptInputType_disabled: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTreeNode<any>, "mat-tree-node", ["matTreeNode"], { 'disabled': "disabled", 'tabIndex': "tabIndex", 'role': "role" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTreeNode<any>>;
 }
@@ -80,14 +80,14 @@ export declare class MatTreeNodeOutlet implements CdkTreeNodeOutlet {
 export declare class MatTreeNodePadding<T> extends CdkTreeNodePadding<T> {
     indent: number;
     level: number;
-    static ngAcceptInputType_level: number | string;
+    static ngAcceptInputType_level: number | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTreeNodePadding<any>, "[matTreeNodePadding]", never, { 'level': "matTreeNodePadding", 'indent': "matTreeNodePaddingIndent" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTreeNodePadding<any>>;
 }
 
 export declare class MatTreeNodeToggle<T> extends CdkTreeNodeToggle<T> {
     recursive: boolean;
-    static ngAcceptInputType_recursive: boolean | string;
+    static ngAcceptInputType_recursive: boolean | string | null | undefined;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTreeNodeToggle<any>, "[matTreeNodeToggle]", never, { 'recursive': "matTreeNodeToggleRecursive" }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTreeNodeToggle<any>>;
 }


### PR DESCRIPTION
We need to accept `null` and `undefined` for coercion members
to make them work with the `async` pipe. The overall problem
remains for other non-coercion inputs, but since the majority
of inputs are coerced, we only make the change to these.

The overall problem applies to _all_ inputs, but it's not clear
yet how this issue can be solved for all inputs. This involves
discussion with the framework team.

More information: https://hackmd.io/@devversion/rkKOD8ZjB