### PR TITLE
fix: consistently use const enum

### DIFF
--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -7,7 +7,7 @@
  */
 
 /** The possible ways the browser may handle the horizontal scroll axis in RTL languages. */
-export enum RtlScrollAxisType {
+export const enum RtlScrollAxisType {
   /**
    * scrollLeft is 0 when scrolled all the way left and (scrollWidth - clientWidth) when scrolled
    * all the way right.

--- a/src/cdk/schematics/update-tool/target-version.ts
+++ b/src/cdk/schematics/update-tool/target-version.ts
@@ -7,6 +7,8 @@
  */
 
 /** Possible versions that can be automatically migrated by `ng update`. */
+// Used in an `Object.keys` call below so it can't be `const enum`.
+// tslint:disable-next-line:prefer-const-enum
 export enum TargetVersion {
   V6 = 'version 6',
   V7 = 'version 7',

--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -22,6 +22,7 @@ export interface ModifierKeys {
 // dependency on any particular testing framework here. Instead we'll just maintain this supported
 // list of keys and let individual concrete `HarnessEnvironment` classes map them to whatever key
 // representation is used in its respective testing framework.
+// tslint:disable-next-line:prefer-const-enum Seems like this causes some issues with System.js
 export enum TestKey {
   BACKSPACE,
   TAB,

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -70,7 +70,7 @@ export const MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR: any = {
  * Represents the different states that require custom transitions between them.
  * @docs-private
  */
-export enum TransitionCheckState {
+export const enum TransitionCheckState {
   /** The initial state of the component before any user interaction. */
   Init,
   /** The state representing the component when it's becoming checked. */

--- a/src/material/core/ripple/ripple-ref.ts
+++ b/src/material/core/ripple/ripple-ref.ts
@@ -9,7 +9,7 @@
 import {RippleConfig, RippleRenderer} from './ripple-renderer';
 
 /** Possible states for a ripple element. */
-export enum RippleState {
+export const enum RippleState {
   FADING_IN, VISIBLE, FADING_OUT, HIDDEN
 }
 

--- a/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/import-manager.ts
+++ b/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/import-manager.ts
@@ -13,7 +13,7 @@ import * as ts from 'typescript';
 // tslint:disable:no-bitwise
 
 /** Enum describing the possible states of an analyzed import. */
-enum ImportState {
+const enum ImportState {
   UNMODIFIED = 0b0,
   MODIFIED = 0b10,
   ADDED = 0b100,

--- a/tools/public_api_guard/cdk/platform.d.ts
+++ b/tools/public_api_guard/cdk/platform.d.ts
@@ -26,7 +26,7 @@ export declare class PlatformModule {
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<PlatformModule, never, never, never>;
 }
 
-export declare enum RtlScrollAxisType {
+export declare const enum RtlScrollAxisType {
     NORMAL = 0,
     NEGATED = 1,
     INVERTED = 2

--- a/tools/public_api_guard/material/checkbox.d.ts
+++ b/tools/public_api_guard/material/checkbox.d.ts
@@ -81,7 +81,7 @@ export declare class MatCheckboxRequiredValidator extends CheckboxRequiredValida
     static ɵfac: i0.ɵɵFactoryDef<MatCheckboxRequiredValidator>;
 }
 
-export declare enum TransitionCheckState {
+export declare const enum TransitionCheckState {
     Init = 0,
     Checked = 1,
     Unchecked = 2,

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -441,7 +441,7 @@ export declare class RippleRenderer {
     setupTriggerEvents(elementOrElementRef: HTMLElement | ElementRef<HTMLElement>): void;
 }
 
-export declare enum RippleState {
+export declare const enum RippleState {
     FADING_IN = 0,
     VISIBLE = 1,
     FADING_OUT = 2,

--- a/tools/tslint-rules/preferConstEnumRule.ts
+++ b/tools/tslint-rules/preferConstEnumRule.ts
@@ -1,0 +1,22 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
+
+/**
+ * Rule that enforces that we use `const enum` rather than a plain `enum`.
+ */
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+  }
+}
+
+class Walker extends Lint.RuleWalker {
+  visitEnumDeclaration(node: ts.EnumDeclaration) {
+    if (!tsutils.hasModifier(node.modifiers, ts.SyntaxKind.ConstKeyword)) {
+      this.addFailureAtNode(node.name, 'Enums should be declared as `const enum`.');
+    }
+
+    super.visitEnumDeclaration(node);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -117,6 +117,7 @@
     "require-breaking-change-version": true,
     "class-list-signatures": true,
     "no-nested-ternary": true,
+    "prefer-const-enum": true,
     "coercion-types": [true,
       ["coerceBooleanProperty", "coerceCssPixelValue", "coerceNumberProperty"],
       {


### PR DESCRIPTION
Plain `enum` declarations generate a bunch of code that can't be minified very well and is included even if the enum isn't used. In most places we use `const enum` which inlines the value on consumption, but we have a few leftovers that are still using plain enums. These changes switch all of the remaining usages (except for one) and add a lint rule to enforce consistency in the future.

**Caretaker note:** this has a small chance of being breaking if any of the enums are used in a view. I doubt that's the case, but we should re-evaluate if something breaks in g3.