### PR TITLE
feat(datepicker): polish up date range selector

### DIFF
--- a/src/dev-app/datepicker/datepicker-demo.html
+++ b/src/dev-app/datepicker/datepicker-demo.html
@@ -175,12 +175,21 @@
 <div class="demo-range-group">
   <mat-form-field>
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input [formGroup]="range1" [rangePicker]="range1Picker">
+    <mat-date-range-input
+      [formGroup]="range1"
+      [rangePicker]="range1Picker"
+      [min]="minDate"
+      [max]="maxDate"
+      [disabled]="inputDisabled"
+      [dateFilter]="filterOdd ? dateFilter : undefined">
       <input matStartDate formControlName="start" placeholder="Start date"/>
       <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle [for]="range1Picker" matSuffix></mat-datepicker-toggle>
-    <mat-date-range-picker #range1Picker></mat-date-range-picker>
+    <mat-date-range-picker
+      [touchUi]="touch"
+      [disabled]="datepickerDisabled"
+      #range1Picker></mat-date-range-picker>
   </mat-form-field>
   <div>{{range1.value | json}}</div>
 </div>
@@ -188,12 +197,21 @@
 <div class="demo-range-group">
   <mat-form-field appearance="fill">
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input [formGroup]="range2" [rangePicker]="range2Picker">
+    <mat-date-range-input
+      [formGroup]="range2"
+      [rangePicker]="range2Picker"
+      [min]="minDate"
+      [max]="maxDate"
+      [disabled]="inputDisabled"
+      [dateFilter]="filterOdd ? dateFilter : undefined">
       <input matStartDate formControlName="start" placeholder="Start date"/>
       <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle [for]="range2Picker" matSuffix></mat-datepicker-toggle>
-    <mat-date-range-picker #range2Picker></mat-date-range-picker>
+    <mat-date-range-picker
+      [touchUi]="touch"
+      [disabled]="datepickerDisabled"
+      #range2Picker></mat-date-range-picker>
   </mat-form-field>
   <div>{{range2.value | json}}</div>
 </div>
@@ -201,12 +219,21 @@
 <div class="demo-range-group">
   <mat-form-field appearance="outline">
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input [formGroup]="range3" [rangePicker]="range3Picker">
+    <mat-date-range-input
+      [formGroup]="range3"
+      [rangePicker]="range3Picker"
+      [min]="minDate"
+      [max]="maxDate"
+      [disabled]="inputDisabled"
+      [dateFilter]="filterOdd ? dateFilter : undefined">
       <input matStartDate formControlName="start" placeholder="Start date"/>
       <input matEndDate formControlName="end" placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle [for]="range3Picker" matSuffix></mat-datepicker-toggle>
-    <mat-date-range-picker #range3Picker></mat-date-range-picker>
+    <mat-date-range-picker
+      [touchUi]="touch"
+      [disabled]="datepickerDisabled"
+      #range3Picker></mat-date-range-picker>
   </mat-form-field>
   <div>{{range3.value | json}}</div>
 </div>

--- a/src/material/core/datetime/date-selection-model.ts
+++ b/src/material/core/datetime/date-selection-model.ts
@@ -147,18 +147,11 @@ export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRan
 
     if (start == null) {
       start = date;
-    } else if (end == null) {
+    } else if (end == null && date && this.adapter.compareDate(date, start) > 0) {
       end = date;
-    } else if (date) {
-      if (this.adapter.compareDate(date, start) <= 0) {
-        start = date;
-
-        if (end) {
-          end = null;
-        }
-      } else {
-        end = date;
-      }
+    } else {
+      start = date;
+      end = null;
     }
 
     super.updateSelection(new DateRange<D>(start, end), this);

--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -137,6 +137,10 @@ $mat-calendar-weekday-table-font-size: 11px !default;
       color: mat-color(map-get($theme, warn), text);
     }
   }
+
+  .mat-date-range-input-inner:disabled {
+    color: mat-color($foreground, disabled-text);
+  }
 }
 
 @mixin mat-datepicker-typography($config) {

--- a/src/material/datepicker/date-range-input.scss
+++ b/src/material/datepicker/date-range-input.scss
@@ -24,6 +24,9 @@ $mat-date-range-input-placeholder-transition:
   transition: $mat-date-range-input-placeholder-transition;
 
   .mat-form-field-hide-placeholder & {
+    // Disable text selection, because the user can click
+    // through the main label when the input is disabled.
+    @include user-select(none);
     color: transparent;
     transition: none;
   }
@@ -57,6 +60,10 @@ $mat-date-range-input-placeholder-transition:
   .mat-form-field-hide-placeholder &,
   .mat-date-range-input-hide-placeholders & {
     @include input-placeholder {
+      // Disable text selection, because the user can click
+      // through the main label when the input is disabled.
+      @include user-select(none);
+
       // Needs to be !important, because the placeholder will end up inheriting the
       // input color in IE, if the consumer overrides it with a higher specificity.
       color: transparent !important;

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -140,13 +140,21 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   private _max: D | null;
 
   /** Whether the input is disabled. */
+  @Input()
   get disabled(): boolean {
-    if (this._startInput && this._endInput) {
-      return this._startInput.disabled && this._endInput.disabled;
-    }
-
-    return false;
+    return (this._startInput && this._endInput) ?
+      (this._startInput.disabled && this._endInput.disabled) :
+      this._groupDisabled;
   }
+  set disabled(value: boolean) {
+    const newValue = coerceBooleanProperty(value);
+
+    if (newValue !== this._groupDisabled) {
+      this._groupDisabled = newValue;
+      this._disabledChange.next(this.disabled);
+    }
+  }
+  _groupDisabled = false;
 
   /** Whether the input is in an error state. */
   get errorState(): boolean {
@@ -218,9 +226,12 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
    * @docs-private
    */
   onContainerClick(): void {
-    if (!this.focused) {
-      // TODO(crisbeto): maybe this should go to end input if start has a value?
-      this._startInput.focus();
+    if (!this.focused && !this.disabled) {
+      if (!this._model || !this._model.selection.start) {
+        this._startInput.focus();
+      } else {
+        this._endInput.focus();
+      }
     }
   }
 
@@ -317,4 +328,5 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   }
 
   static ngAcceptInputType_required: BooleanInput;
+  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -81,7 +81,7 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
 
   /** Whether the datepicker-input is disabled. */
   @Input()
-  get disabled(): boolean { return !!this._disabled; }
+  get disabled(): boolean { return !!this._disabled || this._parentDisabled(); }
   set disabled(value: boolean) {
     const newValue = coerceBooleanProperty(value);
     const element = this._elementRef.nativeElement;
@@ -192,6 +192,10 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
         this.dateInput.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
         this.dateChange.emit(new MatDatepickerInputEvent(this, this._elementRef.nativeElement));
         this._formatValue(value);
+
+        if (this._outsideValueChanged) {
+          this._outsideValueChanged();
+        }
       }
     });
   }
@@ -205,8 +209,14 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
   /** Converts a value from the model into a native value for the input. */
   protected abstract _getValueFromModel(modelValue: S): D | null;
 
-  /** The combined form control validator for this input. */
+  /** Combined form control validator for this input. */
   protected abstract _validator: ValidatorFn | null;
+
+  /**
+   * Callback that'll be invoked when the selection model is changed
+   * from somewhere that's not the current datepicker input.
+   */
+  protected abstract _outsideValueChanged?: () => void;
 
   /** Whether the last value set on the input was valid. */
   protected _lastValueValid = false;
@@ -328,6 +338,14 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
     } else {
       this._pendingValue = value;
     }
+  }
+
+  /**
+   * Checks whether a parent control is disabled. This is in place so that it can be overridden
+   * by inputs extending this one which can be placed inside of a group that can be disabled.
+   */
+  protected _parentDisabled() {
+    return false;
   }
 
   // Accept `any` to avoid conflicts with other directives on `<input>` that

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -176,6 +176,9 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
     return this._dateFilter;
   }
 
+  // Unnecessary when selecting a single date.
+  protected _outsideValueChanged: undefined;
+
   // Accept `any` to avoid conflicts with other directives on `<input>` that
   // may accept different types.
   static ngAcceptInputType_value: any;

--- a/src/material/datepicker/multi-year-view.ts
+++ b/src/material/datepicker/multi-year-view.ts
@@ -295,8 +295,6 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
   private _setSelectedYear(value: DateRange<D> | D | null) {
     this._selectedYear = null;
 
-    // TODO(crisbeto): showing a date range in a multi-year view might look weird.
-    // Revisit once closer to completion.
     if (value instanceof DateRange) {
       const displayValue = value.start || value.end;
 

--- a/src/material/datepicker/year-view.ts
+++ b/src/material/datepicker/year-view.ts
@@ -330,8 +330,6 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
 
   /** Sets the currently-selected month based on a model value. */
   private _setSelectedMonth(value: DateRange<D> | D | null) {
-    // TODO(crisbeto): showing a date range in a year view might look weird.
-    // Revisit once closer to completion.
     if (value instanceof DateRange) {
       this._selectedMonth = this._getMonthInCurrentYear(value.start) ||
                             this._getMonthInCurrentYear(value.end);

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -144,6 +144,7 @@ export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>
 
 export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> implements MatDatepickerControl<D | null> {
     _datepicker: MatDatepicker<D>;
+    protected _outsideValueChanged: undefined;
     protected _validator: ValidatorFn | null;
     get dateFilter(): DateFilterFn<D | null>;
     set dateFilter(value: DateFilterFn<D | null>);
@@ -228,11 +229,13 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     _ariaLabelledBy: string | null;
     _disabledChange: Subject<boolean>;
     _endInput: MatEndDate<D>;
+    _groupDisabled: boolean;
     _startInput: MatStartDate<D>;
     controlType: string;
     get dateFilter(): DateFilterFn<D>;
     set dateFilter(value: DateFilterFn<D>);
     get disabled(): boolean;
+    set disabled(value: boolean);
     get empty(): boolean;
     get errorState(): boolean;
     focused: boolean;
@@ -263,8 +266,9 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     ngOnDestroy(): void;
     onContainerClick(): void;
     setDescribedByIds(ids: string[]): void;
+    static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_required: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDateRangeInput<any>, "mat-date-range-input", ["matDateRangeInput"], { "rangePicker": "rangePicker"; "required": "required"; "dateFilter": "dateFilter"; "min": "min"; "max": "max"; "separator": "separator"; }, {}, ["_startInput", "_endInput"]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDateRangeInput<any>, "mat-date-range-input", ["matDateRangeInput"], { "rangePicker": "rangePicker"; "required": "required"; "dateFilter": "dateFilter"; "min": "min"; "max": "max"; "disabled": "disabled"; "separator": "separator"; }, {}, ["_startInput", "_endInput"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatDateRangeInput<any>>;
 }
 


### PR DESCRIPTION
Makes a bunch of changes to polish up the behavior of the date range picker.

- Makes the range selection logic a bit smarter about when to pick start/end so that it's more intuitive.
- Fixes hovering over disabled cells triggering the range selection styles.
- Fixes a "changed after checked" error when selecting a range using the keyboard.
- Implements validation that the start isn't after the end, and that the end isn't before the start.
- Adds the missing ARIA attributes.
- Fixes being able to select the placeholders of a disabled range input.
- Adds the ability to disable the entire range input.
- Fixes the inputs not graying out their values when they're disabled.
- Makes the range input a bit smarter about which input to focus on click.

With these changes the date range picker should be mostly feature-complete.