### PR TITLE
feat(material/chips): add focusLastChipOnBackspace to MatChipList

### DIFF
--- a/src/material/chips/chip-default-options.ts
+++ b/src/material/chips/chip-default-options.ts
@@ -6,14 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ENTER} from '@angular/cdk/keycodes';
 import {InjectionToken} from '@angular/core';
 
 /** Default options, for the chips module, that can be overridden. */
 export interface MatChipsDefaultOptions {
   /** The list of key codes that will trigger a chipEnd event. */
-  separatorKeyCodes: number[] | Set<number>;
+  separatorKeyCodes?: number[] | Set<number>;
+
+  /** Whether to focus the last chip if BACKSPACE is pressed when the input is empty. */
+  focusLastChipOnBackspace?: boolean;
 }
+
+export const DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS: Required<MatChipsDefaultOptions> = {
+  separatorKeyCodes: [ENTER],
+  focusLastChipOnBackspace: true,
+};
 
 /** Injection token to be used to override the default options for the chips module. */
 export const MAT_CHIPS_DEFAULT_OPTIONS =
-    new InjectionToken<MatChipsDefaultOptions>('mat-chips-default-options');
+  new InjectionToken<MatChipsDefaultOptions>('mat-chips-default-options');

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -9,7 +9,11 @@
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Directive, ElementRef, EventEmitter, Inject, Input, OnChanges, Output} from '@angular/core';
 import {hasModifierKey, TAB} from '@angular/cdk/keycodes';
-import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
+import {
+  MAT_CHIPS_DEFAULT_OPTIONS,
+  MatChipsDefaultOptions,
+  DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS,
+} from './chip-default-options';
 import {MatChipList} from './chip-list';
 import {MatChipTextControl} from './chip-text-control';
 
@@ -74,7 +78,7 @@ export class MatChipInput implements MatChipTextControl, OnChanges {
    * Defaults to `[ENTER]`.
    */
   @Input('matChipInputSeparatorKeyCodes')
-  separatorKeyCodes: number[] | Set<number> = this._defaultOptions.separatorKeyCodes;
+  separatorKeyCodes: number[] | Set<number>;
 
   /** Emitted when a chip is to be added. */
   @Output('matChipInputTokenEnd')
@@ -100,8 +104,10 @@ export class MatChipInput implements MatChipTextControl, OnChanges {
 
   constructor(
     protected _elementRef: ElementRef<HTMLInputElement>,
-    @Inject(MAT_CHIPS_DEFAULT_OPTIONS) private _defaultOptions: MatChipsDefaultOptions) {
+    @Inject(MAT_CHIPS_DEFAULT_OPTIONS) _defaultOptions: MatChipsDefaultOptions) {
     this._inputElement = this._elementRef.nativeElement as HTMLInputElement;
+    this.separatorKeyCodes =
+      _defaultOptions.separatorKeyCodes || DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS.separatorKeyCodes;
   }
 
   ngOnChanges() {

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -602,14 +602,13 @@ describe('MatChipList', () => {
           expect(manager.activeItemIndex).toEqual(-1);
         });
 
-        it('should initialize focusLastChipOnBackspace from the MatChipDefaultOptions', () => {
+        it('should initialize focusLastChipOnBackspace from MatChipDefaultOptions', () => {
           fixture.destroy();
 
           TestBed.resetTestingModule();
           fixture = createComponent(FormFieldChipList, [{
             provide: MAT_CHIPS_DEFAULT_OPTIONS,
             useValue: {
-              ...DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS,
               focusLastChipOnBackspace: false,
             } as MatChipsDefaultOptions,
           }]);

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -49,11 +49,7 @@ import {MatInputModule} from '../input/index';
 import {MatChip} from './chip';
 import {MatChipInputEvent} from './chip-input';
 import {MatChipEvent, MatChipList, MatChipRemove, MatChipsModule} from './index';
-import {
-  DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS,
-  MAT_CHIPS_DEFAULT_OPTIONS,
-  MatChipsDefaultOptions,
-} from './chip-default-options';
+import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
 
 describe('MatChipList', () => {
   let fixture: ComponentFixture<any>;

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -605,6 +605,7 @@ describe('MatChipList', () => {
         it('should initialize focusLastChipOnBackspace from the MatChipDefaultOptions', () => {
           fixture.destroy();
 
+          TestBed.resetTestingModule();
           fixture = createComponent(FormFieldChipList, [{
             provide: MAT_CHIPS_DEFAULT_OPTIONS,
             useValue: {

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -49,7 +49,11 @@ import {MatInputModule} from '../input/index';
 import {MatChip} from './chip';
 import {MatChipInputEvent} from './chip-input';
 import {MatChipEvent, MatChipList, MatChipRemove, MatChipsModule} from './index';
-
+import {
+  DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS,
+  MAT_CHIPS_DEFAULT_OPTIONS,
+  MatChipsDefaultOptions,
+} from './chip-default-options';
 
 describe('MatChipList', () => {
   let fixture: ComponentFixture<any>;
@@ -598,6 +602,24 @@ describe('MatChipList', () => {
           expect(manager.activeItemIndex).toEqual(-1);
         });
 
+        it('should initialize focusLastChipOnBackspace from the MatChipDefaultOptions', () => {
+          fixture.destroy();
+
+          fixture = createComponent(FormFieldChipList, [{
+            provide: MAT_CHIPS_DEFAULT_OPTIONS,
+            useValue: {
+              ...DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS,
+              focusLastChipOnBackspace: false,
+            } as MatChipsDefaultOptions,
+          }]);
+          fixture.detectChanges();
+
+          chipListDebugElement = fixture.debugElement.query(By.directive(MatChipList))!;
+          chipListNativeElement = chipListDebugElement.nativeElement;
+          chipListInstance = chipListDebugElement.componentInstance;
+
+          expect(chipListInstance.focusLastChipOnBackspace).toBeFalse();
+        });
       });
     });
 

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -544,7 +544,7 @@ describe('MatChipList', () => {
 
       describe('when the input has focus', () => {
 
-        it('should not focus the last chip when press DELETE', () => {
+        it('should not focus the last chip when pressing DELETE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
           let DELETE_EVENT: KeyboardEvent =
               createKeyboardEvent('keydown', DELETE, nativeInput);
@@ -561,7 +561,7 @@ describe('MatChipList', () => {
           expect(manager.activeItemIndex).toEqual(-1);
         });
 
-        it('should focus the last chip when press BACKSPACE', () => {
+        it('should focus the last chip when pressing BACKSPACE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
           let BACKSPACE_EVENT: KeyboardEvent =
               createKeyboardEvent('keydown', BACKSPACE, undefined, nativeInput);
@@ -576,6 +576,26 @@ describe('MatChipList', () => {
 
           // It focuses the last chip
           expect(manager.activeItemIndex).toEqual(chips.length - 1);
+        });
+
+        it('should not focus the last chip when pressing BACKSPACE and' +
+          ' focusLastChipOnBackspace=false', () => {
+          let nativeInput = fixture.nativeElement.querySelector('input');
+          let BACKSPACE_EVENT: KeyboardEvent =
+            createKeyboardEvent('keydown', BACKSPACE, undefined, nativeInput);
+
+          chipListInstance.focusLastChipOnBackspace = false;
+
+          // Focus the input
+          nativeInput.focus();
+          expect(manager.activeItemIndex).toBe(-1);
+
+          // Press the BACKSPACE key
+          chipListInstance._keydown(BACKSPACE_EVENT);
+          fixture.detectChanges();
+
+          // It does not focus the last chip
+          expect(manager.activeItemIndex).toEqual(-1);
         });
 
       });

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -20,6 +20,7 @@ import {
   DoCheck,
   ElementRef,
   EventEmitter,
+  Inject,
   Input,
   OnDestroy,
   OnInit,
@@ -40,6 +41,11 @@ import {MatFormFieldControl} from '@angular/material/form-field';
 import {merge, Observable, Subject, Subscription} from 'rxjs';
 import {startWith, takeUntil} from 'rxjs/operators';
 import {MatChip, MatChipEvent, MatChipSelectionChange} from './chip';
+import {
+  MatChipsDefaultOptions,
+  MAT_CHIPS_DEFAULT_OPTIONS,
+  DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS,
+} from './chip-default-options';
 import {MatChipTextControl} from './chip-text-control';
 
 
@@ -52,9 +58,9 @@ class MatChipListBase {
               /** @docs-private */
               public ngControl: NgControl) {}
 }
-const _MatChipListMixinBase: CanUpdateErrorStateCtor & typeof MatChipListBase =
-    mixinErrorState(MatChipListBase);
 
+const _MatChipListMixinBase: CanUpdateErrorStateCtor & typeof MatChipListBase =
+  mixinErrorState(MatChipListBase);
 
 // Increasing integer for generating unique ids for chip-list components.
 let nextUniqueId = 0;
@@ -67,7 +73,6 @@ export class MatChipListChange {
     /** Value of the chip list when the event was emitted. */
     public value: any) { }
 }
-
 
 /**
  * A material design chips component (named ChipList for its similarity to the List component).
@@ -317,7 +322,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
 
   /** Event emitted when the selected chip list value has been changed by the user. */
   @Output() readonly change: EventEmitter<MatChipListChange> =
-      new EventEmitter<MatChipListChange>();
+    new EventEmitter<MatChipListChange>();
 
   /**
    * Event that emits whenever the raw value of the chip-list changes. This is here primarily
@@ -333,24 +338,30 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     descendants: true
   }) chips: QueryList<MatChip>;
 
-  /**
-   * Whether the last chip should be focused when the user
-   * presses BACKSPACE when the input is empty.
-   */
-  @Input() focusLastChipOnBackspace: boolean = true;
+  /** Whether to focus the last chip if BACKSPACE is pressed when the input is empty. */
+  @Input() focusLastChipOnBackspace: boolean;
 
-  constructor(protected _elementRef: ElementRef<HTMLElement>,
-              private _changeDetectorRef: ChangeDetectorRef,
-              @Optional() private _dir: Directionality,
-              @Optional() _parentForm: NgForm,
-              @Optional() _parentFormGroup: FormGroupDirective,
-              _defaultErrorStateMatcher: ErrorStateMatcher,
-              /** @docs-private */
-              @Optional() @Self() public ngControl: NgControl) {
+  constructor(
+    protected _elementRef: ElementRef<HTMLElement>,
+    private _changeDetectorRef: ChangeDetectorRef,
+    @Optional() private _dir: Directionality,
+    @Optional() _parentForm: NgForm,
+    @Optional() _parentFormGroup: FormGroupDirective,
+    _defaultErrorStateMatcher: ErrorStateMatcher,
+    /** @docs-private */
+    @Optional() @Self() public ngControl: NgControl,
+    @Inject(MAT_CHIPS_DEFAULT_OPTIONS) _defaultOptions: MatChipsDefaultOptions,
+  ) {
     super(_defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl);
+
     if (this.ngControl) {
       this.ngControl.valueAccessor = this;
     }
+
+    this.focusLastChipOnBackspace =
+      _defaultOptions.focusLastChipOnBackspace !== undefined
+        ? _defaultOptions.focusLastChipOnBackspace
+        : DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS.focusLastChipOnBackspace;
   }
 
   ngAfterContentInit() {

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -333,6 +333,12 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     descendants: true
   }) chips: QueryList<MatChip>;
 
+  /**
+   * Whether the last chip should be focused when the user
+   * presses BACKSPACE when the input is empty.
+   */
+  @Input() focusLastChipOnBackspace: boolean = true;
+
   constructor(protected _elementRef: ElementRef<HTMLElement>,
               private _changeDetectorRef: ChangeDetectorRef,
               @Optional() private _dir: Directionality,
@@ -495,7 +501,9 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     const target = event.target as HTMLElement;
 
     // If they are on an empty input and hit backspace, focus the last chip
-    if (event.keyCode === BACKSPACE && this._isInputEmpty(target)) {
+    if (event.keyCode === BACKSPACE &&
+      this._isInputEmpty(target) &&
+      this.focusLastChipOnBackspace) {
       this._keyManager.setLastItemActive();
       event.preventDefault();
     } else if (target && target.classList.contains('mat-chip')) {
@@ -586,7 +594,7 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   private _selectValue(value: any, isUserInput: boolean = true): MatChip | undefined {
 
     const correspondingChip = this.chips.find(chip => {
-      return chip.value != null && this._compareWith(chip.value,  value);
+      return chip.value != null && this._compareWith(chip.value, value);
     });
 
     if (correspondingChip) {

--- a/src/material/chips/chips-module.ts
+++ b/src/material/chips/chips-module.ts
@@ -6,11 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ENTER} from '@angular/cdk/keycodes';
 import {NgModule} from '@angular/core';
 import {ErrorStateMatcher} from '@angular/material/core';
 import {MatChip, MatChipAvatar, MatChipRemove, MatChipTrailingIcon} from './chip';
-import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
+import {MAT_CHIPS_DEFAULT_OPTIONS, DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS} from './chip-default-options';
 import {MatChipInput} from './chip-input';
 import {MatChipList} from './chip-list';
 
@@ -30,9 +29,7 @@ const CHIP_DECLARATIONS = [
     ErrorStateMatcher,
     {
       provide: MAT_CHIPS_DEFAULT_OPTIONS,
-      useValue: {
-        separatorKeyCodes: [ENTER]
-      } as MatChipsDefaultOptions
+      useValue: DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS,
     }
   ]
 })

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -1,3 +1,5 @@
+export declare const DEFAULT_MAT_CHIPS_DEFAULT_OPTIONS: Required<MatChipsDefaultOptions>;
+
 export declare const MAT_CHIPS_DEFAULT_OPTIONS: InjectionToken<MatChipsDefaultOptions>;
 
 export declare class MatChip extends _MatChipMixinBase implements FocusableOption, OnDestroy, CanColor, CanDisableRipple, RippleTarget, HasTabIndex {
@@ -148,7 +150,7 @@ export declare class MatChipList extends _MatChipListMixinBase implements MatFor
     set value(value: any);
     readonly valueChange: EventEmitter<any>;
     constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher,
-    ngControl: NgControl);
+    ngControl: NgControl, _defaultOptions: MatChipsDefaultOptions);
     _allowFocusEscape(): void;
     _blur(): void;
     _focusInput(options?: FocusOptions): void;
@@ -174,7 +176,7 @@ export declare class MatChipList extends _MatChipListMixinBase implements MatFor
     static ngAcceptInputType_required: BooleanInput;
     static ngAcceptInputType_selectable: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatChipList, "mat-chip-list", ["matChipList"], { "errorStateMatcher": "errorStateMatcher"; "multiple": "multiple"; "compareWith": "compareWith"; "value": "value"; "required": "required"; "placeholder": "placeholder"; "disabled": "disabled"; "ariaOrientation": "aria-orientation"; "selectable": "selectable"; "tabIndex": "tabIndex"; "focusLastChipOnBackspace": "focusLastChipOnBackspace"; }, { "change": "change"; "valueChange": "valueChange"; }, ["chips"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<MatChipList, [null, null, { optional: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatChipList, [null, null, { optional: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }, null]>;
 }
 
 export declare class MatChipListChange {
@@ -194,7 +196,8 @@ export declare class MatChipRemove {
 }
 
 export interface MatChipsDefaultOptions {
-    separatorKeyCodes: number[] | Set<number>;
+    focusLastChipOnBackspace?: boolean;
+    separatorKeyCodes?: number[] | Set<number>;
 }
 
 export declare class MatChipSelectionChange {

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -128,6 +128,7 @@ export declare class MatChipList extends _MatChipListMixinBase implements MatFor
     set disabled(value: boolean);
     get empty(): boolean;
     errorStateMatcher: ErrorStateMatcher;
+    focusLastChipOnBackspace: boolean;
     get focused(): boolean;
     get id(): string;
     get multiple(): boolean;
@@ -172,7 +173,7 @@ export declare class MatChipList extends _MatChipListMixinBase implements MatFor
     static ngAcceptInputType_multiple: BooleanInput;
     static ngAcceptInputType_required: BooleanInput;
     static ngAcceptInputType_selectable: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatChipList, "mat-chip-list", ["matChipList"], { "errorStateMatcher": "errorStateMatcher"; "multiple": "multiple"; "compareWith": "compareWith"; "value": "value"; "required": "required"; "placeholder": "placeholder"; "disabled": "disabled"; "ariaOrientation": "aria-orientation"; "selectable": "selectable"; "tabIndex": "tabIndex"; }, { "change": "change"; "valueChange": "valueChange"; }, ["chips"], ["*"]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatChipList, "mat-chip-list", ["matChipList"], { "errorStateMatcher": "errorStateMatcher"; "multiple": "multiple"; "compareWith": "compareWith"; "value": "value"; "required": "required"; "placeholder": "placeholder"; "disabled": "disabled"; "ariaOrientation": "aria-orientation"; "selectable": "selectable"; "tabIndex": "tabIndex"; "focusLastChipOnBackspace": "focusLastChipOnBackspace"; }, { "change": "change"; "valueChange": "valueChange"; }, ["chips"], ["*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatChipList, [null, null, { optional: true; }, { optional: true; }, { optional: true; }, null, { optional: true; self: true; }]>;
 }
 


### PR DESCRIPTION
* By default, when pressing backspace when the input is focused and empty, the last chip (if exists) would be focused.
* This makes is so that when people delete the content they wrote, they will eventually start deleting chips.
* This PR puts this behavior behind a flag (which is turned on by default, to preserve current default behaviour)
* When the flag is turned off, the last chip will not get focused when backspace is pressed.

Fixes: #18659