### PR TITLE
fix(material-experimental/mdc-chips): support custom errorStateMatcher

### DIFF
--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -206,6 +206,9 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   }
   protected _value: any;
 
+  /** An object used to control when error messages are shown. */
+  @Input() errorStateMatcher: ErrorStateMatcher;
+
   /** Combined stream of all of the child chips' blur events. */
   get chipBlurChanges(): Observable<MatChipEvent> {
     return merge(...this._chips.map(chip => chip._onBlur));


### PR DESCRIPTION
MatChipGrid should have an errorStateMatcher Input in order to be
backwards compatible with the old non-mdc MatChipList.