### PR TITLE
build: fix missing amd module name for primary entry-point

### DIFF
--- a/src/material/BUILD.bazel
+++ b/src/material/BUILD.bazel
@@ -14,6 +14,7 @@ load("//tools:defaults.bzl", "ng_package", "ts_library")
 ts_library(
     name = "material",
     srcs = ["index.ts"],
+    module_name = "@angular/material",
 )
 
 filegroup(


### PR DESCRIPTION
Even though the primary entry-point of Angular Material is empty,
it should still have an AMD module name (similar to the CDK).

A good example is that consumers of Angular Material in a Bazel
project can have the unnamed bundle as input of a target (like
ts_devserver). RequireJS will then throw about an anonymous
module.

Fixes #17720