### PR TITLE
chore: remove unused webdriver-manager yarn script alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lint": "yarn -s tslint && yarn -s bazel:format-lint && yarn -s ownerslint",
     "e2e": "bazel test //src/... --test_tag_filters=e2e",
     "deploy-dev-app": "node ./scripts/deploy-dev-app.js",
-    "webdriver-manager": "webdriver-manager",
     "breaking-changes": "ts-node --project scripts scripts/breaking-changes.ts",
     "gulp": "gulp",
     "stage-release": "ts-node --project tools/release/ tools/release/stage-release.ts",


### PR DESCRIPTION
The webdriver-manager is no longer needed now that we run e2e tests with Bazel.
The script we added for it in the `package.json` can be removed.