### PR TITLE
fix(cdk/platform): scroll behaviour support check

### DIFF
--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -30,7 +30,7 @@ let rtlScrollAxisType: RtlScrollAxisType;
 
 /** Check whether the browser supports scroll behaviors. */
 export function supportsScrollBehavior(): boolean {
-  return !!(typeof document == 'object'  && 'scrollBehavior' in document.documentElement!.style);
+  return !!(typeof document == 'object' && document && 'scrollBehavior' in document.documentElement!.style);
 }
 
 /**


### PR DESCRIPTION
Fixes the check for scroll behaviour when `document` is `null` (when not in a browser).