### PR TITLE
fix(datepicker): memory leak in popup mode

### DIFF
--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -108,7 +108,6 @@ export declare class MatDatepicker<D> implements OnDestroy, CanColor {
     readonly _disabledChange: Subject<boolean>;
     readonly _maxDate: D | null;
     readonly _minDate: D | null;
-    _popupRef: OverlayRef;
     _selected: D | null;
     readonly _selectedChanged: Subject<D>;
     calendarHeaderComponent: ComponentType<any>;
@@ -144,12 +143,17 @@ export declare const matDatepickerAnimations: {
     readonly fadeInCalendar: AnimationTriggerMetadata;
 };
 
-export declare class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase implements AfterViewInit, CanColor {
+export declare class MatDatepickerContent<D> extends _MatDatepickerContentMixinBase implements AfterViewInit, OnDestroy, CanColor {
+    _animationDone: Subject<void>;
+    _animationState: 'enter' | 'void';
     _calendar: MatCalendar<D>;
     _isAbove: boolean;
     datepicker: MatDatepicker<D>;
-    constructor(elementRef: ElementRef);
+    constructor(elementRef: ElementRef,
+    _changeDetectorRef?: ChangeDetectorRef | undefined);
+    _startExitAnimation(): void;
     ngAfterViewInit(): void;
+    ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDatepickerContent<any>, "mat-datepicker-content", ["matDatepickerContent"], { "color": "color"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any>>;
 }


### PR DESCRIPTION
Fixes the datepicker leaking memory when it is opened and closed in popup mode. The leak seems to come from the fact that we're detaching, rather than disposing of, the overlay when it is closed. We did this in the past to support an animation while closing the calendar, but it seems to cause the animations engine further down the line to retain the elements memory since they aren't being removed immediately.

These changes resolve the issue by triggering the exit animation, waiting for it to finish and disposing of the overlay. We weren't gaining too much by reusing the overlay from the previous approach, because the calendar was being removed and re-created every time anyway.

Fixes #17896.