### PR TITLE
build: update rules_sass version to latest

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,11 +15,10 @@ http_archive(
 # Add sass rules
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "77e241148f26d5dbb98f96fe0029d8f221c6cb75edbb83e781e08ac7f5322c5f",
-    strip_prefix = "rules_sass-1.24.0",
+    sha256 = "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
+    strip_prefix = "rules_sass-1.25.0",
     urls = [
-        "https://github.com/bazelbuild/rules_sass/archive/1.24.0.zip",
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.24.0.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
     ],
 )
 


### PR DESCRIPTION
Updates `rules_sass` to the latest version that contains: https://github.com/bazelbuild/rules_sass/commit/dd0079be310f918d50fe6a196ff82e5872433eb4.

This fixes that errors are reported silently and only shown once the CSS file is
served in the browser. It still means that the message is not printed in the terminal
because https://github.com/bazelbuild/rules_sass/issues/96 is not fixed yet.