### PR TITLE
fix(schematics): do not depend on external dependency for colors

### DIFF
--- a/src/cdk/schematics/BUILD.bazel
+++ b/src/cdk/schematics/BUILD.bazel
@@ -36,7 +36,6 @@ ts_library(
         "@npm//glob",
         "@npm//parse5",
         "@npm//typescript",
-        "@npm//chalk",
     ],
 )
 

--- a/src/cdk/schematics/ng-update/index.ts
+++ b/src/cdk/schematics/ng-update/index.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Rule} from '@angular-devkit/schematics';
-import chalk from 'chalk';
+import {Rule, SchematicContext} from '@angular-devkit/schematics';
 import {TargetVersion} from '../update-tool/target-version';
 import {cdkUpgradeData} from './upgrade-data';
 import {createUpgradeRule} from './upgrade-rules';
@@ -33,14 +32,15 @@ export function updateToV9(): Rule {
 }
 
 /** Function that will be called when the migration completed. */
-function onMigrationComplete(targetVersion: TargetVersion, hasFailures: boolean) {
-  console.log();
-  console.log(chalk.green(`  ✓  Updated Angular CDK to ${targetVersion}`));
-  console.log();
+function onMigrationComplete(context: SchematicContext, targetVersion: TargetVersion,
+                             hasFailures: boolean) {
+  context.logger.info('');
+  context.logger.info(`  ✓  Updated Angular CDK to ${targetVersion}`);
+  context.logger.info('');
 
   if (hasFailures) {
-    console.log(chalk.yellow(
+    context.logger.warn(
         '  ⚠  Some issues were detected but could not be fixed automatically. Please check the ' +
-        'output above and fix these issues manually.'));
+        'output above and fix these issues manually.');
   }
 }

--- a/src/cdk/schematics/ng-update/upgrade-rules/class-inheritance-rule.ts
+++ b/src/cdk/schematics/ng-update/upgrade-rules/class-inheritance-rule.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import chalk from 'chalk';
 import * as ts from 'typescript';
 import {MigrationRule} from '../../update-tool/migration-rule';
 import {PropertyNameUpgradeData} from '../data/property-names';
@@ -54,9 +53,9 @@ export class ClassInheritanceRule extends MigrationRule<RuleUpgradeData> {
       if (data) {
         this.createFailureAtNode(
             node,
-            `Found class "${chalk.bold(className)}" which extends class ` +
-                `"${chalk.bold(typeName)}". Please note that the base class property ` +
-                `"${chalk.red(data.replace)}" has changed to "${chalk.green(data.replaceWith)}". ` +
+            `Found class "${className}" which extends class ` +
+                `"${typeName}". Please note that the base class property ` +
+                `"${data.replace}" has changed to "${data.replaceWith}". ` +
                 `You may need to update your class as well.`);
       }
     });

--- a/src/cdk/schematics/ng-update/upgrade-rules/index.ts
+++ b/src/cdk/schematics/ng-update/upgrade-rules/index.ts
@@ -44,13 +44,16 @@ export const cdkMigrationRules: MigrationRuleType<RuleUpgradeData>[] = [
 
 type NullableMigrationRule = MigrationRuleType<RuleUpgradeData|null>;
 
+type PostMigrationFn = (context: SchematicContext, targetVersion: TargetVersion,
+                        hasFailure: boolean) => void;
+
 /**
  * Creates a Angular schematic rule that runs the upgrade for the
  * specified target version.
  */
 export function createUpgradeRule(
     targetVersion: TargetVersion, extraRules: NullableMigrationRule[], upgradeData: RuleUpgradeData,
-    onMigrationCompleteFn?: (targetVersion: TargetVersion, hasFailures: boolean) => void): Rule {
+    onMigrationCompleteFn?: PostMigrationFn): Rule {
   return async (tree: Tree, context: SchematicContext) => {
     const logger = context.logger;
     const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
@@ -99,7 +102,7 @@ export function createUpgradeRule(
     }
 
     if (onMigrationCompleteFn) {
-      onMigrationCompleteFn(targetVersion, hasRuleFailures);
+      onMigrationCompleteFn(context, targetVersion, hasRuleFailures);
     }
   };
 }

--- a/src/material/schematics/BUILD.bazel
+++ b/src/material/schematics/BUILD.bazel
@@ -34,7 +34,6 @@ ts_library(
         "@npm//@types/node",
         "@npm//tslint",
         "@npm//typescript",
-        "@npm//chalk",
     ],
 )
 

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Rule} from '@angular-devkit/schematics';
+import {Rule, SchematicContext} from '@angular-devkit/schematics';
 import {createUpgradeRule, TargetVersion} from '@angular/cdk/schematics';
-import chalk from 'chalk';
 
 import {materialUpgradeData} from './upgrade-data';
 import {HammerGesturesRule} from './upgrade-rules/hammer-gestures-v9/hammer-gestures-rule';
@@ -58,14 +57,15 @@ export function updateToV9(): Rule {
 }
 
 /** Function that will be called when the migration completed. */
-function onMigrationComplete(targetVersion: TargetVersion, hasFailures: boolean) {
-  console.log();
-  console.log(chalk.green(`  ✓  Updated Angular Material to ${targetVersion}`));
-  console.log();
+function onMigrationComplete(context: SchematicContext, targetVersion: TargetVersion,
+                             hasFailures: boolean) {
+  context.logger.info('');
+  context.logger.info(`  ✓  Updated Angular Material to ${targetVersion}`);
+  context.logger.info('');
 
   if (hasFailures) {
-    console.log(chalk.yellow(
+    context.logger.warn(
       '  ⚠  Some issues were detected but could not be fixed automatically. Please check the ' +
-      'output above and fix these issues manually.'));
+      'output above and fix these issues manually.');
   }
 }

--- a/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/hammer-gestures-rule.ts
+++ b/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/hammer-gestures-rule.ts
@@ -31,7 +31,6 @@ import {
 import {InsertChange} from '@schematics/angular/utility/change';
 import {getWorkspace} from '@schematics/angular/utility/config';
 import {WorkspaceProject} from '@schematics/angular/utility/workspace-models';
-import chalk from 'chalk';
 import {readFileSync} from 'fs';
 import {dirname, join, relative} from 'path';
 import * as ts from 'typescript';
@@ -851,10 +850,10 @@ export class HammerGesturesRule extends MigrationRule<null> {
    */
   static globalPostMigration(tree: Tree, context: SchematicContext): PostMigrationAction {
     // Always notify the developer that the Hammer v9 migration does not migrate tests.
-    context.logger.info(chalk.yellow(
+    context.logger.info(
         '\n⚠  General notice: The HammerJS v9 migration for Angular Components is not able to ' +
         'migrate tests. Please manually clean up tests in your project if they rely on ' +
-        (this.globalUsesHammer ? 'the deprecated Angular Material gesture config.' : 'HammerJS.')));
+        (this.globalUsesHammer ? 'the deprecated Angular Material gesture config.' : 'HammerJS.'));
     context.logger.info(
         'Read more about migrating tests: https://git.io/ng-material-v9-hammer-migrate-tests');
 


### PR DESCRIPTION
Currently we assume that `chalk` always is installed. This has worked
without any issues for a long time because most CLI projects had chalk
installed. This could potentially change in the projects, or the verison of
chalk could accidentally be older/more recent than what our schematics
expect. We just remove colors and depend on the devkit logger for colors
based on specific logging levels.