### PR TITLE
docs(youtube-player component): fix incorrect syntax

### DIFF
--- a/src/youtube-player/README.md
+++ b/src/youtube-player/README.md
@@ -34,7 +34,7 @@ export class YoutubePlayerExampleModule {
 
 // example-component.ts
 @Component({
-  template: '<youtube-player videoId="PRQCAL_RMVo" />',
+  template: '<youtube-player videoId="PRQCAL_RMVo"></youtube-player>',
   selector: 'youtube-player-example',
 })
 class YoutubePlayerExample implements OnInit {


### PR DESCRIPTION
### PR Checklist
Please check if your PR fulfills the following requirements:

 

- [x] The commit message follows our guidelines: 

https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

- [ ]  Tests for the changes have been added (for bug fixes / features)

- [x]  Docs have been added / updated (for bug fixes / features)


### PR Type
What kind of change does this PR introduce?

- [ ]  Bugfix
- [ ]  Feature
- [ ]  Code style update (formatting, local variables)
- [x]  Refactoring (no functional changes, no api changes)
- [ ]  Build related changes
- [ ]  CI related changes
- [x]  Documentation content changes
- [ ]  angular.io application / infrastructure changes
- [ ]  Other... Please describe:


### What is the current behavior?
If you use the example `<youtube-player videoId="PRQCAL_RMVo" />`
you have 
**ERROR in Errors parsing template: Only void and foreign elements can be self closed "youtube-player" ("[ERROR ->]<youtube-player videoId="PRQCAL_RMVo" />")**
the right way is :
<youtube-player videoId="PRQCAL_RMVo"></youtube-player>

thats happend in "src/youtube-player/README.md " ,line 37.

### What is the new behavior?
### Does this PR introduce a breaking change?
 

- [ ] Yes
- [x]  No

Other information