### PR TITLE
fix(mat-button-toggle): mat-button-toggle element should not have a focus indicator class.

### DIFF
--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -394,7 +394,7 @@ const _MatButtonToggleMixinBase: CanDisableRippleCtor & typeof MatButtonToggleBa
     '[class.mat-button-toggle-checked]': 'checked',
     '[class.mat-button-toggle-disabled]': 'disabled',
     '[class.mat-button-toggle-appearance-standard]': 'appearance === "standard"',
-    'class': 'mat-button-toggle mat-focus-indicator',
+    'class': 'mat-button-toggle',
     // Always reset the tabindex to -1 so it doesn't conflict with the one on the `button`,
     // but can still receive focus from things like cdkFocusInitial.
     '[attr.tabindex]': '-1',


### PR DESCRIPTION
This class was mistakenly added onto both the `<mat-button-toggle>` element and its child `<button>`. It should only be on the child `<button>`, because only the child is in the tab order. The only reason the parent `<mat-button-toggle>` has a `tabindex="-1"` is so that it can work with things like`cdkFocusInitial`.