### PR TITLE
fix(material/datepicker): remove fixed width as not working on mobile

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-events/datepicker-events-example.css
+++ b/src/components-examples/material/datepicker/datepicker-events/datepicker-events-example.css
@@ -1,5 +1,4 @@
 .example-events {
-  width: 400px;
   height: 200px;
   border: 1px solid #555;
   overflow: auto;


### PR DESCRIPTION
In date picker the events example is not responsive on mobile because it has fixed width now changed it to max-width

![Datepicker   Angular Material (1)](https://user-images.githubusercontent.com/39260684/70077457-e5e85b80-1626-11ea-9723-aa37a7851485.png)
