### PR TITLE
build: update to rules_nodejs@0.42.3

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,6 +40,7 @@ test --test_output=errors
 # Configures script to do version stamping.
 # See https://docs.bazel.build/versions/master/user-manual.html#flag--workspace_status_command
 build:release --workspace_status_command="node ./tools/bazel-stamp-vars.js"
+build:release --stamp
 
 ################################
 # View Engine / Ivy toggle     #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,8 +8,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Add NodeJS rules
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "8dc1466f8563f3aa4ac7ab7aa3c96651eb7764108219f40b2d1c918e1a81c601",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.41.0/rules_nodejs-0.41.0.tar.gz"],
+    sha256 = "a54b2511d6dae42c1f7cdaeb08144ee2808193a088004fc3b464a04583d5aa2e",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.42.3/rules_nodejs-0.42.3.tar.gz"],
 )
 
 # Add sass rules


### PR DESCRIPTION
Updating to latest rules_nodejs which properly handles stamping for
releases.  Previously rollup_bundle and npm_package were unable to
be cached remotely.
See https://github.com/bazelbuild/rules_nodejs/pull/1441 for changes.

With new requirements from changes in rules_nodejs, we now must add
--stamp to bazel builds we wish to include stamping.