### PR TITLE
refactor(datepicker): implement date selection model provider 

### DIFF
--- a/src/material/core/datetime/date-selection-model.ts
+++ b/src/material/core/datetime/date-selection-model.ts
@@ -70,6 +70,11 @@ export class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D> {
   asDate(): D | null {
     return this.isValid() ? this._date : null;
   }
+
+  setDate(date: D | null) {
+    this._date = date;
+    this._valueChangesSubject.next();
+  }
 }
 
 /**

--- a/src/material/core/datetime/date-selection-model.ts
+++ b/src/material/core/datetime/date-selection-model.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DateAdapter} from '@angular/material/core';
+import {Subject, Observable} from 'rxjs';
+
+export abstract class MatDateSelectionModel<D> {
+  protected _valueChangesSubject = new Subject<void>();
+  valueChanges: Observable<void> = this._valueChangesSubject.asObservable();
+
+  constructor(protected readonly adapter: DateAdapter<D>) {}
+
+  destroy() {
+    this._valueChangesSubject.complete();
+  }
+
+  abstract add(date: D | null): void;
+  abstract isComplete(): boolean;
+  abstract isSame(other: MatDateSelectionModel<D>): boolean;
+  abstract isValid(): boolean;
+}
+
+export interface DateRange<D> {
+  start: D | null;
+  end: D | null;
+}
+
+/**
+ * Concrete implementation of a MatDateSelectionModel that holds a single date.
+ */
+export class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D> {
+  private _date: D | null = null;
+
+  constructor(adapter: DateAdapter<D>, date?: D | null) {
+    super(adapter);
+    this._date = date === undefined ? null : date;
+  }
+
+  add(date: D | null) {
+    this._date = date;
+    this._valueChangesSubject.next();
+  }
+
+  compareDate(other: MatSingleDateSelectionModel<D>) {
+    const date = this.asDate();
+    const otherDate = other.asDate();
+    if (date != null && otherDate != null) {
+      return this.adapter.compareDate(date, otherDate);
+    }
+    return date === otherDate;
+  }
+
+  isComplete() { return this._date != null; }
+
+  isSame(other: MatDateSelectionModel<D>): boolean {
+    return other instanceof MatSingleDateSelectionModel &&
+        this.adapter.sameDate(other.asDate(), this._date);
+  }
+
+  isValid(): boolean {
+    return this._date != null && this.adapter.isDateInstance(this._date) &&
+           this.adapter.isValid(this._date);
+  }
+
+  asDate(): D | null {
+    return this.isValid() ? this._date : null;
+  }
+}
+
+/**
+ * Concrete implementation of a MatDateSelectionModel that holds a date range, represented by
+ * a start date and an end date.
+ */
+export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<D> {
+  private _start: D | null = null;
+  private _end: D | null = null;
+
+  constructor(adapter: DateAdapter<D>, start?: D | null, end?: D | null) {
+    super(adapter);
+    this._start = start === undefined ? null : start;
+    this._end = end === undefined ? null : end;
+  }
+
+  /**
+   * Adds an additional date to the range. If no date is set thus far, it will set it to the
+   * beginning. If the beginning is set, it will set it to the end.
+   * If add is called on a complete selection, it will empty the selection and set it as the start.
+   */
+  add(date: D | null): void {
+    if (this._start == null) {
+      this._start = date;
+    } else if (this._end == null) {
+      this._end = date;
+    } else {
+      this._start = date;
+      this._end = null;
+    }
+
+    this._valueChangesSubject.next();
+  }
+
+  setRange(start: D | null, end: D | null) {
+    this._start = start;
+    this._end = end;
+  }
+
+  isComplete(): boolean {
+    return this._start != null && this._end != null;
+  }
+
+  isSame(other: MatDateSelectionModel<D>): boolean {
+    if (other instanceof MatRangeDateSelectionModel) {
+      const otherRange = other.asRange();
+      return this.adapter.sameDate(this._start, otherRange.start) &&
+             this.adapter.sameDate(this._end, otherRange.end);
+    }
+    return false;
+  }
+
+  isValid(): boolean {
+    return this._start != null && this._end != null &&
+        this.adapter.isValid(this._start!) && this.adapter.isValid(this._end!);
+  }
+
+  asRange(): DateRange<D> {
+    return {
+      start: this._start,
+      end: this._end,
+    };
+  }
+}

--- a/src/material/core/datetime/index.ts
+++ b/src/material/core/datetime/index.ts
@@ -17,6 +17,7 @@ export * from './date-adapter';
 export * from './date-formats';
 export * from './native-date-adapter';
 export * from './native-date-formats';
+export * from './date-selection-model';
 
 
 @NgModule({

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -25,7 +25,13 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MatDateFormats,
+  MatDateSelectionModel,
+  MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER,
+} from '@angular/material/core';
 import {Subject, Subscription} from 'rxjs';
 import {MatCalendarCellCssClasses} from './calendar-body';
 import {createMissingDateImplError} from './datepicker-errors';
@@ -179,6 +185,7 @@ export class MatCalendarHeader<D> {
   exportAs: 'matCalendar',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER]
 })
 export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDestroy, OnChanges {
   /** An input indicating the type of the header component, if set. */
@@ -188,6 +195,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   _calendarHeaderPortal: Portal<any>;
 
   private _intlChanges: Subscription;
+  private _selectedChanges: Subscription;
 
   /**
    * Used for scheduling that focus should be moved to the active cell on the next tick.
@@ -209,11 +217,11 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
 
   /** The currently selected date. */
   @Input()
-  get selected(): D | null { return this._selected; }
+  get selected(): D | null { return this._model.selection; }
   set selected(value: D | null) {
-    this._selected = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
+    const newValue = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
+    this._model.updateSelection(newValue, this);
   }
-  private _selected: D | null;
 
   /** The minimum selectable date. */
   @Input()
@@ -237,7 +245,10 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   /** Function that can be used to add custom CSS classes to dates. */
   @Input() dateClass: (date: D) => MatCalendarCellCssClasses;
 
-  /** Emits when the currently selected date changes. */
+  /**
+   * Emits when the currently selected date changes.
+   * @breaking-change 11.0.0 Emitted value to change to `D | null`.
+   */
   @Output() readonly selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
   /**
@@ -293,7 +304,8 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   constructor(_intl: MatDatepickerIntl,
               @Optional() private _dateAdapter: DateAdapter<D>,
               @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
-              private _changeDetectorRef: ChangeDetectorRef) {
+              private _changeDetectorRef: ChangeDetectorRef,
+              private _model: MatDateSelectionModel<D | null, D>) {
 
     if (!this._dateAdapter) {
       throw createMissingDateImplError('DateAdapter');
@@ -306,6 +318,13 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     this._intlChanges = _intl.changes.subscribe(() => {
       _changeDetectorRef.markForCheck();
       this.stateChanges.next();
+    });
+
+    this._selectedChanges = _model.selectionChanged.subscribe(event => {
+      // @breaking-change 11.0.0 Remove null check once `event.selection` is allowed to be null.
+      if (event.selection) {
+        this.selectedChange.emit(event.selection);
+      }
     });
   }
 
@@ -325,6 +344,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   }
 
   ngOnDestroy() {
+    this._selectedChanges.unsubscribe();
     this._intlChanges.unsubscribe();
     this.stateChanges.complete();
   }
@@ -361,9 +381,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
 
   /** Handles date selection in the month view. */
   _dateSelected(date: D | null): void {
-    if (date && !this._dateAdapter.sameDate(date, this.selected)) {
-      this.selectedChange.emit(date);
-    }
+    this._model.add(date);
   }
 
   /** Handles year selection in the multiyear view. */

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -7,10 +7,8 @@
     [maxDate]="datepicker._maxDate"
     [dateFilter]="datepicker._dateFilter"
     [headerComponent]="datepicker.calendarHeaderComponent"
-    [selected]="datepicker._selected"
     [dateClass]="datepicker.dateClass"
     [@fadeInCalendar]="'enter'"
-    (selectedChange)="datepicker.select($event)"
     (yearSelected)="datepicker._selectYear($event)"
     (monthSelected)="datepicker._selectMonth($event)"
     (_userSelection)="datepicker.close()">

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -32,8 +32,8 @@ import {
 import {
   DateAdapter,
   MAT_DATE_FORMATS,
-  MatSingleDateSelectionModel,
   MatDateFormats,
+  MatSingleDateSelectionModel,
   ThemePalette,
 } from '@angular/material/core';
 import {MatFormField} from '@angular/material/form-field';
@@ -67,10 +67,10 @@ export class MatDatepickerInputEvent<D> {
   value: D | null;
 
   constructor(
-    /** Reference to the datepicker input component that emitted the event. */
-    public target: MatDatepickerInput<D>,
-    /** Reference to the native input element associated with the datepicker input. */
-    public targetElement: HTMLElement) {
+      /** Reference to the datepicker input component that emitted the event. */
+      public target: MatDatepickerInput<D>,
+      /** Reference to the native input element associated with the datepicker input. */
+      public targetElement: HTMLElement) {
     this.value = this.target.value;
   }
 }
@@ -129,22 +129,20 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
 
   /** The value of the input. */
   @Input()
-  get value(): D | null { return this._selection.asDate(); }
+  get value(): D | null { return this._selectionModel.selection; }
   set value(value: D | null) {
-    value  = this._dateAdapter.deserialize(value);
-    const oldDate = this._selection.asDate();
-    const isDifferent = !this._dateAdapter.sameDate(oldDate, value);
-    this._selection.setDate(value);
+    value = this._dateAdapter.deserialize(value);
+    this._lastValueValid = !value || this._dateAdapter.isValid(value);
+    value = this._getValidDateOrNull(value);
+    const oldDate = this._selectionModel.selection;
+    this._selectionModel.selection = value;
+    this._formatValue(value);
 
-    this._lastValueValid = this._selection.isValid();
-
-    this._formatValue(this._selection.asDate());
-
-    if (isDifferent) {
-      this._valueChange.emit(this.value);
+    if (!this._dateAdapter.sameDate(oldDate, value)) {
+      this._valueChange.emit(value);
     }
   }
-  private _selection: MatSingleDateSelectionModel<D>;
+  private _selectionModel: MatSingleDateSelectionModel<D>;
 
   /** The minimum valid date. */
   @Input()
@@ -259,7 +257,7 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
       throw createMissingDateImplError('MAT_DATE_FORMATS');
     }
 
-    this._selection = new MatSingleDateSelectionModel(this._dateAdapter, null);
+    this._selectionModel = new MatSingleDateSelectionModel(this._dateAdapter);
 
     // Update the displayed date when the locale changes.
     this._localeSubscription = _dateAdapter.localeChanges.subscribe(() => {
@@ -334,8 +332,8 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
     this._lastValueValid = !date || this._dateAdapter.isValid(date);
     date = this._getValidDateOrNull(date);
 
-    if (!this._dateAdapter.sameDate(date, this._selection.asDate())) {
-      this._selection.setDate(date);
+    if (!this._dateAdapter.sameDate(date, this._selectionModel.selection)) {
+      this._selectionModel.selection = date;
       this._cvaOnChange(date);
       this._valueChange.emit(date);
       this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -33,8 +33,8 @@ import {
   DateAdapter,
   MAT_DATE_FORMATS,
   MatDateFormats,
-  MatSingleDateSelectionModel,
   ThemePalette,
+  MatDateSelectionModel,
 } from '@angular/material/core';
 import {MatFormField} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
@@ -100,21 +100,27 @@ export class MatDatepickerInputEvent<D> {
 export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {
   /** The datepicker that this input is associated with. */
   @Input()
-  set matDatepicker(value: MatDatepicker<D>) {
-    if (!value) {
+  set matDatepicker(datepicker: MatDatepicker<D>) {
+    if (!datepicker) {
       return;
     }
 
-    this._datepicker = value;
-    this._datepicker._registerInput(this);
-    this._datepickerSubscription.unsubscribe();
+    this._datepicker = datepicker;
+    this._model = this._datepicker._registerInput(this);
+    this._valueChangesSubscription.unsubscribe();
 
-    this._datepickerSubscription = this._datepicker._selectedChanged.subscribe((selected: D) => {
-      this.value = selected;
-      this._cvaOnChange(selected);
-      this._onTouched();
-      this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-      this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+    if (this._pendingValue) {
+      this._assignValue(this._pendingValue);
+    }
+
+    this._valueChangesSubscription = this._model.selectionChanged.subscribe(event => {
+      if (event.source !== this) {
+        this._cvaOnChange(event.selection);
+        this._onTouched();
+        this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this._formatValue(event.selection);
+      }
     });
   }
   _datepicker: MatDatepicker<D>;
@@ -129,20 +135,20 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
 
   /** The value of the input. */
   @Input()
-  get value(): D | null { return this._selectionModel.selection; }
+  get value(): D | null { return this._model ? this._model.selection : this._pendingValue; }
   set value(value: D | null) {
     value = this._dateAdapter.deserialize(value);
     this._lastValueValid = !value || this._dateAdapter.isValid(value);
     value = this._getValidDateOrNull(value);
-    const oldDate = this._selectionModel.selection;
-    this._selectionModel.selection = value;
+    const oldDate = this.value;
+    this._assignValue(value);
     this._formatValue(value);
 
     if (!this._dateAdapter.sameDate(oldDate, value)) {
       this._valueChange.emit(value);
     }
   }
-  private _selectionModel: MatSingleDateSelectionModel<D>;
+  private _model: MatDateSelectionModel<D | null, D> | undefined;
 
   /** The minimum valid date. */
   @Input()
@@ -201,12 +207,16 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
   _onTouched = () => {};
 
   private _cvaOnChange: (value: any) => void = () => {};
-
   private _validatorOnChange = () => {};
-
-  private _datepickerSubscription = Subscription.EMPTY;
-
+  private _valueChangesSubscription = Subscription.EMPTY;
   private _localeSubscription = Subscription.EMPTY;
+
+  /**
+   * Since the value is kept on the datepicker which is assigned in an Input,
+   * we might get a value before we have a datepicker. This property keeps track
+   * of the value until we have somewhere to assign it.
+   */
+  private _pendingValue: D | null;
 
   /** The form control validator for whether the input parses. */
   private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
@@ -257,8 +267,6 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
       throw createMissingDateImplError('MAT_DATE_FORMATS');
     }
 
-    this._selectionModel = new MatSingleDateSelectionModel(this._dateAdapter);
-
     // Update the displayed date when the locale changes.
     this._localeSubscription = _dateAdapter.localeChanges.subscribe(() => {
       this.value = this.value;
@@ -266,7 +274,7 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
   }
 
   ngOnDestroy() {
-    this._datepickerSubscription.unsubscribe();
+    this._valueChangesSubscription.unsubscribe();
     this._localeSubscription.unsubscribe();
     this._valueChange.complete();
     this._disabledChange.complete();
@@ -332,8 +340,8 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
     this._lastValueValid = !date || this._dateAdapter.isValid(date);
     date = this._getValidDateOrNull(date);
 
-    if (!this._dateAdapter.sameDate(date, this._selectionModel.selection)) {
-      this._selectionModel.selection = date;
+    if (!this._dateAdapter.sameDate(date, this.value)) {
+      this._assignValue(date);
       this._cvaOnChange(date);
       this._valueChange.emit(date);
       this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
@@ -373,6 +381,18 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
    */
   private _getValidDateOrNull(obj: any): D | null {
     return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
+  }
+
+  /** Assigns a value to the model. */
+  private _assignValue(value: D | null) {
+    // We may get some incoming values before the datepicker was
+    // assigned. Save the value so that we can assign it later.
+    if (this._model) {
+      this._model.updateSelection(value, this);
+      this._pendingValue = null;
+    } else {
+      this._pendingValue = value;
+    }
   }
 
   // Accept `any` to avoid conflicts with other directives on `<input>` that

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -12,7 +12,12 @@ import {
 import {Component, FactoryProvider, Type, ValueProvider, ViewChild} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, inject, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
-import {MAT_DATE_LOCALE, MatNativeDateModule, NativeDateModule} from '@angular/material/core';
+import {
+  MAT_DATE_LOCALE,
+  MatNativeDateModule,
+  NativeDateModule,
+  MatDateSelectionModel,
+} from '@angular/material/core';
 import {MatFormField, MatFormFieldModule} from '@angular/material/form-field';
 import {DEC, JAN, JUL, JUN, SEP} from '@angular/material/testing';
 import {By} from '@angular/platform-browser';
@@ -66,12 +71,15 @@ describe('MatDatepicker', () => {
     describe('standard datepicker', () => {
       let fixture: ComponentFixture<StandardDatepicker>;
       let testComponent: StandardDatepicker;
+      let model: MatDateSelectionModel<Date | null, Date>;
 
       beforeEach(fakeAsync(() => {
         fixture = createComponent(StandardDatepicker, [MatNativeDateModule]);
         fixture.detectChanges();
 
         testComponent = fixture.componentInstance;
+        model = fixture.debugElement.query(By.directive(MatDatepicker))
+            .injector.get(MatDateSelectionModel);
       }));
 
       afterEach(fakeAsync(() => {
@@ -274,8 +282,8 @@ describe('MatDatepicker', () => {
 
       it('clicking the currently selected date should close the calendar ' +
          'without firing selectedChanged', fakeAsync(() => {
-        const selectedChangedSpy =
-            spyOn(testComponent.datepicker._selectedChanged, 'next').and.callThrough();
+        const spy = jasmine.createSpy('selectionChanged spy');
+        const selectedSubscription = model.selectionChanged.subscribe(spy);
 
         for (let changeCount = 1; changeCount < 3; changeCount++) {
           const currentDay = changeCount;
@@ -291,15 +299,16 @@ describe('MatDatepicker', () => {
           flush();
         }
 
-        expect(selectedChangedSpy.calls.count()).toEqual(1);
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(document.querySelector('mat-dialog-container')).toBeNull();
         expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 2));
+        selectedSubscription.unsubscribe();
       }));
 
       it('pressing enter on the currently selected date should close the calendar without ' +
          'firing selectedChanged', () => {
-        const selectedChangedSpy =
-            spyOn(testComponent.datepicker._selectedChanged, 'next').and.callThrough();
+        const spy = jasmine.createSpy('selectionChanged spy');
+        const selectedSubscription = model.selectionChanged.subscribe(spy);
 
         testComponent.datepicker.open();
         fixture.detectChanges();
@@ -312,9 +321,10 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         fixture.whenStable().then(() => {
-          expect(selectedChangedSpy.calls.count()).toEqual(0);
+          expect(spy).not.toHaveBeenCalled();
           expect(document.querySelector('mat-dialog-container')).toBeNull();
           expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 1));
+          selectedSubscription.unsubscribe();
         });
       });
 
@@ -507,11 +517,13 @@ describe('MatDatepicker', () => {
         const fixture = createComponent(DelayedDatepicker, [MatNativeDateModule]);
         const testComponent: DelayedDatepicker = fixture.componentInstance;
         const toSelect = new Date(2017, JAN, 1);
-
         fixture.detectChanges();
 
+        const model = fixture.debugElement.query(By.directive(MatDatepicker))
+          .injector.get(MatDateSelectionModel);
+
         expect(testComponent.datepickerInput.value).toBeNull();
-        expect(testComponent.datepicker._selected).toBeNull();
+        expect(model.selection).toBeNull();
 
         testComponent.assignedDatepicker = testComponent.datepicker;
         fixture.detectChanges();
@@ -522,7 +534,7 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         expect(testComponent.datepickerInput.value).toEqual(toSelect);
-        expect(testComponent.datepicker._selected).toEqual(toSelect);
+        expect(model.selection).toEqual(toSelect);
       }));
     });
 
@@ -672,6 +684,7 @@ describe('MatDatepicker', () => {
     describe('datepicker with ngModel', () => {
       let fixture: ComponentFixture<DatepickerWithNgModel>;
       let testComponent: DatepickerWithNgModel;
+      let model: MatDateSelectionModel<Date | null, Date>;
 
       beforeEach(fakeAsync(() => {
         fixture = createComponent(DatepickerWithNgModel, [MatNativeDateModule]);
@@ -681,6 +694,8 @@ describe('MatDatepicker', () => {
           fixture.detectChanges();
 
           testComponent = fixture.componentInstance;
+          model = fixture.debugElement.query(By.directive(MatDatepicker))
+            .injector.get(MatDateSelectionModel);
         });
       }));
 
@@ -691,7 +706,7 @@ describe('MatDatepicker', () => {
 
       it('should update datepicker when model changes', fakeAsync(() => {
         expect(testComponent.datepickerInput.value).toBeNull();
-        expect(testComponent.datepicker._selected).toBeNull();
+        expect(model.selection).toBeNull();
 
         let selected = new Date(2017, JAN, 1);
         testComponent.selected = selected;
@@ -700,7 +715,7 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         expect(testComponent.datepickerInput.value).toEqual(selected);
-        expect(testComponent.datepicker._selected).toEqual(selected);
+        expect(model.selection).toEqual(selected);
       }));
 
       it('should update model when date is selected', fakeAsync(() => {
@@ -820,12 +835,15 @@ describe('MatDatepicker', () => {
     describe('datepicker with formControl', () => {
       let fixture: ComponentFixture<DatepickerWithFormControl>;
       let testComponent: DatepickerWithFormControl;
+      let model: MatDateSelectionModel<Date | null, Date>;
 
       beforeEach(fakeAsync(() => {
         fixture = createComponent(DatepickerWithFormControl, [MatNativeDateModule]);
         fixture.detectChanges();
 
         testComponent = fixture.componentInstance;
+        model = fixture.debugElement.query(By.directive(MatDatepicker))
+            .injector.get(MatDateSelectionModel);
       }));
 
       afterEach(fakeAsync(() => {
@@ -835,14 +853,14 @@ describe('MatDatepicker', () => {
 
       it('should update datepicker when formControl changes', () => {
         expect(testComponent.datepickerInput.value).toBeNull();
-        expect(testComponent.datepicker._selected).toBeNull();
+        expect(model.selection).toBeNull();
 
         let selected = new Date(2017, JAN, 1);
         testComponent.formControl.setValue(selected);
         fixture.detectChanges();
 
         expect(testComponent.datepickerInput.value).toEqual(selected);
-        expect(testComponent.datepicker._selected).toEqual(selected);
+        expect(model.selection).toEqual(selected);
       });
 
       it('should update formControl when date is selected', () => {

--- a/src/material/datepicker/datepicker.ts
+++ b/src/material/datepicker/datepicker.ts
@@ -42,9 +42,11 @@ import {
   DateAdapter,
   mixinColor,
   ThemePalette,
+  MatDateSelectionModel,
+  MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER,
 } from '@angular/material/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
-import {merge, Subject, Subscription} from 'rxjs';
+import {merge, Subject} from 'rxjs';
 import {filter, take} from 'rxjs/operators';
 import {MatCalendar} from './calendar';
 import {matDatepickerAnimations} from './datepicker-animations';
@@ -136,6 +138,7 @@ export class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase
   exportAs: 'matDatepicker',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
+  providers: [MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER]
 })
 export class MatDatepicker<D> implements OnDestroy, CanColor {
   private _scrollStrategy: () => ScrollStrategy;
@@ -230,11 +233,6 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
   /** The id for the datepicker calendar. */
   id: string = `mat-datepicker-${datepickerUid++}`;
 
-  /** The currently selected date. */
-  get _selected(): D | null { return this._validSelected; }
-  set _selected(value: D | null) { this._validSelected = value; }
-  private _validSelected: D | null = null;
-
   /** The minimum selectable date. */
   get _minDate(): D | null {
     return this._datepickerInput && this._datepickerInput.min;
@@ -264,17 +262,11 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
   /** The element that was focused before the datepicker was opened. */
   private _focusedElementBeforeOpen: HTMLElement | null = null;
 
-  /** Subscription to value changes in the associated input element. */
-  private _inputSubscription = Subscription.EMPTY;
-
   /** The input element this datepicker is associated with. */
   _datepickerInput: MatDatepickerInput<D>;
 
   /** Emits when the datepicker is disabled. */
   readonly _disabledChange = new Subject<boolean>();
-
-  /** Emits new selected date when selected date changes. */
-  readonly _selectedChanged = new Subject<D>();
 
   constructor(private _dialog: MatDialog,
               private _overlay: Overlay,
@@ -283,7 +275,8 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
               @Inject(MAT_DATEPICKER_SCROLL_STRATEGY) scrollStrategy: any,
               @Optional() private _dateAdapter: DateAdapter<D>,
               @Optional() private _dir: Directionality,
-              @Optional() @Inject(DOCUMENT) private _document: any) {
+              @Optional() @Inject(DOCUMENT) private _document: any,
+              private _model: MatDateSelectionModel<D | null, D>) {
     if (!this._dateAdapter) {
       throw createMissingDateImplError('DateAdapter');
     }
@@ -293,7 +286,6 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
 
   ngOnDestroy() {
     this.close();
-    this._inputSubscription.unsubscribe();
     this._disabledChange.complete();
 
     if (this._popupRef) {
@@ -304,11 +296,7 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
 
   /** Selects the given date */
   select(date: D): void {
-    let oldValue = this._selected;
-    this._selected = date;
-    if (!this._dateAdapter.sameDate(oldValue, this._selected)) {
-      this._selectedChanged.next(date);
-    }
+    this._model.add(date);
   }
 
   /** Emits the selected year in multiyear view */
@@ -324,14 +312,14 @@ export class MatDatepicker<D> implements OnDestroy, CanColor {
   /**
    * Register an input with this datepicker.
    * @param input The datepicker input to register with this datepicker.
+   * @returns Selection model that the input should hook itself up to.
    */
-  _registerInput(input: MatDatepickerInput<D>): void {
+  _registerInput(input: MatDatepickerInput<D>): MatDateSelectionModel<D | null, D> {
     if (this._datepickerInput) {
       throw Error('A MatDatepicker can only be associated with a single input.');
     }
     this._datepickerInput = input;
-    this._inputSubscription =
-        this._datepickerInput._valueChange.subscribe((value: D | null) => this._selected = value);
+    return this._model;
   }
 
   /** Open the calendar. */

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -79,9 +79,13 @@ export declare abstract class DateAdapter<D> {
     abstract today(): D;
 }
 
-export interface DateRange<D> {
-    end: D | null;
-    start: D | null;
+export declare class DateRange<D> {
+    readonly end: D | null;
+    readonly start: D | null;
+    constructor(range?: {
+        start?: D | null;
+        end?: D | null;
+    } | null);
 }
 
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;
@@ -205,7 +209,7 @@ export declare const MAT_OPTION_PARENT_COMPONENT: InjectionToken<MatOptionParent
 
 export declare const MAT_RIPPLE_GLOBAL_OPTIONS: InjectionToken<RippleGlobalOptions>;
 
-export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY<D>(parent: MatSingleDateSelectionModel<D>, adapter: DateAdapter<D>): MatSingleDateSelectionModel<D>;
+export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
 
 export declare const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
@@ -227,17 +231,19 @@ export declare type MatDateFormats = {
     };
 };
 
-export declare abstract class MatDateSelectionModel<D> {
-    protected _valueChangesSubject: Subject<void>;
+export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>> implements OnDestroy {
     protected readonly adapter: DateAdapter<D>;
+    selection: S;
     valueChanges: Observable<void>;
-    constructor(adapter: DateAdapter<D>);
+    protected constructor(adapter: DateAdapter<D>, _selection: S);
     abstract add(date: D | null): void;
-    destroy(): void;
     abstract isComplete(): boolean;
     abstract isSame(other: MatDateSelectionModel<D>): boolean;
     abstract isValid(): boolean;
+    ngOnDestroy(): void;
     abstract overlaps(range: DateRange<D>): boolean;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDateSelectionModel<any, any>, never, never, {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDateSelectionModel<any, any>>;
 }
 
 export declare const MATERIAL_SANITY_CHECKS: InjectionToken<SanityChecks>;
@@ -334,15 +340,16 @@ export declare class MatPseudoCheckboxModule {
 
 export declare type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
 
-export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<D> {
-    constructor(adapter: DateAdapter<D>, start?: D | null, end?: D | null);
+export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
+    constructor(adapter: DateAdapter<D>, range?: {
+        start?: D | null;
+        end?: D | null;
+    } | null);
     add(date: D | null): void;
-    asRange(): DateRange<D>;
     isComplete(): boolean;
-    isSame(other: MatDateSelectionModel<D>): boolean;
+    isSame(other: MatDateSelectionModel<any>): boolean;
     isValid(): boolean;
     overlaps(range: DateRange<D>): boolean;
-    setRange(start: D | null, end: D | null): void;
     static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>>;
     static ɵprov: i0.ɵɵInjectableDef<MatRangeDateSelectionModel<any>>;
 }
@@ -372,16 +379,13 @@ export declare class MatRippleModule {
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatRippleModule, [typeof i1.MatRipple], [typeof i2.MatCommonModule, typeof i3.PlatformModule], [typeof i1.MatRipple, typeof i2.MatCommonModule]>;
 }
 
-export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D> {
+export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
     constructor(adapter: DateAdapter<D>, date?: D | null);
     add(date: D | null): void;
-    asDate(): D | null;
-    compareDate(other: MatSingleDateSelectionModel<D>): number | boolean;
     isComplete(): boolean;
-    isSame(other: MatDateSelectionModel<D>): boolean;
+    isSame(other: MatDateSelectionModel<any>): boolean;
     isValid(): boolean;
     overlaps(range: DateRange<D>): boolean;
-    setDate(date: D | null): void;
     static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>>;
     static ɵprov: i0.ɵɵInjectableDef<MatSingleDateSelectionModel<any>>;
 }

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -79,6 +79,11 @@ export declare abstract class DateAdapter<D> {
     abstract today(): D;
 }
 
+export interface DateRange<D> {
+    end: D | null;
+    start: D | null;
+}
+
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;
 
 export declare const defaultRippleAnimationConfig: {
@@ -218,6 +223,18 @@ export declare type MatDateFormats = {
     };
 };
 
+export declare abstract class MatDateSelectionModel<D> {
+    protected _valueChangesSubject: Subject<void>;
+    protected readonly adapter: DateAdapter<D>;
+    valueChanges: Observable<void>;
+    constructor(adapter: DateAdapter<D>);
+    abstract add(date: D | null): void;
+    destroy(): void;
+    abstract isComplete(): boolean;
+    abstract isSame(other: MatDateSelectionModel<D>): boolean;
+    abstract isValid(): boolean;
+}
+
 export declare const MATERIAL_SANITY_CHECKS: InjectionToken<SanityChecks>;
 
 export declare class MatLine {
@@ -312,6 +329,16 @@ export declare class MatPseudoCheckboxModule {
 
 export declare type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
 
+export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<D> {
+    constructor(adapter: DateAdapter<D>, start?: D | null, end?: D | null);
+    add(date: D | null): void;
+    asRange(): DateRange<D>;
+    isComplete(): boolean;
+    isSame(other: MatDateSelectionModel<D>): boolean;
+    isValid(): boolean;
+    setRange(start: D | null, end: D | null): void;
+}
+
 export declare class MatRipple implements OnInit, OnDestroy, RippleTarget {
     animation: RippleAnimationConfig;
     centered: boolean;
@@ -335,6 +362,16 @@ export declare class MatRipple implements OnInit, OnDestroy, RippleTarget {
 export declare class MatRippleModule {
     static ɵinj: i0.ɵɵInjectorDef<MatRippleModule>;
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatRippleModule, [typeof i1.MatRipple], [typeof i2.MatCommonModule, typeof i3.PlatformModule], [typeof i1.MatRipple, typeof i2.MatCommonModule]>;
+}
+
+export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D> {
+    constructor(adapter: DateAdapter<D>, date?: D | null);
+    add(date: D | null): void;
+    asDate(): D | null;
+    compareDate(other: MatSingleDateSelectionModel<D>): number | boolean;
+    isComplete(): boolean;
+    isSame(other: MatDateSelectionModel<D>): boolean;
+    isValid(): boolean;
 }
 
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -82,10 +82,14 @@ export declare abstract class DateAdapter<D> {
 export declare class DateRange<D> {
     readonly end: D | null;
     readonly start: D | null;
-    constructor(range?: {
-        start?: D | null;
-        end?: D | null;
-    } | null);
+    constructor(
+    start: D | null,
+    end: D | null);
+}
+
+export interface DateSelectionModelChange<S> {
+    selection: S;
+    source: unknown;
 }
 
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;
@@ -233,15 +237,18 @@ export declare type MatDateFormats = {
 
 export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>> implements OnDestroy {
     protected readonly adapter: DateAdapter<D>;
-    selection: S;
-    valueChanges: Observable<void>;
-    protected constructor(adapter: DateAdapter<D>, _selection: S);
+    readonly selection: S;
+    selectionChanged: Observable<DateSelectionModelChange<S>>;
+    protected constructor(
+    adapter: DateAdapter<D>,
+    selection: S);
     abstract add(date: D | null): void;
     abstract isComplete(): boolean;
-    abstract isSame(other: MatDateSelectionModel<D>): boolean;
+    abstract isSame(other: S): boolean;
     abstract isValid(): boolean;
     ngOnDestroy(): void;
     abstract overlaps(range: DateRange<D>): boolean;
+    updateSelection(value: S, source: unknown): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDateSelectionModel<any, any>, never, never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDateSelectionModel<any, any>>;
 }
@@ -341,13 +348,10 @@ export declare class MatPseudoCheckboxModule {
 export declare type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
 
 export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
-    constructor(adapter: DateAdapter<D>, range?: {
-        start?: D | null;
-        end?: D | null;
-    } | null);
+    constructor(adapter: DateAdapter<D>);
     add(date: D | null): void;
     isComplete(): boolean;
-    isSame(other: MatDateSelectionModel<any>): boolean;
+    isSame(other: DateRange<D>): boolean;
     isValid(): boolean;
     overlaps(range: DateRange<D>): boolean;
     static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>>;
@@ -380,10 +384,10 @@ export declare class MatRippleModule {
 }
 
 export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
-    constructor(adapter: DateAdapter<D>, date?: D | null);
+    constructor(adapter: DateAdapter<D>);
     add(date: D | null): void;
     isComplete(): boolean;
-    isSame(other: MatDateSelectionModel<any>): boolean;
+    isSame(other: D): boolean;
     isValid(): boolean;
     overlaps(range: DateRange<D>): boolean;
     static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>>;

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -205,6 +205,10 @@ export declare const MAT_OPTION_PARENT_COMPONENT: InjectionToken<MatOptionParent
 
 export declare const MAT_RIPPLE_GLOBAL_OPTIONS: InjectionToken<RippleGlobalOptions>;
 
+export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY<D>(parent: MatSingleDateSelectionModel<D>, adapter: DateAdapter<D>): MatSingleDateSelectionModel<D>;
+
+export declare const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
+
 export declare class MatCommonModule {
     constructor(highContrastModeDetector: HighContrastModeDetector, sanityChecks: any);
     static ɵinj: i0.ɵɵInjectorDef<MatCommonModule>;
@@ -233,6 +237,7 @@ export declare abstract class MatDateSelectionModel<D> {
     abstract isComplete(): boolean;
     abstract isSame(other: MatDateSelectionModel<D>): boolean;
     abstract isValid(): boolean;
+    abstract overlaps(range: DateRange<D>): boolean;
 }
 
 export declare const MATERIAL_SANITY_CHECKS: InjectionToken<SanityChecks>;
@@ -336,7 +341,10 @@ export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel
     isComplete(): boolean;
     isSame(other: MatDateSelectionModel<D>): boolean;
     isValid(): boolean;
+    overlaps(range: DateRange<D>): boolean;
     setRange(start: D | null, end: D | null): void;
+    static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>>;
+    static ɵprov: i0.ɵɵInjectableDef<MatRangeDateSelectionModel<any>>;
 }
 
 export declare class MatRipple implements OnInit, OnDestroy, RippleTarget {
@@ -372,7 +380,10 @@ export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionMode
     isComplete(): boolean;
     isSame(other: MatDateSelectionModel<D>): boolean;
     isValid(): boolean;
+    overlaps(range: DateRange<D>): boolean;
     setDate(date: D | null): void;
+    static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>>;
+    static ɵprov: i0.ɵɵInjectableDef<MatSingleDateSelectionModel<any>>;
 }
 
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -372,6 +372,7 @@ export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionMode
     isComplete(): boolean;
     isSame(other: MatDateSelectionModel<D>): boolean;
     isValid(): boolean;
+    setDate(date: D | null): void;
 }
 
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -32,7 +32,7 @@ export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecke
     stateChanges: Subject<void>;
     readonly yearSelected: EventEmitter<D>;
     yearView: MatYearView<D>;
-    constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef);
+    constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef, _model: MatDateSelectionModel<D | null, D>);
     _dateSelected(date: D | null): void;
     _goToDateInView(date: D, view: 'month' | 'year' | 'multi-year'): void;
     _monthSelectedInYearView(normalizedMonth: D): void;
@@ -109,8 +109,6 @@ export declare class MatDatepicker<D> implements OnDestroy, CanColor {
     readonly _maxDate: D | null;
     readonly _minDate: D | null;
     _popupRef: OverlayRef;
-    _selected: D | null;
-    readonly _selectedChanged: Subject<D>;
     calendarHeaderComponent: ComponentType<any>;
     closedStream: EventEmitter<void>;
     color: ThemePalette;
@@ -125,8 +123,8 @@ export declare class MatDatepicker<D> implements OnDestroy, CanColor {
     startView: 'month' | 'year' | 'multi-year';
     touchUi: boolean;
     readonly yearSelected: EventEmitter<D>;
-    constructor(_dialog: MatDialog, _overlay: Overlay, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, scrollStrategy: any, _dateAdapter: DateAdapter<D>, _dir: Directionality, _document: any);
-    _registerInput(input: MatDatepickerInput<D>): void;
+    constructor(_dialog: MatDialog, _overlay: Overlay, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, scrollStrategy: any, _dateAdapter: DateAdapter<D>, _dir: Directionality, _document: any, _model: MatDateSelectionModel<D | null, D>);
+    _registerInput(input: MatDatepickerInput<D>): MatDateSelectionModel<D | null, D>;
     _selectMonth(normalizedMonth: D): void;
     _selectYear(normalizedYear: D): void;
     close(): void;


### PR DESCRIPTION
Reworks the datepicker-related directives to move the source of the value into the new datepicker selection provider.

**Note:** I've switched everything except the calendar views to use the value from the model. Since the views are supposed dumb components which are managed the calendar, I thought that it doesn't make sense for them to know about the selection model, because they don't always update the model.