### PR TITLE
fix: reduce amount of generated high contrast styles

### DIFF
--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -22,7 +22,7 @@
 .mat-mdc-fab,
 .mat-mdc-mini-fab,
 .mat-mdc-icon-button {
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }

--- a/src/material-experimental/mdc-card/card.scss
+++ b/src/material-experimental/mdc-card/card.scss
@@ -16,7 +16,7 @@ $mat-card-default-padding: 16px !default;
 // Add styles to the root card to have an outline in high-contrast mode.
 // TODO(jelbourn): file bug for MDC supporting high-contrast mode on `.mdc-card`.
 .mat-mdc-card {
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }

--- a/src/material-experimental/mdc-chips/chips.scss
+++ b/src/material-experimental/mdc-chips/chips.scss
@@ -22,7 +22,7 @@
     transition-duration: 1ms;
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
 
     &:focus {
@@ -79,7 +79,7 @@ input.mat-mdc-chip-input {
 }
 
 .mdc-chip__checkmark-path {
-  @include cdk-high-contrast(black-on-white) {
+  @include cdk-high-contrast(black-on-white, off) {
     // SVG colors won't be changed in high contrast mode and since the checkmark is white
     // by default, it'll blend in with the background in black-on-white mode. Override the color
     // to ensure that it's visible. We need !important, because the theme styles are very specific.

--- a/src/material-experimental/mdc-menu/menu.scss
+++ b/src/material-experimental/mdc-menu/menu.scss
@@ -23,7 +23,7 @@
   // The CDK positioning uses flexbox to anchor the element, whereas MDC uses `position: absolute`.
   position: static;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }
@@ -75,7 +75,7 @@
     }
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     &.cdk-program-focused,
     &.cdk-keyboard-focused,
     &-highlighted {

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
@@ -55,7 +55,7 @@
 }
 
 
-@include cdk-high-contrast {
+@include cdk-high-contrast(active, off) {
   .mat-mdc-slide-toggle-focused {
     .mdc-switch__track {
       // Usually 1px would be enough, but MDC reduces the opacity on the

--- a/src/material-experimental/mdc-slider/slider.scss
+++ b/src/material-experimental/mdc-slider/slider.scss
@@ -26,7 +26,7 @@ $mat-slider-horizontal-margin: 8px !default;
   width: auto;
   min-width: $mat-slider-min-size - (2 * $mat-slider-horizontal-margin);
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     // The slider track isn't visible in high contrast mode so we work
     // around it by setting an outline and removing the height to make it look solid.
     .mdc-slider__track-container {

--- a/src/material-experimental/popover-edit/_popover-edit.scss
+++ b/src/material-experimental/popover-edit/_popover-edit.scss
@@ -81,7 +81,7 @@
     display: block;
     padding: 16px 24px;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       // Note that normally we use 1px for high contrast outline, however here we use 3,
       // because the popover is rendered on top of a table which already has some borders
       // and doesn't have a backdrop. The thicker outline makes it easier to differentiate.

--- a/src/material/autocomplete/autocomplete.scss
+++ b/src/material/autocomplete/autocomplete.scss
@@ -38,7 +38,7 @@ $mat-autocomplete-panel-border-radius: 4px !default;
     margin-top: -1px;
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }

--- a/src/material/badge/_badge-theme.scss
+++ b/src/material/badge/_badge-theme.scss
@@ -98,7 +98,7 @@ $mat-badge-large-size: $mat-badge-default-size + 6;
     color: mat-color($primary, default-contrast);
     background: mat-color($primary);
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       outline: solid 1px;
       border-radius: 0;
     }

--- a/src/material/bottom-sheet/bottom-sheet-container.scss
+++ b/src/material/bottom-sheet/bottom-sheet-container.scss
@@ -17,7 +17,7 @@ $mat-bottom-sheet-container-horizontal-padding: 16px !default;
   max-height: 80vh;
   overflow: auto;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: 1px solid;
   }
 }

--- a/src/material/button-toggle/button-toggle.scss
+++ b/src/material/button-toggle/button-toggle.scss
@@ -20,7 +20,7 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   border-radius: $mat-button-toggle-legacy-border-radius;
   -webkit-tap-highlight-color: transparent;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }
@@ -29,7 +29,7 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
 .mat-button-toggle-group-appearance-standard {
   border-radius: $mat-button-toggle-standard-border-radius;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: 0;
   }
 }
@@ -58,7 +58,7 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
       opacity: 1;
 
       // In high contrast mode `opacity: 1` will show the overlay as solid so we fall back 0.5.
-      @include cdk-high-contrast {
+      @include cdk-high-contrast(active, off) {
         opacity: 0.5;
       }
     }
@@ -78,7 +78,7 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   &.cdk-keyboard-focused:not(.mat-button-toggle-disabled) .mat-button-toggle-focus-overlay {
     opacity: 0.12;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       opacity: 0.5;
     }
   }
@@ -128,14 +128,14 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
     // Changing the background color for the selected item won't be visible in high contrast mode.
     // We fall back to using the overlay to draw a brighter, semi-transparent tint on top instead.
     // It uses a border, because the browser will render it using a brighter color.
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       opacity: 0.5;
       height: 0;
     }
   }
 }
 
-@include cdk-high-contrast {
+@include cdk-high-contrast(active, off) {
   .mat-button-toggle-checked {
     &.mat-button-toggle-appearance-standard .mat-button-toggle-focus-overlay {
       border-bottom: solid $mat-button-toggle-standard-height;

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -121,14 +121,14 @@
     transition: none;
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     // Note that IE will render this in the same way, no
     // matter whether the theme is light or dark. This helps
     // with the readability of focused buttons.
     background-color: #fff;
   }
 
-  @include cdk-high-contrast(black-on-white) {
+  @include cdk-high-contrast(black-on-white, off) {
     // For the black-on-white high contrast mode, the browser will set this element
     // to white, making it blend in with the background, hence why we need to set
     // it explicitly to black.
@@ -167,7 +167,7 @@
 
 // Add an outline to make buttons more visible in high contrast mode. Stroked buttons
 // don't need a special look in high-contrast mode, because those already have an outline.
-@include cdk-high-contrast {
+@include cdk-high-contrast(active, off) {
   .mat-button, .mat-flat-button, .mat-raised-button, .mat-icon-button, .mat-fab, .mat-mini-fab {
     outline: solid 1px;
   }

--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -37,7 +37,7 @@ $mat-card-header-size: 40px !default;
     }
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -253,7 +253,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
     transition: none;
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     // Note that we change the border style of the checkbox frame to dotted because this
     // is how IE/Edge similarly treats native checkboxes in high contrast mode.
     .mat-checkbox.cdk-keyboard-focused & {
@@ -279,7 +279,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
   // `.mat-checkbox` here is redundant, but we need it to increase the specificity so that
   // these styles don't get overwritten by the `background-color` from the theme.
   .mat-checkbox & {
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       // Needs to be removed because it hides the checkbox outline.
       background: none;
     }
@@ -329,7 +329,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
     width: $_mat-checkbox-mark-stroke-size;
   }
 
-  @include cdk-high-contrast(black-on-white) {
+  @include cdk-high-contrast(black-on-white, off) {
     // In the checkbox theme this `stroke` has !important which ends up overriding the browser's
     // automatic color inversion so we need to re-invert it ourselves for black-on-white.
     stroke: #000 !important;
@@ -345,7 +345,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
   transform: scaleX(0) rotate(0deg);
   border-radius: 2px;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     height: 0;
     border-top: solid $height;
     margin-top: $height;
@@ -409,7 +409,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
 .mat-checkbox-disabled {
   cursor: default;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     opacity: 0.5;
   }
 }

--- a/src/material/chips/chips.scss
+++ b/src/material/chips/chips.scss
@@ -82,7 +82,7 @@ $mat-chip-remove-size: 18px;
     }
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
 
     &:focus {

--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -29,7 +29,7 @@
     }
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     $high-contrast-border-width: 1px;
 
     // Add a margin to offset the border that we're adding to active option, in order
@@ -69,7 +69,7 @@
   pointer-events: none;
 
   // Prevents the ripple from completely covering the option in high contrast mode.
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     opacity: 0.5;
   }
 }

--- a/src/material/core/ripple/_ripple.scss
+++ b/src/material/core/ripple/_ripple.scss
@@ -37,7 +37,7 @@ $mat-ripple-color-opacity: 0.1;
     transform: scale(0);
 
     // In high contrast mode the ripple is opaque, causing it to obstruct the content.
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       display: none;
     }
   }

--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -61,13 +61,13 @@ $mat-calendar-body-cell-content-size: 100% - $mat-calendar-body-cell-content-mar
   // Choosing a value clearly larger than the height ensures we get the correct capsule shape.
   border-radius: 999px;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     border: none;
   }
 }
 
 
-@include cdk-high-contrast {
+@include cdk-high-contrast(active, off) {
   .mat-datepicker-popup:not(:empty),
   .mat-calendar-body-selected {
     outline: solid 1px;

--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -24,7 +24,7 @@ $mat-dialog-button-margin: 8px !default;
   min-height: inherit;
   max-height: inherit;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }

--- a/src/material/expansion/expansion-panel.scss
+++ b/src/material/expansion/expansion-panel.scss
@@ -29,7 +29,7 @@
     }
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 

--- a/src/material/form-field/form-field-fill.scss
+++ b/src/material/form-field/form-field-fill.scss
@@ -28,7 +28,7 @@ $mat-form-field-fill-subscript-padding:
     padding: $mat-form-field-fill-line-spacing $mat-form-field-fill-side-padding 0
              $mat-form-field-fill-side-padding;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       outline: solid 1px;
     }
   }
@@ -46,7 +46,7 @@ $mat-form-field-fill-subscript-padding:
     bottom: 0;
     height: $mat-form-field-fill-underline-ripple-height;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       height: 0;
       border-top: solid $mat-form-field-fill-underline-ripple-height;
     }

--- a/src/material/form-field/form-field-input.scss
+++ b/src/material/form-field/form-field-input.scss
@@ -181,7 +181,7 @@ select.mat-input-element {
     // as the background, however this causes it blend in because we've reset the `background`
     // above. We have to add a more specific selector in order to ensure that it gets the
     // `color` from our theme instead.
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       .mat-focused & {
         color: inherit;
       }

--- a/src/material/form-field/form-field-legacy.scss
+++ b/src/material/form-field/form-field-legacy.scss
@@ -38,7 +38,7 @@ $mat-form-field-legacy-underline-height: 1px !default;
   .mat-form-field-underline {
     height: $mat-form-field-legacy-underline-height;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       height: 0;
       border-top: solid $mat-form-field-legacy-underline-height;
     }
@@ -53,7 +53,7 @@ $mat-form-field-legacy-underline-height: 1px !default;
     // the desired form-field ripple height. See: angular/components#6351
     overflow: hidden;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       height: 0;
       border-top: solid $height;
     }
@@ -63,7 +63,7 @@ $mat-form-field-legacy-underline-height: 1px !default;
     background-position: 0;
     background-color: transparent;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       border-top-style: dotted;
       border-top-width: 2px;
     }

--- a/src/material/form-field/form-field-standard.scss
+++ b/src/material/form-field/form-field-standard.scss
@@ -22,7 +22,7 @@ $mat-form-field-standard-padding-top: 0.75em !default;
   .mat-form-field-underline {
     height: $mat-form-field-standard-underline-height;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       height: 0;
       border-top: solid $mat-form-field-standard-underline-height;
     }
@@ -33,7 +33,7 @@ $mat-form-field-standard-padding-top: 0.75em !default;
     bottom: 0;
     height: $height;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       height: 0;
       border-top: $height;
     }
@@ -43,7 +43,7 @@ $mat-form-field-standard-padding-top: 0.75em !default;
     background-position: 0;
     background-color: transparent;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       border-top-style: dotted;
       border-top-width: 2px;
     }

--- a/src/material/form-field/form-field.scss
+++ b/src/material/form-field/form-field.scss
@@ -58,7 +58,7 @@ $mat-form-field-default-infix-width: 180px !default;
   // Since we can't remove the border altogether or replace it with a margin, because it'll throw
   // off the baseline, and we can't use a base64-encoded 1x1 transparent image because of CSP,
   // we work around it by setting a linear gradient that goes from `transparent` to `transparent`.
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     border-image: linear-gradient(transparent, transparent);
   }
 }

--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -304,7 +304,7 @@ mat-action-list {
   pointer-events: none;
 }
 
-@include cdk-high-contrast {
+@include cdk-high-contrast(active, off) {
   .mat-selection-list:focus {
     outline-style: dotted;
   }

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -28,7 +28,7 @@ $mat-menu-submenu-indicator-size: 10px !default;
     pointer-events: none;
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }
@@ -53,7 +53,7 @@ $mat-menu-submenu-indicator-size: 10px !default;
     pointer-events: none;
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     &.cdk-program-focused,
     &.cdk-keyboard-focused,
     &-highlighted {

--- a/src/material/progress-bar/progress-bar.scss
+++ b/src/material/progress-bar/progress-bar.scss
@@ -32,7 +32,7 @@ $mat-progress-bar-piece-animation-duration: 250ms !default;
     // during the background scroll animation.
     width: calc(100% + 10px);
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       display: none;
     }
   }
@@ -43,7 +43,7 @@ $mat-progress-bar-piece-animation-duration: 250ms !default;
     transform-origin: top left;
     transition: transform $mat-progress-bar-piece-animation-duration ease;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       border-top: solid 5px;
       opacity: 0.5;
     }
@@ -61,7 +61,7 @@ $mat-progress-bar-piece-animation-duration: 250ms !default;
     transform-origin: top left;
     transition: transform $mat-progress-bar-piece-animation-duration ease;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       border-top: solid $mat-progress-bar-height;
     }
   }

--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -85,7 +85,7 @@ $mat-radio-ripple-radius: 20px;
   .mat-radio-checked & {
     transform: scale(0.5);
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       // Since we use a background color to render the circle, it won't be
       // displayed in high contrast mode. Use a border as a fallback.
       border: solid $mat-radio-size / 2;
@@ -183,7 +183,7 @@ $mat-radio-ripple-radius: 20px;
   left: 50%;
 }
 
-@include cdk-high-contrast {
+@include cdk-high-contrast(active, off) {
   .mat-radio-disabled {
     opacity: 0.5;
   }

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -97,7 +97,7 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
   min-width: 100%; // prevents some animation twitching and test inconsistencies in IE11
   border-radius: 4px;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }

--- a/src/material/sidenav/drawer.scss
+++ b/src/material/sidenav/drawer.scss
@@ -86,7 +86,7 @@ $mat-drawer-over-drawer-z-index: 4;
     }
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     opacity: 0.5;
   }
 }
@@ -123,13 +123,13 @@ $mat-drawer-over-drawer-z-index: 4;
   transform: translate3d(-100%, 0, 0);
 
   &, [dir='rtl'] &.mat-drawer-end {
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       border-right: $high-contrast-border;
     }
   }
 
   [dir='rtl'] &, &.mat-drawer-end {
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       border-left: $high-contrast-border;
       border-right: none;
     }

--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -217,7 +217,7 @@ $mat-slide-toggle-bar-track-width: $mat-slide-toggle-bar-width - $mat-slide-togg
 }
 
 /** Custom styling to make the slide-toggle usable in high contrast mode. */
-@include cdk-high-contrast {
+@include cdk-high-contrast(active, off) {
   .mat-slide-toggle-thumb,
   .mat-slide-toggle-bar {
     border: 1px solid;

--- a/src/material/slider/slider.scss
+++ b/src/material/slider/slider.scss
@@ -143,7 +143,7 @@ $mat-slider-focus-ring-size: 30px !default;
               border-radius  $swift-ease-out-duration $swift-ease-out-timing-function,
               background-color  $swift-ease-out-duration $swift-ease-out-timing-function;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }
@@ -303,7 +303,7 @@ $mat-slider-focus-ring-size: 30px !default;
     height: $mat-slider-track-thickness;
     width: 100%;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       height: 0;
       outline: solid $mat-slider-track-thickness;
       top: $mat-slider-track-thickness / 2;
@@ -343,7 +343,7 @@ $mat-slider-focus-ring-size: 30px !default;
       transform: rotate(45deg);
     }
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       .mat-slider-thumb-label,
       .mat-slider-thumb-label-text {
         transform: none;
@@ -393,7 +393,7 @@ $mat-slider-focus-ring-size: 30px !default;
     width: $mat-slider-track-thickness;
     height: 100%;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       width: 0;
       outline: solid $mat-slider-track-thickness;
       left: $mat-slider-track-thickness / 2;

--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -19,7 +19,7 @@ $mat-snack-bar-spacing-margin-handset: 8px !default;
   min-height: $mat-snack-bar-min-height;
   transform-origin: center;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     border: solid 1px;
   }
 }

--- a/src/material/sort/sort-header.scss
+++ b/src/material/sort/sort-header.scss
@@ -77,7 +77,7 @@ $mat-sort-header-arrow-hint-opacity: 0.38;
   display: flex;
   align-items: center;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     width: 0;
     border-left: solid $mat-sort-header-arrow-thickness;
   }
@@ -100,7 +100,7 @@ $mat-sort-header-arrow-hint-opacity: 0.38;
   background: currentColor;
   transform: rotate(45deg);
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     width: 0;
     height: 0;
     border-top: solid $mat-sort-header-arrow-thickness;
@@ -116,7 +116,7 @@ $mat-sort-header-arrow-hint-opacity: 0.38;
   position: absolute;
   top: 0;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     width: 0;
     height: 0;
     border-left: solid $mat-sort-header-arrow-pointer-length;

--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -27,7 +27,7 @@ $mat-tab-animation-duration: 500ms !default;
       opacity: 1;
     }
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       $outline-width: 2px;
       outline: dotted $outline-width;
       outline-offset: -$outline-width; // Not supported on IE, but looks better everywhere else.
@@ -37,7 +37,7 @@ $mat-tab-animation-duration: 500ms !default;
   &.mat-tab-disabled {
     cursor: default;
 
-    @include cdk-high-contrast {
+    @include cdk-high-contrast(active, off) {
       opacity: 0.5;
     }
   }
@@ -49,7 +49,7 @@ $mat-tab-animation-duration: 500ms !default;
     white-space: nowrap;
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     opacity: 1;
   }
 }
@@ -69,7 +69,7 @@ $mat-tab-animation-duration: 500ms !default;
     top: 0;
   }
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid $height;
     height: 0;
   }

--- a/src/material/toolbar/toolbar.scss
+++ b/src/material/toolbar/toolbar.scss
@@ -22,7 +22,7 @@ $mat-toolbar-height-mobile-landscape: 48px !default;
 }
 
 .mat-toolbar {
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }

--- a/src/material/tooltip/tooltip.scss
+++ b/src/material/tooltip/tooltip.scss
@@ -25,7 +25,7 @@ $mat-tooltip-handset-margin: 24px;
   overflow: hidden;
   text-overflow: ellipsis;
 
-  @include cdk-high-contrast {
+  @include cdk-high-contrast(active, off) {
     outline: solid 1px;
   }
 }


### PR DESCRIPTION
Since we know that all of our components have encapsulation turned off, we can pass in the encapsulation parameter to the `cdk-high-contrast` mixin and avoid having to output the styles twice.