### PR TITLE
build: re-enable browserstack safari tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,10 +528,8 @@ workflows:
           filters: *ignore_presubmit_branch_filter
       - tests_local_browsers:
           filters: *ignore_presubmit_branch_filter
-      # TODO(devversion): temporarily disabled until BrowserStack fixes an issue
-      # where Safari browsers cannot be launched due to a missing `device'.
-      #- tests_browserstack:
-      #    filters: *ignore_presubmit_branch_filter
+      - tests_browserstack:
+          filters: *ignore_presubmit_branch_filter
       - tests_saucelabs:
           filters: *ignore_presubmit_branch_filter
       - e2e_tests:

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -60,8 +60,7 @@ merge:
       - "ci/circleci: lint"
       - "ci/circleci: bazel_build"
       - "ci/circleci: tests_local_browsers"
-      # TODO(devversion): temporarily disabled until Browserstack tests are re-enabled.
-      # - "ci/circleci: tests_browserstack"
+      - "ci/circleci: tests_browserstack"
       - "ci/circleci: tests_saucelabs"
       - "ci/circleci: build_release_packages"
 


### PR DESCRIPTION
BrowserStack team supposedly fixed the upstream issues. We can re-enable
the browserstack tests. It was unclear how long it will take the BS team
to fix the server issues, so we temporarily disabled the job before.

This reverts commit 555037a8e8de81d1cafbe31100c72b3a085dfe5b.