### PR TITLE
fix(a11y): avoid errors when trying to add high contrast class

### DIFF
--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -62,10 +62,13 @@ export class HighContrastModeDetector {
 
     // Get the computed style for the background color, collapsing spaces to normalize between
     // browsers. Once we get this color, we no longer need the test element. Access the `window`
-    // via the document so we can fake it in tests.
-    const documentWindow = this._document.defaultView!;
+    // via the document so we can fake it in tests. Note that we have extra null checks, because
+    // this logic will likely run during app bootstrap and throwing can break the entire app.
+    const documentWindow = this._document.defaultView || window;
+    const computedStyle = (documentWindow && documentWindow.getComputedStyle) ?
+        documentWindow.getComputedStyle(testElement) : null;
     const computedColor =
-        (documentWindow.getComputedStyle(testElement).backgroundColor || '').replace(/ /g, '');
+        (computedStyle && computedStyle.backgroundColor || '').replace(/ /g, '');
     this._document.body.removeChild(testElement);
 
     switch (computedColor) {


### PR DESCRIPTION
Found this in some errors logs. The `document.defaultView` can be null in some cases which causes a null pointer error to be thrown. Furthermore, these changes add a few more null checks to ensure that we don't throw if `getComputedStyle` isn't available.

**Note:** setting this as a P2, because we run this logic during bootstrap as a part of the `MatCommonModule` which can cause the entire app to break down.