### PR TITLE
feat(form-field): expose label content element id for custom controls

### DIFF
--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/example-tel-input-example.html
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/example-tel-input-example.html
@@ -1,4 +1,7 @@
-<div [formGroup]="parts" class="example-tel-input-container">
+<div role="group" class="example-tel-input-container"
+     [formGroup]="parts"
+     [attr.aria-labelledby]="_formField?.getLabelId()"
+     [attr.aria-describedby]="describedBy">
   <input
     class="example-tel-input-element"
     formControlName="area" size="3"

--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.ts
@@ -1,8 +1,9 @@
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {Component, ElementRef, Input, OnDestroy, Optional, Self} from '@angular/core';
-import {FormBuilder, FormGroup, ControlValueAccessor, NgControl, Validators} from '@angular/forms';
-import {MatFormFieldControl} from '@angular/material-experimental/mdc-form-field';
+import {Component, ElementRef, Inject, Input, OnDestroy, Optional, Self} from '@angular/core';
+import {ControlValueAccessor, FormBuilder, FormGroup, NgControl, Validators} from '@angular/forms';
+import {MatFormField, MatFormFieldControl} from '@angular/material-experimental/mdc-form-field';
+import {MAT_FORM_FIELD} from '@angular/material/form-field';
 import {Subject} from 'rxjs';
 
 /** @title Form field with custom telephone number input control. */
@@ -27,7 +28,6 @@ export class MyTel {
   host: {
     '[class.example-floating]': 'shouldLabelFloat',
     '[id]': 'id',
-    '[attr.aria-describedby]': 'describedBy',
   }
 })
 export class MyTelInput implements ControlValueAccessor, MatFormFieldControl<MyTel>, OnDestroy {
@@ -94,6 +94,7 @@ export class MyTelInput implements ControlValueAccessor, MatFormFieldControl<MyT
     formBuilder: FormBuilder,
     private _focusMonitor: FocusMonitor,
     private _elementRef: ElementRef<HTMLElement>,
+    @Optional() @Inject(MAT_FORM_FIELD) public _formField: MatFormField,
     @Optional() @Self() public ngControl: NgControl) {
 
     this.parts = formBuilder.group({

--- a/src/components-examples/material/form-field/form-field-custom-control/example-tel-input-example.html
+++ b/src/components-examples/material/form-field/form-field-custom-control/example-tel-input-example.html
@@ -1,4 +1,7 @@
-<div [formGroup]="parts" class="example-tel-input-container">
+<div role="group" class="example-tel-input-container"
+     [formGroup]="parts"
+     [attr.aria-labelledby]="_formField?.getLabelId()"
+     [attr.aria-describedby]="describedBy">
   <input class="example-tel-input-element"
          formControlName="area" size="3"
          maxLength="3"

--- a/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
@@ -3,6 +3,7 @@ import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   Component,
   ElementRef,
+  Inject,
   Input,
   OnDestroy,
   Optional,
@@ -10,15 +11,15 @@ import {
   ViewChild
 } from '@angular/core';
 import {
-  FormBuilder,
-  FormGroup,
+  AbstractControl,
   ControlValueAccessor,
-  NgControl,
-  Validators,
+  FormBuilder,
   FormControl,
-  AbstractControl
+  FormGroup,
+  NgControl,
+  Validators
 } from '@angular/forms';
-import {MatFormFieldControl} from '@angular/material/form-field';
+import {MAT_FORM_FIELD, MatFormField, MatFormFieldControl} from '@angular/material/form-field';
 import {Subject} from 'rxjs';
 
 /** @title Form field with custom telephone number input control. */
@@ -51,7 +52,6 @@ export class MyTel {
   host: {
     '[class.example-floating]': 'shouldLabelFloat',
     '[id]': 'id',
-    '[attr.aria-describedby]': 'describedBy'
   }
 })
 export class MyTelInput
@@ -134,8 +134,9 @@ export class MyTelInput
     formBuilder: FormBuilder,
     private _focusMonitor: FocusMonitor,
     private _elementRef: ElementRef<HTMLElement>,
-    @Optional() @Self() public ngControl: NgControl
-  ) {
+    @Optional() @Inject(MAT_FORM_FIELD) public _formField: MatFormField,
+    @Optional() @Self() public ngControl: NgControl) {
+
     this.parts = formBuilder.group({
       area: [
         null,

--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -192,11 +192,11 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
   }
   private _hintLabel = '';
 
-  // Unique id for the hint label.
-  _hintLabelId = `mat-mdc-hint-${nextUniqueId++}`;
-
   // Unique id for the internal form field label.
-  _labelId = `mat-mdc-form-field-label-${nextUniqueId++}`;
+  readonly _labelId = `mat-mdc-form-field-label-${nextUniqueId++}`;
+
+  // Unique id for the hint label.
+  readonly _hintLabelId = `mat-mdc-hint-${nextUniqueId++}`;
 
   /** State of the mat-hint and mat-error animations. */
   _subscriptAnimationState = '';
@@ -356,6 +356,13 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
   ngOnDestroy() {
     this._destroyed.next();
     this._destroyed.complete();
+  }
+
+  /**
+   * Gets the id of the label element. If no label is present, returns `null`.
+   */
+  getLabelId(): string|null {
+    return this._hasFloatingLabel() ? this._labelId : null;
   }
 
   /**

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -219,10 +219,10 @@ export class MatFormField extends _MatFormFieldMixinBase
   private _hintLabel = '';
 
   // Unique id for the hint label.
-  _hintLabelId: string = `mat-hint-${nextUniqueId++}`;
+  readonly _hintLabelId: string = `mat-hint-${nextUniqueId++}`;
 
-  // Unique id for the internal form field label.
-  _labelId = `mat-form-field-label-${nextUniqueId++}`;
+  // Unique id for the label element.
+  readonly _labelId = `mat-form-field-label-${nextUniqueId++}`;
 
   /**
    * Whether the label should always float, never float or float as the user types.
@@ -298,6 +298,13 @@ export class MatFormField extends _MatFormFieldMixinBase
     this.appearance = (_defaults && _defaults.appearance) ? _defaults.appearance : 'legacy';
     this._hideRequiredMarker = (_defaults && _defaults.hideRequiredMarker != null) ?
         _defaults.hideRequiredMarker : false;
+  }
+
+  /**
+   * Gets the id of the label element. If no label is present, returns `null`.
+   */
+  getLabelId(): string|null {
+    return this._hasFloatingLabel() ? this._labelId : null;
   }
 
   /**

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -1168,7 +1168,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       return null;
     }
 
-    return this._parentFormField._labelId || null;
+    return this._parentFormField.getLabelId();
   }
 
   /** Determines the `aria-activedescendant` to be set on the host. */

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -28,12 +28,12 @@ export declare class MatFormField extends _MatFormFieldMixinBase implements Afte
     _elementRef: ElementRef;
     _errorChildren: QueryList<MatError>;
     _hintChildren: QueryList<MatHint>;
-    _hintLabelId: string;
+    readonly _hintLabelId: string;
     _inputContainerRef: ElementRef;
     get _labelChild(): MatLabel;
     _labelChildNonStatic: MatLabel;
     _labelChildStatic: MatLabel;
-    _labelId: string;
+    readonly _labelId: string;
     _placeholderChild: MatPlaceholder;
     _prefixChildren: QueryList<MatPrefix>;
     get _shouldAlwaysFloat(): boolean;
@@ -59,6 +59,7 @@ export declare class MatFormField extends _MatFormFieldMixinBase implements Afte
     _shouldLabelFloat(): boolean;
     protected _validateControlChild(): void;
     getConnectedOverlayOrigin(): ElementRef;
+    getLabelId(): string | null;
     ngAfterContentChecked(): void;
     ngAfterContentInit(): void;
     ngAfterViewInit(): void;


### PR DESCRIPTION
Currently, the form-field always creates a label element as sibling
to projected form-field controls. For native controls, the label is
associated with the controls using the `for` attribute.

This doesn't work for custom controls which might not be based
on native controls. e.g. the `mat-select`. In those cases, the
appropriate aria attributes need to be applied with `aria-labelledby`
that refers to the label content element.

Since this is a common pattern for custom controls that don't use
native controls, we need to expose the element id for the label content.

Currently we already do this for the select, but just prefixed it with
an underscore. This denotes it as private API while there is obviously a
use-case for exposing this publicly. Best example is how the select _needs_ it.

**Note**: If we decide to go with that change, the target is usually `minor`, but it might be worth checking if we could get it into `master` earlier for our MDC form-field changes. 