### PR TITLE
refactor: remove inherited coercion acceptance members

### DIFF
--- a/src/components-examples/cdk/stepper/cdk-custom-stepper-without-form/cdk-custom-stepper-without-form-example.ts
+++ b/src/components-examples/cdk/stepper/cdk-custom-stepper-without-form/cdk-custom-stepper-without-form-example.ts
@@ -20,10 +20,4 @@ export class CustomStepper extends CdkStepper {
   onClick(index: number): void {
     this.selectedIndex = index;
   }
-
-  // These properties are required so that the Ivy template type checker in strict mode knows
-  // what kind of values are accepted by the `linear` and `selectedIndex` inputs which
-  // are inherited from `CdkStepper`.
-  static ngAcceptInputType_linear: boolean | string | null | undefined;
-  static ngAcceptInputType_selectedIndex: number | string | null | undefined;
 }

--- a/src/material-experimental/mdc-button/button-base.ts
+++ b/src/material-experimental/mdc-button/button-base.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BooleanInput} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
 import {Directive, ElementRef, HostListener, NgZone, ViewChild} from '@angular/core';
 import {
@@ -124,6 +125,9 @@ export class MatButtonBase extends _MatButtonBaseMixin implements CanDisable, Ca
   _isRippleDisabled() {
     return this.disableRipple || this.disabled;
   }
+
+  static ngAcceptInputType_disabled: BooleanInput;
+  static ngAcceptInputType_disableRipple: BooleanInput;
 }
 
 /** Shared inputs by buttons using the `<a>` tag */

--- a/src/material-experimental/mdc-button/button.ts
+++ b/src/material-experimental/mdc-button/button.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
 import {
   ChangeDetectionStrategy,
@@ -56,9 +55,6 @@ export class MatButton extends MatButtonBase {
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, platform, ngZone, animationMode);
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }
 
 /**
@@ -87,7 +83,4 @@ export class MatAnchor extends MatAnchorBase {
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, platform, ngZone, animationMode);
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material-experimental/mdc-button/fab.ts
+++ b/src/material-experimental/mdc-button/fab.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
 import {
   ChangeDetectionStrategy,
@@ -55,9 +54,6 @@ export class MatFabButton extends MatButtonBase {
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, platform, ngZone, animationMode);
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }
 
 
@@ -87,7 +83,4 @@ export class MatFabAnchor extends MatAnchor {
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, platform, ngZone, animationMode);
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material-experimental/mdc-button/icon-button.ts
+++ b/src/material-experimental/mdc-button/icon-button.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
 import {
   ChangeDetectionStrategy,
@@ -52,9 +51,6 @@ export class MatIconButton extends MatButtonBase {
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, platform, ngZone, animationMode);
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }
 
 /**
@@ -81,7 +77,4 @@ export class MatIconAnchor extends MatAnchorBase {
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, platform, ngZone, animationMode);
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material-experimental/mdc-chips/chip-listbox.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.ts
@@ -557,6 +557,5 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
   static ngAcceptInputType_multiple: BooleanInput;
   static ngAcceptInputType_selectable: BooleanInput;
   static ngAcceptInputType_required: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
 }
 

--- a/src/material-experimental/mdc-chips/chip-option.ts
+++ b/src/material-experimental/mdc-chips/chip-option.ts
@@ -227,8 +227,4 @@ export class MatChipOption extends MatChip {
 
   static ngAcceptInputType_selectable: BooleanInput;
   static ngAcceptInputType_selected: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_removable: BooleanInput;
-  static ngAcceptInputType_highlighted: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {BACKSPACE, DELETE} from '@angular/cdk/keycodes';
 import {
   AfterContentInit,
@@ -149,9 +148,4 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
         this._handleInteraction(event);
     }
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_removable: BooleanInput;
-  static ngAcceptInputType_highlighted: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material-experimental/mdc-input/input.ts
+++ b/src/material-experimental/mdc-input/input.ts
@@ -42,10 +42,5 @@ import {MatInput as BaseMatInput} from '@angular/material/input';
   },
   providers: [{provide: MatFormFieldControl, useExisting: MatInput}],
 })
-export class MatInput extends BaseMatInput {
-  static ngAcceptInputType_disabled: boolean | string | null | undefined;
-  static ngAcceptInputType_readonly: boolean | string | null | undefined;
-  static ngAcceptInputType_required: boolean | string | null | undefined;
-  static ngAcceptInputType_value: any;
-}
+export class MatInput extends BaseMatInput {}
 

--- a/src/material-experimental/mdc-menu/menu-item.ts
+++ b/src/material-experimental/mdc-menu/menu-item.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {Component, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 import {MatMenuItem as BaseMatMenuItem} from '@angular/material/menu';
 
@@ -37,6 +36,4 @@ import {MatMenuItem as BaseMatMenuItem} from '@angular/material/menu';
   ]
 })
 export class MatMenuItem extends BaseMatMenuItem {
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material-experimental/mdc-menu/menu.ts
+++ b/src/material-experimental/mdc-menu/menu.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {Overlay, ScrollStrategy} from '@angular/cdk/overlay';
 import {
   ChangeDetectionStrategy,
@@ -71,7 +70,4 @@ export class MatMenu extends BaseMatMenu {
     // - should update the elevation when the same menu is opened at a different depth
     // - should not increase the elevation if the user specified a custom one
   }
-
-  static ngAcceptInputType_overlapTrigger: BooleanInput;
-  static ngAcceptInputType_hasBackdrop: BooleanInput;
 }

--- a/src/material-experimental/mdc-table/cell.ts
+++ b/src/material-experimental/mdc-table/cell.ts
@@ -63,7 +63,6 @@ export class MatColumnDef extends CdkColumnDef {
   @Input('matColumnDef') name: string;
 
   static ngAcceptInputType_sticky: BooleanInput;
-  static ngAcceptInputType_stickyEnd: BooleanInput;
 }
 
 /** Header cell template container that adds the right classes and role. */

--- a/src/material-experimental/mdc-table/table.ts
+++ b/src/material-experimental/mdc-table/table.ts
@@ -8,7 +8,6 @@
 
 import {ChangeDetectionStrategy, Component, OnInit, ViewEncapsulation} from '@angular/core';
 import {CDK_TABLE_TEMPLATE, CdkTable} from '@angular/cdk/table';
-import {BooleanInput} from '@angular/cdk/coercion';
 
 @Component({
   selector: 'table[mat-table]',
@@ -27,8 +26,6 @@ import {BooleanInput} from '@angular/cdk/coercion';
 export class MatTable<T> extends CdkTable<T> implements OnInit {
   /** Overrides the sticky CSS class set by the `CdkTable`. */
   protected stickyCssClass = 'mat-mdc-table-sticky';
-
-  static ngAcceptInputType_multiTemplateDataRows: BooleanInput;
 
   // After ngOnInit, the `CdkTable` has created and inserted the table sections (thead, tbody,
   // tfoot). MDC requires the `mdc-data-table__content` class to be added to the body.

--- a/src/material-experimental/mdc-tabs/tab-group.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.ts
@@ -77,8 +77,5 @@ export class MatTabGroup extends _MatTabGroupBase {
   }
 
   static ngAcceptInputType_fitInkBarToContent: BooleanInput;
-  static ngAcceptInputType_dynamicHeight: BooleanInput;
   static ngAcceptInputType_animationDuration: NumberInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material-experimental/mdc-tabs/tab-header.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, NumberInput} from '@angular/cdk/coercion';
+import {BooleanInput} from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -75,5 +75,4 @@ export class MatTabHeader extends _MatTabHeaderBase implements AfterContentInit 
   }
 
   static ngAcceptInputType_disableRipple: BooleanInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }

--- a/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
+++ b/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
@@ -55,5 +55,4 @@ export class MatTabLabelWrapper extends BaseMatTabLabelWrapper
   }
 
   static ngAcceptInputType_fitInkBarToContent: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -36,7 +36,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {Platform} from '@angular/cdk/platform';
 import {MatInkBar, MatInkBarItem, MatInkBarFoundation} from '../ink-bar';
-import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coercion';
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {BehaviorSubject, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
@@ -104,7 +104,6 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
 
   static ngAcceptInputType_fitInkBarToContent: BooleanInput;
   static ngAcceptInputType_disableRipple: BooleanInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }
 
 /**
@@ -156,7 +155,4 @@ export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnInit
     super.ngOnDestroy();
     this._foundation.destroy();
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material-experimental/mdc-tabs/tab.ts
+++ b/src/material-experimental/mdc-tabs/tab.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -39,6 +38,4 @@ export class MatTab extends BaseMatTab {
 
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
   @ContentChild(MatTabLabel) templateLabel: MatTabLabel;
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -181,7 +181,4 @@ export class MatAnchor extends MatButton {
       event.stopImmediatePropagation();
     }
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material/expansion/accordion.ts
+++ b/src/material/expansion/accordion.ts
@@ -103,5 +103,4 @@ export class MatAccordion extends CdkAccordion implements MatAccordionBase, Afte
   }
 
   static ngAcceptInputType_hideToggle: BooleanInput;
-  static ngAcceptInputType_multi: BooleanInput;
 }

--- a/src/material/input/autosize.ts
+++ b/src/material/input/autosize.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, NumberInput} from '@angular/cdk/coercion';
 import {CdkTextareaAutosize} from '@angular/cdk/text-field';
 import {Directive, Input} from '@angular/core';
 
@@ -42,8 +41,4 @@ export class MatTextareaAutosize extends CdkTextareaAutosize {
   @Input()
   get matTextareaAutosize(): boolean { return this.enabled; }
   set matTextareaAutosize(value: boolean) { this.enabled = value; }
-
-  static ngAcceptInputType_minRows: NumberInput;
-  static ngAcceptInputType_maxRows: NumberInput;
-  static ngAcceptInputType_enabled: BooleanInput;
 }

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -475,6 +475,9 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
         this._directDescendantItems.notifyOnChanges();
       });
   }
+
+  static ngAcceptInputType_overlapTrigger: BooleanInput;
+  static ngAcceptInputType_hasBackdrop: BooleanInput;
 }
 
 /** @docs-private We show the "_MatMenu" class as "MatMenu" in the docs. */
@@ -516,7 +519,4 @@ export class _MatMenu extends MatMenu {
       @Inject(MAT_MENU_DEFAULT_OPTIONS) defaultOptions: MatMenuDefaultOptions) {
     super(elementRef, ngZone, defaultOptions);
   }
-
-  static ngAcceptInputType_overlapTrigger: BooleanInput;
-  static ngAcceptInputType_hasBackdrop: BooleanInput;
 }

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -332,10 +332,6 @@ export class MatSpinner extends MatProgressSpinner {
     super(elementRef, platform, document, animationMode, defaults);
     this.mode = 'indeterminate';
   }
-
-  static ngAcceptInputType_diameter: NumberInput;
-  static ngAcceptInputType_strokeWidth: NumberInput;
-  static ngAcceptInputType_value: NumberInput;
 }
 
 

--- a/src/material/sidenav/sidenav.ts
+++ b/src/material/sidenav/sidenav.ts
@@ -104,9 +104,6 @@ export class MatSidenav extends MatDrawer {
   static ngAcceptInputType_fixedInViewport: BooleanInput;
   static ngAcceptInputType_fixedTopGap: NumberInput;
   static ngAcceptInputType_fixedBottomGap: NumberInput;
-  static ngAcceptInputType_disableClose: BooleanInput;
-  static ngAcceptInputType_autoFocus: BooleanInput;
-  static ngAcceptInputType_opened: BooleanInput;
 }
 
 
@@ -136,7 +133,5 @@ export class MatSidenavContainer extends MatDrawerContainer {
   _allDrawers: QueryList<MatSidenav>;
 
   @ContentChild(MatSidenavContent) _content: MatSidenavContent;
-
-  static ngAcceptInputType_autosize: BooleanInput;
   static ngAcceptInputType_hasBackdrop: BooleanInput;
 }

--- a/src/material/stepper/stepper.ts
+++ b/src/material/stepper/stepper.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {BooleanInput, NumberInput} from '@angular/cdk/coercion';
+import {BooleanInput} from '@angular/cdk/coercion';
 import {
   CdkStep,
   CdkStepper,
@@ -81,11 +81,6 @@ export class MatStep extends CdkStep implements ErrorStateMatcher {
 
     return originalErrorState || customErrorState;
   }
-
-  static ngAcceptInputType_editable: BooleanInput;
-  static ngAcceptInputType_hasError: BooleanInput;
-  static ngAcceptInputType_optional: BooleanInput;
-  static ngAcceptInputType_completed: BooleanInput;
 }
 
 
@@ -137,8 +132,6 @@ export class MatStepper extends CdkStepper implements AfterContentInit {
   static ngAcceptInputType_optional: BooleanInput;
   static ngAcceptInputType_completed: BooleanInput;
   static ngAcceptInputType_hasError: BooleanInput;
-  static ngAcceptInputType_linear: BooleanInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }
 
 @Component({
@@ -171,8 +164,6 @@ export class MatHorizontalStepper extends MatStepper {
   static ngAcceptInputType_optional: BooleanInput;
   static ngAcceptInputType_completed: BooleanInput;
   static ngAcceptInputType_hasError: BooleanInput;
-  static ngAcceptInputType_linear: BooleanInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }
 
 @Component({
@@ -209,6 +200,4 @@ export class MatVerticalStepper extends MatStepper {
   static ngAcceptInputType_optional: BooleanInput;
   static ngAcceptInputType_completed: BooleanInput;
   static ngAcceptInputType_hasError: BooleanInput;
-  static ngAcceptInputType_linear: BooleanInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }

--- a/src/material/table/cell.ts
+++ b/src/material/table/cell.ts
@@ -63,7 +63,6 @@ export class MatColumnDef extends CdkColumnDef {
   @Input('matColumnDef') name: string;
 
   static ngAcceptInputType_sticky: BooleanInput;
-  static ngAcceptInputType_stickyEnd: BooleanInput;
 }
 
 /** Header cell template container that adds the right classes and role. */

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {CDK_TABLE_TEMPLATE, CdkTable} from '@angular/cdk/table';
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
@@ -30,6 +29,4 @@ import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/co
 export class MatTable<T> extends CdkTable<T> {
   /** Overrides the sticky CSS class set by the `CdkTable`. */
   protected stickyCssClass = 'mat-table-sticky';
-
-  static ngAcceptInputType_multiTemplateDataRows: BooleanInput;
 }

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -22,7 +22,7 @@ import {
   Input,
 } from '@angular/core';
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {coerceNumberProperty} from '@angular/cdk/coercion';
+import {coerceNumberProperty, NumberInput} from '@angular/cdk/coercion';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {FocusKeyManager, FocusableOption} from '@angular/cdk/a11y';
 import {END, ENTER, HOME, SPACE, hasModifierKey} from '@angular/cdk/keycodes';
@@ -587,4 +587,6 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
 
     return {maxScrollDistance, distance: this._scrollDistance};
   }
+
+  static ngAcceptInputType_selectedIndex: NumberInput;
 }

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -375,6 +375,11 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
     }
     return this.selectedIndex === idx ? 0 : -1;
   }
+
+  static ngAcceptInputType_dynamicHeight: BooleanInput;
+  static ngAcceptInputType_animationDuration: NumberInput;
+  static ngAcceptInputType_selectedIndex: NumberInput;
+  static ngAcceptInputType_disableRipple: BooleanInput;
 }
 
 /**
@@ -412,9 +417,4 @@ export class MatTabGroup extends _MatTabGroupBase {
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, changeDetectorRef, defaultConfig, animationMode);
   }
-
-  static ngAcceptInputType_dynamicHeight: BooleanInput;
-  static ngAcceptInputType_animationDuration: NumberInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -28,7 +28,7 @@ import {
   Directive,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coercion';
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {MatInkBar} from './ink-bar';
 import {MatTabLabelWrapper} from './tab-label-wrapper';
 import {Platform} from '@angular/cdk/platform';
@@ -107,5 +107,4 @@ export class MatTabHeader extends _MatTabHeaderBase {
   }
 
   static ngAcceptInputType_disableRipple: BooleanInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -41,7 +41,7 @@ import {
   RippleTarget,
   ThemePalette,
 } from '@angular/material/core';
-import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coercion';
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {FocusMonitor, FocusableOption} from '@angular/cdk/a11y';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MatInkBar} from '../ink-bar';
@@ -181,7 +181,6 @@ export class MatTabNav extends _MatTabNavBase {
   }
 
   static ngAcceptInputType_disableRipple: BooleanInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }
 
 // Boilerplate for applying mixins to MatTabLink.
@@ -250,6 +249,9 @@ export class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnDestroy, 
   ngOnDestroy() {
     this._focusMonitor.stopMonitoring(this.elementRef);
   }
+
+  static ngAcceptInputType_disabled: BooleanInput;
+  static ngAcceptInputType_disableRipple: BooleanInput;
 }
 
 
@@ -288,7 +290,4 @@ export class MatTabLink extends _MatTabLinkBase implements OnDestroy {
     super.ngOnDestroy();
     this._tabLinkRipple._removeTriggerEvents();
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
 }

--- a/src/material/tree/padding.ts
+++ b/src/material/tree/padding.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {NumberInput} from '@angular/cdk/coercion';
 import {CdkTreeNodePadding} from '@angular/cdk/tree';
 import {Directive, Input} from '@angular/core';
 
@@ -23,6 +22,4 @@ export class MatTreeNodePadding<T> extends CdkTreeNodePadding<T> {
 
   /** The indent for each level. Default number 40px from material design menu sub-menu spec. */
   @Input('matTreeNodePaddingIndent') indent: number;
-
-  static ngAcceptInputType_level: NumberInput;
 }

--- a/src/material/tree/toggle.ts
+++ b/src/material/tree/toggle.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {CdkTreeNodeToggle} from '@angular/cdk/tree';
 import {Directive, Input} from '@angular/core';
 
@@ -19,6 +18,4 @@ import {Directive, Input} from '@angular/core';
 })
 export class MatTreeNodeToggle<T> extends CdkTreeNodeToggle<T> {
   @Input('matTreeNodeToggleRecursive') recursive: boolean = false;
-
-  static ngAcceptInputType_recursive: BooleanInput;
 }

--- a/tools/public_api_guard/material/button.d.ts
+++ b/tools/public_api_guard/material/button.d.ts
@@ -2,8 +2,6 @@ export declare class MatAnchor extends MatButton {
     tabIndex: number;
     constructor(focusMonitor: FocusMonitor, elementRef: ElementRef, animationMode: string);
     _haltDisabledEvents(event: Event): void;
-    static ngAcceptInputType_disableRipple: BooleanInput;
-    static ngAcceptInputType_disabled: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAnchor, "a[mat-button], a[mat-raised-button], a[mat-icon-button], a[mat-fab],             a[mat-mini-fab], a[mat-stroked-button], a[mat-flat-button]", ["matButton", "matAnchor"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "color": "color"; "tabIndex": "tabIndex"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatAnchor>;
 }

--- a/tools/public_api_guard/material/expansion.d.ts
+++ b/tools/public_api_guard/material/expansion.d.ts
@@ -14,7 +14,6 @@ export declare class MatAccordion extends CdkAccordion implements MatAccordionBa
     _handleHeaderKeydown(event: KeyboardEvent): void;
     ngAfterContentInit(): void;
     static ngAcceptInputType_hideToggle: BooleanInput;
-    static ngAcceptInputType_multi: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatAccordion, "mat-accordion", ["matAccordion"], { "multi": "multi"; "hideToggle": "hideToggle"; "displayMode": "displayMode"; "togglePosition": "togglePosition"; }, {}, ["_headers"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatAccordion>;
 }

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -76,9 +76,6 @@ export declare class MatTextareaAutosize extends CdkTextareaAutosize {
     set matAutosizeMinRows(value: number);
     get matTextareaAutosize(): boolean;
     set matTextareaAutosize(value: boolean);
-    static ngAcceptInputType_enabled: BooleanInput;
-    static ngAcceptInputType_maxRows: NumberInput;
-    static ngAcceptInputType_minRows: NumberInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTextareaAutosize, "textarea[mat-autosize], textarea[matTextareaAutosize]", ["matTextareaAutosize"], { "cdkAutosizeMinRows": "cdkAutosizeMinRows"; "cdkAutosizeMaxRows": "cdkAutosizeMaxRows"; "matAutosizeMinRows": "matAutosizeMinRows"; "matAutosizeMaxRows": "matAutosizeMaxRows"; "matAutosize": "mat-autosize"; "matTextareaAutosize": "matTextareaAutosize"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTextareaAutosize>;
 }

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -1,7 +1,5 @@
 export declare class _MatMenu extends MatMenu {
     constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone, defaultOptions: MatMenuDefaultOptions);
-    static ngAcceptInputType_hasBackdrop: BooleanInput;
-    static ngAcceptInputType_overlapTrigger: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<_MatMenu, "mat-menu", ["matMenu"], {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatMenu>;
 }
@@ -53,6 +51,8 @@ export declare class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatM
     resetActiveItem(): void;
     setElevation(depth: number): void;
     setPositionClasses(posX?: MenuPositionX, posY?: MenuPositionY): void;
+    static ngAcceptInputType_hasBackdrop: BooleanInput;
+    static ngAcceptInputType_overlapTrigger: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatMenuBase, never, never, { "backdropClass": "backdropClass"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; "ariaDescribedby": "aria-describedby"; "xPosition": "xPosition"; "yPosition": "yPosition"; "overlapTrigger": "overlapTrigger"; "hasBackdrop": "hasBackdrop"; "panelClass": "class"; "classList": "classList"; }, { "closed": "closed"; "close": "close"; }, ["lazyContent", "_allItems", "items"]>;
     static ɵfac: i0.ɵɵFactoryDef<_MatMenuBase>;
 }

--- a/tools/public_api_guard/material/progress-spinner.d.ts
+++ b/tools/public_api_guard/material/progress-spinner.d.ts
@@ -39,9 +39,6 @@ export declare class MatProgressSpinnerModule {
 
 export declare class MatSpinner extends MatProgressSpinner {
     constructor(elementRef: ElementRef<HTMLElement>, platform: Platform, document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
-    static ngAcceptInputType_diameter: NumberInput;
-    static ngAcceptInputType_strokeWidth: NumberInput;
-    static ngAcceptInputType_value: NumberInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSpinner, "mat-spinner", never, { "color": "color"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatSpinner>;
 }

--- a/tools/public_api_guard/material/sidenav.d.ts
+++ b/tools/public_api_guard/material/sidenav.d.ts
@@ -103,12 +103,9 @@ export declare class MatSidenav extends MatDrawer {
     set fixedInViewport(value: boolean);
     get fixedTopGap(): number;
     set fixedTopGap(value: number);
-    static ngAcceptInputType_autoFocus: BooleanInput;
-    static ngAcceptInputType_disableClose: BooleanInput;
     static ngAcceptInputType_fixedBottomGap: NumberInput;
     static ngAcceptInputType_fixedInViewport: BooleanInput;
     static ngAcceptInputType_fixedTopGap: NumberInput;
-    static ngAcceptInputType_opened: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSidenav, "mat-sidenav", ["matSidenav"], { "fixedInViewport": "fixedInViewport"; "fixedTopGap": "fixedTopGap"; "fixedBottomGap": "fixedBottomGap"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatSidenav>;
 }
@@ -116,7 +113,6 @@ export declare class MatSidenav extends MatDrawer {
 export declare class MatSidenavContainer extends MatDrawerContainer {
     _allDrawers: QueryList<MatSidenav>;
     _content: MatSidenavContent;
-    static ngAcceptInputType_autosize: BooleanInput;
     static ngAcceptInputType_hasBackdrop: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSidenavContainer, "mat-sidenav-container", ["matSidenavContainer"], {}, {}, ["_content", "_allDrawers"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatSidenavContainer>;

--- a/tools/public_api_guard/material/stepper.d.ts
+++ b/tools/public_api_guard/material/stepper.d.ts
@@ -11,9 +11,7 @@ export declare class MatHorizontalStepper extends MatStepper {
     static ngAcceptInputType_completed: BooleanInput;
     static ngAcceptInputType_editable: BooleanInput;
     static ngAcceptInputType_hasError: BooleanInput;
-    static ngAcceptInputType_linear: BooleanInput;
     static ngAcceptInputType_optional: BooleanInput;
-    static ngAcceptInputType_selectedIndex: NumberInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatHorizontalStepper, "mat-horizontal-stepper", ["matHorizontalStepper"], { "selectedIndex": "selectedIndex"; "labelPosition": "labelPosition"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatHorizontalStepper>;
 }
@@ -22,10 +20,6 @@ export declare class MatStep extends CdkStep implements ErrorStateMatcher {
     stepLabel: MatStepLabel;
     constructor(stepper: MatStepper, _errorStateMatcher: ErrorStateMatcher, stepperOptions?: StepperOptions);
     isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean;
-    static ngAcceptInputType_completed: BooleanInput;
-    static ngAcceptInputType_editable: BooleanInput;
-    static ngAcceptInputType_hasError: BooleanInput;
-    static ngAcceptInputType_optional: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatStep, "mat-step", ["matStep"], {}, {}, ["stepLabel"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatStep>;
 }
@@ -74,9 +68,7 @@ export declare class MatStepper extends CdkStepper implements AfterContentInit {
     static ngAcceptInputType_completed: BooleanInput;
     static ngAcceptInputType_editable: BooleanInput;
     static ngAcceptInputType_hasError: BooleanInput;
-    static ngAcceptInputType_linear: BooleanInput;
     static ngAcceptInputType_optional: BooleanInput;
-    static ngAcceptInputType_selectedIndex: NumberInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStepper, "[matStepper]", never, { "disableRipple": "disableRipple"; }, { "animationDone": "animationDone"; }, ["_steps", "_icons"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatStepper>;
 }
@@ -127,9 +119,7 @@ export declare class MatVerticalStepper extends MatStepper {
     static ngAcceptInputType_completed: BooleanInput;
     static ngAcceptInputType_editable: BooleanInput;
     static ngAcceptInputType_hasError: BooleanInput;
-    static ngAcceptInputType_linear: BooleanInput;
     static ngAcceptInputType_optional: BooleanInput;
-    static ngAcceptInputType_selectedIndex: NumberInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatVerticalStepper, "mat-vertical-stepper", ["matVerticalStepper"], { "selectedIndex": "selectedIndex"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatVerticalStepper>;
 }

--- a/tools/public_api_guard/material/table.d.ts
+++ b/tools/public_api_guard/material/table.d.ts
@@ -12,7 +12,6 @@ export declare class MatCellDef extends CdkCellDef {
 export declare class MatColumnDef extends CdkColumnDef {
     name: string;
     static ngAcceptInputType_sticky: BooleanInput;
-    static ngAcceptInputType_stickyEnd: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatColumnDef, "[matColumnDef]", never, { "sticky": "sticky"; "name": "matColumnDef"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatColumnDef>;
 }
@@ -73,7 +72,6 @@ export declare class MatRowDef<T> extends CdkRowDef<T> {
 
 export declare class MatTable<T> extends CdkTable<T> {
     protected stickyCssClass: string;
-    static ngAcceptInputType_multiTemplateDataRows: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTable<any>, "mat-table, table[mat-table]", ["matTable"], {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTable<any>>;
 }

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -62,6 +62,10 @@ export declare abstract class _MatTabGroupBase extends _MatTabGroupMixinBase imp
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     realignInkBar(): void;
+    static ngAcceptInputType_animationDuration: NumberInput;
+    static ngAcceptInputType_disableRipple: BooleanInput;
+    static ngAcceptInputType_dynamicHeight: BooleanInput;
+    static ngAcceptInputType_selectedIndex: NumberInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabGroupBase, never, never, { "dynamicHeight": "dynamicHeight"; "selectedIndex": "selectedIndex"; "headerPosition": "headerPosition"; "animationDuration": "animationDuration"; "disablePagination": "disablePagination"; "backgroundColor": "backgroundColor"; }, { "selectedIndexChange": "selectedIndexChange"; "focusChange": "focusChange"; "animationDone": "animationDone"; "selectedTabChange": "selectedTabChange"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabGroupBase>;
 }
@@ -85,6 +89,8 @@ export declare class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnD
     constructor(_tabNavBar: _MatTabNavBase, elementRef: ElementRef, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string, _focusMonitor: FocusMonitor, animationMode?: string);
     focus(): void;
     ngOnDestroy(): void;
+    static ngAcceptInputType_disableRipple: BooleanInput;
+    static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabLinkBase, never, never, { "active": "active"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabLinkBase>;
 }
@@ -182,10 +188,6 @@ export declare class MatTabGroup extends _MatTabGroupBase {
     _tabBodyWrapper: ElementRef;
     _tabHeader: MatTabGroupBaseHeader;
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, defaultConfig?: MatTabsConfig, animationMode?: string);
-    static ngAcceptInputType_animationDuration: NumberInput;
-    static ngAcceptInputType_disableRipple: BooleanInput;
-    static ngAcceptInputType_dynamicHeight: BooleanInput;
-    static ngAcceptInputType_selectedIndex: NumberInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTabGroup, "mat-tab-group", ["matTabGroup"], { "color": "color"; "disableRipple": "disableRipple"; }, {}, ["_allTabs"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabGroup>;
 }
@@ -199,7 +201,6 @@ export declare class MatTabHeader extends _MatTabHeaderBase {
     _tabListContainer: ElementRef;
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler, dir: Directionality, ngZone: NgZone, platform: Platform, animationMode?: string);
     static ngAcceptInputType_disableRipple: BooleanInput;
-    static ngAcceptInputType_selectedIndex: NumberInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTabHeader, "mat-tab-header", never, { "selectedIndex": "selectedIndex"; }, { "selectFocusedIndex": "selectFocusedIndex"; "indexFocused": "indexFocused"; }, ["_items"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabHeader>;
 }
@@ -225,8 +226,6 @@ export declare class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase imp
 export declare class MatTabLink extends _MatTabLinkBase implements OnDestroy {
     constructor(tabNavBar: MatTabNav, elementRef: ElementRef, ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string, focusMonitor: FocusMonitor, animationMode?: string);
     ngOnDestroy(): void;
-    static ngAcceptInputType_disableRipple: BooleanInput;
-    static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTabLink, "[mat-tab-link], [matTabLink]", ["matTabLink"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabLink>;
 }
@@ -241,7 +240,6 @@ export declare class MatTabNav extends _MatTabNavBase {
     constructor(elementRef: ElementRef, dir: Directionality, ngZone: NgZone, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler,
     platform?: Platform, animationMode?: string);
     static ngAcceptInputType_disableRipple: BooleanInput;
-    static ngAcceptInputType_selectedIndex: NumberInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTabNav, "[mat-tab-nav-bar]", ["matTabNavBar", "matTabNav"], { "color": "color"; }, {}, ["_items"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabNav>;
 }

--- a/tools/public_api_guard/material/tree.d.ts
+++ b/tools/public_api_guard/material/tree.d.ts
@@ -84,14 +84,12 @@ export declare class MatTreeNodeOutlet implements CdkTreeNodeOutlet {
 export declare class MatTreeNodePadding<T> extends CdkTreeNodePadding<T> {
     indent: number;
     level: number;
-    static ngAcceptInputType_level: NumberInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTreeNodePadding<any>, "[matTreeNodePadding]", never, { "level": "matTreeNodePadding"; "indent": "matTreeNodePaddingIndent"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTreeNodePadding<any>>;
 }
 
 export declare class MatTreeNodeToggle<T> extends CdkTreeNodeToggle<T> {
     recursive: boolean;
-    static ngAcceptInputType_recursive: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTreeNodeToggle<any>, "[matTreeNodeToggle]", never, { "recursive": "matTreeNodeToggleRecursive"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTreeNodeToggle<any>>;
 }

--- a/tools/tslint-rules/coercionTypesRule.ts
+++ b/tools/tslint-rules/coercionTypesRule.ts
@@ -40,9 +40,9 @@ class Walker extends Lint.RuleWalker {
 
   visitClassDeclaration(node: ts.ClassDeclaration) {
     if (this._shouldLintClass(node)) {
-      this._lintClass(node, node);
+      this._lintClass(node, node, true);
       this._lintSuperClasses(node);
-      this._lintInterfaces(node, node);
+      this._lintInterfaces(node, node, true);
     }
     super.visitClassDeclaration(node);
   }
@@ -107,12 +107,14 @@ class Walker extends Lint.RuleWalker {
    * @param node Class declaration to be checked.
    * @param sourceClass Class declaration on which to look for static properties that declare the
    *    accepted values for the setter.
+   * @param expectDeclaredMembers Whether acceptance members should be expected or unexpected.
    */
-  private _lintClass(node: ts.ClassDeclaration, sourceClass: ts.ClassDeclaration): void {
+  private _lintClass(node: ts.ClassDeclaration, sourceClass: ts.ClassDeclaration,
+      expectDeclaredMembers: boolean): void {
     node.members.forEach(member => {
       if (ts.isSetAccessor(member) && usesCoercion(member, this._coercionFunctions) &&
           this._shouldCheckSetter(member)) {
-        this._checkForStaticMember(sourceClass, member.name.getText());
+        this._checkStaticMember(sourceClass, member.name.getText(), expectDeclaredMembers);
       }
     });
   }
@@ -137,8 +139,10 @@ class Walker extends Lint.RuleWalker {
           symbol.valueDeclaration : null;
 
       if (currentClass) {
-        this._lintClass(currentClass, node);
-        this._lintInterfaces(currentClass, node);
+        // Acceptance members should not be re-declared in the derived class. This
+        // is because acceptance members are inherited.
+        this._lintClass(currentClass, node, false);
+        this._lintInterfaces(currentClass, node, false);
       }
     }
   }
@@ -148,8 +152,10 @@ class Walker extends Lint.RuleWalker {
    * @param node Class declaration to be checked.
    * @param sourceClass Class declaration on which to look for static properties that declare the
    *    accepted values for the setter.
+   * @param expectDeclaredMembers Whether acceptance members should be expected or unexpected.
    */
-  private _lintInterfaces(node: ts.ClassDeclaration, sourceClass: ts.ClassDeclaration): void {
+  private _lintInterfaces(node: ts.ClassDeclaration, sourceClass: ts.ClassDeclaration,
+                          expectDeclaredMembers: boolean): void {
     if (!node.heritageClauses) {
       return;
     }
@@ -161,7 +167,8 @@ class Walker extends Lint.RuleWalker {
             const propNames = this._coercionInterfaces[clauseType.expression.text];
 
             if (propNames) {
-              propNames.forEach(propName => this._checkForStaticMember(sourceClass, propName));
+              propNames.forEach(propName =>
+                  this._checkStaticMember(sourceClass, propName, expectDeclaredMembers));
             }
           }
         });
@@ -170,22 +177,19 @@ class Walker extends Lint.RuleWalker {
   }
 
   /**
-   * Checks whether a class declaration has a static member, corresponding
-   * to the specified setter name, and logs a failure if it doesn't.
-   * @param node
-   * @param setterName
+   * Based on whether the acceptance members are expected or not, this method checks whether
+   * the specified class declaration matches the condition.
    */
-  private _checkForStaticMember(node: ts.ClassDeclaration, setterName: string) {
-    const coercionPropertyName = `${TYPE_ACCEPT_MEMBER_PREFIX}${setterName}`;
-    const correspondingCoercionProperty = node.members.find(member => {
-      return ts.isPropertyDeclaration(member) &&
-             tsutils.hasModifier(member.modifiers, ts.SyntaxKind.StaticKeyword) &&
-             member.name.getText() === coercionPropertyName;
-    });
-
-    if (!correspondingCoercionProperty) {
+  private _checkStaticMember(node: ts.ClassDeclaration, setterName: string,
+                             expectDeclaredMembers: boolean) {
+    const {memberName, memberNode} = this._lookupStaticMember(node, setterName);
+    if (expectDeclaredMembers && !memberNode) {
       this.addFailureAtNode(node.name || node, `Class must declare static coercion ` +
-                                               `property called ${coercionPropertyName}.`);
+        `property called ${memberName}.`);
+    } else if (!expectDeclaredMembers && memberNode) {
+      this.addFailureAtNode(node.name || node, `Class should not declare static coercion ` +
+        `property called ${memberName}. Acceptance members are inherited.`,
+        Lint.Replacement.deleteText(memberNode.getFullStart(), memberNode.getFullWidth()));
     }
   }
 
@@ -195,34 +199,25 @@ class Walker extends Lint.RuleWalker {
     if (!node.decorators) {
       return false;
     }
-
-    // If the class is a component we should lint.
+    // If the class is a component,  we should lint it.
     if (node.decorators.some(decorator => isDecoratorCalled(decorator, 'Component'))) {
       return true;
     }
+    // If the class is a directive, we should lint it.
+    return node.decorators.some(decorator => isDecoratorCalled(decorator, 'Directive'));
+  }
 
-    const directiveDecorator =
-        node.decorators.find(decorator => isDecoratorCalled(decorator, 'Directive'));
-
-    if (directiveDecorator) {
-      const firstArg = (directiveDecorator.expression as ts.CallExpression).arguments[0];
-      const metadata = firstArg && ts.isObjectLiteralExpression(firstArg) ? firstArg : null;
-      const selectorProp = metadata ?
-          metadata.properties.find((prop): prop is ts.PropertyAssignment => {
-            return ts.isPropertyAssignment(prop) && prop.name && ts.isIdentifier(prop.name) &&
-                prop.name.text === 'selector';
-          }) :
-          null;
-      const selectorText =
-          selectorProp != null && ts.isStringLiteralLike(selectorProp.initializer) ?
-          selectorProp.initializer.text :
-          null;
-
-      // We only want to lint directives with a selector (i.e. no abstract directives).
-      return selectorText !== null;
-    }
-
-    return false;
+  /** Looks for a static member that corresponds to the given property. */
+  private _lookupStaticMember(node: ts.ClassDeclaration, propName: string)
+    : {memberName: string, memberNode?: ts.PropertyDeclaration} {
+    const coercionPropertyName = `${TYPE_ACCEPT_MEMBER_PREFIX}${propName}`;
+    const correspondingCoercionProperty = node.members
+      .find((member): member is ts.PropertyDeclaration => {
+        return ts.isPropertyDeclaration(member) &&
+          tsutils.hasModifier(member.modifiers, ts.SyntaxKind.StaticKeyword) &&
+          member.name.getText() === coercionPropertyName;
+      });
+    return {memberName: coercionPropertyName, memberNode: correspondingCoercionProperty};
   }
 
   /** Determines whether a setter node should be checked by the lint rule. */


### PR DESCRIPTION
Previously Angular did not inherit coercion acceptance members until we submitted an issue
on the framework side. This issue will be fixed with https://github.com/angular/angular/pull/34296.

In preparation for that change to land, this PR removes all unnecessary acceptance members and
updates the lint rule to avoid future duplications (the rule is also used to make that refactoring)