### PR TITLE
refactor: all-typography mixin should use all-theme to avoid code duplication

### DIFF
--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -1,3 +1,4 @@
+@import '../material/core/core';
 @import '../material/core/theming/all-theme';
 @import '../material/core/density/all-density';
 @import '../material/core/focus-indicator/focus-indicator';

--- a/src/e2e-app/theme.scss
+++ b/src/e2e-app/theme.scss
@@ -1,3 +1,4 @@
+@import '../material/core/core';
 @import '../material/core/theming/all-theme';
 @import '../material-experimental/mdc-theming/all-theme';
 @import '../material-experimental/mdc-typography/all-typography';

--- a/src/material/core/_core-theme.scss
+++ b/src/material/core/_core-theme.scss
@@ -1,0 +1,48 @@
+@import './theming/theming';
+@import './style/elevation';
+@import './ripple/ripple';
+@import './option/option-theme';
+@import './option/optgroup-theme';
+@import './selection/pseudo-checkbox/pseudo-checkbox-theme';
+
+@mixin mat-core-color($config) {
+  // Wrapper element that provides the theme background when the user's content isn't
+  // inside of a `mat-sidenav-container`. Note that we need to exclude the ampersand
+  // selector in case the mixin is included at the top level.
+  .mat-app-background#{if(&, ', &.mat-app-background', '')} {
+    $background: map-get($config, background);
+    $foreground: map-get($config, foreground);
+
+    background-color: mat-color($background, background);
+    color: mat-color($foreground, text);
+  }
+
+  // Provides external CSS classes for each elevation value. Each CSS class is formatted as
+  // `mat-elevation-z$zValue` where `$zValue` corresponds to the z-space to which the element is
+  // elevated.
+  @for $zValue from 0 through 24 {
+    .#{$_mat-elevation-prefix}#{$zValue} {
+      @include _mat-theme-elevation($zValue, $config);
+    }
+  }
+
+  // Marker that is used to determine whether the user has added a theme to their page.
+  @at-root {
+    .mat-theme-loaded-marker {
+      display: none;
+    }
+  }
+}
+
+// Mixin that renders all of the core styles that depend on the theme.
+@mixin mat-core-theme($theme) {
+  @include mat-ripple-theme($theme);
+  @include mat-option-theme($theme);
+  @include mat-optgroup-theme($theme);
+  @include mat-pseudo-checkbox-theme($theme);
+
+  $color: mat-get-color-config($theme);
+  @if $color != null {
+    @include mat-core-color($color);
+  }
+}

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -1,14 +1,8 @@
-@import '../../cdk/overlay/overlay';
 @import '../../cdk/a11y/a11y';
+@import '../../cdk/overlay/overlay';
 @import '../../cdk/text-field/text-field';
-
-// Core styles that can be used to apply material design treatments to any element.
-@import 'style/elevation';
-@import 'ripple/ripple';
-@import 'option/option-theme';
-@import 'option/optgroup-theme';
-@import 'selection/pseudo-checkbox/pseudo-checkbox-theme';
-@import 'typography/all-typography';
+@import './ripple/ripple';
+@import './typography/all-typography';
 
 // Mixin that renders all of the core styles that are not theme-dependent.
 @mixin mat-core($typography-config: null) {
@@ -17,46 +11,4 @@
   @include cdk-a11y();
   @include cdk-overlay();
   @include cdk-text-field();
-}
-
-@mixin mat-core-color($config) {
-  // Wrapper element that provides the theme background when the user's content isn't
-  // inside of a `mat-sidenav-container`. Note that we need to exclude the ampersand
-  // selector in case the mixin is included at the top level.
-  .mat-app-background#{if(&, ', &.mat-app-background', '')} {
-    $background: map-get($config, background);
-    $foreground: map-get($config, foreground);
-
-    background-color: mat-color($background, background);
-    color: mat-color($foreground, text);
-  }
-
-  // Provides external CSS classes for each elevation value. Each CSS class is formatted as
-  // `mat-elevation-z$zValue` where `$zValue` corresponds to the z-space to which the element is
-  // elevated.
-  @for $zValue from 0 through 24 {
-    .#{$_mat-elevation-prefix}#{$zValue} {
-      @include _mat-theme-elevation($zValue, $config);
-    }
-  }
-
-  // Marker that is used to determine whether the user has added a theme to their page.
-  @at-root {
-    .mat-theme-loaded-marker {
-      display: none;
-    }
-  }
-}
-
-// Mixin that renders all of the core styles that depend on the theme.
-@mixin mat-core-theme($theme) {
-  @include mat-ripple-theme($theme);
-  @include mat-option-theme($theme);
-  @include mat-optgroup-theme($theme);
-  @include mat-pseudo-checkbox-theme($theme);
-
-  $color: mat-get-color-config($theme);
-  @if $color != null {
-    @include mat-core-color($color);
-  }
 }

--- a/src/material/core/theming/_all-theme.scss
+++ b/src/material/core/theming/_all-theme.scss
@@ -1,5 +1,5 @@
 // Import all the theming functionality.
-@import '../core';
+@import '../core-theme';
 @import '../../autocomplete/autocomplete-theme';
 @import '../../badge/badge-theme';
 @import '../../bottom-sheet/bottom-sheet-theme';

--- a/src/material/core/theming/prebuilt/deeppurple-amber.scss
+++ b/src/material/core/theming/prebuilt/deeppurple-amber.scss
@@ -1,3 +1,4 @@
+@import '../../core';
 @import '../all-theme';
 
 

--- a/src/material/core/theming/prebuilt/indigo-pink.scss
+++ b/src/material/core/theming/prebuilt/indigo-pink.scss
@@ -1,3 +1,4 @@
+@import '../../core';
 @import '../all-theme';
 
 

--- a/src/material/core/theming/prebuilt/pink-bluegrey.scss
+++ b/src/material/core/theming/prebuilt/pink-bluegrey.scss
@@ -1,3 +1,4 @@
+@import '../../core';
 @import '../all-theme';
 
 

--- a/src/material/core/theming/prebuilt/purple-green.scss
+++ b/src/material/core/theming/prebuilt/purple-green.scss
@@ -1,3 +1,4 @@
+@import '../../core';
 @import '../all-theme';
 
 

--- a/src/material/core/theming/tests/BUILD.bazel
+++ b/src/material/core/theming/tests/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "sass_binary")
+load("//tools:defaults.bzl", "sass_binary", "sass_library")
 
 # Test theme used to ensure that our themes will compile using CSS variables in
 # the palettes.
@@ -19,4 +19,20 @@ sass_binary(
     testonly = True,
     src = "test-theming-api.scss",
     deps = ["//src/material/core:theming_scss_lib"],
+)
+
+# Exposes the theming bundle as a Sass library. The theming bundle output does not
+# have the proper Sass info provider set. To fix this, we wrap the file in a `sass_library`.
+sass_library(
+    name = "theming_bundle_scss_lib",
+    srcs = ["//src/material:theming_bundle"],
+)
+
+# Sass binary which is used to ensure that the theming bundle exposes the necessary
+# mixins and variables for creating themes.
+sass_binary(
+    name = "test-theming-bundle",
+    testonly = True,
+    src = "test-theming-bundle.scss",
+    deps = [":theming_bundle_scss_lib"],
 )

--- a/src/material/core/theming/tests/test-theming-bundle.scss
+++ b/src/material/core/theming/tests/test-theming-bundle.scss
@@ -1,0 +1,23 @@
+// Imports the theming bundle. Needs to be an absolute bin-dir import path as on Windows,
+// runfiles are not symlinked, so the Sass compilation happens in the workspace directory
+// with the include paths being set to the `bazel-bin` directory.
+@import 'src/material/theming';
+
+@include mat-core();
+
+$theme: mat-light-theme((
+  color: (
+    primary: $mat-red,
+    accent: $mat-blue,
+  ),
+  density: -2,
+));
+
+// If one of these mixins is not available, the compilation will fail and the
+// test will be reported as failing.
+@include angular-material-theme($theme);
+@include angular-material-typography();
+@include angular-material-color($theme);
+@include _angular-material-density($theme);
+@include mat-core-theme($theme);
+@include mat-button-theme($theme);

--- a/src/material/core/typography/_all-typography.scss
+++ b/src/material/core/typography/_all-typography.scss
@@ -1,41 +1,5 @@
+@import '../theming/all-theme';
 @import './typography';
-@import '../../autocomplete/autocomplete-theme';
-@import '../../badge/badge-theme';
-@import '../../bottom-sheet/bottom-sheet-theme';
-@import '../../button/button-theme';
-@import '../../button-toggle/button-toggle-theme';
-@import '../../card/card-theme';
-@import '../../checkbox/checkbox-theme';
-@import '../../chips/chips-theme';
-@import '../../divider/divider-theme';
-@import '../../table/table-theme';
-@import '../../datepicker/datepicker-theme';
-@import '../../dialog/dialog-theme';
-@import '../../expansion/expansion-theme';
-@import '../../grid-list/grid-list-theme';
-@import '../../icon/icon-theme';
-@import '../../input/input-theme';
-@import '../../list/list-theme';
-@import '../../menu/menu-theme';
-@import '../../paginator/paginator-theme';
-@import '../../progress-bar/progress-bar-theme';
-@import '../../progress-spinner/progress-spinner-theme';
-@import '../../radio/radio-theme';
-@import '../../select/select-theme';
-@import '../../sidenav/sidenav-theme';
-@import '../../slide-toggle/slide-toggle-theme';
-@import '../../slider/slider-theme';
-@import '../../stepper/stepper-theme';
-@import '../../sort/sort-theme';
-@import '../../tabs/tabs-theme';
-@import '../../toolbar/toolbar-theme';
-@import '../../tooltip/tooltip-theme';
-@import '../../snack-bar/snack-bar-theme';
-@import '../option/option-theme';
-@import '../option/optgroup-theme';
-@import '../../form-field/form-field-theme';
-@import '../../tree/tree-theme';
-
 
 // Includes all of the typographic styles.
 @mixin angular-material-typography($config-or-theme: null) {
@@ -47,47 +11,9 @@
     $config: mat-typography-config();
   }
 
-  // TODO: Do not use individual mixins. Instead, use the all-theme mixin and only specify a
-  // `typography` config while setting `color` and `density` to `null`. This is currently
-  // not possible as it would introduce a circular dependency for typography because the
-  // `mat-core` mixin that is transitively loaded by the `all-theme` file, imports
-  // `all-typography` which would then load `all-theme` again. This causes a cycle.
-
-  @include mat-badge-typography($config);
-  @include mat-base-typography($config);
-  @include mat-autocomplete-typography($config);
-  @include mat-bottom-sheet-typography($config);
-  @include mat-button-typography($config);
-  @include mat-button-toggle-typography($config);
-  @include mat-card-typography($config);
-  @include mat-checkbox-typography($config);
-  @include mat-chips-typography($config);
-  @include mat-divider-typography($config);
-  @include mat-table-typography($config);
-  @include mat-datepicker-typography($config);
-  @include mat-dialog-typography($config);
-  @include mat-expansion-panel-typography($config);
-  @include mat-form-field-typography($config);
-  @include mat-grid-list-typography($config);
-  @include mat-icon-typography($config);
-  @include mat-input-typography($config);
-  @include mat-menu-typography($config);
-  @include mat-paginator-typography($config);
-  @include mat-progress-bar-typography($config);
-  @include mat-progress-spinner-typography($config);
-  @include mat-radio-typography($config);
-  @include mat-select-typography($config);
-  @include mat-sidenav-typography($config);
-  @include mat-slide-toggle-typography($config);
-  @include mat-slider-typography($config);
-  @include mat-stepper-typography($config);
-  @include mat-sort-typography($config);
-  @include mat-tabs-typography($config);
-  @include mat-toolbar-typography($config);
-  @include mat-tooltip-typography($config);
-  @include mat-list-typography($config);
-  @include mat-option-typography($config);
-  @include mat-optgroup-typography($config);
-  @include mat-snack-bar-typography($config);
-  @include mat-tree-typography($config);
+  @include angular-material-theme((
+    color: null,
+    density: null,
+    typography: $config,
+  ));
 }

--- a/src/material/theming-bundle.scss
+++ b/src/material/theming-bundle.scss
@@ -1,6 +1,7 @@
 // File for which all imports are resolved and bundled. This is the entry-point for
 // the `@angular/material` theming Sass bundle. See `//src/material:theming_bundle`.
 
+@import './core/core';
 @import './core/color/all-color';
 @import './core/density/all-density';
 @import './core/theming/all-theme';

--- a/src/universal-app/theme.scss
+++ b/src/universal-app/theme.scss
@@ -1,3 +1,4 @@
+@import '../material/core/core';
 @import '../material/core/theming/all-theme';
 @import '../material-experimental/mdc-theming/all-theme';
 @import '../material-experimental/mdc-typography/all-typography';


### PR DESCRIPTION
As discussed in our team meeting, we want to get rid of the duplication of
individual theme, color, density and typography mixins
(similar to how we did it for all-density and all-color).

We couldn't simplify the all-typography mixin because the `core-theme`
mixin is stored in a file that relies on `all-typography`. This causes
a circular dependency when `all-typography` would then rely on `all-theme`.

To fix this, we split the `mat-core-theme` and `mat-core` mixin into
separate files. This avoids the circular dependency. Additionally, a test
has been created that ensures that the theming bundle still exposes the
necessary mixins/variables as needed.