### PR TITLE
fix(table): error when nesting tables

### DIFF
--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -7,8 +7,17 @@
  */
 
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
-import {ContentChild, Directive, ElementRef, Input, TemplateRef} from '@angular/core';
+import {
+  ContentChild,
+  Directive,
+  ElementRef,
+  Input,
+  TemplateRef,
+  Inject,
+  Optional,
+} from '@angular/core';
 import {CanStick, CanStickCtor, mixinHasStickyInput} from './can-stick';
+import {CDK_TABLE} from './tokens';
 
 
 /** Base interface for a cell definition. Captures a column's cell template definition. */
@@ -67,12 +76,10 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
   set name(name: string) {
     // If the directive is set without a name (updated programatically), then this setter will
     // trigger with an empty string and should not overwrite the programatically set value.
-    if (!name) {
-      return;
+    if (name) {
+      this._name = name;
+      this.cssClassFriendlyName = name.replace(/[^a-z0-9_-]/ig, '-');
     }
-
-    this._name = name;
-    this.cssClassFriendlyName = name.replace(/[^a-z0-9_-]/ig, '-');
   }
   _name: string;
 
@@ -107,6 +114,10 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
    * do not match are replaced by the '-' character.
    */
   cssClassFriendlyName: string;
+
+  constructor(@Inject(CDK_TABLE) @Optional() public _table?: any) {
+    super();
+  }
 
   static ngAcceptInputType_sticky: BooleanInput;
   static ngAcceptInputType_stickyEnd: BooleanInput;

--- a/src/cdk/table/public-api.ts
+++ b/src/cdk/table/public-api.ts
@@ -13,6 +13,7 @@ export * from './table-module';
 export * from './sticky-styler';
 export * from './can-stick';
 export * from './text-column';
+export * from './tokens';
 
 /** Re-export DataSource for a more intuitive experience for users of just the table. */
 export {DataSource} from '@angular/cdk/collections';

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -19,10 +19,13 @@ import {
   SimpleChanges,
   TemplateRef,
   ViewContainerRef,
-  ViewEncapsulation
+  ViewEncapsulation,
+  Inject,
+  Optional
 } from '@angular/core';
 import {CanStick, CanStickCtor, mixinHasStickyInput} from './can-stick';
 import {CdkCellDef, CdkColumnDef} from './cell';
+import {CDK_TABLE} from './tokens';
 
 /**
  * The row template that can be used by the mat-table. Should not be used outside of the
@@ -91,7 +94,10 @@ const _CdkHeaderRowDefBase: CanStickCtor&typeof CdkHeaderRowDefBase =
   inputs: ['columns: cdkHeaderRowDef', 'sticky: cdkHeaderRowDefSticky'],
 })
 export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, OnChanges {
-  constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
+  constructor(
+    template: TemplateRef<any>,
+    _differs: IterableDiffers,
+    @Inject(CDK_TABLE) @Optional() public _table?: any) {
     super(template, _differs);
   }
 
@@ -119,7 +125,10 @@ const _CdkFooterRowDefBase: CanStickCtor&typeof CdkFooterRowDefBase =
   inputs: ['columns: cdkFooterRowDef', 'sticky: cdkFooterRowDefSticky'],
 })
 export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, OnChanges {
-  constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
+  constructor(
+    template: TemplateRef<any>,
+    _differs: IterableDiffers,
+    @Inject(CDK_TABLE) @Optional() public _table?: any) {
     super(template, _differs);
   }
 
@@ -152,7 +161,10 @@ export class CdkRowDef<T> extends BaseRowDef {
 
   // TODO(andrewseguin): Add an input for providing a switch function to determine
   //   if this template should be used.
-  constructor(template: TemplateRef<any>, _differs: IterableDiffers) {
+  constructor(
+    template: TemplateRef<any>,
+    _differs: IterableDiffers,
+    @Inject(CDK_TABLE) @Optional() public _table?: any) {
     super(template, _differs);
   }
 }

--- a/src/cdk/table/table.spec.ts
+++ b/src/cdk/table/table.spec.ts
@@ -482,6 +482,21 @@ describe('CdkTable', () => {
     ]);
   });
 
+  it('should be able to nest tables', () => {
+    const thisFixture = createComponent(NestedHtmlTableApp);
+    thisFixture.detectChanges();
+    const outerTable = thisFixture.nativeElement.querySelector('table');
+    const innerTable = outerTable.querySelector('table');
+    const outerRows = Array.from<HTMLTableRowElement>(outerTable.querySelector('tbody').rows);
+    const innerRows = Array.from<HTMLTableRowElement>(innerTable.querySelector('tbody').rows);
+
+    expect(outerTable).toBeTruthy();
+    expect(outerRows.map(row => row.cells.length)).toEqual([3, 3, 3]);
+
+    expect(innerTable).toBeTruthy();
+    expect(innerRows.map(row => row.cells.length)).toEqual([3, 3, 3]);
+  });
+
   it('should apply correct roles for native table elements', () => {
     const thisFixture = createComponent(NativeHtmlTableApp);
     const thisTableElement: HTMLTableElement = thisFixture.nativeElement.querySelector('table');
@@ -2274,6 +2289,55 @@ class NativeHtmlTableApp {
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
   @ViewChild(CdkTable) table: CdkTable<TestData>;
+}
+
+
+@Component({
+  template: `
+    <table cdk-table [dataSource]="dataSource">
+      <ng-container cdkColumnDef="column_a">
+        <th cdk-header-cell *cdkHeaderCellDef> Column A</th>
+        <td cdk-cell *cdkCellDef="let row">{{row.a}}</td>
+      </ng-container>
+
+      <ng-container cdkColumnDef="column_b">
+        <th cdk-header-cell *cdkHeaderCellDef> Column B</th>
+        <td cdk-cell *cdkCellDef="let row">
+          <table cdk-table [dataSource]="dataSource">
+            <ng-container cdkColumnDef="column_a">
+              <th cdk-header-cell *cdkHeaderCellDef> Column A</th>
+              <td cdk-cell *cdkCellDef="let row"> {{row.a}}</td>
+            </ng-container>
+
+            <ng-container cdkColumnDef="column_b">
+              <th cdk-header-cell *cdkHeaderCellDef> Column B</th>
+              <td cdk-cell *cdkCellDef="let row"> {{row.b}}</td>
+            </ng-container>
+
+            <ng-container cdkColumnDef="column_c">
+              <th cdk-header-cell *cdkHeaderCellDef> Column C</th>
+              <td cdk-cell *cdkCellDef="let row"> {{row.c}}</td>
+            </ng-container>
+
+            <tr cdk-header-row *cdkHeaderRowDef="columnsToRender"></tr>
+            <tr cdk-row *cdkRowDef="let row; columns: columnsToRender" class="customRowClass"></tr>
+          </table>
+        </td>
+      </ng-container>
+
+      <ng-container cdkColumnDef="column_c">
+        <th cdk-header-cell *cdkHeaderCellDef> Column C</th>
+        <td cdk-cell *cdkCellDef="let row">{{row.c}}</td>
+      </ng-container>
+
+      <tr cdk-header-row *cdkHeaderRowDef="columnsToRender"></tr>
+      <tr cdk-row *cdkRowDef="let row; columns: columnsToRender" class="customRowClass"></tr>
+    </table>
+  `
+})
+class NestedHtmlTableApp {
+  dataSource: FakeDataSource | undefined = new FakeDataSource();
+  columnsToRender = ['column_a', 'column_b', 'column_c'];
 }
 
 @Component({

--- a/src/cdk/table/text-column.spec.ts
+++ b/src/cdk/table/text-column.spec.ts
@@ -7,7 +7,7 @@ import {
 } from './table-errors';
 import {CdkTableModule} from './table-module';
 import {expectTableToMatchContent} from './table.spec';
-import {TEXT_COLUMN_OPTIONS, TextColumnOptions} from './text-column';
+import {TEXT_COLUMN_OPTIONS, TextColumnOptions} from './tokens';
 
 
 describe('CdkTextColumn', () => {

--- a/src/cdk/table/text-column.ts
+++ b/src/cdk/table/text-column.ts
@@ -10,7 +10,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   Inject,
-  InjectionToken,
   Input,
   OnDestroy,
   OnInit,
@@ -25,23 +24,8 @@ import {
   getTableTextColumnMissingParentTableError,
   getTableTextColumnMissingNameError,
 } from './table-errors';
+import {TEXT_COLUMN_OPTIONS, TextColumnOptions} from './tokens';
 
-
-/** Configurable options for `CdkTextColumn`. */
-export interface TextColumnOptions<T> {
-  /**
-   * Default function that provides the header text based on the column name if a header
-   * text is not provided.
-   */
-  defaultHeaderTextTransform?: (name: string) => string;
-
-  /** Default data accessor to use if one is not provided. */
-  defaultDataAccessor?: (data: T, name: string) => string;
-}
-
-/** Injection token that can be used to specify the text column options. */
-export const TEXT_COLUMN_OPTIONS =
-    new InjectionToken<TextColumnOptions<any>>('text-column-options');
 
 /**
  * Column that simply shows text content for the header and row cells. Assumes that the table

--- a/src/cdk/table/tokens.ts
+++ b/src/cdk/table/tokens.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '@angular/core';
+
+/**
+ * Used to provide a table to some of the sub-components without causing a circular dependency.
+ * @docs-private
+ */
+export const CDK_TABLE = new InjectionToken<any>('CDK_TABLE');
+
+/** Configurable options for `CdkTextColumn`. */
+export interface TextColumnOptions<T> {
+  /**
+   * Default function that provides the header text based on the column name if a header
+   * text is not provided.
+   */
+  defaultHeaderTextTransform?: (name: string) => string;
+
+  /** Default data accessor to use if one is not provided. */
+  defaultDataAccessor?: (data: T, name: string) => string;
+}
+
+/** Injection token that can be used to specify the text column options. */
+export const TEXT_COLUMN_OPTIONS =
+    new InjectionToken<TextColumnOptions<any>>('text-column-options');

--- a/src/material-experimental/mdc-table/table.spec.ts
+++ b/src/material-experimental/mdc-table/table.spec.ts
@@ -27,6 +27,7 @@ describe('MDC-based MatTable', () => {
         MatTableWithPaginatorApp,
         StickyTableApp,
         TableWithNgContainerRow,
+        NestedTableApp,
       ],
     }).compileComponents();
   }));
@@ -79,6 +80,22 @@ describe('MDC-based MatTable', () => {
         ['Footer A'],
       ]);
     });
+
+    it('should be able to nest tables', () => {
+      const fixture = TestBed.createComponent(NestedTableApp);
+      fixture.detectChanges();
+      const outerTable = fixture.nativeElement.querySelector('table');
+      const innerTable = outerTable.querySelector('table');
+      const outerRows = Array.from<HTMLTableRowElement>(outerTable.querySelector('tbody').rows);
+      const innerRows = Array.from<HTMLTableRowElement>(innerTable.querySelector('tbody').rows);
+
+      expect(outerTable).toBeTruthy();
+      expect(outerRows.map(row => row.cells.length)).toEqual([3, 3, 3, 3]);
+
+      expect(innerTable).toBeTruthy();
+      expect(innerRows.map(row => row.cells.length)).toEqual([3, 3, 3, 3]);
+    });
+
   });
 
   it('should render with MatTableDataSource and sort', () => {
@@ -548,6 +565,57 @@ class MatTableApp {
   isFourthRow = (i: number, _rowData: TestData) => i == 3;
 
   @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
+}
+
+@Component({
+  template: `
+    <table mat-table [dataSource]="dataSource">
+      <ng-container matColumnDef="column_a">
+        <th mat-header-cell *matHeaderCellDef>Column A</th>
+        <td mat-cell *matCellDef="let row">{{row.a}}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="column_b">
+        <th mat-header-cell *matHeaderCellDef>Column B</th>
+        <td mat-cell *matCellDef="let row">
+          <table mat-table [dataSource]="dataSource">
+            <ng-container matColumnDef="column_a">
+              <th mat-header-cell *matHeaderCellDef> Column A</th>
+              <td mat-cell *matCellDef="let row"> {{row.a}}</td>
+              <td mat-footer-cell *matFooterCellDef> Footer A</td>
+            </ng-container>
+
+            <ng-container matColumnDef="column_b">
+              <th mat-header-cell *matHeaderCellDef> Column B</th>
+              <td mat-cell *matCellDef="let row"> {{row.b}}</td>
+              <td mat-footer-cell *matFooterCellDef> Footer B</td>
+            </ng-container>
+
+            <ng-container matColumnDef="column_c">
+              <th mat-header-cell *matHeaderCellDef> Column C</th>
+              <td mat-cell *matCellDef="let row"> {{row.c}}</td>
+              <td mat-footer-cell *matFooterCellDef> Footer C</td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="columnsToRender"></tr>
+            <tr mat-row *matRowDef="let row; columns: columnsToRender"></tr>
+          </table>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="column_c">
+        <th mat-header-cell *matHeaderCellDef>Column C</th>
+        <td mat-cell *matCellDef="let row">{{row.c}}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columnsToRender"></tr>
+      <tr mat-row *matRowDef="let row; columns: columnsToRender"></tr>
+    </table>
+  `
+})
+class NestedTableApp {
+  dataSource: FakeDataSource | null = new FakeDataSource();
+  columnsToRender = ['column_a', 'column_b', 'column_c'];
 }
 
 @Component({

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -30,6 +30,7 @@ describe('MatTable', () => {
         MatTableWithPaginatorApp,
         StickyTableApp,
         TableWithNgContainerRow,
+        NestedHtmlTableApp,
       ],
     }).compileComponents();
   }));
@@ -97,6 +98,21 @@ describe('MatTable', () => {
       [data[2].a, data[2].b, data[2].c],
       [data[3].a, data[3].b, data[3].c],
     ]);
+  });
+
+  it('should be able to nest tables', () => {
+    const fixture = TestBed.createComponent(NestedHtmlTableApp);
+    fixture.detectChanges();
+    const outerTable = fixture.nativeElement.querySelector('table');
+    const innerTable = outerTable.querySelector('table');
+    const outerRows = Array.from<HTMLTableRowElement>(outerTable.querySelector('tbody').rows);
+    const innerRows = Array.from<HTMLTableRowElement>(innerTable.querySelector('tbody').rows);
+
+    expect(outerTable).toBeTruthy();
+    expect(outerRows.map(row => row.cells.length)).toEqual([3, 3, 3, 3]);
+
+    expect(innerTable).toBeTruthy();
+    expect(innerRows.map(row => row.cells.length)).toEqual([3, 3, 3, 3]);
   });
 
   it('should render with MatTableDataSource and sort', () => {
@@ -596,6 +612,54 @@ class NativeHtmlTableApp {
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
   @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
+}
+
+@Component({
+  template: `
+    <table mat-table [dataSource]="dataSource">
+      <ng-container matColumnDef="column_a">
+        <th mat-header-cell *matHeaderCellDef> Column A</th>
+        <td mat-cell *matCellDef="let row">{{row.a}}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="column_b">
+        <th mat-header-cell *matHeaderCellDef> Column B</th>
+        <td mat-cell *matCellDef="let row">
+          <table mat-table [dataSource]="dataSource">
+            <ng-container matColumnDef="column_a">
+              <th mat-header-cell *matHeaderCellDef> Column A</th>
+              <td mat-cell *matCellDef="let row"> {{row.a}}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="column_b">
+              <th mat-header-cell *matHeaderCellDef> Column B</th>
+              <td mat-cell *matCellDef="let row"> {{row.b}}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="column_c">
+              <th mat-header-cell *matHeaderCellDef> Column C</th>
+              <td mat-cell *matCellDef="let row"> {{row.c}}</td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="columnsToRender"></tr>
+            <tr mat-row *matRowDef="let row; columns: columnsToRender"></tr>
+          </table>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="column_c">
+        <th mat-header-cell *matHeaderCellDef> Column C</th>
+        <td mat-cell *matCellDef="let row">{{row.c}}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columnsToRender"></tr>
+      <tr mat-row *matRowDef="let row; columns: columnsToRender"></tr>
+    </table>
+  `
+})
+class NestedHtmlTableApp {
+  dataSource: FakeDataSource | null = new FakeDataSource();
+  columnsToRender = ['column_a', 'column_b', 'column_c'];
 }
 
 @Component({

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CDK_TABLE_TEMPLATE, CdkTable} from '@angular/cdk/table';
+import {CDK_TABLE_TEMPLATE, CdkTable, CDK_TABLE} from '@angular/cdk/table';
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
 
 /**
@@ -20,7 +20,10 @@ import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/co
   host: {
     'class': 'mat-table',
   },
-  providers: [{provide: CdkTable, useExisting: MatTable}],
+  providers: [
+    {provide: CdkTable, useExisting: MatTable},
+    {provide: CDK_TABLE, useExisting: MatTable}
+  ],
   encapsulation: ViewEncapsulation.None,
   // See note on CdkTable for explanation on why this uses the default change detection strategy.
   // tslint:disable-next-line:validate-decorators

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -25,6 +25,8 @@ export declare type CanStickCtor = Constructor<CanStick>;
 
 export declare const CDK_ROW_TEMPLATE = "<ng-container cdkCellOutlet></ng-container>";
 
+export declare const CDK_TABLE: InjectionToken<any>;
+
 export declare const CDK_TABLE_TEMPLATE = "\n  <ng-content select=\"caption\"></ng-content>\n  <ng-container headerRowOutlet></ng-container>\n  <ng-container rowOutlet></ng-container>\n  <ng-container footerRowOutlet></ng-container>\n";
 
 export declare class CdkCell extends BaseCdkCell {
@@ -75,6 +77,7 @@ export interface CdkCellOutletRowContext<T> {
 export declare class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
     _name: string;
     _stickyEnd: boolean;
+    _table?: any;
     cell: CdkCellDef;
     cssClassFriendlyName: string;
     footerCell: CdkFooterCellDef;
@@ -83,6 +86,7 @@ export declare class CdkColumnDef extends _CdkColumnDefBase implements CanStick 
     set name(name: string);
     get stickyEnd(): boolean;
     set stickyEnd(v: boolean);
+    constructor(_table?: any);
     static ngAcceptInputType_sticky: BooleanInput;
     static ngAcceptInputType_stickyEnd: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkColumnDef, "[cdkColumnDef]", never, { "sticky": "sticky"; "name": "cdkColumnDef"; "stickyEnd": "stickyEnd"; }, {}, ["cell", "headerCell", "footerCell"]>;
@@ -108,7 +112,8 @@ export declare class CdkFooterRow {
 }
 
 export declare class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, OnChanges {
-    constructor(template: TemplateRef<any>, _differs: IterableDiffers);
+    _table?: any;
+    constructor(template: TemplateRef<any>, _differs: IterableDiffers, _table?: any);
     ngOnChanges(changes: SimpleChanges): void;
     static ngAcceptInputType_sticky: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkFooterRowDef, "[cdkFooterRowDef]", never, { "columns": "cdkFooterRowDef"; "sticky": "cdkFooterRowDefSticky"; }, {}, never>;
@@ -134,7 +139,8 @@ export declare class CdkHeaderRow {
 }
 
 export declare class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, OnChanges {
-    constructor(template: TemplateRef<any>, _differs: IterableDiffers);
+    _table?: any;
+    constructor(template: TemplateRef<any>, _differs: IterableDiffers, _table?: any);
     ngOnChanges(changes: SimpleChanges): void;
     static ngAcceptInputType_sticky: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkHeaderRowDef, "[cdkHeaderRowDef]", never, { "columns": "cdkHeaderRowDef"; "sticky": "cdkHeaderRowDefSticky"; }, {}, never>;
@@ -147,8 +153,9 @@ export declare class CdkRow {
 }
 
 export declare class CdkRowDef<T> extends BaseRowDef {
+    _table?: any;
     when: (index: number, rowData: T) => boolean;
-    constructor(template: TemplateRef<any>, _differs: IterableDiffers);
+    constructor(template: TemplateRef<any>, _differs: IterableDiffers, _table?: any);
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkRowDef<any>, "[cdkRowDef]", never, { "columns": "cdkRowDefColumns"; "when": "cdkRowDefWhen"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkRowDef<any>>;
 }


### PR DESCRIPTION
Previously we used to support nesting tables, but in v9 we had to make some changes in order to handle all cases in Ivy. As a result, nesting was broken due to parent tables picking up the cell definitions of their children. These changes add some logic to account for tables being nested.

Fixes #18768.