### PR TITLE
feat(list): Add single select mode.

### DIFF
--- a/src/components-examples/material/list/index.ts
+++ b/src/components-examples/material/list/index.ts
@@ -5,17 +5,20 @@ import {MatListModule} from '@angular/material/list';
 import {ListOverviewExample} from './list-overview/list-overview-example';
 import {ListSectionsExample} from './list-sections/list-sections-example';
 import {ListSelectionExample} from './list-selection/list-selection-example';
+import {ListSingleSelectionExample} from './list-single-selection/list-single-selection-example';
 
 export {
   ListOverviewExample,
   ListSectionsExample,
   ListSelectionExample,
+  ListSingleSelectionExample,
 };
 
 const EXAMPLES = [
   ListOverviewExample,
   ListSectionsExample,
   ListSelectionExample,
+  ListSingleSelectionExample,
 ];
 
 @NgModule({

--- a/src/components-examples/material/list/list-single-selection/list-single-selection-example.css
+++ b/src/components-examples/material/list/list-single-selection/list-single-selection-example.css
@@ -1,0 +1,1 @@
+/** No styles for this example. */

--- a/src/components-examples/material/list/list-single-selection/list-single-selection-example.html
+++ b/src/components-examples/material/list/list-single-selection/list-single-selection-example.html
@@ -1,0 +1,9 @@
+<mat-selection-list #shoes [multiple]="false">
+  <mat-list-option *ngFor="let shoe of typesOfShoes">
+    {{shoe}}
+  </mat-list-option>
+</mat-selection-list>
+
+<p>
+  Option selected: {{shoes.selectedOptions.selected}}
+</p>

--- a/src/components-examples/material/list/list-single-selection/list-single-selection-example.ts
+++ b/src/components-examples/material/list/list-single-selection/list-single-selection-example.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+
+/**
+ * @title List with single selection
+ */
+@Component({
+  selector: 'list-single-selection-example',
+  styleUrls: ['list-single-selection-example.css'],
+  templateUrl: 'list-single-selection-example.html',
+})
+export class ListSingleSelectionExample {
+  typesOfShoes: string[] = ['Boots', 'Clogs', 'Loafers', 'Moccasins', 'Sneakers'];
+}

--- a/src/dev-app/list/list-demo.html
+++ b/src/dev-app/list/list-demo.html
@@ -162,4 +162,22 @@
       <button mat-raised-button (click)="groceries.deselectAll()">Deselect all</button>
     </p>
   </div>
+  
+  <div>
+    <h2>Single Selection list</h2>
+
+    <mat-selection-list #favorite 
+                        [(ngModel)]="favoriteOptions"
+                        [multiple]="false"
+                        color="primary">
+      <h3 mat-subheader>Favorite Grocery</h3>
+
+      <mat-list-option value="bananas">Bananas</mat-list-option>
+      <mat-list-option selected value="oranges">Oranges</mat-list-option>
+      <mat-list-option value="apples">Apples</mat-list-option>
+      <mat-list-option value="strawberries" color="warn">Strawberries</mat-list-option>
+    </mat-selection-list>
+
+    <p>Selected: {{favoriteOptions | json}}</p>
+  </div>
 </div>

--- a/src/dev-app/list/list-demo.ts
+++ b/src/dev-app/list/list-demo.ts
@@ -70,6 +70,8 @@ export class ListDemo {
     this.modelChangeEventCount++;
   }
 
+  favoriteOptions: string[] = [];
+
   alertItem(msg: string) {
     alert(msg);
   }

--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -33,6 +33,10 @@
       background: mat-color($background, 'hover');
     }
   }
+
+  .mat-selection-list-single-select .mat-list-option.mat-selected {
+    background: mat-color($background, hover, 0.12);
+  }
 }
 
 @mixin mat-list-typography($config) {

--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -34,8 +34,10 @@
     }
   }
 
-  .mat-list-option.mat-single-selected {
-    background: mat-color($background, hover, 0.12);
+  .mat-list-single-selected-option {
+    &, &:hover, &:focus {
+      background: mat-color($background, hover, 0.12);
+    }
   }
 }
 

--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -34,7 +34,7 @@
     }
   }
 
-  .mat-selection-list-single-select .mat-list-option.mat-selected {
+  .mat-list-option.mat-single-selected {
     background: mat-color($background, hover, 0.12);
   }
 }

--- a/src/material/list/list-option.html
+++ b/src/material/list/list-option.html
@@ -7,6 +7,7 @@
     [matRippleDisabled]="_isRippleDisabled()"></div>
 
   <mat-pseudo-checkbox
+    *ngIf="selectionList.multiple"
     [state]="selected ? 'checked' : 'unchecked'"
     [disabled]="disabled"></mat-pseudo-checkbox>
 

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -188,13 +188,14 @@ describe('MatSelectionList without forms', () => {
       expect(selectList.selected.length).toBe(0);
     });
 
-    it('should not add the mat-single-selected class (in multiple mode)', () => {
+    it('should not add the mat-list-single-selected-option class (in multiple mode)', () => {
       let testListItem = listOptions[2].injector.get<MatListOption>(MatListOption);
 
       testListItem._handleClick();
       fixture.detectChanges();
 
-      expect(listOptions[2].nativeElement.classList.contains('mat-single-selected')).toBe(false);
+      expect(listOptions[2].nativeElement.classList.contains('mat-list-single-selected-option'))
+          .toBe(false);
     });
 
     it('should not allow selection of disabled items', () => {
@@ -924,14 +925,17 @@ describe('MatSelectionList without forms', () => {
       fixture.detectChanges();
 
       expect(selectList.selected).toEqual([testListItem1]);
-      expect(listOption[1].nativeElement.classList.contains('mat-single-selected')).toBe(true);
+      expect(listOption[1].nativeElement.classList.contains('mat-list-single-selected-option'))
+          .toBe(true);
 
       dispatchFakeEvent(testListItem2._getHostElement(), 'click');
       fixture.detectChanges();
 
       expect(selectList.selected).toEqual([testListItem2]);
-      expect(listOption[1].nativeElement.classList.contains('mat-single-selected')).toBe(false);
-      expect(listOption[2].nativeElement.classList.contains('mat-single-selected')).toBe(true);
+      expect(listOption[1].nativeElement.classList.contains('mat-list-single-selected-option'))
+          .toBe(false);
+      expect(listOption[2].nativeElement.classList.contains('mat-list-single-selected-option'))
+          .toBe(true);
     });
 
     it('should not show check boxes', () => {

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -93,13 +93,11 @@ describe('MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(0);
       expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('false');
-      expect(listOptions[2].nativeElement.classList.contains('mat-selected')).toBe(false);
 
       testListItem.toggle();
       fixture.detectChanges();
 
       expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('true');
-      expect(listOptions[2].nativeElement.classList.contains('mat-selected')).toBe(true);
       expect(listOptions[2].nativeElement.getAttribute('aria-disabled')).toBe('false');
       expect(selectList.selected.length).toBe(1);
     });
@@ -112,9 +110,7 @@ describe('MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(0);
       expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('false');
-      expect(listOptions[2].nativeElement.classList.contains('mat-selected')).toBe(false);
       expect(listOptions[1].nativeElement.getAttribute('aria-selected')).toBe('false');
-      expect(listOptions[1].nativeElement.classList.contains('mat-selected')).toBe(false);
 
       testListItem.toggle();
       fixture.detectChanges();
@@ -124,9 +120,7 @@ describe('MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(2);
       expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('true');
-      expect(listOptions[2].nativeElement.classList.contains('mat-selected')).toBe(true);
       expect(listOptions[1].nativeElement.getAttribute('aria-selected')).toBe('true');
-      expect(listOptions[1].nativeElement.classList.contains('mat-selected')).toBe(true);
       expect(listOptions[1].nativeElement.getAttribute('aria-disabled')).toBe('false');
       expect(listOptions[2].nativeElement.getAttribute('aria-disabled')).toBe('false');
     });
@@ -193,6 +187,15 @@ describe('MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(0);
     });
+
+    it('should not add the mat-single-selected class (in multiple mode)', () => {
+      let testListItem = listOptions[2].injector.get<MatListOption>(MatListOption);
+
+      testListItem._handleClick();
+      fixture.detectChanges();
+
+      expect(listOptions[2].nativeElement.classList.contains('mat-single-selected')).toBe(false);
+    })
 
     it('should not allow selection of disabled items', () => {
       let testListItem = listOptions[0].injector.get<MatListOption>(MatListOption);
@@ -921,11 +924,14 @@ describe('MatSelectionList without forms', () => {
       fixture.detectChanges();
 
       expect(selectList.selected).toEqual([testListItem1]);
+      expect(listOption[1].nativeElement.classList.contains('mat-single-selected')).toBe(true);
 
       dispatchFakeEvent(testListItem2._getHostElement(), 'click');
       fixture.detectChanges();
 
       expect(selectList.selected).toEqual([testListItem2]);
+      expect(listOption[1].nativeElement.classList.contains('mat-single-selected')).toBe(false);
+      expect(listOption[2].nativeElement.classList.contains('mat-single-selected')).toBe(true);
     });
 
     it('should not show check boxes', () => {
@@ -950,33 +956,9 @@ describe('MatSelectionList without forms', () => {
       expect(selectList.selected).toEqual([testListItem1]);
     });
 
-    it('sanely handles toggling single/multiple mode after bootstrap', () => {
-      const testListItem1 = listOption[1].injector.get<MatListOption>(MatListOption);
-      const testListItem2 = listOption[2].injector.get<MatListOption>(MatListOption);
-      const selected = () => selectionList.injector.get<MatSelectionList>(MatSelectionList)
-          .selectedOptions.selected;
-
-      expect(selected().length).toBe(0);
-
-      dispatchFakeEvent(testListItem1._getHostElement(), 'click');
-      fixture.detectChanges();
-
-      expect(selected()).toEqual([testListItem1]);
-
+    it('throws an exception when toggling single/multiple mode after bootstrap', () => {
       fixture.componentInstance.multiple = true;
-      fixture.detectChanges();
-
-      expect(selected()).toEqual([testListItem1]);
-
-      dispatchFakeEvent(testListItem2._getHostElement(), 'click');
-      fixture.detectChanges();
-
-      expect(selected()).toEqual([testListItem1, testListItem2]);
-
-      fixture.componentInstance.multiple = false;
-      fixture.detectChanges();
-
-      expect(selected()).toEqual([testListItem1]);
+      expect(() => fixture.detectChanges()).toThrow(new Error('Cannot change `multiple` mode of mat-selection-list after initialization.'));
     });
   });
 });

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -93,11 +93,13 @@ describe('MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(0);
       expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('false');
+      expect(listOptions[2].nativeElement.classList.contains('mat-selected')).toBe(false);
 
       testListItem.toggle();
       fixture.detectChanges();
 
       expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(listOptions[2].nativeElement.classList.contains('mat-selected')).toBe(true);
       expect(listOptions[2].nativeElement.getAttribute('aria-disabled')).toBe('false');
       expect(selectList.selected.length).toBe(1);
     });
@@ -110,7 +112,9 @@ describe('MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(0);
       expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('false');
+      expect(listOptions[2].nativeElement.classList.contains('mat-selected')).toBe(false);
       expect(listOptions[1].nativeElement.getAttribute('aria-selected')).toBe('false');
+      expect(listOptions[1].nativeElement.classList.contains('mat-selected')).toBe(false);
 
       testListItem.toggle();
       fixture.detectChanges();
@@ -120,7 +124,9 @@ describe('MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(2);
       expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(listOptions[2].nativeElement.classList.contains('mat-selected')).toBe(true);
       expect(listOptions[1].nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(listOptions[1].nativeElement.classList.contains('mat-selected')).toBe(true);
       expect(listOptions[1].nativeElement.getAttribute('aria-disabled')).toBe('false');
       expect(listOptions[2].nativeElement.getAttribute('aria-disabled')).toBe('false');
     });
@@ -882,6 +888,97 @@ describe('MatSelectionList without forms', () => {
       expect(listOption.classList).toContain('mat-list-item-with-avatar');
     });
   });
+
+  describe('with single selection', () => {
+    let fixture: ComponentFixture<SelectionListWithListOptions>;
+    let listOption: DebugElement[];
+    let selectionList: DebugElement;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [
+          SelectionListWithListOptions,
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(SelectionListWithListOptions);
+      fixture.componentInstance.multiple = false;
+      listOption = fixture.debugElement.queryAll(By.directive(MatListOption));
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
+      fixture.detectChanges();
+    }));
+
+    it('should select one option at a time', () => {
+      const testListItem1 = listOption[1].injector.get<MatListOption>(MatListOption);
+      const testListItem2 = listOption[2].injector.get<MatListOption>(MatListOption);
+      const selectList =
+          selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+
+      dispatchFakeEvent(testListItem1._getHostElement(), 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected).toEqual([testListItem1]);
+
+      dispatchFakeEvent(testListItem2._getHostElement(), 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected).toEqual([testListItem2]);
+    });
+
+    it('should not show check boxes', () => {
+      expect(fixture.nativeElement.querySelector('mat-pseudo-checkbox')).toBeFalsy();
+    });
+
+    it('should not deselect the target option on click', () => {
+      const testListItem1 = listOption[1].injector.get<MatListOption>(MatListOption);
+      const selectList =
+          selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+
+      dispatchFakeEvent(testListItem1._getHostElement(), 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected).toEqual([testListItem1]);
+
+      dispatchFakeEvent(testListItem1._getHostElement(), 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected).toEqual([testListItem1]);
+    });
+
+    it('sanely handles toggling single/multiple mode after bootstrap', () => {
+      const testListItem1 = listOption[1].injector.get<MatListOption>(MatListOption);
+      const testListItem2 = listOption[2].injector.get<MatListOption>(MatListOption);
+      const selected = () => selectionList.injector.get<MatSelectionList>(MatSelectionList)
+          .selectedOptions.selected;
+
+      expect(selected().length).toBe(0);
+
+      dispatchFakeEvent(testListItem1._getHostElement(), 'click');
+      fixture.detectChanges();
+
+      expect(selected()).toEqual([testListItem1]);
+
+      fixture.componentInstance.multiple = true;
+      fixture.detectChanges();
+
+      expect(selected()).toEqual([testListItem1]);
+
+      dispatchFakeEvent(testListItem2._getHostElement(), 'click');
+      fixture.detectChanges();
+
+      expect(selected()).toEqual([testListItem1, testListItem2]);
+
+      fixture.componentInstance.multiple = false;
+      fixture.detectChanges();
+
+      expect(selected()).toEqual([testListItem1]);
+    });
+  });
 });
 
 describe('MatSelectionList with forms', () => {
@@ -1255,7 +1352,8 @@ describe('MatSelectionList with forms', () => {
     id="selection-list-1"
     (selectionChange)="onValueChange($event)"
     [disableRipple]="listRippleDisabled"
-    [color]="selectionListColor">
+    [color]="selectionListColor"
+    [multiple]="multiple">
     <mat-list-option checkboxPosition="before" disabled="true" value="inbox"
                      [color]="firstOptionColor">
       Inbox (disabled selection-option)
@@ -1274,6 +1372,7 @@ describe('MatSelectionList with forms', () => {
 class SelectionListWithListOptions {
   showLastOption: boolean = true;
   listRippleDisabled = false;
+  multiple = true;
   selectionListColor: ThemePalette;
   firstOptionColor: ThemePalette;
 

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -195,7 +195,7 @@ describe('MatSelectionList without forms', () => {
       fixture.detectChanges();
 
       expect(listOptions[2].nativeElement.classList.contains('mat-single-selected')).toBe(false);
-    })
+    });
 
     it('should not allow selection of disabled items', () => {
       let testListItem = listOptions[0].injector.get<MatListOption>(MatListOption);
@@ -958,7 +958,8 @@ describe('MatSelectionList without forms', () => {
 
     it('throws an exception when toggling single/multiple mode after bootstrap', () => {
       fixture.componentInstance.multiple = true;
-      expect(() => fixture.detectChanges()).toThrow(new Error('Cannot change `multiple` mode of mat-selection-list after initialization.'));
+      expect(() => fixture.detectChanges()).toThrow(new Error(
+          'Cannot change `multiple` mode of mat-selection-list after initialization.'));
     });
   });
 });

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -385,9 +385,10 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
 
     if (newValue !== this._multiple) {
       if (this._contentInitialized) {
-        throw new Error('Cannot change `multiple` mode of mat-selection-list after initialization.');
+        throw new Error(
+            'Cannot change `multiple` mode of mat-selection-list after initialization.');
       }
-      
+
       this._multiple = newValue;
       this.selectedOptions = new SelectionModel(this._multiple, this.selectedOptions.selected);
     }

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -40,6 +40,7 @@ import {
   SimpleChanges,
   ViewChild,
   ViewEncapsulation,
+  isDevMode,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
@@ -109,7 +110,7 @@ export class MatSelectionListChange {
     // be placed inside a parent that has one of the other colors with a higher specificity.
     '[class.mat-accent]': 'color !== "primary" && color !== "warn"',
     '[class.mat-warn]': 'color === "warn"',
-    '[class.mat-single-selected]': 'selected && !selectionList.multiple',
+    '[class.mat-list-single-selected-option]': 'selected && !selectionList.multiple',
     '[attr.aria-selected]': 'selected',
     '[attr.aria-disabled]': 'disabled',
   },
@@ -384,7 +385,7 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
     const newValue = coerceBooleanProperty(value);
 
     if (newValue !== this._multiple) {
-      if (this._contentInitialized) {
+      if (isDevMode() && this._contentInitialized) {
         throw new Error(
             'Cannot change `multiple` mode of mat-selection-list after initialization.');
       }

--- a/tools/public_api_guard/material/list.d.ts
+++ b/tools/public_api_guard/material/list.d.ts
@@ -94,6 +94,7 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
     color: ThemePalette;
     compareWith: (o1: any, o2: any) => boolean;
     disabled: boolean;
+    multiple: boolean;
     options: QueryList<MatListOption>;
     selectedOptions: SelectionModel<MatListOption>;
     readonly selectionChange: EventEmitter<MatSelectionListChange>;
@@ -116,7 +117,8 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
     writeValue(values: string[]): void;
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSelectionList, "mat-selection-list", ["matSelectionList"], { "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "color": "color"; "compareWith": "compareWith"; "disabled": "disabled"; }, { "selectionChange": "selectionChange"; }, ["options"]>;
+    static ngAcceptInputType_multiple: BooleanInput;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSelectionList, "mat-selection-list", ["matSelectionList"], { "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "color": "color"; "compareWith": "compareWith"; "disabled": "disabled"; "multiple": "multiple"; }, { "selectionChange": "selectionChange"; }, ["options"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatSelectionList>;
 }
 


### PR DESCRIPTION
Adds support for single selection to mat-selection list, using multiple="false" or [multiple]="false".

Styling is updated to match single-select mat-select panels, including a persistent highlight and hiding the check boxes.