### PR TITLE
docs(examples): all examples should use mat-form-field's fill appearance by default

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-custom-icon/datepicker-custom-icon-example.html
+++ b/src/components-examples/material/datepicker/datepicker-custom-icon/datepicker-custom-icon-example.html
@@ -1,5 +1,6 @@
 <mat-form-field class="example-full-width">
-  <input matInput [matDatepicker]="picker" placeholder="Choose a date">
+  <mat-label>Choose a date</mat-label>
+  <input matInput [matDatepicker]="picker">
   <mat-datepicker-toggle matSuffix [for]="picker">
     <mat-icon matDatepickerToggleIcon>keyboard_arrow_down</mat-icon>
   </mat-datepicker-toggle>

--- a/src/components-examples/material/datepicker/datepicker-date-class/datepicker-date-class-example.html
+++ b/src/components-examples/material/datepicker/datepicker-date-class/datepicker-date-class-example.html
@@ -1,5 +1,6 @@
 <mat-form-field class="example-full-width">
-  <input matInput [matDatepicker]="picker" placeholder="Choose a date">
+  <mat-label>Choose a date</mat-label>
+  <input matInput [matDatepicker]="picker">
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
   <mat-datepicker [dateClass]="dateClass" #picker></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-disabled/datepicker-disabled-example.html
+++ b/src/components-examples/material/datepicker/datepicker-disabled/datepicker-disabled-example.html
@@ -1,6 +1,7 @@
 <p>
   <mat-form-field>
-    <input matInput [matDatepicker]="dp1" placeholder="Completely disabled" disabled>
+    <mat-label>Completely disabled</mat-label>
+    <input matInput [matDatepicker]="dp1" disabled>
     <mat-datepicker-toggle matSuffix [for]="dp1"></mat-datepicker-toggle>
     <mat-datepicker #dp1></mat-datepicker>
   </mat-form-field>
@@ -8,7 +9,8 @@
 
 <p>
   <mat-form-field>
-    <input matInput [matDatepicker]="dp2" placeholder="Popup disabled">
+    <mat-label>Popup disabled</mat-label>
+    <input matInput [matDatepicker]="dp2">
     <mat-datepicker-toggle matSuffix [for]="dp2" disabled></mat-datepicker-toggle>
     <mat-datepicker #dp2></mat-datepicker>
   </mat-form-field>
@@ -16,7 +18,8 @@
 
 <p>
   <mat-form-field>
-    <input matInput [matDatepicker]="dp3" placeholder="Input disabled" disabled>
+    <mat-label>Input disabled</mat-label>
+    <input matInput [matDatepicker]="dp3" disabled>
     <mat-datepicker-toggle matSuffix [for]="dp3"></mat-datepicker-toggle>
     <mat-datepicker #dp3 disabled="false"></mat-datepicker>
   </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-events/datepicker-events-example.html
+++ b/src/components-examples/material/datepicker/datepicker-events/datepicker-events-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput [matDatepicker]="picker" placeholder="Input & change events"
+  <mat-label>Input & change events</mat-label>
+  <input matInput [matDatepicker]="picker"
          (dateInput)="addEvent('input', $event)" (dateChange)="addEvent('change', $event)">
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
   <mat-datepicker #picker></mat-datepicker>

--- a/src/components-examples/material/datepicker/datepicker-filter/datepicker-filter-example.html
+++ b/src/components-examples/material/datepicker/datepicker-filter/datepicker-filter-example.html
@@ -1,5 +1,6 @@
 <mat-form-field class="example-full-width">
-  <input matInput [matDatepickerFilter]="myFilter" [matDatepicker]="picker" placeholder="Choose a date">
+  <mat-label>Choose a date</mat-label>
+  <input matInput [matDatepickerFilter]="myFilter" [matDatepicker]="picker">
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
   <mat-datepicker #picker></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-formats/datepicker-formats-example.html
+++ b/src/components-examples/material/datepicker/datepicker-formats/datepicker-formats-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput [matDatepicker]="dp" placeholder="Verbose datepicker" [formControl]="date">
+  <mat-label>Verbose datepicker</mat-label>
+  <input matInput [matDatepicker]="dp" [formControl]="date">
   <mat-datepicker-toggle matSuffix [for]="dp"></mat-datepicker-toggle>
   <mat-datepicker #dp></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.html
+++ b/src/components-examples/material/datepicker/datepicker-locale/datepicker-locale-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput [matDatepicker]="dp" placeholder="Different locale">
+  <mat-label>Different locale</mat-label>
+  <input matInput [matDatepicker]="dp">
   <mat-datepicker-toggle matSuffix [for]="dp"></mat-datepicker-toggle>
   <mat-datepicker #dp></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-min-max/datepicker-min-max-example.html
+++ b/src/components-examples/material/datepicker/datepicker-min-max/datepicker-min-max-example.html
@@ -1,5 +1,6 @@
 <mat-form-field class="example-full-width">
-  <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="picker" placeholder="Choose a date">
+  <mat-label>Choose a date</mat-label>
+  <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="picker">
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
   <mat-datepicker #picker></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-moment/datepicker-moment-example.html
+++ b/src/components-examples/material/datepicker/datepicker-moment/datepicker-moment-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput [matDatepicker]="dp" placeholder="Moment.js datepicker" [formControl]="date">
+  <mat-label>Moment.js datepicker</mat-label>
+  <input matInput [matDatepicker]="dp" [formControl]="date">
   <mat-datepicker-toggle matSuffix [for]="dp"></mat-datepicker-toggle>
   <mat-datepicker #dp></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-overview/datepicker-overview-example.html
+++ b/src/components-examples/material/datepicker/datepicker-overview/datepicker-overview-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput [matDatepicker]="picker" placeholder="Choose a date">
+  <mat-label>Choose a date</mat-label>
+  <input matInput [matDatepicker]="picker">
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
   <mat-datepicker #picker></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-start-view/datepicker-start-view-example.html
+++ b/src/components-examples/material/datepicker/datepicker-start-view/datepicker-start-view-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput [matDatepicker]="picker" placeholder="Choose a date">
+  <mat-label>Choose a date</mat-label>
+  <input matInput [matDatepicker]="picker">
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
   <mat-datepicker #picker startView="year" [startAt]="startDate"></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-touch/datepicker-touch-example.html
+++ b/src/components-examples/material/datepicker/datepicker-touch/datepicker-touch-example.html
@@ -1,5 +1,6 @@
 <mat-form-field class="example-full-width">
-  <input matInput [matDatepicker]="picker" placeholder="Choose a date">
+  <mat-label>Choose a date</mat-label>
+  <input matInput [matDatepicker]="picker">
   <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
   <mat-datepicker touchUi #picker></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-value/datepicker-value-example.html
+++ b/src/components-examples/material/datepicker/datepicker-value/datepicker-value-example.html
@@ -1,18 +1,21 @@
 <mat-form-field>
-  <input matInput [matDatepicker]="picker1" placeholder="Angular forms" [formControl]="date">
+  <mat-label>Angular forms</mat-label>
+  <input matInput [matDatepicker]="picker1" [formControl]="date">
   <mat-datepicker-toggle matSuffix [for]="picker1"></mat-datepicker-toggle>
   <mat-datepicker #picker1></mat-datepicker>
 </mat-form-field>
 
 <mat-form-field>
-  <input matInput [matDatepicker]="picker2" placeholder="Angular forms (w/ deserialization)"
+  <mat-label>Angular forms (w/ deserialization)</mat-label>
+  <input matInput [matDatepicker]="picker2"
          [formControl]="serializedDate">
   <mat-datepicker-toggle matSuffix [for]="picker2"></mat-datepicker-toggle>
   <mat-datepicker #picker2></mat-datepicker>
 </mat-form-field>
 
 <mat-form-field>
-  <input matInput [matDatepicker]="picker3" placeholder="Value binding" [value]="date.value">
+  <mat-label>Value binding</mat-label>
+  <input matInput [matDatepicker]="picker3" [value]="date.value">
   <mat-datepicker-toggle matSuffix [for]="picker3"></mat-datepicker-toggle>
   <mat-datepicker #picker3></mat-datepicker>
 </mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-views-selection/datepicker-views-selection-example.html
+++ b/src/components-examples/material/datepicker/datepicker-views-selection/datepicker-views-selection-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput [matDatepicker]="dp" placeholder="Month and Year" [formControl]="date">
+  <mat-label>Month and Year</mat-label>
+  <input matInput [matDatepicker]="dp" [formControl]="date">
   <mat-datepicker-toggle matSuffix [for]="dp"></mat-datepicker-toggle>
   <mat-datepicker #dp
                   startView="multi-year"

--- a/src/components-examples/material/dialog/dialog-overview/dialog-overview-example-dialog.html
+++ b/src/components-examples/material/dialog/dialog-overview/dialog-overview-example-dialog.html
@@ -2,6 +2,7 @@
 <div mat-dialog-content>
   <p>What's your favorite animal?</p>
   <mat-form-field>
+    <mat-label>Favorite Animal</mat-label>
     <input matInput [(ngModel)]="data.animal">
   </mat-form-field>
 </div>

--- a/src/components-examples/material/dialog/dialog-overview/dialog-overview-example.html
+++ b/src/components-examples/material/dialog/dialog-overview/dialog-overview-example.html
@@ -1,7 +1,8 @@
 <ol>
   <li>
     <mat-form-field>
-      <input matInput [(ngModel)]="name" placeholder="What's your name?">
+      <mat-label>What's your name?</mat-label>
+      <input matInput [(ngModel)]="name">
     </mat-form-field>
   </li>
   <li>

--- a/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.css
+++ b/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.css
@@ -11,3 +11,7 @@
   justify-content: space-between;
   align-items: center;
 }
+
+.example-headers-align .mat-form-field + .mat-form-field {
+  margin-left: 8px;
+}

--- a/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.html
+++ b/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.html
@@ -15,11 +15,13 @@
     </mat-expansion-panel-header>
 
     <mat-form-field>
-      <input matInput placeholder="First name">
+      <mat-label>First name</mat-label>
+      <input matInput>
     </mat-form-field>
 
     <mat-form-field>
-      <input matInput type="number" min="1" placeholder="Age">
+      <mat-label>Age</mat-label>
+      <input matInput type="number" min="1">
     </mat-form-field>
 
   </mat-expansion-panel>
@@ -36,7 +38,8 @@
     </mat-expansion-panel-header>
 
     <mat-form-field>
-      <input matInput placeholder="Country">
+      <mat-label>Country</mat-label>
+      <input matInput>
     </mat-form-field>
   </mat-expansion-panel>
 
@@ -52,7 +55,8 @@
     </mat-expansion-panel-header>
 
     <mat-form-field>
-      <input matInput placeholder="Date" [matDatepicker]="picker" (focus)="picker.open()" readonly>
+      <mat-label>Date</mat-label>
+      <input matInput [matDatepicker]="picker" (focus)="picker.open()" readonly>
     </mat-form-field>
     <mat-datepicker #picker></mat-datepicker>
   </mat-expansion-panel>

--- a/src/components-examples/material/expansion/expansion-overview/expansion-overview-example.css
+++ b/src/components-examples/material/expansion/expansion-overview/expansion-overview-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+.mat-form-field + .mat-form-field {
+  margin-left: 8px;
+}

--- a/src/components-examples/material/expansion/expansion-overview/expansion-overview-example.html
+++ b/src/components-examples/material/expansion/expansion-overview/expansion-overview-example.html
@@ -10,11 +10,13 @@
     </mat-expansion-panel-header>
 
     <mat-form-field>
-      <input matInput placeholder="First name">
+      <mat-label>First name</mat-label>
+      <input matInput>
     </mat-form-field>
 
     <mat-form-field>
-      <input matInput placeholder="Age">
+      <mat-label>Age</mat-label>
+      <input matInput type="number" min="1">
     </mat-form-field>
   </mat-expansion-panel>
   <mat-expansion-panel (opened)="panelOpenState = true"

--- a/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.css
+++ b/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.css
@@ -8,6 +8,6 @@
   align-items: center;
 }
 
-mat-form-field {
-  margin-right: 12px;
+.example-headers-align .mat-form-field + .mat-form-field {
+  margin-left: 8px;
 }

--- a/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.html
+++ b/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.html
@@ -11,11 +11,13 @@
     </mat-expansion-panel-header>
 
     <mat-form-field>
-      <input matInput placeholder="First name">
+      <mat-label>First name</mat-label>
+      <input matInput>
     </mat-form-field>
 
     <mat-form-field>
-      <input matInput type="number" min="1" placeholder="Age">
+      <mat-label>Age</mat-label>
+      <input matInput type="number" min="1">
     </mat-form-field>
 
     <mat-action-row>
@@ -35,7 +37,8 @@
     </mat-expansion-panel-header>
 
     <mat-form-field>
-      <input matInput placeholder="Country">
+      <mat-label>Country</mat-label>
+      <input matInput>
     </mat-form-field>
 
     <mat-action-row>
@@ -56,7 +59,8 @@
     </mat-expansion-panel-header>
 
     <mat-form-field>
-      <input matInput placeholder="Date" [matDatepicker]="picker" (focus)="picker.open()" readonly>
+      <mat-label>Date</mat-label>
+      <input matInput [matDatepicker]="picker" (focus)="picker.open()" readonly>
     </mat-form-field>
     <mat-datepicker #picker></mat-datepicker>
 

--- a/src/components-examples/material/input/input-clearable/input-clearable-example.html
+++ b/src/components-examples/material/input/input-clearable/input-clearable-example.html
@@ -1,5 +1,6 @@
 <mat-form-field class="example-form-field">
-  <input matInput type="text" placeholder="Clearable input" [(ngModel)]="value">
+  <mat-label>Clearable input</mat-label>
+  <input matInput type="text" [(ngModel)]="value">
   <button mat-button *ngIf="value" matSuffix mat-icon-button aria-label="Clear" (click)="value=''">
     <mat-icon>close</mat-icon>
   </button>

--- a/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.html
+++ b/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.html
@@ -1,7 +1,8 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
-    <input matInput placeholder="Email" [formControl]="emailFormControl"
-           [errorStateMatcher]="matcher">
+    <mat-label>Email</mat-label>
+    <input matInput [formControl]="emailFormControl" [errorStateMatcher]="matcher"
+           placeholder="Ex. pat@example.com">
     <mat-hint>Errors appear instantly!</mat-hint>
     <mat-error *ngIf="emailFormControl.hasError('email') && !emailFormControl.hasError('required')">
       Please enter a valid email address

--- a/src/components-examples/material/input/input-errors/input-errors-example.html
+++ b/src/components-examples/material/input/input-errors/input-errors-example.html
@@ -1,6 +1,7 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
-    <input matInput placeholder="Email" [formControl]="emailFormControl">
+    <mat-label>Email</mat-label>
+    <input matInput [formControl]="emailFormControl" placeholder="Ex. pat@example.com">
     <mat-error *ngIf="emailFormControl.hasError('email') && !emailFormControl.hasError('required')">
       Please enter a valid email address
     </mat-error>

--- a/src/components-examples/material/input/input-form/input-form-example.html
+++ b/src/components-examples/material/input/input-form/input-form-example.html
@@ -1,35 +1,43 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
-    <input matInput placeholder="Company (disabled)" disabled value="Google">
+    <mat-label>Company (disabled)</mat-label>
+    <input matInput disabled value="Google">
   </mat-form-field>
 
   <table class="example-full-width" cellspacing="0"><tr>
     <td><mat-form-field class="example-full-width">
-      <input matInput placeholder="First name">
+      <mat-label>First name</mat-label>
+      <input matInput>
     </mat-form-field></td>
     <td><mat-form-field class="example-full-width">
-      <input matInput placeholder="Long Last Name That Will Be Truncated">
+      <mat-label>Long Last Name That Will Be Truncated</mat-label>
+      <input matInput>
     </mat-form-field></td>
   </tr></table>
 
   <p>
     <mat-form-field class="example-full-width">
-      <textarea matInput placeholder="Address">1600 Amphitheatre Pkwy</textarea>
+      <mat-label>Address</mat-label>
+      <textarea matInput placeholder="Ex. 100 Main St">1600 Amphitheatre Pkwy</textarea>
     </mat-form-field>
     <mat-form-field class="example-full-width">
-      <textarea matInput placeholder="Address 2"></textarea>
+      <mat-label>Address 2</mat-label>
+      <textarea matInput></textarea>
     </mat-form-field>
   </p>
 
   <table class="example-full-width" cellspacing="0"><tr>
     <td><mat-form-field class="example-full-width">
-      <input matInput placeholder="City">
+      <mat-label>City</mat-label>
+      <input matInput placeholder="Ex. San Francisco">
     </mat-form-field></td>
     <td><mat-form-field class="example-full-width">
-      <input matInput placeholder="State">
+      <mat-label>State</mat-label>
+      <input matInput placeholder="Ex. California">
     </mat-form-field></td>
     <td><mat-form-field class="example-full-width">
-      <input matInput #postalCode maxlength="5" placeholder="Postal Code" value="94043">
+      <mat-label>Postal Code</mat-label>
+      <input matInput #postalCode maxlength="5" placeholder="Ex. 94105" value="94043">
       <mat-hint align="end">{{postalCode.value.length}} / 5</mat-hint>
     </mat-form-field></td>
   </tr></table>

--- a/src/components-examples/material/input/input-hint/input-hint-example.html
+++ b/src/components-examples/material/input/input-hint/input-hint-example.html
@@ -1,9 +1,8 @@
 <form class="example-form">
-
   <mat-form-field class="example-full-width">
-    <input matInput #message maxlength="256" placeholder="Message">
+    <mat-label>Message</mat-label>
+    <input matInput #message maxlength="256" placeholder="Ex. I need help with...">
     <mat-hint align="start"><strong>Don't disclose personal info</strong> </mat-hint>
     <mat-hint align="end">{{message.value.length}} / 256</mat-hint>
   </mat-form-field>
-  
 </form>

--- a/src/components-examples/material/input/input-overview/input-overview-example.html
+++ b/src/components-examples/material/input/input-overview/input-overview-example.html
@@ -1,9 +1,11 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
-    <input matInput placeholder="Favorite food" value="Sushi">
+    <mat-label>Favorite food</mat-label>
+    <input matInput placeholder="Ex. Pizza" value="Sushi">
   </mat-form-field>
 
   <mat-form-field class="example-full-width">
-    <textarea matInput placeholder="Leave a comment"></textarea>
+    <mat-label>Leave a comment</mat-label>
+    <textarea matInput placeholder="Ex. It makes me feel..."></textarea>
   </mat-form-field>
 </form>

--- a/src/components-examples/material/input/input-prefix-suffix/input-prefix-suffix-example.html
+++ b/src/components-examples/material/input/input-prefix-suffix/input-prefix-suffix-example.html
@@ -1,9 +1,8 @@
 <form class="example-form">
-
   <mat-form-field class="example-full-width">
+    <mat-label>Telephone</mat-label>
     <span matPrefix>+1 &nbsp;</span>
-    <input type="tel" matInput placeholder="Telephone">
+    <input type="tel" matInput placeholder="555-555-1234">
     <mat-icon matSuffix>mode_edit</mat-icon>
   </mat-form-field>
-  
 </form>

--- a/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.css
+++ b/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.css
@@ -1,3 +1,3 @@
-mat-form-field {
+.mat-form-field {
   margin-right: 12px;
 }

--- a/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.html
+++ b/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.html
@@ -1,23 +1,22 @@
 <mat-form-field>
-  List length:
-  <input matInput [(ngModel)]="length">
+  <mat-label>List length</mat-label>
+  <input matInput [(ngModel)]="length" type="number">
 </mat-form-field>
 
 <mat-form-field>
-  Page size:
-  <input matInput [(ngModel)]="pageSize">
+  <mat-label>Page size</mat-label>
+  <input matInput [(ngModel)]="pageSize" type="number">
 </mat-form-field>
 <mat-form-field>
-  Page size options:
-  <input matInput
-         [ngModel]="pageSizeOptions"
-         (ngModelChange)="setPageSizeOptions($event)">
+  <mat-label>Page size options</mat-label>
+  <input matInput [ngModel]="pageSizeOptions" (ngModelChange)="setPageSizeOptions($event)"
+         [ngModelOptions]="{updateOn: 'blur'}" placeholder="Ex. 10,25,50">
 </mat-form-field>
 
 <mat-paginator [length]="length"
-              [pageSize]="pageSize"
-              [pageSizeOptions]="pageSizeOptions"
-              (page)="pageEvent = $event">
+               [pageSize]="pageSize"
+               [pageSizeOptions]="pageSizeOptions"
+               (page)="pageEvent = $event">
 </mat-paginator>
 
 <div *ngIf="pageEvent">

--- a/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.ts
+++ b/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.ts
@@ -19,6 +19,8 @@ export class PaginatorConfigurableExample {
   pageEvent: PageEvent;
 
   setPageSizeOptions(setPageSizeOptionsInput: string) {
-    this.pageSizeOptions = setPageSizeOptionsInput.split(',').map(str => +str);
+    if (setPageSizeOptionsInput) {
+      this.pageSizeOptions = setPageSizeOptionsInput.split(',').map(str => +str);
+    }
   }
 }

--- a/src/components-examples/material/select/select-custom-trigger/select-custom-trigger-example.html
+++ b/src/components-examples/material/select/select-custom-trigger/select-custom-trigger-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <mat-select placeholder="Toppings" [formControl]="toppings" multiple>
+  <mat-label>Toppings</mat-label>
+  <mat-select [formControl]="toppings" multiple>
     <mat-select-trigger>
       {{toppings.value ? toppings.value[0] : ''}}
       <span *ngIf="toppings.value?.length > 1" class="example-additional-selection">

--- a/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.html
+++ b/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.html
@@ -11,10 +11,12 @@
     <mat-sidenav-content [formGroup]="options">
       <p><mat-checkbox formControlName="fixed">Fixed</mat-checkbox></p>
       <p><mat-form-field>
-        <input matInput type="number" formControlName="top" placeholder="Top gap">
+        <mat-label>Top gap</mat-label>
+        <input matInput type="number" formControlName="top">
       </mat-form-field></p>
       <p><mat-form-field>
-        <input matInput type="number" formControlName="bottom" placeholder="Bottom gap">
+        <mat-label>Bottom gap</mat-label>
+        <input matInput type="number" formControlName="bottom">
       </mat-form-field></p>
       <p><button mat-button (click)="sidenav.toggle()">Toggle</button></p>
     </mat-sidenav-content>
@@ -23,4 +25,4 @@
   <mat-toolbar class="example-footer">Footer</mat-toolbar>
 </ng-container>
 
-<div *ngIf="!shouldRun">Please open on Stackblitz to see result</div>
+<div *ngIf="!shouldRun">Please open on StackBlitz to see result</div>

--- a/src/components-examples/material/slider/slider-configurable/slider-configurable-example.css
+++ b/src/components-examples/material/slider/slider-configurable/slider-configurable-example.css
@@ -1,5 +1,5 @@
 .example-h2 {
-  margin: 10px;
+  margin: 0 8px 16px;
 }
 
 .example-section {
@@ -10,7 +10,7 @@
 }
 
 .example-margin {
-  margin: 10px;
+  margin: 8px;
 }
 
 .mat-slider-horizontal {
@@ -19,4 +19,12 @@
 
 .mat-slider-vertical {
   height: 300px;
+}
+
+.mat-card + .mat-card {
+  margin-top: 8px;
+}
+
+.example-result-card h2 {
+  margin: 0 8px;
 }

--- a/src/components-examples/material/slider/slider-configurable/slider-configurable-example.html
+++ b/src/components-examples/material/slider/slider-configurable/slider-configurable-example.html
@@ -4,16 +4,20 @@
 
     <section class="example-section">
       <mat-form-field class="example-margin">
-        <input matInput type="number" placeholder="Value" [(ngModel)]="value">
+        <mat-label>Value</mat-label>
+        <input matInput type="number" [(ngModel)]="value">
       </mat-form-field>
       <mat-form-field class="example-margin">
-        <input matInput type="number" placeholder="Min value" [(ngModel)]="min">
+        <mat-label>Min value</mat-label>
+        <input matInput type="number" [(ngModel)]="min">
       </mat-form-field>
       <mat-form-field class="example-margin">
-        <input matInput type="number" placeholder="Max value" [(ngModel)]="max">
+        <mat-label>Max value</mat-label>
+        <input matInput type="number" [(ngModel)]="max">
       </mat-form-field>
       <mat-form-field class="example-margin">
-        <input matInput type="number" placeholder="Step size" [(ngModel)]="step">
+        <mat-label>Step size</mat-label>
+        <input matInput type="number" [(ngModel)]="step">
       </mat-form-field>
     </section>
 
@@ -23,7 +27,8 @@
         Auto ticks
       </mat-checkbox>
       <mat-form-field class="example-margin" *ngIf="showTicks && !autoTicks">
-        <input matInput type="number" placeholder="Tick interval" [(ngModel)]="tickInterval">
+        <mat-label>Tick interval</mat-label>
+        <input matInput type="number" [(ngModel)]="tickInterval">
       </mat-form-field>
     </section>
 
@@ -43,9 +48,9 @@
   </mat-card-content>
 </mat-card>
 
-<mat-card class="result">
+<mat-card class="example-result-card">
   <mat-card-content>
-    <h2 class="example-h2">Result</h2>
+    <h2>Result</h2>
 
     <mat-slider
         class="example-margin"

--- a/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.css
+++ b/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+.mat-form-field {
+  margin-right: 8px;
+}

--- a/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.html
@@ -3,6 +3,6 @@
   <input type="number" [(ngModel)]="durationInSeconds" matInput>
 </mat-form-field>
 
-<button mat-button (click)="openSnackBar()" aria-label="Show an example snack-bar">
+<button mat-stroked-button (click)="openSnackBar()" aria-label="Show an example snack-bar">
   Pizza party
 </button>

--- a/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.html
@@ -1,9 +1,11 @@
 <mat-form-field>
-  <input matInput value="Disco party!" placeholder="Message" #message>
+  <mat-label>Message</mat-label>
+  <input matInput value="Disco party!" #message>
 </mat-form-field>
 
 <mat-form-field>
-  <input matInput value="Dance" placeholder="Action" #action>
+  <mat-label>Action</mat-label>
+  <input matInput value="Dance" #action>
 </mat-form-field>
 
-<button mat-button (click)="openSnackBar(message.value, action.value)">Show snack-bar</button>
+<button mat-stroked-button (click)="openSnackBar(message.value, action.value)">Show snack-bar</button>

--- a/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.css
+++ b/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.css
@@ -1,3 +1,3 @@
-mat-form-field {
-  margin-right: 12px;
+.mat-form-field {
+  margin-right: 8px;
 }

--- a/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <mat-select placeholder="Horizontal position" [(value)]="horizontalPosition">
+  <mat-label>Horizontal position</mat-label>
+  <mat-select [(value)]="horizontalPosition">
     <mat-option value="start">Start</mat-option>
     <mat-option value="center">Center</mat-option>
     <mat-option value="end">End</mat-option>
@@ -8,12 +9,13 @@
   </mat-select>
 </mat-form-field>
 <mat-form-field>
-  <mat-select placeholder="Vertical position" [(value)]="verticalPosition">
+  <mat-label>Vertical position</mat-label>
+  <mat-select [(value)]="verticalPosition">
     <mat-option value="top">Top</mat-option>
     <mat-option value="bottom">Bottom</mat-option>
   </mat-select>
 </mat-form-field>
 
-<button mat-button (click)="openSnackBar()" aria-label="Show an example snack-bar">
+<button mat-stroked-button (click)="openSnackBar()" aria-label="Show an example snack-bar">
   Pool party!
 </button>

--- a/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.ts
@@ -14,14 +14,13 @@ import {
   styleUrls: ['snack-bar-position-example.css'],
 })
 export class SnackBarPositionExample {
-
   horizontalPosition: MatSnackBarHorizontalPosition = 'start';
   verticalPosition: MatSnackBarVerticalPosition = 'bottom';
 
   constructor(private _snackBar: MatSnackBar) {}
 
   openSnackBar() {
-    this._snackBar.open('Canonball!!', 'End now', {
+    this._snackBar.open('Cannonball!!', 'End now', {
       duration: 500,
       horizontalPosition: this.horizontalPosition,
       verticalPosition: this.verticalPosition,

--- a/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.css
+++ b/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.css
@@ -1,1 +1,7 @@
-/** No CSS for this example */
+.mat-stepper-horizontal {
+  margin-top: 8px;
+}
+
+.mat-form-field {
+  margin-top: 16px;
+}

--- a/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
+++ b/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
@@ -7,7 +7,8 @@
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
-        <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
+        <mat-label>Name</mat-label>
+        <input matInput formControlName="firstCtrl" placeholder="Last name, First name" required>
       </mat-form-field>
       <div>
         <button mat-button matStepperNext>Next</button>
@@ -18,7 +19,9 @@
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
       <mat-form-field>
-        <input matInput placeholder="Address" formControlName="secondCtrl" required>
+        <mat-label>Address</mat-label>
+        <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
+               required>
       </mat-form-field>
       <div>
         <button mat-button matStepperPrevious>Back</button>
@@ -28,7 +31,7 @@
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Done</ng-template>
-    You are now done.
+    <p>You are now done.</p>
     <div>
       <button mat-button matStepperPrevious>Back</button>
       <button mat-button (click)="stepper.reset()">Reset</button>

--- a/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.css
+++ b/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.css
@@ -1,0 +1,3 @@
+.mat-form-field {
+  margin-top: 16px;
+}

--- a/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
+++ b/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
@@ -3,6 +3,7 @@
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
+        <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
@@ -14,7 +15,9 @@
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
       <mat-form-field>
-        <input matInput placeholder="Address" formControlName="secondCtrl" required>
+        <mat-label>Address</mat-label>
+        <input matInput placeholder="Ex. 1 Main St, New York, NY" formControlName="secondCtrl"
+               required>
       </mat-form-field>
       <div>
         <button mat-button matStepperPrevious>Back</button>
@@ -24,7 +27,7 @@
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Done</ng-template>
-    You are now done.
+    <p>You are now done.</p>
     <div>
       <button mat-button matStepperPrevious>Back</button>
       <button mat-button (click)="stepper.reset()">Reset</button>

--- a/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.css
+++ b/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+.mat-form-field {
+  margin-top: 16px;
+}

--- a/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
+++ b/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
@@ -1,33 +1,36 @@
 <mat-horizontal-stepper labelPosition="bottom" #stepper>
-    <mat-step [stepControl]="firstFormGroup">
-        <form [formGroup]="firstFormGroup">
-            <ng-template matStepLabel>Fill out your name</ng-template>
-            <mat-form-field>
-                <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
-            </mat-form-field>
-            <div>
-                <button mat-button matStepperNext>Next</button>
-            </div>
-        </form>
-    </mat-step>
-    <mat-step [stepControl]="secondFormGroup" optional>
-        <form [formGroup]="secondFormGroup">
-            <ng-template matStepLabel>Fill out your address</ng-template>
-            <mat-form-field>
-                <input matInput placeholder="Address" formControlName="secondCtrl" required>
-            </mat-form-field>
-            <div>
-                <button mat-button matStepperPrevious>Back</button>
-                <button mat-button matStepperNext>Next</button>
-            </div>
-        </form>
-    </mat-step>
-    <mat-step>
-        <ng-template matStepLabel>Done</ng-template>
-        You are now done.
-        <div>
-            <button mat-button matStepperPrevious>Back</button>
-            <button mat-button (click)="stepper.reset()">Reset</button>
-        </div>
-    </mat-step>
+  <mat-step [stepControl]="firstFormGroup">
+    <form [formGroup]="firstFormGroup">
+      <ng-template matStepLabel>Fill out your name</ng-template>
+      <mat-form-field>
+        <mat-label>Name</mat-label>
+        <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
+      </mat-form-field>
+      <div>
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+  <mat-step [stepControl]="secondFormGroup" optional>
+    <form [formGroup]="secondFormGroup">
+      <ng-template matStepLabel>Fill out your address</ng-template>
+      <mat-form-field>
+        <mat-label>Address</mat-label>
+        <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
+               required>
+      </mat-form-field>
+      <div>
+        <button mat-button matStepperPrevious>Back</button>
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Done</ng-template>
+    <p>You are now done.</p>
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button (click)="stepper.reset()">Reset</button>
+    </div>
+  </mat-step>
 </mat-horizontal-stepper>

--- a/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.css
+++ b/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.css
@@ -1,1 +1,7 @@
-/** No CSS for this example */
+.mat-stepper-horizontal {
+  margin-top: 8px;
+}
+
+.mat-form-field {
+  margin-top: 16px;
+}

--- a/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
+++ b/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
@@ -7,6 +7,7 @@
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
+        <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
@@ -18,7 +19,9 @@
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
       <mat-form-field>
-        <input matInput placeholder="Address" formControlName="secondCtrl" required>
+        <mat-label>Address</mat-label>
+        <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
+               required>
       </mat-form-field>
       <div>
         <button mat-button matStepperPrevious>Back</button>
@@ -28,7 +31,7 @@
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Done</ng-template>
-    You are now done.
+    <p>You are now done.</p>
     <div>
       <button mat-button matStepperPrevious>Back</button>
       <button mat-button (click)="stepper.reset()">Reset</button>

--- a/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.css
+++ b/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.css
@@ -1,1 +1,7 @@
-/** No CSS for this example */
+.mat-stepper-horizontal {
+  margin-top: 8px;
+}
+
+.mat-form-field {
+  margin-top: 16px;
+}

--- a/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
+++ b/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
@@ -6,6 +6,7 @@
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
+        <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
@@ -17,7 +18,9 @@
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
       <mat-form-field>
-        <input matInput placeholder="Address" formControlName="secondCtrl" required>
+        <mat-label>Address</mat-label>
+        <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
+               required>
       </mat-form-field>
       <div>
         <button mat-button matStepperPrevious>Back</button>
@@ -27,7 +30,7 @@
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Done</ng-template>
-    You are now done.
+    <p>You are now done.</p>
     <div>
       <button mat-button matStepperPrevious>Back</button>
       <button mat-button (click)="stepper.reset()">Reset</button>

--- a/src/components-examples/material/stepper/stepper-states/stepper-states-example.css
+++ b/src/components-examples/material/stepper/stepper-states/stepper-states-example.css
@@ -1,0 +1,7 @@
+.mat-stepper-horizontal {
+  margin-top: 8px;
+}
+
+.mat-form-field {
+  margin-top: 16px;
+}

--- a/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
+++ b/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
@@ -3,6 +3,7 @@
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
+        <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
@@ -14,7 +15,9 @@
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
       <mat-form-field>
-        <input matInput placeholder="Address" formControlName="secondCtrl" required>
+        <mat-label>Address</mat-label>
+        <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
+               required>
       </mat-form-field>
       <div>
         <button mat-button matStepperPrevious>Back</button>
@@ -24,7 +27,7 @@
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Done</ng-template>
-    You are now done.
+    <p>You are now done.</p>
     <div>
       <button mat-button matStepperPrevious>Back</button>
       <button mat-button (click)="stepper.reset()">Reset</button>

--- a/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.css
+++ b/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.css
@@ -1,1 +1,7 @@
-/** No CSS for this example */
+.mat-stepper-vertical {
+  margin-top: 8px;
+}
+
+.mat-form-field {
+  margin-top: 16px;
+}

--- a/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
+++ b/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
@@ -6,6 +6,7 @@
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
       <mat-form-field>
+        <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
@@ -17,7 +18,9 @@
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
       <mat-form-field>
-        <input matInput placeholder="Address" formControlName="secondCtrl" required>
+        <mat-label>Address</mat-label>
+        <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
+               required>
       </mat-form-field>
       <div>
         <button mat-button matStepperPrevious>Back</button>
@@ -27,7 +30,7 @@
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Done</ng-template>
-    You are now done.
+    <p>You are now done.</p>
     <div>
       <button mat-button matStepperPrevious>Back</button>
       <button mat-button (click)="stepper.reset()">Reset</button>

--- a/src/components-examples/material/table/table-filtering/table-filtering-example.html
+++ b/src/components-examples/material/table/table-filtering/table-filtering-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  <mat-label>Filter</mat-label>
+  <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Ex. ium">
 </mat-form-field>
 
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">

--- a/src/components-examples/material/table/table-overview/table-overview-example.html
+++ b/src/components-examples/material/table/table-overview/table-overview-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  <mat-label>Filter</mat-label>
+  <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Ex. Mia">
 </mat-form-field>
 
 <div class="mat-elevation-z8">

--- a/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.html
+++ b/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.html
@@ -1,9 +1,7 @@
-<div>
-  <span class="example-input-label"> Selected tab index: </span>
-  <mat-form-field>
-    <input matInput type="number" [formControl]="selected">
-  </mat-form-field>
-</div>
+<mat-form-field>
+  <mat-label>Selected tab index</mat-label>
+  <input matInput type="number" [formControl]="selected">
+</mat-form-field>
 
 <div>
   <button mat-raised-button

--- a/src/components-examples/material/tooltip/tooltip-auto-hide/tooltip-auto-hide-example.html
+++ b/src/components-examples/material/tooltip/tooltip-auto-hide/tooltip-auto-hide-example.html
@@ -1,5 +1,6 @@
 <mat-form-field>
-  <mat-select placeholder="Tooltip position" [formControl]="position">
+  <mat-label>Tooltip position</mat-label>
+  <mat-select [formControl]="position">
     <mat-option *ngFor="let positionOption of positionOptions" [value]="positionOption">
       {{positionOption}}
     </mat-option>

--- a/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.css
+++ b/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.css
@@ -1,4 +1,4 @@
-.example-user-input {
-  display: block;
-  width: 150px;
+.mat-form-field + .mat-form-field,
+.mat-raised-button {
+  margin-left: 8px;
 }

--- a/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.html
+++ b/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.html
@@ -1,19 +1,18 @@
 <mat-form-field class="example-user-input">
-  <input matInput placeholder="Show delay (milliseconds)"
-         type="number"
-         aria-label="Adds a delay between hovering over the button and displaying the tooltip"
-         [formControl]="showDelay">
+  <mat-label>Show delay</mat-label>
+  <input matInput type="number" [formControl]="showDelay"
+         aria-label="Adds a delay between hovering over the button and displaying the tooltip">
+  <mat-hint>milliseconds</mat-hint>
 </mat-form-field>
 
 <mat-form-field class="example-user-input">
-  <input matInput placeholder="Hide delay (milliseconds)"
-         type="number"
-         aria-label="Adds a delay between hovering away from the button and hiding the tooltip"
-         [formControl]="hideDelay">
+  <mat-label>Hide delay</mat-label>
+  <input matInput type="number" [formControl]="hideDelay"
+         aria-label="Adds a delay between hovering away from the button and hiding the tooltip">
+  <mat-hint>milliseconds</mat-hint>
 </mat-form-field>
 
-<button mat-raised-button
-        matTooltip="Info about the action"
+<button mat-raised-button matTooltip="Info about the action"
         [matTooltipShowDelay]="showDelay.value"
         [matTooltipHideDelay]="hideDelay.value"
         aria-label="Button that displays a tooltip with a customized delay in showing and hiding">

--- a/src/components-examples/material/tooltip/tooltip-message/tooltip-message-example.html
+++ b/src/components-examples/material/tooltip/tooltip-message/tooltip-message-example.html
@@ -1,5 +1,6 @@
 <mat-form-field class="example-user-input">
-  <input matInput placeholder="Tooltip message" [formControl]="message">
+  <mat-label>Tooltip message</mat-label>
+  <input matInput [formControl]="message">
 </mat-form-field>
 
 <button mat-raised-button

--- a/src/components-examples/material/tooltip/tooltip-position/tooltip-position-example.html
+++ b/src/components-examples/material/tooltip/tooltip-position/tooltip-position-example.html
@@ -1,5 +1,6 @@
 <mat-form-field class="example-user-input">
-  <mat-select placeholder="Tooltip position" [formControl]="position">
+  <mat-label>Tooltip position</mat-label>
+  <mat-select [formControl]="position">
     <mat-option *ngFor="let positionOption of positionOptions" [value]="positionOption">
       {{positionOption}}
     </mat-option>

--- a/src/components-examples/material/tree/tree-checklist/tree-checklist-example.css
+++ b/src/components-examples/material/tree/tree-checklist/tree-checklist-example.css
@@ -1,0 +1,3 @@
+.mat-form-field {
+  margin-right: 4px;
+}

--- a/src/components-examples/material/tree/tree-checklist/tree-checklist-example.html
+++ b/src/components-examples/material/tree/tree-checklist/tree-checklist-example.html
@@ -9,7 +9,8 @@
   <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>
     <button mat-icon-button disabled></button>
     <mat-form-field>
-      <input matInput #itemValue placeholder="New item...">
+      <mat-label>New item...</mat-label>
+      <input matInput #itemValue placeholder="Ex. Lettuce">
     </mat-form-field>
     <button mat-button (click)="saveNode(node, itemValue.value)">Save</button>
   </mat-tree-node>

--- a/tools/example-module/example-module.template
+++ b/tools/example-module/example-module.template
@@ -10,6 +10,7 @@
  ******************************************************************************/
 
 import {NgModule} from '@angular/core';
+import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
 
 ${exampleImports}
 
@@ -26,9 +27,14 @@ export const EXAMPLE_MODULES = ${exampleModules};
 
 export const EXAMPLE_LIST = [${exampleList}];
 
+// Default MatFormField appearance to 'fill' as that is the new recommended approach and the
+// `legacy` and `standard` appearances are scheduled for deprecation in version 10.
 @NgModule({
   imports: EXAMPLE_MODULES,
   exports: EXAMPLE_MODULES,
+  providers: [
+    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'fill' } },
+  ],
 })
 export class ExampleModule { }
 


### PR DESCRIPTION
- stop using the soon to be deprecated legacy appearance by default
- fix issues where labels were specified in the `placeholder` attribute
  - instead of a `mat-label`

Relates to #14792