### PR TITLE
fix(drag-drop): defer resolving scrollable parents until first drag

### DIFF
--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -145,7 +145,7 @@ export interface CdkDragStart<T = any> {
     source: CdkDrag<T>;
 }
 
-export declare class CdkDropList<T = any> implements AfterContentInit, OnDestroy {
+export declare class CdkDropList<T = any> implements OnDestroy {
     _dropListRef: DropListRef<CdkDropList<T>>;
     autoScrollDisabled: boolean;
     connectedTo: (CdkDropList | string)[] | CdkDropList | string;
@@ -171,7 +171,6 @@ export declare class CdkDropList<T = any> implements AfterContentInit, OnDestroy
     exit(item: CdkDrag): void;
     getItemIndex(item: CdkDrag): number;
     getSortedItems(): CdkDrag[];
-    ngAfterContentInit(): void;
     ngOnDestroy(): void;
     removeItem(item: CdkDrag): void;
     start(): void;


### PR DESCRIPTION
Currently we resolve a drop list's scrollable parents inside `ngAfterViewInit`, but this might be too early if the element is being projected. These changes move the logic to the first time the user starts dragging which should guarantee that the DOM structure has settled.

Fixes #18737.