### PR TITLE
fix(form-field): delete top border from focus animation

### DIFF
--- a/src/material/form-field/form-field-outline.scss
+++ b/src/material/form-field/form-field-outline.scss
@@ -103,7 +103,6 @@ $mat-form-field-outline-subscript-padding:
     .mat-form-field-outline-end,
     .mat-form-field-outline-gap {
       border-width: $mat-form-field-outline-thick-width;
-      transition: border-color 300ms $swift-ease-out-timing-function;
     }
   }
 


### PR DESCRIPTION
Form field outline top border reduce its opacity during animation when focusing.
According to MDC examples this transition should be instant.

Fixes #17884