### PR TITLE
feat(material/icon): New NoopIconModule for silencing unit test errors

### DIFF
--- a/src/material/config.bzl
+++ b/src/material/config.bzl
@@ -26,6 +26,7 @@ entryPoints = [
     "grid-list",
     "grid-list/testing",
     "icon",
+    "icon/testing",
     "input",
     "list",
     "list/testing",

--- a/src/material/icon/testing/BUILD.bazel
+++ b/src/material/icon/testing/BUILD.bazel
@@ -1,0 +1,25 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "ng_module")
+
+ng_module(
+    name = "testing",
+    srcs = [
+        "fake-icon-registry.ts",
+        "index.ts",
+        "public-api.ts",
+    ],
+    module_name = "@angular/material/icon/testing",
+    deps = [
+        "//src/cdk/coercion",
+        "//src/material/icon",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//rxjs",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob(["**/*.ts"]),
+)

--- a/src/material/icon/testing/fake-icon-registry.ts
+++ b/src/material/icon/testing/fake-icon-registry.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable, NgModule, OnDestroy} from '@angular/core';
+import {MatIconRegistry} from '@angular/material/icon';
+import {Observable, of as observableOf} from 'rxjs';
+
+// tslint:disable:no-any Impossible to tell param types.
+type PublicApi<T> = {
+  [K in keyof T]: T[K] extends (...x: any[]) => T ? (...x: any[]) => PublicApi<T> : T[K]
+};
+// tslint:enable:no-any
+
+/**
+ * A null icon registry that must be imported to allow disabling of custom
+ * icons.
+ */
+@Injectable()
+export class FakeMatIconRegistry implements PublicApi<MatIconRegistry>, OnDestroy {
+  addSvgIcon(): this {
+    return this;
+  }
+
+  addSvgIconLiteral(): this {
+    return this;
+  }
+
+  addSvgIconInNamespace(): this {
+    return this;
+  }
+
+  addSvgIconLiteralInNamespace(): this {
+    return this;
+  }
+
+  addSvgIconSet(): this {
+    return this;
+  }
+
+  addSvgIconSetLiteral(): this {
+    return this;
+  }
+
+  addSvgIconSetInNamespace(): this {
+    return this;
+  }
+
+  addSvgIconSetLiteralInNamespace(): this {
+    return this;
+  }
+
+  registerFontClassAlias(): this {
+    return this;
+  }
+
+  classNameForFontAlias(alias: string): string {
+    return alias;
+  }
+
+  getDefaultFontSetClass() {
+    return 'material-icons';
+  }
+
+  getSvgIconFromUrl(): Observable<SVGElement> {
+    return observableOf(this._generateEmptySvg());
+  }
+
+  getNamedSvgIcon(): Observable<SVGElement> {
+    return observableOf(this._generateEmptySvg());
+  }
+
+  setDefaultFontSetClass(): this {
+    return this;
+  }
+
+  ngOnDestroy() { }
+
+  private _generateEmptySvg(): SVGElement {
+    const emptySvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    emptySvg.classList.add('fake-testing-svg');
+    return emptySvg;
+  }
+}
+
+/** Import this module in tests to install the null icon registry. */
+@NgModule({
+  providers: [{provide: MatIconRegistry, useClass: FakeMatIconRegistry}]
+})
+export class MatIconTestingModule {
+}

--- a/src/material/icon/testing/index.ts
+++ b/src/material/icon/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material/icon/testing/public-api.ts
+++ b/src/material/icon/testing/public-api.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './fake-icon-registry';

--- a/tools/public_api_guard/material/icon/testing.d.ts
+++ b/tools/public_api_guard/material/icon/testing.d.ts
@@ -1,0 +1,24 @@
+export declare class FakeMatIconRegistry implements PublicApi<MatIconRegistry>, OnDestroy {
+    addSvgIcon(): this;
+    addSvgIconInNamespace(): this;
+    addSvgIconLiteral(): this;
+    addSvgIconLiteralInNamespace(): this;
+    addSvgIconSet(): this;
+    addSvgIconSetInNamespace(): this;
+    addSvgIconSetLiteral(): this;
+    addSvgIconSetLiteralInNamespace(): this;
+    classNameForFontAlias(alias: string): string;
+    getDefaultFontSetClass(): string;
+    getNamedSvgIcon(): Observable<SVGElement>;
+    getSvgIconFromUrl(): Observable<SVGElement>;
+    ngOnDestroy(): void;
+    registerFontClassAlias(): this;
+    setDefaultFontSetClass(): this;
+    static ɵfac: i0.ɵɵFactoryDef<FakeMatIconRegistry>;
+    static ɵprov: i0.ɵɵInjectableDef<FakeMatIconRegistry>;
+}
+
+export declare class MatIconTestingModule {
+    static ɵinj: i0.ɵɵInjectorDef<MatIconTestingModule>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatIconTestingModule, never, never, never>;
+}


### PR DESCRIPTION
Introducing the NoopIconModule to help silence Karma tests throwing warnings about custom icons not found. This added a lot of noise to tests output and it's now gone when `NoopMatIconModule` is installed in tests. The actual error this silences is `Error retrieving icon :xyz! Unable to find icon with the name ":xyz"`