### PR TITLE
build: disallow nested ternary expressions

### DIFF
--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -90,8 +90,13 @@ export class CdkScrollable implements OnInit, OnDestroy {
     const isRtl = this.dir && this.dir.value == 'rtl';
 
     // Rewrite start & end offsets as right or left offsets.
-    options.left = options.left == null ? (isRtl ? options.end : options.start) : options.left;
-    options.right = options.right == null ? (isRtl ? options.start : options.end) : options.right;
+    if (options.left == null) {
+      options.left = isRtl ? options.end : options.start;
+    }
+
+    if (options.right == null) {
+      options.right = isRtl ? options.start : options.end;
+    }
 
     // Rewrite the bottom offset as a top offset.
     if (options.bottom != null) {

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -88,11 +88,13 @@ export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy 
   }
   set cdkVirtualForOf(value: DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined) {
     this._cdkVirtualForOf = value;
-    const ds = isDataSource(value) ? value :
-        // Slice the value if its an NgIterable to ensure we're working with an array.
-        new ArrayDataSource<T>(
-            value instanceof Observable ? value : Array.prototype.slice.call(value || []));
-    this._dataSourceChanges.next(ds);
+    if (isDataSource(value)) {
+      this._dataSourceChanges.next(value);
+    } else {
+      // Slice the value if its an NgIterable to ensure we're working with an array.
+      this._dataSourceChanges.next(new ArrayDataSource<T>(
+          value instanceof Observable ? value : Array.prototype.slice.call(value || [])));
+    }
   }
   _cdkVirtualForOf: DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined;
 

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -358,8 +358,9 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
    *     in horizontal mode.
    */
   measureScrollOffset(from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number {
-    return super.measureScrollOffset(
-        from ? from : this.orientation === 'horizontal' ? 'start' : 'top');
+    return from ?
+      super.measureScrollOffset(from) :
+      super.measureScrollOffset(this.orientation === 'horizontal' ? 'start' : 'top');
   }
 
   /** Measure the combined size of all of the rendered items. */

--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -507,10 +507,13 @@ function _valueAsString(value: unknown) {
   }
   // `JSON.stringify` doesn't handle RegExp properly, so we need a custom replacer.
   try {
-    return JSON.stringify(value, (_, v) =>
-        v instanceof RegExp ? `/${v.toString()}/` :
-            typeof v === 'string' ? v.replace('/\//g', '\\/') : v
-    ).replace(/"\/\//g, '\\/').replace(/\/\/"/g, '\\/').replace(/\\\//g, '/');
+    return JSON.stringify(value, (_, v) => {
+      if (v instanceof RegExp) {
+        return `/${v.toString()}/`;
+      }
+
+      return typeof v === 'string' ? v.replace('/\//g', '\\/') : v;
+    }).replace(/"\/\//g, '\\/').replace(/\/\/"/g, '\\/').replace(/\\\//g, '/');
   } catch {
     // `JSON.stringify` will throw if the object is cyclical,
     // in this case the best we can do is report the value as `{...}`.

--- a/src/cdk/testing/testbed/fake-events/event-objects.ts
+++ b/src/cdk/testing/testbed/fake-events/event-objects.ts
@@ -85,8 +85,24 @@ export function createKeyboardEvent(type: string, keyCode: number = 0, key: stri
   } else {
     // `initKeyboardEvent` expects to receive modifiers as a whitespace-delimited string
     // See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyboardEvent
-    const modifiersStr = (modifiers.control ? 'Control ' : '' + modifiers.alt ? 'Alt ' : '' +
-        modifiers.shift ? 'Shift ' : '' + modifiers.meta ? 'Meta' : '').trim();
+    let modifiersList = '';
+
+    if (modifiers.control) {
+      modifiersList += 'Control ';
+    }
+
+    if (modifiers.alt) {
+      modifiersList += 'Alt ';
+    }
+
+    if (modifiers.shift) {
+      modifiersList += 'Shift ';
+    }
+
+    if (modifiers.meta) {
+      modifiersList += 'Meta ';
+    }
+
     event.initKeyboardEvent(type,
         true, /* canBubble */
         true, /* cancelable */
@@ -94,7 +110,7 @@ export function createKeyboardEvent(type: string, keyCode: number = 0, key: stri
         0, /* char */
         key, /* key */
         0, /* location */
-        modifiersStr, /* modifiersList */
+        modifiersList.trim(), /* modifiersList */
         false /* repeat */);
   }
 

--- a/src/components-examples/material/form-field/form-field-error/form-field-error-example.ts
+++ b/src/components-examples/material/form-field/form-field-error/form-field-error-example.ts
@@ -11,8 +11,10 @@ export class FormFieldErrorExample {
   email = new FormControl('', [Validators.required, Validators.email]);
 
   getErrorMessage() {
-    return this.email.hasError('required') ? 'You must enter a value' :
-        this.email.hasError('email') ? 'Not a valid email' :
-            '';
+    if (this.email.hasError('required')) {
+      return 'You must enter a value';
+    }
+
+    return this.email.hasError('email') ? 'Not a valid email' : '';
   }
 }

--- a/src/components-examples/material/slider/slider-configurable/slider-configurable-example.ts
+++ b/src/components-examples/material/slider/slider-configurable/slider-configurable-example.ts
@@ -22,6 +22,10 @@ export class SliderConfigurableExample {
   tickInterval = 1;
 
   getSliderTickInterval(): number | 'auto' {
-    return this.showTicks ? (this.autoTicks ? 'auto' : this.tickInterval) : 0;
+    if (this.showTicks) {
+      return this.autoTicks ? 'auto' : this.tickInterval;
+    }
+
+    return 0;
   }
 }

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -363,7 +363,11 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
 
   /** Gets the value for the `aria-checked` attribute of the native input. */
   _getAriaChecked(): 'true'|'false'|'mixed' {
-    return this.checked ? 'true' : (this.indeterminate ? 'mixed' : 'false');
+    if (this.checked) {
+      return 'true';
+    }
+
+    return this.indeterminate ? 'mixed' : 'false';
   }
 
   /** Sets whether the given CSS class should be applied to the native input. */

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -337,7 +337,11 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   }
 
   _getAriaChecked(): 'true' | 'false' | 'mixed' {
-    return this.checked ? 'true' : (this.indeterminate ? 'mixed' : 'false');
+    if (this.checked) {
+      return 'true';
+    }
+
+    return this.indeterminate ? 'mixed' : 'false';
   }
 
   private _transitionCheckState(newState: TransitionCheckState) {

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -353,8 +353,16 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
 
   /** Updates today's date after an update of the active date */
   updateTodaysDate() {
-    let view = this.currentView == 'month' ? this.monthView :
-            (this.currentView == 'year' ? this.yearView : this.multiYearView);
+    const currentView = this.currentView;
+    let view: MatMonthView<D> | MatYearView<D> | MatMultiYearView<D>;
+
+    if (currentView === 'month') {
+      view = this.monthView;
+    } else if (currentView === 'year') {
+      view = this.yearView;
+    } else {
+      view = this.multiYearView;
+    }
 
     view.ngAfterContentInit();
   }

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -1091,7 +1091,11 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** Gets the index of the provided option in the option list. */
   private _getOptionIndex(option: MatOption): number | undefined {
     return this.options.reduce((result: number | undefined, current: MatOption, index: number) => {
-      return result === undefined ? (option === current ? index : undefined) : result;
+      if (result !== undefined) {
+        return result;
+      }
+
+      return option === current ? index : undefined;
     }, undefined);
   }
 

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -423,9 +423,14 @@ export class MatSlider extends _MatSliderMixinBase
     };
 
     if (this._isMinValue && this._thumbGap) {
-      let side = this.vertical ?
-          (this._invertAxis ? 'Bottom' : 'Top') :
-          (this._invertAxis ? 'Right' : 'Left');
+      let side: string;
+
+      if (this.vertical) {
+        side = this._invertAxis ? 'Bottom' : 'Top';
+      } else {
+        side = this._invertAxis ? 'Right' : 'Left';
+      }
+
       styles[`padding${side}`] = `${this._thumbGap}px`;
     }
 

--- a/tools/tslint-rules/noNestedTernaryRule.ts
+++ b/tools/tslint-rules/noNestedTernaryRule.ts
@@ -1,0 +1,37 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+
+/** Rule that enforces that ternary expressions aren't being nested. */
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithFunction(sourceFile, context => {
+      (function walk(node: ts.Node) {
+        if (!ts.isConditionalExpression(node)) {
+          ts.forEachChild(node, walk);
+        } else if (hasNestedTernary(node)) {
+          context.addFailureAtNode(node, 'Nested ternary expression are not allowed.');
+        }
+      })(context.sourceFile);
+    }, this.getOptions().ruleArguments);
+  }
+}
+
+/** Checks whether a ternary expression has another ternary inside of it. */
+function hasNestedTernary(rootNode: ts.ConditionalExpression): boolean {
+  let hasNestedTernaryDescendant = false;
+
+  // Start from the immediate children of the root node.
+  rootNode.forEachChild(function walk(node: ts.Node) {
+    // Stop checking if we've hit a ternary. Also note that we don't descend
+    // into call expressions, because it's valid to have a ternary expression
+    // inside of a callback which is one of the arguments of a ternary.
+    if (ts.isConditionalExpression(node)) {
+      hasNestedTernaryDescendant = true;
+    } else if (!ts.isCallExpression(node)) {
+      node.forEachChild(walk);
+    }
+  });
+
+  return hasNestedTernaryDescendant;
+}

--- a/tslint.json
+++ b/tslint.json
@@ -116,6 +116,7 @@
     "ng-on-changes-property-access": true,
     "require-breaking-change-version": true,
     "class-list-signatures": true,
+    "no-nested-ternary": true,
     "coercion-types": [true,
       ["coerceBooleanProperty", "coerceCssPixelValue", "coerceNumberProperty"],
       {


### PR DESCRIPTION
Sets up a lint rule that doesn't allow nested ternary expressions. Also cleans up all of the failures.