### PR TITLE
build: update to rules_nodejs v1.4.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,8 +8,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Add NodeJS rules
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"],
+    sha256 = "c9e59009049fa42198f7087b80398fc4b2698a0f0c7fdde4fb3540c899c9b309",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.4.0/rules_nodejs-1.4.0.tar.gz"],
 )
 
 # Add sass rules

--- a/package.json
+++ b/package.json
@@ -71,11 +71,11 @@
     "@angular/router": "^9.0.1",
     "@bazel/bazelisk": "^1.3.0",
     "@bazel/buildifier": "^0.29.0",
-    "@bazel/ibazel": "^0.12.0",
-    "@bazel/jasmine": "^1.3.0",
-    "@bazel/karma": "^1.3.0",
-    "@bazel/protractor": "^1.3.0",
-    "@bazel/typescript": "^1.3.0",
+    "@bazel/ibazel": "^0.12.2",
+    "@bazel/jasmine": "^1.4.0",
+    "@bazel/karma": "^1.4.0",
+    "@bazel/protractor": "^1.4.0",
+    "@bazel/typescript": "^1.4.0",
     "@firebase/app-types": "^0.3.2",
     "@octokit/rest": "^16.28.7",
     "@schematics/angular": "^9.0.2",
@@ -155,8 +155,6 @@
   },
   "resolutions": {
     "dgeni-packages/typescript": "3.7.4",
-    "@bazel/jasmine/jasmine": "3.5.0",
-    "@bazel/jasmine/jasmine-core": "3.5.0",
     "**/graceful-fs": "4.2.2"
   }
 }

--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -164,8 +164,8 @@ function applyPatch(patchFile) {
     return;
   }
 
-  writePatchMarker(patchMarkerPath);
   shelljs.cat(patchFile).exec('patch -p0');
+  writePatchMarker(patchMarkerPath);
 }
 
 /**

--- a/tools/postinstall/manifest_externs_hermeticity.patch
+++ b/tools/postinstall/manifest_externs_hermeticity.patch
@@ -61,27 +61,27 @@ diff --git node_modules/@bazel/typescript/internal/tsc_wrapped/tsc_wrapped.js no
 index 0346123..3d9bc64 100644
 --- node_modules/@bazel/typescript/internal/tsc_wrapped/tsc_wrapped.js
 +++ node_modules/@bazel/typescript/internal/tsc_wrapped/tsc_wrapped.js
-@@ -307,6 +307,23 @@
-         }
-         else {
-             diagnostics = emitWithTypescript(program, compilationTargets, transforms);
-+            if (bazelOpts.manifest) {
-+                fs.writeFileSync(bazelOpts.manifest, "");
-+            }
-+            if (bazelOpts.tsickleExternsPath) {
-+                fs.writeFileSync(bazelOpts.tsickleExternsPath, "");
-+                if (bazelOpts.tsickleGenerateExterns && compilerHost.provideExternalModuleDtsNamespace) {
-+                    for (const extern of compilationTargets) {
-+                        if (!extern.isDeclarationFile)
-+                            continue;
-+                        const outputBaseDir = options.outDir;
-+                        const relativeOutputPath = compilerHost.relativeOutputPath(extern.fileName);
-+                        mkdirp(outputBaseDir, path.dirname(relativeOutputPath));
-+                        const outputPath = path.join(outputBaseDir, relativeOutputPath);
-+                        fs.writeFileSync(outputPath, "");
-+                    }
+@@ -381,6 +381,23 @@ function createProgramAndEmit(fileLoader, options, bazelOpts, files, disabledTse
+     }
+     else {
+         diagnostics = emitWithTypescript(program, compilationTargets, transformers);
++        if (bazelOpts.manifest) {
++            fs.writeFileSync(bazelOpts.manifest, "");
++        }
++        if (bazelOpts.tsickleExternsPath) {
++            fs.writeFileSync(bazelOpts.tsickleExternsPath, "");
++            if (bazelOpts.tsickleGenerateExterns && compilerHost.provideExternalModuleDtsNamespace) {
++                for (const extern of compilationTargets) {
++                    if (!extern.isDeclarationFile)
++                        continue;
++                    const outputBaseDir = options.outDir;
++                    const relativeOutputPath = compilerHost.relativeOutputPath(extern.fileName);
++                    mkdirp(outputBaseDir, path.dirname(relativeOutputPath));
++                    const outputPath = path.join(outputBaseDir, relativeOutputPath);
++                    fs.writeFileSync(outputPath, "");
 +                }
 +            }
-         }
-         if (diagnostics.length > 0) {
-             console.error(bazelDiagnostics.format(bazelOpts.target, diagnostics));
++        }
+     }
+     if (diagnostics.length > 0) {
+         worker_1.debug('compilation failed at', new Error().stack);

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,36 +259,37 @@
     "@bazel/buildifier-linux_x64" "0.29.0"
     "@bazel/buildifier-win32_x64" "0.29.0"
 
-"@bazel/ibazel@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.12.0.tgz#97aea5ee2d41d91995539df89efe11fd3fe128ca"
-  integrity sha512-8ix3hmaV30xD9FIa9aJBtKhxUOBDo0NEULgOhgz5c8nytnD0ipPWqssWWq0iFU8oRBHpvNnuIESbzL1h/LU5iw==
+"@bazel/ibazel@^0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.12.2.tgz#98a290dbf8025076dd3040eab4f13a3d7e99357c"
+  integrity sha512-CktVREceZn+6VokQ7A2qByuXBSGRM0THuyv68JUShHYyCkYS94nYMZEIe5NXk12CRzcpMLfZGD5Gdtr+jWs9pw==
 
-"@bazel/jasmine@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-1.3.0.tgz#1d03aa67c18f122ffed4eb88e85455a797a8121d"
-  integrity sha512-HY633xVy83eyLWt4o6CT8zHDxzVk+UfXCWCCWgJXWqpkB2BoYlq0Bvvpqcuj7Ilzn9vNX6w8gVeddRckIdBa/Q==
+"@bazel/jasmine@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-1.4.0.tgz#c4124090f933a879d8b0fc7c2c2c2436f17094fe"
+  integrity sha512-As7hqdmkUJLKNAUmj6CkFR2azaHA6dxdOLFNasrXX4Qc+jBXxDEgnGb4DSFewn5ds45BKahZOpCsKH3Fq1g4Sw==
   dependencies:
-    jasmine "~3.4.0"
-    jasmine-core "~3.4.0"
+    jasmine "~3.5.0"
+    jasmine-core "~3.5.0"
+    jasmine-reporters "~2.3.2"
     v8-coverage "1.0.9"
 
-"@bazel/karma@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@bazel/karma/-/karma-1.3.0.tgz#8d4c336f04357ccc9633b9b6cdf8c79b15793ef1"
-  integrity sha512-TyGoLBGTt9Mlp/FhwAytYaolUfrwMYuhNNzOYQ0lNzF73oEXOD1G9vIYLn2NvxQLPAaa2guBmNWSf0EkLhMuiw==
+"@bazel/karma@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@bazel/karma/-/karma-1.4.0.tgz#42517b3a236d0589da265e195814960e6b4a691c"
+  integrity sha512-KLBKZHN4b9w+Ll9DrW6+mqKeR6a4kuc4PMPWNIqrgTHBTnJgRQpnDR4V/kyqEjcmJ9zG/rJgzkrboRHyXsQrxA==
   dependencies:
     tmp "0.1.0"
 
-"@bazel/protractor@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@bazel/protractor/-/protractor-1.3.0.tgz#050edc3480a6b5cf2b4c96daeced5cb871839298"
-  integrity sha512-EwTlHbMwHIyPy7FhDiKLum2nlmmy27p/yQzWzN8dRnCIjmq4ezTfgNMnyZ5Z9HiQ2HM4kyzNx1f65eKNXXZK7w==
+"@bazel/protractor@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@bazel/protractor/-/protractor-1.4.0.tgz#577bc7243d88b58fc4733e39b233f38ee97eeebb"
+  integrity sha512-flAzhCAfkVjOQQT1JOLvUz5PBiNKgg8/4jMUw90ZcOSj8u6mOSrR0Fh7LT7V+Rc3VLrH+uNaP9Iq31gjEKxl6A==
 
-"@bazel/typescript@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-1.3.0.tgz#6df7409ad8b2fcd80dfe859904fe91aacfb1a2cf"
-  integrity sha512-F1Cjnjby+b3cO+rVuZY/9tzepf8wgoXZP9PtFmVWTQ+NtBkKEYx6IQ3AXZJl33mYVoN/Zb5qBTrGW/QfHUvakw==
+"@bazel/typescript@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-1.4.0.tgz#8a86c3c58c3ebe17ccb2f71b35720457f4bc434a"
+  integrity sha512-VFUCAyGXMZDx/ZyZ8YUj5rn/Rg9xSxoZxcqxJ457YxMzWGISKpNyzgUty9J/ZVcPg1xKKoISSvcjQWFtWOwX2A==
   dependencies:
     protobufjs "6.8.8"
     semver "5.6.0"
@@ -6509,7 +6510,7 @@ istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-jasmine-core@3.5.0, jasmine-core@^3.5.0, jasmine-core@~3.4.0, jasmine-core@~3.5.0:
+jasmine-core@3.5.0, jasmine-core@^3.5.0, jasmine-core@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
   integrity sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==
@@ -6518,6 +6519,14 @@ jasmine-core@~2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.8.0.tgz#bcc979ae1f9fd05701e45e52e65d3a5d63f1a24e"
   integrity sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=
+
+jasmine-reporters@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/jasmine-reporters/-/jasmine-reporters-2.3.2.tgz#898818ffc234eb8b3f635d693de4586f95548d43"
+  integrity sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==
+  dependencies:
+    mkdirp "^0.5.1"
+    xmldom "^0.1.22"
 
 jasmine@2.8.0:
   version "2.8.0"
@@ -6528,7 +6537,7 @@ jasmine@2.8.0:
     glob "^7.0.6"
     jasmine-core "~2.8.0"
 
-jasmine@3.5.0, jasmine@~3.4.0:
+jasmine@3.5.0, jasmine@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.5.0.tgz#7101eabfd043a1fc82ac24e0ab6ec56081357f9e"
   integrity sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==
@@ -12237,6 +12246,11 @@ xmldom@0.1.x:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
   integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
+
+xmldom@^0.1.22:
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
+  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
Updates to the latest rules_nodejs version. Also removes the
unnecessary Yarn resolution since we sent an upstream fix to
update to the latest jasmine version. See: https://github.com/bazelbuild/rules_nodejs/commit/98fab935ae672708bb5ce681ccb5ba204fed994f

The manifest `@bazel/typescript` patch had to be updated due to recent changes to
`tsc_wrapped`. I'm hoping we can spend some time porting these changes upstream.
It's unclear though if its worth the effort if we eventually simply use `tsc` in Bazel.