### PR TITLE
fix(virtual-scroll-viewport): changeDetection run before translate scroll content.

### DIFF
--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -389,16 +389,16 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   /** Run change detection. */
   private _doChangeDetection() {
     this._isChangeDetectionPending = false;
-
-    // Apply changes to Angular bindings. Note: We must call `markForCheck` to run change detection
-    // from the root, since the repeated items are content projected in. Calling `detectChanges`
-    // instead does not properly check the projected content.
-    this.ngZone.run(() => this._changeDetectorRef.markForCheck());
+    
     // Apply the content transform. The transform can't be set via an Angular binding because
     // bypassSecurityTrustStyle is banned in Google. However the value is safe, it's composed of
     // string literals, a variable that can only be 'X' or 'Y', and user input that is run through
     // the `Number` function first to coerce it to a numeric value.
     this._contentWrapper.nativeElement.style.transform = this._renderedContentTransform;
+    // Apply changes to Angular bindings. Note: We must call `markForCheck` to run change detection
+    // from the root, since the repeated items are content projected in. Calling `detectChanges`
+    // instead does not properly check the projected content.
+    this.ngZone.run(() => this._changeDetectorRef.markForCheck());
 
     const runAfterChangeDetection = this._runAfterChangeDetection;
     this._runAfterChangeDetection = [];

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -389,7 +389,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   /** Run change detection. */
   private _doChangeDetection() {
     this._isChangeDetectionPending = false;
-    
+
     // Apply the content transform. The transform can't be set via an Angular binding because
     // bypassSecurityTrustStyle is banned in Google. However the value is safe, it's composed of
     // string literals, a variable that can only be 'X' or 'Y', and user input that is run through


### PR DESCRIPTION
Currently, reading some properties of the viewport element during the scroll (ngAfterViewChecked), can cause a scroll back.

this._contentWrapper.nativeElement.style.transform must be set before changeDetection.

Fix #17597
See [stackblitz](https://stackblitz.com/edit/components-issue-ooljyt).