### PR TITLE
fix(material-experimental/radio): remove input click handler

### DIFF
--- a/src/material-experimental/mdc-radio/radio.html
+++ b/src/material-experimental/mdc-radio/radio.html
@@ -12,8 +12,7 @@
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"
            [attr.aria-describedby]="ariaDescribedby"
-           (change)="_onInputChange($event)"
-           (click)="_onInputClick($event)">
+           (change)="_onInputChange($event)">
     <div class="mdc-radio__background">
       <div class="mdc-radio__outer-circle"></div>
       <div class="mdc-radio__inner-circle"></div>


### PR DESCRIPTION
Since the MDC radio actually uses the input, we do not need to stop the propagation as done in `onInputClick` defined in our current/legacy `radio.ts`. Additionally, this needs to be removed because now users adding `(click)` handlers to the radio will not receive their events if the click is on the input