### PR TITLE
fix(tree): complete viewChange stream on destroy

### DIFF
--- a/src/cdk/tree/tree.spec.ts
+++ b/src/cdk/tree/tree.spec.ts
@@ -71,6 +71,18 @@ describe('CdkTree', () => {
     expect(!!CdkTreeNode.mostRecentTreeNode).toBe(false);
   });
 
+  it('should complete the viewChange stream on destroy', () => {
+    configureCdkTreeTestingModule([SimpleCdkTreeApp]);
+    const fixture = TestBed.createComponent(SimpleCdkTreeApp);
+    fixture.detectChanges();
+    const spy = jasmine.createSpy('completeSpy');
+    const subscription = fixture.componentInstance.tree.viewChange.subscribe({complete: spy});
+
+    fixture.destroy();
+    expect(spy).toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
+
   describe('flat tree', () => {
     describe('should initialize', () => {
       let fixture: ComponentFixture<SimpleCdkTreeApp>;

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -140,6 +140,7 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
   ngOnDestroy() {
     this._nodeOutlet.viewContainer.clear();
 
+    this.viewChange.complete();
     this._onDestroy.next();
     this._onDestroy.complete();
 


### PR DESCRIPTION
Fixes the tree not completing its `viewChange` stream.