### PR TITLE
feat(material-experimental/selection): Add Material version for `cdk-experimental/selection`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -114,6 +114,7 @@
 /src/material-experimental/mdc-theming/**          @mmalerba
 /src/material-experimental/mdc-typography/**       @mmalerba
 /src/material-experimental/popover-edit/**         @kseamon @andrewseguin
+/src/material-experimental/selection/**            @yifange @jelbourn
 
 # CDK experimental package
 /src/cdk-experimental/*                            @jelbourn

--- a/src/components-examples/BUILD.bazel
+++ b/src/components-examples/BUILD.bazel
@@ -44,6 +44,7 @@ EXAMPLE_PACKAGES = [
     "//src/components-examples/material/badge",
     "//src/components-examples/material/autocomplete",
     "//src/components-examples/material-experimental/popover-edit",
+    "//src/components-examples/material-experimental/selection",
     "//src/components-examples/cdk/tree",
     "//src/components-examples/cdk/text-field",
     "//src/components-examples/cdk/table",

--- a/src/components-examples/material-experimental/selection/BUILD.bazel
+++ b/src/components-examples/material-experimental/selection/BUILD.bazel
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "ng_module")
+
+ng_module(
+    name = "selection",
+    srcs = glob(["**/*.ts"]),
+    assets = glob([
+        "**/*.html",
+        "**/*.css",
+    ]),
+    module_name = "@angular/components-examples/material-experimental/selection",
+    deps = [
+        "//src/cdk/collections",
+        "//src/cdk/table",
+        "//src/material-experimental/selection",
+        "//src/material/checkbox",
+        "@npm//@angular/forms",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob([
+        "**/*.html",
+        "**/*.css",
+        "**/*.ts",
+    ]),
+)

--- a/src/components-examples/material-experimental/selection/index.ts
+++ b/src/components-examples/material-experimental/selection/index.ts
@@ -1,0 +1,34 @@
+import {MatSelectionModule} from '@angular/material-experimental/selection';
+import {MatTableModule} from '@angular/material/table';
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+
+import {MatSelectionColumnExample} from './mat-selection-column/mat-selection-column-example';
+import {MatSelectionListExample} from './mat-selection-list/mat-selection-list-example';
+
+export {
+  MatSelectionListExample,
+  MatSelectionColumnExample,
+};
+
+const EXAMPLES = [
+  MatSelectionListExample,
+  MatSelectionColumnExample,
+];
+
+@NgModule({
+  imports: [
+    MatSelectionModule,
+    MatTableModule,
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatCheckboxModule,
+  ],
+  declarations: EXAMPLES,
+  exports: EXAMPLES,
+})
+export class MatSelectionExamplesModule {
+}

--- a/src/components-examples/material-experimental/selection/mat-selection-column/mat-selection-column-example.css
+++ b/src/components-examples/material-experimental/selection/mat-selection-column/mat-selection-column-example.css
@@ -1,0 +1,3 @@
+.example-table {
+  width: 100%;
+}

--- a/src/components-examples/material-experimental/selection/mat-selection-column/mat-selection-column-example.html
+++ b/src/components-examples/material-experimental/selection/mat-selection-column/mat-selection-column-example.html
@@ -1,0 +1,30 @@
+Selected: {{selected}}
+<table class="example-table" mat-table [dataSource]="dataSource" matSelection [matSelectionMultiple]="true" (matSelectionChange)="selectionChanged($event)">
+    <mat-selection-column name="select"></mat-selection-column>
+    <!-- Position Column -->
+    <ng-container matColumnDef="position">
+      <th mat-header-cell *matHeaderCellDef> No. </th>
+      <td mat-cell *matCellDef="let element"> {{element.position}} </td>
+    </ng-container>
+
+    <!-- Name Column -->
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef> Name </th>
+      <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+    </ng-container>
+
+    <!-- Weight Column -->
+    <ng-container matColumnDef="weight">
+      <th mat-header-cell *matHeaderCellDef> Weight </th>
+      <td mat-cell *matCellDef="let element"> {{element.weight}} </td>
+    </ng-container>
+
+    <!-- Symbol Column -->
+    <ng-container matColumnDef="symbol">
+      <th mat-header-cell *matHeaderCellDef> Symbol </th>
+      <td mat-cell *matCellDef="let element"> {{element.symbol}} </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;" matRowSelection [matRowSelectionValue]="row"></tr>
+</table>

--- a/src/components-examples/material-experimental/selection/mat-selection-column/mat-selection-column-example.ts
+++ b/src/components-examples/material-experimental/selection/mat-selection-column/mat-selection-column-example.ts
@@ -1,0 +1,58 @@
+import {Component, OnDestroy} from '@angular/core';
+import {SelectionChange} from '@angular/material-experimental/selection';
+import {ReplaySubject} from 'rxjs';
+
+/**
+ * @title Table that uses `matSelectionColumn` which allows users to select rows.
+ */
+@Component({
+  selector: 'mat-selection-column-example',
+  templateUrl: 'mat-selection-column-example.html',
+  styleUrls: ['mat-selection-column-example.css'],
+})
+export class MatSelectionColumnExample implements OnDestroy {
+  private readonly _destroyed = new ReplaySubject(1);
+
+  displayedColumns: string[] = ['select', 'position', 'name', 'weight', 'symbol'];
+  dataSource = ELEMENT_DATA;
+  selected: string[] = [];
+
+  ngOnDestroy() {
+    this._destroyed.next();
+    this._destroyed.complete();
+  }
+
+  selectionChanged(event: SelectionChange<PeriodicElement>) {
+    this.selected = event.after.map((select) => select.value.name);
+  }
+}
+
+interface PeriodicElement {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: PeriodicElement[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+  {position: 11, name: 'Sodium', weight: 22.9897, symbol: 'Na'},
+  {position: 12, name: 'Magnesium', weight: 24.305, symbol: 'Mg'},
+  {position: 13, name: 'Aluminum', weight: 26.9815, symbol: 'Al'},
+  {position: 14, name: 'Silicon', weight: 28.0855, symbol: 'Si'},
+  {position: 15, name: 'Phosphorus', weight: 30.9738, symbol: 'P'},
+  {position: 16, name: 'Sulfur', weight: 32.065, symbol: 'S'},
+  {position: 17, name: 'Chlorine', weight: 35.453, symbol: 'Cl'},
+  {position: 18, name: 'Argon', weight: 39.948, symbol: 'Ar'},
+  {position: 19, name: 'Potassium', weight: 39.0983, symbol: 'K'},
+  {position: 20, name: 'Calcium', weight: 40.078, symbol: 'Ca'},
+];

--- a/src/components-examples/material-experimental/selection/mat-selection-list/mat-selection-list-example.html
+++ b/src/components-examples/material-experimental/selection/mat-selection-list/mat-selection-list-example.html
@@ -1,0 +1,45 @@
+<h3><code>native input</code></h3>
+Selected: {{selected1}}
+<ul matSelection [dataSource]="data" [matSelectionMultiple]="true" (matSelectionChange)="selected1 = getCurrentSelected($event)">
+  <input type="checkbox" matSelectAll #allToggler="matSelectAll"
+      [checked]="allToggler.checked | async"
+      [indeterminate]="allToggler.indeterminate | async"
+      (click)="allToggler.toggle($event)">
+  <li *ngFor="let item of data">
+    <input type="checkbox" matSelectionToggle #toggler="matSelectionToggle" [matSelectionToggleValue]="item"
+      [checked]="toggler.checked | async" (click)="toggler.toggle()">
+    {{item}}
+  </li>
+</ul>
+
+<h3><code>mat-checkbox</code></h3>
+Selected: {{selected2}}
+<ul matSelection [dataSource]="data" [matSelectionMultiple]="true" (matSelectionChange)="selected2 = getCurrentSelected($event)">
+  <mat-checkbox matSelectAll #toggle1="matSelectAll" [indeterminate]="toggle1.indeterminate | async"></mat-checkbox>
+  <li *ngFor="let item of data">
+    <mat-checkbox matSelectionToggle [matSelectionToggleValue]="item"></mat-checkbox>
+    {{item}}
+  </li>
+</ul>
+
+<h3><code>Single select with mat-checkbox</code></h3>
+Selected: {{selected3}}
+<ul matSelection [dataSource]="data" [matSelectionMultiple]="false" (matSelectionChange)="selected3 = getCurrentSelected($event)">
+  <li *ngFor="let item of data">
+    <mat-checkbox matSelectionToggle [matSelectionToggleValue]="item"></mat-checkbox>
+    {{item}}
+  </li>
+</ul>
+
+<h3><code>with trackBy</code></h3>
+Selected: {{selected4}}
+<ul matSelection [dataSource]="data" [matSelectionMultiple]="true" [trackBy]="trackByFn" (matSelectionChange)="selected4 = getCurrentSelected($event)">
+  <mat-checkbox matSelectAll #toggle2="matSelectAll" [indeterminate]="toggle2.indeterminate | async"></mat-checkbox>
+  <li *ngFor="let item of data; index as i; trackBy: trackByFn">
+    <mat-checkbox matSelectionToggle [matSelectionToggleValue]="item" [matSelectionToggleIndex]="i"></mat-checkbox>
+    {{item}}
+  </li>
+</ul>
+
+<button (click)="changeElementName()">Change element names and the already selected stays</button>
+<button (click)="reset()">reset</button>

--- a/src/components-examples/material-experimental/selection/mat-selection-list/mat-selection-list-example.ts
+++ b/src/components-examples/material-experimental/selection/mat-selection-list/mat-selection-list-example.ts
@@ -1,0 +1,53 @@
+import {SelectionChange} from '@angular/cdk-experimental/selection';
+import {Component, OnDestroy} from '@angular/core';
+import {ReplaySubject} from 'rxjs';
+
+/**
+ * @title Mat Selection on a simple list.
+ */
+@Component({
+  selector: 'mat-selection-list-example',
+  templateUrl: 'mat-selection-list-example.html',
+})
+export class MatSelectionListExample implements OnDestroy {
+  private readonly _destroyed = new ReplaySubject(1);
+
+  data = ELEMENT_NAMES;
+
+  selected1: string[] = [];
+  selected2: string[] = [];
+  selected3: string[] = [];
+  selected4: string[] = [];
+
+  ngOnDestroy() {
+    this._destroyed.next();
+    this._destroyed.complete();
+  }
+
+  getCurrentSelected(event: SelectionChange<string>) {
+    return event.after.map((select) => select.value);
+  }
+
+  trackByFn(index: number, value: string) {
+    return index;
+  }
+
+  changeElementName() {
+    this.data = ELEMENT_SYMBOLS;
+  }
+
+  reset() {
+    this.data = ELEMENT_NAMES;
+  }
+}
+
+const ELEMENT_NAMES = [
+  'Hydrogen',   'Helium',   'Lithium',  'Beryllium', 'Boron',     'Carbon',   'Nitrogen',
+  'Oxygen',     'Fluorine', 'Neon',     'Sodium',    'Magnesium', 'Aluminum', 'Silicon',
+  'Phosphorus', 'Sulfur',   'Chlorine', 'Argon',     'Potassium', 'Calcium',
+];
+
+const ELEMENT_SYMBOLS = [
+  'H',  'He', 'Li', 'Be', 'B', 'C', 'N',  'O',  'F', 'Ne',
+  'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca'
+];

--- a/src/dev-app/example/example-list.ts
+++ b/src/dev-app/example/example-list.ts
@@ -10,8 +10,6 @@ import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {EXAMPLE_COMPONENTS} from '@angular/components-examples';
 import {Component, Input} from '@angular/core';
 
-console.log(EXAMPLE_COMPONENTS);
-
 /** Displays a set of components-examples in a mat-accordion. */
 @Component({
   selector: 'material-example-list',

--- a/src/dev-app/selection/BUILD.bazel
+++ b/src/dev-app/selection/BUILD.bazel
@@ -7,6 +7,7 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     deps = [
         "//src/components-examples/cdk-experimental/selection",
+        "//src/components-examples/material-experimental/selection",
         "//src/dev-app/example",
         "@npm//@angular/forms",
         "@npm//@angular/router",

--- a/src/dev-app/selection/selection-demo-module.ts
+++ b/src/dev-app/selection/selection-demo-module.ts
@@ -7,6 +7,8 @@
  */
 
 import {CdkSelectionExamplesModule} from '@angular/components-examples/cdk-experimental/selection';
+import {MatSelectionExamplesModule} from
+'@angular/components-examples/material-experimental/selection';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
@@ -16,6 +18,7 @@ import {SelectionDemo} from './selection-demo';
 @NgModule({
   imports: [
     CdkSelectionExamplesModule,
+    MatSelectionExamplesModule,
     FormsModule,
     RouterModule.forChild([{path: '', component: SelectionDemo}]),
   ],

--- a/src/dev-app/selection/selection-demo.ts
+++ b/src/dev-app/selection/selection-demo.ts
@@ -15,6 +15,12 @@ import {Component} from '@angular/core';
 
     <h3>CDK selection column and CDK row selection with CDK table</h3>
     <cdk-selection-column-example></cdk-selection-column-example>
+
+    <h3>Mat selection with a list</h3>
+    <mat-selection-list-example></mat-selection-list-example>
+
+    <h3>Mat selection column and Mat row selection with Mat table</h3>
+    <mat-selection-column-example></mat-selection-column-example>
   `,
 })
 export class SelectionDemo {

--- a/src/material-experimental/config.bzl
+++ b/src/material-experimental/config.bzl
@@ -27,6 +27,7 @@ entryPoints = [
     "mdc-table",
     "mdc-tabs",
     "popover-edit",
+    "selection",
 ]
 
 # List of all non-testing entry-points of the Angular material-experimental package.

--- a/src/material-experimental/selection/BUILD.bazel
+++ b/src/material-experimental/selection/BUILD.bazel
@@ -1,0 +1,35 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "ng_module", "sass_binary", "sass_library")
+
+ng_module(
+    name = "selection",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    assets = [":selection_column_scss"],
+    module_name = "@angular/material-experimental/selection",
+    deps = [
+        "//src/cdk-experimental/selection",
+        "//src/material/checkbox",
+        "//src/material/table",
+        "@npm//@angular/core",
+    ],
+)
+
+sass_library(
+    name = "selection_scss_lib",
+    srcs = glob(["**/_*.scss"]),
+    deps = [],
+)
+
+sass_binary(
+    name = "selection_column_scss",
+    src = "selection-column.scss",
+    include_paths = [
+        "external/npm/node_modules",
+    ],
+    deps = [
+    ],
+)

--- a/src/material-experimental/selection/_selection.scss
+++ b/src/material-experimental/selection/_selection.scss
@@ -1,0 +1,3 @@
+@mixin mat-selection-theme($theme) {}
+
+@mixin mat-selection-typography($config) {}

--- a/src/material-experimental/selection/index.ts
+++ b/src/material-experimental/selection/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';
+

--- a/src/material-experimental/selection/public-api.ts
+++ b/src/material-experimental/selection/public-api.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './selection';
+export * from './select-all';
+export * from './selection-toggle';
+export * from './selection-column';
+export * from './row-selection';
+export * from './selection-module';

--- a/src/material-experimental/selection/row-selection.ts
+++ b/src/material-experimental/selection/row-selection.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CdkRowSelection} from '@angular/cdk-experimental/selection';
+import {Input, Directive} from '@angular/core';
+
+
+/**
+ * Applies `mat-selected` class and `aria-selected` to an element.
+ *
+ * Must be used within a parent `MatSelection` directive.
+ * Must be provided with the value. The index is required if `trackBy` is used on the `CdkSelection`
+ * directive.
+ */
+@Directive({
+  selector: '[matRowSelection]',
+  host: {
+    '[class.mat-selected]': '_selection.isSelected(this.value, this.index)',
+    '[attr.aria-selected]': '_selection.isSelected(this.value, this.index)',
+  },
+  providers: [{provide: CdkRowSelection, useExisting: MatRowSelection}]
+})
+export class MatRowSelection<T> extends CdkRowSelection<T> {
+  /** The value that is associated with the row */
+  @Input('matRowSelectionValue') value: T;
+
+  /** The index of the value in the list. Required when used with `trackBy` */
+  @Input('matRowSelectionIndex') index: number|undefined;
+}

--- a/src/material-experimental/selection/select-all.ts
+++ b/src/material-experimental/selection/select-all.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CdkSelectAll} from '@angular/cdk-experimental/selection';
+import {Directive} from '@angular/core';
+
+
+/**
+ * Makes the element a select-all toggle.
+ *
+ * Must be used within a parent `MatSelection` directive. It toggles the selection states
+ * of all the selection toggles connected with the `MatSelection` directive.
+ * If the element implements `ControlValueAccessor`, e.g. `MatCheckbox`, the directive
+ * automatically connects it with the select-all state provided by the `MatSelection` directive. If
+ * not, use `checked` to get the checked state, `indeterminate` to get the indeterminate state,
+ * and `toggle()` to change the selection state.
+ */
+@Directive({
+  selector: '[matSelectAll]',
+  exportAs: 'matSelectAll',
+  providers: [{provide: CdkSelectAll, useExisting: MatSelectAll}]
+})
+export class MatSelectAll<T> extends CdkSelectAll<T> {
+}

--- a/src/material-experimental/selection/selection-column.scss
+++ b/src/material-experimental/selection/selection-column.scss
@@ -1,0 +1,5 @@
+th.mat-selection-column-header,
+td.mat-selection-column-cell {
+  text-align: center;
+  width: 48px;
+}

--- a/src/material-experimental/selection/selection-column.ts
+++ b/src/material-experimental/selection/selection-column.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MatCellDef, MatColumnDef, MatHeaderCellDef, MatTable} from '@angular/material/table';
+import {
+  Component,
+  Input,
+  isDevMode,
+  OnDestroy,
+  OnInit,
+  Optional,
+  ViewChild,
+  ChangeDetectionStrategy,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import {MatSelection} from './selection';
+
+/**
+ * Column that adds row selecting checkboxes and a select-all checkbox if `matSelectionMultiple` is
+ * `true`.
+ *
+ * Must be used within a parent `MatSelection` directive.
+ */
+@Component({
+  selector: 'mat-selection-column',
+  template: `
+    <ng-container matColumnDef>
+      <th mat-header-cell *matHeaderCellDef class="mat-selection-column-header">
+        <mat-checkbox *ngIf="selection.multiple"
+            matSelectAll
+            #allToggler="matSelectAll"
+            [indeterminate]="allToggler.indeterminate | async"></mat-checkbox>
+      </th>
+      <td mat-cell *matCellDef="let row; let i = $index" class="mat-selection-column-cell">
+        <mat-checkbox
+            matSelectionToggle
+            [matSelectionToggleValue]="row"
+            [matSelectionToggleIndex]="i"></mat-checkbox>
+      </td>
+    </ng-container>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styleUrls: ['selection-column.css'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class MatSelectionColumn<T> implements OnInit, OnDestroy {
+  /** Column name that should be used to reference this column. */
+  @Input()
+  get name(): string {
+    return this._name;
+  }
+  set name(name: string) {
+    this._name = name;
+
+    this._syncColumnDefName();
+  }
+  private _name: string;
+
+  @ViewChild(MatColumnDef, {static: true}) private readonly _columnDef: MatColumnDef;
+  @ViewChild(MatCellDef, {static: true}) private readonly _cell: MatCellDef;
+  @ViewChild(MatHeaderCellDef, {static: true}) private readonly _headerCell: MatHeaderCellDef;
+
+  constructor(
+      @Optional() private _table: MatTable<T>,
+      @Optional() readonly selection: MatSelection<T>,
+  ) {}
+
+  ngOnInit() {
+    if (!this.selection && isDevMode()) {
+      throw Error('MatSelectionColumn: missing MatSelection in the parent');
+    }
+
+    this._syncColumnDefName();
+
+    if (this._table) {
+      this._columnDef.cell = this._cell;
+      this._columnDef.headerCell = this._headerCell;
+      this._table.addColumnDef(this._columnDef);
+    } else if (isDevMode()) {
+      throw Error('MatSelectionColumn: missing parent table');
+    }
+  }
+
+  ngOnDestroy() {
+    if (this._table) {
+      this._table.removeColumnDef(this._columnDef);
+    }
+  }
+
+  private _syncColumnDefName() {
+    if (this._columnDef) {
+      this._columnDef.name = this._name;
+    }
+  }
+}

--- a/src/material-experimental/selection/selection-module.ts
+++ b/src/material-experimental/selection/selection-module.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// TODO(yifange): Move the table-specific code to a separate module from the other selection
+// behaviors once we move it out of experiemental.
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatTableModule} from '@angular/material/table';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatSelectAll} from './select-all';
+import {MatSelection} from './selection';
+import {MatSelectionToggle} from './selection-toggle';
+import {MatSelectionColumn} from './selection-column';
+import {MatRowSelection} from './row-selection';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatCheckboxModule,
+  ],
+  exports: [
+    MatSelectAll,
+    MatSelection,
+    MatSelectionToggle,
+    MatSelectionColumn,
+    MatRowSelection,
+  ],
+  declarations: [
+    MatSelectAll,
+    MatSelection,
+    MatSelectionToggle,
+    MatSelectionColumn,
+    MatRowSelection,
+  ],
+})
+export class MatSelectionModule {
+}

--- a/src/material-experimental/selection/selection-toggle.ts
+++ b/src/material-experimental/selection/selection-toggle.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CdkSelectionToggle} from '@angular/cdk-experimental/selection';
+import {Directive, Input} from '@angular/core';
+
+/**
+ * Makes the element a selection toggle.
+ *
+ * Must be used within a parent `MatSelection` directive.
+ * Must be provided with the value. If `trackBy` is used on `MatSelection`, the index of the value
+ * is required. If the element implements `ControlValueAccessor`, e.g. `MatCheckbox`, the directive
+ * automatically connects it with the selection state provided by the `MatSelection` directive. If
+ * not, use `checked$` to get the checked state of the value, and `toggle()` to change the selection
+ * state.
+ */
+@Directive({
+  selector: '[matSelectionToggle]',
+  exportAs: 'matSelectionToggle',
+  providers: [{provide: CdkSelectionToggle, useExisting: MatSelectionToggle}]
+})
+export class MatSelectionToggle<T> extends CdkSelectionToggle<T> {
+  /** The value that is associated with the toggle */
+  @Input('matSelectionToggleValue') value: T;
+
+  /** The index of the value in the list. Required when used with `trackBy` */
+  @Input('matSelectionToggleIndex') index: number|undefined;
+}

--- a/src/material-experimental/selection/selection.ts
+++ b/src/material-experimental/selection/selection.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CdkSelection, SelectionChange} from '@angular/cdk-experimental/selection';
+import {Directive, Input, Output, EventEmitter} from '@angular/core';
+
+
+/**
+ * Manages the selection states of the items and provides methods to check and update the selection
+ * states.
+ * It must be applied to the parent element if `matSelectionToggle`, `matSelectAll`,
+ * `matRowSelection` and `matSelectionColumn` are applied.
+ */
+@Directive({
+  selector: '[matSelection]',
+  exportAs: 'matSelection',
+  providers: [{provide: CdkSelection, useExisting: MatSelection}]
+})
+export class MatSelection<T> extends CdkSelection<T> {
+  /** Whether to support multiple selection */
+  @Input('matSelectionMultiple') multiple: boolean;
+
+  /** Emits when selection changes. */
+  @Output('matSelectionChange') change = new EventEmitter<SelectionChange<T>>();
+}
+
+/**
+ * Represents the change in the selection set.
+ */
+export {SelectionChange} from '@angular/cdk-experimental/selection';


### PR DESCRIPTION
Add Material directives and components that make adding selection state to a list of items easier.

* `MatSelection`: "mat-" alias of `CdkSelection`
* `MatSelectionToggle`: "mat-" alias of `CdkSelectionToggle`
* `MatSelectAll`: "mat-" alias of `CdkSelectAll`
* `MatRowSelection`: "mat-" alias of `CdkRowSelection`
* `MatSelectionColumn`: Similar to `CdkSelectionColumn`.  Use `<mat-checkbox>` instead of native `<input>`.

Issue #18581