### PR TITLE
fix(form-field): error when trying to lock label into position too early

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -422,7 +422,7 @@ export class MatFormField extends _MatFormFieldMixinBase
     if (this._hasFloatingLabel() && this._canLabelFloat) {
       // If animations are disabled, we shouldn't go in here,
       // because the `transitionend` will never fire.
-      if (this._animationsEnabled) {
+      if (this._animationsEnabled && this._label) {
         this._showAlwaysAnimate = true;
 
         fromEvent(this._label.nativeElement, 'transitionend').pipe(take(1)).subscribe(() => {

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -850,6 +850,13 @@ describe('MatInput without forms', () => {
     expect(inputContainer.floatLabel).toBe('always');
   }));
 
+  it('should not throw when trying to animate and lock too early', fakeAsync(() => {
+    const fixture = createComponent(MatInputTextTestController);
+    const formField = fixture.debugElement.query(By.directive(MatFormField))!
+        .componentInstance as MatFormField;
+    expect(() => formField._animateAndLockLabel()).not.toThrow();
+  }));
+
   it('should not highlight when focusing a readonly input', fakeAsync(() => {
     let fixture = createComponent(MatInputWithReadonlyInput);
     fixture.detectChanges();


### PR DESCRIPTION
Fixes an error that is thrown by the form field's `_animateAndLockLabel` if it's called before `ngAfterViewInit`. This can happen if an autocomplete receives focus too early.

Fixes #18663.