### PR TITLE
test(datepicker): add tests for the date range picker

### DIFF
--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -1,7 +1,8 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
-import {MatCalendarBody, MatCalendarCell, MatCalendarCellCssClasses} from './calendar-body';
+import {MatCalendarBody, MatCalendarCell} from './calendar-body';
 import {By} from '@angular/platform-browser';
+import {dispatchMouseEvent, dispatchFakeEvent} from '@angular/cdk/testing/private';
 
 
 describe('MatCalendarBody', () => {
@@ -9,9 +10,8 @@ describe('MatCalendarBody', () => {
     TestBed.configureTestingModule({
       declarations: [
         MatCalendarBody,
-
-        // Test components.
         StandardCalendarBody,
+        RangeCalendarBody,
       ],
     });
 
@@ -113,27 +113,475 @@ describe('MatCalendarBody', () => {
 
   });
 
+  describe('range calendar body', () => {
+    const startClass = 'mat-calendar-body-range-start';
+    const inRangeClass = 'mat-calendar-body-in-range';
+    const endClass = 'mat-calendar-body-range-end';
+    const comparisonStartClass = 'mat-calendar-body-comparison-start';
+    const inComparisonClass = 'mat-calendar-body-in-comparison-range';
+    const comparisonEndClass = 'mat-calendar-body-comparison-end';
+    const bridgeStart = 'mat-calendar-body-comparison-bridge-start';
+    const bridgeEnd = 'mat-calendar-body-comparison-bridge-end';
+    let fixture: ComponentFixture<RangeCalendarBody>;
+    let testComponent: RangeCalendarBody;
+    let cells: HTMLElement[];
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(RangeCalendarBody);
+      fixture.detectChanges();
+      testComponent = fixture.componentInstance;
+      cells = Array.from(fixture.nativeElement.querySelectorAll('.mat-calendar-body-cell'));
+    });
+
+    it('should render a range', () => {
+      testComponent.startValue = 1;
+      testComponent.endValue = 5;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).toContain(startClass);
+      expect(cells[1].classList).toContain(inRangeClass);
+      expect(cells[2].classList).toContain(inRangeClass);
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[4].classList).toContain(endClass);
+    });
+
+    it('should render a comparison range', () => {
+      testComponent.comparisonStart = 1;
+      testComponent.comparisonEnd = 5;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).toContain(comparisonStartClass);
+      expect(cells[1].classList).toContain(inComparisonClass);
+      expect(cells[2].classList).toContain(inComparisonClass);
+      expect(cells[3].classList).toContain(inComparisonClass);
+      expect(cells[4].classList).toContain(comparisonEndClass);
+    });
+
+    it('should be able to render two completely overlapping ranges', () => {
+      testComponent.startValue = testComponent.comparisonStart = 1;
+      testComponent.endValue = testComponent.comparisonEnd = 5;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).toContain(startClass);
+      expect(cells[0].classList).toContain(comparisonStartClass);
+
+      expect(cells[1].classList).toContain(inRangeClass);
+      expect(cells[1].classList).toContain(inComparisonClass);
+
+      expect(cells[2].classList).toContain(inRangeClass);
+      expect(cells[2].classList).toContain(inComparisonClass);
+
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[3].classList).toContain(inComparisonClass);
+
+      expect(cells[4].classList).toContain(endClass);
+      expect(cells[4].classList).toContain(comparisonEndClass);
+    });
+
+    it('should mark a cell as a start bridge if it is the end of the main range ' +
+      'and the start of the comparison', () => {
+      testComponent.startValue = 1;
+      testComponent.endValue = 5;
+      testComponent.comparisonStart = 5;
+      testComponent.comparisonEnd = 10;
+      fixture.detectChanges();
+
+      expect(cells[4].classList).toContain(bridgeStart);
+    });
+
+    it('should not mark a cell as a start bridge if there is no end range value', () => {
+      testComponent.startValue = 1;
+      testComponent.endValue = undefined;
+      testComponent.comparisonStart = 5;
+      testComponent.comparisonEnd = 10;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(bridgeStart))).toBe(false);
+    });
+
+    it('should mark a cell as an end bridge if it is the start of the main range ' +
+      'and the end of the comparison', () => {
+      testComponent.comparisonStart = 1;
+      testComponent.comparisonEnd = 5;
+      testComponent.startValue = 5;
+      testComponent.endValue = 10;
+      fixture.detectChanges();
+
+      expect(cells[4].classList).toContain(bridgeEnd);
+    });
+
+    it('should not mark a cell as an end bridge if there is no end range value', () => {
+      testComponent.comparisonStart = 1;
+      testComponent.comparisonEnd = 5;
+      testComponent.startValue = 5;
+      testComponent.endValue = undefined;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(bridgeEnd))).toBe(false);
+    });
+
+    it('should be able to show a main range inside a comparison range', () => {
+      testComponent.comparisonStart = 1;
+      testComponent.comparisonEnd = 5;
+      testComponent.startValue = 2;
+      testComponent.endValue = 4;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).toContain(comparisonStartClass);
+
+      expect(cells[1].classList).toContain(inComparisonClass);
+      expect(cells[1].classList).toContain(startClass);
+
+      expect(cells[2].classList).toContain(inComparisonClass);
+      expect(cells[2].classList).toContain(inRangeClass);
+
+      expect(cells[3].classList).toContain(inComparisonClass);
+      expect(cells[3].classList).toContain(endClass);
+
+      expect(cells[4].classList).toContain(comparisonEndClass);
+    });
+
+    it('should be able to show a comparison range inside a main range', () => {
+      testComponent.startValue = 1;
+      testComponent.endValue = 5;
+      testComponent.comparisonStart = 2;
+      testComponent.comparisonEnd = 4;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).toContain(startClass);
+
+      expect(cells[1].classList).toContain(inRangeClass);
+      expect(cells[1].classList).toContain(comparisonStartClass);
+
+      expect(cells[2].classList).toContain(inRangeClass);
+      expect(cells[2].classList).toContain(inComparisonClass);
+
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[3].classList).toContain(comparisonEndClass);
+
+      expect(cells[4].classList).toContain(endClass);
+    });
+
+    it('should be able to show a range that is larger than the calendar', () => {
+      testComponent.startValue = -10;
+      testComponent.endValue = 100;
+      fixture.detectChanges();
+
+      expect(cells.every(cell => cell.classList.contains(inRangeClass))).toBe(true);
+      expect(cells.some(cell => cell.classList.contains(startClass))).toBe(false);
+      expect(cells.some(cell => cell.classList.contains(endClass))).toBe(false);
+    });
+
+    it('should be able to show a comparison range that is larger than the calendar', () => {
+      testComponent.comparisonStart = -10;
+      testComponent.comparisonEnd = 100;
+      fixture.detectChanges();
+
+      expect(cells.every(cell => cell.classList.contains(inComparisonClass))).toBe(true);
+      expect(cells.some(cell => cell.classList.contains(comparisonStartClass))).toBe(false);
+      expect(cells.some(cell => cell.classList.contains(comparisonEndClass))).toBe(false);
+    });
+
+    it('should be able to show a range that starts before the beginning of the calendar', () => {
+      testComponent.startValue = -10;
+      testComponent.endValue = 2;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(startClass))).toBe(false);
+      expect(cells[0].classList).toContain(inRangeClass);
+      expect(cells[1].classList).toContain(endClass);
+    });
+
+    it('should be able to show a comparison range that starts before the beginning of the calendar',
+      () => {
+        testComponent.comparisonStart = -10;
+        testComponent.comparisonEnd = 2;
+        fixture.detectChanges();
+
+        expect(cells.some(cell => cell.classList.contains(comparisonStartClass))).toBe(false);
+        expect(cells[0].classList).toContain(inComparisonClass);
+        expect(cells[1].classList).toContain(comparisonEndClass);
+      });
+
+    it('should be able to show a range that ends after the end of the calendar', () => {
+      testComponent.startValue = 27;
+      testComponent.endValue = 50;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(endClass))).toBe(false);
+      expect(cells[26].classList).toContain(startClass);
+      expect(cells[27].classList).toContain(inRangeClass);
+    });
+
+    it('should be able to show a comparison range that ends after the end of the calendar', () => {
+      testComponent.comparisonStart = 27;
+      testComponent.comparisonEnd = 50;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(comparisonEndClass))).toBe(false);
+      expect(cells[26].classList).toContain(comparisonStartClass);
+      expect(cells[27].classList).toContain(inComparisonClass);
+    });
+
+    it('should be able to show a range that ends after the end of the calendar', () => {
+      testComponent.startValue = 27;
+      testComponent.endValue = 50;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(endClass))).toBe(false);
+      expect(cells[26].classList).toContain(startClass);
+      expect(cells[27].classList).toContain(inRangeClass);
+    });
+
+    it('should be able to mark a date both as the range start and end', () => {
+      testComponent.startValue = 1;
+      testComponent.endValue = 1;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).toContain(startClass);
+      expect(cells[0].classList).toContain(endClass);
+    });
+
+    it('should be able to mark a date both as the comparison range start and end', () => {
+      testComponent.comparisonStart = 1;
+      testComponent.comparisonEnd = 1;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).toContain(comparisonStartClass);
+      expect(cells[0].classList).toContain(comparisonEndClass);
+    });
+
+    it('should not mark a date as the range end if it comes before the start', () => {
+      testComponent.startValue = 2;
+      testComponent.endValue = 1;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).not.toContain(endClass);
+      expect(cells[0].classList).not.toContain(inRangeClass);
+      expect(cells[1].classList).toContain(startClass);
+    });
+
+    it('should not mark a date as the comparison range end if it comes before the start', () => {
+      testComponent.comparisonStart = 2;
+      testComponent.comparisonEnd = 1;
+      fixture.detectChanges();
+
+      expect(cells[0].classList).not.toContain(comparisonEndClass);
+      expect(cells[0].classList).not.toContain(inComparisonClass);
+      expect(cells[1].classList).toContain(comparisonStartClass);
+    });
+
+    it('should not show a range if there is no start', () => {
+      testComponent.startValue = undefined;
+      testComponent.endValue = 10;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(inRangeClass))).toBe(false);
+      expect(cells.some(cell => cell.classList.contains(endClass))).toBe(false);
+    });
+
+    it('should not show a comparison range if there is no start', () => {
+      testComponent.comparisonStart = undefined;
+      testComponent.comparisonEnd = 10;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(inComparisonClass))).toBe(false);
+      expect(cells.some(cell => cell.classList.contains(comparisonEndClass))).toBe(false);
+    });
+
+    it('should not show a comparison range if there is no end', () => {
+      testComponent.comparisonStart = 10;
+      testComponent.comparisonEnd = undefined;
+      fixture.detectChanges();
+
+      expect(cells.some(cell => cell.classList.contains(inComparisonClass))).toBe(false);
+      expect(cells.some(cell => cell.classList.contains(comparisonEndClass))).toBe(false);
+    });
+
+    it('should preview the selected range after the user clicks on a start and hovers away', () => {
+      cells[2].click();
+      fixture.detectChanges();
+
+      dispatchMouseEvent(cells[5], 'mouseenter');
+      fixture.detectChanges();
+
+      expect(cells[2].classList).toContain(startClass);
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[4].classList).toContain(inRangeClass);
+      expect(cells[5].classList).toContain(endClass);
+
+      // Go a few cells ahead.
+      dispatchMouseEvent(cells[7], 'mouseenter');
+      fixture.detectChanges();
+
+      expect(cells[5].classList).not.toContain(endClass);
+      expect(cells[5].classList).toContain(inRangeClass);
+      expect(cells[6].classList).toContain(inRangeClass);
+      expect(cells[7].classList).toContain(endClass);
+
+      // Go back a few cells.
+      dispatchMouseEvent(cells[4], 'mouseenter');
+      fixture.detectChanges();
+
+      expect(cells[5].classList).not.toContain(inRangeClass);
+      expect(cells[6].classList).not.toContain(inRangeClass);
+      expect(cells[7].classList).not.toContain(endClass);
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[4].classList).toContain(endClass);
+    });
+
+    it('should preview the selected range after the user selects a start and moves focus away',
+      () => {
+        cells[2].click();
+        fixture.detectChanges();
+
+        dispatchFakeEvent(cells[5], 'focus');
+        fixture.detectChanges();
+
+        expect(cells[2].classList).toContain(startClass);
+        expect(cells[3].classList).toContain(inRangeClass);
+        expect(cells[4].classList).toContain(inRangeClass);
+        expect(cells[5].classList).toContain(endClass);
+
+        // Go a few cells ahead.
+        dispatchFakeEvent(cells[7], 'focus');
+        fixture.detectChanges();
+
+        expect(cells[5].classList).not.toContain(endClass);
+        expect(cells[5].classList).toContain(inRangeClass);
+        expect(cells[6].classList).toContain(inRangeClass);
+        expect(cells[7].classList).toContain(endClass);
+
+        // Go back a few cells.
+        dispatchFakeEvent(cells[4], 'focus');
+        fixture.detectChanges();
+
+        expect(cells[5].classList).not.toContain(inRangeClass);
+        expect(cells[6].classList).not.toContain(inRangeClass);
+        expect(cells[7].classList).not.toContain(endClass);
+        expect(cells[3].classList).toContain(inRangeClass);
+        expect(cells[4].classList).toContain(endClass);
+      });
+
+    it('should not be able to extend the range before the start', () => {
+      cells[5].click();
+      fixture.detectChanges();
+
+      dispatchMouseEvent(cells[2], 'mouseenter');
+      fixture.detectChanges();
+
+      expect(cells[5].classList).toContain(startClass);
+      expect(cells.some(cell => cell.classList.contains(inRangeClass))).toBe(false);
+    });
+
+    it('should be able to show a range, starting before the beginning of the calendar, ' +
+      'while hovering', () => {
+        fixture.componentInstance.startValue = -1;
+        fixture.detectChanges();
+
+        dispatchMouseEvent(cells[2], 'mouseenter');
+        fixture.detectChanges();
+
+        expect(cells.some(cell => cell.classList.contains(startClass))).toBe(false);
+        expect(cells[0].classList).toContain(inRangeClass);
+        expect(cells[1].classList).toContain(inRangeClass);
+        expect(cells[2].classList).toContain(endClass);
+      });
+
+    it('should be able to show a range, starting before the beginning of the calendar, ' +
+      'while moving focus', () => {
+        fixture.componentInstance.startValue = -1;
+        fixture.detectChanges();
+
+        dispatchMouseEvent(cells[2], 'focus');
+        fixture.detectChanges();
+
+        expect(cells.some(cell => cell.classList.contains(startClass))).toBe(false);
+        expect(cells[0].classList).toContain(inRangeClass);
+        expect(cells[1].classList).toContain(inRangeClass);
+        expect(cells[2].classList).toContain(endClass);
+      });
+
+    it('should remove the preview if the user moves their pointer away', () => {
+      cells[2].click();
+      fixture.detectChanges();
+
+      dispatchMouseEvent(cells[4], 'mouseenter');
+      fixture.detectChanges();
+
+      expect(cells[2].classList).toContain(startClass);
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[4].classList).toContain(endClass);
+
+      // Move the pointer away.
+      dispatchMouseEvent(cells[4], 'mouseleave');
+      fixture.detectChanges();
+
+      expect(cells[2].classList).toContain(startClass);
+      expect(cells[3].classList).not.toContain(inRangeClass);
+      expect(cells[4].classList).not.toContain(endClass);
+
+      // Move the pointer back in to a different cell.
+      dispatchMouseEvent(cells[5], 'mouseenter');
+      fixture.detectChanges();
+
+      expect(cells[2].classList).toContain(startClass);
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[4].classList).toContain(inRangeClass);
+      expect(cells[5].classList).toContain(endClass);
+    });
+
+    it('should remove the preview if the user moves their focus away', () => {
+      cells[2].click();
+      fixture.detectChanges();
+
+      dispatchFakeEvent(cells[4], 'focus');
+      fixture.detectChanges();
+
+      expect(cells[2].classList).toContain(startClass);
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[4].classList).toContain(endClass);
+
+      // Move the pointer away.
+      dispatchFakeEvent(cells[4], 'blur');
+      fixture.detectChanges();
+
+      expect(cells[2].classList).toContain(startClass);
+      expect(cells[3].classList).not.toContain(inRangeClass);
+      expect(cells[4].classList).not.toContain(endClass);
+
+      // Move the pointer back in to a different cell.
+      dispatchFakeEvent(cells[5], 'focus');
+      fixture.detectChanges();
+
+      expect(cells[2].classList).toContain(startClass);
+      expect(cells[3].classList).toContain(inRangeClass);
+      expect(cells[4].classList).toContain(inRangeClass);
+      expect(cells[5].classList).toContain(endClass);
+    });
+
+  });
+
 });
 
 
 @Component({
-  template: `<table mat-calendar-body
-                    [label]="label"
-                    [rows]="rows"
-                    [todayValue]="todayValue"
-                    [startValue]="selectedValue"
-                    [endValue]="selectedValue"
-                    [labelMinRequiredCells]="labelMinRequiredCells"
-                    [numCols]="numCols"
-                    [activeCell]="10"
-                    (selectedValueChange)="onSelect($event)">
-             </table>`,
+  template: `
+    <table mat-calendar-body
+          [label]="label"
+          [rows]="rows"
+          [todayValue]="todayValue"
+          [startValue]="selectedValue"
+          [endValue]="selectedValue"
+          [labelMinRequiredCells]="labelMinRequiredCells"
+          [numCols]="numCols"
+          [activeCell]="10"
+          (selectedValueChange)="onSelect($event)">
+    </table>`,
 })
 class StandardCalendarBody {
   label = 'Jan 2017';
-  rows = [[1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14]].map(row => {
-    return row.map(cell => createCell(cell, cell % 2 === 0 ? 'even' : undefined));
-  });
+  rows = createCalendarCells(2);
   todayValue = 3;
   selectedValue = 4;
   labelMinRequiredCells = 3;
@@ -144,6 +592,56 @@ class StandardCalendarBody {
   }
 }
 
-function createCell(value: number, cellClasses?: MatCalendarCellCssClasses) {
-  return new MatCalendarCell(value, `${value}`, `${value}-label`, true, cellClasses);
+@Component({
+  template: `
+    <table mat-calendar-body
+          [rows]="rows"
+          [startValue]="startValue"
+          [endValue]="endValue"
+          [comparisonStart]="comparisonStart"
+          [comparisonEnd]="comparisonEnd"
+          (selectedValueChange)="onSelect($event)">
+    </table>`,
+})
+class RangeCalendarBody {
+  rows = createCalendarCells(4);
+  startValue: number | undefined;
+  endValue: number | undefined;
+  comparisonStart: number | undefined;
+  comparisonEnd: number | undefined;
+
+  onSelect(value: number) {
+    if (!this.startValue) {
+      this.startValue = value;
+    } else if (!this.endValue) {
+      this.endValue = value;
+    } else {
+      this.startValue = value;
+      this.endValue = undefined;
+    }
+  }
+}
+
+/**
+ * Creates a 2d array of days, split into weeks.
+ * @param weeks Number of weeks that should be generated.
+ */
+function createCalendarCells(weeks: number): MatCalendarCell[][] {
+  const rows: number[][] = [];
+  let dayCounter = 1;
+
+  for (let i = 0; i < weeks; i++) {
+    const row = [];
+
+    while (row.length < 7) {
+      row.push(dayCounter++);
+    }
+
+    rows.push(row);
+  }
+
+  return rows.map(row => row.map(cell => {
+    return new MatCalendarCell(cell, `${cell}`, `${cell}-label`, true,
+        cell % 2 === 0 ? 'even' : undefined);
+  }));
 }

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -206,7 +206,11 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
 
   /** Gets whether a value is the end of the main range. */
   _isRangeEnd(value: number) {
-    return value === this.endValue || (value === this._hoveredValue && value >= this.startValue);
+    if (!this.startValue || value < this.startValue) {
+      return false;
+    }
+
+    return value === this.endValue || value === this._hoveredValue;
   }
 
   /** Gets whether a value is within the currently-selected range. */
@@ -254,7 +258,8 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
 
   /** Gets whether a value is the end of the comparison range. */
   _isComparisonEnd(value: number) {
-    return value === this.comparisonEnd;
+    return this.comparisonStart && value >= this.comparisonStart &&
+           value === this.comparisonEnd;
   }
 
   /** Gets whether a value is within the current comparison range. */

--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -394,6 +394,54 @@ describe('MatDatepicker', () => {
     expect(end.nativeElement.getAttribute('max')).toContain('2020');
   });
 
+  it('should pass the range input value through to the calendar', () => {
+    const fixture = createComponent(StandardRangePicker);
+    const {start, end} = fixture.componentInstance.range.controls;
+    let overlayContainerElement: HTMLElement;
+    start.setValue(new Date(2020, 1, 2));
+    end.setValue(new Date(2020, 1, 5));
+    inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
+      overlayContainerElement = overlayContainer.getContainerElement();
+    })();
+    fixture.detectChanges();
+
+    fixture.componentInstance.rangePicker.open();
+    fixture.detectChanges();
+
+    const rangeTexts = Array.from(overlayContainerElement!.querySelectorAll([
+      '.mat-calendar-body-range-start',
+      '.mat-calendar-body-in-range',
+      '.mat-calendar-body-range-end'
+    ].join(','))).map(cell => cell.textContent!.trim());
+
+    expect(rangeTexts).toEqual(['2', '3', '4', '5']);
+  });
+
+  it('should pass the comparison range through to the calendar', () => {
+    const fixture = createComponent(StandardRangePicker);
+    let overlayContainerElement: HTMLElement;
+
+    // Set startAt to guarantee that the calendar opens on the proper month.
+    fixture.componentInstance.comparisonStart =
+        fixture.componentInstance.startAt = new Date(2020, 1, 2);
+    fixture.componentInstance.comparisonEnd = new Date(2020, 1, 5);
+    inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
+      overlayContainerElement = overlayContainer.getContainerElement();
+    })();
+    fixture.detectChanges();
+
+    fixture.componentInstance.rangePicker.open();
+    fixture.detectChanges();
+
+    const rangeTexts = Array.from(overlayContainerElement!.querySelectorAll([
+      '.mat-calendar-body-comparison-start',
+      '.mat-calendar-body-in-comparison-range',
+      '.mat-calendar-body-comparison-end'
+    ].join(','))).map(cell => cell.textContent!.trim());
+
+    expect(rangeTexts).toEqual(['2', '3', '4', '5']);
+  });
+
 });
 
 @Component({
@@ -407,12 +455,16 @@ describe('MatDatepicker', () => {
         [separator]="separator"
         [min]="minDate"
         [max]="maxDate"
-        [dateFilter]="dateFilter">
+        [dateFilter]="dateFilter"
+        [comparisonStart]="comparisonStart"
+        [comparisonEnd]="comparisonEnd">
         <input #start formControlName="start" matStartDate placeholder="Start date"/>
         <input #end formControlName="end" matEndDate placeholder="End date"/>
       </mat-date-range-input>
 
-      <mat-date-range-picker #rangePicker></mat-date-range-picker>
+      <mat-date-range-picker
+        [startAt]="startAt"
+        #rangePicker></mat-date-range-picker>
     </mat-form-field>
   `
 })
@@ -425,6 +477,9 @@ class StandardRangePicker {
   rangeDisabled = false;
   minDate: Date | null = null;
   maxDate: Date | null = null;
+  comparisonStart: Date | null = null;
+  comparisonEnd: Date | null = null;
+  startAt: Date | null = null;
   dateFilter = () => true;
 
   range = new FormGroup({

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -254,6 +254,8 @@ export class MatMonthView<D> implements AfterContentInit, OnDestroy {
         return;
       case ESCAPE:
         // Abort the current range selection if the user presses escape mid-selection.
+        // Note that we handle it here, rather than the `mat-calendar-body` where have the
+        // rest of the range logic, because focus may have moved outside the calendar body.
         if (this._matCalendarBody._hoveredValue > -1) {
           this.selectedChange.emit(null);
           this._userSelection.emit();

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -81,7 +81,7 @@ export declare class MatCalendarBody implements OnChanges, OnDestroy {
     _isActiveCell(rowIndex: number, colIndex: number): boolean;
     _isComparisonBridgeEnd(value: number, rowIndex: number, colIndex: number): boolean;
     _isComparisonBridgeStart(value: number, rowIndex: number, colIndex: number): boolean;
-    _isComparisonEnd(value: number): boolean;
+    _isComparisonEnd(value: number): boolean | 0 | null;
     _isComparisonStart(value: number): boolean;
     _isInComparisonRange(value: number): boolean | 0 | null;
     _isInRange(value: number): boolean;


### PR DESCRIPTION
Adds more tests for the date range picker functionality. These cover the logic for displaying and selecting the range, as well as the integration between the range input, range picker and calendar.

Also fixes a couple of smaller issues that were revealed while I was writing the tests.