### PR TITLE
Fix default checkbox size to align with guidelines

### DIFF
--- a/src/material/core/style/_checkbox-common.scss
+++ b/src/material/core/style/_checkbox-common.scss
@@ -1,7 +1,7 @@
 @import './variables';
 
 // The width/height of the checkbox element.
-$mat-checkbox-size: 16px !default;
+$mat-checkbox-size: 18px !default;
 
 // The width of the checkbox border shown when the checkbox is unchecked.
 $mat-checkbox-border-width: 2px;


### PR DESCRIPTION
Fixes #17656 

Both [Material Designs Guidlines](https://material.io/components/selection-controls/#) and [Material Designs Sketch UI Kit](https://storage.googleapis.com/material-design/downloads/material-design-stickersheet.sketch) show the default size of a checkbox as 18x18 (14x14 + 2px border) upon inspecting the code.