### PR TITLE
feat(a11y): allow to queue announcements in LiveAnnouncer

### DIFF
--- a/src/cdk/a11y/live-announcer/live-announcer-tokens.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer-tokens.ts
@@ -32,6 +32,12 @@ export interface LiveAnnouncerDefaultOptions {
 
   /** Default duration for the announcement messages. */
   duration?: number;
+
+  /**
+   * Indicates whether announcements should be queued or each next one should
+   * override the previous one.
+   */
+  useQueue?: boolean;
 }
 
 /** Injection token that can be used to configure the default options for the LiveAnnouncer. */

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -238,6 +238,125 @@ describe('LiveAnnouncer', () => {
 
   });
 
+  describe('with a queue', () => {
+    beforeEach(() => {
+      return TestBed.configureTestingModule({
+        imports: [A11yModule],
+        declarations: [TestApp],
+        providers: [{
+          provide: LIVE_ANNOUNCER_DEFAULT_OPTIONS,
+          useValue: {
+            useQueue: true,
+          } as LiveAnnouncerDefaultOptions,
+        }],
+      });
+    });
+
+    beforeEach(fakeAsync(inject([LiveAnnouncer], (la: LiveAnnouncer) => {
+      announcer = la;
+    })));
+
+    afterEach(() => {
+      getLiveElements().forEach((el) => {
+        document.body.removeChild(el);
+      });
+    });
+
+    it('should apply the aria-live value polite by default', fakeAsync(() => {
+      // There is a live element for the non-queue announcer.
+      expect(getLiveElements().length).toBe(1);
+
+      announcer.announce('Hey Google');
+      tick(100);
+
+      expect(getLiveElements().length).toBe(2);
+      const liveElement = getLiveElements()[1];
+      expect(liveElement.textContent).toBe('Hey Google');
+      expect(liveElement.getAttribute('aria-live')).toBe('polite');
+      tick(1000);
+    }));
+
+    it('should correctly update the politeness attribute', fakeAsync(() => {
+      // There is a live element for the non-queue announcer.
+      expect(getLiveElements().length).toBe(1);
+
+      announcer.announce('Hey Google', 'assertive');
+      tick(100);
+
+      expect(getLiveElements().length).toBe(2);
+      const liveElement = getLiveElements()[1];
+      expect(liveElement.textContent).toBe('Hey Google');
+      expect(liveElement.getAttribute('aria-live')).toBe('assertive');
+      tick(1000);
+    }));
+
+    it('clears an announcement after a delay', fakeAsync(() => {
+      // There is a live element for the non-queue announcer.
+      expect(getLiveElements().length).toBe(1);
+      announcer.announce('Hey Google', 200);
+      tick(100);
+
+      // Announcement was added.
+      const announcements = getLiveElements();
+      expect(announcements.length).toBe(2);
+      expect(announcements[1].textContent).toBe('Hey Google');
+
+      // Announcement was removed.
+      tick(200);
+      expect(getLiveElements().length).toBe(1);
+    }));
+
+    it('clears an announcement after 1s by default', fakeAsync(() => {
+      // There is a live element for the non-queue announcer.
+      expect(getLiveElements().length).toBe(1);
+
+      announcer.announce('Hey Google');
+      tick(100);
+
+      // Announcement was added.
+      const announcements = getLiveElements();
+      expect(announcements.length).toBe(2);
+      expect(announcements[1].textContent).toBe('Hey Google');
+
+      // Announcement still here.
+      tick(999);
+      expect(getLiveElements().length).toBe(2);
+      // Announcement was removed.
+      tick(1);
+      expect(getLiveElements().length).toBe(1);
+    }));
+
+    it('announces messages with a delay between them', fakeAsync(() => {
+      // There is a live element for the non-queue announcer.
+      expect(getLiveElements().length).toBe(1);
+      announcer.announce('Hey');
+      announcer.announce('Google');
+
+      const announcements = getLiveElements();
+      const helloAnnouncement = announcements[1];
+      const worldAnnouncement = announcements[2];
+      // There are no messages at first, we just added the elements to let screen
+      // readers notice that there are aria-live sections on the page.
+      expect(helloAnnouncement.textContent).toBe('');
+      expect(worldAnnouncement.textContent).toBe('');
+
+      // Wait for the first message to be added.
+      tick(100);
+      expect(helloAnnouncement.textContent).toBe('Hey');
+      expect(worldAnnouncement.textContent).toBe('');
+
+      // Wait for the second message to be added.
+      tick(100);
+      expect(helloAnnouncement.textContent).toBe('Hey');
+      expect(worldAnnouncement.textContent).toBe('Google');
+
+      // Wait for messages to be removed.
+      tick(1000);
+      expect(getLiveElements().length).toBe(1);
+    }));
+
+  });
+
 });
 
 describe('CdkAriaLive', () => {
@@ -329,6 +448,10 @@ describe('CdkAriaLive', () => {
 
 function getLiveElement(): Element {
   return document.body.querySelector('.cdk-live-announcer-element')!;
+}
+
+function getLiveElements(): NodeListOf<Element> {
+  return document.body.querySelectorAll('.cdk-live-announcer-element') as NodeListOf<Element>;
 }
 
 @Component({template: `<button (click)="announceText('Test')">Announce</button>`})

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -25,7 +25,31 @@ import {
   LIVE_ANNOUNCER_ELEMENT_TOKEN,
   LIVE_ANNOUNCER_DEFAULT_OPTIONS,
 } from './live-announcer-tokens';
+import {TaskQueue} from './task-queue';
 
+/**
+ * The amount of time to wait between adding an announcer into the DOM and
+ * setting the text to it (causing it to be read). Notes on this value:
+ * This 100ms timeout is necessary for some browser + screen-reader combinations:
+ * - Both JAWS and NVDA over IE11 will not announce anything without a non-zero timeout.
+ * - With Chrome and IE11 with NVDA or JAWS, a repeated (identical) message won't be read a
+ *   second time without clearing and then using a non-zero delay.
+ * (using JAWS 17 at time of this writing).
+ */
+const ARIA_LIVE_ANNOUNCER_DELAY_MS = 100;
+
+/**
+ * The amount of time after a live announcement is added to the DOM before it's
+ * removed. This keeps the announcement node in the DOM for long enough for the
+ * screen reader to pick it up and announce it, but it doesn't linger on the
+ * page as the user continues browsing to the end of the document. From testing,
+ * queued live announce messages are read, even if the node containing them is
+ * removed before the message starts playing.
+ */
+const ARIA_LIVE_ANNOUNCER_REMOVAL_DELAY_MS = 1000;
+
+/** Class for the hidden div element with an aria-live attribute. */
+const LIVE_ELEMENT_CLASS = 'cdk-live-announcer-element';
 
 @Injectable({providedIn: 'root'})
 export class LiveAnnouncer implements OnDestroy {
@@ -36,6 +60,7 @@ export class LiveAnnouncer implements OnDestroy {
   constructor(
       @Optional() @Inject(LIVE_ANNOUNCER_ELEMENT_TOKEN) elementToken: any,
       private _ngZone: NgZone,
+      private _taskQueue: TaskQueue,
       @Inject(DOCUMENT) _document: any,
       @Optional() @Inject(LIVE_ANNOUNCER_DEFAULT_OPTIONS)
       private _defaultOptions?: LiveAnnouncerDefaultOptions) {
@@ -44,6 +69,7 @@ export class LiveAnnouncer implements OnDestroy {
     // reference browser globals (HTMLElement, Document) on non-browser environments, since having
     // a class decorator causes TypeScript to preserve the constructor signature types.
     this._document = _document;
+    this._removePreviousLiveElements();
     this._liveElement = elementToken || this._createLiveElement();
   }
 
@@ -106,27 +132,11 @@ export class LiveAnnouncer implements OnDestroy {
       duration = defaultOptions.duration;
     }
 
-    // TODO: ensure changing the politeness works on all environments we support.
-    this._liveElement.setAttribute('aria-live', politeness);
-
-    // This 100ms timeout is necessary for some browser + screen-reader combinations:
-    // - Both JAWS and NVDA over IE11 will not announce anything without a non-zero timeout.
-    // - With Chrome and IE11 with NVDA or JAWS, a repeated (identical) message won't be read a
-    //   second time without clearing and then using a non-zero delay.
-    // (using JAWS 17 at time of this writing).
-    return this._ngZone.runOutsideAngular(() => {
-      return new Promise(resolve => {
-        clearTimeout(this._previousTimeout);
-        this._previousTimeout = setTimeout(() => {
-          this._liveElement.textContent = message;
-          resolve();
-
-          if (typeof duration === 'number') {
-            this._previousTimeout = setTimeout(() => this.clear(), duration);
-          }
-        }, 100);
-      });
-    });
+    if (defaultOptions && defaultOptions.useQueue) {
+      return this._enqueueAnnouncement(message, politeness, duration);
+    } else {
+      return this._announceImmediately(message, politeness, duration);
+    }
   }
 
   /**
@@ -149,17 +159,59 @@ export class LiveAnnouncer implements OnDestroy {
     }
   }
 
-  private _createLiveElement(): HTMLElement {
-    const elementClass = 'cdk-live-announcer-element';
-    const previousElements = this._document.getElementsByClassName(elementClass);
-    const liveEl = this._document.createElement('div');
+  private _enqueueAnnouncement(
+      message: string, politeness: AriaLivePoliteness, duration?: number): Promise<void> {
+    const liveElement = this._createLiveElement();
+    // TODO: ensure changing the politeness works on all environments we support.
+    liveElement.setAttribute('aria-live', politeness);
 
+    return new Promise(resolve => {
+      this._taskQueue.enqueue(() => {
+        liveElement.textContent = message;
+        resolve();
+
+        duration = duration ? duration : ARIA_LIVE_ANNOUNCER_REMOVAL_DELAY_MS;
+        this._ngZone.runOutsideAngular(() => {
+          setTimeout(() => {
+            this._document.body.removeChild(liveElement);
+          }, duration);
+        });
+      }, politeness, ARIA_LIVE_ANNOUNCER_DELAY_MS);
+    });
+  }
+
+  private _announceImmediately(
+      message: string, politeness: AriaLivePoliteness, duration?: number): Promise<void> {
+    // TODO: ensure changing the politeness works on all environments we support.
+    this._liveElement.setAttribute('aria-live', politeness);
+
+    return this._ngZone.runOutsideAngular(() => {
+      return new Promise(resolve => {
+        clearTimeout(this._previousTimeout);
+        this._previousTimeout = setTimeout(() => {
+          this._liveElement.textContent = message;
+          resolve();
+
+          if (typeof duration === 'number') {
+            this._previousTimeout = setTimeout(() => this.clear(), duration);
+          }
+        }, ARIA_LIVE_ANNOUNCER_DELAY_MS);
+      });
+    });
+  }
+
+  private _removePreviousLiveElements(): void {
+    const previousElements = this._document.getElementsByClassName(LIVE_ELEMENT_CLASS);
     // Remove any old containers. This can happen when coming in from a server-side-rendered page.
     for (let i = 0; i < previousElements.length; i++) {
       previousElements[i].parentNode!.removeChild(previousElements[i]);
     }
+  }
 
-    liveEl.classList.add(elementClass);
+  private _createLiveElement(): HTMLElement {
+    const liveEl = this._document.createElement('div');
+
+    liveEl.classList.add(LIVE_ELEMENT_CLASS);
     liveEl.classList.add('cdk-visually-hidden');
 
     liveEl.setAttribute('aria-atomic', 'true');

--- a/src/cdk/a11y/live-announcer/task-queue.spec.ts
+++ b/src/cdk/a11y/live-announcer/task-queue.spec.ts
@@ -1,0 +1,89 @@
+import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+
+import {TaskQueue} from './task-queue';
+
+import {A11yModule} from '../index';
+
+describe('TaskQueue', () => {
+  let taskQueue: TaskQueue;
+
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [A11yModule],
+  }));
+
+  beforeEach(fakeAsync(inject([TaskQueue], (tq: TaskQueue) => {
+    taskQueue = tq;
+  })));
+
+  it('runs a task', fakeAsync(() => {
+    let ran = false;
+
+    taskQueue.enqueue(() => {
+      ran = true;
+    }, 'polite', 5);
+
+    // Task is scheduled but not executed yet.
+    expect(ran).toBe(false);
+    // Wait for execution.
+    tick(5);
+    // Task is executed.
+    expect(ran).toBe(true);
+  }));
+
+  it('runs tasks in order', fakeAsync(() => {
+    const ran: number[] = [];
+
+    taskQueue.enqueue(() => {
+      ran.push(1);
+    }, 'polite', 5);
+    taskQueue.enqueue(() => {
+      expect(ran).toEqual([1]);
+      ran.push(2);
+    }, 'polite', 5);
+    taskQueue.enqueue(() => {
+      expect(ran).toEqual([1, 2]);
+      ran.push(3);
+    }, 'polite', 5);
+
+    // Tasks are scheduled but not executed yet.
+    expect(ran).toEqual([]);
+    // Wait for task 1 execution.
+    tick(5);
+    // Task 1 executed, tasks 2 and 3 are pending.
+    expect(ran).toEqual([1]);
+    // Wait for all tasks.
+    tick(10);
+    // All tasks are executed.
+    expect(ran).toEqual([1, 2, 3]);
+  }));
+
+  it('inserts assertive tasks above polite ones in the queue', fakeAsync(() => {
+    const ran: number[] = [];
+
+    taskQueue.enqueue(() => {
+      ran.push(1);
+    }, 'assertive', 5);
+    taskQueue.enqueue(() => {
+      expect(ran).toEqual([1, 3]);
+      ran.push(2);
+    }, 'polite', 5);
+    taskQueue.enqueue(() => {
+      expect(ran).toEqual([1]);
+      ran.push(3);
+    }, 'assertive', 5);
+
+    // Tasks are scheduled but not executed yet.
+    expect(ran).toEqual([]);
+    // Wait for the first assertive task execution.
+    tick(5);
+    // Task 1 executed, tasks 2 and 3 are pending.
+    expect(ran).toEqual([1]);
+    // Wait for the second assertive task execution.
+    tick(5);
+    expect(ran).toEqual([1, 3]);
+    // Wait for the remaining task.
+    tick(5);
+    expect(ran).toEqual([1, 3, 2]);
+  }));
+});
+

--- a/src/cdk/a11y/live-announcer/task-queue.ts
+++ b/src/cdk/a11y/live-announcer/task-queue.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable, NgZone} from '@angular/core';
+
+import {AriaLivePoliteness} from './live-announcer-tokens';
+
+interface TaskInfo {
+  delay: number;
+  politeness: AriaLivePoliteness;
+  task: () => void;
+}
+
+/**
+ * Queue which executes given tasks with a provided delay between them. It makes sure that screen
+ * readers are able to detect DOM changes. E.g. calling enqueue(foo, 1000), enqueu(bar, 1000)
+ * will execute foo with a 1s delay and bar with a 2s delay.
+ */
+@Injectable({providedIn: 'root'})
+export class TaskQueue {
+  private readonly _queue: TaskInfo[] = [];
+  private _executing = false;
+
+  constructor(private _ngZone: NgZone) {}
+
+  /**
+   * Schedules the `task` for execution in `delay` milliseconds after the last task in the queue
+   * is executed.
+   */
+  enqueue(task: () => void, politeness: AriaLivePoliteness, delay = 0): void {
+    const taskInfo = {delay, politeness, task};
+    this._queue.splice(this._findInsertionIndex(taskInfo), 0, taskInfo);
+    this._run();
+  }
+
+  /**
+   * Assertive tasks should be inserted at the top of the queue right after existing assertive
+   * tasks. Polite tasks should be inserted at the end of the queue.
+   */
+  private _findInsertionIndex(task: TaskInfo) {
+    if (task.politeness === 'assertive') {
+      for (let i = 0; i < this._queue.length; i++) {
+        if (this._queue[i].politeness === 'polite') {
+          return i;
+        }
+      }
+    }
+    return this._queue.length;
+  }
+
+  /**
+   * Does nothing if the queue is empty or some task is already executed. Otherwise dequeues
+   * the next task and runs it with a previously provided delay.
+   */
+  private _run(): void {
+    if (this._queue.length === 0) {
+      // Nothing left to run.
+      return;
+    }
+    if (this._executing) {
+      // Already doing something.
+      return;
+    }
+
+    const {delay, task} = this._queue.shift()!;
+    this._executing = true;
+    this._ngZone.runOutsideAngular(() => {
+      setTimeout(() => {
+        task();
+        this._executing = false;
+        this._run();
+      }, delay);
+    });
+  }
+}
+

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -176,7 +176,7 @@ export declare const LIVE_ANNOUNCER_ELEMENT_TOKEN: InjectionToken<HTMLElement | 
 export declare function LIVE_ANNOUNCER_ELEMENT_TOKEN_FACTORY(): null;
 
 export declare class LiveAnnouncer implements OnDestroy {
-    constructor(elementToken: any, _ngZone: NgZone, _document: any, _defaultOptions?: LiveAnnouncerDefaultOptions | undefined);
+    constructor(elementToken: any, _ngZone: NgZone, _taskQueue: TaskQueue, _document: any, _defaultOptions?: LiveAnnouncerDefaultOptions | undefined);
     announce(message: string): Promise<void>;
     announce(message: string, politeness?: AriaLivePoliteness): Promise<void>;
     announce(message: string, duration?: number): Promise<void>;
@@ -190,6 +190,7 @@ export declare class LiveAnnouncer implements OnDestroy {
 export interface LiveAnnouncerDefaultOptions {
     duration?: number;
     politeness?: AriaLivePoliteness;
+    useQueue?: boolean;
 }
 
 export declare const MESSAGES_CONTAINER_ID = "cdk-describedby-message-container";


### PR DESCRIPTION
Standard LiveAnnouncer operates with a single aria-live element, which means that if several
announcements happen at the same time, only the latest one is actually announced. This change adds
`useQueue` configuration to LiveAnnouncerDefaultOptions. When it's set to `true` LiveAnnouncer
creates a separate aria-live element for each of the announcements and places all messages in
the queue, so they are announced one by one.

Fixes #17852