### PR TITLE
build: resolve module names in circular deps test

### DIFF
--- a/src/circular-deps-test.conf.js
+++ b/src/circular-deps-test.conf.js
@@ -5,12 +5,27 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
+const path = require('path');
+
 module.exports = {
   baseDir: '../',
   goldenFile: '../goldens/ts-circular-deps.json',
-  // The test should not capture deprecated packages such as `http`, or the `webworker` platform.
   glob: `./**/*.ts`,
   // Command that will be displayed if the golden needs to be updated.
   approveCommand: 'yarn ts-circular-deps:approve',
-  resolveModule: () => {}
+  resolveModule,
 };
+
+/**
+ * Custom module resolver that maps specifiers starting with `@angular/` to the
+ * local packages folder. This ensures that imports using the module name can be
+ * resolved. Cross entry-point/package circular dependencies are already be detected
+ * by Bazel, but in rare cases, the module name is used for imports within entry-points.
+ */
+function resolveModule(specifier) {
+  if (specifier.startsWith('@angular/')) {
+    return path.join(__dirname, specifier.substr('@angular/'.length));
+  }
+  return null;
+}


### PR DESCRIPTION
Currently the circular dependencies test only resolves
relative imports. It does not resolve module names
to packages/entry-points which are part of the Angular
Components repository.

To ensure that such repo-specific module names are resolved, we
add a custom module resolver. This helps us making the circular deps
test future-proof in case an entry-point uses module names.

Within an entry-point circular dependencies could be also created
with module name imports.

@josephperrott Sorry. I would have commented on the original PR, but I didn't have a chance to have anther look as the PR still had `merge ready` applied and got merged quickly.