### PR TITLE
build: add tsickle as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "terser": "^4.3.9",
     "ts-api-guardian": "^0.4.6",
     "ts-node": "^3.0.4",
+    "tsickle": "^0.37.1",
     "tslint": "^5.20.0",
     "tsutils": "^3.0.0",
     "typescript": "^3.6.4",


### PR DESCRIPTION
Adds tsickle as explicit dependency. This is necessary because
we access it from `node_modules/tsickle` in a Bazel target that
wraps tsc with tsickle.

In the past we just relied on the transitive dependency of
`@angular/bazel` being hoisted, but the hoisting is not guaranteed
if the lock file changes (e.g. when running `yarn upgrade`). In general,
dependencies we explicitly access, should be added as explicit dependencies.