### PR TITLE
build: update buildifier and fix failures

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,10 +1,10 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//:rollup-globals.bzl", "ROLLUP_GLOBALS")
 load("//src/cdk:config.bzl", "CDK_ENTRYPOINTS")
 load("//src/cdk-experimental:config.bzl", "CDK_EXPERIMENTAL_ENTRYPOINTS")
 load("//src/material:config.bzl", "MATERIAL_ENTRYPOINTS", "MATERIAL_TESTING_ENTRYPOINTS")
 load("//src/material-experimental:config.bzl", "MATERIAL_EXPERIMENTAL_ENTRYPOINTS", "MATERIAL_EXPERIMENTAL_TESTING_ENTRYPOINTS")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "LICENSE",

--- a/guides/BUILD.bazel
+++ b/guides/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "markdown_to_html")
+
+package(default_visibility = ["//visibility:public"])
 
 markdown_to_html(
     name = "guides",

--- a/integration/ts-compat/BUILD.bazel
+++ b/integration/ts-compat/BUILD.bazel
@@ -1,8 +1,8 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
 load("//integration/ts-compat:import-all-entry-points.bzl", "generate_import_all_entry_points_file")
+
+package(default_visibility = ["//visibility:public"])
 
 write_file(
     name = "import-all-entry-points-file",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@angular/platform-server": "^9.1.0",
     "@angular/router": "^9.1.0",
     "@bazel/bazelisk": "^1.3.0",
-    "@bazel/buildifier": "^0.29.0",
+    "@bazel/buildifier": "^2.2.1",
     "@bazel/ibazel": "^0.12.3",
     "@bazel/jasmine": "^1.5.0",
     "@bazel/karma": "^1.5.0",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,9 +1,9 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@npm_bazel_typescript//:index.bzl", "ts_config")
 load("//src/cdk:config.bzl", "CDK_ENTRYPOINTS")
 load("//src/material:config.bzl", "MATERIAL_ENTRYPOINTS", "MATERIAL_TESTING_ENTRYPOINTS")
 load("//tools/dgeni:index.bzl", "dgeni_api_docs")
+
+package(default_visibility = ["//visibility:public"])
 
 cdkApiEntryPoints = CDK_ENTRYPOINTS
 

--- a/src/cdk-experimental/BUILD.bazel
+++ b/src/cdk-experimental/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/cdk-experimental:config.bzl", "CDK_EXPERIMENTAL_TARGETS")
 load("//tools:defaults.bzl", "ng_package", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "cdk-experimental",

--- a/src/cdk-experimental/column-resize/BUILD.bazel
+++ b/src/cdk-experimental/column-resize/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "column-resize",

--- a/src/cdk-experimental/dialog/BUILD.bazel
+++ b/src/cdk-experimental/dialog/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "dialog",

--- a/src/cdk-experimental/popover-edit/BUILD.bazel
+++ b/src/cdk-experimental/popover-edit/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "popover-edit",

--- a/src/cdk-experimental/scrolling/BUILD.bazel
+++ b/src/cdk-experimental/scrolling/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "scrolling",

--- a/src/cdk/BUILD.bazel
+++ b/src/cdk/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/cdk:config.bzl", "CDK_ENTRYPOINTS", "CDK_ENTRYPOINTS_WITH_STYLES", "CDK_SCSS_LIBS", "CDK_TARGETS")
 load("//tools:defaults.bzl", "ng_package", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "cdk",

--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "a11y",

--- a/src/cdk/accordion/BUILD.bazel
+++ b/src/cdk/accordion/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "accordion",

--- a/src/cdk/bidi/BUILD.bazel
+++ b/src/cdk/bidi/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "bidi",

--- a/src/cdk/clipboard/BUILD.bazel
+++ b/src/cdk/clipboard/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "markdown_to_html", "ng_module", "ng_test_library", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "clipboard",

--- a/src/cdk/coercion/BUILD.bazel
+++ b/src/cdk/coercion/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "coercion",

--- a/src/cdk/collections/BUILD.bazel
+++ b/src/cdk/collections/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "collections",

--- a/src/cdk/drag-drop/BUILD.bazel
+++ b/src/cdk/drag-drop/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "drag-drop",

--- a/src/cdk/keycodes/BUILD.bazel
+++ b/src/cdk/keycodes/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "karma_web_test_suite", "markdown_to_html", "ng_module", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 # We need to use "ng_module" here since we want metadata to be generated for keycode
 # constants. This is necessary because some of these constants are statically used in

--- a/src/cdk/layout/BUILD.bazel
+++ b/src/cdk/layout/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "layout",

--- a/src/cdk/observers/BUILD.bazel
+++ b/src/cdk/observers/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "observers",

--- a/src/cdk/overlay/BUILD.bazel
+++ b/src/cdk/overlay/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "overlay",

--- a/src/cdk/platform/BUILD.bazel
+++ b/src/cdk/platform/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "markdown_to_html", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "platform",

--- a/src/cdk/portal/BUILD.bazel
+++ b/src/cdk/portal/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "portal",

--- a/src/cdk/schematics/BUILD.bazel
+++ b/src/cdk/schematics/BUILD.bazel
@@ -1,8 +1,8 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//:packages.bzl", "VERSION_PLACEHOLDER_REPLACEMENTS")
 load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "schematics_assets",

--- a/src/cdk/schematics/testing/BUILD.bazel
+++ b/src/cdk/schematics/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/cdk/schematics/update-tool/BUILD.bazel
+++ b/src/cdk/schematics/update-tool/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "update-tool",

--- a/src/cdk/scrolling/BUILD.bazel
+++ b/src/cdk/scrolling/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -8,6 +6,8 @@ load(
     "ng_web_test_suite",
     "sass_binary",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "scrolling",

--- a/src/cdk/stepper/BUILD.bazel
+++ b/src/cdk/stepper/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "markdown_to_html", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "stepper",

--- a/src/cdk/table/BUILD.bazel
+++ b/src/cdk/table/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "table",

--- a/src/cdk/testing/BUILD.bazel
+++ b/src/cdk/testing/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load("//tools:defaults.bzl", "markdown_to_html", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/cdk/testing/private/BUILD.bazel
+++ b/src/cdk/testing/private/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "private",

--- a/src/cdk/testing/private/e2e/BUILD.bazel
+++ b/src/cdk/testing/private/e2e/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_e2e_test_library")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files(["tsconfig-e2e.json"])
 

--- a/src/cdk/testing/protractor/BUILD.bazel
+++ b/src/cdk/testing/protractor/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "protractor",

--- a/src/cdk/testing/testbed/BUILD.bazel
+++ b/src/cdk/testing/testbed/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testbed",

--- a/src/cdk/testing/tests/BUILD.bazel
+++ b/src/cdk/testing/tests/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "ng_test_library", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "test_components",

--- a/src/cdk/text-field/BUILD.bazel
+++ b/src/cdk/text-field/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "text-field",

--- a/src/cdk/tree/BUILD.bazel
+++ b/src/cdk/tree/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tree",

--- a/src/components-examples/BUILD.bazel
+++ b/src/components-examples/BUILD.bazel
@@ -1,8 +1,8 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "ng_package")
 load("//tools/highlight-files:index.bzl", "highlight_files")
 load("//tools/package-docs-content:index.bzl", "package_docs_content")
+
+package(default_visibility = ["//visibility:public"])
 
 ALL_EXAMPLES = [
     # TODO(devversion): try to have for each entry-point a bazel package so that

--- a/src/components-examples/cdk-experimental/popover-edit/BUILD.bazel
+++ b/src/components-examples/cdk-experimental/popover-edit/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "popover-edit",

--- a/src/components-examples/cdk/a11y/BUILD.bazel
+++ b/src/components-examples/cdk/a11y/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "a11y",

--- a/src/components-examples/cdk/clipboard/BUILD.bazel
+++ b/src/components-examples/cdk/clipboard/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "clipboard",

--- a/src/components-examples/cdk/drag-drop/BUILD.bazel
+++ b/src/components-examples/cdk/drag-drop/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "drag-drop",

--- a/src/components-examples/cdk/platform/BUILD.bazel
+++ b/src/components-examples/cdk/platform/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "platform",

--- a/src/components-examples/cdk/portal/BUILD.bazel
+++ b/src/components-examples/cdk/portal/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "portal",

--- a/src/components-examples/cdk/scrolling/BUILD.bazel
+++ b/src/components-examples/cdk/scrolling/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "scrolling",

--- a/src/components-examples/cdk/stepper/BUILD.bazel
+++ b/src/components-examples/cdk/stepper/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "stepper",

--- a/src/components-examples/cdk/table/BUILD.bazel
+++ b/src/components-examples/cdk/table/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "table",

--- a/src/components-examples/cdk/text-field/BUILD.bazel
+++ b/src/components-examples/cdk/text-field/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "text-field",

--- a/src/components-examples/cdk/tree/BUILD.bazel
+++ b/src/components-examples/cdk/tree/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tree",

--- a/src/components-examples/material-experimental/column-resize/BUILD.bazel
+++ b/src/components-examples/material-experimental/column-resize/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "column-resize",

--- a/src/components-examples/material-experimental/mdc-form-field/BUILD.bazel
+++ b/src/components-examples/material-experimental/mdc-form-field/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-form-field",

--- a/src/components-examples/material-experimental/popover-edit/BUILD.bazel
+++ b/src/components-examples/material-experimental/popover-edit/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "popover-edit",

--- a/src/components-examples/material/autocomplete/BUILD.bazel
+++ b/src/components-examples/material/autocomplete/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "autocomplete",

--- a/src/components-examples/material/badge/BUILD.bazel
+++ b/src/components-examples/material/badge/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "badge",

--- a/src/components-examples/material/bottom-sheet/BUILD.bazel
+++ b/src/components-examples/material/bottom-sheet/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "bottom-sheet",

--- a/src/components-examples/material/button-toggle/BUILD.bazel
+++ b/src/components-examples/material/button-toggle/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "button-toggle",

--- a/src/components-examples/material/button/BUILD.bazel
+++ b/src/components-examples/material/button/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "button",

--- a/src/components-examples/material/card/BUILD.bazel
+++ b/src/components-examples/material/card/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "card",

--- a/src/components-examples/material/checkbox/BUILD.bazel
+++ b/src/components-examples/material/checkbox/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "checkbox",

--- a/src/components-examples/material/chips/BUILD.bazel
+++ b/src/components-examples/material/chips/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "chips",

--- a/src/components-examples/material/core/BUILD.bazel
+++ b/src/components-examples/material/core/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "core",

--- a/src/components-examples/material/datepicker/BUILD.bazel
+++ b/src/components-examples/material/datepicker/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@npm_bazel_typescript//:index.bzl", "ts_config")
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "datepicker",

--- a/src/components-examples/material/dialog/BUILD.bazel
+++ b/src/components-examples/material/dialog/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "dialog",

--- a/src/components-examples/material/divider/BUILD.bazel
+++ b/src/components-examples/material/divider/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "divider",

--- a/src/components-examples/material/expansion/BUILD.bazel
+++ b/src/components-examples/material/expansion/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "expansion",

--- a/src/components-examples/material/form-field/BUILD.bazel
+++ b/src/components-examples/material/form-field/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "form-field",

--- a/src/components-examples/material/grid-list/BUILD.bazel
+++ b/src/components-examples/material/grid-list/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "grid-list",

--- a/src/components-examples/material/icon/BUILD.bazel
+++ b/src/components-examples/material/icon/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "icon",

--- a/src/components-examples/material/input/BUILD.bazel
+++ b/src/components-examples/material/input/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "input",

--- a/src/components-examples/material/list/BUILD.bazel
+++ b/src/components-examples/material/list/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "list",

--- a/src/components-examples/material/menu/BUILD.bazel
+++ b/src/components-examples/material/menu/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "menu",

--- a/src/components-examples/material/paginator/BUILD.bazel
+++ b/src/components-examples/material/paginator/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "paginator",

--- a/src/components-examples/material/progress-bar/BUILD.bazel
+++ b/src/components-examples/material/progress-bar/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "progress-bar",

--- a/src/components-examples/material/progress-spinner/BUILD.bazel
+++ b/src/components-examples/material/progress-spinner/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "progress-spinner",

--- a/src/components-examples/material/radio/BUILD.bazel
+++ b/src/components-examples/material/radio/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "radio",

--- a/src/components-examples/material/select/BUILD.bazel
+++ b/src/components-examples/material/select/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "select",

--- a/src/components-examples/material/sidenav/BUILD.bazel
+++ b/src/components-examples/material/sidenav/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "sidenav",

--- a/src/components-examples/material/slide-toggle/BUILD.bazel
+++ b/src/components-examples/material/slide-toggle/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "slide-toggle",

--- a/src/components-examples/material/slider/BUILD.bazel
+++ b/src/components-examples/material/slider/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "slider",

--- a/src/components-examples/material/snack-bar/BUILD.bazel
+++ b/src/components-examples/material/snack-bar/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "snack-bar",

--- a/src/components-examples/material/sort/BUILD.bazel
+++ b/src/components-examples/material/sort/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "sort",

--- a/src/components-examples/material/stepper/BUILD.bazel
+++ b/src/components-examples/material/stepper/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "stepper",

--- a/src/components-examples/material/table/BUILD.bazel
+++ b/src/components-examples/material/table/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "table",

--- a/src/components-examples/material/tabs/BUILD.bazel
+++ b/src/components-examples/material/tabs/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tabs",

--- a/src/components-examples/material/toolbar/BUILD.bazel
+++ b/src/components-examples/material/toolbar/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "toolbar",

--- a/src/components-examples/material/tooltip/BUILD.bazel
+++ b/src/components-examples/material/tooltip/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tooltip",

--- a/src/components-examples/material/tree/BUILD.bazel
+++ b/src/components-examples/material/tree/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tree",

--- a/src/components-examples/private/BUILD.bazel
+++ b/src/components-examples/private/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "private",

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -1,10 +1,10 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
 load("@build_bazel_rules_nodejs//internal/common:devmode_js_sources.bzl", "devmode_js_sources")
 load("//tools:create-system-config.bzl", "create_system_config")
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
 load("//tools/dev-server:index.bzl", "dev_server")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "dev-app",

--- a/src/dev-app/autocomplete/BUILD.bazel
+++ b/src/dev-app/autocomplete/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "autocomplete",

--- a/src/dev-app/badge/BUILD.bazel
+++ b/src/dev-app/badge/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "badge",

--- a/src/dev-app/baseline/BUILD.bazel
+++ b/src/dev-app/baseline/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "baseline",

--- a/src/dev-app/bottom-sheet/BUILD.bazel
+++ b/src/dev-app/bottom-sheet/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "bottom-sheet",

--- a/src/dev-app/button-toggle/BUILD.bazel
+++ b/src/dev-app/button-toggle/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "button-toggle",

--- a/src/dev-app/button/BUILD.bazel
+++ b/src/dev-app/button/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "button",

--- a/src/dev-app/card/BUILD.bazel
+++ b/src/dev-app/card/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "card",

--- a/src/dev-app/checkbox/BUILD.bazel
+++ b/src/dev-app/checkbox/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "checkbox",

--- a/src/dev-app/chips/BUILD.bazel
+++ b/src/dev-app/chips/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "chips",

--- a/src/dev-app/clipboard/BUILD.bazel
+++ b/src/dev-app/clipboard/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "clipboard",

--- a/src/dev-app/column-resize/BUILD.bazel
+++ b/src/dev-app/column-resize/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "column-resize",

--- a/src/dev-app/connected-overlay/BUILD.bazel
+++ b/src/dev-app/connected-overlay/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "connected-overlay",

--- a/src/dev-app/datepicker/BUILD.bazel
+++ b/src/dev-app/datepicker/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "datepicker",

--- a/src/dev-app/dev-app/BUILD.bazel
+++ b/src/dev-app/dev-app/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "dev-app",

--- a/src/dev-app/dialog/BUILD.bazel
+++ b/src/dev-app/dialog/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "dialog",

--- a/src/dev-app/drag-drop/BUILD.bazel
+++ b/src/dev-app/drag-drop/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "drag-drop",

--- a/src/dev-app/drawer/BUILD.bazel
+++ b/src/dev-app/drawer/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "drawer",

--- a/src/dev-app/example/BUILD.bazel
+++ b/src/dev-app/example/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "example",

--- a/src/dev-app/examples-page/BUILD.bazel
+++ b/src/dev-app/examples-page/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "examples-page",

--- a/src/dev-app/expansion/BUILD.bazel
+++ b/src/dev-app/expansion/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "expansion",

--- a/src/dev-app/focus-origin/BUILD.bazel
+++ b/src/dev-app/focus-origin/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "focus-origin",

--- a/src/dev-app/focus-trap/BUILD.bazel
+++ b/src/dev-app/focus-trap/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "focus-trap",

--- a/src/dev-app/google-map/BUILD.bazel
+++ b/src/dev-app/google-map/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "google-map",

--- a/src/dev-app/grid-list/BUILD.bazel
+++ b/src/dev-app/grid-list/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "grid-list",

--- a/src/dev-app/icon/BUILD.bazel
+++ b/src/dev-app/icon/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "icon",

--- a/src/dev-app/input/BUILD.bazel
+++ b/src/dev-app/input/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "input",

--- a/src/dev-app/list/BUILD.bazel
+++ b/src/dev-app/list/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "list",

--- a/src/dev-app/live-announcer/BUILD.bazel
+++ b/src/dev-app/live-announcer/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "live-announcer",

--- a/src/dev-app/mdc-button/BUILD.bazel
+++ b/src/dev-app/mdc-button/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-button",

--- a/src/dev-app/mdc-card/BUILD.bazel
+++ b/src/dev-app/mdc-card/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-card",

--- a/src/dev-app/mdc-checkbox/BUILD.bazel
+++ b/src/dev-app/mdc-checkbox/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-checkbox",

--- a/src/dev-app/mdc-chips/BUILD.bazel
+++ b/src/dev-app/mdc-chips/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-chips",

--- a/src/dev-app/mdc-input/BUILD.bazel
+++ b/src/dev-app/mdc-input/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-input",

--- a/src/dev-app/mdc-list/BUILD.bazel
+++ b/src/dev-app/mdc-list/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-list",

--- a/src/dev-app/mdc-menu/BUILD.bazel
+++ b/src/dev-app/mdc-menu/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-menu",

--- a/src/dev-app/mdc-progress-bar/BUILD.bazel
+++ b/src/dev-app/mdc-progress-bar/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-progress-bar",

--- a/src/dev-app/mdc-radio/BUILD.bazel
+++ b/src/dev-app/mdc-radio/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-radio",

--- a/src/dev-app/mdc-slide-toggle/BUILD.bazel
+++ b/src/dev-app/mdc-slide-toggle/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-slide-toggle",

--- a/src/dev-app/mdc-slider/BUILD.bazel
+++ b/src/dev-app/mdc-slider/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-slider",

--- a/src/dev-app/mdc-snackbar/BUILD.bazel
+++ b/src/dev-app/mdc-snackbar/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-snackbar",

--- a/src/dev-app/mdc-table/BUILD.bazel
+++ b/src/dev-app/mdc-table/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-table",

--- a/src/dev-app/mdc-tabs/BUILD.bazel
+++ b/src/dev-app/mdc-tabs/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-tabs",

--- a/src/dev-app/menu/BUILD.bazel
+++ b/src/dev-app/menu/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "menu",

--- a/src/dev-app/paginator/BUILD.bazel
+++ b/src/dev-app/paginator/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "paginator",

--- a/src/dev-app/platform/BUILD.bazel
+++ b/src/dev-app/platform/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "platform",

--- a/src/dev-app/popover-edit/BUILD.bazel
+++ b/src/dev-app/popover-edit/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "popover-edit",

--- a/src/dev-app/portal/BUILD.bazel
+++ b/src/dev-app/portal/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "portal",

--- a/src/dev-app/progress-bar/BUILD.bazel
+++ b/src/dev-app/progress-bar/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "progress-bar",

--- a/src/dev-app/progress-spinner/BUILD.bazel
+++ b/src/dev-app/progress-spinner/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "progress-spinner",

--- a/src/dev-app/radio/BUILD.bazel
+++ b/src/dev-app/radio/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "radio",

--- a/src/dev-app/ripple/BUILD.bazel
+++ b/src/dev-app/ripple/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "ripple",

--- a/src/dev-app/screen-type/BUILD.bazel
+++ b/src/dev-app/screen-type/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "screen-type",

--- a/src/dev-app/select/BUILD.bazel
+++ b/src/dev-app/select/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "select",

--- a/src/dev-app/sidenav/BUILD.bazel
+++ b/src/dev-app/sidenav/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "sidenav",

--- a/src/dev-app/slide-toggle/BUILD.bazel
+++ b/src/dev-app/slide-toggle/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "slide-toggle",

--- a/src/dev-app/slider/BUILD.bazel
+++ b/src/dev-app/slider/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "slider",

--- a/src/dev-app/snack-bar/BUILD.bazel
+++ b/src/dev-app/snack-bar/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "snack-bar",

--- a/src/dev-app/stepper/BUILD.bazel
+++ b/src/dev-app/stepper/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "stepper",

--- a/src/dev-app/table/BUILD.bazel
+++ b/src/dev-app/table/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "table",

--- a/src/dev-app/tabs/BUILD.bazel
+++ b/src/dev-app/tabs/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tabs",

--- a/src/dev-app/toolbar/BUILD.bazel
+++ b/src/dev-app/toolbar/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "toolbar",

--- a/src/dev-app/tooltip/BUILD.bazel
+++ b/src/dev-app/tooltip/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tooltip",

--- a/src/dev-app/tree/BUILD.bazel
+++ b/src/dev-app/tree/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tree",

--- a/src/dev-app/typography/BUILD.bazel
+++ b/src/dev-app/typography/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "typography",

--- a/src/dev-app/virtual-scroll/BUILD.bazel
+++ b/src/dev-app/virtual-scroll/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "virtual-scroll",

--- a/src/dev-app/youtube-player/BUILD.bazel
+++ b/src/dev-app/youtube-player/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "youtube-player",

--- a/src/e2e-app/BUILD.bazel
+++ b/src/e2e-app/BUILD.bazel
@@ -1,8 +1,8 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@npm_bazel_typescript//:index.bzl", "ts_devserver")
 load("//:packages.bzl", "getAngularUmdTargets")
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "protractor.conf.js",

--- a/src/google-maps/BUILD.bazel
+++ b/src/google-maps/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "ng_package", "ng_test_library", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "google-maps",

--- a/src/google-maps/testing/BUILD.bazel
+++ b/src/google-maps/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/BUILD.bazel
+++ b/src/material-experimental/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//src/material-experimental:config.bzl",
     "MATERIAL_EXPERIMENTAL_SCSS_LIBS",
@@ -7,6 +5,8 @@ load(
     "MATERIAL_EXPERIMENTAL_TESTING_TARGETS",
 )
 load("//tools:defaults.bzl", "ng_package", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files(["mdc_require_config.js"])
 

--- a/src/material-experimental/column-resize/BUILD.bazel
+++ b/src/material-experimental/column-resize/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@io_bazel_rules_sass//:defs.bzl", "sass_library")
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "column-resize",

--- a/src/material-experimental/mdc-autocomplete/BUILD.bazel
+++ b/src/material-experimental/mdc-autocomplete/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "sass_binary", "sass_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-autocomplete",

--- a/src/material-experimental/mdc-button/BUILD.bazel
+++ b/src/material-experimental/mdc-button/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-button",

--- a/src/material-experimental/mdc-button/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-button/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/mdc-card/BUILD.bazel
+++ b/src/material-experimental/mdc-card/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "sass_binary", "sass_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-card",

--- a/src/material-experimental/mdc-checkbox/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-checkbox",

--- a/src/material-experimental/mdc-checkbox/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/mdc-chips/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "ng_module",
@@ -8,6 +6,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-chips",

--- a/src/material-experimental/mdc-chips/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/mdc-form-field/BUILD.bazel
+++ b/src/material-experimental/mdc-form-field/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -8,6 +6,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-form-field",

--- a/src/material-experimental/mdc-form-field/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-form-field/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/mdc-helpers/BUILD.bazel
+++ b/src/material-experimental/mdc-helpers/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "sass_library")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "mdc-helpers",

--- a/src/material-experimental/mdc-input/BUILD.bazel
+++ b/src/material-experimental/mdc-input/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -9,6 +7,8 @@ load(
     "ng_web_test_suite",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-input",

--- a/src/material-experimental/mdc-input/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-input/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/mdc-list/BUILD.bazel
+++ b/src/material-experimental/mdc-list/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-list",

--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-menu",

--- a/src/material-experimental/mdc-menu/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/mdc-progress-bar/BUILD.bazel
+++ b/src/material-experimental/mdc-progress-bar/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-progress-bar",

--- a/src/material-experimental/mdc-progress-bar/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-progress-bar/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "testing",

--- a/src/material-experimental/mdc-radio/BUILD.bazel
+++ b/src/material-experimental/mdc-radio/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "ng_module",
@@ -8,6 +6,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-radio",

--- a/src/material-experimental/mdc-select/BUILD.bazel
+++ b/src/material-experimental/mdc-select/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -8,6 +6,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-select",

--- a/src/material-experimental/mdc-sidenav/BUILD.bazel
+++ b/src/material-experimental/mdc-sidenav/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "sass_binary", "sass_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-sidenav",

--- a/src/material-experimental/mdc-slide-toggle/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-slide-toggle",

--- a/src/material-experimental/mdc-slide-toggle/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/mdc-slider/BUILD.bazel
+++ b/src/material-experimental/mdc-slider/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-slider",

--- a/src/material-experimental/mdc-slider/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-slider/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material-experimental/mdc-snackbar/BUILD.bazel
+++ b/src/material-experimental/mdc-snackbar/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module", "sass_binary", "sass_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-snackbar",

--- a/src/material-experimental/mdc-table/BUILD.bazel
+++ b/src/material-experimental/mdc-table/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-table",

--- a/src/material-experimental/mdc-tabs/BUILD.bazel
+++ b/src/material-experimental/mdc-tabs/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "mdc-tabs",

--- a/src/material-experimental/mdc-theming/BUILD.bazel
+++ b/src/material-experimental/mdc-theming/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "sass_binary", "sass_library")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "mdc-theming",

--- a/src/material-experimental/mdc-typography/BUILD.bazel
+++ b/src/material-experimental/mdc-typography/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "sass_library")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "mdc-typography",

--- a/src/material-experimental/popover-edit/BUILD.bazel
+++ b/src/material-experimental/popover-edit/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "ng_module",
@@ -7,6 +5,8 @@ load(
     "ng_web_test_suite",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "popover-edit",

--- a/src/material-moment-adapter/BUILD.bazel
+++ b/src/material-moment-adapter/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@npm_bazel_typescript//:index.bzl", "ts_config")
 load("//tools:defaults.bzl", "ng_module", "ng_package", "ng_test_library", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "material-moment-adapter",

--- a/src/material/BUILD.bazel
+++ b/src/material/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@npm//scss-bundle:index.bzl", "scss_bundle")
 load("//src/cdk:config.bzl", "CDK_SCSS_LIBS")
 load(
@@ -10,6 +8,8 @@ load(
     "MATERIAL_TESTING_TARGETS",
 )
 load("//tools:defaults.bzl", "ng_package", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "material",

--- a/src/material/autocomplete/BUILD.bazel
+++ b/src/material/autocomplete/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "autocomplete",

--- a/src/material/autocomplete/testing/BUILD.bazel
+++ b/src/material/autocomplete/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/badge/BUILD.bazel
+++ b/src/material/badge/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -8,6 +6,8 @@ load(
     "ng_web_test_suite",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "badge",

--- a/src/material/badge/testing/BUILD.bazel
+++ b/src/material/badge/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/bottom-sheet/BUILD.bazel
+++ b/src/material/bottom-sheet/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "bottom-sheet",

--- a/src/material/bottom-sheet/testing/BUILD.bazel
+++ b/src/material/bottom-sheet/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/button-toggle/BUILD.bazel
+++ b/src/material/button-toggle/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "button-toggle",

--- a/src/material/button-toggle/testing/BUILD.bazel
+++ b/src/material/button-toggle/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/button/BUILD.bazel
+++ b/src/material/button/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "button",

--- a/src/material/button/testing/BUILD.bazel
+++ b/src/material/button/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/card/BUILD.bazel
+++ b/src/material/card/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "card",

--- a/src/material/checkbox/BUILD.bazel
+++ b/src/material/checkbox/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "checkbox",

--- a/src/material/checkbox/testing/BUILD.bazel
+++ b/src/material/checkbox/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/chips/BUILD.bazel
+++ b/src/material/chips/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "chips",

--- a/src/material/core/BUILD.bazel
+++ b/src/material/core/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/material:config.bzl", "MATERIAL_SCSS_LIBS")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files(["theming/_theming.scss"])
 

--- a/src/material/core/testing/BUILD.bazel
+++ b/src/material/core/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "datepicker",

--- a/src/material/dialog/BUILD.bazel
+++ b/src/material/dialog/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "dialog",

--- a/src/material/dialog/testing/BUILD.bazel
+++ b/src/material/dialog/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/divider/BUILD.bazel
+++ b/src/material/divider/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "divider",

--- a/src/material/divider/testing/BUILD.bazel
+++ b/src/material/divider/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/expansion/BUILD.bazel
+++ b/src/material/expansion/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "expansion",

--- a/src/material/expansion/testing/BUILD.bazel
+++ b/src/material/expansion/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/form-field/BUILD.bazel
+++ b/src/material/form-field/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -7,6 +5,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "form-field",

--- a/src/material/form-field/testing/BUILD.bazel
+++ b/src/material/form-field/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/form-field/testing/control/BUILD.bazel
+++ b/src/material/form-field/testing/control/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "control",

--- a/src/material/grid-list/BUILD.bazel
+++ b/src/material/grid-list/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "grid-list",

--- a/src/material/grid-list/testing/BUILD.bazel
+++ b/src/material/grid-list/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/icon/BUILD.bazel
+++ b/src/material/icon/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "icon",

--- a/src/material/icon/testing/BUILD.bazel
+++ b/src/material/icon/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "testing",

--- a/src/material/input/BUILD.bazel
+++ b/src/material/input/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -10,6 +8,8 @@ load(
     "ng_web_test_suite",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "input",

--- a/src/material/input/testing/BUILD.bazel
+++ b/src/material/input/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/list/BUILD.bazel
+++ b/src/material/list/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "list",

--- a/src/material/list/testing/BUILD.bazel
+++ b/src/material/list/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/menu/BUILD.bazel
+++ b/src/material/menu/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "menu",

--- a/src/material/menu/testing/BUILD.bazel
+++ b/src/material/menu/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/paginator/BUILD.bazel
+++ b/src/material/paginator/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "paginator",

--- a/src/material/paginator/testing/BUILD.bazel
+++ b/src/material/paginator/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/progress-bar/BUILD.bazel
+++ b/src/material/progress-bar/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "progress-bar",

--- a/src/material/progress-bar/testing/BUILD.bazel
+++ b/src/material/progress-bar/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/progress-spinner/BUILD.bazel
+++ b/src/material/progress-spinner/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "progress-spinner",

--- a/src/material/progress-spinner/testing/BUILD.bazel
+++ b/src/material/progress-spinner/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/radio/BUILD.bazel
+++ b/src/material/radio/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "radio",

--- a/src/material/radio/testing/BUILD.bazel
+++ b/src/material/radio/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/schematics/BUILD.bazel
+++ b/src/material/schematics/BUILD.bazel
@@ -1,8 +1,8 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//:packages.bzl", "VERSION_PLACEHOLDER_REPLACEMENTS")
 load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "schematics_assets",

--- a/src/material/select/BUILD.bazel
+++ b/src/material/select/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "select",

--- a/src/material/select/testing/BUILD.bazel
+++ b/src/material/select/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/sidenav/BUILD.bazel
+++ b/src/material/sidenav/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "sidenav",

--- a/src/material/sidenav/testing/BUILD.bazel
+++ b/src/material/sidenav/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/slide-toggle/BUILD.bazel
+++ b/src/material/slide-toggle/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "slide-toggle",

--- a/src/material/slide-toggle/testing/BUILD.bazel
+++ b/src/material/slide-toggle/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/slider/BUILD.bazel
+++ b/src/material/slider/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "slider",

--- a/src/material/slider/testing/BUILD.bazel
+++ b/src/material/slider/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/snack-bar/BUILD.bazel
+++ b/src/material/snack-bar/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "snack-bar",

--- a/src/material/snack-bar/testing/BUILD.bazel
+++ b/src/material/snack-bar/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/sort/BUILD.bazel
+++ b/src/material/sort/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "sort",

--- a/src/material/sort/testing/BUILD.bazel
+++ b/src/material/sort/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/stepper/BUILD.bazel
+++ b/src/material/stepper/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "stepper",

--- a/src/material/table/BUILD.bazel
+++ b/src/material/table/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "table",

--- a/src/material/table/testing/BUILD.bazel
+++ b/src/material/table/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/tabs/BUILD.bazel
+++ b/src/material/tabs/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tabs",

--- a/src/material/tabs/testing/BUILD.bazel
+++ b/src/material/tabs/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",

--- a/src/material/testing/BUILD.bazel
+++ b/src/material/testing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "testing",

--- a/src/material/toolbar/BUILD.bazel
+++ b/src/material/toolbar/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
@@ -11,6 +9,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "toolbar",

--- a/src/material/tooltip/BUILD.bazel
+++ b/src/material/tooltip/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tooltip",

--- a/src/material/tree/BUILD.bazel
+++ b/src/material/tree/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "markdown_to_html",
@@ -9,6 +7,8 @@ load(
     "sass_binary",
     "sass_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tree",

--- a/src/universal-app/BUILD.bazel
+++ b/src/universal-app/BUILD.bazel
@@ -1,11 +1,11 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
 load("//src/cdk:config.bzl", "CDK_TARGETS")
 load("//src/cdk-experimental:config.bzl", "CDK_EXPERIMENTAL_TARGETS")
 load("//src/material:config.bzl", "MATERIAL_TARGETS")
 load("//src/material-experimental:config.bzl", "MATERIAL_EXPERIMENTAL_TARGETS")
 load("//tools:defaults.bzl", "ng_module", "sass_binary", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "kitchen-sink",

--- a/src/youtube-player/BUILD.bazel
+++ b/src/youtube-player/BUILD.bazel
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//tools:defaults.bzl",
     "ng_module",
@@ -7,6 +5,8 @@ load(
     "ng_test_library",
     "ng_web_test_suite",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "youtube-player",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:create-system-config.bzl", "create_system_config")
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files(["bazel-karma-local-config.js"])
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "system-config-tmpl.js",

--- a/tools/dev-server/BUILD.bazel
+++ b/tools/dev-server/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files(["launcher_template.sh"])
 

--- a/tools/dev-server/index.bzl
+++ b/tools/dev-server/index.bzl
@@ -69,15 +69,17 @@ dev_server_rule = rule(
         "launcher": "%{name}.sh",
     },
     attrs = {
-        "srcs": attr.label_list(allow_files = True, doc = """
-          Sources that should be available to the dev-server. This attribute can be
-          used for explicit files. This attribute only uses the files exposed by the
-          DefaultInfo provider (i.e. TypeScript targets should be added to "deps").
-        """),
         "additional_root_paths": attr.string_list(doc = """
           Additionally paths to serve files from. The paths should be formatted
           as manifest paths (e.g. "my_workspace/src")
         """),
+        "deps": attr.label_list(
+            allow_files = True,
+            doc = """
+              Dependencies that need to be available to the dev-server. This attribute can be
+              used for TypeScript targets which provide multiple flavors of output.
+            """,
+        ),
         "historyApiFallback": attr.bool(
             default = True,
             doc = """
@@ -89,13 +91,11 @@ dev_server_rule = rule(
             default = 4200,
             doc = """The port that the devserver will listen on.""",
         ),
-        "deps": attr.label_list(
-            allow_files = True,
-            doc = """
-              Dependencies that need to be available to the dev-server. This attribute can be
-              used for TypeScript targets which provide multiple flavors of output.
-            """,
-        ),
+        "srcs": attr.label_list(allow_files = True, doc = """
+          Sources that should be available to the dev-server. This attribute can be
+          used for explicit files. This attribute only uses the files exposed by the
+          DefaultInfo provider (i.e. TypeScript targets should be added to "deps").
+        """),
         "_bash_runfile_helpers": attr.label(default = Label("@bazel_tools//tools/bash/runfiles")),
         "_dev_server_bin": attr.label(
             default = Label("//tools/dev-server:dev-server_bin"),

--- a/tools/dgeni/BUILD.bazel
+++ b/tools/dgeni/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 nodejs_binary(
     name = "dgeni",

--- a/tools/dgeni/index.bzl
+++ b/tools/dgeni/index.bzl
@@ -70,14 +70,14 @@ def _dgeni_api_docs(ctx):
 dgeni_api_docs = rule(
     implementation = _dgeni_api_docs,
     attrs = {
-        # List of labels that need to be available when Dgeni processes the entry points.
-        # This usually contains the source files and Angular packages which will be read
-        # by the dgeni-packages typeScript processor.
-        "srcs": attr.label_list(allow_files = True),
 
         # String dictionary that defines a package and its entry points. e.g.
         # { "cdk": ["a11y", "platform", "bidi"] }.
         "entry_points": attr.string_list_dict(mandatory = True),
+        # List of labels that need to be available when Dgeni processes the entry points.
+        # This usually contains the source files and Angular packages which will be read
+        # by the dgeni-packages typeScript processor.
+        "srcs": attr.label_list(allow_files = True),
 
         # NodeJS binary target that runs Dgeni and parses the passed command arguments.
         "_dgeni_bin": attr.label(

--- a/tools/example-module/BUILD.bazel
+++ b/tools/example-module/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "example-module-lib",

--- a/tools/highlight-files/BUILD.bazel
+++ b/tools/highlight-files/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "sources",

--- a/tools/markdown-to-html/BUILD.bazel
+++ b/tools/markdown-to-html/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "transform-markdown",

--- a/tools/package-docs-content/BUILD.bazel
+++ b/tools/package-docs-content/BUILD.bazel
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 nodejs_binary(
     name = "package-docs-content",

--- a/tools/public_api_guard/BUILD.bazel
+++ b/tools/public_api_guard/BUILD.bazel
@@ -1,8 +1,8 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//src/cdk:config.bzl", "CDK_ENTRYPOINTS")
 load("//src/material:config.bzl", "MATERIAL_ENTRYPOINTS", "MATERIAL_TESTING_ENTRYPOINTS")
 load(":generate-guard-tests.bzl", "generate_test_targets")
+
+package(default_visibility = ["//visibility:public"])
 
 golden_files = ["cdk/%s.d.ts" % e for e in CDK_ENTRYPOINTS] + \
                ["material/%s.d.ts" % e for e in MATERIAL_ENTRYPOINTS + MATERIAL_TESTING_ENTRYPOINTS] + [

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,29 +240,10 @@
   resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.3.0.tgz#dc312dd30ad01e9af86e53b40795ab6e545fa55b"
   integrity sha512-73H1nq3572tTf+dhDT86aWQN+LCyfxrh05jabqPXp6cpR8soxte3gS5oUqkN36fUe+J2HzNiV4CXZTz4Xytd3Q==
 
-"@bazel/buildifier-darwin_x64@0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@bazel/buildifier-darwin_x64/-/buildifier-darwin_x64-0.29.0.tgz#13dfaf3ea4d89f9d4da00085e894e90b7d302342"
-  integrity sha512-jiQIZo5z1c8oFokD2jObrkB04Bs+7RaUJ6WlHV9BBeJiRMGfRVUBUrOF5eJPk6VB8qknIOfHvJD/Ym5XUc1Zlw==
-
-"@bazel/buildifier-linux_x64@0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@bazel/buildifier-linux_x64/-/buildifier-linux_x64-0.29.0.tgz#0191fc46735a1c281878642673844f2b717cd8dc"
-  integrity sha512-sXXY0gP4oC1nC1G8Baqd7kyBL/y9/qOqftKSkDe2Y7gBoc9GslwyexwDxTSxK0Gun/4Vcvc2eRu7b83hMOxuag==
-
-"@bazel/buildifier-win32_x64@0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@bazel/buildifier-win32_x64/-/buildifier-win32_x64-0.29.0.tgz#a63438c7a7d2dc593e626ed6e163e9d8ea93917a"
-  integrity sha512-hnOQfPhQNAIqbrhsHT3MWAyAZSUhKwxzEuZJZoOsGrW8fPonhKysdvfZJqfqJ6vDVYaMJKvLnSO1c9QZRhU7kQ==
-
-"@bazel/buildifier@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@bazel/buildifier/-/buildifier-0.29.0.tgz#7984739270c8d1dd23650f87a810e1e6367188d9"
-  integrity sha512-skJ7vVff7x3tB8crBCtJji2wU09uH0uD2N30xfOpVUgsMJSXktAQMj8+RPdMBqJQ9XS5+O5lmRthR35Ua7xQXA==
-  optionalDependencies:
-    "@bazel/buildifier-darwin_x64" "0.29.0"
-    "@bazel/buildifier-linux_x64" "0.29.0"
-    "@bazel/buildifier-win32_x64" "0.29.0"
+"@bazel/buildifier@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier/-/buildifier-2.2.1.tgz#b5b21d0042ea48a9c43b54ec4824d4d6505988bc"
+  integrity sha512-fDWMV2x03/K5dZnAEBeKS0gpn0LWCiv5kjhMB6q0f1Q5x6S7/+xoownxgWyNRo+qHxn+a2CtQSCRUpSC8QNg/w==
 
 "@bazel/ibazel@^0.12.3":
   version "0.12.3"


### PR DESCRIPTION
Our version of `@bazel/buildifier` is pretty old. These changes bump to the latest version and fix the new failures that showed up.