### PR TITLE
build: minor improvements to testing script

### DIFF
--- a/scripts/run-component-tests.js
+++ b/scripts/run-component-tests.js
@@ -76,7 +76,8 @@ shelljs.exec(`yarn -s ${bazelBinary} ${bazelAction} ${testLabels.join(' ')}`);
 function getBazelPackageOfComponentName(name) {
   // Before guessing any Bazel package, we test if the name contains the
   // package name already. If so, we just use that for Bazel package.
-  const targetName = convertPathToBazelLabel(name);
+  const targetName = convertPathToBazelLabel(name) ||
+                     convertPathToBazelLabel(path.join(packagesDir, name));
   if (targetName !== null) {
     return targetName;
   }
@@ -89,8 +90,9 @@ function getBazelPackageOfComponentName(name) {
       return guessTargetName;
     }
   }
-  throw Error(chalk.red(`Could not find test target for specified component: ` +
+  console.error(chalk.red(`Could not find test target for specified component: ` +
     `${chalk.yellow(name)}. Looked in packages: ${orderedGuessPackages.join(', ')}`));
+  process.exit(1);
 }
 
 /** Converts a path to a Bazel label. */


### PR DESCRIPTION
* Currently the test script doesn't support doing something like `yarn test material/stepper`, instead we have to pass in `src/material/stepper` explicitly. These changes make it so that we don't have to pass in `src`, because it's easy to forget.
* Makes it so we exit the process, rather than throw an error when a target isn't found. This makes it easier to locate the error message since there won't be a large stack trace moving it up.