### PR TITLE
fix(material/checkbox): unable to focus checkbox with tooltip

### DIFF
--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -9,7 +9,7 @@
            [attr.value]="value"
            [disabled]="disabled"
            [attr.name]="name"
-           [tabIndex]="tabIndex"
+           [tabIndex]="-1"
            [attr.aria-label]="ariaLabel || null"
            [attr.aria-labelledby]="ariaLabelledby"
            [attr.aria-checked]="_getAriaChecked()"

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -187,6 +187,10 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
   .mat-ripple-element:not(.mat-checkbox-persistent-ripple) {
     opacity: 0.16;
   }
+
+  &:focus {
+    outline: none;
+  }
 }
 
 .mat-checkbox-layout {

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -50,6 +50,7 @@ import {
   MatCheckboxClickAction,
   MatCheckboxDefaultOptions
 } from './checkbox-config';
+import {hasModifierKey, SPACE} from '@angular/cdk/keycodes';
 
 
 // Increasing integer for generating unique ids for checkbox components.
@@ -119,7 +120,7 @@ const _MatCheckboxMixinBase:
   host: {
     'class': 'mat-checkbox',
     '[id]': 'id',
-    '[attr.tabindex]': 'null',
+    '[attr.tabindex]': 'disabled ? -1 : (tabIndex || 0)',
     '[class.mat-checkbox-indeterminate]': 'indeterminate',
     '[class.mat-checkbox-checked]': 'checked',
     '[class.mat-checkbox-disabled]': 'disabled',
@@ -234,6 +235,9 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
 
     // TODO: Remove this after the `_clickAction` parameter is removed as an injection parameter.
     this._clickAction = this._clickAction || this._options.clickAction;
+    _ngZone.runOutsideAngular(() => {
+        elementRef.nativeElement.addEventListener('keydown', this._handleKeydown);
+    });
   }
 
   ngAfterViewInit() {
@@ -497,4 +501,12 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   static ngAcceptInputType_required: BooleanInput;
   static ngAcceptInputType_disableRipple: BooleanInput;
   static ngAcceptInputType_indeterminate: BooleanInput;
+
+   _handleKeydown = (event: KeyboardEvent) => {
+       if (event.keyCode === SPACE && !hasModifierKey(event)) {
+           event.preventDefault();
+           event.stopPropagation();
+           this._ngZone.run(() => this.toggle());
+       }
+   }
 }


### PR DESCRIPTION
Fix bug in Angular Material 'checkbox' with tooltip. Checkbox with tooltip cannot be focused by tab key.
related to: https://github.com/angular/components/issues/15294