### PR TITLE
fix(dialog): use view container from config when attaching content

### DIFF
--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -613,6 +613,21 @@ describe('MatDialog', () => {
     expect(dialogRef.componentInstance.directionality.value).toBe('ltr');
   });
 
+  it('should use the passed in ViewContainerRef from the config', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
+    viewContainerFixture.detectChanges();
+    flush();
+
+    // One view ref is for the container and one more for the component with the content.
+    expect(testViewContainerRef.length).toBe(2);
+
+    dialogRef.close();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(testViewContainerRef.length).toBe(0);
+  }));
+
   it('should close all of the dialogs', fakeAsync(() => {
     dialog.open(PizzaMsg);
     dialog.open(PizzaMsg);

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -257,11 +257,11 @@ export class MatDialog implements OnDestroy {
     if (componentOrTemplateRef instanceof TemplateRef) {
       dialogContainer.attachTemplatePortal(
         new TemplatePortal<T>(componentOrTemplateRef, null!,
-          <any>{ $implicit: config.data, dialogRef }));
+          <any>{$implicit: config.data, dialogRef}));
     } else {
       const injector = this._createInjector<T>(config, dialogRef, dialogContainer);
       const contentRef = dialogContainer.attachComponentPortal<T>(
-          new ComponentPortal(componentOrTemplateRef, undefined, injector));
+          new ComponentPortal(componentOrTemplateRef, config.viewContainerRef, injector));
       dialogRef.componentInstance = contentRef.instance;
     }
 


### PR DESCRIPTION
Currently we only use the specified `ViewContainerRef` to attach the dialog container, but not the content itself. We couldn't fix this until now due to the bug that was fixed by #17731.