### PR TITLE
fix(dialog): recapture focus when clicking on backdrop when closing is disabled

### DIFF
--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -94,6 +94,14 @@ export class MatDialogRef<T, R = any> {
         event.preventDefault();
         this.close();
       });
+
+    _overlayRef.backdropClick().subscribe(() => {
+      if (this.disableClose) {
+        this._containerInstance._recaptureFocus();
+      } else {
+        this.close();
+      }
+    });
   }
 
   /**

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -968,6 +968,29 @@ describe('MatDialog', () => {
 
       expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeFalsy();
     }));
+
+    it('should recapture focus when clicking on the backdrop', fakeAsync(() => {
+      dialog.open(PizzaMsg, {
+        disableClose: true,
+        viewContainerRef: testViewContainerRef
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+      let input = overlayContainerElement.querySelector('input') as HTMLInputElement;
+
+      expect(document.activeElement).toBe(input, 'Expected input to be focused on open');
+
+      input.blur(); // Programmatic clicks might not move focus so we simulate it.
+      backdrop.click();
+      viewContainerFixture.detectChanges();
+      flush();
+
+      expect(document.activeElement).toBe(input, 'Expected input to stay focused after click');
+    }));
+
   });
 
   describe('hasBackdrop option', () => {

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -248,15 +248,6 @@ export class MatDialog implements OnDestroy {
     const dialogRef =
         new MatDialogRef<T, R>(overlayRef, dialogContainer, config.id);
 
-    // When the dialog backdrop is clicked, we want to close it.
-    if (config.hasBackdrop) {
-      overlayRef.backdropClick().subscribe(() => {
-        if (!dialogRef.disableClose) {
-          dialogRef.close();
-        }
-      });
-    }
-
     if (componentOrTemplateRef instanceof TemplateRef) {
       dialogContainer.attachTemplatePortal(
         new TemplatePortal<T>(componentOrTemplateRef, null!,

--- a/tools/public_api_guard/material/dialog.d.ts
+++ b/tools/public_api_guard/material/dialog.d.ts
@@ -99,6 +99,7 @@ export declare class MatDialogContainer extends BasePortalOutlet {
     _config: MatDialogConfig);
     _onAnimationDone(event: AnimationEvent): void;
     _onAnimationStart(event: AnimationEvent): void;
+    _recaptureFocus(): void;
     _startExitAnimation(): void;
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C>;


### PR DESCRIPTION
`MatDialog` has an option to disable closing by clicking on the backdrop, but this can lead to focus being bumped back to the `body` and allowing users to tab past the dialog. These changes add some extra logic to recapture focus when the user clicks on the backdrop.

Fixes #18799.