### PR TITLE
build: include tslib as explicit dependency for `ng_package` rule

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -100,7 +100,7 @@ def ng_module(
         **kwargs
     )
 
-def ng_package(name, data = [], globals = ROLLUP_GLOBALS, readme_md = None, **kwargs):
+def ng_package(name, data = [], deps = [], globals = ROLLUP_GLOBALS, readme_md = None, **kwargs):
     # If no readme file has been specified explicitly, use the default readme for
     # release packages from "src/README.md".
     if not readme_md:
@@ -119,6 +119,10 @@ def ng_package(name, data = [], globals = ROLLUP_GLOBALS, readme_md = None, **kw
         name = name,
         globals = globals,
         data = data + [":license_copied"],
+        # Tslib needs to be explicitly specified as dependency here, so that the `ng_package`
+        # rollup bundling action can include tslib. Tslib is usually a transitive dependency of
+        # entry-points passed to `ng_package`, but the rule does not collect transitive deps.
+        deps = deps + ["@npm//tslib"],
         readme_md = readme_md,
         substitutions = VERSION_PLACEHOLDER_REPLACEMENTS,
         **kwargs


### PR DESCRIPTION
In a previous commit we removed `tslib` from the rollup globals so
that `ng_package` can bundle `tslib` into the UMD bundles.

This works fine in non-sandbox environments (e.g. windows), but doesn't
work in sandbox environments because `ng_package` does not bring in
transitive dependencies from entry-points. Hence we need to explicitly
pass in `tslib` as dependency for `ng_package`. This matches what
`angular/angular` does for including tslib.