### PR TITLE
docs(material/expansion-panel): throws No provider found for DateAdapter

### DIFF
--- a/src/components-examples/material/expansion/index.ts
+++ b/src/components-examples/material/expansion/index.ts
@@ -1,6 +1,7 @@
 import {NgModule} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatDatepickerModule} from '@angular/material/datepicker';
+import {MatNativeDateModule} from '@angular/material/core';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {MatIconModule} from '@angular/material/icon';
 import {MatInputModule} from '@angular/material/input';
@@ -26,6 +27,7 @@ const EXAMPLES = [
   imports: [
     MatButtonModule,
     MatDatepickerModule,
+    MatNativeDateModule,
     MatExpansionModule,
     MatIconModule,
     MatInputModule,


### PR DESCRIPTION
- import MatNativeDateModule

Fixes #18771

I was able to reproduce this and verify the fix in the `dev-app`.