### PR TITLE
fix(material-experimental/mdc-slide-toggle): update adapter to match new interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/youtube": "^0.0.38",
     "@webcomponents/custom-elements": "^1.1.0",
     "core-js": "^2.6.9",
-    "material-components-web": "5.0.0-canary.c6808c51c.0",
+    "material-components-web": "5.0.0-canary.b602226ce.0",
     "rxjs": "^6.5.3",
     "systemjs": "0.19.43",
     "tslib": "^1.10.0",

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
@@ -95,6 +95,9 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
     removeClass: className => this._switchElement.nativeElement.classList.remove(className),
     setNativeControlChecked: checked => this._checked = checked,
     setNativeControlDisabled: disabled => this._disabled = disabled,
+    setNativeControlAttr: (name, value) => {
+      this._inputElement.nativeElement.setAttribute(name, value);
+    }
   };
 
   /** Whether the slide toggle is currently focused. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,542 +325,542 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.3.2.tgz#a92dc544290e2893bd8c02a81e684dae3d8e7c85"
   integrity sha512-ZD8lTgW07NGgo75bTyBJA8Lt9+NweNzot7lrsBtIvfciwUzaFJLsv2EShqjBeuhF7RpG6YFucJ6m67w5buCtzw==
 
-"@material/animation@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-5.0.0-canary.c6808c51c.0.tgz#ca87b522279efa22725d608abca06af043f3dcee"
-  integrity sha512-RdgzfUcLr+wOtRN7TqJnvc5YsI3F2aIDRRHKmfWo3vb0KminLU9F1ashxQ6KUUz3mWmdT3y3RwKuR2nVoVPTgQ==
+"@material/animation@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-5.0.0-canary.b602226ce.0.tgz#736ddcf005572b0f6e48d5ae60661f7456d0ce8c"
+  integrity sha512-4eRRpdrGcMuB1fV+zpUVG3s0va3aX4bW5Emxe1FDaanMq73T5seXuLTip3d3mrB5J6I79Hh46HNSVriqK2WyZw==
   dependencies:
     tslib "^1.9.3"
 
-"@material/auto-init@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/auto-init/-/auto-init-5.0.0-canary.c6808c51c.0.tgz#7f2c2872c6e9f2161aaa9ade43034cb8ae9ebe04"
-  integrity sha512-i/Qtf5EWYibWYKNs/IKFC8fjwBVPRhP8Qf0ils0Xb2alaFrVXbCgh06EFzi/185IKN4ce6Kb9BK7zJ/WHBJuvQ==
+"@material/auto-init@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/auto-init/-/auto-init-5.0.0-canary.b602226ce.0.tgz#0d0e508a422597daedabaa526e486da5ba4f9bcc"
+  integrity sha512-++cNuvLyWirIBkapxKtXHIr1lfA6uQmSH/dEXbVzkMpUrqLfU8hssczRRGLwojGGUIIK/OF8eLA7eiNHhV2lmg==
   dependencies:
-    "@material/base" "5.0.0-canary.c6808c51c.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/base@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/base/-/base-5.0.0-canary.c6808c51c.0.tgz#d45da74f15a0a4cdb6f53e3a36b02bbe88616965"
-  integrity sha512-LYCvUAVgKCW5HGs/Qc8qW1wKXl+A7wQIrbllBtCfZ+2PS1cxg8IKul9Tvm0QHvswYhSe33a7owbta+h2AGUGtQ==
+"@material/base@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-5.0.0-canary.b602226ce.0.tgz#88d09d82b82cc399f63976becc6bf2b4421fd1c7"
+  integrity sha512-Qwfj2/Ny5HpyW2UN8V8oocA7lnidNy32Te/RkTV78LIVlilBwQO9dh3RIBuNwFKsnuY62v360sKnf+dNEJ3JiA==
   dependencies:
     tslib "^1.9.3"
 
-"@material/button@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/button/-/button-5.0.0-canary.c6808c51c.0.tgz#b549cdb6375a309136e40bde62d9db840899115f"
-  integrity sha512-BpwgOF69nhMwWqUYuHAdiYZ3dntCCilXw5PZ0lYaLsX+fpBh/03OgVwXXxj2Ux4uP6e++tzPbmn8WruWHeGlyg==
+"@material/button@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/button/-/button-5.0.0-canary.b602226ce.0.tgz#0e42f215c3bacdd5a168721b522717825313dfe1"
+  integrity sha512-YI8O2oV/cuZ2SRaWknLVVAuvgQ6kHcSsPEj7lanskkkOzW4/LLmHmc2/CHY6UeaVbUN0yLijDag+nEOITXTilQ==
   dependencies:
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/touch-target" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/touch-target" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
 
-"@material/card@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/card/-/card-5.0.0-canary.c6808c51c.0.tgz#80347f74bd5e93cbe13835a97b5d2db39c347a12"
-  integrity sha512-tzA2G3vMxNM4idhZfpyhRMdcZg2xtlGxeZfo/hXKTSmvXs5lM80gsKY0q8Qh3kx7FwP2PuQy3UwJMDA6Gxf8CQ==
+"@material/card@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/card/-/card-5.0.0-canary.b602226ce.0.tgz#70a5218f84b7f7b19561715ac7c3da2304b9e267"
+  integrity sha512-oJ905+PCiCk3+awwqrd/ahKPUqpubmZWJPjdv8P1X5aERP3pwy4XOQASHZntLxivp1sigAKmDTE6mH0yEix6BQ==
   dependencies:
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
 
-"@material/checkbox@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/checkbox/-/checkbox-5.0.0-canary.c6808c51c.0.tgz#fda25a96465a2848f4036fa6c215203a618ae85d"
-  integrity sha512-e6lp+Z16cSTQ7CE5W3unbyuA/yYlIHwlfgvLG7RFXY79leERqa9nu0h6M7rxXnna0rH00fJnOJTLPRAwLIgZJA==
+"@material/checkbox@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/checkbox/-/checkbox-5.0.0-canary.b602226ce.0.tgz#2249f41cb991c8295d1a26484d6d6b3e9d7a3b22"
+  integrity sha512-Gz1IMmWingwSwtwQydl/UWV1NahtH8HXQp08n7eZDBJmJ42Zpf0qN8QjgJvromWqErztWWv83Pbu3QIoeV/2gw==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/touch-target" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/touch-target" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/chips@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/chips/-/chips-5.0.0-canary.c6808c51c.0.tgz#1e389215cc8a52f7531093de37d21270e3254dd8"
-  integrity sha512-D2sDJQauZtZZnV3I8iOkBQQ/smz8yHQ6p4v8KESl61w5ztXSTL9jegeMhVFe2rbK5KZXw5q0cAZFe9bV0tw7lg==
+"@material/chips@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/chips/-/chips-5.0.0-canary.b602226ce.0.tgz#3cadd051d03379b80f1a06550f0be2f3b5bfb90d"
+  integrity sha512-pLAiB/0+GGXHDFMFdlyCZClnp1B2ASG4wXTWLAqECB1lZmY4ke+KlSA68UKfIEFxSxFuiJx8C5wswZ8WbH3w5g==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/checkbox" "5.0.0-canary.c6808c51c.0"
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/touch-target" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/checkbox" "5.0.0-canary.b602226ce.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/touch-target" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/data-table@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/data-table/-/data-table-5.0.0-canary.c6808c51c.0.tgz#22dca0a81184fef7cc81f4e6b0ea6eb37b64b19f"
-  integrity sha512-eMjhSSoFIM16OI/HJK7U4mOFB2FzKNQJgdtnt7qL8T8meaanAYrR2ChvP6e8WsJ9W4vdUmPW+e3AS36M06U3CA==
+"@material/data-table@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/data-table/-/data-table-5.0.0-canary.b602226ce.0.tgz#787e8c2452a7d64c54df696a506870e7c887f8e8"
+  integrity sha512-Y5HZQ9cQzcsALwK+Rr0YMhC2Tki0M4Ro/JMrytpqtx3xlx8KUCYfQhi7XM1D0vX2oZwNwMMn7GMqUwvlfyp5BQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/checkbox" "5.0.0-canary.c6808c51c.0"
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/checkbox" "5.0.0-canary.b602226ce.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.10.0"
 
-"@material/density@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/density/-/density-5.0.0-canary.c6808c51c.0.tgz#11a1f3dca71e617865ab9bc563094731f87fcd5e"
-  integrity sha512-RkUCQWaou30B06na2lbeKoOByylwYQ7gRUx4PW1ZAm4D3ftmhmxo9oPrC/e3KOGrld/wPEl5/G5P/p6Jwfi1uw==
+"@material/density@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/density/-/density-5.0.0-canary.b602226ce.0.tgz#94db9822102756ec94f3aa3467f1c0d971998e7d"
+  integrity sha512-Sqfvj0xyA8fxuAOrIlaOMfj4oSPzI1cmCC3NoHxF+AeILQXW0s2GgPCeHIXaWiB2WjHodvjpe5zq0NNQVV+gUw==
 
-"@material/dialog@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/dialog/-/dialog-5.0.0-canary.c6808c51c.0.tgz#9c91339e57e7ba5099561432588c7c1c3af1fbeb"
-  integrity sha512-kg9hNLEYwXNIfJFcOwGwmJV/L4DkWR1rmK/oqNZrPVGkO5DhSZzGoQpHa0Lri3wg0RGRPRcML8JZkCX4P1b3rg==
+"@material/dialog@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/dialog/-/dialog-5.0.0-canary.b602226ce.0.tgz#e6c8eae5e01d8209f231d44ebf0e88777d1c92b6"
+  integrity sha512-lgkkxKUHSLWLgEO2UpMQa1BVgI0lg5byniQMu+rWo4pB0EtTvj7xmff4/ja3v46MpHWDuhwEhbDh375T4s7X2g==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/touch-target" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/touch-target" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     focus-trap "^5.0.0"
     tslib "^1.9.3"
 
-"@material/dom@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-5.0.0-canary.c6808c51c.0.tgz#379a35d3a94d329da7e4368427a7b6bc4295e019"
-  integrity sha512-/KlSYmsr+rs7Uc6nMhU9Rp1XlGVVlgYAoZpXcacVn0/BK30KNRCSi62sZLxFD7hxoW1hkHzm90i+rhjaVDC9ew==
+"@material/dom@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-5.0.0-canary.b602226ce.0.tgz#64d9d2191d5047a6a5baaf9b3251e350f2cf11c2"
+  integrity sha512-2k62o5PLEH5fI5Oe46MZ3eX5vR021EnWTcLKAkgwm3T0GIGxUeizHnkrJMyBI2QECAS4EjpOvlytGTCvMbiBkA==
   dependencies:
     tslib "^1.9.3"
 
-"@material/drawer@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/drawer/-/drawer-5.0.0-canary.c6808c51c.0.tgz#7caa58d63c8aa78f69f84fefc3f1807680e79572"
-  integrity sha512-rHCBDRR/KgHFFXfhK2BvlzMs3KdUM5i7jOxeEuRbllRPBb0YNMxizIc8cspTIx55ZoZ/naTaCFigA20xLwne8g==
+"@material/drawer@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/drawer/-/drawer-5.0.0-canary.b602226ce.0.tgz#269fe5d1bcab35274f19b2030c76dd67525df429"
+  integrity sha512-kk9iIOKVik35v118XKCZvDSAWXI5Mw1SKIT9cAFHbUgFPFtbE8rUdnozVAeBawH0vT3KnrTiNR5zwAoksVbopg==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/list" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/list" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     focus-trap "^5.0.0"
     tslib "^1.9.3"
 
-"@material/elevation@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-5.0.0-canary.c6808c51c.0.tgz#eaf05776677da5afe8b9f7638a4a74a12db022df"
-  integrity sha512-rGjVrr/0QYFvieprjoInwp5B/Hgw0170OYlpjSXk5PTcukM9YBy8GVQFXP2JZ4EE9txqSpUci5JA5SXCQZHkqg==
+"@material/elevation@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-5.0.0-canary.b602226ce.0.tgz#fd24844f4b4a928e984d452d5064c1669d7c51e6"
+  integrity sha512-btk+wH91A7TWkMN3PbbhAupkZlFF8aJpjs/wT/++/foH6ddDLItj+EQrgaJIVCsbkKw2kI1A1KVqqSnuRvBTNA==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
 
-"@material/fab@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/fab/-/fab-5.0.0-canary.c6808c51c.0.tgz#663c03072d57c51330fc0c73d1cbd8c3ef770855"
-  integrity sha512-R0kDiCndVYjZfu+YMu8S2bpWzVMSppjj0erP8AXZCJiSSo7A+uLBOolgiNSrMV7+1SLv5od1WJFZ0Fw/NZAt6A==
+"@material/fab@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/fab/-/fab-5.0.0-canary.b602226ce.0.tgz#859184891ccd99c3a55e1992b93e2af5487a7be8"
+  integrity sha512-edHL5EL/XtTmp9expepAx9qnLgRebZ7wVq04kfQ9Yjn6SSBBgv+nVYq8oqjohJQWqEU0RDBZ1gqMO7HhTcyc6g==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/touch-target" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/touch-target" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
 
-"@material/feature-targeting@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-5.0.0-canary.c6808c51c.0.tgz#b1a5c8c8e13e3f1bc1ee23ada8701214fc18c162"
-  integrity sha512-Zagy6tSuHm4URr3pny3qFIcxECYB2vxzzr7NEqkcTyhIkaUAL+iYiTjrfuvNN/h5jYbzsu95xn+ZMVaFkoR8HQ==
+"@material/feature-targeting@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-5.0.0-canary.b602226ce.0.tgz#9240cca37f3604fc314436d5b33771c6139afdbf"
+  integrity sha512-2AZc+O3THhRqw+e+UqEHlqye+3O3eCakxXtpuxigOlssWGi+kEMTH+iDGrrOpcImcTKMh82h2DlpQ9tHsU23cw==
 
-"@material/floating-label@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-5.0.0-canary.c6808c51c.0.tgz#3467f9562c94ad1e54df382836d85613c6b52f98"
-  integrity sha512-Yz9rUvm2JDQfiLitEwBBkLu9/Xkt85v9fRzXDaCkGFFRkQbg2MPl7OmJvDzlwjEmij6Qqpw/VfblX8APTx/i/w==
+"@material/floating-label@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-5.0.0-canary.b602226ce.0.tgz#39c6fb097ec5c825d9bae2c944156a3ad32e1c1f"
+  integrity sha512-uhkFY3iBH1itzgIUq7DJ/BA1IrxM9huYgHTlnQEa6u55407CpCv9erlnwvJMTWncUNqA5P0ktZ+QU2sWN9jOvA==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/form-field@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-5.0.0-canary.c6808c51c.0.tgz#8ab52f099a1ddbd825dd15790d9c70cac711057c"
-  integrity sha512-akEwaO8zdQnlmu8LTbaFanR25oHF40WOQGD+fjSnewiVD+sMiVnGlpOo6OeU9HukP2FN6ZpF4qR8c9ziHqBcXQ==
+"@material/form-field@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-5.0.0-canary.b602226ce.0.tgz#e6e412f0beb49128ec10ffc49e60445daa7c1f8a"
+  integrity sha512-HyrKuGjIOTnW/0WeZjfsm8TH84AEH7D/qyx672B3owyLXH4+9RsBNctowP3bi999uwEryAxPHZ4+A7nz8iBVGA==
   dependencies:
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/grid-list@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/grid-list/-/grid-list-5.0.0-canary.c6808c51c.0.tgz#b510b51e1b088de0b3aa74b03ec89ec8ea7d3814"
-  integrity sha512-9Mfu+KYDwc1QQjtnfpGU4O6cucSFUbnHfqbtdfCM4ZBdDertvVKADq0mcJZCEMgFOx33rdPwGCz9uQXhh2ehYQ==
+"@material/grid-list@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/grid-list/-/grid-list-5.0.0-canary.b602226ce.0.tgz#93b8b7cd64eae54a823f506ece2ec9392110d423"
+  integrity sha512-qf7d3uQFmo4mr+jSF5z/+LpvHV72FNX8xUCfIW9i0eWM+IFsUL6rpOqZ9VKMpifDpjyATKH7K5HxYFe6CRy9sA==
   dependencies:
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/icon-button@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/icon-button/-/icon-button-5.0.0-canary.c6808c51c.0.tgz#d46c7d4ec4e21195c4f2763b8771e10bf8599b45"
-  integrity sha512-kbQBtODIgdXDEBT50a0cXsdGmWJ02rkVN9VundmKnfZ2i+BY1cCdtRf2UPYbiB4eJfsIFlHIqs0+gCs0ZN7C8g==
+"@material/icon-button@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/icon-button/-/icon-button-5.0.0-canary.b602226ce.0.tgz#c75113e11796c4575e5d0a271ba50d3fcea160a4"
+  integrity sha512-q0iGsBhN4Pjoio9yuqaDKG1ziQj24ggeMhfs5F4d6GVPnmWleSO0qn4wwkcTB3S6Utwt/4RNZUCJuA7C1YAnUA==
   dependencies:
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/image-list@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/image-list/-/image-list-5.0.0-canary.c6808c51c.0.tgz#4fd7202e2733cc4e66e2e4119e82f61659cb0ee5"
-  integrity sha512-8lmpo1wACWce9s2dzI3Ht9D1CMh/+dFcOs/fm30JhY62i464bsoGEsRhy1yMH2PCRVplb/WTmTABGjqG+MDhDQ==
+"@material/image-list@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/image-list/-/image-list-5.0.0-canary.b602226ce.0.tgz#62c6a3f163d312773d4d3454525b13cdb8a12c40"
+  integrity sha512-8uaFt6JtRYaWQG9YxH7RfIQOT1Z7axkfJROtG/98MgKBo7DWtX7pyuV4X6dnic9xOn5X87a+y6vXP3uE//sXTQ==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
 
-"@material/layout-grid@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/layout-grid/-/layout-grid-5.0.0-canary.c6808c51c.0.tgz#bdbe668902e7d3993fd7941062cf1a1dd389d6bc"
-  integrity sha512-VdA6RIEdrvEWzdwrYIhu7OqNL2nrZRBnyrFLXb6sXhDDiA9iLKPUORLS2z+t3yInCqgtcZSlKV0wmmWCHXnV5g==
+"@material/layout-grid@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/layout-grid/-/layout-grid-5.0.0-canary.b602226ce.0.tgz#6964a837df9905a726ce369ee223e20e9fa2a591"
+  integrity sha512-jLd2JCuZ78ycMoM0LADMizOZudQ/j85l3uRK948xqSfpxNQM/mUoFALAyBmwfeph5r7cIuRatqXIraC+CehAkA==
 
-"@material/line-ripple@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-5.0.0-canary.c6808c51c.0.tgz#a6a3f88bc09f8fb64d53062a53497e2a7c02a277"
-  integrity sha512-+qN7IN4E1bY7ag5kgr4bFYohfc7FxxToqjA0YaEf0W/emmIOKbx7P3JPcVC+g2bJ8FVr1ppsgQL40Mz+Ilyxsg==
+"@material/line-ripple@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-5.0.0-canary.b602226ce.0.tgz#84a2023dd948105e0f65c07b27dfeb386ec0cc52"
+  integrity sha512-+ZbLanjgSGVt2VOv4SK/rkxiv1ebfUTk76IG8dXllgyMUkps3ILDyfPM9Mz2tiNATCaNirVAGDqxSKS8rlUocw==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/linear-progress@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/linear-progress/-/linear-progress-5.0.0-canary.c6808c51c.0.tgz#7277337d79e381f3cbd29cad7fad3c2ad2f6f6a5"
-  integrity sha512-K9rhMNiYi8V2FOg5dcE8fIZjvZSG561RaA7d2dziP6hZ7KX3Y8UYg3FUKPV9qxj3zdshlDUSEelwK8jJwjeXVg==
+"@material/linear-progress@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/linear-progress/-/linear-progress-5.0.0-canary.b602226ce.0.tgz#e628bc0144cdce1f1e29da44489551b5fdba8bb9"
+  integrity sha512-K1MsEJDovoaGquF1gKhNdECMtF3/j3h/GiOWEDonNLef6MS4vRBxJln9fiYnQsN15jdY1zNEyufCvHDouNbVdg==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/list@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/list/-/list-5.0.0-canary.c6808c51c.0.tgz#94001065895151986fec6d79bcb4ba10a1124873"
-  integrity sha512-ePxaRt+W4g4S4QTdZPjOzZyQMGMEJ7R4OGpWKasQ15Tjda/tBVssEPdtt/IHSFh6fneFal+McbxYKd3U02WjFA==
+"@material/list@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/list/-/list-5.0.0-canary.b602226ce.0.tgz#6d8829132595aa603ff78c499181bfadf30a06f4"
+  integrity sha512-2bRKQqo+PFv1uyIbFghKuxv95K4aEFhegtDkTRu7/QF99N4N4Jlpy1mkp/N4tTXlxm9WKAYThODuhrJt3jqW+A==
   dependencies:
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/menu-surface@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/menu-surface/-/menu-surface-5.0.0-canary.c6808c51c.0.tgz#94ded1a562cbe2b25014ccac6fb636fedc182a59"
-  integrity sha512-agzx04sofSC6epI/DGc3YQrZGiLJm9HFL7FwodhX2jA5OZWwVZQu2z6lhCUnkDnR34QkVgw+67xdQySfHbwnZw==
+"@material/menu-surface@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/menu-surface/-/menu-surface-5.0.0-canary.b602226ce.0.tgz#b4ab0338b230577e2701086f686247642a934f49"
+  integrity sha512-AOD9eZCFpBUTFMICFmxvMDNZYTrYqePFfjFwJh9pe15ps+ep/cqdiLlWmieq9xQvqWl0T37oWXpHQEA2ahJsEw==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/menu@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-5.0.0-canary.c6808c51c.0.tgz#05a6140d31e6b5fde731babbcef3a8ec16094325"
-  integrity sha512-TdkgiefjngbWUkd31+dCuDOnc2+0PRiu0xkZHiuckq/DBW5ThA+OE/8ORSMYOXslJQKA+dXDGVoSGLlf7KWVLQ==
+"@material/menu@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-5.0.0-canary.b602226ce.0.tgz#72bd4c034715ba246e7d25dbea16fc82f2140c76"
+  integrity sha512-ZBrKTDw0O1vS+tX6sbM/TRitcTXoN5CxoASrW6vvU9xmVmetLKXJ9Ua24HDZHUyHf1Z7+oGzmBCfpo9VhVvuRg==
   dependencies:
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/list" "5.0.0-canary.c6808c51c.0"
-    "@material/menu-surface" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/list" "5.0.0-canary.b602226ce.0"
+    "@material/menu-surface" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/notched-outline@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-5.0.0-canary.c6808c51c.0.tgz#78e459945373bd351ec71db38cdb7a21e6bb7b2f"
-  integrity sha512-vg5WJXycK9uwvXOAB5UoI7pASkvlwqW+a8hZwTlIhXqbS0Pr4CMNmXEneHOheJXgCM09imhl7E/ihDB65JXTiQ==
+"@material/notched-outline@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-5.0.0-canary.b602226ce.0.tgz#03b64710a061459e93e15630b3db0e1bf201cef7"
+  integrity sha512-FyPIIFxPhsJHP1Hnj+jnRFrLsDBMPqkHnSLXTBXfrP8XS7RAEtT6oIegdIKrVWifZXMqCBCTrEQzlqB/Xvfirg==
   dependencies:
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/floating-label" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/floating-label" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/radio@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-5.0.0-canary.c6808c51c.0.tgz#918a45b09d3f773cd8197ebb37db41d790c1931b"
-  integrity sha512-90FEOpaiT5Ly5GEjo3pW2UEWwyqhQE90tEcdoImpqQgCPjmkUhYd81loDivvXY/yGDKfaPHJUvD7bF/vcx7qoQ==
+"@material/radio@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-5.0.0-canary.b602226ce.0.tgz#b8fca8117359049d12395e7a80aa70ef9c82e7fa"
+  integrity sha512-qUR3lBTOfslBCtgD1xq8GxKByZXZ6F0C6SBYcLWUFG9C07f/GcZJYxwtk3om3jsSxaD+MOE5wEe51v+6jYKL/w==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/touch-target" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/touch-target" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/ripple@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-5.0.0-canary.c6808c51c.0.tgz#146d6d0138f20134c7f0390107ab9a29436ed6ea"
-  integrity sha512-n5FBAiONlPUJyqqAF14la5rXt0DntEpkJNa7vviCf8xKJSIhDeK4dfsn8nqYjk3xw7PFl8lEFDO3+K0ArS9mpg==
+"@material/ripple@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-5.0.0-canary.b602226ce.0.tgz#18a4e7c0c63765f4e96f2c0ca02a4ceb2d93b5d0"
+  integrity sha512-2EcJZhuUAXimu9u9YPZoqbV/8Jkj9PsdEMh1HbQzGYFTfCf200AwbwxcDDqZIjgY6tWGL19dU4WtULYV/fhrxQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/rtl@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-5.0.0-canary.c6808c51c.0.tgz#9ce430d7bb9d2cd99448550311e8bfaf050005b3"
-  integrity sha512-N5bhTiDqjYXmuRiiwVwM1a3flJgPbx9cc2lsAb+ouxsIv/YvRwujQUObfQkU4e/E8bwrODyk4Kca/xo/YNjuoQ==
+"@material/rtl@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-5.0.0-canary.b602226ce.0.tgz#10abec019a090c12bfe299c93194586907a1c584"
+  integrity sha512-M2q4Y2wwz72VMTr6YIz9NE2Hb96mukWR+kk1JxpiQg3WSb9W38mhqGj2cAUqMVeADskIq6CxF698uE4i/z2hEw==
 
-"@material/select@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/select/-/select-5.0.0-canary.c6808c51c.0.tgz#ad58d32f86b73231a8dc1e8671caa9a85aada941"
-  integrity sha512-qL9xrCZtG1ccTMNhXMzVIC3AA41JlKv9+E95QgxGxBMO5egUn5lPYT+Hhsu1UmelxRW9n9ON0oxXoY/MoafiRw==
+"@material/select@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/select/-/select-5.0.0-canary.b602226ce.0.tgz#3ddb3a3c5e4d387a7fd55ec78801b9cc8ac3abc1"
+  integrity sha512-XqU/4pCf043k4+l4ujsF3/JmFfLocqD2UcJ2a2pE3JQTsQKiMCuPeriop4YUGhy4bM+HjbqQTHxN6roLr8erbA==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/floating-label" "5.0.0-canary.c6808c51c.0"
-    "@material/line-ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/menu" "5.0.0-canary.c6808c51c.0"
-    "@material/menu-surface" "5.0.0-canary.c6808c51c.0"
-    "@material/notched-outline" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/floating-label" "5.0.0-canary.b602226ce.0"
+    "@material/line-ripple" "5.0.0-canary.b602226ce.0"
+    "@material/menu" "5.0.0-canary.b602226ce.0"
+    "@material/menu-surface" "5.0.0-canary.b602226ce.0"
+    "@material/notched-outline" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/shape@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-5.0.0-canary.c6808c51c.0.tgz#89711d6cdfe39e1d0d35bd096d6dc6b337d6a030"
-  integrity sha512-RQ8uV3Eucslqt8DwnAw/uha+Ccvocvv0m+6ztF7Cpa6QN1Oih3wqRFqU04tNeitqIb+SOCmWHjWN+fdk0QusIw==
+"@material/shape@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-5.0.0-canary.b602226ce.0.tgz#21ab255467b748f9bedee6a57670ade15a5e61e7"
+  integrity sha512-9oAKHx6QfR+ck9nWadQCIDr69lJtzdje58eUHm9jTFVc6+tAmtkqV8HVJSvoqPEJ2PIEKkbivCTvITCXEBxAJg==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
 
-"@material/slider@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/slider/-/slider-5.0.0-canary.c6808c51c.0.tgz#22b536304e6e84c3a17d9bd8d50a2db30e21e282"
-  integrity sha512-yiiMxCcR0Avlcd3IhyH3s3kEXpPeXKQ7AusJyAZKp+75yfPtpVhXbnnOApVqaPTfDoPN9idV4x4cOemxQWdlEw==
+"@material/slider@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/slider/-/slider-5.0.0-canary.b602226ce.0.tgz#970ae6df304a81de7535ad8343056497c77419bd"
+  integrity sha512-2IL+5mEUKQp3x6Ims3NJO/i8pMiF6GAl1MxDESat+HQ9Y0YHfhBZM5P8xu5uiMRGMHoBlCIdbyAztEeKxWFyFQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/snackbar@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-5.0.0-canary.c6808c51c.0.tgz#ada8df0a515212e71457da0641d54ff82d08ec00"
-  integrity sha512-8UGqGT9UC7x0aZ/hTPkYJkgWDxMfU9peVEubAD8I+GwCxfeJ67OmPZbnJprYkL4kXz9pohMZNdDIiOCOmeqjig==
+"@material/snackbar@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-5.0.0-canary.b602226ce.0.tgz#665456ca92acbc2f7031f481a92f61dd416f34bd"
+  integrity sha512-70eKkKQOebqJ/RNiTUUUChio+Iyv+9LUBWOqe1i1BJ7kE+s8IMWED0lQUbALtwgP+iWdEkx7E3B2D4JZHd0WoQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/button" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/icon-button" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/button" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/icon-button" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/switch@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-5.0.0-canary.c6808c51c.0.tgz#bd632c21fbc3ae44ec667f9f0aa2c2c4a857fb48"
-  integrity sha512-lYNiSg3BPxbZOZ3GAIh5nnmuI+nA8u2Tk+7cyYK3yus80cE5k7//DVBJzvruc8J2wcMvnsGarqYJrYPIl87Vsw==
+"@material/switch@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-5.0.0-canary.b602226ce.0.tgz#8c2fedf7e8d034b12e736879a0bfb4a83b778750"
+  integrity sha512-YTS9AciOC8nLQjAogUePhZNO68bxqrHq+qy0Ri1VB4+r2aSZKG9a48eT4Pxgx8Zh+kVJoVUjba8QFhojlEOtPQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/tab-bar@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-bar/-/tab-bar-5.0.0-canary.c6808c51c.0.tgz#934369c27aa98949472e594258e5f8297c1ced20"
-  integrity sha512-B+Wnbd8o6eAALOtSaK8ioF+nwbHlC9A8MNI1skzwvmbuJn7kGvRQtIOHW2n7rT4/CsatcRxKJ94lFDLs8v1icQ==
+"@material/tab-bar@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-bar/-/tab-bar-5.0.0-canary.b602226ce.0.tgz#2cc29283bbfabff87f749d0f0dfdabd236da8dd7"
+  integrity sha512-atDj+Cv3y69HAOAAT7ZjnbK0vMWL1wu/7/CvLybWUCNObN019tpL4SAvxTNm1CBMN0RjgQdP2r9dluJ3+wfY2Q==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/tab" "5.0.0-canary.c6808c51c.0"
-    "@material/tab-scroller" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/tab" "5.0.0-canary.b602226ce.0"
+    "@material/tab-scroller" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/tab-indicator@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-indicator/-/tab-indicator-5.0.0-canary.c6808c51c.0.tgz#bff7b63a9d8145d04ac8358d237466b549a65934"
-  integrity sha512-Xj8N8dSue3TtsYzAVGpOG3VuMEmwh9twHGTxVomIQ4G3uAT//ffaRRKtkvi81f7LLKIl8qAAkUpqviMELc+F6A==
+"@material/tab-indicator@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-indicator/-/tab-indicator-5.0.0-canary.b602226ce.0.tgz#731d38f5bddbcc3b7ec1a3202fb5be27ce0a04aa"
+  integrity sha512-7sL2d/RZRy4mTDLpVK2rnoNYIecVFrvoJIxFQmzTw5/yvyguKjDMCVYpnyr1C4jzJ5KZI7rr3uJqU/x3Ole+Uw==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/tab-scroller@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-scroller/-/tab-scroller-5.0.0-canary.c6808c51c.0.tgz#20493643b71bc62a7ca4a7802324c6a13cfab26e"
-  integrity sha512-/kBq3ZZpT3ke4Qva/KvDhBbC52sLPH1aIt1Zoo4O8VEfUrIBVbWRJVas2J2m3HHdbLEAEhp7VKSem4Jmk/zZ/w==
+"@material/tab-scroller@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-scroller/-/tab-scroller-5.0.0-canary.b602226ce.0.tgz#e2a8bff6859f4c2189cd18d35be031476ad6bff2"
+  integrity sha512-jdmFhz3DxE6wGDBaij7tVRbhuGUsVafQg3rG24cSsFTGWhnUq3JmlpmwylI7ywfQv8bg0UUGa/24EJ2VCrPMnQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/tab" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/tab" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/tab@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/tab/-/tab-5.0.0-canary.c6808c51c.0.tgz#4716e6afd59d12be9c7ef847aff2fa37e9528da0"
-  integrity sha512-dlUO9Mq7oEqNVAMXZEhQBbSTRe6s+YCWd2BUwKeOYJ1sbSW2Zrm2rmae4UoGy4ejDF76xGywpsVT6tVN6emC7A==
+"@material/tab@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/tab/-/tab-5.0.0-canary.b602226ce.0.tgz#ba5d9d0fd64ae24bd217a93b0ec5596d33600fc5"
+  integrity sha512-vram0OWoxEgaZSTKJYCPg/Ay3sKMUmlWNi5VZdLCRj/pZLg97REm/qf9YOzmNmfm/4kdueQDHenUMZuDz2z2qw==
   dependencies:
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/tab-indicator" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/tab-indicator" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/textfield@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-5.0.0-canary.c6808c51c.0.tgz#70e06f79a18b851aadf0e3d7b899d905db7cbbd0"
-  integrity sha512-AraWXfjlKreYJM9h/+fneCy4vM7ckk8tymKQyZS2cT9HD/UuGeH9Asa8XJ29+TK1E4k+/2hkPMexiQRsXSfGGA==
+"@material/textfield@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-5.0.0-canary.b602226ce.0.tgz#77f53eb5259afb0dfd9c78326ebc9f16b66b9a12"
+  integrity sha512-Grplq7GPm0ffsaol4y6Z4i0EncbwB1yg8FLQElX1IZQ8WrZrb2Wdkwjl3T8zF/ZKblDxnK5f9gTtfBm/dDV7aw==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/floating-label" "5.0.0-canary.c6808c51c.0"
-    "@material/line-ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/notched-outline" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/floating-label" "5.0.0-canary.b602226ce.0"
+    "@material/line-ripple" "5.0.0-canary.b602226ce.0"
+    "@material/notched-outline" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/theme@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-5.0.0-canary.c6808c51c.0.tgz#a6be5356a0586b1cde8a116d8a147ba21280c39f"
-  integrity sha512-tGFEz6aZvMwNG2VX29TCPALMslIF15bywsKm6WG9dqv+cd/XlKnHpwB8yhMj8HsWI7asvjFKpv3Pqz1cIn/DSQ==
+"@material/theme@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-5.0.0-canary.b602226ce.0.tgz#cfdc5599cfb9b9b1a23163814550bc0671cea04f"
+  integrity sha512-r/0iprESQzrXWw3ifcrN2sGxkyRSU362qhEA5jP4Am9ZdcHIx+gF26RQQggbRnQRMqWt0AXSvJdrBCx+PTqzIA==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
 
-"@material/top-app-bar@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/top-app-bar/-/top-app-bar-5.0.0-canary.c6808c51c.0.tgz#6d7c72cd2e75e8fc4c04edebb04cc66c47ec5c9c"
-  integrity sha512-G34U6J/4/YPQwZPrSFnuZD66Jz3m7lIfYqEfYMFGIjh7JiEeJ9BOxVWsfQ5elX6a5EapVCXKg5hCUnBwlByWqQ==
+"@material/top-app-bar@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/top-app-bar/-/top-app-bar-5.0.0-canary.b602226ce.0.tgz#d733970a8b1273c8a2b372a17edbe3cb0242926d"
+  integrity sha512-K8osjlYP/7mSA9SmPUHt+UnkkXwA2AtSGspU+rV3HOxk+wJtrN0eU8pFPxzhTNBQpIfGE7kSbqZdTkF/3xrj8A==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/icon-button" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/icon-button" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
     tslib "^1.9.3"
 
-"@material/touch-target@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/touch-target/-/touch-target-5.0.0-canary.c6808c51c.0.tgz#6a3b3ca5f3c3270a72a63613db9a43676c096d32"
-  integrity sha512-9kz1G5QI9Jjlj5iOAOIinKefo6rDtuwIXdV9jT3XWBiYto6JRlEemF4nPUt3iUHuzApyGbEjDggTlXKCNBD4Ag==
+"@material/touch-target@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/touch-target/-/touch-target-5.0.0-canary.b602226ce.0.tgz#f13daa8354e5ecd805ef7a805a8e042a4caabab9"
+  integrity sha512-QYJSQuoyU+F6klhTYaI1bI6xMMBqePpC3x4+bfxGqPkDjUORk9yPJ9vXAAdqf7RRFHgbrrEdRRKWWYsSk8P5lQ==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
 
-"@material/typography@5.0.0-canary.c6808c51c.0":
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-5.0.0-canary.c6808c51c.0.tgz#f2deb5116d404f6a4dedc3f7e82aa8d2534b5766"
-  integrity sha512-HCKT8Ja2jRWerpGKj+En83fFD7eaVCtVXBl3EJlK/XQEVqJinuo9GBAYFl52IWUbTbbuORv2nxe2dFoGCdgGTg==
+"@material/typography@5.0.0-canary.b602226ce.0":
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-5.0.0-canary.b602226ce.0.tgz#c032b6dcc7d47a7fdb2d25499e2c935a4ecd2bb5"
+  integrity sha512-NoIjd0FQf0elCp3HOTQnFmchlTqdlqR9K1KsNC5AQeMhENNt1Dnz92vCVYUkDF4lYF5dkdG6L0KRTXnAg7wKww==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
 
 "@microsoft/api-extractor-model@7.4.1":
   version "7.4.1"
@@ -7563,55 +7563,55 @@ matchdep@^2.0.0:
     resolve "^1.4.0"
     stack-trace "0.0.10"
 
-material-components-web@5.0.0-canary.c6808c51c.0:
-  version "5.0.0-canary.c6808c51c.0"
-  resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-5.0.0-canary.c6808c51c.0.tgz#76879fc70998e074b56ff1c6bee7691d3e1f7e6a"
-  integrity sha512-B2aVFjGOeXFmmXXTpB5IJSwXSWXcn1XnW3MOhArE7B8j5RvfOqlECjQeaOqjW7bm3OjJSDbZpaRMtlBxuLJsBQ==
+material-components-web@5.0.0-canary.b602226ce.0:
+  version "5.0.0-canary.b602226ce.0"
+  resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-5.0.0-canary.b602226ce.0.tgz#9f42aecc09c7d76e64dd541704f843e8d636419d"
+  integrity sha512-ZW67ERk/lZqgN0xEC7Mda4I6a1n8N+UiwBbB8NzpmvRUwSzf642rvbJz9ddmlLb2iw95FXBhAYLp1OsBEmfHFA==
   dependencies:
-    "@material/animation" "5.0.0-canary.c6808c51c.0"
-    "@material/auto-init" "5.0.0-canary.c6808c51c.0"
-    "@material/base" "5.0.0-canary.c6808c51c.0"
-    "@material/button" "5.0.0-canary.c6808c51c.0"
-    "@material/card" "5.0.0-canary.c6808c51c.0"
-    "@material/checkbox" "5.0.0-canary.c6808c51c.0"
-    "@material/chips" "5.0.0-canary.c6808c51c.0"
-    "@material/data-table" "5.0.0-canary.c6808c51c.0"
-    "@material/density" "5.0.0-canary.c6808c51c.0"
-    "@material/dialog" "5.0.0-canary.c6808c51c.0"
-    "@material/dom" "5.0.0-canary.c6808c51c.0"
-    "@material/drawer" "5.0.0-canary.c6808c51c.0"
-    "@material/elevation" "5.0.0-canary.c6808c51c.0"
-    "@material/fab" "5.0.0-canary.c6808c51c.0"
-    "@material/feature-targeting" "5.0.0-canary.c6808c51c.0"
-    "@material/floating-label" "5.0.0-canary.c6808c51c.0"
-    "@material/form-field" "5.0.0-canary.c6808c51c.0"
-    "@material/grid-list" "5.0.0-canary.c6808c51c.0"
-    "@material/icon-button" "5.0.0-canary.c6808c51c.0"
-    "@material/image-list" "5.0.0-canary.c6808c51c.0"
-    "@material/layout-grid" "5.0.0-canary.c6808c51c.0"
-    "@material/line-ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/linear-progress" "5.0.0-canary.c6808c51c.0"
-    "@material/list" "5.0.0-canary.c6808c51c.0"
-    "@material/menu" "5.0.0-canary.c6808c51c.0"
-    "@material/menu-surface" "5.0.0-canary.c6808c51c.0"
-    "@material/notched-outline" "5.0.0-canary.c6808c51c.0"
-    "@material/radio" "5.0.0-canary.c6808c51c.0"
-    "@material/ripple" "5.0.0-canary.c6808c51c.0"
-    "@material/rtl" "5.0.0-canary.c6808c51c.0"
-    "@material/select" "5.0.0-canary.c6808c51c.0"
-    "@material/shape" "5.0.0-canary.c6808c51c.0"
-    "@material/slider" "5.0.0-canary.c6808c51c.0"
-    "@material/snackbar" "5.0.0-canary.c6808c51c.0"
-    "@material/switch" "5.0.0-canary.c6808c51c.0"
-    "@material/tab" "5.0.0-canary.c6808c51c.0"
-    "@material/tab-bar" "5.0.0-canary.c6808c51c.0"
-    "@material/tab-indicator" "5.0.0-canary.c6808c51c.0"
-    "@material/tab-scroller" "5.0.0-canary.c6808c51c.0"
-    "@material/textfield" "5.0.0-canary.c6808c51c.0"
-    "@material/theme" "5.0.0-canary.c6808c51c.0"
-    "@material/top-app-bar" "5.0.0-canary.c6808c51c.0"
-    "@material/touch-target" "5.0.0-canary.c6808c51c.0"
-    "@material/typography" "5.0.0-canary.c6808c51c.0"
+    "@material/animation" "5.0.0-canary.b602226ce.0"
+    "@material/auto-init" "5.0.0-canary.b602226ce.0"
+    "@material/base" "5.0.0-canary.b602226ce.0"
+    "@material/button" "5.0.0-canary.b602226ce.0"
+    "@material/card" "5.0.0-canary.b602226ce.0"
+    "@material/checkbox" "5.0.0-canary.b602226ce.0"
+    "@material/chips" "5.0.0-canary.b602226ce.0"
+    "@material/data-table" "5.0.0-canary.b602226ce.0"
+    "@material/density" "5.0.0-canary.b602226ce.0"
+    "@material/dialog" "5.0.0-canary.b602226ce.0"
+    "@material/dom" "5.0.0-canary.b602226ce.0"
+    "@material/drawer" "5.0.0-canary.b602226ce.0"
+    "@material/elevation" "5.0.0-canary.b602226ce.0"
+    "@material/fab" "5.0.0-canary.b602226ce.0"
+    "@material/feature-targeting" "5.0.0-canary.b602226ce.0"
+    "@material/floating-label" "5.0.0-canary.b602226ce.0"
+    "@material/form-field" "5.0.0-canary.b602226ce.0"
+    "@material/grid-list" "5.0.0-canary.b602226ce.0"
+    "@material/icon-button" "5.0.0-canary.b602226ce.0"
+    "@material/image-list" "5.0.0-canary.b602226ce.0"
+    "@material/layout-grid" "5.0.0-canary.b602226ce.0"
+    "@material/line-ripple" "5.0.0-canary.b602226ce.0"
+    "@material/linear-progress" "5.0.0-canary.b602226ce.0"
+    "@material/list" "5.0.0-canary.b602226ce.0"
+    "@material/menu" "5.0.0-canary.b602226ce.0"
+    "@material/menu-surface" "5.0.0-canary.b602226ce.0"
+    "@material/notched-outline" "5.0.0-canary.b602226ce.0"
+    "@material/radio" "5.0.0-canary.b602226ce.0"
+    "@material/ripple" "5.0.0-canary.b602226ce.0"
+    "@material/rtl" "5.0.0-canary.b602226ce.0"
+    "@material/select" "5.0.0-canary.b602226ce.0"
+    "@material/shape" "5.0.0-canary.b602226ce.0"
+    "@material/slider" "5.0.0-canary.b602226ce.0"
+    "@material/snackbar" "5.0.0-canary.b602226ce.0"
+    "@material/switch" "5.0.0-canary.b602226ce.0"
+    "@material/tab" "5.0.0-canary.b602226ce.0"
+    "@material/tab-bar" "5.0.0-canary.b602226ce.0"
+    "@material/tab-indicator" "5.0.0-canary.b602226ce.0"
+    "@material/tab-scroller" "5.0.0-canary.b602226ce.0"
+    "@material/textfield" "5.0.0-canary.b602226ce.0"
+    "@material/theme" "5.0.0-canary.b602226ce.0"
+    "@material/top-app-bar" "5.0.0-canary.b602226ce.0"
+    "@material/touch-target" "5.0.0-canary.b602226ce.0"
+    "@material/typography" "5.0.0-canary.b602226ce.0"
 
 mathml-tag-names@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
The `MDCSwitchAdapter` was changed in the most-recent canary release which is breaking the CI check.