### PR TITLE
fix(material-experimental/mdc-form-field): scrollbar always visible on textarea in IE

### DIFF
--- a/src/material-experimental/mdc-form-field/_mdc-text-field-textarea-overrides.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-textarea-overrides.scss
@@ -25,6 +25,10 @@
     margin: 0;
     padding: 0;
     border: none;
+
+    // By default IE always renders scrollbars on textarea.
+    // This brings it in line with other browsers.
+    overflow: auto;
   }
 
   // By default, MDC aligns the label using percentage. This will be overwritten based


### PR DESCRIPTION
Fixes the scroll bars of a textarea elements always being visible on IE.