### PR TITLE
fix(material/dialog): use passed in ComponentFactoryResolver to resolve dialog content

### DIFF
--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -330,7 +330,12 @@ export abstract class _MatDialogBase<C extends _MatDialogContainerBase> implemen
     } else {
       const injector = this._createInjector<T>(config, dialogRef, dialogContainer);
       const contentRef = dialogContainer.attachComponentPortal<T>(
-        new ComponentPortal(componentOrTemplateRef, config.viewContainerRef, injector),
+        new ComponentPortal(
+          componentOrTemplateRef,
+          config.viewContainerRef,
+          injector,
+          config.componentFactoryResolver,
+        ),
       );
       dialogRef.componentInstance = contentRef.instance;
     }


### PR DESCRIPTION
Currently the `ComponentFactoryResolver` from the dialog config is only used for the dialog container. These changes switch to also use it for the dialog content component.

Fixes #17702.