### PR TITLE
fix(material/list): selection list incorrectly preselecting options without a value in some cases

### DIFF
--- a/scripts/check-mdc-tests-config.ts
+++ b/scripts/check-mdc-tests-config.ts
@@ -91,6 +91,7 @@ export const config = {
       'should not attempt to focus the next option when the destroyed option was not focused',
       'should use `compareWith` function when updating option selection state',
       'should only be in the tab order if it has options',
+      'should not preselect options without values when the list of options is swapped',
 
       // MDC does not support SHIFT + ARROW for item selection. Tracked as a feature request:
       // https://github.com/material-components/material-components-web/issues/6364.

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -50,6 +50,7 @@ describe('MatSelectionList without forms', () => {
           SelectionListWithIndirectChildOptions,
           SelectionListWithSelectedOptionAndValue,
           SelectionListWithIndirectDescendantLines,
+          SelectionListWithDynamicOptionsWithoutValue,
         ],
       });
 
@@ -800,6 +801,34 @@ describe('MatSelectionList without forms', () => {
       expect(optionNativeElements
           .every(element => element.classList.contains('mat-focus-indicator'))).toBe(true);
       });
+
+    it('should not preselect options without values when the list of options is swapped', () => {
+      const componentFixture = TestBed.createComponent(SelectionListWithDynamicOptionsWithoutValue);
+      componentFixture.detectChanges();
+      listOptions = componentFixture.debugElement.queryAll(By.directive(MatListOption));
+      selectionList = componentFixture.debugElement.query(By.directive(MatSelectionList))!;
+      const list: MatSelectionList = selectionList.componentInstance;
+
+      expect(list.options.map(option => option.selected)).toEqual([false, false]);
+
+      componentFixture.componentInstance.items = [
+        {name: 'One', selected: true},
+        {name: 'Two', selected: false}
+      ];
+      componentFixture.detectChanges();
+
+      expect(list.options.map(option => option.selected)).toEqual([true, false]);
+
+      // Assign identical data again, but use different
+      // object references so the list is re-rendered.
+      componentFixture.componentInstance.items = [
+        {name: 'One', selected: true},
+        {name: 'Two', selected: false}
+      ];
+      componentFixture.detectChanges();
+
+      expect(list.options.map(option => option.selected)).toEqual([true, false]);
+    });
 
   });
 
@@ -1874,4 +1903,21 @@ class SelectionListWithIndirectDescendantLines {
 `})
 class ListOptionWithTwoWayBinding {
   selected = false;
+}
+
+
+@Component({
+  template: `
+    <mat-selection-list>
+      <mat-list-option *ngFor="let item of items" [selected]="item.selected">
+        {{item.name}}
+      </mat-list-option>
+    </mat-selection-list>
+  `
+})
+class SelectionListWithDynamicOptionsWithoutValue {
+  items = [
+    {name: 'One', selected: false},
+    {name: 'Two', selected: false}
+  ];
 }

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -650,7 +650,9 @@ export class MatSelectionList extends _MatSelectionListBase implements CanDisabl
 
   /** Returns the values of the selected options. */
   private _getSelectedOptionValues(): string[] {
-    return this.options.filter(option => option.selected).map(option => option.value);
+    return this.options.filter(option => {
+      return option.selected && option.value !== undefined;
+    }).map(option => option.value);
   }
 
   /** Toggles the state of the currently focused option if enabled. */


### PR DESCRIPTION
The way we keep track of the value of an entire selection list is by taking all of the `selected` options and putting their values in an array. When the set of options is swapped out we look through that array to determine whether an option should be preselected. This breaks down if an option doesn't have a value, because we end up with a value array looking like `[undefined]` which will cause the option to be preselected incorrectly. These changes work around the issue by not adding options without a value to the value array.

Fixes #17839.