### PR TITLE
feat(sort): add test harness

### DIFF
--- a/src/material/config.bzl
+++ b/src/material/config.bzl
@@ -40,6 +40,7 @@ entryPoints = [
     "snack-bar",
     "snack-bar/testing",
     "sort",
+    "sort/testing",
     "stepper",
     "table",
     "tabs",

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -73,6 +73,7 @@ interface MatSortHeaderColumnDef {
   templateUrl: 'sort-header.html',
   styleUrls: ['sort-header.css'],
   host: {
+    'class': 'mat-sort-header',
     '(click)': '_handleClick()',
     '(mouseenter)': '_setIndicatorHintVisible(true)',
     '(mouseleave)': '_setIndicatorHintVisible(false)',

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -64,6 +64,7 @@ const _MatSortMixinBase: HasInitializedCtor & CanDisableCtor & typeof MatSortBas
 @Directive({
   selector: '[matSort]',
   exportAs: 'matSort',
+  host: {'class': 'mat-sort'},
   inputs: ['disabled: matSortDisabled']
 })
 export class MatSort extends _MatSortMixinBase

--- a/src/material/sort/testing/BUILD.bazel
+++ b/src/material/sort/testing/BUILD.bazel
@@ -1,0 +1,51 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material/sort/testing",
+    deps = [
+        "//src/cdk/testing",
+        "//src/material/sort",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob(["**/*.ts"]),
+)
+
+ng_test_library(
+    name = "harness_tests_lib",
+    srcs = ["shared.spec.ts"],
+    deps = [
+        ":testing",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/sort",
+        "@npm//@angular/platform-browser",
+    ],
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["shared.spec.ts"],
+    ),
+    deps = [
+        ":harness_tests_lib",
+        ":testing",
+        "//src/material/sort",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [":unit_tests_lib"],
+)

--- a/src/material/sort/testing/index.ts
+++ b/src/material/sort/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material/sort/testing/public-api.ts
+++ b/src/material/sort/testing/public-api.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './sort-harness';
+export * from './sort-header-harness';
+export * from './sort-harness-filters';

--- a/src/material/sort/testing/shared.spec.ts
+++ b/src/material/sort/testing/shared.spec.ts
@@ -1,0 +1,183 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatSortModule, Sort} from '@angular/material/sort';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatSortHarness} from './sort-harness';
+
+/** Shared tests to run on both the original and MDC-based sort. */
+export function runHarnessTests(
+    sortModule: typeof MatSortModule,
+    sortHarness: typeof MatSortHarness) {
+  let fixture: ComponentFixture<SortHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [sortModule, NoopAnimationsModule],
+      declarations: [SortHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SortHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load harness for mat-sort', async () => {
+    const sorts = await loader.getAllHarnesses(sortHarness);
+    expect(sorts.length).toBe(1);
+  });
+
+  it('should load the harnesses for all the headers in a mat-sort', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const headers = await sort.getSortHeaders();
+    expect(headers.length).toBe(5);
+  });
+
+  it('should be able to filter headers by their label text', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const headers = await sort.getSortHeaders({label: 'Carbs'});
+    expect(headers.length).toBe(1);
+    expect(await headers[0].getLabel()).toBe('Carbs');
+  });
+
+  it('should be able to filter headers by their labels via a regex', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const headers = await sort.getSortHeaders({label: /^C/});
+    const labels = await Promise.all(headers.map(header => header.getLabel()));
+    expect(headers.length).toBe(2);
+    expect(labels).toEqual(['Calories', 'Carbs']);
+  });
+
+  it('should be able to filter headers by their sorted state', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    let headers = await sort.getSortHeaders({sortDirection: ''});
+    expect(headers.length).toBe(5);
+
+    await headers[0].click();
+
+    headers = await sort.getSortHeaders({sortDirection: 'asc'});
+
+    expect(headers.length).toBe(1);
+  });
+
+  it('should be able to get the label of a header', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const headers = await sort.getSortHeaders();
+    const labels = await Promise.all(headers.map(header => header.getLabel()));
+    expect(labels).toEqual(['Dessert', 'Calories', 'Fat', 'Carbs', 'Protein']);
+  });
+
+  it('should be able to get the aria-label of a header', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const headers = await sort.getSortHeaders();
+    const labels = await Promise.all(headers.map(header => header.getAriaLabel()));
+
+    expect(labels).toEqual([
+      'Change sorting for name',
+      'Change sorting for calories',
+      'Change sorting for fat',
+      'Change sorting for carbs',
+      'Change sorting for protein'
+    ]);
+  });
+
+  it('should get the disabled state of a header', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const thirdHeader = (await sort.getSortHeaders())[2];
+
+    expect(await thirdHeader.isDisabled()).toBe(false);
+
+    fixture.componentInstance.disableThirdHeader = true;
+    fixture.detectChanges();
+
+    expect(await thirdHeader.isDisabled()).toBe(true);
+  });
+
+  it('should get the active state of a header', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const secondHeader = (await sort.getSortHeaders())[1];
+
+    expect(await secondHeader.isActive()).toBe(false);
+
+    await secondHeader.click();
+
+    expect(await secondHeader.isActive()).toBe(true);
+  });
+
+  it('should get the sorte direction of a header', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const secondHeader = (await sort.getSortHeaders())[1];
+
+    expect(await secondHeader.getSortDirection()).toBe('');
+
+    await secondHeader.click();
+    expect(await secondHeader.getSortDirection()).toBe('asc');
+
+    await secondHeader.click();
+    expect(await secondHeader.getSortDirection()).toBe('desc');
+  });
+
+  it('should get the active header', async () => {
+    const sort = await loader.getHarness(sortHarness);
+    const fifthHeader = (await sort.getSortHeaders())[4];
+
+    expect(await sort.getActiveHeader()).toBeNull();
+
+    await fifthHeader.click();
+
+    const activeHeader = await sort.getActiveHeader();
+    expect(activeHeader).toBeTruthy();
+    expect(await activeHeader!.getLabel()).toBe('Protein');
+  });
+}
+
+@Component({
+  template: `
+    <table matSort (matSortChange)="sortData($event)">
+      <tr>
+        <th mat-sort-header="name">Dessert</th>
+        <th mat-sort-header="calories">Calories</th>
+        <th mat-sort-header="fat" [disabled]="disableThirdHeader">Fat</th>
+        <th mat-sort-header="carbs">Carbs</th>
+        <th mat-sort-header="protein">Protein</th>
+      </tr>
+
+      <tr *ngFor="let dessert of sortedData">
+        <td>{{dessert.name}}</td>
+        <td>{{dessert.calories}}</td>
+        <td>{{dessert.fat}}</td>
+        <td>{{dessert.carbs}}</td>
+        <td>{{dessert.protein}}</td>
+      </tr>
+    </table>
+  `
+})
+class SortHarnessTest {
+  disableThirdHeader = false;
+  desserts = [
+    {name: 'Frozen yogurt', calories: 159, fat: 6, carbs: 24, protein: 4},
+    {name: 'Ice cream sandwich', calories: 237, fat: 9, carbs: 37, protein: 4},
+    {name: 'Eclair', calories: 262, fat: 16, carbs: 24, protein: 6},
+    {name: 'Cupcake', calories: 305, fat: 4, carbs: 67, protein: 4},
+    {name: 'Gingerbread', calories: 356, fat: 16, carbs: 49, protein: 4},
+  ];
+
+  sortedData = this.desserts.slice();
+
+  sortData(sort: Sort) {
+    const data = this.desserts.slice();
+
+    if (!sort.active || sort.direction === '') {
+      this.sortedData = data;
+    } else {
+      this.sortedData = data.sort((a, b) => {
+        const aValue = (a as any)[sort.active];
+        const bValue = (b as any)[sort.active];
+        return (aValue < bValue ? -1 : 1) * (sort.direction === 'asc' ? 1 : -1);
+      });
+    }
+  }
+}
+

--- a/src/material/sort/testing/sort-harness-filters.ts
+++ b/src/material/sort/testing/sort-harness-filters.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+import {SortDirection} from '@angular/material/sort';
+
+export interface SortHarnessFilters extends BaseHarnessFilters {
+}
+
+export interface SortHeaderHarnessFilters extends BaseHarnessFilters {
+  label?: string | RegExp;
+  sortDirection?: SortDirection;
+}

--- a/src/material/sort/testing/sort-harness.spec.ts
+++ b/src/material/sort/testing/sort-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatSortModule} from '@angular/material/sort';
+import {runHarnessTests} from '@angular/material/sort/testing/shared.spec';
+import {MatSortHarness} from './sort-harness';
+
+describe('Non-MDC-based MatSortHarness', () => {
+  runHarnessTests(MatSortModule, MatSortHarness);
+});

--- a/src/material/sort/testing/sort-harness.ts
+++ b/src/material/sort/testing/sort-harness.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {SortHarnessFilters, SortHeaderHarnessFilters} from './sort-harness-filters';
+import {MatSortHeaderHarness} from './sort-header-harness';
+
+/** Harness for interacting with a standard `mat-sort` in tests. */
+export class MatSortHarness extends ComponentHarness {
+  static hostSelector = '.mat-sort';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `mat-sort` with specific attributes.
+   * @param options Options for narrowing the search.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: SortHarnessFilters = {}): HarnessPredicate<MatSortHarness> {
+    return new HarnessPredicate(MatSortHarness, options);
+  }
+
+  /** Gets all of the sort headers in the `mat-sort`. */
+  async getSortHeaders(filter: SortHeaderHarnessFilters = {}): Promise<MatSortHeaderHarness[]> {
+    return this.locatorForAll(MatSortHeaderHarness.with(filter))();
+  }
+
+  /** Gets the selected header in the `mat-sort`. */
+  async getActiveHeader(): Promise<MatSortHeaderHarness|null> {
+    const headers = await this.getSortHeaders();
+    for (let i = 0; i < headers.length; i++) {
+      if (await headers[i].isActive()) {
+        return headers[i];
+      }
+    }
+    return null;
+  }
+}

--- a/src/material/sort/testing/sort-header-harness.ts
+++ b/src/material/sort/testing/sort-header-harness.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {SortDirection} from '@angular/material/sort';
+import {SortHeaderHarnessFilters} from './sort-harness-filters';
+
+/** Harness for interacting with a standard Angular Material sort header in tests. */
+export class MatSortHeaderHarness extends ComponentHarness {
+  static hostSelector = '.mat-sort-header';
+  private _button = this.locatorFor('.mat-sort-header-button');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to
+   * search for a sort header with specific attributes.
+   */
+  static with(options: SortHeaderHarnessFilters = {}): HarnessPredicate<MatSortHeaderHarness> {
+    return new HarnessPredicate(MatSortHeaderHarness, options)
+        .addOption('label', options.label,
+            (harness, label) => HarnessPredicate.stringMatches(harness.getLabel(), label))
+        .addOption('sortDirection', options.sortDirection, (harness, sortDirection) => {
+          return HarnessPredicate.stringMatches(harness.getSortDirection(), sortDirection);
+        });
+  }
+
+  /** Gets the label of the sort header. */
+  async getLabel(): Promise<string> {
+    return (await this._button()).text();
+  }
+
+  /** Gets the sorting direction of the header. */
+  async getSortDirection(): Promise<SortDirection> {
+    const host = await this.host();
+    const ariaSort = await host.getAttribute('aria-sort');
+
+    if (ariaSort === 'ascending') {
+      return 'asc';
+    } else if (ariaSort === 'descending') {
+      return 'desc';
+    }
+
+    return '';
+  }
+
+  /** Gets the aria-label of the sort header. */
+  async getAriaLabel(): Promise<string|null> {
+    return (await this._button()).getAttribute('aria-label');
+  }
+
+  /** Gets whether the sort header is currently being sorted by. */
+  async isActive(): Promise<boolean> {
+    return !!(await this.getSortDirection());
+  }
+
+  /** Whether the sort header is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const button = await this._button();
+    return (await button.getAttribute('disabled')) != null;
+  }
+
+  /** Clicks the header to change its sorting direction. Only works if the header is enabled. */
+  async click(): Promise<void> {
+    return (await this.host()).click();
+  }
+}

--- a/test/karma-system-config.js
+++ b/test/karma-system-config.js
@@ -150,6 +150,8 @@ System.config({
     '@angular/material/snack-bar/testing': 'dist/packages/material/snack-bar/testing/index.js',
     '@angular/material/snack-bar/testing/shared.spec': 'dist/packages/material/snack-bar/testing/shared.spec.js',
     '@angular/material/sort': 'dist/packages/material/sort/index.js',
+    '@angular/material/sort/testing': 'dist/packages/material/sort/testing/index.js',
+    '@angular/material/sort/testing/shared.spec': 'dist/packages/material/sort/testing/shared.spec.js',
     '@angular/material/stepper': 'dist/packages/material/stepper/index.js',
     '@angular/material/table': 'dist/packages/material/table/index.js',
     '@angular/material/tabs': 'dist/packages/material/tabs/index.js',

--- a/tools/public_api_guard/material/sort/testing.d.ts
+++ b/tools/public_api_guard/material/sort/testing.d.ts
@@ -1,0 +1,25 @@
+export declare class MatSortHarness extends ComponentHarness {
+    getActiveHeader(): Promise<MatSortHeaderHarness | null>;
+    getSortHeaders(filter?: SortHeaderHarnessFilters): Promise<MatSortHeaderHarness[]>;
+    static hostSelector: string;
+    static with(options?: SortHarnessFilters): HarnessPredicate<MatSortHarness>;
+}
+
+export declare class MatSortHeaderHarness extends ComponentHarness {
+    click(): Promise<void>;
+    getAriaLabel(): Promise<string | null>;
+    getLabel(): Promise<string>;
+    getSortDirection(): Promise<SortDirection>;
+    isActive(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: SortHeaderHarnessFilters): HarnessPredicate<MatSortHeaderHarness>;
+}
+
+export interface SortHarnessFilters extends BaseHarnessFilters {
+}
+
+export interface SortHeaderHarnessFilters extends BaseHarnessFilters {
+    label?: string | RegExp;
+    sortDirection?: SortDirection;
+}


### PR DESCRIPTION
Sets up a test harness that covers `MatSort` and `MatSortHeader`.