### PR TITLE
fix(material-experimental/mdc-form-field): fix baseline and handle custom controls better

### DIFF
--- a/src/components-examples/material-experimental/mdc-form-field/BUILD.bazel
+++ b/src/components-examples/material-experimental/mdc-form-field/BUILD.bazel
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "ng_module")
+
+ng_module(
+    name = "mdc-form-field",
+    srcs = glob(["**/*.ts"]),
+    assets = glob([
+        "**/*.html",
+        "**/*.css",
+    ]),
+    module_name = "@angular/components-examples/material-experimental/mdc-form-field",
+    deps = [
+        "//src/cdk/a11y",
+        "//src/cdk/coercion",
+        "//src/material-experimental/mdc-form-field",
+        "//src/material-experimental/mdc-input",
+        "//src/material/icon",
+        "@npm//@angular/common",
+        "@npm//@angular/forms",
+        "@npm//rxjs",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob([
+        "**/*.html",
+        "**/*.css",
+        "**/*.ts",
+    ]),
+)

--- a/src/components-examples/material-experimental/mdc-form-field/index.ts
+++ b/src/components-examples/material-experimental/mdc-form-field/index.ts
@@ -1,0 +1,31 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {ReactiveFormsModule} from '@angular/forms';
+import {MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {
+  FormFieldCustomControlExample,
+  MyTelInput
+} from './mdc-form-field-custom-control/form-field-custom-control-example';
+
+export {
+  FormFieldCustomControlExample,
+  MyTelInput,
+};
+
+const EXAMPLES = [
+  FormFieldCustomControlExample,
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  declarations: [...EXAMPLES, MyTelInput],
+  exports: EXAMPLES,
+})
+export class MdcFormFieldExamplesModule {
+}

--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/example-tel-input-example.css
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/example-tel-input-example.css
@@ -1,0 +1,21 @@
+.example-tel-input-container {
+  display: flex;
+}
+
+.example-tel-input-element {
+  border: none;
+  background: none;
+  padding: 0;
+  outline: none;
+  font: inherit;
+  text-align: center;
+}
+
+.example-tel-input-spacer {
+  opacity: 0;
+  transition: opacity 200ms;
+}
+
+:host.example-floating .example-tel-input-spacer {
+  opacity: 1;
+}

--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/example-tel-input-example.html
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/example-tel-input-example.html
@@ -1,0 +1,10 @@
+<div [formGroup]="parts" class="example-tel-input-container">
+  <input class="example-tel-input-element" formControlName="area" size="3"
+         aria-label="Area code" (input)="_handleInput()">
+  <span class="example-tel-input-spacer">&ndash;</span>
+  <input class="example-tel-input-element" formControlName="exchange" size="3"
+         aria-label="Exchange code" (input)="_handleInput()">
+  <span class="example-tel-input-spacer">&ndash;</span>
+  <input class="example-tel-input-element" formControlName="subscriber" size="4"
+         aria-label="Subscriber number" (input)="_handleInput()">
+</div>

--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.css
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.html
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.html
@@ -1,0 +1,6 @@
+<mat-form-field>
+  <mat-label>Phone number</mat-label>
+  <example-tel-input required></example-tel-input>
+  <mat-icon matSuffix>phone</mat-icon>
+  <mat-hint>Include area code</mat-hint>
+</mat-form-field>

--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.ts
@@ -1,0 +1,155 @@
+import {FocusMonitor} from '@angular/cdk/a11y';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {Component, ElementRef, Input, OnDestroy, Optional, Self} from '@angular/core';
+import {FormBuilder, FormGroup, ControlValueAccessor, NgControl} from '@angular/forms';
+import {MatFormFieldControl} from '@angular/material-experimental/mdc-form-field';
+import {Subject} from 'rxjs';
+
+/** @title Form field with custom telephone number input control. */
+@Component({
+  selector: 'form-field-custom-control-example',
+  templateUrl: 'form-field-custom-control-example.html',
+  styleUrls: ['form-field-custom-control-example.css'],
+})
+export class FormFieldCustomControlExample {}
+
+/** Data structure for holding telephone number. */
+export class MyTel {
+  constructor(public area: string, public exchange: string, public subscriber: string) {}
+}
+
+/** Custom `MatFormFieldControl` for telephone number input. */
+@Component({
+  selector: 'example-tel-input',
+  templateUrl: 'example-tel-input-example.html',
+  styleUrls: ['example-tel-input-example.css'],
+  providers: [{provide: MatFormFieldControl, useExisting: MyTelInput}],
+  host: {
+    '[class.example-floating]': 'shouldLabelFloat',
+    '[id]': 'id',
+    '[attr.aria-describedby]': 'describedBy',
+  }
+})
+export class MyTelInput implements ControlValueAccessor, MatFormFieldControl<MyTel>, OnDestroy {
+  static nextId = 0;
+
+  parts: FormGroup;
+  stateChanges = new Subject<void>();
+  focused = false;
+  errorState = false;
+  controlType = 'example-tel-input';
+  id = `example-tel-input-${MyTelInput.nextId++}`;
+  describedBy = '';
+  onChange = (_: any) => {};
+  onTouched = () => {};
+
+  get empty() {
+    const {value: {area, exchange, subscriber}} = this.parts;
+
+    return !area && !exchange && !subscriber;
+  }
+
+  get shouldLabelFloat() { return this.focused || !this.empty; }
+
+  @Input()
+  get placeholder(): string { return this._placeholder; }
+  set placeholder(value: string) {
+    this._placeholder = value;
+    this.stateChanges.next();
+  }
+  private _placeholder: string;
+
+  @Input()
+  get required(): boolean { return this._required; }
+  set required(value: boolean) {
+    this._required = coerceBooleanProperty(value);
+    this.stateChanges.next();
+  }
+  private _required = false;
+
+  @Input()
+  get disabled(): boolean { return this._disabled; }
+  set disabled(value: boolean) {
+    this._disabled = coerceBooleanProperty(value);
+    this._disabled ? this.parts.disable() : this.parts.enable();
+    this.stateChanges.next();
+  }
+  private _disabled = false;
+
+  @Input()
+  get value(): MyTel | null {
+    const {value: {area, exchange, subscriber}} = this.parts;
+    if (area.length === 3 && exchange.length === 3 && subscriber.length === 4) {
+      return new MyTel(area, exchange, subscriber);
+    }
+    return null;
+  }
+  set value(tel: MyTel | null) {
+    const {area, exchange, subscriber} = tel || new MyTel('', '', '');
+    this.parts.setValue({area, exchange, subscriber});
+    this.stateChanges.next();
+  }
+
+  constructor(
+    formBuilder: FormBuilder,
+    private _focusMonitor: FocusMonitor,
+    private _elementRef: ElementRef<HTMLElement>,
+    @Optional() @Self() public ngControl: NgControl) {
+
+    this.parts = formBuilder.group({
+      area: '',
+      exchange: '',
+      subscriber: '',
+    });
+
+    _focusMonitor.monitor(_elementRef, true).subscribe(origin => {
+      if (this.focused && !origin) {
+        this.onTouched();
+      }
+      this.focused = !!origin;
+      this.stateChanges.next();
+    });
+
+    if (this.ngControl != null) {
+      this.ngControl.valueAccessor = this;
+    }
+  }
+
+  ngOnDestroy() {
+    this.stateChanges.complete();
+    this._focusMonitor.stopMonitoring(this._elementRef);
+  }
+
+  setDescribedByIds(ids: string[]) {
+    this.describedBy = ids.join(' ');
+  }
+
+  onContainerClick(event: MouseEvent) {
+    if ((event.target as Element).tagName.toLowerCase() != 'input') {
+      this._elementRef.nativeElement.querySelector('input')!.focus();
+    }
+  }
+
+  writeValue(tel: MyTel | null): void {
+    this.value = tel;
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  _handleInput(): void {
+    this.onChange(this.parts.value);
+  }
+
+  static ngAcceptInputType_disabled: boolean | string | null | undefined;
+  static ngAcceptInputType_required: boolean | string | null | undefined;
+}

--- a/src/dev-app/mdc-input/BUILD.bazel
+++ b/src/dev-app/mdc-input/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
         "mdc-input-demo.html",
     ],
     deps = [
+        "//src/components-examples/material-experimental/mdc-form-field",
         "//src/material-experimental/mdc-form-field",
         "//src/material-experimental/mdc-input",
         "//src/material/autocomplete",

--- a/src/dev-app/mdc-input/mdc-input-demo-module.ts
+++ b/src/dev-app/mdc-input/mdc-input-demo-module.ts
@@ -7,6 +7,9 @@
  */
 
 import {CommonModule} from '@angular/common';
+import {
+  MdcFormFieldExamplesModule
+} from '@angular/components-examples/material-experimental/mdc-form-field';
 import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
@@ -36,6 +39,7 @@ import {MdcInputDemo} from './mdc-input-demo';
     MatInputModule,
     MatTabsModule,
     MatToolbarModule,
+    MdcFormFieldExamplesModule,
     ReactiveFormsModule,
     RouterModule.forChild([{path: '', component: MdcInputDemo}]),
   ],

--- a/src/dev-app/mdc-input/mdc-input-demo.html
+++ b/src/dev-app/mdc-input/mdc-input-demo.html
@@ -650,3 +650,23 @@
     </mat-tab-group>
   </mat-card-content>
 </mat-card>
+
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Baseline</mat-toolbar>
+  <mat-card-content>
+    <span style="display: inline-block; margin-top: 20px">Shifted text</span>
+    <mat-form-field>
+      <mat-label>Label</mat-label>
+      <input matInput>
+    </mat-form-field>
+  </mat-card-content>
+</mat-card>
+
+
+<mat-card class="demo-card demo-basic">
+  <mat-toolbar color="primary">Examples</mat-toolbar>
+  <mat-card-content>
+    <h4>Custom control</h4>
+    <form-field-custom-control-example></form-field-custom-control-example>
+  </mat-card-content>
+</mat-card>

--- a/src/material-experimental/mdc-form-field/_form-field-sizing.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-sizing.scss
@@ -15,3 +15,23 @@ $mat-form-field-default-infix-width: 180px !default;
 // Minimum amount of space between start and end hints in the subscript. MDC does not
 // have built-in support for hints.
 $mat-form-field-hint-min-space: 1em !default;
+
+// Vertical spacing of the text-field if there is no label. MDC hard-codes the spacing
+// into their styles, but their spacing variables would not work for our form-field
+// structure anyway. This is because MDC's input elements are larger than the text, and
+// their padding variables are calculated with respect to the vertical empty space of the
+// inputs. We take the explicit numbers provided by the Material Design specification.
+// https://material.io/components/text-fields/#specs
+$mat-form-field-no-label-padding-bottom: 16px;
+$mat-form-field-no-label-padding-top: 20px;
+
+// Vertical spacing of the text-field if there is a label. MDC hard-codes the spacing
+// into their styles, but their spacing variables would not work for our form-field
+// structure anyway. This is because MDC's input elements are larger than the text, and
+// their padding variables are calculated with respect to the vertical empty space of the
+// inputs. We take the numbers provided by the Material Design specification. **Note** that
+// the drawn values in the spec are slightly shifted because the spec assumes that typed input
+// text exceeds the input element boundaries. We account for this since typed input text does
+// not overflow in browsers by default.
+$mat-form-field-with-label-input-padding-top: 24px;
+$mat-form-field-with-label-input-padding-bottom: 12px;

--- a/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
@@ -14,18 +14,49 @@
     display: none;
   }
 
+  // Unset the border set by MDC. We move the border (which serves as the Material Design
+  // text-field bottom line) into its own element. This is necessary because we want the
+  // bottom-line to span across the whole form-field (including prefixes and suffixes).
+  // Also we want to ensure that font styles are inherited for input elements. We want input
+  // text to align with surrounding text. Also font inheritance has been enabled in the non
+  // MDC-based implementation of the form-field too, so we need it for backwards compatibility.
   .mat-mdc-input-element {
-    // By default, MDC limits the height of a form-field to the height of an input, and
-    // overwrites the height to "auto" if a textarea is used. As mentioned in the comment
-    // above for the floating label, we do not know what type of control is used, so we
-    // shift the fixed height to the actual input element and let the form-field adjust
-    // based on the needed height. This makes it work for both input and textarea.
-    height: $mdc-text-field-height;
-
-    // Unset the border set by MDC. We move the border (which serves as the Material Design
-    // text-field bottom line) into its own element. This is necessary because we want the
-    // bottom-line to span across the whole form-field (including prefixes and suffixes).
+    font: inherit;
     border: none;
+  }
+
+  // Reset the padding that MDC sets on native input elements. We cannot rely on this
+  // spacing as we support arbitrary form-field controls which aren't necessarily matching
+  // the "mdc-text-field__input" class. Note: We need the first selector to overwrite the
+  // default no-label MDC padding styles which are set with a very high specificity.
+  .mdc-text-field--no-label:not(.mdc-text-field--outlined):not(.mdc-text-field--textarea)
+  .mat-mdc-input-element.mdc-text-field__input,
+  .mat-mdc-input-element {
+    padding: 0;
+  }
+
+  // MDC changes the vertical spacing of the input if there is no label. Since we moved
+  // the spacing of the input to the parent infix container (to support custom controls),
+  // we need to replicate these styles for the infix container. The goal is that the input
+  // placeholder vertically aligns with floating labels of other filled inputs. Note that
+  // outline appearance currently still relies on the input spacing due to a notched-outline
+  // limitation. TODO: https://github.com/material-components/material-components-web/issues/5326
+  .mdc-text-field--no-label:not(.mdc-text-field--outlined):not(.mdc-text-field--textarea)
+  .mat-mdc-form-field-infix {
+    padding-top: $mat-form-field-no-label-padding-top;
+    padding-bottom: $mat-form-field-no-label-padding-bottom;
+  }
+
+  // MDC adds vertical spacing to inputs. We removed this spacing and intend to add it
+  // to the infix container. This is necessary to ensure that custom form-field controls
+  // also have the proper Material Design spacing to the label and bottom-line. Note that
+  // outline appearance currently still relies on the input spacing due to a notched-outline
+  // limitation. TODO: https://github.com/material-components/material-components-web/issues/5326
+  .mat-mdc-text-field-wrapper:not(.mdc-text-field--outlined) .mat-mdc-form-field-infix {
+    // Apply the default text-field input padding to the infix container. We removed the
+    // padding from the input elements in order to support arbitrary form-field controls.
+    padding-top: $mat-form-field-with-label-input-padding-top;
+    padding-bottom: $mat-form-field-with-label-input-padding-bottom;
   }
 
   // Root element of the mdc-text-field. As explained in the height overwrites above, MDC
@@ -52,18 +83,6 @@
   // floating label. See https://github.com/material-components/material-components-web/issues/5326
   // TODO(devversion): Remove this workaround/nesting once the feature is available.
   .mat-mdc-text-field-wrapper:not(.mdc-text-field--outlined) {
-    // Reset horizontal spacing of the input. This is necessary because we move the horizontal
-    // spacing to the form-field flex container. We do this because prefixes and suffixes should
-    // adjoin the actual control infix. The spacing is still needed for outline and fill
-    // appearances and should surround the prefixes, suffixes and infix. Note that we need
-    // increased specificity because MDC has high specificity for the default padding styles.
-    .mat-mdc-input-element {
-      padding: {
-        left: 0;
-        right: 0;
-      }
-    }
-
     // We removed the horizontal inset on input elements, but need to re-add the spacing to
     // the actual form-field flex container that contains the prefixes, suffixes and infix.
     .mat-mdc-form-field-flex {
@@ -76,5 +95,12 @@
     .mdc-floating-label {
       left: 0;
     }
+  }
+
+  // MDC sets the input elements in outline appearance to "display: flex". There seems to
+  // be no particular reason why this is needed. We set it to "inline-block", as it otherwise
+  // could shift the baseline.
+  .mat-mdc-text-field-wrapper.mdc-text-field--outlined .mdc-text-field__input {
+    display: inline-block;
   }
 }

--- a/src/material-experimental/mdc-form-field/_mdc-text-field-textarea-overrides.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-textarea-overrides.scss
@@ -20,9 +20,9 @@
     box-sizing: border-box;
     height: auto;
     // Using padding for textareas causes a bad user experience because the text outside
-    // of the text box will overflow vertically. In order to avoid this overflow where small
-    // parts of the previous/followed lines are visible, we use margin for vertical spacing.
-    margin: $mat-form-field-baseline 0 $mdc-text-field-input-padding-bottom;
+    // of the text box will overflow vertically. Also, the vertical spacing for controls
+    // is set through the infix container to allow for arbitrary form-field controls.
+    margin: 0;
     padding: 0;
     border: none;
   }

--- a/src/material-experimental/mdc-form-field/form-field.scss
+++ b/src/material-experimental/mdc-form-field/form-field.scss
@@ -21,7 +21,6 @@
   // this container contains the text-field and the subscript. The subscript
   // should be displayed below the text-field. Hence the column direction.
   flex-direction: column;
-  vertical-align: middle;
 }
 
 // Container that contains the prefixes, infix and suffixes. These elements should
@@ -42,4 +41,9 @@
   width: $mat-form-field-default-infix-width;
   // Needed so that the floating label does not overlap with prefixes or suffixes.
   position: relative;
+
+  // We add a minimum height in order to ensure that custom controls have the same
+  // default vertical space as text-field inputs (with respect to the vertical padding).
+  min-height: $mdc-text-field-height;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
* Fixes the baseline of form-field controls and their inputs. Previously
the baseline was incorrect due to flex alignment and `vertical-align` misuse.
* Improves support for custom form-field controls by ensuring that
spacing applied to MDC inputs, also applies to custom controls.
   * The same will be needed for the outline appearance, but
   unfortunately we cannot apply any spacing to the infix until we find
   a solution for: https://github.com/material-components/material-components-web/issues/5326