### PR TITLE
fix(tabs): better high contrast indication on supported browsers

### DIFF
--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -28,7 +28,9 @@ $mat-tab-animation-duration: 500ms !default;
     }
 
     @include cdk-high-contrast {
-      outline: dotted 2px;
+      $outline-width: 2px;
+      outline: dotted $outline-width;
+      outline-offset: -$outline-width; // Not supported on IE, but looks better everywhere else.
     }
   }
 


### PR DESCRIPTION
We add an outline for focus indication in high contrast mode for tabs, but part of it gets clipped, because of `overflow: hidden`. These changes add a negative offset to ensure that it doesn't clip. Note that this isn't supported on IE, but it's a progressive enhncement for Edge and Firefox.