### PR TITLE
fix(datepicker): add gap between range rows and handle rtl

### DIFF
--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -14,6 +14,8 @@ $mat-calendar-body-cell-radius: 999px !default;
 $mat-calendar-body-min-size: 7 * $mat-calendar-body-cell-min-size !default;
 $mat-calendar-body-cell-content-size: 100% - $mat-calendar-body-cell-content-margin * 2 !default;
 
+$mat-calendar-range-end-body-cell-size:
+    $mat-calendar-body-cell-content-size + $mat-calendar-body-cell-content-margin !default;
 
 .mat-calendar-body {
   min-width: $mat-calendar-body-min-size;
@@ -43,10 +45,44 @@ $mat-calendar-body-cell-content-size: 100% - $mat-calendar-body-cell-content-mar
   &::before {
     content: '';
     position: absolute;
-    top: 0;
-    bottom: 0;
+    top: $mat-calendar-body-cell-content-margin;
     left: 0;
-    right: 0;
+
+    // We want the range background to be slightly shorter than the cell so
+    // that there's a gap when the range goes across multiple rows.
+    height: $mat-calendar-body-cell-content-size;
+    width: 100%;
+  }
+}
+
+.mat-calendar-body-range-start::before {
+  // Since the range background isn't a perfect circle, we need to size
+  // and offset the start so that it aligns with the main circle.
+  left: $mat-calendar-body-cell-content-margin;
+  width: $mat-calendar-range-end-body-cell-size;
+  border-top-left-radius: $mat-calendar-body-cell-radius;
+  border-bottom-left-radius: $mat-calendar-body-cell-radius;
+
+  [dir='rtl'] & {
+    left: 0;
+    border-radius: 0;
+    border-top-right-radius: $mat-calendar-body-cell-radius;
+    border-bottom-right-radius: $mat-calendar-body-cell-radius;
+  }
+}
+
+.mat-calendar-body-range-end::before {
+  // Since the range background isn't a perfect circle, we need to
+  // resize the end so that it aligns with the main circle.
+  width: $mat-calendar-range-end-body-cell-size;
+  border-top-right-radius: $mat-calendar-body-cell-radius;
+  border-bottom-right-radius: $mat-calendar-body-cell-radius;
+
+  [dir='rtl'] & {
+    left: $mat-calendar-body-cell-content-margin;
+    border-radius: 0;
+    border-top-left-radius: $mat-calendar-body-cell-radius;
+    border-bottom-left-radius: $mat-calendar-body-cell-radius;
   }
 }
 
@@ -79,16 +115,6 @@ $mat-calendar-body-cell-content-size: 100% - $mat-calendar-body-cell-content-mar
   @include cdk-high-contrast(active, off) {
     border: none;
   }
-}
-
-.mat-calendar-body-range-start::before {
-  border-top-left-radius: $mat-calendar-body-cell-radius;
-  border-bottom-left-radius: $mat-calendar-body-cell-radius;
-}
-
-.mat-calendar-body-range-end::before {
-  border-top-right-radius: $mat-calendar-body-cell-radius;
-  border-bottom-right-radius: $mat-calendar-body-cell-radius;
 }
 
 @include cdk-high-contrast(active, off) {

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -213,7 +213,8 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
 
     if (cell) {
       this._ngZone.run(() => {
-        this._hoveredValue = cell.enabled ? cell.compareValue : -1;
+        this._hoveredValue =
+            cell.enabled && cell.compareValue !== this.startValue ? cell.compareValue : -1;
         this._changeDetectorRef.markForCheck();
       });
     }


### PR DESCRIPTION
* Makes the range background shorter so that there's a gap when a range spans across multiple rows. This makes it easier to see what's going on.
* Fixes the range styles not accounting for RTL layouts.

Before/After for reference:
![before](https://user-images.githubusercontent.com/4450522/75610054-3f6d0300-5b0e-11ea-903c-69bb04fc987b.png)
![after](https://user-images.githubusercontent.com/4450522/75610058-41cf5d00-5b0e-11ea-8abb-3ca629306bf0.png)
