### PR TITLE
docs(tree): injectable decorator set on wrong class

### DIFF
--- a/src/components-examples/material/tree/tree-dynamic/tree-dynamic-example.ts
+++ b/src/components-examples/material/tree/tree-dynamic/tree-dynamic-example.ts
@@ -14,6 +14,7 @@ export class DynamicFlatNode {
  * Database for dynamic data. When expanding a node in the tree, the data source will need to fetch
  * the descendants data from the database.
  */
+@Injectable({providedIn: 'root'})
 export class DynamicDatabase {
   dataMap = new Map<string, string[]>([
     ['Fruits', ['Apple', 'Orange', 'Banana']],
@@ -44,7 +45,6 @@ export class DynamicDatabase {
  * The input will be a json object string, and the output is a list of `FileNode` with nested
  * structure.
  */
-@Injectable()
 export class DynamicDataSource implements DataSource<DynamicFlatNode> {
 
   dataChange = new BehaviorSubject<DynamicFlatNode[]>([]);
@@ -118,8 +118,7 @@ export class DynamicDataSource implements DataSource<DynamicFlatNode> {
 @Component({
   selector: 'tree-dynamic-example',
   templateUrl: 'tree-dynamic-example.html',
-  styleUrls: ['tree-dynamic-example.css'],
-  providers: [DynamicDatabase]
+  styleUrls: ['tree-dynamic-example.css']
 })
 export class TreeDynamicExample {
   constructor(database: DynamicDatabase) {


### PR DESCRIPTION
Fixes the `Injectable` decorator being set on the wrong class in one of the tree examples. This hasn't broken until now because that class isn't using DI anyway.

Fixes #17815.