### PR TITLE
Enable tree-shaking of more services

### DIFF
--- a/src/cdk/drag-drop/drag-drop-module.ts
+++ b/src/cdk/drag-drop/drag-drop-module.ts
@@ -14,7 +14,6 @@ import {CdkDrag} from './directives/drag';
 import {CdkDragHandle} from './directives/drag-handle';
 import {CdkDragPreview} from './directives/drag-preview';
 import {CdkDragPlaceholder} from './directives/drag-placeholder';
-import {DragDrop} from './drag-drop';
 
 const DRAG_DROP_DIRECTIVES = [
   CdkDropList,
@@ -28,6 +27,5 @@ const DRAG_DROP_DIRECTIVES = [
 @NgModule({
   imports: DRAG_DROP_DIRECTIVES,
   exports: [CdkScrollableModule, ...DRAG_DROP_DIRECTIVES],
-  providers: [DragDrop],
 })
 export class DragDropModule {}

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -210,6 +210,5 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
 @NgModule({
   exports: [CdkObserveContent],
   declarations: [CdkObserveContent],
-  providers: [MutationObserverFactory],
 })
 export class ObserversModule {}

--- a/src/cdk/overlay/overlay-module.ts
+++ b/src/cdk/overlay/overlay-module.ts
@@ -10,7 +10,6 @@ import {BidiModule} from '@angular/cdk/bidi';
 import {PortalModule} from '@angular/cdk/portal';
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import {NgModule} from '@angular/core';
-import {Overlay} from './overlay';
 import {
   CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER,
   CdkConnectedOverlay,
@@ -20,6 +19,6 @@ import {
 @NgModule({
   imports: [BidiModule, PortalModule, ScrollingModule, CdkConnectedOverlay, CdkOverlayOrigin],
   exports: [CdkConnectedOverlay, CdkOverlayOrigin, ScrollingModule],
-  providers: [Overlay, CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER],
+  providers: [CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER],
 })
 export class OverlayModule {}

--- a/src/material/chips/module.ts
+++ b/src/material/chips/module.ts
@@ -9,7 +9,7 @@
 import {ENTER} from '@angular/cdk/keycodes';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {ErrorStateMatcher, MatCommonModule, MatRippleModule} from '@angular/material/core';
+import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatChip} from './chip';
 import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './tokens';
 import {MatChipEditInput} from './chip-edit-input';
@@ -41,7 +41,6 @@ const CHIP_DECLARATIONS = [
   exports: [MatCommonModule, CHIP_DECLARATIONS],
   declarations: [MatChipAction, CHIP_DECLARATIONS],
   providers: [
-    ErrorStateMatcher,
     {
       provide: MAT_CHIPS_DEFAULT_OPTIONS,
       useValue: {

--- a/src/material/datepicker/datepicker-module.ts
+++ b/src/material/datepicker/datepicker-module.ts
@@ -22,7 +22,6 @@ import {
   MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
 } from './datepicker-base';
 import {MatDatepickerInput} from './datepicker-input';
-import {MatDatepickerIntl} from './datepicker-intl';
 import {MatDatepickerToggle, MatDatepickerToggleIcon} from './datepicker-toggle';
 import {MatMonthView} from './month-view';
 import {MatMultiYearView} from './multi-year-view';
@@ -82,6 +81,6 @@ import {MatDatepickerActions, MatDatepickerApply, MatDatepickerCancel} from './d
     MatDatepickerCancel,
     MatDatepickerApply,
   ],
-  providers: [MatDatepickerIntl, MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER],
+  providers: [MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER],
 })
 export class MatDatepickerModule {}

--- a/src/material/legacy-chips/chips-module.ts
+++ b/src/material/legacy-chips/chips-module.ts
@@ -8,7 +8,7 @@
 
 import {ENTER} from '@angular/cdk/keycodes';
 import {NgModule} from '@angular/core';
-import {ErrorStateMatcher, MatCommonModule} from '@angular/material/core';
+import {MatCommonModule} from '@angular/material/core';
 import {
   MatLegacyChip,
   MatLegacyChipAvatar,
@@ -40,7 +40,6 @@ const CHIP_DECLARATIONS = [
   exports: CHIP_DECLARATIONS,
   declarations: CHIP_DECLARATIONS,
   providers: [
-    ErrorStateMatcher,
     {
       provide: MAT_LEGACY_CHIPS_DEFAULT_OPTIONS,
       useValue: {

--- a/src/material/legacy-input/input-module.ts
+++ b/src/material/legacy-input/input-module.ts
@@ -8,7 +8,7 @@
 
 import {TextFieldModule} from '@angular/cdk/text-field';
 import {NgModule} from '@angular/core';
-import {ErrorStateMatcher, MatCommonModule} from '@angular/material/core';
+import {MatCommonModule} from '@angular/material/core';
 import {MatLegacyFormFieldModule} from '@angular/material/legacy-form-field';
 import {MatLegacyInput} from './input';
 
@@ -26,6 +26,5 @@ import {MatLegacyInput} from './input';
     MatLegacyFormFieldModule,
     MatLegacyInput,
   ],
-  providers: [ErrorStateMatcher],
 })
 export class MatLegacyInputModule {}

--- a/src/material/stepper/stepper-module.ts
+++ b/src/material/stepper/stepper-module.ts
@@ -10,7 +10,7 @@ import {PortalModule} from '@angular/cdk/portal';
 import {CdkStepperModule} from '@angular/cdk/stepper';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {ErrorStateMatcher, MatCommonModule, MatRippleModule} from '@angular/material/core';
+import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatIconModule} from '@angular/material/icon';
 import {MatStepHeader} from './step-header';
 import {MatStepLabel} from './step-label';
@@ -50,6 +50,6 @@ import {MatStepContent} from './step-content';
     MatStepperIcon,
     MatStepContent,
   ],
-  providers: [MAT_STEPPER_INTL_PROVIDER, ErrorStateMatcher],
+  providers: [MAT_STEPPER_INTL_PROVIDER],
 })
 export class MatStepperModule {}


### PR DESCRIPTION
This branch is an attempt to improve tree-shaking of several services.

I started by removing the services that are `providedIn: 'root'` from the `providers` of any module, as that should not be needed and actually prevents them from being removed by tree-shaking.

I am investigating whether the remaining services (such as `MatDialog` and `Overlay`) need to be provided explicitly or if they can also become tree-shakable.

This branch aims at fixing https://github.com/angular/components/issues/11581 and https://github.com/angular/components/issues/18944

