### PR TITLE
fix(a11y): don't allow passing in null to FocusMonitor.focusVia

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -293,7 +293,7 @@ export class FocusMonitor implements OnDestroy {
    * @param origin Focus origin.
    * @param options Options that can be used to configure the focus behavior.
    */
-  focusVia(element: HTMLElement, origin: FocusOrigin, options?: FocusOptions): void;
+  focusVia(element: HTMLElement, origin: NonNullable<FocusOrigin>, options?: FocusOptions): void;
 
   /**
    * Focuses the element via the specified focus origin.
@@ -301,20 +301,20 @@ export class FocusMonitor implements OnDestroy {
    * @param origin Focus origin.
    * @param options Options that can be used to configure the focus behavior.
    */
-  focusVia(element: ElementRef<HTMLElement>, origin: FocusOrigin, options?: FocusOptions): void;
+  focusVia(element: ElementRef<HTMLElement>,
+           origin: NonNullable<FocusOrigin>,
+           options?: FocusOptions): void;
 
   focusVia(element: HTMLElement | ElementRef<HTMLElement>,
-          origin: FocusOrigin,
-          options?: FocusOptions): void {
+           origin: NonNullable<FocusOrigin>,
+           options?: FocusOptions): void {
 
     const nativeElement = coerceElement(element);
-
     this._setOriginForCurrentEventQueue(origin);
 
-    // `focus` isn't available on the server
+    // `focus` isn't available on the server.
     if (typeof nativeElement.focus === 'function') {
-      // Cast the element to `any`, because the TS typings don't have the `options` parameter yet.
-      (nativeElement as any).focus(options);
+      nativeElement.focus(options);
     }
   }
 

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -127,7 +127,7 @@ export class MatButton extends _MatButtonMixinBase
   }
 
   /** Focuses the button. */
-  focus(origin: FocusOrigin = 'program', options?: FocusOptions): void {
+  focus(origin: NonNullable<FocusOrigin> = 'program', options?: FocusOptions): void {
     this._focusMonitor.focusVia(this._getHostElement(), origin, options);
   }
 

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -435,7 +435,7 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   }
 
   /** Focuses the checkbox. */
-  focus(origin: FocusOrigin = 'keyboard', options?: FocusOptions): void {
+  focus(origin: NonNullable<FocusOrigin> = 'keyboard', options?: FocusOptions): void {
     this._focusMonitor.focusVia(this._inputElement, origin, options);
   }
 

--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -192,7 +192,7 @@ export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, Focusa
    * @param origin Origin of the action that triggered the focus.
    * @docs-private
    */
-  focus(origin: FocusOrigin = 'program', options?: FocusOptions) {
+  focus(origin: NonNullable<FocusOrigin> = 'program', options?: FocusOptions) {
     this._focusMonitor.focusVia(this._element, origin, options);
   }
 

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -94,7 +94,7 @@ export class MatMenuItem extends _MatMenuItemMixinBase
   }
 
   /** Focuses the menu item. */
-  focus(origin: FocusOrigin = 'program', options?: FocusOptions): void {
+  focus(origin: NonNullable<FocusOrigin> = 'program', options?: FocusOptions): void {
     if (this._focusMonitor) {
       this._focusMonitor.focusVia(this._getHostElement(), origin, options);
     } else {

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -262,7 +262,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
    * Focuses the menu trigger.
    * @param origin Source of the menu trigger's focus.
    */
-  focus(origin: FocusOrigin = 'program', options?: FocusOptions) {
+  focus(origin: NonNullable<FocusOrigin> = 'program', options?: FocusOptions) {
     if (this._focusMonitor) {
       this._focusMonitor.focusVia(this._element, origin, options);
     } else {

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -349,7 +349,8 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
 
     // Note that we don't check via `instanceof HTMLElement` so that we can cover SVGs as well.
     if (this._elementFocusedBeforeDrawerWasOpened) {
-      this._focusMonitor.focusVia(this._elementFocusedBeforeDrawerWasOpened, this._openedVia);
+      this._focusMonitor.focusVia(this._elementFocusedBeforeDrawerWasOpened,
+          this._openedVia || 'program');
     } else {
       this._elementRef.nativeElement.blur();
     }

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -100,8 +100,8 @@ export declare class FocusMonitor implements OnDestroy {
     constructor(_ngZone: NgZone, _platform: Platform,
     document: any | null, options: FocusMonitorOptions | null);
     _onBlur(event: FocusEvent, element: HTMLElement): void;
-    focusVia(element: HTMLElement, origin: FocusOrigin, options?: FocusOptions): void;
-    focusVia(element: ElementRef<HTMLElement>, origin: FocusOrigin, options?: FocusOptions): void;
+    focusVia(element: HTMLElement, origin: NonNullable<FocusOrigin>, options?: FocusOptions): void;
+    focusVia(element: ElementRef<HTMLElement>, origin: NonNullable<FocusOrigin>, options?: FocusOptions): void;
     monitor(element: HTMLElement, checkChildren?: boolean): Observable<FocusOrigin>;
     monitor(element: ElementRef<HTMLElement>, checkChildren?: boolean): Observable<FocusOrigin>;
     ngOnDestroy(): void;

--- a/tools/public_api_guard/material/button.d.ts
+++ b/tools/public_api_guard/material/button.d.ts
@@ -15,7 +15,7 @@ export declare class MatButton extends _MatButtonMixinBase implements AfterViewI
     _getHostElement(): any;
     _hasHostAttributes(...attributes: string[]): boolean;
     _isRippleDisabled(): boolean;
-    focus(origin?: FocusOrigin, options?: FocusOptions): void;
+    focus(origin?: NonNullable<FocusOrigin>, options?: FocusOptions): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ngAcceptInputType_disableRipple: BooleanInput;

--- a/tools/public_api_guard/material/checkbox.d.ts
+++ b/tools/public_api_guard/material/checkbox.d.ts
@@ -43,7 +43,7 @@ export declare class MatCheckbox extends _MatCheckboxMixinBase implements Contro
     _onInputClick(event: Event): void;
     _onInteractionEvent(event: Event): void;
     _onLabelTextChange(): void;
-    focus(origin?: FocusOrigin, options?: FocusOptions): void;
+    focus(origin?: NonNullable<FocusOrigin>, options?: FocusOptions): void;
     ngAfterViewChecked(): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;

--- a/tools/public_api_guard/material/expansion.d.ts
+++ b/tools/public_api_guard/material/expansion.d.ts
@@ -110,7 +110,7 @@ export declare class MatExpansionPanelHeader implements AfterViewInit, OnDestroy
     _keydown(event: KeyboardEvent): void;
     _showToggle(): boolean;
     _toggle(): void;
-    focus(origin?: FocusOrigin, options?: FocusOptions): void;
+    focus(origin?: NonNullable<FocusOrigin>, options?: FocusOptions): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatExpansionPanelHeader, "mat-expansion-panel-header", never, { "expandedHeight": "expandedHeight"; "collapsedHeight": "collapsedHeight"; }, {}, never, ["mat-panel-title", "mat-panel-description", "*"]>;

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -114,7 +114,7 @@ export declare class MatMenuItem extends _MatMenuItemMixinBase implements Focusa
     _getHostElement(): HTMLElement;
     _getTabIndex(): string;
     _handleMouseEnter(): void;
-    focus(origin?: FocusOrigin, options?: FocusOptions): void;
+    focus(origin?: NonNullable<FocusOrigin>, options?: FocusOptions): void;
     getLabel(): string;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
@@ -169,7 +169,7 @@ export declare class MatMenuTrigger implements AfterContentInit, OnDestroy {
     _handleKeydown(event: KeyboardEvent): void;
     _handleMousedown(event: MouseEvent): void;
     closeMenu(): void;
-    focus(origin?: FocusOrigin, options?: FocusOptions): void;
+    focus(origin?: NonNullable<FocusOrigin>, options?: FocusOptions): void;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     openMenu(): void;


### PR DESCRIPTION
Passing in null to the `FocusMonitor.focusVia` method is currently supported, but it doesn't make sense. These changes make it impossible via typings.