### PR TITLE
build: fix dev-server running in snippet mode

### DIFF
--- a/tools/dev-server/dev-server.ts
+++ b/tools/dev-server/dev-server.ts
@@ -27,9 +27,10 @@ export class DevServer {
     port: this.port,
     notify: false,
     ghostMode: false,
-    server: false,
-    logSnippet: false,
-    middleware: (req, res) => this._bazelMiddleware(req, res),
+    server: {
+      directory: false,
+      middleware: [(req, res) => this._bazelMiddleware(req, res)],
+    },
   };
 
   constructor(
@@ -72,6 +73,7 @@ export class DevServer {
       if (!absoluteJoinedPath.startsWith(absoluteRootPath)) {
         res.statusCode = 500;
         res.end('Error: Detected directory traversal');
+        return;
       }
     }
 


### PR DESCRIPTION
Browsersync has 3 possible modes. `snippet`, `proxy` and `server`. We
currently run with `snippet` even though we actually want to serve with
the live-reloading script being injected automatically.

In order to ensure that Browsersync runs in the `server` mode and
properly prints the URL to the http server, we re-enable the
`server` option that has been disabled in the past for security reasons.
The logic to prevent directory traversal still remains, and we also
explicitly disable directory listing (even though we have manual request
interception).

@jelbourn I verified that your directory traversal logic still works:

```ts
curl --path-as-is http://localhost:4200/../../../../../../../../../../Desktop/test.ts
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    73  100    73    0     0  73000      0 --:--:-- --:--:-- --:--:-- 73000
TEST FILE CONTENT
```

```ts
curl --path-as-is http://localhost:4200/../../../../../../../../../../Desktop/test.ts
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    35  100    35    0     0   2187      0 --:--:-- --:--:-- --:--:--  2187
Error: Detected directory traversal
```