### PR TITLE
build: update tslint to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "ts-api-guardian": "^0.5.0",
     "ts-node": "^3.0.4",
     "tsickle": "0.38.1",
-    "tslint": "^6.0.0",
+    "tslint": "^6.1.0",
     "tsutils": "^3.0.0",
     "typescript": "~3.8.3",
     "typescript-3.6": "npm:typescript@~3.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11506,10 +11506,10 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-6.0.0.tgz#1c0148beac4779924216302f192cdaa153618310"
-  integrity sha512-9nLya8GBtlFmmFMW7oXXwoXS1NkrccqTqAtwXzdPV9e2mqSEvCki6iHL/Fbzi5oqbugshzgGPk7KBb2qNP1DSA==
+tslint@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-6.1.0.tgz#c6c611b8ba0eed1549bf5a59ba05a7732133d851"
+  integrity sha512-fXjYd/61vU6da04E505OZQGb2VCN2Mq3doeWcOIryuG+eqdmFUXTYVwdhnbEu2k46LNLgUYt9bI5icQze/j0bQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"


### PR DESCRIPTION
Updates tslint to the latest version that has support
for the new TypeScript 3.8 import and private identifier
syntax.

This tslint release was not available when we landed the original
TypeScript 3.8 update PR.