### PR TITLE
refactor: use recommended approach for asserting observables

### DIFF
--- a/src/cdk/collections/array-data-source.ts
+++ b/src/cdk/collections/array-data-source.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Observable, of as observableOf} from 'rxjs';
+import {Observable, isObservable, of as observableOf} from 'rxjs';
 import {DataSource} from './data-source';
 
 
@@ -17,7 +17,7 @@ export class ArrayDataSource<T> extends DataSource<T> {
   }
 
   connect(): Observable<T[] | ReadonlyArray<T>> {
-    return this._data instanceof Observable ? this._data : observableOf(this._data);
+    return isObservable(this._data) ? this._data : observableOf(this._data);
   }
 
   disconnect() {}

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -30,7 +30,7 @@ import {
   TrackByFunction,
   ViewContainerRef,
 } from '@angular/core';
-import {Observable, Subject, of as observableOf} from 'rxjs';
+import {Observable, Subject, of as observableOf, isObservable} from 'rxjs';
 import {pairwise, shareReplay, startWith, switchMap, takeUntil} from 'rxjs/operators';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
 
@@ -93,7 +93,7 @@ export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy 
     } else {
       // Slice the value if its an NgIterable to ensure we're working with an array.
       this._dataSourceChanges.next(new ArrayDataSource<T>(
-          value instanceof Observable ? value : Array.prototype.slice.call(value || [])));
+          isObservable(value) ? value : Array.prototype.slice.call(value || [])));
     }
   }
   _cdkVirtualForOf: DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined;

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -37,7 +37,14 @@ import {
   ViewContainerRef,
   ViewEncapsulation
 } from '@angular/core';
-import {BehaviorSubject, Observable, of as observableOf, Subject, Subscription} from 'rxjs';
+import {
+  BehaviorSubject,
+  Observable,
+  of as observableOf,
+  Subject,
+  Subscription,
+  isObservable,
+} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {CdkColumnDef} from './cell';
 import {
@@ -832,7 +839,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
 
     if (isDataSource(this.dataSource)) {
       dataStream = this.dataSource.connect(this);
-    } else if (this.dataSource instanceof Observable) {
+    } else if (isObservable(this.dataSource)) {
       dataStream = this.dataSource;
     } else if (Array.isArray(this.dataSource)) {
       dataStream = observableOf(this.dataSource);

--- a/src/cdk/tree/control/nested-tree-control.ts
+++ b/src/cdk/tree/control/nested-tree-control.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Observable} from 'rxjs';
+import {Observable, isObservable} from 'rxjs';
 import {take, filter} from 'rxjs/operators';
 import {BaseTreeControl} from './base-tree-control';
 
@@ -45,7 +45,7 @@ export class NestedTreeControl<T> extends BaseTreeControl<T> {
     const childrenNodes = this.getChildren(dataNode);
     if (Array.isArray(childrenNodes)) {
       childrenNodes.forEach((child: T) => this._getDescendants(descendants, child));
-    } else if (childrenNodes instanceof Observable) {
+    } else if (isObservable(childrenNodes)) {
       // TypeScript as of version 3.5 doesn't seem to treat `Boolean` like a function that
       // returns a `boolean` specifically in the context of `filter`, so we manually clarify that.
       childrenNodes.pipe(take(1), filter(Boolean as () => boolean))

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -15,7 +15,7 @@ import {
   OnDestroy,
   QueryList,
 } from '@angular/core';
-import {Observable} from 'rxjs';
+import {isObservable} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
 import {CDK_TREE_NODE_OUTLET_NODE, CdkTreeNodeOutlet} from './outlet';
@@ -70,7 +70,7 @@ export class CdkNestedTreeNode<T> extends CdkTreeNode<T> implements AfterContent
     const childrenNodes = this._tree.treeControl.getChildren(this.data);
     if (Array.isArray(childrenNodes)) {
       this.updateChildrenNodes(childrenNodes as T[]);
-    } else if (childrenNodes instanceof Observable) {
+    } else if (isObservable(childrenNodes)) {
       childrenNodes.pipe(takeUntil(this._destroyed))
         .subscribe(result => this.updateChildrenNodes(result));
     }

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -27,7 +27,14 @@ import {
   ViewEncapsulation,
   TrackByFunction
 } from '@angular/core';
-import {BehaviorSubject, Observable, of as observableOf, Subject, Subscription} from 'rxjs';
+import {
+  BehaviorSubject,
+  Observable,
+  of as observableOf,
+  Subject,
+  Subscription,
+  isObservable,
+} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {TreeControl} from './control/tree-control';
 import {CdkTreeNodeDef, CdkTreeNodeOutletContext} from './node';
@@ -194,7 +201,7 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
 
     if (isDataSource(this._dataSource)) {
       dataStream = this._dataSource.connect(this);
-    } else if (this._dataSource instanceof Observable) {
+    } else if (isObservable(this._dataSource)) {
       dataStream = this._dataSource;
     } else if (Array.isArray(this._dataSource)) {
       dataStream = observableOf(this._dataSource);
@@ -366,7 +373,7 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
       const childrenNodes = this._tree.treeControl.getChildren(this._data);
       if (Array.isArray(childrenNodes)) {
         this._setRoleFromChildren(childrenNodes as T[]);
-      } else if (childrenNodes instanceof Observable) {
+      } else if (isObservable(childrenNodes)) {
         childrenNodes.pipe(takeUntil(this._destroyed))
             .subscribe(children => this._setRoleFromChildren(children));
       }


### PR DESCRIPTION
Switches the assertions for whether a value is an observable to use `isObservable`, rather than `value instanceof Observable` which has been the recommended approach since rxjs 6.1.

See https://github.com/ReactiveX/RxJS/commit/edb33e5.