### PR TITLE
build: make cross entrypoint rule an AbstractRule

### DIFF
--- a/tools/tslint-rules/noCrossEntryPointRelativeImportsRule.ts
+++ b/tools/tslint-rules/noCrossEntryPointRelativeImportsRule.ts
@@ -13,8 +13,8 @@ const BUILD_BAZEL_FILE = 'BUILD.bazel';
  * unintentionally and could break module resolution since the folder structure
  * changes in the Angular Package release output.
  */
-export class Rule extends Lint.Rules.TypedRule {
-  applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     return this.applyWithFunction(sourceFile, checkSourceFile, this.getOptions().ruleArguments);
   }
 }
@@ -31,7 +31,7 @@ function checkSourceFile(ctx: Lint.WalkContext<string[]>) {
     return;
   }
 
-  const visitNode = (node: ts.Node) => {
+  (function visitNode(node: ts.Node) {
     if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
       if (!node.moduleSpecifier || !ts.isStringLiteralLike(node.moduleSpecifier) ||
           !node.moduleSpecifier.text.startsWith('.')) {
@@ -54,9 +54,7 @@ function checkSourceFile(ctx: Lint.WalkContext<string[]>) {
       return;
     }
     ts.forEachChild(node, visitNode);
-  };
-
-  ts.forEachChild(ctx.sourceFile, visitNode);
+  })(ctx.sourceFile);
 }
 
 /** Finds the closest Bazel build package for the given path. */


### PR DESCRIPTION
Currently the cross entrypoint import rule is a `TypedRule` which means that it might use the type checker and it won't work in vscode. Since it doesn't actually use the type checker, these changes turn it into an `AbstractRule`.