### PR TITLE
fix(material/checkbox): incorrect text color when placed inside an overlay with a dark theme

### DIFF
--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -32,6 +32,12 @@
     fill: $checkbox-mark-color;
   }
 
+  .mat-checkbox-label {
+    // Explicitly set the text color since the checkbox may be
+    // inside an overlay that doesn't have the proper theme text color.
+    color: theming.get-color-from-palette($foreground, 'text');
+  }
+
   .mat-checkbox-checkmark-path {
     // !important is needed here because a stroke must be set as an
     // attribute on the SVG in order for line animation to work properly.


### PR DESCRIPTION
This is along the same lines as #18742. The checkbox inherits its text color from the closest parent which may not be correct once the element is moved out into an overlay.