### PR TITLE
test(layout): remove unneeded LayoutModule

### DIFF
--- a/src/cdk/layout/media-matcher.spec.ts
+++ b/src/cdk/layout/media-matcher.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {MediaMatcher} from './media-matcher';
-import {TestBed, inject} from '@angular/core/testing';
+import {inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 
 describe('MediaMatcher', () => {

--- a/src/cdk/layout/media-matcher.spec.ts
+++ b/src/cdk/layout/media-matcher.spec.ts
@@ -5,19 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {LayoutModule} from './index';
 import {MediaMatcher} from './media-matcher';
-import {async, TestBed, inject} from '@angular/core/testing';
+import {TestBed, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 
 describe('MediaMatcher', () => {
   let mediaMatcher: MediaMatcher;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [LayoutModule]
-    });
-  }));
 
   beforeEach(inject([MediaMatcher], (mm: MediaMatcher) => {
     mediaMatcher = mm;


### PR DESCRIPTION
LayoutModule is an empty `NgModule` remnant from
before treeshakable providers were introduced. It is
no longer needed in this test.