### PR TITLE
build: render safari detection in platform demo and example

### DIFF
--- a/src/components-examples/cdk/platform/cdk-platform-overview/cdk-platform-overview-example.html
+++ b/src/components-examples/cdk/platform/cdk-platform-overview/cdk-platform-overview-example.html
@@ -6,6 +6,7 @@
 <p>Is Webkit: {{platform.WEBKIT}}</p>
 <p>Is Trident: {{platform.TRIDENT}}</p>
 <p>Is Edge: {{platform.EDGE}}</p>
+<p>Is Safari: {{platform.SAFARI}}</p>
 <p>Supported input types: {{supportedInputTypes}}</p>
 <p>Supports passive event listeners: {{supportsPassiveEventListeners}}</p>
 <p>Supports scroll behavior: {{supportsScrollBehavior}}</p>

--- a/src/dev-app/platform/platform-demo.html
+++ b/src/dev-app/platform/platform-demo.html
@@ -1,12 +1,13 @@
-<p>Is Android: {{ platform.ANDROID }}</p>
-<p>Is iOS: {{ platform.IOS }}</p>
-<p>Is Firefox: {{ platform.FIREFOX }}</p>
-<p>Is Blink: {{ platform.BLINK }}</p>
-<p>Is Webkit: {{ platform.WEBKIT }}</p>
-<p>Is Trident: {{ platform.TRIDENT }}</p>
-<p>Is Edge: {{ platform.EDGE }}</p>
+<p>Is Android: {{platform.ANDROID}}</p>
+<p>Is iOS: {{platform.IOS}}</p>
+<p>Is Firefox: {{platform.FIREFOX}}</p>
+<p>Is Blink: {{platform.BLINK}}</p>
+<p>Is Webkit: {{platform.WEBKIT}}</p>
+<p>Is Trident: {{platform.TRIDENT}}</p>
+<p>Is Edge: {{platform.EDGE}}</p>
+<p>Is Safari: {{platform.SAFARI}}</p>
 
 <p>
   Supported input types:
-  <span *ngFor="let type of supportedInputTypes">{{ type }}, </span>
+  <span *ngFor="let type of supportedInputTypes">{{type}}, </span>
 </p>


### PR DESCRIPTION
Currently we render all possible detection states of the `Platform`
service in the demo and example, except for `Safari`.

Related to #18198