### PR TITLE
refactor: clean up datepicker base class abstract methods

### DIFF
--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -60,14 +60,18 @@ export const MAT_DATE_RANGE_INPUT_PARENT =
  * Base class for the individual inputs that can be projected inside a `mat-date-range-input`.
  */
 @Directive()
-class MatDateRangeInputPartBase<D>
+abstract class MatDateRangeInputPartBase<D>
   extends MatDatepickerInputBase<DateRange<D>, D> implements OnInit, DoCheck {
 
   /** @docs-private */
   ngControl: NgControl;
 
   /** @docs-private */
-  updateErrorState: () => void;
+  abstract updateErrorState(): void;
+
+  protected abstract _validator: ValidatorFn | null;
+  protected abstract _assignValueToModel(value: D | null): void;
+  protected abstract _getValueFromModel(modelValue: DateRange<D>): D | null;
 
   constructor(
     @Inject(MAT_DATE_RANGE_INPUT_PARENT) public _rangeInput: MatDateRangeInputParent,
@@ -129,17 +133,12 @@ class MatDateRangeInputPartBase<D>
   protected _openPopup(): void {
     this._rangeInput._openDatepicker();
   }
-
-  // Dummy property implementations since we can't pass an abstract class
-  // into a mixin. These are overridden by the individual input classes.
-  protected _validator: ValidatorFn | null;
-  protected _assignValueToModel: (value: D | null) => void;
-  protected _getValueFromModel: (modelValue: DateRange<D>) => D | null;
 }
 
 const _MatDateRangeInputBase:
     CanUpdateErrorStateCtor & typeof MatDateRangeInputPartBase =
-    mixinErrorState(MatDateRangeInputPartBase);
+    // Needs to be `as any`, because the base class is abstract.
+    mixinErrorState(MatDateRangeInputPartBase as any);
 
 /** Input for entering the start date in a `mat-date-range-input`. */
 @Directive({
@@ -170,8 +169,12 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D>
   implements CanUpdateErrorState {
   // TODO(crisbeto): start-range-specific validators should go here.
   protected _validator = Validators.compose([this._parseValidator]);
-  protected _getValueFromModel = (modelValue: DateRange<D>) => modelValue.start;
-  protected _assignValueToModel = (value: D | null) => {
+
+  protected _getValueFromModel(modelValue: DateRange<D>) {
+    return modelValue.start;
+  }
+
+  protected _assignValueToModel(value: D | null) {
     if (this._model) {
       this._model.updateSelection(new DateRange(value, this._model.selection.end), this);
     }
@@ -216,8 +219,12 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D>
 export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
   // TODO(crisbeto): end-range-specific validators should go here.
   protected _validator = Validators.compose([this._parseValidator]);
-  protected _getValueFromModel = (modelValue: DateRange<D>) => modelValue.end;
-  protected _assignValueToModel = (value: D | null) => {
+
+  protected _getValueFromModel(modelValue: DateRange<D>) {
+    return modelValue.end;
+  }
+
+  protected _assignValueToModel(value: D | null) {
     if (this._model) {
       this._model.updateSelection(new DateRange(this._model.selection.start, value), this);
     }

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {
   Directive,
   ElementRef,
@@ -183,5 +182,4 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> {
   // Accept `any` to avoid conflicts with other directives on `<input>` that
   // may accept different types.
   static ngAcceptInputType_value: any;
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -184,7 +184,6 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | nu
     protected _openPopup(): void;
     getConnectedOverlayOrigin(): ElementRef;
     getPopupConnectionElementRef(): ElementRef;
-    static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_value: any;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerInput<any>, "input[matDatepicker]", ["matDatepickerInput"], { "matDatepicker": "matDatepicker"; "min": "min"; "max": "max"; "matDatepickerFilter": "matDatepickerFilter"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerInput<any>>;
@@ -281,9 +280,9 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
 }
 
 export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
-    protected _assignValueToModel: (value: D | null) => void;
-    protected _getValueFromModel: (modelValue: DateRange<D>) => D | null;
     protected _validator: ValidatorFn | null;
+    protected _assignValueToModel(value: D | null): void;
+    protected _getValueFromModel(modelValue: DateRange<D>): D | null;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>>;
@@ -356,9 +355,9 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
 }
 
 export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
-    protected _assignValueToModel: (value: D | null) => void;
-    protected _getValueFromModel: (modelValue: DateRange<D>) => D | null;
     protected _validator: ValidatorFn | null;
+    protected _assignValueToModel(value: D | null): void;
+    protected _getValueFromModel(modelValue: DateRange<D>): D | null;
     getMirrorValue(): string;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, {}, {}, never>;


### PR DESCRIPTION
I had to do some hacky workarounds in order, because I couldn't figure out how to deal with an abstract class that was being passed into a mixin. These changes clean up the workarounds.