### PR TITLE
fix(scrolling): update virtual scroll viewport size on resize

### DIFF
--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -16,7 +16,15 @@ import {
   Directive,
   ViewContainerRef
 } from '@angular/core';
-import {async, ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
+import {
+  async,
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  inject,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import {animationFrameScheduler, Subject} from 'rxjs';
 
 
@@ -72,6 +80,17 @@ describe('CdkVirtualScrollViewport', () => {
       flush();
       viewport.checkViewportSize();
       expect(viewport.getViewportSize()).toBe(500);
+    }));
+
+    it('should update the viewport size when the page viewport changes', fakeAsync(() => {
+      finishInit(fixture);
+      spyOn(viewport, 'checkViewportSize').and.callThrough();
+
+      dispatchFakeEvent(window, 'resize');
+      fixture.detectChanges();
+      tick(20); // The resize listener is debounced so we need to flush it.
+
+      expect(viewport.checkViewportSize).toHaveBeenCalled();
     }));
 
     it('should get the rendered range', fakeAsync(() => {

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -105,7 +105,8 @@ export declare class CdkVirtualScrollViewport extends CdkScrollable implements O
     orientation: 'horizontal' | 'vertical';
     renderedRangeStream: Observable<ListRange>;
     scrolledIndexChange: Observable<number>;
-    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher);
+    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher,
+    viewportRuler?: ViewportRuler);
     attach(forOf: CdkVirtualForOf<any>): void;
     checkViewportSize(): void;
     detach(): void;


### PR DESCRIPTION
We currently cache the size of the virtual scroll viewport, but it may become inaccurate if it's a percentage of the page viewport and the page is resized. These changes add an extra call that'll update the virtual scroll viewport on resize.

Fixes #16802.