### PR TITLE
fix(material-experimental/mdc-chips): checkmark not visible in high contrast black-on-white mode

### DIFF
--- a/src/material-experimental/mdc-chips/chips.scss
+++ b/src/material-experimental/mdc-chips/chips.scss
@@ -71,3 +71,12 @@ $mat-chip-input-width: 150px;
 input.mat-mdc-chip-input {
   flex: 1 0 $mat-chip-input-width;
 }
+
+.mdc-chip__checkmark-path {
+  @include cdk-high-contrast(black-on-white) {
+    // SVG colors won't be changed in high contrast mode and since the checkmark is white
+    // by default, it'll blend in with the background in black-on-white mode. Override the color
+    // to ensure that it's visible. We need !important, because the theme styles are very specific.
+    stroke: #000 !important;
+  }
+}


### PR DESCRIPTION
In high contrast mode SVG colors aren't changed which means that the white checkmark in the `mat-chip` will blend in with the background in black-on-white mode. These changes add an override to make the checkmark black in this case.