### PR TITLE
fix(list): incorrectly selecting items when moving focus using shift + arrow key in single selection mode

### DIFF
--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -999,6 +999,44 @@ describe('MatSelectionList without forms', () => {
       expect(listOptions.every(option => !option.componentInstance.selected)).toBe(true);
     });
 
+    it('should focus, but not toggle, the next item when pressing SHIFT + UP_ARROW in single ' +
+      'selection mode', () => {
+        const manager = selectionList.componentInstance._keyManager;
+        const upKeyEvent = createKeyboardEvent('keydown', UP_ARROW);
+        Object.defineProperty(upKeyEvent, 'shiftKey', {get: () => true});
+
+        dispatchFakeEvent(listOptions[3].nativeElement, 'focus');
+        expect(manager.activeItemIndex).toBe(3);
+
+        expect(listOptions[1].componentInstance.selected).toBe(false);
+        expect(listOptions[2].componentInstance.selected).toBe(false);
+
+        selectionList.componentInstance._keydown(upKeyEvent);
+        fixture.detectChanges();
+
+        expect(listOptions[1].componentInstance.selected).toBe(false);
+        expect(listOptions[2].componentInstance.selected).toBe(false);
+      });
+
+    it('should focus, but not toggle, the next item when pressing SHIFT + DOWN_ARROW ' +
+      'in single selection mode', () => {
+        const manager = selectionList.componentInstance._keyManager;
+        const downKeyEvent = createKeyboardEvent('keydown', DOWN_ARROW);
+        Object.defineProperty(downKeyEvent, 'shiftKey', {get: () => true});
+
+        dispatchFakeEvent(listOptions[0].nativeElement, 'focus');
+        expect(manager.activeItemIndex).toBe(0);
+
+        expect(listOptions[1].componentInstance.selected).toBe(false);
+        expect(listOptions[2].componentInstance.selected).toBe(false);
+
+        selectionList.componentInstance._keydown(downKeyEvent);
+        fixture.detectChanges();
+
+        expect(listOptions[1].componentInstance.selected).toBe(false);
+        expect(listOptions[2].componentInstance.selected).toBe(false);
+      });
+
   });
 });
 

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -557,7 +557,7 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
         }
     }
 
-    if ((keyCode === UP_ARROW || keyCode === DOWN_ARROW) && event.shiftKey &&
+    if (this.multiple && (keyCode === UP_ARROW || keyCode === DOWN_ARROW) && event.shiftKey &&
         manager.activeItemIndex !== previousFocusIndex) {
       this._toggleFocusedOption();
     }


### PR DESCRIPTION
The functionality that allows selecting items while moving focus using shift + arrow key is currently always enabled, however it should only apply in multi selection mode.