### PR TITLE
build: add lint rule to disallow invocation of lifecycle hooks

### DIFF
--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -364,7 +364,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
       view = this.multiYearView;
     }
 
-    view.ngAfterContentInit();
+    view._init();
   }
 
   /** Handles date selection in the month view. */

--- a/tools/tslint-rules/noLifecycleInvocationRule.ts
+++ b/tools/tslint-rules/noLifecycleInvocationRule.ts
@@ -1,0 +1,69 @@
+import * as path from 'path';
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+import * as minimatch from 'minimatch';
+
+const hooks = new Set([
+  'ngOnChanges',
+  'ngOnInit',
+  'ngDoCheck',
+  'ngAfterContentInit',
+  'ngAfterContentChecked',
+  'ngAfterViewInit',
+  'ngAfterViewChecked',
+  'ngOnDestroy',
+  'ngDoBootstrap'
+]);
+
+/** Rule that prevents direct calls of the Angular lifecycle hooks */
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+  }
+}
+
+class Walker extends Lint.RuleWalker {
+  /** Whether the walker should check the current source file. */
+  private _enabled: boolean;
+
+  constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+    super(sourceFile, options);
+    const fileGlobs = options.ruleArguments;
+    const relativeFilePath = path.relative(process.cwd(), sourceFile.fileName);
+    this._enabled = fileGlobs.some(p => minimatch(relativeFilePath, p));
+  }
+
+  visitPropertyAccessExpression(node: ts.PropertyAccessExpression) {
+    // Flag any accesses of the lifecycle hooks that are
+    // inside function call and don't match the allowed criteria.
+    if (this._enabled && ts.isCallExpression(node.parent) && hooks.has(node.name.text) &&
+        !this._isAllowedAccessor(node)) {
+      this.addFailureAtNode(node, 'Manually invoking Angular lifecycle hooks is not allowed.');
+    }
+
+    return super.visitPropertyAccessExpression(node);
+  }
+
+  /** Checks whether the accessor of an Angular lifecycle hook expression is allowed. */
+  private _isAllowedAccessor(node: ts.PropertyAccessExpression): boolean {
+    // We only allow accessing the lifecycle hooks via super.
+    if (node.expression.kind !== ts.SyntaxKind.SuperKeyword) {
+      return false;
+    }
+
+    let parent = node.parent;
+
+    // Even if the access is on a `super` expression, verify that the hook is being called
+    // from inside a method with the same name (e.g. to avoid calling `ngAfterViewInit` from
+    // inside `ngOnInit`).
+    while (parent && !ts.isSourceFile(parent)) {
+      if (ts.isMethodDeclaration(parent)) {
+        return (parent.name as ts.Identifier).text === node.name.text;
+      } else {
+        parent = parent.parent;
+      }
+    }
+
+    return false;
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -119,6 +119,7 @@
     "class-list-signatures": true,
     "no-nested-ternary": true,
     "prefer-const-enum": true,
+    "no-lifecycle-invocation": [true, "**/!(*.spec).ts"],
     "coercion-types": [true,
       ["coerceBooleanProperty", "coerceCssPixelValue", "coerceNumberProperty"],
       {


### PR DESCRIPTION
Adds a lint rule that will flag any cases where a lifecycle hook is invoked directly. There's an exception for test files where we need to call `ngOnDestroy` manually on providers, as well as on `super`.

Also fixes a memory leak in the calendar that prompted the rule to be written.

**Note:** not merge safe, because I had to make a change in the calendar to get everything to pass.