### PR TITLE
docs(a11y): update high contrast description in readme

### DIFF
--- a/src/cdk/a11y/a11y.md
+++ b/src/cdk/a11y/a11y.md
@@ -184,8 +184,9 @@ class:
 
 ### Targeting high contrast users
 The `a11y` package offers a mixin that allows you to target users that have the Windows high
-contrast mode turned on, via a media query. To target high contrast users, you can wrap your
-styles with the `cdk-high-contrast` mixin:
+contrast mode turned on. To target high contrast users, you can wrap your styles with the
+`cdk-high-contrast` mixin. The mixin works by targeting a CSS class which is added to the `body`
+by the CDK when high contrast mode is detected at runtime.
 
 ```scss
 button {


### PR DESCRIPTION
Updates an outdated description about how the high contrast detection works.

Fixes #18148.