### PR TITLE
build: disallow usages of the first operator

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -86,6 +86,7 @@
       ["fdescribe"],
       ["xit"],
       ["xdescribe"],
+      {"name": ["first"], "message": "Use take(1) instead."},
       {"name": ["Object", "assign"], "message": "Use the spread operator instead."}
     ],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.


### PR DESCRIPTION
The `first` operator will throw if the observable completes before it has emitted. A long time ago we went through and updated all the usages to `take(1)`, but recently a couple of new usages were introduced so we might as well lint for it so it doesn't happen again.