### PR TITLE
chore: avoid syntax warnings in dev app on IE

### DIFF
--- a/src/dev-app/index.html
+++ b/src/dev-app/index.html
@@ -23,25 +23,25 @@
 </head>
 <body>
   <dev-app>Loading...</dev-app>
-</body>
 
-<script src="core-js/client/core.js"></script>
-<script src="zone.js/dist/zone.js"></script>
-<script src="systemjs/dist/system.js"></script>
-<script src="system-config.js"></script>
-<script src="https://www.youtube.com/iframe_api"></script>
-<script src="https://maps.googleapis.com/maps/api/js"></script>
-<script>
-  System.config({
-    map: {
-      // Maps imports where the AMD module names start with workspace name (commonly done in Bazel).
-      // This is needed for compatibility with dynamic runfile resolution of the devserver and the
-      // static runfile resolution done in the "pkg_web" rule. In the built web package, the output
-      // tree artifact serves as workspace root and root of the current dev-app Bazel package.
-      'angular_material': '',
-      'angular_material/src/dev-app': '',
-    }
-  });
-  System.import('main').catch(console.error.bind(console));
-</script>
+  <script src="core-js/client/core.js"></script>
+  <script src="zone.js/dist/zone.js"></script>
+  <script src="systemjs/dist/system.js"></script>
+  <script src="system-config.js"></script>
+  <script src="https://www.youtube.com/iframe_api"></script>
+  <script src="https://maps.googleapis.com/maps/api/js"></script>
+  <script>
+    System.config({
+      map: {
+        // Maps imports where the AMD module names start with workspace name (commonly done in Bazel).
+        // This is needed for compatibility with dynamic runfile resolution of the devserver and the
+        // static runfile resolution done in the "pkg_web" rule. In the built web package, the output
+        // tree artifact serves as workspace root and root of the current dev-app Bazel package.
+        'angular_material': '',
+        'angular_material/src/dev-app': '',
+      }
+    });
+    System.import('main').catch(console.error.bind(console));
+  </script>
+</body>
 </html>


### PR DESCRIPTION
Fixes IE logging some invalid syntax warnings because we had a few tags outside the `body`.