### PR TITLE
refactor(datepicker): clean up date selection model

### DIFF
--- a/src/material/core/datetime/index.ts
+++ b/src/material/core/datetime/index.ts
@@ -17,7 +17,6 @@ export * from './date-adapter';
 export * from './date-formats';
 export * from './native-date-adapter';
 export * from './native-date-formats';
-export * from './date-selection-model';
 
 
 @NgModule({

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -29,9 +29,6 @@ import {
   DateAdapter,
   MAT_DATE_FORMATS,
   MatDateFormats,
-  MatDateSelectionModel,
-  MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER,
-  DateRange,
 } from '@angular/material/core';
 import {Subject, Subscription} from 'rxjs';
 import {MatCalendarCellCssClasses} from './calendar-body';
@@ -45,6 +42,11 @@ import {
   yearsPerPage
 } from './multi-year-view';
 import {MatYearView} from './year-view';
+import {
+  MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER,
+  DateRange,
+  MatDateSelectionModel,
+} from './date-selection-model';
 
 /**
  * Possible views for the calendar.

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -36,10 +36,10 @@ import {
   DateAdapter,
   MatDateFormats,
   ErrorStateMatcher,
-  DateRange,
 } from '@angular/material/core';
 import {BooleanInput} from '@angular/cdk/coercion';
 import {MatDatepickerInputBase, DateFilterFn} from './datepicker-input-base';
+import {DateRange} from './date-selection-model';
 
 /** Parent component that should be wrapped around `MatStartDate` and `MatEndDate`. */
 export interface MatDateRangeInputParent<D> {

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -20,12 +20,7 @@ import {
   ElementRef,
 } from '@angular/core';
 import {MatFormFieldControl, MatFormField} from '@angular/material/form-field';
-import {
-  DateRange,
-  ThemePalette,
-  DateAdapter,
-  MatDateSelectionModel,
-} from '@angular/material/core';
+import {ThemePalette, DateAdapter} from '@angular/material/core';
 import {NgControl, ControlContainer} from '@angular/forms';
 import {Subject, merge} from 'rxjs';
 import {coerceBooleanProperty, BooleanInput} from '@angular/cdk/coercion';
@@ -39,6 +34,7 @@ import {MatDatepickerControl} from './datepicker-base';
 import {createMissingDateImplError} from './datepicker-errors';
 import {DateFilterFn} from './datepicker-input-base';
 import {MatDateRangePicker} from './date-range-picker';
+import {DateRange, MatDateSelectionModel} from './date-selection-model';
 
 let nextUniqueId = 0;
 

--- a/src/material/datepicker/date-range-picker.ts
+++ b/src/material/datepicker/date-range-picker.ts
@@ -7,9 +7,9 @@
  */
 
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-import {MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER, DateRange} from '@angular/material/core';
 import {MatDatepickerBase, MatDatepickerContent} from './datepicker-base';
 import {MatDateRangeInput} from './date-range-input';
+import {MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER, DateRange} from './date-selection-model';
 
 // TODO(mmalerba): We use a component instead of a directive here so the user can use implicit
 // template reference variables (e.g. #d vs #d="matDateRangePicker"). We can change this to a

--- a/src/material/datepicker/date-selection-model.ts
+++ b/src/material/datepicker/date-selection-model.ts
@@ -7,7 +7,7 @@
  */
 
 import {FactoryProvider, Injectable, Optional, SkipSelf, OnDestroy} from '@angular/core';
-import {DateAdapter} from './date-adapter';
+import {DateAdapter} from '@angular/material/core';
 import {Observable, Subject} from 'rxjs';
 
 /** A class representing a range of dates. */
@@ -76,15 +76,6 @@ export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<
 
   /** Checks whether the current selection is complete. */
   abstract isComplete(): boolean;
-
-  /** Checks whether the current selection is identical to the passed-in selection. */
-  abstract isSame(other: S): boolean;
-
-  /** Checks whether the current selection is valid. */
-  abstract isValid(): boolean;
-
-  /** Checks whether the current selection overlaps with the given range. */
-  abstract overlaps(range: DateRange<D>): boolean;
 }
 
 /**  A selection model that contains a single date. */
@@ -106,27 +97,8 @@ export class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | nu
    * Checks whether the current selection is complete. In the case of a single date selection, this
    * is true if the current selection is not null.
    */
-  isComplete() { return this.selection != null; }
-
-  /** Checks whether the current selection is identical to the passed-in selection. */
-  isSame(other: D): boolean {
-    return this.adapter.sameDate(other, this.selection);
-  }
-
-  /**
-   * Checks whether the current selection is valid. In the case of a single date selection, this
-   * means that the current selection is not null and is a valid date.
-   */
-  isValid(): boolean {
-    return this.selection != null && this.adapter.isDateInstance(this.selection) &&
-        this.adapter.isValid(this.selection);
-  }
-
-  /** Checks whether the current selection overlaps with the given range. */
-  overlaps(range: DateRange<D>): boolean {
-    return !!(this.selection && range.start && range.end &&
-        this.adapter.compareDate(range.start, this.selection) <= 0 &&
-        this.adapter.compareDate(this.selection, range.end) <= 0);
+  isComplete() {
+    return this.selection != null;
   }
 }
 
@@ -163,45 +135,6 @@ export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRan
    */
   isComplete(): boolean {
     return this.selection.start != null && this.selection.end != null;
-  }
-
-  /** Checks whether the current selection is identical to the passed-in selection. */
-  isSame(other: DateRange<D>): boolean {
-      return this.adapter.sameDate(this.selection.start, other.start) &&
-             this.adapter.sameDate(this.selection.end, other.end);
-  }
-
-  /**
-   * Checks whether the current selection is valid. In the case of a date range selection, this
-   * means that the current selection has a `start` and `end` that are both non-null and valid
-   * dates.
-   */
-  isValid(): boolean {
-    return this.selection.start != null && this.selection.end != null &&
-        this.adapter.isValid(this.selection.start!) && this.adapter.isValid(this.selection.end!);
-  }
-
-  /**
-   * Returns true if the given range and the selection overlap in any way. False if otherwise, that
-   * includes incomplete selections or ranges.
-   */
-  overlaps(range: DateRange<D>): boolean {
-    if (!(this.selection.start && this.selection.end && range.start && range.end)) {
-      return false;
-    }
-
-    return (
-        this._isBetween(range.start, this.selection.start, this.selection.end) ||
-        this._isBetween(range.end, this.selection.start, this.selection.end) ||
-        (
-            this.adapter.compareDate(range.start, this.selection.start) <= 0 &&
-            this.adapter.compareDate(this.selection.end, range.end) <= 0
-        )
-    );
-  }
-
-  private _isBetween(value: D, from: D, to: D): boolean {
-    return this.adapter.compareDate(from, value) <= 0 && this.adapter.compareDate(value, to) <= 0;
   }
 }
 

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -44,8 +44,6 @@ import {
   DateAdapter,
   mixinColor,
   ThemePalette,
-  MatDateSelectionModel,
-  ExtractDateTypeFromSelection,
 } from '@angular/material/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {merge, Subject, Observable} from 'rxjs';
@@ -55,6 +53,7 @@ import {matDatepickerAnimations} from './datepicker-animations';
 import {createMissingDateImplError} from './datepicker-errors';
 import {MatCalendarCellCssClasses} from './calendar-body';
 import {DateFilterFn} from './datepicker-input-base';
+import {ExtractDateTypeFromSelection, MatDateSelectionModel} from './date-selection-model';
 
 /** Used to generate a unique ID for each datepicker instance. */
 let datepickerUid = 0;

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -29,11 +29,10 @@ import {
   DateAdapter,
   MAT_DATE_FORMATS,
   MatDateFormats,
-  MatDateSelectionModel,
-  ExtractDateTypeFromSelection,
 } from '@angular/material/core';
 import {Subscription} from 'rxjs';
 import {createMissingDateImplError} from './datepicker-errors';
+import {ExtractDateTypeFromSelection, MatDateSelectionModel} from './date-selection-model';
 
 /**
  * An event used for datepicker input and change events. We don't always have access to a native

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -16,7 +16,6 @@ import {
   MAT_DATE_LOCALE,
   MatNativeDateModule,
   NativeDateModule,
-  MatDateSelectionModel,
 } from '@angular/material/core';
 import {MatFormField, MatFormFieldModule} from '@angular/material/form-field';
 import {DEC, JAN, JUL, JUN, SEP} from '@angular/material/testing';
@@ -29,7 +28,12 @@ import {MatInputModule} from '../input/index';
 import {MatDatepicker} from './datepicker';
 import {MatDatepickerInput} from './datepicker-input';
 import {MatDatepickerToggle} from './datepicker-toggle';
-import {MAT_DATEPICKER_SCROLL_STRATEGY, MatDatepickerIntl, MatDatepickerModule} from './index';
+import {
+  MAT_DATEPICKER_SCROLL_STRATEGY,
+  MatDatepickerIntl,
+  MatDatepickerModule,
+  MatDateSelectionModel,
+} from './index';
 
 describe('MatDatepicker', () => {
   const SUPPORTS_INTL = typeof Intl != 'undefined';

--- a/src/material/datepicker/datepicker.ts
+++ b/src/material/datepicker/datepicker.ts
@@ -7,9 +7,9 @@
  */
 
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-import {MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER} from '@angular/material/core';
 import {MatDatepickerBase} from './datepicker-base';
 import {MatDatepickerInput} from './datepicker-input';
+import {MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER} from './date-selection-model';
 
 // TODO(mmalerba): We use a component instead of a directive here so the user can use implicit
 // template reference variables (e.g. #d vs #d="matDatepicker"). We can change this to a directive

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -21,11 +21,12 @@ import {
 } from '@angular/cdk/testing/private';
 import {Component} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatNativeDateModule, DateRange} from '@angular/material/core';
+import {MatNativeDateModule} from '@angular/material/core';
 import {DEC, FEB, JAN, MAR, NOV} from '@angular/material/testing';
 import {By} from '@angular/platform-browser';
 import {MatCalendarBody} from './calendar-body';
 import {MatMonthView} from './month-view';
+import {DateRange} from './date-selection-model';
 
 describe('MatMonthView', () => {
   let dir: {value: Direction};

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -33,12 +33,13 @@ import {
   ViewChild,
   OnDestroy,
 } from '@angular/core';
-import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, DateRange} from '@angular/material/core';
+import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {MatCalendarBody, MatCalendarCell, MatCalendarCellCssClasses} from './calendar-body';
 import {createMissingDateImplError} from './datepicker-errors';
 import {Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
+import {DateRange} from './date-selection-model';
 
 
 const DAYS_PER_WEEK = 7;

--- a/src/material/datepicker/multi-year-view.ts
+++ b/src/material/datepicker/multi-year-view.ts
@@ -31,12 +31,13 @@ import {
   ViewEncapsulation,
   OnDestroy,
 } from '@angular/core';
-import {DateAdapter, DateRange} from '@angular/material/core';
+import {DateAdapter} from '@angular/material/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {MatCalendarBody, MatCalendarCell} from './calendar-body';
 import {createMissingDateImplError} from './datepicker-errors';
 import {Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
+import {DateRange} from './date-selection-model';
 
 export const yearsPerPage = 24;
 

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -29,5 +29,6 @@ export * from './month-view';
 export * from './year-view';
 export * from './date-range-input';
 export * from './date-range-picker';
+export * from './date-selection-model';
 export {MatStartDate, MatEndDate} from './date-range-input-parts';
 export {MatMultiYearView, yearsPerPage, yearsPerRow} from './multi-year-view';

--- a/src/material/datepicker/year-view.ts
+++ b/src/material/datepicker/year-view.ts
@@ -32,12 +32,13 @@ import {
   ViewEncapsulation,
   OnDestroy,
 } from '@angular/core';
-import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, DateRange} from '@angular/material/core';
+import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {MatCalendarBody, MatCalendarCell} from './calendar-body';
 import {createMissingDateImplError} from './datepicker-errors';
 import {Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
+import {DateRange} from './date-selection-model';
 
 /**
  * An internal component used to display a single year in the datepicker.

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -79,19 +79,6 @@ export declare abstract class DateAdapter<D> {
     abstract today(): D;
 }
 
-export declare class DateRange<D> {
-    readonly end: D | null;
-    readonly start: D | null;
-    constructor(
-    start: D | null,
-    end: D | null);
-}
-
-export interface DateSelectionModelChange<S> {
-    selection: S;
-    source: unknown;
-}
-
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;
 
 export declare const defaultRippleAnimationConfig: {
@@ -104,8 +91,6 @@ export declare class ErrorStateMatcher {
     static ɵfac: i0.ɵɵFactoryDef<ErrorStateMatcher>;
     static ɵprov: i0.ɵɵInjectableDef<ErrorStateMatcher>;
 }
-
-export declare type ExtractDateTypeFromSelection<T> = T extends DateRange<infer D> ? D : NonNullable<T>;
 
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;
 
@@ -213,15 +198,7 @@ export declare const MAT_NATIVE_DATE_FORMATS: MatDateFormats;
 
 export declare const MAT_OPTION_PARENT_COMPONENT: InjectionToken<MatOptionParentComponent>;
 
-export declare function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
-
-export declare const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
-
 export declare const MAT_RIPPLE_GLOBAL_OPTIONS: InjectionToken<RippleGlobalOptions>;
-
-export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
-
-export declare const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
 export declare class MatCommonModule {
     protected _document?: Document;
@@ -242,24 +219,6 @@ export declare type MatDateFormats = {
         monthYearA11yLabel: any;
     };
 };
-
-export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>> implements OnDestroy {
-    protected readonly adapter: DateAdapter<D>;
-    readonly selection: S;
-    selectionChanged: Observable<DateSelectionModelChange<S>>;
-    protected constructor(
-    adapter: DateAdapter<D>,
-    selection: S);
-    abstract add(date: D | null): void;
-    abstract isComplete(): boolean;
-    abstract isSame(other: S): boolean;
-    abstract isValid(): boolean;
-    ngOnDestroy(): void;
-    abstract overlaps(range: DateRange<D>): boolean;
-    updateSelection(value: S, source: unknown): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDateSelectionModel<any, any>, never, never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatDateSelectionModel<any, any>>;
-}
 
 export declare const MATERIAL_SANITY_CHECKS: InjectionToken<SanityChecks>;
 
@@ -356,17 +315,6 @@ export declare class MatPseudoCheckboxModule {
 
 export declare type MatPseudoCheckboxState = 'unchecked' | 'checked' | 'indeterminate';
 
-export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
-    constructor(adapter: DateAdapter<D>);
-    add(date: D | null): void;
-    isComplete(): boolean;
-    isSame(other: DateRange<D>): boolean;
-    isValid(): boolean;
-    overlaps(range: DateRange<D>): boolean;
-    static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>>;
-    static ɵprov: i0.ɵɵInjectableDef<MatRangeDateSelectionModel<any>>;
-}
-
 export declare class MatRipple implements OnInit, OnDestroy, RippleTarget {
     animation: RippleAnimationConfig;
     centered: boolean;
@@ -392,17 +340,6 @@ export declare class MatRipple implements OnInit, OnDestroy, RippleTarget {
 export declare class MatRippleModule {
     static ɵinj: i0.ɵɵInjectorDef<MatRippleModule>;
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatRippleModule, [typeof i1.MatRipple], [typeof i2.MatCommonModule, typeof i3.PlatformModule], [typeof i1.MatRipple, typeof i2.MatCommonModule]>;
-}
-
-export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
-    constructor(adapter: DateAdapter<D>);
-    add(date: D | null): void;
-    isComplete(): boolean;
-    isSame(other: D): boolean;
-    isValid(): boolean;
-    overlaps(range: DateRange<D>): boolean;
-    static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>>;
-    static ɵprov: i0.ɵɵInjectableDef<MatSingleDateSelectionModel<any>>;
 }
 
 export declare const JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9, NOV = 10, DEC = 11;

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -1,5 +1,20 @@
 export declare type DateFilterFn<D> = (date: D | null) => boolean;
 
+export declare class DateRange<D> {
+    readonly end: D | null;
+    readonly start: D | null;
+    constructor(
+    start: D | null,
+    end: D | null);
+}
+
+export interface DateSelectionModelChange<S> {
+    selection: S;
+    source: unknown;
+}
+
+export declare type ExtractDateTypeFromSelection<T> = T extends DateRange<infer D> ? D : NonNullable<T>;
+
 export declare const MAT_DATEPICKER_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 export declare function MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy;
@@ -13,6 +28,14 @@ export declare const MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER: {
 export declare const MAT_DATEPICKER_VALIDATORS: any;
 
 export declare const MAT_DATEPICKER_VALUE_ACCESSOR: any;
+
+export declare function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
+
+export declare const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
+
+export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
+
+export declare const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
 export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDestroy, OnChanges {
     _calendarHeaderPortal: Portal<any>;
@@ -293,6 +316,21 @@ export declare class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRang
     static ɵfac: i0.ɵɵFactoryDef<MatDateRangePicker<any>>;
 }
 
+export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>> implements OnDestroy {
+    protected readonly adapter: DateAdapter<D>;
+    readonly selection: S;
+    selectionChanged: Observable<DateSelectionModelChange<S>>;
+    protected constructor(
+    adapter: DateAdapter<D>,
+    selection: S);
+    abstract add(date: D | null): void;
+    abstract isComplete(): boolean;
+    ngOnDestroy(): void;
+    updateSelection(value: S, source: unknown): void;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDateSelectionModel<any, any>, never, never, {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDateSelectionModel<any, any>>;
+}
+
 export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
     protected _validator: ValidatorFn | null;
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
@@ -372,6 +410,22 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatMultiYearView<any>, "mat-multi-year-view", ["matMultiYearView"], { "activeDate": "activeDate"; "selected": "selected"; "minDate": "minDate"; "maxDate": "maxDate"; "dateFilter": "dateFilter"; }, { "selectedChange": "selectedChange"; "yearSelected": "yearSelected"; "activeDateChange": "activeDateChange"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatMultiYearView<any>>;
+}
+
+export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
+    constructor(adapter: DateAdapter<D>);
+    add(date: D | null): void;
+    isComplete(): boolean;
+    static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>>;
+    static ɵprov: i0.ɵɵInjectableDef<MatRangeDateSelectionModel<any>>;
+}
+
+export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
+    constructor(adapter: DateAdapter<D>);
+    add(date: D | null): void;
+    isComplete(): boolean;
+    static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>>;
+    static ɵprov: i0.ɵɵInjectableDef<MatSingleDateSelectionModel<any>>;
 }
 
 export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {


### PR DESCRIPTION
- Removes some methods from the date selection model that were put in place under the assumption that they'd be used, but we never ended up using them.
- Moves the selection model out of `core` and into `datepicker`. I decided to do it, because it seems very tightly coupled to the datepicker and I don't see us needing it in other components in the future.