### PR TITLE
refactor: ensure typography mixins expect consistent arguments

### DIFF
--- a/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
+++ b/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
@@ -70,7 +70,7 @@
   $mdc-checkbox-disabled-color: $orig-mdc-checkbox-disabled-color !global;
 }
 
-@mixin mat-checkbox-typography-mdc($config: null) {
+@mixin mat-checkbox-typography-mdc($config) {
   @include mat-using-mdc-typography($config) {
     @include mdc-checkbox-without-ripple($query: $mat-typography-styles-query);
     @include mdc-form-field-core-styles($query: $mat-typography-styles-query);

--- a/src/material-experimental/mdc-list/_list-theme.scss
+++ b/src/material-experimental/mdc-list/_list-theme.scss
@@ -7,7 +7,7 @@
   }
 }
 
-@mixin mat-list-typography-mdc($config: null) {
+@mixin mat-list-typography-mdc($config) {
   @include mat-using-mdc-typography($config) {
     @include mdc-list-without-ripple($query: $mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
+++ b/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
@@ -28,6 +28,6 @@
   }
 }
 
-@mixin mat-progress-bar-typography-mdc($config: null) {
+@mixin mat-progress-bar-typography-mdc($config) {
   // No typography for this component.
 }


### PR DESCRIPTION
Currently we have a few components with typography mixins that do
not match the majority of other components. These components have
typography mixins where the `$config` is optional. We want to always
require a config (similar to how it's done in other components) to avoid
breaking changes in the future, and to have a consistent API.