### PR TITLE
fix(chips): set aria-required on chip input

### DIFF
--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -138,6 +138,15 @@ describe('MatChipInput', () => {
       expect(listElement.getAttribute('tabindex')).toBe('0', 'Expected tabindex to remain 0');
     }));
 
+    it('should be aria-required if the chip list is required', () => {
+      expect(inputNativeElement.hasAttribute('aria-required')).toBe(false);
+
+      fixture.componentInstance.required = true;
+      fixture.detectChanges();
+
+      expect(inputNativeElement.getAttribute('aria-required')).toBe('true');
+    });
+
   });
 
   describe('[addOnBlur]', () => {
@@ -245,7 +254,7 @@ describe('MatChipInput', () => {
 @Component({
   template: `
     <mat-form-field>
-      <mat-chip-list #chipList>
+      <mat-chip-list #chipList [required]="required">
         <mat-chip>Hello</mat-chip>
         <input matInput [matChipInputFor]="chipList"
                   [matChipInputAddOnBlur]="addOnBlur"
@@ -257,7 +266,8 @@ describe('MatChipInput', () => {
 })
 class TestChipInput {
   @ViewChild(MatChipList) chipListInstance: MatChipList;
-  addOnBlur: boolean = false;
+  addOnBlur = false;
+  required = false;
   placeholder = '';
 
   add(_: MatChipInputEvent) {

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -43,6 +43,7 @@ let nextUniqueId = 0;
     '[attr.disabled]': 'disabled || null',
     '[attr.placeholder]': 'placeholder || null',
     '[attr.aria-invalid]': '_chipList && _chipList.ngControl ? _chipList.ngControl.invalid : null',
+    '[attr.aria-required]': '_chipList && _chipList.required || null',
   }
 })
 export class MatChipInput implements MatChipTextControl, OnChanges {


### PR DESCRIPTION
Sets an `aria-required` on the input that's associated with a chip list. Matches something similar we did for the MDC-based chips in #18049 since the MDC chip listbox setup is similar to our current chips setup.