### PR TITLE
build: remove schematic tsconfig project references

### DIFF
--- a/src/cdk/schematics/tsconfig.json
+++ b/src/cdk/schematics/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "declaration": true,
     "lib": ["es2017"],
     "module": "commonjs",

--- a/src/material/schematics/tsconfig.json
+++ b/src/material/schematics/tsconfig.json
@@ -23,9 +23,6 @@
       "@angular/cdk/schematics": ["../../cdk/schematics"]
     }
   },
-  "references": [
-    {"path": "../../cdk/schematics"}
-  ],
   "exclude": [
     "**/*.spec.ts",
     // Exclude the test-setup utility files. Those should not be part of the output.


### PR DESCRIPTION
In the past we set up project references for the
Material and CDK schematics. This was necessary
since the Material schematic code referenced the
CDK schematic code through source files, and this
could have caused an invalid file structure in the
release output.

Nowadays, since we use Bazel, the Material schematics
no longer refer to the source files of the CDK schematics,
and this issue is automatically solved. This also fixes IDE's
like WebStorm incorrectly reporting that the CDK schematics
are not built, when working inside the Material schematics.