### PR TITLE
fix(drag-drop): error if next sibling is removed after drag sequence has started

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1913,7 +1913,8 @@ describe('CdkDrag', () => {
             (boolean | AddEventListenerOptions | undefined)?
           ]) {
             document.addEventListener(...args);
-          }
+          },
+          createComment: (text: string) => document.createComment(text)
         };
         const fixture = createComponent(DraggableInDropZone, [{
           provide: DOCUMENT,
@@ -4505,6 +4506,31 @@ describe('CdkDrag', () => {
           isPointerOverContainer: true,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
+      }));
+
+      it('should not throw if its next sibling is removed while dragging', fakeAsync(() => {
+        const fixture = createComponent(ConnectedDropZonesWithSingleItems);
+        fixture.detectChanges();
+
+        const items = fixture.componentInstance.dragItems.toArray();
+        const item = items[0];
+        const nextSibling = items[1].element.nativeElement;
+        const extraSibling = document.createElement('div');
+        const targetRect = nextSibling.getBoundingClientRect();
+
+        // Manually insert an element after the node to simulate an external package.
+        nextSibling.parentNode!.insertBefore(extraSibling, nextSibling);
+
+        dragElementViaMouse(fixture, item.element.nativeElement,
+          targetRect.left + 1, targetRect.top + 1);
+
+        // Remove the extra node after the element was dropped, but before the animation is over.
+        extraSibling.parentNode!.removeChild(extraSibling);
+
+        expect(() => {
+          flush();
+          fixture.detectChanges();
+        }).not.toThrow();
       }));
 
   });


### PR DESCRIPTION
When a drag sequence is started, we save a reference to the next sibling of the drag element so that we can use it at the end of the sequence to restore the element's original DOM position. This breaks down and throws an error if the next sibling gets removed while the user is dragging. These changes make the approach a bit more robust by inserting a comment node instead.

Fixes #18205.