### PR TITLE
test: menu tests flaky due to missing animation flush

### DIFF
--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -854,6 +854,7 @@ describe('MDC-based MatMenu', () => {
     fixture.detectChanges();
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
+    tick(500);
 
     expect(document.activeElement)
         .toBe(overlayContainerElement.querySelector('.mat-mdc-menu-panel'));
@@ -865,6 +866,7 @@ describe('MDC-based MatMenu', () => {
     fixture.detectChanges();
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
+    tick(500);
 
     expect(document.activeElement)
         .toBe(overlayContainerElement.querySelector('.mat-mdc-menu-panel'));

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -807,6 +807,7 @@ describe('MatMenu', () => {
     fixture.detectChanges();
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
+    tick(500);
 
     expect(document.activeElement).toBe(overlayContainerElement.querySelector('.mat-menu-panel'));
   }));


### PR DESCRIPTION
Follow-up to: 1255139a38e5d8425bb6236c63c3d231301b21da. Should fix flakiness as observed in https://circleci.com/gh/angular/components/100888

Two recently added tests for the menu/mdc-menu and the MDC-one from the
initial commit seem to miss a `tick` to flush the open animation. Without
the flush, the `FakeAsyncTestZone` will report a pending timer on test completion.