### PR TITLE
docs(clipboard): example in readme not working on firefox

### DIFF
--- a/src/cdk/clipboard/clipboard.md
+++ b/src/cdk/clipboard/clipboard.md
@@ -51,7 +51,7 @@ class HeroProfile {
         pending.destroy();
       }
     };
-    setTimeout(attempt);
+    attempt();
   }
 }
 ```


### PR DESCRIPTION
Fixes the example that is given in the docs not working on Firefox, because the initial attempt starts off in a `setTimeout` which isn't allowed.

Fixes #18449.