### PR TITLE
fix(material-experimental/mdc-chips): enter animation not disabled when using noop animations

### DIFF
--- a/src/material-experimental/mdc-chips/chips.scss
+++ b/src/material-experimental/mdc-chips/chips.scss
@@ -16,6 +16,9 @@
     // were disabled via the `NoopAnimationsModule`, the element won't have a transition and
     // `transitionend` won't fire. We work around the issue by assigning a very short transition.
     transition-duration: 1ms;
+
+    // Disables the chip enter animation.
+    animation: none;
   }
 
   @include cdk-high-contrast(active, off) {


### PR DESCRIPTION
Fixes the MDC chips not disabling the chip enter animation when using the `NoopAnimationsModule`.

Fixes #18642.