### PR TITLE
<docs> improvements to material guides

### DIFF
--- a/guides/customizing-component-styles.md
+++ b/guides/customizing-component-styles.md
@@ -2,12 +2,13 @@
 
 ### Styling concepts
 
-There are 3 questions to keep in mind while customizing the styles of Angular Material
+There are 4 questions to keep in mind while customizing the styles of Angular Material
 components:
 
 1. Are your styles encapsulated?
 2. Are your styles more specific than the defaults?
 3. Is the component a child of your component, or does it exist elsewhere in the DOM?
+4. Are the styles you wish to modify created by your Angular Material Theme?
 
 ##### View encapsulation
 
@@ -35,6 +36,20 @@ do not exist as children of your component. Often they are injected elsewhere in
 important to keep in mind, since even using high specificity and shadow-piercing selectors will
 not target elements that are not direct children of your component. Global styles are recommended
 for targeting such components.
+
+##### Customizing Themed Components
+
+Component styles which are dynamic and created by your Angular Material Theme behave differently than 
+other styles.  These styles are compiled from styles.scss (and any files imported into it), and 
+inserted directly into the DOM via \<style> tags in the \<head> of your document.  This creates an
+additional challenge for modifying these styles, as they will override your individual component styles
+unless you use more specific selectors than Angular Material.   In practice, the most effective wayy to modify
+these styles is to create your own custom component theme or alternate theme and include it in
+your styles.scss.  This is true even if you only want to modify a single trait or if the style
+in question does not seem directly related to theme colors but is created by the @angular-material-theme mixin.
+
+You can read about theming components and custom theming [here](https://material.angular.io/guide/theming) and 
+[here](https://material.angular.io/guide/theming-your-components).
 
 ### Styling overlay components
 
@@ -71,3 +86,4 @@ application.
 - Use a deprecated shadow-piercing descendant combinator to force styles to apply to all the child
 elements. Read more about this deprecated solution in the
 [Angular documentation](https://angular.io/guide/component-styles#deprecated-deep--and-ng-deep).
+

--- a/guides/customizing-component-styles.md
+++ b/guides/customizing-component-styles.md
@@ -2,7 +2,7 @@
 
 ### Styling concepts
 
-There are 4 questions to keep in mind while customizing the styles of Angular Material
+There are several questions to keep in mind while customizing the styles of Angular Material
 components:
 
 1. Are your styles encapsulated?
@@ -40,13 +40,13 @@ for targeting such components.
 ##### Customizing Themed Components
 
 Component styles which are dynamic and created by your Angular Material Theme behave differently than 
-other styles.  These styles are compiled from styles.scss (and any files imported into it), and 
-inserted directly into the DOM via \<style> tags in the \<head> of your document.  This creates an
+other styles.  These styles are compiled from `styles.scss` (and any files imported into it), and 
+inserted directly into the DOM via `<style>` tags in the `<head>` of your document. This creates an
 additional challenge for modifying these styles, as they will override your individual component styles
-unless you use more specific selectors than Angular Material.   In practice, the most effective wayy to modify
+unless you use more specific selectors than Angular Material.   In practice, the most effective way to modify
 these styles is to create your own custom component theme or alternate theme and include it in
-your styles.scss.  This is true even if you only want to modify a single trait or if the style
-in question does not seem directly related to theme colors but is created by the @angular-material-theme mixin.
+your `styles.scss`.  This is true even if you only want to modify a single trait or if the style
+in question does not seem directly related to theme colors but is created by the `angular-material-theme` mixin.
 
 You can read about theming components and custom theming [here](https://material.angular.io/guide/theming) and 
 [here](https://material.angular.io/guide/theming-your-components).

--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -51,13 +51,7 @@ Define all styles unaffected by the theme in a separate file referenced directly
 
 #### 3. Include the theme mixin in your application
 Use the Sass `@include` keyword to include a component's theme mixin wherever you're already
-including Angular Material's built-in theme mixins.  You will need to import directly to the file
-where your theme palette definitions have been made (typically styles.scss).  If you are creating 
-many custom component themes, you may wish to place them all in a single file in order to `@include`
-a single secondary theme, just as the Angular Material Theme includes styles for many components.
-This can avoid the additional complexity of creating a cascading chain of `map-get()` and `mat-color`
-commands to import your theme down a tree of imports, or having to `@include` multiple custom
-component themes for each alternate color theme defined for your application.
+including Angular Material's built-in theme mixins.  
 
 ```scss
 // Import library functions for theme creation.
@@ -119,12 +113,13 @@ For example:
 Angular Material's color palettes include specially-keyed
 hues that can be used in your custom components.
 
-``` 
-default: the base color
-lighter: a lightened version of the hue
-darker: a darker version of the hue
-text: the default text color for the palette
-default-contrast: the default contrast color
-lighter-contrast: a lighter contrast color; in a dark theme, usually white
-darker-contrast: a darker contrast color; in a light theme, usually black
-```
+| Key | Description |
+| :--- | :--- |
+| default | the base color |
+| lighter | a lightened version of the hue |
+| darker | a darker version of the hue |
+| text | the default text color for the palette |
+| default-contrast | the default contrast color |
+| lighter-contrast | a lighter contrast color; in a dark theme, usually white |
+| darker-contrast | a darker contrast color; in a light theme, usually black |
+

--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -72,7 +72,7 @@ component themes for each alternate color theme defined for your application.
 $primary: mat-palette($mat-indigo);
 $accent:  mat-palette($mat-pink, A200, A100, A400);
 $theme: mat-light-theme($primary, $accent);
-$alttheme: mat-dark-theme($primary, $accent);
+$alt-theme: mat-dark-theme($primary, $accent);
 
 // Include theme styles for Angular Material components.
 @include angular-material-theme($theme);
@@ -83,7 +83,7 @@ $alttheme: mat-dark-theme($primary, $accent);
 // define theme styles for your alternate theme
 .alternate-theme {
   @include angular-material-theme($alttheme);
-  @include candy-carousel-theme($alttheme);
+  @include candy-carousel-theme($alt-theme);
 }
 ```
 

--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -51,11 +51,19 @@ Define all styles unaffected by the theme in a separate file referenced directly
 
 #### 3. Include the theme mixin in your application
 Use the Sass `@include` keyword to include a component's theme mixin wherever you're already
-including Angular Material's built-in theme mixins. 
+including Angular Material's built-in theme mixins.  You will need to import directly to the file
+where your theme palette definitions have been made (typically styles.scss).  If you are creating 
+many custom component themes, you may wish to place them all in a single file in order to `@include`
+a single secondary theme, just as the Angular Material Theme includes styles for many components.
+This can avoid the additional complexity of creating a cascading chain of `map-get()` and `mat-color`
+commands to import your theme down a tree of imports, or having to `@include` multiple custom
+component themes for each alternate color theme defined for your application.
 
 ```scss
 // Import library functions for theme creation.
 @import '~@angular/material/theming';
+// Import your custom component theme from it's own file
+@import './candy-carousel-theme-styles.scss'
 
 // Include non-theme styles for core.
 @include mat-core();
@@ -64,18 +72,26 @@ including Angular Material's built-in theme mixins.
 $primary: mat-palette($mat-indigo);
 $accent:  mat-palette($mat-pink, A200, A100, A400);
 $theme: mat-light-theme($primary, $accent);
+$alttheme: mat-dark-theme($primary, $accent);
 
 // Include theme styles for Angular Material components.
 @include angular-material-theme($theme);
 
 // Include theme styles for your custom components.
 @include candy-carousel-theme($theme);
+
+// define theme styles for your alternate theme
+.alternate-theme {
+  @include angular-material-theme($alttheme);
+  @include candy-carousel-theme($alttheme);
+}
 ```
 
 
 #### Note: using the `mat-color` function to extract colors from a palette
 You can consume the theming functions and Material Design color palettes from
 `@angular/material/theming`. The `mat-color` Sass function extracts a specific color from a palette.
+
 For example:
 
 ```scss
@@ -96,4 +112,21 @@ For example:
   // Get a contrast color for a hue by adding `-contrast` to any other key.
   border-color: mat-color($primary, '100-contrast');
 }
+```
+
+#### Angular Material Theme Palette keys
+
+Every Angular Material palette color (eg primary, accent, warn) contains 7 defined hues which can be drawn
+out of the palette object with `mat-color`.  
+
+These seven keys are:
+
+``` 
+default: the base color
+lighter: a lightened version of the hue
+darker: a darker version of the hue
+text: the default text color for the palette
+default-contrast: the default contrast color
+lighter-contrast: a lighter contrast color; in a dark theme, usually white
+darker-contrast: a darker contrast color; in a light theme, usually black
 ```

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -46,13 +46,9 @@ The actual path will depend on your server setup.
 
 You can also concatenate the file with the rest of your application's css.
 
-#### Your theme's foundational class(es)
+#### Application background color
 
-If your app's content **is not** placed inside of a `mat-sidenav-container` element, you
-need to add the `mat-app-background` class to your wrapper element (for example the `body`). This
-ensures that the proper theme background is applied to your page.   Further, some individual 
-Angular Material components rely on one of these two classes being present in order to render 
-correctly.
+You may want to change the background color of your application based on your Angular Material theme. If you're using `<mat-sidenav>`, the sidenav content will automatically have an appropriate background color. If you don't use `<mat-sidenav>`, you can manually apply the CSS class `mat-app-background` to apply the theme background color.  If you are using a `mat-dark-theme`, some Material components will be invisible against a white background.
 
 
 ### Defining a custom theme

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -46,9 +46,14 @@ The actual path will depend on your server setup.
 
 You can also concatenate the file with the rest of your application's css.
 
-Finally, if your app's content **is not** placed inside of a `mat-sidenav-container` element, you
+#### Your theme's foundational class(es)
+
+If your app's content **is not** placed inside of a `mat-sidenav-container` element, you
 need to add the `mat-app-background` class to your wrapper element (for example the `body`). This
-ensures that the proper theme background is applied to your page.
+ensures that the proper theme background is applied to your page.   Further, some individual 
+Angular Material components rely on one of these two classes being present in order to render 
+correctly.
+
 
 ### Defining a custom theme
 When you want more customization than a pre-built theme offers, you can create your own theme file.


### PR DESCRIPTION
in re: Issue $721 on angular.material.io, I have attempted to improve the Angular Material docs around custom and component theming to assist new developers in understanding how to interface custom styles with Angular Material.   I wanted to capitalize on my own recent experience in learning this material to shore up the docs with information that I would have found very useful.