### PR TITLE
fix(bottom-sheet): allow result to be passed when dismissing through service

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -400,6 +400,20 @@ describe('MatBottomSheet', () => {
     expect(spy).toHaveBeenCalledWith(1337);
   }));
 
+  it('should be able to pass data when dismissing through the service', fakeAsync(() => {
+    const bottomSheetRef = bottomSheet.open<PizzaMsg, any, number>(PizzaMsg);
+    const spy = jasmine.createSpy('afterDismissed spy');
+
+    bottomSheetRef.afterDismissed().subscribe(spy);
+    viewContainerFixture.detectChanges();
+
+    bottomSheet.dismiss(1337);
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(spy).toHaveBeenCalledWith(1337);
+  }));
+
   it('should close the bottom sheet when going forwards/backwards in history', fakeAsync(() => {
     bottomSheet.open(PizzaMsg);
 

--- a/src/material/bottom-sheet/bottom-sheet.ts
+++ b/src/material/bottom-sheet/bottom-sheet.ts
@@ -112,10 +112,11 @@ export class MatBottomSheet implements OnDestroy {
 
   /**
    * Dismisses the currently-visible bottom sheet.
+   * @param result Data to pass to the bottom sheet instance.
    */
-  dismiss(): void {
+  dismiss<R = any>(result?: R): void {
     if (this._openedBottomSheetRef) {
-      this._openedBottomSheetRef.dismiss();
+      this._openedBottomSheetRef.dismiss(result);
     }
   }
 

--- a/tools/public_api_guard/material/bottom-sheet.d.ts
+++ b/tools/public_api_guard/material/bottom-sheet.d.ts
@@ -6,7 +6,7 @@ export declare class MatBottomSheet implements OnDestroy {
     get _openedBottomSheetRef(): MatBottomSheetRef<any> | null;
     set _openedBottomSheetRef(value: MatBottomSheetRef<any> | null);
     constructor(_overlay: Overlay, _injector: Injector, _parentBottomSheet: MatBottomSheet, _location?: Location | undefined, _defaultOptions?: MatBottomSheetConfig<any> | undefined);
-    dismiss(): void;
+    dismiss<R = any>(result?: R): void;
     ngOnDestroy(): void;
     open<T, D = any, R = any>(component: ComponentType<T>, config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
     open<T, D = any, R = any>(template: TemplateRef<T>, config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;


### PR DESCRIPTION
A bottom sheet can be dismissed both through the bottom sheet ref and the service, but we only allow a result to be passed through the ref. These changes add a paramter to the service as well.