### PR TITLE
build: server-side rendering check not failing for async errors

### DIFF
--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
@@ -1,4 +1,4 @@
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule, ErrorHandler} from '@angular/core';
 import {MatButtonModule} from '@angular/material-experimental/mdc-button';
 import {MatCardModule} from '@angular/material-experimental/mdc-card';
 import {MatCheckboxModule} from '@angular/material-experimental/mdc-checkbox';
@@ -34,6 +34,17 @@ export class KitchenSinkMdc {
   ],
   declarations: [KitchenSinkMdc],
   exports: [KitchenSinkMdc],
+  providers: [{
+    // If an error is thrown asynchronously during server-side rendering it'll get logged to stderr,
+    // but it won't cause the build to fail. We still want to catch these errors so we provide an
+    // `ErrorHandler` that re-throws the error and causes the process to exit correctly.
+    provide: ErrorHandler,
+    useValue: {handleError: ERROR_HANDLER}
+  }]
 })
 export class KitchenSinkMdcModule {
+}
+
+export function ERROR_HANDLER(error: Error) {
+  throw error;
 }

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -2,7 +2,7 @@ import {FocusMonitor} from '@angular/cdk/a11y';
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import {ScrollingModule, ViewportRuler} from '@angular/cdk/scrolling';
 import {CdkTableModule, DataSource} from '@angular/cdk/table';
-import {Component, ElementRef, NgModule} from '@angular/core';
+import {Component, ElementRef, NgModule, ErrorHandler} from '@angular/core';
 import {MatNativeDateModule, MatRippleModule} from '@angular/material/core';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatButtonModule} from '@angular/material/button';
@@ -146,6 +146,17 @@ export class KitchenSink {
   declarations: [KitchenSink, TestEntryComponent],
   exports: [KitchenSink, TestEntryComponent],
   entryComponents: [TestEntryComponent],
+  providers: [{
+    // If an error is thrown asynchronously during server-side rendering it'll get logged to stderr,
+    // but it won't cause the build to fail. We still want to catch these errors so we provide an
+    // `ErrorHandler` that re-throws the error and causes the process to exit correctly.
+    provide: ErrorHandler,
+    useValue: {handleError: ERROR_HANDLER}
+  }]
 })
 export class KitchenSinkModule {
+}
+
+export function ERROR_HANDLER(error: Error) {
+  throw error;
 }


### PR DESCRIPTION
If an error is thrown asynchronously during server-side rendering (e.g. in an rxjs subscription or a `setTimeout`), it'll be logged to the console but the script will still exit with 0. These changes add an `ErrorHandler` that'll rethrow the errors so that the CI fails properly.