### PR TITLE
fix(cdk/testing): don't send unnecessary `Key.chord`s to protractor

### DIFF
--- a/src/cdk/testing/protractor/protractor-element.ts
+++ b/src/cdk/testing/protractor/protractor-element.ts
@@ -111,7 +111,9 @@ export class ProtractorElement implements TestElement {
     const modifierKeys = toProtractorModifierKeys(modifiers);
     const keys = rest.map(k => typeof k === 'string' ? k.split('') : [keyMap[k]])
         .reduce((arr, k) => arr.concat(k), [])
-        .map(k => Key.chord(...modifierKeys, k));
+        // Key.chord doesn't work well with geckodriver (mozilla/geckodriver#1502),
+        // so avoid it if no modifier keys are required.
+        .map(k => modifierKeys.length > 0 ? Key.chord(...modifierKeys, k) : k);
 
     return this.element.sendKeys(...keys);
   }


### PR DESCRIPTION
Because of a bug in geckodriver (mozilla/geckodriver#1502), Key.chord does not work as expected when testing under Firefox. While there is no complete solution to that problem, this change at least reduces the frequency with which users will encounter the bug.

Before: bug encountered on any invocation of sendKeys.
After: bug only encountered when using modifier keys. Plain text can still be entered.