### PR TITLE
fix(chips): clear user agent styles when set on button

### DIFF
--- a/src/material/chips/chips.scss
+++ b/src/material/chips/chips.scss
@@ -33,6 +33,11 @@ $mat-chip-remove-size: 18px;
 
   // Required for the ripple to clip properly in Safari.
   transform: translateZ(0);
+
+  // Chips could be set on buttons so we need to reset the user agent styles.
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
 }
 
 .mat-standard-chip {


### PR DESCRIPTION
Chips can be attached to an element using an attribute which means that they're allowed to be an a `button`. These changes reset the user agent styling for `button`.