### PR TITLE
[cdk/drag-drop cdkDragStartDelay demo] Disable `user-select` on the draggable box.

### DIFF
--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-delay/cdk-drag-drop-delay-example.css
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-delay/cdk-drag-drop-delay-example.css
@@ -16,6 +16,11 @@
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),
               0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none;
 }
 
 .example-box:active {


### PR DESCRIPTION
On iOS 13, press-and-holding for one second on the dragging box causes text to start being selected which can break/severely interrupt the dragging routine. Therefore, `user-select` should be set to `none` to disable the text selecting.

Demo of errant behavior: https://i.imgur.com/xq6fwM4.mp4
(this demo was posted in the following issue and also displays another bug with the drag-drop library on iOS 13 that still needs to be addressed: https://github.com/angular/components/issues/17923#issuecomment-588258600)
https://caniuse.com/#feat=user-select-none