### PR TITLE
fix(material-experimental/mdc-chips): avoid potential server-side rendering errors

### DIFF
--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
@@ -27,8 +27,18 @@ Not yet implemented.
 
 <h2>MDC chips</h2>
 
-<!-- TODO: Copy kitchen sink examples for mat-chip-list here -->
-Not yet implemented.
+<mat-chip-set>
+  <mat-basic-chip>Basic Chip 1</mat-basic-chip>
+  <mat-basic-chip>Basic Chip 2</mat-basic-chip>
+  <mat-basic-chip>Basic Chip 3</mat-basic-chip>
+</mat-chip-set>
+
+<mat-chip-listbox>
+  <mat-chip-option>Extra Small</mat-chip-option>
+  <mat-chip-option>Small</mat-chip-option>
+  <mat-chip-option>Medium</mat-chip-option>
+  <mat-chip-option>Large</mat-chip-option>
+</mat-chip-listbox>
 
 <h2>MDC menu</h2>
 <button mat-button [matMenuTriggerFor]="menu">Open</button>


### PR DESCRIPTION
Fixes a few places in the MDC basec `mat-chip` that can throw if they're hit during server-side rendering. Also sets up the server-side rendering check.