### PR TITLE
refactor: use $execpath instead of deprecated $location

### DIFF
--- a/src/components-examples/BUILD.bazel
+++ b/src/components-examples/BUILD.bazel
@@ -120,13 +120,13 @@ genrule(
     ],
     cmd = """
       # Create source file manifest
-      echo "$(locations //src/components-examples:example-source-files)" \
-          > $(location _example_module.MF)
+      echo "$(execpaths //src/components-examples:example-source-files)" \
+          > $(execpath _example_module.MF)
 
       # Run the bazel entry-point for generating the example module.
-      ./$(location //tools/example-module:bazel-bin) \
-          "$(location _example_module.MF)" \
-          "$(location example-module.ts)" \
+      ./$(execpath //tools/example-module:bazel-bin) \
+          "$(execpath _example_module.MF)" \
+          "$(execpath example-module.ts)" \
           "$$PWD/src/components-examples"
     """,
     output_to_bindir = True,

--- a/src/material/BUILD.bazel
+++ b/src/material/BUILD.bazel
@@ -26,8 +26,8 @@ scss_bundle(
     name = "theming_bundle",
     outs = ["_theming.scss"],
     args = [
-        "--entryFile=$(location //src/material/core:theming/_all-theme.scss)",
-        "--outFile=$(location :_theming.scss)",
+        "--entryFile=$(execpath //src/material/core:theming/_all-theme.scss)",
+        "--outFile=$(execpath :_theming.scss)",
     ],
     data = CDK_SCSS_LIBS + MATERIAL_SCSS_LIBS + [
         "//src/material/core:theming/_all-theme.scss",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -227,7 +227,7 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], tags = [], **k
             outs = ["%s.js" % css_id],
             output_to_bindir = True,
             cmd = """
-        files=($(locations %s))
+        files=($(execpaths %s))
         # Escape all double-quotes so that the content can be safely inlined into the
         # JS template. Note that it needs to be escaped a second time because the string
         # will be evaluated first in Bash and will then be stored in the JS output.


### PR DESCRIPTION
See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables: "This is legacy pre-Starlark behavior and not recommended unless you really know what it does for a particular rule."