### PR TITLE
fix(slider): stop dragging if page loses focus

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -139,6 +139,27 @@ describe('MatSlider', () => {
       expect(sliderNativeElement.classList).not.toContain('mat-slider-sliding');
     });
 
+    it('should stop dragging if the page loses focus', () => {
+      const classlist = sliderNativeElement.classList;
+
+      expect(classlist).not.toContain('mat-slider-sliding');
+
+      dispatchSlideStartEvent(sliderNativeElement, 0);
+      fixture.detectChanges();
+
+      expect(classlist).toContain('mat-slider-sliding');
+
+      dispatchSlideEvent(sliderNativeElement, 0.34);
+      fixture.detectChanges();
+
+      expect(classlist).toContain('mat-slider-sliding');
+
+      dispatchFakeEvent(window, 'blur');
+      fixture.detectChanges();
+
+      expect(classlist).not.toContain('mat-slider-sliding');
+    });
+
     it('should reset active state upon blur', () => {
       sliderInstance._isActive = true;
 


### PR DESCRIPTION
If the page loses focus (e.g. from an `alert` or the window being minimized) while the user is dragging a slider, it'll be stuck as dragging until the user comes back and clicks somewhere which might look weird and change the value. These changes stop the dragging sequence once the page is blurred.