### PR TITLE
build: focus trap demo not working on IE/Edge

### DIFF
--- a/src/dev-app/focus-trap/BUILD.bazel
+++ b/src/dev-app/focus-trap/BUILD.bazel
@@ -13,6 +13,7 @@ ng_module(
     ],
     deps = [
         "//src/cdk/a11y",
+        "//src/cdk/platform",
         "//src/material/button",
         "//src/material/card",
         "//src/material/dialog",

--- a/src/dev-app/focus-trap/focus-trap-demo.html
+++ b/src/dev-app/focus-trap/focus-trap-demo.html
@@ -5,8 +5,11 @@
       <button mat-raised-button (click)="toggleFocus(basicFocusTrap)">
         {{basicFocusTrap && basicFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
       </button>
-      <div class="demo-focus-trap-region" #basicDemoRegion
-        [class.demo-focus-trap-enabled]="(basicFocusTrap && basicFocusTrap.enabled) || false">
+      <div
+        class="demo-focus-trap-region"
+        cdkTrapFocus
+        #basicFocusTrap="cdkTrapFocus"
+        [class.demo-focus-trap-enabled]="basicFocusTrap && basicFocusTrap.enabled">
         <textarea class="demo-focus-trap-element" placeholder="One"></textarea>
         <textarea class="demo-focus-trap-element" placeholder="Two"></textarea>
       </div>
@@ -19,16 +22,20 @@
       <button mat-raised-button (click)="toggleFocus(nestedOuterFocusTrap)">
         {{nestedOuterFocusTrap && nestedOuterFocusTrap.enabled ? "Disable" : "Enable"}} outer FocusTrap
       </button>
-      <div class="demo-focus-trap-region" #nestedOuterDemoRegion
-        [class.demo-focus-trap-enabled]="(nestedOuterFocusTrap && nestedOuterFocusTrap.enabled) || false">
+      <div class="demo-focus-trap-region"
+        cdkTrapFocus
+        #nestedOuterFocusTrap="cdkTrapFocus"
+        [class.demo-focus-trap-enabled]="nestedOuterFocusTrap && nestedOuterFocusTrap.enabled">
         <textarea class="demo-focus-trap-element" placeholder="One"></textarea>
         <textarea class="demo-focus-trap-element" placeholder="Two"></textarea>
         <button mat-raised-button class="demo-focus-trap-element"
           (click)="toggleFocus(nestedInnerFocusTrap)">
           {{nestedInnerFocusTrap && nestedInnerFocusTrap.enabled ? "Disable" : "Enable"}} inner FocusTrap
         </button>
-        <div class="demo-focus-trap-region" #nestedInnerDemoRegion
-          [class.demo-focus-trap-enabled]="(nestedInnerFocusTrap && nestedInnerFocusTrap.enabled) || false">
+        <div class="demo-focus-trap-region"
+          cdkTrapFocus
+          #nestedInnerFocusTrap="cdkTrapFocus"
+          [class.demo-focus-trap-enabled]="nestedInnerFocusTrap && nestedInnerFocusTrap.enabled">
           <textarea class="demo-focus-trap-element" placeholder="Three"></textarea>
           <textarea class="demo-focus-trap-element" placeholder="Four"></textarea>
         </div>
@@ -42,8 +49,10 @@
       <button mat-raised-button (click)="toggleFocus(tabIndexFocusTrap)">
         {{tabIndexFocusTrap && tabIndexFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
        </button>
-      <div class="demo-focus-trap-region" #tabIndexDemoRegion
-        [class.demo-focus-trap-enabled]="(tabIndexFocusTrap && tabIndexFocusTrap.enabled) || false">
+      <div class="demo-focus-trap-region"
+        cdkTrapFocus
+        #tabIndexFocusTrap="cdkTrapFocus"
+        [class.demo-focus-trap-enabled]="tabIndexFocusTrap && tabIndexFocusTrap.enabled">
         <textarea class="demo-focus-trap-element" tabindex="1"
           placeholder="I have tabindex 1"></textarea>
         <textarea class="demo-focus-trap-element" placeholder="One"></textarea>
@@ -56,21 +65,26 @@
 
   <mat-card class="demo-mat-card">
     <mat-toolbar color="primary">Shadow DOMs</mat-toolbar>
-    <mat-card-content class="demo-mat-card-content">
-      <button mat-raised-button (click)="toggleFocus(shadowDomFocusTrap)">
-        {{shadowDomFocusTrap && shadowDomFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
-      </button>
-      <div class="demo-focus-trap-region" #shadowDomDemoRegion
-           [class.demo-focus-trap-enabled]="(shadowDomFocusTrap && shadowDomFocusTrap.enabled) || false">
+    <mat-card-content class="demo-mat-card-content" [ngSwitch]="_supportsShadowDom">
+      <ng-container *ngSwitchCase="true">
+        <button mat-raised-button (click)="toggleFocus(shadowDomFocusTrap)">
+          {{shadowDomFocusTrap && shadowDomFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
+        </button>
+        <div class="demo-focus-trap-region"
+             cdkTrapFocus
+             #shadowDomFocusTrap="cdkTrapFocus"
+             [class.demo-focus-trap-enabled]="shadowDomFocusTrap && shadowDomFocusTrap.enabled">
+          <shadow-dom-demo>
+            <textarea placeholder="I am in a shadow DOM"></textarea>
+          </shadow-dom-demo>
+          <textarea class="demo-focus-trap-element" placeholder="One"></textarea>
+          <textarea class="demo-focus-trap-element" placeholder="Two"></textarea>
+        </div>
         <shadow-dom-demo>
-          <textarea placeholder="I am in a shadow DOM"></textarea>
+          <textarea class="demo-focus-trap-element" placeholder="I am in a shadow DOM"></textarea>
         </shadow-dom-demo>
-        <textarea class="demo-focus-trap-element" placeholder="One"></textarea>
-        <textarea class="demo-focus-trap-element" placeholder="Two"></textarea>
-      </div>
-      <shadow-dom-demo>
-        <textarea class="demo-focus-trap-element" placeholder="I am in a shadow DOM"></textarea>
-      </shadow-dom-demo>
+      </ng-container>
+      <ng-container *ngSwitchCase="false">Shadow DOM not supported</ng-container>
     </mat-card-content>
   </mat-card>
 
@@ -80,8 +94,10 @@
       <button mat-raised-button (click)="toggleFocus(iframeFocusTrap)">
         {{iframeFocusTrap && iframeFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
       </button>
-      <div class="demo-focus-trap-region" #iframeDemoRegion
-           [class.demo-focus-trap-enabled]="(iframeFocusTrap && iframeFocusTrap.enabled) || false">
+      <div class="demo-focus-trap-region"
+           cdkTrapFocus
+           #iframeFocusTrap="cdkTrapFocus"
+           [class.demo-focus-trap-enabled]="iframeFocusTrap && iframeFocusTrap.enabled">
         <iframe class="demo-focus-trap-element"
           srcdoc="<textarea placeholder='I am in an iframe'></textarea>">
         </iframe>
@@ -98,8 +114,10 @@
       <button mat-raised-button (click)="toggleFocus(dynamicFocusTrap)">
         {{dynamicFocusTrap && dynamicFocusTrap.enabled ? "Disable" : "Enable"}} FocusTrap
       </button>
-      <div class="demo-focus-trap-region" #dynamicDemoRegion
-           [class.demo-focus-trap-enabled]="(dynamicFocusTrap && dynamicFocusTrap.enabled) || false">
+      <div class="demo-focus-trap-region"
+           cdkTrapFocus
+           #dynamicFocusTrap="cdkTrapFocus"
+           [class.demo-focus-trap-enabled]="dynamicFocusTrap && dynamicFocusTrap.enabled">
         <textarea class="demo-focus-trap-element" placeholder="One"></textarea>
         <textarea class="demo-focus-trap-element" placeholder="Two"></textarea>
         <button mat-raised-button class="demo-focus-trap-element" (click)="addNewElement()">

--- a/src/dev-app/focus-trap/focus-trap-demo.ts
+++ b/src/dev-app/focus-trap/focus-trap-demo.ts
@@ -6,14 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FocusTrap, FocusTrapFactory} from '@angular/cdk/a11y';
+import {CdkTrapFocus} from '@angular/cdk/a11y';
 import {
   AfterViewInit,
   Component,
   ElementRef,
   ViewChild,
-  ViewEncapsulation} from '@angular/core';
+  ViewEncapsulation,
+  ViewChildren,
+  QueryList,
+} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
+import {_supportsShadowDom} from '@angular/cdk/platform';
 
 @Component({
   selector: 'shadow-dom-demo',
@@ -29,69 +33,28 @@ export class FocusTrapShadowDomDemo {}
   styleUrls: ['focus-trap-demo.css'],
 })
 export class FocusTrapDemo implements AfterViewInit {
+  @ViewChild('newElements')
+  private _newElements: ElementRef<HTMLElement>;
 
-  basicFocusTrap: FocusTrap;
-  @ViewChild('basicDemoRegion', {static: false}) private readonly _basicDemoRegion!: ElementRef;
+  @ViewChildren(CdkTrapFocus)
+  private _focusTraps: QueryList<CdkTrapFocus>;
 
-  nestedOuterFocusTrap: FocusTrap;
-  @ViewChild('nestedOuterDemoRegion', {static: false})
-  private readonly _nestedOuterDemoRegion!: ElementRef;
-  nestedInnerFocusTrap: FocusTrap;
-  @ViewChild('nestedInnerDemoRegion', {static: false})
-  private readonly _nestedInnerDemoRegion!: ElementRef;
+  _supportsShadowDom = _supportsShadowDom();
 
-  tabIndexFocusTrap: FocusTrap;
-  @ViewChild('tabIndexDemoRegion', {static: false})
-  private readonly _tabIndexDemoRegion!: ElementRef;
-
-  shadowDomFocusTrap: FocusTrap;
-  @ViewChild('shadowDomDemoRegion', {static: false})
-  private readonly _shadowDomDemoRegion!: ElementRef;
-
-  iframeFocusTrap: FocusTrap;
-  @ViewChild('iframeDemoRegion', {static: false})
-  private readonly _iframeDemoRegion!: ElementRef;
-
-  dynamicFocusTrap: FocusTrap;
-  @ViewChild('dynamicDemoRegion', {static: false})
-  private readonly _dynamicDemoRegion!: ElementRef;
-  @ViewChild('newElements', {static: false}) private readonly _newElements!: ElementRef;
-
-  constructor(
-    public dialog: MatDialog,
-    private _focusTrapFactory: FocusTrapFactory) {}
+  constructor(public dialog: MatDialog) {}
 
   ngAfterViewInit() {
-    this.basicFocusTrap = this._focusTrapFactory.create(this._basicDemoRegion.nativeElement);
-    this.basicFocusTrap.enabled = false;
-
-    this.nestedOuterFocusTrap = this._focusTrapFactory.create(
-      this._nestedOuterDemoRegion.nativeElement);
-    this.nestedOuterFocusTrap.enabled = false;
-
-    this.nestedInnerFocusTrap = this._focusTrapFactory.create(
-      this._nestedInnerDemoRegion.nativeElement);
-    this.nestedInnerFocusTrap.enabled = false;
-
-    this.tabIndexFocusTrap = this._focusTrapFactory.create(
-      this._tabIndexDemoRegion.nativeElement);
-    this.tabIndexFocusTrap.enabled = false;
-
-    this.shadowDomFocusTrap = this._focusTrapFactory.create(
-      this._shadowDomDemoRegion.nativeElement);
-    this.shadowDomFocusTrap.enabled = false;
-
-    this.iframeFocusTrap = this._focusTrapFactory.create(this._iframeDemoRegion.nativeElement);
-    this.iframeFocusTrap.enabled = false;
-
-    this.dynamicFocusTrap = this._focusTrapFactory.create(this._dynamicDemoRegion.nativeElement);
-    this.dynamicFocusTrap.enabled = false;
+    // We want all the traps to be disabled by default, but doing so while using the value in
+    // the view will result in "changed after checked" errors so we defer it to the next tick.
+    setTimeout(() => {
+      this._focusTraps.forEach(trap => trap.enabled = false);
+    });
   }
 
-  toggleFocus(focusTrap: FocusTrap) {
-    focusTrap.enabled = !focusTrap.enabled;
-    if (focusTrap.enabled) {
-      focusTrap.focusInitialElementWhenReady();
+  toggleFocus(instance: CdkTrapFocus) {
+    instance.enabled = !instance.enabled;
+    if (instance.enabled) {
+      instance.focusTrap.focusInitialElementWhenReady();
     }
   }
 


### PR DESCRIPTION
The focus trap demo throws an error in IE and Edge, because it uses a component with Shadom DOM encapsulation. Adding an `ngIf` around it will break its functionality, because of the way the focus traps are initialized inside `ngAfterViewInit`. These changes switch the demo to use the focus trap directive and make it so we can test the demo against IE and Edge.