### PR TITLE
build: setup snapshot builds for experimental and new packages

### DIFF
--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -15,9 +15,16 @@ if [ -z ${MATERIAL2_BUILDS_TOKEN} ]; then
   exit 1
 fi
 
-# Material packages that need to published.
-PACKAGES=(cdk material material-moment-adapter)
-REPOSITORIES=(cdk-builds material2-builds material2-moment-adapter-builds)
+# Release packages that need to published as snapshots.
+PACKAGES=(
+  cdk
+  cdk-experimental
+  material
+  material-experimental
+  material-moment-adapter
+  google-maps
+  youtube-player
+)
 
 # Command line arguments.
 COMMAND_ARGS=${*}
@@ -117,11 +124,8 @@ publishPackage() {
   echo "Published package artifacts for ${packageName}#${buildVersionName} into ${branchName}"
 }
 
-for ((i = 0; i < ${#PACKAGES[@]}; i++)); do
-  packageName=${PACKAGES[${i}]}
-  packageRepo=${REPOSITORIES[${i}]}
-
-  # Publish artifacts of the current package. Run publishing in a sub-shell to avoid working
-  # directory changes.
-  (publishPackage ${packageName} ${packageRepo})
+for packageName in "${PACKAGES[@]}"; do
+  # Publish artifacts of the current package. Run publishing in a sub-shell to avoid
+  # working directory changes.
+  (publishPackage ${packageName} "${packageName}-builds")
 done


### PR DESCRIPTION
* Sets up snapshot builds for the experimental packages
* Sets up snapshot builds for the new packages (`google-maps`, `youtube-player`)
* Updates snapshot builds repositories to match package name. Similar to how it is done in
  framework, and to improve consistency. This means that: 
  - `material2-builds` becomes `material-builds`
  - `material2-moment-adapter` becomes `material-moment-adapter`.

We can do the rename because Github creates repository redirects. This should prevent breakages for people relying on the builds repositories. Though we never denoted those as public.

@jelbourn @josephperrott If we go with renaming these old build repositories for consistency, then the following things would need to be made:

1. Delete the newly created `material-moment-adapter-builds` repo.
2. Rename `material2-moment-adapter-builds` repo to `material-moment-adapter-builds`
3. Rename `material2-builds` to `material-builds`.