### PR TITLE
build: fix local browser testing target for macOS and linux

### DIFF
--- a/test/bazel-karma-local-config.js
+++ b/test/bazel-karma-local-config.js
@@ -3,6 +3,8 @@
  * want to launch any browser and just enable manual browser debugging.
  */
 
+const bazelKarma = require('@bazel/karma');
+
 module.exports = config => {
   const overwrites = {};
 
@@ -19,9 +21,17 @@ module.exports = config => {
   // Ensures that tests start executing once browsers have been manually connected. We need
   // to use "defineProperty" because the default "@bazel/karma" config overwrites the option.
   Object.defineProperty(overwrites, 'autoWatch', {
-    value: true,
-    writable: false,
+    get: () => true,
+    set: () => {},
+    enumerable: true,
   });
+
+  // When not running with ibazel, do not set up the `@bazel/karma` watcher. This one
+  // relies on ibazel to write to the `stdin` interface. When running without ibazel, the
+  // watcher will kill Karma since there is no data written to the `stdin` interface.
+  if (process.env['IBAZEL_NOTIFY_CHANGES'] !== 'y') {
+    delete bazelKarma['watcher'];
+  }
 
   config.set(overwrites);
 };

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -175,10 +175,9 @@ def karma_web_test_suite(name, **kwargs):
     )
 
     # Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1429
-    native.sh_binary(
+    native.sh_test(
         name = "%s_local" % name,
         srcs = ["%s_local_bin" % name],
-        data = [":%s_local_bin" % name],
         tags = ["manual", "local", "ibazel_notify_changes"],
         testonly = True,
     )


### PR DESCRIPTION
Fixes the local browser testing target for macOS and Linux. The target is still somewhat broken on Windows due to a Bazel change in behavior: https://github.com/bazelbuild/bazel/issues/10621.

There is a valid workaround for windows though, so it's should be good to move forward with this. It's still the recommended approach by `rules_nodejs` that web test target's can be run with `bazel run`.