### PR TITLE
fix(material-experimental/mdc-radio): add strong focus indication

### DIFF
--- a/src/material-experimental/mdc-helpers/_mdc-helpers.scss
+++ b/src/material-experimental/mdc-helpers/_mdc-helpers.scss
@@ -255,10 +255,11 @@ $mat-typography-level-mappings: (
   // Render the focus indicator on focus. Defining a pseudo element's
   // content will cause it to render.
 
-  // For checkboxes and slide toggles, render the focus indicator when we know the hidden input
-  // is focused (slightly different for each control).
+  // For checkboxes, radios and slide toggles, render the focus indicator when we know
+  // the hidden input is focused (slightly different for each control).
   .mdc-checkbox__native-control:focus ~ .mat-mdc-focus-indicator::before,
   .mat-mdc-slide-toggle-focused .mat-mdc-focus-indicator::before,
+  .mat-mdc-radio-button.cdk-focused .mat-focus-indicator::before,
 
   // For all other components, render the focus indicator on focus.
   .mat-mdc-focus-indicator:focus::before {

--- a/src/material-experimental/mdc-radio/radio.html
+++ b/src/material-experimental/mdc-radio/radio.html
@@ -18,7 +18,7 @@
       <div class="mdc-radio__inner-circle"></div>
     </div>
     <div class="mdc-radio__ripple"></div>
-    <div mat-ripple class="mat-radio-ripple"
+    <div mat-ripple class="mat-radio-ripple mat-focus-indicator"
          [matRippleTrigger]="formField"
          [matRippleDisabled]="_isRippleDisabled()"
          [matRippleCentered]="true"

--- a/src/material-experimental/mdc-radio/radio.spec.ts
+++ b/src/material-experimental/mdc-radio/radio.spec.ts
@@ -394,6 +394,14 @@ describe('MDC-based MatRadio', () => {
       expect(radioNativeElements[2].classList).toContain('mat-warn');
     });
 
+    it('should have a focus indicator', () => {
+      const radioRippleNativeElements =
+          radioNativeElements.map(element => element.querySelector('.mat-radio-ripple')!);
+
+      expect(radioRippleNativeElements
+          .every(element => element.classList.contains('mat-focus-indicator'))).toBe(true);
+    });
+
   });
 
   describe('group with ngModel', () => {


### PR DESCRIPTION
The MDC-based radio button was missing the strong focus indication that we have in the base radio button.