### PR TITLE
fix(ng-update): imports to `MatProgressSpinnerModule` not migrated

### DIFF
--- a/src/material/progress-spinner/progress-spinner-module.ts
+++ b/src/material/progress-spinner/progress-spinner-module.ts
@@ -23,6 +23,4 @@ import {MatProgressSpinner, MatSpinner} from './progress-spinner';
     MatSpinner
   ],
 })
-class MatProgressSpinnerModule {}
-
-export {MatProgressSpinnerModule};
+export class MatProgressSpinnerModule {}

--- a/src/material/schematics/ng-update/upgrade-rules/package-imports-v8/material-symbols.json
+++ b/src/material/schematics/ng-update/upgrade-rules/package-imports-v8/material-symbols.json
@@ -313,6 +313,7 @@
   "MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY": "progress-spinner",
   "MatProgressSpinner": "progress-spinner",
   "MatProgressSpinnerDefaultOptions": "progress-spinner",
+  "MatProgressSpinnerModule": "progress-spinner",
   "MatSpinner": "progress-spinner",
   "ProgressSpinnerMode": "progress-spinner",
   "MAT_RADIO_DEFAULT_OPTIONS": "radio",

--- a/tools/public_api_guard/material/progress-spinner.d.ts
+++ b/tools/public_api_guard/material/progress-spinner.d.ts
@@ -29,6 +29,11 @@ export interface MatProgressSpinnerDefaultOptions {
     strokeWidth?: number;
 }
 
+export declare class MatProgressSpinnerModule {
+    static ɵinj: i0.ɵɵInjectorDef<MatProgressSpinnerModule>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatProgressSpinnerModule, [typeof i1.MatProgressSpinner, typeof i1.MatSpinner], [typeof i2.MatCommonModule, typeof i3.CommonModule], [typeof i1.MatProgressSpinner, typeof i1.MatSpinner, typeof i2.MatCommonModule]>;
+}
+
 export declare class MatSpinner extends MatProgressSpinner {
     constructor(elementRef: ElementRef<HTMLElement>, platform: Platform, document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
     static ngAcceptInputType_diameter: number | string | null | undefined;


### PR DESCRIPTION
For v9 we generated a mapping of symbols and their corresponding secondary
entry-points. This map was based on the public API goldens we generate with
ts-api-guardian. Unfortunately ts-api-guardian has known limitations with
aliased exports which do not have the export keyword on the actual declaration.

This means that we currently do not have a mapping for such exports. Temporarily
changing ts-api-guardian to handle such cases showed that the progress-bar 
module is the only instance in the project.

Fixes #17715.

**Note**: This actually brings us to the point where we should re-consider the effort of switching to api-extractor from Microsoft eventually. This was already planned in the past, but we prioritized other things IIRC. The current API goldens are not guaranteed to be complete.