### PR TITLE
refactor(ng-update): do not copy gesture config if only standard HammerJS events are used

### DIFF
--- a/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/hammer-template-check.ts
+++ b/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/hammer-template-check.ts
@@ -8,41 +8,52 @@
 
 import {parse5} from '@angular/cdk/schematics';
 
-/**
- * List of known events which are supported by the "HammerGesturesPlugin" and by
- * the gesture config which was provided by Angular Material.
- */
-const KNOWN_HAMMERJS_EVENTS = [
+/** List of known events which are supported by the "HammerGesturesPlugin". */
+const STANDARD_HAMMERJS_EVENTS = [
   // Events supported by the "HammerGesturesPlugin". See:
   // angular/angular/blob/0119f46d/packages/platform-browser/src/dom/events/hammer_gestures.ts#L19
-  'pan', 'panstart', 'panmove', 'panend', 'pancancel', 'panleft', 'panright', 'panup', 'pandown',
-  'pinch', 'pinchstart', 'pinchmove', 'pinchend', 'pinchcancel', 'pinchin', 'pinchout', 'press',
-  'pressup', 'rotate', 'rotatestart', 'rotatemove', 'rotateend', 'rotatecancel', 'swipe',
-  'swipeleft', 'swiperight', 'swipeup', 'swipedown', 'tap',
-
-  // Events from the Angular Material gesture config.
-  'longpress', 'slide', 'slidestart', 'slideend', 'slideright', 'slideleft'
+  'pan',       'panstart',    'panmove',    'panend',    'pancancel',    'panleft',
+  'panright',  'panup',       'pandown',    'pinch',     'pinchstart',   'pinchmove',
+  'pinchend',  'pinchcancel', 'pinchin',    'pinchout',  'press',        'pressup',
+  'rotate',    'rotatestart', 'rotatemove', 'rotateend', 'rotatecancel', 'swipe',
+  'swipeleft', 'swiperight',  'swipeup',    'swipedown', 'tap',
 ];
+
+/** List of events which are provided by the deprecated Angular Material "GestureConfig". */
+const CUSTOM_MATERIAL_HAMMERJS_EVENS =
+    ['longpress', 'slide', 'slidestart', 'slideend', 'slideright', 'slideleft'];
 
 /**
  * Parses the specified HTML and searches for elements with Angular outputs listening to
  * one of the known HammerJS events. This check naively assumes that the bindings never
  * match on a component output, but only on the Hammer plugin.
  */
-export function isHammerJsUsedInTemplate(html: string): boolean {
+export function isHammerJsUsedInTemplate(html: string):
+    {standardEvents: boolean, customEvents: boolean} {
   const document =
       parse5.parseFragment(html, {sourceCodeLocationInfo: true}) as parse5.DefaultTreeDocument;
-  let result = false;
+  let customEvents = false;
+  let standardEvents = false;
   const visitNodes = nodes => {
-    nodes.forEach(node => {
-      if (node.attrs &&
-          node.attrs.some(attr => KNOWN_HAMMERJS_EVENTS.some(e => `(${e})` === attr.name))) {
-        result = true;
-      } else if (node.childNodes) {
+    nodes.forEach((node: parse5.DefaultTreeElement) => {
+      if (node.attrs) {
+        for (let attr of node.attrs) {
+          if (!customEvents && CUSTOM_MATERIAL_HAMMERJS_EVENS.some(e => `(${e})` === attr.name)) {
+            customEvents = true;
+          }
+          if (!standardEvents && STANDARD_HAMMERJS_EVENTS.some(e => `(${e})` === attr.name)) {
+            standardEvents = true;
+          }
+        }
+      }
+
+      // Do not continue traversing the AST if both type of HammerJS
+      // usages have been detected already.
+      if (node.childNodes && (!customEvents || !standardEvents)) {
         visitNodes(node.childNodes);
       }
     });
   };
   visitNodes(document.childNodes);
-  return result;
+  return {customEvents, standardEvents};
 }


### PR DESCRIPTION
Currently the HammerJS v9 migration always copies the gesture config
if HammerJS events are used. This is not necessary for projects where
only _standard_ HammerJS events are used. These events are provided
by the default hammer gesture config that comes with the `HammerModule`.