### PR TITLE
fix(form-field): deprecate `legacy` and `standard` appearances

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -75,7 +75,12 @@ class MatFormFieldBase {
 const _MatFormFieldMixinBase: CanColorCtor & typeof MatFormFieldBase =
     mixinColor(MatFormFieldBase, 'primary');
 
-/** Possible appearance styles for the form field. */
+/**
+ * Possible appearance styles for the form field.
+ *
+ * Note: The `legacy` and `standard` appearances are deprecated. Please use `fill` or `outline`.
+ * @breaking-change 11.0.0 Remove `legacy` and `standard`.
+ */
 export type MatFormFieldAppearance = 'legacy' | 'standard' | 'fill' | 'outline';
 
 /**


### PR DESCRIPTION
BREAKING CHANGES:
- The `legacy` and `standard` appearance options for `MatFormField` are
now deprecated