### PR TITLE
Revert "Revert "build: fix missing amd module name for primary entry-point (#17757)""

### DIFF
--- a/src/material/BUILD.bazel
+++ b/src/material/BUILD.bazel
@@ -14,6 +14,7 @@ load("//tools:defaults.bzl", "ng_package", "ts_library")
 ts_library(
     name = "material",
     srcs = ["index.ts"],
+    module_name = "@angular/material",
 )
 
 filegroup(


### PR DESCRIPTION
Reverts angular/components#17772

This commit was not the cause of the breakage