### PR TITLE
build: do not merge interface members with class API members

### DIFF
--- a/tools/dgeni/common/class-inheritance.ts
+++ b/tools/dgeni/common/class-inheritance.ts
@@ -1,16 +1,80 @@
+// tslint:disable:no-bitwise
+
+import {ClassExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassExportDoc';
 import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassLikeExportDoc';
+import {InterfaceExportDoc} from 'dgeni-packages/typescript/api-doc-types/InterfaceExportDoc';
+import * as ts from 'typescript';
 
 /** Gets all class like export documents which the given doc inherits from. */
-export function getInheritedDocsOfClass(doc: ClassLikeExportDoc): ClassLikeExportDoc[] {
-  const directBaseDocs = [
-    ...doc.implementsClauses.filter(clause => clause.doc).map(d => d.doc!),
-    ...doc.extendsClauses.filter(clause => clause.doc).map(d => d.doc!),
-  ];
+export function getInheritedDocsOfClass(
+    doc: ClassLikeExportDoc,
+    exportSymbolsToDocsMap: Map<ts.Symbol, ClassLikeExportDoc>): ClassLikeExportDoc[] {
+  const result: ClassLikeExportDoc[] = [];
+  const typeChecker = doc.typeChecker;
+  for (let info of doc.extendsClauses) {
+    if (info.doc) {
+      result.push(info.doc, ...getInheritedDocsOfClass(info.doc, exportSymbolsToDocsMap));
+    } else if (info.type) {
+      // If the heritage info has not been resolved to a Dgeni API document, we try to
+      // interpret the type expression and resolve/create corresponding Dgeni API documents.
+      // An example is the use of mixins. Type-wise mixins are not like real classes, because
+      // they are composed through an intersection type. In order to handle this pattern, we
+      // need to handle intersection types manually and resolve them to Dgeni API documents.
+      const resolvedType = typeChecker.getTypeAtLocation(info.type);
+      const docs = getClassLikeDocsFromType(resolvedType, doc, exportSymbolsToDocsMap);
+      // Add direct class-like types resolved from the expression.
+      result.push(...docs);
+      // Resolve inherited docs of the resolved documents.
+      docs.forEach(d => result.push(...getInheritedDocsOfClass(d, exportSymbolsToDocsMap)));
+    }
+  }
+  return result;
+}
 
-  return [
-    ...directBaseDocs,
-    // recursively collect base documents of direct base documents.
-    ...directBaseDocs.reduce(
-      (res: ClassLikeExportDoc[], d) => res.concat(getInheritedDocsOfClass(d)), []),
-  ];
+/**
+ * Gets all class-like Dgeni documents from the given type. e.g. intersection types of
+ * multiple classes will result in multiple Dgeni API documents for each class.
+ */
+function getClassLikeDocsFromType(
+    type: ts.Type, baseDoc: ClassLikeExportDoc,
+    exportSymbolsToDocsMap: Map<ts.Symbol, ClassLikeExportDoc>): ClassLikeExportDoc[] {
+  let aliasSymbol: ts.Symbol|undefined = undefined;
+  let symbol: ts.Symbol = type.symbol;
+  const typeChecker = baseDoc.typeChecker;
+
+  // Symbols can be aliases of the declaration symbol. e.g. in named import
+  // specifiers. We need to resolve the aliased symbol back to the declaration symbol.
+  if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    aliasSymbol = symbol;
+    symbol = typeChecker.getAliasedSymbol(symbol);
+  }
+
+  // Intersection types are commonly used in TypeScript mixins to express the
+  // class augmentation. e.g. "BaseClass & CanColor".
+  if (type.isIntersection()) {
+    return type.types.reduce(
+        (res, t) => [...res, ...getClassLikeDocsFromType(t, baseDoc, exportSymbolsToDocsMap)],
+        [] as ClassLikeExportDoc[]);
+  } else if (symbol) {
+    // If the given symbol has already been registered within Dgeni, we use the
+    // existing symbol instead of creating a new one. The dgeni typescript package
+    // keeps track of all exported symbols and their corresponding docs. See:
+    // dgeni-packages/blob/master/typescript/src/processors/linkInheritedDocs.ts
+    if (exportSymbolsToDocsMap.has(symbol)) {
+      return [exportSymbolsToDocsMap.get(symbol)!];
+    }
+    let createdDoc: ClassLikeExportDoc|null = null;
+    if ((symbol.flags & ts.SymbolFlags.Class) !== 0) {
+      createdDoc = new ClassExportDoc(baseDoc.host, baseDoc.moduleDoc, symbol, aliasSymbol);
+    } else if ((symbol.flags & ts.SymbolFlags.Interface) !== 0) {
+      createdDoc = new InterfaceExportDoc(baseDoc.host, baseDoc.moduleDoc, symbol, aliasSymbol);
+    }
+    // If a new document has been created, add it to the shared symbol
+    // docs map and return it.
+    if (createdDoc) {
+      exportSymbolsToDocsMap.set(aliasSymbol || symbol, createdDoc);
+      return [createdDoc];
+    }
+  }
+  return [];
 }

--- a/tools/dgeni/docs-package.ts
+++ b/tools/dgeni/docs-package.ts
@@ -1,15 +1,15 @@
 import {Package} from 'dgeni';
+import {ReadTypeScriptModules} from 'dgeni-packages/typescript/processors/readTypeScriptModules';
 import {Host} from 'dgeni-packages/typescript/services/ts-host/host';
+import {TypeFormatFlags} from 'typescript';
 import {HighlightNunjucksExtension} from './nunjucks-tags/highlight';
 import {patchLogService} from './patch-log-service';
 import {AsyncFunctionsProcessor} from './processors/async-functions';
+import {categorizer} from './processors/categorizer';
 import {DocsPrivateFilter} from './processors/docs-private-filter';
-import {Categorizer} from './processors/categorizer';
-import {FilterDuplicateExports} from './processors/filter-duplicate-exports';
-import {MergeInheritedProperties} from './processors/merge-inherited-properties';
 import {EntryPointGrouper} from './processors/entry-point-grouper';
-import {ReadTypeScriptModules} from 'dgeni-packages/typescript/processors/readTypeScriptModules';
-import {TypeFormatFlags} from 'typescript';
+import {FilterDuplicateExports} from './processors/filter-duplicate-exports';
+import {mergeInheritedProperties} from './processors/merge-inherited-properties';
 
 // Dgeni packages that the Material docs package depends on.
 const jsdocPackage = require('dgeni-packages/jsdoc');
@@ -39,13 +39,14 @@ export const apiDocsPackage = new Package('material2-api-docs', [
 apiDocsPackage.processor(new FilterDuplicateExports());
 
 // Processor that merges inherited properties of a class with the class doc.
-apiDocsPackage.processor(new MergeInheritedProperties());
+// Note: needs to use a factory function since the processor relies on DI.
+apiDocsPackage.processor(mergeInheritedProperties);
 
 // Processor that filters out symbols that should not be shown in the docs.
 apiDocsPackage.processor(new DocsPrivateFilter());
 
 // Processor that appends categorization flags to the docs, e.g. `isDirective`, `isNgModule`, etc.
-apiDocsPackage.processor(new Categorizer());
+apiDocsPackage.processor(categorizer);
 
 // Processor to group docs into top-level entry-points such as "tabs", "sidenav", etc.
 apiDocsPackage.processor(new EntryPointGrouper());

--- a/tools/dgeni/processors/categorizer.ts
+++ b/tools/dgeni/processors/categorizer.ts
@@ -1,5 +1,7 @@
 import {DocCollection, Processor} from 'dgeni';
+import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassLikeExportDoc';
 import {MemberDoc} from 'dgeni-packages/typescript/api-doc-types/MemberDoc';
+import * as ts from 'typescript';
 import {getInheritedDocsOfClass} from '../common/class-inheritance';
 import {
   decorateDeprecatedDoc,
@@ -25,6 +27,14 @@ import {isPublicDoc} from '../common/private-docs';
 import {getInputBindingData, getOutputBindingData} from '../common/property-bindings';
 import {sortCategorizedMethodMembers, sortCategorizedPropertyMembers} from '../common/sort-members';
 
+/**
+ * Factory function for the "Categorizer" processor. Dgeni does not support
+ * dependency injection for classes. The symbol docs map is provided by the
+ * TypeScript dgeni package.
+ */
+export function categorizer(exportSymbolsToDocsMap: Map<ts.Symbol, ClassLikeExportDoc>) {
+  return new Categorizer(exportSymbolsToDocsMap);
+}
 
 /**
  * Processor to add properties to docs objects.
@@ -35,8 +45,11 @@ import {sortCategorizedMethodMembers, sortCategorizedPropertyMembers} from '../c
  * isNgModule   | Whether the doc is for an NgModule
  */
 export class Categorizer implements Processor {
-  name = 'categorizer';
   $runBefore = ['docs-processed', 'entryPointGrouper'];
+
+  constructor(
+    /** Shared map that can be used to resolve docs through symbols. */
+    private _exportSymbolsToDocsMap: Map<ts.Symbol, ClassLikeExportDoc>) {}
 
   $process(docs: DocCollection) {
     docs.filter(doc => doc.docType === 'class' || doc.docType === 'interface')
@@ -93,7 +106,7 @@ export class Categorizer implements Processor {
     // store the extended class in a variable.
     classDoc.extendedDoc = classDoc.extendsClauses[0] ? classDoc.extendsClauses[0].doc! : undefined;
     classDoc.directiveMetadata = getDirectiveMetadata(classDoc);
-    classDoc.inheritedDocs = getInheritedDocsOfClass(classDoc);
+    classDoc.inheritedDocs = getInheritedDocsOfClass(classDoc, this._exportSymbolsToDocsMap);
 
     // In case the extended document is not public, we don't want to print it in the
     // rendered class API doc. This causes confusion and also is not helpful as the

--- a/tools/dgeni/processors/docs-private-filter.ts
+++ b/tools/dgeni/processors/docs-private-filter.ts
@@ -9,7 +9,7 @@ import {getDocsPublicTag, isPublicDoc} from '../common/private-docs';
 export class DocsPrivateFilter implements Processor {
   name = 'docs-private-filter';
   $runBefore = ['categorizer'];
-  $runAfter = ['merge-inherited-properties'];
+  $runAfter = ['mergeInheritedProperties'];
 
   $process(docs: DocCollection) {
     return docs.filter(doc => {

--- a/tools/dgeni/processors/merge-inherited-properties.ts
+++ b/tools/dgeni/processors/merge-inherited-properties.ts
@@ -1,15 +1,30 @@
 import {DocCollection, Processor} from 'dgeni';
 import {ClassExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassExportDoc';
+import {ClassLikeExportDoc} from 'dgeni-packages/typescript/api-doc-types/ClassLikeExportDoc';
 import {MemberDoc} from 'dgeni-packages/typescript/api-doc-types/MemberDoc';
+import * as ts from 'typescript';
 import {getInheritedDocsOfClass} from '../common/class-inheritance';
+
+/**
+ * Factory function for the "MergeInheritedProperties" processor. Dgeni does not support
+ * dependency injection for classes. The symbol docs map is provided by the TypeScript
+ * dgeni package.
+ */
+export function mergeInheritedProperties(
+    exportSymbolsToDocsMap: Map<ts.Symbol, ClassLikeExportDoc>) {
+  return new MergeInheritedProperties(exportSymbolsToDocsMap);
+}
 
 /**
  * Processor that merges inherited properties of a class with the class doc. This is necessary
  * to properly show public properties from TypeScript mixin interfaces in the API.
  */
 export class MergeInheritedProperties implements Processor {
-  name = 'merge-inherited-properties';
   $runBefore = ['categorizer'];
+
+  constructor(
+    /** Shared map that can be used to resolve docs through symbols. */
+    private _exportSymbolsToDocsMap: Map<ts.Symbol, ClassLikeExportDoc>) {}
 
   $process(docs: DocCollection) {
     return docs.filter(doc => doc.docType === 'class')
@@ -19,7 +34,7 @@ export class MergeInheritedProperties implements Processor {
   private _addInheritedProperties(doc: ClassExportDoc) {
     // Note that we need to get check all base documents. We cannot assume
     // that directive base documents already have merged inherited members.
-    getInheritedDocsOfClass(doc).forEach(d => {
+    getInheritedDocsOfClass(doc, this._exportSymbolsToDocsMap).forEach(d => {
       d.members.forEach(member => {
         // only add inherited class members which are not "protected" or "private".
         if (member.accessibility === 'public') {
@@ -35,9 +50,9 @@ export class MergeInheritedProperties implements Processor {
       // member doc for the destination class, we clone the member doc. It's important to keep
       // the prototype and reference because later, Dgeni identifies members and properties
       // by using an instance comparison.
-      const newMemberDoc = {...Object.create(memberDoc), ...memberDoc};
+      // tslint:disable-next-line:ban Need to use Object.assign to preserve the prototype.
+      const newMemberDoc = Object.assign(Object.create(memberDoc), memberDoc);
       newMemberDoc.containerDoc = destination;
-
       destination.members.push(newMemberDoc);
     }
   }


### PR DESCRIPTION
Currently we always merge _all_ members defined by interfaces
into the members of Dgeni class API documents. This causes optional
interface members to show up even if they are not implemented.

To fix this, the member merging processor has been reworked to
not even ever consider interfaces for the API docs and to handle mixins
defined through intersection types. Only members which are actually
defined/inherited should show up in the API docs.

Merging properties of interfaces was done in the past to handle mixins, but
this is no longer needed and its generally wrong to merge properties from interfaces.. 


Fixes #17148. Fixes #18014.