### PR TITLE
fix(cdk/testing): TestElement sendKeys method should throw if no keys have been specified

### DIFF
--- a/src/cdk/testing/protractor/protractor-element.ts
+++ b/src/cdk/testing/protractor/protractor-element.ts
@@ -9,6 +9,7 @@
 import {
   _getTextWithExcludedElements,
   ElementDimensions,
+  getNoKeysSpecifiedError,
   ModifierKeys,
   TestElement,
   TestKey,
@@ -161,7 +162,7 @@ export class ProtractorElement implements TestElement {
     const first = modifiersAndKeys[0];
     let modifiers: ModifierKeys;
     let rest: (string | TestKey)[];
-    if (typeof first !== 'string' && typeof first !== 'number') {
+    if (first !== undefined && typeof first !== 'string' && typeof first !== 'number') {
       modifiers = first;
       rest = modifiersAndKeys.slice(1);
     } else {
@@ -176,6 +177,12 @@ export class ProtractorElement implements TestElement {
       // Key.chord doesn't work well with geckodriver (mozilla/geckodriver#1502),
       // so avoid it if no modifier keys are required.
       .map(k => (modifierKeys.length > 0 ? Key.chord(...modifierKeys, k) : k));
+
+    // Throw an error if no keys have been specified. Calling this function with no
+    // keys should not result in a focus event being dispatched unexpectedly.
+    if (keys.length === 0) {
+      throw getNoKeysSpecifiedError();
+    }
 
     return this.element.sendKeys(...keys);
   }

--- a/src/cdk/testing/public-api.ts
+++ b/src/cdk/testing/public-api.ts
@@ -9,6 +9,7 @@
 export * from './component-harness';
 export * from './harness-environment';
 export * from './test-element';
+export * from './test-element-errors';
 export * from './element-dimensions';
 export * from './text-filtering';
 export * from './change-detection';

--- a/src/cdk/testing/test-element-errors.ts
+++ b/src/cdk/testing/test-element-errors.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Returns an error which reports that no keys have been specified.
+ * @docs-private
+ */
+export function getNoKeysSpecifiedError() {
+  return Error('No keys have been specified.');
+}

--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -119,12 +119,14 @@ export interface TestElement {
    * Sends the given string to the input as a series of key presses. Also fires input events
    * and attempts to add the string to the Element's value. Note that some environments cannot
    * reproduce native browser behavior for keyboard shortcuts such as Tab, Ctrl + A, etc.
+   * @throws An error if no keys have been specified.
    */
   sendKeys(...keys: (string | TestKey)[]): Promise<void>;
 
   /**
-   * Sends the given string to the input as a series of key presses. Also fires input events
-   * and attempts to add the string to the Element's value.
+   * Sends the given string to the input as a series of key presses. Also fires input
+   * events and attempts to add the string to the Element's value.
+   * @throws An error if no keys have been specified.
    */
   sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
 

--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -9,6 +9,7 @@
 import {
   ComponentHarness,
   ComponentHarnessConstructor,
+  getNoKeysSpecifiedError,
   HarnessLoader,
   HarnessPredicate,
   parallel,
@@ -345,6 +346,18 @@ export function crossEnvironmentSpecs(
       harness = await getMainComponentHarnessFromEnvironment();
     });
 
+    async function expectAsyncError(fn: () => Promise<void>, expected: Error) {
+      let error: unknown | null = null;
+      try {
+        await fn();
+      } catch (e: unknown) {
+        error = e;
+      }
+      expect(error).not.toBe(null);
+      expect(error instanceof Error).toBe(true);
+      expect((error as Error).message).toBe(expected.message);
+    }
+
     it('should be able to clear', async () => {
       const input = await harness.input();
       await input.sendKeys('Yi');
@@ -352,6 +365,13 @@ export function crossEnvironmentSpecs(
 
       await input.clear();
       expect(await input.getProperty<string>('value')).toBe('');
+    });
+
+    it('sendKeys method should throw if no keys have been specified', async () => {
+      const input = await harness.input();
+      await expectAsyncError(() => input.sendKeys(), getNoKeysSpecifiedError());
+      await expectAsyncError(() => input.sendKeys(''), getNoKeysSpecifiedError());
+      await expectAsyncError(() => input.sendKeys('', ''), getNoKeysSpecifiedError());
     });
 
     it('should be able to click', async () => {

--- a/tools/public_api_guard/cdk/testing.md
+++ b/tools/public_api_guard/cdk/testing.md
@@ -77,6 +77,9 @@ export type EventData = string | number | boolean | undefined | null | EventData
 };
 
 // @public
+export function getNoKeysSpecifiedError(): Error;
+
+// @public
 export function _getTextWithExcludedElements(element: Element, excludeSelector: string): string;
 
 // @public


### PR DESCRIPTION
Previously, calling `sendKeys` without any keys resulted in a runtime
exception `Cannot read X of undefined` error being thrown. This is because
the first element of the passed arguments to `sendKeys` has been considered
always truthy. This assumption is wrong since arbitrary amount of arguments
can be passed due to the spread parameter.

To ensure consistent and reasonable behavior of this function, we fix
the runtime exception mentioned above, but throw if no keys have been
determined (not necessarily only if the arguments length is zero).