### PR TITLE
feat(material/chip): Add focus indicator

### DIFF
--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -240,14 +240,15 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
 
   constructor(public _elementRef: ElementRef<HTMLElement>,
               private _ngZone: NgZone,
-              @Inject(DOCUMENT) private _document: any,
               platform: Platform,
               @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
               globalRippleOptions: RippleGlobalOptions | null,
               // @breaking-change 8.0.0 `animationMode` parameter to become required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
               // @breaking-change 9.0.0 `_changeDetectorRef` parameter to become required.
-              private _changeDetectorRef?: ChangeDetectorRef) {
+              private _changeDetectorRef?: ChangeDetectorRef,
+              // @breaking-change 11.0.0 `_document` parameter to become required.
+              @Optional() @Inject(DOCUMENT) _document?: any) {
     super(_elementRef);
 
     this._addHostClassName();
@@ -255,7 +256,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     // Dynamically create the ripple target, append it within the chip, and use it as the
     // chip's ripple target. Adding the class '.mat-chip-ripple' ensures that it will have
     // the proper styles.
-    this._chipRippleTarget = this._document.createElement('div');
+    this._chipRippleTarget = (_document || document).createElement('div');
     this._chipRippleTarget.classList.add('mat-chip-ripple');
     this._elementRef.nativeElement.appendChild(this._chipRippleTarget);
     this._chipRipple = new RippleRenderer(this, _ngZone, this._chipRippleTarget, platform);

--- a/src/material/chips/chips.scss
+++ b/src/material/chips/chips.scss
@@ -27,7 +27,6 @@ $mat-chip-remove-size: 18px;
 
 .mat-chip {
   position: relative;
-  overflow: hidden;
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
 
@@ -169,6 +168,23 @@ $mat-chip-remove-size: 18px;
       margin-left: 0;
     }
   }
+}
+
+// Styles for the chip's dynamically added ripple target.
+.mat-chip-ripple {
+  @include mat-fill;
+
+  // Disable pointer events for the ripple container and focus overlay because the container
+  // will overlay the user content and we don't want to disable mouse events on the user content.
+  // Pointer events can be safely disabled because the ripple trigger element is the host element.
+  pointer-events: none;
+
+  // Inherit the border radius from the parent so that ripples don't exceed the parent button
+  // boundaries.
+  border-radius: inherit;
+
+  // Ensures that the ripple effect doesn't overflow the ripple target.
+  overflow: hidden;
 }
 
 .mat-chip-list-wrapper {

--- a/src/material/core/focus-indicator/_focus-indicator.scss
+++ b/src/material/core/focus-indicator/_focus-indicator.scss
@@ -31,6 +31,7 @@
   .mat-focus-indicator.mat-button-base::before,
   .mat-focus-indicator.mat-button-base::before,
   .mat-focus-indicator.mat-card::before,
+  .mat-focus-indicator.mat-chip::before,
   .mat-focus-indicator.mat-sort-header-button::before {
     margin: $border-width * -2;
   }

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -25,7 +25,7 @@ export declare class MatChip extends _MatChipMixinBase implements FocusableOptio
     readonly selectionChange: EventEmitter<MatChipSelectionChange>;
     trailingIcon: MatChipTrailingIcon;
     value: any;
-    constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, animationMode?: string, _changeDetectorRef?: ChangeDetectorRef | undefined);
+    constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, animationMode?: string, _changeDetectorRef?: ChangeDetectorRef | undefined, _document?: any);
     _addHostClassName(): void;
     _blur(): void;
     _handleClick(event: Event): void;


### PR DESCRIPTION
**Background:** The chip's focus indicator needs to be offset from the chip itself in order to be sufficiently contrastive because the chip can have a primary/accent fill.  However, given `mat-chip` has `overflow: hidden`, any offset focus indicator will be hidden. The reason `mat-chip` has its overflow hidden is because it also acts as a ripple target. Thus, in order to add a focus indicator to chip, this PR does the following:

* Instead of using the `mat-chip` as the ripple target, dynamically create an element and add it as a child node of the `mat-chip`. This element will be the chip's new ripple target. This element will have its overflow hidden, and the `mat-chip` will have that style removed.
* Add the `.mat-focus-indicator` class to the `mat-chip`.