### PR TITLE
fix(cdk/coercion): add the support for readonly array coercion

### DIFF
--- a/src/cdk/coercion/array.ts
+++ b/src/cdk/coercion/array.ts
@@ -7,6 +7,8 @@
  */
 
 /** Wraps the provided value in an array, unless the provided value is an array. */
+export function coerceArray<T>(value: T | T[]): T[];
+export function coerceArray<T>(value: T | readonly T[]): readonly T[];
 export function coerceArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value];
 }

--- a/tools/public_api_guard/cdk/coercion.d.ts
+++ b/tools/public_api_guard/cdk/coercion.d.ts
@@ -3,6 +3,7 @@ export declare function _isNumberValue(value: any): boolean;
 export declare type BooleanInput = string | boolean | null | undefined;
 
 export declare function coerceArray<T>(value: T | T[]): T[];
+export declare function coerceArray<T>(value: T | readonly T[]): readonly T[];
 
 export declare function coerceBooleanProperty(value: any): boolean;
 


### PR DESCRIPTION
Fixes a type definition of coerceArray so that it accepts both mutable and
immutable arrays.

Fixes #18806