### PR TITLE
Revert "build: fix missing amd module name for primary entry-point (#17757)"

### DIFF
--- a/src/material/BUILD.bazel
+++ b/src/material/BUILD.bazel
@@ -14,7 +14,6 @@ load("//tools:defaults.bzl", "ng_package", "ts_library")
 ts_library(
     name = "material",
     srcs = ["index.ts"],
-    module_name = "@angular/material",
 )
 
 filegroup(


### PR DESCRIPTION
This reverts commit 49977f71f70a11c95e6c1361c48ff843b6688024.

Reverting because this commit breaks the local build for the release
packages. Will further investigate why, but for now we need to revert to
unblock doing a release.