### PR TITLE
Add support for density scaling to MDC-based components

### DIFF
--- a/src/material-experimental/mdc-chips/_mdc-chips.scss
+++ b/src/material-experimental/mdc-chips/_mdc-chips.scss
@@ -43,7 +43,11 @@
   }
 }
 
-@mixin mat-chips-density-mdc($density-scale) {}
+@mixin mat-chips-density-mdc($density-scale) {
+  .mat-mdc-chip {
+    @include mdc-chip-density($density-scale);
+  }
+}
 
 @mixin mat-chips-theme-mdc($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material-experimental/mdc-radio/_mdc-radio.scss
+++ b/src/material-experimental/mdc-radio/_mdc-radio.scss
@@ -37,7 +37,11 @@
   }
 }
 
-@mixin mat-radio-density-mdc($density-scale) {}
+@mixin mat-radio-density-mdc($density-scale) {
+  .mat-mdc-radio-button .mdc-radio {
+    @include mdc-radio-density($density-scale);
+  }
+}
 
 @mixin mat-radio-theme-mdc($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material-experimental/mdc-radio/radio.html
+++ b/src/material-experimental/mdc-radio/radio.html
@@ -23,7 +23,6 @@
          [matRippleTrigger]="formField"
          [matRippleDisabled]="_isRippleDisabled()"
          [matRippleCentered]="true"
-         [matRippleRadius]="20"
          [matRippleAnimation]="{enterDuration: 150}">
       <div class="mat-ripple-element mat-radio-persistent-ripple"></div>
     </div>

--- a/src/material-experimental/mdc-radio/radio.scss
+++ b/src/material-experimental/mdc-radio/radio.scss
@@ -2,6 +2,7 @@
 @import '@material/radio/variables.import';
 @import '@material/form-field/mixins.import';
 @import '../mdc-helpers/mdc-helpers';
+@import '../../material/core/style/layout-common';
 
 @include mdc-radio-without-ripple($query: $mat-base-styles-query);
 @include mdc-form-field-core-styles($query: $mat-base-styles-query);
@@ -9,13 +10,10 @@
 // This is necessary because we do not depend on MDC's ripple, but have our own that should be
 // positioned correctly. This can be removed once we start using MDC's ripple implementation.
 .mat-mdc-radio-button .mat-radio-ripple {
-  position: absolute;
-  left: calc(50% - #{$mdc-radio-icon-size});
-  top: calc(50% - #{$mdc-radio-icon-size});
-  height: $mdc-radio-icon-size * 2;
-  width: $mdc-radio-icon-size * 2;
-  z-index: 1;
+  @include mat-fill;
+
   pointer-events: none;
+  border-radius: 50%;
 
   .mat-ripple-element:not(.mat-radio-persistent-ripple) {
     opacity: $mdc-radio-ripple-opacity;

--- a/src/material-experimental/mdc-slide-toggle/_mdc-slide-toggle.scss
+++ b/src/material-experimental/mdc-slide-toggle/_mdc-slide-toggle.scss
@@ -72,7 +72,11 @@
   }
 }
 
-@mixin mat-slide-toggle-density-mdc($density-scale) {}
+@mixin mat-slide-toggle-density-mdc($density-scale) {
+  .mat-mdc-slide-toggle .mdc-switch {
+    @include mdc-switch-density($density-scale);
+  }
+}
 
 @mixin mat-slide-toggle-theme-mdc($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -7,7 +7,6 @@
         [matRippleTrigger]="switch"
         [matRippleDisabled]="disableRipple || disabled"
         [matRippleCentered]="true"
-        [matRippleRadius]="24"
         [matRippleAnimation]="_rippleAnimation"></div>
       <div class="mdc-switch__thumb"></div>
       <input #input class="mdc-switch__native-control" type="checkbox"

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
@@ -16,6 +16,12 @@
   // The ripple needs extra specificity so the base ripple styling doesn't override its `position`.
   .mat-mdc-slide-toggle-ripple, .mdc-switch__thumb-underlay::before {
     @include mat-fill;
+    border-radius: 50%;
+    // Fixes the ripples not clipping to the border radius on Safari. Uses `:not(:empty)`
+    // in order to avoid creating extra layers when there aren't any ripples.
+    &:not(:empty) {
+      transform: translateZ(0);
+    }
   }
 
   // The MDC switch styles related to the hover state are intertwined with the MDC ripple styles.

--- a/src/material-experimental/mdc-table/_mdc-table.scss
+++ b/src/material-experimental/mdc-table/_mdc-table.scss
@@ -13,7 +13,11 @@
   }
 }
 
-@mixin mat-table-density-mdc($density-scale) {}
+@mixin mat-table-density-mdc($density-scale) {
+  .mat-mdc-table {
+    @include mdc-data-table-density($density-scale);
+  }
+}
 
 @mixin mat-table-theme-mdc($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material-experimental/mdc-tabs/_mdc-tabs.scss
+++ b/src/material-experimental/mdc-tabs/_mdc-tabs.scss
@@ -2,6 +2,7 @@
 @import '@material/tab-indicator/mixins.import';
 @import '@material/tab/mixins.import';
 @import '@material/tab/variables.import';
+@import '@material/tab-bar/mixins.import';
 @import '../mdc-helpers/mdc-helpers';
 
 @mixin mat-tabs-color-mdc($config) {
@@ -98,7 +99,11 @@
   }
 }
 
-@mixin mat-tabs-density-mdc($density-scale) {}
+@mixin mat-tabs-density-mdc($density-scale) {
+  .mat-mdc-tab-header {
+    @include mdc-tab-bar-density($density-scale);
+  }
+}
 
 @mixin mat-tabs-theme-mdc($theme) {
   $color: mat-get-color-config($theme);


### PR DESCRIPTION
Adds support for density scaling to various MDC-based components. Currently the MDC-based form-field is still left as it seems to involve more work (i.e. custom form-field controls etc.)