### PR TITLE
feat(drag-drop): add injection token for configuring the input defaults

### DIFF
--- a/src/cdk/drag-drop/directives/config.ts
+++ b/src/cdk/drag-drop/directives/config.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '@angular/core';
+import {DragRefConfig, Point, DragRef} from '../drag-ref';
+
+/** Possible values that can be used to configure the drag start delay. */
+export type DragStartDelay = number | {touch: number, mouse: number};
+
+/** Possible axis along which dragging can be locked. */
+export type DragAxis = 'x' | 'y';
+
+/** Function that can be used to constrain the position of a dragged element. */
+export type DragConstrainPosition = (point: Point, dragRef: DragRef) => Point;
+
+/** Possible orientations for a drop list. */
+export type DropListOrientation = 'horizontal' | 'vertical';
+
+/**
+ * Injection token that can be used to configure the
+ * behavior of the drag&drop-related components.
+ */
+export const CDK_DRAG_CONFIG = new InjectionToken<DragDropConfig>('CDK_DRAG_CONFIG');
+
+/**
+ * Object that can be used to configure the drag
+ * items and drop lists within a module or a component.
+ */
+export interface DragDropConfig extends Partial<DragRefConfig> {
+  lockAxis?: DragAxis;
+  dragStartDelay?: DragStartDelay;
+  constrainPosition?: DragConstrainPosition;
+  previewClass?: string | string[];
+  boundaryElement?: string;
+  rootElementSelector?: string;
+  draggingDisabled?: boolean;
+  sortingDisabled?: boolean;
+  listAutoScrollDisabled?: boolean;
+  listOrientation?: DropListOrientation;
+}
+
+/**
+ * @deprecated No longer being used. To be removed.
+ * @breaking-change 10.0.0
+ * @docs-private
+ */
+export function CDK_DRAG_CONFIG_FACTORY(): DragDropConfig {
+  return {dragStartThreshold: 5, pointerDirectionChangeThreshold: 5};
+}

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -29,11 +29,12 @@ import {of as observableOf} from 'rxjs';
 
 import {DragDropModule} from '../drag-drop-module';
 import {CdkDragDrop, CdkDragEnter} from '../drag-events';
-import {DragRefConfig, Point, DragRef} from '../drag-ref';
+import {Point, DragRef} from '../drag-ref';
 import {extendStyles} from '../drag-styling';
 import {moveItemInArray} from '../drag-utils';
 
-import {CDK_DRAG_CONFIG, CdkDrag} from './drag';
+import {CdkDrag} from './drag';
+import {CDK_DRAG_CONFIG, DragDropConfig} from './config';
 import {CdkDragHandle} from './drag-handle';
 import {CdkDropList} from './drop-list';
 import {CdkDropListGroup} from './drop-list-group';
@@ -58,7 +59,7 @@ describe('CdkDrag', () => {
                 // have to deal with thresholds.
                 dragStartThreshold: dragDistance,
                 pointerDirectionChangeThreshold: 5
-              } as DragRefConfig
+              } as DragDropConfig
             },
             ...providers
           ],
@@ -1159,6 +1160,32 @@ describe('CdkDrag', () => {
 
         expect(touchmoveEvent.defaultPrevented).toBe(true);
       }));
+
+    it('should be able to configure the drag input defaults through a provider', fakeAsync(() => {
+      const config: DragDropConfig = {
+        draggingDisabled: true,
+        dragStartDelay: 1337,
+        lockAxis: 'y',
+        constrainPosition: () => ({x: 1337, y: 42}),
+        previewClass: 'custom-preview-class',
+        boundaryElement: '.boundary',
+        rootElementSelector: '.root'
+      };
+
+      const fixture = createComponent(PlainStandaloneDraggable, [{
+        provide: CDK_DRAG_CONFIG,
+        useValue: config
+      }]);
+      fixture.detectChanges();
+      const drag = fixture.componentInstance.dragInstance;
+      expect(drag.disabled).toBe(true);
+      expect(drag.dragStartDelay).toBe(1337);
+      expect(drag.lockAxis).toBe('y');
+      expect(drag.constrainPosition).toBe(config.constrainPosition);
+      expect(drag.previewClass).toBe('custom-preview-class');
+      expect(drag.boundaryElement).toBe('.boundary');
+      expect(drag.rootElementSelector).toBe('.root');
+    }));
 
   });
 
@@ -3510,6 +3537,29 @@ describe('CdkDrag', () => {
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
           .toEqual(['One', 'Two', 'Zero', 'Three']);
     }));
+
+    it('should be able to configure the drop input defaults through a provider', fakeAsync(() => {
+      const config: DragDropConfig = {
+        draggingDisabled: true,
+        sortingDisabled: true,
+        listAutoScrollDisabled: true,
+        listOrientation: 'horizontal',
+        lockAxis: 'y'
+      };
+
+      const fixture = createComponent(PlainStandaloneDropList, [{
+        provide: CDK_DRAG_CONFIG,
+        useValue: config
+      }]);
+      fixture.detectChanges();
+      const list = fixture.componentInstance.dropList;
+      expect(list.disabled).toBe(true);
+      expect(list.sortingDisabled).toBe(true);
+      expect(list.autoScrollDisabled).toBe(true);
+      expect(list.orientation).toBe('horizontal');
+      expect(list.lockAxis).toBe('y');
+    }));
+
   });
 
   describe('in a connected drop container', () => {
@@ -5343,6 +5393,20 @@ class NestedDropZones {
   @ViewChild('outerList') outerList: ElementRef<HTMLElement>;
   @ViewChild('innerList') innerList: ElementRef<HTMLElement>;
   items = ['Zero', 'One', 'Two', 'Three'];
+}
+
+@Component({
+  template: `<div cdkDrag></div>`
+})
+class PlainStandaloneDraggable {
+  @ViewChild(CdkDrag) dragInstance: CdkDrag;
+}
+
+@Component({
+  template: `<div cdkDropList></div>`
+})
+class PlainStandaloneDropList {
+  @ViewChild(CdkDropList) dropList: CdkDropList;
 }
 
 /**

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -64,6 +64,12 @@ interface DragHelperTemplate<T = any> {
   context: T;
 }
 
+/** Point on the page or within an element. */
+export interface Point {
+  x: number;
+  y: number;
+}
+
 /**
  * Reference to a draggable item. Used to manipulate or dispose of the item.
  */
@@ -1184,12 +1190,6 @@ export class DragRef<T = any> {
 
     return value ? value.mouse : 0;
   }
-}
-
-/** Point on the page or within an element. */
-export interface Point {
-  x: number;
-  y: number;
 }
 
 /**

--- a/src/cdk/drag-drop/public-api.ts
+++ b/src/cdk/drag-drop/public-api.ts
@@ -16,6 +16,7 @@ export * from './drag-drop-module';
 export * from './drag-drop-registry';
 
 export {CdkDropList} from './directives/drop-list';
+export * from './directives/config';
 export * from './directives/drop-list-group';
 export * from './directives/drag';
 export * from './directives/drag-handle';

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -1,6 +1,6 @@
-export declare const CDK_DRAG_CONFIG: InjectionToken<DragRefConfig>;
+export declare const CDK_DRAG_CONFIG: InjectionToken<DragDropConfig>;
 
-export declare function CDK_DRAG_CONFIG_FACTORY(): DragRefConfig;
+export declare function CDK_DRAG_CONFIG_FACTORY(): DragDropConfig;
 
 export declare const CDK_DROP_LIST: InjectionToken<CdkDropList>;
 
@@ -14,10 +14,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     data: T;
     get disabled(): boolean;
     set disabled(value: boolean);
-    dragStartDelay: number | {
-        touch: number;
-        mouse: number;
-    };
+    dragStartDelay: DragStartDelay;
     dropContainer: CdkDropList;
     dropped: EventEmitter<CdkDragDrop<any>>;
     element: ElementRef<HTMLElement>;
@@ -28,7 +25,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
         x: number;
         y: number;
     };
-    lockAxis: 'x' | 'y';
+    lockAxis: DragAxis;
     moved: Observable<CdkDragMove<T>>;
     previewClass: string | string[];
     released: EventEmitter<CdkDragRelease>;
@@ -36,7 +33,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     started: EventEmitter<CdkDragStart>;
     constructor(
     element: ElementRef<HTMLElement>,
-    dropContainer: CdkDropList, _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragRefConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef);
+    dropContainer: CdkDropList, _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragDropConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef);
     getFreeDragPosition(): {
         readonly x: number;
         readonly y: number;
@@ -159,13 +156,13 @@ export declare class CdkDropList<T = any> implements AfterContentInit, OnDestroy
     entered: EventEmitter<CdkDragEnter<T>>;
     exited: EventEmitter<CdkDragExit<T>>;
     id: string;
-    lockAxis: 'x' | 'y';
-    orientation: 'horizontal' | 'vertical';
+    lockAxis: DragAxis;
+    orientation: DropListOrientation;
     sorted: EventEmitter<CdkDragSortEvent<T>>;
     sortingDisabled: boolean;
     constructor(
     element: ElementRef<HTMLElement>, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined,
-    _scrollDispatcher?: ScrollDispatcher | undefined);
+    _scrollDispatcher?: ScrollDispatcher | undefined, config?: DragDropConfig);
     drop(item: CdkDrag, currentIndex: number, previousContainer: CdkDropList, isPointerOverContainer: boolean): void;
     enter(item: CdkDrag, pointerX: number, pointerY: number): void;
     exit(item: CdkDrag): void;
@@ -192,12 +189,29 @@ export declare class CdkDropListGroup<T> implements OnDestroy {
 
 export declare function copyArrayItem<T = any>(currentArray: T[], targetArray: T[], currentIndex: number, targetIndex: number): void;
 
+export declare type DragAxis = 'x' | 'y';
+
+export declare type DragConstrainPosition = (point: Point, dragRef: DragRef) => Point;
+
 export declare class DragDrop {
     constructor(_document: any, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRef>);
     createDrag<T = any>(element: ElementRef<HTMLElement> | HTMLElement, config?: DragRefConfig): DragRef<T>;
     createDropList<T = any>(element: ElementRef<HTMLElement> | HTMLElement): DropListRef<T>;
     static ɵfac: i0.ɵɵFactoryDef<DragDrop>;
     static ɵprov: i0.ɵɵInjectableDef<DragDrop>;
+}
+
+export interface DragDropConfig extends Partial<DragRefConfig> {
+    boundaryElement?: string;
+    constrainPosition?: DragConstrainPosition;
+    dragStartDelay?: DragStartDelay;
+    draggingDisabled?: boolean;
+    listAutoScrollDisabled?: boolean;
+    listOrientation?: DropListOrientation;
+    lockAxis?: DragAxis;
+    previewClass?: string | string[];
+    rootElementSelector?: string;
+    sortingDisabled?: boolean;
 }
 
 export declare class DragDropModule {
@@ -299,6 +313,13 @@ export interface DragRefConfig {
     dragStartThreshold: number;
     pointerDirectionChangeThreshold: number;
 }
+
+export declare type DragStartDelay = number | {
+    touch: number;
+    mouse: number;
+};
+
+export declare type DropListOrientation = 'horizontal' | 'vertical';
 
 export declare class DropListRef<T = any> {
     autoScrollDisabled: boolean;


### PR DESCRIPTION
Adds an injection token that allows consumers to change the defaults of the various options in the `drag-drop` module. Also moves some repeated inline types into shared ones.

Fixes #17921.