### PR TITLE
refactor: clean up typescript 3.7 workarounds

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -921,7 +921,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
                             scrollPosition: ViewportScrollPosition) {
     // Reset any existing styles. This is necessary in case the
     // preferred position has changed since the last `apply`.
-    let styles = {top: null, bottom: null} as NullableCSSStyleDeclaration;
+    let styles = {top: '', bottom: ''} as CSSStyleDeclaration;
     let overlayPoint = this._getOverlayPoint(originPoint, this._overlayRect, position);
 
     if (this._isPushed) {
@@ -957,7 +957,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
                             scrollPosition: ViewportScrollPosition) {
     // Reset any existing styles. This is necessary in case the preferred position has
     // changed since the last `apply`.
-    let styles = {left: null, right: null} as NullableCSSStyleDeclaration;
+    let styles = {left: '', right: ''} as CSSStyleDeclaration;
     let overlayPoint = this._getOverlayPoint(originPoint, this._overlayRect, position);
 
     if (this._isPushed) {
@@ -1174,15 +1174,6 @@ interface FlexibleFit {
   boundingBoxRect: BoundingBoxRect;
 }
 
-/**
- * Equivalent of CSSStyleDeclaration, but allows for `null` values. We need to do
- * this while we support TS 3.6 and 3.7 since the built-in types are different.
- * TODO(crisbeto): we can switch back to the regular CSSStyleDeclaration once we're running TS 3.7.
- */
-type NullableCSSStyleDeclaration = {
-  [T in keyof CSSStyleDeclaration]: CSSStyleDeclaration[T] | null;
-};
-
 /** A connected position as specified by the user. */
 export interface ConnectedPosition {
   originX: 'start' | 'center' | 'end';
@@ -1198,8 +1189,8 @@ export interface ConnectedPosition {
 }
 
 /** Shallow-extends a stylesheet object with another stylesheet object. */
-function extendStyles(destination: NullableCSSStyleDeclaration,
-                      source: NullableCSSStyleDeclaration): NullableCSSStyleDeclaration {
+function extendStyles(destination: CSSStyleDeclaration,
+                      source: CSSStyleDeclaration): CSSStyleDeclaration {
   for (let key in source) {
     if (source.hasOwnProperty(key)) {
       destination[key] = source[key];

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -41,7 +41,7 @@ import {fromEvent, Subject} from 'rxjs';
 export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   /** Keep track of the previous textarea value to avoid resizing when the value hasn't changed. */
   private _previousValue?: string;
-  private _initialHeight: string | null;
+  private _initialHeight: string | undefined;
   private readonly _destroyed = new Subject<void>();
 
   private _minRows: number;
@@ -119,9 +119,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   ngAfterViewInit() {
     if (this._platform.isBrowser) {
       // Remember the height which we started with in case autosizing is disabled
-      // TODO: as any works around `height` being nullable in TS3.6, but non-null in 3.7.
-      // Remove once on TS3.7.
-      this._initialHeight = this._textareaElement.style.height as any;
+      this._initialHeight = this._textareaElement.style.height;
 
       this.resizeToFitContent();
 
@@ -251,11 +249,9 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   reset() {
     // Do not try to change the textarea, if the initialHeight has not been determined yet
     // This might potentially remove styles when reset() is called before ngAfterViewInit
-    if (this._initialHeight === undefined) {
-      return;
+    if (this._initialHeight !== undefined) {
+      this._textareaElement.style.height = this._initialHeight;
     }
-    // TODO: "as any" inserted for migration to TS3.7.
-    this._textareaElement.style.height = this._initialHeight as any;
   }
 
   // In Ivy the `host` metadata will be merged, whereas in ViewEngine it is overridden. In order


### PR DESCRIPTION
Removes some workarounds that were in place before we could update to TS 3.7.