### PR TITLE
build: add script to deploy dev-app web package to firebase

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "dist/devapp-deploy",
+    "public": "dist/dev-app-web-pkg",
     "rewrites": [
       {
         "source": "/**/!(*.@(js|ts|html|css|json|svg|png|jpg|jpeg))",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test-firefox": "bazel test //src/... --test_tag_filters=-e2e,-browser:chromium-local --build_tag_filters=-browser:chromium-local --build_tests_only",
     "lint": "yarn -s tslint && yarn -s bazel:format-lint && yarn -s ownerslint",
     "e2e": "bazel test //src/... --test_tag_filters=e2e",
-    "deploy": "echo 'Not supported yet. Tracked with COMP-230'",
+    "deploy-dev-app": "node ./scripts/deploy-dev-app.js",
     "webdriver-manager": "webdriver-manager",
     "breaking-changes": "ts-node --project scripts scripts/breaking-changes.ts",
     "gulp": "gulp",

--- a/scripts/deploy-dev-app.js
+++ b/scripts/deploy-dev-app.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/**
+ * Script that builds the dev-app as a static web package that will be
+ * deployed to the currently configured Firebase project.
+ */
+
+const {exec, set, cd, cp, rm} = require('shelljs');
+const {join} = require('path');
+
+// ShellJS should throw if any command fails.
+set('-e');
+
+/** Path to the project directory. */
+const projectDirPath = join(__dirname, '../');
+
+// Go to project directory.
+cd(projectDirPath);
+
+/** Path to the bazel-bin directory. */
+const bazelBinPath = exec(`yarn -s bazel info bazel-bin`).stdout.trim();
+
+/** Output path for the Bazel dev-app web package target. */
+const webPackagePath = join(bazelBinPath, 'src/dev-app/web_package');
+
+/** Destination path where the web package should be copied to. */
+const distPath = join(projectDirPath, 'dist/dev-app-web-pkg');
+
+// Build web package output.
+exec('yarn -s bazel build //src/dev-app:web_package');
+
+// Clear previous deployment artifacts.
+rm('-Rf', distPath);
+
+// Copy the web package from the bazel-bin directory to the project dist
+// path. This is necessary because the Firebase CLI does not support deployment
+// of a public folder outside of the "firebase.json" file.
+cp('-R', webPackagePath, distPath);
+
+// Run the Firebase CLI to deploy the hosting target.
+exec(`yarn -s firebase deploy --only hosting`);


### PR DESCRIPTION
Creates a script that can be used to deploy the dev-app to firebase. Similar to the old gulp task that did the same.