### PR TITLE
test: disambiguate MDC component test names

### DIFF
--- a/src/material-experimental/mdc-button/button.spec.ts
+++ b/src/material-experimental/mdc-button/button.spec.ts
@@ -5,7 +5,7 @@ import {MatButtonModule, MatButton} from './index';
 import {MatRipple, ThemePalette} from '@angular/material/core';
 
 
-describe('MatButton', () => {
+describe('MDC-based MatButton', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({

--- a/src/material-experimental/mdc-checkbox/checkbox.e2e.spec.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.e2e.spec.ts
@@ -1,6 +1,6 @@
 import {browser, by, element, Key} from 'protractor';
 
-describe('MDC checkbox', () => {
+describe('MDC-based checkbox', () => {
   describe('check behavior', () => {
     beforeEach(async () => await browser.get('/mdc-checkbox'));
 

--- a/src/material-experimental/mdc-checkbox/checkbox.spec.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.spec.ts
@@ -18,7 +18,7 @@ import {
 import {MAT_CHECKBOX_DEFAULT_OPTIONS} from '@angular/material/checkbox';
 
 
-describe('MatCheckbox', () => {
+describe('MDC-based MatCheckbox', () => {
   let fixture: ComponentFixture<any>;
 
   function createComponent<T>(componentType: Type<T>, extraDeclarations: Type<any>[] = []) {

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -46,7 +46,7 @@ import {
 } from './index';
 
 
-describe('MatChipGrid', () => {
+describe('MDC-based MatChipGrid', () => {
   let fixture: ComponentFixture<any>;
   let chipGridDebugElement: DebugElement;
   let chipGridNativeElement: HTMLElement;

--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -22,7 +22,7 @@ import {
 } from './index';
 
 
-describe('MatChipInput', () => {
+describe('MDC-based MatChipInput', () => {
   let fixture: ComponentFixture<any>;
   let testChipInput: TestChipInput;
   let inputDebugElement: DebugElement;

--- a/src/material-experimental/mdc-chips/chip-listbox.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.spec.ts
@@ -31,7 +31,7 @@ import {Subject} from 'rxjs';
 import {MatChip, MatChipListbox, MatChipOption, MatChipsModule} from './index';
 
 
-describe('MatChipListbox', () => {
+describe('MDC-based MatChipListbox', () => {
   let fixture: ComponentFixture<any>;
   let chipListboxDebugElement: DebugElement;
   let chipListboxNativeElement: HTMLElement;

--- a/src/material-experimental/mdc-chips/chip-option.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-option.spec.ts
@@ -15,7 +15,7 @@ import {
 } from './index';
 
 
-describe('Option Chips', () => {
+describe('MDC-based Option Chips', () => {
   let fixture: ComponentFixture<any>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;

--- a/src/material-experimental/mdc-chips/chip-remove.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-remove.spec.ts
@@ -4,7 +4,7 @@ import {By} from '@angular/platform-browser';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChip, MatChipsModule} from './index';
 
-describe('Chip Remove', () => {
+describe('MDC-based Chip Remove', () => {
   let fixture: ComponentFixture<TestChip>;
   let testChip: TestChip;
   let chipDebugElement: DebugElement;

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -13,7 +13,7 @@ import {Subject} from 'rxjs';
 import {MatChipEvent, MatChipGrid, MatChipRow, MatChipsModule} from './index';
 
 
-describe('Row Chips', () => {
+describe('MDC-based Row Chips', () => {
   let fixture: ComponentFixture<any>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;

--- a/src/material-experimental/mdc-chips/chip-set.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-set.spec.ts
@@ -5,7 +5,7 @@ import {By} from '@angular/platform-browser';
 import {MatChip, MatChipSet, MatChipsModule} from './index';
 
 
-describe('MatChipSet', () => {
+describe('MDC-based MatChipSet', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule, CommonModule],

--- a/src/material-experimental/mdc-chips/chip.spec.ts
+++ b/src/material-experimental/mdc-chips/chip.spec.ts
@@ -8,7 +8,7 @@ import {Subject} from 'rxjs';
 import {MatChip, MatChipEvent, MatChipSet, MatChipsModule} from './index';
 
 
-describe('MatChip', () => {
+describe('MDC-based MatChip', () => {
   let fixture: ComponentFixture<any>;
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;

--- a/src/material-experimental/mdc-menu/menu.e2e.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.e2e.spec.ts
@@ -10,7 +10,7 @@ import {
 const presenceOf = ExpectedConditions.presenceOf;
 const not = ExpectedConditions.not;
 
-describe('menu', () => {
+describe('MDC-based menu', () => {
   const menuSelector = '.mat-mdc-menu-panel';
   const page = {
     menu: () => element(by.css(menuSelector)),

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -44,7 +44,7 @@ import {
 
 const MENU_PANEL_TOP_PADDING = 8;
 
-describe('MatMenu', () => {
+describe('MDC-based MatMenu', () => {
   let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let focusMonitor: FocusMonitor;

--- a/src/material-experimental/mdc-progress-bar/progress-bar.e2e.spec.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.e2e.spec.ts
@@ -1,7 +1,7 @@
 import {browser} from 'protractor';
 import {expectToExist} from '@angular/cdk/testing/private/e2e';
 
-describe('progress-bar', () => {
+describe('MDC-based progress-bar', () => {
   beforeEach(async () => await browser.get('/mdc-progress-bar'));
 
   it('should render a determinate progress bar', async () => {

--- a/src/material-experimental/mdc-progress-bar/progress-bar.spec.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.spec.ts
@@ -7,7 +7,7 @@ import {MatProgressBarModule} from './index';
 import {MatProgressBar} from './progress-bar';
 
 
-describe('MatProgressBar', () => {
+describe('MDC-based MatProgressBar', () => {
   function createComponent<T>(componentType: Type<T>,
                               imports?: Array<Type<{}>>): ComponentFixture<T> {
     TestBed.configureTestingModule({

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.e2e.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.e2e.spec.ts
@@ -2,7 +2,7 @@ import {browser, element, by, Key} from 'protractor';
 import {expectToExist} from '@angular/cdk/testing/private/e2e';
 
 
-describe('slide-toggle', () => {
+describe('MDC-based slide-toggle', () => {
   const getInput = () => element(by.css('#normal-slide-toggle input'));
   const getNormalToggle = () => element(by.css('#normal-slide-toggle'));
 

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
@@ -7,7 +7,7 @@ import {By} from '@angular/platform-browser';
 import {MatSlideToggle, MatSlideToggleChange, MatSlideToggleModule} from './index';
 import {MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS} from './slide-toggle-config';
 
-describe('MatSlideToggle without forms', () => {
+describe('MDC-based MatSlideToggle without forms', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSlideToggleModule, BidiModule],
@@ -390,7 +390,7 @@ describe('MatSlideToggle without forms', () => {
   });
 });
 
-describe('MatSlideToggle with forms', () => {
+describe('MDC-based MatSlideToggle with forms', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({

--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -25,7 +25,7 @@ import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {MatSlider, MatSliderModule} from './index';
 
-describe('MatMdcSlider', () => {
+describe('MDC-based MatSlider', () => {
   const platform = new Platform();
 
   function createComponent<T>(component: Type<T>): ComponentFixture<T> {

--- a/src/material-experimental/mdc-tabs/tab-body.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-body.spec.ts
@@ -9,7 +9,7 @@ import {MatTabBody, MatTabBodyPortal} from './tab-body';
 import {Subject} from 'rxjs';
 
 
-describe('MatTabBody', () => {
+describe('MDC-based MatTabBody', () => {
   let dir: Direction = 'ltr';
   let dirChange: Subject<Direction> = new Subject<Direction>();
 

--- a/src/material-experimental/mdc-tabs/tab-group.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.spec.ts
@@ -9,7 +9,7 @@ import {Observable} from 'rxjs';
 import {MAT_TABS_CONFIG, MatTab, MatTabGroup, MatTabHeaderPosition, MatTabsModule} from './index';
 
 
-describe('MatTabGroup', () => {
+describe('MDC-based MatTabGroup', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatTabsModule, CommonModule, NoopAnimationsModule],

--- a/src/material-experimental/mdc-tabs/tab-header.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.spec.ts
@@ -26,7 +26,7 @@ import {Subject} from 'rxjs';
 import {ObserversModule, MutationObserverFactory} from '@angular/cdk/observers';
 
 
-describe('MatTabHeader', () => {
+describe('MDC-based MatTabHeader', () => {
   let dir: Direction = 'ltr';
   let change = new Subject();
   let fixture: ComponentFixture<SimpleTabHeaderApp>;

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -11,7 +11,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {MAT_TABS_CONFIG} from '../index';
 
 
-describe('MatTabNavBar', () => {
+describe('MDC-based MatTabNavBar', () => {
   let dir: Direction = 'ltr';
   let dirChange = new Subject();
   let globalRippleOptions: RippleGlobalOptions;

--- a/src/material-experimental/mdc-tabs/tabs.e2e.spec.ts
+++ b/src/material-experimental/mdc-tabs/tabs.e2e.spec.ts
@@ -8,7 +8,7 @@ import {
 } from 'protractor';
 import {pressKeys} from '@angular/cdk/testing/private/e2e';
 
-describe('MDC tabs', () => {
+describe('MDC-based tabs', () => {
   describe('basic behavior', () => {
     let tabLabels: ElementArrayFinder;
     let tabBodies: ElementArrayFinder;


### PR DESCRIPTION
Currently the MDC-based component tests are copied
from the non-MDC based component. The top-level describe
name has not be changed to contain MDC in the most cases.

This causes duplicate tests and it's difficult to tell
from which component a test failure originates from.