### PR TITLE
[prototype] feat: add support for density scaling in MDC based components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,6 +95,7 @@
 /src/material-experimental/mdc-card/**             @mmalerba
 /src/material-experimental/mdc-checkbox/**         @mmalerba
 /src/material-experimental/mdc-chips/**            @mmalerba
+/src/material-experimental/mdc-density/**          @devversion
 /src/material-experimental/mdc-dialog/**           @devversion
 /src/material-experimental/mdc-helpers/**          @mmalerba
 /src/material-experimental/mdc-list/**             @mmalerba

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -94,6 +94,7 @@ sass_binary(
         "external/npm/node_modules",
     ],
     deps = [
+        "//src/material-experimental/mdc-density:all_density",
         "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
         "//src/material-experimental/mdc-theming:all_themes",
         "//src/material-experimental/mdc-typography:all_typography",

--- a/src/dev-app/dev-app/dev-app-layout.html
+++ b/src/dev-app/dev-app/dev-app-layout.html
@@ -41,6 +41,10 @@
                   title="Toggle between RTL and LTR">
             {{dir.value.toUpperCase()}}
           </button>
+          <button mat-button (click)="selectNextDensity()"
+                  title="Use next density scale: {{densityScales[getNextDensityIndex()]}}">
+            Density scale: {{densityScales[this.currentDensityIndex]}}
+          </button>
         </div>
       </div>
     </mat-toolbar>

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -83,11 +83,44 @@ export class DevAppLayout {
     {name: 'MDC Table', route: '/mdc-table'},
   ];
 
+  /** Currently selected density scale based on the index. */
+  currentDensityIndex = 0;
+
+  /** List of possible global density scale values. */
+  densityScales = [0, -1, -2, 'minimum', 'maximum'];
+
   constructor(
       private _element: ElementRef<HTMLElement>, private _overlayContainer: OverlayContainer,
       public rippleOptions: DevAppRippleOptions,
       @Inject(Directionality) public dir: DevAppDirectionality, cdr: ChangeDetectorRef) {
     dir.change.subscribe(() => cdr.markForCheck());
+    this.updateDensityClasses();
+  }
+
+  /** Gets the index of the next density scale that can be selected. */
+  getNextDensityIndex() {
+    return (this.currentDensityIndex + 1) % this.densityScales.length;
+  }
+
+  /** Selects the next possible density scale. */
+  selectNextDensity() {
+    this.currentDensityIndex = this.getNextDensityIndex();
+    this.updateDensityClasses();
+  }
+
+  /**
+   * Updates the density classes on the host element. Applies a unique class for
+   * a given density scale, so that the density styles are conditionally applied.
+   */
+  updateDensityClasses() {
+    for (let i = 0; i < this.densityScales.length; i++) {
+      const className = `demo-density-${this.densityScales[i]}`;
+      if (i === this.currentDensityIndex) {
+        this._element.nativeElement.classList.add(className);
+      } else {
+        this._element.nativeElement.classList.remove(className);
+      }
+    }
   }
 
   toggleFullscreen() {

--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -2,6 +2,7 @@
 @import '../material-experimental/mdc-slider/mdc-slider';
 @import '../material-experimental/mdc-theming/all-theme';
 @import '../material-experimental/mdc-typography/all-typography';
+@import '../material-experimental/mdc-density/all-density';
 @import '../material-experimental/popover-edit/popover-edit';
 
 // Plus imports for other components in your app.
@@ -39,4 +40,14 @@ $dark-theme: mat-dark-theme($dark-primary, $dark-accent, $dark-warn);
   @include angular-material-theme-mdc($dark-theme);
   @include mat-slider-theme-mdc($dark-theme);
   @include mat-popover-edit-theme($dark-theme);
+}
+
+// Create classes for each density scale that is supported by all MDC-based components.
+// The classes are applied conditionally based on the desired density in the dev-app
+// layout component.
+$density-scales: -1, -2, minimum, maximum;
+@each $density in$density-scales {
+  .demo-density-#{$density} {
+    @include angular-material-density-mdc($density);
+  }
 }

--- a/src/material-experimental/mdc-button/_mdc-button-color.scss
+++ b/src/material-experimental/mdc-button/_mdc-button-color.scss
@@ -1,0 +1,254 @@
+@import '@material/theme/mixins';
+@import '@material/button/mixins';
+@import '@material/fab/mixins';
+@import '@material/ripple/mixins';
+@import '@material/icon-button/mixins';
+@import '../../material/core/ripple/ripple';
+@import '../mdc-helpers/mdc-helpers';
+
+// Selector for the element that has a background color and opacity applied to its ::before and
+// ::after for state interactions (hover, active, focus). Their API calls this their
+// "ripple target", but we do not use it as our ripple, just state color.
+$mat-button-state-target: '.mdc-button__ripple';
+
+// Applies the disabled theme color to the text color.
+@mixin _mat-button-disabled-color() {
+  @include mdc-theme-prop(color,
+    mdc-theme-ink-color-for-fill_(disabled, $mdc-theme-background));
+}
+
+// Wraps the content style in a selector for the disabled state.
+// MDC adds theme color by using :not(:disabled), so just using [disabled] once will not
+// override this, neither will it apply to anchor tags. This needs to override the
+// previously set theme color, so it must be ordered after the theme styles.
+// TODO(andrewseguin): Discuss with the MDC team to see if we can avoid the :not(:disabled) by
+// manually styling disabled buttons with a [disabled] selector.
+@mixin _mat-button-apply-disabled-style() {
+  &[disabled][disabled] {
+    @content;
+  }
+}
+
+// The MDC button's ripple ink color is based on the theme color, not on the foreground base
+// which is what the ripple mixin uses. This creates a new theme that sets the color to the
+// foreground base to appropriately color the ink.
+@mixin _mat-button-ripple-ink-color($mdcColor) {
+  @include mat-ripple-theme((
+    foreground: (
+      base: mdc-theme-prop-value($mdcColor)
+    ),
+  ));
+}
+
+// Applies the disabled theme background color for raised buttons. Value is taken from
+// mixin `mdc-button--filled`.
+// TODO(andrewseguin): Discuss with the MDC team about providing a variable for the 0.12 value
+// or otherwise have a mixin we can call to apply this style for both button and anchors.
+@mixin _mat-button-disabled-background() {
+  @include mdc-theme-prop(background-color, rgba(mdc-theme-prop-value(on-surface), 0.12));
+}
+
+@mixin mat-button-color-mdc($theme) {
+  @include mat-using-mdc-theme($theme) {
+    // Add state interactions for hover, focus, press, active. Colors are changed based on
+    // the mixin mdc-states-base-color
+    .mat-mdc-button, .mat-mdc-raised-button, .mat-mdc-unelevated-button, .mat-mdc-outlined-button {
+      @include mdc-states(
+        $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+    }
+
+    .mat-mdc-button, .mat-mdc-outlined-button {
+      &.mat-unthemed {
+        @include mdc-button-ink-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
+      }
+
+      &.mat-primary {
+        @include mdc-button-ink-color(primary, $query: $mat-theme-styles-query);
+        @include mdc-states-base-color(
+          primary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include _mat-button-ripple-ink-color(primary);
+      }
+
+      &.mat-accent {
+        @include mdc-button-ink-color(secondary, $query: $mat-theme-styles-query);
+        @include mdc-states-base-color(
+          secondary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include _mat-button-ripple-ink-color(secondary);
+      }
+
+      &.mat-warn {
+        @include mdc-button-ink-color(error, $query: $mat-theme-styles-query);
+        @include mdc-states-base-color(
+          error, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include _mat-button-ripple-ink-color(error);
+      }
+    }
+
+    .mat-mdc-raised-button,
+    .mat-mdc-unelevated-button {
+      &.mat-unthemed {
+        @include mdc-button-container-fill-color(
+          $mdc-theme-surface, $query: $mat-theme-styles-query);
+        @include mdc-button-ink-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
+        @include mdc-states-base-color(
+          $mdc-theme-on-surface, $query: $mat-theme-styles-query,
+          $ripple-target: $mat-button-state-target);
+      }
+
+      &.mat-primary {
+        @include mdc-button-container-fill-color(primary, $query: $mat-theme-styles-query);
+        @include mdc-button-ink-color(on-primary, $query: $mat-theme-styles-query);
+        @include mdc-states-base-color(
+          on-primary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include _mat-button-ripple-ink-color(on-primary);
+      }
+
+      &.mat-accent {
+        @include mdc-button-container-fill-color(secondary, $query: $mat-theme-styles-query);
+        @include mdc-button-ink-color(on-secondary, $query: $mat-theme-styles-query);
+        @include mdc-states-base-color(
+          on-secondary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include _mat-button-ripple-ink-color(on-secondary);
+      }
+
+      &.mat-warn {
+        @include mdc-button-container-fill-color(error, $query: $mat-theme-styles-query);
+        @include mdc-button-ink-color(on-error, $query: $mat-theme-styles-query);
+        @include mdc-states-base-color(
+          on-error, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include _mat-button-ripple-ink-color(on-error);
+      }
+
+      @include _mat-button-apply-disabled-style() {
+        @include _mat-button-disabled-background();
+      }
+    }
+
+    .mat-mdc-outlined-button {
+      &.mat-unthemed {
+        @include mdc-button-outline-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
+      }
+
+      &.mat-primary {
+        @include mdc-button-outline-color(primary, $query: $mat-theme-styles-query);
+      }
+
+      &.mat-accent {
+        @include mdc-button-outline-color(secondary, $query: $mat-theme-styles-query);
+      }
+
+      &.mat-warn {
+        @include mdc-button-outline-color(error, $query: $mat-theme-styles-query);
+      }
+
+      @include _mat-button-apply-disabled-style() {
+        @include mdc-theme-prop(border-color,
+          mdc-theme-ink-color-for-fill_(disabled, $mdc-theme-background));
+      }
+    }
+
+    .mat-mdc-raised-button {
+      @include _mat-button-apply-disabled-style() {
+        @include mdc-elevation(0, $query: $mat-theme-styles-query);
+      }
+    }
+
+    .mat-mdc-button, .mat-mdc-raised-button, .mat-mdc-unelevated-button, .mat-mdc-outlined-button {
+      @include _mat-button-apply-disabled-style() {
+        @include _mat-button-disabled-color();
+      }
+    }
+
+    @include mdc-button-without-ripple($query: $mat-theme-styles-query);
+  }
+}
+
+@mixin mat-fab-color-mdc($theme) {
+  @include mat-using-mdc-theme($theme) {
+    .mat-mdc-fab, .mat-mdc-mini-fab {
+      @include mdc-states($query: $mat-theme-styles-query);
+
+      &.mat-unthemed {
+        @include mdc-states-base-color(
+          $mdc-theme-on-surface, $query: $mat-theme-styles-query,
+          $ripple-target: $mat-button-state-target);
+        @include mdc-fab-container-color($mdc-theme-surface, $query: $mat-theme-styles-query);
+        @include mdc-fab-ink-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
+      }
+
+      &.mat-primary {
+        @include mdc-states-base-color(
+          on-primary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include mdc-fab-container-color(primary, $query: $mat-theme-styles-query);
+        @include mdc-fab-ink-color(on-primary, $query: $mat-theme-styles-query);
+        @include _mat-button-ripple-ink-color(on-primary);
+      }
+
+      &.mat-accent {
+        @include mdc-states-base-color(
+          on-secondary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include mdc-fab-container-color(secondary, $query: $mat-theme-styles-query);
+        @include mdc-fab-ink-color(on-secondary, $query: $mat-theme-styles-query);
+        @include _mat-button-ripple-ink-color(on-secondary);
+      }
+
+      &.mat-warn {
+        @include mdc-states-base-color(
+          on-error, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include mdc-fab-container-color(error, $query: $mat-theme-styles-query);
+        @include mdc-fab-ink-color(on-error, $query: $mat-theme-styles-query);
+        @include _mat-button-ripple-ink-color(on-error);
+      }
+
+      @include _mat-button-apply-disabled-style() {
+        @include _mat-button-disabled-color();
+        @include _mat-button-disabled-background();
+        @include mdc-elevation(0, $query: $mat-theme-styles-query);
+      }
+    }
+
+    @include mdc-fab-without-ripple($query: $mat-theme-styles-query);
+  }
+}
+
+@mixin mat-icon-button-color-mdc($theme) {
+  @include mat-using-mdc-theme($theme) {
+    .mat-mdc-icon-button {
+      @include mdc-states($query: $mat-theme-styles-query);
+
+      &.mat-unthemed {
+        @include mdc-states-base-color(
+          $mdc-theme-surface, $query: $mat-theme-styles-query,
+          $ripple-target: $mat-button-state-target);
+        @include mdc-icon-button-ink-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
+      }
+
+      &.mat-primary {
+        @include mdc-states-base-color(
+          primary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include mdc-icon-button-ink-color(primary, $query: $mat-theme-styles-query);
+        @include _mat-button-ripple-ink-color(primary);
+      }
+
+      &.mat-accent {
+        @include mdc-states-base-color(
+          secondary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include mdc-icon-button-ink-color(secondary, $query: $mat-theme-styles-query);
+        @include _mat-button-ripple-ink-color(secondary);
+      }
+
+      &.mat-warn {
+        @include mdc-states-base-color(
+          error, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
+        @include mdc-icon-button-ink-color(error, $query: $mat-theme-styles-query);
+        @include _mat-button-ripple-ink-color(error);
+      }
+
+      @include _mat-button-apply-disabled-style() {
+        @include _mat-button-disabled-color();
+      }
+    }
+
+    @include mdc-icon-button-without-ripple($query: $mat-theme-styles-query);
+  }
+}

--- a/src/material-experimental/mdc-button/_mdc-button-density.scss
+++ b/src/material-experimental/mdc-button/_mdc-button-density.scss
@@ -1,0 +1,14 @@
+@import '@material/button/mixins';
+@import '@material/icon-button/mixins';
+
+@mixin mat-button-density-mdc($density-scale) {
+  .mat-mdc-button, .mat-mdc-raised-button, .mat-mdc-unelevated-button, .mat-mdc-outlined-button {
+    @include mdc-button-density($density-scale);
+  }
+}
+
+@mixin mat-icon-button-density-mdc($density-scale) {
+  .mat-mdc-icon-button {
+    @include mdc-icon-button-density($density-scale);
+  }
+}

--- a/src/material-experimental/mdc-button/_mdc-button.scss
+++ b/src/material-experimental/mdc-button/_mdc-button.scss
@@ -1,167 +1,12 @@
 @import '@material/button/mixins';
-@import '@material/button/variables';
-@import '@material/fab/mixins';
-@import '@material/ripple/mixins';
-@import '@material/icon-button/mixins';
-@import '../../material/core/ripple/ripple';
+
 @import '../mdc-helpers/mdc-helpers';
+@import './mdc-button-density';
+@import './mdc-button-color';
 
-// Selector for the element that has a background color and opacity applied to its ::before and
-// ::after for state interactions (hover, active, focus). Their API calls this their
-// "ripple target", but we do not use it as our ripple, just state color.
-$mat-button-state-target: '.mdc-button__ripple';
-
-// Applies the disabled theme color to the text color.
-@mixin _mat-button-disabled-color() {
-  @include mdc-theme-prop(color,
-      mdc-theme-ink-color-for-fill_(disabled, $mdc-theme-background));
-}
-
-// Wraps the content style in a selector for the disabled state.
-// MDC adds theme color by using :not(:disabled), so just using [disabled] once will not
-// override this, neither will it apply to anchor tags. This needs to override the
-// previously set theme color, so it must be ordered after the theme styles.
-// TODO(andrewseguin): Discuss with the MDC team to see if we can avoid the :not(:disabled) by
-// manually styling disabled buttons with a [disabled] selector.
-@mixin _mat-button-apply-disabled-style() {
-  &[disabled][disabled] {
-    @content;
-  }
-}
-
-// The MDC button's ripple ink color is based on the theme color, not on the foreground base
-// which is what the ripple mixin uses. This creates a new theme that sets the color to the
-// foreground base to appropriately color the ink.
-@mixin _mat-button-ripple-ink-color($mdcColor) {
-  @include mat-ripple-theme((
-    foreground: (
-      base: mdc-theme-prop-value($mdcColor)
-    ),
-  ));
-}
-
-// Applies the disabled theme background color for raised buttons. Value is taken from
-// mixin `mdc-button--filled`.
-// TODO(andrewseguin): Discuss with the MDC team about providing a variable for the 0.12 value
-// or otherwise have a mixin we can call to apply this style for both button and anchors.
-@mixin _mat-button-disabled-background() {
-  @include mdc-theme-prop(background-color, rgba(mdc-theme-prop-value(on-surface), 0.12));
-}
-
-
-@mixin mat-button-theme-mdc($theme) {
-  @include mat-using-mdc-theme($theme) {
-    // Add state interactions for hover, focus, press, active. Colors are changed based on
-    // the mixin mdc-states-base-color
-    .mat-mdc-button, .mat-mdc-raised-button, .mat-mdc-unelevated-button, .mat-mdc-outlined-button {
-      @include mdc-states(
-        $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-    }
-
-    .mat-mdc-button, .mat-mdc-outlined-button {
-      &.mat-unthemed {
-        @include mdc-button-ink-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
-      }
-
-      &.mat-primary {
-        @include mdc-button-ink-color(primary, $query: $mat-theme-styles-query);
-        @include mdc-states-base-color(
-          primary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include _mat-button-ripple-ink-color(primary);
-      }
-
-      &.mat-accent {
-        @include mdc-button-ink-color(secondary, $query: $mat-theme-styles-query);
-        @include mdc-states-base-color(
-          secondary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include _mat-button-ripple-ink-color(secondary);
-      }
-
-      &.mat-warn {
-        @include mdc-button-ink-color(error, $query: $mat-theme-styles-query);
-        @include mdc-states-base-color(
-          error, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include _mat-button-ripple-ink-color(error);
-      }
-    }
-
-    .mat-mdc-raised-button,
-    .mat-mdc-unelevated-button {
-      &.mat-unthemed {
-        @include mdc-button-container-fill-color(
-            $mdc-theme-surface, $query: $mat-theme-styles-query);
-        @include mdc-button-ink-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
-        @include mdc-states-base-color(
-          $mdc-theme-on-surface, $query: $mat-theme-styles-query,
-          $ripple-target: $mat-button-state-target);
-      }
-
-      &.mat-primary {
-        @include mdc-button-container-fill-color(primary, $query: $mat-theme-styles-query);
-        @include mdc-button-ink-color(on-primary, $query: $mat-theme-styles-query);
-        @include mdc-states-base-color(
-          on-primary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include _mat-button-ripple-ink-color(on-primary);
-      }
-
-      &.mat-accent {
-        @include mdc-button-container-fill-color(secondary, $query: $mat-theme-styles-query);
-        @include mdc-button-ink-color(on-secondary, $query: $mat-theme-styles-query);
-        @include mdc-states-base-color(
-          on-secondary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include _mat-button-ripple-ink-color(on-secondary);
-      }
-
-      &.mat-warn {
-        @include mdc-button-container-fill-color(error, $query: $mat-theme-styles-query);
-        @include mdc-button-ink-color(on-error, $query: $mat-theme-styles-query);
-        @include mdc-states-base-color(
-          on-error, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include _mat-button-ripple-ink-color(on-error);
-      }
-
-      @include _mat-button-apply-disabled-style() {
-        @include _mat-button-disabled-background();
-      }
-    }
-
-    .mat-mdc-outlined-button {
-      &.mat-unthemed {
-        @include mdc-button-outline-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
-      }
-
-      &.mat-primary {
-        @include mdc-button-outline-color(primary, $query: $mat-theme-styles-query);
-      }
-
-      &.mat-accent {
-        @include mdc-button-outline-color(secondary, $query: $mat-theme-styles-query);
-      }
-
-      &.mat-warn {
-        @include mdc-button-outline-color(error, $query: $mat-theme-styles-query);
-      }
-
-      @include _mat-button-apply-disabled-style() {
-        @include mdc-theme-prop(border-color,
-            mdc-theme-ink-color-for-fill_(disabled, $mdc-theme-background));
-      }
-    }
-
-    .mat-mdc-raised-button {
-      @include _mat-button-apply-disabled-style() {
-        @include mdc-elevation(0, $query: $mat-theme-styles-query);
-      }
-    }
-
-    .mat-mdc-button, .mat-mdc-raised-button, .mat-mdc-unelevated-button, .mat-mdc-outlined-button {
-      @include _mat-button-apply-disabled-style() {
-        @include _mat-button-disabled-color();
-      }
-    }
-
-    @include mdc-button-without-ripple($query: $mat-theme-styles-query);
-  }
+@mixin mat-button-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
+  @include mat-button-color-mdc($theme);
+  @include mat-button-density-mdc($density-scale);
 }
 
 @mixin mat-button-typography-mdc($config) {
@@ -170,52 +15,8 @@ $mat-button-state-target: '.mdc-button__ripple';
   }
 }
 
-@mixin mat-fab-theme-mdc($theme) {
-  @include mat-using-mdc-theme($theme) {
-    .mat-mdc-fab, .mat-mdc-mini-fab {
-      @include mdc-states($query: $mat-theme-styles-query);
-
-      &.mat-unthemed {
-        @include mdc-states-base-color(
-          $mdc-theme-on-surface, $query: $mat-theme-styles-query,
-          $ripple-target: $mat-button-state-target);
-        @include mdc-fab-container-color($mdc-theme-surface, $query: $mat-theme-styles-query);
-        @include mdc-fab-ink-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
-      }
-
-      &.mat-primary {
-        @include mdc-states-base-color(
-          on-primary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include mdc-fab-container-color(primary, $query: $mat-theme-styles-query);
-        @include mdc-fab-ink-color(on-primary, $query: $mat-theme-styles-query);
-        @include _mat-button-ripple-ink-color(on-primary);
-      }
-
-      &.mat-accent {
-        @include mdc-states-base-color(
-          on-secondary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include mdc-fab-container-color(secondary, $query: $mat-theme-styles-query);
-        @include mdc-fab-ink-color(on-secondary, $query: $mat-theme-styles-query);
-        @include _mat-button-ripple-ink-color(on-secondary);
-      }
-
-      &.mat-warn {
-        @include mdc-states-base-color(
-          on-error, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include mdc-fab-container-color(error, $query: $mat-theme-styles-query);
-        @include mdc-fab-ink-color(on-error, $query: $mat-theme-styles-query);
-        @include _mat-button-ripple-ink-color(on-error);
-      }
-
-      @include _mat-button-apply-disabled-style() {
-        @include _mat-button-disabled-color();
-        @include _mat-button-disabled-background();
-        @include mdc-elevation(0, $query: $mat-theme-styles-query);
-      }
-    }
-
-    @include mdc-fab-without-ripple($query: $mat-theme-styles-query);
-  }
+@mixin mat-fab-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
+  @include mat-fab-color-mdc($theme);
 }
 
 @mixin mat-fab-typography-mdc($config) {
@@ -224,46 +25,8 @@ $mat-button-state-target: '.mdc-button__ripple';
   }
 }
 
-@mixin mat-icon-button-theme-mdc($theme) {
-  @include mat-using-mdc-theme($theme) {
-    .mat-mdc-icon-button {
-      @include mdc-states($query: $mat-theme-styles-query);
-
-      &.mat-unthemed {
-        @include mdc-states-base-color(
-          $mdc-theme-surface, $query: $mat-theme-styles-query,
-          $ripple-target: $mat-button-state-target);
-        @include mdc-icon-button-ink-color($mdc-theme-on-surface, $query: $mat-theme-styles-query);
-      }
-
-      &.mat-primary {
-        @include mdc-states-base-color(
-          primary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include mdc-icon-button-ink-color(primary, $query: $mat-theme-styles-query);
-        @include _mat-button-ripple-ink-color(primary);
-      }
-
-      &.mat-accent {
-        @include mdc-states-base-color(
-          secondary, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include mdc-icon-button-ink-color(secondary, $query: $mat-theme-styles-query);
-        @include _mat-button-ripple-ink-color(secondary);
-      }
-
-      &.mat-warn {
-        @include mdc-states-base-color(
-          error, $query: $mat-theme-styles-query, $ripple-target: $mat-button-state-target);
-        @include mdc-icon-button-ink-color(error, $query: $mat-theme-styles-query);
-        @include _mat-button-ripple-ink-color(error);
-      }
-
-      @include _mat-button-apply-disabled-style() {
-        @include _mat-button-disabled-color();
-      }
-    }
-
-    @include mdc-icon-button-without-ripple($query: $mat-theme-styles-query);
-  }
+@mixin mat-icon-button-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
+  @include mat-icon-button-color-mdc($theme);
 }
 
 @mixin mat-icon-button-typography-mdc($config) {

--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -8,8 +8,6 @@
 @include mdc-button-without-ripple($query: $mat-base-styles-query);
 
 .mat-mdc-button, .mat-mdc-unelevated-button, .mat-mdc-raised-button, .mat-mdc-outlined-button {
-  @include mdc-button-density(0, $mat-base-styles-query);
-
   // Add an outline to make buttons more visible in high contrast mode. Stroked buttons
   // don't need a special look in high-contrast mode, because those already have an outline.
   @include cdk-high-contrast {

--- a/src/material-experimental/mdc-card/_mdc-card.scss
+++ b/src/material-experimental/mdc-card/_mdc-card.scss
@@ -2,7 +2,7 @@
 @import '@material/typography/mixins';
 @import '../mdc-helpers/mdc-helpers';
 
-@mixin mat-card-theme-mdc($theme) {
+@mixin mat-card-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
   $foreground: map-get($theme, foreground);
   $is-dark-theme: map-get($theme, is-dark);
 

--- a/src/material-experimental/mdc-checkbox/_mdc-checkbox-color.scss
+++ b/src/material-experimental/mdc-checkbox/_mdc-checkbox-color.scss
@@ -1,0 +1,70 @@
+@import '@material/checkbox/mixins';
+@import '@material/checkbox/variables';
+@import '@material/form-field/mixins';
+@import '@material/theme/functions';
+@import '../mdc-helpers/mdc-helpers';
+
+@mixin mat-checkbox-color-mdc($theme) {
+  $primary: mat-color(map-get($theme, primary));
+  $accent: mat-color(map-get($theme, accent));
+  $warn: mat-color(map-get($theme, warn));
+
+  // Save original values of MDC global variables. We need to save these so we can restore the
+  // variables to their original values and prevent unintended side effects from using this mixin.
+  $orig-mdc-checkbox-mark-color: $mdc-checkbox-mark-color;
+  $orig-mdc-checkbox-baseline-theme-color: $mdc-checkbox-baseline-theme-color;
+  $orig-mdc-checkbox-border-color: $mdc-checkbox-border-color;
+  $orig-mdc-checkbox-disabled-color: $mdc-checkbox-disabled-color;
+
+  @include mat-using-mdc-theme($theme) {
+    $mdc-checkbox-mark-color: mdc-theme-prop-value(on-primary) !global;
+    $mdc-checkbox-baseline-theme-color: primary !global;
+    $mdc-checkbox-border-color: rgba(mdc-theme-prop-value(on-surface), 0.54) !global;
+    $mdc-checkbox-disabled-color: rgba(mdc-theme-prop-value(on-surface), 0.26) !global;
+
+    @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
+    @include mdc-form-field-core-styles($query: $mat-theme-styles-query);
+
+    // MDC's checkbox doesn't support a `color` property. We add support for it by adding a CSS
+    // class for accent and warn style, and applying the appropriate overrides below. Since we don't
+    // use MDC's ripple, we also need to set the color for our replacement ripple.
+    .mat-mdc-checkbox {
+      .mat-ripple-element,
+      .mdc-checkbox__background::before {
+        background: mdc-theme-prop-value(on-surface);
+      }
+
+      .mdc-checkbox--selected ~ .mat-mdc-checkbox-ripple .mat-ripple-element {
+        background: $primary;
+      }
+
+      &.mat-accent {
+        $mdc-checkbox-mark-color: mdc-theme-prop-value(on-secondary) !global;
+        $mdc-checkbox-baseline-theme-color: secondary !global;
+
+        @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
+
+        .mdc-checkbox--selected ~ .mat-mdc-checkbox-ripple .mat-ripple-element {
+          background: $accent;
+        }
+      }
+
+      &.mat-warn {
+        $mdc-checkbox-mark-color: mdc-theme-prop-value(on-error) !global;
+        $mdc-checkbox-baseline-theme-color: error !global;
+
+        @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
+
+        .mdc-checkbox--selected ~ .mat-mdc-checkbox-ripple .mat-ripple-element {
+          background: $warn;
+        }
+      }
+    }
+  }
+
+  // Restore original values of MDC global variables.
+  $mdc-checkbox-mark-color: $orig-mdc-checkbox-mark-color !global;
+  $mdc-checkbox-baseline-theme-color: $orig-mdc-checkbox-baseline-theme-color !global;
+  $mdc-checkbox-border-color: $orig-mdc-checkbox-border-color !global;
+  $mdc-checkbox-disabled-color: $orig-mdc-checkbox-disabled-color !global;
+}

--- a/src/material-experimental/mdc-checkbox/_mdc-checkbox-density.scss
+++ b/src/material-experimental/mdc-checkbox/_mdc-checkbox-density.scss
@@ -1,0 +1,22 @@
+@import '@material/density/functions';
+@import '@material/checkbox/mixins';
+
+@mixin mat-checkbox-density-mdc($density-scale) {
+  $size: mdc-density-prop-value(
+    $density-config: $mdc-checkbox-density-config,
+    $density-scale: $density-scale,
+    $property-name: size
+  );
+
+  .mat-mdc-checkbox-ripple {
+    width: $size;
+    height: $size;
+    top: 50%;
+    left: 50%;
+    margin: (-$size / 2) 0 0 (-$size / 2);
+  }
+
+  .mat-mdc-checkbox .mdc-checkbox {
+    @include mdc-checkbox-density($density-scale);
+  }
+}

--- a/src/material-experimental/mdc-checkbox/_mdc-checkbox.scss
+++ b/src/material-experimental/mdc-checkbox/_mdc-checkbox.scss
@@ -1,73 +1,14 @@
 @import '@material/checkbox/mixins';
 @import '@material/checkbox/variables';
 @import '@material/form-field/mixins';
-@import '@material/ripple/variables';
-@import '@material/theme/functions';
+
+@import './mdc-checkbox-color';
+@import './mdc-checkbox-density';
 @import '../mdc-helpers/mdc-helpers';
 
-@mixin mat-checkbox-theme-mdc($theme) {
-  $primary: mat-color(map-get($theme, primary));
-  $accent: mat-color(map-get($theme, accent));
-  $warn: mat-color(map-get($theme, warn));
-
-  // Save original values of MDC global variables. We need to save these so we can restore the
-  // variables to their original values and prevent unintended side effects from using this mixin.
-  $orig-mdc-checkbox-mark-color: $mdc-checkbox-mark-color;
-  $orig-mdc-checkbox-baseline-theme-color: $mdc-checkbox-baseline-theme-color;
-  $orig-mdc-checkbox-border-color: $mdc-checkbox-border-color;
-  $orig-mdc-checkbox-disabled-color: $mdc-checkbox-disabled-color;
-
-  @include mat-using-mdc-theme($theme) {
-    $mdc-checkbox-mark-color: mdc-theme-prop-value(on-primary) !global;
-    $mdc-checkbox-baseline-theme-color: primary !global;
-    $mdc-checkbox-border-color: rgba(mdc-theme-prop-value(on-surface), 0.54) !global;
-    $mdc-checkbox-disabled-color: rgba(mdc-theme-prop-value(on-surface), 0.26) !global;
-
-    @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
-    @include mdc-form-field-core-styles($query: $mat-theme-styles-query);
-
-    // MDC's checkbox doesn't support a `color` property. We add support for it by adding a CSS
-    // class for accent and warn style, and applying the appropriate overrides below. Since we don't
-    // use MDC's ripple, we also need to set the color for our replacement ripple.
-    .mat-mdc-checkbox {
-      .mat-ripple-element,
-      .mdc-checkbox__background::before {
-        background: mdc-theme-prop-value(on-surface);
-      }
-
-      .mdc-checkbox--selected ~ .mat-mdc-checkbox-ripple .mat-ripple-element {
-        background: $primary;
-      }
-
-      &.mat-accent {
-        $mdc-checkbox-mark-color: mdc-theme-prop-value(on-secondary) !global;
-        $mdc-checkbox-baseline-theme-color: secondary !global;
-
-        @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
-
-        .mdc-checkbox--selected ~ .mat-mdc-checkbox-ripple .mat-ripple-element {
-          background: $accent;
-        }
-      }
-
-      &.mat-warn {
-        $mdc-checkbox-mark-color: mdc-theme-prop-value(on-error) !global;
-        $mdc-checkbox-baseline-theme-color: error !global;
-
-        @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
-
-        .mdc-checkbox--selected ~ .mat-mdc-checkbox-ripple .mat-ripple-element {
-          background: $warn;
-        }
-      }
-    }
-  }
-
-  // Restore original values of MDC global variables.
-  $mdc-checkbox-mark-color: $orig-mdc-checkbox-mark-color !global;
-  $mdc-checkbox-baseline-theme-color: $orig-mdc-checkbox-baseline-theme-color !global;
-  $mdc-checkbox-border-color: $orig-mdc-checkbox-border-color !global;
-  $mdc-checkbox-disabled-color: $orig-mdc-checkbox-disabled-color !global;
+@mixin mat-checkbox-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
+  @include mat-checkbox-color-mdc($theme);
+  @include mat-checkbox-density-mdc($density-scale);
 }
 
 @mixin mat-checkbox-typography-mdc($config: null) {

--- a/src/material-experimental/mdc-checkbox/checkbox.html
+++ b/src/material-experimental/mdc-checkbox/checkbox.html
@@ -31,7 +31,6 @@
       [matRippleTrigger]="checkbox"
       [matRippleDisabled]="disableRipple || disabled"
       [matRippleCentered]="true"
-      [matRippleRadius]="20"
       [matRippleAnimation]="_rippleAnimation"></div>
   </div>
   <label #label

--- a/src/material-experimental/mdc-checkbox/checkbox.scss
+++ b/src/material-experimental/mdc-checkbox/checkbox.scss
@@ -51,13 +51,11 @@
   }
 }
 
-.mat-mdc-checkbox-ripple, .mat-mdc-checkbox .mdc-checkbox__background::before {
-  $ripple-size: 40px;
+.mat-mdc-checkbox-ripple {
+  // Usually the ripple radius would be specified through the MatRipple input, but
+  // since we dynamically adjust the size of the ripple container, we cannot use a
+  // fixed ripple radius.
+  border-radius: 50%;
   position: absolute;
-  width: $ripple-size;
-  height: $ripple-size;
-  top: 50%;
-  left: 50%;
-  margin: (-$ripple-size / 2) 0 0 (-$ripple-size / 2);
   pointer-events: none;
 }

--- a/src/material-experimental/mdc-chips/_mdc-chips-color.scss
+++ b/src/material-experimental/mdc-chips/_mdc-chips-color.scss
@@ -1,0 +1,37 @@
+@import '@material/chips/mixins';
+@import '@material/theme/functions';
+@import '../mdc-helpers/mdc-helpers';
+
+@mixin mat-chips-color-mdc($theme) {
+  @include mdc-chip-set-core-styles($query: $mat-theme-styles-query);
+  @include mdc-chip-without-ripple($query: $mat-theme-styles-query);
+
+  $primary: mat-color(map-get($theme, primary));
+  $accent: mat-color(map-get($theme, accent));
+  $warn: mat-color(map-get($theme, warn));
+  $background: map-get($theme, background);
+
+  $unselected-background: mat-color($background, unselected-chip);
+
+  .mat-mdc-chip {
+    @include mdc-chip-fill-color-accessible($unselected-background);
+
+    &.mat-primary {
+      &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
+        @include mdc-chip-fill-color-accessible($primary);
+      }
+    }
+
+    &.mat-accent {
+      &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
+        @include mdc-chip-fill-color-accessible($accent);
+      }
+    }
+
+    &.mat-warn {
+      &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
+        @include mdc-chip-fill-color-accessible($warn);
+      }
+    }
+  }
+}

--- a/src/material-experimental/mdc-chips/_mdc-chips-density.scss
+++ b/src/material-experimental/mdc-chips/_mdc-chips-density.scss
@@ -1,0 +1,9 @@
+@import '@material/chips/mixins';
+@import '@material/theme/functions';
+@import '../mdc-helpers/mdc-helpers';
+
+@mixin mat-chips-density-mdc($density-scale) {
+  .mat-mdc-chip {
+    @include mdc-chip-density($density-scale);
+  }
+}

--- a/src/material-experimental/mdc-chips/_mdc-chips.scss
+++ b/src/material-experimental/mdc-chips/_mdc-chips.scss
@@ -1,39 +1,12 @@
 @import '@material/chips/mixins';
+
+@import './mdc-chips-color';
+@import './mdc-chips-density';
 @import '../mdc-helpers/mdc-helpers';
-@import '@material/theme/functions';
 
-@mixin mat-chips-theme-mdc($theme) {
-  @include mdc-chip-set-core-styles($query: $mat-theme-styles-query);
-  @include mdc-chip-without-ripple($query: $mat-theme-styles-query);
-
-  $primary: mat-color(map-get($theme, primary));
-  $accent: mat-color(map-get($theme, accent));
-  $warn: mat-color(map-get($theme, warn));
-  $background: map-get($theme, background);
-
-  $unselected-background: mat-color($background, unselected-chip);
-
-  .mat-mdc-chip {
-    @include mdc-chip-fill-color-accessible($unselected-background);
-
-    &.mat-primary {
-      &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-         @include mdc-chip-fill-color-accessible($primary);
-      }
-    }
-
-    &.mat-accent {
-      &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-         @include mdc-chip-fill-color-accessible($accent);
-      }
-    }
-
-    &.mat-warn {
-      &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-         @include mdc-chip-fill-color-accessible($warn);
-      }
-    }
-  }
+@mixin mat-chips-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
+  @include mat-chips-color-mdc($theme);
+  @include mat-chips-density-mdc($density-scale);
 }
 
 @mixin mat-chips-typography-mdc($config) {

--- a/src/material-experimental/mdc-density/BUILD.bazel
+++ b/src/material-experimental/mdc-density/BUILD.bazel
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "sass_library")
+
+sass_library(
+    name = "all_density",
+    srcs = [
+        "_all-density.scss",
+    ],
+    deps = [
+        "//src/material-experimental/mdc-button:mdc_button_scss_lib",
+        "//src/material-experimental/mdc-card:mdc_card_scss_lib",
+        "//src/material-experimental/mdc-checkbox:mdc_checkbox_scss_lib",
+        "//src/material-experimental/mdc-chips:mdc_chips_scss_lib",
+        "//src/material-experimental/mdc-list:mdc_list_scss_lib",
+        "//src/material-experimental/mdc-menu:mdc_menu_scss_lib",
+        "//src/material-experimental/mdc-progress-bar:mdc_progress_bar_scss_lib",
+        "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",
+        "//src/material-experimental/mdc-slide-toggle:mdc_slide_toggle_scss_lib",
+        "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
+        "//src/material-experimental/mdc-table:mdc_table_scss_lib",
+        "//src/material-experimental/mdc-tabs:mdc_tabs_scss_lib",
+    ],
+)

--- a/src/material-experimental/mdc-density/_all-density.scss
+++ b/src/material-experimental/mdc-density/_all-density.scss
@@ -1,0 +1,14 @@
+@import '../mdc-button/mdc-button-density';
+@import '../mdc-checkbox/mdc-checkbox-density';
+@import '../mdc-slide-toggle/mdc-slide-toggle-density';
+@import '../mdc-chips/mdc-chips-density';
+@import '../mdc-tabs/mdc-tabs-density';
+
+@mixin angular-material-density-mdc($density-scale) {
+  @include mat-button-density-mdc($density-scale);
+  @include mat-icon-button-density-mdc($density-scale);
+  @include mat-checkbox-density-mdc($density-scale);
+  @include mat-slide-toggle-density-mdc($density-scale);
+  @include mat-chips-density-mdc($density-scale);
+  @include mat-tabs-density-mdc($density-scale);
+}

--- a/src/material-experimental/mdc-helpers/_mdc-helpers.scss
+++ b/src/material-experimental/mdc-helpers/_mdc-helpers.scss
@@ -9,6 +9,9 @@
 @import '../../material/core/theming/theming';
 @import '../../material/core/typography/typography';
 
+// Default density scale used for MDC based components.
+$mat-default-density-scale: default;
+
 // A set of standard queries to use with MDC's queryable mixins.
 $mat-base-styles-query: mdc-feature-without(mdc-feature-any(color, typography));
 $mat-base-styles-without-animation-query:

--- a/src/material-experimental/mdc-list/_mdc-list.scss
+++ b/src/material-experimental/mdc-list/_mdc-list.scss
@@ -1,4 +1,6 @@
-@mixin mat-list-theme-mdc($theme) {
+@import '../mdc-helpers/mdc-helpers';
+
+@mixin mat-list-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
 }
 
 @mixin mat-list-typography-mdc($config) {

--- a/src/material-experimental/mdc-menu/_mdc-menu.scss
+++ b/src/material-experimental/mdc-menu/_mdc-menu.scss
@@ -5,7 +5,7 @@
 @import '@material/theme/functions';
 @import '../mdc-helpers/mdc-helpers';
 
-@mixin mat-menu-theme-mdc($theme) {
+@mixin mat-menu-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
   @include mat-using-mdc-theme($theme) {
     @include mdc-menu-surface-core-styles($mat-theme-styles-query);
     @include mdc-list-without-ripple($mat-theme-styles-query);

--- a/src/material-experimental/mdc-progress-bar/_mdc-progress-bar.scss
+++ b/src/material-experimental/mdc-progress-bar/_mdc-progress-bar.scss
@@ -12,7 +12,7 @@
   @include mdc-linear-progress-buffer-color($buffer-color, $query: $mat-theme-styles-query);
 }
 
-@mixin mat-progress-bar-theme-mdc($theme) {
+@mixin mat-progress-bar-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
   @include mat-using-mdc-theme($theme) {
     .mat-mdc-progress-bar {
       @include _mat-mdc-progress-bar-color(primary);

--- a/src/material-experimental/mdc-radio/_mdc-radio.scss
+++ b/src/material-experimental/mdc-radio/_mdc-radio.scss
@@ -1,8 +1,9 @@
 @import '../mdc-helpers/mdc-helpers';
 
-@mixin mat-radio-theme-mdc($theme) {
+@mixin mat-radio-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
   @include mat-using-mdc-theme($theme) {
-    // TODO: MDC theme styles here.
+    // TODO: MDC color styles here (see mdc-button)
+    // TODO: MDC density styles (see mdc-button)
   }
 }
 

--- a/src/material-experimental/mdc-slide-toggle/_mdc-slide-toggle-color.scss
+++ b/src/material-experimental/mdc-slide-toggle/_mdc-slide-toggle-color.scss
@@ -1,0 +1,64 @@
+@import '@material/switch/mixins';
+@import '@material/switch/variables';
+@import '@material/form-field/mixins';
+@import '../mdc-helpers/mdc-helpers';
+
+@mixin mat-slide-toggle-color-mdc($theme) {
+  $primary: mat-color(map-get($theme, primary));
+  $accent: mat-color(map-get($theme, accent));
+  $warn: mat-color(map-get($theme, warn));
+
+  // Save original values of MDC global variables. We need to save these so we can restore the
+  // variables to their original values and prevent unintended side effects from using this mixin.
+  $orig-mdc-switch-baseline-theme-color: $mdc-switch-baseline-theme-color;
+
+  @include mat-using-mdc-theme($theme) {
+    $mdc-switch-baseline-theme-color: primary !global;
+
+    @include mdc-form-field-core-styles($query: $mat-theme-styles-query);
+
+    // MDC's switch doesn't support a `color` property. We add support
+    // for it by adding a CSS class for accent and warn style.
+    .mat-mdc-slide-toggle {
+      .mdc-switch__thumb-underlay::before, .mat-ripple-element {
+        background: $mdc-switch-toggled-off-ripple-color;
+      }
+
+      &.mat-primary {
+        @include mdc-switch-without-ripple($query: $mat-theme-styles-query);
+      }
+
+      &.mat-accent {
+        $mdc-switch-baseline-theme-color: secondary !global;
+        @include mdc-switch-without-ripple($query: $mat-theme-styles-query);
+      }
+
+      &.mat-warn {
+        $mdc-switch-baseline-theme-color: error !global;
+        @include mdc-switch-without-ripple($query: $mat-theme-styles-query);
+      }
+    }
+
+    // The ripple color matches the palette only when it's checked.
+    .mat-mdc-slide-toggle-checked {
+      .mdc-switch__thumb-underlay::before, .mat-ripple-element {
+        background: $primary;
+      }
+
+      &.mat-accent {
+        .mdc-switch__thumb-underlay::before, .mat-ripple-element {
+          background: $accent;
+        }
+      }
+
+      &.mat-warn {
+        .mdc-switch__thumb-underlay::before, .mat-ripple-element {
+          background: $warn;
+        }
+      }
+    }
+  }
+
+  // Restore original values of MDC global variables.
+  $mdc-switch-baseline-theme-color: $orig-mdc-switch-baseline-theme-color !global;
+}

--- a/src/material-experimental/mdc-slide-toggle/_mdc-slide-toggle-density.scss
+++ b/src/material-experimental/mdc-slide-toggle/_mdc-slide-toggle-density.scss
@@ -1,0 +1,7 @@
+@import '@material/switch/mixins';
+
+@mixin mat-slide-toggle-density-mdc($density-scale) {
+  .mat-mdc-slide-toggle {
+    @include mdc-switch-density($density-scale);
+  }
+}

--- a/src/material-experimental/mdc-slide-toggle/_mdc-slide-toggle.scss
+++ b/src/material-experimental/mdc-slide-toggle/_mdc-slide-toggle.scss
@@ -1,68 +1,13 @@
 @import '@material/switch/mixins';
-@import '@material/switch/variables';
 @import '@material/form-field/mixins';
-@import '@material/ripple/variables';
-@import '@material/theme/functions';
+
 @import '../mdc-helpers/mdc-helpers';
+@import './mdc-slide-toggle-color';
+@import './mdc-slide-toggle-density';
 
-@mixin mat-slide-toggle-theme-mdc($theme) {
-  $primary: mat-color(map-get($theme, primary));
-  $accent: mat-color(map-get($theme, accent));
-  $warn: mat-color(map-get($theme, warn));
-
-  // Save original values of MDC global variables. We need to save these so we can restore the
-  // variables to their original values and prevent unintended side effects from using this mixin.
-  $orig-mdc-switch-baseline-theme-color: $mdc-switch-baseline-theme-color;
-
-  @include mat-using-mdc-theme($theme) {
-    $mdc-switch-baseline-theme-color: primary !global;
-
-    @include mdc-form-field-core-styles($query: $mat-theme-styles-query);
-
-    // MDC's switch doesn't support a `color` property. We add support
-    // for it by adding a CSS class for accent and warn style.
-    .mat-mdc-slide-toggle {
-      .mdc-switch__thumb-underlay::before, .mat-ripple-element {
-        background: $mdc-switch-toggled-off-ripple-color;
-      }
-
-      &.mat-primary {
-        @include mdc-switch-without-ripple($query: $mat-theme-styles-query);
-      }
-
-      &.mat-accent {
-        $mdc-switch-baseline-theme-color: secondary !global;
-        @include mdc-switch-without-ripple($query: $mat-theme-styles-query);
-      }
-
-      &.mat-warn {
-        $mdc-switch-baseline-theme-color: error !global;
-        @include mdc-switch-without-ripple($query: $mat-theme-styles-query);
-      }
-    }
-
-    // The ripple color matches the palette only when it's checked.
-    .mat-mdc-slide-toggle-checked {
-      .mdc-switch__thumb-underlay::before, .mat-ripple-element {
-        background: $primary;
-      }
-
-      &.mat-accent {
-        .mdc-switch__thumb-underlay::before, .mat-ripple-element {
-          background: $accent;
-        }
-      }
-
-      &.mat-warn {
-        .mdc-switch__thumb-underlay::before, .mat-ripple-element {
-          background: $warn;
-        }
-      }
-    }
-  }
-
-  // Restore original values of MDC global variables.
-  $mdc-switch-baseline-theme-color: $orig-mdc-switch-baseline-theme-color !global;
+@mixin mat-slide-toggle-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
+  @include mat-slide-toggle-color-mdc($theme);
+  @include mat-slide-toggle-density-mdc($density-scale);
 }
 
 @mixin mat-slide-toggle-typography-mdc($config) {

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -7,7 +7,6 @@
         [matRippleTrigger]="switch"
         [matRippleDisabled]="disableRipple || disabled"
         [matRippleCentered]="true"
-        [matRippleRadius]="24"
         [matRippleAnimation]="_rippleAnimation"></div>
       <div class="mdc-switch__thumb"></div>
       <input #input class="mdc-switch__native-control" type="checkbox"

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
@@ -18,6 +18,13 @@
     @include mat-fill;
   }
 
+  // Usually the ripple radius would be specified through an `MatRipple` input, but
+  // since the size of the container adjusts based on the density scale, we cannot rely
+  // on a fixed ripple radius.
+  .mat-mdc-slide-toggle-ripple {
+    border-radius: 50%;
+  }
+
   // The MDC switch styles related to the hover state are intertwined with the MDC ripple styles.
   // We currently don't use the MDC ripple due to size concerns, therefore we need to add some
   // additional styles to restore the hover state.

--- a/src/material-experimental/mdc-slider/_mdc-slider.scss
+++ b/src/material-experimental/mdc-slider/_mdc-slider.scss
@@ -1,7 +1,7 @@
 @import '../mdc-helpers/mdc-helpers';
 @import '@material/slider/mixins';
 
-@mixin mat-slider-theme-mdc($theme) {
+@mixin mat-slider-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
   @include mat-using-mdc-theme($theme) {
     @include mdc-slider-core-styles($query: $mat-theme-styles-query);
 

--- a/src/material-experimental/mdc-table/_mdc-table.scss
+++ b/src/material-experimental/mdc-table/_mdc-table.scss
@@ -1,7 +1,7 @@
 @import '../mdc-helpers/mdc-helpers';
 @import '@material/data-table/mixins';
 
-@mixin mat-table-theme-mdc($theme) {
+@mixin mat-table-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
   @include mat-using-mdc-theme($theme) {
     @include mdc-data-table-core-styles($query: $mat-theme-styles-query);
   }

--- a/src/material-experimental/mdc-tabs/BUILD.bazel
+++ b/src/material-experimental/mdc-tabs/BUILD.bazel
@@ -58,6 +58,7 @@ sass_binary(
     src = "_mdc-tabs.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
+        ":mdc_tabs_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
     ],

--- a/src/material-experimental/mdc-tabs/_mdc-tabs-color.scss
+++ b/src/material-experimental/mdc-tabs/_mdc-tabs-color.scss
@@ -1,0 +1,86 @@
+@import '@material/theme/mixins';
+@import '@material/theme/functions';
+@import '@material/tab-indicator/mixins';
+@import '@material/tab/mixins';
+@import '@material/tab/variables';
+@import '../mdc-helpers/mdc-helpers';
+
+@mixin _mat-mdc-tabs-background($background-color, $foreground-color) {
+  .mat-mdc-tab-header, .mat-mdc-tab-links, .mat-mdc-tab-header-pagination {
+    // Set background color for the tab group
+    @include mdc-theme-prop(background-color, $background-color);
+  }
+
+  // Set labels to contrast against background
+  .mdc-tab__text-label, .mat-mdc-tab-link {
+    @include mdc-theme-prop(color, $foreground-color);
+  }
+
+  .mat-ripple-element, .mdc-tab__ripple::before {
+    @include mdc-theme-prop(background-color, $foreground-color);
+  }
+
+  .mdc-tab-indicator__content--underline, .mat-mdc-tab-header-pagination-chevron {
+    @include mdc-theme-prop(border-color, $foreground-color);
+  }
+}
+
+@mixin _mat-mdc-tabs-palette-styles($color) {
+  @include mdc-tab-without-ripple($query: $mat-theme-styles-query);
+  @include mdc-tab-indicator-underline-color($color, $query: $mat-theme-styles-query);
+  @include mdc-tab-indicator-icon-color($color, $query: $mat-theme-styles-query);
+
+  .mdc-tab__ripple::before,
+  .mat-mdc-tab .mat-ripple-element,
+  .mat-mdc-tab-header-pagination .mat-ripple-element,
+  .mat-mdc-tab-link .mat-ripple-element {
+    @include mdc-theme-prop(background-color, $color);
+  }
+}
+
+@mixin mat-tabs-color-mdc($theme) {
+  // Save original values of MDC global variables. We need to save these so we can restore the
+  // variables to their original values and prevent unintended side effects from using this mixin.
+  $orig-mdc-tab-text-label-color-active: $mdc-tab-text-label-color-active;
+  $orig-mdc-tab-icon-color-active: $mdc-tab-icon-color-active;
+
+  @include mat-using-mdc-theme($theme) {
+    @include _mat-mdc-tabs-palette-styles($mdc-tab-text-label-color-active);
+
+    .mat-mdc-tab-group, .mat-mdc-tab-nav-bar {
+      &.mat-accent {
+        $mdc-tab-text-label-color-active: secondary !global;
+        $mdc-tab-icon-color-active: secondary !global;
+        @include _mat-mdc-tabs-palette-styles($mdc-tab-text-label-color-active);
+      }
+
+      &.mat-warn {
+        $mdc-tab-text-label-color-active: error !global;
+        $mdc-tab-icon-color-active: error !global;
+        @include _mat-mdc-tabs-palette-styles($mdc-tab-text-label-color-active);
+      }
+    }
+
+    .mat-mdc-tab-group {
+      &.mat-background-primary {
+        @include _mat-mdc-tabs-background(primary, on-primary);
+      }
+
+      &.mat-background-accent {
+        @include _mat-mdc-tabs-background(secondary, on-secondary);
+      }
+
+      &.mat-background-warn {
+        @include _mat-mdc-tabs-background(error, on-error);
+      }
+    }
+
+    .mat-mdc-tab-header-pagination-chevron {
+      @include mdc-theme-prop(border-color, on-surface);
+    }
+  }
+
+  // Restore original values of MDC global variables.
+  $mdc-tab-text-label-color-active: $orig-mdc-tab-text-label-color-active !global;
+  $mdc-tab-icon-color-active: $orig-mdc-tab-icon-color-active !global;
+}

--- a/src/material-experimental/mdc-tabs/_mdc-tabs-density.scss
+++ b/src/material-experimental/mdc-tabs/_mdc-tabs-density.scss
@@ -1,0 +1,17 @@
+@import '@material/density/functions';
+@import '@material/tab-bar/variables';
+@import '@material/tab/mixins';
+
+@mixin mat-tabs-density-mdc($density-scale) {
+  $height: mdc-density-prop-value(
+    $density-config: $mdc-tab-bar-density-config,
+    $density-scale: $density-scale,
+    $property-name: height
+  );
+
+  .mat-mdc-tab-header .mdc-tab {
+    // This is usually included by MDC's tab-bar density mixin, but we don't use
+    // the tab-bar because we implement our own pagination.
+    @include mdc-tab-height($height);
+  }
+}

--- a/src/material-experimental/mdc-tabs/_mdc-tabs.scss
+++ b/src/material-experimental/mdc-tabs/_mdc-tabs.scss
@@ -1,87 +1,13 @@
-@import '@material/theme/functions';
 @import '@material/tab-indicator/mixins';
 @import '@material/tab/mixins';
-@import '@material/tab/variables';
+
 @import '../mdc-helpers/mdc-helpers';
+@import './mdc-tabs-color';
+@import './mdc-tabs-density';
 
-@mixin mat-tabs-theme-mdc($theme) {
-  // Save original values of MDC global variables. We need to save these so we can restore the
-  // variables to their original values and prevent unintended side effects from using this mixin.
-  $orig-mdc-tab-text-label-color-active: $mdc-tab-text-label-color-active;
-  $orig-mdc-tab-icon-color-active: $mdc-tab-icon-color-active;
-
-  @include mat-using-mdc-theme($theme) {
-    @include _mat-mdc-tabs-palette-styles($mdc-tab-text-label-color-active);
-
-    .mat-mdc-tab-group, .mat-mdc-tab-nav-bar {
-      &.mat-accent {
-        $mdc-tab-text-label-color-active: secondary !global;
-        $mdc-tab-icon-color-active: secondary !global;
-        @include _mat-mdc-tabs-palette-styles($mdc-tab-text-label-color-active);
-      }
-
-      &.mat-warn {
-        $mdc-tab-text-label-color-active: error !global;
-        $mdc-tab-icon-color-active: error !global;
-        @include _mat-mdc-tabs-palette-styles($mdc-tab-text-label-color-active);
-      }
-    }
-
-    .mat-mdc-tab-group {
-      &.mat-background-primary {
-        @include _mat-mdc-tabs-background(primary, on-primary);
-      }
-
-      &.mat-background-accent {
-        @include _mat-mdc-tabs-background(secondary, on-secondary);
-      }
-
-      &.mat-background-warn {
-        @include _mat-mdc-tabs-background(error, on-error);
-      }
-    }
-
-    .mat-mdc-tab-header-pagination-chevron {
-      @include mdc-theme-prop(border-color, on-surface);
-    }
-  }
-
-  // Restore original values of MDC global variables.
-  $mdc-tab-text-label-color-active: $orig-mdc-tab-text-label-color-active !global;
-  $mdc-tab-icon-color-active: $orig-mdc-tab-icon-color-active !global;
-}
-
-@mixin _mat-mdc-tabs-background($background-color, $foreground-color) {
-  .mat-mdc-tab-header, .mat-mdc-tab-links, .mat-mdc-tab-header-pagination {
-    // Set background color for the tab group
-    @include mdc-theme-prop(background-color, $background-color);
-  }
-
-  // Set labels to contrast against background
-  .mdc-tab__text-label, .mat-mdc-tab-link {
-    @include mdc-theme-prop(color, $foreground-color);
-  }
-
-  .mat-ripple-element, .mdc-tab__ripple::before {
-    @include mdc-theme-prop(background-color, $foreground-color);
-  }
-
-  .mdc-tab-indicator__content--underline, .mat-mdc-tab-header-pagination-chevron {
-    @include mdc-theme-prop(border-color, $foreground-color);
-  }
-}
-
-@mixin _mat-mdc-tabs-palette-styles($color) {
-  @include mdc-tab-without-ripple($query: $mat-theme-styles-query);
-  @include mdc-tab-indicator-underline-color($color, $query: $mat-theme-styles-query);
-  @include mdc-tab-indicator-icon-color($color, $query: $mat-theme-styles-query);
-
-  .mdc-tab__ripple::before,
-  .mat-mdc-tab .mat-ripple-element,
-  .mat-mdc-tab-header-pagination .mat-ripple-element,
-  .mat-mdc-tab-link .mat-ripple-element {
-    @include mdc-theme-prop(background-color, $color);
-  }
+@mixin mat-tabs-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
+  @include mat-tabs-color-mdc($theme);
+  @include mat-tabs-density-mdc($density-scale);
 }
 
 @mixin mat-tabs-typography-mdc($config) {

--- a/src/material-experimental/mdc-tabs/_tabs-common.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-common.scss
@@ -11,10 +11,6 @@ $mat-tab-animation-duration: 500ms !default;
 
 @mixin mat-mdc-tab {
   &.mdc-tab {
-    // This is usually included by MDC's tab bar, however we don't
-    // use it because we implement our own pagination.
-    @include mdc-tab-height($mdc-tab-height, $mat-base-styles-query);
-
     // MDC's tabs stretch to fit the header by default, whereas stretching on our current ones
     // is an opt-in behavior. Also technically we don't need to combine the two classes, but
     // we need the extra specificity to avoid issues with CSS insertion order.

--- a/src/material-experimental/mdc-theming/_all-theme.scss
+++ b/src/material-experimental/mdc-theming/_all-theme.scss
@@ -10,20 +10,20 @@
 @import '../mdc-table/mdc-table';
 @import '../mdc-progress-bar/mdc-progress-bar';
 
-@mixin angular-material-theme-mdc($theme) {
-  @include mat-button-theme-mdc($theme);
-  @include mat-fab-theme-mdc($theme);
-  @include mat-icon-button-theme-mdc($theme);
-  @include mat-card-theme-mdc($theme);
-  @include mat-checkbox-theme-mdc($theme);
-  @include mat-chips-theme-mdc($theme);
-  @include mat-list-theme-mdc($theme);
-  @include mat-menu-theme-mdc($theme);
-  @include mat-progress-bar-theme-mdc($theme);
-  @include mat-radio-theme-mdc($theme);
-  @include mat-slide-toggle-theme-mdc($theme);
-  @include mat-table-theme-mdc($theme);
+@mixin angular-material-theme-mdc($theme, $density-scale: $mat-default-density-scale) {
+  @include mat-button-theme-mdc($theme, $density-scale);
+  @include mat-fab-theme-mdc($theme, $density-scale);
+  @include mat-icon-button-theme-mdc($theme, $density-scale);
+  @include mat-card-theme-mdc($theme, $density-scale);
+  @include mat-checkbox-theme-mdc($theme, $density-scale);
+  @include mat-chips-theme-mdc($theme, $density-scale);
+  @include mat-list-theme-mdc($theme, $density-scale);
+  @include mat-menu-theme-mdc($theme, $density-scale);
+  @include mat-progress-bar-theme-mdc($theme, $density-scale);
+  @include mat-radio-theme-mdc($theme, $density-scale);
+  @include mat-slide-toggle-theme-mdc($theme, $density-scale);
+  @include mat-table-theme-mdc($theme, $density-scale);
   // TODO(andrewjs): Add this back when MDC syncs their slider code into Google-internal code
-  // @include mat-slider-theme-mdc($theme);
-  @include mat-tabs-theme-mdc($theme);
+  // @include mat-slider-theme-mdc($theme, $density-scale);
+  @include mat-tabs-theme-mdc($theme, $density-scale);
 }


### PR DESCRIPTION
This is a prototype and work in progress.

The current experiments unveiled that we need:

1. Feature targeting for "density" mixins. We don't want to include the default density in the non-partial files. We want to maintain the component-specific density styles in separate partial files.
   * MDC inconsistently includes the default density in the `without-ripple` mixins 
   * We need to have a dedicated density mixin anyway, so that developers can override density per component. Hence it would make sense to have a single place for the density per component.
2. Ripples which do not have a hard-coded radius. We can achieve this by using `border-radius` on the ripple container. `MatRipple` will automatically calculate the needed radius.
   * We use this pattern in a few non-MDC based components.. but the calculation is **flawed**. This is because it looks for the furthest edge in the ripple container, but does not respect the border radius. Hence ripple animations appear faster than configured.
3. Ways to add custom density calculations. We do not always use building blocks provided by MDC (e.g. tabs-bar). This seems to be already possible with the current MDC density package.

This prototype intends a single partial file for density and color styles (potentially also typography; though typography styles are minimal most of the time). 

* The density and color styles are combined in the component `theme` mixin. That way, developers have the possibility to overwrite density on a per-component basis (without repeating unrelated styles).
* The component theme includes density because by default, density styles are not included in the component styles. Density needs to be configurable and cannot be part of non-partial Sass files.
* Allows developers to configure the default density without needing to add additional CSS overrides that activate the desired default density.

We include density in the `theme` to avoid breaking changes where developers need to manually setup default density styles for components. Instead, only setting up a theme is required. Though, we still provide _all_ the flexibility to fine-grain overwrite density or to simply specify a default scale for all components.

Open question:

* How does density play together with typography?
   * Based on the Material Design specification, density for text can be handled by adjusting the line height for individual lines. This seems to not fall into the "density scale" pattern, so it seems to be something that needs to be fine-grained by developers if typographic density is desired. Fortunately we provide ways to configure the typography, so we should be covered, but need documentation IMO.
   * Typographic density does not correlate with "component density"

Prototype demo: https://angular-components-test.firebaseapp.com/