### PR TITLE
build: add try/catch to @angular/bazel ng_module patch

### DIFF
--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -98,9 +98,12 @@ searchAndReplace(
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1208.
 applyPatch(path.join(__dirname, './manifest_externs_hermeticity.patch'));
 
-// Pre-req for https://github.com/angular/angular/pull/36333. Can be removed
-// once @angular/bazel is updated here to include this patch.
-applyPatch(path.join(__dirname, './@angular_bazel_ng_module.patch'));
+try {
+  // Temporary patch pre-req for https://github.com/angular/angular/pull/36333.
+  // Can be removed once @angular/bazel is updated here to include this patch.
+  // try/catch needed for this the material CI tests to work in angular/repo
+  applyPatch(path.join(__dirname, './@angular_bazel_ng_module.patch'));
+} catch (_) {}
 
 // Workaround for https://github.com/angular/angular/issues/33452:
 searchAndReplace(/angular_compiler_options = {/, `$&


### PR DESCRIPTION
Navigating the angular/angular & angular/components dependency sandwich.