### PR TITLE
feat(datepicker): allow for the preview range logic to be customized

### DIFF
--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -92,17 +92,42 @@ export class PreserveRangeStrategy<D> implements MatCalendarRangeSelectionStrate
   selectionFinished(date: D, currentRange: DateRange<D>) {
     let {start, end} = currentRange;
 
+    if (start && end) {
+      return this._getRangeRelativeToDate(date, start, end);
+    }
+
     if (start == null) {
       start = date;
     } else if (end == null) {
       end = date;
-    } else if (this._dateAdapter.compareDate(start, date) > 0) {
-      start = date;
-    } else {
-      end = date;
     }
 
     return new DateRange<D>(start, end);
+  }
+
+  createPreview(activeDate: D | null, currentRange: DateRange<D>): DateRange<D> {
+    if (activeDate) {
+      if (currentRange.start && currentRange.end) {
+        return this._getRangeRelativeToDate(activeDate, currentRange.start, currentRange.end);
+      } else if (currentRange.start && !currentRange.end) {
+        return new DateRange(currentRange.start, activeDate);
+      }
+    }
+
+    return new DateRange<D>(null, null);
+  }
+
+  private _getRangeRelativeToDate(date: D | null, start: D, end: D): DateRange<D> {
+    let rangeStart: D | null = null;
+    let rangeEnd: D | null = null;
+
+    if (date) {
+      const delta = Math.round(Math.abs(this._dateAdapter.compareDate(start, end)) / 2);
+      rangeStart = this._dateAdapter.addCalendarDays(date, -delta);
+      rangeEnd = this._dateAdapter.addCalendarDays(date, delta);
+    }
+
+    return new DateRange(rangeStart, rangeEnd);
   }
 }
 

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -194,7 +194,7 @@ describe('MatCalendarBody', () => {
 
     it('should not mark a cell as a start bridge if there is no end range value', () => {
       testComponent.startValue = 1;
-      testComponent.endValue = undefined;
+      testComponent.endValue = null;
       testComponent.comparisonStart = 5;
       testComponent.comparisonEnd = 10;
       fixture.detectChanges();
@@ -217,7 +217,7 @@ describe('MatCalendarBody', () => {
       testComponent.comparisonStart = 1;
       testComponent.comparisonEnd = 5;
       testComponent.startValue = 5;
-      testComponent.endValue = undefined;
+      testComponent.endValue = null;
       fixture.detectChanges();
 
       expect(cells.some(cell => cell.classList.contains(bridgeEnd))).toBe(false);
@@ -375,7 +375,7 @@ describe('MatCalendarBody', () => {
     });
 
     it('should not show a range if there is no start', () => {
-      testComponent.startValue = undefined;
+      testComponent.startValue = null;
       testComponent.endValue = 10;
       fixture.detectChanges();
 
@@ -384,7 +384,7 @@ describe('MatCalendarBody', () => {
     });
 
     it('should not show a comparison range if there is no start', () => {
-      testComponent.comparisonStart = undefined;
+      testComponent.comparisonStart = null;
       testComponent.comparisonEnd = 10;
       fixture.detectChanges();
 
@@ -394,7 +394,7 @@ describe('MatCalendarBody', () => {
 
     it('should not show a comparison range if there is no end', () => {
       testComponent.comparisonStart = 10;
-      testComponent.comparisonEnd = undefined;
+      testComponent.comparisonEnd = null;
       fixture.detectChanges();
 
       expect(cells.some(cell => cell.classList.contains(inComparisonClass))).toBe(false);
@@ -599,20 +599,26 @@ class StandardCalendarBody {
 @Component({
   template: `
     <table mat-calendar-body
+          [isRange]="true"
           [rows]="rows"
           [startValue]="startValue"
           [endValue]="endValue"
           [comparisonStart]="comparisonStart"
           [comparisonEnd]="comparisonEnd"
-          (selectedValueChange)="onSelect($event)">
+          [previewStart]="previewStart"
+          [previewEnd]="previewEnd"
+          (selectedValueChange)="onSelect($event)"
+          (previewChange)="previewChanged($event)">
     </table>`,
 })
 class RangeCalendarBody {
   rows = createCalendarCells(4);
-  startValue: number | undefined;
-  endValue: number | undefined;
-  comparisonStart: number | undefined;
-  comparisonEnd: number | undefined;
+  startValue: number | null;
+  endValue: number | null;
+  comparisonStart: number | null;
+  comparisonEnd: number | null;
+  previewStart: number | null;
+  previewEnd: number | null;
 
   onSelect(event: MatCalendarUserEvent<number>) {
     const value = event.value;
@@ -622,8 +628,13 @@ class RangeCalendarBody {
       this.endValue = value;
     } else {
       this.startValue = value;
-      this.endValue = undefined;
+      this.endValue = null;
     }
+  }
+
+  previewChanged(event: MatCalendarUserEvent<MatCalendarCell<Date> | null>) {
+    this.previewStart = this.startValue;
+    this.previewEnd = event.value?.compareValue || null;
   }
 }
 

--- a/src/material/datepicker/calendar-range-selection-strategy.ts
+++ b/src/material/datepicker/calendar-range-selection-strategy.ts
@@ -19,8 +19,26 @@ export const MAT_CALENDAR_RANGE_SELECTION_STRATEGY =
 
 /** Object that can be provided in order to customize the date range selection behavior. */
 export interface MatCalendarRangeSelectionStrategy<D> {
-  /** Called when the user has finished selecting a value. */
+  /**
+   * Called when the user has finished selecting a value.
+   * @param date Date that was selected. Will be null if the user cleared the selection.
+   * @param currentRange Range that is currently show in the calendar.
+   * @param event DOM event that triggered the selection. Currently only corresponds to a `click`
+   *    event, but it may get expanded in the future.
+   */
   selectionFinished(date: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
+
+  /**
+   * Called when the user has activated a new date (e.g. by hovering over
+   * it or moving focus) and the calendar tries to display a date range.
+   *
+   * @param activeDate Date that the user has activated. Will be null if the user moved
+   *    focus to an element that's no a calendar cell.
+   * @param currentRange Range that is currently shown in the calendar.
+   * @param event DOM event that caused the preview to be changed. Will be either a
+   *    `mouseenter`/`mouseleave` or `focus`/`blur` depending on how the user is navigating.
+   */
+  createPreview(activeDate: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
 }
 
 /** Provides the default date range selection behavior. */
@@ -38,6 +56,18 @@ export class DefaultMatCalendarRangeStrategy<D> implements MatCalendarRangeSelec
     } else {
       start = date;
       end = null;
+    }
+
+    return new DateRange<D>(start, end);
+  }
+
+  createPreview(activeDate: D | null, currentRange: DateRange<D>) {
+    let start: D | null = null;
+    let end: D | null = null;
+
+    if (currentRange.start && !currentRange.end && activeDate) {
+      start = currentRange.start;
+      end = activeDate;
     }
 
     return new DateRange<D>(start, end);

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -389,7 +389,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   }
 
   focusActiveCell() {
-    this._getCurrentViewComponent()._focusActiveCell();
+    this._getCurrentViewComponent()._focusActiveCell(false);
   }
 
   /** Updates today's date after an update of the active date */

--- a/src/material/datepicker/month-view.html
+++ b/src/material/datepicker/month-view.html
@@ -13,9 +13,13 @@
          [endValue]="_rangeEnd!"
          [comparisonStart]="_comparisonRangeStart"
          [comparisonEnd]="_comparisonRangeEnd"
+         [previewStart]="_previewStart"
+         [previewEnd]="_previewEnd"
+         [isRange]="_isRange"
          [labelMinRequiredCells]="3"
          [activeCell]="_dateAdapter.getDate(activeDate) - 1"
          (selectedValueChange)="_dateSelected($event)"
+         (previewChange)="_previewChanged($event)"
          (keydown)="_handleCalendarBodyKeydown($event)">
   </tbody>
 </table>

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -27,6 +27,10 @@ import {By} from '@angular/platform-browser';
 import {MatCalendarBody} from './calendar-body';
 import {MatMonthView} from './month-view';
 import {DateRange} from './date-selection-model';
+import {
+  MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+  DefaultMatCalendarRangeStrategy,
+} from './calendar-range-selection-strategy';
 
 describe('MatMonthView', () => {
   let dir: {value: Direction};
@@ -46,7 +50,8 @@ describe('MatMonthView', () => {
         MonthViewWithDateClass,
       ],
       providers: [
-        {provide: Directionality, useFactory: () => dir = {value: 'ltr'}}
+        {provide: Directionality, useFactory: () => dir = {value: 'ltr'}},
+        {provide: MAT_CALENDAR_RANGE_SELECTION_STRATEGY, useClass: DefaultMatCalendarRangeStrategy}
       ]
     });
 

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -15,6 +15,7 @@ export interface DateSelectionModelChange<S> {
 
 export declare class DefaultMatCalendarRangeStrategy<D> implements MatCalendarRangeSelectionStrategy<D> {
     constructor(_dateAdapter: DateAdapter<D>);
+    createPreview(activeDate: D | null, currentRange: DateRange<D>): DateRange<D>;
     selectionFinished(date: D, currentRange: DateRange<D>): DateRange<D>;
     static ɵfac: i0.ɵɵFactoryDef<DefaultMatCalendarRangeStrategy<any>, never>;
     static ɵprov: i0.ɵɵInjectableDef<DefaultMatCalendarRangeStrategy<any>>;
@@ -93,22 +94,25 @@ export declare class MatCalendarBody implements OnChanges, OnDestroy {
     _cellPadding: string;
     _cellWidth: string;
     _firstRowOffset: number;
-    _previewEnd: number;
     activeCell: number;
     cellAspectRatio: number;
     comparisonEnd: number | null;
     comparisonStart: number | null;
     endValue: number;
+    isRange: boolean;
     label: string;
     labelMinRequiredCells: number;
     numCols: number;
+    previewChange: EventEmitter<MatCalendarUserEvent<MatCalendarCell<any> | null>>;
+    previewEnd: number | null;
+    previewStart: number | null;
     rows: MatCalendarCell[][];
     readonly selectedValueChange: EventEmitter<MatCalendarUserEvent<number>>;
     startValue: number;
     todayValue: number;
     constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone);
     _cellClicked(cell: MatCalendarCell, event: MouseEvent): void;
-    _focusActiveCell(): void;
+    _focusActiveCell(movePreview?: boolean): void;
     _isActiveCell(rowIndex: number, colIndex: number): boolean;
     _isComparisonBridgeEnd(value: number, rowIndex: number, colIndex: number): boolean;
     _isComparisonBridgeStart(value: number, rowIndex: number, colIndex: number): boolean;
@@ -117,26 +121,26 @@ export declare class MatCalendarBody implements OnChanges, OnDestroy {
     _isInComparisonRange(value: number): boolean | 0 | null;
     _isInPreview(value: number): boolean;
     _isInRange(value: number): boolean;
-    _isPreviewEnd(value: number): boolean;
-    _isPreviewStart(value: number): boolean;
+    _isPreviewEnd(value: number): boolean | 0 | null;
+    _isPreviewStart(value: number): boolean | 0 | null;
     _isRangeEnd(value: number): boolean | 0;
     _isRangeStart(value: number): boolean;
     _isSelected(cell: MatCalendarCell): boolean;
-    _isSelectingRange(): boolean;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatCalendarBody, "[mat-calendar-body]", ["matCalendarBody"], { "label": "label"; "rows": "rows"; "todayValue": "todayValue"; "startValue": "startValue"; "endValue": "endValue"; "labelMinRequiredCells": "labelMinRequiredCells"; "numCols": "numCols"; "activeCell": "activeCell"; "cellAspectRatio": "cellAspectRatio"; "comparisonStart": "comparisonStart"; "comparisonEnd": "comparisonEnd"; }, { "selectedValueChange": "selectedValueChange"; }, never, never>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatCalendarBody, "[mat-calendar-body]", ["matCalendarBody"], { "label": "label"; "rows": "rows"; "todayValue": "todayValue"; "startValue": "startValue"; "endValue": "endValue"; "labelMinRequiredCells": "labelMinRequiredCells"; "numCols": "numCols"; "activeCell": "activeCell"; "isRange": "isRange"; "cellAspectRatio": "cellAspectRatio"; "comparisonStart": "comparisonStart"; "comparisonEnd": "comparisonEnd"; "previewStart": "previewStart"; "previewEnd": "previewEnd"; }, { "selectedValueChange": "selectedValueChange"; "previewChange": "previewChange"; }, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatCalendarBody, never>;
 }
 
-export declare class MatCalendarCell {
+export declare class MatCalendarCell<D = any> {
     ariaLabel: string;
     compareValue: number;
     cssClasses: MatCalendarCellCssClasses;
     displayValue: string;
     enabled: boolean;
+    rawValue?: D | undefined;
     value: number;
-    constructor(value: number, displayValue: string, ariaLabel: string, enabled: boolean, cssClasses?: MatCalendarCellCssClasses, compareValue?: number);
+    constructor(value: number, displayValue: string, ariaLabel: string, enabled: boolean, cssClasses?: MatCalendarCellCssClasses, compareValue?: number, rawValue?: D | undefined);
 }
 
 export declare type MatCalendarCellCssClasses = string | string[] | Set<string> | {
@@ -160,6 +164,7 @@ export declare class MatCalendarHeader<D> {
 }
 
 export interface MatCalendarRangeSelectionStrategy<D> {
+    createPreview(activeDate: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
     selectionFinished(date: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
 }
 
@@ -364,8 +369,11 @@ export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
     _comparisonRangeStart: number | null;
     _dateAdapter: DateAdapter<D>;
     _firstWeekOffset: number;
+    _isRange: boolean;
     _matCalendarBody: MatCalendarBody;
     _monthLabel: string;
+    _previewEnd: number | null;
+    _previewStart: number | null;
     _rangeEnd: number | null;
     _rangeStart: number | null;
     _todayDate: number | null;
@@ -389,15 +397,16 @@ export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
     get selected(): DateRange<D> | D | null;
     set selected(value: DateRange<D> | D | null);
     readonly selectedChange: EventEmitter<D | null>;
-    constructor(_changeDetectorRef: ChangeDetectorRef, _dateFormats: MatDateFormats, _dateAdapter: DateAdapter<D>, _dir?: Directionality | undefined);
+    constructor(_changeDetectorRef: ChangeDetectorRef, _dateFormats: MatDateFormats, _dateAdapter: DateAdapter<D>, _dir?: Directionality | undefined, _rangeStrategy?: MatCalendarRangeSelectionStrategy<D> | undefined);
     _dateSelected(event: MatCalendarUserEvent<number>): void;
-    _focusActiveCell(): void;
+    _focusActiveCell(movePreview?: boolean): void;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
     _init(): void;
+    _previewChanged({ event, value: cell }: MatCalendarUserEvent<MatCalendarCell<D> | null>): void;
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatMonthView<any>, "mat-month-view", ["matMonthView"], { "activeDate": "activeDate"; "selected": "selected"; "minDate": "minDate"; "maxDate": "maxDate"; "dateFilter": "dateFilter"; "dateClass": "dateClass"; "comparisonStart": "comparisonStart"; "comparisonEnd": "comparisonEnd"; }, { "selectedChange": "selectedChange"; "_userSelection": "_userSelection"; "activeDateChange": "activeDateChange"; }, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatMonthView<any>, [null, { optional: true; }, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatMonthView<any>, [null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
 
 export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy {


### PR DESCRIPTION
Moves some things around so that the preview range can be controlled through the `MatCalendarRangeSelectionStrategy`.

Example of a customized strategy that takes the preview range and allows for it to be moved around:
![demo](https://user-images.githubusercontent.com/4450522/79498424-93359c00-8029-11ea-9a0a-381169d8f496.gif)
