### PR TITLE
fix(material-experimental/slide-toggle): allow different densities

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -7,7 +7,6 @@
         [matRippleTrigger]="switch"
         [matRippleDisabled]="disableRipple || disabled"
         [matRippleCentered]="true"
-        [matRippleRadius]="24"
         [matRippleAnimation]="_rippleAnimation"></div>
       <div class="mdc-switch__thumb">
           <input #input class="mdc-switch__native-control" type="checkbox"

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
@@ -48,6 +48,10 @@
     opacity: map-get($mdc-ripple-dark-ink-opacities, press);
   }
 
+  .mat-ripple {
+    border-radius: 50%;
+  }
+
   // Angular Material supports disabling all animations when NoopAnimationsModule is imported.
   // TODO(mmalerba): Look into using MDC's Sass queries to separate the animation styles and
   //  conditionally add them. Consider the size cost when deciding whether to switch.


### PR DESCRIPTION
Right now, the slide toggle is hard-coded to a specific size. It is likely that since this component defaults to a large size, users will want to reduce it using density mixins.

This change removes the specific radius size and instead uses radius 50% to adapt to whatever size the input is.