### PR TITLE
fix(material/list): Selection List element should not be focusable.

### DIFF
--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -700,9 +700,9 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
   }
 
   /**
-   * Removes the `tabindex` from the selection list and resets it back afterwards, allowing the
-   * user to tab out of it. This prevents the list from capturing focus and redirecting
-   * it back to within the list, creating a focus trap if it user tries to tab away.
+   * Removes the tabindex from the selection list and resets it back afterwards, allowing the user
+   * to tab out of it. This prevents the list from capturing focus and redirecting it back within
+   * the list, creating a focus trap if it user tries to tab away.
    */
   private _allowFocusEscape() {
     this._tabIndex = -1;

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -53,7 +53,7 @@ import {
 } from '@angular/material/core';
 
 import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
+import {startWith, takeUntil} from 'rxjs/operators';
 
 import {MatListAvatarCssMatStyler, MatListIconCssMatStyler} from './list';
 
@@ -99,7 +99,6 @@ export class MatSelectionListChange {
     '(focus)': '_handleFocus()',
     '(blur)': '_handleBlur()',
     '(click)': '_handleClick()',
-    'tabindex': '-1',
     '[class.mat-list-item-disabled]': 'disabled',
     '[class.mat-list-item-with-avatar]': '_avatar || _icon',
     // Manually set the "primary" or "warn" class if the color has been explicitly
@@ -113,6 +112,7 @@ export class MatSelectionListChange {
     '[class.mat-list-single-selected-option]': 'selected && !selectionList.multiple',
     '[attr.aria-selected]': 'selected',
     '[attr.aria-disabled]': 'disabled',
+    '[attr.tabindex]': '-1',
   },
   templateUrl: 'list-option.html',
   encapsulation: ViewEncapsulation.None,
@@ -323,12 +323,13 @@ export class MatListOption extends _MatListOptionMixinBase implements AfterConte
   inputs: ['disableRipple'],
   host: {
     'role': 'listbox',
-    '[tabIndex]': 'tabIndex',
     'class': 'mat-selection-list mat-list-base',
+    '(focus)': '_onFocus()',
     '(blur)': '_onTouched()',
     '(keydown)': '_keydown($event)',
     '[attr.aria-multiselectable]': 'multiple',
     '[attr.aria-disabled]': 'disabled.toString()',
+    '[attr.tabindex]': '_tabIndex',
   },
   template: '<ng-content></ng-content>',
   styleUrls: ['list.css'],
@@ -351,7 +352,10 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
   @Output() readonly selectionChange: EventEmitter<MatSelectionListChange> =
       new EventEmitter<MatSelectionListChange>();
 
-  /** Tabindex of the selection list. */
+  /**
+   * Tabindex of the selection list.
+   * @breaking-change 11.0.0 Remove `tabIndex` input.
+   */
   @Input() tabIndex: number = 0;
 
   /** Theme color of the selection list. This sets the checkbox color for all list options. */
@@ -398,6 +402,9 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
   /** The currently selected options. */
   selectedOptions = new SelectionModel<MatListOption>(this._multiple);
 
+  /** The tabindex of the selection list. */
+  _tabIndex = -1;
+
   /** View to model callback that should be called whenever the selected options change. */
   private _onChange: (value: any) => void = (_: any) => {};
 
@@ -413,9 +420,11 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
   /** Whether the list has been destroyed. */
   private _isDestroyed: boolean;
 
-  constructor(private _element: ElementRef<HTMLElement>, @Attribute('tabindex') tabIndex: string) {
+  constructor(private _element: ElementRef<HTMLElement>,
+    // @breaking-change 11.0.0 Remove `tabIndex` parameter.
+    @Attribute('tabindex') tabIndex: string,
+    private _changeDetector: ChangeDetectorRef) {
     super();
-    this.tabIndex = parseInt(tabIndex) || 0;
   }
 
   ngAfterContentInit(): void {
@@ -432,6 +441,16 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
     if (this._value) {
       this._setOptionsFromValues(this._value);
     }
+
+    // If the user attempts to tab out of the selection list, allow focus to escape.
+    this._keyManager.tabOut.pipe(takeUntil(this._destroyed)).subscribe(() => {
+      this._allowFocusEscape();
+    });
+
+    // When the number of options change, update the tabindex of the selection list.
+    this.options.changes.pipe(startWith(null), takeUntil(this._destroyed)).subscribe(() => {
+      this._updateTabIndex();
+    });
 
     // Sync external changes to the model back to the options.
     this.selectedOptions.changed.pipe(takeUntil(this._destroyed)).subscribe(event => {
@@ -560,6 +579,22 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
     this.selectionChange.emit(new MatSelectionListChange(this, option));
   }
 
+  /**
+   * When the selection list is focused, we want to move focus to an option within the list. Do this
+   * by setting the appropriate option to be active.
+   */
+  _onFocus(): void {
+    const activeIndex = this._keyManager.activeItemIndex;
+
+    if (!activeIndex || (activeIndex === -1)) {
+      // If there is no active index, set focus to the first option.
+      this._keyManager.setFirstItemActive();
+    } else {
+      // Otherwise, set focus to the active option.
+      this._keyManager.setActiveItem(activeIndex);
+    }
+  }
+
   /** Implemented as part of ControlValueAccessor. */
   writeValue(values: string[]): void {
     this._value = values;
@@ -662,6 +697,25 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
     if (this.options) {
       this.options.forEach(option => option._markForCheck());
     }
+  }
+
+  /**
+   * Removes the `tabindex` from the selection list and resets it back afterwards, allowing the
+   * user to tab out of it. This prevents the list from capturing focus and redirecting
+   * it back to within the list, creating a focus trap if it user tries to tab away.
+   */
+  private _allowFocusEscape() {
+    this._tabIndex = -1;
+
+    setTimeout(() => {
+      this._tabIndex = 0;
+      this._changeDetector.markForCheck();
+    });
+  }
+
+  /** Updates the tabindex based upon if the selection list is empty. */
+  private _updateTabIndex(): void {
+    this._tabIndex = (this.options.length === 0) ? -1 : 0;
   }
 
   static ngAcceptInputType_disabled: BooleanInput;

--- a/tools/public_api_guard/material/list.d.ts
+++ b/tools/public_api_guard/material/list.d.ts
@@ -99,6 +99,7 @@ export declare class MatNavList extends _MatListMixinBase implements CanDisable,
 export declare class MatSelectionList extends _MatSelectionListMixinBase implements CanDisableRipple, AfterContentInit, ControlValueAccessor, OnDestroy, OnChanges {
     _keyManager: FocusKeyManager<MatListOption>;
     _onTouched: () => void;
+    _tabIndex: number;
     _value: string[] | null;
     color: ThemePalette;
     compareWith: (o1: any, o2: any) => boolean;
@@ -110,9 +111,10 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
     selectedOptions: SelectionModel<MatListOption>;
     readonly selectionChange: EventEmitter<MatSelectionListChange>;
     tabIndex: number;
-    constructor(_element: ElementRef<HTMLElement>, tabIndex: string);
+    constructor(_element: ElementRef<HTMLElement>, tabIndex: string, _changeDetector: ChangeDetectorRef);
     _emitChangeEvent(option: MatListOption): void;
     _keydown(event: KeyboardEvent): void;
+    _onFocus(): void;
     _removeOptionFromList(option: MatListOption): MatListOption | null;
     _reportValueChange(): void;
     _setFocusedOption(option: MatListOption): void;


### PR DESCRIPTION
Currently, the `MatSelectionList` `listbox` element itself receives focus on keyboard navigation. This does not follow the Listbox Design Pattern recommendation on the 1.1 ARIA practices (https://www.w3.org/TR/wai-aria-practices-1.1/#Listbox). Per their guidance:

> When a single-select listbox receives focus:
> * If none of the options are selected before the listbox receives focus, the first option receives focus. Optionally, the first option may be automatically selected.
> * If an option is selected before the listbox receives focus, focus is set on the selected option.

This PR changes the keyboard interaction of `MatSelectionList` to follow the guidance above.

I would prefer to use the "roving tabindex" pattern, but given the list options are content-projected, I ran into issues keeping tabindices updated without ExpressionChangedAfter... errors. Thus, I instead essentially followed the implementation used in `MatChipList`. The `listbox` element has `tabindex="0"`, and the `option` elements have `tabindex="-1"`. When the `listbox` is focused, it redirects focus to the proper `option` element.

* When a user attempts to tab out of the selection list, the selection list's `tabindex` is temporarily set to `-1` to allow focus to escape (`MatChipList` does this as well).
* When the selection list has no options, it is removed from the tab order.
* The `[tabIndex]` input on `MatSelectionList` is now unused and should eventually be removed.