### PR TITLE
refactor(material-experimental/mdc-chips): implement trailing icon foundation

### DIFF
--- a/src/material-experimental/mdc-chips/chip-icons.ts
+++ b/src/material-experimental/mdc-chips/chip-icons.ts
@@ -11,6 +11,7 @@ import {
   ChangeDetectorRef,
   Directive,
   ElementRef,
+  OnDestroy,
 } from '@angular/core';
 import {
   CanDisable,
@@ -20,6 +21,7 @@ import {
   mixinDisabled,
   mixinTabIndex,
 } from '@angular/material/core';
+import {MDCChipTrailingActionAdapter, MDCChipTrailingActionFoundation} from '@material/chips';
 import {Subject} from 'rxjs';
 
 
@@ -57,8 +59,42 @@ export class MatChipAvatar {
     'aria-hidden': 'true',
   }
 })
-export class MatChipTrailingIcon {
-  constructor(public _elementRef: ElementRef) {}
+export class MatChipTrailingIcon implements OnDestroy {
+  private _foundation: MDCChipTrailingActionFoundation;
+  private _adapter: MDCChipTrailingActionAdapter = {
+    focus: () => this._elementRef.nativeElement.focus(),
+    getAttribute: (name: string) => this._elementRef.nativeElement.getAttribute(name),
+    setAttribute: (name: string, value: string) => {
+      this._elementRef.nativeElement.setAttribute(name, value);
+    },
+    // TODO(crisbeto): there's also a `trigger` parameter that the chip isn't
+    // handling yet. Consider passing it along once MDC start using it.
+    notifyInteraction: () => {
+      // TODO(crisbeto): uncomment this code once we've inverted the dependency on `MatChip`.
+      // this._chip._notifyInteraction();
+    },
+
+    // TODO(crisbeto): there's also a `key` parameter that the chip isn't
+    // handling yet. Consider passing it along once MDC start using it.
+    notifyNavigation: () => {
+      // TODO(crisbeto): uncomment this code once we've inverted the dependency on `MatChip`.
+      // this._chip._notifyNavigation();
+    }
+  };
+
+  constructor(
+    public _elementRef: ElementRef,
+    // TODO(crisbeto): currently the chip needs a reference to the trailing icon for the deprecated
+    // `setTrailingActionAttr` method. Until the method is removed, we can't use the chip here,
+    // because it causes a circular import.
+    // private _chip: MatChip
+  ) {
+    this._foundation = new MDCChipTrailingActionFoundation(this._adapter);
+  }
+
+  ngOnDestroy() {
+    this._foundation.destroy();
+  }
 
   focus() {
     this._elementRef.nativeElement.focus();
@@ -75,8 +111,8 @@ export class MatChipTrailingIcon {
  * @docs-private
  */
 class MatChipRemoveBase extends MatChipTrailingIcon {
-  constructor(_elementRef: ElementRef) {
-    super(_elementRef);
+  constructor(elementRef: ElementRef) {
+    super(elementRef);
   }
 }
 

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -254,15 +254,12 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
       return (target && (target as Element).classList) ?
           (target as Element).classList.contains(className) : false;
     },
-    notifyInteraction: () => this.interaction.emit(this.id),
+    notifyInteraction: () => this._notifyInteraction(),
     notifySelection: () => {
       // No-op. We call dispatchSelectionEvent ourselves in MatChipOption, because we want to
       // specify whether selection occurred via user input.
     },
-    notifyNavigation: () => {
-      // TODO: This is a new feature added by MDC; consider exposing this event to users in the
-      // future.
-    },
+    notifyNavigation: () => this._notifyNavigation(),
     notifyTrailingIconInteraction: () => this.removeIconInteraction.emit(this.id),
     notifyRemoval: () => {
       this.removed.emit({ chip: this });
@@ -406,6 +403,14 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
   /** Whether or not the ripple should be disabled. */
   _isRippleDisabled(): boolean {
     return this.disabled || this.disableRipple || this._isBasicChip;
+  }
+
+  _notifyInteraction() {
+    this.interaction.emit(this.id);
+  }
+
+  _notifyNavigation() {
+    // TODO: This is a new feature added by MDC. Consider exposing it to users in the future.
   }
 
   static ngAcceptInputType_disabled: BooleanInput;


### PR DESCRIPTION
The new foundation isn't being used yet, but these changes implement it so it's easier to roll out in the future.