### PR TITLE
fix(youtube-player): not picking up static startSeconds and endSeconds

### DIFF
--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -22,7 +22,7 @@ describe('YoutubePlayer', () => {
 
     TestBed.configureTestingModule({
       imports: [YouTubePlayerModule],
-      declarations: [TestApp],
+      declarations: [TestApp, StaticStartEndSecondsApp],
     });
 
     TestBed.compileComponents();
@@ -326,6 +326,17 @@ describe('YoutubePlayer', () => {
     });
   });
 
+  it('should pick up static startSeconds and endSeconds values', () => {
+    const staticSecondsApp = TestBed.createComponent(StaticStartEndSecondsApp);
+    staticSecondsApp.detectChanges();
+
+    playerSpy.getPlayerState.and.returnValue(window.YT!.PlayerState.CUED);
+    events.onReady({target: playerSpy});
+
+    expect(playerSpy.cueVideoById).toHaveBeenCalledWith(
+      jasmine.objectContaining({startSeconds: 42, endSeconds: 1337}));
+  });
+
 });
 
 /** Test component that contains a YouTubePlayer. */
@@ -358,4 +369,14 @@ class TestApp {
   onError = jasmine.createSpy('onError');
   onApiChange = jasmine.createSpy('onApiChange');
   @ViewChild('player') youtubePlayer: YouTubePlayer;
+}
+
+
+@Component({
+  template: `
+    <youtube-player [videoId]="videoId" [startSeconds]="42"[endSeconds]="1337"></youtube-player>
+  `
+})
+class StaticStartEndSecondsApp {
+  videoId = VIDEO_ID;
 }


### PR DESCRIPTION
The way the `youtube-player` is set up is that the start and end seconds are observables which means that the consumer will miss out on any values that were emitted before they subscribed. These changes switch them to a `BehaviorSubject` which emits its last value upon subscription.

Also does some internal cleanup in the component.

Fixes #18212.