### PR TITLE
build: enable all ngtsc strictness flags

### DIFF
--- a/src/components-examples/material/select/select-initial-value/select-initial-value-example.html
+++ b/src/components-examples/material/select/select-initial-value/select-initial-value-example.html
@@ -11,7 +11,7 @@
 <h4>Basic native select with initial value</h4>
 <mat-form-field>
   <mat-label>Favorite Car</mat-label>
-  <select matNativeControl (change)="selectedCar = $event.target.value">
+  <select matNativeControl (change)="selectCar($event)">
     <option value=""></option>
     <option *ngFor="let option of cars" [value]="option.value"
             [selected]="selectedCar === option.value">{{ option.viewValue }}</option>

--- a/src/components-examples/material/select/select-initial-value/select-initial-value-example.ts
+++ b/src/components-examples/material/select/select-initial-value/select-initial-value-example.ts
@@ -31,4 +31,8 @@ export class SelectInitialValueExample {
   ];
   selectedFood = this.foods[2].value;
   selectedCar = this.cars[0].value;
+
+  selectCar(event: Event) {
+    this.selectedCar = (event.target as HTMLSelectElement).value;
+  }
 }

--- a/src/components-examples/material/table/table-filtering/table-filtering-example.html
+++ b/src/components-examples/material/table/table-filtering/table-filtering-example.html
@@ -1,6 +1,6 @@
 <mat-form-field>
   <mat-label>Filter</mat-label>
-  <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Ex. ium">
+  <input matInput (keyup)="applyFilter($event)" placeholder="Ex. ium">
 </mat-form-field>
 
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">

--- a/src/components-examples/material/table/table-filtering/table-filtering-example.ts
+++ b/src/components-examples/material/table/table-filtering/table-filtering-example.ts
@@ -33,7 +33,8 @@ export class TableFilteringExample {
   displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
   dataSource = new MatTableDataSource(ELEMENT_DATA);
 
-  applyFilter(filterValue: string) {
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
     this.dataSource.filter = filterValue.trim().toLowerCase();
   }
 }

--- a/src/components-examples/material/table/table-overview/table-overview-example.html
+++ b/src/components-examples/material/table/table-overview/table-overview-example.html
@@ -1,6 +1,6 @@
 <mat-form-field>
   <mat-label>Filter</mat-label>
-  <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Ex. Mia">
+  <input matInput (keyup)="applyFilter($event)" placeholder="Ex. Mia">
 </mat-form-field>
 
 <div class="mat-elevation-z8">

--- a/src/components-examples/material/table/table-overview/table-overview-example.ts
+++ b/src/components-examples/material/table/table-overview/table-overview-example.ts
@@ -48,7 +48,8 @@ export class TableOverviewExample implements OnInit {
     this.dataSource.sort = this.sort;
   }
 
-  applyFilter(filterValue: string) {
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
     this.dataSource.filter = filterValue.trim().toLowerCase();
 
     if (this.dataSource.paginator) {

--- a/src/dev-app/select/select-demo.html
+++ b/src/dev-app/select/select-demo.html
@@ -398,7 +398,7 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
       <mat-card-content>
         <mat-form-field>
           <mat-label>Starter pokemon</mat-label>
-          <mat-select (change)="latestChangeEvent = $event">
+          <mat-select (selectionChange)="latestChangeEvent = $event">
             <mat-option *ngFor="let creature of pokemon" [value]="creature.value">{{ creature.viewValue }}</mat-option>
           </mat-select>
         </mat-form-field>

--- a/src/e2e-app/radio/radio-e2e.html
+++ b/src/e2e-app/radio/radio-e2e.html
@@ -1,6 +1,6 @@
 <section>
   <mat-radio-group [disabled]="isGroupDisabled"
-                  [(value)]="groupValue"
+                  [value]="groupValue"
                   id="test-group" aria-label="Select a Pokemon">
 
     <mat-radio-button value="fire" id="fire">Charmander</mat-radio-button>

--- a/tools/bazel/postinstall-patches.js
+++ b/tools/bazel/postinstall-patches.js
@@ -12,7 +12,7 @@ const fs = require('fs');
  * Version of the post install patch. Needs to be incremented when patches
  * have been added or removed.
  */
-const PATCH_VERSION = 2;
+const PATCH_VERSION = 3;
 
 /** Path to the project directory. */
 const projectDir = path.join(__dirname, '../..');
@@ -118,9 +118,7 @@ searchAndReplace(`[formatProperty + "_ivy_ngcc"]`, '[formatProperty]',
 
 // Workaround for https://github.com/angular/angular/issues/33452:
 searchAndReplace(/angular_compiler_options = {/, `$&
-        "strictTemplates": True,
-        "strictDomLocalRefTypes ": False,
-        "strictDomEventTypes": False,`, 'node_modules/@angular/bazel/src/ng_module.bzl');
+        "strictTemplates": True,`, 'node_modules/@angular/bazel/src/ng_module.bzl');
 
 // More info in https://github.com/angular/angular/pull/33786
 shelljs.rm('-rf', [


### PR DESCRIPTION
Re-enables the `strictDomLocalRefTypes` and `strictDomEventTypes`, fixes a few legitimate failures and works around the rest.