### PR TITLE
build: ensure correct toolchains used for remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -76,6 +76,13 @@ build:remote --project_id=internal-200822
 # Needed due to: https://github.com/bazelbuild/bazel/issues/7254
 build:remote --define=EXECUTOR=remote
 
+# For remote execution, we use the `ubuntu16_04_clang` toolchain configurations. These only
+# support `k8` or `armeabi-v7a`. Since we run on remotely with `k8` containers, we need to
+# ensure that the proper CPU is configured so that the correct toolchain can be used.
+# https://github.com/bazelbuild/bazel-toolchains/blob/master/configs/ubuntu16_04_clang/10.0.0/bazel_2.1.0/cc/BUILD#L50
+build:remote --cpu=k8
+build:remote --host_cpu=k8
+
 # Setup the remote build execution servers.
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com


### PR DESCRIPTION
Currently the toolchains used for RBE are dependent on the current platform.
This breaks because the remote executors are `k8` based, and the default
`bazel-toolchain` configurations do not work for anything except `k8` or `armeabi-v7a`.