### PR TITLE
fix(cdk/text-field): remove autosize attributes when disabled

### DIFF
--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -26,7 +26,7 @@ describe('CdkTextareaAutosize', () => {
         AutosizeTextAreaWithContent,
         AutosizeTextAreaWithValue,
         AutosizeTextareaWithNgModel,
-        AutosizeTextareaWithoutAutosize,
+        AutosizeTextareaWithEnabledBinding,
       ],
     });
 
@@ -324,17 +324,18 @@ describe('CdkTextareaAutosize', () => {
   }));
 
   it('should not trigger a resize when it is disabled', fakeAsync(() => {
-    const fixtureWithoutAutosize = TestBed.createComponent(AutosizeTextareaWithoutAutosize);
-    textarea = fixtureWithoutAutosize.nativeElement.querySelector('textarea');
-    autosize = fixtureWithoutAutosize.debugElement
+    const disabledFixture = TestBed.createComponent(AutosizeTextareaWithEnabledBinding);
+    textarea = disabledFixture.nativeElement.querySelector('textarea');
+    autosize = disabledFixture.debugElement
       .query(By.css('textarea'))!
       .injector.get<CdkTextareaAutosize>(CdkTextareaAutosize);
 
-    fixtureWithoutAutosize.detectChanges();
+    disabledFixture.componentInstance.enabled = false;
+    disabledFixture.detectChanges();
 
     const previousHeight = textarea.clientHeight;
 
-    fixtureWithoutAutosize.componentInstance.content = `
+    disabledFixture.componentInstance.content = `
     Line
     Line
     Line
@@ -342,7 +343,7 @@ describe('CdkTextareaAutosize', () => {
     Line`;
 
     // Manually call resizeToFitContent instead of faking an `input` event.
-    fixtureWithoutAutosize.detectChanges();
+    disabledFixture.detectChanges();
 
     expect(textarea.clientHeight)
       .withContext('Expected textarea to still have the same size.')
@@ -352,7 +353,7 @@ describe('CdkTextareaAutosize', () => {
       .toBeLessThan(textarea.scrollHeight);
 
     autosize.enabled = true;
-    fixtureWithoutAutosize.detectChanges();
+    disabledFixture.detectChanges();
 
     expect(textarea.clientHeight)
       .withContext('Expected textarea to have grown after enabling autosize.')
@@ -362,7 +363,7 @@ describe('CdkTextareaAutosize', () => {
       .toBe(textarea.scrollHeight);
 
     autosize.enabled = false;
-    fixtureWithoutAutosize.detectChanges();
+    disabledFixture.detectChanges();
 
     expect(textarea.clientHeight)
       .withContext('Expected textarea to have the original size.')
@@ -377,6 +378,22 @@ describe('CdkTextareaAutosize', () => {
     fixture.detectChanges();
 
     expect(textarea.hasAttribute('placeholder')).toBe(false);
+  });
+
+  it('should toggle the autosize-specific attributes based on whether it is disabled', () => {
+    const disabledFixture = TestBed.createComponent(AutosizeTextareaWithEnabledBinding);
+    disabledFixture.componentInstance.enabled = true;
+    disabledFixture.detectChanges();
+    textarea = disabledFixture.nativeElement.querySelector('textarea');
+
+    expect(textarea.classList).toContain('cdk-textarea-autosize');
+    expect(textarea.getAttribute('rows')).toBe('1');
+
+    disabledFixture.componentInstance.enabled = false;
+    disabledFixture.detectChanges();
+
+    expect(textarea.classList).not.toContain('cdk-textarea-autosize');
+    expect(textarea.hasAttribute('rows')).toBe(false);
   });
 });
 
@@ -419,9 +436,10 @@ class AutosizeTextareaWithNgModel {
 }
 
 @Component({
-  template: `<textarea [cdkTextareaAutosize]="false">{{content}}</textarea>`,
+  template: `<textarea [cdkTextareaAutosize]="enabled">{{content}}</textarea>`,
   styles: [textareaStyleReset],
 })
-class AutosizeTextareaWithoutAutosize {
-  content: string = '';
+class AutosizeTextareaWithEnabledBinding {
+  content = '';
+  enabled = true;
 }

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -33,11 +33,12 @@ import {DOCUMENT} from '@angular/common';
   selector: 'textarea[cdkTextareaAutosize]',
   exportAs: 'cdkTextareaAutosize',
   host: {
-    'class': 'cdk-textarea-autosize',
+    // Remove the class when disabled, because it removes the native browser resizing.
+    '[class.cdk-textarea-autosize]': 'enabled',
     // Textarea elements that have the directive applied should have a single row by default.
     // Browsers normally show two rows by default and therefore this limits the minRows binding.
-    'rows': '1',
     '(input)': '_noopInputHandler()',
+    '[attr.rows]': 'enabled ? 1 : null',
   },
 })
 export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {


### PR DESCRIPTION
When auto-sizing is disabled we clear the inline styles that we've set, but we still keep the `rows` attribute and `cdk-textarea-autosize` classes which have an effect on the appearance of the `textarea`. These changes add some data bindings to clear the attributes while disabled.