### PR TITLE
fix(cdk/drag-drop): unable to declare data type of dragged items in CdkDragDrop event

### DIFF
--- a/src/cdk/drag-drop/drag-events.ts
+++ b/src/cdk/drag-drop/drag-events.ts
@@ -54,13 +54,13 @@ export interface CdkDragExit<T = any, I = T> {
 
 
 /** Event emitted when the user drops a draggable item inside a drop container. */
-export interface CdkDragDrop<T, O = T> {
+export interface CdkDragDrop<T, O = T, I = T> {
   /** Index of the item when it was picked up. */
   previousIndex: number;
   /** Current index of the item. */
   currentIndex: number;
   /** Item that is being dropped. */
-  item: CdkDrag;
+  item: CdkDrag<I>;
   /** Container in which the item was dropped. */
   container: CdkDropList<T>;
   /** Container from which the item was picked up. Can be the same as the `container`. */

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -59,7 +59,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkDrag<any>, [null, { optional: true; skipSelf: true; }, null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; self: true; }, { optional: true; skipSelf: true; }]>;
 }
 
-export interface CdkDragDrop<T, O = T> {
+export interface CdkDragDrop<T, O = T, I = T> {
     container: CdkDropList<T>;
     currentIndex: number;
     distance: {
@@ -71,7 +71,7 @@ export interface CdkDragDrop<T, O = T> {
         y: number;
     };
     isPointerOverContainer: boolean;
-    item: CdkDrag;
+    item: CdkDrag<I>;
     previousContainer: CdkDropList<O>;
     previousIndex: number;
 }


### PR DESCRIPTION
Fixes not being able to pass the data type for the `CdkDrag` through the `CdkDragDrop` event.

Fixes #18804.