### PR TITLE
fix(material-experimental/mdc-chips): align with latest MDC markup

### DIFF
--- a/src/material-experimental/mdc-chips/chip.html
+++ b/src/material-experimental/mdc-chips/chip.html
@@ -7,5 +7,7 @@
      [matRippleTrigger]="_elementRef.nativeElement"></span>
 
 <ng-content select="mat-chip-avatar, [matChipAvatar]"></ng-content>
-<div class="mdc-chip__text mdc-chip__action--primary"><ng-content></ng-content></div>
+<div class="mdc-chip__primary-action">
+  <div class="mdc-chip__text"><ng-content></ng-content></div>
+</div>
 <ng-content select="mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"></ng-content>


### PR DESCRIPTION
Aligns the MDC-based chips with the latest MDC markup. Also bumps to the latest MDC Canary version.