### PR TITLE
fix(material-experimental/mdc-form-field): avoid expression changed a…

### DIFF
--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -330,6 +330,9 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
     this._refreshOutlineNotchWidth();
     // Enable animations now. This ensures we don't animate on initial render.
     this._subscriptAnimationState = 'enter';
+    // Because the above changes a value used in the template after it was checked, we need
+    // to trigger CD or the change might not be reflected if there is no other CD scheduled.
+    this._changeDetectorRef.detectChanges();
   }
 
   ngAfterContentInit() {


### PR DESCRIPTION
…fter check

There is currently a bug in the Angular Framework that results in
ExpressionChangedAfterItHasBeenChecked errors not throwing when they
should for OnPush components. Because we modify a variable used in the
template after it was already checked (in ngAfterViewInit), we need to
trigger change detection manually or the change might not be picked up.

This was detected when running the CI for the fix in the framework to make 
the error actually throw when it should: https://github.com/angular/angular/pull/34443

Maybe also worth noting that the non-mdc form-field also calls `detectChanges`
to avoid this same problem: https://github.com/angular/components/blob/e0634c9e379266751f6fa3911f94916c7c465609/src/material/form-field/form-field.ts#L374-L378