### PR TITLE
refactor: remove remaining usages of PortalInjector

### DIFF
--- a/src/cdk-experimental/column-resize/resizable.ts
+++ b/src/cdk-experimental/column-resize/resizable.ts
@@ -16,7 +16,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
-import {ComponentPortal, PortalInjector} from '@angular/cdk/portal';
+import {ComponentPortal} from '@angular/cdk/portal';
 import {Overlay, OverlayRef} from '@angular/cdk/overlay';
 import {CdkColumnDef} from '@angular/cdk/table';
 import {merge, ReplaySubject} from 'rxjs';
@@ -204,10 +204,14 @@ export abstract class Resizable<HandleComponent extends ResizeOverlayHandle>
   }
 
   private _createHandlePortal(): ComponentPortal<HandleComponent> {
-    const injector = new PortalInjector(this.injector, new WeakMap([[
-      ResizeRef,
-      new ResizeRef(this.elementRef, this.overlayRef!, this.minWidthPx, this.maxWidthPx),
-    ]]));
+    const injector = Injector.create({
+      parent: this.injector,
+      providers: [{
+        provide: ResizeRef,
+        useValue: new ResizeRef(this.elementRef, this.overlayRef!, this.minWidthPx, this.maxWidthPx)
+      }]
+    });
+
     return new ComponentPortal(this.getOverlayHandleComponentType(),
         this.viewContainerRef, injector);
   }

--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -15,9 +15,10 @@ import {
   Inject,
   ComponentRef,
   OnDestroy,
-  Type
+  Type,
+  StaticProvider
 } from '@angular/core';
-import {ComponentPortal, PortalInjector, TemplatePortal} from '@angular/cdk/portal';
+import {ComponentPortal, TemplatePortal} from '@angular/cdk/portal';
 import {of as observableOf, Observable, Subject, defer} from 'rxjs';
 import {DialogRef} from './dialog-ref';
 import {Location} from '@angular/common';
@@ -198,9 +199,10 @@ export class Dialog implements OnDestroy {
   protected _attachDialogContainer(overlay: OverlayRef, config: DialogConfig): CdkDialogContainer {
     const container = config.containerComponent || this._injector.get(DIALOG_CONTAINER);
     const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
-    const injector = new PortalInjector(userInjector || this._injector, new WeakMap([
-      [DialogConfig, config]
-    ]));
+    const injector = Injector.create({
+      parent: userInjector || this._injector,
+      providers: [{provide: DialogConfig, useValue: config}]
+    });
     const containerPortal = new ComponentPortal(container, config.viewContainerRef, injector);
     const containerRef: ComponentRef<CdkDialogContainer> = overlay.attach(containerPortal);
     containerRef.instance._config = config;
@@ -280,24 +282,24 @@ export class Dialog implements OnDestroy {
   private _createInjector<T>(
       config: DialogConfig,
       dialogRef: DialogRef<T>,
-      dialogContainer: CdkDialogContainer): PortalInjector {
+      dialogContainer: CdkDialogContainer): Injector {
 
     const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
-    const injectionTokens = new WeakMap<any, any>([
-      [this._injector.get(DIALOG_REF), dialogRef],
-      [this._injector.get(DIALOG_CONTAINER), dialogContainer],
-      [DIALOG_DATA, config.data]
-    ]);
+    const providers: StaticProvider[] = [
+      {provide: this._injector.get(DIALOG_REF), useValue: dialogRef},
+      {provide: this._injector.get(DIALOG_CONTAINER), useValue: dialogContainer},
+      {provide: DIALOG_DATA, useValue: config.data}
+    ];
 
     if (config.direction &&
         (!userInjector || !userInjector.get<Directionality | null>(Directionality, null))) {
-      injectionTokens.set(Directionality, {
-        value: config.direction,
-        change: observableOf()
+      providers.push({
+        provide: Directionality,
+        useValue: {value: config.direction, change: observableOf()}
       });
     }
 
-    return new PortalInjector(userInjector || this._injector, injectionTokens);
+    return Injector.create({parent: userInjector || this._injector, providers});
   }
 
   /**

--- a/src/cdk/portal/portal-injector.ts
+++ b/src/cdk/portal/portal-injector.ts
@@ -12,6 +12,8 @@ import {Injector} from '@angular/core';
  * Custom injector to be used when providing custom
  * injection tokens to components inside a portal.
  * @docs-private
+ * @deprecated Use `Injector.create` instead.
+ * @breaking-change 11.0.0
  */
 export class PortalInjector implements Injector {
   constructor(

--- a/src/material/bottom-sheet/bottom-sheet.ts
+++ b/src/material/bottom-sheet/bottom-sheet.ts
@@ -8,7 +8,7 @@
 
 import {Directionality} from '@angular/cdk/bidi';
 import {Overlay, OverlayConfig, OverlayRef} from '@angular/cdk/overlay';
-import {ComponentPortal, ComponentType, PortalInjector, TemplatePortal} from '@angular/cdk/portal';
+import {ComponentPortal, ComponentType, TemplatePortal} from '@angular/cdk/portal';
 import {
   ComponentRef,
   Injectable,
@@ -19,6 +19,7 @@ import {
   InjectionToken,
   Inject,
   OnDestroy,
+  StaticProvider,
 } from '@angular/core';
 import {Location} from '@angular/common';
 import {of as observableOf} from 'rxjs';
@@ -132,9 +133,10 @@ export class MatBottomSheet implements OnDestroy {
                            config: MatBottomSheetConfig): MatBottomSheetContainer {
 
     const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
-    const injector = new PortalInjector(userInjector || this._injector, new WeakMap([
-      [MatBottomSheetConfig, config]
-    ]));
+    const injector = Injector.create({
+      parent: userInjector || this._injector,
+      providers: [{provide: MatBottomSheetConfig, useValue: config}]
+    });
 
     const containerPortal =
         new ComponentPortal(MatBottomSheetContainer, config.viewContainerRef, injector);
@@ -169,23 +171,23 @@ export class MatBottomSheet implements OnDestroy {
    * @param bottomSheetRef Reference to the bottom sheet.
    */
   private _createInjector<T>(config: MatBottomSheetConfig,
-                             bottomSheetRef: MatBottomSheetRef<T>): PortalInjector {
+                             bottomSheetRef: MatBottomSheetRef<T>): Injector {
 
     const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
-    const injectionTokens = new WeakMap<any, any>([
-      [MatBottomSheetRef, bottomSheetRef],
-      [MAT_BOTTOM_SHEET_DATA, config.data]
-    ]);
+    const providers: StaticProvider[] = [
+      {provide: MatBottomSheetRef, useValue: bottomSheetRef},
+      {provide: MAT_BOTTOM_SHEET_DATA, useValue: config.data}
+    ];
 
     if (config.direction &&
         (!userInjector || !userInjector.get<Directionality | null>(Directionality, null))) {
-      injectionTokens.set(Directionality, {
-        value: config.direction,
-        change: observableOf()
+      providers.push({
+        provide: Directionality,
+        useValue: {value: config.direction, change: observableOf()}
       });
     }
 
-    return new PortalInjector(userInjector || this._injector, injectionTokens);
+    return Injector.create({parent: userInjector || this._injector, providers});
   }
 }
 

--- a/src/material/snack-bar/snack-bar.ts
+++ b/src/material/snack-bar/snack-bar.ts
@@ -9,7 +9,7 @@
 import {LiveAnnouncer} from '@angular/cdk/a11y';
 import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
 import {Overlay, OverlayConfig, OverlayRef} from '@angular/cdk/overlay';
-import {ComponentPortal, ComponentType, PortalInjector, TemplatePortal} from '@angular/cdk/portal';
+import {ComponentPortal, ComponentType, TemplatePortal} from '@angular/cdk/portal';
 import {
   ComponentRef,
   EmbeddedViewRef,
@@ -144,9 +144,10 @@ export class MatSnackBar implements OnDestroy {
                                    config: MatSnackBarConfig): MatSnackBarContainer {
 
     const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
-    const injector = new PortalInjector(userInjector || this._injector, new WeakMap([
-      [MatSnackBarConfig, config]
-    ]));
+    const injector = Injector.create({
+      parent: userInjector || this._injector,
+      providers: [{provide: MatSnackBarConfig, useValue: config}]
+    });
 
     const containerPortal =
         new ComponentPortal(MatSnackBarContainer, config.viewContainerRef, injector);
@@ -273,15 +274,15 @@ export class MatSnackBar implements OnDestroy {
    * @param config Config that was used to create the snack bar.
    * @param snackBarRef Reference to the snack bar.
    */
-  private _createInjector<T>(
-      config: MatSnackBarConfig,
-      snackBarRef: MatSnackBarRef<T>): PortalInjector {
-
+  private _createInjector<T>(config: MatSnackBarConfig, snackBarRef: MatSnackBarRef<T>): Injector {
     const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
 
-    return new PortalInjector(userInjector || this._injector, new WeakMap<any, any>([
-      [MatSnackBarRef, snackBarRef],
-      [MAT_SNACK_BAR_DATA, config.data]
-    ]));
+    return Injector.create({
+      parent: userInjector || this._injector,
+      providers: [
+        {provide: MatSnackBarRef, useValue: snackBarRef},
+        {provide: MAT_SNACK_BAR_DATA, useValue: config.data}
+      ]
+    });
   }
 }


### PR DESCRIPTION
Removes all of the remaining usages of the `PortalInjector` and marks it as deprecated.