### PR TITLE
docs(form-field): use value getter when returning form data

### DIFF
--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.ts
@@ -147,7 +147,7 @@ export class MyTelInput implements ControlValueAccessor, MatFormFieldControl<MyT
   }
 
   _handleInput(): void {
-    this.onChange(this.parts.value);
+    this.onChange(this.value);
   }
 
   static ngAcceptInputType_disabled: boolean | string | null | undefined;

--- a/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
+++ b/src/components-examples/material/form-field/form-field-custom-control/form-field-custom-control-example.ts
@@ -147,7 +147,7 @@ export class MyTelInput implements ControlValueAccessor, MatFormFieldControl<MyT
   }
 
   _handleInput(): void {
-    this.onChange(this.parts.value);
+    this.onChange(this.value);
   }
 
   static ngAcceptInputType_disabled: boolean | string | null | undefined;


### PR DESCRIPTION
This PR fixes an inconsistency in the example for [creating a custom form field control](https://material.angular.io/guide/creating-a-custom-form-field-control).

Now when writing to and updating the value from the custom form field control, the value's setter and getter are used. Instead of a mere object, the component interacting with the custom form field control now deals with an instance of `MyTel`. 

resolves #18537