### PR TITLE
fix(form-field): error when focusing outline form field angular elements on IE/Edge

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -568,10 +568,10 @@ export class MatFormField extends _MatFormFieldMixinBase
     }
 
     for (let i = 0; i < startEls.length; i++) {
-      startEls.item(i).style.width = `${startWidth}px`;
+      startEls[i].style.width = `${startWidth}px`;
     }
     for (let i = 0; i < gapEls.length; i++) {
-      gapEls.item(i).style.width = `${gapWidth}px`;
+      gapEls[i].style.width = `${gapWidth}px`;
     }
 
     this._outlineGapCalculationNeededOnStable =


### PR DESCRIPTION
Fixes an error that was being thrown by IE and Edge when focusing an outline form field, because we were using `item` to access the items inside a `querySelectorAll` result. It seems like `item` isn't available when we're inside a polyfilled web component.

Fixes #16095.