### PR TITLE
Google Maps Options. Merge the default options with incoming

### DIFF
--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -93,7 +93,8 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
   }
   @Input()
   set options(options: google.maps.MapOptions) {
-    this._options.next(options || DEFAULT_OPTIONS);
+    
+    this._options.next(Object.assign(DEFAULT_OPTIONS, options));
   }
 
   /**


### PR DESCRIPTION
We are getting an error when we do not provide a zoom property and this will solve the problem.

`ERROR TypeError: Cannot read property 'zoom' of null
    at Bu (map.js:3)
    at HTMLDivElement.<anonymous> (map.js:3)
    at ZoneDelegate.invokeTask (zone-evergreen.js:391)
    at Object.onInvokeTask (core.js:39680)
    at ZoneDelegate.invokeTask (zone-evergreen.js:390)
    at Zone.runTask (zone-evergreen.js:168)
    at ZoneTask.invokeTask [as invoke] (zone-evergreen.js:465)
    at invokeTask (zone-evergreen.js:1603)
    at HTMLDivElement.globalZoneAwareCallback`