### PR TITLE
build: enforce that the descendants flag is set on all queries

### DIFF
--- a/src/material-experimental/mdc-tabs/tab-header.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.ts
@@ -50,7 +50,7 @@ import {MatInkBar} from './ink-bar';
   },
 })
 export class MatTabHeader extends _MatTabHeaderBase implements AfterContentInit {
-  @ContentChildren(MatTabLabelWrapper) _items: QueryList<MatTabLabelWrapper>;
+  @ContentChildren(MatTabLabelWrapper, {descendants: false}) _items: QueryList<MatTabLabelWrapper>;
   @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
   @ViewChild('tabList', {static: true}) _tabList: ElementRef;
   @ViewChild('nextPaginator') _nextPaginator: ElementRef<HTMLElement>;

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -162,7 +162,7 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
    * @deprecated
    * @breaking-change 8.0.0
    */
-  @ContentChildren(MatMenuItem) items: QueryList<MatMenuItem>;
+  @ContentChildren(MatMenuItem, {descendants: false}) items: QueryList<MatMenuItem>;
 
   /**
    * Menu content that will be rendered lazily.

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -88,7 +88,7 @@ export abstract class _MatTabHeaderBase extends MatPaginatedTabHeader implements
   },
 })
 export class MatTabHeader extends _MatTabHeaderBase {
-  @ContentChildren(MatTabLabelWrapper) _items: QueryList<MatTabLabelWrapper>;
+  @ContentChildren(MatTabLabelWrapper, {descendants: false}) _items: QueryList<MatTabLabelWrapper>;
   @ViewChild(MatInkBar, {static: true}) _inkBar: MatInkBar;
   @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
   @ViewChild('tabList', {static: true}) _tabList: ElementRef;

--- a/tslint.json
+++ b/tslint.json
@@ -154,6 +154,13 @@
         "properties": {
           "*": "^(?!\\s*$).+"
         }
+      },
+      "ContentChildren": {
+        "argument": 1,
+        "required": true,
+        "properties": {
+          "descendants": "^(true|false)$"
+        }
       }
     }, "src/!(a11y-demo|e2e-app|components-examples|universal-app|dev-app)/**/!(*.spec).ts"],
     "require-license-banner": [


### PR DESCRIPTION
Updates the linting config to require that the `descendants` flag is set on all `ContentChildren` queries so that we can avoid backsliding.