### PR TITLE
refactor: clean up datepicker base class abstract methods

### DIFF
--- a/src/dev-app/datepicker/datepicker-demo.html
+++ b/src/dev-app/datepicker/datepicker-demo.html
@@ -169,3 +169,37 @@
     <mat-datepicker #customHeaderNgContentPicker [calendarHeaderComponent]="customHeaderNgContent"></mat-datepicker>
   </mat-form-field>
 </p>
+
+<h2>Range picker</h2>
+<p>
+  <mat-form-field>
+    <mat-label>Enter a date range</mat-label>
+    <mat-date-range-input>
+      <input matStartDate placeholder="Start date">
+      <input matEndDate placeholder="End date">
+    </mat-date-range-input>
+    <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
+  </mat-form-field>
+</p>
+
+<p>
+  <mat-form-field appearance="fill">
+    <mat-label>Enter a date range</mat-label>
+    <mat-date-range-input>
+      <input matStartDate placeholder="Start date">
+      <input matEndDate placeholder="End date">
+    </mat-date-range-input>
+    <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
+  </mat-form-field>
+</p>
+
+<p>
+  <mat-form-field appearance="outline">
+    <mat-label>Enter a date range</mat-label>
+    <mat-date-range-input>
+      <input matStartDate placeholder="Start date">
+      <input matEndDate placeholder="End date">
+    </mat-date-range-input>
+    <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
+  </mat-form-field>
+</p>

--- a/src/dev-app/datepicker/datepicker-demo.html
+++ b/src/dev-app/datepicker/datepicker-demo.html
@@ -171,35 +171,39 @@
 </p>
 
 <h2>Range picker</h2>
-<p>
+
+<div class="demo-range-group">
   <mat-form-field>
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input>
-      <input matStartDate placeholder="Start date">
-      <input matEndDate placeholder="End date">
+    <mat-date-range-input [formGroup]="range1">
+      <input matStartDate formControlName="start" placeholder="Start date"/>
+      <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
   </mat-form-field>
-</p>
+  <div>{{range1.value | json}}</div>
+</div>
 
-<p>
+<div class="demo-range-group">
   <mat-form-field appearance="fill">
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input>
-      <input matStartDate placeholder="Start date">
-      <input matEndDate placeholder="End date">
+    <mat-date-range-input [formGroup]="range2">
+      <input matStartDate formControlName="start" placeholder="Start date"/>
+      <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
   </mat-form-field>
-</p>
+  <div>{{range2.value | json}}</div>
+</div>
 
-<p>
+<div class="demo-range-group">
   <mat-form-field appearance="outline">
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input>
-      <input matStartDate placeholder="Start date">
-      <input matEndDate placeholder="End date">
+    <mat-date-range-input [formGroup]="range3">
+      <input matStartDate formControlName="start" placeholder="Start date"/>
+      <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle matSuffix></mat-datepicker-toggle>
   </mat-form-field>
-</p>
+  <div>{{range3.value | json}}</div>
+</div>

--- a/src/dev-app/datepicker/datepicker-demo.scss
+++ b/src/dev-app/datepicker/datepicker-demo.scss
@@ -2,3 +2,6 @@ mat-calendar {
   width: 300px;
 }
 
+.demo-range-group {
+  margin-bottom: 30px;
+}

--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -15,7 +15,7 @@ import {
   Optional,
   ViewChild
 } from '@angular/core';
-import {FormControl} from '@angular/forms';
+import {FormControl, FormGroup} from '@angular/forms';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, ThemePalette} from '@angular/material/core';
 import {
   MatCalendar,
@@ -47,6 +47,9 @@ export class DatepickerDemo {
   color: ThemePalette;
 
   dateCtrl = new FormControl();
+  range1 = new FormGroup({start: new FormControl(), end: new FormControl()});
+  range2 = new FormGroup({start: new FormControl(), end: new FormControl()});
+  range3 = new FormGroup({start: new FormControl(), end: new FormControl()});
 
   dateFilter: (date: Date | null) => boolean =
     (date: Date | null) => {

--- a/src/material/core/datetime/date-selection-model.ts
+++ b/src/material/core/datetime/date-selection-model.ts
@@ -26,7 +26,11 @@ export class DateRange<D> {
     readonly end: D | null) {}
 }
 
-type ExtractDateTypeFromSelection<T> = T extends DateRange<infer D> ? D : NonNullable<T>;
+/**
+ * Conditionally picks the date type, if a DateRange is passed in.
+ * @docs-private
+ */
+export type ExtractDateTypeFromSelection<T> = T extends DateRange<infer D> ? D : NonNullable<T>;
 
 /** Event emitted by the date selection model when its selection changes. */
 export interface DateSelectionModelChange<S> {
@@ -212,4 +216,18 @@ export const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider = {
   provide: MatDateSelectionModel,
   deps: [[new Optional(), new SkipSelf(), MatDateSelectionModel], DateAdapter],
   useFactory: MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY,
+};
+
+
+/** @docs-private */
+export function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(
+    parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>) {
+  return parent || new MatRangeDateSelectionModel(adapter);
+}
+
+/** Used to provide a range selection model to a component. */
+export const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider = {
+  provide: MatDateSelectionModel,
+  deps: [[new Optional(), new SkipSelf(), MatDateSelectionModel], DateAdapter],
+  useFactory: MAT_RANGE_DATE_SELECTION_MODEL_FACTORY,
 };

--- a/src/material/core/datetime/date-selection-model.ts
+++ b/src/material/core/datetime/date-selection-model.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {FactoryProvider, Injectable, Optional, SkipSelf, OnDestroy} from '@angular/core';
+import {DateAdapter} from './date-adapter';
+import {Observable, Subject} from 'rxjs';
+
+/** A class representing a range of dates. */
+export class DateRange<D> {
+  /**
+   * Ensures that objects with a `start` and `end` property can't be assigned to a variable that
+   * expects a `DateRange`
+   */
+  // tslint:disable-next-line:no-unused-variable
+  private _disableStructuralEquivalency: never;
+
+  constructor(
+    /** The start date of the range. */
+    readonly start: D | null,
+    /** The end date of the range. */
+    readonly end: D | null) {}
+}
+
+type ExtractDateTypeFromSelection<T> = T extends DateRange<infer D> ? D : NonNullable<T>;
+
+/** Event emitted by the date selection model when its selection changes. */
+export interface DateSelectionModelChange<S> {
+  /** New value for the selection. */
+  selection: S;
+
+  /** Object that triggered the change. */
+  source: unknown;
+}
+
+/** A selection model containing a date selection. */
+export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>>
+    implements OnDestroy {
+  private _selectionChanged = new Subject<DateSelectionModelChange<S>>();
+
+  /** Emits when the selection has changed. */
+  selectionChanged: Observable<DateSelectionModelChange<S>> = this._selectionChanged.asObservable();
+
+  protected constructor(
+    /** Date adapter used when interacting with dates in the model. */
+    protected readonly adapter: DateAdapter<D>,
+    /** The current selection. */
+    readonly selection: S) {
+    this.selection = selection;
+  }
+
+  /**
+   * Updates the current selection in the model.
+   * @param value New selection that should be assigned.
+   * @param source Object that triggered the selection change.
+   */
+  updateSelection(value: S, source: unknown) {
+    (this as {selection: S}).selection = value;
+    this._selectionChanged.next({selection: value, source});
+  }
+
+  ngOnDestroy() {
+    this._selectionChanged.complete();
+  }
+
+  /** Adds a date to the current selection. */
+  abstract add(date: D | null): void;
+
+  /** Checks whether the current selection is complete. */
+  abstract isComplete(): boolean;
+
+  /** Checks whether the current selection is identical to the passed-in selection. */
+  abstract isSame(other: S): boolean;
+
+  /** Checks whether the current selection is valid. */
+  abstract isValid(): boolean;
+
+  /** Checks whether the current selection overlaps with the given range. */
+  abstract overlaps(range: DateRange<D>): boolean;
+}
+
+/**  A selection model that contains a single date. */
+@Injectable()
+export class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
+  constructor(adapter: DateAdapter<D>) {
+    super(adapter, null);
+  }
+
+  /**
+   * Adds a date to the current selection. In the case of a single date selection, the added date
+   * simply overwrites the previous selection
+   */
+  add(date: D | null) {
+    super.updateSelection(date, this);
+  }
+
+  /**
+   * Checks whether the current selection is complete. In the case of a single date selection, this
+   * is true if the current selection is not null.
+   */
+  isComplete() { return this.selection != null; }
+
+  /** Checks whether the current selection is identical to the passed-in selection. */
+  isSame(other: D): boolean {
+    return this.adapter.sameDate(other, this.selection);
+  }
+
+  /**
+   * Checks whether the current selection is valid. In the case of a single date selection, this
+   * means that the current selection is not null and is a valid date.
+   */
+  isValid(): boolean {
+    return this.selection != null && this.adapter.isDateInstance(this.selection) &&
+        this.adapter.isValid(this.selection);
+  }
+
+  /** Checks whether the current selection overlaps with the given range. */
+  overlaps(range: DateRange<D>): boolean {
+    return !!(this.selection && range.start && range.end &&
+        this.adapter.compareDate(range.start, this.selection) <= 0 &&
+        this.adapter.compareDate(this.selection, range.end) <= 0);
+  }
+}
+
+/**  A selection model that contains a date range. */
+@Injectable()
+export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
+  constructor(adapter: DateAdapter<D>) {
+    super(adapter, new DateRange<D>(null, null));
+  }
+
+  /**
+   * Adds a date to the current selection. In the case of a date range selection, the added date
+   * fills in the next `null` value in the range. If both the start and the end already have a date,
+   * the selection is reset so that the given date is the new `start` and the `end` is null.
+   */
+  add(date: D | null): void {
+    let {start, end} = this.selection;
+
+    if (start == null) {
+      start = date;
+    } else if (end == null) {
+      end = date;
+    } else {
+      start = date;
+      end = null;
+    }
+
+    super.updateSelection(new DateRange<D>(start, end), this);
+  }
+
+  /**
+   * Checks whether the current selection is complete. In the case of a date range selection, this
+   * is true if the current selection has a non-null `start` and `end`.
+   */
+  isComplete(): boolean {
+    return this.selection.start != null && this.selection.end != null;
+  }
+
+  /** Checks whether the current selection is identical to the passed-in selection. */
+  isSame(other: DateRange<D>): boolean {
+      return this.adapter.sameDate(this.selection.start, other.start) &&
+             this.adapter.sameDate(this.selection.end, other.end);
+  }
+
+  /**
+   * Checks whether the current selection is valid. In the case of a date range selection, this
+   * means that the current selection has a `start` and `end` that are both non-null and valid
+   * dates.
+   */
+  isValid(): boolean {
+    return this.selection.start != null && this.selection.end != null &&
+        this.adapter.isValid(this.selection.start!) && this.adapter.isValid(this.selection.end!);
+  }
+
+  /**
+   * Returns true if the given range and the selection overlap in any way. False if otherwise, that
+   * includes incomplete selections or ranges.
+   */
+  overlaps(range: DateRange<D>): boolean {
+    if (!(this.selection.start && this.selection.end && range.start && range.end)) {
+      return false;
+    }
+
+    return (
+        this._isBetween(range.start, this.selection.start, this.selection.end) ||
+        this._isBetween(range.end, this.selection.start, this.selection.end) ||
+        (
+            this.adapter.compareDate(range.start, this.selection.start) <= 0 &&
+            this.adapter.compareDate(this.selection.end, range.end) <= 0
+        )
+    );
+  }
+
+  private _isBetween(value: D, from: D, to: D): boolean {
+    return this.adapter.compareDate(from, value) <= 0 && this.adapter.compareDate(value, to) <= 0;
+  }
+}
+
+/** @docs-private */
+export function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(
+    parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>) {
+  return parent || new MatSingleDateSelectionModel(adapter);
+}
+
+/** Used to provide a single selection model to a component. */
+export const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider = {
+  provide: MatDateSelectionModel,
+  deps: [[new Optional(), new SkipSelf(), MatDateSelectionModel], DateAdapter],
+  useFactory: MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY,
+};

--- a/src/material/core/datetime/index.ts
+++ b/src/material/core/datetime/index.ts
@@ -17,6 +17,7 @@ export * from './date-adapter';
 export * from './date-formats';
 export * from './native-date-adapter';
 export * from './native-date-formats';
+export * from './date-selection-model';
 
 
 @NgModule({

--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -19,6 +19,7 @@ ng_module(
     assets = [
         ":datepicker-content.css",
         ":datepicker-toggle.css",
+        ":date-range-input.css",
         ":calendar-body.css",
         ":calendar.css",
     ] + glob(["**/*.html"]),
@@ -69,6 +70,12 @@ sass_binary(
     name = "calendar_body_scss",
     src = "calendar-body.scss",
     deps = ["//src/cdk/a11y:a11y_scss_lib"],
+)
+
+sass_binary(
+    name = "date_range_input_scss",
+    src = "date-range-input.scss",
+    deps = ["//src/material/core:core_scss_lib"],
 )
 
 ng_test_library(

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -1,0 +1,178 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directive, ElementRef, Optional, Self, InjectionToken, Inject} from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  NG_VALIDATORS,
+  ControlValueAccessor,
+  Validator,
+  AbstractControl,
+  ValidationErrors,
+  NgForm,
+  FormGroupDirective,
+  NgControl,
+} from '@angular/forms';
+import {
+  CanUpdateErrorState,
+  CanDisable,
+  ErrorStateMatcher,
+  CanDisableCtor,
+  CanUpdateErrorStateCtor,
+  mixinErrorState,
+  mixinDisabled,
+} from '@angular/material/core';
+import {BooleanInput} from '@angular/cdk/coercion';
+
+/**  Parent component that should be wrapped around `MatStartDate` and `MatEndDate`. */
+export interface MatDateRangeInputParent {
+  id: string;
+  _ariaDescribedBy: string | null;
+  _ariaLabelledBy: string | null;
+  _handleChildValueChange: () => void;
+}
+
+/**
+ * Used to provide the date range input wrapper component
+ * to the parts without circular dependencies.
+ */
+export const MAT_DATE_RANGE_INPUT_PARENT =
+    new InjectionToken<MatDateRangeInputParent>('MAT_DATE_RANGE_INPUT_PARENT');
+
+// Boilerplate for applying mixins to MatDateRangeInput.
+/** @docs-private */
+class MatDateRangeInputPartMixinBase {
+  constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
+              public _parentForm: NgForm,
+              public _parentFormGroup: FormGroupDirective,
+              /** @docs-private */
+              public ngControl: NgControl) {}
+}
+const _MatDateRangeInputMixinBase: CanDisableCtor &
+    CanUpdateErrorStateCtor & typeof MatDateRangeInputPartMixinBase =
+    mixinErrorState(mixinDisabled(MatDateRangeInputPartMixinBase));
+
+/**
+ * Base class for the individual inputs that can be projected inside a `mat-date-range-input`.
+ */
+@Directive()
+abstract class MatDateRangeInputPartBase<D> extends _MatDateRangeInputMixinBase implements
+  ControlValueAccessor, Validator, CanUpdateErrorState, CanDisable, CanUpdateErrorState {
+
+  private _onTouched = () => {};
+
+  constructor(
+    protected _elementRef: ElementRef<HTMLInputElement>,
+    @Inject(MAT_DATE_RANGE_INPUT_PARENT) public _rangeInput: MatDateRangeInputParent,
+    defaultErrorStateMatcher: ErrorStateMatcher,
+    @Optional() parentForm: NgForm,
+    @Optional() parentFormGroup: FormGroupDirective,
+    @Optional() @Self() ngControl: NgControl) {
+    super(defaultErrorStateMatcher, parentForm, parentFormGroup, ngControl);
+  }
+
+  /** @docs-private */
+  writeValue(_value: D | null): void {
+    // TODO(crisbeto): implement
+  }
+
+  /** @docs-private */
+  registerOnChange(_fn: () => void): void {
+    // TODO(crisbeto): implement
+  }
+
+  /** @docs-private */
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  /** @docs-private */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  /** @docs-private */
+  validate(_control: AbstractControl): ValidationErrors | null {
+    // TODO(crisbeto): implement
+    return null;
+  }
+
+  /** @docs-private */
+  registerOnValidatorChange(_fn: () => void): void {
+    // TODO(crisbeto): implement
+  }
+
+  /** Gets whether the input is empty. */
+  isEmpty(): boolean {
+    // TODO(crisbeto): should look at the CVA value.
+    return this._elementRef.nativeElement.value.length === 0;
+  }
+
+  /** Focuses the input. */
+  focus(): void {
+    this._elementRef.nativeElement.focus();
+  }
+
+  /** Handles blur events on the input. */
+  _handleBlur(): void {
+    this._onTouched();
+  }
+
+  static ngAcceptInputType_disabled: BooleanInput;
+}
+
+
+/** Input for entering the start date in a `mat-date-range-input`. */
+@Directive({
+  selector: 'input[matStartDate]',
+  inputs: ['disabled'],
+  host: {
+    '[id]': '_rangeInput.id',
+    '[attr.aria-labelledby]': '_rangeInput._ariaLabelledBy',
+    '[attr.aria-describedby]': '_rangeInput._ariaDescribedBy',
+    'class': 'mat-date-range-input-inner',
+    'type': 'text',
+    '(blur)': '_handleBlur()',
+    '(input)': '_rangeInput._handleChildValueChange()'
+  },
+  providers: [
+    {provide: NG_VALUE_ACCESSOR, useExisting: MatStartDate, multi: true},
+    {provide: NG_VALIDATORS, useExisting: MatStartDate, multi: true}
+  ]
+})
+export class MatStartDate<D> extends MatDateRangeInputPartBase<D> {
+  /** Gets the value that should be used when mirroring the input's size. */
+  getMirrorValue(): string {
+    const element = this._elementRef.nativeElement;
+    const value = element.value;
+    return value.length > 0 ? value : element.placeholder;
+  }
+
+  static ngAcceptInputType_disabled: BooleanInput;
+}
+
+
+/** Input for entering the end date in a `mat-date-range-input`. */
+@Directive({
+  selector: 'input[matEndDate]',
+  inputs: ['disabled'],
+  host: {
+    'class': 'mat-date-range-input-inner',
+    '[attr.aria-labelledby]': '_rangeInput._ariaLabelledBy',
+    '[attr.aria-describedby]': '_rangeInput._ariaDescribedBy',
+    '(blur)': '_handleBlur',
+    'type': 'text',
+  },
+  providers: [
+    {provide: NG_VALUE_ACCESSOR, useExisting: MatEndDate, multi: true},
+    {provide: NG_VALIDATORS, useExisting: MatEndDate, multi: true}
+  ]
+})
+export class MatEndDate<D> extends MatDateRangeInputPartBase<D> {
+  static ngAcceptInputType_disabled: BooleanInput;
+}

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -60,14 +60,18 @@ export const MAT_DATE_RANGE_INPUT_PARENT =
  * Base class for the individual inputs that can be projected inside a `mat-date-range-input`.
  */
 @Directive()
-class MatDateRangeInputPartBase<D>
+abstract class MatDateRangeInputPartBase<D>
   extends MatDatepickerInputBase<DateRange<D>, D> implements OnInit, DoCheck {
 
   /** @docs-private */
   ngControl: NgControl;
 
   /** @docs-private */
-  updateErrorState: () => void;
+  abstract updateErrorState: () => void;
+
+  protected abstract _validator: ValidatorFn | null;
+  protected abstract _assignValueToModel(value: D | null): void;
+  protected abstract _getValueFromModel(modelValue: DateRange<D>): D | null;
 
   constructor(
     @Inject(MAT_DATE_RANGE_INPUT_PARENT) public _rangeInput: MatDateRangeInputParent,
@@ -129,17 +133,12 @@ class MatDateRangeInputPartBase<D>
   protected _openPopup(): void {
     this._rangeInput._openDatepicker();
   }
-
-  // Dummy property implementations since we can't pass an abstract class
-  // into a mixin. These are overridden by the individual input classes.
-  protected _validator: ValidatorFn | null;
-  protected _assignValueToModel: (value: D | null) => void;
-  protected _getValueFromModel: (modelValue: DateRange<D>) => D | null;
 }
 
 const _MatDateRangeInputBase:
     CanUpdateErrorStateCtor & typeof MatDateRangeInputPartBase =
-    mixinErrorState(MatDateRangeInputPartBase);
+    // Needs to be `as any`, because the base class is abstract.
+    mixinErrorState(MatDateRangeInputPartBase as any);
 
 /** Input for entering the start date in a `mat-date-range-input`. */
 @Directive({
@@ -170,8 +169,12 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D>
   implements CanUpdateErrorState {
   // TODO(crisbeto): start-range-specific validators should go here.
   protected _validator = Validators.compose([this._parseValidator]);
-  protected _getValueFromModel = (modelValue: DateRange<D>) => modelValue.start;
-  protected _assignValueToModel = (value: D | null) => {
+
+  protected _getValueFromModel(modelValue: DateRange<D>) {
+    return modelValue.start;
+  }
+
+  protected _assignValueToModel(value: D | null) {
     if (this._model) {
       this._model.updateSelection(new DateRange(value, this._model.selection.end), this);
     }
@@ -216,8 +219,12 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D>
 export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
   // TODO(crisbeto): end-range-specific validators should go here.
   protected _validator = Validators.compose([this._parseValidator]);
-  protected _getValueFromModel = (modelValue: DateRange<D>) => modelValue.end;
-  protected _assignValueToModel = (value: D | null) => {
+
+  protected _getValueFromModel(modelValue: DateRange<D>) {
+    return modelValue.end;
+  }
+
+  protected _assignValueToModel(value: D | null) {
     if (this._model) {
       this._model.updateSelection(new DateRange(this._model.selection.start, value), this);
     }

--- a/src/material/datepicker/date-range-input.html
+++ b/src/material/datepicker/date-range-input.html
@@ -1,0 +1,18 @@
+<div
+  class="mat-date-range-input-container"
+  cdkMonitorSubtreeFocus
+  (cdkFocusChange)="focused = $event !== null">
+  <div class="mat-date-range-input-start-wrapper">
+    <ng-content select="input[matStartDate]"></ng-content>
+    <span
+      class="mat-date-range-input-mirror"
+      aria-hidden="true">{{_getInputMirrorValue()}}</span>
+  </div>
+
+  <span class="mat-date-range-input-separator">{{separator}}</span>
+
+  <div class="mat-date-range-input-end-wrapper">
+    <ng-content select="input[matEndDate]"></ng-content>
+  </div>
+</div>
+

--- a/src/material/datepicker/date-range-input.scss
+++ b/src/material/datepicker/date-range-input.scss
@@ -1,0 +1,115 @@
+@import '../core/style/variables';
+@import '../core/style/vendor-prefixes';
+
+$mat-date-range-input-separator-spacing: 4px;
+$mat-date-range-input-part-max-width: calc(50% - #{$mat-date-range-input-separator-spacing});
+$mat-date-range-input-placeholder-transition:
+  color $swift-ease-out-duration $swift-ease-out-duration / 3 $swift-ease-out-timing-function;
+
+// Host of the date range input.
+.mat-date-range-input {
+  display: block;
+  width: 100%;
+}
+
+// Inner container that wraps around all the content.
+.mat-date-range-input-container {
+  display: flex;
+  align-items: center;
+}
+
+// Text shown between the two inputs.
+.mat-date-range-input-separator {
+  margin: 0 $mat-date-range-input-separator-spacing;
+  transition: $mat-date-range-input-placeholder-transition;
+
+  .mat-form-field-hide-placeholder & {
+    color: transparent;
+    transition: none;
+  }
+}
+
+// Underlying input inside the range input.
+.mat-date-range-input-inner {
+  // Reset the input so it's just a transparent rectangle.
+  font: inherit;
+  background: transparent;
+  color: currentColor;
+  border: none;
+  outline: none;
+  padding: 0;
+  margin: 0;
+  vertical-align: bottom;
+  text-align: inherit;
+  -webkit-appearance: none;
+  width: 100%;
+
+  // Remove IE's default clear and reveal icons.
+  &::-ms-clear,
+  &::-ms-reveal {
+    display: none;
+  }
+
+  @include input-placeholder {
+    transition: $mat-date-range-input-placeholder-transition;
+  }
+
+  .mat-form-field-hide-placeholder &,
+  .mat-date-range-input-hide-placeholders & {
+    @include input-placeholder {
+      // Needs to be !important, because the placeholder will end up inheriting the
+      // input color in IE, if the consumer overrides it with a higher specificity.
+      color: transparent !important;
+      -webkit-text-fill-color: transparent;
+      transition: none;
+    }
+  }
+}
+
+// We want the start input to be flush against the separator, no matter how much text it has, but
+// the problem is that inputs have a fixed width. We work around the issue by implementing an
+// auto-resizing input that stretches based on its text, up to a point. It works by having
+// a relatively-positioned wrapper (`.mat-date-range-input-start-wrapper` below) and an absolutely-
+// positioned `input`, as well as a `span` inside the wrapper which mirrors the input's value and
+// placeholder. As the user is typing, the value gets mirrored in the span which causes the wrapper
+// to stretch and the input with it.
+.mat-date-range-input-mirror {
+  // Disable user selection so users don't accidentally copy the text via ctrl + A.
+  @include user-select(none);
+
+  // Hide the element so it doesn't get read out by screen
+  // readers and it doesn't show up behind the input.
+  visibility: hidden;
+
+  // Text inside inputs never wraps so the one in the span shouldn't either.
+  white-space: nowrap;
+  display: inline-block;
+
+  // Prevent the container from collapsing. Make it more
+  // than 1px so the input caret doesn't get clipped.
+  min-width: 2px;
+}
+
+// Wrapper around the start input. Used to facilitate the auto-resizing input.
+.mat-date-range-input-start-wrapper {
+  position: relative;
+  overflow: hidden;
+  max-width: $mat-date-range-input-part-max-width;
+
+  .mat-date-range-input-inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+}
+
+// Wrapper around the end input that makes sure that it has the proper size.
+.mat-date-range-input-end-wrapper {
+  flex-grow: 1;
+  max-width: $mat-date-range-input-part-max-width;
+}
+
+.mat-form-field-type-mat-date-range-input .mat-form-field-infix {
+  // Bump the default width slightly since it's somewhat cramped with two inputs and a separator.
+  width: 200px;
+}

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -162,6 +162,7 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
    */
   onContainerClick(): void {
     if (!this.focused) {
+      // TODO(crisbeto): maybe this should go to end input if start has a value?
       this._startInput.focus();
     }
   }
@@ -193,6 +194,11 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   /** Handles the value in one of the child inputs changing. */
   _handleChildValueChange() {
     this._changeDetectorRef.markForCheck();
+  }
+
+  /** Opens the datepicker associated with the input. */
+  _openDatepicker() {
+    // TODO(crisbeto): implement once the datepicker is in place.
   }
 
   static ngAcceptInputType_required: BooleanInput;

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ViewEncapsulation,
+  Input,
+  Optional,
+  OnDestroy,
+  ContentChild,
+  AfterContentInit,
+  ChangeDetectorRef,
+  Self,
+} from '@angular/core';
+import {MatFormFieldControl, MatFormField} from '@angular/material/form-field';
+import {DateRange} from '@angular/material/core';
+import {NgControl, ControlContainer} from '@angular/forms';
+import {Subject} from 'rxjs';
+import {coerceBooleanProperty, BooleanInput} from '@angular/cdk/coercion';
+import {
+  MatStartDate,
+  MatEndDate,
+  MatDateRangeInputParent,
+  MAT_DATE_RANGE_INPUT_PARENT,
+} from './date-range-input-parts';
+
+let nextUniqueId = 0;
+
+// TODO(crisbeto): when adding live examples, should how to use with `FormGroup`.
+
+@Component({
+  selector: 'mat-date-range-input',
+  templateUrl: 'date-range-input.html',
+  styleUrls: ['date-range-input.css'],
+  exportAs: 'matDateRangeInput',
+  host: {
+    'class': 'mat-date-range-input',
+    '[class.mat-date-range-input-hide-placeholders]': '_shouldHidePlaceholders()',
+    '[attr.id]': 'null',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  providers: [
+    {provide: MatFormFieldControl, useExisting: MatDateRangeInput},
+    {provide: MAT_DATE_RANGE_INPUT_PARENT, useExisting: MatDateRangeInput},
+  ]
+})
+export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
+  MatDateRangeInputParent, AfterContentInit, OnDestroy {
+  /** Current value of the range input. */
+  value: DateRange<D> | null = null;
+
+  /** Emits when the input's state has changed. */
+  stateChanges = new Subject<void>();
+
+  /** Unique ID for the input. */
+  id = `mat-date-range-input-${nextUniqueId++}`;
+
+  /** Whether the control is focused. */
+  focused = false;
+
+  /** Whether the control's label should float. */
+  get shouldLabelFloat(): boolean {
+    return this.focused || !this.empty;
+  }
+
+  /** Name of the form control. */
+  controlType = 'mat-date-range-input';
+
+  /**
+   * Implemented as a part of `MatFormFieldControl`, but not used.
+   * Use `startPlaceholder` and `endPlaceholder` instead.
+   * @docs-private
+   */
+  placeholder: string;
+
+  /** Whether the input is required. */
+  @Input()
+  get required(): boolean { return !!this._required; }
+  set required(value: boolean) {
+    this._required = coerceBooleanProperty(value);
+  }
+  private _required: boolean;
+
+  /** Whether the input is disabled. */
+  get disabled(): boolean {
+    if (this._startInput && this._endInput) {
+      return this._startInput.disabled && this._endInput.disabled;
+    }
+
+    return false;
+  }
+
+  /** Whether the input is in an error state. */
+  get errorState(): boolean {
+    if (this._startInput && this._endInput) {
+      return this._startInput.errorState || this._endInput.errorState;
+    }
+
+    return false;
+  }
+
+  /** Whether the datepicker input is empty. */
+  get empty(): boolean {
+    const startEmpty = this._startInput ? this._startInput.isEmpty() : false;
+    const endEmpty = this._endInput ? this._endInput.isEmpty() : false;
+    return startEmpty && endEmpty;
+  }
+
+  /** Value for the `aria-describedby` attribute of the inputs. */
+  _ariaDescribedBy: string | null = null;
+
+  /** Value for the `aria-labelledby` attribute of the inputs. */
+  _ariaLabelledBy: string | null = null;
+
+  /** Placeholder for the start input. */
+  @Input() startPlaceholder: string;
+
+  /** Placeholder for the end input. */
+  @Input() endPlaceholder: string;
+
+  /** Separator text to be shown between the inputs. */
+  @Input() separator = '–';
+
+  @ContentChild(MatStartDate) _startInput: MatStartDate<D>;
+  @ContentChild(MatEndDate) _endInput: MatEndDate<D>;
+
+  /**
+   * Implemented as a part of `MatFormFieldControl`.
+   * TODO(crisbeto): change type to `AbstractControlDirective` after #18206 lands.
+   * @docs-private
+   */
+  ngControl: NgControl | null;
+
+  constructor(
+    private _changeDetectorRef: ChangeDetectorRef,
+    @Optional() @Self() control: ControlContainer,
+    @Optional() formField?: MatFormField) {
+
+    // TODO(crisbeto): remove `as any` after #18206 lands.
+    this.ngControl = control as any;
+    this._ariaLabelledBy = formField ? formField._labelId : null;
+  }
+
+  /**
+   * Implemented as a part of `MatFormFieldControl`.
+   * @docs-private
+   */
+  setDescribedByIds(ids: string[]): void {
+    this._ariaDescribedBy = ids.length ? ids.join(' ') : null;
+  }
+
+  /**
+   * Implemented as a part of `MatFormFieldControl`.
+   * @docs-private
+   */
+  onContainerClick(): void {
+    if (!this.focused) {
+      this._startInput.focus();
+    }
+  }
+
+  ngAfterContentInit() {
+    if (!this._startInput) {
+      throw Error('mat-date-range-input must contain a matStartDate input');
+    }
+
+    if (!this._endInput) {
+      throw Error('mat-date-range-input must contain a matEndDate input');
+    }
+  }
+
+  ngOnDestroy() {
+    this.stateChanges.complete();
+  }
+
+  /** Gets the value that is used to mirror the state input. */
+  _getInputMirrorValue() {
+    return this._startInput ? this._startInput.getMirrorValue() : '';
+  }
+
+  /** Whether the input placeholders should be hidden. */
+  _shouldHidePlaceholders() {
+    return this._startInput ? !this._startInput.isEmpty() : false;
+  }
+
+  /** Handles the value in one of the child inputs changing. */
+  _handleChildValueChange() {
+    this._changeDetectorRef.markForCheck();
+  }
+
+  static ngAcceptInputType_required: BooleanInput;
+}

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -19,7 +19,7 @@ import {
   Self,
 } from '@angular/core';
 import {MatFormFieldControl, MatFormField} from '@angular/material/form-field';
-import {DateRange} from '@angular/material/core';
+import {DateRange, MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER} from '@angular/material/core';
 import {NgControl, ControlContainer} from '@angular/forms';
 import {Subject} from 'rxjs';
 import {coerceBooleanProperty, BooleanInput} from '@angular/cdk/coercion';
@@ -49,6 +49,10 @@ let nextUniqueId = 0;
   providers: [
     {provide: MatFormFieldControl, useExisting: MatDateRangeInput},
     {provide: MAT_DATE_RANGE_INPUT_PARENT, useExisting: MatDateRangeInput},
+
+    // TODO(crisbeto): this will be provided by the datepicker eventually.
+    // We provide it here for the moment so we have something to test against.
+    MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER,
   ]
 })
 export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -7,10 +7,8 @@
     [maxDate]="datepicker._maxDate"
     [dateFilter]="datepicker._dateFilter"
     [headerComponent]="datepicker.calendarHeaderComponent"
-    [selected]="datepicker._selected"
     [dateClass]="datepicker.dateClass"
     [@fadeInCalendar]="'enter'"
-    (selectedChange)="datepicker.select($event)"
     (yearSelected)="datepicker._selectYear($event)"
     (monthSelected)="datepicker._selectMonth($event)"
     (_userSelection)="datepicker.close()">

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {DOWN_ARROW} from '@angular/cdk/keycodes';
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  OnDestroy,
+  Optional,
+  Output,
+} from '@angular/core';
+import {
+  AbstractControl,
+  ControlValueAccessor,
+  ValidationErrors,
+  Validator,
+  ValidatorFn,
+} from '@angular/forms';
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MatDateFormats,
+  MatDateSelectionModel,
+} from '@angular/material/core';
+import {Subscription} from 'rxjs';
+import {createMissingDateImplError} from './datepicker-errors';
+
+/**
+ * An event used for datepicker input and change events. We don't always have access to a native
+ * input or change event because the event may have been triggered by the user clicking on the
+ * calendar popup. For consistency, we always use MatDatepickerInputEvent instead.
+ */
+export class MatDatepickerInputEvent<D> {
+  /** The new value for the target datepicker input. */
+  value: D | null;
+
+  constructor(
+      /** Reference to the datepicker input component that emitted the event. */
+      public target: MatDatepickerInputBase<D>,
+      /** Reference to the native input element associated with the datepicker input. */
+      public targetElement: HTMLElement) {
+    this.value = this.target.value;
+  }
+}
+
+/** Base class for datepicker inputs. */
+@Directive()
+export abstract class MatDatepickerInputBase<D> implements ControlValueAccessor, OnDestroy,
+  Validator {
+  /** The value of the input. */
+  @Input()
+  get value(): D | null { return this._model ? this._model.selection : this._pendingValue; }
+  set value(value: D | null) {
+    value = this._dateAdapter.deserialize(value);
+    this._lastValueValid = !value || this._dateAdapter.isValid(value);
+    value = this._getValidDateOrNull(value);
+    const oldDate = this.value;
+    this._assignValue(value);
+    this._formatValue(value);
+
+    if (!this._dateAdapter.sameDate(oldDate, value)) {
+      this._valueChange.emit(value);
+    }
+  }
+  protected _model: MatDateSelectionModel<D | null, D> | undefined;
+
+  /** Whether the datepicker-input is disabled. */
+  @Input()
+  get disabled(): boolean { return !!this._disabled; }
+  set disabled(value: boolean) {
+    const newValue = coerceBooleanProperty(value);
+    const element = this._elementRef.nativeElement;
+
+    if (this._disabled !== newValue) {
+      this._disabled = newValue;
+      this._disabledChange.emit(newValue);
+    }
+
+    // We need to null check the `blur` method, because it's undefined during SSR.
+    if (newValue && element.blur) {
+      // Normally, native input elements automatically blur if they turn disabled. This behavior
+      // is problematic, because it would mean that it triggers another change detection cycle,
+      // which then causes a changed after checked error if the input element was focused before.
+      element.blur();
+    }
+  }
+  private _disabled: boolean;
+
+  /** Emits when a `change` event is fired on this `<input>`. */
+  @Output() readonly dateChange: EventEmitter<MatDatepickerInputEvent<D>> =
+      new EventEmitter<MatDatepickerInputEvent<D>>();
+
+  /** Emits when an `input` event is fired on this `<input>`. */
+  @Output() readonly dateInput: EventEmitter<MatDatepickerInputEvent<D>> =
+      new EventEmitter<MatDatepickerInputEvent<D>>();
+
+  /** Emits when the value changes (either due to user input or programmatic change). */
+  _valueChange = new EventEmitter<D | null>();
+
+  /** Emits when the disabled state has changed */
+  _disabledChange = new EventEmitter<boolean>();
+
+  _onTouched = () => {};
+
+  private _cvaOnChange: (value: any) => void = () => {};
+  protected _validatorOnChange = () => {};
+  private _valueChangesSubscription = Subscription.EMPTY;
+  private _localeSubscription = Subscription.EMPTY;
+
+  /**
+   * Since the value is kept on the model which is assigned in an Input,
+   * we might get a value before we have a model. This property keeps track
+   * of the value until we have somewhere to assign it.
+   */
+  private _pendingValue: D | null;
+
+  /** The form control validator for whether the input parses. */
+  protected _parseValidator: ValidatorFn = (): ValidationErrors | null => {
+    return this._lastValueValid ?
+        null : {'matDatepickerParse': {'text': this._elementRef.nativeElement.value}};
+  }
+
+  protected _registerModel(model: MatDateSelectionModel<D | null, D>): void {
+    this._model = model;
+    this._valueChangesSubscription.unsubscribe();
+
+    if (this._pendingValue) {
+      this._assignValue(this._pendingValue);
+    }
+
+    this._valueChangesSubscription = this._model.selectionChanged.subscribe(event => {
+      if (event.source !== this) {
+        this._cvaOnChange(event.selection);
+        this._onTouched();
+        this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this._formatValue(event.selection);
+      }
+    });
+  }
+
+  /** Opens the popup associated with the input. */
+  protected abstract _openPopup(): void;
+
+  /** Assigns a value to the input's model. */
+  protected abstract _assignModelValue(model: D | null): void;
+
+  /** The combined form control validator for this input. */
+  protected abstract _validator: ValidatorFn | null;
+
+  /** Whether the last value set on the input was valid. */
+  protected _lastValueValid = false;
+
+  constructor(
+      protected _elementRef: ElementRef<HTMLInputElement>,
+      @Optional() public _dateAdapter: DateAdapter<D>,
+      @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats) {
+    if (!this._dateAdapter) {
+      throw createMissingDateImplError('DateAdapter');
+    }
+    if (!this._dateFormats) {
+      throw createMissingDateImplError('MAT_DATE_FORMATS');
+    }
+
+    // Update the displayed date when the locale changes.
+    this._localeSubscription = _dateAdapter.localeChanges.subscribe(() => {
+      this.value = this.value;
+    });
+  }
+
+  ngOnDestroy() {
+    this._valueChangesSubscription.unsubscribe();
+    this._localeSubscription.unsubscribe();
+    this._valueChange.complete();
+    this._disabledChange.complete();
+  }
+
+  /** @docs-private */
+  registerOnValidatorChange(fn: () => void): void {
+    this._validatorOnChange = fn;
+  }
+
+  /** @docs-private */
+  validate(c: AbstractControl): ValidationErrors | null {
+    return this._validator ? this._validator(c) : null;
+  }
+
+  // Implemented as part of ControlValueAccessor.
+  writeValue(value: D): void {
+    this.value = value;
+  }
+
+  // Implemented as part of ControlValueAccessor.
+  registerOnChange(fn: (value: any) => void): void {
+    this._cvaOnChange = fn;
+  }
+
+  // Implemented as part of ControlValueAccessor.
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  // Implemented as part of ControlValueAccessor.
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  _onKeydown(event: KeyboardEvent) {
+    const isAltDownArrow = event.altKey && event.keyCode === DOWN_ARROW;
+
+    if (isAltDownArrow && !this._elementRef.nativeElement.readOnly) {
+      this._openPopup();
+      event.preventDefault();
+    }
+  }
+
+  _onInput(value: string) {
+    const lastValueWasValid = this._lastValueValid;
+    let date = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
+    this._lastValueValid = !date || this._dateAdapter.isValid(date);
+    date = this._getValidDateOrNull(date);
+
+    if (!this._dateAdapter.sameDate(date, this.value)) {
+      this._assignValue(date);
+      this._cvaOnChange(date);
+      this._valueChange.emit(date);
+      this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+    } else if (lastValueWasValid !== this._lastValueValid) {
+      this._validatorOnChange();
+    }
+  }
+
+  _onChange() {
+    this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+  }
+
+  /** Handles blur events on the input. */
+  _onBlur() {
+    // Reformat the input only if we have a valid value.
+    if (this.value) {
+      this._formatValue(this.value);
+    }
+
+    this._onTouched();
+  }
+
+  /** Formats a value and sets it on the input element. */
+  private _formatValue(value: D | null) {
+    this._elementRef.nativeElement.value =
+        value ? this._dateAdapter.format(value, this._dateFormats.display.dateInput) : '';
+  }
+
+  /**
+   * @param obj The object to check.
+   * @returns The given object if it is both a date instance and valid, otherwise null.
+   */
+  protected _getValidDateOrNull(obj: any): D | null {
+    return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
+  }
+
+  /** Assigns a value to the model. */
+  private _assignValue(value: D | null) {
+    // We may get some incoming values before the model was
+    // assigned. Save the value so that we can assign it later.
+    if (this._model) {
+      this._assignModelValue(value);
+      this._pendingValue = null;
+    } else {
+      this._pendingValue = value;
+    }
+  }
+
+  // Accept `any` to avoid conflicts with other directives on `<input>` that
+  // may accept different types.
+  static ngAcceptInputType_value: any;
+  static ngAcceptInputType_disabled: BooleanInput;
+}

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -69,7 +69,7 @@ export const MAT_DATEPICKER_VALIDATORS: any = {
   },
   exportAs: 'matDatepickerInput',
 })
-export class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
+export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> {
   /** The datepicker that this input is associated with. */
   @Input()
   set matDatepicker(datepicker: MatDatepicker<D>) {
@@ -170,7 +170,11 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
     }
   }
 
-  protected _assignModelValue(value: D | null): void {
+  protected _getValueFromModel(modelValue: D | null): D | null {
+    return modelValue;
+  }
+
+  protected _assignValueToModel(value: D | null): void {
     if (this._model) {
       this._model.updateSelection(value, this);
     }

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -29,7 +29,13 @@ import {
   ValidatorFn,
   Validators,
 } from '@angular/forms';
-import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, ThemePalette} from '@angular/material/core';
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MatDateFormats,
+  ThemePalette,
+  MatDateSelectionModel,
+} from '@angular/material/core';
 import {MatFormField} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
 import {Subscription} from 'rxjs';
@@ -61,10 +67,10 @@ export class MatDatepickerInputEvent<D> {
   value: D | null;
 
   constructor(
-    /** Reference to the datepicker input component that emitted the event. */
-    public target: MatDatepickerInput<D>,
-    /** Reference to the native input element associated with the datepicker input. */
-    public targetElement: HTMLElement) {
+      /** Reference to the datepicker input component that emitted the event. */
+      public target: MatDatepickerInput<D>,
+      /** Reference to the native input element associated with the datepicker input. */
+      public targetElement: HTMLElement) {
     this.value = this.target.value;
   }
 }
@@ -94,21 +100,27 @@ export class MatDatepickerInputEvent<D> {
 export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {
   /** The datepicker that this input is associated with. */
   @Input()
-  set matDatepicker(value: MatDatepicker<D>) {
-    if (!value) {
+  set matDatepicker(datepicker: MatDatepicker<D>) {
+    if (!datepicker) {
       return;
     }
 
-    this._datepicker = value;
-    this._datepicker._registerInput(this);
-    this._datepickerSubscription.unsubscribe();
+    this._datepicker = datepicker;
+    this._model = this._datepicker._registerInput(this);
+    this._valueChangesSubscription.unsubscribe();
 
-    this._datepickerSubscription = this._datepicker._selectedChanged.subscribe((selected: D) => {
-      this.value = selected;
-      this._cvaOnChange(selected);
-      this._onTouched();
-      this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-      this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+    if (this._pendingValue) {
+      this._assignValue(this._pendingValue);
+    }
+
+    this._valueChangesSubscription = this._model.selectionChanged.subscribe(event => {
+      if (event.source !== this) {
+        this._cvaOnChange(event.selection);
+        this._onTouched();
+        this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
+        this._formatValue(event.selection);
+      }
     });
   }
   _datepicker: MatDatepicker<D>;
@@ -123,20 +135,20 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
 
   /** The value of the input. */
   @Input()
-  get value(): D | null { return this._value; }
+  get value(): D | null { return this._model ? this._model.selection : this._pendingValue; }
   set value(value: D | null) {
     value = this._dateAdapter.deserialize(value);
     this._lastValueValid = !value || this._dateAdapter.isValid(value);
     value = this._getValidDateOrNull(value);
     const oldDate = this.value;
-    this._value = value;
+    this._assignValue(value);
     this._formatValue(value);
 
     if (!this._dateAdapter.sameDate(oldDate, value)) {
       this._valueChange.emit(value);
     }
   }
-  private _value: D | null;
+  private _model: MatDateSelectionModel<D | null, D> | undefined;
 
   /** The minimum valid date. */
   @Input()
@@ -195,12 +207,16 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
   _onTouched = () => {};
 
   private _cvaOnChange: (value: any) => void = () => {};
-
   private _validatorOnChange = () => {};
-
-  private _datepickerSubscription = Subscription.EMPTY;
-
+  private _valueChangesSubscription = Subscription.EMPTY;
   private _localeSubscription = Subscription.EMPTY;
+
+  /**
+   * Since the value is kept on the datepicker which is assigned in an Input,
+   * we might get a value before we have a datepicker. This property keeps track
+   * of the value until we have somewhere to assign it.
+   */
+  private _pendingValue: D | null;
 
   /** The form control validator for whether the input parses. */
   private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
@@ -258,7 +274,7 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
   }
 
   ngOnDestroy() {
-    this._datepickerSubscription.unsubscribe();
+    this._valueChangesSubscription.unsubscribe();
     this._localeSubscription.unsubscribe();
     this._valueChange.complete();
     this._disabledChange.complete();
@@ -325,8 +341,8 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
     this._lastValueValid = !date || this._dateAdapter.isValid(date);
     date = this._getValidDateOrNull(date);
 
-    if (!this._dateAdapter.sameDate(date, this._value)) {
-      this._value = date;
+    if (!this._dateAdapter.sameDate(date, this.value)) {
+      this._assignValue(date);
       this._cvaOnChange(date);
       this._valueChange.emit(date);
       this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
@@ -366,6 +382,18 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
    */
   private _getValidDateOrNull(obj: any): D | null {
     return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
+  }
+
+  /** Assigns a value to the model. */
+  private _assignValue(value: D | null) {
+    // We may get some incoming values before the datepicker was
+    // assigned. Save the value so that we can assign it later.
+    if (this._model) {
+      this._model.updateSelection(value, this);
+      this._pendingValue = null;
+    } else {
+      this._pendingValue = value;
+    }
   }
 
   // Accept `any` to avoid conflicts with other directives on `<input>` that

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -6,26 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
-import {DOWN_ARROW} from '@angular/cdk/keycodes';
+import {BooleanInput} from '@angular/cdk/coercion';
 import {
   Directive,
   ElementRef,
-  EventEmitter,
   forwardRef,
   Inject,
   Input,
-  OnDestroy,
   Optional,
-  Output,
 } from '@angular/core';
 import {
   AbstractControl,
-  ControlValueAccessor,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
   ValidationErrors,
-  Validator,
   ValidatorFn,
   Validators,
 } from '@angular/forms';
@@ -34,13 +28,11 @@ import {
   MAT_DATE_FORMATS,
   MatDateFormats,
   ThemePalette,
-  MatDateSelectionModel,
 } from '@angular/material/core';
 import {MatFormField} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
-import {Subscription} from 'rxjs';
 import {MatDatepicker} from './datepicker';
-import {createMissingDateImplError} from './datepicker-errors';
+import {MatDatepickerInputBase} from './datepicker-input-base';
 
 /** @docs-private */
 export const MAT_DATEPICKER_VALUE_ACCESSOR: any = {
@@ -55,26 +47,6 @@ export const MAT_DATEPICKER_VALIDATORS: any = {
   useExisting: forwardRef(() => MatDatepickerInput),
   multi: true
 };
-
-
-/**
- * An event used for datepicker input and change events. We don't always have access to a native
- * input or change event because the event may have been triggered by the user clicking on the
- * calendar popup. For consistency, we always use MatDatepickerInputEvent instead.
- */
-export class MatDatepickerInputEvent<D> {
-  /** The new value for the target datepicker input. */
-  value: D | null;
-
-  constructor(
-      /** Reference to the datepicker input component that emitted the event. */
-      public target: MatDatepickerInput<D>,
-      /** Reference to the native input element associated with the datepicker input. */
-      public targetElement: HTMLElement) {
-    this.value = this.target.value;
-  }
-}
-
 
 /** Directive used to connect an input to a MatDatepicker. */
 @Directive({
@@ -97,58 +69,16 @@ export class MatDatepickerInputEvent<D> {
   },
   exportAs: 'matDatepickerInput',
 })
-export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {
+export class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
   /** The datepicker that this input is associated with. */
   @Input()
   set matDatepicker(datepicker: MatDatepicker<D>) {
-    if (!datepicker) {
-      return;
+    if (datepicker) {
+      this._datepicker = datepicker;
+      this._registerModel(datepicker._registerInput(this));
     }
-
-    this._datepicker = datepicker;
-    this._model = this._datepicker._registerInput(this);
-    this._valueChangesSubscription.unsubscribe();
-
-    if (this._pendingValue) {
-      this._assignValue(this._pendingValue);
-    }
-
-    this._valueChangesSubscription = this._model.selectionChanged.subscribe(event => {
-      if (event.source !== this) {
-        this._cvaOnChange(event.selection);
-        this._onTouched();
-        this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-        this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-        this._formatValue(event.selection);
-      }
-    });
   }
   _datepicker: MatDatepicker<D>;
-
-  /** Function that can be used to filter out dates within the datepicker. */
-  @Input()
-  set matDatepickerFilter(value: (date: D | null) => boolean) {
-    this._dateFilter = value;
-    this._validatorOnChange();
-  }
-  _dateFilter: (date: D | null) => boolean;
-
-  /** The value of the input. */
-  @Input()
-  get value(): D | null { return this._model ? this._model.selection : this._pendingValue; }
-  set value(value: D | null) {
-    value = this._dateAdapter.deserialize(value);
-    this._lastValueValid = !value || this._dateAdapter.isValid(value);
-    value = this._getValidDateOrNull(value);
-    const oldDate = this.value;
-    this._assignValue(value);
-    this._formatValue(value);
-
-    if (!this._dateAdapter.sameDate(oldDate, value)) {
-      this._valueChange.emit(value);
-    }
-  }
-  private _model: MatDateSelectionModel<D | null, D> | undefined;
 
   /** The minimum valid date. */
   @Input()
@@ -168,60 +98,19 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
   }
   private _max: D | null;
 
-  /** Whether the datepicker-input is disabled. */
+  /** Function that can be used to filter out dates within the datepicker. */
   @Input()
-  get disabled(): boolean { return !!this._disabled; }
-  set disabled(value: boolean) {
-    const newValue = coerceBooleanProperty(value);
-    const element = this._elementRef.nativeElement;
-
-    if (this._disabled !== newValue) {
-      this._disabled = newValue;
-      this._disabledChange.emit(newValue);
-    }
-
-    // We need to null check the `blur` method, because it's undefined during SSR.
-    if (newValue && element.blur) {
-      // Normally, native input elements automatically blur if they turn disabled. This behavior
-      // is problematic, because it would mean that it triggers another change detection cycle,
-      // which then causes a changed after checked error if the input element was focused before.
-      element.blur();
-    }
+  set matDatepickerFilter(value: (date: D | null) => boolean) {
+    this._dateFilter = value;
+    this._validatorOnChange();
   }
-  private _disabled: boolean;
+  _dateFilter: (date: D | null) => boolean;
 
-  /** Emits when a `change` event is fired on this `<input>`. */
-  @Output() readonly dateChange: EventEmitter<MatDatepickerInputEvent<D>> =
-      new EventEmitter<MatDatepickerInputEvent<D>>();
-
-  /** Emits when an `input` event is fired on this `<input>`. */
-  @Output() readonly dateInput: EventEmitter<MatDatepickerInputEvent<D>> =
-      new EventEmitter<MatDatepickerInputEvent<D>>();
-
-  /** Emits when the value changes (either due to user input or programmatic change). */
-  _valueChange = new EventEmitter<D | null>();
-
-  /** Emits when the disabled state has changed */
-  _disabledChange = new EventEmitter<boolean>();
-
-  _onTouched = () => {};
-
-  private _cvaOnChange: (value: any) => void = () => {};
-  private _validatorOnChange = () => {};
-  private _valueChangesSubscription = Subscription.EMPTY;
-  private _localeSubscription = Subscription.EMPTY;
-
-  /**
-   * Since the value is kept on the datepicker which is assigned in an Input,
-   * we might get a value before we have a datepicker. This property keeps track
-   * of the value until we have somewhere to assign it.
-   */
-  private _pendingValue: D | null;
-
-  /** The form control validator for whether the input parses. */
-  private _parseValidator: ValidatorFn = (): ValidationErrors | null => {
-    return this._lastValueValid ?
-        null : {'matDatepickerParse': {'text': this._elementRef.nativeElement.value}};
+  /** The form control validator for the date filter. */
+  private _filterValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+    const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
+    return !this._dateFilter || !controlValue || this._dateFilter(controlValue) ?
+        null : {'matDatepickerFilter': true};
   }
 
   /** The form control validator for the min date. */
@@ -240,62 +129,17 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
         null : {'matDatepickerMax': {'max': this.max, 'actual': controlValue}};
   }
 
-  /** The form control validator for the date filter. */
-  private _filterValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
-    const controlValue = this._getValidDateOrNull(this._dateAdapter.deserialize(control.value));
-    return !this._dateFilter || !controlValue || this._dateFilter(controlValue) ?
-        null : {'matDatepickerFilter': true};
-  }
-
   /** The combined form control validator for this input. */
-  private _validator: ValidatorFn | null =
-      Validators.compose(
-          [this._parseValidator, this._minValidator, this._maxValidator, this._filterValidator]);
-
-  /** Whether the last value set on the input was valid. */
-  private _lastValueValid = false;
+  protected _validator: ValidatorFn | null;
 
   constructor(
-      private _elementRef: ElementRef<HTMLInputElement>,
-      @Optional() public _dateAdapter: DateAdapter<D>,
-      @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
+      elementRef: ElementRef<HTMLInputElement>,
+      @Optional() dateAdapter: DateAdapter<D>,
+      @Optional() @Inject(MAT_DATE_FORMATS) dateFormats: MatDateFormats,
       @Optional() private _formField: MatFormField) {
-    if (!this._dateAdapter) {
-      throw createMissingDateImplError('DateAdapter');
-    }
-    if (!this._dateFormats) {
-      throw createMissingDateImplError('MAT_DATE_FORMATS');
-    }
-
-    // Update the displayed date when the locale changes.
-    this._localeSubscription = _dateAdapter.localeChanges.subscribe(() => {
-      this.value = this.value;
-    });
-  }
-
-  ngOnDestroy() {
-    this._valueChangesSubscription.unsubscribe();
-    this._localeSubscription.unsubscribe();
-    this._valueChange.complete();
-    this._disabledChange.complete();
-  }
-
-  /** @docs-private */
-  registerOnValidatorChange(fn: () => void): void {
-    this._validatorOnChange = fn;
-  }
-
-  /** @docs-private */
-  validate(c: AbstractControl): ValidationErrors | null {
-    return this._validator ? this._validator(c) : null;
-  }
-
-  /**
-   * @deprecated
-   * @breaking-change 8.0.0 Use `getConnectedOverlayOrigin` instead
-   */
-  getPopupConnectionElementRef(): ElementRef {
-    return this.getConnectedOverlayOrigin();
+    super(elementRef, dateAdapter, dateFormats);
+    this._validator = Validators.compose(
+      [this._parseValidator, this._minValidator, this._maxValidator, this._filterValidator]);
   }
 
   /**
@@ -306,93 +150,29 @@ export class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, V
     return this._formField ? this._formField.getConnectedOverlayOrigin() : this._elementRef;
   }
 
-  // Implemented as part of ControlValueAccessor.
-  writeValue(value: D): void {
-    this.value = value;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  registerOnChange(fn: (value: any) => void): void {
-    this._cvaOnChange = fn;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  registerOnTouched(fn: () => void): void {
-    this._onTouched = fn;
-  }
-
-  // Implemented as part of ControlValueAccessor.
-  setDisabledState(isDisabled: boolean): void {
-    this.disabled = isDisabled;
-  }
-
-  _onKeydown(event: KeyboardEvent) {
-    const isAltDownArrow = event.altKey && event.keyCode === DOWN_ARROW;
-
-    if (this._datepicker && isAltDownArrow && !this._elementRef.nativeElement.readOnly) {
-      this._datepicker.open();
-      event.preventDefault();
-    }
-  }
-
-  _onInput(value: string) {
-    const lastValueWasValid = this._lastValueValid;
-    let date = this._dateAdapter.parse(value, this._dateFormats.parse.dateInput);
-    this._lastValueValid = !date || this._dateAdapter.isValid(date);
-    date = this._getValidDateOrNull(date);
-
-    if (!this._dateAdapter.sameDate(date, this.value)) {
-      this._assignValue(date);
-      this._cvaOnChange(date);
-      this._valueChange.emit(date);
-      this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-    } else if (lastValueWasValid !== this._lastValueValid) {
-      this._validatorOnChange();
-    }
-  }
-
-  _onChange() {
-    this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
-  }
-
   /** Returns the palette used by the input's form field, if any. */
   _getThemePalette(): ThemePalette {
     return this._formField ? this._formField.color : undefined;
   }
 
-  /** Handles blur events on the input. */
-  _onBlur() {
-    // Reformat the input only if we have a valid value.
-    if (this.value) {
-      this._formatValue(this.value);
-    }
-
-    this._onTouched();
-  }
-
-  /** Formats a value and sets it on the input element. */
-  private _formatValue(value: D | null) {
-    this._elementRef.nativeElement.value =
-        value ? this._dateAdapter.format(value, this._dateFormats.display.dateInput) : '';
-  }
-
   /**
-   * @param obj The object to check.
-   * @returns The given object if it is both a date instance and valid, otherwise null.
+   * @deprecated
+   * @breaking-change 8.0.0 Use `getConnectedOverlayOrigin` instead
    */
-  private _getValidDateOrNull(obj: any): D | null {
-    return (this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj)) ? obj : null;
+  getPopupConnectionElementRef(): ElementRef {
+    return this.getConnectedOverlayOrigin();
   }
 
-  /** Assigns a value to the model. */
-  private _assignValue(value: D | null) {
-    // We may get some incoming values before the datepicker was
-    // assigned. Save the value so that we can assign it later.
+  /** Opens the associated datepicker. */
+  protected _openPopup(): void {
+    if (this._datepicker) {
+      this._datepicker.open();
+    }
+  }
+
+  protected _assignModelValue(value: D | null): void {
     if (this._model) {
       this._model.updateSelection(value, this);
-      this._pendingValue = null;
-    } else {
-      this._pendingValue = value;
     }
   }
 

--- a/src/material/datepicker/datepicker-module.ts
+++ b/src/material/datepicker/datepicker-module.ts
@@ -26,6 +26,8 @@ import {MatDatepickerToggle, MatDatepickerToggleIcon} from './datepicker-toggle'
 import {MatMonthView} from './month-view';
 import {MatMultiYearView} from './multi-year-view';
 import {MatYearView} from './year-view';
+import {MatDateRangeInput} from './date-range-input';
+import {MatStartDate, MatEndDate} from './date-range-input-parts';
 
 
 @NgModule({
@@ -49,6 +51,9 @@ import {MatYearView} from './year-view';
     MatYearView,
     MatMultiYearView,
     MatCalendarHeader,
+    MatDateRangeInput,
+    MatStartDate,
+    MatEndDate,
   ],
   declarations: [
     MatCalendar,
@@ -62,6 +67,9 @@ import {MatYearView} from './year-view';
     MatYearView,
     MatMultiYearView,
     MatCalendarHeader,
+    MatDateRangeInput,
+    MatStartDate,
+    MatEndDate,
   ],
   providers: [
     MatDatepickerIntl,

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -12,7 +12,12 @@ import {
 import {Component, FactoryProvider, Type, ValueProvider, ViewChild} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, inject, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
-import {MAT_DATE_LOCALE, MatNativeDateModule, NativeDateModule} from '@angular/material/core';
+import {
+  MAT_DATE_LOCALE,
+  MatNativeDateModule,
+  NativeDateModule,
+  MatDateSelectionModel,
+} from '@angular/material/core';
 import {MatFormField, MatFormFieldModule} from '@angular/material/form-field';
 import {DEC, JAN, JUL, JUN, SEP} from '@angular/material/testing';
 import {By} from '@angular/platform-browser';
@@ -66,12 +71,15 @@ describe('MatDatepicker', () => {
     describe('standard datepicker', () => {
       let fixture: ComponentFixture<StandardDatepicker>;
       let testComponent: StandardDatepicker;
+      let model: MatDateSelectionModel<Date | null, Date>;
 
       beforeEach(fakeAsync(() => {
         fixture = createComponent(StandardDatepicker, [MatNativeDateModule]);
         fixture.detectChanges();
 
         testComponent = fixture.componentInstance;
+        model = fixture.debugElement.query(By.directive(MatDatepicker))
+            .injector.get(MatDateSelectionModel);
       }));
 
       afterEach(fakeAsync(() => {
@@ -274,8 +282,8 @@ describe('MatDatepicker', () => {
 
       it('clicking the currently selected date should close the calendar ' +
          'without firing selectedChanged', fakeAsync(() => {
-        const selectedChangedSpy =
-            spyOn(testComponent.datepicker._selectedChanged, 'next').and.callThrough();
+        const spy = jasmine.createSpy('selectionChanged spy');
+        const selectedSubscription = model.selectionChanged.subscribe(spy);
 
         for (let changeCount = 1; changeCount < 3; changeCount++) {
           const currentDay = changeCount;
@@ -291,15 +299,16 @@ describe('MatDatepicker', () => {
           flush();
         }
 
-        expect(selectedChangedSpy.calls.count()).toEqual(1);
+        expect(spy).toHaveBeenCalledTimes(1);
         expect(document.querySelector('mat-dialog-container')).toBeNull();
         expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 2));
+        selectedSubscription.unsubscribe();
       }));
 
       it('pressing enter on the currently selected date should close the calendar without ' +
          'firing selectedChanged', () => {
-        const selectedChangedSpy =
-            spyOn(testComponent.datepicker._selectedChanged, 'next').and.callThrough();
+        const spy = jasmine.createSpy('selectionChanged spy');
+        const selectedSubscription = model.selectionChanged.subscribe(spy);
 
         testComponent.datepicker.open();
         fixture.detectChanges();
@@ -312,9 +321,10 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         fixture.whenStable().then(() => {
-          expect(selectedChangedSpy.calls.count()).toEqual(0);
+          expect(spy).not.toHaveBeenCalled();
           expect(document.querySelector('mat-dialog-container')).toBeNull();
           expect(testComponent.datepickerInput.value).toEqual(new Date(2020, JAN, 1));
+          selectedSubscription.unsubscribe();
         });
       });
 
@@ -507,11 +517,13 @@ describe('MatDatepicker', () => {
         const fixture = createComponent(DelayedDatepicker, [MatNativeDateModule]);
         const testComponent: DelayedDatepicker = fixture.componentInstance;
         const toSelect = new Date(2017, JAN, 1);
-
         fixture.detectChanges();
 
+        const model = fixture.debugElement.query(By.directive(MatDatepicker))
+          .injector.get(MatDateSelectionModel);
+
         expect(testComponent.datepickerInput.value).toBeNull();
-        expect(testComponent.datepicker._selected).toBeNull();
+        expect(model.selection).toBeNull();
 
         testComponent.assignedDatepicker = testComponent.datepicker;
         fixture.detectChanges();
@@ -522,7 +534,7 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         expect(testComponent.datepickerInput.value).toEqual(toSelect);
-        expect(testComponent.datepicker._selected).toEqual(toSelect);
+        expect(model.selection).toEqual(toSelect);
       }));
     });
 
@@ -672,6 +684,7 @@ describe('MatDatepicker', () => {
     describe('datepicker with ngModel', () => {
       let fixture: ComponentFixture<DatepickerWithNgModel>;
       let testComponent: DatepickerWithNgModel;
+      let model: MatDateSelectionModel<Date | null, Date>;
 
       beforeEach(fakeAsync(() => {
         fixture = createComponent(DatepickerWithNgModel, [MatNativeDateModule]);
@@ -681,6 +694,8 @@ describe('MatDatepicker', () => {
           fixture.detectChanges();
 
           testComponent = fixture.componentInstance;
+          model = fixture.debugElement.query(By.directive(MatDatepicker))
+            .injector.get(MatDateSelectionModel);
         });
       }));
 
@@ -691,7 +706,7 @@ describe('MatDatepicker', () => {
 
       it('should update datepicker when model changes', fakeAsync(() => {
         expect(testComponent.datepickerInput.value).toBeNull();
-        expect(testComponent.datepicker._selected).toBeNull();
+        expect(model.selection).toBeNull();
 
         let selected = new Date(2017, JAN, 1);
         testComponent.selected = selected;
@@ -700,7 +715,7 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         expect(testComponent.datepickerInput.value).toEqual(selected);
-        expect(testComponent.datepicker._selected).toEqual(selected);
+        expect(model.selection).toEqual(selected);
       }));
 
       it('should update model when date is selected', fakeAsync(() => {
@@ -820,12 +835,15 @@ describe('MatDatepicker', () => {
     describe('datepicker with formControl', () => {
       let fixture: ComponentFixture<DatepickerWithFormControl>;
       let testComponent: DatepickerWithFormControl;
+      let model: MatDateSelectionModel<Date | null, Date>;
 
       beforeEach(fakeAsync(() => {
         fixture = createComponent(DatepickerWithFormControl, [MatNativeDateModule]);
         fixture.detectChanges();
 
         testComponent = fixture.componentInstance;
+        model = fixture.debugElement.query(By.directive(MatDatepicker))
+            .injector.get(MatDateSelectionModel);
       }));
 
       afterEach(fakeAsync(() => {
@@ -835,14 +853,14 @@ describe('MatDatepicker', () => {
 
       it('should update datepicker when formControl changes', () => {
         expect(testComponent.datepickerInput.value).toBeNull();
-        expect(testComponent.datepicker._selected).toBeNull();
+        expect(model.selection).toBeNull();
 
         let selected = new Date(2017, JAN, 1);
         testComponent.formControl.setValue(selected);
         fixture.detectChanges();
 
         expect(testComponent.datepickerInput.value).toEqual(selected);
-        expect(testComponent.datepicker._selected).toEqual(selected);
+        expect(model.selection).toEqual(selected);
       });
 
       it('should update formControl when date is selected', () => {

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -16,4 +16,6 @@ export * from './datepicker-intl';
 export * from './datepicker-toggle';
 export * from './month-view';
 export * from './year-view';
+export * from './date-range-input';
+export {MatStartDate, MatEndDate} from './date-range-input-parts';
 export {MatMultiYearView, yearsPerPage, yearsPerRow} from './multi-year-view';

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -11,7 +11,12 @@ export * from './calendar';
 export * from './calendar-body';
 export * from './datepicker';
 export * from './datepicker-animations';
-export * from './datepicker-input';
+export {MatDatepickerInputEvent} from './datepicker-input-base';
+export {
+    MAT_DATEPICKER_VALUE_ACCESSOR,
+    MAT_DATEPICKER_VALIDATORS,
+    MatDatepickerInput,
+} from './datepicker-input';
 export * from './datepicker-intl';
 export * from './datepicker-toggle';
 export * from './month-view';

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -105,6 +105,8 @@ export declare class ErrorStateMatcher {
     static ɵprov: i0.ɵɵInjectableDef<ErrorStateMatcher>;
 }
 
+export declare type ExtractDateTypeFromSelection<T> = T extends DateRange<infer D> ? D : NonNullable<T>;
+
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;
 
 export declare type FloatLabelType = 'always' | 'never' | 'auto';
@@ -210,6 +212,10 @@ export declare const MAT_LABEL_GLOBAL_OPTIONS: InjectionToken<LabelOptions>;
 export declare const MAT_NATIVE_DATE_FORMATS: MatDateFormats;
 
 export declare const MAT_OPTION_PARENT_COMPONENT: InjectionToken<MatOptionParentComponent>;
+
+export declare function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
+
+export declare const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
 export declare const MAT_RIPPLE_GLOBAL_OPTIONS: InjectionToken<RippleGlobalOptions>;
 

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -79,6 +79,19 @@ export declare abstract class DateAdapter<D> {
     abstract today(): D;
 }
 
+export declare class DateRange<D> {
+    readonly end: D | null;
+    readonly start: D | null;
+    constructor(
+    start: D | null,
+    end: D | null);
+}
+
+export interface DateSelectionModelChange<S> {
+    selection: S;
+    source: unknown;
+}
+
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;
 
 export declare const defaultRippleAnimationConfig: {
@@ -200,6 +213,10 @@ export declare const MAT_OPTION_PARENT_COMPONENT: InjectionToken<MatOptionParent
 
 export declare const MAT_RIPPLE_GLOBAL_OPTIONS: InjectionToken<RippleGlobalOptions>;
 
+export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
+
+export declare const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
+
 export declare class MatCommonModule {
     constructor(highContrastModeDetector: HighContrastModeDetector, sanityChecks: any);
     static ɵinj: i0.ɵɵInjectorDef<MatCommonModule>;
@@ -217,6 +234,24 @@ export declare type MatDateFormats = {
         monthYearA11yLabel: any;
     };
 };
+
+export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>> implements OnDestroy {
+    protected readonly adapter: DateAdapter<D>;
+    readonly selection: S;
+    selectionChanged: Observable<DateSelectionModelChange<S>>;
+    protected constructor(
+    adapter: DateAdapter<D>,
+    selection: S);
+    abstract add(date: D | null): void;
+    abstract isComplete(): boolean;
+    abstract isSame(other: S): boolean;
+    abstract isValid(): boolean;
+    ngOnDestroy(): void;
+    abstract overlaps(range: DateRange<D>): boolean;
+    updateSelection(value: S, source: unknown): void;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDateSelectionModel<any, any>, never, never, {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDateSelectionModel<any, any>>;
+}
 
 export declare const MATERIAL_SANITY_CHECKS: InjectionToken<SanityChecks>;
 
@@ -313,6 +348,17 @@ export declare class MatPseudoCheckboxModule {
 
 export declare type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
 
+export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
+    constructor(adapter: DateAdapter<D>);
+    add(date: D | null): void;
+    isComplete(): boolean;
+    isSame(other: DateRange<D>): boolean;
+    isValid(): boolean;
+    overlaps(range: DateRange<D>): boolean;
+    static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>>;
+    static ɵprov: i0.ɵɵInjectableDef<MatRangeDateSelectionModel<any>>;
+}
+
 export declare class MatRipple implements OnInit, OnDestroy, RippleTarget {
     animation: RippleAnimationConfig;
     centered: boolean;
@@ -338,6 +384,17 @@ export declare class MatRipple implements OnInit, OnDestroy, RippleTarget {
 export declare class MatRippleModule {
     static ɵinj: i0.ɵɵInjectorDef<MatRippleModule>;
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatRippleModule, [typeof i1.MatRipple], [typeof i2.MatCommonModule, typeof i3.PlatformModule], [typeof i1.MatRipple, typeof i2.MatCommonModule]>;
+}
+
+export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
+    constructor(adapter: DateAdapter<D>);
+    add(date: D | null): void;
+    isComplete(): boolean;
+    isSame(other: D): boolean;
+    isValid(): boolean;
+    overlaps(range: DateRange<D>): boolean;
+    static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>>;
+    static ɵprov: i0.ɵɵInjectableDef<MatSingleDateSelectionModel<any>>;
 }
 
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -38,7 +38,7 @@ export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecke
     stateChanges: Subject<void>;
     readonly yearSelected: EventEmitter<D>;
     yearView: MatYearView<D>;
-    constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef);
+    constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef, _model: MatDateSelectionModel<D | null, D>);
     _dateSelected(date: D | null): void;
     _goToDateInView(date: D, view: 'month' | 'year' | 'multi-year'): void;
     _monthSelectedInYearView(normalizedMonth: D): void;
@@ -114,9 +114,6 @@ export declare class MatDatepicker<D> implements OnDestroy, CanColor {
     readonly _disabledChange: Subject<boolean>;
     get _maxDate(): D | null;
     get _minDate(): D | null;
-    get _selected(): D | null;
-    set _selected(value: D | null);
-    readonly _selectedChanged: Subject<D>;
     calendarHeaderComponent: ComponentType<any>;
     closedStream: EventEmitter<void>;
     get color(): ThemePalette;
@@ -136,8 +133,8 @@ export declare class MatDatepicker<D> implements OnDestroy, CanColor {
     get touchUi(): boolean;
     set touchUi(value: boolean);
     readonly yearSelected: EventEmitter<D>;
-    constructor(_dialog: MatDialog, _overlay: Overlay, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, scrollStrategy: any, _dateAdapter: DateAdapter<D>, _dir: Directionality, _document: any);
-    _registerInput(input: MatDatepickerInput<D>): void;
+    constructor(_dialog: MatDialog, _overlay: Overlay, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, scrollStrategy: any, _dateAdapter: DateAdapter<D>, _dir: Directionality, _document: any, _model: MatDateSelectionModel<D | null, D>);
+    _registerInput(input: MatDatepickerInput<D>): MatDateSelectionModel<D | null, D>;
     _selectMonth(normalizedMonth: D): void;
     _selectYear(normalizedYear: D): void;
     close(): void;
@@ -181,7 +178,7 @@ export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDe
     readonly dateInput: EventEmitter<MatDatepickerInputEvent<D>>;
     get disabled(): boolean;
     set disabled(value: boolean);
-    set matDatepicker(value: MatDatepicker<D>);
+    set matDatepicker(datepicker: MatDatepicker<D>);
     set matDatepickerFilter(value: (date: D | null) => boolean);
     get max(): D | null;
     set max(value: D | null);

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -167,52 +167,34 @@ export declare class MatDatepickerContent<D> extends _MatDatepickerContentMixinB
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any>>;
 }
 
-export declare class MatDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Validator {
-    _dateAdapter: DateAdapter<D>;
+export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
     _dateFilter: (date: D | null) => boolean;
     _datepicker: MatDatepicker<D>;
-    _disabledChange: EventEmitter<boolean>;
-    _onTouched: () => void;
-    _valueChange: EventEmitter<D | null>;
-    readonly dateChange: EventEmitter<MatDatepickerInputEvent<D>>;
-    readonly dateInput: EventEmitter<MatDatepickerInputEvent<D>>;
-    get disabled(): boolean;
-    set disabled(value: boolean);
+    protected _validator: ValidatorFn | null;
     set matDatepicker(datepicker: MatDatepicker<D>);
     set matDatepickerFilter(value: (date: D | null) => boolean);
     get max(): D | null;
     set max(value: D | null);
     get min(): D | null;
     set min(value: D | null);
-    get value(): D | null;
-    set value(value: D | null);
-    constructor(_elementRef: ElementRef<HTMLInputElement>, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _formField: MatFormField);
+    constructor(elementRef: ElementRef<HTMLInputElement>, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats, _formField: MatFormField);
+    protected _assignModelValue(value: D | null): void;
     _getThemePalette(): ThemePalette;
-    _onBlur(): void;
-    _onChange(): void;
-    _onInput(value: string): void;
-    _onKeydown(event: KeyboardEvent): void;
+    protected _openPopup(): void;
     getConnectedOverlayOrigin(): ElementRef;
     getPopupConnectionElementRef(): ElementRef;
-    ngOnDestroy(): void;
-    registerOnChange(fn: (value: any) => void): void;
-    registerOnTouched(fn: () => void): void;
-    registerOnValidatorChange(fn: () => void): void;
-    setDisabledState(isDisabled: boolean): void;
-    validate(c: AbstractControl): ValidationErrors | null;
-    writeValue(value: D): void;
     static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_value: any;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerInput<any>, "input[matDatepicker]", ["matDatepickerInput"], { "matDatepicker": "matDatepicker"; "matDatepickerFilter": "matDatepickerFilter"; "value": "value"; "min": "min"; "max": "max"; "disabled": "disabled"; }, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerInput<any>, "input[matDatepicker]", ["matDatepickerInput"], { "matDatepicker": "matDatepicker"; "min": "min"; "max": "max"; "matDatepickerFilter": "matDatepickerFilter"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerInput<any>>;
 }
 
 export declare class MatDatepickerInputEvent<D> {
-    target: MatDatepickerInput<D>;
+    target: MatDatepickerInputBase<D>;
     targetElement: HTMLElement;
     value: D | null;
     constructor(
-    target: MatDatepickerInput<D>,
+    target: MatDatepickerInputBase<D>,
     targetElement: HTMLElement);
 }
 
@@ -268,23 +250,25 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     _endInput: MatEndDate<D>;
     _startInput: MatStartDate<D>;
     controlType: string;
-    readonly disabled: boolean;
-    readonly empty: boolean;
+    get disabled(): boolean;
+    get empty(): boolean;
     endPlaceholder: string;
-    readonly errorState: boolean;
+    get errorState(): boolean;
     focused: boolean;
     id: string;
     ngControl: NgControl | null;
     placeholder: string;
-    required: boolean;
+    get required(): boolean;
+    set required(value: boolean);
     separator: string;
-    readonly shouldLabelFloat: boolean;
+    get shouldLabelFloat(): boolean;
     startPlaceholder: string;
     stateChanges: Subject<void>;
     value: DateRange<D> | null;
     constructor(_changeDetectorRef: ChangeDetectorRef, control: ControlContainer, formField?: MatFormField);
     _getInputMirrorValue(): string;
     _handleChildValueChange(): void;
+    _openDatepicker(): void;
     _shouldHidePlaceholders(): boolean;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
@@ -295,9 +279,10 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     static ɵfac: i0.ɵɵFactoryDef<MatDateRangeInput<any>>;
 }
 
-export declare class MatEndDate<D> extends MatDateRangeInputPartBase<D> {
+export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+    protected _validator: ValidatorFn | null;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, { "disabled": "disabled"; }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>>;
 }
 
@@ -367,10 +352,11 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
     static ɵfac: i0.ɵɵFactoryDef<MatMultiYearView<any>>;
 }
 
-export declare class MatStartDate<D> extends MatDateRangeInputPartBase<D> {
+export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+    protected _validator: ValidatorFn | null;
     getMirrorValue(): string;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, { "disabled": "disabled"; }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatStartDate<any>>;
 }
 

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -167,7 +167,7 @@ export declare class MatDatepickerContent<D> extends _MatDatepickerContentMixinB
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any>>;
 }
 
-export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
+export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> {
     _dateFilter: (date: D | null) => boolean;
     _datepicker: MatDatepicker<D>;
     protected _validator: ValidatorFn | null;
@@ -178,8 +178,9 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
     get min(): D | null;
     set min(value: D | null);
     constructor(elementRef: ElementRef<HTMLInputElement>, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats, _formField: MatFormField);
-    protected _assignModelValue(value: D | null): void;
+    protected _assignValueToModel(value: D | null): void;
     _getThemePalette(): ThemePalette;
+    protected _getValueFromModel(modelValue: D | null): D | null;
     protected _openPopup(): void;
     getConnectedOverlayOrigin(): ElementRef;
     getPopupConnectionElementRef(): ElementRef;
@@ -189,12 +190,12 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D> {
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerInput<any>>;
 }
 
-export declare class MatDatepickerInputEvent<D> {
-    target: MatDatepickerInputBase<D>;
+export declare class MatDatepickerInputEvent<D, S = unknown> {
+    target: MatDatepickerInputBase<S, D>;
     targetElement: HTMLElement;
     value: D | null;
     constructor(
-    target: MatDatepickerInputBase<D>,
+    target: MatDatepickerInputBase<S, D>,
     targetElement: HTMLElement);
 }
 
@@ -280,6 +281,8 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
 }
 
 export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+    protected _assignValueToModel: (value: D | null) => void;
+    protected _getValueFromModel: (modelValue: DateRange<D>) => D | null;
     protected _validator: ValidatorFn | null;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, {}, never>;
@@ -353,6 +356,8 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
 }
 
 export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+    protected _assignValueToModel: (value: D | null) => void;
+    protected _getValueFromModel: (modelValue: DateRange<D>) => D | null;
     protected _validator: ValidatorFn | null;
     getMirrorValue(): string;
     static ngAcceptInputType_disabled: BooleanInput;

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -235,7 +235,7 @@ export declare class MatDatepickerIntl {
 
 export declare class MatDatepickerModule {
     static ɵinj: i0.ɵɵInjectorDef<MatDatepickerModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatDatepickerModule, [typeof i1.MatCalendar, typeof i2.MatCalendarBody, typeof i3.MatDatepicker, typeof i3.MatDatepickerContent, typeof i4.MatDatepickerInput, typeof i5.MatDatepickerToggle, typeof i5.MatDatepickerToggleIcon, typeof i6.MatMonthView, typeof i7.MatYearView, typeof i8.MatMultiYearView, typeof i1.MatCalendarHeader], [typeof i9.CommonModule, typeof i10.MatButtonModule, typeof i11.MatDialogModule, typeof i12.OverlayModule, typeof i13.A11yModule, typeof i14.PortalModule], [typeof i1.MatCalendar, typeof i2.MatCalendarBody, typeof i3.MatDatepicker, typeof i3.MatDatepickerContent, typeof i4.MatDatepickerInput, typeof i5.MatDatepickerToggle, typeof i5.MatDatepickerToggleIcon, typeof i6.MatMonthView, typeof i7.MatYearView, typeof i8.MatMultiYearView, typeof i1.MatCalendarHeader]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatDatepickerModule, [typeof i1.MatCalendar, typeof i2.MatCalendarBody, typeof i3.MatDatepicker, typeof i3.MatDatepickerContent, typeof i4.MatDatepickerInput, typeof i5.MatDatepickerToggle, typeof i5.MatDatepickerToggleIcon, typeof i6.MatMonthView, typeof i7.MatYearView, typeof i8.MatMultiYearView, typeof i1.MatCalendarHeader, typeof i9.MatDateRangeInput, typeof i10.MatStartDate, typeof i10.MatEndDate], [typeof i11.CommonModule, typeof i12.MatButtonModule, typeof i13.MatDialogModule, typeof i14.OverlayModule, typeof i15.A11yModule, typeof i16.PortalModule], [typeof i1.MatCalendar, typeof i2.MatCalendarBody, typeof i3.MatDatepicker, typeof i3.MatDatepickerContent, typeof i4.MatDatepickerInput, typeof i5.MatDatepickerToggle, typeof i5.MatDatepickerToggleIcon, typeof i6.MatMonthView, typeof i7.MatYearView, typeof i8.MatMultiYearView, typeof i1.MatCalendarHeader, typeof i9.MatDateRangeInput, typeof i10.MatStartDate, typeof i10.MatEndDate]>;
 }
 
 export declare class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDestroy {
@@ -260,6 +260,45 @@ export declare class MatDatepickerToggle<D> implements AfterContentInit, OnChang
 export declare class MatDatepickerToggleIcon {
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerToggleIcon, "[matDatepickerToggleIcon]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerToggleIcon>;
+}
+
+export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, MatDateRangeInputParent, AfterContentInit, OnDestroy {
+    _ariaDescribedBy: string | null;
+    _ariaLabelledBy: string | null;
+    _endInput: MatEndDate<D>;
+    _startInput: MatStartDate<D>;
+    controlType: string;
+    readonly disabled: boolean;
+    readonly empty: boolean;
+    endPlaceholder: string;
+    readonly errorState: boolean;
+    focused: boolean;
+    id: string;
+    ngControl: NgControl | null;
+    placeholder: string;
+    required: boolean;
+    separator: string;
+    readonly shouldLabelFloat: boolean;
+    startPlaceholder: string;
+    stateChanges: Subject<void>;
+    value: DateRange<D> | null;
+    constructor(_changeDetectorRef: ChangeDetectorRef, control: ControlContainer, formField?: MatFormField);
+    _getInputMirrorValue(): string;
+    _handleChildValueChange(): void;
+    _shouldHidePlaceholders(): boolean;
+    ngAfterContentInit(): void;
+    ngOnDestroy(): void;
+    onContainerClick(): void;
+    setDescribedByIds(ids: string[]): void;
+    static ngAcceptInputType_required: BooleanInput;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDateRangeInput<any>, "mat-date-range-input", ["matDateRangeInput"], { "required": "required"; "startPlaceholder": "startPlaceholder"; "endPlaceholder": "endPlaceholder"; "separator": "separator"; }, {}, ["_startInput", "_endInput"]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDateRangeInput<any>>;
+}
+
+export declare class MatEndDate<D> extends MatDateRangeInputPartBase<D> {
+    static ngAcceptInputType_disabled: BooleanInput;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, { "disabled": "disabled"; }, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>>;
 }
 
 export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
@@ -326,6 +365,13 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatMultiYearView<any>, "mat-multi-year-view", ["matMultiYearView"], { "activeDate": "activeDate"; "selected": "selected"; "minDate": "minDate"; "maxDate": "maxDate"; "dateFilter": "dateFilter"; }, { "selectedChange": "selectedChange"; "yearSelected": "yearSelected"; "activeDateChange": "activeDateChange"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatMultiYearView<any>>;
+}
+
+export declare class MatStartDate<D> extends MatDateRangeInputPartBase<D> {
+    getMirrorValue(): string;
+    static ngAcceptInputType_disabled: BooleanInput;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, { "disabled": "disabled"; }, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatStartDate<any>>;
 }
 
 export declare class MatYearView<D> implements AfterContentInit, OnDestroy {

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -281,9 +281,9 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
 }
 
 export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
-    protected _assignValueToModel: (value: D | null) => void;
-    protected _getValueFromModel: (modelValue: DateRange<D>) => D | null;
     protected _validator: ValidatorFn | null;
+    protected _assignValueToModel(value: D | null): void;
+    protected _getValueFromModel(modelValue: DateRange<D>): D | null;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>>;
@@ -356,9 +356,9 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
 }
 
 export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
-    protected _assignValueToModel: (value: D | null) => void;
-    protected _getValueFromModel: (modelValue: DateRange<D>) => D | null;
     protected _validator: ValidatorFn | null;
+    protected _assignValueToModel(value: D | null): void;
+    protected _getValueFromModel(modelValue: DateRange<D>): D | null;
     getMirrorValue(): string;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, {}, {}, never>;


### PR DESCRIPTION
I had to do some hacky workarounds in order, because I couldn't figure out how to deal with an abstract class that was being passed into a mixin. These changes clean up the workarounds.