### PR TITLE
fix(clipboard): leak if directive is destroyed while a copy is pending

### DIFF
--- a/src/cdk/clipboard/copy-to-clipboard.spec.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.spec.ts
@@ -59,7 +59,7 @@ describe('CdkCopyToClipboard', () => {
   it('emits copied event false when copy fails', fakeAsync(() => {
     spyOn(clipboard, 'copy').and.returnValue(false);
     fixture.nativeElement.querySelector('button')!.click();
-    tick();
+    tick(1);
 
     expect(fixture.componentInstance.copied).toHaveBeenCalledWith(false);
   }));
@@ -76,7 +76,7 @@ describe('CdkCopyToClipboard', () => {
 
     fixture.nativeElement.querySelector('button')!.click();
     fixture.detectChanges();
-    tick();
+    tick(3);
 
     expect(attempts).toBe(maxAttempts);
     expect(fixture.componentInstance.copied).toHaveBeenCalledTimes(1);
@@ -98,10 +98,37 @@ describe('CdkCopyToClipboard', () => {
 
     fixture.nativeElement.querySelector('button')!.click();
     fixture.detectChanges();
-    tick();
+    tick(3);
 
     expect(attempts).toBe(maxAttempts);
     expect(fixture.componentInstance.copied).toHaveBeenCalledTimes(1);
     expect(fixture.componentInstance.copied).toHaveBeenCalledWith(false);
   }));
+
+  it('should destroy any pending copies when the directive is destroyed', fakeAsync(() => {
+    const fakeCopy = {
+      copy: jasmine.createSpy('copy spy').and.returnValue(false) as () => boolean,
+      destroy: jasmine.createSpy('destroy spy') as () => void
+    } as PendingCopy;
+
+    fixture.componentInstance.attempts = 10;
+    fixture.detectChanges();
+
+    spyOn(clipboard, 'beginCopy').and.returnValue(fakeCopy);
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('button')!.click();
+    fixture.detectChanges();
+    tick(1);
+
+    expect(fakeCopy.copy).toHaveBeenCalledTimes(2);
+    expect(fakeCopy.destroy).toHaveBeenCalledTimes(0);
+
+    fixture.destroy();
+    tick(1);
+
+    expect(fakeCopy.copy).toHaveBeenCalledTimes(2);
+    expect(fakeCopy.destroy).toHaveBeenCalledTimes(1);
+  }));
+
 });

--- a/tools/public_api_guard/cdk/clipboard.d.ts
+++ b/tools/public_api_guard/cdk/clipboard.d.ts
@@ -1,4 +1,4 @@
-export declare class CdkCopyToClipboard {
+export declare class CdkCopyToClipboard implements OnDestroy {
     _deprecatedCopied: EventEmitter<boolean>;
     attempts: number;
     copied: EventEmitter<boolean>;
@@ -6,6 +6,7 @@ export declare class CdkCopyToClipboard {
     constructor(_clipboard: Clipboard,
     _ngZone?: NgZone | undefined, config?: CdkCopyToClipboardConfig);
     copy(attempts?: number): void;
+    ngOnDestroy(): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkCopyToClipboard, "[cdkCopyToClipboard]", never, { "text": "cdkCopyToClipboard"; "attempts": "cdkCopyToClipboardAttempts"; }, { "copied": "cdkCopyToClipboardCopied"; "_deprecatedCopied": "copied"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkCopyToClipboard>;
 }


### PR DESCRIPTION
If the `cdkCopyToClipboard` directive is destroyed while there are pending copies, we'll create a leak since the `PendingCopy` will never be destroyed. These changes add some extra logic to ensure that the copies are destroyed and the timeouts are cleared.