### PR TITLE
refactor(table): add the ability to get row text organized by column in harness

### DIFF
--- a/src/material/table/testing/row-harness.ts
+++ b/src/material/table/testing/row-harness.ts
@@ -10,6 +10,11 @@ import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {RowHarnessFilters, CellHarnessFilters} from './table-harness-filters';
 import {MatCellHarness, MatHeaderCellHarness, MatFooterCellHarness} from './cell-harness';
 
+/** Text extracted from a table row organized by columns. */
+export interface MatRowHarnessColumnsText {
+  [columnName: string]: string;
+}
+
 /** Harness for interacting with a standard Angular Material table row. */
 export class MatRowHarness extends ComponentHarness {
   /** The selector for the host element of a `MatRowHarness` instance. */
@@ -32,6 +37,11 @@ export class MatRowHarness extends ComponentHarness {
   /** Gets the text of the cells in the row. */
   async getCellTextByIndex(filter: CellHarnessFilters = {}): Promise<string[]> {
     return getCellTextByIndex(this, filter);
+  }
+
+  /** Gets the text inside the row organized by columns. */
+  async getCellTextByColumnName(): Promise<MatRowHarnessColumnsText> {
+    return getCellTextByColumnName(this);
   }
 }
 
@@ -58,6 +68,11 @@ export class MatHeaderRowHarness extends ComponentHarness {
   /** Gets the text of the cells in the header row. */
   async getCellTextByIndex(filter: CellHarnessFilters = {}): Promise<string[]> {
     return getCellTextByIndex(this, filter);
+  }
+
+  /** Gets the text inside the header row organized by columns. */
+  async getCellTextByColumnName(): Promise<MatRowHarnessColumnsText> {
+    return getCellTextByColumnName(this);
   }
 }
 
@@ -86,11 +101,29 @@ export class MatFooterRowHarness extends ComponentHarness {
   async getCellTextByIndex(filter: CellHarnessFilters = {}): Promise<string[]> {
     return getCellTextByIndex(this, filter);
   }
+
+  /** Gets the text inside the footer row organized by columns. */
+  async getCellTextByColumnName(): Promise<MatRowHarnessColumnsText> {
+    return getCellTextByColumnName(this);
+  }
 }
+
 
 async function getCellTextByIndex(harness: {
   getCells: (filter?: CellHarnessFilters) => Promise<MatCellHarness[]>
 }, filter: CellHarnessFilters): Promise<string[]> {
   const cells = await harness.getCells(filter);
   return Promise.all(cells.map(cell => cell.getText()));
+}
+
+async function getCellTextByColumnName(harness: {
+  getCells: () => Promise<MatCellHarness[]>
+}): Promise<MatRowHarnessColumnsText> {
+  const output: MatRowHarnessColumnsText = {};
+  const cells = await harness.getCells();
+  const cellsData = await Promise.all(cells.map(cell => {
+    return Promise.all([cell.getColumnName(), cell.getText()]);
+  }));
+  cellsData.forEach(([columnName, text]) => output[columnName] = text);
+  return output;
 }

--- a/src/material/table/testing/shared.spec.ts
+++ b/src/material/table/testing/shared.spec.ts
@@ -138,6 +138,27 @@ export function runHarnessTests(
       ['10', 'Neon', '20.1797', 'Ne']
     ]);
   });
+
+  it('should be able to get the cell text in a row organized by index', async () => {
+    const table = await loader.getHarness(tableHarness);
+    const rows = await table.getRows();
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(await rows[0].getCellTextByIndex()).toEqual(['1', 'Hydrogen', '1.0079', 'H']);
+  });
+
+  it('should be able to get the cell text in a row organized by columns', async () => {
+    const table = await loader.getHarness(tableHarness);
+    const rows = await table.getRows();
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(await rows[0].getCellTextByColumnName()).toEqual({
+      position: '1',
+      name: 'Hydrogen',
+      weight: '1.0079',
+      symbol: 'H'
+    });
+  });
 }
 
 @Component({

--- a/tools/public_api_guard/material/table/testing.d.ts
+++ b/tools/public_api_guard/material/table/testing.d.ts
@@ -15,6 +15,7 @@ export declare class MatFooterCellHarness extends MatCellHarness {
 }
 
 export declare class MatFooterRowHarness extends ComponentHarness {
+    getCellTextByColumnName(): Promise<MatRowHarnessColumnsText>;
     getCellTextByIndex(filter?: CellHarnessFilters): Promise<string[]>;
     getCells(filter?: CellHarnessFilters): Promise<MatFooterCellHarness[]>;
     static hostSelector: string;
@@ -27,6 +28,7 @@ export declare class MatHeaderCellHarness extends MatCellHarness {
 }
 
 export declare class MatHeaderRowHarness extends ComponentHarness {
+    getCellTextByColumnName(): Promise<MatRowHarnessColumnsText>;
     getCellTextByIndex(filter?: CellHarnessFilters): Promise<string[]>;
     getCells(filter?: CellHarnessFilters): Promise<MatHeaderCellHarness[]>;
     static hostSelector: string;
@@ -34,10 +36,15 @@ export declare class MatHeaderRowHarness extends ComponentHarness {
 }
 
 export declare class MatRowHarness extends ComponentHarness {
+    getCellTextByColumnName(): Promise<MatRowHarnessColumnsText>;
     getCellTextByIndex(filter?: CellHarnessFilters): Promise<string[]>;
     getCells(filter?: CellHarnessFilters): Promise<MatCellHarness[]>;
     static hostSelector: string;
     static with(options?: RowHarnessFilters): HarnessPredicate<MatRowHarness>;
+}
+
+export interface MatRowHarnessColumnsText {
+    [columnName: string]: string;
 }
 
 export declare class MatTableHarness extends ComponentHarness {


### PR DESCRIPTION
Follow-up from the feedback in #17799. Adds a `getCellTextByColumnName` to the `MatRowHarness` which aligns with what we have on the table harness.