### PR TITLE
fix: google-maps and youtube-player package missing tslib dependency

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -3,9 +3,12 @@
 # version for the placeholders.
 ANGULAR_PACKAGE_VERSION = "^9.0.0-0 || ^10.0.0-0"
 MDC_PACKAGE_VERSION = "^4.0.0"
+TSLIB_PACKAGE_VERSION = "^1.9.0"
+
 VERSION_PLACEHOLDER_REPLACEMENTS = {
     "0.0.0-MDC": MDC_PACKAGE_VERSION,
     "0.0.0-NG": ANGULAR_PACKAGE_VERSION,
+    "0.0.0-TSLIB": TSLIB_PACKAGE_VERSION,
 }
 
 # List of default Angular library UMD bundles which are not processed by ngcc.

--- a/src/cdk-experimental/package.json
+++ b/src/cdk-experimental/package.json
@@ -22,7 +22,7 @@
   "peerDependencies": {
     "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
-    "tslib": "^1.9.0"
+    "tslib": "0.0.0-TSLIB"
   },
   "sideEffects": false,
   "publishConfig":{

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",
-    "tslib": "^1.9.0"
+    "tslib": "0.0.0-TSLIB"
   },
   "optionalDependencies": {
     "parse5": "^5.0.0"

--- a/src/google-maps/package.json
+++ b/src/google-maps/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/angular/components/tree/master/src/google-maps#readme",
   "dependencies": {
-    "@types/googlemaps": "^3.37.0"
+    "@types/googlemaps": "^3.37.0",
+    "tslib": "0.0.0-TSLIB"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",

--- a/src/material-experimental/package.json
+++ b/src/material-experimental/package.json
@@ -23,7 +23,7 @@
     "@angular/core": "0.0.0-NG",
     "@angular/material": "0.0.0-PLACEHOLDER",
     "material-components-web": "0.0.0-MDC",
-    "tslib": "^1.9.0"
+    "tslib": "0.0.0-TSLIB"
   },
   "sideEffects": false,
   "publishConfig":{

--- a/src/material-moment-adapter/package.json
+++ b/src/material-moment-adapter/package.json
@@ -23,7 +23,7 @@
     "@angular/material": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
     "moment": "^2.18.1",
-    "tslib": "^1.9.0"
+    "tslib": "0.0.0-TSLIB"
   },
   "ng-update": {
     "packageGroup": [

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -31,7 +31,7 @@
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",
     "@angular/forms": "0.0.0-NG",
-    "tslib": "^1.9.0"
+    "tslib": "0.0.0-TSLIB"
   },
   "schematics": "./schematics/collection.json",
   "ng-update": {

--- a/src/youtube-player/package.json
+++ b/src/youtube-player/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/angular/components/tree/master/src/youtube-player#readme",
   "dependencies": {
-    "@types/youtube": "^0.0.38"
+    "@types/youtube": "^0.0.38",
+    "tslib": "0.0.0-TSLIB"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",


### PR DESCRIPTION
**Note**: Not sure if we want the second commit to be a `fix`. Technically it could break people if `tslib` is not installed. Though that is probably very rare.