### PR TITLE
fix(google-maps): avoid errors when accessing API too early

### DIFF
--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -131,7 +131,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/info-window#InfoWindow.getContent
    */
   getContent(): string|Node {
-    return this._infoWindow!.getContent();
+    return this._infoWindow ? this._infoWindow.getContent() : '';
   }
 
   /**
@@ -140,7 +140,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    * #InfoWindow.getPosition
    */
   getPosition(): google.maps.LatLng|null {
-    return this._infoWindow!.getPosition() || null;
+    return this._infoWindow ? this._infoWindow.getPosition() : null;
   }
 
   /**
@@ -148,7 +148,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/info-window#InfoWindow.getZIndex
    */
   getZIndex(): number {
-    return this._infoWindow!.getZIndex();
+    return this._infoWindow ? this._infoWindow.getZIndex() : -1;
   }
 
   /**

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -276,7 +276,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getAnimation
    */
   getAnimation(): google.maps.Animation|null {
-    return this._marker!.getAnimation() || null;
+    return (this._marker && this._marker.getAnimation()) || null;
   }
 
   /**
@@ -284,7 +284,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getClickable
    */
   getClickable(): boolean {
-    return this._marker!.getClickable();
+    return this._marker ? this._marker.getClickable() : false;
   }
 
   /**
@@ -292,7 +292,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getCursor
    */
   getCursor(): string|null {
-    return this._marker!.getCursor() || null;
+    return (this._marker && this._marker.getCursor()) || null;
   }
 
   /**
@@ -300,7 +300,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getDraggable
    */
   getDraggable(): boolean {
-    return !!this._marker!.getDraggable();
+    return this._marker ? !!this._marker.getDraggable() : false;
   }
 
   /**
@@ -308,7 +308,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getIcon
    */
   getIcon(): string|google.maps.Icon|google.maps.Symbol|null {
-    return this._marker!.getIcon() || null;
+    return (this._marker && this._marker.getIcon()) || null;
   }
 
   /**
@@ -316,7 +316,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getLabel
    */
   getLabel(): google.maps.MarkerLabel|null {
-    return this._marker!.getLabel() || null;
+    return (this._marker && this._marker.getLabel()) || null;
   }
 
   /**
@@ -324,7 +324,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getOpacity
    */
   getOpacity(): number|null {
-    return this._marker!.getOpacity() || null;
+    return (this._marker && this._marker.getOpacity()) || null;
   }
 
   /**
@@ -332,7 +332,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getPosition
    */
   getPosition(): google.maps.LatLng|null {
-    return this._marker!.getPosition() || null;
+    return (this._marker && this._marker.getPosition()) || null;
   }
 
   /**
@@ -340,7 +340,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getShape
    */
   getShape(): google.maps.MarkerShape|null {
-    return this._marker!.getShape() || null;
+    return (this._marker && this._marker.getShape()) || null;
   }
 
   /**
@@ -348,7 +348,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getTitle
    */
   getTitle(): string|null {
-    return this._marker!.getTitle() || null;
+    return (this._marker && this._marker.getTitle()) || null;
   }
 
   /**
@@ -356,7 +356,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getVisible
    */
   getVisible(): boolean {
-    return this._marker!.getVisible();
+    return this._marker ? this._marker.getVisible() : false;
   }
 
   /**
@@ -364,7 +364,7 @@ export class MapMarker implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.getZIndex
    */
   getZIndex(): number|null {
-    return this._marker!.getZIndex() || null;
+    return (this._marker && this._marker.getZIndex()) || null;
   }
 
   private _combineOptions(): Observable<google.maps.MarkerOptions> {

--- a/src/google-maps/map-polyline/map-polyline.ts
+++ b/src/google-maps/map-polyline/map-polyline.ts
@@ -40,7 +40,7 @@ export class MapPolyline implements OnInit, OnDestroy {
   private readonly _destroyed = new Subject<void>();
   private readonly _listeners: google.maps.MapsEventListener[] = [];
 
-  _polyline: google.maps.Polyline; // initialized in ngOnInit
+  _polyline?: google.maps.Polyline; // initialized in ngOnInit
 
   @Input()
   set options(options: google.maps.PolylineOptions) {
@@ -143,7 +143,7 @@ export class MapPolyline implements OnInit, OnDestroy {
         // We'll bring it back in inside the `MapEventManager` only for the events that the
         // user has subscribed to.
         this._ngZone.runOutsideAngular(() => this._polyline = new google.maps.Polyline(options));
-        this._polyline.setMap(this._map._googleMap);
+        this._polyline!.setMap(this._map._googleMap);
         this._eventManager.setTarget(this._polyline);
       });
 
@@ -169,28 +169,29 @@ export class MapPolyline implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/polygon#Polyline.getDraggable
    */
   getDraggable(): boolean {
-    return this._polyline.getDraggable();
+    return this._polyline ? this._polyline.getDraggable() : false;
   }
 
   /**
    * @see developers.google.com/maps/documentation/javascript/reference/polygon#Polyline.getEditable
    */
   getEditable(): boolean {
-    return this._polyline.getEditable();
+    return this._polyline ? this._polyline.getEditable() : false;
   }
 
   /**
    * @see developers.google.com/maps/documentation/javascript/reference/polygon#Polyline.getPath
    */
   getPath(): google.maps.MVCArray<google.maps.LatLng> {
-    return this._polyline.getPath();
+    // @breaking-change 11.0.0 Make the return value nullable.
+    return this._polyline ? this._polyline.getPath() : null!;
   }
 
   /**
    * @see developers.google.com/maps/documentation/javascript/reference/polygon#Polyline.getVisible
    */
   getVisible(): boolean {
-    return this._polyline.getVisible();
+    return this._polyline ? this._polyline.getVisible() : false;
   }
 
   private _combineOptions(): Observable<google.maps.PolylineOptions> {
@@ -205,13 +206,15 @@ export class MapPolyline implements OnInit, OnDestroy {
 
   private _watchForOptionsChanges() {
     this._options.pipe(takeUntil(this._destroyed)).subscribe(options => {
-      this._polyline.setOptions(options);
+      if (this._polyline) {
+        this._polyline.setOptions(options);
+      }
     });
   }
 
   private _watchForPathChanges() {
     this._path.pipe(takeUntil(this._destroyed)).subscribe(path => {
-      if (path) {
+      if (path && this._polyline) {
         this._polyline.setPath(path);
       }
     });

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -123,7 +123,7 @@ export declare class MapMarker implements OnInit, OnDestroy {
 }
 
 export declare class MapPolyline implements OnInit, OnDestroy {
-    _polyline: google.maps.Polyline;
+    _polyline?: google.maps.Polyline;
     set options(options: google.maps.PolylineOptions);
     set path(path: google.maps.MVCArray<google.maps.LatLng> | google.maps.LatLng[] | google.maps.LatLngLiteral[]);
     polylineClick: Observable<google.maps.PolyMouseEvent>;


### PR DESCRIPTION
Fixes a bunch of errors that are thrown if we access the Google Maps-dependent methods before the API has loaded. We had everything typed correctly, but in all cases we were overriding the null checks.