### PR TITLE
test: clean up dom insertions in tests

### DIFF
--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -185,6 +185,10 @@ describe('AriaDescriber', () => {
 
     // Use `querySelectorAll` with an attribute since `getElementById` will stop at the first match.
     expect(document.querySelectorAll(`[id='${MESSAGES_CONTAINER_ID}']`).length).toBe(1);
+
+    if (extraContainer.parentNode) {
+      extraContainer.parentNode.removeChild(extraContainer);
+    }
   });
 
   it('should not describe messages that match up with the aria-label of the element', () => {

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -138,6 +138,10 @@ describe('LiveAnnouncer', () => {
 
       expect(document.body.querySelectorAll('.cdk-live-announcer-element').length)
           .toBe(1, 'Expected only one live announcer element in the DOM.');
+
+      if (extraElement.parentNode) {
+        extraElement.parentNode.removeChild(extraElement);
+      }
     }));
 
     it('should clear any previous timers when a new one is started', fakeAsync(() => {

--- a/src/cdk/clipboard/clipboard.spec.ts
+++ b/src/cdk/clipboard/clipboard.spec.ts
@@ -28,7 +28,9 @@ describe('Clipboard', () => {
   });
 
   afterEach(() => {
-    focusedInput.remove();
+    if (focusedInput.parentNode) {
+      focusedInput.parentNode.removeChild(focusedInput);
+    }
   });
 
   describe('#beginCopy', () => {

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -59,8 +59,11 @@ describe('OverlayContainer', () => {
     document.body.appendChild(extraContainer);
 
     overlayContainer.getContainerElement();
-
     expect(document.querySelectorAll('.cdk-overlay-container').length).toBe(1);
+
+    if (extraContainer.parentNode) {
+      extraContainer.parentNode.removeChild(extraContainer);
+    }
   });
 });
 

--- a/src/material-experimental/mdc-chips/chip-option.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-option.spec.ts
@@ -52,12 +52,6 @@ describe('MDC-based Option Chips', () => {
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChipOption>(MatChipOption);
       testComponent = fixture.debugElement.componentInstance;
-
-      document.body.appendChild(chipNativeElement);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(chipNativeElement);
     });
 
     describe('basic behaviors', () => {

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -50,12 +50,6 @@ describe('MDC-based Row Chips', () => {
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChipRow>(MatChipRow);
       testComponent = fixture.debugElement.componentInstance;
-
-      document.body.appendChild(chipNativeElement);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(chipNativeElement);
     });
 
     describe('basic behaviors', () => {

--- a/src/material-experimental/mdc-chips/chip.spec.ts
+++ b/src/material-experimental/mdc-chips/chip.spec.ts
@@ -43,12 +43,6 @@ describe('MDC-based MatChip', () => {
       chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
-
-      document.body.appendChild(chipNativeElement);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(chipNativeElement);
     });
 
     it('adds the `mat-mdc-basic-chip` class', () => {
@@ -67,12 +61,6 @@ describe('MDC-based MatChip', () => {
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
       testComponent = fixture.debugElement.componentInstance;
-
-      document.body.appendChild(chipNativeElement);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(chipNativeElement);
     });
 
     it('adds the `mat-chip` class', () => {

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -44,12 +44,6 @@ describe('MatChip', () => {
       chipDebugElement = fixture.debugElement.query(By.directive(MatChip))!;
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
-
-      document.body.appendChild(chipNativeElement);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(chipNativeElement);
     });
 
     it('adds the `mat-basic-chip` class', () => {
@@ -69,12 +63,6 @@ describe('MatChip', () => {
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChip>(MatChip);
       testComponent = fixture.debugElement.componentInstance;
-
-      document.body.appendChild(chipNativeElement);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(chipNativeElement);
     });
 
     describe('basic behaviors', () => {


### PR DESCRIPTION
Fixes a few DOM insertion cases that I noticed while looking through some tests. E.g. in all the chips tests we were appending the element to the DOM ourselves and then removing it, even though Angular already inserted it in the DOM for us. Also fixes a few cases where we were inserting elements in tests, but not cleaning them up.