### PR TITLE
build: remove incorrect sass binary for mdc-tabs theme

### DIFF
--- a/src/material-experimental/mdc-tabs/BUILD.bazel
+++ b/src/material-experimental/mdc-tabs/BUILD.bazel
@@ -18,7 +18,6 @@ ng_module(
         exclude = ["**/*.spec.ts"],
     ),
     assets = [
-        ":tabs_scss",
         ":tab-body.css",
         ":tab-header.css",
         ":tab-group.css",
@@ -47,16 +46,6 @@ ng_module(
 sass_library(
     name = "mdc_tabs_scss_lib",
     srcs = glob(["**/_*.scss"]),
-    deps = [
-        "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
-        "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-    ],
-)
-
-sass_binary(
-    name = "tabs_scss",
-    src = "_mdc-tabs.scss",
-    include_paths = ["external/npm/node_modules"],
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",


### PR DESCRIPTION
We never want to build a CSS file for Sass partial files. The
CSS files would be empty since the sources only contain mixins.
Only Sass files which are used in component `styleUrls` should be
built using `sass_binary`.

The `_mdc-tabs.scss` file is a plain partial consumed by the
theming and typography system. Building it through `sass_binary`
is unnecessary and causes ambiguous dependency setup
(two Bazel targets declaring the same file with separate dependencies)