### PR TITLE
fix(material/list): fix up disabled list item styles

### DIFF
--- a/src/material/core/theming/_palette.scss
+++ b/src/material/core/theming/_palette.scss
@@ -705,7 +705,7 @@ $dark-theme-background-palette: (
   selected-disabled-button: map.get($grey-palette, 800),
   disabled-button-toggle: black,
   unselected-chip: map.get($grey-palette, 700),
-  disabled-list-option: black,
+  disabled-list-option: rgba(white, 0.12),
   tooltip: map.get($grey-palette, 700),
 );
 

--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -22,10 +22,11 @@
     .mat-subheader {
       color: theming.get-color-from-palette($foreground, secondary-text);
     }
-  }
 
-  .mat-list-item-disabled {
-    background-color: theming.get-color-from-palette($background, disabled-list-option);
+    .mat-list-item-disabled {
+      background-color: theming.get-color-from-palette($background, disabled-list-option);
+      color: theming.get-color-from-palette($foreground, disabled-text);
+    }
   }
 
   .mat-list-option,


### PR DESCRIPTION
Fixes a couple of issues with the list item's disabled styles:
- In dark themes we were setting the disabled styles to black. This looks out of place since it's not how other components style themselves under dark themes.
- The disabled styles are somewhat similar to the selected styles. These changes also set the text color to the disabled text color to make it easier to distinguish.

Before and after for reference:
![Angular_Material_-_Google_Chrome_2020-03-21_16-00-34](https://user-images.githubusercontent.com/4450522/77229639-55129d00-6b8f-11ea-8c94-83cfb88dc583.png)
![Angular_Material_-_Google_Chrome_2020-03-21_16-10-58](https://user-images.githubusercontent.com/4450522/77229642-580d8d80-6b8f-11ea-8c63-0b39c0294c4d.png)
