### PR TITLE
feat(datepicker): allow for date range selection logic to be customized

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -1,11 +1,27 @@
 [
   [
-    "src/cdk-experimental/dialog/dialog-config.ts",
-    "src/cdk-experimental/dialog/dialog-container.ts"
-  ],
-  [
     "src/cdk-experimental/popover-edit/edit-event-dispatcher.ts",
     "src/cdk-experimental/popover-edit/edit-ref.ts"
+  ],
+  [
+    "src/cdk/scrolling/scroll-dispatcher.ts",
+    "src/cdk/scrolling/scrollable.ts"
+  ],
+  [
+    "src/cdk/scrolling/virtual-scroll-viewport.ts",
+    "src/cdk/scrolling/virtual-for-of.ts"
+  ],
+  [
+    "src/cdk/scrolling/virtual-scroll-strategy.ts",
+    "src/cdk/scrolling/virtual-scroll-viewport.ts"
+  ],
+  [
+    "src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts",
+    "src/cdk/overlay/overlay-ref.ts"
+  ],
+  [
+    "src/cdk-experimental/dialog/dialog-config.ts",
+    "src/cdk-experimental/dialog/dialog-container.ts"
   ],
   [
     "src/cdk/drag-drop/drag-ref.ts",
@@ -25,28 +41,12 @@
     "src/cdk/drag-drop/directives/drag.ts"
   ],
   [
-    "src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts",
-    "src/cdk/overlay/overlay-ref.ts"
+    "src/cdk/testing/private/e2e/actions.ts",
+    "src/cdk/testing/private/e2e/query.ts"
   ],
   [
     "src/cdk/schematics/testing/index.ts",
     "src/cdk/schematics/testing/test-case-setup.ts"
-  ],
-  [
-    "src/cdk/scrolling/scroll-dispatcher.ts",
-    "src/cdk/scrolling/scrollable.ts"
-  ],
-  [
-    "src/cdk/scrolling/virtual-scroll-viewport.ts",
-    "src/cdk/scrolling/virtual-for-of.ts"
-  ],
-  [
-    "src/cdk/scrolling/virtual-scroll-strategy.ts",
-    "src/cdk/scrolling/virtual-scroll-viewport.ts"
-  ],
-  [
-    "src/cdk/testing/private/e2e/actions.ts",
-    "src/cdk/testing/private/e2e/query.ts"
   ],
   [
     "src/material/core/ripple/ripple-ref.ts",
@@ -55,6 +55,10 @@
   [
     "src/material/datepicker/datepicker.ts",
     "src/material/datepicker/datepicker-input.ts"
+  ],
+  [
+    "src/material/datepicker/date-range-input.ts",
+    "src/material/datepicker/date-range-picker.ts"
   ],
   [
     "src/material/grid-list/grid-list.ts",

--- a/src/dev-app/datepicker/datepicker-demo-module.ts
+++ b/src/dev-app/datepicker/datepicker-demo-module.ts
@@ -18,7 +18,12 @@ import {MatIconModule} from '@angular/material/icon';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
-import {CustomHeader, CustomHeaderNgContent, DatepickerDemo} from './datepicker-demo';
+import {
+  CustomHeader,
+  CustomHeaderNgContent,
+  DatepickerDemo,
+  CustomRangeStrategy,
+} from './datepicker-demo';
 
 @NgModule({
   imports: [
@@ -35,7 +40,7 @@ import {CustomHeader, CustomHeaderNgContent, DatepickerDemo} from './datepicker-
     ReactiveFormsModule,
     RouterModule.forChild([{path: '', component: DatepickerDemo}]),
   ],
-  declarations: [CustomHeader, CustomHeaderNgContent, DatepickerDemo],
+  declarations: [CustomHeader, CustomHeaderNgContent, DatepickerDemo, CustomRangeStrategy],
 })
 export class DatepickerDemoModule {
 }

--- a/src/dev-app/datepicker/datepicker-demo.html
+++ b/src/dev-app/datepicker/datepicker-demo.html
@@ -244,3 +244,17 @@
   </mat-form-field>
   <div>{{range3.value | json}}</div>
 </div>
+
+
+<h2>Range picker with custom selection strategy</h2>
+<div class="demo-range-group">
+  <mat-form-field>
+    <mat-label>Enter a date range</mat-label>
+    <mat-date-range-input [rangePicker]="range4Picker">
+      <input matStartDate placeholder="Start date"/>
+      <input matEndDate placeholder="End date"/>
+    </mat-date-range-input>
+    <mat-datepicker-toggle [for]="range4Picker" matSuffix></mat-datepicker-toggle>
+    <mat-date-range-picker customRangeStrategy #range4Picker></mat-date-range-picker>
+  </mat-form-field>
+</div>

--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -14,14 +14,19 @@ import {
   OnDestroy,
   Optional,
   ViewChild,
-  ViewEncapsulation
+  ViewEncapsulation,
+  Directive,
+  Injectable
 } from '@angular/core';
 import {FormControl, FormGroup} from '@angular/forms';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats, ThemePalette} from '@angular/material/core';
 import {
   MatCalendar,
   MatCalendarHeader,
-  MatDatepickerInputEvent
+  MatDatepickerInputEvent,
+  MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+  MatCalendarRangeSelectionStrategy,
+  DateRange
 } from '@angular/material/datepicker';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
@@ -78,6 +83,37 @@ export class DatepickerDemo {
   customHeader = CustomHeader;
   customHeaderNgContent = CustomHeaderNgContent;
 }
+
+/** Range selection strategy that preserves the current range. */
+@Injectable()
+export class PreserveRangeStrategy<D> implements MatCalendarRangeSelectionStrategy<D> {
+  constructor(private _dateAdapter: DateAdapter<D>) {}
+
+  selectionFinished(date: D, currentRange: DateRange<D>) {
+    let {start, end} = currentRange;
+
+    if (start == null) {
+      start = date;
+    } else if (end == null) {
+      end = date;
+    } else if (this._dateAdapter.compareDate(start, date) > 0) {
+      start = date;
+    } else {
+      end = date;
+    }
+
+    return new DateRange<D>(start, end);
+  }
+}
+
+@Directive({
+  selector: '[customRangeStrategy]',
+  providers: [{
+    provide: MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+    useClass: PreserveRangeStrategy
+  }]
+})
+export class CustomRangeStrategy {}
 
 // Custom header component for datepicker
 @Component({

--- a/src/material/datepicker/calendar-body.html
+++ b/src/material/datepicker/calendar-body.html
@@ -50,7 +50,7 @@
       [attr.aria-label]="item.ariaLabel"
       [attr.aria-disabled]="!item.enabled || null"
       [attr.aria-selected]="_isSelected(item)"
-      (click)="_cellClicked(item)"
+      (click)="_cellClicked(item, $event)"
       [style.width]="_cellWidth"
       [style.paddingTop]="_cellPadding"
       role="button"

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -1,6 +1,6 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
-import {MatCalendarBody, MatCalendarCell} from './calendar-body';
+import {MatCalendarBody, MatCalendarCell, MatCalendarUserEvent} from './calendar-body';
 import {By} from '@angular/platform-browser';
 import {dispatchMouseEvent, dispatchFakeEvent} from '@angular/cdk/testing/private';
 
@@ -591,8 +591,8 @@ class StandardCalendarBody {
   labelMinRequiredCells = 3;
   numCols = 7;
 
-  onSelect(value: number) {
-    this.selectedValue = value;
+  onSelect(event: MatCalendarUserEvent<number>) {
+    this.selectedValue = event.value;
   }
 }
 
@@ -614,7 +614,8 @@ class RangeCalendarBody {
   comparisonStart: number | undefined;
   comparisonEnd: number | undefined;
 
-  onSelect(value: number) {
+  onSelect(event: MatCalendarUserEvent<number>) {
+    const value = event.value;
     if (!this.startValue) {
       this.startValue = value;
     } else if (!this.endValue) {

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -40,6 +40,11 @@ export class MatCalendarCell {
               public compareValue = value) {}
 }
 
+/** Event emitted when a date inside the calendar is triggered as a result of a user action. */
+export interface MatCalendarUserEvent<D> {
+  value: D;
+  event: Event;
+}
 
 /**
  * An internal component used to display calendar data in a table.
@@ -96,7 +101,8 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
   @Input() comparisonEnd: number | null;
 
   /** Emits when a new value is selected. */
-  @Output() readonly selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
+  @Output() readonly selectedValueChange: EventEmitter<MatCalendarUserEvent<number>> =
+      new EventEmitter<MatCalendarUserEvent<number>>();
 
   /** The number of blank cells to put at the beginning for the first row. */
   _firstRowOffset: number;
@@ -128,9 +134,9 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
   }
 
   /** Called when a cell is clicked. */
-  _cellClicked(cell: MatCalendarCell): void {
+  _cellClicked(cell: MatCalendarCell, event: MouseEvent): void {
     if (cell.enabled) {
-      this.selectedValueChange.emit(cell.value);
+      this.selectedValueChange.emit({value: cell.value, event});
     }
   }
 

--- a/src/material/datepicker/calendar-range-selection-strategy.ts
+++ b/src/material/datepicker/calendar-range-selection-strategy.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable, InjectionToken} from '@angular/core';
+import {DateAdapter} from '@angular/material/core';
+import {DateRange} from './date-selection-model';
+
+// TODO(crisbeto): this needs to be expanded to allow for the preview range to be customized.
+
+/** Injection token used to customize the date range selection behavior. */
+export const MAT_CALENDAR_RANGE_SELECTION_STRATEGY =
+    new InjectionToken<MatCalendarRangeSelectionStrategy<any>>(
+        'MAT_CALENDAR_RANGE_SELECTION_STRATEGY');
+
+/** Object that can be provided in order to customize the date range selection behavior. */
+export interface MatCalendarRangeSelectionStrategy<D> {
+  /** Called when the user has finished selecting a value. */
+  selectionFinished(date: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
+}
+
+/** Provides the default date range selection behavior. */
+@Injectable()
+export class DefaultMatCalendarRangeStrategy<D> implements MatCalendarRangeSelectionStrategy<D> {
+  constructor(private _dateAdapter: DateAdapter<D>) {}
+
+  selectionFinished(date: D, currentRange: DateRange<D>) {
+    let {start, end} = currentRange;
+
+    if (start == null) {
+      start = date;
+    } else if (end == null && date && this._dateAdapter.compareDate(date, start) > 0) {
+      end = date;
+    } else {
+      start = date;
+      end = null;
+    }
+
+    return new DateRange<D>(start, end);
+  }
+}

--- a/src/material/datepicker/calendar.html
+++ b/src/material/datepicker/calendar.html
@@ -11,8 +11,7 @@
       [dateClass]="dateClass"
       [comparisonStart]="comparisonStart"
       [comparisonEnd]="comparisonEnd"
-      (selectedChange)="_dateSelected($event)"
-      (_userSelection)="_userSelected()">
+      (_userSelection)="_dateSelected($event)">
   </mat-month-view>
 
   <mat-year-view

--- a/src/material/datepicker/date-selection-model.ts
+++ b/src/material/datepicker/date-selection-model.ts
@@ -7,7 +7,6 @@
  */
 
 import {FactoryProvider, Injectable, Optional, SkipSelf, OnDestroy} from '@angular/core';
-import {DateAdapter} from '@angular/material/core';
 import {Observable, Subject} from 'rxjs';
 
 /** A class representing a range of dates. */
@@ -50,8 +49,6 @@ export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<
   selectionChanged: Observable<DateSelectionModelChange<S>> = this._selectionChanged.asObservable();
 
   protected constructor(
-    /** Date adapter used when interacting with dates in the model. */
-    protected readonly adapter: DateAdapter<D>,
     /** The current selection. */
     readonly selection: S) {
     this.selection = selection;
@@ -81,8 +78,8 @@ export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<
 /**  A selection model that contains a single date. */
 @Injectable()
 export class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
-  constructor(adapter: DateAdapter<D>) {
-    super(adapter, null);
+  constructor() {
+    super(null);
   }
 
   /**
@@ -105,8 +102,8 @@ export class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | nu
 /**  A selection model that contains a date range. */
 @Injectable()
 export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
-  constructor(adapter: DateAdapter<D>) {
-    super(adapter, new DateRange<D>(null, null));
+  constructor() {
+    super(new DateRange<D>(null, null));
   }
 
   /**
@@ -119,7 +116,7 @@ export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRan
 
     if (start == null) {
       start = date;
-    } else if (end == null && date && this.adapter.compareDate(date, start) > 0) {
+    } else if (end == null) {
       end = date;
     } else {
       start = date;
@@ -140,27 +137,27 @@ export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRan
 
 /** @docs-private */
 export function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(
-    parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>) {
-  return parent || new MatSingleDateSelectionModel(adapter);
+    parent: MatSingleDateSelectionModel<unknown>) {
+  return parent || new MatSingleDateSelectionModel();
 }
 
 /** Used to provide a single selection model to a component. */
 export const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider = {
   provide: MatDateSelectionModel,
-  deps: [[new Optional(), new SkipSelf(), MatDateSelectionModel], DateAdapter],
+  deps: [[new Optional(), new SkipSelf(), MatDateSelectionModel]],
   useFactory: MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY,
 };
 
 
 /** @docs-private */
 export function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(
-    parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>) {
-  return parent || new MatRangeDateSelectionModel(adapter);
+    parent: MatSingleDateSelectionModel<unknown>) {
+  return parent || new MatRangeDateSelectionModel();
 }
 
 /** Used to provide a range selection model to a component. */
 export const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider = {
   provide: MatDateSelectionModel,
-  deps: [[new Optional(), new SkipSelf(), MatDateSelectionModel], DateAdapter],
+  deps: [[new Optional(), new SkipSelf(), MatDateSelectionModel]],
   useFactory: MAT_RANGE_DATE_SELECTION_MODEL_FACTORY,
 };

--- a/src/material/datepicker/datepicker-module.ts
+++ b/src/material/datepicker/datepicker-module.ts
@@ -29,6 +29,10 @@ import {MatYearView} from './year-view';
 import {MatDateRangeInput} from './date-range-input';
 import {MatStartDate, MatEndDate} from './date-range-input-parts';
 import {MatDateRangePicker} from './date-range-picker';
+import {
+  MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+  DefaultMatCalendarRangeStrategy
+} from './calendar-range-selection-strategy';
 
 
 @NgModule({
@@ -77,6 +81,10 @@ import {MatDateRangePicker} from './date-range-picker';
   providers: [
     MatDatepickerIntl,
     MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
+    {
+      provide: MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+      useClass: DefaultMatCalendarRangeStrategy
+    }
   ],
   entryComponents: [
     MatDatepickerContent,

--- a/src/material/datepicker/multi-year-view.ts
+++ b/src/material/datepicker/multi-year-view.ts
@@ -33,7 +33,7 @@ import {
 } from '@angular/core';
 import {DateAdapter} from '@angular/material/core';
 import {Directionality} from '@angular/cdk/bidi';
-import {MatCalendarBody, MatCalendarCell} from './calendar-body';
+import {MatCalendarBody, MatCalendarCell, MatCalendarUserEvent} from './calendar-body';
 import {createMissingDateImplError} from './datepicker-errors';
 import {Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
@@ -174,7 +174,8 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
   }
 
   /** Handles when a new year is selected. */
-  _yearSelected(year: number) {
+  _yearSelected(event: MatCalendarUserEvent<number>) {
+    const year = event.value;
     this.yearSelected.emit(this._dateAdapter.createDate(year, 0, 1));
     let month = this._dateAdapter.getMonth(this.activeDate);
     let daysInMonth =
@@ -222,7 +223,7 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
         break;
       case ENTER:
       case SPACE:
-        this._yearSelected(this._dateAdapter.getYear(this._activeDate));
+        this._yearSelected({value: this._dateAdapter.getYear(this._activeDate), event});
         break;
       default:
         // Don't prevent default or focus active cell on keys that we don't explicitly handle.

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -10,6 +10,7 @@ export * from './datepicker-module';
 export * from './calendar';
 export * from './calendar-body';
 export * from './datepicker';
+export * from './calendar-range-selection-strategy';
 export * from './datepicker-animations';
 export {
   MAT_DATEPICKER_SCROLL_STRATEGY,

--- a/src/material/datepicker/year-view.spec.ts
+++ b/src/material/datepicker/year-view.spec.ts
@@ -108,7 +108,7 @@ describe('MatYearView', () => {
       testComponent.date = new Date(2017, JUL, 31);
       fixture.detectChanges();
 
-      testComponent.yearView._monthSelected(JUN);
+      testComponent.yearView._monthSelected({value: JUN, event: null!});
       fixture.detectChanges();
 
       expect(testComponent.selected).toEqual(new Date(2017, JUN, 30));

--- a/src/material/datepicker/year-view.ts
+++ b/src/material/datepicker/year-view.ts
@@ -34,7 +34,7 @@ import {
 } from '@angular/core';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
 import {Directionality} from '@angular/cdk/bidi';
-import {MatCalendarBody, MatCalendarCell} from './calendar-body';
+import {MatCalendarBody, MatCalendarCell, MatCalendarUserEvent} from './calendar-body';
 import {createMissingDateImplError} from './datepicker-errors';
 import {Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
@@ -153,7 +153,8 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
   }
 
   /** Handles when a new month is selected. */
-  _monthSelected(month: number) {
+  _monthSelected(event: MatCalendarUserEvent<number>) {
+    const month = event.value;
     const normalizedDate =
           this._dateAdapter.createDate(this._dateAdapter.getYear(this.activeDate), month, 1);
 
@@ -206,7 +207,7 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
         break;
       case ENTER:
       case SPACE:
-        this._monthSelected(this._dateAdapter.getMonth(this._activeDate));
+        this._monthSelected({value: this._dateAdapter.getMonth(this._activeDate), event});
         break;
       default:
         // Don't prevent default or focus active cell on keys that we don't explicitly handle.

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -13,7 +13,16 @@ export interface DateSelectionModelChange<S> {
     source: unknown;
 }
 
+export declare class DefaultMatCalendarRangeStrategy<D> implements MatCalendarRangeSelectionStrategy<D> {
+    constructor(_dateAdapter: DateAdapter<D>);
+    selectionFinished(date: D, currentRange: DateRange<D>): DateRange<D>;
+    static ɵfac: i0.ɵɵFactoryDef<DefaultMatCalendarRangeStrategy<any>, never>;
+    static ɵprov: i0.ɵɵInjectableDef<DefaultMatCalendarRangeStrategy<any>>;
+}
+
 export declare type ExtractDateTypeFromSelection<T> = T extends DateRange<infer D> ? D : NonNullable<T>;
+
+export declare const MAT_CALENDAR_RANGE_SELECTION_STRATEGY: InjectionToken<MatCalendarRangeSelectionStrategy<any>>;
 
 export declare const MAT_DATEPICKER_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
@@ -29,11 +38,11 @@ export declare const MAT_DATEPICKER_VALIDATORS: any;
 
 export declare const MAT_DATEPICKER_VALUE_ACCESSOR: any;
 
-export declare function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
+export declare function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>): MatSingleDateSelectionModel<unknown>;
 
 export declare const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
-export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
+export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>): MatSingleDateSelectionModel<unknown>;
 
 export declare const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
@@ -65,11 +74,10 @@ export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecke
     stateChanges: Subject<void>;
     readonly yearSelected: EventEmitter<D>;
     yearView: MatYearView<D>;
-    constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef, _model: MatDateSelectionModel<DateRange<D> | D | null>);
-    _dateSelected(date: D | null): void;
+    constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef, _model: MatDateSelectionModel<DateRange<D> | D | null>, _rangeSelectionStrategy?: MatCalendarRangeSelectionStrategy<D> | undefined);
+    _dateSelected(event: MatCalendarUserEvent<D | null>): void;
     _goToDateInView(date: D, view: 'month' | 'year' | 'multi-year'): void;
     _monthSelectedInYearView(normalizedMonth: D): void;
-    _userSelected(): void;
     _yearSelectedInMultiYearView(normalizedYear: D): void;
     focusActiveCell(): void;
     ngAfterContentInit(): void;
@@ -78,7 +86,7 @@ export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecke
     ngOnDestroy(): void;
     updateTodaysDate(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatCalendar<any>, "mat-calendar", ["matCalendar"], { "headerComponent": "headerComponent"; "startAt": "startAt"; "startView": "startView"; "selected": "selected"; "minDate": "minDate"; "maxDate": "maxDate"; "dateFilter": "dateFilter"; "dateClass": "dateClass"; "comparisonStart": "comparisonStart"; "comparisonEnd": "comparisonEnd"; }, { "selectedChange": "selectedChange"; "yearSelected": "yearSelected"; "monthSelected": "monthSelected"; "_userSelection": "_userSelection"; }, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatCalendar<any>, [null, { optional: true; }, { optional: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatCalendar<any>, [null, { optional: true; }, { optional: true; }, null, null, { optional: true; }]>;
 }
 
 export declare class MatCalendarBody implements OnChanges, OnDestroy {
@@ -95,11 +103,11 @@ export declare class MatCalendarBody implements OnChanges, OnDestroy {
     labelMinRequiredCells: number;
     numCols: number;
     rows: MatCalendarCell[][];
-    readonly selectedValueChange: EventEmitter<number>;
+    readonly selectedValueChange: EventEmitter<MatCalendarUserEvent<number>>;
     startValue: number;
     todayValue: number;
     constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone);
-    _cellClicked(cell: MatCalendarCell): void;
+    _cellClicked(cell: MatCalendarCell, event: MouseEvent): void;
     _focusActiveCell(): void;
     _isActiveCell(rowIndex: number, colIndex: number): boolean;
     _isComparisonBridgeEnd(value: number, rowIndex: number, colIndex: number): boolean;
@@ -149,6 +157,15 @@ export declare class MatCalendarHeader<D> {
     previousEnabled(): boolean;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatCalendarHeader<any>, "mat-calendar-header", ["matCalendarHeader"], {}, {}, never, ["*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatCalendarHeader<any>, [null, null, { optional: true; }, { optional: true; }, null]>;
+}
+
+export interface MatCalendarRangeSelectionStrategy<D> {
+    selectionFinished(date: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
+}
+
+export interface MatCalendarUserEvent<D> {
+    event: Event;
+    value: D;
 }
 
 export declare type MatCalendarView = 'month' | 'year' | 'multi-year';
@@ -320,18 +337,16 @@ export declare class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRang
 }
 
 export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>> implements OnDestroy {
-    protected readonly adapter: DateAdapter<D>;
     readonly selection: S;
     selectionChanged: Observable<DateSelectionModelChange<S>>;
     protected constructor(
-    adapter: DateAdapter<D>,
     selection: S);
     abstract add(date: D | null): void;
     abstract isComplete(): boolean;
     ngOnDestroy(): void;
     updateSelection(value: S, source: unknown): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDateSelectionModel<any, any>, never, never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatDateSelectionModel<any, any>>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDateSelectionModel<any, any>, never>;
 }
 
 export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
@@ -341,7 +356,7 @@ export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements 
     protected _getValueFromModel(modelValue: DateRange<D>): D | null;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
 
 export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
@@ -354,7 +369,7 @@ export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
     _rangeEnd: number | null;
     _rangeStart: number | null;
     _todayDate: number | null;
-    readonly _userSelection: EventEmitter<void>;
+    readonly _userSelection: EventEmitter<MatCalendarUserEvent<D | null>>;
     _weekdays: {
         long: string;
         narrow: string;
@@ -375,7 +390,7 @@ export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
     set selected(value: DateRange<D> | D | null);
     readonly selectedChange: EventEmitter<D | null>;
     constructor(_changeDetectorRef: ChangeDetectorRef, _dateFormats: MatDateFormats, _dateAdapter: DateAdapter<D>, _dir?: Directionality | undefined);
-    _dateSelected(date: number): void;
+    _dateSelected(event: MatCalendarUserEvent<number>): void;
     _focusActiveCell(): void;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
     _init(): void;
@@ -408,7 +423,7 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
     _getActiveCell(): number;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
     _init(): void;
-    _yearSelected(year: number): void;
+    _yearSelected(event: MatCalendarUserEvent<number>): void;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatMultiYearView<any>, "mat-multi-year-view", ["matMultiYearView"], { "activeDate": "activeDate"; "selected": "selected"; "minDate": "minDate"; "maxDate": "maxDate"; "dateFilter": "dateFilter"; }, { "selectedChange": "selectedChange"; "yearSelected": "yearSelected"; "activeDateChange": "activeDateChange"; }, never, never>;
@@ -416,18 +431,18 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
 }
 
 export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
-    constructor(adapter: DateAdapter<D>);
+    constructor();
     add(date: D | null): void;
     isComplete(): boolean;
-    static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>>;
+    static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>, never>;
     static ɵprov: i0.ɵɵInjectableDef<MatRangeDateSelectionModel<any>>;
 }
 
 export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
-    constructor(adapter: DateAdapter<D>);
+    constructor();
     add(date: D | null): void;
     isComplete(): boolean;
-    static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>>;
+    static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>, never>;
     static ɵprov: i0.ɵɵInjectableDef<MatSingleDateSelectionModel<any>>;
 }
 
@@ -440,7 +455,7 @@ export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implement
     getMirrorValue(): string;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, {}, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatStartDate<any>, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatStartDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
 
 export declare class MatYearView<D> implements AfterContentInit, OnDestroy {
@@ -466,7 +481,7 @@ export declare class MatYearView<D> implements AfterContentInit, OnDestroy {
     _focusActiveCell(): void;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
     _init(): void;
-    _monthSelected(month: number): void;
+    _monthSelected(event: MatCalendarUserEvent<number>): void;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatYearView<any>, "mat-year-view", ["matYearView"], { "activeDate": "activeDate"; "selected": "selected"; "minDate": "minDate"; "maxDate": "maxDate"; "dateFilter": "dateFilter"; }, { "selectedChange": "selectedChange"; "monthSelected": "monthSelected"; "activeDateChange": "activeDateChange"; }, never, never>;


### PR DESCRIPTION
As discussed, adds a provider that allows the consumer to customize how the range is changed after the user has selected a value. For now it only has one method (`selectionFinished`), but the interface should allow us to add more later on.