### PR TITLE
fix(material-experimental): consolidate mixins in e2e theme file

### DIFF
--- a/src/e2e-app/BUILD.bazel
+++ b/src/e2e-app/BUILD.bazel
@@ -73,16 +73,8 @@ sass_binary(
         "external/npm/node_modules",
     ],
     deps = [
-        "//src/material-experimental/mdc-button:mdc_button_scss_lib",
-        "//src/material-experimental/mdc-card:mdc_card_scss_lib",
-        "//src/material-experimental/mdc-checkbox:mdc_checkbox_scss_lib",
-        "//src/material-experimental/mdc-chips:mdc_chips_scss_lib",
-        "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
-        "//src/material-experimental/mdc-menu:mdc_menu_scss_lib",
-        "//src/material-experimental/mdc-progress-bar:mdc_progress_bar_scss_lib",
-        "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",
-        "//src/material-experimental/mdc-slide-toggle:mdc_slide_toggle_scss_lib",
-        "//src/material-experimental/mdc-tabs:mdc_tabs_scss_lib",
+        "//src/material-experimental/mdc-theming:all_themes",
+        "//src/material-experimental/mdc-typography:all_typography",
         "//src/material/core:theming_scss_lib",
     ],
 )

--- a/src/e2e-app/theme.scss
+++ b/src/e2e-app/theme.scss
@@ -1,14 +1,6 @@
 @import '../material/core/theming/all-theme';
-@import '../material-experimental/mdc-button/mdc-button';
-@import '../material-experimental/mdc-card/mdc-card';
-@import '../material-experimental/mdc-checkbox/mdc-checkbox';
-@import '../material-experimental/mdc-chips/mdc-chips';
-@import '../material-experimental/mdc-helpers/mdc-helpers';
-@import '../material-experimental/mdc-menu/mdc-menu';
-@import '../material-experimental/mdc-radio/mdc-radio';
-@import '../material-experimental/mdc-slide-toggle/mdc-slide-toggle';
-@import '../material-experimental/mdc-tabs/mdc-tabs';
-@import '../material-experimental/mdc-progress-bar/mdc-progress-bar';
+@import '../material-experimental/mdc-theming/all-theme';
+@import '../material-experimental/mdc-typography/all-typography';
 
 // Plus imports for other components in your app.
 
@@ -16,17 +8,7 @@
 // have to load a single css file for Angular Material in your app.
 // **Be sure that you only ever include this mixin once!**
 @include mat-core();
-@include mat-button-typography-mdc(mat-typography-config());
-@include mat-icon-button-typography-mdc(mat-typography-config());
-@include mat-fab-typography-mdc(mat-typography-config());
-@include mat-card-typography-mdc(mat-typography-config());
-@include mat-checkbox-typography-mdc(mat-typography-config());
-@include mat-chips-typography-mdc(mat-typography-config());
-@include mat-menu-typography-mdc(mat-typography-config());
-@include mat-radio-typography-mdc(mat-typography-config());
-@include mat-slide-toggle-typography-mdc(mat-typography-config());
-@include mat-tabs-typography-mdc(mat-typography-config());
-@include mat-progress-bar-typography-mdc(mat-typography-config());
+@include angular-material-typography-mdc();
 
 // Define the default theme (same as the example above).
 $candy-app-primary: mat-palette($mat-indigo);
@@ -35,14 +17,4 @@ $candy-app-theme: mat-light-theme($candy-app-primary, $candy-app-accent);
 
 // Include the default theme styles.
 @include angular-material-theme($candy-app-theme);
-@include mat-button-theme-mdc($candy-app-theme);
-@include mat-icon-button-theme-mdc($candy-app-theme);
-@include mat-fab-theme-mdc($candy-app-theme);
-@include mat-card-theme-mdc($candy-app-theme);
-@include mat-checkbox-theme-mdc($candy-app-theme);
-@include mat-chips-theme-mdc($candy-app-theme);
-@include mat-menu-theme-mdc($candy-app-theme);
-@include mat-radio-theme-mdc($candy-app-theme);
-@include mat-slide-toggle-theme-mdc($candy-app-theme);
-@include mat-tabs-theme-mdc($candy-app-theme);
-@include mat-progress-bar-theme-mdc($candy-app-theme);
+@include angular-material-theme-mdc($candy-app-theme);


### PR DESCRIPTION
Not sure if there was a reason why we are doing this in this particular theme file, but I assume it's just a legacy thing