### PR TITLE
refactor: clean up ReplaySubject usages

### DIFF
--- a/src/cdk-experimental/popover-edit/lens-directives.ts
+++ b/src/cdk-experimental/popover-edit/lens-directives.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ReplaySubject} from 'rxjs';
+import {Subject} from 'rxjs';
 import {
   Directive,
   ElementRef,
@@ -41,7 +41,7 @@ export type PopoverEditClickOutBehavior = 'close' | 'submit' | 'noop';
   providers: [EditRef],
 })
 export class CdkEditControl<FormValue> implements OnDestroy, OnInit {
-  protected readonly destroyed = new ReplaySubject<void>();
+  protected readonly destroyed = new Subject<void>();
 
   /**
    * Specifies what should happen when the user clicks outside of the edit lens.

--- a/src/cdk-experimental/popover-edit/table-directives.ts
+++ b/src/cdk-experimental/popover-edit/table-directives.ts
@@ -19,7 +19,7 @@ import {
   ViewContainerRef,
   HostListener,
 } from '@angular/core';
-import {fromEvent, fromEventPattern, merge, ReplaySubject} from 'rxjs';
+import {fromEvent, fromEventPattern, merge, Subject} from 'rxjs';
 import {
   filter,
   map,
@@ -65,7 +65,7 @@ const MOUSE_MOVE_THROTTLE_TIME_MS = 10;
   providers: [EditEventDispatcher, EditServices],
 })
 export class CdkEditable implements AfterViewInit, OnDestroy {
-  protected readonly destroyed = new ReplaySubject<void>();
+  protected readonly destroyed = new Subject<void>();
 
   constructor(
       protected readonly elementRef: ElementRef,
@@ -202,7 +202,7 @@ export class CdkPopoverEdit<C> implements AfterViewInit, OnDestroy {
 
   protected focusTrap?: FocusTrap;
   protected overlayRef?: OverlayRef;
-  protected readonly destroyed = new ReplaySubject<void>();
+  protected readonly destroyed = new Subject<void>();
 
   constructor(
       protected readonly services: EditServices, protected readonly elementRef: ElementRef,
@@ -374,7 +374,7 @@ export class CdkPopoverEditTabOut<C> extends CdkPopoverEdit<C> {
   selector: '[cdkRowHoverContent]',
 })
 export class CdkRowHoverContent implements AfterViewInit, OnDestroy {
-  protected readonly destroyed = new ReplaySubject<void>();
+  protected readonly destroyed = new Subject<void>();
   protected viewRef: EmbeddedViewRef<any>|null = null;
 
   private _row?: Element;


### PR DESCRIPTION
Replaces some usages of `ReplaySubject` with a plain `Subject` since we don't use `ReplaySubject` anywhere else in the codebase and in these cases it doesn't provide any benefit. This should lead to less code being imported as a result of Material.