### PR TITLE
build: remove entryComponents from development apps

### DIFF
--- a/src/a11y-demo/a11y-demo-module.ts
+++ b/src/a11y-demo/a11y-demo-module.ts
@@ -114,17 +114,6 @@ export class AccessibilityRoutingModule {}
     TabsAccessibilityDemo,
     ToolbarAccessibilityDemo,
     TooltipAccessibilityDemo,
-  ],
-  entryComponents: [
-    DialogAccessibilityDemo,
-    DialogAddressFormDialog,
-    DialogFruitExampleDialog,
-    DialogNeptuneExampleDialog,
-    DialogNeptuneIFrameDialog,
-    DialogWelcomeExampleDialog,
-    FoggyTabContent,
-    RainyTabContent,
-    SunnyTabContent,
   ]
 })
 export class AccessibilityDemoModule {}

--- a/src/dev-app/bottom-sheet/bottom-sheet-demo-module.ts
+++ b/src/dev-app/bottom-sheet/bottom-sheet-demo-module.ts
@@ -37,7 +37,6 @@ import {BottomSheetDemo, ExampleBottomSheet} from './bottom-sheet-demo';
     RouterModule.forChild([{path: '', component: BottomSheetDemo}]),
   ],
   declarations: [BottomSheetDemo, ExampleBottomSheet],
-  entryComponents: [ExampleBottomSheet],
 })
 export class BottomSheetDemoModule {
 }

--- a/src/dev-app/datepicker/datepicker-demo-module.ts
+++ b/src/dev-app/datepicker/datepicker-demo-module.ts
@@ -36,7 +36,6 @@ import {CustomHeader, CustomHeaderNgContent, DatepickerDemo} from './datepicker-
     RouterModule.forChild([{path: '', component: DatepickerDemo}]),
   ],
   declarations: [CustomHeader, CustomHeaderNgContent, DatepickerDemo],
-  entryComponents: [CustomHeader, CustomHeaderNgContent],
 })
 export class DatepickerDemoModule {
 }

--- a/src/dev-app/dialog/dialog-demo-module.ts
+++ b/src/dev-app/dialog/dialog-demo-module.ts
@@ -31,7 +31,6 @@ import {ContentElementDialog, DialogDemo, IFrameDialog, JazzDialog} from './dial
     RouterModule.forChild([{path: '', component: DialogDemo}]),
   ],
   declarations: [ContentElementDialog, DialogDemo, IFrameDialog, JazzDialog],
-  entryComponents: [ContentElementDialog, IFrameDialog, JazzDialog],
 })
 export class DialogDemoModule {
 }

--- a/src/dev-app/focus-trap/focus-trap-demo-module.ts
+++ b/src/dev-app/focus-trap/focus-trap-demo-module.ts
@@ -27,7 +27,6 @@ import {FocusTrapDemo, FocusTrapShadowDomDemo, FocusTrapDialogDemo} from './focu
     RouterModule.forChild([{path: '', component: FocusTrapDemo}]),
   ],
   declarations: [FocusTrapDemo, FocusTrapShadowDomDemo, FocusTrapDialogDemo],
-  entryComponents: [FocusTrapDialogDemo],
 })
 export class FocusTrapDemoModule {
 }

--- a/src/dev-app/portal/portal-demo-module.ts
+++ b/src/dev-app/portal/portal-demo-module.ts
@@ -17,7 +17,6 @@ import {PortalDemo, ScienceJoke} from './portal-demo';
     RouterModule.forChild([{path: '', component: PortalDemo}]),
   ],
   declarations: [PortalDemo, ScienceJoke],
-  entryComponents: [ScienceJoke],
 })
 export class PortalDemoModule {
 }

--- a/src/e2e-app/dialog/dialog-e2e-module.ts
+++ b/src/e2e-app/dialog/dialog-e2e-module.ts
@@ -13,7 +13,6 @@ import {DialogE2E, TestDialog} from './dialog-e2e';
 @NgModule({
   imports: [MatDialogModule],
   declarations: [DialogE2E, TestDialog],
-  entryComponents: [TestDialog]
 })
 export class DialogE2eModule {
 }

--- a/tools/example-module/example-module.template
+++ b/tools/example-module/example-module.template
@@ -31,7 +31,6 @@ export const EXAMPLE_LIST = [${exampleList}];
 @NgModule({
   imports: EXAMPLE_MODULES,
   exports: EXAMPLE_MODULES,
-  entryComponents: EXAMPLE_LIST,
 })
 export class ExampleModule { }
 


### PR DESCRIPTION
Since we're running the development apps with Ivy we no longer need to specify `entryComponents`.