### PR TITLE
fix(cdk/focus-trap): EventListenerInertStrategy focus fix

### DIFF
--- a/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
+++ b/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
@@ -28,6 +28,21 @@ describe('EventListenerFocusTrapInertStrategy', () => {
         'Expected first focusable element to be focused');
   }));
 
+  it('refocuses the most recently focused FocusTrap element when focus moves outside the FocusTrap',
+    fakeAsync(() => {
+      const fixture = createComponent(SimpleFocusTrap, providers);
+      const componentInstance = fixture.componentInstance;
+      fixture.detectChanges();
+
+      componentInstance.secondFocusableElement.nativeElement.focus();
+      componentInstance.outsideFocusableElement.nativeElement.focus();
+      flush();
+
+      expect(componentInstance.activeElement).toBe(
+        componentInstance.secondFocusableElement.nativeElement,
+        'Expected second focusable element to be focused because it was the last focused');
+  }));
+
   it('does not intercept focus when focus moves to another element in the FocusTrap',
     fakeAsync(() => {
       const fixture = createComponent(SimpleFocusTrap, providers);


### PR DESCRIPTION
EventListenerInertStrategy should return focus to the most recently
focused element when focus escapes the trapped element, rather than
always sending it to the first one.