### PR TITLE
fix(document-injection): Update to use injected document

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1948,6 +1948,7 @@ describe('CdkDrag', () => {
         // mode in unit tests and there are some issues with doing it in e2e tests.
         const fakeDocument = {
           body: document.body,
+          documentElement: document.documentElement,
           fullscreenElement: document.createElement('div'),
           ELEMENT_NODE: Node.ELEMENT_NODE,
           querySelectorAll: function(...args: [string]) {

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -7,11 +7,11 @@
  */
 
 import {Platform} from '@angular/cdk/platform';
-import {ElementRef, Injectable, NgZone, OnDestroy} from '@angular/core';
+import {ElementRef, Injectable, NgZone, OnDestroy, Optional, Inject} from '@angular/core';
 import {fromEvent, of as observableOf, Subject, Subscription, Observable, Observer} from 'rxjs';
 import {auditTime, filter} from 'rxjs/operators';
 import {CdkScrollable} from './scrollable';
-
+import {DOCUMENT} from '@angular/common';
 
 /** Time in ms to throttle the scrolling events by default. */
 export const DEFAULT_SCROLL_TIME = 20;
@@ -22,7 +22,15 @@ export const DEFAULT_SCROLL_TIME = 20;
  */
 @Injectable({providedIn: 'root'})
 export class ScrollDispatcher implements OnDestroy {
-  constructor(private _ngZone: NgZone, private _platform: Platform) { }
+  /** Used to reference correct document/window */
+  protected _document?: Document;
+
+  constructor(private _ngZone: NgZone,
+              private _platform: Platform,
+              /** @breaking-change 11.0.0 make document required */
+              @Optional() @Inject(DOCUMENT) document?: any) {
+    this._document = document;
+  }
 
   /** Subject for notifying that a registered scrollable reference element has been scrolled. */
   private _scrolled = new Subject<CdkScrollable|void>();
@@ -38,6 +46,16 @@ export class ScrollDispatcher implements OnDestroy {
    * scroll event subscriptions.
    */
   scrollContainers: Map<CdkScrollable, Subscription> = new Map();
+
+  /** Access injected document if available or fallback to global document reference */
+  get document(): Document {
+    return this._document || document;
+  }
+
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  get window(): Window {
+    return this.document.defaultView || window;
+  }
 
   /**
    * Registers a scrollable instance with the service and listens for its scrolled events. When the
@@ -153,7 +171,7 @@ export class ScrollDispatcher implements OnDestroy {
   /** Sets up the global scroll listeners. */
   private _addGlobalListener() {
     this._globalSubscription = this._ngZone.runOutsideAngular(() => {
-      return fromEvent(window.document, 'scroll').subscribe(() => this._scrolled.next());
+      return fromEvent(this.window.document, 'scroll').subscribe(() => this._scrolled.next());
     });
   }
 

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -47,16 +47,6 @@ export class ScrollDispatcher implements OnDestroy {
    */
   scrollContainers: Map<CdkScrollable, Subscription> = new Map();
 
-  /** Access injected document if available or fallback to global document reference */
-  get document(): Document {
-    return this._document || document;
-  }
-
-  /** Use defaultView of injected document if available or fallback to global window reference */
-  get window(): Window {
-    return this.document.defaultView || window;
-  }
-
   /**
    * Registers a scrollable instance with the service and listens for its scrolled events. When the
    * scrollable is scrolled, the service emits the event to its scrolled observable.
@@ -154,6 +144,17 @@ export class ScrollDispatcher implements OnDestroy {
     return scrollingContainers;
   }
 
+  /** Access injected document if available or fallback to global document reference */
+  private _getDocument(): Document {
+    return this._document || document;
+  }
+
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  private _getWindow(): Window {
+    const doc = this._getDocument();
+    return doc.defaultView || window;
+  }
+
   /** Returns true if the element is contained within the provided Scrollable. */
   private _scrollableContainsElement(scrollable: CdkScrollable, elementRef: ElementRef): boolean {
     let element: HTMLElement | null = elementRef.nativeElement;
@@ -171,7 +172,8 @@ export class ScrollDispatcher implements OnDestroy {
   /** Sets up the global scroll listeners. */
   private _addGlobalListener() {
     this._globalSubscription = this._ngZone.runOutsideAngular(() => {
-      return fromEvent(this.window.document, 'scroll').subscribe(() => this._scrolled.next());
+      const window = this._getWindow();
+      return fromEvent(window.document, 'scroll').subscribe(() => this._scrolled.next());
     });
   }
 

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -7,9 +7,10 @@
  */
 
 import {Platform} from '@angular/cdk/platform';
-import {Injectable, NgZone, OnDestroy} from '@angular/core';
+import {Injectable, NgZone, OnDestroy, Optional, Inject} from '@angular/core';
 import {merge, of as observableOf, fromEvent, Observable, Subscription} from 'rxjs';
 import {auditTime} from 'rxjs/operators';
+import {DOCUMENT} from '@angular/common';
 
 /** Time in ms to throttle the resize events by default. */
 export const DEFAULT_RESIZE_TIME = 20;
@@ -35,16 +36,34 @@ export class ViewportRuler implements OnDestroy {
   /** Subscription to streams that invalidate the cached viewport dimensions. */
   private _invalidateCache: Subscription;
 
-  constructor(private _platform: Platform, ngZone: NgZone) {
+  /** Used to reference correct document/window */
+  protected _document?: Document;
+
+  constructor(private _platform: Platform,
+              ngZone: NgZone,
+              /** @breaking-change 11.0.0 make document required */
+              @Optional() @Inject(DOCUMENT) document?: any) {
+    this._document = document;
+
     ngZone.runOutsideAngular(() => {
       this._change = _platform.isBrowser ?
-          merge(fromEvent(window, 'resize'), fromEvent(window, 'orientationchange')) :
+          merge(fromEvent(this.window, 'resize'), fromEvent(this.window, 'orientationchange')) :
           observableOf();
 
       // Note that we need to do the subscription inside `runOutsideAngular`
       // since subscribing is what causes the event listener to be added.
       this._invalidateCache = this.change().subscribe(() => this._updateViewportSize());
     });
+  }
+
+  /** Access injected document if available or fallback to global document reference */
+  get document(): Document {
+    return this._document || document;
+  }
+
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  get window(): Window {
+    return this.document.defaultView || window;
   }
 
   ngOnDestroy() {
@@ -105,13 +124,13 @@ export class ViewportRuler implements OnDestroy {
     // `scrollTop` and `scrollLeft` is inconsistent. However, using the bounding rect of
     // `document.documentElement` works consistently, where the `top` and `left` values will
     // equal negative the scroll position.
-    const documentElement = document.documentElement!;
+    const documentElement = this.document.documentElement!;
     const documentRect = documentElement.getBoundingClientRect();
 
-    const top = -documentRect.top || document.body.scrollTop || window.scrollY ||
+    const top = -documentRect.top || this.document.body.scrollTop || this.window.scrollY ||
                  documentElement.scrollTop || 0;
 
-    const left = -documentRect.left || document.body.scrollLeft || window.scrollX ||
+    const left = -documentRect.left || this.document.body.scrollLeft || this.window.scrollX ||
                   documentElement.scrollLeft || 0;
 
     return {top, left};
@@ -128,7 +147,7 @@ export class ViewportRuler implements OnDestroy {
   /** Updates the cached viewport size. */
   private _updateViewportSize() {
     this._viewportSize = this._platform.isBrowser ?
-        {width: window.innerWidth, height: window.innerHeight} :
+        {width: this.window.innerWidth, height: this.window.innerHeight} :
         {width: 0, height: 0};
   }
 }

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -21,11 +21,13 @@ import {
   OnDestroy,
   NgZone,
   HostListener,
+  Optional,
+  Inject,
 } from '@angular/core';
 import {Platform} from '@angular/cdk/platform';
 import {auditTime, takeUntil} from 'rxjs/operators';
 import {fromEvent, Subject} from 'rxjs';
-
+import {DOCUMENT} from '@angular/common';
 
 /** Directive to automatically resize a textarea to fit its content. */
 @Directive({
@@ -89,11 +91,27 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   /** Cached height of a textarea with a single row. */
   private _cachedLineHeight: number;
 
-  constructor(
-    private _elementRef: ElementRef<HTMLElement>,
-    private _platform: Platform,
-    private _ngZone: NgZone) {
+  /** Used to reference correct document/window */
+  protected _document?: Document;
+
+  constructor(private _elementRef: ElementRef<HTMLElement>,
+              private _platform: Platform,
+              private _ngZone: NgZone,
+              /** @breaking-change 11.0.0 make document required */
+              @Optional() @Inject(DOCUMENT) document?: any) {
+    this._document = document;
+
     this._textareaElement = this._elementRef.nativeElement as HTMLTextAreaElement;
+  }
+
+  /** Access injected document if available or fallback to global document reference */
+  get document(): Document {
+    return this._document || document;
+  }
+
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  get window(): Window {
+    return this.document.defaultView || window;
   }
 
   /** Sets the minimum height of the textarea as determined by minRows. */
@@ -124,7 +142,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
       this.resizeToFitContent();
 
       this._ngZone.runOutsideAngular(() => {
-        fromEvent(window, 'resize')
+        fromEvent(this.window, 'resize')
           .pipe(auditTime(16), takeUntil(this._destroyed))
           .subscribe(() => this.resizeToFitContent(true));
       });
@@ -277,7 +295,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
     // Also note that we have to assert that the textarea is focused before we set the
     // selection range. Setting the selection range on a non-focused textarea will cause
     // it to receive focus on IE and Edge.
-    if (!this._destroyed.isStopped && document.activeElement === textarea) {
+    if (!this._destroyed.isStopped && this.document.activeElement === textarea) {
       textarea.setSelectionRange(selectionStart, selectionEnd);
     }
   }

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -225,9 +225,9 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
   }
 
   ngAfterViewInit() {
-    if (typeof window !== 'undefined') {
+    if (typeof this.window !== 'undefined') {
       this._zone.runOutsideAngular(() => {
-        window.addEventListener('blur', this._windowBlurHandler);
+        this.window.addEventListener('blur', this._windowBlurHandler);
       });
 
       if (_supportsShadowDom()) {
@@ -252,14 +252,19 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
   }
 
   ngOnDestroy() {
-    if (typeof window !== 'undefined') {
-      window.removeEventListener('blur', this._windowBlurHandler);
+    if (typeof this.window !== 'undefined') {
+      this.window.removeEventListener('blur', this._windowBlurHandler);
     }
 
     this._viewportSubscription.unsubscribe();
     this._componentDestroyed = true;
     this._destroyPanel();
     this._closeKeyEventStream.complete();
+  }
+
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  get window(): Window {
+    return this._document?.defaultView || window;
   }
 
   /** Whether or not the autocomplete panel is open. */

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -225,9 +225,11 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
   }
 
   ngAfterViewInit() {
-    if (typeof this.window !== 'undefined') {
+    const window = this._getWindow();
+
+    if (typeof window !== 'undefined') {
       this._zone.runOutsideAngular(() => {
-        this.window.addEventListener('blur', this._windowBlurHandler);
+        window.addEventListener('blur', this._windowBlurHandler);
       });
 
       if (_supportsShadowDom()) {
@@ -252,19 +254,16 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
   }
 
   ngOnDestroy() {
-    if (typeof this.window !== 'undefined') {
-      this.window.removeEventListener('blur', this._windowBlurHandler);
+    const window = this._getWindow();
+
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('blur', this._windowBlurHandler);
     }
 
     this._viewportSubscription.unsubscribe();
     this._componentDestroyed = true;
     this._destroyPanel();
     this._closeKeyEventStream.complete();
-  }
-
-  /** Use defaultView of injected document if available or fallback to global window reference */
-  get window(): Window {
-    return this._document?.defaultView || window;
   }
 
   /** Whether or not the autocomplete panel is open. */
@@ -762,6 +761,11 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
   private _canOpen(): boolean {
     const element = this._element.nativeElement;
     return !element.readOnly && !element.disabled && !this._autocompleteDisabled;
+  }
+
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  private _getWindow(): Window {
+    return this._document?.defaultView || window;
   }
 
   static ngAcceptInputType_autocompleteDisabled: BooleanInput;

--- a/src/material/core/common-behaviors/common-module.ts
+++ b/src/material/core/common-behaviors/common-module.ts
@@ -91,17 +91,18 @@ export class MatCommonModule {
     }
   }
 
-  /** Access injected document if available or fallback to global document reference */
-  get document(): Document | null {
-    const doc = this._document || document;
-    return typeof doc === 'object' && doc ? doc : null;
-  }
+    /** Access injected document if available or fallback to global document reference */
+    private _getDocument(): Document | null {
+      const doc = this._document || document;
+      return typeof doc === 'object' && doc ? doc : null;
+    }
 
-  /** Use defaultView of injected document if available or fallback to global window reference */
-  get window(): Window | null {
-    const win = this.document?.defaultView || window;
-    return typeof win === 'object' && win ? win : null;
-  }
+    /** Use defaultView of injected document if available or fallback to global window reference */
+    private _getWindow(): Window | null {
+      const doc = this._getDocument();
+      const win = doc?.defaultView || window;
+      return typeof win === 'object' && win ? win : null;
+    }
 
   /** Whether any sanity checks are enabled. */
   private _checksAreEnabled(): boolean {
@@ -110,15 +111,16 @@ export class MatCommonModule {
 
   /** Whether the code is running in tests. */
   private _isTestEnv() {
-    const window = this.window as any;
+    const window = this._getWindow() as any;
     return window && (window.__karma__ || window.jasmine);
   }
 
   private _checkDoctypeIsDefined(): void {
     const isEnabled = this._checksAreEnabled() &&
       (this._sanityChecks === true || (this._sanityChecks as GranularSanityChecks).doctype);
+    const document = this._getDocument();
 
-    if (isEnabled && this.document && !this.document.doctype) {
+    if (isEnabled && document && !document.doctype) {
       console.warn(
         'Current document does not have a doctype. This may cause ' +
         'some Angular Material components not to behave as expected.'
@@ -131,16 +133,17 @@ export class MatCommonModule {
     // and the `body` won't be defined if the consumer put their scripts in the `head`.
     const isDisabled = !this._checksAreEnabled() ||
       (this._sanityChecks === false || !(this._sanityChecks as GranularSanityChecks).theme);
+    const document = this._getDocument();
 
-    if (isDisabled || !this.document || !this.document.body ||
+    if (isDisabled || !document || !document.body ||
         typeof getComputedStyle !== 'function') {
       return;
     }
 
-    const testElement = this.document.createElement('div');
+    const testElement = document.createElement('div');
 
     testElement.classList.add('mat-theme-loaded-marker');
-    this.document.body.appendChild(testElement);
+    document.body.appendChild(testElement);
 
     const computedStyle = getComputedStyle(testElement);
 
@@ -155,7 +158,7 @@ export class MatCommonModule {
       );
     }
 
-    this.document.body.removeChild(testElement);
+    document.body.removeChild(testElement);
   }
 
   /** Checks whether the material version matches the cdk version */

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -516,6 +516,11 @@ export class MatSlider extends _MatSliderMixinBase
     });
   }
 
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  get window(): Window {
+    return this._document?.defaultView || window;
+  }
+
   ngOnInit() {
     this._focusMonitor
         .monitor(this._elementRef, true)
@@ -716,8 +721,8 @@ export class MatSlider extends _MatSliderMixinBase
         body.addEventListener('touchcancel', this._pointerUp, activeEventOptions);
       }
     }
-    if (typeof window !== 'undefined' && window) {
-      window.addEventListener('blur', this._windowBlur);
+    if (typeof this.window !== 'undefined' && this.window) {
+      this.window.addEventListener('blur', this._windowBlur);
     }
   }
 
@@ -731,8 +736,8 @@ export class MatSlider extends _MatSliderMixinBase
       body.removeEventListener('touchend', this._pointerUp, activeEventOptions);
       body.removeEventListener('touchcancel', this._pointerUp, activeEventOptions);
     }
-    if (typeof window !== 'undefined' && window) {
-      window.removeEventListener('blur', this._windowBlur);
+    if (typeof this.window !== 'undefined' && this.window) {
+      this.window.removeEventListener('blur', this._windowBlur);
     }
   }
 

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -516,11 +516,6 @@ export class MatSlider extends _MatSliderMixinBase
     });
   }
 
-  /** Use defaultView of injected document if available or fallback to global window reference */
-  get window(): Window {
-    return this._document?.defaultView || window;
-  }
-
   ngOnInit() {
     this._focusMonitor
         .monitor(this._elementRef, true)
@@ -703,6 +698,11 @@ export class MatSlider extends _MatSliderMixinBase
     }
   }
 
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  private _getWindow(): Window {
+    return this._document?.defaultView || window;
+  }
+
   /**
    * Binds our global move and end events. They're bound at the document level and only while
    * dragging so that the user doesn't have to keep their pointer exactly over the slider
@@ -721,8 +721,11 @@ export class MatSlider extends _MatSliderMixinBase
         body.addEventListener('touchcancel', this._pointerUp, activeEventOptions);
       }
     }
-    if (typeof this.window !== 'undefined' && this.window) {
-      this.window.addEventListener('blur', this._windowBlur);
+
+    const window = this._getWindow();
+
+    if (typeof window !== 'undefined' && window) {
+      window.addEventListener('blur', this._windowBlur);
     }
   }
 
@@ -736,8 +739,11 @@ export class MatSlider extends _MatSliderMixinBase
       body.removeEventListener('touchend', this._pointerUp, activeEventOptions);
       body.removeEventListener('touchcancel', this._pointerUp, activeEventOptions);
     }
-    if (typeof this.window !== 'undefined' && this.window) {
-      this.window.removeEventListener('blur', this._windowBlur);
+
+    const window = this._getWindow();
+
+    if (typeof window !== 'undefined' && window) {
+      window.removeEventListener('blur', this._windowBlur);
     }
   }
 

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -92,7 +92,9 @@ export declare class FocusKeyManager<T> extends ListKeyManager<FocusableOption &
 }
 
 export declare class FocusMonitor implements OnDestroy {
-    constructor(_ngZone: NgZone, _platform: Platform);
+    protected _document?: Document;
+    constructor(_ngZone: NgZone, _platform: Platform,
+    document?: any);
     _onBlur(event: FocusEvent, element: HTMLElement): void;
     focusVia(element: HTMLElement, origin: FocusOrigin, options?: FocusOptions): void;
     focusVia(element: ElementRef<HTMLElement>, origin: FocusOrigin, options?: FocusOptions): void;

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -154,9 +154,11 @@ export declare class FixedSizeVirtualScrollStrategy implements VirtualScrollStra
 }
 
 export declare class ScrollDispatcher implements OnDestroy {
+    protected _document?: Document;
     _globalSubscription: Subscription | null;
     scrollContainers: Map<CdkScrollable, Subscription>;
-    constructor(_ngZone: NgZone, _platform: Platform);
+    constructor(_ngZone: NgZone, _platform: Platform,
+    document?: any);
     ancestorScrolled(elementRef: ElementRef, auditTimeInMs?: number): Observable<CdkScrollable | void>;
     deregister(scrollable: CdkScrollable): void;
     getAncestorScrollContainers(elementRef: ElementRef): CdkScrollable[];
@@ -173,7 +175,9 @@ export declare class ScrollingModule {
 }
 
 export declare class ViewportRuler implements OnDestroy {
-    constructor(_platform: Platform, ngZone: NgZone);
+    protected _document?: Document;
+    constructor(_platform: Platform, ngZone: NgZone,
+    document?: any);
     change(throttleTime?: number): Observable<Event>;
     getViewportRect(): ClientRect;
     getViewportScrollPosition(): ViewportScrollPosition;

--- a/tools/public_api_guard/cdk/text-field.d.ts
+++ b/tools/public_api_guard/cdk/text-field.d.ts
@@ -24,13 +24,15 @@ export declare class CdkAutofill implements OnDestroy, OnInit {
 }
 
 export declare class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
+    protected _document?: Document;
     get enabled(): boolean;
     set enabled(value: boolean);
     get maxRows(): number;
     set maxRows(value: number);
     get minRows(): number;
     set minRows(value: number);
-    constructor(_elementRef: ElementRef<HTMLElement>, _platform: Platform, _ngZone: NgZone);
+    constructor(_elementRef: ElementRef<HTMLElement>, _platform: Platform, _ngZone: NgZone,
+    document?: any);
     _noopInputHandler(): void;
     _setMaxHeight(): void;
     _setMinHeight(): void;

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -201,7 +201,9 @@ export declare const MAT_OPTION_PARENT_COMPONENT: InjectionToken<MatOptionParent
 export declare const MAT_RIPPLE_GLOBAL_OPTIONS: InjectionToken<RippleGlobalOptions>;
 
 export declare class MatCommonModule {
-    constructor(highContrastModeDetector: HighContrastModeDetector, sanityChecks: any);
+    protected _document?: Document;
+    constructor(highContrastModeDetector: HighContrastModeDetector, sanityChecks: any,
+    document?: any);
     static ɵinj: i0.ɵɵInjectorDef<MatCommonModule>;
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatCommonModule, never, [typeof i1.BidiModule], [typeof i1.BidiModule]>;
 }


### PR DESCRIPTION
Update several classes in Material and the CDK to reference
the injected document instead of accessing the global document
and window variables. This fixes use-cases where the document
is dynamically provided. This change follows the pattern used
in several other places such as the Cdk OverlayContainer.