### PR TITLE
fix(radio): Move .mat-radio-input above .mat-focus-indicator.

### DIFF
--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -19,6 +19,8 @@
         (change)="_onInputChange($event)"
         (click)="_onInputClick($event)">
 
+    <!-- The ripple comes after the input so that we can target it with a CSS
+         sibling selector when the input is focused. -->
     <div mat-ripple class="mat-radio-ripple mat-focus-indicator"
          [matRippleTrigger]="label"
          [matRippleDisabled]="_isRippleDisabled()"

--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -5,16 +5,6 @@
   <div class="mat-radio-container">
     <div class="mat-radio-outer-circle"></div>
     <div class="mat-radio-inner-circle"></div>
-    <div mat-ripple class="mat-radio-ripple mat-focus-indicator"
-         [matRippleTrigger]="label"
-         [matRippleDisabled]="_isRippleDisabled()"
-         [matRippleCentered]="true"
-         [matRippleRadius]="20"
-         [matRippleAnimation]="{enterDuration: 150}">
-
-      <div class="mat-ripple-element mat-radio-persistent-ripple"></div>
-    </div>
-
     <input #input class="mat-radio-input cdk-visually-hidden" type="radio"
         [id]="inputId"
         [checked]="checked"
@@ -28,6 +18,16 @@
         [attr.aria-describedby]="ariaDescribedby"
         (change)="_onInputChange($event)"
         (click)="_onInputClick($event)">
+
+    <div mat-ripple class="mat-radio-ripple mat-focus-indicator"
+         [matRippleTrigger]="label"
+         [matRippleDisabled]="_isRippleDisabled()"
+         [matRippleCentered]="true"
+         [matRippleRadius]="20"
+         [matRippleAnimation]="{enterDuration: 150}">
+
+      <div class="mat-ripple-element mat-radio-persistent-ripple"></div>
+    </div>
   </div>
 
   <!-- The label content for radio control. -->


### PR DESCRIPTION
The reason why we want to do this is so that we can apply styles to `.mat-focus-indicator` based upon whether or not `.mat-radio-input` is focused. We can't do this right now, because we there is no way to "look backwards" with CSS selectors. After this change, we will be able to write:

```
.mat-radio-input:focus ~ .mat-focus-indicator
```

This change also aligns the DOM structure of radio button with checkbox and slide toggle (the two latter components already have their inputs *before* the focus indicator element in the DOM).

Ran TGP, no failures.