### PR TITLE
build: use `online: false` for browsersync

### DIFF
--- a/tools/dev-server/dev-server.ts
+++ b/tools/dev-server/dev-server.ts
@@ -23,6 +23,7 @@ export class DevServer {
   /** Options of the browser-sync server. */
   options: browserSync.Options = {
     open: false,
+    online: false,
     port: this.port,
     notify: false,
     ghostMode: false,


### PR DESCRIPTION
The `online` features cause an internal Google security auditing tool to complain