### PR TITLE
fix(slide-toggle): incorrect text color when placed inside an overlay with a dark theme

### DIFF
--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -46,6 +46,10 @@
   .mat-slide-toggle {
     @include _mat-slide-toggle-checked($accent, $thumb-checked-hue);
 
+    // Explicitly set the text color since the slide toggle may be
+    // inside an overlay that doesn't have the proper theme text color.
+    color: mat-color($foreground, 'text');
+
     &.mat-primary {
       @include _mat-slide-toggle-checked($primary, $thumb-checked-hue);
     }


### PR DESCRIPTION
The slide toggle doesn't define its text color, but inherits it from the closest theme root element. The problem is that if the element is moved out to something like an overlay, the color may be inherited from the `body` which won't be correct. These changes explicitly set the `color`.

Fixes #18701.