### PR TITLE
fix(text-field): correctly check _initialHeight

### DIFF
--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -114,7 +114,9 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   ngAfterViewInit() {
     if (this._platform.isBrowser) {
       // Remember the height which we started with in case autosizing is disabled
-      this._initialHeight = this._textareaElement.style.height;
+      // TODO: as any works around `height` being nullable in TS3.6, but non-null in 3.7.
+      // Remove once on TS3.7.
+      this._initialHeight = this._textareaElement.style.height as any;
 
       this.resizeToFitContent();
 
@@ -247,7 +249,8 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     if (this._initialHeight === undefined) {
       return;
     }
-    this._textareaElement.style.height = this._initialHeight;
+    // TODO: "as any" inserted for migration to TS3.7.
+    this._textareaElement.style.height = this._initialHeight as any;
   }
 
   // In Ivy the `host` metadata will be merged, whereas in ViewEngine it is overridden. In order


### PR DESCRIPTION
TypeScript 3.7 flags the assignment on line 250 because `style.height` must not be `null`.

The underlying reason though appears to be that the comparison checks against `=== undefined`, where the field only declares `null` as an option. The field is not initialized, so `undefined` is the correct value to compare to and type to use.