### PR TITLE
feat: add mixins for density styles of all components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,7 @@
 /src/material/core/animation/**                    @jelbourn
 /src/material/core/common-behaviors/**             @jelbourn @devversion
 /src/material/core/datetime/**                     @mmalerba
+/src/material/core/density/**                      @devversion
 /src/material/core/error/**                        @crisbeto @mmalerba
 /src/material/core/focus-indicator/**              @jelbourn @zelliott
 /src/material/core/gestures/**                     @jelbourn

--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -1,4 +1,5 @@
 @import '../material/core/theming/all-theme';
+@import '../material/core/density/all-density';
 @import '../material-experimental/mdc-slider/slider-theme';
 @import '../material/core/focus-indicator/focus-indicator';
 @import '../material-experimental/column-resize/column-resize';
@@ -83,6 +84,7 @@ $dark-theme: mat-dark-theme((
 $density-scales: (-1, -2, minimum, maximum);
 @each $density in$density-scales {
   .demo-density-#{$density} {
+    @include _angular-material-density($density);
     @include angular-material-density-mdc($density);
   }
 }

--- a/src/material-experimental/mdc-density/BUILD.bazel
+++ b/src/material-experimental/mdc-density/BUILD.bazel
@@ -4,23 +4,6 @@ load("//tools:defaults.bzl", "sass_library")
 
 sass_library(
     name = "all_density",
-    srcs = [
-        "_all-density.scss",
-    ],
-    deps = [
-        "//src/material-experimental/mdc-button:mdc_button_scss_lib",
-        "//src/material-experimental/mdc-card:mdc_card_scss_lib",
-        "//src/material-experimental/mdc-checkbox:mdc_checkbox_scss_lib",
-        "//src/material-experimental/mdc-chips:mdc_chips_scss_lib",
-        "//src/material-experimental/mdc-form-field:mdc_form_field_scss_lib",
-        "//src/material-experimental/mdc-input:mdc_input_scss_lib",
-        "//src/material-experimental/mdc-list:mdc_list_scss_lib",
-        "//src/material-experimental/mdc-menu:mdc_menu_scss_lib",
-        "//src/material-experimental/mdc-progress-bar:mdc_progress_bar_scss_lib",
-        "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",
-        "//src/material-experimental/mdc-slide-toggle:mdc_slide_toggle_scss_lib",
-        "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
-        "//src/material-experimental/mdc-table:mdc_table_scss_lib",
-        "//src/material-experimental/mdc-tabs:mdc_tabs_scss_lib",
-    ],
+    srcs = ["_all-density.scss"],
+    deps = ["//src/material-experimental/mdc-theming:all_themes"],
 )

--- a/src/material-experimental/mdc-density/_all-density.scss
+++ b/src/material-experimental/mdc-density/_all-density.scss
@@ -1,33 +1,9 @@
-@import '../mdc-button/button-theme';
-@import '../mdc-card/card-theme';
-@import '../mdc-checkbox/checkbox-theme';
-@import '../mdc-chips/chips-theme';
-@import '../mdc-list/list-theme';
-@import '../mdc-menu/menu-theme';
-@import '../mdc-radio/radio-theme';
-@import '../mdc-slide-toggle/slide-toggle-theme';
-@import '../mdc-slider/slider-theme';
-@import '../mdc-tabs/tabs-theme';
-@import '../mdc-table/table-theme';
-@import '../mdc-progress-bar/progress-bar-theme';
-@import '../mdc-input/input-theme';
-@import '../mdc-form-field/form-field-theme';
+@import '../mdc-theming/all-theme';
 
 @mixin angular-material-density-mdc($config: null) {
-  @include mat-button-density-mdc($config);
-  @include mat-fab-density-mdc($config);
-  @include mat-icon-button-density-mdc($config);
-  @include mat-card-density-mdc($config);
-  @include mat-checkbox-density-mdc($config);
-  @include mat-chips-density-mdc($config);
-  @include mat-list-density-mdc($config);
-  @include mat-menu-density-mdc($config);
-  @include mat-radio-density-mdc($config);
-  @include mat-slide-toggle-density-mdc($config);
-  @include mat-slider-density-mdc($config);
-  @include mat-tabs-density-mdc($config);
-  @include mat-table-density-mdc($config);
-  @include mat-progress-bar-density-mdc($config);
-  @include mat-input-density-mdc($config);
-  @include mat-form-field-density-mdc($config);
+  @include angular-material-theme-mdc((
+    color: null,
+    typography: null,
+    density: $config,
+  ));
 }

--- a/src/material-experimental/mdc-typography/BUILD.bazel
+++ b/src/material-experimental/mdc-typography/BUILD.bazel
@@ -9,23 +9,6 @@ filegroup(
 
 sass_library(
     name = "all_typography",
-    srcs = [
-        "_all-typography.scss",
-    ],
-    deps = [
-        "//src/material-experimental/mdc-button:mdc_button_scss_lib",
-        "//src/material-experimental/mdc-card:mdc_card_scss_lib",
-        "//src/material-experimental/mdc-checkbox:mdc_checkbox_scss_lib",
-        "//src/material-experimental/mdc-chips:mdc_chips_scss_lib",
-        "//src/material-experimental/mdc-form-field:mdc_form_field_scss_lib",
-        "//src/material-experimental/mdc-input:mdc_input_scss_lib",
-        "//src/material-experimental/mdc-list:mdc_list_scss_lib",
-        "//src/material-experimental/mdc-menu:mdc_menu_scss_lib",
-        "//src/material-experimental/mdc-progress-bar:mdc_progress_bar_scss_lib",
-        "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",
-        "//src/material-experimental/mdc-slide-toggle:mdc_slide_toggle_scss_lib",
-        "//src/material-experimental/mdc-slider:mdc_slider_scss_lib",
-        "//src/material-experimental/mdc-table:mdc_table_scss_lib",
-        "//src/material-experimental/mdc-tabs:mdc_tabs_scss_lib",
-    ],
+    srcs = ["_all-typography.scss"],
+    deps = ["//src/material-experimental/mdc-theming:all_themes"],
 )

--- a/src/material-experimental/mdc-typography/_all-typography.scss
+++ b/src/material-experimental/mdc-typography/_all-typography.scss
@@ -1,37 +1,13 @@
-@import '../mdc-button/button-theme';
-@import '../mdc-card/card-theme';
-@import '../mdc-checkbox/checkbox-theme';
-@import '../mdc-chips/chips-theme';
-@import '../mdc-list/list-theme';
-@import '../mdc-menu/menu-theme';
-@import '../mdc-radio/radio-theme';
-@import '../mdc-slide-toggle/slide-toggle-theme';
-@import '../mdc-slider/slider-theme';
-@import '../mdc-tabs/tabs-theme';
-@import '../mdc-table/table-theme';
-@import '../mdc-progress-bar/progress-bar-theme';
-@import '../mdc-input/input-theme';
-@import '../mdc-form-field/form-field-theme';
+@import '../mdc-theming/all-theme';
 
 @mixin angular-material-typography-mdc($config: null) {
   @if $config == null {
     $config: mat-typography-config();
   }
 
-  @include mat-button-typography-mdc($config);
-  @include mat-fab-typography-mdc($config);
-  @include mat-icon-button-typography-mdc($config);
-  @include mat-card-typography-mdc($config);
-  @include mat-checkbox-typography-mdc($config);
-  @include mat-chips-typography-mdc($config);
-  @include mat-list-typography-mdc($config);
-  @include mat-menu-typography-mdc($config);
-  @include mat-radio-typography-mdc($config);
-  @include mat-slide-toggle-typography-mdc($config);
-  @include mat-slider-typography-mdc($config);
-  @include mat-tabs-typography-mdc($config);
-  @include mat-table-typography-mdc($config);
-  @include mat-progress-bar-typography-mdc($config);
-  @include mat-input-typography-mdc($config);
-  @include mat-form-field-typography-mdc($config);
+  @include angular-material-theme-mdc((
+    color: null,
+    density: null,
+    typography: $config,
+  ));
 }

--- a/src/material/core/density/_all-density.scss
+++ b/src/material/core/density/_all-density.scss
@@ -1,0 +1,10 @@
+@import '../theming/all-theme';
+
+// Includes all of the density styles.
+@mixin _angular-material-density($config) {
+  @include angular-material-theme((
+    color: null,
+    typography: null,
+    density: $config,
+  ));
+}

--- a/src/material/core/typography/_all-typography.scss
+++ b/src/material/core/typography/_all-typography.scss
@@ -43,6 +43,12 @@
     $config: mat-typography-config();
   }
 
+  // TODO: Do not use individual mixins. Instead, use the all-theme mixin and only specify a
+  // `typography` config while setting `color` and `density` to `null`. This is currently
+  // not possible as it would introduce a circular dependency for typography because the
+  // `mat-core` mixin that is transitively loaded by the `all-theme` file, imports
+  // `all-typography` which would then load `all-theme` again. This causes a cycle.
+
   @include mat-badge-typography($config);
   @include mat-base-typography($config);
   @include mat-autocomplete-typography($config);


### PR DESCRIPTION
Similarly to `mdc-density`, we add a mixin for all of the density styles
that will exist in `src/material`.

Additionally, mdc-typography and mdc-theming mixins are simplified
now that the `all-theme` mixins can control individual theming system
parts. This does not work for `@angular/material` typography due to
a cyclic dependency which we could eliminate if we require people
to _explicitly_ import the file where the `mat-core` mixin originates from.