### PR TITLE
fix(platform): RTL scrolling behavior detection not using cached value in some cases

### DIFF
--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -26,11 +26,11 @@ export enum RtlScrollAxisType {
 }
 
 /** Cached result of the way the browser handles the horizontal scroll axis in RTL mode. */
-let rtlScrollAxisType: RtlScrollAxisType;
+let rtlScrollAxisType: RtlScrollAxisType|undefined;
 
 /** Check whether the browser supports scroll behaviors. */
 export function supportsScrollBehavior(): boolean {
-  return !!(typeof document == 'object'  && 'scrollBehavior' in document.documentElement!.style);
+  return !!(typeof document == 'object' && 'scrollBehavior' in document.documentElement!.style);
 }
 
 /**
@@ -43,7 +43,7 @@ export function getRtlScrollAxisType(): RtlScrollAxisType {
     return RtlScrollAxisType.NORMAL;
   }
 
-  if (!rtlScrollAxisType) {
+  if (rtlScrollAxisType == null) {
     // Create a 1px wide scrolling container and a 2px wide content element.
     const scrollContainer = document.createElement('div');
     const containerStyle = scrollContainer.style;


### PR DESCRIPTION
The `getRtlScrollAxisType` function caches its value so that we don't have to hit the DOM multiple times to detect the behavior. The problem is that when it reads the cached value, it does a simple falsy check which will also be true when we've resolved the value to `NORMAL` (which is 0).