### PR TITLE
refactor(cdk-experimental/column-resize): clean up ReplaySubject usages

### DIFF
--- a/src/cdk-experimental/column-resize/column-resize.ts
+++ b/src/cdk-experimental/column-resize/column-resize.ts
@@ -7,7 +7,7 @@
  */
 
 import {AfterViewInit, Directive, ElementRef, NgZone, OnDestroy} from '@angular/core';
-import {fromEvent, merge, ReplaySubject} from 'rxjs';
+import {fromEvent, merge, Subject} from 'rxjs';
 import {filter, map, mapTo, pairwise, startWith, take, takeUntil} from 'rxjs/operators';
 
 import {_closest, _matches} from '@angular/cdk-experimental/popover-edit';
@@ -27,7 +27,7 @@ let nextId = 0;
  */
 @Directive()
 export abstract class ColumnResize implements AfterViewInit, OnDestroy {
-  protected readonly destroyed = new ReplaySubject<void>();
+  protected readonly destroyed = new Subject<void>();
 
   /* Publicly accessible interface for triggering and being notified of resizes. */
   abstract readonly columnResizeNotifier: ColumnResizeNotifier;

--- a/src/cdk-experimental/column-resize/overlay-handle.ts
+++ b/src/cdk-experimental/column-resize/overlay-handle.ts
@@ -11,7 +11,7 @@ import {coerceCssPixelValue} from '@angular/cdk/coercion';
 import {Directionality} from '@angular/cdk/bidi';
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {CdkColumnDef} from '@angular/cdk/table';
-import {fromEvent, ReplaySubject} from 'rxjs';
+import {fromEvent, Subject} from 'rxjs';
 import {
   distinctUntilChanged,
   filter,
@@ -37,7 +37,7 @@ import {ResizeRef} from './resize-ref';
  */
 @Directive()
 export abstract class ResizeOverlayHandle implements AfterViewInit, OnDestroy {
-  protected readonly destroyed = new ReplaySubject<void>();
+  protected readonly destroyed = new Subject<void>();
 
   protected abstract readonly columnDef: CdkColumnDef;
   protected abstract readonly document: Document;

--- a/src/cdk-experimental/column-resize/resizable.ts
+++ b/src/cdk-experimental/column-resize/resizable.ts
@@ -19,7 +19,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {ComponentPortal, PortalInjector} from '@angular/cdk/portal';
 import {Overlay, OverlayRef} from '@angular/cdk/overlay';
 import {CdkColumnDef} from '@angular/cdk/table';
-import {merge, ReplaySubject} from 'rxjs';
+import {merge, Subject} from 'rxjs';
 import {filter, takeUntil} from 'rxjs/operators';
 
 import {_closest} from '@angular/cdk-experimental/popover-edit';
@@ -45,7 +45,7 @@ export abstract class Resizable<HandleComponent extends ResizeOverlayHandle>
 
   protected inlineHandle?: HTMLElement;
   protected overlayRef?: OverlayRef;
-  protected readonly destroyed = new ReplaySubject<void>();
+  protected readonly destroyed = new Subject<void>();
 
   protected abstract readonly columnDef: CdkColumnDef;
   protected abstract readonly columnResize: ColumnResize;


### PR DESCRIPTION
Replaces some usages of `ReplaySubject` with a plain `Subject` since we don't use ReplaySubject anywhere else in the codebase and in these cases it doesn't provide any benefit. This should lead to less code being imported as a result of the CDK.