### PR TITLE
fix(material-experimental): better server-side rendering support for progress bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/youtube": "^0.0.38",
     "@webcomponents/custom-elements": "^1.1.0",
     "core-js": "^2.6.9",
-    "material-components-web": "6.0.0-canary.9930d9cc5.0",
+    "material-components-web": "6.0.0-canary.927fa902c.0",
     "rxjs": "^6.5.3",
     "systemjs": "0.19.43",
     "tslib": "^1.10.0",

--- a/src/material-experimental/mdc-checkbox/BUILD.bazel
+++ b/src/material-experimental/mdc-checkbox/BUILD.bazel
@@ -23,7 +23,6 @@ ng_module(
     module_name = "@angular/material-experimental/mdc-checkbox",
     deps = [
         "//src/cdk/coercion",
-        "//src/cdk/platform",
         "//src/material/checkbox",
         "//src/material/core",
         "@npm//@angular/animations",

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -7,7 +7,6 @@
  */
 
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
-import {Platform} from '@angular/cdk/platform';
 import {
   AfterViewInit,
   Attribute,
@@ -211,7 +210,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
   private _checkboxAdapter: MDCCheckboxAdapter = {
     addClass: (className) => this._setClass(className, true),
     removeClass: (className) => this._setClass(className, false),
-    forceLayout: () => this._platform.isBrowser && this._checkbox.nativeElement.offsetWidth,
+    forceLayout: () => this._checkbox.nativeElement.offsetWidth,
     hasNativeControl: () => !!this._nativeCheckbox,
     isAttachedToDOM: () => !!this._checkbox.nativeElement.parentNode,
     isChecked: () => this.checked,
@@ -233,7 +232,6 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
 
   constructor(
       private _changeDetectorRef: ChangeDetectorRef,
-      private _platform: Platform,
       @Attribute('tabindex') tabIndex: string,
       /**
        * @deprecated `_clickAction` parameter to be removed, use

--- a/src/material-experimental/mdc-progress-bar/BUILD.bazel
+++ b/src/material-experimental/mdc-progress-bar/BUILD.bazel
@@ -23,7 +23,6 @@ ng_module(
     module_name = "@angular/material-experimental/mdc-progress-bar",
     deps = [
         "//src/cdk/bidi",
-        "//src/cdk/platform",
         "//src/material/core",
         "//src/material/progress-bar",
         "@npm//@angular/core",

--- a/src/material-experimental/mdc-progress-bar/progress-bar.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.ts
@@ -27,7 +27,6 @@ import {MDCLinearProgressAdapter, MDCLinearProgressFoundation} from '@material/l
 import {Subscription, fromEvent, Observable} from 'rxjs';
 import {filter} from 'rxjs/operators';
 import {Directionality} from '@angular/cdk/bidi';
-import {Platform} from '@angular/cdk/platform';
 
 // Boilerplate for applying mixins to MatProgressBar.
 /** @docs-private */
@@ -63,7 +62,6 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements AfterVie
 
   constructor(public _elementRef: ElementRef<HTMLElement>,
               private _ngZone: NgZone,
-              private _platform: Platform,
               @Optional() private _dir?: Directionality,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
     super(_elementRef);
@@ -79,7 +77,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements AfterVie
   /** Adapter used by MDC to interact with the DOM. */
   private _adapter: MDCLinearProgressAdapter = {
     addClass: (className: string) => this._rootElement.classList.add(className),
-    forceLayout: () => this._platform.isBrowser && this._rootElement.offsetWidth,
+    forceLayout: () => this._rootElement.offsetWidth,
     removeAttribute: (name: string) => this._rootElement.removeAttribute(name),
     setAttribute: (name: string, value: string) => this._rootElement.setAttribute(name, value),
     hasClass: (className: string) => this._rootElement.classList.contains(className),
@@ -184,8 +182,7 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements AfterVie
   private _syncFoundation() {
     const foundation = this._foundation;
 
-    // Don't sync any state if we're not in a browser, because MDC uses some window APIs.
-    if (foundation && this._platform.isBrowser) {
+    if (foundation) {
       const direction = this._dir ? this._dir.value : 'ltr';
       const mode = this.mode;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,559 +287,560 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.3.2.tgz#a92dc544290e2893bd8c02a81e684dae3d8e7c85"
   integrity sha512-ZD8lTgW07NGgo75bTyBJA8Lt9+NweNzot7lrsBtIvfciwUzaFJLsv2EShqjBeuhF7RpG6YFucJ6m67w5buCtzw==
 
-"@material/animation@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-6.0.0-canary.9930d9cc5.0.tgz#5c9ee97ebe2d2a9a3b217a8aed0793e3c0864bcb"
-  integrity sha512-8bJClmIz4dsdde0bjueSVHBaJXO+sNHWpdE4Ak0zbhWq80WhtWpB1n6GrKE39fgZmYIrLPN0/SANfN0XHRTZvQ==
+"@material/animation@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-6.0.0-canary.927fa902c.0.tgz#df0f75f798d3e0cc49f328b1c76e37fac601d5e1"
+  integrity sha512-HB0jDRP+Hqtli/KMLS87xO7jfLDEI58joaJ/GvVd3HTo0ClxOq8IxHuTVHjZFaTw6Q57ZPPShCGaBf/coXDQ2g==
   dependencies:
     tslib "^1.9.3"
 
-"@material/auto-init@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/auto-init/-/auto-init-6.0.0-canary.9930d9cc5.0.tgz#e0a9051328800e23f1c3139c5d9f1a8ccf1bd423"
-  integrity sha512-/5wU1o0LAPI2HsKg1uY3am1atF9BySV89RXhUayhi0udroxchhaGUKkZ1sOZ6hJbXAkLb79bXpA3EugIr8fPHw==
+"@material/auto-init@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/auto-init/-/auto-init-6.0.0-canary.927fa902c.0.tgz#b9dfdccaaec6e7131be94612eafed943ee1257d4"
+  integrity sha512-7WnLa/gnt8DH3wTghsg18HK5hvM4wqOBm8ZyMYhLo+apOIJ+lucHfWFBnpwxgLKyzGnLDpBgSwEJkhbNegIxDA==
   dependencies:
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/base@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/base/-/base-6.0.0-canary.9930d9cc5.0.tgz#ecb1361c30ea174d2616f39b6314f9e9dccc53a0"
-  integrity sha512-RyCltsaxUwKmoUiWBk88diE3WlWCa85SrHWPIw6ScxlwsMjt/4UVWvJRyAvb5DbpbjJSTzSJXiquqfqCqEJFNA==
+"@material/base@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-6.0.0-canary.927fa902c.0.tgz#840aef2dccc472dde509ef1a685eaef48381816a"
+  integrity sha512-HepW52v2nAvjFUJ4hhTxJ4exCZBMoDCGNq/CFZr+xRVxt9cEcVYnm5jllUi/xJsSVKiH8xZl1yp8wRtKSxl5kw==
   dependencies:
     tslib "^1.9.3"
 
-"@material/button@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/button/-/button-6.0.0-canary.9930d9cc5.0.tgz#60fc37740a321b18dfdb9f85e4e99bb313fa4d61"
-  integrity sha512-m36ihBckF/pBn+4LdfKUO7WdTmSw9M+Q6Ijkx2Mu6crCv+Uve3GLAYaxx336UhAlQPUEA4QZ6G92Tb+DqZoGSg==
+"@material/button@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/button/-/button-6.0.0-canary.927fa902c.0.tgz#6f1f060c62ca75d514dad6befcd2405d591c7d43"
+  integrity sha512-pOeq61yrFEkBb8oEUfCUQCbgw8WeMMOZ4X+4gTwBklFW/8ONDXuCBU821B5n4UXTW3C0muxO8oZE44NhjhSY0w==
   dependencies:
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/touch-target" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/touch-target" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
 
-"@material/card@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/card/-/card-6.0.0-canary.9930d9cc5.0.tgz#6c9591208ba3d799d1804afc30c69fc12f70bdc7"
-  integrity sha512-roarTjxWg+IrBPUuSJSvOp9OJEnuYpseGJNua3wkDsJdItoKxNBN8194hqV8Qn6S7LXoksTbFan0uWfl3Eur3w==
+"@material/card@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/card/-/card-6.0.0-canary.927fa902c.0.tgz#4334ac9cfbc054994ecf0b86a15d849ab2eac0c0"
+  integrity sha512-Ffa9HbCbzBm1JjRDTNchdkBA/DK+hErMzHU3JI6tYmnrvOQ+xD+W8aIkac3r3Mx2z5WaUMSuuXD+ArzCe3KyzA==
   dependencies:
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
 
-"@material/checkbox@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/checkbox/-/checkbox-6.0.0-canary.9930d9cc5.0.tgz#3b98a8d6facfcaa7f048f8cf78090831dee100ce"
-  integrity sha512-l40UFG+mzHsvrerFF+wprXpMZMBPxWuwq+DMaBSJrrY6SkPL9MRIPy0+z5O4bgMB8X91TVvAVI1VuIRiFtWg/g==
+"@material/checkbox@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/checkbox/-/checkbox-6.0.0-canary.927fa902c.0.tgz#00e4fa4d2a22f97906b03ad895aeed561458e91f"
+  integrity sha512-IiLzKqV6AH1VUGy77/XBGR+RSCMbXPL/vr/KRY1o3BX8UUuvGDnbalVp9pYBSLKZqPL4Y73m3sJe6KywUlcS1w==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/touch-target" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/touch-target" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/chips@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/chips/-/chips-6.0.0-canary.9930d9cc5.0.tgz#b2bdd112887f477f72383c4d7ed77f8f7dd4f4b5"
-  integrity sha512-c23t91XubCPOzUhL3+nnXrGw85IB2Kmkvp5fCWXabI0cQz50d9mYat5xc8xY+qHMQMXz5mfVP5vfSGo/EYxpWg==
+"@material/chips@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/chips/-/chips-6.0.0-canary.927fa902c.0.tgz#c472677bc95eba72bfe6a0b4fcd2b496b7492940"
+  integrity sha512-33v/qon6fa9oQ7Hwfh1s9CkaZfFmv6ptaiK1p4eZXLU9fPnONpp/6RygrzX0VdM6TZMVQIpSOHCqzetiGiZCNQ==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/checkbox" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/touch-target" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/checkbox" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/touch-target" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/circular-progress@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/circular-progress/-/circular-progress-6.0.0-canary.9930d9cc5.0.tgz#c64def6885cd8ac449f16c924c801464058f0d96"
-  integrity sha512-FzOfdFAcnzQIv4tRM/yjy5W8yKrIvj+PCQ6l3NtEvq4/iVDZ5fjFtXLmODtGt6n0GEoqZ1jLkCZeiBS4HktY3w==
+"@material/circular-progress@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/circular-progress/-/circular-progress-6.0.0-canary.927fa902c.0.tgz#777c6c7d28f959e8f8c208d148ad047000c98da0"
+  integrity sha512-3/RItmFp2JGpqWnb3Dr8qltCExulRe95ZvMN9ay+iSL1/GH0TaL3Vret7Aipjg35aW4BQFrkP1DosBk9zjGbbg==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/progress-indicator" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/progress-indicator" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/data-table@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/data-table/-/data-table-6.0.0-canary.9930d9cc5.0.tgz#2288190f752ccb644a2ca9bfe68d4d122815f106"
-  integrity sha512-iyEBKgrbvLkBTfBnuVRVFb1+gUcQf5wS7zPy/MKE2ZWA85M/903Jfc31p652igIyS9CyEGgAalJIF6vUOPOXlg==
+"@material/data-table@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/data-table/-/data-table-6.0.0-canary.927fa902c.0.tgz#02c6ebd5031964528f4f59f2e7d2942097135717"
+  integrity sha512-mWcrt0bT1rQt5lNZhE0zJdw269G+dfjrXk+fSNtHzM419j1BiY9rGFmnR2y2iV9OQVsqJi1qloJTq4o8y/F4/w==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/checkbox" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/icon-button" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/checkbox" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/icon-button" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
     tslib "^1.10.0"
 
-"@material/density@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/density/-/density-6.0.0-canary.9930d9cc5.0.tgz#3abd64b5dc76fdf927911afb11beec8165d5e792"
-  integrity sha512-nZrv0eCuY/dvtILDcjmk6cMdRpxWRPEB9WuJNplXKTX1/Cn+s1xW9LVqBW5r8tEmI3NbxOQY3i4kHjilDVfB2A==
+"@material/density@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/density/-/density-6.0.0-canary.927fa902c.0.tgz#69d343f2ac298d9dfdaae3d64423157054fcd859"
+  integrity sha512-66m3jFX4c6CzTVyWnQ0grBFjRqolgd4hmmQamDcyeIMVOOeYQ2dVq3xq3tKbidXGcDKiB9dwso2kSYExBgp0tw==
 
-"@material/dialog@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/dialog/-/dialog-6.0.0-canary.9930d9cc5.0.tgz#0b652108b99744ee122bb322ae458c5a7b3f83d4"
-  integrity sha512-kUDotJjBHFQk3Ri/eY6ICQk277a6QplOVVq3D00cb5e4hMn8O9fwM1Fhs5f+XtlrOohZSTatrUoYB8vxuK5EVA==
+"@material/dialog@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/dialog/-/dialog-6.0.0-canary.927fa902c.0.tgz#9ffadc5260eff231071d735e33909dc59026fa91"
+  integrity sha512-JelItxjN9KMg+cKl/uVdo0p1iKobH4JjfPK7Y+nfOq5FERz8ohH+/950QtaPGbBXHFRJ02EoWJAHejgbL9rcDQ==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/button" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/touch-target" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/button" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/touch-target" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/dom@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-6.0.0-canary.9930d9cc5.0.tgz#22359e63f457892d95ee2bc11a27aee96de9644c"
-  integrity sha512-qN/gzKyaEx8U9kUynIO+eZg6cMjt4ZUiQ1WJnWT+eRsy/7HDLySSKZdy5SfzurQLLRUNmjwETQqNa3IqBhGkxg==
-  dependencies:
-    tslib "^1.9.3"
-
-"@material/drawer@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/drawer/-/drawer-6.0.0-canary.9930d9cc5.0.tgz#06c030a405c093830499670f1c329f3b2ce3a4c9"
-  integrity sha512-mOQmvujDZkgmdxDsUFF+i1kpXlAO+bb0Si1IJbJRwN7P2G/xNE8povHbUAZrOxWbDoBwt0XogVZjCwpYSie3sA==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/list" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/elevation@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-6.0.0-canary.9930d9cc5.0.tgz#990b83bae46768f93c954003080da744028f1510"
-  integrity sha512-XPkRB6LCL1c3lQWrNonQlunhuXPJ0bl8hloHuGnTTlDMbLq/0+39skMnOE9Np/3Xs06+ZVPWD3eQ4E2tX7PleQ==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-
-"@material/fab@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/fab/-/fab-6.0.0-canary.9930d9cc5.0.tgz#3417ea01e9452970604a940b7244a74a362f85e9"
-  integrity sha512-f6ZuwyMt+6XwZDkvjHo+KP1nhNISA/EBgqzfcEA2BKFejfHVhJF2DaIjMBEUZF7vHWeba4vbYAzM8qjvVO0Wpg==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/touch-target" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
-
-"@material/feature-targeting@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-6.0.0-canary.9930d9cc5.0.tgz#5e64073937564bc2a194aad96bb410071cc8328d"
-  integrity sha512-Lbup9ONZEMZOfAAOPYS61H3f7B1pNoYYchxLnW3TYkG3lZalqmjwxc8kfkIKaMJyAdT9xx8FY8AzG96tX0rKKQ==
-
-"@material/floating-label@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-6.0.0-canary.9930d9cc5.0.tgz#15cb4c7161828bea6c93445d03ce07cfda680115"
-  integrity sha512-CtOhuVseyhkkI3l2M/k7ns1EPIpVTJ6LK5AJBO/yZ4ZssPV4a+xmgcKwHSMhn+G4XrvVInTiq+/GaHgfyThUVA==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/form-field@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-6.0.0-canary.9930d9cc5.0.tgz#1b62673fc870e03e1eda478ea5384a2e3ab2d09a"
-  integrity sha512-mxN6TTzlQdgXw2Wh/wAh6VYL7kbkNl1sEYvTLBbsTo2qnEtqS5Hap/UQDVubu06HkKSvAKk4LuVsRJIXfCBQ1A==
-  dependencies:
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/icon-button@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/icon-button/-/icon-button-6.0.0-canary.9930d9cc5.0.tgz#d1399cf1a2e91ba34564b7652f8d5ec122c34dbe"
-  integrity sha512-V3kwkpH1iFy98oMXNzwHb8BI24IE2QJ2kZ9dvHnffKM4qEo1UbABtQmWK+5x5F7V69RmEoR4gnhqSvlGt0y43Q==
-  dependencies:
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/image-list@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/image-list/-/image-list-6.0.0-canary.9930d9cc5.0.tgz#e909624e40c7f844bda7dc26ff7ce6fca358e3a4"
-  integrity sha512-FgiT7fukKguUd+wiU00qflCXh0+9KHbgDQaUEg+LAJvh7CqC32fBuj3O21/2S3r32Ne7tIvemx34N5/H2lVb1Q==
-  dependencies:
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
-
-"@material/layout-grid@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/layout-grid/-/layout-grid-6.0.0-canary.9930d9cc5.0.tgz#0cd94784460e28148af45814ef52ca3ccf220ecf"
-  integrity sha512-k5RtZ+Yr+nK7EG2t7TOuJOCddk14bKh/hL7yt00tksqX6bzigSXUtU2prUFlBHcI4nmVszdiTk2A4jWn+vzL1Q==
-
-"@material/line-ripple@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-6.0.0-canary.9930d9cc5.0.tgz#7a601a6266d112da6333229dba0cec60574b3112"
-  integrity sha512-wt3Prg9Xre89LvK9BfsWaAO/eQpMfh73claFJXLpl0Inw9UwcMFP7okr/BDG+jlupOr3bwHRzlQQrBfBllBKKA==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/linear-progress@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/linear-progress/-/linear-progress-6.0.0-canary.9930d9cc5.0.tgz#ed22deeaf774427b2e7b8e89b4e5a4d66a46d4b7"
-  integrity sha512-91cOabFbcdoN7g62CNz1KC/89wHSqsXBq2HCykmDFcX5n+ANTBjdyvRulWVc/ZjVwBfIQwBi8vD1brw30U6ZMQ==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/progress-indicator" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/list@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/list/-/list-6.0.0-canary.9930d9cc5.0.tgz#0a6ecfa48b98e724781d4c832a2f9f1f05bf9d6a"
-  integrity sha512-BrP2+Kzo8azX89VmdJ1EwnV5cvnTnW166B8L7EpKVeNM/W7sFO5HONuFKS5YSJJ1nwe8Jr7elxLrXQZ3IDMGoQ==
-  dependencies:
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/menu-surface@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/menu-surface/-/menu-surface-6.0.0-canary.9930d9cc5.0.tgz#925474a34a3c97515523f866eb90830e9d519462"
-  integrity sha512-GmhWlNJ8i5Gyt4SAY1Xo64xKiu7KML8DthyvQqIzD6bMWwDC5/2d2sHe1ZajcGRMGwLw1tZMI4b9GncAD3FQYg==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/menu@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-6.0.0-canary.9930d9cc5.0.tgz#bc7dff59962ca5b008b557d60df90f1c07c99cb7"
-  integrity sha512-qG+HyQNntnZGLvlPvTSm7KT1xOgle6pHvT0sdeWLsCY4X4y1UZ4xEgYC1JHvrFwF6rpJBSFiPQYbFT0fjOu8YQ==
-  dependencies:
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/list" "6.0.0-canary.9930d9cc5.0"
-    "@material/menu-surface" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/notched-outline@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-6.0.0-canary.9930d9cc5.0.tgz#895a5eaaf255329a0d340a1291a01c86e97362d8"
-  integrity sha512-dn6OrD7Euq8QLrY0bha3VBl+ztsbzZwU2hfe5+1oq+w8b2yb3KeScFQrtCOKcssPaWky9Eg3SkFBBZtHp3YZ4Q==
-  dependencies:
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/floating-label" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    tslib "^1.9.3"
-
-"@material/progress-indicator@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/progress-indicator/-/progress-indicator-6.0.0-canary.9930d9cc5.0.tgz#ebfc5119d4f6b994b9feba23a4b939dc9a15d5f7"
-  integrity sha512-bM8it7Vzfeyz1fOyJa6tArkv1dsuiV+EFfSTbx+5Ts4v8LdBf23Eoq14FUSga0asHGRJDA3UStGDxb7gXvaJgQ==
+"@material/dom@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/dom/-/dom-6.0.0-canary.927fa902c.0.tgz#3930db242768e9b81507990e5e5fbdb65467079b"
+  integrity sha512-+gIFTuAJvC7aQx2FzxiQgHNNBpeqEakYEkxtDgKRZado53qoty7FrYGieDMdxqDG1FQQzHs3S/ojWEGf5S81Ww==
   dependencies:
     tslib "^1.9.3"
 
-"@material/radio@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-6.0.0-canary.9930d9cc5.0.tgz#3339ddc318509a8c5bc4d1afbadf6cc3ee28d5ba"
-  integrity sha512-kzT6/40vy/EzcGU9pXG9tnzWkICj4uFoBeg8lhUxkdr/6FY/n2OnbjjosQrzF6mDIopYTnXbspq6Jl8DGAl5Lg==
+"@material/drawer@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/drawer/-/drawer-6.0.0-canary.927fa902c.0.tgz#d322cd246a126f79ae8b277209b6a74e0a2432f1"
+  integrity sha512-RqILg4Zzqdc6oceCKP1bhrBbEEIlN/gE2e7udC+xWO5JzmrF4Gl/hTIihW+NuOdPplgP09A+B+H5OWcjzdkXtQ==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/touch-target" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/list" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/ripple@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-6.0.0-canary.9930d9cc5.0.tgz#84e6acff79488a04dd2670c52d63596cc641fe04"
-  integrity sha512-yHkCy7hY5Me2ZMxkq0C8IAKlcgbaTlHRfN2SiLoSuZM4/6ahhGpa5qKc7BD/42+JPDIMAgpDXwK8DrV3OFCf6Q==
+"@material/elevation@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-6.0.0-canary.927fa902c.0.tgz#27868ccfe4092ada68c42db80aaeafe5cd6ac22b"
+  integrity sha512-o3MhTRthTdrucAt2OJGm0xISBivtFTcnBDRTSrcdOwF+3Y9T27GB1jlZbtLd3oeP1r3wdv2r0XmXQlrzkad0+g==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+
+"@material/fab@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/fab/-/fab-6.0.0-canary.927fa902c.0.tgz#11ee66bc18d0bda27e2e676546dd2ecdeec009a1"
+  integrity sha512-zRu1TxCIG3/1ShUrGJtFuM6Rv7L78qXH2cxXX0c2oECV4YFsznqCutWCMVh/soGf1eD77tPhlbgfD3ce+DT9sQ==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/touch-target" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
+
+"@material/feature-targeting@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-6.0.0-canary.927fa902c.0.tgz#f8ec1d9c2ce172e6a6045a72312fa69fe381fd73"
+  integrity sha512-7+gbPjj2qJd4ADo0vrzm4RtWxgp96YhOaefxg/RnjVlt01mkG5vY1R8xewWwaSEfPgGCaVRKswH7Uoaf8Q5noA==
+
+"@material/floating-label@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/floating-label/-/floating-label-6.0.0-canary.927fa902c.0.tgz#f8a80885fa79a350e8edb7e2cc1d945e16b15678"
+  integrity sha512-wSyd8DAsF+M8JPZyDD9OwaXHd/x7V0a0Q5yZ/Bs/Z+Mptx2nFV1jYMvpwyISTm6jFKzGaUiYdcWCQOzS9USp4w==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/rtl@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-6.0.0-canary.9930d9cc5.0.tgz#c96ecc8e9b68b34f6938343056064b46c2c75928"
-  integrity sha512-/Y4nIJ/qipmGnvMKKyf79VHYE5GWeTe69eK5xYuWCPNNc888564rpiqjsVquDgKtLEn1HPeECmfSM8Yj5r8WQw==
-
-"@material/select@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/select/-/select-6.0.0-canary.9930d9cc5.0.tgz#d29c04c033119b887a75cdbbe00f7964685b21c8"
-  integrity sha512-BG6RkChqHJtdPcz/qIceoMpVTa2RNbAQcj/vnuPeCQ7VDCPqWa2xUqSJe32N57r3qBHaTWzrYkko3gEy9bN5+g==
+"@material/form-field@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/form-field/-/form-field-6.0.0-canary.927fa902c.0.tgz#d0960f22534343243d5d787047dceae381bfe7f9"
+  integrity sha512-h7j6D2tRAzyymFdB3La0sHMtBTKTlmodZdhmqAKxYeDyp25IYV94vvJ6QHtnMmOjQNKE+PjrAeiElIi/R52QhQ==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/floating-label" "6.0.0-canary.9930d9cc5.0"
-    "@material/line-ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/menu" "6.0.0-canary.9930d9cc5.0"
-    "@material/menu-surface" "6.0.0-canary.9930d9cc5.0"
-    "@material/notched-outline" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/shape@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-6.0.0-canary.9930d9cc5.0.tgz#7c1ee6b69ac6556c5626b310c0fcc92f7158b50a"
-  integrity sha512-4JSmQGsP+qeXdoCMuAjD8rq7H3kGnxNAh8qR3teGqBTtybn7joYhK36sGAOmr6p2bFLLlosJ52y/wG2/r1shpw==
+"@material/icon-button@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/icon-button/-/icon-button-6.0.0-canary.927fa902c.0.tgz#ad3beba6ac4470beaabaf2f9c1fd76370b91f1c3"
+  integrity sha512-f1qaMpaTckMVe71LcGx5Lg/rHX+DxKOoFkmZSQv6Gahd5QOIZh+SpJk8qfuhMdbtLeHHJvqXHxTcgw3mrw1O1w==
   dependencies:
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-
-"@material/slider@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/slider/-/slider-6.0.0-canary.9930d9cc5.0.tgz#4fae97baa3f12888b7ea64bab97cd6df274fc19f"
-  integrity sha512-SmRA0MHorlOHeDgE64njxDYwIlajequdCANnyyLWg+LwVDkCtwMkN/VDAXP6TvzbN4clSezj5m8SuV1SCR4yXw==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/snackbar@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-6.0.0-canary.9930d9cc5.0.tgz#92868058a0f64f439cbbe247c65a0a2ce8f561cc"
-  integrity sha512-587kIpLT6akLfg5JrqhBd7EkxTxrWEA3L7QMY98CaWKxRBf+nTht47QtyMpG5k7z6x2RQf43G8izABKS3XXw+Q==
+"@material/image-list@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/image-list/-/image-list-6.0.0-canary.927fa902c.0.tgz#1f62c6b48f1c49dfd9c3b6141a0576487e083135"
+  integrity sha512-lz20E3sMAKzve3dw9UIMQxW/2gqFhiFu5VXvV1isW1/vkv6jA7YHl85JdDetNJYsAGo8tDYtYbdelQaiHOHkcg==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/button" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/icon-button" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
+
+"@material/layout-grid@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/layout-grid/-/layout-grid-6.0.0-canary.927fa902c.0.tgz#a6adfed64295c0e0e711450e8f8ed8d0c5d377a0"
+  integrity sha512-TPB5bleLnH343jQp3+pV/DW5rBPgAT4H/8hnQJL60Rcjq+OA2nAZ2K13m+eoWFd+sOZx02LAjMrB3Qvjwf1hJQ==
+
+"@material/line-ripple@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/line-ripple/-/line-ripple-6.0.0-canary.927fa902c.0.tgz#52be325b5d7b99ba53f365c20599a5206de67fd3"
+  integrity sha512-5AUBou4oenMBjuwpejknQVzlXecqFKgcjRnRePn9EPxly0+4DTtGqGMaHR+Z3UIwJcNG4dLHqwf65C5e+YjQXg==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/switch@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-6.0.0-canary.9930d9cc5.0.tgz#bb0afe708d6c34dace495292240a83cfaa86d055"
-  integrity sha512-Ttg5cViGNvGbdvdPdvufSRNv4/ylbxr8RMlMSH1VgYC86HE+AhAgYKOge0QvowG886ejPJcr+6+88ZzwOGS6Vw==
+"@material/linear-progress@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/linear-progress/-/linear-progress-6.0.0-canary.927fa902c.0.tgz#7c3f05088dd83071a1a8d3d97bca7a52ffaa439d"
+  integrity sha512-yeVq2L7bQDRYGv+UxdqlpnLEb2TchxVGMVrAAY/JidC6MARjcdu1zLWC1UJ17cz5iATHEbP5lqJsUHIL1+tMTg==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/progress-indicator" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/tab-bar@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-bar/-/tab-bar-6.0.0-canary.9930d9cc5.0.tgz#dd1f794f012202bf644d6b8641d0a11a35de4b3f"
-  integrity sha512-N4mnvXsBylVNxJLj92XgFqCmtTCtbLaQ9jMNhNKBTZVDgsY0chrDB2o1tNqEgIbONZvyA+tkBYhd2iGdBbeLFQ==
+"@material/list@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/list/-/list-6.0.0-canary.927fa902c.0.tgz#78ae6278eefa65bb782d061a7f391ea1f266bdfb"
+  integrity sha512-uclNG+Q3iHm3dXAY5CGoziwKALstOPVXtpXn/17JBJURq/NmX9W3ENXBJ6yKxeCFAVl4m1IfaA+ZatMr3KGppw==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/tab" "6.0.0-canary.9930d9cc5.0"
-    "@material/tab-scroller" "6.0.0-canary.9930d9cc5.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/tab-indicator@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-indicator/-/tab-indicator-6.0.0-canary.9930d9cc5.0.tgz#54ae1ff734da9ff83bd5f30ab73497cc366877b2"
-  integrity sha512-OuEwBGogiWM3HWXLroi+CRkN0R7gJJcZ9ldEmXntOY+eE8wPdvo0MbIVC3HddiqPwLUxm4vNflu7ayCJDYAnSw==
+"@material/menu-surface@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/menu-surface/-/menu-surface-6.0.0-canary.927fa902c.0.tgz#c078c0f9c93fa599fb7951d59056e2e2e7cb7ab2"
+  integrity sha512-zZYTK/FxGPFd68rPiP3qwXSiXs1zB0+Zh6UUFBEaW8wWopW2DlqU1iqqqnNCu9AAQv6X5xCI2W3t8cH7+Bh7wA==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/tab-scroller@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/tab-scroller/-/tab-scroller-6.0.0-canary.9930d9cc5.0.tgz#2312f08d5517a308f016aaa6f2668732d6a19659"
-  integrity sha512-F0NpyDe/OM8IyAKSBDozXPXjopvI383rXN9ieUBjVAlpx7cDyzc+sCJYolmUW0c2U5C8KBxHcAsxHi3RC0XREg==
+"@material/menu@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/menu/-/menu-6.0.0-canary.927fa902c.0.tgz#4081b5e936148c204545bd06785dbbe204c7924a"
+  integrity sha512-Q6ZXLriGkHs9WTq59B5Oe6R2QfQjYXXne8z2+p1M6v4YltWTk9bcjgNRnOTlN8OICsDDNpVkng2dHBrFJaeudA==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/tab" "6.0.0-canary.9930d9cc5.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/list" "6.0.0-canary.927fa902c.0"
+    "@material/menu-surface" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/tab@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/tab/-/tab-6.0.0-canary.9930d9cc5.0.tgz#f63d1b2537dc7ca118939d6a9a5a763884a54b50"
-  integrity sha512-/Au1/F0+3xhmBLlriOitgaMTZ5D1Nx9mTll+Unos2p2UPhuKSZb3iTBEqdAI+KEIOsoQfcuiTKnTPiUIW78LbA==
+"@material/notched-outline@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/notched-outline/-/notched-outline-6.0.0-canary.927fa902c.0.tgz#3b1a75d21a2b434947ebc7aea6419b132e279239"
+  integrity sha512-5Bf1j4B7yl/CopwLGKkuBBUWkEw0yrgJjDPT2jByuR8DOZKJQVajS7amYcbTlvOqHHjulqpF0tv3BL27+RCCsA==
   dependencies:
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/tab-indicator" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/floating-label" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/textfield@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-6.0.0-canary.9930d9cc5.0.tgz#9e7527c232c980569ce6237efdce18bdc1cde1e3"
-  integrity sha512-YuB+2KMGKLsSd7s7LJh20ADQrdxJfP4RwlvRpLzeAH8F9g2o0uE8JbrnrQyYSq+U3nN5Nn+9YipFuMLfEu0S4w==
+"@material/progress-indicator@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/progress-indicator/-/progress-indicator-6.0.0-canary.927fa902c.0.tgz#45bf0bd8af25e9a6de7e2a458b4c07a1b1f97d82"
+  integrity sha512-0C5GYHsueTRUQmpwbdT7K3RZqb08LR1YsQkWRgMKFp1nyxcWKYoYOjf0UInGOSEsosQvk0i1fpIjC15h7cbUeA==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/floating-label" "6.0.0-canary.9930d9cc5.0"
-    "@material/line-ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/notched-outline" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
     tslib "^1.9.3"
 
-"@material/theme@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-6.0.0-canary.9930d9cc5.0.tgz#8e590abc0c0789a4e91770a103e2684ec32278bd"
-  integrity sha512-ecQFx4z6M/u1AN124lkbLpxA8Txipxdra/1/mT12cHYEdqbFPxBe/jVGzjyeB8LwzTUdzXYZx/IEeLepsZFhyA==
+"@material/radio@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/radio/-/radio-6.0.0-canary.927fa902c.0.tgz#41d12acc3d650b7ce0b70477ea9781b84c1206fa"
+  integrity sha512-NvYr/pW3k4YHAmXzTrYuBZypbAjKS7WGYPOK9yAOX03OVsi/r/yZWWX1WL5DGd+lPJdL97/ufk2oDZIAgPDcxQ==
   dependencies:
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-
-"@material/top-app-bar@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/top-app-bar/-/top-app-bar-6.0.0-canary.9930d9cc5.0.tgz#1f60932b4ec685091dc4d6a9d57256c223482ff3"
-  integrity sha512-0ygIIO7Rk+r5pXXvEzhqle1ALKDGFLj/tFe4PwdDfCa/D8/Nr0IzLo3ltGOAXBJmTIaH1sCIJhImM1oWZu6j5Q==
-  dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/touch-target" "6.0.0-canary.927fa902c.0"
     tslib "^1.9.3"
 
-"@material/touch-target@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/touch-target/-/touch-target-6.0.0-canary.9930d9cc5.0.tgz#d4d47cb7d361c876ce98d3c19310754b7cfd807b"
-  integrity sha512-ioqtTIgIhHNTi7gH+/TjPmd7KA13JP+/grySngWWlVXf3IU4gZzXchIONYqOpo/i1xvp40gp2Sovs9eG+EslDQ==
+"@material/ripple@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-6.0.0-canary.927fa902c.0.tgz#a61155900cb0e61c435f2cd2da270e65587c7743"
+  integrity sha512-8MWkl37lNujIs6+5Wa/1p/xe0Q3ug+wB42eLTaJ/jkIeRGp/IWUr60yIvpaeBDkHJsiaDFoBExVD2BnzdxZM/g==
   dependencies:
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
 
-"@material/typography@6.0.0-canary.9930d9cc5.0":
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-6.0.0-canary.9930d9cc5.0.tgz#870457b56079fd7ddaaf7d8d2a7f270dc1e7ccb3"
-  integrity sha512-DRQJmnhS/MhBxFL274QKh0uoevEXES5oNazLrkjcACvFvV+jg9iVjm7kacyvWDnW93g3QBt7Mt46LN4KiEQUuQ==
+"@material/rtl@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-6.0.0-canary.927fa902c.0.tgz#c6e432658b5fd6c8ee0a05048f416a43ad56a05d"
+  integrity sha512-aRbVNvKYXd/+987ZrG62cJrKVDLS3EQnocJ8jE6KJ6vu0XepV1ntDI2g91an5BF4h7XQYB/WWvKOncnb/oLQDw==
+
+"@material/select@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/select/-/select-6.0.0-canary.927fa902c.0.tgz#51ce6edb59786e47e4bbdaab10fcde1f2fcd1571"
+  integrity sha512-2SQqag1mrZkH5dzVj/fSLSnEYhFvDMjoKbtDnX5uiyNFFuvMcwfTSnRTp5/EY2+zgS6e9Ve11lG8/Le8sQsj5A==
   dependencies:
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/floating-label" "6.0.0-canary.927fa902c.0"
+    "@material/line-ripple" "6.0.0-canary.927fa902c.0"
+    "@material/menu" "6.0.0-canary.927fa902c.0"
+    "@material/menu-surface" "6.0.0-canary.927fa902c.0"
+    "@material/notched-outline" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/shape@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/shape/-/shape-6.0.0-canary.927fa902c.0.tgz#ca171a1c5a47a32d0ce5498e777b3978c41837d1"
+  integrity sha512-4KSLE0ROnEO7su4nXb2AMzH3ZfUtg1VAzqD+2angdASLKDZMup0GSPj0mkfJaO9CZObEwNvnkJzSOJ6Aej9sOQ==
+  dependencies:
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+
+"@material/slider@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/slider/-/slider-6.0.0-canary.927fa902c.0.tgz#dcac13b73d6946e385450344eb345d8047398a03"
+  integrity sha512-RLfC2o6II6xfjzXC1iX9CukZRBBaslyKbbPhUJEFjxLHggolIiP+cqmqb/WkQjN4Itj1GSR0Y++69/FMjVoj7Q==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/snackbar@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/snackbar/-/snackbar-6.0.0-canary.927fa902c.0.tgz#775c30db38155d3a7d4c4708dd7bf6794961f8b8"
+  integrity sha512-L8zyYSUG3KCrOovJcgXq2nSnwf6PA9TYXbgID6qCYVsYlBpuCf4EmtGKKawLdvp5Wo1E8+Eg7NRJ3BV777jflg==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/button" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/icon-button" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/switch@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-6.0.0-canary.927fa902c.0.tgz#ed4b7d2406eb4c1eb8dd2d7225934bd485384897"
+  integrity sha512-6A/Ia5oZShId5U8kHrzdLJ6xtJ9vnhb+aMuiGcijny1Yk/qnv1+AQW3Qn4AxxzRPBu/eFeq6M+n1YzOGYveziA==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/tab-bar@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-bar/-/tab-bar-6.0.0-canary.927fa902c.0.tgz#9fd8b345d10a3d40935a4828b94b2baa473d0735"
+  integrity sha512-MtHEEV4Y9oMmjcDV8fF9NsZwCMDh37ioDwrERXm9p8jovRIV52ftkDV4n3/fjBrMw3b/jQ3I99VkOnGuwm9AwA==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/tab" "6.0.0-canary.927fa902c.0"
+    "@material/tab-scroller" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/tab-indicator@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-indicator/-/tab-indicator-6.0.0-canary.927fa902c.0.tgz#0f481dc7b50c27ce3e6be2c20471b75826d2a282"
+  integrity sha512-Ki9msOavlAICjKzrooYXxBQPHt+9QLYmCTVEFCDdUNXv4U+y7yEPV4LMV/XVagscW5LZluUQ4X7sVwU6z5btkg==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/tab-scroller@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/tab-scroller/-/tab-scroller-6.0.0-canary.927fa902c.0.tgz#7a1175d7e80bede41f8397be137674ec4335dee3"
+  integrity sha512-a9sIK07zymL9w3hJyNAEGhbBWB2OTeDqaTA5stJlxJpKZzXQr+2jDCzh0GgCJKQeUq+/TWW+oUsXrkJiMQzh6A==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/tab" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/tab@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/tab/-/tab-6.0.0-canary.927fa902c.0.tgz#15069851098af9d94d07992cf90f58d00045d1ce"
+  integrity sha512-PShVY1GVj+Zj5o9USFYKMeOJdqQG+/+KI2TOEE4ysUd1l9M/3L67D9zFFgyIwGcYyD2crBjG6/9V0/3Ei9VQJw==
+  dependencies:
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/tab-indicator" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/textfield@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/textfield/-/textfield-6.0.0-canary.927fa902c.0.tgz#8be51af7756882886b81ffdccc690bfef77171d1"
+  integrity sha512-VGyctfmHUW9G9UiIzmD+DuvlwHvTM7ud9f7nADv4vfUJgQuaUiVhzGVzRkV3ZoEIr/7cO8pEqJ5v+QXhYZz8oA==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/floating-label" "6.0.0-canary.927fa902c.0"
+    "@material/line-ripple" "6.0.0-canary.927fa902c.0"
+    "@material/notched-outline" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/theme@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-6.0.0-canary.927fa902c.0.tgz#c3fc0e41d28b473b6508971e9b72a5b937596f71"
+  integrity sha512-GC2N2BFR/7ALm8Le7QLHxawa/B8Jfc2YFICCaIqnOS+CqBKeg4YmGWSyrgYncuUauhH6G1/IJuJ/muielUuS/g==
+  dependencies:
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+
+"@material/top-app-bar@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/top-app-bar/-/top-app-bar-6.0.0-canary.927fa902c.0.tgz#8aa7e04483fafb5fdadadbacb2a83b823eef8ab2"
+  integrity sha512-X/5TNxxbl7o3MI8ZgOFKisRSyW13gZ6sNabwish6BNMmHPX83aBRAv4ZhW6t3hNgrb5Nx5ind4DqfWWf2upwRA==
+  dependencies:
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
+    tslib "^1.9.3"
+
+"@material/touch-target@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/touch-target/-/touch-target-6.0.0-canary.927fa902c.0.tgz#e3fc07722fc5dea166498ef5b7c8b80d26525b84"
+  integrity sha512-O7cljOgCwvVnv+IBTMMDaktym5qhrjqzXA8iMntKq1VpFZtcPXhadvx7+TvoPEi3z/jmbtJqr6COJIInx2Ycxw==
+  dependencies:
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+
+"@material/typography@6.0.0-canary.927fa902c.0":
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/@material/typography/-/typography-6.0.0-canary.927fa902c.0.tgz#5f2e3d5b4bd01428b701f2b642a94129a3efd28c"
+  integrity sha512-RhR0UWsYDQMZ+kroovm+sdeSx8csQMd8ijzQXrqJb+mTbGGNa+HArfmaqLr5P4n6Y1DYqcf4U6vKD4HmMwzECQ==
+  dependencies:
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
 
 "@microsoft/api-extractor-model@7.4.1":
   version "7.4.1"
@@ -7615,55 +7616,55 @@ matchdep@^2.0.0:
     resolve "^1.4.0"
     stack-trace "0.0.10"
 
-material-components-web@6.0.0-canary.9930d9cc5.0:
-  version "6.0.0-canary.9930d9cc5.0"
-  resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-6.0.0-canary.9930d9cc5.0.tgz#e7f406c2510a86246a04a2f118d063d3495e3796"
-  integrity sha512-yJfhyDn3oz15E5mWSv3GomzOct6DWocqW1kCNjqxaL1JSSDd2NT4sM2aIOT6ASgM/nCBGWA3Jz1l8f28AuSplw==
+material-components-web@6.0.0-canary.927fa902c.0:
+  version "6.0.0-canary.927fa902c.0"
+  resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-6.0.0-canary.927fa902c.0.tgz#7e584f3c6caabd472f26ac3f15cb3588efcd9cd8"
+  integrity sha512-7nj64IqEgBwMsR0bI6Xzqx83BOb6oS5qGlfCfVmWLoEX7+fVFKz7Aj5pgogRMsL3kNmcDqZkCCqGZoOz5hCeYw==
   dependencies:
-    "@material/animation" "6.0.0-canary.9930d9cc5.0"
-    "@material/auto-init" "6.0.0-canary.9930d9cc5.0"
-    "@material/base" "6.0.0-canary.9930d9cc5.0"
-    "@material/button" "6.0.0-canary.9930d9cc5.0"
-    "@material/card" "6.0.0-canary.9930d9cc5.0"
-    "@material/checkbox" "6.0.0-canary.9930d9cc5.0"
-    "@material/chips" "6.0.0-canary.9930d9cc5.0"
-    "@material/circular-progress" "6.0.0-canary.9930d9cc5.0"
-    "@material/data-table" "6.0.0-canary.9930d9cc5.0"
-    "@material/density" "6.0.0-canary.9930d9cc5.0"
-    "@material/dialog" "6.0.0-canary.9930d9cc5.0"
-    "@material/dom" "6.0.0-canary.9930d9cc5.0"
-    "@material/drawer" "6.0.0-canary.9930d9cc5.0"
-    "@material/elevation" "6.0.0-canary.9930d9cc5.0"
-    "@material/fab" "6.0.0-canary.9930d9cc5.0"
-    "@material/feature-targeting" "6.0.0-canary.9930d9cc5.0"
-    "@material/floating-label" "6.0.0-canary.9930d9cc5.0"
-    "@material/form-field" "6.0.0-canary.9930d9cc5.0"
-    "@material/icon-button" "6.0.0-canary.9930d9cc5.0"
-    "@material/image-list" "6.0.0-canary.9930d9cc5.0"
-    "@material/layout-grid" "6.0.0-canary.9930d9cc5.0"
-    "@material/line-ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/linear-progress" "6.0.0-canary.9930d9cc5.0"
-    "@material/list" "6.0.0-canary.9930d9cc5.0"
-    "@material/menu" "6.0.0-canary.9930d9cc5.0"
-    "@material/menu-surface" "6.0.0-canary.9930d9cc5.0"
-    "@material/notched-outline" "6.0.0-canary.9930d9cc5.0"
-    "@material/radio" "6.0.0-canary.9930d9cc5.0"
-    "@material/ripple" "6.0.0-canary.9930d9cc5.0"
-    "@material/rtl" "6.0.0-canary.9930d9cc5.0"
-    "@material/select" "6.0.0-canary.9930d9cc5.0"
-    "@material/shape" "6.0.0-canary.9930d9cc5.0"
-    "@material/slider" "6.0.0-canary.9930d9cc5.0"
-    "@material/snackbar" "6.0.0-canary.9930d9cc5.0"
-    "@material/switch" "6.0.0-canary.9930d9cc5.0"
-    "@material/tab" "6.0.0-canary.9930d9cc5.0"
-    "@material/tab-bar" "6.0.0-canary.9930d9cc5.0"
-    "@material/tab-indicator" "6.0.0-canary.9930d9cc5.0"
-    "@material/tab-scroller" "6.0.0-canary.9930d9cc5.0"
-    "@material/textfield" "6.0.0-canary.9930d9cc5.0"
-    "@material/theme" "6.0.0-canary.9930d9cc5.0"
-    "@material/top-app-bar" "6.0.0-canary.9930d9cc5.0"
-    "@material/touch-target" "6.0.0-canary.9930d9cc5.0"
-    "@material/typography" "6.0.0-canary.9930d9cc5.0"
+    "@material/animation" "6.0.0-canary.927fa902c.0"
+    "@material/auto-init" "6.0.0-canary.927fa902c.0"
+    "@material/base" "6.0.0-canary.927fa902c.0"
+    "@material/button" "6.0.0-canary.927fa902c.0"
+    "@material/card" "6.0.0-canary.927fa902c.0"
+    "@material/checkbox" "6.0.0-canary.927fa902c.0"
+    "@material/chips" "6.0.0-canary.927fa902c.0"
+    "@material/circular-progress" "6.0.0-canary.927fa902c.0"
+    "@material/data-table" "6.0.0-canary.927fa902c.0"
+    "@material/density" "6.0.0-canary.927fa902c.0"
+    "@material/dialog" "6.0.0-canary.927fa902c.0"
+    "@material/dom" "6.0.0-canary.927fa902c.0"
+    "@material/drawer" "6.0.0-canary.927fa902c.0"
+    "@material/elevation" "6.0.0-canary.927fa902c.0"
+    "@material/fab" "6.0.0-canary.927fa902c.0"
+    "@material/feature-targeting" "6.0.0-canary.927fa902c.0"
+    "@material/floating-label" "6.0.0-canary.927fa902c.0"
+    "@material/form-field" "6.0.0-canary.927fa902c.0"
+    "@material/icon-button" "6.0.0-canary.927fa902c.0"
+    "@material/image-list" "6.0.0-canary.927fa902c.0"
+    "@material/layout-grid" "6.0.0-canary.927fa902c.0"
+    "@material/line-ripple" "6.0.0-canary.927fa902c.0"
+    "@material/linear-progress" "6.0.0-canary.927fa902c.0"
+    "@material/list" "6.0.0-canary.927fa902c.0"
+    "@material/menu" "6.0.0-canary.927fa902c.0"
+    "@material/menu-surface" "6.0.0-canary.927fa902c.0"
+    "@material/notched-outline" "6.0.0-canary.927fa902c.0"
+    "@material/radio" "6.0.0-canary.927fa902c.0"
+    "@material/ripple" "6.0.0-canary.927fa902c.0"
+    "@material/rtl" "6.0.0-canary.927fa902c.0"
+    "@material/select" "6.0.0-canary.927fa902c.0"
+    "@material/shape" "6.0.0-canary.927fa902c.0"
+    "@material/slider" "6.0.0-canary.927fa902c.0"
+    "@material/snackbar" "6.0.0-canary.927fa902c.0"
+    "@material/switch" "6.0.0-canary.927fa902c.0"
+    "@material/tab" "6.0.0-canary.927fa902c.0"
+    "@material/tab-bar" "6.0.0-canary.927fa902c.0"
+    "@material/tab-indicator" "6.0.0-canary.927fa902c.0"
+    "@material/tab-scroller" "6.0.0-canary.927fa902c.0"
+    "@material/textfield" "6.0.0-canary.927fa902c.0"
+    "@material/theme" "6.0.0-canary.927fa902c.0"
+    "@material/top-app-bar" "6.0.0-canary.927fa902c.0"
+    "@material/touch-target" "6.0.0-canary.927fa902c.0"
+    "@material/typography" "6.0.0-canary.927fa902c.0"
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
I got some changes in with https://github.com/material-components/material-components-web/pull/5792 which allow us to properly render a progress bar during server-side rendering, instead of turning it into a noop. These changes remove all of the `isBrowser` checks.

I also removed the `isBrowser` check from the MDC checkbox, because the `offsetWidth` access is safe, even though the property might be undefined.