### PR TITLE
build: enable strict attribute type checking

### DIFF
--- a/src/a11y-demo/dialog/dialog-neptune-a11y.html
+++ b/src/a11y-demo/dialog/dialog-neptune-a11y.html
@@ -22,6 +22,6 @@
     Read more on Wikipedia
   </a>
 
-  <button mat-button color="secondary" (click)="showInStackedDialog()">
+  <button mat-button color="accent" (click)="showInStackedDialog()">
     Show in dialog</button>
 </mat-dialog-actions>

--- a/src/a11y-demo/progress-spinner/progress-spinner-a11y.html
+++ b/src/a11y-demo/progress-spinner/progress-spinner-a11y.html
@@ -1,6 +1,6 @@
 <section>
   <h2>Loading indicator (Indeterminate progress spinner)</h2>
-  <mat-spinner color="indeterminate" [strokeWidth]="1" aria-label="Loading"></mat-spinner>
+  <mat-spinner mode="indeterminate" [strokeWidth]="1" aria-label="Loading"></mat-spinner>
   <mat-spinner color="accent" aria-label="Loading"></mat-spinner>
 </section>
 

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
@@ -86,11 +86,11 @@ Not yet implemented.
 
 <nav mat-tab-nav-bar>
  <a mat-tab-link href="https://google.com">Google</a>
- <a mat-tab-link href="https://google.com" active>Also Google</a>
+ <a mat-tab-link href="https://google.com" [active]="true">Also Google</a>
 </nav>
 
 <h2>Progress bar</h2>
-<mat-progress-bar value="25"></mat-progress-bar>
-<mat-progress-bar mode="buffer" value="25" bufferValue="60"></mat-progress-bar>
+<mat-progress-bar [value]="25"></mat-progress-bar>
+<mat-progress-bar mode="buffer" [value]="25" [bufferValue]="60"></mat-progress-bar>
 <mat-progress-bar mode="indeterminate"></mat-progress-bar>
 <mat-progress-bar mode="query"></mat-progress-bar>

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -157,7 +157,7 @@
 <h2>Progress bar</h2>
 
 <mat-progress-bar value="25"></mat-progress-bar>
-<mat-progress-bar mode="buffer" value="25" bufferValue="60"></mat-progress-bar>
+<mat-progress-bar mode="buffer" value="25" [bufferValue]="60"></mat-progress-bar>
 <mat-progress-bar mode="indeterminate"></mat-progress-bar>
 <mat-progress-bar mode="query"></mat-progress-bar>
 
@@ -225,7 +225,7 @@
 
 <nav mat-tab-nav-bar>
  <a mat-tab-link href="https://google.com">Google</a>
- <a mat-tab-link href="https://google.com" active>Also Google</a>
+ <a mat-tab-link href="https://google.com" [active]="true">Also Google</a>
 </nav>
 
 <h2>Paginator</h2>

--- a/tools/bazel/postinstall-patches.js
+++ b/tools/bazel/postinstall-patches.js
@@ -12,7 +12,7 @@ const fs = require('fs');
  * Version of the post install patch. Needs to be incremented when patches
  * have been added or removed.
  */
-const PATCH_VERSION = 1;
+const PATCH_VERSION = 2;
 
 /** Path to the project directory. */
 const projectDir = path.join(__dirname, '../..');
@@ -120,7 +120,6 @@ searchAndReplace(`[formatProperty + "_ivy_ngcc"]`, '[formatProperty]',
 searchAndReplace(/angular_compiler_options = {/, `$&
         "strictTemplates": True,
         "strictDomLocalRefTypes ": False,
-        "strictAttributeTypes": False,
         "strictDomEventTypes": False,`, 'node_modules/@angular/bazel/src/ng_module.bzl');
 
 // More info in https://github.com/angular/angular/pull/33786


### PR DESCRIPTION
When we initially enabled strict template type checking in the
components repository, we temporarily disabled the strict attribute
type checking due to an issue with `NgModel` and the disabled input.

`NgModel` seems to behave as expected and the issue we are facing for
some elements where `NgModel#disabled` is incompatible with the
disabled input of Angular Material components (where string is allowed)
is correctly reported by ngtsc.

We can satisfy both input signatures and actually enable the flag to
catch attribute typing/coercion issues which are actually affecting
components we ship.