### PR TITLE
docs(material/select): new examples - basic reactive form and initial value w/o form

### DIFF
--- a/src/components-examples/material/select/index.ts
+++ b/src/components-examples/material/select/index.ts
@@ -18,6 +18,8 @@ import {SelectOverviewExample} from './select-overview/select-overview-example';
 import {SelectPanelClassExample} from './select-panel-class/select-panel-class-example';
 import {SelectResetExample} from './select-reset/select-reset-example';
 import {SelectValueBindingExample} from './select-value-binding/select-value-binding-example';
+import {SelectReactiveFormExample} from './select-reactive-form/select-reactive-form-example';
+import {SelectInitialValueExample} from './select-initial-value/select-initial-value-example';
 
 export {
   SelectCustomTriggerExample,
@@ -25,11 +27,13 @@ export {
   SelectErrorStateMatcherExample,
   SelectFormExample,
   SelectHintErrorExample,
+  SelectInitialValueExample,
   SelectMultipleExample,
   SelectNoRippleExample,
   SelectOptgroupExample,
   SelectOverviewExample,
   SelectPanelClassExample,
+  SelectReactiveFormExample,
   SelectResetExample,
   SelectValueBindingExample,
 };
@@ -40,11 +44,13 @@ const EXAMPLES = [
   SelectErrorStateMatcherExample,
   SelectFormExample,
   SelectHintErrorExample,
+  SelectInitialValueExample,
   SelectMultipleExample,
   SelectNoRippleExample,
   SelectOptgroupExample,
   SelectOverviewExample,
   SelectPanelClassExample,
+  SelectReactiveFormExample,
   SelectResetExample,
   SelectValueBindingExample,
 ];

--- a/src/components-examples/material/select/select-form/select-form-example.ts
+++ b/src/components-examples/material/select/select-form/select-form-example.ts
@@ -1,11 +1,11 @@
 import {Component} from '@angular/core';
 
-export interface Food {
+interface Food {
   value: string;
   viewValue: string;
 }
 
-export interface Car {
+interface Car {
   value: string;
   viewValue: string;
 }

--- a/src/components-examples/material/select/select-hint-error/select-hint-error-example.ts
+++ b/src/components-examples/material/select/select-hint-error/select-hint-error-example.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
 
-export interface Animal {
+interface Animal {
   name: string;
   sound: string;
 }
@@ -13,7 +13,7 @@ export interface Animal {
   styleUrls: ['select-hint-error-example.css'],
 })
 export class SelectHintErrorExample {
-  animalControl = new FormControl('', [Validators.required]);
+  animalControl = new FormControl('', Validators.required);
   selectFormControl = new FormControl('', Validators.required);
   animals: Animal[] = [
     {name: 'Dog', sound: 'Woof!'},

--- a/src/components-examples/material/select/select-initial-value/select-initial-value-example.css
+++ b/src/components-examples/material/select/select-initial-value/select-initial-value-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/src/components-examples/material/select/select-initial-value/select-initial-value-example.html
+++ b/src/components-examples/material/select/select-initial-value/select-initial-value-example.html
@@ -1,0 +1,20 @@
+<h4>Basic mat-select with initial value</h4>
+<mat-form-field>
+  <mat-label>Favorite Food</mat-label>
+  <mat-select [(value)]="selectedFood">
+    <mat-option></mat-option>
+    <mat-option [value]="option.value" *ngFor="let option of foods">{{ option.viewValue }}</mat-option>
+  </mat-select>
+</mat-form-field>
+<p>You selected: {{selectedFood}}</p>
+
+<h4>Basic native select with initial value</h4>
+<mat-form-field>
+  <mat-label>Favorite Car</mat-label>
+  <select matNativeControl (change)="selectedCar = $event.target.value">
+    <option value=""></option>
+    <option *ngFor="let option of cars" [value]="option.value"
+            [selected]="selectedCar === option.value">{{ option.viewValue }}</option>
+  </select>
+</mat-form-field>
+<p>You selected: {{selectedCar}}</p>

--- a/src/components-examples/material/select/select-initial-value/select-initial-value-example.ts
+++ b/src/components-examples/material/select/select-initial-value/select-initial-value-example.ts
@@ -1,0 +1,34 @@
+import {Component} from '@angular/core';
+
+interface Food {
+  value: string;
+  viewValue: string;
+}
+
+interface Car {
+  value: string;
+  viewValue: string;
+}
+
+/**
+ * @title Basic select with initial value and no form
+ */
+@Component({
+  selector: 'select-initial-value-example',
+  templateUrl: 'select-initial-value-example.html',
+  styleUrls: ['select-initial-value-example.css'],
+})
+export class SelectInitialValueExample {
+  foods: Food[] = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+    {value: 'tacos-2', viewValue: 'Tacos'}
+  ];
+  cars: Car[] = [
+    {value: 'ford', viewValue: 'Ford'},
+    {value: 'chevrolet', viewValue: 'Chevrolet'},
+    {value: 'dodge', viewValue: 'Dodge'}
+  ];
+  selectedFood = this.foods[2].value;
+  selectedCar = this.cars[0].value;
+}

--- a/src/components-examples/material/select/select-optgroup/select-optgroup-example.ts
+++ b/src/components-examples/material/select/select-optgroup/select-optgroup-example.ts
@@ -1,12 +1,12 @@
 import {Component} from '@angular/core';
 import {FormControl} from '@angular/forms';
 
-export interface Pokemon {
+interface Pokemon {
   value: string;
   viewValue: string;
 }
 
-export interface PokemonGroup {
+interface PokemonGroup {
   disabled?: boolean;
   name: string;
   pokemon: Pokemon[];

--- a/src/components-examples/material/select/select-overview/select-overview-example.ts
+++ b/src/components-examples/material/select/select-overview/select-overview-example.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 
-export interface Food {
+interface Food {
   value: string;
   viewValue: string;
 }

--- a/src/components-examples/material/select/select-reactive-form/select-reactive-form-example.css
+++ b/src/components-examples/material/select/select-reactive-form/select-reactive-form-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/src/components-examples/material/select/select-reactive-form/select-reactive-form-example.html
+++ b/src/components-examples/material/select/select-reactive-form/select-reactive-form-example.html
@@ -1,0 +1,24 @@
+<form [formGroup]="form">
+  <h4>mat-select</h4>
+  <mat-form-field>
+    <mat-label>Favorite Food</mat-label>
+    <mat-select [formControl]="foodControl" name="food">
+      <mat-option>None</mat-option>
+      <mat-option *ngFor="let food of foods" [value]="food.value">
+        {{food.viewValue}}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+  <p>Selected: {{foodControl.value}}</p>
+  <h4>Native select</h4>
+  <mat-form-field>
+    <mat-label>Favorite Car</mat-label>
+    <select matNativeControl [formControl]="carControl" name="car">
+      <option value="">None</option>
+      <option *ngFor="let car of cars" [value]="car.value">
+        {{car.viewValue}}
+      </option>
+    </select>
+  </mat-form-field>
+  <p>Selected: {{carControl.value}}</p>
+</form>

--- a/src/components-examples/material/select/select-reactive-form/select-reactive-form-example.ts
+++ b/src/components-examples/material/select/select-reactive-form/select-reactive-form-example.ts
@@ -1,0 +1,43 @@
+import {Component} from '@angular/core';
+import {FormControl, FormGroup} from '@angular/forms';
+
+interface Food {
+  value: string;
+  viewValue: string;
+}
+
+interface Car {
+  value: string;
+  viewValue: string;
+}
+
+/**
+ * @title Select in a reactive form
+ */
+@Component({
+  selector: 'select-reactive-form-example',
+  templateUrl: 'select-reactive-form-example.html',
+  styleUrls: ['select-reactive-form-example.css'],
+})
+export class SelectReactiveFormExample {
+  form: FormGroup;
+  foods: Food[] = [
+    {value: 'steak-0', viewValue: 'Steak'},
+    {value: 'pizza-1', viewValue: 'Pizza'},
+    {value: 'tacos-2', viewValue: 'Tacos'}
+  ];
+  cars: Car[] = [
+    {value: 'volvo', viewValue: 'Volvo'},
+    {value: 'saab', viewValue: 'Saab'},
+    {value: 'mercedes', viewValue: 'Mercedes'}
+  ];
+  foodControl = new FormControl(this.foods[2].value);
+  carControl = new FormControl(this.cars[1].value);
+
+  constructor() {
+    this.form = new FormGroup({
+      food: this.foodControl,
+      car: this.carControl
+    });
+  }
+}


### PR DESCRIPTION
- demonstrates the new style of assigning initial values to native select
  - that is required by Ivy in version 9
- Related breaking change docs:
  - https://next.angular.io/guide/ivy-compatibility-examples#cannot-bind-to-value-property-of-select-with-ngfor

Fixes #18167