### PR TITLE
fix(drag-drop): detect changes on custom preview/placeholder before measuring

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -884,6 +884,7 @@ export class DragRef<T = any> {
     if (previewTemplate) {
       const viewRef = previewConfig!.viewContainer.createEmbeddedView(previewTemplate,
                                                                       previewConfig!.context);
+      viewRef.detectChanges();
       preview = getRootNode(viewRef, this._document);
       this._previewRef = viewRef;
 
@@ -984,6 +985,7 @@ export class DragRef<T = any> {
         placeholderTemplate,
         placeholderConfig!.context
       );
+      this._placeholderRef.detectChanges();
       placeholder = getRootNode(this._placeholderRef, this._document);
     } else {
       placeholder = deepCloneNode(this._rootElement);


### PR DESCRIPTION
When a custom preview/placeholder is created, its dimensions are measured so that they can be used while sorting. The problem is that we weren't detecting changes after creation which can cause the dimensions to be incorrect, if they change based on a data binding. These changes check for changes after inserting the embedded view.

Fixes #18622.