### PR TITLE
refactor: remove @dynamic tag from harness classes

### DIFF
--- a/src/cdk/testing/tests/harnesses/sub-component-harness.ts
+++ b/src/cdk/testing/tests/harnesses/sub-component-harness.ts
@@ -14,7 +14,6 @@ export interface SubComponentHarnessFilters extends BaseHarnessFilters {
   itemCount?: number;
 }
 
-/** @dynamic */
 export class SubComponentHarness extends ComponentHarness {
   static readonly hostSelector = 'test-sub';
 

--- a/src/material-experimental/form-field/testing/form-field-harness.ts
+++ b/src/material-experimental/form-field/testing/form-field-harness.ts
@@ -23,10 +23,8 @@ import {FormFieldHarnessFilters} from './form-field-harness-filters';
 // Also support chip list harness.
 /** Possible harnesses of controls which can be bound to a form-field. */
 export type FormFieldControlHarness = MatInputHarness|MatSelectHarness;
-/**
- * Harness for interacting with a standard Material form-field's in tests.
- * @dynamic
- */
+
+/** Harness for interacting with a standard Material form-field's in tests. */
 export class MatFormFieldHarness extends ComponentHarness {
   static hostSelector = '.mat-form-field';
 

--- a/src/material-experimental/input/testing/input-harness.ts
+++ b/src/material-experimental/input/testing/input-harness.ts
@@ -12,10 +12,7 @@ import {
 } from '@angular/material-experimental/form-field/testing/control';
 import {InputHarnessFilters} from './input-harness-filters';
 
-/**
- * Harness for interacting with a standard Material inputs in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard Material inputs in tests. */
 export class MatInputHarness extends MatFormFieldControlHarness {
   static hostSelector = '[matInput]';
 

--- a/src/material-experimental/mdc-button/testing/button-harness.ts
+++ b/src/material-experimental/mdc-button/testing/button-harness.ts
@@ -11,10 +11,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ButtonHarnessFilters} from '@angular/material/button/testing';
 
 
-/**
- * Harness for interacting with a MDC-based mat-button in tests.
- * @dynamic
- */
+/** Harness for interacting with a MDC-based mat-button in tests. */
 export class MatButtonHarness extends ComponentHarness {
   // TODO(jelbourn) use a single class, like `.mat-button-base`
   static hostSelector = [

--- a/src/material-experimental/mdc-checkbox/testing/checkbox-harness.ts
+++ b/src/material-experimental/mdc-checkbox/testing/checkbox-harness.ts
@@ -10,10 +10,7 @@ import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {CheckboxHarnessFilters} from '@angular/material/checkbox/testing';
 
-/**
- * Harness for interacting with a MDC-based mat-checkbox in tests.
- * @dynamic
- */
+/** Harness for interacting with a MDC-based mat-checkbox in tests. */
 export class MatCheckboxHarness extends ComponentHarness {
   static hostSelector = 'mat-checkbox';
 

--- a/src/material-experimental/mdc-chips/testing/chip-grid-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-grid-harness.ts
@@ -11,10 +11,7 @@ import {ChipGridHarnessFilters} from './chip-harness-filters';
 import {MatChipInputHarness} from './chip-input-harness';
 import {MatChipRowHarness} from './chip-row-harness';
 
-/**
- * Harness for interacting with a mat-chip-grid in tests.
- * @dynamic
- */
+/** Harness for interacting with a mat-chip-grid in tests. */
 export class MatChipGridHarness extends ComponentHarness {
   static hostSelector = 'mat-chip-grid';
 

--- a/src/material-experimental/mdc-chips/testing/chip-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-harness.ts
@@ -9,10 +9,7 @@
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {ChipHarnessFilters} from './chip-harness-filters';
 
-/**
- * Harness for interacting with a mat-chip in tests.
- * @dynamic
- */
+/** Harness for interacting with a mat-chip in tests. */
 export class MatChipHarness extends ComponentHarness {
   static hostSelector = 'mat-basic-chip, mat-chip';
 

--- a/src/material-experimental/mdc-chips/testing/chip-input-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-input-harness.ts
@@ -9,10 +9,7 @@
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {ChipInputHarnessFilters} from './chip-harness-filters';
 
-/**
- * Harness for interacting with a grid's chip input in tests.
- * @dynamic
- */
+/** Harness for interacting with a grid's chip input in tests. */
 export class MatChipInputHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-chip-input';
 

--- a/src/material-experimental/mdc-chips/testing/chip-listbox-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-listbox-harness.ts
@@ -10,10 +10,7 @@ import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {ChipListboxHarnessFilters} from './chip-harness-filters';
 import {MatChipOptionHarness} from './chip-option-harness';
 
-/**
- * Harness for interacting with a mat-chip-listbox in tests.
- * @dynamic
- */
+/** Harness for interacting with a mat-chip-listbox in tests. */
 export class MatChipListboxHarness extends ComponentHarness {
   static hostSelector = 'mat-chip-listbox';
 

--- a/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
@@ -10,10 +10,7 @@ import {HarnessPredicate} from '@angular/cdk/testing';
 import {MatChipHarness} from './chip-harness';
 import {ChipOptionHarnessFilters} from './chip-harness-filters';
 
-/**
- * Harness for interacting with a mat-chip-option in tests.
- * @dynamic
- */
+/** Harness for interacting with a mat-chip-option in tests. */
 export class MatChipOptionHarness extends MatChipHarness {
   static hostSelector = 'mat-basic-chip-option, mat-chip-option';
 

--- a/src/material-experimental/mdc-chips/testing/chip-row-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-row-harness.ts
@@ -10,10 +10,7 @@ import {HarnessPredicate} from '@angular/cdk/testing';
 import {ChipRowHarnessFilters} from './chip-harness-filters';
 import {MatChipHarness} from './chip-harness';
 
-/**
- * Harness for interacting with a mat-chip-row in tests.
- * @dynamic
- */
+/** Harness for interacting with a mat-chip-row in tests. */
 export class MatChipRowHarness extends MatChipHarness {
   static hostSelector = 'mat-chip-row, mat-basic-chip-row';
 

--- a/src/material-experimental/mdc-chips/testing/chip-set-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-set-harness.ts
@@ -10,10 +10,7 @@ import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {MatChipHarness} from './chip-harness';
 import {ChipSetHarnessFilters} from './chip-harness-filters';
 
-/**
- * Harness for interacting with a mat-chip-set in tests.
- * @dynamic
- */
+/** Harness for interacting with a mat-chip-set in tests. */
 export class MatChipSetHarness extends ComponentHarness {
   static hostSelector = 'mat-chip-set';
 

--- a/src/material-experimental/mdc-menu/testing/menu-harness.ts
+++ b/src/material-experimental/mdc-menu/testing/menu-harness.ts
@@ -13,10 +13,7 @@ import {
   MenuItemHarnessFilters
 } from '@angular/material/menu/testing';
 
-/**
- * Harness for interacting with a MDC-based mat-menu in tests.
- * @dynamic
- */
+/** Harness for interacting with a MDC-based mat-menu in tests. */
 export class MatMenuHarness extends ComponentHarness {
   static hostSelector = '.mat-menu-trigger';
 
@@ -79,10 +76,7 @@ export class MatMenuHarness extends ComponentHarness {
 }
 
 
-/**
- * Harness for interacting with a standard mat-menu in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-menu in tests. */
 export class MatMenuItemHarness extends ComponentHarness {
   static hostSelector = '.mat-menu-item';
 

--- a/src/material-experimental/mdc-progress-bar/testing/progress-bar-harness.ts
+++ b/src/material-experimental/mdc-progress-bar/testing/progress-bar-harness.ts
@@ -10,10 +10,7 @@ import {coerceNumberProperty} from '@angular/cdk/coercion';
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {ProgressBarHarnessFilters} from '@angular/material/progress-bar/testing';
 
-/**
- * Harness for interacting with an MDC-based `mat-progress-bar` in tests.
- * @dynamic
- */
+/** Harness for interacting with an MDC-based `mat-progress-bar` in tests. */
 export class MatProgressBarHarness extends ComponentHarness {
   static hostSelector = 'mat-progress-bar';
 

--- a/src/material-experimental/mdc-slide-toggle/testing/slide-toggle-harness.ts
+++ b/src/material-experimental/mdc-slide-toggle/testing/slide-toggle-harness.ts
@@ -11,10 +11,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {SlideToggleHarnessFilters} from '@angular/material/slide-toggle/testing';
 
 
-/**
- * Harness for interacting with a MDC-based mat-slide-toggle in tests.
- * @dynamic
- */
+/** Harness for interacting with a MDC-based mat-slide-toggle in tests. */
 export class MatSlideToggleHarness extends ComponentHarness {
   static hostSelector = 'mat-slide-toggle';
 

--- a/src/material-experimental/mdc-slider/testing/slider-harness.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-harness.ts
@@ -10,10 +10,7 @@ import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {SliderHarnessFilters} from '@angular/material/slider/testing';
 
-/**
- * Harness for interacting with a MDC mat-slider in tests.
- * @dynamic
- */
+/** Harness for interacting with a MDC mat-slider in tests. */
 export class MatSliderHarness extends ComponentHarness {
   static hostSelector = 'mat-slider';
 

--- a/src/material-experimental/select/testing/option-harness.ts
+++ b/src/material-experimental/select/testing/option-harness.ts
@@ -19,10 +19,7 @@ export interface OptionGroupHarnessFilters extends BaseHarnessFilters {
   labelText?: string;
 }
 
-/**
- * Harness for interacting with a the `mat-option` for a `mat-select` in tests.
- * @dynamic
- */
+/** Harness for interacting with a the `mat-option` for a `mat-select` in tests. */
 export class MatSelectOptionHarness extends ComponentHarness {
   // TODO(crisbeto): things to add here when adding a common option harness:
   // - isDisabled
@@ -50,10 +47,7 @@ export class MatSelectOptionHarness extends ComponentHarness {
   }
 }
 
-/**
- * Harness for interacting with a the `mat-optgroup` for a `mat-select` in tests.
- * @dynamic
- */
+/** Harness for interacting with a the `mat-optgroup` for a `mat-select` in tests. */
 export class MatSelectOptionGroupHarness extends ComponentHarness {
   private _label = this.locatorFor('.mat-optgroup-label');
   static hostSelector = '.mat-select-panel .mat-optgroup';

--- a/src/material-experimental/select/testing/select-harness.ts
+++ b/src/material-experimental/select/testing/select-harness.ts
@@ -16,10 +16,7 @@ import {MatSelectOptionHarness, MatSelectOptionGroupHarness} from './option-harn
 /** Selector for the select panel. */
 const PANEL_SELECTOR = '.mat-select-panel';
 
-/**
- * Harness for interacting with a standard mat-select in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-select in tests. */
 export class MatSelectHarness extends MatFormFieldControlHarness {
   private _documentRootLocator = this.documentRootLocatorFactory();
   private _panel = this._documentRootLocator.locatorFor(PANEL_SELECTOR);

--- a/src/material/autocomplete/testing/autocomplete-harness.ts
+++ b/src/material/autocomplete/testing/autocomplete-harness.ts
@@ -19,10 +19,7 @@ import {
 /** Selector for the autocomplete panel. */
 const PANEL_SELECTOR = '.mat-autocomplete-panel';
 
-/**
- * Harness for interacting with a standard mat-autocomplete in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-autocomplete in tests. */
 export class MatAutocompleteHarness extends ComponentHarness {
   private _documentRootLocator = this.documentRootLocatorFactory();
   private _optionalPanel = this._documentRootLocator.locatorForOptional(PANEL_SELECTOR);

--- a/src/material/autocomplete/testing/option-harness.ts
+++ b/src/material/autocomplete/testing/option-harness.ts
@@ -19,10 +19,7 @@ export interface OptionGroupHarnessFilters extends BaseHarnessFilters {
   labelText?: string | RegExp;
 }
 
-/**
- * Harness for interacting with a the `mat-option` for a `mat-autocomplete` in tests.
- * @dynamic
- */
+/** Harness for interacting with a the `mat-option` for a `mat-autocomplete` in tests. */
 export class MatAutocompleteOptionHarness extends ComponentHarness {
   static hostSelector = '.mat-autocomplete-panel .mat-option';
 
@@ -43,10 +40,7 @@ export class MatAutocompleteOptionHarness extends ComponentHarness {
   }
 }
 
-/**
- * Harness for interacting with a the `mat-optgroup` for a `mat-autocomplete` in tests.
- * @dynamic
- */
+/** Harness for interacting with a the `mat-optgroup` for a `mat-autocomplete` in tests. */
 export class MatAutocompleteOptionGroupHarness extends ComponentHarness {
   private _label = this.locatorFor('.mat-optgroup-label');
   static hostSelector = '.mat-autocomplete-panel .mat-optgroup';

--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -11,10 +11,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ButtonHarnessFilters} from './button-harness-filters';
 
 
-/**
- * Harness for interacting with a standard mat-button in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-button in tests. */
 export class MatButtonHarness extends ComponentHarness {
   // TODO(jelbourn) use a single class, like `.mat-button-base`
   static hostSelector = [

--- a/src/material/checkbox/testing/checkbox-harness.ts
+++ b/src/material/checkbox/testing/checkbox-harness.ts
@@ -10,10 +10,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {CheckboxHarnessFilters} from './checkbox-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-checkbox in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-checkbox in tests. */
 export class MatCheckboxHarness extends ComponentHarness {
   static hostSelector = 'mat-checkbox';
 

--- a/src/material/dialog/testing/dialog-harness.ts
+++ b/src/material/dialog/testing/dialog-harness.ts
@@ -10,10 +10,7 @@ import {ComponentHarness, HarnessPredicate, TestKey} from '@angular/cdk/testing'
 import {DialogRole} from '@angular/material/dialog';
 import {DialogHarnessFilters} from './dialog-harness-filters';
 
-/**
- * Harness for interacting with a standard MatDialog in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard MatDialog in tests. */
 export class MatDialogHarness extends ComponentHarness {
   // Developers can provide a custom component or template for the
   // dialog. The canonical dialog parent is the "MatDialogContainer".

--- a/src/material/menu/testing/menu-harness.ts
+++ b/src/material/menu/testing/menu-harness.ts
@@ -10,10 +10,7 @@ import {ComponentHarness, HarnessPredicate, TestElement, TestKey} from '@angular
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {MenuHarnessFilters, MenuItemHarnessFilters} from './menu-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-menu in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-menu in tests. */
 export class MatMenuHarness extends ComponentHarness {
   static hostSelector = '.mat-menu-trigger';
 
@@ -113,10 +110,7 @@ export class MatMenuHarness extends ComponentHarness {
 }
 
 
-/**
- * Harness for interacting with a standard mat-menu-item in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-menu-item in tests. */
 export class MatMenuItemHarness extends ComponentHarness {
   static hostSelector = '.mat-menu-item';
 

--- a/src/material/progress-bar/testing/progress-bar-harness.ts
+++ b/src/material/progress-bar/testing/progress-bar-harness.ts
@@ -10,10 +10,7 @@ import {coerceNumberProperty} from '@angular/cdk/coercion';
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {ProgressBarHarnessFilters} from './progress-bar-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-progress-bar in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-progress-bar in tests. */
 export class MatProgressBarHarness extends ComponentHarness {
   static hostSelector = 'mat-progress-bar';
 

--- a/src/material/progress-spinner/testing/progress-spinner-harness.ts
+++ b/src/material/progress-spinner/testing/progress-spinner-harness.ts
@@ -11,10 +11,7 @@ import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {ProgressSpinnerMode} from '@angular/material/progress-spinner';
 import {ProgressSpinnerHarnessFilters} from './progress-spinner-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-progress-spinner in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-progress-spinner in tests. */
 export class MatProgressSpinnerHarness extends ComponentHarness {
   static hostSelector = 'mat-progress-spinner';
 

--- a/src/material/radio/testing/radio-harness.ts
+++ b/src/material/radio/testing/radio-harness.ts
@@ -10,10 +10,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {RadioButtonHarnessFilters, RadioGroupHarnessFilters} from './radio-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-radio-group in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-radio-group in tests. */
 export class MatRadioGroupHarness extends ComponentHarness {
   static hostSelector = 'mat-radio-group';
 
@@ -148,10 +145,7 @@ export class MatRadioGroupHarness extends ComponentHarness {
   }
 }
 
-/**
- * Harness for interacting with a standard mat-radio-button in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-radio-button in tests. */
 export class MatRadioButtonHarness extends ComponentHarness {
   static hostSelector = 'mat-radio-button';
 

--- a/src/material/sidenav/testing/drawer-harness.ts
+++ b/src/material/sidenav/testing/drawer-harness.ts
@@ -9,10 +9,7 @@
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {DrawerHarnessFilters} from './drawer-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-drawer in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-drawer in tests. */
 export class MatDrawerHarness extends ComponentHarness {
   static hostSelector = '.mat-drawer';
 

--- a/src/material/sidenav/testing/sidenav-harness.ts
+++ b/src/material/sidenav/testing/sidenav-harness.ts
@@ -10,10 +10,7 @@ import {HarnessPredicate} from '@angular/cdk/testing';
 import {MatDrawerHarness} from './drawer-harness';
 import {DrawerHarnessFilters} from './drawer-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-sidenav in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-sidenav in tests. */
 export class MatSidenavHarness extends MatDrawerHarness {
   static hostSelector = '.mat-sidenav';
 

--- a/src/material/slide-toggle/testing/slide-toggle-harness.ts
+++ b/src/material/slide-toggle/testing/slide-toggle-harness.ts
@@ -11,10 +11,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {SlideToggleHarnessFilters} from './slide-toggle-harness-filters';
 
 
-/**
- * Harness for interacting with a standard mat-slide-toggle in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-slide-toggle in tests. */
 export class MatSlideToggleHarness extends ComponentHarness {
   static hostSelector = 'mat-slide-toggle';
 

--- a/src/material/slider/testing/slider-harness.ts
+++ b/src/material/slider/testing/slider-harness.ts
@@ -10,10 +10,7 @@ import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
 import {SliderHarnessFilters} from './slider-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-slider in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-slider in tests. */
 export class MatSliderHarness extends ComponentHarness {
   static hostSelector = 'mat-slider';
 

--- a/src/material/snack-bar/testing/snack-bar-harness.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.ts
@@ -9,10 +9,7 @@
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {SnackBarHarnessFilters} from './snack-bar-harness-filters';
 
-/**
- * Harness for interacting with a standard mat-snack-bar in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-snack-bar in tests. */
 export class MatSnackBarHarness extends ComponentHarness {
   // Developers can provide a custom component or template for the
   // snackbar. The canonical snack-bar parent is the "MatSnackBarContainer".

--- a/src/material/tabs/testing/tab-group-harness.ts
+++ b/src/material/tabs/testing/tab-group-harness.ts
@@ -10,10 +10,7 @@ import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {TabGroupHarnessFilters, TabHarnessFilters} from './tab-harness-filters';
 import {MatTabHarness} from './tab-harness';
 
-/**
- * Harness for interacting with a standard mat-tab-group in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard mat-tab-group in tests. */
 export class MatTabGroupHarness extends ComponentHarness {
   static hostSelector = '.mat-tab-group';
 

--- a/src/material/tabs/testing/tab-harness.ts
+++ b/src/material/tabs/testing/tab-harness.ts
@@ -9,10 +9,7 @@
 import {ComponentHarness, HarnessLoader, HarnessPredicate} from '@angular/cdk/testing';
 import {TabHarnessFilters} from './tab-harness-filters';
 
-/**
- * Harness for interacting with a standard Angular Material tab-label in tests.
- * @dynamic
- */
+/** Harness for interacting with a standard Angular Material tab-label in tests. */
 export class MatTabHarness extends ComponentHarness {
   static hostSelector = '.mat-tab-label';
 


### PR DESCRIPTION
The `@dynamic` should no longer be needed since the harnesses
will be built as part of a vanilla TypeScript compilation.