### PR TITLE
fix(material/tree): Apply aria-level to all nodes

### DIFF
--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -120,6 +120,15 @@ describe('CdkTree', () => {
         })).toBe(true);
       });
 
+      it('with the right aria-levels', () => {
+        // add a child to the first node
+        let data = dataSource.data;
+        dataSource.addChild(data[0], true);
+
+        const ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
+        expect(ariaLevels).toEqual(['1', '2', '1', '1']);
+      });
+
       it('with the right data', () => {
         expect(dataSource.data.length).toBe(3);
 

--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -126,7 +126,7 @@ describe('CdkTree', () => {
         dataSource.addChild(data[0], true);
 
         const ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
-        expect(ariaLevels).toEqual(['1', '2', '1', '1']);
+        expect(ariaLevels).toEqual(['2', '3', '2', '2']);
       });
 
       it('with the right data', () => {

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -22,18 +22,18 @@ import {
   OnDestroy,
   OnInit,
   QueryList,
+  TrackByFunction,
   ViewChild,
   ViewContainerRef,
-  ViewEncapsulation,
-  TrackByFunction
+  ViewEncapsulation
 } from '@angular/core';
 import {
   BehaviorSubject,
+  isObservable,
   Observable,
   of as observableOf,
   Subject,
   Subscription,
-  isObservable,
 } from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {TreeControl} from './control/tree-control';
@@ -339,6 +339,7 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
   /**
    * The role of the node should always be 'treeitem'.
    */
+  // TODO: mark as deprecated
   @Input() role: 'treeitem' | 'group' = 'treeitem';
 
   constructor(protected _elementRef: ElementRef<HTMLElement>,
@@ -362,7 +363,8 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
   focus(): void {
     this._elementRef.nativeElement.focus();
   }
-  
+
+  // TODO: role should eventually just be set in the component host
   protected _setRoleFromData(): void {
     if (!this._tree.treeControl.isExpandable && !this._tree.treeControl.getChildren) {
       throw getTreeControlFunctionsMissingError();

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -364,23 +364,9 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
   }
   
   protected _setRoleFromData(): void {
-    if (this._tree.treeControl.isExpandable) {
-      this.role = this._tree.treeControl.isExpandable(this._data) ? 'treeitem' : 'treeitem';
-    } else {
-      if (!this._tree.treeControl.getChildren) {
-        throw getTreeControlFunctionsMissingError();
-      }
-      const childrenNodes = this._tree.treeControl.getChildren(this._data);
-      if (Array.isArray(childrenNodes)) {
-        this._setRoleFromChildren(childrenNodes as T[]);
-      } else if (isObservable(childrenNodes)) {
-        childrenNodes.pipe(takeUntil(this._destroyed))
-          .subscribe(children => this._setRoleFromChildren(children));
-      }
+    if (!this._tree.treeControl.isExpandable && !this._tree.treeControl.getChildren) {
+      throw getTreeControlFunctionsMissingError();
     }
-  }
-
-  protected _setRoleFromChildren(children: T[]) {
     this.role = 'treeitem';
   }
 }

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -299,7 +299,7 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
   exportAs: 'cdkTreeNode',
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.aria-level]': 'role === "treeitem" ? level : null',
+    '[attr.aria-level]': 'level',
     '[attr.role]': 'role',
     'class': 'cdk-tree-node',
   },

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -337,8 +337,7 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
   }
 
   /**
-   * The role of the node should be 'group' if it's an internal node,
-   * and 'treeitem' if it's a leaf node.
+   * The role of the node should always be 'treeitem'.
    */
   @Input() role: 'treeitem' | 'group' = 'treeitem';
 
@@ -363,10 +362,10 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
   focus(): void {
     this._elementRef.nativeElement.focus();
   }
-
+  
   protected _setRoleFromData(): void {
     if (this._tree.treeControl.isExpandable) {
-      this.role = this._tree.treeControl.isExpandable(this._data) ? 'group' : 'treeitem';
+      this.role = this._tree.treeControl.isExpandable(this._data) ? 'treeitem' : 'treeitem';
     } else {
       if (!this._tree.treeControl.getChildren) {
         throw getTreeControlFunctionsMissingError();
@@ -376,12 +375,12 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
         this._setRoleFromChildren(childrenNodes as T[]);
       } else if (isObservable(childrenNodes)) {
         childrenNodes.pipe(takeUntil(this._destroyed))
-            .subscribe(children => this._setRoleFromChildren(children));
+          .subscribe(children => this._setRoleFromChildren(children));
       }
     }
   }
 
   protected _setRoleFromChildren(children: T[]) {
-    this.role = children && children.length ? 'group' : 'treeitem';
+    this.role = 'treeitem';
   }
 }

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -299,7 +299,7 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
   exportAs: 'cdkTreeNode',
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.aria-level]': 'level',
+    '[attr.aria-level]': 'level + 1',
     '[attr.role]': 'role',
     'class': 'cdk-tree-node',
   },

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -44,7 +44,7 @@ const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNo
   inputs: ['disabled', 'tabIndex'],
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.aria-level]': 'level',
+    '[attr.aria-level]': 'level + 1',
     '[attr.role]': 'role',
     'class': 'mat-tree-node'
   },

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -45,7 +45,7 @@ const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNo
   host: {
     '[attr.aria-expanded]': 'isExpanded',
     '[attr.aria-level]': 'level + 1',
-    '[attr.role]': `'treeitem'`,
+    '[attr.role]': 'role',
     'class': 'mat-tree-node'
   },
   providers: [{provide: CdkTreeNode, useExisting: MatTreeNode}]
@@ -88,7 +88,7 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
   exportAs: 'matNestedTreeNode',
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.role]': `'treeitem'`,
+    '[attr.role]': 'role',
     'class': 'mat-nested-tree-node',
   },
   providers: [

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -44,7 +44,7 @@ const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNo
   inputs: ['disabled', 'tabIndex'],
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.aria-level]': 'role === "treeitem" ? level : null',
+    '[attr.aria-level]': 'level',
     '[attr.role]': 'role',
     'class': 'mat-tree-node'
   },

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -45,7 +45,7 @@ const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNo
   host: {
     '[attr.aria-expanded]': 'isExpanded',
     '[attr.aria-level]': 'level + 1',
-    '[attr.role]': 'role',
+    '[attr.role]': `'treeitem'`,
     'class': 'mat-tree-node'
   },
   providers: [{provide: CdkTreeNode, useExisting: MatTreeNode}]
@@ -88,7 +88,7 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
   exportAs: 'matNestedTreeNode',
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.role]': 'role',
+    '[attr.role]': `'treeitem'`,
     'class': 'mat-nested-tree-node',
   },
   providers: [

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -64,6 +64,17 @@ describe('MatTree', () => {
         });
       });
 
+      it('with the right aria-level attrs', () => {
+        // add a child to the first node
+        let data = underlyingDataSource.data;
+        underlyingDataSource.addChild(data[2]);
+        component.treeControl.expandAll();
+        fixture.detectChanges();
+
+        const ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
+        expect(ariaLevels).toEqual(['0', '0', '0', '1']);
+      });
+
       it('with the right data', () => {
         expect(underlyingDataSource.data.length).toBe(3);
 

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -72,7 +72,7 @@ describe('MatTree', () => {
         fixture.detectChanges();
 
         const ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
-        expect(ariaLevels).toEqual(['0', '0', '0', '1']);
+        expect(ariaLevels).toEqual(['1', '1', '1', '2']);
       });
 
       it('with the right data', () => {

--- a/tools/public_api_guard/cdk/tree.d.ts
+++ b/tools/public_api_guard/cdk/tree.d.ts
@@ -74,7 +74,6 @@ export declare class CdkTreeNode<T> implements FocusableOption, OnDestroy {
     get level(): number;
     role: 'treeitem' | 'group';
     constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T>);
-    protected _setRoleFromChildren(children: T[]): void;
     protected _setRoleFromData(): void;
     focus(): void;
     ngOnDestroy(): void;


### PR DESCRIPTION
Previously, only leaf nodes had aria-level applied.

This is an incremental change since this is an unfamiliar codebase for
me. The main benefit it will have on its own is that it will allow
anyone doing custom dom manipulation to know what level the node is on.
Otherwise by itself there is no change in how NVDA reads nodes with
children. (It currently reads them as literally "grouping"; no
information about the contents is provided).

This change will be necessary for a later change I'm planning, wherein
the role of parent nodes will be changed from "group" to "treeitem", in
accordance with how roles are applied in WAI-ARIA reference examples
such as
https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-1/treeview-1b.html