### PR TITLE
fix(datepicker): add hover indication to navigation buttons

### DIFF
--- a/src/material/datepicker/calendar.scss
+++ b/src/material/datepicker/calendar.scss
@@ -35,6 +35,10 @@ $mat-calendar-next-icon-transform: translateX(-2px) rotate(45deg);
 .mat-calendar-controls {
   display: flex;
   margin: $mat-calendar-controls-vertical-padding $mat-calendar-controls-side-margin;
+
+  .mat-icon-button:hover .mat-button-focus-overlay {
+    opacity: 0.04;
+  }
 }
 
 .mat-calendar-spacer {


### PR DESCRIPTION
The calendar navigation buttons use `mat-icon-button` which explicitly doesn't have hover indication for some reason (see https://github.com/angular/components/blob/master/src/material/button/button.scss#L13). I'm not exactly sure about the reasoning in `mat-button`, so I decided to scope these changes only to the calendar so we don't cause unexpected behavior.

Fixes #18958.