### PR TITLE
fix(sidenav): run autosize debounce timer outside the NgZone

### DIFF
--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -630,10 +630,13 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
       this._changeDetectorRef.markForCheck();
     });
 
-    this._doCheckSubject.pipe(
-      debounceTime(10), // Arbitrary debounce time, less than a frame at 60fps
-      takeUntil(this._destroyed)
-    ).subscribe(() => this.updateContentMargins());
+    // Avoid hitting the NgZone through the debounce timeout.
+    this._ngZone.runOutsideAngular(() => {
+      this._doCheckSubject.pipe(
+        debounceTime(10), // Arbitrary debounce time, less than a frame at 60fps
+        takeUntil(this._destroyed)
+      ).subscribe(() => this.updateContentMargins());
+    });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Fixes the timer that we use to debounce the autosize calls being run inside the NgZone.

Fixes #18894.