### PR TITLE
fix(datepicker): range input label pointing to non-existent id

### DIFF
--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -174,6 +174,7 @@ const _MatDateRangeInputBase:
     '(input)': '_onInput($event.target.value)',
     '(change)': '_onChange()',
     '(keydown)': '_onKeydown($event)',
+    '[attr.id]': '_rangeInput.id',
     '[attr.aria-labelledby]': '_rangeInput._ariaLabelledBy',
     '[attr.aria-describedby]': '_rangeInput._ariaDescribedBy',
     '[attr.aria-haspopup]': '_rangeInput.rangePicker ? "dialog" : null',

--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -140,6 +140,16 @@ describe('MatDatepicker', () => {
     expect(rangeInput.classList).toContain(hideClass);
   });
 
+  it('should point the label aria-owns to the id of the start input', () => {
+    const fixture = createComponent(StandardRangePicker);
+    fixture.detectChanges();
+    const label = fixture.nativeElement.querySelector('label');
+    const start = fixture.componentInstance.start.nativeElement;
+
+    expect(start.id).toBeTruthy();
+    expect(label.getAttribute('aria-owns')).toBe(start.id);
+  });
+
   it('should point the input aria-labelledby to the form field label', () => {
     const fixture = createComponent(StandardRangePicker);
     fixture.detectChanges();

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -13,8 +13,6 @@ import {
   Inject,
   Input,
   Optional,
-  Output,
-  AfterViewInit,
 } from '@angular/core';
 import {
   NG_VALIDATORS,


### PR DESCRIPTION
This is something that I put the code in for in the beginning, but forgot to wire up. The `aria-owns` of the `label` in the `mat-form-field` needs to point to the id of the start input, but it didn't have an id.