### PR TITLE
fix(google-maps): update to latest typings and remove manual override

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@angular/elements": "^9.1.0",
     "@angular/forms": "^9.1.0",
     "@angular/platform-browser": "^9.1.0",
-    "@types/googlemaps": "^3.37.0",
+    "@types/googlemaps": "^3.39.3",
     "@types/youtube": "^0.0.38",
     "@webcomponents/custom-elements": "^1.1.0",
     "core-js": "^2.6.9",

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -12,8 +12,7 @@ import {
   DEFAULT_HEIGHT,
   DEFAULT_OPTIONS,
   DEFAULT_WIDTH,
-  GoogleMap,
-  UpdatedGoogleMap
+  GoogleMap
 } from './google-map';
 
 /** Represents boundaries of a map to be used in tests. */
@@ -32,7 +31,7 @@ const testPosition: google.maps.LatLngLiteral = {
 
 describe('GoogleMap', () => {
   let mapConstructorSpy: jasmine.Spy;
-  let mapSpy: jasmine.SpyObj<UpdatedGoogleMap>;
+  let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -33,15 +33,6 @@ interface GoogleMapsWindow extends Window {
   google?: typeof google;
 }
 
-// TODO(mbehrlich): Update this to use original map after updating DefinitelyTyped
-/**
- * Extends the Google Map interface due to the Definitely Typed implementation
- * missing "getClickableIcons".
- */
-export interface UpdatedGoogleMap extends google.maps.Map {
-  getClickableIcons: () => boolean;
-}
-
 /** default options set to the Googleplex */
 export const DEFAULT_OPTIONS: google.maps.MapOptions = {
   center: {lat: 37.421995, lng: -122.084092},
@@ -75,7 +66,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
   private readonly _zoom = new BehaviorSubject<number|undefined>(undefined);
   private readonly _destroy = new Subject<void>();
   private _mapEl: HTMLElement;
-  _googleMap: UpdatedGoogleMap;
+  _googleMap: google.maps.Map;
 
   /** Whether we're currently rendering inside a browser. */
   _isBrowser: boolean;
@@ -270,7 +261,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
       this._setSize();
       this._googleMapChanges = this._initializeMap(this._combineOptions());
       this._googleMapChanges.subscribe((googleMap: google.maps.Map) => {
-        this._googleMap = googleMap as UpdatedGoogleMap;
+        this._googleMap = googleMap;
         this._eventManager.setTarget(this._googleMap);
       });
 

--- a/src/google-maps/map-circle/map-circle.spec.ts
+++ b/src/google-maps/map-circle/map-circle.spec.ts
@@ -2,7 +2,7 @@ import {Component, ViewChild} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
-import {DEFAULT_OPTIONS, UpdatedGoogleMap} from '../google-map/google-map';
+import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {GoogleMapsModule} from '../google-maps-module';
 import {
   createCircleConstructorSpy,
@@ -15,7 +15,7 @@ import {
 import {MapCircle} from './map-circle';
 
 describe('MapCircle', () => {
-  let mapSpy: jasmine.SpyObj<UpdatedGoogleMap>;
+  let mapSpy: jasmine.SpyObj<google.maps.Map>;
   let circleCenter: google.maps.LatLngLiteral;
   let circleRadius: number;
   let circleOptions: google.maps.CircleOptions;

--- a/src/google-maps/map-info-window/map-info-window.spec.ts
+++ b/src/google-maps/map-info-window/map-info-window.spec.ts
@@ -2,7 +2,7 @@ import {Component, ViewChild} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
-import {DEFAULT_OPTIONS, UpdatedGoogleMap} from '../google-map/google-map';
+import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {MapMarker} from '../map-marker/map-marker';
 import {
   createInfoWindowConstructorSpy,
@@ -16,7 +16,7 @@ import {GoogleMapsModule} from '../google-maps-module';
 import {MapInfoWindow} from './map-info-window';
 
 describe('MapInfoWindow', () => {
-  let mapSpy: jasmine.SpyObj<UpdatedGoogleMap>;
+  let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({

--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -2,7 +2,7 @@ import {Component, ViewChild} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
-import {DEFAULT_OPTIONS, UpdatedGoogleMap} from '../google-map/google-map';
+import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {
   createMapConstructorSpy,
   createMapSpy,
@@ -15,7 +15,7 @@ import {GoogleMapsModule} from '../google-maps-module';
 import {DEFAULT_MARKER_OPTIONS, MapMarker} from './map-marker';
 
 describe('MapMarker', () => {
-  let mapSpy: jasmine.SpyObj<UpdatedGoogleMap>;
+  let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({

--- a/src/google-maps/map-polygon/map-polygon.spec.ts
+++ b/src/google-maps/map-polygon/map-polygon.spec.ts
@@ -2,7 +2,7 @@ import {Component, ViewChild} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
-import {DEFAULT_OPTIONS, UpdatedGoogleMap} from '../google-map/google-map';
+import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {GoogleMapsModule} from '../google-maps-module';
 import {
   createMapConstructorSpy,
@@ -15,7 +15,7 @@ import {
 import {MapPolygon} from './map-polygon';
 
 describe('MapPolygon', () => {
-  let mapSpy: jasmine.SpyObj<UpdatedGoogleMap>;
+  let mapSpy: jasmine.SpyObj<google.maps.Map>;
   let polygonPath: google.maps.LatLngLiteral[];
   let polygonOptions: google.maps.PolygonOptions;
 

--- a/src/google-maps/map-polyline/map-polyline.spec.ts
+++ b/src/google-maps/map-polyline/map-polyline.spec.ts
@@ -2,7 +2,7 @@ import {Component, ViewChild} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
-import {DEFAULT_OPTIONS, UpdatedGoogleMap} from '../google-map/google-map';
+import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {GoogleMapsModule} from '../google-maps-module';
 import {
   createMapConstructorSpy,
@@ -15,7 +15,7 @@ import {
 import {MapPolyline} from './map-polyline';
 
 describe('MapPolyline', () => {
-  let mapSpy: jasmine.SpyObj<UpdatedGoogleMap>;
+  let mapSpy: jasmine.SpyObj<google.maps.Map>;
   let polylinePath: google.maps.LatLngLiteral[];
   let polylineOptions: google.maps.PolylineOptions;
 

--- a/src/google-maps/map-rectangle/map-rectangle.spec.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.spec.ts
@@ -2,7 +2,7 @@ import {Component, ViewChild} from '@angular/core';
 import {async, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
-import {DEFAULT_OPTIONS, UpdatedGoogleMap} from '../google-map/google-map';
+import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {GoogleMapsModule} from '../google-maps-module';
 import {
   createMapConstructorSpy,
@@ -15,7 +15,7 @@ import {
 import {MapRectangle} from './map-rectangle';
 
 describe('MapRectangle', () => {
-  let mapSpy: jasmine.SpyObj<UpdatedGoogleMap>;
+  let mapSpy: jasmine.SpyObj<google.maps.Map>;
   let rectangleBounds: google.maps.LatLngBoundsLiteral;
   let rectangleOptions: google.maps.RectangleOptions;
 

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {UpdatedGoogleMap} from '../google-map/google-map';
 
 /** Window interface for testing */
 export interface TestingWindow extends Window {
@@ -24,7 +23,7 @@ export interface TestingWindow extends Window {
 }
 
 /** Creates a jasmine.SpyObj for a google.maps.Map. */
-export function createMapSpy(options: google.maps.MapOptions): jasmine.SpyObj<UpdatedGoogleMap> {
+export function createMapSpy(options: google.maps.MapOptions): jasmine.SpyObj<google.maps.Map> {
   const mapSpy = jasmine.createSpyObj('google.maps.Map', [
     'setOptions', 'setCenter', 'setZoom', 'setMap', 'addListener', 'fitBounds', 'panBy', 'panTo',
     'panToBounds', 'getBounds', 'getCenter', 'getClickableIcons', 'getHeading', 'getMapTypeId',
@@ -36,7 +35,7 @@ export function createMapSpy(options: google.maps.MapOptions): jasmine.SpyObj<Up
 
 /** Creates a jasmine.Spy to watch for the constructor of a google.maps.Map. */
 export function createMapConstructorSpy(
-    mapSpy: jasmine.SpyObj<UpdatedGoogleMap>, apiLoaded = true): jasmine.Spy {
+    mapSpy: jasmine.SpyObj<google.maps.Map>, apiLoaded = true): jasmine.Spy {
   const mapConstructorSpy =
       jasmine.createSpy('Map constructor', (_el: Element, _options: google.maps.MapOptions) => {
         return mapSpy;

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -1,5 +1,5 @@
 export declare class GoogleMap implements OnChanges, OnInit, OnDestroy {
-    _googleMap: UpdatedGoogleMap;
+    _googleMap: google.maps.Map;
     _isBrowser: boolean;
     boundsChanged: Observable<void>;
     set center(center: google.maps.LatLngLiteral | google.maps.LatLng);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/googlemaps@^3.37.0":
-  version "3.37.0"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.37.0.tgz#85596a2b93ded3850ac83ff575b66c34053c0ac8"
-  integrity sha512-kUF1DCVJISf6HZQdgROIs98C0MS40AK5KXxyOju5L1aifNXqMkN5siSGErHYxpEMkDcTA/hu6Dr22fZBTt2qRA==
+"@types/googlemaps@^3.39.3":
+  version "3.39.3"
+  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.39.3.tgz#8664e424f335802c8aa46a94676666b0a0f31d97"
+  integrity sha512-L8O9HAVFZj0TuiS8h5ORthiMsrrhjxTC8XUusp5k47oXCst4VTm+qWKvrAvmYMybZVokbp4Udco1mNwJrTNZPQ==
 
 "@types/gulp@*":
   version "4.0.5"


### PR DESCRIPTION
Bumps us to the latest version of the Google Maps typings and removes a workaround that was in place due to the old ones being incomplete.