### PR TITLE
fix(typography): default to normal letter spacing

### DIFF
--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -6,7 +6,7 @@
   $line-height: $font-size,
   $font-weight: 400,
   $font-family: null,
-  $letter-spacing: null) {
+  $letter-spacing: normal) {
 
   @return (
     font-size: $font-size,


### PR DESCRIPTION
MDC assumes that a typography config has letter-spacing defined. This change sets the value to be `normal` unless otherwise provided.