### PR TITLE
fix(popover-edit): Pipe editingOrFocused with _startWithNullDistinct …

### DIFF
--- a/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
+++ b/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
@@ -118,7 +118,7 @@ export class EditEventDispatcher {
   private readonly _hoveredContentStateDistinct = combineLatest([
       this._getFirstRowWithHoverContent(),
       this._getLastRowWithHoverContent(),
-      this.editingOrFocused,
+      this.editingOrFocused.pipe(this._startWithNullDistinct),
       this.hovering.pipe(
           distinctUntilChanged(),
           audit(row => this.mouseMove.pipe(


### PR DESCRIPTION
…to initialize _hoveredContentStateDistinct observable.

It is possible that the _hoveredContentStateDistinct observable is subscribed to after the first emission from editingOrFocused. This results in _hoveredContentStateDistinct not emitting an initial state until there is a new edit or focus event. When this occurs, the user will not see any hover content until they click into a cell. 