### PR TITLE
fix(datepicker): handle date ranges across multiple months

### DIFF
--- a/src/material/datepicker/calendar-body.html
+++ b/src/material/datepicker/calendar-body.html
@@ -36,9 +36,9 @@
       [attr.data-mat-col]="colIndex"
       [class.mat-calendar-body-disabled]="!item.enabled"
       [class.mat-calendar-body-active]="_isActiveCell(rowIndex, colIndex)"
-      [class.mat-calendar-body-in-range]="_isInRange(item.value)"
-      [class.mat-calendar-body-range-start]="item.value === startValue"
-      [class.mat-calendar-body-range-end]="item.value === endValue || item.value === _hoveredValue"
+      [class.mat-calendar-body-in-range]="_isInRange(item.compareValue)"
+      [class.mat-calendar-body-range-start]="item.compareValue === startValue"
+      [class.mat-calendar-body-range-end]="item.compareValue === endValue || item.compareValue === _hoveredValue"
       [attr.aria-label]="item.ariaLabel"
       [attr.aria-disabled]="!item.enabled || null"
       [attr.aria-selected]="_isSelected(item)"
@@ -49,7 +49,7 @@
       [style.paddingBottom]="_cellPadding">
       <div class="mat-calendar-body-cell-content"
         [class.mat-calendar-body-selected]="_isSelected(item)"
-        [class.mat-calendar-body-today]="todayValue === item.value">
+        [class.mat-calendar-body-today]="todayValue === item.compareValue">
         {{item.displayValue}}
       </div>
   </td>

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -36,7 +36,8 @@ export class MatCalendarCell {
               public displayValue: string,
               public ariaLabel: string,
               public enabled: boolean,
-              public cssClasses: MatCalendarCellCssClasses = {}) {}
+              public cssClasses: MatCalendarCellCssClasses = {},
+              public compareValue = value) {}
 }
 
 
@@ -67,11 +68,10 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
   /** The value in the table that corresponds to today. */
   @Input() todayValue: number;
 
-  /** The value in the table that is currently selected. */
-  // @Input() selectedValue: number;
-
+  /** Start value of the selected date range. */
   @Input() startValue: number;
 
+  /** End value of the selected date range. */
   @Input() endValue: number;
 
   /** The minimum number of free cells needed to fit the label in the first row. */
@@ -126,7 +126,7 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
 
   /** Returns whether a cell should be marked as selected. */
   _isSelected(cell: MatCalendarCell) {
-    return this.startValue === cell.value || this.endValue === cell.value;
+    return this.startValue === cell.compareValue || this.endValue === cell.compareValue;
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -209,7 +209,7 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
 
     if (cell) {
       this._ngZone.run(() => {
-        this._hoveredValue = cell.value;
+        this._hoveredValue = cell.compareValue;
         this._changeDetectorRef.markForCheck();
       });
     }

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -86,11 +86,12 @@ export declare class MatCalendarBody implements OnChanges, OnDestroy {
 
 export declare class MatCalendarCell {
     ariaLabel: string;
+    compareValue: number;
     cssClasses: MatCalendarCellCssClasses;
     displayValue: string;
     enabled: boolean;
     value: number;
-    constructor(value: number, displayValue: string, ariaLabel: string, enabled: boolean, cssClasses?: MatCalendarCellCssClasses);
+    constructor(value: number, displayValue: string, ariaLabel: string, enabled: boolean, cssClasses?: MatCalendarCellCssClasses, compareValue?: number);
 }
 
 export declare type MatCalendarCellCssClasses = string | string[] | Set<string> | {


### PR DESCRIPTION
Currently we don't handle date ranges across months, because we store the date cell's value as the date in the current month. These changes add another value that will be used comparisons and which is based on the time since epoch.