### PR TITLE
fix(material-experimental/mdc-button): some button variants not visible in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -9,17 +9,22 @@
 
 .mat-mdc-button, .mat-mdc-unelevated-button, .mat-mdc-raised-button, .mat-mdc-outlined-button {
   @include mdc-button-density(0, $mat-base-styles-query);
-
-  // Add an outline to make buttons more visible in high contrast mode. Stroked buttons
-  // don't need a special look in high-contrast mode, because those already have an outline.
-  @include cdk-high-contrast {
-    &:not(.mdc-button--outlined) {
-      outline: solid 1px;
-    }
-  }
-
   @include _mat-button-interactive();
   @include _mat-button-disabled();
+}
+
+// Add an outline to make buttons more visible in high contrast mode. Stroked buttons
+// don't need a special look in high-contrast mode, because those already have an outline.
+.mat-mdc-button:not(.mdc-button--outlined),
+.mat-mdc-unelevated-button:not(.mdc-button--outlined),
+.mat-mdc-raised-button:not(.mdc-button--outlined),
+.mat-mdc-outlined-button:not(.mdc-button--outlined),
+.mat-mdc-fab,
+.mat-mdc-mini-fab,
+.mat-mdc-icon-button {
+  @include cdk-high-contrast {
+    outline: solid 1px;
+  }
 }
 
 // Since the stroked button has has an actual border that reduces the available space for


### PR DESCRIPTION
Fixes the MDC-based fab, mini fab and icon button variants not being visible in high contrast mode, because they don't have a border or an outline.