### PR TITLE
docs(select): hide private api from docs

### DIFF
--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -336,7 +336,12 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** Panel containing the select options. */
   @ViewChild('panel') panel: ElementRef;
 
-  /** Overlay pane containing the options. */
+  /**
+   * Overlay pane containing the options.
+   * @deprecated To be turned into a private API.
+   * @breaking-change 10.0.0
+   * @docs-private
+   */
   @ViewChild(CdkConnectedOverlay) overlayDir: CdkConnectedOverlay;
 
   /** All of the defined select options. */


### PR DESCRIPTION
Hides the `MatSelect.overlayDir` from the docs since it's supposed to be a private API. Also marks it to be renamed in 10.0.0.

Fixes #17678.