### PR TITLE
fix(material/form-field): remove form field required marker coloring

### DIFF
--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -20,7 +20,6 @@
   // Label colors. Required is used for the `*` star shown in the label.
   $label-color: mat-color($foreground, secondary-text, if($is-dark-theme, 0.7, 0.6));
   $focused-label-color: mat-color($primary, text);
-  $required-label-color: mat-color($accent, text);
 
   // Underline colors.
   $underline-color-base: mat-color($foreground, divider, if($is-dark-theme, 1, 0.87));
@@ -46,10 +45,6 @@
     &.mat-warn {
       color: $underline-color-warn;
     }
-  }
-
-  .mat-focused .mat-form-field-required-marker {
-    color: $required-label-color;
   }
 
   .mat-form-field-ripple {


### PR DESCRIPTION
Fixes a bug in the Angular Material `form-field` style where the required-marker (asterisk) is specifically colored in the accent color, contrary to what is defined in the current material design spec.

Fixes #18326
Fixes #16826

EDIT: Added #16826 to issues that will be fixed by this PR