### PR TITLE
docs(sort): fix grammar in the 'sort' documentation

### DIFF
--- a/src/material/sort/sort.md
+++ b/src/material/sort/sort.md
@@ -7,11 +7,11 @@ to tabular data.
 
 To add sorting behavior and styling to a set of table headers, add the `<mat-sort-header>` component
 to each header and provide an `id` that will identify it. These headers should be contained within a
-parent element with the `matSort` directive, which will emit an `matSortChange` event when the user
+parent element with the `matSort` directive, which will emit a `matSortChange` event when the user
  triggers sorting on the header.
 
 Users can trigger the sort header through a mouse click or keyboard action. When this happens, the
-`matSort` will emit an `matSortChange` event that contains the ID of the header triggered and the
+`matSort` will emit a `matSortChange` event that contains the ID of the header triggered and the
 direction to sort (`asc` or `desc`).
 
 #### Changing the sort order
@@ -23,18 +23,18 @@ To reverse the sort order for all headers, set the `matSortStart` to `desc` on t
 directive. To reverse the order only for a specific header, set the `start` input only on the header
 instead.
 
-To prevent the user from clearing the sort sort state from an already sorted column, set
+To prevent the user from clearing the sort state from an already sorted column, set
 `matSortDisableClear` to `true` on the `matSort` to affect all headers, or set `disableClear` to
 `true` on a specific header.
 
 #### Disabling sorting
 
 If you want to prevent the user from changing the sorting order of any column, you can use the
-`matSortDisabled` binding on the `mat-sort`, or the `disabled` on an single `mat-sort-header`.
+`matSortDisabled` binding on the `mat-sort`, or the `disabled` on a single `mat-sort-header`.
 
 #### Using sort with the mat-table
 
-When used on an `mat-table` header, it is not required to set an `mat-sort-header` id on because
+When used on a `mat-table` header, it is not required to set a `mat-sort-header` id on because
 by default it will use the id of the column.
 
 <!-- example(table-sorting) -->


### PR DESCRIPTION
Changed some incorrect uses of "an" to "a". Removed a duplicate word.