### PR TITLE
refactor: change isDateInstance return type to is D

### DIFF
--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -235,7 +235,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     return super.deserialize(value);
   }
 
-  isDateInstance(obj: any): boolean {
+  isDateInstance(obj: any): obj is _moment.Moment {
     return moment.isMoment(obj);
   }
 

--- a/src/material/core/datetime/date-adapter.ts
+++ b/src/material/core/datetime/date-adapter.ts
@@ -188,7 +188,7 @@ export abstract class DateAdapter<D> {
    * @param obj The object to check
    * @returns Whether the object is a date instance.
    */
-  abstract isDateInstance(obj: any): boolean;
+  abstract isDateInstance(obj: any): obj is D;
 
   /**
    * Checks whether the given date is valid.

--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -267,7 +267,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
     return super.deserialize(value);
   }
 
-  isDateInstance(obj: any) {
+  isDateInstance(obj: any): obj is Date {
     return obj instanceof Date;
   }
 

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -70,7 +70,7 @@ export declare abstract class DateAdapter<D> {
     abstract getYear(date: D): number;
     abstract getYearName(date: D): string;
     abstract invalid(): D;
-    abstract isDateInstance(obj: any): boolean;
+    abstract isDateInstance(obj: any): obj is D;
     abstract isValid(date: D): boolean;
     abstract parse(value: any, parseFormat: any): D | null;
     sameDate(first: D | null, second: D | null): boolean;
@@ -375,7 +375,7 @@ export declare class NativeDateAdapter extends DateAdapter<Date> {
     getYear(date: Date): number;
     getYearName(date: Date): string;
     invalid(): Date;
-    isDateInstance(obj: any): boolean;
+    isDateInstance(obj: any): obj is Date;
     isValid(date: Date): boolean;
     parse(value: any): Date | null;
     toIso8601(date: Date): string;


### PR DESCRIPTION
Change return type of `DateAdapter.isDateInstance` from boolean to `obj is D`