### PR TITLE
build: remove browsersync snippet log

### DIFF
--- a/tools/dev-server/dev-server.ts
+++ b/tools/dev-server/dev-server.ts
@@ -28,6 +28,7 @@ export class DevServer {
     notify: false,
     ghostMode: false,
     server: false,
+    logSnippet: false,
     middleware: (req, res) => this._bazelMiddleware(req, res),
   };
 


### PR DESCRIPTION
After we disabled the `server` option in Browsersync, we started getting some extra logs which can be distracting. These changes remove the log.