### PR TITLE
refactor: move common date input logic into base class

### DIFF
--- a/src/dev-app/datepicker/datepicker-demo.html
+++ b/src/dev-app/datepicker/datepicker-demo.html
@@ -171,35 +171,39 @@
 </p>
 
 <h2>Range picker</h2>
-<p>
+
+<div class="demo-range-group">
   <mat-form-field>
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input>
-      <input matStartDate placeholder="Start date">
-      <input matEndDate placeholder="End date">
+    <mat-date-range-input [formGroup]="range1">
+      <input matStartDate formControlName="start" placeholder="Start date"/>
+      <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
   </mat-form-field>
-</p>
+  <div>{{range1.value | json}}</div>
+</div>
 
-<p>
+<div class="demo-range-group">
   <mat-form-field appearance="fill">
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input>
-      <input matStartDate placeholder="Start date">
-      <input matEndDate placeholder="End date">
+    <mat-date-range-input [formGroup]="range2">
+      <input matStartDate formControlName="start" placeholder="Start date"/>
+      <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
   </mat-form-field>
-</p>
+  <div>{{range2.value | json}}</div>
+</div>
 
-<p>
+<div class="demo-range-group">
   <mat-form-field appearance="outline">
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input>
-      <input matStartDate placeholder="Start date">
-      <input matEndDate placeholder="End date">
+    <mat-date-range-input [formGroup]="range3">
+      <input matStartDate formControlName="start" placeholder="Start date"/>
+      <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
   </mat-form-field>
-</p>
+  <div>{{range3.value | json}}</div>
+</div>

--- a/src/dev-app/datepicker/datepicker-demo.scss
+++ b/src/dev-app/datepicker/datepicker-demo.scss
@@ -2,3 +2,6 @@ mat-calendar {
   width: 300px;
 }
 
+.demo-range-group {
+  margin-bottom: 30px;
+}

--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -15,7 +15,7 @@ import {
   Optional,
   ViewChild
 } from '@angular/core';
-import {FormControl} from '@angular/forms';
+import {FormControl, FormGroup} from '@angular/forms';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, ThemePalette} from '@angular/material/core';
 import {
   MatCalendar,
@@ -47,6 +47,9 @@ export class DatepickerDemo {
   color: ThemePalette;
 
   dateCtrl = new FormControl();
+  range1 = new FormGroup({start: new FormControl(), end: new FormControl()});
+  range2 = new FormGroup({start: new FormControl(), end: new FormControl()});
+  range3 = new FormGroup({start: new FormControl(), end: new FormControl()});
 
   dateFilter: (date: Date | null) => boolean =
     (date: Date | null) => {

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -162,6 +162,7 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
    */
   onContainerClick(): void {
     if (!this.focused) {
+      // TODO(crisbeto): maybe this should go to end input if start has a value?
       this._startInput.focus();
     }
   }
@@ -193,6 +194,11 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   /** Handles the value in one of the child inputs changing. */
   _handleChildValueChange() {
     this._changeDetectorRef.markForCheck();
+  }
+
+  /** Opens the datepicker associated with the input. */
+  _openDatepicker() {
+    // TODO(crisbeto): implement once the datepicker is in place.
   }
 
   static ngAcceptInputType_required: BooleanInput;

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {DOWN_ARROW} from '@angular/cdk/keycodes';
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  OnDestroy,
+  Optional,
+  Output,
+} from '@angular/core';
+import {
+  AbstractControl,
+  ControlValueAccessor,
+  ValidationErrors,
+  Validator,
+  ValidatorFn,
+} from '@angular/forms';
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MatDateFormats,
+  MatDateSelectionModel,
+} from '@angular/material/core';
+import {Subscription} from 'rxjs';
+import {createMissingDateImplError} from './datepicker-errors';
+
+/**
+ * An event used for datepicker input and change events. We don't always have access to a native
+ * input or change event because the event may have been triggered by the user clicking on the
+ * calendar popup. For consistency, we always use MatDatepickerInputEvent instead.
+ */
+export class MatDatepickerInputEvent<D> {
+  /** The new value for the target datepicker input. */
+  value: D | null;
+
+  constructor(
+      /** Reference to the datepicker input component that emitted the event. */
+      public target: MatDatepickerInputBase<D>,
+      /** Reference to the native input element associated with the datepicker input. */
+      public targetElement: HTMLElement) {
+    this.value = this.target.value;
+  }
+}
+
+/** Base class for datepicker inputs. */
+@Directive()
+export abstract class MatDatepickerInputBase<D> implements ControlValueAccessor, OnDestroy,
+  Validator {
+  /** The value of the input. */
+  @Input()
+  get value(): D | null { return this._model ? this._model.selection : this._pendingValue; }
+  set value(value: D | null) {
+    value = this._dateAdapter.deserialize(value);
+    this._lastValueValid = !value || this._dateAdapter.isValid(value);
+    value = this._getValidDateOrNull(value);
+    const oldDate = this.value;
+    this._assignValue(value);
+    this._formatValue(value);
+
+    if (!this._dateAdapter.sameDate(oldDate, value)) {
+      this._valueChange.emit(value);
+    }
+  }
+  protected _model: MatDateSelectionModel<D | null, D> | undefined;
+
+  /** Whether the datepicker-input is disabled. */
+  @Input()
+  get disabled(): boolean { return !!this._disabled; }
+  set disabled(value: boolean) {
+    const newValue = coerceBooleanProperty(value);
+    const element = this._elementRef.nativeElement;
+
+    if (this._disabled !== newValue) {
+      this._disabled = newValue;
+      this._disabledChange.emit(newValue);
+    }
+
+    // We need to null check the `blur` method, because it's undefined during SSR.
+    if (newValue && element.blur) {
+      // Normally, native input elements automatically blur if they turn disabled. This behavior
+      // is problematic, because it would mean that it triggers another change detection cycle,
+      // which then causes a changed after checked error if the input element was focused before.
+      element.blur();
+    }
+  }
+  private _disabled: boolean;
+
+  /** Emits when a `change` event is fired on this `<input>`. */
+  @Output() readonly dateChange: EventEmitter<MatDatepickerInputEvent<D>> =
+      new EventEmitter<MatDatepickerInputEvent<D>>();
+
+  /** Emits when an `input` event is fired on this `<input>`. */
+  @Output() readonly dateInput: EventEmitter<MatDatepickerInputEvent<D>> =
+      new EventEmitter<MatDatepickerInputEvent<D>>();
+
+  /** Emits when the value changes (either due to user input or programmatic change). */
+  _valueChange = new EventEmitter<D | null>();
+
+  /** Emits when the disabled state has changed */
+  _disabledChange = new EventEmitter<boolean>();
+
+  _onTouched = () => {};
+
+  private _cvaOnChange: (value: any) => void = () => {};
+  protected _validatorOnChange = () => {};
+  private _valueChangesSubscription = Subscription.EMPTY;
+  private _localeSubscription = Subscription.EMPTY;
+
+  /**
+   * Since the value is kept on the model which is assigned in an Input,
+   * we might get a value before we have a model. This property keeps track
+   * of the value until we have somewhere to assign it.
+   */
+  private _pendingValue: D | null;
+
+  /** The form control validator for whether the input parses. */
+  protected _parseValidator: ValidatorFn = (): ValidationErrors | null => {
+    return this._lastValueValid ?
+        null : {'matDatepickerParse': {'text': this._elementRef.nativeElement.value}};
+  }
+
+  protected _registerModel(model: MatDateSelectionModel<D | null, D>): void {
+    this._model = model;
+    this._valueChangesSubscription.unsubscribe();
+
+    if (this._pendingValue) {
+      this._assignValue(this._pendingValue);
+    }
+
+    this._valueChangesSubscription = this._model.selectionChanged.subscribe(event => {
+      if (event.source !== this) {
+        this._cvaOnChange(event.selection);
+        this._onTouched();
+        this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this._formatValue(event.selection);
+      }
+    });
+  }
+
+  /** Opens the popup associated with the input. */
+  protected abstract _openPopup(): void;
+
+  /** Assigns a value to the input's model. */
+  protected abstract _assignModelValue(model: D | null): void;
+
+  /** The combined form control validator for this input. */
+  protected abstract _validator: ValidatorFn | null;
+
+  /** Whether the last value set on the input was valid. */
+  protected _lastValueValid = false;
+
+  constructor(
+      protected _elementRef: ElementRef<HTMLInputElement>,
+      @Optional() public _dateAdapter: DateAdapter<D>,
+      @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats) {
+    if (!this._dateAdapter) {
+      throw createMissingDateImplError('DateAdapter');
+    }
+    if (!this._dateFormats) {
+      throw createMissingDateImplError('MAT_DATE_FORMATS');
+    }
+
+    // Update the displayed date when the locale changes.
+    this._localeSubscription = _dateAdapter.localeChanges.subscribe(() => {
+      this.value = this.value;
+    });
+  }
+
+  ngOnDestroy() {
+    this._valueChangesSubscription.unsubscribe();
+    this._localeSubscription.unsubscribe();
+    this._valueChange.complete();
+    this._disabledChange.complete();
+  }
+
+  /** @docs-private */
+  registerOnValidatorChange(fn: () => void): void {
+    this._validatorOnChange = fn;
+  }
+
+  /** @docs-private */
+  validate(c: AbstractControl): ValidationErrors | null {
+    return this._validator ? this._validator(c) : null;
+  }
+
+  // Implemented as part of ControlValueAccessor.
+  writeValue(value: D): void {
+    this.value = value;
+  }
+
+  // Implemented as part of ControlValueAccessor.
+  registerOnChange(fn: (value: any) => void): void {
+    this._cvaOnChange = fn;
+  }
+
+  // Implemented as part of ControlValueAccessor.
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  // Implemented as part of ControlValueAccessor.
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  _onKeydown(event: KeyboardEvent) {
+    const isAltDownArrow = event.altKey && event.keyCode === DOWN_ARROW;
+
+    if (isAltDownArrow && !this._elementRef.nativeElement.readOnly) {
+      this._openPopup();
+      event.preventDefault();
+    }
+  }
+
+  _onInput(value: string) {
+    const lastValueWasValid = this._lastValueValid;
+    let date = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
+    this._lastValueValid = !date || this._dateAdapter.isValid(date);
+    date = this._getValidDateOrNull(date);
+
+    if (!this._dateAdapter.sameDate(date, this.value)) {
+      this._assignValue(date);
+      this._cvaOnChange(date);
+      this._valueChange.emit(date);
+      this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+    } else if (lastValueWasValid !== this._lastValueValid) {
+      this._validatorOnChange();
+    }
+  }
+
+  _onChange() {
+    this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+  }
+
+  /** Handles blur events on the input. */
+  _onBlur() {
+    // Reformat the input only if we have a valid value.
+    if (this.value) {
+      this._formatValue(this.value);
+    }
+
+    this._onTouched();
+  }
+
+  /** Formats a value and sets it on the input element. */
+  private _formatValue(value: D | null) {
+    this._elementRef.nativeElement.value =
+        value ? this._dateAdapter.format(value, this._dateFormats.display.dateInput) : '';
+  }
+
+  /**
+   * @param obj The object to check.
+   * @returns The given object if it is both a date instance and valid, otherwise null.
+   */
+  protected _getValidDateOrNull(obj: any): D | null {
+    return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
+  }
+
+  /** Assigns a value to the model. */
+  private _assignValue(value: D | null) {
+    // We may get some incoming values before the model was
+    // assigned. Save the value so that we can assign it later.
+    if (this._model) {
+      this._assignModelValue(value);
+      this._pendingValue = null;
+    } else {
+      this._pendingValue = value;
+    }
+  }
+
+  // Accept `any` to avoid conflicts with other directives on `<input>` that
+  // may accept different types.
+  static ngAcceptInputType_value: any;
+  static ngAcceptInputType_disabled: BooleanInput;
+}

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -6,26 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
-import {DOWN_ARROW} from '@angular/cdk/keycodes';
+import {BooleanInput} from '@angular/cdk/coercion';
 import {
   Directive,
   ElementRef,
-  EventEmitter,
   forwardRef,
   Inject,
   Input,
-  OnDestroy,
   Optional,
-  Output,
 } from '@angular/core';
 import {
   AbstractControl,
-  ControlValueAccessor,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
   ValidationErrors,
-  Validator,
   ValidatorFn,
   Validators,
 } from '@angular/forms';
@@ -34,13 +28,11 @@ import {
   MAT_DATE_FORMATS,
   MatDateFormats,
   ThemePalette,
-  MatDateSelectionModel,
 } from '@angular/material/core';
 import {MatFormField} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
-import {Subscription} from 'rxjs';
 import {MatDatepicker} from './datepicker';
-import {createMissingDateImplError} from './datepicker-errors';
+import {MatDatepickerInputBase} from './datepicker-input-base';
 
 /** @docs-private */
 export const MAT_DATEPICKER_VALUE_ACCESSOR: any = {
@@ -55,26 +47,6 @@ export const MAT_DATEPICKER_VALIDATORS: any = {
   useExisting: forwardRef(() => MatDatepickerInput),
   multi: true
 };
-
-
-/**
- * An event used for datepicker input and change events. We don't always have access to a native
- * input or change event because the event may have been triggered by the user clicking on the
- * calendar popup. For consistency, we always use MatDatepickerInputEvent instead.
- */
-export class MatDatepickerInputEvent<D> {
-  /** The new value for the target datepicker input. */
-  value: D | null;
-
-  constructor(
-      /** Reference to the datepicker input component that emitted the event. */
-      public target: MatDatepickerInput<D>,
-      /** Reference to the native input element associated with the datepicker input. */
-      public targetElement: HTMLElement) {
-    this.value = this.target.value;
-  }
-}
-
 
 /** Directive used to connect an input to a MatDatepicker. */
 @Directive({
@@ -97,58 +69,16 @@ export class MatDatepickerInputEvent<D> {
   },
   exportAs: 'matDatepickerInput',
 })
-export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {
+export class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
   /** The datepicker that this input is associated with. */
   @Input()
   set matDatepicker(datepicker: MatDatepicker<D>) {
-    if (!datepicker) {
-      return;
+    if (datepicker) {
+      this._datepicker = datepicker;
+      this._registerModel(datepicker._registerInput(this));
     }
-
-    this._datepicker = datepicker;
-    this._model = this._datepicker._registerInput(this);
-    this._valueChangesSubscription.unsubscribe();
-
-    if (this._pendingValue) {
-      this._assignValue(this._pendingValue);
-    }
-
-    this._valueChangesSubscription = this._model.selectionChanged.subscribe(event => {
-      if (event.source !== this) {
-        this._cvaOnChange(event.selection);
-        this._onTouched();
-        this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-        this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-        this._formatValue(event.selection);
-      }
-    });
   }
   _datepicker: MatDatepicker<D>;
-
-  /** Function that can be used to filter out dates within the datepicker. */
-  @Input()
-  set matDatepickerFilter(value: (date: D | null) => boolean) {
-    this._dateFilter = value;
-    this._validatorOnChange();
-  }
-  _dateFilter: (date: D | null) => boolean;
-
-  /** The value of the input. */
-  @Input()
-  get value(): D | null { return this._model ? this._model.selection : this._pendingValue; }
-  set value(value: D | null) {
-    value = this._dateAdapter.deserialize(value);
-    this._lastValueValid = !value || this._dateAdapter.isValid(value);
-    value = this._getValidDateOrNull(value);
-    const oldDate = this.value;
-    this._assignValue(value);
-    this._formatValue(value);
-
-    if (!this._dateAdapter.sameDate(oldDate, value)) {
-      this._valueChange.emit(value);
-    }
-  }
-  private _model: MatDateSelectionModel<D | null, D> | undefined;
 
   /** The minimum valid date. */
   @Input()
@@ -168,60 +98,19 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
   }
   private _max: D | null;
 
-  /** Whether the datepicker-input is disabled. */
+  /** Function that can be used to filter out dates within the datepicker. */
   @Input()
-  get disabled(): boolean { return !!this._disabled; }
-  set disabled(value: boolean) {
-    const newValue = coerceBooleanProperty(value);
-    const element = this._elementRef.nativeElement;
-
-    if (this._disabled !== newValue) {
-      this._disabled = newValue;
-      this._disabledChange.emit(newValue);
-    }
-
-    // We need to null check the `blur` method, because it's undefined during SSR.
-    if (newValue && element.blur) {
-      // Normally, native input elements automatically blur if they turn disabled. This behavior
-      // is problematic, because it would mean that it triggers another change detection cycle,
-      // which then causes a changed after checked error if the input element was focused before.
-      element.blur();
-    }
+  set matDatepickerFilter(value: (date: D | null) => boolean) {
+    this._dateFilter = value;
+    this._validatorOnChange();
   }
-  private _disabled: boolean;
+  _dateFilter: (date: D | null) => boolean;
 
-  /** Emits when a `change` event is fired on this `<input>`. */
-  @Output() readonly dateChange: EventEmitter<MatDatepickerInputEvent<D>> =
-      new EventEmitter<MatDatepickerInputEvent<D>>();
-
-  /** Emits when an `input` event is fired on this `<input>`. */
-  @Output() readonly dateInput: EventEmitter<MatDatepickerInputEvent<D>> =
-      new EventEmitter<MatDatepickerInputEvent<D>>();
-
-  /** Emits when the value changes (either due to user input or programmatic change). */
-  _valueChange = new EventEmitter<D | null>();
-
-  /** Emits when the disabled state has changed */
-  _disabledChange = new EventEmitter<boolean>();
-
-  _onTouched = () => {};
-
-  private _cvaOnChange: (value: any) => void = () => {};
-  private _validatorOnChange = () => {};
-  private _valueChangesSubscription = Subscription.EMPTY;
-  private _localeSubscription = Subscription.EMPTY;
-
-  /**
-   * Since the value is kept on the datepicker which is assigned in an Input,
-   * we might get a value before we have a datepicker. This property keeps track
-   * of the value until we have somewhere to assign it.
-   */
-  private _pendingValue: D | null;
-
-  /** The form control validator for whether the input parses. */
-  private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
-    return this._lastValueValid ?
-        null : {'matDatepickerParse': {'text': this._elementRef.nativeElement.value}};
+  /** The form control validator for the date filter. */
+  private _filterValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+    const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
+    return !this._dateFilter || !controlValue || this._dateFilter(controlValue) ?
+        null : {'matDatepickerFilter': true};
   }
 
   /** The form control validator for the min date. */
@@ -240,62 +129,17 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
         null : {'matDatepickerMax': {'max': this.max, 'actual': controlValue}};
   }
 
-  /** The form control validator for the date filter. */
-  private _filterValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
-    const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
-    return !this._dateFilter || !controlValue || this._dateFilter(controlValue) ?
-        null : {'matDatepickerFilter': true};
-  }
-
   /** The combined form control validator for this input. */
-  private _validator: ValidatorFn | null =
-      Validators.compose(
-          [this._parseValidator, this._minValidator, this._maxValidator, this._filterValidator]);
-
-  /** Whether the last value set on the input was valid. */
-  private _lastValueValid = false;
+  protected _validator: ValidatorFn | null;
 
   constructor(
-      private _elementRef: ElementRef<HTMLInputElement>,
-      @Optional() public _dateAdapter: DateAdapter<D>,
-      @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
+      elementRef: ElementRef<HTMLInputElement>,
+      @Optional() dateAdapter: DateAdapter<D>,
+      @Optional() @Inject(MAT_DATE_FORMATS) dateFormats: MatDateFormats,
       @Optional() private _formField: MatFormField) {
-    if (!this._dateAdapter) {
-      throw createMissingDateImplError('DateAdapter');
-    }
-    if (!this._dateFormats) {
-      throw createMissingDateImplError('MAT_DATE_FORMATS');
-    }
-
-    // Update the displayed date when the locale changes.
-    this._localeSubscription = _dateAdapter.localeChanges.subscribe(() => {
-      this.value = this.value;
-    });
-  }
-
-  ngOnDestroy() {
-    this._valueChangesSubscription.unsubscribe();
-    this._localeSubscription.unsubscribe();
-    this._valueChange.complete();
-    this._disabledChange.complete();
-  }
-
-  /** @docs-private */
-  registerOnValidatorChange(fn: () => void): void {
-    this._validatorOnChange = fn;
-  }
-
-  /** @docs-private */
-  validate(c: AbstractControl): ValidationErrors | null {
-    return this._validator ? this._validator(c) : null;
-  }
-
-  /**
-   * @deprecated
-   * @breaking-change 8.0.0 Use `getConnectedOverlayOrigin` instead
-   */
-  getPopupConnectionElementRef(): ElementRef {
-    return this.getConnectedOverlayOrigin();
+    super(elementRef, dateAdapter, dateFormats);
+    this._validator = Validators.compose(
+      [this._parseValidator, this._minValidator, this._maxValidator, this._filterValidator]);
   }
 
   /**
@@ -306,93 +150,29 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
     return this._formField ? this._formField.getConnectedOverlayOrigin() : this._elementRef;
   }
 
-  // Implemented as part of ControlValueAccessor.
-  writeValue(value: D): void {
-    this.value = value;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  registerOnChange(fn: (value: any) => void): void {
-    this._cvaOnChange = fn;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  registerOnTouched(fn: () => void): void {
-    this._onTouched = fn;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  setDisabledState(isDisabled: boolean): void {
-    this.disabled = isDisabled;
-  }
-
-  _onKeydown(event: KeyboardEvent) {
-    const isAltDownArrow = event.altKey && event.keyCode === DOWN_ARROW;
-
-    if (this._datepicker && isAltDownArrow && !this._elementRef.nativeElement.readOnly) {
-      this._datepicker.open();
-      event.preventDefault();
-    }
-  }
-
-  _onInput(value: string) {
-    const lastValueWasValid = this._lastValueValid;
-    let date = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
-    this._lastValueValid = !date || this._dateAdapter.isValid(date);
-    date = this._getValidDateOrNull(date);
-
-    if (!this._dateAdapter.sameDate(date, this.value)) {
-      this._assignValue(date);
-      this._cvaOnChange(date);
-      this._valueChange.emit(date);
-      this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-    } else if (lastValueWasValid !== this._lastValueValid) {
-      this._validatorOnChange();
-    }
-  }
-
-  _onChange() {
-    this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-  }
-
   /** Returns the palette used by the input's form field, if any. */
   _getThemePalette(): ThemePalette {
     return this._formField ? this._formField.color : undefined;
   }
 
-  /** Handles blur events on the input. */
-  _onBlur() {
-    // Reformat the input only if we have a valid value.
-    if (this.value) {
-      this._formatValue(this.value);
-    }
-
-    this._onTouched();
-  }
-
-  /** Formats a value and sets it on the input element. */
-  private _formatValue(value: D | null) {
-    this._elementRef.nativeElement.value =
-        value ? this._dateAdapter.format(value, this._dateFormats.display.dateInput) : '';
-  }
-
   /**
-   * @param obj The object to check.
-   * @returns The given object if it is both a date instance and valid, otherwise null.
+   * @deprecated
+   * @breaking-change 8.0.0 Use `getConnectedOverlayOrigin` instead
    */
-  private _getValidDateOrNull(obj: any): D | null {
-    return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
+  getPopupConnectionElementRef(): ElementRef {
+    return this.getConnectedOverlayOrigin();
   }
 
-  /** Assigns a value to the model. */
-  private _assignValue(value: D | null) {
-    // We may get some incoming values before the datepicker was
-    // assigned. Save the value so that we can assign it later.
+  /** Opens the associated datepicker. */
+  protected _openPopup(): void {
+    if (this._datepicker) {
+      this._datepicker.open();
+    }
+  }
+
+  protected _assignModelValue(value: D | null): void {
     if (this._model) {
       this._model.updateSelection(value, this);
-      this._pendingValue = null;
-    } else {
-      this._pendingValue = value;
     }
   }
 

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -11,7 +11,12 @@ export * from './calendar';
 export * from './calendar-body';
 export * from './datepicker';
 export * from './datepicker-animations';
-export * from './datepicker-input';
+export {MatDatepickerInputEvent} from './datepicker-input-base';
+export {
+    MAT_DATEPICKER_VALUE_ACCESSOR,
+    MAT_DATEPICKER_VALIDATORS,
+    MatDatepickerInput,
+} from './datepicker-input';
 export * from './datepicker-intl';
 export * from './datepicker-toggle';
 export * from './month-view';

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -156,48 +156,32 @@ export declare class MatDatepickerContent<D> extends _MatDatepickerContentMixinB
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any>>;
 }
 
-export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {
-    _dateAdapter: DateAdapter<D>;
+export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
     _dateFilter: (date: D | null) => boolean;
     _datepicker: MatDatepicker<D>;
-    _disabledChange: EventEmitter<boolean>;
-    _onTouched: () => void;
-    _valueChange: EventEmitter<D | null>;
-    readonly dateChange: EventEmitter<MatDatepickerInputEvent<D>>;
-    readonly dateInput: EventEmitter<MatDatepickerInputEvent<D>>;
-    disabled: boolean;
+    protected _validator: ValidatorFn | null;
     matDatepicker: MatDatepicker<D>;
     matDatepickerFilter: (date: D | null) => boolean;
     max: D | null;
     min: D | null;
-    value: D | null;
-    constructor(_elementRef: ElementRef<HTMLInputElement>, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _formField: MatFormField);
+    constructor(elementRef: ElementRef<HTMLInputElement>, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats, _formField: MatFormField);
+    protected _assignModelValue(value: D | null): void;
     _getThemePalette(): ThemePalette;
-    _onBlur(): void;
-    _onChange(): void;
-    _onInput(value: string): void;
-    _onKeydown(event: KeyboardEvent): void;
+    protected _openPopup(): void;
     getConnectedOverlayOrigin(): ElementRef;
     getPopupConnectionElementRef(): ElementRef;
-    ngOnDestroy(): void;
-    registerOnChange(fn: (value: any) => void): void;
-    registerOnTouched(fn: () => void): void;
-    registerOnValidatorChange(fn: () => void): void;
-    setDisabledState(isDisabled: boolean): void;
-    validate(c: AbstractControl): ValidationErrors | null;
-    writeValue(value: D): void;
     static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_value: any;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerInput<any>, "input[matDatepicker]", ["matDatepickerInput"], { "matDatepicker": "matDatepicker"; "matDatepickerFilter": "matDatepickerFilter"; "value": "value"; "min": "min"; "max": "max"; "disabled": "disabled"; }, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerInput<any>, "input[matDatepicker]", ["matDatepickerInput"], { "matDatepicker": "matDatepicker"; "min": "min"; "max": "max"; "matDatepickerFilter": "matDatepickerFilter"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerInput<any>>;
 }
 
 export declare class MatDatepickerInputEvent<D> {
-    target: MatDatepickerInput<D>;
+    target: MatDatepickerInputBase<D>;
     targetElement: HTMLElement;
     value: D | null;
     constructor(
-    target: MatDatepickerInput<D>,
+    target: MatDatepickerInputBase<D>,
     targetElement: HTMLElement);
 }
 
@@ -269,6 +253,7 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     constructor(_changeDetectorRef: ChangeDetectorRef, control: ControlContainer, formField?: MatFormField);
     _getInputMirrorValue(): string;
     _handleChildValueChange(): void;
+    _openDatepicker(): void;
     _shouldHidePlaceholders(): boolean;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
@@ -279,9 +264,10 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     static ɵfac: i0.ɵɵFactoryDef<MatDateRangeInput<any>>;
 }
 
-export declare class MatEndDate<D> extends MatDateRangeInputPartBase<D> {
+export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+    protected _validator: ValidatorFn | null;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, { "disabled": "disabled"; }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>>;
 }
 
@@ -343,10 +329,11 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
     static ɵfac: i0.ɵɵFactoryDef<MatMultiYearView<any>>;
 }
 
-export declare class MatStartDate<D> extends MatDateRangeInputPartBase<D> {
+export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+    protected _validator: ValidatorFn | null;
     getMirrorValue(): string;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, { "disabled": "disabled"; }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatStartDate<any>>;
 }
 


### PR DESCRIPTION
Moves the common logic for a date input into a base class and implements it for the range inputs.