### PR TITLE
fix(text-field): update autofill keyframes 

### DIFF
--- a/src/cdk/text-field/_text-field.scss
+++ b/src/cdk/text-field/_text-field.scss
@@ -5,16 +5,12 @@
   // needed to prevent LibSass from stripping the keyframes out.
   // Based on: https://medium.com/@brunn/detecting-autofilled-fields-in-javascript-aed598d25da7
   @keyframes cdk-text-field-autofill-start {
-    0% {
-    }
-    100% {
-    }
+    0% {/*!*/}
+    100% {/*!*/}
   }
   @keyframes cdk-text-field-autofill-end {
-    0% {
-    }
-    100% {
-    }
+    0% {/*!*/}
+    100% {/*!*/}
   }
 
   .cdk-text-field-autofill-monitored:-webkit-autofill {

--- a/src/cdk/text-field/_text-field.scss
+++ b/src/cdk/text-field/_text-field.scss
@@ -4,8 +4,18 @@
   // by watching for the animation events that are fired when they start. Note: the /*!*/ comment is
   // needed to prevent LibSass from stripping the keyframes out.
   // Based on: https://medium.com/@brunn/detecting-autofilled-fields-in-javascript-aed598d25da7
-  @keyframes cdk-text-field-autofill-start {/*!*/}
-  @keyframes cdk-text-field-autofill-end {/*!*/}
+  @keyframes cdk-text-field-autofill-start {
+    0% {
+    }
+    100% {
+    }
+  }
+  @keyframes cdk-text-field-autofill-end {
+    0% {
+    }
+    100% {
+    }
+  }
 
   .cdk-text-field-autofill-monitored:-webkit-autofill {
     animation-name: cdk-text-field-autofill-start;


### PR DESCRIPTION
AutofillMonitor does not work after upgrading to Chrome 80, because the event 'animationstart' has stopped triggering for empty keyframes (see #18461 )