### PR TITLE
build: migrate to new --define=angular_ivy_enabled flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,9 +40,11 @@ build:release --workspace_status_command="node ./tools/bazel-stamp-vars.js"
 ################################
 # View Engine / Ivy toggle     #
 ################################
+build:view-engine --define=angular_ivy_enabled=False
+build:ivy --define=angular_ivy_enabled=True
 
-# Use "legacy" for ViewEngine and "aot" for Ivy
-build --define=compile=aot
+# Set Ivy as the default
+build --config=ivy
 
 #######################
 # Remote HTTP Caching #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,8 +403,8 @@ jobs:
       - *setup_bazel_binary
 
       # Run project tests with NGC and View Engine.
-      - run: bazel build src/... --build_tag_filters=-docs-package,-e2e --define=compile=legacy
-      - run: bazel test src/... --build_tag_filters=-docs-package,-e2e --test_tag_filters=-e2e --define=compile=legacy
+      - run: bazel build src/... --build_tag_filters=-docs-package,-e2e --config=view-engine
+      - run: bazel test src/... --build_tag_filters=-docs-package,-e2e --test_tag_filters=-e2e --config=view-engine
 
   # ----------------------------------------------------------------------------
   # Job that runs all Bazel tests against View Engine from angular/angular#master.
@@ -426,8 +426,8 @@ jobs:
       # Setup Angular snapshots by installing the artifacts from the Github repositories.
       - run: node ./scripts/circleci/setup-angular-snapshots.js --tag master
       # Run project tests with NGC and View Engine.
-      - run: bazel build src/... --build_tag_filters=-docs-package,-e2e --define=compile=legacy
-      - run: bazel test src/... --build_tag_filters=-docs-package,-e2e --test_tag_filters=-e2e --define=compile=legacy
+      - run: bazel build src/... --build_tag_filters=-docs-package,-e2e --config=view-engine
+      - run: bazel test src/... --build_tag_filters=-docs-package,-e2e --test_tag_filters=-e2e --config=view-engine
 
   # ----------------------------------------------------------------------------
   # Job that runs all Bazel tests against material-components-web#master.

--- a/packages.bzl
+++ b/packages.bzl
@@ -39,7 +39,8 @@ ANGULAR_LIBRARY_IVY_UMDS = ANGULAR_NO_NGCC_BUNDLES + [
 
 """
   Gets the list of targets for the Angular library UMD bundles. Conditionally
-  switches between View Engine or Ivy UMD bundles based on the "--define=compile" flag.
+  switches between View Engine or Ivy UMD bundles based on the 
+  "--config={ivy,view-engine}" flag.
 """
 
 def getAngularUmdTargets():

--- a/scripts/build-packages-dist.js
+++ b/scripts/build-packages-dist.js
@@ -41,17 +41,17 @@ if (module === require.main) {
  * output directory.
  */
 function defaultBuildReleasePackages() {
-  buildReleasePackages('legacy', join(projectDir, 'dist/releases'));
+  buildReleasePackages(false, join(projectDir, 'dist/releases'));
 }
 
 /**
  * Builds the release packages with the given compile mode and copies
  * the package output into the given directory.
  */
-function buildReleasePackages(compileMode, distPath) {
+function buildReleasePackages(useIvy, distPath) {
   console.log('######################################');
   console.log('  Building release packages...');
-  console.log(`  Compile mode: ${compileMode}`);
+  console.log(`  Compiling with Ivy: ${useIvy}`);
   console.log('######################################');
 
   // List of targets to build. e.g. "src/cdk:npm_package", or "src/material:npm_package".
@@ -73,7 +73,7 @@ function buildReleasePackages(compileMode, distPath) {
 
   // Build with "--config=release" so that Bazel runs the workspace stamping script. The
   // stamping script ensures that the version placeholder is populated in the release output.
-  exec(`${bazelCmd} build --config=release --define=compile=${compileMode} ${targets.join(' ')}`);
+  exec(`${bazelCmd} build --config=release --config=${useIvy ? 'ivy' : 'view-engine'} ${targets.join(' ')}`);
 
   // Delete the distribution directory so that the output is guaranteed to be clean. Re-create
   // the empty directory so that we can copy the release packages into it later.

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -99,7 +99,7 @@ sass_binary(
 
 expand_template(
     name = "system-config",
-    configuration_env_vars = ["compile"],
+    configuration_env_vars = ["angular_ivy_enabled"],
     output_name = "system-config.js",
     substitutions = {
         "$CDK_ENTRYPOINTS_TMPL": str(CDK_ENTRYPOINTS),

--- a/src/dev-app/system-config-tmpl.js
+++ b/src/dev-app/system-config-tmpl.js
@@ -16,7 +16,7 @@ var MATERIAL_PACKAGES = $MATERIAL_ENTRYPOINTS_TMPL;
 var MATERIAL_EXPERIMENTAL_PACKAGES = $MATERIAL_EXPERIMENTAL_ENTRYPOINTS_TMPL;
 
 /** Whether the dev-app is served with Ivy enabled. */
-var isRunningWithIvy = '$COMPILE_TMPL' === 'aot';
+var isRunningWithIvy = '$ANGULAR_IVY_ENABLED_TMPL'.toString() === 'True';
 
 /** Bazel runfile path referring to the "src/" folder of the project. */
 var srcRunfilePath = 'angular_material/src';

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -17,6 +17,6 @@ platform(
 config_setting(
     name = "view_engine_mode",
     values = {
-        "define": "compile=legacy",
+        "define": "angular_ivy_enabled=False",
     },
 )


### PR DESCRIPTION
Remove all usage of --define=compile=* within the repo, using --config=ivy and
--config=view-engine instead.  This matches the changes in the angular/angular
repo and is clearer to developers what the flag is actually doing.