### PR TITLE
fix(material-experimental/mdc-radio): able to focus disabled radio button via click

### DIFF
--- a/src/material-experimental/mdc-radio/radio.spec.ts
+++ b/src/material-experimental/mdc-radio/radio.spec.ts
@@ -776,7 +776,7 @@ describe('MDC-based MatRadio', () => {
           .toBe(4, 'Expected the tabindex to be set to "4".');
     });
 
-    it('should remove the tabindex from the host element', () => {
+    it('should set the tabindex to -1 on the host element', () => {
       const predefinedFixture = TestBed.createComponent(RadioButtonWithPredefinedTabindex);
       predefinedFixture.detectChanges();
 
@@ -796,6 +796,15 @@ describe('MDC-based MatRadio', () => {
       expect(radioButtonEl.hasAttribute('aria-label')).toBe(false);
       expect(radioButtonEl.hasAttribute('aria-describedby')).toBe(false);
       expect(radioButtonEl.hasAttribute('aria-labelledby')).toBe(false);
+    });
+
+    it('should remove the tabindex from the host element when disabled', () => {
+      const radioButton = fixture.debugElement.query(By.css('.mat-mdc-radio-button')).nativeElement;
+
+      fixture.componentInstance.disabled = true;
+      fixture.detectChanges();
+
+      expect(radioButton.hasAttribute('tabindex')).toBe(false);
     });
 
   });
@@ -964,10 +973,11 @@ class RadioGroupWithFormControl {
 }
 
 @Component({
-  template: `<mat-radio-button [tabIndex]="tabIndex"></mat-radio-button>`
+  template: `<mat-radio-button [disabled]="disabled" [tabIndex]="tabIndex"></mat-radio-button>`
 })
 class FocusableRadioButton {
   tabIndex: number;
+  disabled = false;
 }
 
 @Component({

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -81,7 +81,7 @@ export class MatRadioGroup extends BaseMatRadioGroup {
     '[class.mat-primary]': 'color === "primary"',
     '[class.mat-accent]': 'color === "accent"',
     '[class.mat-warn]': 'color === "warn"',
-    '[attr.tabindex]': '-1',
+    '[attr.tabindex]': 'disabled ? null : -1',
     '[attr.aria-label]': 'null',
     '[attr.aria-labelledby]': 'null',
     '[attr.aria-describedby]': 'null',


### PR DESCRIPTION
We have an existing fix for the regular radio button at #15499, but since it hasn't been merged yet, it got transferred to the MDC-based one.

Fixes users being able to focus a disabled radio button by clicking on it. The issue comes from us preserving the -1 tabindex, even if the button is disabled.