### PR TITLE
build: inherited members not showing up in API docs

### DIFF
--- a/tools/dgeni/processors/merge-inherited-properties.ts
+++ b/tools/dgeni/processors/merge-inherited-properties.ts
@@ -35,7 +35,8 @@ export class MergeInheritedProperties implements Processor {
       // member doc for the destination class, we clone the member doc. It's important to keep
       // the prototype and reference because later, Dgeni identifies members and properties
       // by using an instance comparison.
-      const newMemberDoc = {...Object.create(memberDoc), ...memberDoc};
+      // tslint:disable-next-line:ban Need to use Object.assign to preserve the prototype.
+      const newMemberDoc = Object.assign(Object.create(memberDoc), memberDoc);
       newMemberDoc.containerDoc = destination;
 
       destination.members.push(newMemberDoc);


### PR DESCRIPTION
d2ea0b8e5f30c521f8e896d3296f1d41bbbf26d3 switched `Object.assign` to a spread assignment
in the `MergeInheritedProperties` processor.

This broke the cloning of member Dgeni documents and caused the
inherited members to not show up in the API docs.

https://next.material.angular.io/components/button/api. Notice that
no inputs like `color` and `disabled` are shown.