### PR TITLE
fix(tabs): group alignment propagating to nested groups

### DIFF
--- a/src/material-experimental/mdc-tabs/_tabs-common.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-common.scss
@@ -144,16 +144,18 @@ $mat-tab-animation-duration: 500ms !default;
 }
 
 // Structural styles for the element that wraps the paginated header items.
-@mixin mat-mdc-paginated-tab-header-item-wrapper {
+@mixin mat-mdc-paginated-tab-header-item-wrapper($parent) {
   display: flex;
   flex: 1 0 auto;
 
+  // We need to set the parent here explicitly, in order to prevent the alignment
+  // from any parent tab groups from propagating down to the children when nesting.
   // Note that these are used as inputs so they shouldn't be changed to `mat-mdc-`.
-  [mat-align-tabs='center'] & {
+  [mat-align-tabs='center'] > #{$parent} & {
     justify-content: center;
   }
 
-  [mat-align-tabs='end'] & {
+  [mat-align-tabs='end'] > #{$parent} & {
     justify-content: flex-end;
   }
 }

--- a/src/material-experimental/mdc-tabs/tab-header.scss
+++ b/src/material-experimental/mdc-tabs/tab-header.scss
@@ -17,5 +17,5 @@
 }
 
 .mat-mdc-tab-labels {
-  @include mat-mdc-paginated-tab-header-item-wrapper;
+  @include mat-mdc-paginated-tab-header-item-wrapper('.mat-mdc-tab-header');
 }

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.scss
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.scss
@@ -6,7 +6,7 @@
 @include mat-mdc-paginated-tab-header;
 
 .mat-mdc-tab-links {
-  @include mat-mdc-paginated-tab-header-item-wrapper;
+  @include mat-mdc-paginated-tab-header-item-wrapper('.mat-mdc-tab-link-container');
 }
 
 .mat-mdc-tab-link-container {

--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -138,14 +138,16 @@ $mat-tab-animation-duration: 500ms !default;
 }
 
 // Structural styles for the element that wraps the paginated header items.
-@mixin paginated-tab-header-item-wrapper {
+@mixin paginated-tab-header-item-wrapper($parent) {
   display: flex;
 
-  [mat-align-tabs='center'] & {
+  // We need to set the parent here explicitly, in order to prevent the alignment
+  // from any parent tab groups from propagating down to the children when nesting.
+  [mat-align-tabs='center'] > #{$parent} & {
     justify-content: center;
   }
 
-  [mat-align-tabs='end'] & {
+  [mat-align-tabs='end'] > #{$parent} & {
     justify-content: flex-end;
   }
 }

--- a/src/material/tabs/tab-header.scss
+++ b/src/material/tabs/tab-header.scss
@@ -8,7 +8,7 @@
 }
 
 .mat-tab-labels {
-  @include paginated-tab-header-item-wrapper;
+  @include paginated-tab-header-item-wrapper('.mat-tab-header');
 }
 
 .mat-tab-label-container {

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.scss
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.scss
@@ -4,7 +4,7 @@
 @include paginated-tab-header;
 
 .mat-tab-links {
-  @include paginated-tab-header-item-wrapper;
+  @include paginated-tab-header-item-wrapper('.mat-tab-link-container');
 }
 
 .mat-ink-bar {


### PR DESCRIPTION
The selector that applies the alignment to the tab header was too broad which meant that it was applying to any nested tab groups.

Fixes #19035.