### PR TITLE
docs: fix typos in CDK and Material tree examples

### DIFF
--- a/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.ts
+++ b/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.ts
@@ -33,7 +33,7 @@ const TREE_DATA: ExampleFlatNode[] = [
     expandable: false,
     level: 2,
   }, {
-    name: 'Brussel sprouts',
+    name: 'Brussels sprouts',
     expandable: false,
     level: 2,
   }, {

--- a/src/components-examples/cdk/tree/cdk-tree-nested/cdk-tree-nested-example.ts
+++ b/src/components-examples/cdk/tree/cdk-tree-nested/cdk-tree-nested-example.ts
@@ -26,7 +26,7 @@ const TREE_DATA: FoodNode[] = [
         name: 'Green',
         children: [
           {name: 'Broccoli'},
-          {name: 'Brussel sprouts'},
+          {name: 'Brussels sprouts'},
         ]
       }, {
         name: 'Orange',

--- a/src/components-examples/example-data.ts
+++ b/src/components-examples/example-data.ts
@@ -3,8 +3,8 @@
 import {EXAMPLE_COMPONENTS} from './example-module';
 
 /**
- * Example data
- *   with information about Component name, selector, files used in example, and path to examples
+ * Example data with information about component name, selector, files used in example, and path to
+ * examples.
  */
 export class ExampleData {
 

--- a/src/components-examples/material/tree/tree-flat-overview/tree-flat-overview-example.ts
+++ b/src/components-examples/material/tree/tree-flat-overview/tree-flat-overview-example.ts
@@ -4,7 +4,7 @@ import {MatTreeFlatDataSource, MatTreeFlattener} from '@angular/material/tree';
 
 /**
  * Food data with nested structure.
- * Each node has a name and an optiona list of children.
+ * Each node has a name and an optional list of children.
  */
 interface FoodNode {
   name: string;
@@ -26,7 +26,7 @@ const TREE_DATA: FoodNode[] = [
         name: 'Green',
         children: [
           {name: 'Broccoli'},
-          {name: 'Brussel sprouts'},
+          {name: 'Brussels sprouts'},
         ]
       }, {
         name: 'Orange',

--- a/src/components-examples/material/tree/tree-nested-overview/tree-nested-overview-example.ts
+++ b/src/components-examples/material/tree/tree-nested-overview/tree-nested-overview-example.ts
@@ -4,7 +4,7 @@ import {MatTreeNestedDataSource} from '@angular/material/tree';
 
 /**
  * Food data with nested structure.
- * Each node has a name and an optiona list of children.
+ * Each node has a name and an optional list of children.
  */
 interface FoodNode {
   name: string;
@@ -26,7 +26,7 @@ const TREE_DATA: FoodNode[] = [
         name: 'Green',
         children: [
           {name: 'Broccoli'},
-          {name: 'Brussel sprouts'},
+          {name: 'Brussels sprouts'},
         ]
       }, {
         name: 'Orange',

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -685,7 +685,7 @@ const TREE_DATA: FoodNode[] = [
         name: 'Green',
         children: [
           {name: 'Broccoli'},
-          {name: 'Brussel sprouts'},
+          {name: 'Brussels sprouts'},
         ]
       }, {
         name: 'Orange',


### PR DESCRIPTION
- optiona -> optional
- Brussel sprouts -> Brussels sprouts