### PR TITLE
Add density styles for non-experimental components without MDC equivalent

### DIFF
--- a/src/dev-app/stepper/stepper-demo.html
+++ b/src/dev-app/stepper/stepper-demo.html
@@ -1,5 +1,10 @@
 <mat-checkbox [(ngModel)]="isNonLinear">Disable linear mode</mat-checkbox>
 <mat-checkbox [(ngModel)]="disableRipple">Disable header ripple</mat-checkbox>
+<p>
+  <button mat-stroked-button (click)="showLabelBottom = !showLabelBottom">
+    Toggle label position
+  </button>
+</p>
 
 <h3>Linear Vertical Stepper Demo using a single form</h3>
 <form [formGroup]="formGroup">
@@ -52,7 +57,8 @@
 
 <h3>Linear Horizontal Stepper Demo using a different form for each step</h3>
 <mat-horizontal-stepper #linearHorizontalStepper="matHorizontalStepper" [linear]="!isNonLinear"
-                        [disableRipple]="disableRipple">
+                        [disableRipple]="disableRipple"
+                        [labelPosition]="showLabelBottom ? 'bottom' : 'end'">
   <mat-step [stepControl]="nameFormGroup">
     <form [formGroup]="nameFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>

--- a/src/dev-app/stepper/stepper-demo.ts
+++ b/src/dev-app/stepper/stepper-demo.ts
@@ -19,6 +19,7 @@ export class StepperDemo implements OnInit {
   isNonLinear = false;
   isNonEditable = false;
   disableRipple = false;
+  showLabelBottom = false;
 
   nameFormGroup: FormGroup;
   emailFormGroup: FormGroup;

--- a/src/material-experimental/mdc-list/_list-theme.scss
+++ b/src/material-experimental/mdc-list/_list-theme.scss
@@ -1,3 +1,5 @@
+@import '@material/density/functions.import';
+@import '@material/list/variables.import';
 @import '@material/list/mixins.import';
 @import '../mdc-helpers/mdc-helpers';
 
@@ -12,7 +14,21 @@
   }
 }
 
-@mixin mat-mdc-list-density($density-scale) {}
+@mixin mat-mdc-list-density($density-scale) {
+  $height: mdc-density-prop-value(
+    $density-config: $mdc-list-single-line-density-config,
+    $density-scale: $density-scale,
+    $property-name: height,
+  );
+
+  // MDC list provides a mixin called `mdc-list-single-line-density`, but we cannot use
+  // that mixin the generated generated density styles are scoped to `.mdc-list-item`, while
+  // the styles should actually only affect single-line list items. This has been reported as
+  // a bug in the MDC repository: https://github.com/material-components/material-components-web/issues/5737.
+  .mat-mdc-list-item-single-line {
+    @include mdc-list-single-line-height($height);
+  }
+}
 
 @mixin mat-mdc-list-theme($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -32,6 +32,8 @@ export class MatListItemBase implements AfterContentInit, OnDestroy {
     this._ngZone.runOutsideAngular(() => {
       this._subscriptions.add(this.lines.changes.pipe(startWith(this.lines))
           .subscribe((lines: QueryList<ElementRef<Element>>) => {
+            this._element.nativeElement.classList
+                .toggle('mat-mdc-list-item-single-line', lines.length <= 1);
             lines.forEach((line: ElementRef<Element>, index: number) => {
               line.nativeElement.classList.toggle('mdc-list-item__primary-text', index === 0);
               line.nativeElement.classList.toggle('mdc-list-item__secondary-text', index !== 0);

--- a/src/material/button-toggle/BUILD.bazel
+++ b/src/material/button-toggle/BUILD.bazel
@@ -33,7 +33,10 @@ ng_module(
 sass_library(
     name = "button_toggle_scss_lib",
     srcs = glob(["**/_*.scss"]),
-    deps = ["//src/material/core:core_scss_lib"],
+    deps = [
+        "//src/cdk/a11y:a11y_scss_lib",
+        "//src/material/core:core_scss_lib",
+    ],
 )
 
 sass_binary(

--- a/src/material/button-toggle/_button-toggle-theme.scss
+++ b/src/material/button-toggle/_button-toggle-theme.scss
@@ -1,7 +1,10 @@
+@import '../../cdk/a11y/a11y';
 @import '../core/style/elevation';
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/typography/typography-utils';
+@import '../core/density/index';
+@import './button-toggle-variables';
 
 @mixin mat-button-toggle-color($config) {
   $foreground: map-get($config, foreground);
@@ -86,7 +89,21 @@
   }
 }
 
-@mixin _mat-button-toggle-density($density-scale) {}
+@mixin _mat-button-toggle-density($density-scale) {
+  $standard-height: mat-density-prop-value(
+      $mat-button-toggle-standard-density-config, $density-scale, height);
+
+  .mat-button-toggle-appearance-standard .mat-button-toggle-label-content {
+    line-height: $standard-height;
+  }
+
+  @include cdk-high-contrast(active, off) {
+    .mat-button-toggle-checked.mat-button-toggle-appearance-standard
+    .mat-button-toggle-focus-overlay {
+      border-bottom: solid $standard-height;
+    }
+  }
+}
 
 @mixin mat-button-toggle-theme($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material/button-toggle/_button-toggle-theme.scss
+++ b/src/material/button-toggle/_button-toggle-theme.scss
@@ -90,7 +90,7 @@
 }
 
 @mixin _mat-button-toggle-density($density-scale) {
-  $standard-height: mat-density-prop-value(
+  $standard-height: _mat-density-prop-value(
       $mat-button-toggle-standard-density-config, $density-scale, height);
 
   .mat-button-toggle-appearance-standard .mat-button-toggle-label-content {

--- a/src/material/button-toggle/_button-toggle-variables.scss
+++ b/src/material/button-toggle/_button-toggle-variables.scss
@@ -1,0 +1,14 @@
+$mat-button-toggle-standard-height: 48px !default;
+// Minimum height for highest density can vary based on the content that developers
+// project into button-toggle's. We use a minimum of `24px` though because commonly
+// icons or text are displayed. Icons by default have a size of `24px`.
+$mat-button-toggle-standard-minimum-height: 24px !default;
+$mat-button-toggle-standard-maximum-height: $mat-button-toggle-standard-height !default;
+
+$mat-button-toggle-standard-density-config: (
+  height: (
+    default: $mat-button-toggle-standard-height,
+    maximum: $mat-button-toggle-standard-maximum-height,
+    minimum: $mat-button-toggle-standard-minimum-height,
+  )
+) !default;

--- a/src/material/button-toggle/button-toggle.scss
+++ b/src/material/button-toggle/button-toggle.scss
@@ -3,7 +3,6 @@
 @import '../../cdk/a11y/a11y';
 
 $mat-button-toggle-standard-padding: 0 12px !default;
-$mat-button-toggle-standard-height: 48px !default;
 $mat-button-toggle-standard-border-radius: 4px !default;
 
 $mat-button-toggle-legacy-padding: 0 16px !default;
@@ -104,7 +103,6 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
   position: relative;
 
   .mat-button-toggle-appearance-standard & {
-    line-height: $mat-button-toggle-standard-height;
     padding: $mat-button-toggle-standard-padding;
   }
 }
@@ -131,14 +129,6 @@ $mat-button-toggle-legacy-border-radius: 2px !default;
     @include cdk-high-contrast(active, off) {
       opacity: 0.5;
       height: 0;
-    }
-  }
-}
-
-@include cdk-high-contrast(active, off) {
-  .mat-button-toggle-checked {
-    &.mat-button-toggle-appearance-standard .mat-button-toggle-focus-overlay {
-      border-bottom: solid $mat-button-toggle-standard-height;
     }
   }
 }

--- a/src/material/core/density/README.md
+++ b/src/material/core/density/README.md
@@ -1,0 +1,3 @@
+Density Sass functions and mixins have been extracted from `@material/density`. We do this to
+avoid adding a new dependency to `@angular/material` until we figured out how dependencies on
+MDC are managed.

--- a/src/material/core/density/_index.scss
+++ b/src/material/core/density/_index.scss
@@ -1,44 +1,22 @@
-//
-// Copyright 2019 Google Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-
 // Taken from mat-density with small modifications to not rely on the new Sass module system.
 // https://github.com/material-components/material-components-web/blob/master/packages/mdc-density
 
-$mat-density-interval: 4px !default;
-$mat-density-minimum-scale: minimum !default;
-$mat-density-maximum-scale: maximum !default;
-$mat-density-supported-scales: (default, minimum, maximum) !default;
-$mat-density-supported-properties: (height, size) !default;
-$mat-density-default-scale: 0 !default;
+$_mat-density-interval: 4px !default;
+$_mat-density-minimum-scale: minimum !default;
+$_mat-density-maximum-scale: maximum !default;
+$_mat-density-supported-scales: (default, minimum, maximum) !default;
+$_mat-density-supported-properties: (height, size) !default;
+$_mat-density-default-scale: 0 !default;
 
-@function mat-density-prop-value($density-config, $density-scale, $property-name) {
+@function _mat-density-prop-value($density-config, $density-scale, $property-name) {
   @if (type-of($density-scale) == 'string' and
-      index($list: $mat-density-supported-scales, $value: $density-scale) == null) {
-    @error 'mat-density: Supported density scales #{$mat-density-supported-scales}, '  +
+      index($list: $_mat-density-supported-scales, $value: $density-scale) == null) {
+    @error 'mat-density: Supported density scales #{$_mat-density-supported-scales}, '  +
       'but received #{$density-scale}.';
   }
 
-  @if (index($list: $mat-density-supported-properties, $value: $property-name) == null) {
-    @error 'mat-density: Supported density properties #{$mat-density-supported-properties},' +
+  @if (index($list: $_mat-density-supported-properties, $value: $property-name) == null) {
+    @error 'mat-density: Supported density properties #{$_mat-density-supported-properties},' +
       'but received #{$property-name}.';
   }
 
@@ -49,11 +27,11 @@ $mat-density-default-scale: 0 !default;
     $value: map_get($property-scale-map, $density-scale);
   }
   @else {
-    $value: map_get($property-scale-map, default) + $density-scale * $mat-density-interval;
+    $value: map_get($property-scale-map, default) + $density-scale * $_mat-density-interval;
   }
 
-  $min-value: map_get($property-scale-map, $mat-density-minimum-scale);
-  $max-value: map_get($property-scale-map, $mat-density-maximum-scale);
+  $min-value: map_get($property-scale-map, $_mat-density-minimum-scale);
+  $max-value: map_get($property-scale-map, $_mat-density-maximum-scale);
 
   @if ($value < $min-value or $value > $max-value) {
     @error 'mat-density: #{$property-name} must be between #{$min-value} and ' +

--- a/src/material/core/density/_index.scss
+++ b/src/material/core/density/_index.scss
@@ -1,0 +1,64 @@
+//
+// Copyright 2019 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Taken from mat-density with small modifications to not rely on the new Sass module system.
+// https://github.com/material-components/material-components-web/blob/master/packages/mdc-density
+
+$mat-density-interval: 4px !default;
+$mat-density-minimum-scale: minimum !default;
+$mat-density-maximum-scale: maximum !default;
+$mat-density-supported-scales: (default, minimum, maximum) !default;
+$mat-density-supported-properties: (height, size) !default;
+$mat-density-default-scale: 0 !default;
+
+@function mat-density-prop-value($density-config, $density-scale, $property-name) {
+  @if (type-of($density-scale) == 'string' and
+      index($list: $mat-density-supported-scales, $value: $density-scale) == null) {
+    @error 'mat-density: Supported density scales #{$mat-density-supported-scales}, '  +
+      'but received #{$density-scale}.';
+  }
+
+  @if (index($list: $mat-density-supported-properties, $value: $property-name) == null) {
+    @error 'mat-density: Supported density properties #{$mat-density-supported-properties},' +
+      'but received #{$property-name}.';
+  }
+
+  $value: null;
+  $property-scale-map: map_get($density-config, $property-name);
+
+  @if map_has_key($property-scale-map, $density-scale) {
+    $value: map_get($property-scale-map, $density-scale);
+  }
+  @else {
+    $value: map_get($property-scale-map, default) + $density-scale * $mat-density-interval;
+  }
+
+  $min-value: map_get($property-scale-map, $mat-density-minimum-scale);
+  $max-value: map_get($property-scale-map, $mat-density-maximum-scale);
+
+  @if ($value < $min-value or $value > $max-value) {
+    @error 'mat-density: #{$property-name} must be between #{$min-value} and ' +
+      '#{$max-value} (inclusive), but received #{$value}.';
+  }
+
+  @return $value;
+}

--- a/src/material/paginator/BUILD.bazel
+++ b/src/material/paginator/BUILD.bazel
@@ -34,7 +34,9 @@ ng_module(
 sass_library(
     name = "paginator_scss_lib",
     srcs = glob(["**/_*.scss"]),
-    deps = ["//src/material/core:core_scss_lib"],
+    deps = [
+        "//src/material/core:core_scss_lib",
+    ],
 )
 
 sass_binary(

--- a/src/material/paginator/_paginator-theme.scss
+++ b/src/material/paginator/_paginator-theme.scss
@@ -1,7 +1,8 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/typography/typography-utils';
-
+@import '../core/density/index';
+@import './paginator-variables';
 
 @mixin mat-paginator-color($config) {
   $foreground: map-get($config, foreground);
@@ -47,7 +48,12 @@
   }
 }
 
-@mixin _mat-paginator-density($density-scale) {}
+@mixin _mat-paginator-density($density-scale) {
+  $height: mat-density-prop-value($mat-paginator-density-config, $density-scale, height);
+  .mat-paginator-container {
+    min-height: $height;
+  }
+}
 
 @mixin mat-paginator-theme($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material/paginator/_paginator-theme.scss
+++ b/src/material/paginator/_paginator-theme.scss
@@ -49,7 +49,7 @@
 }
 
 @mixin _mat-paginator-density($density-scale) {
-  $height: mat-density-prop-value($mat-paginator-density-config, $density-scale, height);
+  $height: _mat-density-prop-value($mat-paginator-density-config, $density-scale, height);
   .mat-paginator-container {
     min-height: $height;
   }

--- a/src/material/paginator/_paginator-variables.scss
+++ b/src/material/paginator/_paginator-variables.scss
@@ -1,0 +1,13 @@
+$mat-paginator-height: 56px !default;
+// Minimum height for paginator's in the highest density is determined based on how
+// much the paginator can shrink until the content exceeds (i.e. navigation buttons).
+$mat-paginator-minimum-height: 40px !default;
+$mat-paginator-maximum-height: $mat-paginator-height !default;
+
+$mat-paginator-density-config: (
+  height: (
+    default: $mat-paginator-height,
+    maximum: $mat-paginator-maximum-height,
+    minimum: $mat-paginator-minimum-height,
+  )
+) !default;

--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -1,6 +1,4 @@
-$mat-paginator-height: 56px;
 $mat-paginator-padding: 0 8px;
-
 $mat-paginator-page-size-margin-right: 8px;
 
 $mat-paginator-items-per-page-label-margin: 0 4px;
@@ -9,30 +7,8 @@ $mat-paginator-selector-trigger-width: 56px;
 $mat-paginator-selector-trigger-outline-width: 64px;
 $mat-paginator-selector-trigger-fill-width: 64px;
 
-/** @deprecated Use `$mat-paginator-selector-trigger-width` instead. @breaking-change 8.0.0 */
-$mat-paginator-selector-trigger-min-width: $mat-paginator-selector-trigger-width;
-
-/** @deprecated Unused. To be removed */
-$mat-paginator-range-actions-min-height: 48px;
-
 $mat-paginator-range-label-margin: 0 32px 0 24px;
-
-$mat-paginator-button-margin: 8px;
-$mat-paginator-button-icon-height: 8px;
-$mat-paginator-button-icon-width: 8px;
-
-$mat-paginator-button-increment-icon-margin: 12px;
-$mat-paginator-button-decrement-icon-margin: 16px;
-
-$mat-paginator-button-first-last-icon-width: 14px;
-
-$mat-paginator-button-first-icon-margin: 3px;
-$mat-paginator-button-last-icon-margin: 15px;
-
-
-$mat-paginator-button-first-decrement-icon-margin: 21px;
-$mat-paginator-button-last-increment-icon-margin: 9px;
-
+$mat-paginator-button-icon-size: 28px;
 
 .mat-paginator {
   display: block;
@@ -48,7 +24,6 @@ $mat-paginator-button-last-increment-icon-margin: 9px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  min-height: $mat-paginator-height;
   padding: $mat-paginator-padding;
   flex-wrap: wrap-reverse;
   width: 100%;
@@ -92,7 +67,7 @@ $mat-paginator-button-last-increment-icon-margin: 9px;
 }
 
 .mat-paginator-icon {
-  width: $mat-paginator-height / 2;
+  width: $mat-paginator-button-icon-size;
   fill: currentColor;
 
   [dir='rtl'] & {

--- a/src/material/stepper/BUILD.bazel
+++ b/src/material/stepper/BUILD.bazel
@@ -42,19 +42,27 @@ ng_module(
 sass_library(
     name = "stepper_scss_lib",
     srcs = glob(["**/_*.scss"]),
-    deps = ["//src/material/core:core_scss_lib"],
+    deps = [
+        "//src/material/core:core_scss_lib",
+    ],
 )
 
 sass_binary(
     name = "stepper_scss",
     src = "stepper.scss",
-    deps = ["//src/material/core:core_scss_lib"],
+    deps = [
+        ":stepper_scss_lib",
+        "//src/material/core:core_scss_lib",
+    ],
 )
 
 sass_binary(
     name = "step_header_scss",
     src = "step-header.scss",
-    deps = ["//src/material/core:core_scss_lib"],
+    deps = [
+        ":stepper_scss_lib",
+        "//src/material/core:core_scss_lib",
+    ],
 )
 
 ng_test_library(

--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -1,6 +1,8 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/typography/typography-utils';
+@import '../core/density/index';
+@import './stepper-variables';
 
 @mixin mat-stepper-color($config) {
   $foreground: map-get($config, foreground);
@@ -102,7 +104,38 @@
   }
 }
 
-@mixin _mat-stepper-density($density-scale) {}
+@mixin _mat-stepper-density($density-scale) {
+  $height: mat-density-prop-value($mat-stepper-density-config, $density-scale, height);
+  $vertical-padding: ($height - $mat-stepper-label-header-height) / 2;
+
+  .mat-horizontal-stepper-header {
+    height: $height;
+  }
+
+  .mat-stepper-label-position-bottom .mat-horizontal-stepper-header,
+  .mat-vertical-stepper-header, {
+    padding: $vertical-padding $mat-stepper-side-gap;
+  }
+
+  // Ensures that the vertical lines for the step content exceed into the step
+  // headers with a given distance (`$mat-stepper-line-gap`) to the step icon.
+  .mat-stepper-vertical-line::before {
+    top: $mat-stepper-line-gap - $vertical-padding;
+    bottom: $mat-stepper-line-gap - $vertical-padding;
+  }
+
+  // Ensures that the horizontal lines for the step header are centered vertically.
+  .mat-stepper-label-position-bottom .mat-horizontal-stepper-header {
+    &::after, &::before {
+      top: $vertical-padding + $mat-stepper-label-header-height / 2;
+    }
+  }
+
+  // Ensures that the horizontal line for the step content is aligned centered vertically.
+  .mat-stepper-label-position-bottom .mat-stepper-horizontal-line {
+    top: $vertical-padding + $mat-stepper-label-header-height / 2;
+  }
+}
 
 @mixin mat-stepper-theme($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -105,7 +105,7 @@
 }
 
 @mixin _mat-stepper-density($density-scale) {
-  $height: mat-density-prop-value($mat-stepper-density-config, $density-scale, height);
+  $height: _mat-density-prop-value($mat-stepper-density-config, $density-scale, height);
   $vertical-padding: ($height - $mat-stepper-label-header-height) / 2;
 
   .mat-horizontal-stepper-header {

--- a/src/material/stepper/_stepper-variables.scss
+++ b/src/material/stepper/_stepper-variables.scss
@@ -1,0 +1,29 @@
+$mat-stepper-header-height: 72px !default;
+// Minimum height for highest density stepper's is determined based on how much
+// stepper headers can shrink until the step icon or step label exceed. We can't use
+// a value below `42px` because the optional label for steps would otherwise exceed.
+$mat-stepper-header-minimum-height: 42px !default;
+$mat-stepper-header-maximum-height: $mat-stepper-header-height !default;
+
+$mat-stepper-density-config: (
+  height: (
+    default: $mat-stepper-header-height,
+    maximum: $mat-stepper-header-maximum-height,
+    minimum: $mat-stepper-header-minimum-height,
+  )
+) !default;
+
+// Note: These variables are not denoted with `!default` because they are used in the non-theme
+// component styles. Modifying these variables does not have the desired effect for consumers.
+$mat-stepper-label-header-height: 24px;
+$mat-stepper-label-position-bottom-top-gap: 16px;
+$mat-stepper-label-min-width: 50px;
+
+$mat-vertical-stepper-content-margin: 36px;
+
+$mat-stepper-side-gap: 24px;
+$mat-stepper-line-width: 1px;
+$mat-stepper-line-gap: 8px;
+
+$mat-step-sub-label-font-size: 12px;
+$mat-step-header-icon-size: 16px;

--- a/src/material/stepper/step-header.scss
+++ b/src/material/stepper/step-header.scss
@@ -1,12 +1,5 @@
 @import '../core/style/layout-common';
-
-$mat-stepper-label-header-height: 24px !default;
-$mat-stepper-label-min-width: 50px !default;
-$mat-stepper-side-gap: 24px !default;
-$mat-vertical-stepper-content-margin: 36px !default;
-$mat-stepper-line-gap: 8px !default;
-$mat-step-sub-label-font-size: 12px;
-$mat-step-header-icon-size: 16px !default;
+@import './stepper-variables';
 
 .mat-step-header {
   overflow: hidden;

--- a/src/material/stepper/stepper.scss
+++ b/src/material/stepper/stepper.scss
@@ -1,12 +1,5 @@
 @import '../core/style/variables';
-
-$mat-horizontal-stepper-header-height: 72px !default;
-$mat-stepper-label-header-height: 24px !default;
-$mat-stepper-label-position-bottom-top-gap: 16px !default;
-$mat-stepper-side-gap: 24px !default;
-$mat-vertical-stepper-content-margin: 36px !default;
-$mat-stepper-line-width: 1px !default;
-$mat-stepper-line-gap: 8px !default;
+@import './stepper-variables';
 
 .mat-stepper-vertical,
 .mat-stepper-horizontal {
@@ -35,7 +28,6 @@ $mat-stepper-line-gap: 8px !default;
     margin: 0;
     min-width: 0;
     position: relative;
-    top: $mat-stepper-side-gap + $mat-stepper-label-header-height / 2;
   }
 }
 
@@ -46,13 +38,12 @@ $mat-stepper-line-gap: 8px !default;
   display: inline-block;
   height: 0;
   position: absolute;
-  top: $mat-stepper-side-gap + $mat-stepper-label-header-height / 2;
-  width: calc(50% - #{$mat-stepper-label-header-height / 2 + $mat-stepper-line-gap});
+  width: calc(50% - #{$mat-stepper-side-gap / 2 + $mat-stepper-line-gap});
 }
 
 .mat-horizontal-stepper-header {
   display: flex;
-  height: $mat-horizontal-stepper-header-height;
+  height: $mat-stepper-header-height;
   overflow: hidden;
   align-items: center;
   padding: 0 $mat-stepper-side-gap;
@@ -73,7 +64,6 @@ $mat-stepper-line-gap: 8px !default;
     // We use auto instead of fixed 104px (by spec) because when there is an optional step
     //  the height is greater than that
     height: auto;
-    padding: $mat-stepper-side-gap;
 
     &:not(:last-child)::after,
     [dir='rtl'] &:not(:first-child)::after {
@@ -109,7 +99,6 @@ $mat-stepper-line-gap: 8px !default;
 .mat-vertical-stepper-header {
   display: flex;
   align-items: center;
-  padding: $mat-stepper-side-gap;
 
   // We can't use `max-height` here, because it breaks the flexbox centering in IE.
   height: $mat-stepper-label-header-height;
@@ -152,8 +141,6 @@ $mat-stepper-line-gap: 8px !default;
 .mat-stepper-vertical-line::before {
   content: '';
   position: absolute;
-  top: $mat-stepper-line-gap - $mat-stepper-side-gap;
-  bottom: $mat-stepper-line-gap - $mat-stepper-side-gap;
   left: 0;
   border-left-width: $mat-stepper-line-width;
   border-left-style: solid;

--- a/src/material/toolbar/BUILD.bazel
+++ b/src/material/toolbar/BUILD.bazel
@@ -31,7 +31,9 @@ ng_module(
 sass_library(
     name = "toolbar_scss_lib",
     srcs = glob(["**/_*.scss"]),
-    deps = ["//src/material/core:core_scss_lib"],
+    deps = [
+        "//src/material/core:core_scss_lib",
+    ],
 )
 
 sass_binary(
@@ -39,7 +41,6 @@ sass_binary(
     src = "toolbar.scss",
     deps = [
         "//src/cdk/a11y:a11y_scss_lib",
-        "//src/material/core:core_scss_lib",
     ],
 )
 

--- a/src/material/toolbar/_toolbar-theme.scss
+++ b/src/material/toolbar/_toolbar-theme.scss
@@ -1,7 +1,18 @@
+@import '../core/density/index';
+@import '../core/style/variables';
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/typography/typography-utils';
+@import './toolbar-variables';
 
+@mixin _mat-toolbar-height($height) {
+  .mat-toolbar-multiple-rows {
+    min-height: $height;
+  }
+  .mat-toolbar-row, .mat-toolbar-single-row {
+    height: $height;
+  }
+}
 
 @mixin _mat-toolbar-color($palette) {
   background: mat-color($palette);
@@ -68,7 +79,22 @@
   }
 }
 
-@mixin _mat-toolbar-density($density-scale) {}
+@mixin _mat-toolbar-density($density-scale) {
+  $height-desktop: mat-density-prop-value(
+      $mat-toolbar-desktop-density-config, $density-scale, height);
+  $height-mobile: mat-density-prop-value(
+      $mat-toolbar-mobile-density-config, $density-scale, height);
+
+  // Set the default height for the toolbar.
+  @include _mat-toolbar-height($height-desktop);
+
+  // As per specs, toolbars should have a different height in mobile devices. This has been
+  // specified in the old guidelines and is still observable in the new specifications by looking at
+  // the spec images. See: https://material.io/design/components/app-bars-top.html#anatomy
+  @media ($mat-xsmall) {
+    @include _mat-toolbar-height($height-mobile);
+  }
+}
 
 @mixin mat-toolbar-theme($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material/toolbar/_toolbar-theme.scss
+++ b/src/material/toolbar/_toolbar-theme.scss
@@ -80,9 +80,9 @@
 }
 
 @mixin _mat-toolbar-density($density-scale) {
-  $height-desktop: mat-density-prop-value(
+  $height-desktop: _mat-density-prop-value(
       $mat-toolbar-desktop-density-config, $density-scale, height);
-  $height-mobile: mat-density-prop-value(
+  $height-mobile: _mat-density-prop-value(
       $mat-toolbar-mobile-density-config, $density-scale, height);
 
   // Set the default height for the toolbar.

--- a/src/material/toolbar/_toolbar-variables.scss
+++ b/src/material/toolbar/_toolbar-variables.scss
@@ -1,0 +1,28 @@
+// Minimum height for toolbar's in the highest density is difficult to determine because
+// developers can project arbitrary content. We use a minimum value that ensures that most
+// common content (e.g. icon buttons) does not exceed the row boundaries in highest density.
+$mat-toolbar-minimum-height: 44px !default;
+
+$mat-toolbar-height-desktop: 64px !default;
+$mat-toolbar-maximum-height-desktop: $mat-toolbar-height-desktop !default;
+$mat-toolbar-minimum-height-desktop: $mat-toolbar-minimum-height !default;
+
+$mat-toolbar-height-mobile: 56px !default;
+$mat-toolbar-maximum-height-mobile: $mat-toolbar-height-mobile !default;
+$mat-toolbar-minimum-height-mobile: $mat-toolbar-minimum-height !default;
+
+$mat-toolbar-desktop-density-config: (
+  height: (
+    default: $mat-toolbar-height-desktop,
+    maximum: $mat-toolbar-maximum-height-desktop,
+    minimum: $mat-toolbar-minimum-height-desktop,
+  )
+) !default;
+
+$mat-toolbar-mobile-density-config: (
+  height: (
+    default: $mat-toolbar-height-mobile,
+    maximum: $mat-toolbar-maximum-height-mobile,
+    minimum: $mat-toolbar-minimum-height-mobile,
+  )
+) !default;

--- a/src/material/toolbar/toolbar.scss
+++ b/src/material/toolbar/toolbar.scss
@@ -1,25 +1,6 @@
-@import '../core/style/variables';
 @import '../../cdk/a11y/a11y';
 
-$mat-toolbar-height-desktop: 64px !default;
-$mat-toolbar-height-mobile: 56px !default;
 $mat-toolbar-row-padding: 16px !default;
-
-/** @deprecated @breaking-change 8.0.0 */
-$mat-toolbar-height-mobile-portrait: 56px !default;
-/** @deprecated @breaking-change 8.0.0 */
-$mat-toolbar-height-mobile-landscape: 48px !default;
-
-
-
-@mixin mat-toolbar-height($height) {
-  .mat-toolbar-multiple-rows {
-    min-height: $height;
-  }
-  .mat-toolbar-row, .mat-toolbar-single-row {
-    height: $height;
-  }
-}
 
 .mat-toolbar {
   @include cdk-high-contrast(active, off) {
@@ -48,14 +29,4 @@ $mat-toolbar-height-mobile-landscape: 48px !default;
   box-sizing: border-box;
   flex-direction: column;
   width: 100%;
-}
-
-// Set the default height for the toolbar.
-@include mat-toolbar-height($mat-toolbar-height-desktop);
-
-// As per specs, toolbars should have a different height in mobile devices. This has been
-// specified in the old guidelines and is still observable in the new specifications by looking at
-// the spec images. See: https://material.io/design/components/app-bars-top.html#anatomy
-@media ($mat-xsmall) {
-  @include mat-toolbar-height($mat-toolbar-height-mobile);
 }

--- a/src/material/tree/BUILD.bazel
+++ b/src/material/tree/BUILD.bazel
@@ -30,7 +30,9 @@ ng_module(
 sass_library(
     name = "tree_scss_lib",
     srcs = glob(["**/_*.scss"]),
-    deps = ["//src/material/core:core_scss_lib"],
+    deps = [
+        "//src/material/core:core_scss_lib",
+    ],
 )
 
 sass_binary(

--- a/src/material/tree/_tree-theme.scss
+++ b/src/material/tree/_tree-theme.scss
@@ -1,6 +1,8 @@
+@import '../core/density/index';
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/typography/typography-utils';
+@import  './tree-variables';
 
 @mixin mat-tree-color($config) {
   $background: map-get($config, background);
@@ -28,7 +30,12 @@
   }
 }
 
-@mixin _mat-tree-density($density-scale) {}
+@mixin _mat-tree-density($density-scale) {
+  $height: mat-density-prop-value($mat-tree-density-config, $density-scale, height);
+  .mat-tree-node {
+    min-height: $height;
+  }
+}
 
 @mixin mat-tree-theme($theme) {
   $color: mat-get-color-config($theme);

--- a/src/material/tree/_tree-theme.scss
+++ b/src/material/tree/_tree-theme.scss
@@ -31,7 +31,7 @@
 }
 
 @mixin _mat-tree-density($density-scale) {
-  $height: mat-density-prop-value($mat-tree-density-config, $density-scale, height);
+  $height: _mat-density-prop-value($mat-tree-density-config, $density-scale, height);
   .mat-tree-node {
     min-height: $height;
   }

--- a/src/material/tree/_tree-variables.scss
+++ b/src/material/tree/_tree-variables.scss
@@ -1,0 +1,14 @@
+$mat-tree-node-height: 48px !default;
+// Minimum height for tree nodes in highest density is difficult to determine as
+// developers can display arbitrary content. We use a minimum height which ensures
+// that common content placed in tree nodes does not exceed (e.g. icons, checkboxes).
+$mat-tree-node-minimum-height: 24px !default;
+$mat-tree-node-maximum-height: $mat-tree-node-height !default;
+
+$mat-tree-density-config: (
+  height: (
+    default: $mat-tree-node-height,
+    maximum: $mat-tree-node-maximum-height,
+    minimum: $mat-tree-node-minimum-height,
+  )
+) !default;

--- a/src/material/tree/tree.scss
+++ b/src/material/tree/tree.scss
@@ -1,5 +1,3 @@
-$mat-node-height: 48px;
-
 .mat-tree {
   display: block;
 }
@@ -7,7 +5,6 @@ $mat-node-height: 48px;
 .mat-tree-node {
   display: flex;
   align-items: center;
-  min-height: $mat-node-height;
   flex: 1;
   word-wrap: break-word;
 }


### PR DESCRIPTION
**Note**: I wasn't sure how and whether we should do `expansion`. The height is hard-coded into an `@angular/animation` transition. We could/should revisit this in a follow-up? The problem I see here is that expansion actually provides inputs for specifying height. That doesn't play nicely with density.