### PR TITLE
Changes for more convenient API to only generate color, density or typography styles 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -99,6 +99,7 @@
 /src/material-experimental/mdc-card/**             @mmalerba
 /src/material-experimental/mdc-checkbox/**         @mmalerba
 /src/material-experimental/mdc-chips/**            @mmalerba
+/src/material-experimental/mdc-color/**            @jelbourn @devversion
 /src/material-experimental/mdc-density/**          @devversion
 /src/material-experimental/mdc-dialog/**           @devversion
 /src/material-experimental/mdc-form-field/**       @devversion @mmalerba

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 /src/material/core/*                               @jelbourn
 /src/material/core/testing/**                      @crisbeto
 /src/material/core/animation/**                    @jelbourn
+/src/material/core/color/**                        @jelbourn @devversion
 /src/material/core/common-behaviors/**             @jelbourn @devversion
 /src/material/core/datetime/**                     @mmalerba
 /src/material/core/density/**                      @devversion

--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -3,31 +3,30 @@ In order to style your own components with Angular Material's tooling, the compo
 be defined with Sass.
 
 #### 1. Define all color and typography styles in a "theme file" for the component
-First, create a Sass mixin that accepts an Angular Material theme and outputs the color-specific
-styles for the component. An Angular Material theme definition is a Sass map.
+First, create a Sass mixin that accepts an Angular Material color configuration and
+outputs the color-specific styles for the component. A color configuration is a Sass map.
 
 For example, if building a custom carousel component:
 ```scss
 // Import library functions for theme creation.
 @import '~@angular/material/theming';
 
-// Define a mixin that accepts a theme and outputs the theme-specific styles.
-@mixin candy-carousel-theme($theme) {
+@mixin candy-carousel-color($config) {
   // Extract the palettes you need from the theme definition.
-  $primary: map-get($theme, primary);
-  $accent: map-get($theme, accent);
+  $primary: map-get($config, primary);
+  $accent: map-get($config, accent);
   
   // Define any styles affected by the theme.
   .candy-carousel {
     // Use mat-color to extract individual colors from a palette.
-    background-color: mat-color($primary);
-    border-color: mat-color($accent, A400);
+    background-color: mat-color($config);
+    border-color: mat-color($config, A400);
   }
 }
 ```
 
-Second, create another Sass mixin that accepts an Angular Material typography definition and outputs
-typographic styles. For example:
+Second, create another Sass mixin that accepts an Angular Material typography configuration
+and outputs typographic styles. For example:
 
 ```scss
 @mixin candy-carousel-typography($config) {
@@ -37,6 +36,27 @@ typographic styles. For example:
       size: mat-font-size($config, body-1);
       weight: mat-font-weight($config, body-1);
     }
+  }
+}
+```
+
+Finally, create a mixin that accepts an Angular Material theme, and delegates to the individual
+theming system mixins based on the configurations. A theme consists of configurations for
+individual theming systems (`color` and `typography`).
+
+```scss
+@mixin candy-carousel-theme($theme) {
+  // Extracts the color and typography configurations from the theme.
+  $color: mat-get-color-config($theme);
+  $typography: mat-get-typography-config($theme);
+
+  // Do not generate styles if configurations for individual theming
+  // systems have been explicitly set to `null`.
+  @if $color != null {
+    @include candy-carousel-color($color); 
+  }
+  @if $typography != null {
+    @include candy-carousel-typography($typography);
   }
 }
 ```
@@ -63,7 +83,12 @@ including Angular Material's built-in theme mixins.
 // Define your application's custom theme.
 $primary: mat-palette($mat-indigo);
 $accent:  mat-palette($mat-pink, A200, A100, A400);
-$theme: mat-light-theme($primary, $accent);
+$theme: mat-light-theme((
+  color: (
+    primary: $primary,
+    accent: $accent,
+  )
+));
 
 // Include theme styles for Angular Material components.
 @include angular-material-theme($theme);

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -3,12 +3,12 @@
 
 ### What is a theme?
 
-Theming is the ability to systematically customize Angular Material Design components to
+Angular Material's theming system enables you to customize components to
 better reflect your product's brand. A theme consists of configurations for the individual
-`color` and `typography` systems in Angular Material. The library's approach to theming is
-based on the guidance from the [Material Design spec][1].
+`color` and `typography` systems in Angular Material. The library's approach to theming reflects
+the guidance from the [Material Design spec][1].
 
-In Angular Material, a color configuration is created by composing multiple palettes. In
+In Angular Material, you create a color configuration by composing multiple palettes. In
 particular, a color configuration consists of:
 
 * A primary palette: colors most widely used across all screens and components.
@@ -17,10 +17,10 @@ particular, a color configuration consists of:
 * A foreground palette: colors for text and icons.
 * A background palette: colors used for element backgrounds.
 
-Additionally, in Angular Material, a configuration for the `typography` system can be part
-of a theme. More information on how typography works can be [found in a dedicated guide][3].
+Additionally, in Angular Material, a configuration may optionally include `typography` settings.
+More information on how typography works can be [found in a dedicated guide][3].
 
-In Angular Material, all theme styles are generated _statically_ at build-time so that your
+Angular Material theme styles are generated _statically_ at build-time so that your
 app doesn't have to spend cycles generating theme styles on startup.
 
 ### Using a pre-built theme
@@ -65,7 +65,7 @@ multiple times, your application will end up with multiple copies of these commo
 2. Defines a **theme** data structure as the composition of configurations for the individual
 theming systems (`color` and `typography`). This object can be created with either the
 `mat-light-theme` function or the `mat-dark-theme` function. The output of this function is then
-passed to the  `angular-material-theme` mixin, which will output all of the corresponding styles
+passed to the `angular-material-theme` mixin, which will output all of the corresponding styles
 for the theme.
 
 

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -2,21 +2,26 @@
 
 
 ### What is a theme?
-A **theme** is the set of colors that will be applied to the Angular Material components. The
-library's approach to theming is based on the guidance from the [Material Design spec][1].
 
-In Angular Material, a theme is created by composing multiple palettes. In particular,
-a theme consists of:
+Theming is the ability to systematically customize Angular Material Design components to
+better reflect your product's brand. A theme consists of configurations for the individual
+`color` and `typography` systems in Angular Material. The library's approach to theming is
+based on the guidance from the [Material Design spec][1].
+
+In Angular Material, a color configuration is created by composing multiple palettes. In
+particular, a color configuration consists of:
+
 * A primary palette: colors most widely used across all screens and components.
 * An accent palette: colors used for the floating action button and interactive elements.
 * A warn palette: colors used to convey error state.
 * A foreground palette: colors for text and icons.
 * A background palette: colors used for element backgrounds.
 
+Additionally, in Angular Material, a configuration for the `typography` system can be part
+of a theme. More information on how typography works can be [found in a dedicated guide][3].
+
 In Angular Material, all theme styles are generated _statically_ at build-time so that your
 app doesn't have to spend cycles generating theme styles on startup.
-
-[1]: https://material.io/archive/guidelines/style/color.html#color-color-palette
 
 ### Using a pre-built theme
 Angular Material comes prepackaged with several pre-built theme css files. These theme files also
@@ -57,10 +62,11 @@ A custom theme file does two things:
 1. Imports the `mat-core()` Sass mixin. This includes all common styles that are used by multiple
 components. **This should only be included once in your application.** If this mixin is included
 multiple times, your application will end up with multiple copies of these common styles.
-2. Defines a **theme** data structure as the composition of multiple palettes. This object can be
-created with either the `mat-light-theme` function or the `mat-dark-theme` function. The output of
-this function is then passed to the  `angular-material-theme` mixin, which will output all of the
-corresponding styles for the theme.
+2. Defines a **theme** data structure as the composition of configurations for the individual
+theming systems (`color` and `typography`). This object can be created with either the
+`mat-light-theme` function or the `mat-dark-theme` function. The output of this function is then
+passed to the  `angular-material-theme` mixin, which will output all of the corresponding styles
+for the theme.
 
 
 A typical theme file will look something like this:
@@ -82,8 +88,15 @@ $candy-app-accent:  mat-palette($mat-pink, A200, A100, A400);
 // The warn palette is optional (defaults to red).
 $candy-app-warn:    mat-palette($mat-red);
 
-// Create the theme object (a Sass map containing all of the palettes).
-$candy-app-theme: mat-light-theme($candy-app-primary, $candy-app-accent, $candy-app-warn);
+// Create the theme object. A theme consists of configurations for individual
+// theming systems such as `color` or `typography`.
+$candy-app-theme: mat-light-theme((
+  color: (
+    primary: $candy-app-primary,
+    accent: $candy-app-accent,
+    warn: $candy-app-warn,  
+  )
+));
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
@@ -135,9 +148,14 @@ theme.
 // Define the default theme (same as the example above).
 $candy-app-primary: mat-palette($mat-indigo);
 $candy-app-accent:  mat-palette($mat-pink, A200, A100, A400);
-$candy-app-theme:   mat-light-theme($candy-app-primary, $candy-app-accent);
+$candy-app-theme:   mat-light-theme((
+  color: (
+    primary: $candy-app-primary,
+    accent: $candy-app-accent,
+  )
+));
 
-// Include the default theme styles.
+// Include the default theme styles (color and default density)
 @include angular-material-theme($candy-app-theme);
 
 
@@ -145,24 +163,34 @@ $candy-app-theme:   mat-light-theme($candy-app-primary, $candy-app-accent);
 $dark-primary: mat-palette($mat-blue-grey);
 $dark-accent:  mat-palette($mat-amber, A200, A100, A400);
 $dark-warn:    mat-palette($mat-deep-orange);
-$dark-theme:   mat-dark-theme($dark-primary, $dark-accent, $dark-warn);
+$dark-theme:   mat-dark-theme((
+  color: (
+    primary: $dark-primary,
+    accent: $dark-accent,
+    warn: $dark-warn,
+  )
+));
 
-// Include the alternative theme styles inside of a block with a CSS class. You can make this
+// Include the dark color styles inside of a block with a CSS class. You can make this
 // CSS class whatever you want. In this example, any component inside of an element with
 // `.unicorn-dark-theme` will be affected by this alternate dark theme instead of the default theme.
 .unicorn-dark-theme {
-  @include angular-material-theme($dark-theme);
+  @include angular-material-color($dark-theme);
 }
 ```
 
 In the above example, any component inside of a parent with the `unicorn-dark-theme` class will use
 the dark theme, while other components will fall back to the default `$candy-app-theme`.
 
-You can include as many themes as you like in this manner. You can also `@include` the
-`angular-material-theme` in separate files and then lazily load them based on an end-user
+You can include as many color schemes as you like in this manner. You can also `@include` the
+`angular-material-color` in separate files and then lazily load them based on an end-user
 interaction (how to lazily load the CSS assets will vary based on your application).
 
 It's important to remember, however, that the `mat-core` mixin should only ever be included _once_.
+Similarly, the `angular-material-theme` mixin should not be used multiple times as it generates
+styles for all configured theming system parts. For example, typography styles would be generated
+multiple times, even though the configuration did not change. Instead, use fine-grained mixins such
+as `angular-material-color` that only result in styles being generated for the [color system][2].
 
 ##### Multiple themes and overlay-based components
 Since certain components (e.g. menu, select, dialog, etc.) are inside of a global overlay container,
@@ -203,7 +231,12 @@ the `mat-core-theme` mixin as well, which contains theme-specific styles for com
 // Define the theme.
 $candy-app-primary: mat-palette($mat-indigo);
 $candy-app-accent:  mat-palette($mat-pink, A200, A100, A400);
-$candy-app-theme:   mat-light-theme($candy-app-primary, $candy-app-accent);
+$candy-app-theme:   mat-light-theme((
+  color: (
+    primary: $candy-app-primary,
+    accent: $candy-app-accent,
+  )
+));
 
 // Include the theme styles for only specified components.
 @include mat-core-theme($candy-app-theme);
@@ -251,3 +284,7 @@ function changeTheme(themeName) {
 ### Theming your own components
 For more details about theming your own components,
 see [theming-your-components.md](./theming-your-components.md).
+
+[1]: https://material.io/archive/guidelines/style/color.html#color-color-palette
+[2]: https://material.io/design/color
+[3]: ./typography.md

--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -82,6 +82,6 @@ $density-scales: (-1, -2, minimum, maximum);
 @each $density in$density-scales {
   .demo-density-#{$density} {
     @include _angular-material-density($density);
-    @include angular-material-density-mdc($density);
+    @include angular-material-mdc-density($density);
   }
 }

--- a/src/material-experimental/mdc-color/BUILD.bazel
+++ b/src/material-experimental/mdc-color/BUILD.bazel
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tools:defaults.bzl", "sass_library")
+
+sass_library(
+    name = "all_color",
+    srcs = ["_all-color.scss"],
+    deps = ["//src/material-experimental/mdc-theming:all_themes"],
+)

--- a/src/material-experimental/mdc-color/_all-color.scss
+++ b/src/material-experimental/mdc-color/_all-color.scss
@@ -1,0 +1,18 @@
+@import '../mdc-theming/all-theme';
+
+@mixin angular-material-mdc-color($config-or-theme) {
+  // In case a theme object has been passed instead of a configuration for
+  // the color system, extract the color config from the theme object.
+  $config: if(_mat-is-theme-object($config-or-theme),
+      mat-get-color-config($config-or-theme), $config-or-theme);
+
+  @if $config == null {
+    @error 'No color configuration specified.';
+  }
+
+  @include angular-material-mdc-theme((
+    color: $config,
+    typography: null,
+    density: null,
+  ));
+}

--- a/src/material-experimental/mdc-density/_all-density.scss
+++ b/src/material-experimental/mdc-density/_all-density.scss
@@ -1,6 +1,15 @@
 @import '../mdc-theming/all-theme';
 
-@mixin angular-material-density-mdc($config: null) {
+@mixin angular-material-mdc-density($config-or-theme) {
+  // In case a theme object has been passed instead of a configuration for
+  // the density system, extract the density config from the theme object.
+  $config: if(_mat-is-theme-object($config-or-theme),
+      mat-get-density-config($config-or-theme), $config-or-theme);
+
+  @if $config == null {
+    @error 'No density configuration specified.';
+  }
+
   @include angular-material-mdc-theme((
     color: null,
     typography: null,

--- a/src/material-experimental/mdc-typography/_all-typography.scss
+++ b/src/material-experimental/mdc-typography/_all-typography.scss
@@ -1,6 +1,10 @@
 @import '../mdc-theming/all-theme';
 
-@mixin angular-material-mdc-typography($config: null) {
+@mixin angular-material-mdc-typography($config-or-theme: null) {
+  $config: if(_mat-is-theme-object($config-or-theme),
+      mat-get-typography-config($config-or-theme), $config-or-theme);
+
+  // If no actual color configuration has been specified, create a default one.
   @if $config == null {
     $config: mat-typography-config();
   }

--- a/src/material/BUILD.bazel
+++ b/src/material/BUILD.bazel
@@ -26,11 +26,12 @@ scss_bundle(
     name = "theming_bundle",
     outs = ["_theming.scss"],
     args = [
-        "--entryFile=$(location //src/material/core:theming/_all-theme.scss)",
+        "--entryFile=$(location :theming-bundle.scss)",
         "--outFile=$(location :_theming.scss)",
     ],
     data = CDK_SCSS_LIBS + MATERIAL_SCSS_LIBS + [
-        "//src/material/core:theming/_all-theme.scss",
+        "theming-bundle.scss",
+        "//src/material/core:theming_scss_lib",
         # Config file is required by "scss-bundle" and will be automatically
         # loaded by the CLI. It expects the config to be in the execroot.
         "//:scss-bundle.config.json",

--- a/src/material/core/BUILD.bazel
+++ b/src/material/core/BUILD.bazel
@@ -41,11 +41,21 @@ ng_module(
     ],
 )
 
+ALL_THEMING_FILES = [
+    # The `_core.scss` file needs to be added here too because it depends
+    # on the `_all-typography` file.
+    "_core.scss",
+    "color/_all-color.scss",
+    "density/_all-density.scss",
+    "theming/_all-theme.scss",
+    "typography/_all-typography.scss",
+]
+
 sass_library(
     name = "core_scss_lib",
     srcs = glob(
         ["**/_*.scss"],
-        exclude = ["theming/_all-theme.scss"],
+        exclude = ALL_THEMING_FILES,
     ),
     deps = [
         "//src/cdk/a11y:a11y_scss_lib",
@@ -56,9 +66,7 @@ sass_library(
 
 sass_library(
     name = "theming_scss_lib",
-    srcs = [
-        "theming/_all-theme.scss",
-    ],
+    srcs = ALL_THEMING_FILES,
     deps = MATERIAL_SCSS_LIBS,
 )
 

--- a/src/material/core/color/_all-color.scss
+++ b/src/material/core/color/_all-color.scss
@@ -1,14 +1,13 @@
 @import '../theming/all-theme';
 
 // Includes all of the color styles.
-@mixin angular-material-color($config) {
+@mixin angular-material-color($config-or-theme) {
   // In case a theme object has been passed instead of a configuration for
   // the color system, extract the color config from the theme object.
-  @if type_of($config) == 'map' {
-    $config: map_get($config, color);
-  }
-  // If no actual color configuration has been specified, report an error.
-  @if not $config {
+  $config: if(_mat-is-theme-object($config-or-theme),
+      mat-get-color-config($config-or-theme), $config-or-theme);
+
+  @if $config == null {
     @error 'No color configuration specified.';
   }
 

--- a/src/material/core/color/_all-color.scss
+++ b/src/material/core/color/_all-color.scss
@@ -1,0 +1,20 @@
+@import '../theming/all-theme';
+
+// Includes all of the color styles.
+@mixin angular-material-color($config) {
+  // In case a theme object has been passed instead of a configuration for
+  // the color system, extract the color config from the theme object.
+  @if type_of($config) == 'map' {
+    $config: map_get($config, color);
+  }
+  // If no actual color configuration has been specified, report an error.
+  @if not $config {
+    @error 'No color configuration specified.';
+  }
+
+  @include angular-material-theme((
+    color: $config,
+    typography: null,
+    density: null,
+  ));
+}

--- a/src/material/core/density/_all-density.scss
+++ b/src/material/core/density/_all-density.scss
@@ -1,7 +1,16 @@
 @import '../theming/all-theme';
 
 // Includes all of the density styles.
-@mixin _angular-material-density($config) {
+@mixin _angular-material-density($config-or-theme) {
+  // In case a theme object has been passed instead of a configuration for
+  // the density system, extract the density config from the theme object.
+  $config: if(_mat-is-theme-object($config-or-theme),
+      mat-get-density-config($config-or-theme), $config-or-theme);
+
+  @if $config == null {
+    @error 'No density configuration specified.';
+  }
+
   @include angular-material-theme((
     color: null,
     typography: null,

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -107,16 +107,6 @@
   @return map_merge($theme, $color);
 }
 
-// Whether the specified object is a color configuration. This function is needed for backwards
-// compatibility of individual component theme mixins, because developers could pass in a color
-// configuration instead of a theme container object to a theme mixin.
-@function _mat-is-color-config($config) {
-  @return map_has_key($config, primary) and
-          map_has_key($config, accent) and map_has_key($config, warn) and
-          map_has_key($config, is-dark) and map_has_key($config, foreground) and
-          map_has_key($config, background);
-}
-
 // Creates a light-themed color configuration from the specified
 // primary, accent and warn palettes.
 @function _mat-create-light-color-config($primary, $accent, $warn: null) {
@@ -212,14 +202,14 @@
 }
 
 @function mat-get-color-config($theme, $default: null) {
+  // Before we introduced the new pattern for constructing a theme, developers passed the color
+  // configuration directly to the theme mixins. This can be still the case if developers construct
+  // a theme manually and pass it to a theme. We support this for backwards compatibility.
+  @if not _mat-is-theme-object($theme) {
+    @return $theme;
+  }
   @if map_has_key($theme, color) {
     @return map_get($theme, color);
-  }
-  // Before we introduced the new pattern for construcing a theme, developers passed the color
-  // configuration to the theme mixins. This can be still the case if developers construct a
-  // theme manually and pass it to a theme. We support this for backwards compatibility.
-  @if _mat-is-color-config($theme) {
-    @return $theme;
   }
   @return $default;
 }
@@ -237,4 +227,15 @@
     @return map_get($theme, typography);
   }
   @return $default;
+}
+
+// Checks whether the given value resolves to a theme object. Theme objects are always
+// of type `map` and can optionally only specify `color`, `density` or `typography`.
+@function _mat-is-theme-object($value) {
+  @return type-of($value) == 'map' and (
+    map_has_key($value, color) or
+    map_has_key($value, density) or
+    map_has_key($value, typography) or
+    length($value) == 0
+  );
 }

--- a/src/material/core/theming/prebuilt/deeppurple-amber.scss
+++ b/src/material/core/theming/prebuilt/deeppurple-amber.scss
@@ -8,7 +8,12 @@
 $primary: mat-palette($mat-deep-purple);
 $accent:  mat-palette($mat-amber, A200, A100, A400);
 
-$theme: mat-light-theme($primary, $accent);
+$theme: mat-light-theme((
+  color: (
+    primary: $primary,
+    accent: $accent,
+  )
+));
 
 // Include all theme styles for the components.
 @include angular-material-theme($theme);

--- a/src/material/core/theming/prebuilt/indigo-pink.scss
+++ b/src/material/core/theming/prebuilt/indigo-pink.scss
@@ -8,7 +8,12 @@
 $primary: mat-palette($mat-indigo);
 $accent:  mat-palette($mat-pink, A200, A100, A400);
 
-$theme: mat-light-theme($primary, $accent);
+$theme: mat-light-theme((
+  color: (
+    primary: $primary,
+    accent: $accent
+  )
+));
 
 // Include all theme styles for the components.
 @include angular-material-theme($theme);

--- a/src/material/core/theming/prebuilt/pink-bluegrey.scss
+++ b/src/material/core/theming/prebuilt/pink-bluegrey.scss
@@ -8,7 +8,12 @@
 $primary: mat-palette($mat-pink, 700, 500, 900);
 $accent:  mat-palette($mat-blue-grey, A200, A100, A400);
 
-$theme: mat-dark-theme($primary, $accent);
+$theme: mat-dark-theme((
+  color: (
+    primary: $primary,
+    accent: $accent
+  )
+));
 
 // Include all theme styles for the components.
 @include angular-material-theme($theme);

--- a/src/material/core/theming/prebuilt/purple-green.scss
+++ b/src/material/core/theming/prebuilt/purple-green.scss
@@ -8,7 +8,12 @@
 $primary: mat-palette($mat-purple, 700, 500, 800);
 $accent:  mat-palette($mat-green, A200, A100, A400);
 
-$theme: mat-dark-theme($primary, $accent);
+$theme: mat-dark-theme((
+  color: (
+    primary: $primary,
+    accent: $accent
+  )
+));
 
 // Include all theme styles for the components.
 @include angular-material-theme($theme);

--- a/src/material/core/theming/tests/test-css-variables-theme.scss
+++ b/src/material/core/theming/tests/test-css-variables-theme.scss
@@ -19,6 +19,12 @@
 // Theme used to test that our themes would compile if the colors were specified as CSS variables.
 ._demo-css-variables-theme {
   $palette: mat-palette($mat-blue-grey);
-  $theme: mat-dark-theme($palette, $palette, $palette);
+  $theme: mat-dark-theme((
+    color: (
+      primary: $palette,
+      accent: $palette,
+      warn: $palette
+    )
+  ));
   @include angular-material-theme(replace-all-values($theme, var(--test-var)));
 }

--- a/src/material/core/theming/tests/test-theming-api.scss
+++ b/src/material/core/theming/tests/test-theming-api.scss
@@ -1,3 +1,6 @@
+@import '../../density/all-density';
+@import '../../color/all-color';
+@import '../../typography/all-typography';
 @import '../all-theme';
 
 // A new way to configure themes has been introduced. This Sass file ensures that the theming
@@ -202,6 +205,27 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
   @include _my-custom-theme-new-api($new-api-dark-theme);
 }
 
+// Test which ensures that either theme objects, or individual system configurations
+// can be passed to the all-density, all-typography or all-color mixins.
+@mixin test-all-theme-mixins-arguments() {
+  $test-themes: (
+    $legacy-light-theme,
+    $legacy-dark-theme,
+    $new-api-light-theme,
+    $new-api-dark-theme
+  );
+
+  @each $theme in $test-themes {
+    @include angular-material-typography($theme);
+    @include angular-material-color($theme);
+    @include _angular-material-density($theme);
+  }
+
+  @include angular-material-typography(map_get($light-theme-only-typography, typography));
+  @include _angular-material-density(map_get($light-theme-only-density, density));
+  @include angular-material-color(map_get($new-api-dark-theme, color));
+}
+
 // Include all tests. Sass will throw if one of the tests fails.
 @include test-create-color-config();
 @include test-default-theming-system-configs();
@@ -211,3 +235,4 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
 @include test-get-density-config();
 @include test-get-typography-config();
 @include test-custom-theme-backwards-compatibility();
+@include test-all-theme-mixins-arguments();

--- a/src/material/core/typography/_all-typography.scss
+++ b/src/material/core/typography/_all-typography.scss
@@ -38,8 +38,12 @@
 
 
 // Includes all of the typographic styles.
-@mixin angular-material-typography($config: null) {
-  @if $config == null {
+@mixin angular-material-typography($config-or-theme: null) {
+  $config: if(_mat-is-theme-object($config-or-theme),
+      mat-get-typography-config($config-or-theme), $config-or-theme);
+
+  // If no actual color configuration has been specified, create a default one.
+  @if not $config {
     $config: mat-typography-config();
   }
 

--- a/src/material/schematics/ng-add/theming/create-custom-theme.ts
+++ b/src/material/schematics/ng-add/theming/create-custom-theme.ts
@@ -28,8 +28,15 @@ $${name}-accent: mat-palette($mat-pink, A200, A100, A400);
 // The warn palette is optional (defaults to red).
 $${name}-warn: mat-palette($mat-red);
 
-// Create the theme object (a Sass map containing all of the palettes).
-$${name}-theme: mat-light-theme($${name}-primary, $${name}-accent, $${name}-warn);
+// Create the theme object. A theme consists of configurations for individual
+// theming systems such as "color" or "typography".
+$${name}-theme: mat-light-theme((
+  color: (
+    primary: $${name}-primary,
+    accent: $${name}-accent,
+    warn: $${name}-warn,
+  )
+));
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component

--- a/src/material/theming-bundle.scss
+++ b/src/material/theming-bundle.scss
@@ -1,0 +1,7 @@
+// File for which all imports are resolved and bundled. This is the entry-point for
+// the `@angular/material` theming Sass bundle. See `//src/material:theming_bundle`.
+
+@import './core/color/all-color';
+@import './core/density/all-density';
+@import './core/theming/all-theme';
+@import './core/typography/all-typography';


### PR DESCRIPTION
As discussed in the last meeting. We make the API for the theming bulk mixins such as `angular-material-color` more convenient, by allowing consumers to just pass a theme object.

Additionally, an initial draft for the documentation update has been included. Similarly, usages to the legacy theming color API have been replaced (also in the `ng-add` schematic)