### PR TITLE
fix(cdk/overlay): support SVG element as overlay origin

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -767,6 +767,35 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
     });
 
+    describe('with origin set to an SVG element', () => {
+      beforeEach(() => {
+        originElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as any;
+        originElement.style.position = 'absolute';
+        originElement.style.width = `${DEFAULT_WIDTH}px`;
+        originElement.style.height = `${DEFAULT_HEIGHT}px`;
+        document.body.appendChild(originElement);
+      });
+
+      it('should position the panel correctly', () => {
+        const originRect = originElement.getBoundingClientRect();
+
+        positionStrategy
+          .setOrigin(originElement)
+          .withPositions([{
+            originX: 'start',
+            originY: 'bottom',
+            overlayX: 'start',
+            overlayY: 'top'
+          }]);
+
+        attachOverlay({positionStrategy});
+
+        const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
+        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
+      })
+    });
+
     it('should account for the `offsetX` pushing the overlay out of the screen', () => {
       // Position the element so it would have enough space to fit.
       originElement.style.top = '200px';

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -768,16 +768,11 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     describe('with origin set to an SVG element', () => {
-      beforeEach(() => {
-        document.body.removeChild(originElement);
-        originElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as any;
-        originElement.style.position = 'absolute';
-        originElement.style.width = `${DEFAULT_WIDTH}px`;
-        originElement.style.height = `${DEFAULT_HEIGHT}px`;
-        document.body.appendChild(originElement);
-      });
-
       it('should position the panel correctly', () => {
+        document.body.removeChild(originElement);
+        originElement = createBlockElement('svg', 'http://www.w3.org/2000/svg');
+        document.body.appendChild(originElement);
+
         const originRect = originElement.getBoundingClientRect();
 
         positionStrategy
@@ -2622,8 +2617,15 @@ function createPositionedBlockElement() {
 }
 
 /** Creates a block element with a default size. */
-function createBlockElement() {
-  const element = document.createElement('div');
+function createBlockElement(tagName = 'div', ns?: string) {
+  let element;
+
+  if (ns) {
+    element = document.createElementNS(ns, tagName) as HTMLElement;
+  } else {
+    element = document.createElement(tagName);
+  }
+
   element.style.width = `${DEFAULT_WIDTH}px`;
   element.style.height = `${DEFAULT_HEIGHT}px`;
   element.style.backgroundColor = 'rebeccapurple';

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -767,29 +767,27 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
     });
 
-    describe('with origin set to an SVG element', () => {
-      it('should position the panel correctly', () => {
-        document.body.removeChild(originElement);
-        originElement = createBlockElement('svg', 'http://www.w3.org/2000/svg');
-        document.body.appendChild(originElement);
+    it('should position the panel correctly when the origin is an SVG element', () => {
+      document.body.removeChild(originElement);
+      originElement = createBlockElement('svg', 'http://www.w3.org/2000/svg');
+      document.body.appendChild(originElement);
 
-        const originRect = originElement.getBoundingClientRect();
+      const originRect = originElement.getBoundingClientRect();
 
-        positionStrategy
-          .setOrigin(originElement)
-          .withPositions([{
-            originX: 'start',
-            originY: 'bottom',
-            overlayX: 'start',
-            overlayY: 'top'
-          }]);
+      positionStrategy
+        .setOrigin(originElement)
+        .withPositions([{
+          originX: 'start',
+          originY: 'bottom',
+          overlayX: 'start',
+          overlayY: 'top'
+        }]);
 
-        attachOverlay({positionStrategy});
+      attachOverlay({positionStrategy});
 
-        const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
-        expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
-        expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
-      });
+      const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+      expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
+      expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
     });
 
     it('should account for the `offsetX` pushing the overlay out of the screen', () => {

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -794,7 +794,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
         const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
         expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
         expect(Math.floor(overlayRect.left)).toBe(Math.floor(originRect.left));
-      })
+      });
     });
 
     it('should account for the `offsetX` pushing the overlay out of the screen', () => {

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -2615,11 +2615,11 @@ function createPositionedBlockElement() {
 }
 
 /** Creates a block element with a default size. */
-function createBlockElement(tagName = 'div', ns?: string) {
+function createBlockElement(tagName = 'div', namespace?: string) {
   let element;
 
-  if (ns) {
-    element = document.createElementNS(ns, tagName) as HTMLElement;
+  if (namespace) {
+    element = document.createElementNS(namespace, tagName) as HTMLElement;
   } else {
     element = document.createElement(tagName);
   }

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -769,6 +769,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
     describe('with origin set to an SVG element', () => {
       beforeEach(() => {
+        document.body.removeChild(originElement);
         originElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as any;
         originElement.style.position = 'absolute';
         originElement.style.width = `${DEFAULT_WIDTH}px`;

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -1110,6 +1110,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
       return origin.nativeElement.getBoundingClientRect();
     }
 
+    // Check for Element so SVG elements are also supported.
     if (origin instanceof Element) {
       return origin.getBoundingClientRect();
     }

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -1110,7 +1110,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
       return origin.nativeElement.getBoundingClientRect();
     }
 
-    if (origin instanceof HTMLElement) {
+    if (origin instanceof Element) {
       return origin.getBoundingClientRect();
     }
 


### PR DESCRIPTION
Currently when you provide an `SVGElement` when calling `flexibleConnectedTo(...)`, it will not use the bounding client rect in the `_getOriginRect()` method, causing the overlay to appear at the top left of the viewport.

This 1-liner fixes that by checking whether origin is an instance of `Element` instead of `HTMLElement`. No other changes are required.

I looked at `flexible-connected-position-strategy.spec.ts`, but i didn't see an obvious place to add a test (i did not see any tests checking if specifiying an `HTMLElement` or `ElementRef` are supported either).