### PR TITLE
refactor(cdk): use overloads to indicate deprecated constructor signatures

### DIFF
--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -73,13 +73,14 @@ export class CdkCopyToClipboard implements OnDestroy {
   /** Timeout for the current copy attempt. */
   private _currentTimeout: any;
 
+  constructor(clipboard: Clipboard, ngZone: NgZone, config?: CdkCopyToClipboardConfig);
+
+  /** @deprecated @breaking-change 10.0.0 */
+  constructor(clipboard: Clipboard, ngZone?: NgZone, config?: CdkCopyToClipboardConfig);
+
   constructor(
     private _clipboard: Clipboard,
-    /**
-     * @deprecated _ngZone parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    private _ngZone?: NgZone,
+    private _ngZone: NgZone,
     @Optional() @Inject(CKD_COPY_TO_CLIPBOARD_CONFIG) config?: CdkCopyToClipboardConfig) {
 
     if (config && config.attempts != null) {

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -152,15 +152,29 @@ export class CdkDropList<T = any> implements AfterContentInit, OnDestroy {
   private _unsortedItems = new Set<CdkDrag>();
 
   constructor(
+    element: ElementRef<HTMLElement>,
+    dragDrop: DragDrop,
+    changeDetectorRef: ChangeDetectorRef,
+    dir: Directionality | undefined,
+    group: CdkDropListGroup<CdkDropList> | undefined,
+    scrollDispatcher: ScrollDispatcher,
+    config?: DragDropConfig);
+
+  /** @deprecated @breaking-change 11.0.0 */
+  constructor(
+    element: ElementRef<HTMLElement>,
+    dragDrop: DragDrop,
+    changeDetectorRef: ChangeDetectorRef,
+    dir: Directionality | undefined,
+    group: CdkDropListGroup<CdkDropList> | undefined,
+    scrollDispatcher?: ScrollDispatcher,
+    config?: DragDropConfig);
+
+  constructor(
       /** Element that the drop list is attached to. */
       public element: ElementRef<HTMLElement>, dragDrop: DragDrop,
       private _changeDetectorRef: ChangeDetectorRef, @Optional() private _dir?: Directionality,
       @Optional() @SkipSelf() private _group?: CdkDropListGroup<CdkDropList>,
-
-      /**
-       * @deprecated _scrollDispatcher parameter to become required.
-       * @breaking-change 11.0.0
-       */
       private _scrollDispatcher?: ScrollDispatcher,
       @Optional() @Inject(CDK_DRAG_CONFIG) config?: DragDropConfig) {
     this._dropListRef = dragDrop.createDropList(element);

--- a/src/cdk/overlay/fullscreen-overlay-container.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.ts
@@ -24,14 +24,13 @@ export class FullscreenOverlayContainer extends OverlayContainer implements OnDe
   private _fullScreenEventName: string | undefined;
   private _fullScreenListener: () => void;
 
-  constructor(
-    @Inject(DOCUMENT) _document: any,
-    /**
-     * @deprecated `platform` parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    platform?: Platform) {
-    super(_document, platform);
+  constructor(document: any, platform: Platform);
+
+  /** @deprecated @breaking-change 10.0.0 */
+  constructor(document: any);
+
+  constructor(@Inject(DOCUMENT) _document: any, platform?: Platform) {
+    super(_document, platform!);
   }
 
   ngOnDestroy() {

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -30,13 +30,12 @@ export class OverlayContainer implements OnDestroy {
   protected _containerElement: HTMLElement;
   protected _document: Document;
 
-  constructor(
-    @Inject(DOCUMENT) document: any,
-    /**
-     * @deprecated `platform` parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    protected _platform?: Platform) {
+  constructor(document: any, platform: Platform);
+
+  /** @deprecated @breaking-change 10.0.0 */
+  constructor(document: any);
+
+  constructor(@Inject(DOCUMENT) document: any, protected _platform?: Platform) {
     this._document = document;
   }
 

--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -24,16 +24,26 @@ export class DomPortalOutlet extends BasePortalOutlet {
   private _document: Document;
 
   constructor(
+    outletElement: Element,
+    componentFactoryResolver: ComponentFactoryResolver,
+    appRef: ApplicationRef,
+    defaultInjector: Injector,
+    document: any);
+
+  /** @deprecated @breaking-change 10.0.0 */
+  constructor(
+    outletElement: Element,
+    componentFactoryResolver: ComponentFactoryResolver,
+    appRef: ApplicationRef,
+    defaultInjector: Injector,
+    document?: any);
+
+  constructor(
       /** Element into which the content is projected. */
       public outletElement: Element,
       private _componentFactoryResolver: ComponentFactoryResolver,
       private _appRef: ApplicationRef,
       private _defaultInjector: Injector,
-
-      /**
-       * @deprecated `_document` Parameter to be made required.
-       * @breaking-change 10.0.0
-       */
       _document?: any) {
     super();
     this._document = _document;

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -80,13 +80,18 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
   private _attachedRef: CdkPortalOutletAttachedRef;
 
   constructor(
+    componentFactoryResolver: ComponentFactoryResolver,
+    viewContainerRef: ViewContainerRef,
+    document: any);
+
+  /** @deprecated @breaking-change 9.0.0 */
+  constructor(
+    componentFactoryResolver: ComponentFactoryResolver,
+    viewContainerRef: ViewContainerRef);
+
+  constructor(
       private _componentFactoryResolver: ComponentFactoryResolver,
       private _viewContainerRef: ViewContainerRef,
-
-      /**
-       * @deprecated `_document` parameter to be made required.
-       * @breaking-change 9.0.0
-       */
       @Inject(DOCUMENT) _document?: any) {
     super();
     this._document = _document;

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -152,6 +152,22 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   /** Subscription to changes in the viewport size. */
   private _viewportChanges = Subscription.EMPTY;
 
+  constructor(elementRef: ElementRef<HTMLElement>,
+    changeDetectorRef: ChangeDetectorRef,
+    ngZone: NgZone,
+    scrollStrategy: VirtualScrollStrategy,
+    dir: Directionality,
+    scrollDispatcher: ScrollDispatcher,
+    viewportRuler: ViewportRuler);
+
+  /** @deprecated @breaking-change 11.0.0 */
+  constructor(elementRef: ElementRef<HTMLElement>,
+    changeDetectorRef: ChangeDetectorRef,
+    ngZone: NgZone,
+    scrollStrategy: VirtualScrollStrategy,
+    dir: Directionality,
+    scrollDispatcher: ScrollDispatcher);
+
   constructor(public elementRef: ElementRef<HTMLElement>,
               private _changeDetectorRef: ChangeDetectorRef,
               ngZone: NgZone,
@@ -159,10 +175,6 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
                   private _scrollStrategy: VirtualScrollStrategy,
               @Optional() dir: Directionality,
               scrollDispatcher: ScrollDispatcher,
-              /**
-               * @deprecated `viewportRuler` parameter to become required.
-               * @breaking-change 11.0.0
-               */
               @Optional() viewportRuler?: ViewportRuler) {
     super(elementRef, scrollDispatcher, ngZone, dir);
 

--- a/tools/public_api_guard/cdk/clipboard.d.ts
+++ b/tools/public_api_guard/cdk/clipboard.d.ts
@@ -3,8 +3,8 @@ export declare class CdkCopyToClipboard implements OnDestroy {
     attempts: number;
     copied: EventEmitter<boolean>;
     text: string;
-    constructor(_clipboard: Clipboard,
-    _ngZone?: NgZone | undefined, config?: CdkCopyToClipboardConfig);
+    constructor(clipboard: Clipboard, ngZone: NgZone, config?: CdkCopyToClipboardConfig);
+    constructor(clipboard: Clipboard, ngZone?: NgZone, config?: CdkCopyToClipboardConfig);
     copy(attempts?: number): void;
     ngOnDestroy(): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkCopyToClipboard, "[cdkCopyToClipboard]", never, { "text": "cdkCopyToClipboard"; "attempts": "cdkCopyToClipboardAttempts"; }, { "copied": "cdkCopyToClipboardCopied"; "_deprecatedCopied": "copied"; }, never>;

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -162,9 +162,8 @@ export declare class CdkDropList<T = any> implements AfterContentInit, OnDestroy
     orientation: DropListOrientation;
     sorted: EventEmitter<CdkDragSortEvent<T>>;
     sortingDisabled: boolean;
-    constructor(
-    element: ElementRef<HTMLElement>, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined,
-    _scrollDispatcher?: ScrollDispatcher | undefined, config?: DragDropConfig);
+    constructor(element: ElementRef<HTMLElement>, dragDrop: DragDrop, changeDetectorRef: ChangeDetectorRef, dir: Directionality | undefined, group: CdkDropListGroup<CdkDropList> | undefined, scrollDispatcher: ScrollDispatcher, config?: DragDropConfig);
+    constructor(element: ElementRef<HTMLElement>, dragDrop: DragDrop, changeDetectorRef: ChangeDetectorRef, dir: Directionality | undefined, group: CdkDropListGroup<CdkDropList> | undefined, scrollDispatcher?: ScrollDispatcher, config?: DragDropConfig);
     addItem(item: CdkDrag): void;
     drop(item: CdkDrag, currentIndex: number, previousContainer: CdkDropList, isPointerOverContainer: boolean): void;
     enter(item: CdkDrag, pointerX: number, pointerY: number): void;

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -152,8 +152,8 @@ export declare type FlexibleConnectedPositionStrategyOrigin = ElementRef | HTMLE
 };
 
 export declare class FullscreenOverlayContainer extends OverlayContainer implements OnDestroy {
-    constructor(_document: any,
-    platform?: Platform);
+    constructor(document: any);
+    constructor(document: any, platform: Platform);
     protected _createContainer(): void;
     getFullscreenElement(): Element;
     ngOnDestroy(): void;
@@ -226,8 +226,8 @@ export declare class OverlayContainer implements OnDestroy {
     protected _containerElement: HTMLElement;
     protected _document: Document;
     protected _platform?: Platform | undefined;
-    constructor(document: any,
-    _platform?: Platform | undefined);
+    constructor(document: any);
+    constructor(document: any, platform: Platform);
     protected _createContainer(): void;
     getContainerElement(): HTMLElement;
     ngOnDestroy(): void;

--- a/tools/public_api_guard/cdk/portal.d.ts
+++ b/tools/public_api_guard/cdk/portal.d.ts
@@ -27,8 +27,8 @@ export declare class CdkPortalOutlet extends BasePortalOutlet implements OnInit,
     get attachedRef(): CdkPortalOutletAttachedRef;
     get portal(): Portal<any> | null;
     set portal(portal: Portal<any> | null);
-    constructor(_componentFactoryResolver: ComponentFactoryResolver, _viewContainerRef: ViewContainerRef,
-    _document?: any);
+    constructor(componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef);
+    constructor(componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, document: any);
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C>;
     ngOnDestroy(): void;
@@ -63,9 +63,8 @@ export declare class DomPortalHost extends DomPortalOutlet {
 export declare class DomPortalOutlet extends BasePortalOutlet {
     attachDomPortal: (portal: DomPortal<HTMLElement>) => void;
     outletElement: Element;
-    constructor(
-    outletElement: Element, _componentFactoryResolver: ComponentFactoryResolver, _appRef: ApplicationRef, _defaultInjector: Injector,
-    _document?: any);
+    constructor(outletElement: Element, componentFactoryResolver: ComponentFactoryResolver, appRef: ApplicationRef, defaultInjector: Injector, document: any);
+    constructor(outletElement: Element, componentFactoryResolver: ComponentFactoryResolver, appRef: ApplicationRef, defaultInjector: Injector, document?: any);
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C>;
     dispose(): void;

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -111,8 +111,8 @@ export declare class CdkVirtualScrollViewport extends CdkScrollable implements O
     set orientation(orientation: 'horizontal' | 'vertical');
     renderedRangeStream: Observable<ListRange>;
     scrolledIndexChange: Observable<number>;
-    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher,
-    viewportRuler?: ViewportRuler);
+    constructor(elementRef: ElementRef<HTMLElement>, changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher);
+    constructor(elementRef: ElementRef<HTMLElement>, changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher, viewportRuler: ViewportRuler);
     attach(forOf: CdkVirtualForOf<any>): void;
     checkViewportSize(): void;
     detach(): void;


### PR DESCRIPTION
Historically we've been using `@deprecated` on constructor paramters to indicate when they're going to become required. This is incorrect, because it won't show up in tooling that looks for breaking changes.

These changes reworks all of the deprecated constructor signatures in the CDK to use overloads.

This PR is intended as a test run to see if there are any issues with the approach, before we can roll it out to Material which has a lot more constructor deprecations.