### PR TITLE
refactor(expansion): avoid unnecessary spacing check

### DIFF
--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -182,10 +182,7 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
   /** Determines whether the expansion panel should have spacing between it and its siblings. */
   _hasSpacing(): boolean {
     if (this.accordion) {
-      // We don't need to subscribe to the `stateChanges` of the parent accordion because each time
-      // the [displayMode] input changes, the change detection will also cover the host bindings
-      // of this expansion panel.
-      return (this.expanded ? this.accordion.displayMode : this._getExpandedState()) === 'default';
+      return this.expanded && this.accordion.displayMode === 'default';
     }
     return false;
   }


### PR DESCRIPTION
The where expanded equals to `false`, and where the return value of
the `_getExpandedState` method is compared to `default` will always
evaluate to `false`. This is because the method return value does not
have any overlap with `default`. It only returns `expanded` or `collapsed`.

This seems to be a leftover from https://github.com/angular/components/commit/f9bd5d4bb53b71e40b89d51f77ea42da17a2c967.