### PR TITLE
fix detecting scroll behavior in edge

### DIFF
--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -30,7 +30,11 @@ let rtlScrollAxisType: RtlScrollAxisType;
 
 /** Check whether the browser supports scroll behaviors. */
 export function supportsScrollBehavior(): boolean {
-  return !!(typeof document == 'object'  && document.documentElement.style &&  document.documentElement.style.scrollBehavior);
+  return !!(
+    typeof document == 'object' &&
+    document.documentElement.style &&
+    document.documentElement.style.scrollBehavior
+  );
 }
 
 /**
@@ -75,7 +79,7 @@ export function getRtlScrollAxisType(): RtlScrollAxisType {
       // return 0 when we read it again.
       scrollContainer.scrollLeft = 1;
       rtlScrollAxisType =
-          scrollContainer.scrollLeft === 0 ? RtlScrollAxisType.NEGATED : RtlScrollAxisType.INVERTED;
+        scrollContainer.scrollLeft === 0 ? RtlScrollAxisType.NEGATED : RtlScrollAxisType.INVERTED;
     }
 
     scrollContainer.parentNode!.removeChild(scrollContainer);

--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -30,7 +30,7 @@ let rtlScrollAxisType: RtlScrollAxisType;
 
 /** Check whether the browser supports scroll behaviors. */
 export function supportsScrollBehavior(): boolean {
-  return !!(typeof document == 'object'  && 'scrollBehavior' in document.documentElement!.style);
+  return !!(typeof document == 'object'  && document.documentElement.style &&  document.documentElement.style.scrollBehavior);
 }
 
 /**


### PR DESCRIPTION
``` ts
'scrollBehavior' in document.documentElement!.style
```
 returns true after using overlay due [to this code](https://github.com/angular/components/blob/master/src/cdk/overlay/scroll/block-scroll-strategy.ts#L63). This check returns false for an edge before opening modal

from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in)
> If you set a property to undefined but do not delete it, the in operator returns true for that property.

I faced this issue in production in my app. I'm using virtual scrolling for `mat-select` in our modal. 
After trying to open select and restore the scrolling index of the selected item app crashes in the edge.
Please have a look at this issue.

This is my code to restore the index
```ts
  @ViewChild(CdkVirtualScrollViewport, { static: true }) vsViewport: CdkVirtualScrollViewport;
/// indx => index of the selected item
this.vsViewport.scrollToIndex(indx);
```