### PR TITLE
build: try/catch the @angular/bazel rules_nodejs 1.0.0 patch

### DIFF
--- a/tools/bazel/postinstall-patches.js
+++ b/tools/bazel/postinstall-patches.js
@@ -29,10 +29,13 @@ shelljs.cd(projectDir);
 // Workaround for https://github.com/angular/angular/issues/18810.
 shelljs.exec('ngc -p angular-tsconfig.json');
 
-// Temporary patch to make @angular/bazel compatible with rules_nodejs 1.0.0.
-// This is needed to resolve the dependency sandwich between angular components and
-// repo framework. It can be removed with a future @angular/bazel update.
-applyPatch(path.join(__dirname, './angular_bazel_rules_nodejs_1.0.0.patch'));
+try {
+  // Temporary patch to make @angular/bazel compatible with rules_nodejs 1.0.0.
+  // This is needed to resolve the dependency sandwich between angular components and
+  // repo framework. It can be removed with a future @angular/bazel update.
+  // try/catch needed for this the material CI tests to work in angular/repo
+  applyPatch(path.join(__dirname, './angular_bazel_rules_nodejs_1.0.0.patch'));
+} catch (_) {}
 
 // Temporary patch for ts-api-guardian to be compatible with rules_nodejs 1.0.0.
 // TODO: a new ts-api-guardian release is needed.


### PR DESCRIPTION
This is needed for the material unit test to pass on angular repo in https://github.com/angular/angular/pull/34589 otherwise the patch fails (since the changes are already made in that context) and throws and the CI job fails with:

```
      if (config.fatal) throw e;
                        ^

Error: exec:
    at Object.error (/tmp/material2/node_modules/shelljs/src/common.js:110:27)
    at execSync (/tmp/material2/node_modules/shelljs/src/exec.js:102:12)
    at String._exec (/tmp/material2/node_modules/shelljs/src/exec.js:205:12)
    at String.<anonymous> (/tmp/material2/node_modules/shelljs/src/common.js:335:23)
    at applyPatch (/tmp/material2/tools/bazel/postinstall-patches.js:186:26)
    at Object.<anonymous> (/tmp/material2/tools/bazel/postinstall-patches.js:35:1)
    at Module._compile (internal/modules/cjs/loader.js:936:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:947:10)
    at Module.load (internal/modules/cjs/loader.js:790:32)
    at Function.Module._load (internal/modules/cjs/loader.js:703:12)
error Command failed with exit code 1.
)
``