### PR TITLE
test: clean up usages of deprecated TestBed method

### DIFF
--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -48,7 +48,7 @@ describe('FocusTrap', () => {
       // focus event handler directly.
       const result = focusTrapInstance.focusLastTabbableElement();
 
-      const platformId = TestBed.get(PLATFORM_ID);
+      const platformId = TestBed.inject(PLATFORM_ID);
       // In iOS button elements are never tabbable, so the last element will be the input.
       const lastElement = new Platform(platformId).IOS ? 'input' : 'button';
 

--- a/src/cdk/clipboard/clipboard.spec.ts
+++ b/src/cdk/clipboard/clipboard.spec.ts
@@ -17,8 +17,8 @@ describe('Clipboard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
 
-    clipboard = TestBed.get(Clipboard);
-    document = TestBed.get(DOCUMENT);
+    clipboard = TestBed.inject(Clipboard);
+    document = TestBed.inject(DOCUMENT);
     execCommand = spyOn(document, 'execCommand').and.returnValue(true);
     body = document.body;
 

--- a/src/cdk/clipboard/copy-to-clipboard.spec.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.spec.ts
@@ -39,7 +39,7 @@ describe('CdkCopyToClipboard', () => {
 
     const host = fixture.componentInstance;
     host.content = COPY_CONTENT;
-    clipboard = TestBed.get(Clipboard);
+    clipboard = TestBed.inject(Clipboard);
     fixture.detectChanges();
   });
 

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -3217,7 +3217,7 @@ describe('CdkDrag', () => {
 
       const cleanup = makePageScrollable();
       const item = fixture.componentInstance.dragItems.first.element.nativeElement;
-      const viewportRuler: ViewportRuler = TestBed.get(ViewportRuler);
+      const viewportRuler = TestBed.inject(ViewportRuler);
       const viewportSize = viewportRuler.getViewportSize();
 
       expect(viewportRuler.getViewportScrollPosition().top).toBe(0);
@@ -3238,7 +3238,7 @@ describe('CdkDrag', () => {
 
       const cleanup = makePageScrollable();
       const item = fixture.componentInstance.dragItems.first.element.nativeElement;
-      const viewportRuler: ViewportRuler = TestBed.get(ViewportRuler);
+      const viewportRuler = TestBed.inject(ViewportRuler);
       const viewportSize = viewportRuler.getViewportSize();
 
       scrollTo(0, viewportSize.height * 5);
@@ -3261,7 +3261,7 @@ describe('CdkDrag', () => {
 
       const cleanup = makePageScrollable('horizontal');
       const item = fixture.componentInstance.dragItems.first.element.nativeElement;
-      const viewportRuler: ViewportRuler = TestBed.get(ViewportRuler);
+      const viewportRuler = TestBed.inject(ViewportRuler);
       const viewportSize = viewportRuler.getViewportSize();
 
       expect(viewportRuler.getViewportScrollPosition().left).toBe(0);
@@ -3282,7 +3282,7 @@ describe('CdkDrag', () => {
 
       const cleanup = makePageScrollable('horizontal');
       const item = fixture.componentInstance.dragItems.first.element.nativeElement;
-      const viewportRuler: ViewportRuler = TestBed.get(ViewportRuler);
+      const viewportRuler = TestBed.inject(ViewportRuler);
       const viewportSize = viewportRuler.getViewportSize();
 
       scrollTo(viewportSize.width * 5, 0);
@@ -3305,7 +3305,7 @@ describe('CdkDrag', () => {
         fixture.detectChanges();
 
         const list = fixture.componentInstance.dropInstance.element.nativeElement;
-        const viewportRuler: ViewportRuler = TestBed.get(ViewportRuler);
+        const viewportRuler = TestBed.inject(ViewportRuler);
         const item = fixture.componentInstance.dragItems.first.element.nativeElement;
 
         // Position the list so that its top aligns with the viewport top. That way the pointer
@@ -3343,7 +3343,7 @@ describe('CdkDrag', () => {
         fixture.detectChanges();
 
         const list = fixture.componentInstance.dropInstance.element.nativeElement;
-        const viewportRuler: ViewportRuler = TestBed.get(ViewportRuler);
+        const viewportRuler = TestBed.inject(ViewportRuler);
         const item = fixture.componentInstance.dragItems.first.element.nativeElement;
 
         // Position the list so that its top aligns with the viewport top. That way the pointer


### PR DESCRIPTION
Replaces all the usages of the deprecated `TestBed.get` with `TestBed.inject` which has better type inference.