### PR TITLE
build: add option to start karma without browser

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -2,6 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 load("//tools:defaults.bzl", "ts_library")
 
+exports_files(["bazel-karma-local-config.js"])
+
 # Common set-up for all Angular Material and CDK tests.
 ts_library(
     name = "angular_test_init",

--- a/test/bazel-karma-local-config.js
+++ b/test/bazel-karma-local-config.js
@@ -1,0 +1,27 @@
+/**
+ * Karma configuration that is used by Bazel karma_web_test targets which do not
+ * want to launch any browser and just enable manual browser debugging.
+ */
+
+module.exports = config => {
+  const overwrites = {};
+
+  // By default "@bazel/karma" configures Chrome as browser. Since we don't want
+  // to launch any browser at all, we overwrite the "browsers" option. Since the
+  // default config tries to extend the browsers array with "Chrome", we need to
+  // always return a new empty array.
+  Object.defineProperty(overwrites, 'browsers', {
+    get: () => [],
+    set: () => {},
+    enumerable: true
+  });
+
+  // Ensures that tests start executing once browsers have been manually connected. We need
+  // to use "defineProperty" because the default "@bazel/karma" config overwrites the option.
+  Object.defineProperty(overwrites, 'autoWatch', {
+    value: true,
+    writable: false,
+  });
+
+  config.set(overwrites);
+};

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -3,7 +3,7 @@
 load("@io_bazel_rules_sass//:defs.bzl", _sass_binary = "sass_binary", _sass_library = "sass_library")
 load("@npm_angular_bazel//:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
 load("@npm_bazel_jasmine//:index.bzl", _jasmine_node_test = "jasmine_node_test")
-load("@npm_bazel_karma//:index.bzl", _karma_web_test_suite = "karma_web_test_suite")
+load("@npm_bazel_karma//:index.bzl", _karma_web_test = "karma_web_test", _karma_web_test_suite = "karma_web_test_suite")
 load("@npm_bazel_protractor//:index.bzl", _protractor_web_test_suite = "protractor_web_test_suite")
 load("@npm_bazel_typescript//:index.bzl", _ts_library = "ts_library")
 load("//:packages.bzl", "VERSION_PLACEHOLDER_REPLACEMENTS", "getAngularUmdTargets")
@@ -154,14 +154,38 @@ def ng_e2e_test_library(deps = [], tsconfig = None, **kwargs):
         **kwargs
     )
 
-def karma_web_test_suite(deps = [], srcs = [], **kwargs):
+def karma_web_test_suite(name, **kwargs):
+    web_test_args = {}
+    kwargs["srcs"] = ["@npm//:node_modules/tslib/tslib.js"] + getAngularUmdTargets() + kwargs.get("srcs", [])
+    kwargs["deps"] = ["//tools/rxjs:rxjs_umd_modules"] + kwargs.get("deps", [])
+
+    for opt_name in kwargs.keys():
+        # Filter out options which are specific to "karma_web_test" targets. We cannot
+        # pass options like "browsers" to the local web test target.
+        if not opt_name in ["wrapped_test_tags", "browsers", "wrapped_test_tags", "tags"]:
+            web_test_args[opt_name] = kwargs[opt_name]
+
+    # Custom standalone web test that can be run to test against any browser
+    # that is manually connected to.
+    _karma_web_test(
+        name = "%s_local_bin" % name,
+        config_file = "//test:bazel-karma-local-config.js",
+        tags = ["manual"],
+        **web_test_args
+    )
+
+    # Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1429
+    native.sh_binary(
+        name = "%s_local" % name,
+        srcs = ["%s_local_bin" % name],
+        data = [":%s_local_bin" % name],
+        tags = ["manual", "local", "ibazel_notify_changes"],
+        testonly = True,
+    )
+
+    # Default test suite with all configured browsers.
     _karma_web_test_suite(
-        deps = ["//tools/rxjs:rxjs_umd_modules"] + deps,
-        # Required for running the compiled ng modules that use TypeScript import helpers.
-        # TODO(jelbourn): remove UMDs from here once we don't have to manually include them
-        srcs = [
-            "@npm//:node_modules/tslib/tslib.js",
-        ] + getAngularUmdTargets() + srcs,
+        name = name,
         **kwargs
     )
 


### PR DESCRIPTION
Adds a way to start Karma without a browser. Similar to `yarn gulp
test:static`.

The targets can be run the following way and work with `ibazel` watch
mode. `yarn ibazel run src/cdk/a11y:unit_tests_static`.