### PR TITLE
build: delete rxjs d.ts files referencing rxjs-compat

### DIFF
--- a/tools/bazel/postinstall-patches.js
+++ b/tools/bazel/postinstall-patches.js
@@ -105,6 +105,37 @@ searchAndReplace(/angular_compiler_options = {/, `$&
         "strictAttributeTypes": False,
         "strictDomEventTypes": False,`, 'node_modules/@angular/bazel/src/ng_module.bzl');
 
+// More info in https://github.com/angular/angular/pull/33786
+shelljs.rm('-rf', [
+  'node_modules/rxjs/add/',
+  'node_modules/rxjs/observable/',
+  'node_modules/rxjs/operator/',
+  // rxjs/operators is a public entry point that also contains files to support legacy deep import
+  // paths, so we need to preserve index.* and package.json files that are required for module
+  // resolution.
+  'node_modules/rxjs/operators/!(index.*|package.json)',
+  'node_modules/rxjs/scheduler/',
+  'node_modules/rxjs/symbol/',
+  'node_modules/rxjs/util/',
+  'node_modules/rxjs/internal/Rx.d.ts',
+  'node_modules/rxjs/AsyncSubject.*',
+  'node_modules/rxjs/BehaviorSubject.*',
+  'node_modules/rxjs/InnerSubscriber.*',
+  'node_modules/rxjs/interfaces.*',
+  'node_modules/rxjs/Notification.*',
+  'node_modules/rxjs/Observable.*',
+  'node_modules/rxjs/Observer.*',
+  'node_modules/rxjs/Operator.*',
+  'node_modules/rxjs/OuterSubscriber.*',
+  'node_modules/rxjs/ReplaySubject.*',
+  'node_modules/rxjs/Rx.*',
+  'node_modules/rxjs/Scheduler.*',
+  'node_modules/rxjs/Subject.*',
+  'node_modules/rxjs/SubjectSubscription.*',
+  'node_modules/rxjs/Subscriber.*',
+  'node_modules/rxjs/Subscription.*',
+]);
+
 /**
  * Reads the specified file and replaces matches of the search expression
  * with the given replacement. Throws if no changes were made.


### PR DESCRIPTION
From local testing moved build time of `//src/material:npm_package` from `182.22s.` -> `97.95s.`