### PR TITLE
fix(ng-update): do not throw if project does not have dependencies

### DIFF
--- a/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/hammer-gestures-rule.ts
+++ b/src/material/schematics/ng-update/upgrade-rules/hammer-gestures-v9/hammer-gestures-rule.ts
@@ -877,9 +877,8 @@ export class HammerGesturesRule extends MigrationRule<null> {
 
     const packageJson = JSON.parse(tree.read('/package.json')!.toString('utf8'));
 
-    // We do not handle the case where someone manually added "hammerjs"
-    // to the dev dependencies.
-    if (packageJson.dependencies[HAMMER_MODULE_SPECIFIER]) {
+    // We do not handle the case where someone manually added "hammerjs" to the dev dependencies.
+    if (packageJson.dependencies && packageJson.dependencies[HAMMER_MODULE_SPECIFIER]) {
       delete packageJson.dependencies[HAMMER_MODULE_SPECIFIER];
       tree.overwrite('/package.json', JSON.stringify(packageJson, null, 2));
       return true;


### PR DESCRIPTION
The v9 hammerjs migration in some cases tries to remove `hammerjs`
from the workspace `package.json`. It always assumes that there is
a `dependencies` property. This is not always guaranteed because a
project doesn't need to define this property. This change guards against
this case and avoids a runtime migration exception.

Fixes #18469.