### PR TITLE
fix(drag-drop): expose Point interface

### DIFF
--- a/src/cdk/drag-drop/public-api.ts
+++ b/src/cdk/drag-drop/public-api.ts
@@ -7,7 +7,7 @@
  */
 
 export {DragDrop} from './drag-drop';
-export {DragRef, DragRefConfig} from './drag-ref';
+export {DragRef, DragRefConfig, Point} from './drag-ref';
 export {DropListRef} from './drop-list-ref';
 
 export * from './drag-events';

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -390,4 +390,9 @@ export declare class DropListRef<T = any> {
 
 export declare function moveItemInArray<T = any>(array: T[], fromIndex: number, toIndex: number): void;
 
+export interface Point {
+    x: number;
+    y: number;
+}
+
 export declare function transferArrayItem<T = any>(currentArray: T[], targetArray: T[], currentIndex: number, targetIndex: number): void;


### PR DESCRIPTION
The `Point` interface is part of some public APIs, but wasn't being exported.

Fixes #19001.