### PR TITLE
feat(cdk/testing): support querying for multiple TestHarness / Compon…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev-app": "ibazel run //src/dev-app:devserver",
     "test": "bazel test //src/... --test_tag_filters=-e2e,-browser:firefox-local --build_tag_filters=-browser:firefox-local --build_tests_only",
     "test-firefox": "bazel test //src/... --test_tag_filters=-e2e,-browser:chromium-local --build_tag_filters=-browser:chromium-local --build_tests_only",
-    "lint": "gulp lint && yarn -s bazel:format-lint",
+    "lint": "yarn -s tslint && yarn -s bazel:format-lint && yarn -s ownerslint",
     "e2e": "bazel test //src/... --test_tag_filters=e2e",
     "deploy": "echo 'Not supported yet. Tracked with COMP-230'",
     "webdriver-manager": "webdriver-manager",

--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -503,7 +503,9 @@ function _valueAsString(value: unknown) {
         v instanceof RegExp ? `/${v.toString()}/` :
             typeof v === 'string' ? v.replace('/\//g', '\\/') : v
     ).replace(/"\/\//g, '\\/').replace(/\/\/"/g, '\\/').replace(/\\\//g, '/');
-  } catch (e) {
+  } catch {
+    // `JSON.stringify` will throw if the object is cyclical,
+    // in this case the best we can do is report the value as `{...}`.
     return '{...}';
   }
 }

--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -18,6 +18,43 @@ export type AsyncPredicate<T> = (item: T) => Promise<boolean>;
 export type AsyncOptionPredicate<T, O> = (item: T, option: O) => Promise<boolean>;
 
 /**
+ * A query for a `ComponentHarness`, which is expressed as either a `ComponentHarnessConstructor` or
+ * a `HarnessPredicate`.
+ */
+export type HarnessQuery<T extends ComponentHarness> =
+    ComponentHarnessConstructor<T> | HarnessPredicate<T>;
+
+/**
+ * The type returned by the functions that the `locatorFor*` methods create.
+ * Maps the input type array and creates a type union from the mapped array:
+ * - `ComponentHarnessConstructor&lt;T&gt;` maps to `T`
+ * - `HarnessPredicate&lt;T&gt;` maps to `T`
+ * - `string` maps to `TestElement`
+ *
+ * e.g.
+ * The type:
+ * `LocatorFnResult&lt;[
+ *   ComponentHarnessConstructor&lt;MyHarness&gt;,
+ *   HarnessPredicate&lt;MyOtherHarness&gt;,
+ *   string
+ * ]&gt;`
+ * is equivalent to:
+ * `MyHarness | MyOtherHarness | TestElement`.
+ */
+export type LocatorFnResult<T extends (HarnessQuery<any> | string)[]> = {
+  [I in keyof T]:
+      // Map `ComponentHarnessConstructor<C>` to `C`.
+      T[I] extends new (...args: any[]) => infer C ? C :
+      // Map `HarnessPredicate<C>` to `C`.
+      T[I] extends { harnessType: new (...args: any[]) => infer C } ? C :
+      // Map `string` to `TestElement`.
+      T[I] extends string ? TestElement :
+      // Map everything else to `never` (should not happen due to the type constraint on `T`).
+      never;
+}[number];
+
+
+/**
  * Interface used to load ComponentHarness objects. This interface is used by test authors to
  * instantiate `ComponentHarness`es.
  */
@@ -46,21 +83,19 @@ export interface HarnessLoader {
    * `HarnessLoader`'s root element, and returns a `ComponentHarness` for that instance. If multiple
    * matching components are found, a harness for the first one is returned. If no matching
    * component is found, an error is thrown.
-   * @param harnessType The type of harness to create
+   * @param query A query for a harness to create
    * @return An instance of the given harness type
    * @throws If a matching component instance can't be found.
    */
-  getHarness<T extends ComponentHarness>(
-      harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): Promise<T>;
+  getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
 
   /**
    * Searches for all instances of the component corresponding to the given harness type under the
    * `HarnessLoader`'s root element, and returns a list `ComponentHarness` for each instance.
-   * @param harnessType The type of harness to create
+   * @param query A query for a harness to create
    * @return A list instances of the given harness type.
    */
-  getAllHarnesses<T extends ComponentHarness>(
-      harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): Promise<T[]>;
+  getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
 }
 
 /**
@@ -76,72 +111,88 @@ export interface LocatorFactory {
   rootElement: TestElement;
 
   /**
-   * Creates an asynchronous locator function that can be used to search for elements with the given
-   * selector under the root element of this `LocatorFactory`. When the resulting locator function
-   * is invoked, if multiple matching elements are found, the first element is returned. If no
-   * elements are found, an error is thrown.
-   * @param selector The selector for the element that the locator function should search for.
-   * @return An asynchronous locator function that searches for elements with the given selector,
-   *     and either finds one or throws an error
+   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
+   * or element under the root element of this `LocatorFactory`.
+   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for the
+   *   first element or harness matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If no matches are found, the
+   *   `Promise` rejects.
+   *
+   * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
+   * `DivHarness.hostSelector === 'div'`:
+   * - `await lf.locatorFor(DivHarness, 'div')()` gets a `DivHarness` instance for `#d1`
+   * - `await lf.locatorFor('div', DivHarness)()` gets a `TestElement` instance for `#d1`
+   * - `await lf.locatorFor('span')()` throws because the `Promise` rejects.
    */
-  locatorFor(selector: string): AsyncFactoryFn<TestElement>;
+  locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T):
+      AsyncFactoryFn<LocatorFnResult<T>>;
 
   /**
-   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` for a
-   * component matching the given harness type under the root element of this `LocatorFactory`.
-   * When the resulting locator function is invoked, if multiple matching components are found, a
-   * harness for the first one is returned. If no components are found, an error is thrown.
-   * @param harnessType The type of harness to search for.
-   * @return An asynchronous locator function that searches components matching the given harness
-   *     type, and either returns a `ComponentHarness` for the component, or throws an error.
+   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
+   * or element under the root element of this `LocatorFactory`.
+   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for the
+   *   first element or harness matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If no matches are found, the
+   *   `Promise` is resolved with `null`.
+   *
+   * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
+   * `DivHarness.hostSelector === 'div'`:
+   * - `await lf.locatorForOptional(DivHarness, 'div')()` gets a `DivHarness` instance for `#d1`
+   * - `await lf.locatorForOptional('div', DivHarness)()` gets a `TestElement` instance for `#d1`
+   * - `await lf.locatorForOptional('span')()` gets `null`.
    */
-  locatorFor<T extends ComponentHarness>(
-      harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T>;
+  locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T):
+      AsyncFactoryFn<LocatorFnResult<T> | null>;
 
   /**
-   * Creates an asynchronous locator function that can be used to search for elements with the given
-   * selector under the root element of this `LocatorFactory`. When the resulting locator function
-   * is invoked, if multiple matching elements are found, the first element is returned. If no
-   * elements are found, null is returned.
-   * @param selector The selector for the element that the locator function should search for.
-   * @return An asynchronous locator function that searches for elements with the given selector,
-   *     and either finds one or returns null.
+   * Creates an asynchronous locator function that can be used to find `ComponentHarness` instances
+   * or elements under the root element of this `LocatorFactory`.
+   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for all
+   *   elements and harnesses matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If an element matches more than
+   *   one `ComponentHarness` class, the locator gets an instance of each for the same element. If
+   *   an element matches multiple `string` selectors, only one `TestElement` instance is returned
+   *   for that element.
+   *
+   * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
+   * `DivHarness.hostSelector === 'div'` and `IdIsD1Harness.hostSelector === '#d1'`:
+   * - `await lf.locatorForAll(DivHarness, 'div')()` gets `[
+   *     DivHarness, // for #d1
+   *     TestElement, // for #d1
+   *     DivHarness, // for #d2
+   *     TestElement // for #d2
+   *   ]`
+   * - `await lf.locatorForAll('div', '#d1')()` gets `[
+   *     TestElement, // for #d1
+   *     TestElement // for #d2
+   *   ]`
+   * - `await lf.locatorForAll(DivHarness, IdIsD1Harness)()` gets `[
+   *     DivHarness, // for #d1
+   *     IdIsD1Harness, // for #d1
+   *     DivHarness // for #d2
+   *   ]`
+   * - `await lf.locatorForAll('span')()` gets `[]`.
    */
-  locatorForOptional(selector: string): AsyncFactoryFn<TestElement | null>;
-
-  /**
-   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` for a
-   * component matching the given harness type under the root element of this `LocatorFactory`.
-   * When the resulting locator function is invoked, if multiple matching components are found, a
-   * harness for the first one is returned. If no components are found, null is returned.
-   * @param harnessType The type of harness to search for.
-   * @return An asynchronous locator function that searches components matching the given harness
-   *     type, and either returns a `ComponentHarness` for the component, or null if none is found.
-   */
-  locatorForOptional<T extends ComponentHarness>(
-      harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T | null>;
-
-  /**
-   * Creates an asynchronous locator function that can be used to search for a list of elements with
-   * the given selector under the root element of this `LocatorFactory`. When the resulting locator
-   * function is invoked, a list of matching elements is returned.
-   * @param selector The selector for the element that the locator function should search for.
-   * @return An asynchronous locator function that searches for elements with the given selector,
-   *     and either finds one or throws an error
-   */
-  locatorForAll(selector: string): AsyncFactoryFn<TestElement[]>;
-
-  /**
-   * Creates an asynchronous locator function that can be used to find a list of
-   * `ComponentHarness`es for all components matching the given harness type under the root element
-   * of this `LocatorFactory`. When the resulting locator function is invoked, a list of
-   * `ComponentHarness`es for the matching components is returned.
-   * @param harnessType The type of harness to search for.
-   * @return An asynchronous locator function that searches components matching the given harness
-   *     type, and returns a list of `ComponentHarness`es.
-   */
-  locatorForAll<T extends ComponentHarness>(
-      harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T[]>;
+  locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T):
+      AsyncFactoryFn<LocatorFnResult<T>[]>;
 
   /**
    * Gets a `HarnessLoader` instance for an element under the root of this `LocatorFactory`.
@@ -203,83 +254,93 @@ export abstract class ComponentHarness {
   }
 
   /**
-   * Creates an asynchronous locator function that can be used to search for elements with the given
-   * selector under the host element of this `ComponentHarness`. When the resulting locator function
-   * is invoked, if multiple matching elements are found, the first element is returned. If no
-   * elements are found, an error is thrown.
-   * @param selector The selector for the element that the locator function should search for.
-   * @return An asynchronous locator function that searches for elements with the given selector,
-   *     and either finds one or throws an error
+   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
+   * or element under the host element of this `ComponentHarness`.
+   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for the
+   *   first element or harness matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If no matches are found, the
+   *   `Promise` rejects.
+   *
+   * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
+   * `DivHarness.hostSelector === 'div'`:
+   * - `await ch.locatorFor(DivHarness, 'div')()` gets a `DivHarness` instance for `#d1`
+   * - `await ch.locatorFor('div', DivHarness)()` gets a `TestElement` instance for `#d1`
+   * - `await ch.locatorFor('span')()` throws because the `Promise` rejects.
    */
-  protected locatorFor(selector: string): AsyncFactoryFn<TestElement>;
-
-  /**
-   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` for a
-   * component matching the given harness type under the host element of this `ComponentHarness`.
-   * When the resulting locator function is invoked, if multiple matching components are found, a
-   * harness for the first one is returned. If no components are found, an error is thrown.
-   * @param harnessType The type of harness to search for.
-   * @return An asynchronous locator function that searches components matching the given harness
-   *     type, and either returns a `ComponentHarness` for the component, or throws an error.
-   */
-  protected locatorFor<T extends ComponentHarness>(
-      harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T>;
-
-  protected locatorFor(arg: any) {
-    return this.locatorFactory.locatorFor(arg);
+  protected locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T):
+      AsyncFactoryFn<LocatorFnResult<T>> {
+    return this.locatorFactory.locatorFor(...queries);
   }
 
   /**
-   * Creates an asynchronous locator function that can be used to search for elements with the given
-   * selector under the host element of this `ComponentHarness`. When the resulting locator function
-   * is invoked, if multiple matching elements are found, the first element is returned. If no
-   * elements are found, null is returned.
-   * @param selector The selector for the element that the locator function should search for.
-   * @return An asynchronous locator function that searches for elements with the given selector,
-   *     and either finds one or returns null.
+   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
+   * or element under the host element of this `ComponentHarness`.
+   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for the
+   *   first element or harness matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If no matches are found, the
+   *   `Promise` is resolved with `null`.
+   *
+   * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
+   * `DivHarness.hostSelector === 'div'`:
+   * - `await ch.locatorForOptional(DivHarness, 'div')()` gets a `DivHarness` instance for `#d1`
+   * - `await ch.locatorForOptional('div', DivHarness)()` gets a `TestElement` instance for `#d1`
+   * - `await ch.locatorForOptional('span')()` gets `null`.
    */
-  protected locatorForOptional(selector: string): AsyncFactoryFn<TestElement | null>;
-
-  /**
-   * Creates an asynchronous locator function that can be used to find a `ComponentHarness` for a
-   * component matching the given harness type under the host element of this `ComponentHarness`.
-   * When the resulting locator function is invoked, if multiple matching components are found, a
-   * harness for the first one is returned. If no components are found, null is returned.
-   * @param harnessType The type of harness to search for.
-   * @return An asynchronous locator function that searches components matching the given harness
-   *     type, and either returns a `ComponentHarness` for the component, or null if none is found.
-   */
-  protected locatorForOptional<T extends ComponentHarness>(
-      harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T | null>;
-
-  protected locatorForOptional(arg: any) {
-    return this.locatorFactory.locatorForOptional(arg);
+  protected locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T):
+      AsyncFactoryFn<LocatorFnResult<T> | null> {
+    return this.locatorFactory.locatorForOptional(...queries);
   }
 
   /**
-   * Creates an asynchronous locator function that can be used to search for a list of elements with
-   * the given selector under the host element of this `ComponentHarness`. When the resulting
-   * locator function is invoked, a list of matching elements is returned.
-   * @param selector The selector for the element that the locator function should search for.
-   * @return An asynchronous locator function that searches for elements with the given selector,
-   *     and either finds one or throws an error
+   * Creates an asynchronous locator function that can be used to find `ComponentHarness` instances
+   * or elements under the host element of this `ComponentHarness`.
+   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the selector specified by the string.
+   *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
+   *     given class.
+   *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
+   *     predicate.
+   * @return An asynchronous locator function that searches for and returns a `Promise` for all
+   *   elements and harnesses matching the given search criteria. Matches are ordered first by
+   *   order in the DOM, and second by order in the queries list. If an element matches more than
+   *   one `ComponentHarness` class, the locator gets an instance of each for the same element. If
+   *   an element matches multiple `string` selectors, only one `TestElement` instance is returned
+   *   for that element.
+   *
+   * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
+   * `DivHarness.hostSelector === 'div'` and `IdIsD1Harness.hostSelector === '#d1'`:
+   * - `await ch.locatorForAll(DivHarness, 'div')()` gets `[
+   *     DivHarness, // for #d1
+   *     TestElement, // for #d1
+   *     DivHarness, // for #d2
+   *     TestElement // for #d2
+   *   ]`
+   * - `await ch.locatorForAll('div', '#d1')()` gets `[
+   *     TestElement, // for #d1
+   *     TestElement // for #d2
+   *   ]`
+   * - `await ch.locatorForAll(DivHarness, IdIsD1Harness)()` gets `[
+   *     DivHarness, // for #d1
+   *     IdIsD1Harness, // for #d1
+   *     DivHarness // for #d2
+   *   ]`
+   * - `await ch.locatorForAll('span')()` gets `[]`.
    */
-  protected locatorForAll(selector: string): AsyncFactoryFn<TestElement[]>;
-
-  /**
-   * Creates an asynchronous locator function that can be used to find a list of
-   * `ComponentHarness`es for all components matching the given harness type under the host element
-   * of this `ComponentHarness`. When the resulting locator function is invoked, a list of
-   * `ComponentHarness`es for the matching components is returned.
-   * @param harnessType The type of harness to search for.
-   * @return An asynchronous locator function that searches components matching the given harness
-   *     type, and returns a list of `ComponentHarness`es.
-   */
-  protected locatorForAll<T extends ComponentHarness>(
-      harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T[]>;
-
-  protected locatorForAll(arg: any) {
-    return this.locatorFactory.locatorForAll(arg);
+  protected locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T):
+      AsyncFactoryFn<LocatorFnResult<T>[]> {
+    return this.locatorFactory.locatorForAll(...queries);
   }
 
   /**
@@ -366,10 +427,8 @@ export class HarnessPredicate<T extends ComponentHarness> {
    * @return this (for method chaining).
    */
   addOption<O>(name: string, option: O | undefined, predicate: AsyncOptionPredicate<T, O>) {
-    // Add quotes around strings to differentiate them from other values
-    const value = typeof option === 'string' ? `"${option}"` : `${option}`;
     if (option !== undefined) {
-      this.add(`${name} = ${value}`, item => predicate(item, option));
+      this.add(`${name} = ${_valueAsString(option)}`, item => predicate(item, option));
     }
     return this;
   }
@@ -420,4 +479,16 @@ export class HarnessPredicate<T extends ComponentHarness> {
       });
     }
   }
+}
+
+/** Represent a value as a string for the purpose of logging. */
+function _valueAsString(value: unknown) {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  // `JSON.stringify` doesn't handle RegExp properly, so we need a custom replacer.
+  return JSON.stringify(value, (_, v) =>
+      v instanceof RegExp ? `/${v.toString()}/` :
+          typeof v === 'string' ? v.replace('/\//g', '\\/') : v
+  ).replace(/"\/\//g, '\\/').replace(/\/\/"/g, '\\/').replace(/\\\//g, '/');
 }

--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -25,11 +25,16 @@ export type HarnessQuery<T extends ComponentHarness> =
     ComponentHarnessConstructor<T> | HarnessPredicate<T>;
 
 /**
- * The type returned by the functions that the `locatorFor*` methods create.
- * Maps the input type array and creates a type union from the mapped array:
- * - `ComponentHarnessConstructor&lt;T&gt;` maps to `T`
- * - `HarnessPredicate&lt;T&gt;` maps to `T`
- * - `string` maps to `TestElement`
+ * The result type obtained when searching using a particular list of queries. This type depends on
+ * the particular items being queried.
+ * - If one of the queries is for a `ComponentHarnessConstructor<C1>`, it means that the result
+ *   might be a harness of type `C1`
+ * - If one of the queries is for a `HarnessPredicate<C2>`, it means that the result might be a
+ *   harness of type `C2`
+ * - If one of the queries is for a `string`, it means that the result might be a `TestElement`.
+ *
+ * Since we don't know for sure which query will match, the result type if the union of the types
+ * for all possible results.
  *
  * e.g.
  * The type:
@@ -113,8 +118,8 @@ export interface LocatorFactory {
   /**
    * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
    * or element under the root element of this `LocatorFactory`.
-   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
-   *   - A `string` searches for elements matching the selector specified by the string.
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
    *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
    *     given class.
    *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
@@ -122,7 +127,8 @@ export interface LocatorFactory {
    * @return An asynchronous locator function that searches for and returns a `Promise` for the
    *   first element or harness matching the given search criteria. Matches are ordered first by
    *   order in the DOM, and second by order in the queries list. If no matches are found, the
-   *   `Promise` rejects.
+   *   `Promise` rejects. The type that the `Promise` resolves to is a union of all result types for
+   *   each query.
    *
    * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
    * `DivHarness.hostSelector === 'div'`:
@@ -136,8 +142,8 @@ export interface LocatorFactory {
   /**
    * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
    * or element under the root element of this `LocatorFactory`.
-   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
-   *   - A `string` searches for elements matching the selector specified by the string.
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
    *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
    *     given class.
    *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
@@ -145,7 +151,8 @@ export interface LocatorFactory {
    * @return An asynchronous locator function that searches for and returns a `Promise` for the
    *   first element or harness matching the given search criteria. Matches are ordered first by
    *   order in the DOM, and second by order in the queries list. If no matches are found, the
-   *   `Promise` is resolved with `null`.
+   *   `Promise` is resolved with `null`. The type that the `Promise` resolves to is a union of all
+   *   result types for each query or null.
    *
    * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
    * `DivHarness.hostSelector === 'div'`:
@@ -159,8 +166,8 @@ export interface LocatorFactory {
   /**
    * Creates an asynchronous locator function that can be used to find `ComponentHarness` instances
    * or elements under the root element of this `LocatorFactory`.
-   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
-   *   - A `string` searches for elements matching the selector specified by the string.
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
    *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
    *     given class.
    *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
@@ -170,7 +177,8 @@ export interface LocatorFactory {
    *   order in the DOM, and second by order in the queries list. If an element matches more than
    *   one `ComponentHarness` class, the locator gets an instance of each for the same element. If
    *   an element matches multiple `string` selectors, only one `TestElement` instance is returned
-   *   for that element.
+   *   for that element. The type that the `Promise` resolves to is an array where each element is
+   *   the union of all result types for each query.
    *
    * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
    * `DivHarness.hostSelector === 'div'` and `IdIsD1Harness.hostSelector === '#d1'`:
@@ -256,8 +264,8 @@ export abstract class ComponentHarness {
   /**
    * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
    * or element under the host element of this `ComponentHarness`.
-   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
-   *   - A `string` searches for elements matching the selector specified by the string.
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
    *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
    *     given class.
    *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
@@ -265,7 +273,8 @@ export abstract class ComponentHarness {
    * @return An asynchronous locator function that searches for and returns a `Promise` for the
    *   first element or harness matching the given search criteria. Matches are ordered first by
    *   order in the DOM, and second by order in the queries list. If no matches are found, the
-   *   `Promise` rejects.
+   *   `Promise` rejects. The type that the `Promise` resolves to is a union of all result types for
+   *   each query.
    *
    * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
    * `DivHarness.hostSelector === 'div'`:
@@ -281,8 +290,8 @@ export abstract class ComponentHarness {
   /**
    * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
    * or element under the host element of this `ComponentHarness`.
-   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
-   *   - A `string` searches for elements matching the selector specified by the string.
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
    *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
    *     given class.
    *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
@@ -290,7 +299,8 @@ export abstract class ComponentHarness {
    * @return An asynchronous locator function that searches for and returns a `Promise` for the
    *   first element or harness matching the given search criteria. Matches are ordered first by
    *   order in the DOM, and second by order in the queries list. If no matches are found, the
-   *   `Promise` is resolved with `null`.
+   *   `Promise` is resolved with `null`. The type that the `Promise` resolves to is a union of all
+   *   result types for each query or null.
    *
    * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
    * `DivHarness.hostSelector === 'div'`:
@@ -306,8 +316,8 @@ export abstract class ComponentHarness {
   /**
    * Creates an asynchronous locator function that can be used to find `ComponentHarness` instances
    * or elements under the host element of this `ComponentHarness`.
-   * @param {...*} queries A list of queries specifying which harnesses and elements to search for:
-   *   - A `string` searches for elements matching the selector specified by the string.
+   * @param queries A list of queries specifying which harnesses and elements to search for:
+   *   - A `string` searches for elements matching the CSS selector specified by the string.
    *   - A `ComponentHarness` constructor searches for `ComponentHarness` instances matching the
    *     given class.
    *   - A `HarnessPredicate` searches for `ComponentHarness` instances matching the given
@@ -317,7 +327,8 @@ export abstract class ComponentHarness {
    *   order in the DOM, and second by order in the queries list. If an element matches more than
    *   one `ComponentHarness` class, the locator gets an instance of each for the same element. If
    *   an element matches multiple `string` selectors, only one `TestElement` instance is returned
-   *   for that element.
+   *   for that element. The type that the `Promise` resolves to is an array where each element is
+   *   the union of all result types for each query.
    *
    * e.g. Given the following DOM: `<div id="d1" /><div id="d2" />`, and assuming
    * `DivHarness.hostSelector === 'div'` and `IdIsD1Harness.hostSelector === '#d1'`:
@@ -487,8 +498,12 @@ function _valueAsString(value: unknown) {
     return 'undefined';
   }
   // `JSON.stringify` doesn't handle RegExp properly, so we need a custom replacer.
-  return JSON.stringify(value, (_, v) =>
-      v instanceof RegExp ? `/${v.toString()}/` :
-          typeof v === 'string' ? v.replace('/\//g', '\\/') : v
-  ).replace(/"\/\//g, '\\/').replace(/\/\/"/g, '\\/').replace(/\\\//g, '/');
+  try {
+    return JSON.stringify(value, (_, v) =>
+        v instanceof RegExp ? `/${v.toString()}/` :
+            typeof v === 'string' ? v.replace('/\//g', '\\/') : v
+    ).replace(/"\/\//g, '\\/').replace(/\/\/"/g, '\\/').replace(/\\\//g, '/');
+  } catch (e) {
+    return '{...}';
+  }
 }

--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -176,11 +176,13 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
 
   /**
    * Check whether the given query matches the given element, if it does return the matched
-   * `TestElement` or `ComponentHarness`, if it does not, return null.
+   * `TestElement` or `ComponentHarness`, if it does not, return null. In cases where the caller
+   * knows for sure that the query matches the element's selector, `skipSelectorCheck` can be used
+   * to skip verification and optimize performance.
    */
   private async _getQueryResultForElement<T extends ComponentHarness>(
       query: string | HarnessPredicate<T>, rawElement: E, testElement: TestElement,
-      skipSelectorCheck: boolean): Promise<T | TestElement | null> {
+      skipSelectorCheck: boolean = false): Promise<T | TestElement | null> {
     if (typeof query === 'string') {
       return ((skipSelectorCheck || await testElement.matchesSelector(query)) ? testElement : null);
     }

--- a/src/cdk/testing/private/expect-async-error.ts
+++ b/src/cdk/testing/private/expect-async-error.ts
@@ -10,7 +10,7 @@
  * Expects the asynchronous function to throw an error that matches
  * the specified expectation.
  */
-export async function expectAsyncError(fn: () => Promise<any>, expectation: RegExp) {
+export async function expectAsyncError(fn: () => Promise<any>, expectation: RegExp | string) {
   let error: string|null = null;
   try {
     await fn();
@@ -18,5 +18,9 @@ export async function expectAsyncError(fn: () => Promise<any>, expectation: RegE
     error = e.toString();
   }
   expect(error).not.toBe(null);
-  expect(error!).toMatch(expectation, 'Expected error to be thrown.');
+  if (expectation instanceof RegExp) {
+    expect(error!).toMatch(expectation, 'Expected error to be thrown.');
+  } else {
+    expect(error!).toBe(expectation, 'Expected error to be throw.');
+  }
 }

--- a/src/cdk/testing/tests/BUILD.bazel
+++ b/src/cdk/testing/tests/BUILD.bazel
@@ -37,6 +37,7 @@ ng_test_library(
         ":test_components",
         ":test_harnesses",
         "//src/cdk/testing",
+        "//src/cdk/testing/private",
         "//src/cdk/testing/testbed",
     ],
 )
@@ -47,6 +48,7 @@ ng_e2e_test_library(
     deps = [
         ":test_harnesses",
         "//src/cdk/testing",
+        "//src/cdk/testing/private",
         "//src/cdk/testing/protractor",
     ],
 )

--- a/src/cdk/testing/tests/harnesses/main-component-harness.ts
+++ b/src/cdk/testing/tests/harnesses/main-component-harness.ts
@@ -8,7 +8,7 @@
 
 import {ComponentHarness} from '../../component-harness';
 import {TestElement, TestKey} from '../../test-element';
-import {SubComponentHarness} from './sub-component-harness';
+import {SubComponentHarness, SubComponentSpecialHarness} from './sub-component-harness';
 
 export class WrongComponentHarness extends ComponentHarness {
   static readonly hostSelector = 'wrong-selector';
@@ -72,6 +72,15 @@ export class MainComponentHarness extends ComponentHarness {
   readonly directAncestorSelectorSubcomponent =
       this.locatorForAll(SubComponentHarness.with({ancestor: '.other >'}));
 
+  readonly subcomponentHarnessesAndElements =
+      this.locatorForAll('#counter', SubComponentHarness);
+  readonly subcomponentHarnessAndElementsRedundant =
+      this.locatorForAll(
+          SubComponentHarness.with({title: /test/}), 'test-sub', SubComponentHarness, 'test-sub');
+  readonly subcomponentAndSpecialHarnesses =
+      this.locatorForAll(SubComponentHarness, SubComponentSpecialHarness);
+  readonly missingElementsAndHarnesses =
+      this.locatorFor('.not-found', SubComponentHarness.with({title: /not found/}));
 
   private _testTools = this.locatorFor(SubComponentHarness);
 

--- a/src/cdk/testing/tests/harnesses/sub-component-harness.ts
+++ b/src/cdk/testing/tests/harnesses/sub-component-harness.ts
@@ -16,7 +16,7 @@ export interface SubComponentHarnessFilters extends BaseHarnessFilters {
 
 /** @dynamic */
 export class SubComponentHarness extends ComponentHarness {
-  static readonly hostSelector = 'test-sub';
+  static readonly hostSelector: string = 'test-sub';
 
   static with(options: SubComponentHarnessFilters = {}) {
     return new HarnessPredicate(SubComponentHarness, options)
@@ -31,8 +31,17 @@ export class SubComponentHarness extends ComponentHarness {
   readonly getItems = this.locatorForAll('li');
   readonly globalElement = this.documentRootLocatorFactory().locatorFor('#username');
 
+  async titleText() {
+    return (await this.title()).text();
+  }
+
   async getItem(index: number): Promise<TestElement> {
     const items = await this.getItems();
     return items[index];
   }
+}
+
+/** @dynamic */
+export class SubComponentSpecialHarness extends SubComponentHarness {
+  static readonly hostSelector = 'test-sub.test-special';
 }

--- a/src/cdk/testing/tests/protractor.e2e.spec.ts
+++ b/src/cdk/testing/tests/protractor.e2e.spec.ts
@@ -1,8 +1,14 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessLoader,
+  TestElement
+} from '@angular/cdk/testing';
+import {expectAsyncError} from '@angular/cdk/testing/private';
 import {ProtractorHarnessEnvironment} from '@angular/cdk/testing/protractor';
 import {browser} from 'protractor';
 import {MainComponentHarness} from './harnesses/main-component-harness';
-import {SubComponentHarness} from './harnesses/sub-component-harness';
+import {SubComponentHarness, SubComponentSpecialHarness} from './harnesses/sub-component-harness';
 
 describe('ProtractorHarnessEnvironment', () => {
   beforeEach(async () => {
@@ -30,8 +36,9 @@ describe('ProtractorHarnessEnvironment', () => {
         await loader.getChildLoader('error');
         fail('Expected to throw');
       } catch (e) {
-        expect(e.message)
-          .toBe('Expected to find element matching selector: "error", but none was found');
+        expect(e.message).toBe(
+            'Failed to find element matching one of the following queries:' +
+            '\n(HarnessLoader for element matching selector: "error")');
       }
     });
 
@@ -53,8 +60,8 @@ describe('ProtractorHarnessEnvironment', () => {
         fail('Expected to throw');
       } catch (e) {
         expect(e.message).toBe(
-            'Expected to find element for SubComponentHarness matching selector:' +
-            ' "test-sub", but none was found');
+            'Failed to find element matching one of the following queries:' +
+            '\n(SubComponentHarness with host element matching selector: "test-sub")');
       }
     });
 
@@ -82,7 +89,8 @@ describe('ProtractorHarnessEnvironment', () => {
         fail('Expected to throw');
       } catch (e) {
         expect(e.message).toBe(
-          'Expected to find element matching selector: "wrong locator", but none was found');
+            'Failed to find element matching one of the following queries:' +
+            '\n(TestElement for element matching selector: "wrong locator")');
       }
     });
 
@@ -115,8 +123,8 @@ describe('ProtractorHarnessEnvironment', () => {
         fail('Expected to throw');
       } catch (e) {
         expect(e.message).toBe(
-            'Expected to find element for WrongComponentHarness matching selector:' +
-            ' "wrong-selector", but none was found');
+            'Failed to find element matching one of the following queries:' +
+            '\n(WrongComponentHarness with host element matching selector: "wrong-selector")');
       }
     });
 
@@ -283,9 +291,9 @@ describe('ProtractorHarnessEnvironment', () => {
             fail('Expected to throw');
           } catch (e) {
             expect(e.message).toBe(
-                'Expected to find element for SubComponentHarness matching selector: "test-sub"' +
-                ' (with restrictions: has ancestor matching selector ".not-found"),' +
-                ' but none was found');
+                'Failed to find element matching one of the following queries:' +
+                '\n(SubComponentHarness with host element matching selector: "test-sub"' +
+                ' satisfying the constraints: has ancestor matching selector ".not-found")');
           }
         });
 
@@ -320,6 +328,75 @@ describe('ProtractorHarnessEnvironment', () => {
     it('should load all harnesses with direct ancestor selector restriction', async () => {
       const subcomps = await harness.directAncestorSelectorSubcomponent();
       expect(subcomps.length).toBe(2);
+    });
+
+    it('should get TestElements and ComponentHarnesses', async () => {
+      const results = await harness.subcomponentHarnessesAndElements();
+      expect(results.length).toBe(5);
+
+      // The counter should appear in the DOM before the test-sub elements.
+      await checkIsElement(results[0], '#counter');
+
+      // Followed by the SubComponentHarness instances in the correct order.
+      await checkIsHarness(results[1], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of test tools'));
+      await checkIsHarness(results[2], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of test methods'));
+      await checkIsHarness(results[3], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of other 1'));
+      await checkIsHarness(results[4], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of other 2'));
+    });
+
+    it('should get TestElements and ComponentHarnesses with redundant queries', async () => {
+      const results = await harness.subcomponentHarnessAndElementsRedundant();
+      expect(results.length).toBe(8);
+
+      // Each subcomponent should have a TestElement result and a SubComponentHarness result.
+      // For the first two elements, the harness should come first, as it matches the first query
+      // to locatorForAll, the HarnessPredicate.
+      await checkIsHarness(results[0], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of test tools'));
+      await checkIsElement(results[1], '.subcomponents test-sub:nth-child(1)');
+      await checkIsHarness(results[2], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of test methods'));
+      await checkIsElement(results[3], '.subcomponents test-sub:nth-child(2)');
+
+      // For the last two elements, the harness should come second, as they do not match the first
+      // query, therefore the second query, the TestElement selector is the first to match.
+      await checkIsElement(results[4], '.other test-sub:nth-child(1)');
+      await checkIsHarness(results[5], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of other 1'));
+      await checkIsElement(results[6], '.other test-sub:nth-child(2)');
+      await checkIsHarness(results[7], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of other 2'));
+    });
+
+    it('should get harnesses of different types matching same element', async () => {
+      const results = await harness.subcomponentAndSpecialHarnesses();
+      expect(results.length).toBe(5);
+
+      // The first element should have a SubComponentHarness and a SubComponentSpecialHarness.
+      await checkIsHarness(results[0], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of test tools'));
+      await checkIsHarness(results[1], SubComponentSpecialHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of test tools'));
+
+      // The rest only have a SubComponentHarness.
+      await checkIsHarness(results[2], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of test methods'));
+      await checkIsHarness(results[3], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of other 1'));
+      await checkIsHarness(results[4], SubComponentHarness, async subHarness =>
+          expect(await subHarness.titleText()).toBe('List of other 2'));
+    });
+
+    it('should throw when multiple queries fail to match', async () => {
+      await expectAsyncError(() => harness.missingElementsAndHarnesses(),
+          'Error: Failed to find element matching one of the following queries:' +
+          '\n(TestElement for element matching selector: ".not-found"),' +
+          '\n(SubComponentHarness with host element matching selector: "test-sub" satisfying' +
+          ' the constraints: title = /not found/)');
     });
   });
 
@@ -365,10 +442,27 @@ describe('ProtractorHarnessEnvironment', () => {
         fail('Expected to throw');
       } catch (e) {
         expect(e.message).toBe(
-            'Expected to find element for SubComponentHarness matching selector: "test-sub"' +
-            ' (with restrictions: title = "List of test tools", item count = 4),' +
-            ' but none was found');
+            'Failed to find element matching one of the following queries:' +
+            '\n(SubComponentHarness with host element matching selector: "test-sub" satisfying' +
+            ' the constraints: title = "List of test tools", item count = 4)');
       }
     });
   });
 });
+
+async function checkIsElement(result: ComponentHarness | TestElement, selector?: string) {
+  expect(result instanceof ComponentHarness).toBe(false);
+  if (selector) {
+    expect(await (result as TestElement).matchesSelector(selector)).toBe(true);
+  }
+}
+
+async function checkIsHarness<T extends ComponentHarness>(
+    result: ComponentHarness | TestElement,
+    harnessType: ComponentHarnessConstructor<T>,
+    finalCheck?: (harness: T) => Promise<unknown>) {
+  expect(result.constructor === harnessType).toBe(true);
+  if (finalCheck) {
+    await finalCheck(result as T);
+  }
+}

--- a/src/cdk/testing/tests/test-main-component.html
+++ b/src/cdk/testing/tests/test-main-component.html
@@ -19,7 +19,7 @@
   <textarea id="memo" aria-label="memo">{{memo}}</textarea>
 </div>
 <div class="subcomponents">
-  <test-sub title="test tools" [items]="testTools"></test-sub>
+  <test-sub class="test-special" title="test tools" [items]="testTools"></test-sub>
   <test-sub title="test methods" [items]="testMethods"></test-sub>
 </div>
 <div class="other">

--- a/src/material-experimental/form-field/testing/form-field-harness.ts
+++ b/src/material-experimental/form-field/testing/form-field-harness.ts
@@ -13,9 +13,9 @@ import {
   HarnessQuery,
   TestElement
 } from '@angular/cdk/testing';
-import {MatFormFieldControlHarness} from '@angular/material-experimental/form-field/testing/control';
 import {MatInputHarness} from '@angular/material-experimental/input/testing';
 import {MatSelectHarness} from '@angular/material-experimental/select/testing';
+import {MatFormFieldControlHarness} from './control';
 import {FormFieldHarnessFilters} from './form-field-harness-filters';
 
 // TODO(devversion): support datepicker harness once developed (COMP-203).

--- a/src/material-experimental/form-field/testing/form-field-harness.ts
+++ b/src/material-experimental/form-field/testing/form-field-harness.ts
@@ -10,11 +10,10 @@ import {
   ComponentHarness,
   ComponentHarnessConstructor,
   HarnessPredicate,
+  HarnessQuery,
   TestElement
 } from '@angular/cdk/testing';
-import {
-  MatFormFieldControlHarness
-} from '@angular/material-experimental/form-field/testing/control';
+import {MatFormFieldControlHarness} from '@angular/material-experimental/form-field/testing/control';
 import {MatInputHarness} from '@angular/material-experimental/input/testing';
 import {MatSelectHarness} from '@angular/material-experimental/select/testing';
 import {FormFieldHarnessFilters} from './form-field-harness-filters';
@@ -85,8 +84,7 @@ export class MatFormFieldHarness extends ComponentHarness {
       Promise<X|null>;
 
   // Implementation of the "getControl" method overload signatures.
-  async getControl<X extends MatFormFieldControlHarness>(type?: ComponentHarnessConstructor<X>|
-                                                         HarnessPredicate<X>) {
+  async getControl<X extends MatFormFieldControlHarness>(type?: HarnessQuery<X>) {
     if (type) {
       return this.locatorForOptional(type)();
     }

--- a/tools/public_api_guard/cdk/testing.d.ts
+++ b/tools/public_api_guard/cdk/testing.d.ts
@@ -15,12 +15,9 @@ export declare abstract class ComponentHarness {
     protected documentRootLocatorFactory(): LocatorFactory;
     protected forceStabilize(): Promise<void>;
     host(): Promise<TestElement>;
-    protected locatorFor(selector: string): AsyncFactoryFn<TestElement>;
-    protected locatorFor<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T>;
-    protected locatorForAll(selector: string): AsyncFactoryFn<TestElement[]>;
-    protected locatorForAll<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T[]>;
-    protected locatorForOptional(selector: string): AsyncFactoryFn<TestElement | null>;
-    protected locatorForOptional<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T | null>;
+    protected locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
+    protected locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
+    protected locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
     protected waitForTasksOutsideAngular(): Promise<void>;
 }
 
@@ -39,28 +36,25 @@ export declare abstract class HarnessEnvironment<E> implements HarnessLoader, Lo
     documentRootLocatorFactory(): LocatorFactory;
     abstract forceStabilize(): Promise<void>;
     getAllChildLoaders(selector: string): Promise<HarnessLoader[]>;
-    getAllHarnesses<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): Promise<T[]>;
+    getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
     protected abstract getAllRawElements(selector: string): Promise<E[]>;
     getChildLoader(selector: string): Promise<HarnessLoader>;
     protected abstract getDocumentRoot(): E;
-    getHarness<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): Promise<T>;
+    getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
     harnessLoaderFor(selector: string): Promise<HarnessLoader>;
     harnessLoaderForAll(selector: string): Promise<HarnessLoader[]>;
     harnessLoaderForOptional(selector: string): Promise<HarnessLoader | null>;
-    locatorFor(selector: string): AsyncFactoryFn<TestElement>;
-    locatorFor<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T>;
-    locatorForAll(selector: string): AsyncFactoryFn<TestElement[]>;
-    locatorForAll<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T[]>;
-    locatorForOptional(selector: string): AsyncFactoryFn<TestElement | null>;
-    locatorForOptional<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T | null>;
+    locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
+    locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
+    locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
     abstract waitForTasksOutsideAngular(): Promise<void>;
 }
 
 export interface HarnessLoader {
     getAllChildLoaders(selector: string): Promise<HarnessLoader[]>;
-    getAllHarnesses<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): Promise<T[]>;
+    getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
     getChildLoader(selector: string): Promise<HarnessLoader>;
-    getHarness<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): Promise<T>;
+    getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
 }
 
 export declare class HarnessPredicate<T extends ComponentHarness> {
@@ -75,6 +69,8 @@ export declare class HarnessPredicate<T extends ComponentHarness> {
     static stringMatches(s: string | Promise<string>, pattern: string | RegExp): Promise<boolean>;
 }
 
+export declare type HarnessQuery<T extends ComponentHarness> = ComponentHarnessConstructor<T> | HarnessPredicate<T>;
+
 export interface LocatorFactory {
     rootElement: TestElement;
     documentRootLocatorFactory(): LocatorFactory;
@@ -82,14 +78,17 @@ export interface LocatorFactory {
     harnessLoaderFor(selector: string): Promise<HarnessLoader>;
     harnessLoaderForAll(selector: string): Promise<HarnessLoader[]>;
     harnessLoaderForOptional(selector: string): Promise<HarnessLoader | null>;
-    locatorFor(selector: string): AsyncFactoryFn<TestElement>;
-    locatorFor<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T>;
-    locatorForAll(selector: string): AsyncFactoryFn<TestElement[]>;
-    locatorForAll<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T[]>;
-    locatorForOptional(selector: string): AsyncFactoryFn<TestElement | null>;
-    locatorForOptional<T extends ComponentHarness>(harnessType: ComponentHarnessConstructor<T> | HarnessPredicate<T>): AsyncFactoryFn<T | null>;
+    locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
+    locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
+    locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
     waitForTasksOutsideAngular(): Promise<void>;
 }
+
+export declare type LocatorFnResult<T extends (HarnessQuery<any> | string)[]> = {
+    [I in keyof T]: T[I] extends new (...args: any[]) => infer C ? C : T[I] extends {
+        harnessType: new (...args: any[]) => infer C;
+    } ? C : T[I] extends string ? TestElement : never;
+}[number];
 
 export interface TestElement {
     blur(): Promise<void>;


### PR DESCRIPTION
…entHarness at once in locatorFor

This feature is needed for the MatListHarness, so we can query for a combined list of list items, headers, and dividers, while maintaining the DOM order. The new API is a super-set of the old one, so non-breaking.