### PR TITLE
feat(material/autocomplete) settable height of option; settable height of panel

### DIFF
--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -49,21 +49,23 @@ import {MatFormField} from '@angular/material/form-field';
 import {defer, fromEvent, merge, Observable, of as observableOf, Subject, Subscription} from 'rxjs';
 import {delay, filter, map, switchMap, take, tap} from 'rxjs/operators';
 
-import {MatAutocomplete} from './autocomplete';
+import {
+  MatAutocomplete,
+  AUTOCOMPLETE_OPTION_HEIGHT,
+  AUTOCOMPLETE_PANEL_HEIGHT
+} from './autocomplete';
 import {MatAutocompleteOrigin} from './autocomplete-origin';
 
+/**
+ * Add exports also here for back-capability.
+ */
+export {AUTOCOMPLETE_OPTION_HEIGHT, AUTOCOMPLETE_PANEL_HEIGHT};
 
 /**
  * The following style constants are necessary to save here in order
  * to properly calculate the scrollTop of the panel. Because we are not
  * actually focusing the active item, scroll must be handled manually.
  */
-
-/** The height of each autocomplete option. */
-export const AUTOCOMPLETE_OPTION_HEIGHT = 48;
-
-/** The total height of the autocomplete panel. */
-export const AUTOCOMPLETE_PANEL_HEIGHT = 256;
 
 /** Injection token that determines the scroll handling while the autocomplete panel is open. */
 export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY =
@@ -508,9 +510,9 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
     } else {
       const newScrollPosition = _getOptionScrollPosition(
         index + labelCount,
-        AUTOCOMPLETE_OPTION_HEIGHT,
+        this.autocomplete._getOptionHeightPx(),
         this.autocomplete._getScrollTop(),
-        AUTOCOMPLETE_PANEL_HEIGHT
+        this.autocomplete._getPanelHeightPx()
       );
 
       this.autocomplete._setScrollTop(newScrollPosition);

--- a/src/material/autocomplete/autocomplete.html
+++ b/src/material/autocomplete/autocomplete.html
@@ -1,5 +1,9 @@
 <ng-template>
-  <div class="mat-autocomplete-panel" role="listbox" [id]="id" [ngClass]="_classList" #panel>
+  <div  class="mat-autocomplete-panel"
+        role="listbox"
+        [id]="id"
+        [ngClass]="_classList"
+        [ngStyle]="{'maxHeight': _getPanelHeightInlineStyle() }" #panel>
     <ng-content></ng-content>
   </div>
 </ng-template>

--- a/src/material/autocomplete/autocomplete.md
+++ b/src/material/autocomplete/autocomplete.md
@@ -90,6 +90,50 @@ injection token.
 
 <!-- example(autocomplete-auto-active-first-option) -->
 
+### Setting custom height of option
+If you need to change the height of option in autocomplete panel, you can do so by setting `optionHeight` input on the `mat-autocomplete`
+component.
+
+```html
+<mat-form-field>
+  <input type="text" matInput [formControl]="myControl" [matAutocomplete]="auto">
+</mat-form-field>
+
+<mat-autocomplete #auto="matAutocomplete" [optionHeight]="16">
+  <mat-option *ngFor="let option of options" [value]="option">{{option}}</mat-option>
+</mat-autocomplete>
+```
+
+If you would like to let component to detect a height of option automatically (for example if you've changed global styles of `mat-option`) you can set `optionHeight` into `auto`.
+
+```html
+<mat-form-field>
+  <input type="text" matInput [formControl]="myControl" [matAutocomplete]="auto">
+</mat-form-field>
+
+<mat-autocomplete #auto="matAutocomplete" [optionHeight]="'auto'">
+  <mat-option *ngFor="let option of options" [value]="option">{{option}}</mat-option>
+</mat-autocomplete>
+```
+
+If an input `optionHeight` isn't defined, will be used a default value `AUTOCOMPLETE_OPTION_HEIGHT` (48px).
+
+### Setting custom height of panel
+If you need to change the height of an autocomplete panel, you can do so by setting `panelHeight` input on the `mat-autocomplete`
+component.
+
+```html
+<mat-form-field>
+  <input type="text" matInput [formControl]="myControl" [matAutocomplete]="auto">
+</mat-form-field>
+
+<mat-autocomplete #auto="matAutocomplete" [panelHeight]="240">
+  <mat-option *ngFor="let option of options" [value]="option">{{option}}</mat-option>
+</mat-autocomplete>
+```
+
+If an input `panelHeight` isn't defined, will be used a default value `AUTOCOMPLETE_PANEL_HEIGHT` (256px).
+
 ### Autocomplete on a custom input element
 
 While `mat-autocomplete` supports attaching itself to a `mat-form-field`, you can also set it on

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -2593,6 +2593,410 @@ describe('MatAutocomplete', () => {
 
     expect(formControl.value).toBe('Cal', 'Expected new value to be propagated to model');
   }));
+
+  describe('option height is defined', () => {
+    let fixture: ComponentFixture<AutocompleteWithDefinedOptionHeight>;
+    let DOWN_ARROW_EVENT: KeyboardEvent;
+    let UP_ARROW_EVENT: KeyboardEvent;
+
+    beforeEach(fakeAsync(() => {
+      fixture = createComponent(AutocompleteWithDefinedOptionHeight);
+      fixture.detectChanges();
+
+      DOWN_ARROW_EVENT = createKeyboardEvent('keydown', DOWN_ARROW);
+      UP_ARROW_EVENT = createKeyboardEvent('keydown', UP_ARROW);
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+    }));
+
+    it('should have height of option 16px', () => {
+      const optionEls =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      expect(trigger.panelOpen)
+          .toBe(true, 'Expected first down press to open the pane.');
+
+      expect(Math.round(optionEls[0].getBoundingClientRect().height))
+          .toBe(16, 'Expected height of option is 16');
+
+    });
+
+    it('should scroll to active options below the fold', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer =
+          document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+
+      // These down arrows will set the 7th option active, below the fold.
+      for (let i = 6; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect scroll still 0
+      expect(scrollContainer.scrollTop)
+          .toEqual(0, `Expected panel to reveal the sixth option.`);
+
+      // These down arrows will set the 17th option active, below the fold.
+      for (let i = 10; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect option bottom minus the panel height (272 - 256 = 16)
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel to reveal the sixth option.`);
+    });
+
+    it('should scroll to active options on UP arrow', () => {
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+      fixture.detectChanges();
+
+      // Expect option bottom minus the panel height (528 - 256 = 272)
+      expect(scrollContainer.scrollTop).toEqual(272, `Expected panel to reveal last option.`);
+    });
+
+    it('should not scroll to active options that are fully in the panel', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 17th option active, below the fold.
+      for (let i = 16; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect option bottom minus the panel height (272 - 256 = 16)
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel to reveal the sixth option.`);
+
+      // These up arrows will set the 2nd option active
+      for (let i = 14; i >= 1; i -= 1) {
+        trigger._handleKeydown(UP_ARROW_EVENT);
+      }
+
+      // Expect no scrolling to have occurred. Still showing bottom of 6th option.
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel not to scroll up since sixth option still fully visible.`);
+    });
+
+    it('should scroll to active options that are above the panel', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 18th option active, below the fold.
+      for (let i = 17; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // These down arrows will set the 2d option active, below the fold.
+      for (let i = 16; i >= 1; i -= 1) {
+        trigger._handleKeydown(UP_ARROW_EVENT);
+      }
+
+      // Expect to show the top of the 2nd option at the top of the panel
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel to scroll up when option is above panel.`);
+    });
+
+  });
+
+  describe('option height is auto detected', () => {
+    let fixture: ComponentFixture<AutocompleteWithAutoDetectedOptionHeight>;
+    let DOWN_ARROW_EVENT: KeyboardEvent;
+    let UP_ARROW_EVENT: KeyboardEvent;
+    const style = document.createElement('style');
+    style.type = 'text/css';
+    style.innerHTML = 'mat-option { height: 16px!important; }';
+
+    beforeAll(() => {
+      document.getElementsByTagName('head')[0].appendChild(style);
+    });
+
+    beforeEach(fakeAsync(() => {
+      fixture = createComponent(AutocompleteWithAutoDetectedOptionHeight);
+      fixture.detectChanges();
+
+      DOWN_ARROW_EVENT = createKeyboardEvent('keydown', DOWN_ARROW);
+      UP_ARROW_EVENT = createKeyboardEvent('keydown', UP_ARROW);
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+    }));
+
+    afterAll(() => {
+      if (style.parentNode) {
+        style.parentNode.removeChild(style);
+      }
+    });
+
+    it('should have height of option 16px', () => {
+      const optionEls =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      expect(trigger.panelOpen)
+          .toBe(true, 'Expected first down press to open the pane.');
+
+      expect(Math.round(optionEls[0].getBoundingClientRect().height))
+          .toBe(16, 'Expected height of option is 16');
+
+    });
+
+    it('should scroll to active options below the fold', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer =
+          document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+
+      // These down arrows will set the 7th option active, below the fold.
+      for (let i = 6; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect scroll still 0
+      expect(scrollContainer.scrollTop)
+          .toEqual(0, `Expected panel to reveal the sixth option.`);
+
+      // These down arrows will set the 17th option active, below the fold.
+      for (let i = 10; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect option bottom minus the panel height (272 - 256 = 16)
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel to reveal the sixth option.`);
+    });
+
+    it('should scroll to active options on UP arrow', () => {
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+      fixture.detectChanges();
+
+      // Expect option bottom minus the panel height (528 - 256 = 272)
+      expect(scrollContainer.scrollTop).toEqual(272, `Expected panel to reveal last option.`);
+    });
+
+    it('should not scroll to active options that are fully in the panel', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 17th option active, below the fold.
+      for (let i = 16; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect option bottom minus the panel height (272 - 256 = 16)
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel to reveal the sixth option.`);
+
+      // These up arrows will set the 2nd option active
+      for (let i = 14; i >= 1; i -= 1) {
+        trigger._handleKeydown(UP_ARROW_EVENT);
+      }
+
+      // Expect no scrolling to have occurred. Still showing bottom of 6th option.
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel not to scroll up since sixth option still fully visible.`);
+    });
+
+    it('should scroll to active options that are above the panel', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 18th option active, below the fold.
+      for (let i = 17; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // These down arrows will set the 2d option active, below the fold.
+      for (let i = 16; i >= 1; i -= 1) {
+        trigger._handleKeydown(UP_ARROW_EVENT);
+      }
+
+      // Expect to show the top of the 2nd option at the top of the panel
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel to scroll up when option is above panel.`);
+    });
+
+  });
+
+  describe('option and panel heights are defined', () => {
+    let fixture: ComponentFixture<AutocompleteWithDefinedOptionAndPanelHeights>;
+    let DOWN_ARROW_EVENT: KeyboardEvent;
+    let UP_ARROW_EVENT: KeyboardEvent;
+
+    beforeEach(fakeAsync(() => {
+      fixture = createComponent(AutocompleteWithDefinedOptionAndPanelHeights);
+      fixture.detectChanges();
+
+      DOWN_ARROW_EVENT = createKeyboardEvent('keydown', DOWN_ARROW);
+      UP_ARROW_EVENT = createKeyboardEvent('keydown', UP_ARROW);
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+    }));
+
+    it('should have height of option 16px', () => {
+      const optionEls =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      expect(Math.round(scrollContainer.getBoundingClientRect().height)).
+        toEqual(240, `Expected panel height is 240.`);
+
+      expect(trigger.panelOpen)
+          .toBe(true, 'Expected first down press to open the pane.');
+
+      expect(Math.round(optionEls[0].getBoundingClientRect().height))
+          .toBe(16, 'Expected height of option is 16');
+
+    });
+
+    it('should scroll to active options below the fold', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer =
+          document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+
+      // These down arrows will set the 7th option active, below the fold.
+      for (let i = 6; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect scroll still 0
+      expect(scrollContainer.scrollTop)
+          .toEqual(0, `Expected panel to reveal the sixth option.`);
+
+      // These down arrows will set the 17th option active, below the fold.
+      for (let i = 10; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect option bottom minus the panel height (272 - 240 = 32)
+      expect(scrollContainer.scrollTop)
+          .toEqual(32, `Expected panel to reveal the sixth option.`);
+    });
+
+    it('should scroll to active options on UP arrow', () => {
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+      fixture.detectChanges();
+
+      // Expect option bottom minus the panel height (528 - 240 = 288)
+      expect(scrollContainer.scrollTop).toEqual(288, `Expected panel to reveal last option.`);
+    });
+
+    it('should not scroll to active options that are fully in the panel', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 17th option active, below the fold.
+      for (let i = 16; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // Expect option bottom minus the panel height (272 - 240 = 32)
+      expect(scrollContainer.scrollTop)
+          .toEqual(32, `Expected panel to reveal the sixth option.`);
+
+      // These up arrows will set the 2nd option active
+      for (let i = 14; i >= 1; i -= 1) {
+        trigger._handleKeydown(UP_ARROW_EVENT);
+      }
+
+      // Expect no scrolling to have occurred. Still showing bottom of 6th option.
+      expect(scrollContainer.scrollTop)
+          .toEqual(32, `Expected panel not to scroll up since sixth option still fully visible.`);
+    });
+
+    it('should scroll to active options that are above the panel', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer = document.querySelector('.cdk-overlay-pane .mat-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 18th option active, below the fold.
+      for (let i = 17; i >= 1; i -= 1) {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+      }
+
+      // These down arrows will set the 2d option active, below the fold.
+      for (let i = 16; i >= 1; i -= 1) {
+        trigger._handleKeydown(UP_ARROW_EVENT);
+      }
+
+      // Expect to show the top of the 2nd option at the top of the panel
+      expect(scrollContainer.scrollTop)
+          .toEqual(16, `Expected panel to scroll up when option is above panel.`);
+    });
+
+  });
+
 });
 
 const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
@@ -3007,7 +3411,6 @@ class AutocompleteWithNativeAutocompleteAttribute {
 class InputWithoutAutocompleteAndDisabled {
 }
 
-
 @Component({
   template: `
     <mat-form-field>
@@ -3026,4 +3429,277 @@ class AutocompleteWithActivatedEvent {
   @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
   @ViewChild(MatAutocomplete) autocomplete: MatAutocomplete;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
+}
+
+@Component({template: `
+<mat-form-field [floatLabel]="floatLabel" [style.width.px]="width">
+  <input
+    matInput
+    placeholder="State"
+    [matAutocomplete]="auto"
+    [matAutocompletePosition]="position"
+    [matAutocompleteDisabled]="autocompleteDisabled"
+    [formControl]="stateCtrl">
+</mat-form-field>
+
+<mat-autocomplete [class]="panelClass" #auto="matAutocomplete" [displayWith]="displayFn"
+  [disableRipple]="disableRipple" (opened)="openedSpy()" (closed)="closedSpy()"
+  [optionHeight]="16">
+  <mat-option *ngFor="let state of filteredStates" [value]="state">
+    <span>{{ state.code }}: {{ state.name }}</span>
+  </mat-option>
+</mat-autocomplete>
+`})
+class AutocompleteWithDefinedOptionHeight implements OnDestroy {
+  stateCtrl = new FormControl();
+  filteredStates: any[];
+  valueSub: Subscription;
+  floatLabel = 'auto';
+  position = 'auto';
+  width: number;
+  disableRipple = false;
+  autocompleteDisabled = false;
+  panelClass = 'class-one class-two';
+  openedSpy = jasmine.createSpy('autocomplete opened spy');
+  closedSpy = jasmine.createSpy('autocomplete closed spy');
+
+  @ViewChild(MatAutocompleteTrigger, {static: true}) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocomplete) panel: MatAutocomplete;
+  @ViewChild(MatFormField) formField: MatFormField;
+  @ViewChildren(MatOption) options: QueryList<MatOption>;
+
+  states = [
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+  ];
+
+
+  constructor() {
+    this.filteredStates = this.states;
+    this.valueSub = this.stateCtrl.valueChanges.subscribe(val => {
+      this.filteredStates = val ? this.states.filter((s) => s.name.match(new RegExp(val, 'gi')))
+                                : this.states;
+    });
+  }
+
+  displayFn(value: any): string {
+    return value ? value.name : value;
+  }
+
+  ngOnDestroy() {
+    this.valueSub.unsubscribe();
+  }
+}
+
+@Component({template: `
+<mat-form-field [floatLabel]="floatLabel" [style.width.px]="width">
+  <input
+    matInput
+    placeholder="State"
+    [matAutocomplete]="auto"
+    [matAutocompletePosition]="position"
+    [matAutocompleteDisabled]="autocompleteDisabled"
+    [formControl]="stateCtrl">
+</mat-form-field>
+
+<mat-autocomplete [class]="panelClass" #auto="matAutocomplete" [displayWith]="displayFn"
+  [disableRipple]="disableRipple" (opened)="openedSpy()" (closed)="closedSpy()"
+  [optionHeight]="'auto'">
+  <mat-option *ngFor="let state of filteredStates" [value]="state">
+    <span>{{ state.code }}: {{ state.name }}</span>
+  </mat-option>
+</mat-autocomplete>
+`})
+class AutocompleteWithAutoDetectedOptionHeight implements OnDestroy {
+  stateCtrl = new FormControl();
+  filteredStates: any[];
+  valueSub: Subscription;
+  floatLabel = 'auto';
+  position = 'auto';
+  width: number;
+  disableRipple = false;
+  autocompleteDisabled = false;
+  panelClass = 'class-one class-two';
+  openedSpy = jasmine.createSpy('autocomplete opened spy');
+  closedSpy = jasmine.createSpy('autocomplete closed spy');
+
+  @ViewChild(MatAutocompleteTrigger, {static: true}) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocomplete) panel: MatAutocomplete;
+  @ViewChild(MatFormField) formField: MatFormField;
+  @ViewChildren(MatOption) options: QueryList<MatOption>;
+
+  states = [
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+  ];
+
+
+  constructor() {
+    this.filteredStates = this.states;
+    this.valueSub = this.stateCtrl.valueChanges.subscribe(val => {
+      this.filteredStates = val ? this.states.filter((s) => s.name.match(new RegExp(val, 'gi')))
+                                : this.states;
+    });
+  }
+
+  displayFn(value: any): string {
+    return value ? value.name : value;
+  }
+
+  ngOnDestroy() {
+    this.valueSub.unsubscribe();
+  }
+}
+
+@Component({template: `
+<mat-form-field [floatLabel]="floatLabel" [style.width.px]="width">
+  <input
+    matInput
+    placeholder="State"
+    [matAutocomplete]="auto"
+    [matAutocompletePosition]="position"
+    [matAutocompleteDisabled]="autocompleteDisabled"
+    [formControl]="stateCtrl">
+</mat-form-field>
+
+<mat-autocomplete [class]="panelClass" #auto="matAutocomplete" [displayWith]="displayFn"
+  [disableRipple]="disableRipple" (opened)="openedSpy()" (closed)="closedSpy()"
+  [optionHeight]="16" [panelHeight]="240">
+  <mat-option *ngFor="let state of filteredStates" [value]="state">
+    <span>{{ state.code }}: {{ state.name }}</span>
+  </mat-option>
+</mat-autocomplete>
+`})
+class AutocompleteWithDefinedOptionAndPanelHeights implements OnDestroy {
+  stateCtrl = new FormControl();
+  filteredStates: any[];
+  valueSub: Subscription;
+  floatLabel = 'auto';
+  position = 'auto';
+  width: number;
+  disableRipple = false;
+  autocompleteDisabled = false;
+  panelClass = 'class-one class-two';
+  openedSpy = jasmine.createSpy('autocomplete opened spy');
+  closedSpy = jasmine.createSpy('autocomplete closed spy');
+
+  @ViewChild(MatAutocompleteTrigger, {static: true}) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocomplete) panel: MatAutocomplete;
+  @ViewChild(MatFormField) formField: MatFormField;
+  @ViewChildren(MatOption) options: QueryList<MatOption>;
+
+  states = [
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+  ];
+
+
+  constructor() {
+    this.filteredStates = this.states;
+    this.valueSub = this.stateCtrl.valueChanges.subscribe(val => {
+      this.filteredStates = val ? this.states.filter((s) => s.name.match(new RegExp(val, 'gi')))
+                                : this.states;
+    });
+  }
+
+  displayFn(value: any): string {
+    return value ? value.name : value;
+  }
+
+  ngOnDestroy() {
+    this.valueSub.unsubscribe();
+  }
 }

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -85,6 +85,12 @@ export function MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY(): MatAutocompleteDefau
   return {autoActiveFirstOption: false};
 }
 
+/** The height of each autocomplete option. */
+export const AUTOCOMPLETE_OPTION_HEIGHT = 48;
+
+/** The total height of the autocomplete panel. */
+export const AUTOCOMPLETE_PANEL_HEIGHT = 256;
+
 @Component({
   selector: 'mat-autocomplete',
   templateUrl: 'autocomplete.html',
@@ -150,6 +156,27 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
    */
   @Input() panelWidth: string | number;
 
+  /**
+   * Specify the height of each option in the autocomplete panel, px. Default 48
+   * auto - to detect option height automatically
+   * number - to set height as inline style
+   * undefined - to use default value AUTOCOMPLETE_OPTION_HEIGHT
+   */
+  @Input() optionHeight: number | 'auto' | undefined;
+
+  /**
+   * Uses to prevent multiple requests to DOM and remember last height of option.
+   * Uses only with option "auto"
+   */
+  private _cachedOptionHeight: number = 0;
+
+  /**
+   * Specify the height of the autocomplete panel, px. Default 256
+   * number - to set height as inline style
+   * undefined - to use default value AUTOCOMPLETE_PANEL_HEIGHT
+   */
+  @Input() panelHeight: number | undefined;
+
   /** Event that is emitted whenever an option from the list is selected. */
   @Output() readonly optionSelected: EventEmitter<MatAutocompleteSelectedEvent> =
       new EventEmitter<MatAutocompleteSelectedEvent>();
@@ -208,6 +235,61 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
 
   ngOnDestroy() {
     this._activeOptionChanges.unsubscribe();
+  }
+
+  /**
+   * Returns height of option. Uses in scope of MatAutocompleteTrigger
+   */
+  _getOptionHeightPx(): number {
+    if (this.optionHeight === 'auto') {
+      if (this.options.length > 0) {
+        if (this._cachedOptionHeight === 0) {
+          this._cachedOptionHeight = this.options.first._getHeightHostElement();
+        }
+        return this._cachedOptionHeight;
+      } else {
+        return 0;
+      }
+    } else if (typeof this.optionHeight === 'number') {
+      return this.optionHeight;
+    } else {
+      return AUTOCOMPLETE_OPTION_HEIGHT;
+    }
+  }
+
+  /**
+   * Returns height of option. Uses in scope of MatOption
+   * It also returs undefined to let MatOption component do not
+   * define anyhow height of option.
+   */
+  getOptionHeight(): number | undefined {
+    if (this.optionHeight === 'auto') {
+      return undefined;
+    } else {
+      return this._getOptionHeightPx();
+    }
+  }
+
+  /**
+   * Returns height of whole panel
+   */
+  _getPanelHeightPx(): number {
+    if (this.panelHeight === undefined) {
+      return AUTOCOMPLETE_PANEL_HEIGHT;
+    } else {
+      return this.panelHeight;
+    }
+  }
+
+  /**
+   * Returns height of whole panel to be injected as inline style into panel
+   */
+  _getPanelHeightInlineStyle(): string {
+    if (this.panelHeight === undefined) {
+      return '';
+    } else {
+      return this.panelHeight + 'px';
+    }
   }
 
   /**

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -51,6 +51,7 @@ export class MatOptionSelectionChange {
 export interface MatOptionParentComponent {
   disableRipple?: boolean;
   multiple?: boolean;
+  getOptionHeight?: () => number | undefined;
 }
 
 /**
@@ -75,6 +76,7 @@ export const MAT_OPTION_PARENT_COMPONENT =
     '[attr.aria-selected]': '_getAriaSelected()',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[class.mat-option-disabled]': 'disabled',
+    '[style.height]': '_getInlineStyleHeight()',
     '(click)': '_selectViaInteraction()',
     '(keydown)': '_handleKeydown($event)',
     'class': 'mat-option mat-focus-indicator',
@@ -240,6 +242,31 @@ export class MatOption implements FocusableOption, AfterViewChecked, OnDestroy {
   /** Gets the host DOM element. */
   _getHostElement(): HTMLElement {
     return this._element.nativeElement;
+  }
+
+  /** Gets actual height of the host DOM element. */
+  _getHeightHostElement(): number {
+    if (!this._element) {
+      return 0;
+    }
+    return this._element.nativeElement.getBoundingClientRect().height;
+  }
+
+  _getInlineStyleHeight(): string {
+    if (!this._parent) {
+      return '';
+    }
+    if (typeof this._parent.getOptionHeight !== 'function') {
+      return '';
+    }
+    const height: number | undefined = this._parent.getOptionHeight();
+    if (height === undefined) {
+      return '';
+    }
+    if (isNaN(height) || !isFinite(height)) {
+      return '';
+    }
+    return height + 'px';
   }
 
   ngAfterViewChecked() {

--- a/tools/public_api_guard/material/autocomplete.d.ts
+++ b/tools/public_api_guard/material/autocomplete.d.ts
@@ -57,7 +57,7 @@ export declare class MatAutocomplete extends _MatAutocompleteMixinBase implement
     ngOnDestroy(): void;
     static ngAcceptInputType_autoActiveFirstOption: BooleanInput;
     static ngAcceptInputType_disableRipple: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": "disableRipple"; "displayWith": "displayWith"; "autoActiveFirstOption": "autoActiveFirstOption"; "panelWidth": "panelWidth"; "optionHeight": "optionHeight"; "panelHeight": "panelHeight"; "classList": "class"; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; }, ["options", "optionGroups"]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": "disableRipple"; "displayWith": "displayWith"; "autoActiveFirstOption": "autoActiveFirstOption"; "panelWidth": "panelWidth"; "optionHeight": "optionHeight"; "panelHeight": "panelHeight"; "classList": "class"; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; "optionActivated": "optionActivated"; }, ["options", "optionGroups"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatAutocomplete>;
 }
 

--- a/tools/public_api_guard/material/autocomplete.d.ts
+++ b/tools/public_api_guard/material/autocomplete.d.ts
@@ -57,7 +57,7 @@ export declare class MatAutocomplete extends _MatAutocompleteMixinBase implement
     ngOnDestroy(): void;
     static ngAcceptInputType_autoActiveFirstOption: BooleanInput;
     static ngAcceptInputType_disableRipple: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { 'disableRipple': "disableRipple", 'displayWith': "displayWith", 'autoActiveFirstOption': "autoActiveFirstOption", 'panelWidth': "panelWidth", 'optionHeight': "optionHeight", 'panelHeight': "panelHeight", 'classList': "class" }, { 'optionSelected': "optionSelected", 'opened': "opened", 'closed': "closed" }, ["options", "optionGroups"]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": "disableRipple"; "displayWith": "displayWith"; "autoActiveFirstOption": "autoActiveFirstOption"; "panelWidth": "panelWidth"; "optionHeight": "optionHeight"; "panelHeight": "panelHeight"; "classList": "class"; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; }, ["options", "optionGroups"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatAutocomplete>;
 }
 

--- a/tools/public_api_guard/material/autocomplete.d.ts
+++ b/tools/public_api_guard/material/autocomplete.d.ts
@@ -36,22 +36,28 @@ export declare class MatAutocomplete extends _MatAutocompleteMixinBase implement
     readonly opened: EventEmitter<void>;
     readonly optionActivated: EventEmitter<MatAutocompleteActivatedEvent>;
     optionGroups: QueryList<MatOptgroup>;
+    optionHeight: number | 'auto' | undefined;
     readonly optionSelected: EventEmitter<MatAutocompleteSelectedEvent>;
     options: QueryList<MatOption>;
     panel: ElementRef;
+    panelHeight: number | undefined;
     panelWidth: string | number;
     showPanel: boolean;
     template: TemplateRef<any>;
     constructor(_changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, defaults: MatAutocompleteDefaultOptions);
     _emitSelectEvent(option: MatOption): void;
+    _getOptionHeightPx(): number;
+    _getPanelHeightInlineStyle(): string;
+    _getPanelHeightPx(): number;
     _getScrollTop(): number;
     _setScrollTop(scrollTop: number): void;
     _setVisibility(): void;
+    getOptionHeight(): number | undefined;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     static ngAcceptInputType_autoActiveFirstOption: BooleanInput;
     static ngAcceptInputType_disableRipple: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": "disableRipple"; "displayWith": "displayWith"; "autoActiveFirstOption": "autoActiveFirstOption"; "panelWidth": "panelWidth"; "classList": "class"; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; "optionActivated": "optionActivated"; }, ["options", "optionGroups"]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { 'disableRipple': "disableRipple", 'displayWith': "displayWith", 'autoActiveFirstOption': "autoActiveFirstOption", 'panelWidth': "panelWidth", 'optionHeight': "optionHeight", 'panelHeight': "panelHeight", 'classList': "class" }, { 'optionSelected': "optionSelected", 'opened': "opened", 'closed': "closed" }, ["options", "optionGroups"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatAutocomplete>;
 }
 

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -262,7 +262,9 @@ export declare class MatOption implements FocusableOption, AfterViewChecked, OnD
     get viewValue(): string;
     constructor(_element: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _parent: MatOptionParentComponent, group: MatOptgroup);
     _getAriaSelected(): boolean | null;
+    _getHeightHostElement(): number;
     _getHostElement(): HTMLElement;
+    _getInlineStyleHeight(): string;
     _getTabIndex(): string;
     _handleKeydown(event: KeyboardEvent): void;
     _selectViaInteraction(): void;
@@ -286,6 +288,7 @@ export declare class MatOptionModule {
 
 export interface MatOptionParentComponent {
     disableRipple?: boolean;
+    getOptionHeight?: () => number | undefined;
     multiple?: boolean;
 }
 


### PR DESCRIPTION
feat(material/autocomplete) settable height of option; settable height of panel

Allows defining a height of option and a height of panel by setting `optionHieght` or/and `panelHeight` inputs on `mat-autocomplete` component.

Fixes: #18030
Related to: #3810, #10038