### PR TITLE
fix(dialog): DOM nodes not cleaned up if view container is destroyed before close animation starts

### DIFF
--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -99,40 +99,40 @@ export class MatDialogRef<T, R = any> {
   close(dialogResult?: R): void {
     this._result = dialogResult;
  
-     // Transition the backdrop in parallel to the dialog.
-     this._containerInstance._animationStateChanged.pipe(
-       filter(event => event.phaseName === 'start'),
-       take(1)
-     )
-     .subscribe(() => {
-       this._beforeClosed.next(dialogResult);
-       this._beforeClosed.complete();
-       this._state = MatDialogState.CLOSED;
-       this._overlayRef.detachBackdrop();
-     });
- 
-     this._containerInstance._startExitAnimation();
-     this._state = MatDialogState.CLOSING;
- 
-     // The logic that disposes of the overlay depends on the exit animation completing, however
-     // it isn't guaranteed if the parent view is destroyed before that event. Add a fallback
-     // observer which will clean everything up if the animation hasn't completed within a specified
-     // amount of time plus 100ms. We don't need to run this outside the NgZone, because for the
-     // vast majority of cases the timeout will have been cleared before it has the chance to fire.
-     race(
-       this._containerInstance._animationStateChanged
-         .pipe(
-           filter(event => event.phaseName === 'done' && event.toState === 'exit'),
-           map(event => event.totalTime)
-         ),
-       of(null).pipe(delay(200), mapTo(200)) //200ms = estimated animation time of 100ms + 100ms
-     ).subscribe(() => {
-       // Checks if the overlay still exists after assumed animation time has elapsed
-       if (this._overlayRef.hasAttached()) {
-         // Dispose of overlay assuming animation has not completed in time
-         this._overlayRef.dispose();
-       }
-     });
+    // Transition the backdrop in parallel to the dialog.
+    this._containerInstance._animationStateChanged.pipe(
+      filter(event => event.phaseName === 'start'),
+      take(1)
+    )
+    .subscribe(() => {
+      this._beforeClosed.next(dialogResult);
+      this._beforeClosed.complete();
+      this._state = MatDialogState.CLOSED;
+      this._overlayRef.detachBackdrop();
+    });
+
+    this._containerInstance._startExitAnimation();
+    this._state = MatDialogState.CLOSING;
+
+    // The logic that disposes of the overlay depends on the exit animation completing, however
+    // it isn't guaranteed if the parent view is destroyed before that event. Add a fallback
+    // observer which will clean everything up if the animation hasn't completed within a specified
+    // amount of time plus 100ms. We don't need to run this outside the NgZone, because for the
+    // vast majority of cases the timeout will have been cleared before it has the chance to fire.
+    race(
+      this._containerInstance._animationStateChanged
+        .pipe(
+          filter(event => event.phaseName === 'done' && event.toState === 'exit'),
+          map(event => event.totalTime)
+        ),
+      of(null).pipe(delay(200), mapTo(200)) //200ms = estimated animation time of 100ms + 100ms
+    ).subscribe(() => {
+      // Checks if the overlay still exists after assumed animation time has elapsed
+      if (this._overlayRef.hasAttached()) {
+        // Dispose of overlay assuming animation has not completed in time
+        this._overlayRef.dispose();
+      }
+    });
    }
 
   /**

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -8,8 +8,8 @@
 
 import {ESCAPE, hasModifierKey} from '@angular/cdk/keycodes';
 import {GlobalPositionStrategy, OverlayRef} from '@angular/cdk/overlay';
-import {Observable, Subject} from 'rxjs';
-import {filter, take} from 'rxjs/operators';
+import {Observable, Subject, race, of} from 'rxjs';
+import {filter, take, map, delay, mapTo} from 'rxjs/operators';
 import {DialogPosition} from './dialog-config';
 import {MatDialogContainer} from './dialog-container';
 
@@ -44,12 +44,6 @@ export class MatDialogRef<T, R = any> {
   /** Result to be passed to afterClosed. */
   private _result: R | undefined;
 
-  /** Handle to the timeout that's running as a fallback in case the exit animation doesn't fire. */
-  private _closeFallbackTimeout: number;
-
-  /** Handle to the timeout that's running as a fallback in case no animation fire */
-  private _destroyCloseFallbackTimeout: number;
-
   /** Current state of the dialog. */
   private _state = MatDialogState.OPEN;
 
@@ -76,7 +70,6 @@ export class MatDialogRef<T, R = any> {
       filter(event => event.phaseName === 'done' && event.toState === 'exit'),
       take(1)
     ).subscribe(() => {
-      clearTimeout(this._closeFallbackTimeout);
       this._overlayRef.dispose();
     });
 
@@ -105,43 +98,42 @@ export class MatDialogRef<T, R = any> {
    */
   close(dialogResult?: R): void {
     this._result = dialogResult;
-
-    // Transition the backdrop in parallel to the dialog.
-    this._containerInstance._animationStateChanged.pipe(
-      filter(event => event.phaseName === 'start'),
-      take(1)
-    )
-    .subscribe(event => {
-      this._beforeClosed.next(dialogResult);
-      this._beforeClosed.complete();
-      this._state = MatDialogState.CLOSED;
-      this._overlayRef.detachBackdrop();
-
-      // The logic that disposes of the overlay depends on the exit animation completing, however
-      // it isn't guaranteed if the parent view is destroyed while it's running. Add a fallback
-      // timeout which will clean everything up if the animation hasn't fired within the specified
-      // amount of time plus 100ms. We don't need to run this outside the NgZone, because for the
-      // vast majority of cases the timeout will have been cleared before it has the chance to fire.
-      this._closeFallbackTimeout = setTimeout(() => {
-        this._overlayRef.dispose();
-      }, event.totalTime + 100);
-
-      // Now that the observable close fallback exists clear the backup one
-      clearTimeout(this._destroyCloseFallbackTimeout);
-    });
-
-    this._containerInstance._startExitAnimation();
-    this._state = MatDialogState.CLOSING;
-
-    // Similar to _closeFallbackTimeout but acts as a fallback till the animationStateChanged
-    // observable executes for edge Cases like path changes with dialog open which might not
-    // have time to allow allow any animation events.
-    this._destroyCloseFallbackTimeout = setTimeout(() => {
-      if (this._overlayRef.hasAttached()) {
-        this._overlayRef.dispose();
-      }
-    }, 0);
-  }
+ 
+     // Transition the backdrop in parallel to the dialog.
+     this._containerInstance._animationStateChanged.pipe(
+       filter(event => event.phaseName === 'start'),
+       take(1)
+     )
+     .subscribe(() => {
+       this._beforeClosed.next(dialogResult);
+       this._beforeClosed.complete();
+       this._state = MatDialogState.CLOSED;
+       this._overlayRef.detachBackdrop();
+     });
+ 
+     this._containerInstance._startExitAnimation();
+     this._state = MatDialogState.CLOSING;
+ 
+     // The logic that disposes of the overlay depends on the exit animation completing, however
+     // it isn't guaranteed if the parent view is destroyed before that event. Add a fallback
+     // observer which will clean everything up if the animation hasn't completed within a specified
+     // amount of time plus 100ms. We don't need to run this outside the NgZone, because for the
+     // vast majority of cases the timeout will have been cleared before it has the chance to fire.
+     race(
+       this._containerInstance._animationStateChanged
+         .pipe(
+           filter(event => event.phaseName === 'done' && event.toState === 'exit'),
+           map(event => event.totalTime)
+         ),
+       of(null).pipe(delay(200), mapTo(200)) //200ms = estimated animation time of 100ms + 100ms
+     ).subscribe(() => {
+       // Checks if the overlay still exists after assumed animation time has elapsed
+       if (this._overlayRef.hasAttached()) {
+         // Dispose of overlay assuming animation has not completed in time
+         this._overlayRef.dispose();
+       }
+     });
+   }
 
   /**
    * Gets an observable that is notified when the dialog is finished opening.

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -120,13 +120,17 @@ export class MatDialogRef<T, R = any> {
     // amount of time plus 100ms.
     race(
       this._containerInstance._animationStateChanged
-        .pipe(
-          filter(event => event.phaseName === 'done' && event.toState === 'exit'),
-          map(event => event.totalTime)
-        ),
+      .pipe(
+        filter(event => event.phaseName === 'done' && event.toState === 'exit'),
+        map(event => event.totalTime)
+      ),
       of(null)
-      .pipe((take(1)), delay(200), mapTo(200)) // 200ms = estimated animation time of 100ms + 100ms
-    ).subscribe(() => {
+        .pipe(delay(200), mapTo(200)) // 200ms = estimated animation time of 100ms + 100ms
+    )
+    .pipe(
+      take(1)
+    )
+    .subscribe(() => {
       // Checks if the overlay still exists after assumed animation time has elapsed
       if (this._overlayRef.hasAttached()) {
         // Dispose of overlay assuming animation has not completed in time

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -98,7 +98,7 @@ export class MatDialogRef<T, R = any> {
    */
   close(dialogResult?: R): void {
     this._result = dialogResult;
- 
+
     // Transition the backdrop in parallel to the dialog.
     this._containerInstance._animationStateChanged.pipe(
       filter(event => event.phaseName === 'start'),
@@ -125,7 +125,7 @@ export class MatDialogRef<T, R = any> {
           filter(event => event.phaseName === 'done' && event.toState === 'exit'),
           map(event => event.totalTime)
         ),
-      of(null).pipe(delay(200), mapTo(200)) //200ms = estimated animation time of 100ms + 100ms
+      of(null).pipe(delay(200), mapTo(200)) // 200ms = estimated animation time of 100ms + 100ms
     ).subscribe(() => {
       // Checks if the overlay still exists after assumed animation time has elapsed
       if (this._overlayRef.hasAttached()) {

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -117,15 +117,15 @@ export class MatDialogRef<T, R = any> {
     // The logic that disposes of the overlay depends on the exit animation completing, however
     // it isn't guaranteed if the parent view is destroyed before that event. Add a fallback
     // observer which will clean everything up if the animation hasn't completed within a specified
-    // amount of time plus 100ms. We don't need to run this outside the NgZone, because for the
-    // vast majority of cases the timeout will have been cleared before it has the chance to fire.
+    // amount of time plus 100ms.
     race(
       this._containerInstance._animationStateChanged
         .pipe(
           filter(event => event.phaseName === 'done' && event.toState === 'exit'),
           map(event => event.totalTime)
         ),
-      of(null).pipe(delay(200), mapTo(200)) // 200ms = estimated animation time of 100ms + 100ms
+      of(null)
+      .pipe((take(1)), delay(200), mapTo(200)) // 200ms = estimated animation time of 100ms + 100ms
     ).subscribe(() => {
       // Checks if the overlay still exists after assumed animation time has elapsed
       if (this._overlayRef.hasAttached()) {

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -47,7 +47,7 @@ export class MatDialogRef<T, R = any> {
   /** Handle to the timeout that's running as a fallback in case the exit animation doesn't fire. */
   private _closeFallbackTimeout: number;
 
-  /** Handle to the timeout that's running as a fallback in case the entire andimation doesn't fire */
+  /** Handle to the timeout that's running as a fallback in case no animation fire */
   private _destroyCloseFallbackTimeout: number;
 
   /** Current state of the dialog. */
@@ -133,9 +133,9 @@ export class MatDialogRef<T, R = any> {
     this._containerInstance._startExitAnimation();
     this._state = MatDialogState.CLOSING;
 
-    // Similar to _closeFallbackTimeout but acts as a fallback till the animationStateChanged observable
-    // executes for edge Cases like path changes with dialog open which might not have time to allow
-    // allow any animation events
+    // Similar to _closeFallbackTimeout but acts as a fallback till the animationStateChanged 
+    // observable executes for edge Cases like path changes with dialog open which might not 
+    // have time to allow allow any animation events.
     this._destroyCloseFallbackTimeout = setTimeout(() => {
       if (this._overlayRef.hasAttached()) {
         this._overlayRef.dispose();

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -133,8 +133,8 @@ export class MatDialogRef<T, R = any> {
     this._containerInstance._startExitAnimation();
     this._state = MatDialogState.CLOSING;
 
-    // Similar to _closeFallbackTimeout but acts as a fallback till the animationStateChanged 
-    // observable executes for edge Cases like path changes with dialog open which might not 
+    // Similar to _closeFallbackTimeout but acts as a fallback till the animationStateChanged
+    // observable executes for edge Cases like path changes with dialog open which might not
     // have time to allow allow any animation events.
     this._destroyCloseFallbackTimeout = setTimeout(() => {
       if (this._overlayRef.hasAttached()) {

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -207,6 +207,16 @@ describe('MatDialog', () => {
     expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
   }));
 
+  it('should dispose of dialog if view container is destroyed before animating', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
+
+    viewContainerFixture.detectChanges();
+    viewContainerFixture.destroy();
+    flush();
+
+    expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
+  }));
+
   it('should dispatch the beforeClosed and afterClosed events when the ' +
     'overlay is detached externally', fakeAsync(inject([Overlay], (overlay: Overlay) => {
       const dialogRef = dialog.open(PizzaMsg, {

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -208,10 +208,12 @@ describe('MatDialog', () => {
   }));
 
   it('should dispose of dialog if view container is destroyed before animating', fakeAsync(() => {
-    const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
+    dialog.open(PizzaMsg);
 
+    expect(overlayContainerElement.querySelectorAll('mat-dialog-container').length).toBe(1);
+
+    dialog.ngOnDestroy();
     viewContainerFixture.detectChanges();
-    viewContainerFixture.destroy();
     flush();
 
     expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();


### PR DESCRIPTION
Currently the dialog's cleanup logic is tied to its exit animation completing and the close animation starting. This usually isn't a problem since by default the dialog is attached to the application ref, however if the consumer has set a viewContainerRef and that ref is destroyed before animation even starts, the exit animation event will never fire. These changes add a timeout as a fallback in case the animation doesn't start.

Fixes #17891.