### PR TITLE
build: bump to latest MDC Canary to fix regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/youtube": "^0.0.38",
     "@webcomponents/custom-elements": "^1.1.0",
     "core-js": "^2.6.9",
-    "material-components-web": "5.0.0-canary.6092f71ee.0",
+    "material-components-web": "5.0.0-canary.80a4d326f.0",
     "rxjs": "^6.5.3",
     "systemjs": "0.19.43",
     "tslib": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,536 +325,535 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.3.2.tgz#a92dc544290e2893bd8c02a81e684dae3d8e7c85"
   integrity sha512-ZD8lTgW07NGgo75bTyBJA8Lt9+NweNzot7lrsBtIvfciwUzaFJLsv2EShqjBeuhF7RpG6YFucJ6m67w5buCtzw==
 
-"@material/animation@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-5.0.0-canary.6092f71ee.0.tgz#ad81d79e84c08cdcde94971a222efcefd4d3ef49"
-  integrity sha512-gY8wzzDDNhRiYvvmu/oSbWbp+4DXdAV+wlwKVCidK3E8Ry4/h+YjbEu8m69HzHZile0R5jCUb7r9Bx/kuKxyyA==
+"@material/animation@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-5.0.0-canary.80a4d326f.0.tgz#0e004b8c75f1b201d9130bc43c9fabb0a6ea8db3"
+  integrity sha512-QeNznXYDBy/2wj8CQmZCK9vudbwgi0Taigexr9mDy621NYVnmlp5J+/bN671i1sdRWVjNyXb5tFeu+9XF8VBbg==
   dependencies:
     tslib "^1.9.3"
 
-"@material/auto-init@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/auto-init/-/auto-init-5.0.0-canary.6092f71ee.0.tgz#4ddd7b1a5f9d591a586d977c252625cadbfab508"
-  integrity sha512-2Ma1UewGt3OEVVprUW51pyPudTKkIsE3yAceMeappZmRwKqGqTe7cK6ZLVUohnLftCWV4BV1eaeQAZinlBpOBQ==
+"@material/auto-init@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/auto-init/-/auto-init-5.0.0-canary.80a4d326f.0.tgz#f9b09290f0f0e6aac8619fafe7fbad1c410edf82"
+  integrity sha512-TXX8Ks1fnEUHkVw8jBibsTt0IiXtIIltGcbOr6EvVy6cLtV2yXBRhJlC9FfHWGE61y55VWFDB9iCNRRUS9NxHw==
   dependencies:
-    "@material/base" "5.0.0-canary.6092f71ee.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/base@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/base/-/base-5.0.0-canary.6092f71ee.0.tgz#11addb8426277d18dcb5a067e0bb02a6bcbba0c6"
-  integrity sha512-sUrtVqKL8Y/XldZNjwQA07wuuPP/GPnFxVkwQz+YCTUWLfJM9K7jFO2Hg74l/KGI4NshZtPfsXFzFcVVcK/gbg==
+"@material/base@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-5.0.0-canary.80a4d326f.0.tgz#2059d4ff00f512e91f194ccda3704dceb1a38af3"
+  integrity sha512-I9Hruzd1wRBpiz8ftKgfJ8l9+LhLmmOV1oA9Xk7/EyeZvqPAuOg+9kpz7yvOPdJx3FaXsUZ1aMrbvSiwBhtRXQ==
   dependencies:
     tslib "^1.9.3"
 
-"@material/button@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/button/-/button-5.0.0-canary.6092f71ee.0.tgz#227c7eec073bcdf5af92adf8917285dd4bbe626c"
-  integrity sha512-7qCdl1/wc3KoLwKjNwCcSoFoT0aw5vLGu/9bXSlgHm77scP6ZIBncGHQXI9x7vN+9iAQyGx95RXGjSwfouv1Jg==
+"@material/button@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/button/-/button-5.0.0-canary.80a4d326f.0.tgz#205309f9824d185564f3ad5e412986811fe0b862"
+  integrity sha512-w3ze+noNqjX00Qo8DQj4hNyDgjv0/wes+HV2k8Z0ezz5WAyplCTI00yDk3NAUw/iXTOBwFT2FaSwVVj6YyFlEg==
   dependencies:
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/touch-target" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/touch-target" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
 
-"@material/card@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/card/-/card-5.0.0-canary.6092f71ee.0.tgz#b563a67d14daff05bf7ee1c3c82e0e9487584cb0"
-  integrity sha512-LRU5jsXrEx0CIqqIyDjMYXLrp4fHzwYBgKmhL1Whz71tjuJ1dUCn03tKd8ir151iMbG/eWO1zECiuzvTGBqikA==
+"@material/card@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/card/-/card-5.0.0-canary.80a4d326f.0.tgz#f2c4a31077aec0d7418d0f33e7f486150d254b64"
+  integrity sha512-DAh8QruWlBuM6uQqbC3RXnbuewzraC7i/hk+tmhClSl+ycyCQd2bbwqQVJMXR0vldetF5jE7a+nKa1DZsn23og==
   dependencies:
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
 
-"@material/checkbox@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/checkbox/-/checkbox-5.0.0-canary.6092f71ee.0.tgz#be18348475401e516ca789d96178dc1fc0d4a1bd"
-  integrity sha512-MDOCFeeKUpjGAqZwvFJ+DQX0oAks0qRcZwNsQuM3+JRT4IVlWumUzaMi4xIVaDBwtXi4LzSkDrlO3ta0vYV2pQ==
+"@material/checkbox@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/checkbox/-/checkbox-5.0.0-canary.80a4d326f.0.tgz#45b766a4a04d24afbe31fbe63d7517e1e168958b"
+  integrity sha512-KSog5YdKJCwYPoRI3E5zP7A7KNx5bPxO6as7PNNE6xced2l1mXwQkJNquvMKZjjfLWPAP5z9yuTv+zySD1LYyQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/touch-target" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/touch-target" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/chips@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/chips/-/chips-5.0.0-canary.6092f71ee.0.tgz#7972aa66533805b5ba6d43ffb345b5d846e0addf"
-  integrity sha512-j+LztGltSF2Ph6c8m4NLokOJoTIF+JfkceM/GO9JDsqdKDOyoJEYneUsaQQGEDlXvqFLhckrAtCMAsWoxgIqXw==
+"@material/chips@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/chips/-/chips-5.0.0-canary.80a4d326f.0.tgz#e523a1d6dee717fb753a343fdebda1194fc05804"
+  integrity sha512-XytliiVRNMQ17LEpFVHlifDjx1NrnytjvMlkBoC3FXnPLIK88Tx4oSTAzfIzn9vt4l+v/UwaVoS8b9iaQmonTQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/checkbox" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/touch-target" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/checkbox" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/touch-target" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/data-table@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/data-table/-/data-table-5.0.0-canary.6092f71ee.0.tgz#c0c7b15015454e9222d7d9ad413a1f0c0497e39a"
-  integrity sha512-l2eZwpk7V2vIlroBRsJ9TJK7llpTJ6sMwda5s60eQTcZqrBk/kg/F6l55CA9isYv3mTnHiYJyn75hr6UWSyw3g==
+"@material/data-table@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/data-table/-/data-table-5.0.0-canary.80a4d326f.0.tgz#e3ca7eee42a28a4fbb9474a5737853fdd2e4dcac"
+  integrity sha512-n3cnkMezHq9Rb3VtMpbNBSnPsZnGUrRiLitH8UsgRIoyUT2F4nfuYH4+W+XwPJ8XAqbRdNbL5IqOj+SoxEH5WA==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/checkbox" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/checkbox" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.10.0"
 
-"@material/density@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/density/-/density-5.0.0-canary.6092f71ee.0.tgz#f3ca7504754ef739045491940f4f2884fc0d94bc"
-  integrity sha512-ai+OtL8EsR6mIwhDjT07ZDaTkurJzkBj8Xdtwtm18Nr+liIbwDEV64wvDbtRQgA58DnlBSwxTwJsMbD/N6Ni5Q==
+"@material/density@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/density/-/density-5.0.0-canary.80a4d326f.0.tgz#abc10bc2991f905ae524759391658bc52411d8e9"
+  integrity sha512-jTv7S/+R0bYDYAvDsgRtC8v8epfg0NSbWQG92M8TaMmKovASIy+9Ear3KIDgjCplZ18HGPBNLdf+pHqu2f+hIg==
 
-"@material/dialog@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/dialog/-/dialog-5.0.0-canary.6092f71ee.0.tgz#4edd4841b73d2ddc77b52412b3e683ff6c76d663"
-  integrity sha512-0ZUCSSDypNGAe03vGMJACXxFcOoH/unecSA93cLksnJC5vfB2NJwUiZL/8lfuwXVpf8kRbk1LZCAMtofd1kbpQ==
+"@material/dialog@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/dialog/-/dialog-5.0.0-canary.80a4d326f.0.tgz#b641f3e37b7b9b88327a43e195296935611de6f7"
+  integrity sha512-6Ieu3d4LTWE/IiXKOUzj6IqhnrtwLHu6IjOi07rjxdUlqI1Vp3zFz0L8sjavsbROmxsMd4s4NdXniUL+fUkFnA==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/button" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/touch-target" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
-    focus-trap "^5.0.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/button" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/touch-target" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/dom@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-5.0.0-canary.6092f71ee.0.tgz#a03fa7fa3b7bbf6f31c2d20d19799510ff199714"
-  integrity sha512-DuYDYkk8WI5BMNcqgKBAtWPRkflK9XJf+1/LVXCRoQxS11tocsMnX4DGvoBMy5e4qeT1qB/SUyKerNgjYcftOw==
+"@material/dom@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-5.0.0-canary.80a4d326f.0.tgz#98ea18ae340dfe7577b78107c00468355bef124a"
+  integrity sha512-lYbPCfYz7pmFc0bt6RC1OdrQd1pQp1f57VAlq6paAgqLZnT01Vwqzi9IN9vZYodk3P3y6yQXOGnk/1MRB6jV1g==
   dependencies:
     tslib "^1.9.3"
 
-"@material/drawer@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/drawer/-/drawer-5.0.0-canary.6092f71ee.0.tgz#a910050bef9d2c1b349d600ce8046c812b3a07ac"
-  integrity sha512-XP+F3b0IJqtzbYwysSLmUm4moIaQUbYz3s8xCtvy8zmORzKh888UKFrDz9wdhWpl8ejdwm8q53+w+rZKvV9NOg==
+"@material/drawer@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/drawer/-/drawer-5.0.0-canary.80a4d326f.0.tgz#044a85850098fe5d46adc0e9e88709a7def7c94f"
+  integrity sha512-Me7Rg0HERGsTMQI6eH7QjvybaRjgwYC93oVmaCGHDLXdBXF76p/OvAt0BrDCJtZgCrPStouWTsG4gH8+zbgKuA==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/list" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
-    focus-trap "^5.0.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/list" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/elevation@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-5.0.0-canary.6092f71ee.0.tgz#ec5885d06bdb0d3a0022e6aae9914313ab461737"
-  integrity sha512-g8CZxCeou9c8t0ARItphMiEwCsdjcC4a6nn9CeR0k46/ZHyITVDoXLfVuC5McmlxPUKsH3iW1U0Fo4Ie/onEeQ==
+"@material/elevation@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-5.0.0-canary.80a4d326f.0.tgz#bbfa7f2aa1996a09dd8ba15cf78e4d0f21c523d7"
+  integrity sha512-iWoGrluPbTgpc2zu0AkrWSMzHc0kmY1L/6G8PYI1cl6CW7SLBC0NEJUfTdZXA2mWsCAQ9iIcgd6S28WSE2Phvg==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
 
-"@material/fab@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/fab/-/fab-5.0.0-canary.6092f71ee.0.tgz#ad9d1c9c9e95c9e8464d63ca70a413e7646ecce7"
-  integrity sha512-qamtdbF6C7aJjSkwnrNFywZU9B3oJAyufVfxJf50jrI0CW9qNAh7UtPPmXMCJcKp6wPaGWbeqHT102rNulPB1g==
+"@material/fab@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/fab/-/fab-5.0.0-canary.80a4d326f.0.tgz#1d8d6da367bc3adc5aa78932cd1a6ca0a84b4ba7"
+  integrity sha512-hJrKIRDz5Rk//sShi7yqyWv+zF8a0s/gUzCpbz/EvONS7bL6WU1/GVHdMEmlTzE2xLZDQ9Bjw2zjJorjdxkk7Q==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/touch-target" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/touch-target" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
 
-"@material/feature-targeting@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-5.0.0-canary.6092f71ee.0.tgz#9c547aac2532ab5740ca0641e84d3850193cdfa4"
-  integrity sha512-NQQFvKYNTPwivduzMkL0QcCoyljGN8Uu10XjZ+M5sFLURUbm3ryyE+zHUuQHAzl+U9hSqvBi32WfjH9JIdN7Ew==
+"@material/feature-targeting@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-5.0.0-canary.80a4d326f.0.tgz#fd21c258ccd86e70aa93166a19b0429dc01b9fd8"
+  integrity sha512-yTQhT3rzEfHX8bmkEtWOP3G3KZ1fZ5ufwIcROAvP48m+GD3KSvelyAiKUnf5MZE4EV4R27XnAgumf79WK9DFfw==
 
-"@material/floating-label@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-5.0.0-canary.6092f71ee.0.tgz#4e1452eb85e3e3b2bcf0f9c954588befb9648a18"
-  integrity sha512-l5wsLZnzmqfn+fLHoTCpT32/ULxK/RLVHIc+ZwSG6aDA6EfbdPHnaQoqliE3k0H2hXz0r0UXzCu9Py0vY5uZKA==
+"@material/floating-label@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-5.0.0-canary.80a4d326f.0.tgz#60992d7e99830c3ee6bba82d8b35e5c688d650b1"
+  integrity sha512-BBmNRTVk4sPey+zYQux+9n3a+Kprh9Z0d57bLFRD4deqoCZSNA5qAOpG+qP4zHnnUnZWn8eSxDWbR3L0mkEPmQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/form-field@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-5.0.0-canary.6092f71ee.0.tgz#5a32184f1f62a166067e98e6624de67ea3f1f63c"
-  integrity sha512-uucLorhFVLwBD7C6/WiP8z+VtGv85wX5z0zKX6RjwhZKYQB67fsBMx7GYIRD8+Ns3/7qumtPs1haTsCyIJojww==
+"@material/form-field@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-5.0.0-canary.80a4d326f.0.tgz#68139f6df5dd5af17fe0a9a2f243a84a9fa9d85b"
+  integrity sha512-yvLCTQckO0TPVphNlaDUB31iBfjGdV4fmHu6ieT7j5MSX9SGxuJqHzoPnwZVIrt7drfyiUeovoiArHpn3QWODQ==
   dependencies:
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/icon-button@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/icon-button/-/icon-button-5.0.0-canary.6092f71ee.0.tgz#4ff91995ab2c01fbf41c33af19d39856e6b3a288"
-  integrity sha512-4FJMMBrlF3JMnbDLL37av8lTSN+jznC8dliStyorK5v3FyHIBRY1+aTZwldaDrwb0x3Dgc5+IX1dIqN1h8rccg==
+"@material/icon-button@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/icon-button/-/icon-button-5.0.0-canary.80a4d326f.0.tgz#cb05b0bb9a9724142f7fc22692edb5ef79dd6ee3"
+  integrity sha512-pEe8BHnMfKFSbq/v88g+2FC1LcYLGYl8g/IBizjOCj7dlQMH3FvlH33C2NRXngt5HJmq+KZg3v1BRHiIp5WkoQ==
   dependencies:
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/image-list@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/image-list/-/image-list-5.0.0-canary.6092f71ee.0.tgz#346d8825f652cfa1742f64dd65151a0fa23cd27c"
-  integrity sha512-n/rb0yqXXKF4Wx7vuzbGnI2oHyP5+tUNN+1zjo8DXq92sa567tbC/k9RPjwq9+heXb9XXhAAz4ybC6uGsVdq2Q==
+"@material/image-list@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/image-list/-/image-list-5.0.0-canary.80a4d326f.0.tgz#0d3f6fec73e5a6c6755f662b5a1d394a9e4b4bf1"
+  integrity sha512-0a8fld8LK5Bu2mPw88g2U/C6/5Z4oYUQkRonCo5u8eKHiF0YrFQcMxHkC09B1ReY4JYWvgAQ7qAbB0vfflzUAQ==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
 
-"@material/layout-grid@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/layout-grid/-/layout-grid-5.0.0-canary.6092f71ee.0.tgz#5d411a3f3cbbf4603ec7a076fca1c58af4f1891e"
-  integrity sha512-Xz+rIST8297zfQFciTnN1MJZzClkwmxkKKDpIKzftGjDjC9OIZqwL+1E9SR2eKLNFINvY/oMoZvqkezxz0HUfA==
+"@material/layout-grid@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/layout-grid/-/layout-grid-5.0.0-canary.80a4d326f.0.tgz#0a1b2216de01a24bcbd81d55a74eacf80096d291"
+  integrity sha512-H9dj6thKwVStsfMiVQf4riqB/H8600XvYdyL1/P6p6BetGOfLqqsC3vzSv9tYWYF4D1T4qZjQLk131ILkPtylg==
 
-"@material/line-ripple@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-5.0.0-canary.6092f71ee.0.tgz#4a950ef4330b18c3b0d308932b4e90a92e116c80"
-  integrity sha512-6ybvHEySRrPOgNjTjDTdtVy4NqmAQVx1jv2Mxuets+g1J3mqH5nwUUwZpi7st0NS/aLC3B7M1R7rA/xe1Iqwmw==
+"@material/line-ripple@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-5.0.0-canary.80a4d326f.0.tgz#8a606f9b165ac26518f2d7bd2c64bb3f00bf8fd4"
+  integrity sha512-v6sgkEzVgSZuvLBsjAoGemF2kep0K+nbPA4AzHapniob34v4XF8Y66eRQNMAQcuMv6Q2UcJFjNV20pKFZteYeQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/linear-progress@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/linear-progress/-/linear-progress-5.0.0-canary.6092f71ee.0.tgz#2dc6d03267c977de3dc8054aa671344dc6ee204f"
-  integrity sha512-CqX6K0oC3Iphsi3SGAoT1mjYZmSg4NDoxpo/TCNzPmIsRgUiPnj/mcQ1GC1fANjHoVjTcJikbg7OqMSTUyi5Pw==
+"@material/linear-progress@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/linear-progress/-/linear-progress-5.0.0-canary.80a4d326f.0.tgz#18edb8c507f42842a8b6f514168b93f60c473308"
+  integrity sha512-OcqCiq4fxdy58aVkaCfFviQdA/gp32CMslKlPiuBjVxkT3J89FVD/TMrCdXEXlKq27FV7o91t2iKXH5XloJ5aA==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/list@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/list/-/list-5.0.0-canary.6092f71ee.0.tgz#77f6b0e7f139cefe7240d850b54b8da6c97c013e"
-  integrity sha512-vRRTxenEpnPn71WRF4N+F6PlY8Cw0li1tVzUydbC/wLruXiZ8Pc7foKf9a5RwNyNfN3j9ESUI6qvmTi1gJrmng==
+"@material/list@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/list/-/list-5.0.0-canary.80a4d326f.0.tgz#3deb8b34eed57d9a4fb307c82c5a7a5d5e05437c"
+  integrity sha512-DeyH+gc2gclYEWMRki+yeWFvSRc0fWX3GKCmha7DNzkflAXuMN+9vhAzs5IC0NT9ZIH28RRt6eMI46ByCNqc/A==
   dependencies:
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/menu-surface@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/menu-surface/-/menu-surface-5.0.0-canary.6092f71ee.0.tgz#ec78a33b61d462546e49a6ae4a101ff2beef464b"
-  integrity sha512-vEH70AHC4oDWh05ppTXCGG/po+vzJWcOp8jN3TcCmivJfjb+wSdWzzkCrxXdENRonKftCLugKB5NXXEUvo/HpQ==
+"@material/menu-surface@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/menu-surface/-/menu-surface-5.0.0-canary.80a4d326f.0.tgz#6f676615e5fee910c1ac1ae8c5bc43e3782c5791"
+  integrity sha512-QzfvfBTV5SzbMV6pFcSC/x7GAjE6caRX2jy9prBxFY9Jfr3GqDNWyL0ZrxXz7Llxv/WqyYrPBF9R0J+owcNZ8Q==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/menu@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-5.0.0-canary.6092f71ee.0.tgz#f448df373dd73b223ac033f75bf3824f9d018db8"
-  integrity sha512-JMmAZfkU7tJD+G8w3Wx1vyLMm/DB++nNI7Fo/3mLyar9hTWouVaCaEdemHDLsZjQfz5bmal3cCjvRlJ19XtobA==
+"@material/menu@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-5.0.0-canary.80a4d326f.0.tgz#677b063f937eb4ee8bd82a23ba8787a519b05eb9"
+  integrity sha512-y2oQUJ+dysZzh4Fv585QSxB7uTD9VSmoUIhKwcDcBiYLnYdG7+58ZdrSvotGmZjdnoezwJnPZbq1Y7/kZNvG6w==
   dependencies:
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/list" "5.0.0-canary.6092f71ee.0"
-    "@material/menu-surface" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/list" "5.0.0-canary.80a4d326f.0"
+    "@material/menu-surface" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/notched-outline@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-5.0.0-canary.6092f71ee.0.tgz#894de86aec2064f0638020f670d2850b3934d836"
-  integrity sha512-N3Z4+/wnbfsABzoASjbvLxPHqV4S19ab5Ah13Vd0IfWPqwyJG7xtFIEMjkJEQRfUOQ0wpBlcFeHZ6OBeXHGqnA==
+"@material/notched-outline@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-5.0.0-canary.80a4d326f.0.tgz#80dd4a06ed4182231a7a2411263deb1d6f7e783c"
+  integrity sha512-i6YdzNLmsvQjwxFBcGY1/DrQ30PvvtWMh0qbPBhL0WOtaTZ9uhQnh/KS/ZNyVTnQlt5LzDwARsCGJE1DFyJr+w==
   dependencies:
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/floating-label" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/floating-label" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/radio@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-5.0.0-canary.6092f71ee.0.tgz#3d8fde792811a063a887975edc8ed00caec0dbc8"
-  integrity sha512-KKY6z36XAsXbPDXlc33WwN8DfUDbm0Aju+zeV91Ik1QJ8ari1EFmcVKl/t16NEZ7Pp7JGC6PCIsHr4j0yr8sBg==
+"@material/radio@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-5.0.0-canary.80a4d326f.0.tgz#8a31d0f14158ccd3730a3445f594d318d4abb10d"
+  integrity sha512-JtbeCPjDWjLMwSalBknOVBRE4A1g0oqdFHs5IEtR5JO+jTvQ3VhHPlQgIxqxhvwKW2AgcwQIe1sMZ+jmyQe/Yg==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/touch-target" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/touch-target" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/ripple@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-5.0.0-canary.6092f71ee.0.tgz#b3249945c7eea5b9164b16cf41811db23899d874"
-  integrity sha512-XNsa34JlNTtC+WgOJistFtarSaF0FEQOxIA/+M2M+xHHuFB5AF9Z3jrcSebfPklTS0WpWwdXFOco5YuCuQmJ5g==
+"@material/ripple@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-5.0.0-canary.80a4d326f.0.tgz#fdf30d2b67326398dcf2a2c0c325f2a5bc750a08"
+  integrity sha512-b9XGZ+nr1cHnvOICP53jWfsYMTYBpjou9WVTJoNGWFNcZmAQmjdyPqxhT6f6+djg+IBF4dV6jWXZMTVPd0mhqg==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/rtl@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-5.0.0-canary.6092f71ee.0.tgz#76acc65d5e526da63f16863190178119cb11a0ad"
-  integrity sha512-HjnAy0U24O2N3XlZvkBa64lKgwWQSdqmoefGc8eqzaqN6AlyIfKXXn3K4Zz854bsXTw2k4WM39HLwIFpL9x+0Q==
+"@material/rtl@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-5.0.0-canary.80a4d326f.0.tgz#db8f378f163b1be90e5a154586405a169a346867"
+  integrity sha512-4Cf8A5hMVNFocxjXhrEaPcANbRL2ipHOJvQlWv1Aa6RBDY5UwO1v5LxJ+L822R3Kr4jx0YAu91fmtZYqz2/zZQ==
 
-"@material/select@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/select/-/select-5.0.0-canary.6092f71ee.0.tgz#e6dec86eb66c0df34bf02e51df43d06c353eca6b"
-  integrity sha512-/yhcy0VtMTf0Y/HFKYa58YwcTTdI9Z4caenQDMgKxzKH8/eBoo3sDX2ZclVNoCFXpFMLuLljESqkKV8ZDNjrUA==
+"@material/select@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/select/-/select-5.0.0-canary.80a4d326f.0.tgz#4b867e6fdb2110ac0f9387539d87aa983f088b37"
+  integrity sha512-FddLyk5noaGXDdDK3/k6+MmOb1Qk9t9VMm2eDOA7Fwto2HlR5gX19R4T/kG897/q9TIxQ4fq8HmhsGCJ3Y077g==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/floating-label" "5.0.0-canary.6092f71ee.0"
-    "@material/line-ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/menu" "5.0.0-canary.6092f71ee.0"
-    "@material/menu-surface" "5.0.0-canary.6092f71ee.0"
-    "@material/notched-outline" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/floating-label" "5.0.0-canary.80a4d326f.0"
+    "@material/line-ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/menu" "5.0.0-canary.80a4d326f.0"
+    "@material/menu-surface" "5.0.0-canary.80a4d326f.0"
+    "@material/notched-outline" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/shape@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-5.0.0-canary.6092f71ee.0.tgz#2dc8e57992ca7a88179c2a6168d3af05f2867d44"
-  integrity sha512-vCSvnmSPSdr7ZeXK3lFGmwxSl8bWxCNHjCtMw5D6LED2MxWSgXToMfZml6xOTPHTjgQoPjc94nrVrpkOoNZXmw==
+"@material/shape@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-5.0.0-canary.80a4d326f.0.tgz#192f43f62bf82d954035276669e1911908300149"
+  integrity sha512-cT1MOXaKUDgBfXs6MxBSHGK6r7b7LU/uyubUg24o+yM0KvR8XcHjlzm6dW1cRTr6bmfyFsCBEOyEQOFDTzRKVw==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
 
-"@material/slider@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/slider/-/slider-5.0.0-canary.6092f71ee.0.tgz#b27ef2cc4d3436441512de60724c83dadcb938ef"
-  integrity sha512-zuPXDKEe12jsTpnlG+b1DtpqYZJeP8tcWFcvuIUJNV7RXHxsRK48HVLP69AMJDrwwAzzwQ+iDbuyiKa6xO4JvA==
+"@material/slider@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/slider/-/slider-5.0.0-canary.80a4d326f.0.tgz#3457af3c8828d38b6d1cd41a18586aacb6cfc5bf"
+  integrity sha512-G/3qCMPrNEZ/Q9uNczu7M+WJco+7lBKwYAvOeMsXQHrHZLqOF/iXzG/Eq8A29M1k7DCFwgdL2P+FJ/o8PJDPAg==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/snackbar@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-5.0.0-canary.6092f71ee.0.tgz#0eecc421e8143a3388825730dfd3929b06796dde"
-  integrity sha512-gfreDMUh0M11NamkiH5LywlxIwQ+pIEGuX0hxeD1nRYHr9V2aHMM3KW1FTrCSRmXzcjcmlyWwHaflFn/88AuMg==
+"@material/snackbar@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-5.0.0-canary.80a4d326f.0.tgz#f8ab651f3baa042a7c6653ca1d791fed6341cdf2"
+  integrity sha512-kcxE5Pu/QpmJdWfANUPpkIvXieYd1XFkvoZrHBjERcSsVgadp4vswHkL6ZOgAY/UOtW4d31Vx6l/OJimqC1JOQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/button" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/icon-button" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/button" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/icon-button" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/switch@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-5.0.0-canary.6092f71ee.0.tgz#7ddd47b3ceb991c033554ca2db9a4d01468315a4"
-  integrity sha512-TpfM6ze1iPdVNWlY4xVjvWuDXDxMcJujYiYaAN7WETPSCBbZZnax5MigsAuTSDMCWcR2NOcy5u+aa+rAf4HCYg==
+"@material/switch@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-5.0.0-canary.80a4d326f.0.tgz#21de413f1d7cc581bb3bc178ad14fcad2b5f390c"
+  integrity sha512-b4VXqw/8Lyd7pcQTtAsXTW3CZpTNtCVbwIrO6t1/QvreR7XoH3yQvNrsDPN8PJFPUu/TDmPirqDrttMr2lr7rQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/tab-bar@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-bar/-/tab-bar-5.0.0-canary.6092f71ee.0.tgz#1e24a71366ea4333201b496b3ad62ed643f0cc85"
-  integrity sha512-1NhyW8cnjXHdGLlQ7oIYLoJ1w7xZUqJMmsQTvntJDTXoOllL3xUFLW1AF3vIf8tQb26tIGLeT5O8+edlbi0Q3A==
+"@material/tab-bar@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-bar/-/tab-bar-5.0.0-canary.80a4d326f.0.tgz#239a9ae9c66ec2d088968e665b6c2b456558c24f"
+  integrity sha512-1CMKdikXei9toKtkSRdcxV/8ZT5TJ7Ml0+xhAQmQOUUEKS3nqOX7j2KTuuQAyYndlH2UNEXoF33jmHtYNOOvUw==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/tab" "5.0.0-canary.6092f71ee.0"
-    "@material/tab-scroller" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/tab" "5.0.0-canary.80a4d326f.0"
+    "@material/tab-scroller" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/tab-indicator@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-indicator/-/tab-indicator-5.0.0-canary.6092f71ee.0.tgz#d99aa923d20336eb2be6f4b59be3a968d301886e"
-  integrity sha512-u090taIKVzFfXeYzIqOlukv2J0lM9aGsWJnWJJ9Xl4cvTEUH4bN+5rezf6w26l9uEDvvLs3o8yOsxPuTV3/MiA==
+"@material/tab-indicator@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-indicator/-/tab-indicator-5.0.0-canary.80a4d326f.0.tgz#db5dea32e0c6060535bc1179cd4d7733004e6b5b"
+  integrity sha512-2lD0N+AMlpNUtgCpHilW4960dLu/k25i1WQVukZ5uns14mpGaqAiGb2BRTu/D7HN4fa+GzvxsF4E+JEn9m2mFw==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/tab-scroller@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-scroller/-/tab-scroller-5.0.0-canary.6092f71ee.0.tgz#30d64f076b18ece506e605cf405a69490ae09441"
-  integrity sha512-Ta1HULzNJKwCATPD8E3hf0TD53AhWlOfx8Plt91RW8EdGxL37wvo1le77dP29TXMm7ZFrsf/ziS7zxSX8mP+Ug==
+"@material/tab-scroller@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-scroller/-/tab-scroller-5.0.0-canary.80a4d326f.0.tgz#72ea0d90e3c50527ba5734741ded6df9c6f4506e"
+  integrity sha512-wRuRwScSnUBeV8osZTZ/IT47M6HQw9Rp20gd171IPA4MhYiArfKN/bLuim6t0k2IO2SVKI61uQZ8NAtE8TBcDQ==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/tab" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/tab" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/tab@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/tab/-/tab-5.0.0-canary.6092f71ee.0.tgz#8695a5e39908b27f9decbaa4964242479d0949ee"
-  integrity sha512-jrvC4ykxbgDSfQNE7t99IP6oOHHpzdT1o1HhWemgRuzjvUhTkDXuBRtxWbByXR42sAw++ueGIMu5wA1v0gtGZQ==
+"@material/tab@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/tab/-/tab-5.0.0-canary.80a4d326f.0.tgz#b7351c8d8f8d61d4c2d5c60e6160ebf62fe02c13"
+  integrity sha512-Hx/qqnfXCmvc17VoGBdmp/ybbY40pcDlIqQzuw3lq504xKMITAg10H7fr2X/AKOld9ou8BuUXgnJGVeCrJoSIg==
   dependencies:
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/tab-indicator" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/tab-indicator" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/textfield@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-5.0.0-canary.6092f71ee.0.tgz#9622233efc893a0b11a71195ec93599e47459e24"
-  integrity sha512-Up1O7czqUOVu585ewLI6rYhfgGVRVxwD1eriSqgVtX/RE2+SzWLbM2JkJ1e0L5LYQmLQIjKRqty2jcqV4lyUnw==
+"@material/textfield@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-5.0.0-canary.80a4d326f.0.tgz#a4cdf8053112c4af92415eb7105527f6a0e1c2d9"
+  integrity sha512-hGqLnTXQSFy5NzNqjwSzju2p1sUQ3SU2WCdA1soGNF/1wJiMOadk2iUv0AUFT5yflV8uS1zuhhU/VD/YztGlLw==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/floating-label" "5.0.0-canary.6092f71ee.0"
-    "@material/line-ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/notched-outline" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/floating-label" "5.0.0-canary.80a4d326f.0"
+    "@material/line-ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/notched-outline" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/theme@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-5.0.0-canary.6092f71ee.0.tgz#e20d2793c0d754238e02858c979b7259ccb93220"
-  integrity sha512-YEnO/QPkgyU0NOG9HQ3FVMb0h1s6lqFZBD2ejn9Q/x+2swaxtX2EfqyAFDNVQDrNsijVVjk05+WJObDpUg0xZA==
+"@material/theme@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-5.0.0-canary.80a4d326f.0.tgz#56aaffa6adf5a8e5074cbeb51dc654cd86ca0dd9"
+  integrity sha512-sfcurCSfZlHW7rI2UELFF3x1JB2iYOROMpUd+553SF6MIJrg+6Xg2NcE0egFvbefKeMKFIwP0+dMZRAEv6awKg==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
 
-"@material/top-app-bar@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/top-app-bar/-/top-app-bar-5.0.0-canary.6092f71ee.0.tgz#d19f9b8b9100d647502a2d63091eec6b0b63d04b"
-  integrity sha512-Jfbc0lcolx1wsvFKezJpkQGImgOz6vvxczfcavDwlOdfxXYN6OYUJD9jC9bYR6HRjEgE6tJqqmswi5tQtAKZew==
+"@material/top-app-bar@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/top-app-bar/-/top-app-bar-5.0.0-canary.80a4d326f.0.tgz#e952a65971cec69cb63a9ed37bfecb3019d7ce66"
+  integrity sha512-yTnNE4aK4qhzcgKRxvsDXfhgGuuZaJYxnkAN3vOxUEl9vvX1XG8LwU8sItixsF07wDT15JXg0aY7667oREWQFw==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
     tslib "^1.9.3"
 
-"@material/touch-target@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/touch-target/-/touch-target-5.0.0-canary.6092f71ee.0.tgz#26febab0c803bea6f6592521ce7ed6d3c10d2444"
-  integrity sha512-lI4C/N6q1dzkZ9YOvxpA7GGphTbqPy2jw2E6WmY1SSK/BmVjcZgdAVW/dijR1o4HS7nonIm4Ob7w7DFFTH+ZFQ==
+"@material/touch-target@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/touch-target/-/touch-target-5.0.0-canary.80a4d326f.0.tgz#61710ce0f203c0bfb427c1a015f6162592721868"
+  integrity sha512-FuHQHyOoXI7XZ/dseiznDKB+fhYNaxNTo+t7+wjaVmR/tP0kbvsvACtfKVLjVMJdriWEwSm73qiZeFhF1b3PQA==
   dependencies:
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
 
-"@material/typography@5.0.0-canary.6092f71ee.0":
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-5.0.0-canary.6092f71ee.0.tgz#57f52cc7c62b5e3898a21ea3879b6cd3d3713ed1"
-  integrity sha512-MVw+kPKBWv6lqtKzwrPVKMwgfN2nxbjkhhF2Wkw0wv3AGpavssytMmFBj0dlGDUl3e/tRa2gpQHspWRyaqjr/Q==
+"@material/typography@5.0.0-canary.80a4d326f.0":
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-5.0.0-canary.80a4d326f.0.tgz#ceeb47e5b3358f754ce18ffd506030b5a9e26437"
+  integrity sha512-ntExE1kVDRQzmziHGIrRD74Sf37aCM/CifnctO1ZdNaYCUhKITQq7DlKHN8sfPW35OZ9bAxEeP+2LOU+/VE6jQ==
   dependencies:
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
 
 "@microsoft/api-extractor-model@7.4.1":
   version "7.4.1"
@@ -4824,14 +4823,6 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-focus-trap@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-5.0.1.tgz#285f9df2cd9f5ef82dd1abb5d8a70e66cd4f99e3"
-  integrity sha512-vU7zEdL3y+kfkuwBbT9456JH8QfyemdcdZ2gKMfmgLyAs9NQAkSVQBSZmb9nlb1cVMo+iCsddqeGJog00pd2EQ==
-  dependencies:
-    tabbable "^4.0.0"
-    xtend "^4.0.1"
-
 follow-redirects@1.5.10, follow-redirects@^1.0.0:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -7557,54 +7548,54 @@ matchdep@^2.0.0:
     resolve "^1.4.0"
     stack-trace "0.0.10"
 
-material-components-web@5.0.0-canary.6092f71ee.0:
-  version "5.0.0-canary.6092f71ee.0"
-  resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-5.0.0-canary.6092f71ee.0.tgz#623f16ef354eaa61c933e9ba417ffa89a6120d90"
-  integrity sha512-iEtTkZ42UDBNNcN2cGL0lRT/iCvlwJZpE0TdjLgGSwaph2rIwK7A67sjT5eZ/e7PVP97BGI56oUi2vam/SiLlQ==
+material-components-web@5.0.0-canary.80a4d326f.0:
+  version "5.0.0-canary.80a4d326f.0"
+  resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-5.0.0-canary.80a4d326f.0.tgz#7dedb6b5a3f21e5b3fc8fc2c9976bb837ecf75fd"
+  integrity sha512-zQOFQvvVJ7qLmNDqEhuq7tzkiYSiTw2O308EprRC1fkEjeuNiU4TY3W3xn1L4MFs5kYrtuqf+EiZYJJe2GGEDg==
   dependencies:
-    "@material/animation" "5.0.0-canary.6092f71ee.0"
-    "@material/auto-init" "5.0.0-canary.6092f71ee.0"
-    "@material/base" "5.0.0-canary.6092f71ee.0"
-    "@material/button" "5.0.0-canary.6092f71ee.0"
-    "@material/card" "5.0.0-canary.6092f71ee.0"
-    "@material/checkbox" "5.0.0-canary.6092f71ee.0"
-    "@material/chips" "5.0.0-canary.6092f71ee.0"
-    "@material/data-table" "5.0.0-canary.6092f71ee.0"
-    "@material/density" "5.0.0-canary.6092f71ee.0"
-    "@material/dialog" "5.0.0-canary.6092f71ee.0"
-    "@material/dom" "5.0.0-canary.6092f71ee.0"
-    "@material/drawer" "5.0.0-canary.6092f71ee.0"
-    "@material/elevation" "5.0.0-canary.6092f71ee.0"
-    "@material/fab" "5.0.0-canary.6092f71ee.0"
-    "@material/feature-targeting" "5.0.0-canary.6092f71ee.0"
-    "@material/floating-label" "5.0.0-canary.6092f71ee.0"
-    "@material/form-field" "5.0.0-canary.6092f71ee.0"
-    "@material/icon-button" "5.0.0-canary.6092f71ee.0"
-    "@material/image-list" "5.0.0-canary.6092f71ee.0"
-    "@material/layout-grid" "5.0.0-canary.6092f71ee.0"
-    "@material/line-ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/linear-progress" "5.0.0-canary.6092f71ee.0"
-    "@material/list" "5.0.0-canary.6092f71ee.0"
-    "@material/menu" "5.0.0-canary.6092f71ee.0"
-    "@material/menu-surface" "5.0.0-canary.6092f71ee.0"
-    "@material/notched-outline" "5.0.0-canary.6092f71ee.0"
-    "@material/radio" "5.0.0-canary.6092f71ee.0"
-    "@material/ripple" "5.0.0-canary.6092f71ee.0"
-    "@material/rtl" "5.0.0-canary.6092f71ee.0"
-    "@material/select" "5.0.0-canary.6092f71ee.0"
-    "@material/shape" "5.0.0-canary.6092f71ee.0"
-    "@material/slider" "5.0.0-canary.6092f71ee.0"
-    "@material/snackbar" "5.0.0-canary.6092f71ee.0"
-    "@material/switch" "5.0.0-canary.6092f71ee.0"
-    "@material/tab" "5.0.0-canary.6092f71ee.0"
-    "@material/tab-bar" "5.0.0-canary.6092f71ee.0"
-    "@material/tab-indicator" "5.0.0-canary.6092f71ee.0"
-    "@material/tab-scroller" "5.0.0-canary.6092f71ee.0"
-    "@material/textfield" "5.0.0-canary.6092f71ee.0"
-    "@material/theme" "5.0.0-canary.6092f71ee.0"
-    "@material/top-app-bar" "5.0.0-canary.6092f71ee.0"
-    "@material/touch-target" "5.0.0-canary.6092f71ee.0"
-    "@material/typography" "5.0.0-canary.6092f71ee.0"
+    "@material/animation" "5.0.0-canary.80a4d326f.0"
+    "@material/auto-init" "5.0.0-canary.80a4d326f.0"
+    "@material/base" "5.0.0-canary.80a4d326f.0"
+    "@material/button" "5.0.0-canary.80a4d326f.0"
+    "@material/card" "5.0.0-canary.80a4d326f.0"
+    "@material/checkbox" "5.0.0-canary.80a4d326f.0"
+    "@material/chips" "5.0.0-canary.80a4d326f.0"
+    "@material/data-table" "5.0.0-canary.80a4d326f.0"
+    "@material/density" "5.0.0-canary.80a4d326f.0"
+    "@material/dialog" "5.0.0-canary.80a4d326f.0"
+    "@material/dom" "5.0.0-canary.80a4d326f.0"
+    "@material/drawer" "5.0.0-canary.80a4d326f.0"
+    "@material/elevation" "5.0.0-canary.80a4d326f.0"
+    "@material/fab" "5.0.0-canary.80a4d326f.0"
+    "@material/feature-targeting" "5.0.0-canary.80a4d326f.0"
+    "@material/floating-label" "5.0.0-canary.80a4d326f.0"
+    "@material/form-field" "5.0.0-canary.80a4d326f.0"
+    "@material/icon-button" "5.0.0-canary.80a4d326f.0"
+    "@material/image-list" "5.0.0-canary.80a4d326f.0"
+    "@material/layout-grid" "5.0.0-canary.80a4d326f.0"
+    "@material/line-ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/linear-progress" "5.0.0-canary.80a4d326f.0"
+    "@material/list" "5.0.0-canary.80a4d326f.0"
+    "@material/menu" "5.0.0-canary.80a4d326f.0"
+    "@material/menu-surface" "5.0.0-canary.80a4d326f.0"
+    "@material/notched-outline" "5.0.0-canary.80a4d326f.0"
+    "@material/radio" "5.0.0-canary.80a4d326f.0"
+    "@material/ripple" "5.0.0-canary.80a4d326f.0"
+    "@material/rtl" "5.0.0-canary.80a4d326f.0"
+    "@material/select" "5.0.0-canary.80a4d326f.0"
+    "@material/shape" "5.0.0-canary.80a4d326f.0"
+    "@material/slider" "5.0.0-canary.80a4d326f.0"
+    "@material/snackbar" "5.0.0-canary.80a4d326f.0"
+    "@material/switch" "5.0.0-canary.80a4d326f.0"
+    "@material/tab" "5.0.0-canary.80a4d326f.0"
+    "@material/tab-bar" "5.0.0-canary.80a4d326f.0"
+    "@material/tab-indicator" "5.0.0-canary.80a4d326f.0"
+    "@material/tab-scroller" "5.0.0-canary.80a4d326f.0"
+    "@material/textfield" "5.0.0-canary.80a4d326f.0"
+    "@material/theme" "5.0.0-canary.80a4d326f.0"
+    "@material/top-app-bar" "5.0.0-canary.80a4d326f.0"
+    "@material/touch-target" "5.0.0-canary.80a4d326f.0"
+    "@material/typography" "5.0.0-canary.80a4d326f.0"
 
 mathml-tag-names@^2.1.1:
   version "2.1.1"
@@ -10965,11 +10956,6 @@ systemjs@0.19.43:
   integrity sha1-mQLOW9qroDQTV1kCxrsYutLdq44=
   dependencies:
     when "^3.7.5"
-
-tabbable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
-  integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
 
 table@^5.4.6:
   version "5.4.6"


### PR DESCRIPTION
We recently updated to the latest MDC Canary to fix some build issues and be able to use the feature targeting for the form field, but it also came in with a regression. These changes update to a newer Canary version that has a fix for the regression (https://github.com/material-components/material-components-web/pull/5512).