### PR TITLE
fix(clipboard): not restoring focus to SVG elements

### DIFF
--- a/src/cdk/clipboard/clipboard.spec.ts
+++ b/src/cdk/clipboard/clipboard.spec.ts
@@ -68,6 +68,21 @@ describe('Clipboard', () => {
       expect(document.activeElement).toBe(focusedInput);
     });
 
+    it('does not move focus away from focused SVG element', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('focusable', 'true');
+      svg.setAttribute('tabindex', '0');
+      document.body.appendChild(svg);
+
+      svg.focus();
+      expect(document.activeElement).toBe(svg);
+
+      clipboard.copy(COPY_CONTENT);
+      expect(document.activeElement).toBe(svg);
+
+      svg.parentNode!.removeChild(svg);
+    });
+
     describe('when execCommand fails', () => {
       beforeEach(() => {
         execCommand.and.throwError('could not copy');

--- a/src/cdk/clipboard/pending-copy.ts
+++ b/src/cdk/clipboard/pending-copy.ts
@@ -43,13 +43,13 @@ export class PendingCopy {
 
     try {  // Older browsers could throw if copy is not supported.
       if (textarea) {
-        const currentFocus = this._document.activeElement;
+        const currentFocus = this._document.activeElement as HTMLOrSVGElement | null;
 
         textarea.select();
         textarea.setSelectionRange(0, textarea.value.length);
         successful = this._document.execCommand('copy');
 
-        if (currentFocus && currentFocus instanceof HTMLElement) {
+        if (currentFocus) {
           currentFocus.focus();
         }
       }


### PR DESCRIPTION
When the clipboard is copying something, focus is temporarily moved to a `textarea` and moved back. The logic that moves it checks whether the previous element was an `HTMLElement`, but that doesn't cover returning focus to an SVG element.