### PR TITLE
build: fix missing transitive dependencies for axe-protractor

### DIFF
--- a/src/e2e-app/input/input-e2e.html
+++ b/src/e2e-app/input/input-e2e.html
@@ -1,23 +1,27 @@
 <section>
   <p>
     <mat-form-field>
-      <input matInput type="text" id="text-input" placeholder="Enter some text">
+      <mat-label>Enter some text</mat-label>
+      <input matInput type="text" id="text-input">
     </mat-form-field>
   </p>
   <p>
     <mat-form-field>
-      <input matInput type="number" id="number-input" placeholder="Enter a number">
+      <mat-label>Enter a number</mat-label>
+      <input matInput type="number" id="number-input">
     </mat-form-field>
   </p>
   <p>
     <mat-form-field>
-      <textarea matInput id="text-area" placeholder="Enter some text"></textarea>
+      <mat-label>Enter some text</mat-label>
+      <textarea matInput id="text-area"></textarea>
     </mat-form-field>
   </p>
   <p>
     <mat-form-field>
-      <textarea matInput cdkTextareaAutosize cdkAutosizeMaxRows="10" id="autosize-text-area"
-                placeholder="Enter some text"></textarea>
+      <mat-label>Enter some text</mat-label>
+      <textarea matInput cdkTextareaAutosize cdkAutosizeMaxRows="10" id="autosize-text-area">
+      </textarea>
     </mat-form-field>
   </p>
 </section>

--- a/src/e2e-app/mdc-tabs/mdc-tabs-e2e.html
+++ b/src/e2e-app/mdc-tabs/mdc-tabs-e2e.html
@@ -3,7 +3,10 @@
     <mat-tab>
       <ng-template mat-tab-label>One</ng-template>
       <mat-form-field>
-        <textarea matInput placeholder="Autosize textarea" cdkTextareaAutosize>This is an autosize textarea, it should adjust to the size of its content.</textarea>
+        <mat-label>Autosize textarea</mat-label>
+        <textarea matInput cdkTextareaAutosize>
+          This is an autosize textarea, it should adjust to the size of its content.
+        </textarea>
       </mat-form-field>
     </mat-tab>
     <mat-tab>

--- a/src/e2e-app/tabs/tabs-e2e.html
+++ b/src/e2e-app/tabs/tabs-e2e.html
@@ -3,7 +3,10 @@
     <mat-tab>
       <ng-template mat-tab-label>One</ng-template>
       <mat-form-field>
-        <textarea matInput placeholder="Autosize textarea" cdkTextareaAutosize>This is an autosize textarea, it should adjust to the size of its content.</textarea>
+        <mat-label>Autosize textarea</mat-label>
+        <textarea matInput cdkTextareaAutosize>
+          This is an autosize textarea, it should adjust to the size of its content.
+        </textarea>
       </mat-form-field>
     </mat-tab>
     <mat-tab>

--- a/src/e2e-app/test_suite.bzl
+++ b/src/e2e-app/test_suite.bzl
@@ -6,6 +6,7 @@ def e2e_test_suite(name, data = [], tags = ["e2e"], deps = []):
         configuration = "//src/e2e-app:protractor.conf.js",
         data = [
             "//tools/axe-protractor",
+            "@npm//axe-webdriverjs",
         ] + data,
         on_prepare = "//src/e2e-app:start-devserver.js",
         server = "//src/e2e-app:devserver",

--- a/tools/axe-protractor/BUILD.bazel
+++ b/tools/axe-protractor/BUILD.bazel
@@ -3,9 +3,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "axe-protractor",
     srcs = [
-        "index.js",
         "build-message.js",
-        # "axe-webdriver" is required to run "axe-protractor".
-        "@npm//axe-webdriverjs",
+        "index.js",
     ],
 )

--- a/tools/axe-protractor/index.js
+++ b/tools/axe-protractor/index.js
@@ -13,8 +13,8 @@ const checkedPages = [];
 /**
  * Protractor plugin hook which always runs when Angular successfully bootstrapped.
  */
-function onPageStable() {
-  AxeBuilder(browser.driver)
+async function onPageStable() {
+  await AxeBuilder(browser.driver)
     .configure(this.config || {})
     .analyze(results => handleResults(this, results));
 }
@@ -32,7 +32,7 @@ function handleResults(context, results) {
     checkedPages.push(results.url);
 
     results.violations.forEach(violation => {
-      
+
       let specName = `${violation.help} (${results.url})`;
       let message = '\n' + buildMessage(violation);
 


### PR DESCRIPTION
Specifying the `axe-webdriverjs` dependency in a filegroup does not bring in the transitive dependencies. This meant that the axe-protractor plugin is unable to run successfully.