### PR TITLE
fix(list): no selected indication in high contrast mode while in single selection

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -319,6 +319,27 @@ mat-action-list {
       outline: dotted 1px;
     }
   }
+
+  // In single selection mode, the selected option is indicated by changing its
+  // background color, but that doesn't work in high contrast mode. We add an
+  // alternate indication by rendering out a circle.
+  .mat-list-single-selected-option::after {
+    $size: 10px;
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: $mat-list-side-padding;
+    transform: translateY(-50%);
+    width: $size;
+    height: 0;
+    border-bottom: solid $size;
+    border-radius: $size;
+  }
+
+  [dir='rtl'] .mat-list-single-selected-option::after {
+    right: auto;
+    left: $mat-list-side-padding;
+  }
 }
 
 


### PR DESCRIPTION
When a selection list is in single selection mode, it indicates which item is selected by changing its background color which is invisible in high contrast mode. These changes work around the issue by rendering out a circle next to the selected item. I went with the circle since it looks like a radio button which is what the list behaves as.

Here's what it looks like:
![Angular_Material_‎-_Microsoft_Edge_2020-02-22_16-52-49](https://user-images.githubusercontent.com/4450522/75095358-26a3a100-5594-11ea-8261-5a8cbadeca88.png)
