### PR TITLE
docs: mat-bottom-sheet remove entrycomponents reference

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -49,38 +49,6 @@ export class HobbitSheet {
 }
 ```
 
-### Configuring bottom sheet content via `entryComponents`
-
-Similarly to `MatDialog`, `MatBottomSheet` instantiates components at run-time. In order for it to
-work, the Angular compiler needs extra information to create the necessary `ComponentFactory` for
-your bottom sheet content component.
-
-Any components that are include inside of a bottom sheet have to be added to the `entryComponents`
-inside your `NgModule`.
-
-
-```ts
-@NgModule({
-  imports: [
-    // ...
-    MatBottomSheetModule
-  ],
-
-  declarations: [
-    AppComponent,
-    ExampleBottomSheetComponent
-  ],
-
-  entryComponents: [
-    ExampleBottomSheetComponent
-  ],
-
-  providers: [],
-  bootstrap: [AppComponent]
-})
-export class AppModule {}
-```
-
 ### Specifying global configuration defaults
 Default bottom sheet options can be specified by providing an instance of `MatBottomSheetConfig`
 for `MAT_BOTTOM_SHEET_DEFAULT_OPTIONS` in your application's root module.


### PR DESCRIPTION
This is not needed anymore as of angular v9