### PR TITLE
fix(cdk/drag-and-drop): cdkDrag directive override transform styles

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -1081,7 +1081,7 @@ export class DragRef<T = any> {
     // Cache the previous transform amount only after the first drag sequence, because
     // we don't want our own transforms to stack on top of each other.
     if (this._initialTransform == null) {
-      this._initialTransform = this._rootElement.style.transform || '';
+      this._initialTransform = getComputedStyle(this._rootElement).transform || '';
     }
 
     // Preserve the previous `transform` value, if there was one. Note that we apply our own


### PR DESCRIPTION
Fixes the bug that cdkDrag directive override transform styles on the root element

Fixes #18143