### PR TITLE
build: run saucelabs and browserstack tests with ivy

### DIFF
--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -45,7 +45,7 @@ task(':test:build-system-config', () => {
   const configOutputPath = join(buildConfig.outputDir, 'karma-system-config.js');
   shelljs.cd(buildConfig.projectDir);
   const bazelGenfilesDir = shelljs.exec('yarn -s bazel info bazel-genfiles').stdout.trim();
-  shelljs.exec('yarn -s bazel build //test:system-config.js --config=view-engine');
+  shelljs.exec('yarn -s bazel build //test:system-config.js');
   shelljs.cp(join(bazelGenfilesDir, 'test/system-config.js'), configOutputPath);
   shelljs.chmod('u+w', configOutputPath);
 });

--- a/tools/system-config-tmpl.js
+++ b/tools/system-config-tmpl.js
@@ -121,9 +121,10 @@ function setupFrameworkPackages() {
       var entryPointName = segments.length ? moduleName + '/' + segments.join('/') : moduleName;
       var bundlePath = 'bundles/' + bundleName;
       // When running with Ivy, we need to load the ngcc processed UMD bundles.
-      // These are stored in the "__ivy_ngcc_" folder that has been generated
-      // since we run ngcc with "--create-ivy-entry-points".
-      if (isRunningWithIvy) {
+      // These are stored in the `__ivy_ngcc_` folder that has been generated
+      // since we run ngcc with `--create-ivy-entry-points`. Filter out the compiler
+      // package because it won't be processed by ngcc.
+      if (isRunningWithIvy && entryPointName !== '@angular/compiler') {
         bundlePath = '__ivy_ngcc__/' + bundlePath;
       }
       packagesConfig[entryPointName] = {


### PR DESCRIPTION
We recently regressed when we switched to the auto-generated
SystemJS configuration in terms of how those legacy karma tests
run. Previously they ran with Ivy, but currently they run with view
engine. We should switch them back to Ivy since Ivy is the default in
version 9.