### PR TITLE
build: temporarily disable safari 10 browserstack tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,8 +525,10 @@ workflows:
           filters: *ignore_presubmit_branch_filter
       - tests_local_browsers:
           filters: *ignore_presubmit_branch_filter
-      - tests_browserstack:
-          filters: *ignore_presubmit_branch_filter
+      # TODO(devversion): temporarily disabled until BrowserStack fixes an issue
+      # where Safari browsers cannot be launched due to a missing `device'.
+      #- tests_browserstack:
+      #    filters: *ignore_presubmit_branch_filter
       - tests_saucelabs:
           filters: *ignore_presubmit_branch_filter
       - e2e_tests:

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -60,7 +60,7 @@ merge:
       - "ci/circleci: lint"
       - "ci/circleci: bazel_build"
       - "ci/circleci: tests_local_browsers"
-      # TODO(devveesion): temporarily disabled until Browserstack tests are re-enabled.
+      # TODO(devversion): temporarily disabled until Browserstack tests are re-enabled.
       # - "ci/circleci: tests_browserstack"
       - "ci/circleci: tests_saucelabs"
       - "ci/circleci: build_release_packages"

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -60,7 +60,8 @@ merge:
       - "ci/circleci: lint"
       - "ci/circleci: bazel_build"
       - "ci/circleci: tests_local_browsers"
-      - "ci/circleci: tests_browserstack"
+      # TODO(devveesion): temporarily disabled until Browserstack tests are re-enabled.
+      # - "ci/circleci: tests_browserstack"
       - "ci/circleci: tests_saucelabs"
       - "ci/circleci: build_release_packages"
 


### PR DESCRIPTION
Disabling Safari 10 BrowserStack test temporarily since they started failing magically.

The server complains about a missing `device` capability. This doesn't make sense since we are not testing mobile devices where a `device` name needs to be specified.