### PR TITLE
fix(material-experimental/mdc-button): add base css class to all buttons

### DIFF
--- a/src/material-experimental/mdc-button/button-base.ts
+++ b/src/material-experimental/mdc-button/button-base.ts
@@ -35,6 +35,9 @@ export const MAT_BUTTON_HOST = {
   // an unthemed version. If color is undefined, apply a CSS class that makes it easy to
   // select and style this "theme".
   '[class.mat-unthemed]': '!color',
+  // Add a class that applies to all buttons. This makes it easier to target if somebody
+  // wants to target all Material buttons.
+  '[class.mat-mdc-button-base]': 'true',
   'class': 'mat-mdc-focus-indicator',
 };
 
@@ -148,6 +151,9 @@ export const MAT_ANCHOR_HOST = {
   // an unthemed version. If color is undefined, apply a CSS class that makes it easy to
   // select and style this "theme".
   '[class.mat-unthemed]': '!color',
+  // Add a class that applies to all buttons. This makes it easier to target if somebody
+  // wants to target all Material buttons.
+  '[class.mat-mdc-button-base]': 'true',
   'class': 'mat-mdc-focus-indicator',
 };
 

--- a/src/material-experimental/mdc-button/button-base.ts
+++ b/src/material-experimental/mdc-button/button-base.ts
@@ -151,10 +151,10 @@ export const MAT_ANCHOR_HOST = {
   // an unthemed version. If color is undefined, apply a CSS class that makes it easy to
   // select and style this "theme".
   '[class.mat-unthemed]': '!color',
+  'class': 'mat-mdc-focus-indicator',
   // Add a class that applies to all buttons. This makes it easier to target if somebody
   // wants to target all Material buttons.
   '[class.mat-mdc-button-base]': 'true',
-  'class': 'mat-mdc-focus-indicator',
 };
 
 /**

--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -61,7 +61,8 @@ $mat-dialog-button-margin: 8px !default;
     justify-content: center;
   }
 
-  .mat-button-base + .mat-button-base {
+  .mat-button-base + .mat-button-base,
+  .mat-mdc-button-base + .mat-mdc-button-base {
     margin-left: $mat-dialog-button-margin;
 
     [dir='rtl'] & {

--- a/src/material/expansion/expansion-panel.scss
+++ b/src/material/expansion/expansion-panel.scss
@@ -72,7 +72,7 @@
   justify-content: flex-end;
   padding: 16px 8px 16px 24px;
 
-  button.mat-button-base {
+  button.mat-button-base, button.mat-mdc-button-base {
     margin-left: 8px;
 
     [dir='rtl'] & {


### PR DESCRIPTION
This class is similar to `mat-button-base` and is used by other components to style buttons, e.g. dialog action buttons, expansion panel)

This is added to the styles of those other components for the case where someone uses our current dialog with the new MDC button