### PR TITLE
build: print error if prerender test fails

### DIFF
--- a/src/universal-app/prerender.ts
+++ b/src/universal-app/prerender.ts
@@ -26,7 +26,8 @@ result
     writeFileSync(filename, content, 'utf-8');
     console.log('Prerender done.');
   })
-  // If rendering the module factory fails, exit the process with an error code because otherwise
-  // the CI task will not recognize the failure and will show as "success". The error message
-  // will be printed automatically by the `renderModuleFactory` method.
-  .catch(() => process.exit(1));
+  // If rendering the module factory fails, re-throw the error in order to print the
+  // failure to the console, and to exit the process with a non-zero exit code.
+  .catch(error => {
+    throw error;
+  });


### PR DESCRIPTION
Currently the errors are sometimes not printed if the prerendering test
target fails. We fix this by always re-throwing the error at top-level. This
also ensures that the process exits with a non-zero exit code.