### PR TITLE
build: Object.assign linting not working

### DIFF
--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -565,7 +565,8 @@ describe('MDC-based MatChipGrid', () => {
       dispatchMouseEvent(chipRemoveDebugElements[2].nativeElement, 'click');
       fixture.detectChanges();
 
-      const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+      const fakeEvent = createFakeEvent('transitionend');
+      (fakeEvent as any).propertyName = 'width';
       chipElements[2].nativeElement.dispatchEvent(fakeEvent);
 
       fixture.detectChanges();
@@ -729,7 +730,8 @@ describe('MDC-based MatChipGrid', () => {
         chip.focus();
         dispatchKeyboardEvent(chip, 'keydown', BACKSPACE);
         fixture.detectChanges();
-        const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+        const fakeEvent = createFakeEvent('transitionend');
+        (fakeEvent as any).propertyName = 'width';
         chip.dispatchEvent(fakeEvent);
         fixture.detectChanges();
         tick();

--- a/src/material-experimental/mdc-chips/chip-remove.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-remove.spec.ts
@@ -59,7 +59,8 @@ describe('MDC-based Chip Remove', () => {
       buttonElement.click();
       fixture.detectChanges();
 
-      const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+      const fakeEvent = createFakeEvent('transitionend');
+      (fakeEvent as any).propertyName = 'width';
       chipNativeElement.dispatchEvent(fakeEvent);
 
       expect(testChip.didRemove).toHaveBeenCalled();

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -94,7 +94,8 @@ describe('MDC-based Row Chips', () => {
         chipInstance.remove();
         fixture.detectChanges();
 
-        const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+        const fakeEvent = createFakeEvent('transitionend');
+        (fakeEvent as any).propertyName = 'width';
         chipNativeElement.dispatchEvent(fakeEvent);
 
         expect(testComponent.chipRemove).toHaveBeenCalledWith({chip: chipInstance});
@@ -123,8 +124,8 @@ describe('MDC-based Row Chips', () => {
           chipInstance._keydown(DELETE_EVENT);
           fixture.detectChanges();
 
-          const fakeEvent = Object.assign(createFakeEvent('transitionend'),
-            {propertyName: 'width'});
+          const fakeEvent = createFakeEvent('transitionend');
+          (fakeEvent as any).propertyName = 'width';
           chipNativeElement.dispatchEvent(fakeEvent);
 
           expect(testComponent.chipRemove).toHaveBeenCalled();
@@ -138,8 +139,8 @@ describe('MDC-based Row Chips', () => {
           chipInstance._keydown(BACKSPACE_EVENT);
           fixture.detectChanges();
 
-          const fakeEvent = Object.assign(createFakeEvent('transitionend'),
-            {propertyName: 'width'});
+          const fakeEvent = createFakeEvent('transitionend');
+          (fakeEvent as any).propertyName = 'width';
           chipNativeElement.dispatchEvent(fakeEvent);
 
           expect(testComponent.chipRemove).toHaveBeenCalled();
@@ -160,8 +161,8 @@ describe('MDC-based Row Chips', () => {
           chipInstance._keydown(DELETE_EVENT);
           fixture.detectChanges();
 
-          const fakeEvent = Object.assign(createFakeEvent('transitionend'),
-            {propertyName: 'width'});
+          const fakeEvent = createFakeEvent('transitionend');
+          (fakeEvent as any).propertyName = 'width';
           chipNativeElement.dispatchEvent(fakeEvent);
 
           expect(testComponent.chipRemove).not.toHaveBeenCalled();
@@ -176,8 +177,8 @@ describe('MDC-based Row Chips', () => {
           chipInstance._keydown(BACKSPACE_EVENT);
           fixture.detectChanges();
 
-          const fakeEvent = Object.assign(createFakeEvent('transitionend'),
-            {propertyName: 'width'});
+          const fakeEvent = createFakeEvent('transitionend');
+          (fakeEvent as any).propertyName = 'width';
           chipNativeElement.dispatchEvent(fakeEvent);
 
           expect(testComponent.chipRemove).not.toHaveBeenCalled();

--- a/src/material-experimental/mdc-chips/chip.spec.ts
+++ b/src/material-experimental/mdc-chips/chip.spec.ts
@@ -109,7 +109,8 @@ describe('MDC-based MatChip', () => {
       chipInstance.remove();
       fixture.detectChanges();
 
-      const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'width'});
+      const fakeEvent = createFakeEvent('transitionend');
+      (fakeEvent as any).propertyName = 'width';
       chipNativeElement.dispatchEvent(fakeEvent);
 
       expect(testComponent.chipRemove).toHaveBeenCalledWith({chip: chipInstance});

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -829,8 +829,8 @@ describe('MatInput without forms', () => {
     expect(inputContainer._shouldAlwaysFloat).toBe(false);
     expect(inputContainer.floatLabel).toBe('always');
 
-    const fakeEvent = Object.assign(createFakeEvent('transitionend'), {propertyName: 'transform'});
-
+    const fakeEvent = createFakeEvent('transitionend');
+    (fakeEvent as any).propertyName = 'transform';
     label.dispatchEvent(fakeEvent);
     fixture.detectChanges();
 

--- a/tools/dgeni/processors/merge-inherited-properties.ts
+++ b/tools/dgeni/processors/merge-inherited-properties.ts
@@ -35,7 +35,7 @@ export class MergeInheritedProperties implements Processor {
       // member doc for the destination class, we clone the member doc. It's important to keep
       // the prototype and reference because later, Dgeni identifies members and properties
       // by using an instance comparison.
-      const newMemberDoc = Object.assign(Object.create(memberDoc), memberDoc);
+      const newMemberDoc = {...Object.create(memberDoc), ...memberDoc};
       newMemberDoc.containerDoc = destination;
 
       destination.members.push(newMemberDoc);

--- a/tslint.json
+++ b/tslint.json
@@ -86,7 +86,7 @@
       ["fdescribe"],
       ["xit"],
       ["xdescribe"],
-      {"name": "Object.assign", "message": "Use the spread operator instead."}
+      {"name": ["Object", "assign"], "message": "Use the spread operator instead."}
     ],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.
     "linebreak-style": [true, "LF"],


### PR DESCRIPTION
A long time ago we decided to ban uses of `Object.assign` because of some issues in g3, but the way we wrote it for the `ban` lint rule meant that it wouldn't be caught. These changes tweak the syntax and fix the cases that are being caught now.