### PR TITLE
docs(guides/typography): update recommended font url

### DIFF
--- a/guides/typography.md
+++ b/guides/typography.md
@@ -31,7 +31,7 @@ To get started, you first include the `Roboto` font with the 300, 400 and 500 we
 You can host it yourself or include it from [Google Fonts][2]:
 
 ```html
-<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
 ```
 
 Now you can add the appropriate CSS classes to the elements that you want to style:


### PR DESCRIPTION
Update the Google Fonts URL to include `display=swap` which is now recommended. This improves font loading performance and fixes a Google Lighthouse Audit warning.

Fixes #17697