### PR TITLE
docs(menu): fix inaccurate descriptions

### DIFF
--- a/src/material-experimental/mdc-menu/menu-item.ts
+++ b/src/material-experimental/mdc-menu/menu-item.ts
@@ -11,8 +11,7 @@ import {Component, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/co
 import {MatMenuItem as BaseMatMenuItem} from '@angular/material/menu';
 
 /**
- * This directive is intended to be used inside an mat-menu tag.
- * It exists mostly to set the role attribute.
+ * Single item inside of a `mat-menu`. Provides the menu item styling and accessibility treatment.
  */
 @Component({
   selector: '[mat-menu-item]',

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -36,8 +36,7 @@ const _MatMenuItemMixinBase: CanDisableRippleCtor & CanDisableCtor & typeof MatM
     mixinDisableRipple(mixinDisabled(MatMenuItemBase));
 
 /**
- * This directive is intended to be used inside an mat-menu tag.
- * It exists mostly to set the role attribute.
+ * Single item inside of a `mat-menu`. Provides the menu item styling and accessibility treatment.
  */
 @Component({
   selector: '[mat-menu-item]',

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -66,10 +66,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({passive: tr
 
 // TODO(andrewseguin): Remove the kebab versions in favor of camelCased attribute selectors
 
-/**
- * This directive is intended to be used in conjunction with an mat-menu tag.  It is
- * responsible for toggling the display of the provided menu instance.
- */
+/** Directive applied to an element that should trigger a `mat-menu`. */
 @Directive({
   selector: `[mat-menu-trigger-for], [matMenuTriggerFor]`,
   host: {


### PR DESCRIPTION
Fixes the inaccurate description of the menu item which was saying that it's a directive (even though it's a component) and that it's only there to provide the `role`. Also updates the description for the menu trigger.

Fixes #18013.