### PR TITLE
fix(schematics): global typography class always being added

### DIFF
--- a/src/material/schematics/ng-add/index.spec.ts
+++ b/src/material/schematics/ng-add/index.spec.ts
@@ -387,4 +387,27 @@ describe('ng-add schematic', () => {
       expect(buffer.toString()).toContain('<body class="one mat-typography two">');
     });
   });
+
+  it('should not add the global typography class if the user did not opt into it', async () => {
+    appTree.overwrite('projects/material/src/index.html', `
+      <html>
+        <head></head>
+        <body class="one two"></body>
+      </html>
+    `);
+
+    const tree = await runner.runSchematicAsync('ng-add-setup-project', {
+      typography: false
+    }, appTree).toPromise();
+
+    const workspace = getWorkspace(tree);
+    const project = getProjectFromWorkspace(workspace);
+    const indexFiles = getProjectIndexFiles(project);
+    expect(indexFiles.length).toBe(1);
+
+    indexFiles.forEach(indexPath => {
+      const buffer = tree.read(indexPath)!;
+      expect(buffer.toString()).toContain('<body class="one two">');
+    });
+  });
 });

--- a/src/material/schematics/ng-add/theming/theming.ts
+++ b/src/material/schematics/ng-add/theming/theming.ts
@@ -57,7 +57,9 @@ export function addTypographyClass(options: Schema): (host: Tree) => Tree {
       throw new SchematicsException('No project index HTML file could be found.');
     }
 
-    projectIndexFiles.forEach(indexFilePath => addBodyClass(host, indexFilePath, 'mat-typography'));
+    if (options.typography) {
+      projectIndexFiles.forEach(path => addBodyClass(host, path, 'mat-typography'));
+    }
 
     return host;
   };


### PR DESCRIPTION
In #17602 a new prompt to `ng-add` was added which allowed consumers to opt into adding the `mat-typgoraphy` style globally, but it looks like the option was never read so the class is always being added.

Fixes #16776.