### PR TITLE
build: remove unused variable in docs-content publishing script

### DIFF
--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -40,7 +40,6 @@ commitSha=$(git rev-parse --short HEAD)
 commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)
 commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
 commitMessage=$(git log --oneline -n 1)
-commitTag="${buildVersion}-${commitSha}"
 
 # Note that we cannot store the commit SHA in its own version segment
 # as it will not comply with the semver specification. For example:


### PR DESCRIPTION
This is a minor change for code health and removes an unnecessary
variable in the docs-content publish script. 

Someone reported this to me at some point.