### PR TITLE
fix(youtube-player): unable to bind to events after initialization

### DIFF
--- a/src/youtube-player/BUILD.bazel
+++ b/src/youtube-player/BUILD.bazel
@@ -44,6 +44,7 @@ ng_test_library(
     deps = [
         ":youtube-player",
         "@npm//@angular/platform-browser",
+        "@npm//rxjs",
     ],
 )
 

--- a/src/youtube-player/fake-youtube-player.ts
+++ b/src/youtube-player/fake-youtube-player.ts
@@ -35,29 +35,38 @@ export function createFakeYtNamespace(): FakeYtNamespace {
   ]);
 
   let playerConfig: YT.PlayerOptions | undefined;
+  const boundListeners = new Map<keyof YT.Events, Set<(event: any) => void>>();
   const playerCtorSpy = jasmine.createSpy('Player Constructor');
+
   playerCtorSpy.and.callFake((_el: Element, config: YT.PlayerOptions) => {
     playerConfig = config;
     return playerSpy;
   });
 
-  const eventHandlerFactory = (name: keyof YT.Events) => {
+  playerSpy.addEventListener.and.callFake((name: keyof YT.Events, listener: (e: any) => any) => {
+    if (!boundListeners.has(name)) {
+      boundListeners.set(name, new Set());
+    }
+    boundListeners.get(name)!.add(listener);
+  });
+
+  playerSpy.removeEventListener.and.callFake((name: keyof YT.Events, listener: (e: any) => any) => {
+    if (boundListeners.has(name)) {
+      boundListeners.get(name)!.delete(listener);
+    }
+  });
+
+  function eventHandlerFactory(name: keyof YT.Events) {
     return (arg: Object = {}) => {
       if (!playerConfig) {
         throw new Error(`Player not initialized before ${name} called`);
       }
 
-      if (playerConfig && playerConfig.events && playerConfig.events[name]) {
-        playerConfig.events[name]!(arg as any);
-      }
-
-      for (const [event, callback] of playerSpy.addEventListener.calls.allArgs()) {
-        if (event === name) {
-          callback(arg as YT.PlayerEvent);
-        }
+      if (boundListeners.has(name)) {
+        boundListeners.get(name)!.forEach(callback => callback(arg));
       }
     };
-  };
+  }
 
   const events: Required<YT.Events> = {
     onReady: eventHandlerFactory('onReady'),

--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -3,6 +3,7 @@ import {Component, ViewChild} from '@angular/core';
 import {YouTubePlayerModule} from './youtube-module';
 import {YouTubePlayer, DEFAULT_PLAYER_WIDTH, DEFAULT_PLAYER_HEIGHT} from './youtube-player';
 import {createFakeYtNamespace} from './fake-youtube-player';
+import {Subscription} from 'rxjs';
 
 const VIDEO_ID = 'a12345';
 
@@ -22,7 +23,7 @@ describe('YoutubePlayer', () => {
 
     TestBed.configureTestingModule({
       imports: [YouTubePlayerModule],
-      declarations: [TestApp, StaticStartEndSecondsApp],
+      declarations: [TestApp, StaticStartEndSecondsApp, NoEventsApp],
     });
 
     TestBed.compileComponents();
@@ -411,6 +412,48 @@ describe('YoutubePlayer', () => {
       jasmine.objectContaining({startSeconds: 42, endSeconds: 1337}));
   });
 
+  it('should be able to subscribe to events after initialization', () => {
+    const noEventsApp = TestBed.createComponent(NoEventsApp);
+    noEventsApp.detectChanges();
+    events.onReady({target: playerSpy});
+    noEventsApp.detectChanges();
+
+    const player = noEventsApp.componentInstance.player;
+    const subscriptions: Subscription[] = [];
+    const readySpy = jasmine.createSpy('ready spy');
+    const stateChangeSpy = jasmine.createSpy('stateChange spy');
+    const playbackQualityChangeSpy = jasmine.createSpy('playbackQualityChange spy');
+    const playbackRateChangeSpy = jasmine.createSpy('playbackRateChange spy');
+    const errorSpy = jasmine.createSpy('error spy');
+    const apiChangeSpy = jasmine.createSpy('apiChange spy');
+
+    subscriptions.push(player.ready.subscribe(readySpy));
+    events.onReady({target: playerSpy});
+    expect(readySpy).toHaveBeenCalledWith({target: playerSpy});
+
+    subscriptions.push(player.stateChange.subscribe(stateChangeSpy));
+    events.onStateChange({target: playerSpy, data: 5});
+    expect(stateChangeSpy).toHaveBeenCalledWith({target: playerSpy, data: 5});
+
+    subscriptions.push(player.playbackQualityChange.subscribe(playbackQualityChangeSpy));
+    events.onPlaybackQualityChange({target: playerSpy, data: 'large'});
+    expect(playbackQualityChangeSpy).toHaveBeenCalledWith({target: playerSpy, data: 'large'});
+
+    subscriptions.push(player.playbackRateChange.subscribe(playbackRateChangeSpy));
+    events.onPlaybackRateChange({target: playerSpy, data: 2});
+    expect(playbackRateChangeSpy).toHaveBeenCalledWith({target: playerSpy, data: 2});
+
+    subscriptions.push(player.error.subscribe(errorSpy));
+    events.onError({target: playerSpy, data: 5});
+    expect(errorSpy).toHaveBeenCalledWith({target: playerSpy, data: 5});
+
+    subscriptions.push(player.apiChange.subscribe(apiChangeSpy));
+    events.onApiChange({target: playerSpy});
+    expect(apiChangeSpy).toHaveBeenCalledWith({target: playerSpy});
+
+    subscriptions.forEach(subscription => subscription.unsubscribe());
+  });
+
 });
 
 /** Test component that contains a YouTubePlayer. */
@@ -448,9 +491,18 @@ class TestApp {
 
 @Component({
   template: `
-    <youtube-player [videoId]="videoId" [startSeconds]="42"[endSeconds]="1337"></youtube-player>
+    <youtube-player [videoId]="videoId" [startSeconds]="42" [endSeconds]="1337"></youtube-player>
   `
 })
 class StaticStartEndSecondsApp {
+  videoId = VIDEO_ID;
+}
+
+
+@Component({
+  template: `<youtube-player [videoId]="videoId"></youtube-player>`
+})
+class NoEventsApp {
+  @ViewChild(YouTubePlayer) player: YouTubePlayer;
   videoId = VIDEO_ID;
 }

--- a/tools/public_api_guard/youtube-player/youtube-player.d.ts
+++ b/tools/public_api_guard/youtube-player/youtube-player.d.ts
@@ -1,15 +1,15 @@
 export declare class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
-    apiChange: EventEmitter<YT.PlayerEvent>;
+    apiChange: Observable<YT.PlayerEvent>;
     set endSeconds(endSeconds: number | undefined);
-    error: EventEmitter<YT.OnErrorEvent>;
+    error: Observable<YT.OnErrorEvent>;
     get height(): number | undefined;
     set height(height: number | undefined);
-    playbackQualityChange: EventEmitter<YT.OnPlaybackQualityChangeEvent>;
-    playbackRateChange: EventEmitter<YT.OnPlaybackRateChangeEvent>;
-    ready: EventEmitter<YT.PlayerEvent>;
+    playbackQualityChange: Observable<YT.OnPlaybackQualityChangeEvent>;
+    playbackRateChange: Observable<YT.OnPlaybackRateChangeEvent>;
+    ready: Observable<YT.PlayerEvent>;
     showBeforeIframeApiLoads: boolean | undefined;
     set startSeconds(startSeconds: number | undefined);
-    stateChange: EventEmitter<YT.OnStateChangeEvent>;
+    stateChange: Observable<YT.OnStateChangeEvent>;
     set suggestedQuality(suggestedQuality: YT.SuggestedVideoQuality | undefined);
     get videoId(): string | undefined;
     set videoId(videoId: string | undefined);


### PR DESCRIPTION
The `youtube-player` component is set up so that it won't bind any events if there aren't any listeners at the time the player is created. This makes it impossible to bind an event by getting a reference to the player using `ViewChild` and subscribing to it. These changes fix the issue using a lazy observable which binds any events once the user subscribes and transfers them between players.