### PR TITLE
refactor(material-experimental/mdc-form-field): unset MDC custom baseline adjustment

### DIFF
--- a/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
@@ -126,4 +126,14 @@
   .mat-mdc-form-field .mat-mdc-text-field-wrapper.mdc-text-field .mdc-notched-outline__notch {
     padding-top: 0;
   }
+
+  // Unset the baseline adjustment styles that are applied to the `.mdc-text-field` before
+  // pseudo element. We control the vertical alignment of form field controls using infix
+  // spacing since we support custom form-field controls. Those don't necessarily have an
+  // explicit height that matches with the Material Design specification. If the height isn't
+  // explicitly set to a specific value by MDC, the control will not align correctly vertically.
+  // e.g. No vertical spacing to the bottom-line if the control is too large.
+  .mat-mdc-text-field-wrapper::before {
+    content: none;
+  }
 }


### PR DESCRIPTION
Recently with b2e86918e83d90ad1226b2fd85d9b58dd661d898, we updated to the latest canary version
of the MDC text-field. MDC updated how they align the input vertically.
We decided to still use our custom alignment using padding that will
also work for custom form field controls.

Since we still use padding alignment, we can unset the MDC
custom baseline styles. These currently have no effect, but
will cause the form-field to always have a minimum height that
needs extra treatment for the density levels.

**Note**: I will send an upstream PR on `material-components-web`. We should have more flexibility (individual mixins) for parts of the form-field. That should reduce unnecessary styles, and we should also not need any overrides.