### PR TITLE
docs(datepicker): bump max date in example

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-min-max/datepicker-min-max-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-min-max/datepicker-min-max-example.ts
@@ -7,6 +7,13 @@ import {Component} from '@angular/core';
   styleUrls: ['datepicker-min-max-example.css'],
 })
 export class DatepickerMinMaxExample {
-  minDate = new Date(2000, 0, 1);
-  maxDate = new Date(2020, 0, 1);
+  minDate: Date;
+  maxDate: Date;
+
+  constructor() {
+    // Set the minimum to January 1st 20 years in the past and December 31st a year in the future.
+    const currentYear = new Date().getFullYear();
+    this.minDate = new Date(currentYear - 20, 0, 1);
+    this.maxDate = new Date(currentYear + 1, 11, 31);
+  }
 }


### PR DESCRIPTION
Currently the maximum date in one of the examples is January 1st 2020 which is coming up. These changes make it a bit more maintainable by setting it to December 31st one year in the future.

Fixes #17657.