### PR TITLE
fix(google-maps): not rendering until mapTypeId is set

### DIFF
--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -74,7 +74,10 @@ describe('GoogleMap', () => {
     const container = fixture.debugElement.query(By.css('div'))!;
     expect(container.nativeElement.style.height).toBe(DEFAULT_HEIGHT);
     expect(container.nativeElement.style.width).toBe(DEFAULT_WIDTH);
-    expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, DEFAULT_OPTIONS);
+    expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, {
+      ...DEFAULT_OPTIONS,
+      mapTypeId: undefined
+    });
   });
 
   it('sets height and width of the map', () => {
@@ -89,7 +92,10 @@ describe('GoogleMap', () => {
     const container = fixture.debugElement.query(By.css('div'))!;
     expect(container.nativeElement.style.height).toBe('750px');
     expect(container.nativeElement.style.width).toBe('400px');
-    expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, DEFAULT_OPTIONS);
+    expect(mapConstructorSpy).toHaveBeenCalledWith(container.nativeElement, {
+      ...DEFAULT_OPTIONS,
+      mapTypeId: undefined
+    });
 
     fixture.componentInstance.height = '650px';
     fixture.componentInstance.width = '350px';

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -45,8 +45,7 @@ export interface UpdatedGoogleMap extends google.maps.Map {
 /** default options set to the Googleplex */
 export const DEFAULT_OPTIONS: google.maps.MapOptions = {
   center: {lat: 37.421995, lng: -122.084092},
-  zoom: 17,
-  mapTypeId: undefined
+  zoom: 17
 };
 
 /** Arbitrary default height for the map element */


### PR DESCRIPTION
In 2a6aae179a436886395cc8ecc631f7c7be4dff24 I added the ability to set the `mapTypeId` and after I was done with it and ran the unit tests, I added a default of `undefined` to the `DEFAULT_OPTIONS` so the tests didn't have to be updated. It looks like having the `undefined` in the defaults causes Google Maps not to render anything in the map until the map type changes. These changes remove the default value and update the tests instead.

Fixes #18965.