### PR TITLE
fix(drag-drop): not working correctly inside transplanted views

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1358,6 +1358,47 @@ describe('CdkDrag', () => {
       expect(fixture.componentInstance.dropInstance.data).toBe(fixture.componentInstance.items);
     });
 
+    it('should register an item with the drop container', () => {
+      const fixture = createComponent(DraggableInDropZone);
+      fixture.detectChanges();
+      const list = fixture.componentInstance.dropInstance;
+
+      spyOn(list, 'addItem').and.callThrough();
+
+      fixture.componentInstance.items.push({value: 'Extra', margin: 0, height: ITEM_HEIGHT});
+      fixture.detectChanges();
+
+      expect(list.addItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove an item from the drop container', () => {
+      const fixture = createComponent(DraggableInDropZone);
+      fixture.detectChanges();
+      const list = fixture.componentInstance.dropInstance;
+
+      spyOn(list, 'removeItem').and.callThrough();
+
+      fixture.componentInstance.items.pop();
+      fixture.detectChanges();
+
+      expect(list.removeItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return the items sorted by their position in the DOM', () => {
+      const fixture = createComponent(DraggableInDropZone);
+      const items = fixture.componentInstance.items;
+      fixture.detectChanges();
+
+      // Insert a couple of items in the start and the middle so the list gets shifted around.
+      items.unshift({value: 'Extra 0', margin: 0, height: ITEM_HEIGHT});
+      items.splice(3, 0, {value: 'Extra 1', margin: 0, height: ITEM_HEIGHT});
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.dropInstance.getSortedItems().map(item => {
+        return item.element.nativeElement.textContent!.trim();
+      })).toEqual(['Extra 0', 'Zero', 'One', 'Extra 1', 'Two', 'Three']);
+    });
+
     it('should sync the drop list inputs with the drop list ref', () => {
       const fixture = createComponent(DraggableInDropZone);
       fixture.detectChanges();
@@ -5167,7 +5208,7 @@ class ConnectedDropZones implements AfterViewInit {
         this.groupedDragItems.push([]);
       }
 
-      this.groupedDragItems[index].push(...dropZone._draggables.toArray());
+      this.groupedDragItems[index].push(...dropZone.getSortedItems());
     });
   }
 }

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -215,6 +215,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     // assigning the drop container both from here and the list.
     if (dropContainer) {
       this._dragRef._withDropContainer(dropContainer._dropListRef);
+      dropContainer.addItem(this);
     }
 
     this._syncInputs(this._dragRef);
@@ -303,6 +304,10 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (this.dropContainer) {
+      this.dropContainer.removeItem(this);
+    }
+
     this._destroyed.next();
     this._destroyed.complete();
     this._dragRef.dispose();

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -143,7 +143,6 @@ export interface CdkDragStart<T = any> {
 }
 
 export declare class CdkDropList<T = any> implements AfterContentInit, OnDestroy {
-    _draggables: QueryList<CdkDrag>;
     _dropListRef: DropListRef<CdkDropList<T>>;
     autoScrollDisabled: boolean;
     connectedTo: (CdkDropList | string)[] | CdkDropList | string;
@@ -163,17 +162,20 @@ export declare class CdkDropList<T = any> implements AfterContentInit, OnDestroy
     constructor(
     element: ElementRef<HTMLElement>, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined,
     _scrollDispatcher?: ScrollDispatcher | undefined, config?: DragDropConfig);
+    addItem(item: CdkDrag): void;
     drop(item: CdkDrag, currentIndex: number, previousContainer: CdkDropList, isPointerOverContainer: boolean): void;
     enter(item: CdkDrag, pointerX: number, pointerY: number): void;
     exit(item: CdkDrag): void;
     getItemIndex(item: CdkDrag): number;
+    getSortedItems(): CdkDrag[];
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
+    removeItem(item: CdkDrag): void;
     start(): void;
     static ngAcceptInputType_autoScrollDisabled: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_sortingDisabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { "connectedTo": "cdkDropListConnectedTo"; "data": "cdkDropListData"; "orientation": "cdkDropListOrientation"; "id": "id"; "lockAxis": "cdkDropListLockAxis"; "disabled": "cdkDropListDisabled"; "sortingDisabled": "cdkDropListSortingDisabled"; "enterPredicate": "cdkDropListEnterPredicate"; "autoScrollDisabled": "cdkDropListAutoScrollDisabled"; }, { "dropped": "cdkDropListDropped"; "entered": "cdkDropListEntered"; "exited": "cdkDropListExited"; "sorted": "cdkDropListSorted"; }, ["_draggables"]>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { "connectedTo": "cdkDropListConnectedTo"; "data": "cdkDropListData"; "orientation": "cdkDropListOrientation"; "id": "id"; "lockAxis": "cdkDropListLockAxis"; "disabled": "cdkDropListDisabled"; "sortingDisabled": "cdkDropListSortingDisabled"; "enterPredicate": "cdkDropListEnterPredicate"; "autoScrollDisabled": "cdkDropListAutoScrollDisabled"; }, { "dropped": "cdkDropListDropped"; "entered": "cdkDropListEntered"; "exited": "cdkDropListExited"; "sorted": "cdkDropListSorted"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkDropList<any>>;
 }
 
@@ -298,6 +300,7 @@ export declare class DragRef<T = any> {
     getFreeDragPosition(): Readonly<Point>;
     getPlaceholderElement(): HTMLElement;
     getRootElement(): HTMLElement;
+    getVisibleElement(): HTMLElement;
     isDragging(): boolean;
     reset(): void;
     setFreeDragPosition(value: Point): this;
@@ -368,8 +371,8 @@ export declare class DropListRef<T = any> {
     _stopScrolling(): void;
     connectedTo(connectedTo: DropListRef[]): this;
     dispose(): void;
-    drop(item: DragRef, currentIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point): void;
-    enter(item: DragRef, pointerX: number, pointerY: number): void;
+    drop(item: DragRef, currentIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, previousIndex?: number): void;
+    enter(item: DragRef, pointerX: number, pointerY: number, index?: number): void;
     exit(item: DragRef): void;
     getItemIndex(item: DragRef): number;
     isDragging(): boolean;


### PR DESCRIPTION
Currently the CDK drag&drop is set up so that it keeps track of the items inside each drop list via `ContentChildren`, however this doesn't work properly inside of a transplanted view (e.g. in the header of a `mat-table`). There are two main problems inside transplanted views:

1. On the first change detection the `ContentChildren` query may be empty, even though the items exist. Usually they're fine on the second run, but that may be too late, because the user could've started dragging already.
2. Even if we somehow ensured that the `ContentChildren` is up-to-date when dragging starts, Angular won't update the order of the transplanted view items in the query once they're shuffled around.

To work around these limitations and to make it possible to support more advanced usages like in `mat-table`, these changes switch to keeping track of the items using DI. Whenever an item is created or destroyed, it registers/deregisters itself with the closest drop list. Since the insertion order can be different from the DOM order, we use `compareDocumentPosition` to sort the items right before dragging starts.

Fixes #18482.