### PR TITLE
feat(button-toggle): add test harness

### DIFF
--- a/src/material/button-toggle/testing/BUILD.bazel
+++ b/src/material/button-toggle/testing/BUILD.bazel
@@ -1,0 +1,57 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material/button-toggle/testing",
+    deps = [
+        "//src/cdk/coercion",
+        "//src/cdk/testing",
+        "//src/material/button-toggle",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob(["**/*.ts"]),
+)
+
+ng_test_library(
+    name = "harness_tests_lib",
+    srcs = [
+        "button-toggle-group-shared.spec.ts",
+        "button-toggle-shared.spec.ts",
+    ],
+    deps = [
+        ":testing",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/button-toggle",
+    ],
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = [
+            "button-toggle-shared.spec.ts",
+            "button-toggle-group-shared.spec.ts",
+        ],
+    ),
+    deps = [
+        ":harness_tests_lib",
+        ":testing",
+        "//src/material/button-toggle",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [":unit_tests_lib"],
+)

--- a/src/material/button-toggle/testing/button-toggle-group-harness-filters.ts
+++ b/src/material/button-toggle/testing/button-toggle-group-harness-filters.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+/** Criteria that can be used to filter a list of `MatButtonToggleGroupHarness` instances. */
+export interface ButtonToggleGroupHarnessFilters extends BaseHarnessFilters {
+}

--- a/src/material/button-toggle/testing/button-toggle-group-harness.ts
+++ b/src/material/button-toggle/testing/button-toggle-group-harness.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {MatButtonToggleAppearance} from '@angular/material/button-toggle';
+import {ButtonToggleGroupHarnessFilters} from './button-toggle-group-harness-filters';
+import {ButtonToggleHarnessFilters} from './button-toggle-harness-filters';
+import {MatButtonToggleHarness} from './button-toggle-harness';
+
+
+/** Harness for interacting with a standard mat-button-toggle in tests. */
+export class MatButtonToggleGroupHarness extends ComponentHarness {
+  /** The selector for the host element of a `MatButton` instance. */
+  static hostSelector = 'mat-button-toggle-group';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatButtonToggleGroupHarness`
+   * that meets certain criteria.
+   * @param options Options for filtering which button toggle instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: ButtonToggleGroupHarnessFilters = {}):
+    HarnessPredicate<MatButtonToggleGroupHarness> {
+    return new HarnessPredicate(MatButtonToggleGroupHarness, options);
+  }
+
+  /**
+   * Gets the button toggles that are inside the group.
+   * @param filter Optionally filters which toggles are included.
+   */
+  async getToggles(filter: ButtonToggleHarnessFilters = {}): Promise<MatButtonToggleHarness[]> {
+    return this.locatorForAll(MatButtonToggleHarness.with(filter))();
+  }
+
+  /** Gets whether the button toggle group is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-disabled') === 'true';
+  }
+
+  /** Gets whether the button toggle group is laid out vertically. */
+  async isVertical(): Promise<boolean> {
+    return (await this.host()).hasClass('mat-button-toggle-vertical');
+  }
+
+  /** Gets the appearance that the group is using. */
+  async getAppearance(): Promise<MatButtonToggleAppearance> {
+    const host = await this.host();
+    const className = 'mat-button-toggle-group-appearance-standard';
+    return await host.hasClass(className) ? 'standard' : 'legacy';
+  }
+}

--- a/src/material/button-toggle/testing/button-toggle-group-shared.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-group-shared.spec.ts
@@ -1,0 +1,72 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatButtonToggleModule, MatButtonToggleAppearance} from '@angular/material/button-toggle';
+import {MatButtonToggleGroupHarness} from './button-toggle-group-harness';
+
+/** Shared tests to run on both the original and MDC-based button toggle group. */
+export function runHarnessTests(
+    buttonToggleModule: typeof MatButtonToggleModule,
+    buttonToggleGroupHarness: typeof MatButtonToggleGroupHarness) {
+  let fixture: ComponentFixture<ButtonToggleGroupHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [buttonToggleModule],
+      declarations: [ButtonToggleGroupHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ButtonToggleGroupHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load all button toggle group harnesses', async () => {
+    const groups = await loader.getAllHarnesses(buttonToggleGroupHarness);
+    expect(groups.length).toBe(1);
+  });
+
+  it('should load the the toggles inside the group', async () => {
+    const group = await loader.getHarness(buttonToggleGroupHarness);
+    const toggles = await group.getToggles();
+    expect(toggles.length).toBe(2);
+  });
+
+  it('should get whether the group is disabled', async () => {
+    const group = await loader.getHarness(buttonToggleGroupHarness);
+    expect(await group.isDisabled()).toBe(false);
+    fixture.componentInstance.disabled = true;
+    expect(await group.isDisabled()).toBe(true);
+  });
+
+  it('should get whether the group is vertical', async () => {
+    const group = await loader.getHarness(buttonToggleGroupHarness);
+    expect(await group.isVertical()).toBe(false);
+    fixture.componentInstance.vertical = true;
+    expect(await group.isVertical()).toBe(true);
+  });
+
+  it('should get whether the group appearance', async () => {
+    const group = await loader.getHarness(buttonToggleGroupHarness);
+    expect(await group.getAppearance()).toBe('standard');
+    fixture.componentInstance.appearance = 'legacy';
+    expect(await group.getAppearance()).toBe('legacy');
+  });
+}
+
+@Component({
+  template: `
+    <mat-button-toggle-group [disabled]="disabled" [vertical]="vertical" [appearance]="appearance">
+      <mat-button-toggle value="1">One</mat-button-toggle>
+      <mat-button-toggle value="2">Two</mat-button-toggle>
+    </mat-button-toggle-group>
+  `
+})
+class ButtonToggleGroupHarnessTest {
+  disabled = false;
+  vertical = false;
+  appearance: MatButtonToggleAppearance = 'standard';
+}
+

--- a/src/material/button-toggle/testing/button-toggle-group.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-group.spec.ts
@@ -1,0 +1,7 @@
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {runHarnessTests} from './button-toggle-group-shared.spec';
+import {MatButtonToggleGroupHarness} from './button-toggle-group-harness';
+
+describe('Non-MDC-based MatButtonToggleGroupHarness', () => {
+  runHarnessTests(MatButtonToggleModule, MatButtonToggleGroupHarness);
+});

--- a/src/material/button-toggle/testing/button-toggle-harness-filters.ts
+++ b/src/material/button-toggle/testing/button-toggle-harness-filters.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+/** Criteria that can be used to filter a list of `MatButtonToggleHarness` instances. */
+export interface ButtonToggleHarnessFilters extends BaseHarnessFilters {
+  /** Only find instances whose text matches the given value. */
+  text?: string | RegExp;
+  /** Only find instances whose name matches the given value. */
+  name?: string | RegExp;
+  /** Only find instances that are checked. */
+  checked?: boolean;
+}

--- a/src/material/button-toggle/testing/button-toggle-harness.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {runHarnessTests} from './button-toggle-shared.spec';
+import {MatButtonToggleHarness} from './button-toggle-harness';
+
+describe('Non-MDC-based MatButtonToggleHarness', () => {
+  runHarnessTests(MatButtonToggleModule, MatButtonToggleHarness);
+});

--- a/src/material/button-toggle/testing/button-toggle-harness.ts
+++ b/src/material/button-toggle/testing/button-toggle-harness.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {MatButtonToggleAppearance} from '@angular/material/button-toggle';
+import {ButtonToggleHarnessFilters} from './button-toggle-harness-filters';
+
+
+/** Harness for interacting with a standard mat-button-toggle in tests. */
+export class MatButtonToggleHarness extends ComponentHarness {
+  /** The selector for the host element of a `MatButton` instance. */
+  static hostSelector = 'mat-button-toggle';
+
+  private _label = this.locatorFor('.mat-button-toggle-label-content');
+  private _button = this.locatorFor('.mat-button-toggle-button');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatButtonToggleHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which button toggle instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: ButtonToggleHarnessFilters = {}): HarnessPredicate<MatButtonToggleHarness> {
+    return new HarnessPredicate(MatButtonToggleHarness, options)
+        .addOption('text', options.text,
+            (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text))
+        .addOption('name', options.name,
+            (harness, name) => HarnessPredicate.stringMatches(harness.getName(), name))
+        .addOption('checked', options.checked,
+            async (harness, checked) => (await harness.isChecked()) === checked);
+  }
+
+  /** Gets a boolean promise indicating if the button toggle is checked. */
+  async isChecked(): Promise<boolean> {
+    const checked = (await this._button()).getAttribute('aria-pressed');
+    return coerceBooleanProperty(await checked);
+  }
+
+  /** Gets a boolean promise indicating if the button toggle is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const disabled = (await this._button()).getAttribute('disabled');
+    return coerceBooleanProperty(await disabled);
+  }
+
+  /** Gets a promise for the button toggle's name. */
+  async getName(): Promise<string | null> {
+    return (await this._button()).getAttribute('name');
+  }
+
+  /** Gets a promise for the button toggle's aria-label. */
+  async getAriaLabel(): Promise<string | null> {
+    return (await this._button()).getAttribute('aria-label');
+  }
+
+  /** Gets a promise for the button toggles's aria-labelledby. */
+  async getAriaLabelledby(): Promise<string | null> {
+    return (await this._button()).getAttribute('aria-labelledby');
+  }
+
+  /** Gets a promise for the button toggle's text. */
+  async getText(): Promise<string> {
+    return (await this._label()).text();
+  }
+
+  /** Gets the appearance that the button toggle is using. */
+  async getAppearance(): Promise<MatButtonToggleAppearance> {
+    const host = await this.host();
+    const className = 'mat-button-toggle-appearance-standard';
+    return await host.hasClass(className) ? 'standard' : 'legacy';
+  }
+
+  /** Focuses the toggle. */
+  async focus(): Promise<void> {
+    return (await this._button()).focus();
+  }
+
+  /** Blurs the toggle. */
+  async blur(): Promise<void> {
+    return (await this._button()).blur();
+  }
+
+  /** Toggle the checked state of the buttons toggle. */
+  async toggle(): Promise<void> {
+    return (await this._button()).click();
+  }
+
+  /**
+   * Puts the button toggle in a checked state by toggling it if it's
+   * currently unchecked, or doing nothing if it is already checked.
+   */
+  async check(): Promise<void> {
+    if (!(await this.isChecked())) {
+      await this.toggle();
+    }
+  }
+
+  /**
+   * Puts the button toggle in an unchecked state by toggling it if it's
+   * currently checked, or doing nothing if it's already unchecked.
+   */
+  async uncheck(): Promise<void> {
+    if (await this.isChecked()) {
+      await this.toggle();
+    }
+  }
+}

--- a/src/material/button-toggle/testing/button-toggle-shared.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-shared.spec.ts
@@ -1,0 +1,146 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatButtonToggleHarness} from './button-toggle-harness';
+
+/** Shared tests to run on both the original and MDC-based button toggles. */
+export function runHarnessTests(
+    buttonToggleModule: typeof MatButtonToggleModule,
+    buttonToggleHarness: typeof MatButtonToggleHarness) {
+  let fixture: ComponentFixture<ButtonToggleHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [buttonToggleModule],
+      declarations: [ButtonToggleHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ButtonToggleHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load all button toggle harnesses', async () => {
+    const toggles = await loader.getAllHarnesses(buttonToggleHarness);
+    expect(toggles.length).toBe(2);
+  });
+
+  it('should load a button toggle with exact label', async () => {
+    const toggles = await loader.getAllHarnesses(buttonToggleHarness.with({text: 'First'}));
+    expect(toggles.length).toBe(1);
+    expect(await toggles[0].getText()).toBe('First');
+  });
+
+  it('should load a button toggle with regex label match', async () => {
+    const toggles = await loader.getAllHarnesses(buttonToggleHarness.with({text: /^s/i}));
+    expect(toggles.length).toBe(1);
+    expect(await toggles[0].getText()).toBe('Second');
+  });
+
+  it('should get the toggle checked state', async () => {
+    const [checkedToggle, uncheckedToggle] = await loader.getAllHarnesses(buttonToggleHarness);
+    expect(await checkedToggle.isChecked()).toBe(true);
+    expect(await uncheckedToggle.isChecked()).toBe(false);
+  });
+
+  it('should get the toggle disabled state', async () => {
+    const [enabledToggle, disabledToggle] = await loader.getAllHarnesses(buttonToggleHarness);
+    expect(await enabledToggle.isDisabled()).toBe(false);
+    expect(await disabledToggle.isDisabled()).toBe(true);
+  });
+
+  it('should get the toggle name', async () => {
+    const toggle = await loader.getHarness(buttonToggleHarness.with({text: 'First'}));
+    expect(await toggle.getName()).toBe('first-name');
+  });
+
+  it('should get the toggle aria-label', async () => {
+    const toggle = await loader.getHarness(buttonToggleHarness.with({text: 'First'}));
+    expect(await toggle.getAriaLabel()).toBe('First toggle');
+  });
+
+  it('should get the toggle aria-labelledby', async () => {
+    const toggle = await loader.getHarness(buttonToggleHarness.with({text: 'Second'}));
+    expect(await toggle.getAriaLabelledby()).toBe('second-label');
+  });
+
+  it('should get the toggle label text', async () => {
+    const [firstToggle, secondToggle] = await loader.getAllHarnesses(buttonToggleHarness);
+    expect(await firstToggle.getText()).toBe('First');
+    expect(await secondToggle.getText()).toBe('Second');
+  });
+
+  it('should get the toggle appearance', async () => {
+    const [firstToggle, secondToggle] = await loader.getAllHarnesses(buttonToggleHarness);
+    expect(await firstToggle.getAppearance()).toBe('standard');
+    expect(await secondToggle.getAppearance()).toBe('legacy');
+  });
+
+  it('should focus the button toggle', async () => {
+    const toggle = await loader.getHarness(buttonToggleHarness.with({text: 'First'}));
+    expect(getActiveElementTagName()).not.toBe('button');
+    await toggle.focus();
+    expect(getActiveElementTagName()).toBe('button');
+  });
+
+  it('should blur the button toggle', async () => {
+    const toggle = await loader.getHarness(buttonToggleHarness.with({text: 'First'}));
+    await toggle.focus();
+    expect(getActiveElementTagName()).toBe('button');
+    await toggle.blur();
+    expect(getActiveElementTagName()).not.toBe('button');
+  });
+
+  it('should toggle the button value', async () => {
+    fixture.componentInstance.disabled = false;
+    const [checkedToggle, uncheckedToggle] = await loader.getAllHarnesses(buttonToggleHarness);
+    await checkedToggle.toggle();
+    await uncheckedToggle.toggle();
+    expect(await checkedToggle.isChecked()).toBe(false);
+    expect(await uncheckedToggle.isChecked()).toBe(true);
+  });
+
+  it('should check the button toggle', async () => {
+    fixture.componentInstance.disabled = false;
+    const [checkedToggle, uncheckedToggle] = await loader.getAllHarnesses(buttonToggleHarness);
+    await checkedToggle.check();
+    await uncheckedToggle.check();
+    expect(await checkedToggle.isChecked()).toBe(true);
+    expect(await uncheckedToggle.isChecked()).toBe(true);
+  });
+
+  it('should uncheck the button toggle', async () => {
+    fixture.componentInstance.disabled = false;
+    const [checkedToggle, uncheckedToggle] = await loader.getAllHarnesses(buttonToggleHarness);
+    await checkedToggle.uncheck();
+    await uncheckedToggle.uncheck();
+    expect(await checkedToggle.isChecked()).toBe(false);
+    expect(await uncheckedToggle.isChecked()).toBe(false);
+  });
+}
+
+function getActiveElementTagName() {
+  return document.activeElement ? document.activeElement.tagName.toLowerCase() : '';
+}
+
+@Component({
+  template: `
+      <mat-button-toggle
+        name="first-name"
+        value="first-value"
+        aria-label="First toggle"
+        checked>First</mat-button-toggle>
+      <mat-button-toggle
+        [disabled]="disabled"
+        aria-labelledby="second-label"
+        appearance="legacy">Second</mat-button-toggle>
+      <span id="second-label">Second toggle</span>
+  `
+})
+class ButtonToggleHarnessTest {
+  disabled = true;
+}
+

--- a/src/material/button-toggle/testing/index.ts
+++ b/src/material/button-toggle/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material/button-toggle/testing/public-api.ts
+++ b/src/material/button-toggle/testing/public-api.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './button-toggle-harness';
+export * from './button-toggle-harness-filters';
+export * from './button-toggle-group-harness';
+export * from './button-toggle-group-harness-filters';

--- a/src/material/config.bzl
+++ b/src/material/config.bzl
@@ -8,6 +8,7 @@ entryPoints = [
     "button",
     "button/testing",
     "button-toggle",
+    "button-toggle/testing",
     "card",
     "checkbox",
     "checkbox/testing",

--- a/test/karma-system-config.js
+++ b/test/karma-system-config.js
@@ -110,6 +110,11 @@ System.config({
     '@angular/material/button/testing': 'dist/packages/material/button/testing/index.js',
     '@angular/material/button/testing/shared.spec': 'dist/packages/material/button/testing/shared.spec.js',
     '@angular/material/button-toggle': 'dist/packages/material/button-toggle/index.js',
+    '@angular/material/button-toggle/testing': 'dist/packages/material/button-toggle/testing/index.js',
+    '@angular/material/button-toggle/testing/button-toggle-shared.spec':
+        'dist/packages/material/button-toggle/testing/button-toggle-shared.spec.js',
+    '@angular/material/button-toggle/testing/button-toggle-group.spec':
+        'dist/packages/material/button-toggle/testing/button-toggle-group.spec.js',
     '@angular/material/card': 'dist/packages/material/card/index.js',
     '@angular/material/checkbox': 'dist/packages/material/checkbox/index.js',
     '@angular/material/checkbox/testing': 'dist/packages/material/checkbox/testing/index.js',

--- a/tools/public_api_guard/material/button-toggle/testing.d.ts
+++ b/tools/public_api_guard/material/button-toggle/testing.d.ts
@@ -1,0 +1,34 @@
+export interface ButtonToggleGroupHarnessFilters extends BaseHarnessFilters {
+}
+
+export interface ButtonToggleHarnessFilters extends BaseHarnessFilters {
+    checked?: boolean;
+    name?: string | RegExp;
+    text?: string | RegExp;
+}
+
+export declare class MatButtonToggleGroupHarness extends ComponentHarness {
+    getAppearance(): Promise<MatButtonToggleAppearance>;
+    getToggles(filter?: ButtonToggleHarnessFilters): Promise<MatButtonToggleHarness[]>;
+    isDisabled(): Promise<boolean>;
+    isVertical(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: ButtonToggleGroupHarnessFilters): HarnessPredicate<MatButtonToggleGroupHarness>;
+}
+
+export declare class MatButtonToggleHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    check(): Promise<void>;
+    focus(): Promise<void>;
+    getAppearance(): Promise<MatButtonToggleAppearance>;
+    getAriaLabel(): Promise<string | null>;
+    getAriaLabelledby(): Promise<string | null>;
+    getName(): Promise<string | null>;
+    getText(): Promise<string>;
+    isChecked(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    toggle(): Promise<void>;
+    uncheck(): Promise<void>;
+    static hostSelector: string;
+    static with(options?: ButtonToggleHarnessFilters): HarnessPredicate<MatButtonToggleHarness>;
+}


### PR DESCRIPTION
Sets up test harnesses for `mat-button-toggle` and `mat-button-toggle-group`.