### PR TITLE
fix(overlay): restore previous host element before attaching

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -114,13 +114,13 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
   attach(portal: Portal<any>): any {
     let attachResult = this._portalOutlet.attach(portal);
 
-    if (this._positionStrategy) {
-      this._positionStrategy.attach(this);
-    }
-
     // Update the pane element with the given configuration.
     if (!this._host.parentElement && this._previousHostParent) {
       this._previousHostParent.appendChild(this._host);
+    }
+
+    if (this._positionStrategy) {
+      this._positionStrategy.attach(this);
     }
 
     this._updateStackingOrder();

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -444,6 +444,29 @@ describe('Overlay', () => {
       expect(overlayContainerElement.querySelectorAll('.fake-positioned').length).toBe(1);
     }));
 
+    it('should have the overlay in the DOM in position strategy when reattaching', fakeAsync(() => {
+      let overlayPresentInDom = false;
+
+      config.positionStrategy = {
+        attach: (ref: OverlayRef) => overlayPresentInDom = !!ref.hostElement.parentElement,
+        apply: () => {},
+        dispose: () => {}
+      };
+
+      const overlayRef = overlay.create(config);
+
+      overlayRef.attach(componentPortal);
+      expect(overlayPresentInDom).toBeTruthy('Expected host element to be attached to the DOM.');
+
+      overlayRef.detach();
+      zone.simulateZoneExit();
+      tick();
+
+      overlayRef.attach(componentPortal);
+
+      expect(overlayPresentInDom).toBeTruthy('Expected host element to be attached to the DOM.');
+    }));
+
     it('should not apply the position if it detaches before the zone stabilizes', fakeAsync(() => {
       config.positionStrategy = new FakePositionStrategy();
 


### PR DESCRIPTION
The first time when `PositionStrategy.attach()` is called, the overlay is already added to the DOM. However, after detaching and attaching again, it is not yet added to the DOM.

This PR changes the order and first restores the host element back, and then invokes the `attach()` method.