### PR TITLE
fix(material/form-field): undeprecated legacy and standard appearances

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -75,12 +75,7 @@ class MatFormFieldBase {
 const _MatFormFieldMixinBase: CanColorCtor & typeof MatFormFieldBase =
     mixinColor(MatFormFieldBase, 'primary');
 
-/**
- * Possible appearance styles for the form field.
- *
- * Note: The `legacy` and `standard` appearances are deprecated. Please use `fill` or `outline`.
- * @breaking-change 11.0.0 Remove `legacy` and `standard`.
- */
+/** Possible appearance styles for the form field. */
 export type MatFormFieldAppearance = 'legacy' | 'standard' | 'fill' | 'outline';
 
 /**


### PR DESCRIPTION
There are a few bugs to address with outline and fill styles before we
can deprecate these.