### PR TITLE
fix(datepicker): error in IE/Edge for static disabled binding

### DIFF
--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -18,6 +18,7 @@ import {
   OnDestroy,
   Optional,
   Output,
+  AfterViewInit,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -91,7 +92,12 @@ export class MatDatepickerInputEvent<D> {
   },
   exportAs: 'matDatepickerInput',
 })
-export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {
+export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, AfterViewInit,
+  Validator {
+
+  /** Whether the component has been initialized. */
+  private _isInitialized: boolean;
+
   /** The datepicker that this input is associated with. */
   @Input()
   set matDatepicker(value: MatDatepicker<D>) {
@@ -169,7 +175,10 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
     }
 
     // We need to null check the `blur` method, because it's undefined during SSR.
-    if (newValue && element.blur) {
+    // In Ivy static bindings are invoked earlier, before the element is attached to the DOM.
+    // This can cause an error to be thrown in some browsers (IE/Edge) which assert that the
+    // element has been inserted.
+    if (newValue && this._isInitialized && element.blur) {
       // Normally, native input elements automatically blur if they turn disabled. This behavior
       // is problematic, because it would mean that it triggers another change detection cycle,
       // which then causes a changed after checked error if the input element was focused before.
@@ -255,6 +264,10 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
     this._localeSubscription = _dateAdapter.localeChanges.subscribe(() => {
       this.value = this.value;
     });
+  }
+
+  ngAfterViewInit() {
+    this._isInitialized = true;
   }
 
   ngOnDestroy() {

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -170,7 +170,7 @@ export declare class MatDatepickerContent<D> extends _MatDatepickerContentMixinB
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any>>;
 }
 
-export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {
+export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, AfterViewInit, Validator {
     _dateAdapter: DateAdapter<D>;
     _dateFilter: (date: D | null) => boolean;
     _datepicker: MatDatepicker<D>;
@@ -197,6 +197,7 @@ export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDe
     _onKeydown(event: KeyboardEvent): void;
     getConnectedOverlayOrigin(): ElementRef;
     getPopupConnectionElementRef(): ElementRef;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     registerOnChange(fn: (value: any) => void): void;
     registerOnTouched(fn: () => void): void;


### PR DESCRIPTION
IE/Edge can throw an error for a datepicker input which has a static `disabled` binding. The error is thrown, because static bindings in Ivy are invoked before the element is in the DOM which browsers seem to have an assertion against.

**Note:** I wasn't able to write a unit test for this, because we need to get a hold of the input during creation mode, before directives are matched, which seems to not be possible with `TestBed`.