### PR TITLE
fix(sidenav): unable to close by pressing escape in side mode

### DIFF
--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -204,7 +204,7 @@ describe('MatDrawer', () => {
       expect(testComponent.closeCount).toBe(0, 'Expected no close events.');
       expect(testComponent.closeStartCount).toBe(0, 'Expected no close start events.');
 
-      const event = dispatchKeyboardEvent(drawer.nativeElement, 'keydown', ESCAPE);
+      const event = dispatchKeyboardEvent(document, 'keydown', ESCAPE);
       fixture.detectChanges();
       flush();
 
@@ -230,7 +230,7 @@ describe('MatDrawer', () => {
 
       const event = createKeyboardEvent('keydown', ESCAPE);
       Object.defineProperty(event, 'altKey', {get: () => true});
-      dispatchEvent(drawer.nativeElement, event);
+      dispatchEvent(document, event);
       fixture.detectChanges();
       flush();
 
@@ -258,7 +258,7 @@ describe('MatDrawer', () => {
       fixture.detectChanges();
       tick();
 
-      dispatchKeyboardEvent(drawer.nativeElement, 'keydown', ESCAPE);
+      dispatchKeyboardEvent(document, 'keydown', ESCAPE);
       fixture.detectChanges();
       tick();
 


### PR DESCRIPTION
We currently listen for `keydown` events on the sidenav so that we know when to close it, however in `side` mode we don't trap focus inside the sidenav which means that unless the user goes into the sidenav manually, the escape listener won't work. These changes fix the issue by listening to keyboard events at the `document` level.

Fixes #17965.