### PR TITLE
refactor(tree): remove renderer usage

### DIFF
--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -69,7 +69,11 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
 
   constructor(private _treeNode: CdkTreeNode<T>,
               private _tree: CdkTree<T>,
-              private _renderer: Renderer2,
+              /**
+               * @deprecated _renderer parameter no longer being used. To be removed.
+               * @breaking-change 11.0.0
+               */
+              _renderer: Renderer2,
               private _element: ElementRef<HTMLElement>,
               @Optional() private _dir: Directionality) {
     this._setPadding();
@@ -104,8 +108,8 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
       const element = this._element.nativeElement;
       const paddingProp = this._dir && this._dir.value === 'rtl' ? 'paddingRight' : 'paddingLeft';
       const resetProp = paddingProp === 'paddingLeft' ? 'paddingRight' : 'paddingLeft';
-      this._renderer.setStyle(element, paddingProp, padding);
-      this._renderer.setStyle(element, resetProp, null);
+      element.style[paddingProp] = padding || '';
+      element.style[resetProp] = '';
       this._currentPadding = padding;
     }
   }

--- a/tools/public_api_guard/cdk/tree.d.ts
+++ b/tools/public_api_guard/cdk/tree.d.ts
@@ -113,7 +113,8 @@ export declare class CdkTreeNodePadding<T> implements OnDestroy {
     indentUnits: string;
     get level(): number;
     set level(value: number);
-    constructor(_treeNode: CdkTreeNode<T>, _tree: CdkTree<T>, _renderer: Renderer2, _element: ElementRef<HTMLElement>, _dir: Directionality);
+    constructor(_treeNode: CdkTreeNode<T>, _tree: CdkTree<T>,
+    _renderer: Renderer2, _element: ElementRef<HTMLElement>, _dir: Directionality);
     _paddingIndent(): string | null;
     _setPadding(forceChange?: boolean): void;
     ngOnDestroy(): void;


### PR DESCRIPTION
We've mostly gotten rid of the `Renderer2` usages in favor of native APIs, but this is one of the few places left where we were still using it.