### PR TITLE
Revert "fix(radio): clicks not landing correctly in some cases on Chrome (#18357)"

### DIFF
--- a/src/material/radio/BUILD.bazel
+++ b/src/material/radio/BUILD.bazel
@@ -55,7 +55,6 @@ ng_test_library(
     ),
     deps = [
         ":radio",
-        "//src/cdk/a11y",
         "//src/cdk/testing/private",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -1,9 +1,8 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick, inject} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {Component, DebugElement, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
-import {FocusMonitor} from '@angular/cdk/a11y';
 
 import {MAT_RADIO_DEFAULT_OPTIONS} from './radio';
 import {MatRadioButton, MatRadioChange, MatRadioGroup, MatRadioModule} from './index';
@@ -395,21 +394,6 @@ describe('MatRadio', () => {
       expect(radioRippleNativeElements
           .every(element => element.classList.contains('mat-focus-indicator'))).toBe(true);
     });
-
-    it('should not manually move focus to underlying input when focus comes from mouse or touch',
-      inject([FocusMonitor], (focusMonitor: FocusMonitor) => {
-        const radioElement = radioNativeElements[0];
-        const inputElement = radioInputElements[0];
-        expect(document.activeElement).not.toBe(inputElement);
-
-        focusMonitor.focusVia(radioElement, 'mouse');
-        fixture.detectChanges();
-        expect(document.activeElement).not.toBe(inputElement);
-
-        focusMonitor.focusVia(radioElement, 'touch');
-        fixture.detectChanges();
-        expect(document.activeElement).not.toBe(inputElement);
-      }));
 
   });
 

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -351,6 +351,10 @@ const _MatRadioButtonMixinBase:
     '[attr.aria-label]': 'null',
     '[attr.aria-labelledby]': 'null',
     '[attr.aria-describedby]': 'null',
+    // Note: under normal conditions focus shouldn't land on this element, however it may be
+    // programmatically set, for example inside of a focus trap, in this case we want to forward
+    // the focus to the native element.
+    '(focus)': '_inputElement.nativeElement.focus()',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -536,13 +540,7 @@ export class MatRadioButton extends _MatRadioButtonMixinBase
     this._focusMonitor
       .monitor(this._elementRef, true)
       .subscribe(focusOrigin => {
-        // Only forward focus manually when it was received programmatically or through the
-        // keyboard. We should not do this for mouse/touch focus for two reasons:
-        // 1. It can prevent clicks from landing in Chrome (see #18269).
-        // 2. They're already handled by the wrapping `label` element.
-        if (focusOrigin === 'keyboard' || focusOrigin === 'program') {
-          this._inputElement.nativeElement.focus();
-        } else if (!focusOrigin && this.radioGroup) {
+        if (!focusOrigin && this.radioGroup) {
           this.radioGroup._touch();
         }
       });


### PR DESCRIPTION
Had problems internally when users wanted to focus an `<input>` inside of a radio option after that option is selected. Please commit the changes to a new PR so we can continue working on it

This reverts commit fe298350cd8391ce9a24b56c275c297bdf2b8a12.