### PR TITLE
build: prevent creating runfiles tree during remote builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,6 +40,7 @@ test --test_output=errors
 # Configures script to do version stamping.
 # See https://docs.bazel.build/versions/master/user-manual.html#flag--workspace_status_command
 build:release --workspace_status_command="node ./tools/bazel-stamp-vars.js"
+build:release --stamp
 
 ################################
 # View Engine / Ivy toggle     #

--- a/.bazelrc
+++ b/.bazelrc
@@ -102,6 +102,9 @@ build:remote --bes_results_url="https://source.cloud.google.com/results/invocati
 # Set remote caching settings
 build:remote --remote_accept_cached=true
 
+# When building remotely, runfile trees are created from in-memory manifests
+build:remote --build_runfile_manifests=false
+
 ################################
 # --config=debug               #
 ################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,8 +8,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Add NodeJS rules
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "8dc1466f8563f3aa4ac7ab7aa3c96651eb7764108219f40b2d1c918e1a81c601",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.41.0/rules_nodejs-0.41.0.tar.gz"],
+    sha256 = "a54b2511d6dae42c1f7cdaeb08144ee2808193a088004fc3b464a04583d5aa2e",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.42.3/rules_nodejs-0.42.3.tar.gz"],
 )
 
 # Add sass rules


### PR DESCRIPTION
Runfiles trees are not needed when building remotely as the trees
are actually created from in-memory manifests