### PR TITLE
perf(drag-drop): avoid unnecessary change detection on pointer down events

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -364,8 +364,10 @@ export class DragRef<T = any> {
         this._removeRootElementListeners(this._rootElement);
       }
 
-      element.addEventListener('mousedown', this._pointerDown, activeEventListenerOptions);
-      element.addEventListener('touchstart', this._pointerDown, passiveEventListenerOptions);
+      this._ngZone.runOutsideAngular(() => {
+        element.addEventListener('mousedown', this._pointerDown, activeEventListenerOptions);
+        element.addEventListener('touchstart', this._pointerDown, passiveEventListenerOptions);
+      });
       this._initialTransform = undefined;
       this._rootElement = element;
     }


### PR DESCRIPTION
When the drag&drop was initially implemented it had to trigger change detection immediately once dragging started so that the data bindings get updated correctly. After some time we introduced a threshold for dragging that also triggers its own change detection and makes the initial change detection unnecessary.

Fixes #18726.