### PR TITLE
build: update to latest `@bazel/ibazel` version v0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@angular/router": "^9.1.0-next.4",
     "@bazel/bazelisk": "^1.3.0",
     "@bazel/buildifier": "^0.29.0",
-    "@bazel/ibazel": "0.12.0",
+    "@bazel/ibazel": "^0.12.3",
     "@bazel/jasmine": "^1.4.0",
     "@bazel/karma": "^1.4.0",
     "@bazel/protractor": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,10 +260,10 @@
     "@bazel/buildifier-linux_x64" "0.29.0"
     "@bazel/buildifier-win32_x64" "0.29.0"
 
-"@bazel/ibazel@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.12.0.tgz#97aea5ee2d41d91995539df89efe11fd3fe128ca"
-  integrity sha512-8ix3hmaV30xD9FIa9aJBtKhxUOBDo0NEULgOhgz5c8nytnD0ipPWqssWWq0iFU8oRBHpvNnuIESbzL1h/LU5iw==
+"@bazel/ibazel@^0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.12.3.tgz#c8c82647f920cd529c7793c50e087e1a754a5973"
+  integrity sha512-dyx62Uo5kogrxFmqFNpGvbavfr8yjmuQlOyZczOuA60piULwlUsO7Oh3/1OUWKDSXaMMqHhFQfpdl+z0HjI6TQ==
 
 "@bazel/jasmine@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
Updates to the latest `@bazel/ibazel` version that properly
resolves local `@bazel/bazelisk` installations.

The support for this temporarily broke from `0.12.0` to `0.12.2`.
https://github.com/bazelbuild/bazel-watcher/issues/352.