### PR TITLE
fix(list): no disabled indication in high contrast mode

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -305,6 +305,12 @@ mat-action-list {
 
 .mat-list-item-disabled {
   pointer-events: none;
+
+  // Since we can't use a color to indicate that the list
+  // item is disabled, we have to use opacity instead.
+  @include cdk-high-contrast {
+    opacity: 0.5;
+  }
 }
 
 @include cdk-high-contrast(active, off) {


### PR DESCRIPTION
Fixes not being able to distinguish disabled list items in high contrast mode.