### PR TITLE
fix(material/input): apply static class binding to host

### DIFF
--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -71,8 +71,7 @@ const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase =
     /**
      * @breaking-change 8.0.0 remove .mat-form-field-autofill-control in favor of AutofillMonitor.
      */
-    '[class.mat-form-field-autofill-control]': 'true',
-    '[class.mat-input-element]': 'true',
+    'class': 'mat-input-element mat-form-field-autofill-control',
     '[class.mat-input-server]': '_isServer',
     // Native input properties that are overwritten by Angular inputs need to be synced with
     // the native input element. Otherwise property bindings for those don't work.


### PR DESCRIPTION
Partially reverting https://github.com/angular/components/pull/18180

Unfortunately, having `[class]` binding meant the classes are not set before autosize runs, so bringing this back to be static. Leaving the bindings in the MDC version since it seems to successfully remove the class