### PR TITLE
build: create merge script w/ cherry-picking 

### DIFF
--- a/merge-config.js
+++ b/merge-config.js
@@ -1,0 +1,52 @@
+module.exports = () => {
+  const {major, minor} = parseVersion(require('./package').version);
+  const patchBranch = `${major}.${minor}.x`;
+  const minorBranch = `${major}.x`;
+
+  return {
+    projectRoot: __dirname,
+    repository: {
+      user: 'angular',
+      name: 'components',
+    },
+    // By default, the merge script merges locally with `git cherry-pick` and autosquash.
+    // This has the downside of pull requests showing up as `Closed` instead of `Merged`.
+    // In the components repository, since we don't use fixup or squash commits, we can
+    // use the Github API merge strategy. That way we ensure that PRs show up as `Merged`.
+    githubApiMerge: {
+      default: 'squash',
+      labels: [
+        {pattern: 'preserve commits', method: 'rebase'}
+      ]
+    },
+    claSignedLabel: 'cla: yes',
+    mergeReadyLabel: 'merge ready',
+    commitMessageFixupLabel: 'commit message fixup',
+    labels: [
+      {
+        pattern: 'target: patch',
+        branches: ['master', patchBranch],
+      },
+      {
+        pattern: 'target: minor',
+        branches: ['master', minorBranch],
+      },
+      {
+        pattern: 'target: major',
+        branches: ['master'],
+      },
+      {
+        pattern: 'target: development-branch',
+        // Merge PRs with the given label only into the target branch that has
+        // been specified through the Github UI.
+        branches: (target) => [target],
+      }
+    ],
+  }
+};
+
+/** Converts a version string into an object. */
+function parseVersion(version) {
+  const [major = 0, minor = 0, patch = 0] = version.split('.').map(segment => Number(segment));
+  return {major, minor, patch};
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "stylelint": "stylelint \"src/**/*.+(css|scss)\" --config .stylelintrc.json --syntax scss",
     "resync-caretaker-app": "ts-node --project scripts scripts/caretaking/resync-caretaker-app-prs.ts",
     "ts-circular-deps:check": "yarn -s ts-circular-deps check --config ./src/circular-deps-test.conf.js",
-    "ts-circular-deps:approve": "yarn -s ts-circular-deps approve --config ./src/circular-deps-test.conf.js"
+    "ts-circular-deps:approve": "yarn -s ts-circular-deps approve --config ./src/circular-deps-test.conf.js",
+    "merge": "ts-node --project scripts scripts/merge-script/cli.ts --config ./merge-config.js"
   },
   "version": "9.2.1",
   "dependencies": {

--- a/scripts/merge-script/cli.ts
+++ b/scripts/merge-script/cli.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import chalk from 'chalk';
+import * as minimist from 'minimist';
+import {isAbsolute, resolve} from 'path';
+
+import {Config, readAndValidateConfig} from './config';
+import {promptConfirm} from './console';
+import {MergeResult, MergeStatus, PullRequestMergeTask} from './index';
+
+// Run the CLI.
+main();
+
+/**
+ * Entry-point for the merge script CLI. The script can be used to merge individual pull requests
+ * into branches based on the `PR target` labels that have been set in a configuration. The script
+ * aims to reduce the manual work that needs to be performed to cherry-pick a PR into multiple
+ * branches based on a target label.
+ */
+async function main() {
+  const {config, prNumber, force, githubToken} = parseCommandLine();
+  const api = new PullRequestMergeTask(config, githubToken);
+
+  // Perform the merge. Force mode can be activated through a command line flag.
+  // Alternatively, if the merge fails with non-fatal failures, the script
+  // will prompt whether it should rerun in force mode.
+  const mergeResult = await api.merge(prNumber, force);
+
+  // Handle the result of the merge. If failures have been reported, exit
+  // the process with a non-zero exit code.
+  if (!await handleMergeResult(mergeResult, force)) {
+    process.exit(1);
+  }
+
+  /**
+   * Prompts whether the specified pull request should be forcibly merged. If so, merges
+   * the specified pull request forcibly (ignoring non-critical failures).
+   * @returns Whether the specified pull request has been forcibly merged.
+   */
+  async function promptAndPerformForceMerge(): Promise<boolean> {
+    if (await promptConfirm('Do you want to forcibly proceed with merging?')) {
+      // Perform the merge in force mode. This means that non-fatal failures
+      // are ignored and the merge continues.
+      const forceMergeResult = await api.merge(prNumber, true);
+      // Handle the merge result. Note that we disable the force merge prompt since
+      // a failed force merge will never succeed with a second force merge.
+      return await handleMergeResult(forceMergeResult, true);
+    }
+    return false;
+  }
+
+  /**
+   * Handles the merge result by printing console messages, exiting the process
+   * based on the result, or by restarting the merge if force mode has been enabled.
+   * @returns Whether the merge was successful or not.
+   */
+  async function handleMergeResult(result: MergeResult, disableForceMergePrompt = false) {
+    const {failure, status} = result;
+    const canForciblyMerge = failure && failure.nonFatal;
+
+    switch (status) {
+      case MergeStatus.SUCCESS:
+        console.info(chalk.green(`Successfully merged the pull request: ${prNumber}`));
+        return true;
+      case MergeStatus.DIRTY_WORKING_DIR:
+        console.error(chalk.red(
+            `Local working repository not clean. Please make sure there are ` +
+            `no uncommitted changes.`));
+        return false;
+      case MergeStatus.UNKNOWN_GIT_ERROR:
+        console.error(chalk.red(
+            'An unknown Git error has been thrown. Please check the output ' +
+            'above for details.'));
+        return false;
+      case MergeStatus.FAILED:
+        console.error(chalk.yellow(`Could not merge the specified pull request.`));
+        console.error(chalk.red(failure!.message));
+        if (canForciblyMerge && !disableForceMergePrompt) {
+          console.info();
+          console.info(chalk.yellow('The pull request above failed due to non-critical errors.'));
+          console.info(chalk.yellow(`This error can be forcibly ignored if desired.`));
+          return await promptAndPerformForceMerge();
+        }
+        return false;
+      default:
+        throw Error(`Unexpected merge result: ${status}`);
+    }
+  }
+}
+
+// TODO(devversion): Use Yargs for this once the script has been moved to `angular/angular`.
+/** Parses the command line and returns the passed options. */
+function parseCommandLine():
+    {config: Config, force: boolean, prNumber: number, dryRun?: boolean, githubToken: string} {
+  const {config: configPath, githubToken: githubTokenArg, force, _: [prNumber]} =
+      minimist<any>(process.argv.slice(2), {
+        string: ['githubToken', 'config', 'pr'],
+        alias: {
+          'githubToken': 'github-token',
+        },
+      });
+
+  if (!configPath) {
+    console.error(chalk.red('No configuration file specified. Please pass the `--config` option.'));
+    process.exit(1);
+  }
+
+  if (!prNumber) {
+    console.error(chalk.red('No pull request specified. Please pass a pull request number.'));
+    process.exit(1);
+  }
+
+  const configFilePath = isAbsolute(configPath) ? configPath : resolve(configPath);
+  const {config, errors} = readAndValidateConfig(configFilePath);
+
+  if (errors) {
+    console.error(chalk.red('Configuration could not be read:'));
+    errors.forEach(desc => console.error(chalk.yellow(`  *  ${desc}`)));
+    process.exit(1);
+  }
+
+  const githubToken = githubTokenArg || process.env.GITHUB_TOKEN || process.env.TOKEN;
+  if (!githubToken) {
+    console.error(
+        chalk.red('No Github token is set. Please set the `GITHUB_TOKEN` environment variable.'));
+    console.error(chalk.red('Alternatively, pass the `--github-token` command line flag.'));
+    process.exit(1);
+  }
+
+  return {config: config!, prNumber, githubToken, force};
+}

--- a/scripts/merge-script/config.ts
+++ b/scripts/merge-script/config.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {dirname, resolve} from 'path';
+import {GithubApiMergeStrategyConfig} from './strategies/api-merge';
+
+/**
+ * Possible merge methods supported by the Github API.
+ * https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button.
+ */
+export type GithubApiMergeMethod = 'merge'|'squash'|'rebase';
+
+/**
+ * Target labels represent Github pull requests labels. These labels instruct the merge
+ * script into which branches a given pull request should be merged to.
+ */
+export interface TargetLabel {
+  /** Pattern that matches the given target label. */
+  pattern: RegExp|string;
+  /**
+   * List of branches a pull request with this target label should be merged into.
+   * Can also be wrapped in a function that accepts the target branch specified in the
+   * Github Web UI. This is useful for supporting labels like `target: development-branch`.
+   */
+  branches: string[]|((githubTargetBranch: string) => string[]);
+}
+
+/** Configuration for the merge script. */
+export interface Config {
+  /** Relative path (based on the config location) to the project root. */
+  projectRoot: string;
+  /** Configuration for the upstream repository. */
+  repository: {user: string; name: string; useSsh?: boolean};
+  /** List of target labels. */
+  labels: TargetLabel[];
+  /** Required base commits for given branches. */
+  requiredBaseCommits?: {[branchName: string]: string};
+  /** Pattern that matches labels which imply a signed CLA. */
+  claSignedLabel: string|RegExp;
+  /** Pattern that matches labels which imply a merge ready pull request. */
+  mergeReadyLabel: string|RegExp;
+  /** Label which can be applied to fixup commit messages in the merge script. */
+  commitMessageFixupLabel: string|RegExp;
+  /**
+   * Whether pull requests should be merged using the Github API. This can be enabled
+   * if projects want to have their pull requests show up as `Merged` in the Github UI.
+   * The downside is that fixup or squash commits no longer work as the Github API does
+   * not support this.
+   */
+  githubApiMerge: false | GithubApiMergeStrategyConfig;
+}
+
+/** Reads and validates the configuration file at the specified location. */
+export function readAndValidateConfig(filePath: string): {config?: Config, errors?: string[]} {
+  // Capture errors when the configuration cannot be read. Errors will be thrown if the file
+  // does not exist, if the config file cannot be evaluated, or if no default export is found.
+  try {
+    const config = require(filePath)() as Config;
+    const errors = validateConfig(config);
+    if (errors.length) {
+      return {errors};
+    }
+    // Resolves the project root path to an absolute path based on the
+    // config file location.
+    config.projectRoot = resolve(dirname(filePath), config.projectRoot);
+    return {config};
+  } catch (e) {
+    return {errors: [`File could not be loaded. Error: ${e.message}`]};
+  }
+}
+
+/** Validates the specified configuration. Returns a list of failure messages. */
+function validateConfig(config: Config): string[] {
+  const errors: string[] = [];
+  if (!config.projectRoot) {
+    errors.push('Missing project root.');
+  }
+  if (!config.labels) {
+    errors.push('No label configuration.');
+  } else if (!Array.isArray(config.labels)) {
+    errors.push('Label configuration needs to be an array.');
+  }
+  if (!config.repository) {
+    errors.push('No repository is configured.');
+  } else if (!config.repository.user || !config.repository.name) {
+    errors.push('Repository configuration needs to specify a `user` and repository `name`.');
+  }
+  if (!config.claSignedLabel) {
+    errors.push('No CLA signed label configured.');
+  }
+  if (!config.mergeReadyLabel) {
+    errors.push('No merge ready label configured.');
+  }
+  if (config.githubApiMerge === undefined) {
+    errors.push('No explicit choice of merge strategy. Please set `githubApiMerge`.');
+  }
+  return errors;
+}

--- a/scripts/merge-script/console.ts
+++ b/scripts/merge-script/console.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {prompt} from 'inquirer';
+
+/** Prompts the user with a confirmation question and a specified message. */
+export async function promptConfirm(message: string, defaultValue = false): Promise<boolean> {
+  return (await prompt<{result: boolean}>({
+           type: 'confirm',
+           name: 'result',
+           message: message,
+           default: defaultValue,
+         }))
+      .result;
+}

--- a/scripts/merge-script/failures.ts
+++ b/scripts/merge-script/failures.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Class that can be used to describe pull request failures. A failure
+ * is described through a human-readable message and a flag indicating
+ * whether it is non-fatal or not.
+ */
+export class PullRequestFailure {
+  constructor(
+      /** Human-readable message for the failure */
+      public message: string,
+      /** Whether the failure is non-fatal and can be forcibly ignored. */
+      public nonFatal = false) {}
+
+  static claUnsigned() {
+    return new this(`CLA has not been signed. Please make sure the PR author has signed the CLA.`);
+  }
+
+  static failingCiJobs() {
+    return new this(`Failing CI jobs.`, true);
+  }
+
+  static pendingCiJobs() {
+    return new this(`Pending CI jobs.`, true);
+  }
+
+  static notMergeReady() {
+    return new this(`Not marked as merge ready.`);
+  }
+
+  static noTargetLabel() {
+    return new this(`No target branch could be determined. Please ensure a target label is set.`);
+  }
+
+  static mismatchingTargetBranch(allowedBranches: string[]) {
+    return new this(
+        `Pull request is set to wrong base branch. Please update the PR in the Github UI ` +
+        `to one of the following branches: ${allowedBranches.join(', ')}.`);
+  }
+
+  static unsatisfiedBaseSha() {
+    return new this(
+        `Pull request has not been rebased recently and could be bypassing CI checks. ` +
+        `Please rebase the PR.`);
+  }
+
+  static mergeConflicts(failedBranches: string[]) {
+    return new this(
+        `Could not merge pull request into the following branches due to merge ` +
+        `conflicts: ${
+            failedBranches.join(', ')}. Please rebase the PR or update the target label.`);
+  }
+
+  static unknownMergeError() {
+    return new this(`Unknown merge error occurred. Please see console output above for debugging.`);
+  }
+
+  static unableToFixupCommitMessageSquashOnly() {
+    return new this(
+        `Unable to fixup commit message of pull request. Commit message can only be ` +
+        `modified if the PR is merged using squash.`);
+  }
+
+  static notFound() {
+    return new this(`Pull request could not be found upstream.`);
+  }
+}

--- a/scripts/merge-script/git.ts
+++ b/scripts/merge-script/git.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as Octokit from '@octokit/rest';
+import {spawnSync, SpawnSyncOptions, SpawnSyncReturns} from 'child_process';
+import {Config} from './config';
+
+/** Error for failed Git commands. */
+export class GitCommandError extends Error {
+  constructor(public commandArgs: string[]) {
+    super(`Command failed: git ${commandArgs.join(' ')}`);
+  }
+}
+
+export class GitClient {
+  /** Short-hand for accessing the repository configuration. */
+  repoConfig = this._config.repository;
+  /** Octokit request parameters object for targeting the configured repository. */
+  repoParams = {owner: this.repoConfig.user, repo: this.repoConfig.name};
+  /** URL that resolves to the configured repository. */
+  repoGitUrl = this.repoConfig.useSsh ?
+      `git@github.com:${this.repoConfig.user}/${this.repoConfig.name}.git` :
+      `https://${this._githubToken}@github.com/${this.repoConfig.user}/${this.repoConfig.name}.git`;
+  /** Instance of the authenticated Github octokit API. */
+  api: Octokit;
+
+  constructor(private _githubToken: string, private _config: Config) {
+    this.api = new Octokit({auth: _githubToken});
+  }
+
+  /** Executes the given git command. Throws if the command fails. */
+  run(args: string[], options?: SpawnSyncOptions): Omit<SpawnSyncReturns<string>, 'status'> {
+    const result = this.runGraceful(args, options);
+    if (result.status !== 0) {
+      throw new GitCommandError(args);
+    }
+    // Omit `status` from the type so that it's obvious that the status is never
+    // non-zero as explained in the method description.
+    return result as Omit<SpawnSyncReturns<string>, 'status'>;
+  }
+
+  /**
+   * Spawns a given Git command process. Does not throw if the command fails. Additionally,
+   * the "stderr" output is inherited and will be printed in case of errors. This makes it
+   * easier to debug failed commands.
+   */
+  runGraceful(args: string[], options: SpawnSyncOptions = {}): SpawnSyncReturns<string> {
+    // To improve the debugging experience in case something fails, we print
+    // all executed Git commands.
+    console.info('Executing: git', ...args);
+    return spawnSync('git', args, {
+      cwd: this._config.projectRoot,
+      stdio: ['pipe', 'pipe', 'inherit'],
+      ...options,
+      // Encoding is always `utf8` and not overridable. This ensures that this method
+      // always returns `string` as output instead of buffers.
+      encoding: 'utf8',
+    });
+  }
+
+  /** Whether the given branch contains the specified SHA. */
+  hasCommit(branchName: string, sha: string): boolean {
+    return this.run(['branch', branchName, '--contains', sha]).stdout !== '';
+  }
+
+  /** Gets the currently checked out branch. */
+  getCurrentBranch(): string {
+    return this.run(['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
+  }
+
+  /** Gets whether the current Git repository has uncommitted changes. */
+  hasUncommittedChanges(): boolean {
+    return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
+  }
+}

--- a/scripts/merge-script/index.ts
+++ b/scripts/merge-script/index.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Config} from './config';
+import {PullRequestFailure} from './failures';
+import {GitClient, GitCommandError} from './git';
+import {isPullRequest, loadAndValidatePullRequest,} from './pull-request';
+import {GithubApiMergeStrategy} from './strategies/api-merge';
+import {AutosquashMergeStrategy} from './strategies/autosquash-merge';
+
+/** Describes the status of a pull request merge. */
+export const enum MergeStatus {
+  UNKNOWN_GIT_ERROR,
+  DIRTY_WORKING_DIR,
+  SUCCESS,
+  FAILED,
+}
+
+/** Result of a pull request merge. */
+export interface MergeResult {
+  /** Overall status of the merge. */
+  status: MergeStatus;
+  /** List of pull request failures. */
+  failure?: PullRequestFailure;
+}
+
+
+/**
+ * Class that accepts a merge script configuration and Github token. It provides
+ * a programmatic interface for merging multiple pull requests based on their
+ * labels that have been resolved through the merge script configuration.
+ */
+export class PullRequestMergeTask {
+  /** Git client that can be used to execute Git commands. */
+  git = new GitClient(this._githubToken, this.config);
+
+  constructor(public config: Config, private _githubToken: string) {}
+
+  /**
+   * Merges the given pull request and pushes it upstream.
+   * @param prNumber Pull request that should be merged.
+   * @param force Whether non-critical pull request failures should be ignored.
+   */
+  async merge(prNumber: number, force = false): Promise<MergeResult> {
+    if (this.git.hasUncommittedChanges()) {
+      return {status: MergeStatus.DIRTY_WORKING_DIR};
+    }
+
+    const pullRequest = await loadAndValidatePullRequest(this, prNumber, force);
+
+    if (!isPullRequest(pullRequest)) {
+      return {status: MergeStatus.FAILED, failure: pullRequest};
+    }
+
+    const strategy = this.config.githubApiMerge ?
+        new GithubApiMergeStrategy(this.git, this.config.githubApiMerge) :
+        new AutosquashMergeStrategy(this.git);
+
+    // Branch that is currently checked out so that we can switch back to it once
+    // the pull request has been merged.
+    let previousBranch: null|string = null;
+
+    // The following block runs Git commands as child processes. These Git commands can fail.
+    // We want to capture these command errors and return an appropriate merge request status.
+    try {
+      previousBranch = this.git.getCurrentBranch();
+
+      // Run preparations for the merge (e.g. fetching branches).
+      await strategy.prepare(pullRequest);
+
+      // Perform the merge and capture potential failures.
+      const failure = await strategy.merge(pullRequest);
+      if (failure !== null) {
+        return {status: MergeStatus.FAILED, failure};
+      }
+
+      // Switch back to the previous branch. We need to do this before deleting the temporary
+      // branches because we cannot delete branches which are currently checked out.
+      this.git.run(['checkout', '-f', previousBranch]);
+
+      await strategy.cleanup(pullRequest);
+
+      // Return a successful merge status.
+      return {status: MergeStatus.SUCCESS};
+    } catch (e) {
+      // Catch all git command errors and return a merge result w/ git error status code.
+      // Other unknown errors which aren't caused by a git command are re-thrown.
+      if (e instanceof GitCommandError) {
+        return {status: MergeStatus.UNKNOWN_GIT_ERROR};
+      }
+      throw e;
+    } finally {
+      // Always try to restore the branch if possible. We don't want to leave
+      // the repository in a different state than before.
+      if (previousBranch !== null) {
+        this.git.runGraceful(['checkout', '-f', previousBranch]);
+      }
+    }
+  }
+}

--- a/scripts/merge-script/pull-request.ts
+++ b/scripts/merge-script/pull-request.ts
@@ -50,17 +50,18 @@ export async function loadAndValidatePullRequest(
 
   if (!labels.some(name => matchesPattern(name, config.mergeReadyLabel))) {
     return PullRequestFailure.notMergeReady();
-  } else if (!labels.some(name => matchesPattern(name, config.claSignedLabel))) {
+  }
+  if (!labels.some(name => matchesPattern(name, config.claSignedLabel))) {
     return PullRequestFailure.claUnsigned();
   }
-
-  const {data: {state}} =
-      await git.api.repos.getCombinedStatusForRef({...git.repoParams, ref: prData.head.sha});
 
   const targetLabel = getTargetLabelFromPullRequest(config, labels);
   if (targetLabel === null) {
     return PullRequestFailure.noTargetLabel();
   }
+
+  const {data: {state}} =
+      await git.api.repos.getCombinedStatusForRef({...git.repoParams, ref: prData.head.sha});
 
   if (state === 'failure' && !ignoreNonFatalFailures) {
     return PullRequestFailure.failingCiJobs();

--- a/scripts/merge-script/pull-request.ts
+++ b/scripts/merge-script/pull-request.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as Octokit from '@octokit/rest';
+import {PullRequestFailure} from './failures';
+import {GitClient} from './git';
+import {PullRequestMergeTask} from './index';
+import {matchesPattern} from './string-pattern';
+import {getBranchesFromTargetLabel, getTargetLabelFromPullRequest} from './target-label';
+
+/** Interface that describes a pull request. */
+export interface PullRequest {
+  /** Number of the pull request. */
+  prNumber: number;
+  /** Title of the pull request. */
+  title: string;
+  /** Labels applied to the pull request. */
+  labels: string[];
+  /** List of branches this PR should be merged into. */
+  targetBranches: string[];
+  /** Branch that the PR targets in the Github UI. */
+  githubTargetBranch: string;
+  /** Count of commits in this pull request. */
+  commitCount: number;
+  /** Optional SHA that this pull request needs to be based on. */
+  requiredBaseSha?: string;
+  /** Whether the pull request commit message fixup. */
+  needsCommitMessageFixup: boolean;
+}
+
+/**
+ * Loads and validates the specified pull request against the given configuration.
+ * If the pull requests fails, a pull request failure is returned.
+ */
+export async function loadAndValidatePullRequest(
+    {git, config}: PullRequestMergeTask, prNumber: number,
+    ignoreNonFatalFailures = false): Promise<PullRequest|PullRequestFailure> {
+  const prData = await fetchPullRequestFromGithub(git, prNumber);
+
+  if (prData === null) {
+    return PullRequestFailure.notFound();
+  }
+
+  const labels = prData.labels.map(l => l.name);
+
+  if (!labels.some(name => matchesPattern(name, config.mergeReadyLabel))) {
+    return PullRequestFailure.notMergeReady();
+  } else if (!labels.some(name => matchesPattern(name, config.claSignedLabel))) {
+    return PullRequestFailure.claUnsigned();
+  }
+
+  const {data: {state}} =
+      await git.api.repos.getCombinedStatusForRef({...git.repoParams, ref: prData.head.sha});
+
+  const targetLabel = getTargetLabelFromPullRequest(config, labels);
+  if (targetLabel === null) {
+    return PullRequestFailure.noTargetLabel();
+  }
+
+  if (state === 'failure' && !ignoreNonFatalFailures) {
+    return PullRequestFailure.failingCiJobs();
+  }
+  if (state === 'pending' && !ignoreNonFatalFailures) {
+    return PullRequestFailure.pendingCiJobs();
+  }
+
+  const githubTargetBranch = prData.base.ref;
+  const requiredBaseSha =
+      config.requiredBaseCommits && config.requiredBaseCommits[githubTargetBranch];
+  const needsCommitMessageFixup = !!config.commitMessageFixupLabel &&
+      labels.some(name => matchesPattern(name, config.commitMessageFixupLabel));
+
+  return {
+    prNumber,
+    labels,
+    requiredBaseSha,
+    githubTargetBranch,
+    needsCommitMessageFixup,
+    title: prData.title,
+    targetBranches: getBranchesFromTargetLabel(targetLabel, githubTargetBranch),
+    commitCount: prData.commits,
+  };
+}
+
+/** Fetches a pull request from Github. Returns null if an error occurred. */
+async function fetchPullRequestFromGithub(
+    git: GitClient, prNumber: number): Promise<Octokit.PullsGetResponse|null> {
+  try {
+    const result = await git.api.pulls.get({...git.repoParams, pull_number: prNumber});
+    return result.data;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether the specified value resolves to a pull request. */
+export function isPullRequest(v: PullRequestFailure|PullRequest): v is PullRequest {
+  return (v as PullRequest).targetBranches !== undefined;
+}

--- a/scripts/merge-script/strategies/api-merge.ts
+++ b/scripts/merge-script/strategies/api-merge.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// TODO: Import this from a better location. e.g. `commit-message/parse.d.ts`.
+import {parseCommitMessage} from '@angular/dev-infra-private/commit-message/validate';
+import {PullsListCommitsResponse, PullsMergeParams} from '@octokit/rest';
+import {prompt} from 'inquirer';
+
+import {GithubApiMergeMethod} from '../config';
+import {PullRequestFailure} from '../failures';
+import {GitClient} from '../git';
+import {PullRequest} from '../pull-request';
+import {matchesPattern} from '../string-pattern';
+
+import {MergeStrategy, TEMP_PR_HEAD_BRANCH} from './strategy';
+
+/** Configuration for the Github API merge strategy. */
+export interface GithubApiMergeStrategyConfig {
+  /** Default method used for merging pull requests */
+  default: GithubApiMergeMethod;
+  /** Labels which specify a different merge method than the default. */
+  labels?: {pattern: string, method: GithubApiMergeMethod}[];
+}
+
+/** Separator between commit message header and body. */
+const COMMIT_HEADER_SEPARATOR = '\n\n';
+
+/**
+ * Merge strategy that primarily leverages the Github API. The strategy merges a given
+ * pull request into a target branch using the API. This ensures that Github displays
+ * the pull request as merged. The merged commits are then cherry-picked into the remaining
+ * target branches using the local Git instance. The benefit is that the Github merged state
+ * is properly set, but a notable downside is that PRs cannot use fixup or squash commits.
+ */
+export class GithubApiMergeStrategy extends MergeStrategy {
+
+  constructor(git: GitClient, private _config: GithubApiMergeStrategyConfig) {
+    super(git);
+  }
+
+  async merge(pullRequest: PullRequest): Promise<PullRequestFailure|null> {
+    const {githubTargetBranch, prNumber, targetBranches, requiredBaseSha, needsCommitMessageFixup} =
+        pullRequest;
+    // If the pull request does not have its base branch set to any determined target
+    // branch, we cannot merge using the API.
+    if (targetBranches.every(t => t !== githubTargetBranch)) {
+      return PullRequestFailure.mismatchingTargetBranch(targetBranches);
+    }
+
+    // In cases where a required base commit is specified for this pull request, check if
+    // the pull request contains the given commit. If not, return a pull request failure.
+    // This check is useful for enforcing that PRs are rebased on top of a given commit.
+    // e.g. a commit that changes the code ownership validation. PRs which are not rebased
+    // could bypass new codeowner ship rules.
+    if (requiredBaseSha && !this.git.hasCommit(TEMP_PR_HEAD_BRANCH, requiredBaseSha)) {
+      return PullRequestFailure.unsatisfiedBaseSha();
+    }
+
+    const method = this._getMergeActionFromPullRequest(pullRequest);
+    const cherryPickTargetBranches = targetBranches.filter(b => b !== githubTargetBranch);
+
+    // First cherry-pick the PR into all local target branches in dry-run mode. This is
+    // purely for testing so that we can figure out whether the PR can be cherry-picked
+    // into the other target branches. We don't want to merge the PR through the API, and
+    // then run into cherry-pick conflicts after the initial merge already completed.
+    const failure = await this._checkMergability(pullRequest, cherryPickTargetBranches);
+
+    // If the PR could not be cherry-picked into all target branches locally, we know it can't
+    // be done through the Github API either. We abort merging and pass-through the failure.
+    if (failure !== null) {
+      return failure;
+    }
+
+    const mergeOptions: PullsMergeParams = {
+      pull_number: prNumber,
+      merge_method: method,
+      ...this.git.repoParams,
+    };
+
+    if (needsCommitMessageFixup) {
+      // Commit message fixup does not work with other merge methods as the Github API only
+      // allows commit message modifications for squash merging.
+      if (method !== 'squash') {
+        return PullRequestFailure.unableToFixupCommitMessageSquashOnly();
+      }
+      await this._promptCommitMessageEdit(pullRequest, mergeOptions);
+    }
+
+    // Merge the pull request using the Github API into the selected base branch.
+    const {status, data: {sha}} = await this.git.api.pulls.merge(mergeOptions);
+
+    // https://developer.github.com/v3/pulls/#response-if-merge-cannot-be-performed
+    // Pull request cannot be merged due to merge conflicts.
+    if (status === 405) {
+      return PullRequestFailure.mergeConflicts([githubTargetBranch]);
+    }
+    if (status !== 200) {
+      return PullRequestFailure.unknownMergeError();
+    }
+
+    // If the PR does  not need to be merged into any other target branches,
+    // we exit here as we already completed the merge.
+    if (!cherryPickTargetBranches.length) {
+      return null;
+    }
+
+    // Refresh the target branch the PR has been merged into through the API. We need
+    // to re-fetch as otherwise we cannot cherry-pick the new commits into the remaining
+    // target branches.
+    this.fetchTargetBranches([githubTargetBranch]);
+
+    // Number of commits that have landed in the target branch. This could vary from
+    // the count of commits in the PR due to squashing.
+    const targetCommitsCount = method === 'squash' ? 1 : pullRequest.commitCount;
+
+    // Cherry pick the merged commits into the remaining target branches.
+    const failedBranches = await this.cherryPickIntoTargetBranches(
+        `${sha}~${targetCommitsCount}..${sha}`, cherryPickTargetBranches);
+
+    // We already checked whether the PR can be cherry-picked into the target branches,
+    // but in case the cherry-pick somehow fails, we still handle the conflicts here. The
+    // commits created through the Github API could be different (i.e. through squash).
+    if (failedBranches.length) {
+      return PullRequestFailure.mergeConflicts(failedBranches);
+    }
+
+    this.pushTargetBranchesUpstream(cherryPickTargetBranches);
+    return null;
+  }
+
+  /**
+   * Prompts the user for the commit message changes. Unlike as in the autosquash merge
+   * strategy, we cannot start an interactive rebase because we merge using the Github API.
+   * The Github API only allows modifications to PR title and body for squash merges.
+   */
+  async _promptCommitMessageEdit(pullRequest: PullRequest, mergeOptions: PullsMergeParams) {
+    const commitMessage = await this._getDefaultSquashCommitMessage(pullRequest);
+    const {result} = await prompt<{result: string}>({
+      type: 'editor',
+      name: 'result',
+      message: 'Please update the commit message',
+      default: commitMessage,
+    });
+
+    // Split the new message into title and message. This is necessary because the
+    // Github API expects title and message to be passed separately.
+    const [newTitle, ...newMessage] = result.split(COMMIT_HEADER_SEPARATOR);
+
+    // Update the merge options so that the changes are reflected in there.
+    mergeOptions.commit_title = `${newTitle} (#${pullRequest.prNumber})`;
+    mergeOptions.commit_message = newMessage.join(COMMIT_HEADER_SEPARATOR);
+  }
+
+  /**
+   * Gets a commit message for the given pull request. Github by default concatenates
+   * multiple commit messages if a PR is merged in squash mode. We try to replicate this
+   * behavior here so that we have a default commit message that can be fixed up.
+   */
+  private async _getDefaultSquashCommitMessage(pullRequest: PullRequest): Promise<string> {
+    const commits = (await this._getPullRequestCommitMessages(pullRequest))
+                        .map(message => ({message, parsed: parseCommitMessage(message)}));
+    const messageBase = `${pullRequest.title}${COMMIT_HEADER_SEPARATOR}`;
+    if (commits.length <= 1) {
+      return `${messageBase}${commits[0].parsed.body}`;
+    }
+    const joinedMessages = commits.map(c => `* ${c.message}`).join(COMMIT_HEADER_SEPARATOR);
+    return `${messageBase}${joinedMessages}`;
+  }
+
+  /** Gets all commit messages of commits in the pull request. */
+  private async _getPullRequestCommitMessages({prNumber}: PullRequest) {
+    const request = this.git.api.pulls.listCommits.endpoint.merge(
+        {...this.git.repoParams, pull_number: prNumber});
+    const allCommits: PullsListCommitsResponse = await this.git.api.paginate(request);
+    return allCommits.map(({commit}) => commit.message);
+  }
+
+  /**
+   * Checks if given pull request could be merged into its target branches.
+   * @returns A pull request failure if it the PR could not be merged.
+   */
+  private async _checkMergability(pullRequest: PullRequest, targetBranches: string[]):
+      Promise<null|PullRequestFailure> {
+    const revisionRange = this.getPullRequestRevisionRange(pullRequest);
+    const failedBranches =
+        this.cherryPickIntoTargetBranches(revisionRange, targetBranches, {dryRun: true});
+
+    if (failedBranches.length) {
+      return PullRequestFailure.mergeConflicts(failedBranches);
+    }
+    return null;
+  }
+
+  /** Determines the merge action from the given pull request. */
+  private _getMergeActionFromPullRequest({labels}: PullRequest): GithubApiMergeMethod {
+    if (this._config.labels) {
+      const matchingLabel =
+          this._config.labels.find(({pattern}) => labels.some(l => matchesPattern(l, pattern)));
+      if (matchingLabel !== undefined) {
+        return matchingLabel.method;
+      }
+    }
+    return this._config.default;
+  }
+}

--- a/scripts/merge-script/strategies/autosquash-merge.ts
+++ b/scripts/merge-script/strategies/autosquash-merge.ts
@@ -1,0 +1,73 @@
+import {join} from 'path';
+import {PullRequestFailure} from '../failures';
+import {PullRequest} from '../pull-request';
+import {MergeStrategy, TEMP_PR_HEAD_BRANCH} from './strategy';
+
+/** Path to the commit message filter script. Git expects this paths to use forward slashes. */
+const MSG_FILTER_SCRIPT = join(__dirname, './commit-message-filter.js').replace(/\\/g, '/');
+
+/**
+ * Merge strategy that does not use the Github API for merging. Instead, it fetches
+ * all target branches and the PR locally. The PR is then cherry-picked with autosquash
+ * enabled into the target branches. The benefit is the support for fixup and squash commits.
+ * A notable downside though is that Github does not show the PR as `Merged` due to non
+ * fast-forward merges
+ */
+export class AutosquashMergeStrategy extends MergeStrategy {
+  /**
+   * Merges the specified pull request into the target branches and pushes the target
+   * branches upstream. This method requires the temporary target branches to be fetched
+   * already as we don't want to fetch the target branches per pull request merge. This
+   * would causes unnecessary multiple fetch requests when multiple PRs are merged.
+   * @throws {GitCommandError} An unknown Git command error occurred that is not
+   *   specific to the pull request merge.
+   * @returns A pull request failure or null in case of success.
+   */
+  async merge(pullRequest: PullRequest): Promise<PullRequestFailure|null> {
+    const {prNumber, targetBranches, requiredBaseSha, needsCommitMessageFixup} = pullRequest;
+    // In case a required base is specified for this pull request, check if the pull
+    // request contains the given commit. If not, return a pull request failure. This
+    // check is useful for enforcing that PRs are rebased on top of a given commit. e.g.
+    // a commit that changes the codeowner ship validation. PRs which are not rebased
+    // could bypass new codeowner ship rules.
+    if (requiredBaseSha && !this.git.hasCommit(TEMP_PR_HEAD_BRANCH, requiredBaseSha)) {
+      return PullRequestFailure.unsatisfiedBaseSha();
+    }
+
+    // Git revision range that matches the pull request commits.
+    const revisionRange = this.getPullRequestRevisionRange(pullRequest);
+    // Git revision for the first commit the pull request is based on.
+    const baseRevision = this.getPullRequestBaseRevision(pullRequest);
+
+    // By default, we rebase the pull request so that fixup or squash commits are
+    // automatically collapsed. Optionally, if a commit message fixup is needed, we
+    // make this an interactive rebase so that commits can be selectively modified
+    // before the merge completes.
+    const branchBeforeRebase = this.git.getCurrentBranch();
+    const rebaseArgs = ['--autosquash', baseRevision, TEMP_PR_HEAD_BRANCH];
+    if (needsCommitMessageFixup) {
+      this.git.run(['rebase', '--interactive', ...rebaseArgs], {stdio: 'inherit'});
+    } else {
+      this.git.run(['rebase', ...rebaseArgs]);
+    }
+
+    // Update pull requests commits to reference the pull request. This matches what
+    // Github does when pull requests are merged through the Web UI. The motivation is
+    // that it should be easy to determine which pull request contained a given commit.
+    // **Note**: The filter-branch command relies on the working tree, so we want to make
+    // sure that we are on the initial branch where the merge script has been run.
+    this.git.run(['checkout', '-f', branchBeforeRebase]);
+    this.git.run(
+        ['filter-branch', '-f', '--msg-filter', `${MSG_FILTER_SCRIPT} ${prNumber}`, revisionRange]);
+
+    // Cherry-pick the pull request into all determined target branches.
+    const failedBranches = this.cherryPickIntoTargetBranches(revisionRange, targetBranches);
+
+    if (failedBranches.length) {
+      return PullRequestFailure.mergeConflicts(failedBranches);
+    }
+
+    this.pushTargetBranchesUpstream(targetBranches);
+    return null;
+  }
+}

--- a/scripts/merge-script/strategies/commit-message-filter.js
+++ b/scripts/merge-script/strategies/commit-message-filter.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * Script that can be passed as commit message filter to `git filter-branch --msg-filter`.
+ * The script rewrites commit messages to contain a Github instruction to close the
+ * corresponding pull request. For more details. See: https://git.io/Jv64r.
+ */
+
+if (require.main === module) {
+  const [prNumber] = process.argv.slice(2);
+  if (!prNumber) {
+    console.error('No pull request number specified.');
+    process.exit(1);
+  }
+
+  let commitMessage = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('readable', () => {
+    const chunk = process.stdin.read();
+    if (chunk !== null) {
+      commitMessage += chunk;
+    }
+  });
+
+  process.stdin.on('end', () => {
+    console.info(rewriteCommitMessage(commitMessage, prNumber));
+  });
+}
+
+function rewriteCommitMessage(message, prNumber) {
+  const lines = message.split(/\n/);
+  // Add the pull request number to the commit message title. This matches what
+  // Github does when PRs are merged on the web through the `Squash and Merge` button.
+  lines[0] += ` (#${prNumber})`;
+  // Push a new line that instructs Github to close the specified pull request.
+  lines.push(`Closes #${prNumber}`);
+  return lines.join('\n');
+}

--- a/scripts/merge-script/strategies/strategy.ts
+++ b/scripts/merge-script/strategies/strategy.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PullRequestFailure} from '../failures';
+import {GitClient} from '../git';
+import {PullRequest} from '../pull-request';
+
+/**
+ * Name of a temporary branch that contains the head of a currently-processed PR. Note
+ * that a branch name should be used that most likely does not conflict with other local
+ * development branches.
+ */
+export const TEMP_PR_HEAD_BRANCH = 'merge_pr_head';
+
+/**
+ * Base class for merge strategies. A merge strategy accepts a pull request and
+ * merges it into the determined target branches.
+ */
+export abstract class MergeStrategy {
+  constructor(protected git: GitClient) {}
+
+  /**
+   * Prepares a merge of the given pull request. The strategy by default will
+   * fetch all target branches and the pull request into local temporary branches.
+   */
+  async prepare(pullRequest: PullRequest) {
+    this.fetchTargetBranches(
+        pullRequest.targetBranches, `pull/${pullRequest.prNumber}/head:${TEMP_PR_HEAD_BRANCH}`);
+  }
+
+  /**
+   * Performs the merge of the given pull request. This needs to be implemented
+   * by individual merge strategies.
+   */
+  abstract merge(pullRequest: PullRequest): Promise<null|PullRequestFailure>;
+
+  /** Cleans up the pull request merge. e.g. deleting temporary local branches. */
+  async cleanup(pullRequest: PullRequest) {
+    // Delete all temporary target branches.
+    pullRequest.targetBranches.forEach(
+        branchName => this.git.run(['branch', '-D', this.getLocalTargetBranchName(branchName)]));
+
+    // Delete temporary branch for the pull request head.
+    this.git.run(['branch', '-D', TEMP_PR_HEAD_BRANCH]);
+  }
+
+  /** Gets the revision range for all commits in the given pull request. */
+  protected getPullRequestRevisionRange(pullRequest: PullRequest): string {
+    return `${this.getPullRequestBaseRevision(pullRequest)}..${TEMP_PR_HEAD_BRANCH}`;
+  }
+
+  /** Gets the base revision of a pull request. i.e. the commit the PR is based on. */
+  protected getPullRequestBaseRevision(pullRequest: PullRequest): string {
+    return `${TEMP_PR_HEAD_BRANCH}~${pullRequest.commitCount}`;
+  }
+
+  /** Gets a deterministic local branch name for a given branch. */
+  protected getLocalTargetBranchName(targetBranch: string): string {
+    return `merge_pr_target_${targetBranch.replace(/\//g, '_')}`;
+  }
+
+  /**
+   * Cherry-picks the given revision range into the specified target branches.
+   * @returns A list of branches for which the revisions could not be cherry-picked into.
+   */
+  protected cherryPickIntoTargetBranches(revisionRange: string, targetBranches: string[], options: {
+    dryRun?: boolean
+  } = {}) {
+    const cherryPickArgs = [revisionRange];
+    const failedBranches: string[] = [];
+
+    if (options.dryRun) {
+      // https://git-scm.com/docs/git-cherry-pick#Documentation/git-cherry-pick.txt---no-commit
+      // This causes `git cherry-pick` to not generate any commits. Instead, the changes are
+      // applied directly in the working tree. This allow us to easily discard the changes
+      // for dry-run purposes.
+      cherryPickArgs.push('--no-commit');
+    }
+
+    // Cherry-pick the refspec into all determined target branches.
+    for (const branchName of targetBranches) {
+      const localTargetBranch = this.getLocalTargetBranchName(branchName);
+      // Checkout the local target branch.
+      this.git.run(['checkout', localTargetBranch]);
+      // Cherry-pick the refspec into the target branch.
+      if (this.git.runGraceful(['cherry-pick', ...cherryPickArgs]).status !== 0) {
+        // Abort the failed cherry-pick. We do this because Git persists the failed
+        // cherry-pick state globally in the repository. This could prevent future
+        // pull request merges as a Git thinks a cherry-pick is still in progress.
+        this.git.runGraceful(['cherry-pick', '--abort']);
+        failedBranches.push(branchName);
+      }
+      // If we run with dry run mode, we reset the local target branch so that all dry-run
+      // cherry-pick changes are discard. Changes are applied to the working tree and index.
+      if (options.dryRun) {
+        this.git.run(['reset', '--hard', 'HEAD']);
+      }
+    }
+    return failedBranches;
+  }
+
+  /**
+   * Fetches the given target branches. Also accepts a list of additional refspecs that
+   * should be fetched. This is helpful as multiple slow fetches could be avoided.
+   */
+  protected fetchTargetBranches(names: string[], ...extraRefspecs: string[]) {
+    const fetchRefspecs = names.map(targetBranch => {
+      const localTargetBranch = this.getLocalTargetBranchName(targetBranch);
+      return `refs/heads/${targetBranch}:${localTargetBranch}`;
+    });
+    // Fetch all target branches with a single command. We don't want to fetch them
+    // individually as that could cause an unnecessary slow-down.
+    this.git.run(['fetch', '-f', this.git.repoGitUrl, ...fetchRefspecs, ...extraRefspecs]);
+  }
+
+  /** Pushes the given target branches upstream. */
+  protected pushTargetBranchesUpstream(names: string[]) {
+    const pushRefspecs = names.map(targetBranch => {
+      const localTargetBranch = this.getLocalTargetBranchName(targetBranch);
+      return `${localTargetBranch}:refs/heads/${targetBranch}`;
+    });
+    // Push all target branches with a single command if we don't run in dry-run mode.
+    // We don't want to push them individually as that could cause an unnecessary slow-down.
+    this.git.run(['push', this.git.repoGitUrl, ...pushRefspecs]);
+  }
+}

--- a/scripts/merge-script/string-pattern.ts
+++ b/scripts/merge-script/string-pattern.ts
@@ -1,0 +1,4 @@
+/** Checks whether the specified value matches the given pattern. */
+export function matchesPattern(value: string, pattern: RegExp|string): boolean {
+  return typeof pattern === 'string' ? value === pattern : pattern.test(value);
+}

--- a/scripts/merge-script/target-label.ts
+++ b/scripts/merge-script/target-label.ts
@@ -1,0 +1,19 @@
+import {Config, TargetLabel} from './config';
+import {matchesPattern} from './string-pattern';
+
+/** Gets the target label from the specified pull request labels. */
+export function getTargetLabelFromPullRequest(config: Config, labels: string[]): TargetLabel|null {
+  for (const label of labels) {
+    const match = config.labels.find(({pattern}) => matchesPattern(label, pattern));
+    if (match !== undefined) {
+      return match;
+    }
+  }
+  return null;
+}
+
+/** Gets the branches from the specified target label. */
+export function getBranchesFromTargetLabel(
+    label: TargetLabel, githubTargetBranch: string): string[] {
+  return typeof label.branches === 'function' ? label.branches(githubTargetBranch) : label.branches;
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "outDir": "../dist/dev-infra-scripts",
+    "target": "es2015",
     "lib": ["es2016"],
     "types": ["node"],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "downlevelIteration": true
   }
 }


### PR DESCRIPTION
Creates a merge script that automatically merges pull
requests from Github and cherry-picks them into the
right publish branches based on the PR target label.

The script has been designed in an extensible and programmatically
acessible way, so that it can be used in other Angular repositories too.

The script provides infrastructure for PR merge safety checks. e.g.
it currently enforces that the CLA is signed, or that the merge ready
label is assigned, or that no CI checks are failing / pending.