### PR TITLE
fix(material-experimental/popover-edit): closing instantly when opening with enter key

### DIFF
--- a/src/cdk-experimental/popover-edit/lens-directives.ts
+++ b/src/cdk-experimental/popover-edit/lens-directives.ts
@@ -194,11 +194,14 @@ export class CdkEditClose<FormValue> {
   // can move this back into `host`.
   // tslint:disable:no-host-decorator-in-concrete
   @HostListener('click')
-  @HostListener('keyup.enter')
-  @HostListener('keyup.space')
+  @HostListener('keydown.enter')
+  @HostListener('keydown.space')
   closeEdit(): void {
     // Note that we use `click` here, rather than a keyboard event, because some screen readers
-    // will emit a fake click event instead of an enter keyboard event on buttons.
+    // will emit a fake click event instead of an enter keyboard event on buttons. For the keyboard
+    // events we use `keydown`, rather than `keyup`, because we use `keydown` to open the overlay
+    // as well. If we were to use `keyup`, the user could end up opening and closing within
+    // the same event sequence if focus was moved quickly.
     this.editRef.close();
   }
 }


### PR DESCRIPTION
We use `keydown` to open the popover edit overlay and `keyup` to close it which can lead to situations where the user opens and closes the popup immediately. Seems to have been introduced by #18194.

For reference:
![demo](https://user-images.githubusercontent.com/4450522/74105694-72038b80-4b60-11ea-82ce-ef4059dd9302.gif)

cc @kseamon 