### PR TITLE
fix(tree): not allowing horizontal overflow

### DIFF
--- a/src/material/tree/tree.scss
+++ b/src/material/tree/tree.scss
@@ -9,7 +9,6 @@ $mat-node-height: 48px;
   align-items: center;
   min-height: $mat-node-height;
   flex: 1;
-  overflow: hidden;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
The way the tree styles were set up initially means that the tree element can't cause its parent to overflow. Given that the tree can have a lot of nesting, this is bound to happen with deeper trees. These changes remove the default `overflow: hidden` since it doesn't seem to be doing much.

Fixes #18182.