### PR TITLE
fix(ng-update): avoid error if project has folder ending with style extension

### DIFF
--- a/src/cdk/schematics/update-tool/BUILD.bazel
+++ b/src/cdk/schematics/update-tool/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     deps = [
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",
+        "@npm//@schematics/angular",
         "@npm//@types/glob",
         "@npm//@types/node",
         "@npm//typescript",

--- a/src/cdk/schematics/utils/project-tsconfig-paths.spec.ts
+++ b/src/cdk/schematics/utils/project-tsconfig-paths.spec.ts
@@ -1,6 +1,6 @@
 import {HostTree} from '@angular-devkit/schematics';
 import {UnitTestTree} from '@angular-devkit/schematics/testing';
-import {getProjectTsConfigPaths} from './project-tsconfig-paths';
+import {getTargetTsconfigPath, getWorkspaceConfigGracefully} from './project-tsconfig-paths';
 
 describe('project tsconfig paths', () => {
   let testTree: UnitTestTree;
@@ -14,7 +14,10 @@ describe('project tsconfig paths', () => {
         {my_name: {architect: {build: {options: {tsConfig: './my-custom-config.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['my-custom-config.json']);
+    const config = getWorkspaceConfigGracefully(testTree);
+    expect(config).not.toBeNull();
+    expect(getTargetTsconfigPath(config!.projects['my_name'], 'build'))
+      .toEqual('my-custom-config.json');
   });
 
   it('should be able to read workspace configuration which is using JSON5 features', () => {
@@ -34,7 +37,10 @@ describe('project tsconfig paths', () => {
       },
     }`);
 
-    expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['my-build-config.json']);
+    const config = getWorkspaceConfigGracefully(testTree);
+    expect(config).not.toBeNull();
+    expect(getTargetTsconfigPath(config!.projects['with_tests'], 'build'))
+      .toEqual('my-build-config.json');
   });
 
   it('should detect test tsconfig path inside of angular.json file', () => {
@@ -43,7 +49,10 @@ describe('project tsconfig paths', () => {
       projects: {my_name: {architect: {test: {options: {tsConfig: './my-test-config.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree).testPaths).toEqual(['my-test-config.json']);
+    const config = getWorkspaceConfigGracefully(testTree);
+    expect(config).not.toBeNull();
+    expect(getTargetTsconfigPath(config!.projects['my_name'], 'test'))
+      .toEqual('my-test-config.json');
   });
 
   it('should detect test tsconfig path inside of .angular.json file', () => {
@@ -53,15 +62,9 @@ describe('project tsconfig paths', () => {
         {with_tests: {architect: {test: {options: {tsConfig: './my-test-config.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree).testPaths).toEqual(['my-test-config.json']);
-  });
-
-  it('should not return duplicate tsconfig files', () => {
-    testTree.create('/tsconfig.json', '');
-    testTree.create('/.angular.json', JSON.stringify({
-      projects: {app: {architect: {build: {options: {tsConfig: 'tsconfig.json'}}}}}
-    }));
-
-    expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['tsconfig.json']);
+    const config = getWorkspaceConfigGracefully(testTree);
+    expect(config).not.toBeNull();
+    expect(getTargetTsconfigPath(config!.projects['with_tests'], 'test'))
+      .toEqual('my-test-config.json');
   });
 });

--- a/src/cdk/schematics/utils/project-tsconfig-paths.ts
+++ b/src/cdk/schematics/utils/project-tsconfig-paths.ts
@@ -8,49 +8,13 @@
 
 import {JsonParseMode, normalize, parseJson} from '@angular-devkit/core';
 import {Tree} from '@angular-devkit/schematics';
-import {WorkspaceProject} from '@schematics/angular/utility/workspace-models';
+import {WorkspaceProject, WorkspaceSchema} from '@schematics/angular/utility/workspace-models';
 
 /** Name of the default Angular CLI workspace configuration files. */
 const defaultWorkspaceConfigPaths = ['/angular.json', '/.angular.json'];
 
-/**
- * Gets all tsconfig paths from a CLI project by reading the workspace configuration
- * and looking for common tsconfig locations.
- */
-export function getProjectTsConfigPaths(tree: Tree): {buildPaths: string[], testPaths: string[]} {
-  // Start with some tsconfig paths that are generally used within CLI projects. Note
-  // that we are not interested in IDE-specific tsconfig files (e.g. /tsconfig.json)
-  const buildPaths = new Set<string>([]);
-  const testPaths = new Set<string>([]);
-
-  // Add any tsconfig directly referenced in a build or test task of the angular.json workspace.
-  const workspace = getWorkspaceConfigGracefully(tree);
-
-  if (workspace) {
-    const projects = Object.keys(workspace.projects).map(name => workspace.projects[name]);
-    for (const project of projects) {
-      const buildPath = getTargetTsconfigPath(project, 'build');
-      const testPath = getTargetTsconfigPath(project, 'test');
-
-      if (buildPath) {
-        buildPaths.add(buildPath);
-      }
-
-      if (testPath) {
-        testPaths.add(testPath);
-      }
-    }
-  }
-
-  // Filter out tsconfig files that don't exist in the CLI project.
-  return {
-    buildPaths: Array.from(buildPaths).filter(p => tree.exists(p)),
-    testPaths: Array.from(testPaths).filter(p => tree.exists(p)),
-  };
-}
-
 /** Gets the tsconfig path from the given target within the specified project. */
-function getTargetTsconfigPath(project: WorkspaceProject, targetName: string): string|null {
+export function getTargetTsconfigPath(project: WorkspaceProject, targetName: string): string|null {
   if (project.targets && project.targets[targetName] && project.targets[targetName].options &&
       project.targets[targetName].options.tsConfig) {
     return normalize(project.targets[targetName].options.tsConfig);
@@ -69,7 +33,7 @@ function getTargetTsconfigPath(project: WorkspaceProject, targetName: string): s
  * versions of the CLI. Also it's important to resolve the workspace gracefully because
  * the CLI project could be still using `.angular-cli.json` instead of thew new config.
  */
-function getWorkspaceConfigGracefully(tree: Tree): any {
+export function getWorkspaceConfigGracefully(tree: Tree): null|WorkspaceSchema {
   const path = defaultWorkspaceConfigPaths.find(filePath => tree.exists(filePath));
   const configBuffer = tree.read(path!);
 
@@ -80,7 +44,7 @@ function getWorkspaceConfigGracefully(tree: Tree): any {
   try {
     // Parse the workspace file as JSON5 which is also supported for CLI
     // workspace configurations.
-    return parseJson(configBuffer.toString(), JsonParseMode.Json5);
+    return parseJson(configBuffer.toString(), JsonParseMode.Json5) as unknown as WorkspaceSchema;
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
Previously, we always queried for `.css` and `.scss` files in the whole
workspace. We relied on `glob` for this, but did not disable folder
matching. Hence, it could happen that in some cases the migration rule
tried reading content from a directory (resulting in `EISDIR` error).

Additionally, we always queried for files in the actual workspace root.
This has downsides and is not correct because it could mean that
stylesheets from other projects are accidentally read (in case of a
monorepo for example).

Fixes #18434.