### PR TITLE
fix(material/tree): Do not add aria-expanded to leaf nodes

### DIFF
--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -103,9 +103,18 @@ describe('CdkTree', () => {
       it('with the right accessibility roles', () => {
         expect(treeElement.getAttribute('role')).toBe('tree');
 
-        expect(getNodes(treeElement).every(node => {
-          return node.getAttribute('role') === 'treeitem';
-        })).toBe(true);
+	expect(getNodes(treeElement).every(node => {
+	  return node.getAttribute('role') === 'treeitem';
+	})).toBe(true);
+      });
+
+      it('with the right aria-levels', () => {
+	// add a child to the first node
+	let data = dataSource.data;
+	const child = dataSource.addChild(data[0], true);
+
+        const ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
+        expect(ariaLevels).toEqual(["1", "2", "1", "1"]);
       });
 
       it('with the right data', () => {

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -291,7 +291,7 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
   exportAs: 'cdkTreeNode',
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.aria-level]': 'role === "treeitem" ? level : null',
+    '[attr.aria-level]': 'level',
     '[attr.role]': 'role',
     'class': 'cdk-tree-node',
   },

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -290,7 +290,7 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
   selector: 'cdk-tree-node',
   exportAs: 'cdkTreeNode',
   host: {
-    '[attr.aria-expanded]': 'isExpanded',
+    '[attr.aria-expanded]': 'expandable ? isExpanded : null',
     '[attr.aria-level]': 'level',
     '[attr.role]': 'role',
     'class': 'cdk-tree-node',
@@ -334,6 +334,8 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
    */
   @Input() role: 'treeitem' | 'group' = 'treeitem';
 
+  expandable = false;
+
   constructor(protected _elementRef: ElementRef<HTMLElement>,
               protected _tree: CdkTree<T>) {
     CdkTreeNode.mostRecentTreeNode = this as CdkTreeNode<T>;
@@ -358,6 +360,7 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
 
   protected _setRoleFromData(): void {
     if (this._tree.treeControl.isExpandable) {
+      this.expandable = this._tree.treeControl.isExpandable(this._data);
       this.role = this._tree.treeControl.isExpandable(this._data) ? 'group' : 'treeitem';
     } else {
       if (!this._tree.treeControl.getChildren) {
@@ -374,6 +377,7 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
   }
 
   protected _setRoleFromChildren(children: T[]) {
+    this.expandable = children && children.length > 0;
     this.role = children && children.length ? 'group' : 'treeitem';
   }
 }

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -44,7 +44,7 @@ const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNo
   inputs: ['disabled', 'tabIndex'],
   host: {
     '[attr.aria-expanded]': 'isExpanded',
-    '[attr.aria-level]': 'role === "treeitem" ? level : null',
+    '[attr.aria-level]': 'level',
     '[attr.role]': 'role',
     'class': 'mat-tree-node'
   },

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -43,7 +43,7 @@ const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNo
   exportAs: 'matTreeNode',
   inputs: ['disabled', 'tabIndex'],
   host: {
-    '[attr.aria-expanded]': 'isExpanded',
+    '[attr.aria-expanded]': 'expandable ? isExpanded : null',
     '[attr.aria-level]': 'level',
     '[attr.role]': 'role',
     'class': 'mat-tree-node'
@@ -86,7 +86,7 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
   selector: 'mat-nested-tree-node',
   exportAs: 'matNestedTreeNode',
   host: {
-    '[attr.aria-expanded]': 'isExpanded',
+    '[attr.aria-expanded]': 'expandable ? isExpanded : null',
     '[attr.role]': 'role',
     'class': 'mat-nested-tree-node',
   },

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -61,6 +61,7 @@ describe('MatTree', () => {
 
         getNodes(treeElement).forEach(node => {
           expect(node.getAttribute('role')).toBe('treeitem');
+          expect(node.getAttribute('aria-level')).toBe('0');
         });
       });
 

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -64,6 +64,16 @@ describe('MatTree', () => {
         });
       });
 
+      it('with the right aria-levels', () => {
+	// add a child to the first node
+	let data = underlyingDataSource.data;
+	underlyingDataSource.addChild(data[2]);
+        fixture.detectChanges();
+
+        const ariaLevels = getNodes(treeElement).map(n => n.getAttribute('aria-level'));
+        expect(ariaLevels).toEqual(["0", "0", "0", "1"]);
+      });
+
       it('with the right data', () => {
         expect(underlyingDataSource.data.length).toBe(3);
 

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -567,7 +567,10 @@ function expectFlatTreeToMatch(treeElement: Element, expectedPaddingIndent: numb
     }
   }
 
-  getNodes(treeElement).forEach((node, index) => {
+  const nodes = getNodes(treeElement);
+  expect(nodes.length).toBe(expectedTree.length);
+
+  nodes.forEach((node, index) => {
     const expected = expectedTree ?
       expectedTree[index] :
       null;


### PR DESCRIPTION
This is a work-in-progress. It is also dependent on #17818, so that's why there are unrelated aria-level changes.

When I test a mat-tree with a screen reader, for leaf nodes it will read out that the node is collapsed, which does not make sense. The previous code was just checking if the node was expanded; the solution is to first check if the node is expandable, and if not, set the value to null so the attribute is not added to the element.

I have a few questions that I ran into that I will leave in comments closer to the code in question. 