### PR TITLE
refactor: remove ts 3.7 compatibility type cast in ripple-renderer

### DIFF
--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -146,9 +146,12 @@ export class RippleRenderer {
     ripple.style.height = `${radius * 2}px`;
     ripple.style.width = `${radius * 2}px`;
 
-    // If the color is not set, the default CSS color will be used.
-    // TODO(TS3.7): Type 'string | null' is not assignable to type 'string'.
-    ripple.style.backgroundColor = (config.color || null) as any;
+    // If a custom color has been specified, set it as inline style. If no color is
+    // set, the default color will be applied through the ripple theme styles.
+    if (config.color != null) {
+      ripple.style.backgroundColor = config.color;
+    }
+
     ripple.style.transitionDuration = `${duration}ms`;
 
     this._containerElement.appendChild(ripple);


### PR DESCRIPTION
8fd9d7d39944c02b6c863c7aee76ecbb19c8603e added a type cast to an assignment in the `RippleRenderer` in order
to make it compatible with TS 3.7.

To make the assignment compatible with TS 3.7 in a way that does not require a
type-cast, we just assign the `backgroundColor` style property if actually needed.