### PR TITLE
build: switch mdc snapshot test to run against master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,7 @@ jobs:
     environment:
       GCP_DECRYPT_TOKEN: *gcp_decrypt_token
       MDC_REPO_URL: "https://github.com/material-components/material-components-web.git"
-      MDC_REPO_BRANCH: "develop"
+      MDC_REPO_BRANCH: "master"
       MDC_REPO_TMP_DIR: "/tmp/material-components-web"
     steps:
       - *checkout_code


### PR DESCRIPTION
We currently run the MDC snapshot tests against their `develop`
branch. This breaks at the moment since MDC deleted the branch
in order to release a new major version.

It's unclear what Git process they use, but considering they use
Gitflow, then the `develop` branch should have not been deleted. This
would be ideal for us.. because then we can just _always_ run against
`develop`.

For now though, since the branch does not exist anymore, we should
switch to master so that the CI job can be green.