### PR TITLE
fix(form-field): add missing material common module

### DIFF
--- a/src/material/form-field/form-field-module.ts
+++ b/src/material/form-field/form-field-module.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ObserversModule} from '@angular/cdk/observers';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {ObserversModule} from '@angular/cdk/observers';
+import {MatCommonModule} from '@angular/material/core';
 import {MatError} from './error';
 import {MatFormField} from './form-field';
 import {MatHint} from './hint';
@@ -29,9 +30,11 @@ import {MatSuffix} from './suffix';
   ],
   imports: [
     CommonModule,
+    MatCommonModule,
     ObserversModule,
   ],
   exports: [
+    MatCommonModule,
     MatError,
     MatFormField,
     MatHint,

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -103,7 +103,7 @@ export interface MatFormFieldDefaultOptions {
 
 export declare class MatFormFieldModule {
     static ɵinj: i0.ɵɵInjectorDef<MatFormFieldModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatFormFieldModule, [typeof i1.MatError, typeof i2.MatFormField, typeof i3.MatHint, typeof i4.MatLabel, typeof i5.MatPlaceholder, typeof i6.MatPrefix, typeof i7.MatSuffix], [typeof i8.CommonModule, typeof i9.ObserversModule], [typeof i1.MatError, typeof i2.MatFormField, typeof i3.MatHint, typeof i4.MatLabel, typeof i5.MatPlaceholder, typeof i6.MatPrefix, typeof i7.MatSuffix]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatFormFieldModule, [typeof i1.MatError, typeof i2.MatFormField, typeof i3.MatHint, typeof i4.MatLabel, typeof i5.MatPlaceholder, typeof i6.MatPrefix, typeof i7.MatSuffix], [typeof i8.CommonModule, typeof i9.MatCommonModule, typeof i10.ObserversModule], [typeof i9.MatCommonModule, typeof i1.MatError, typeof i2.MatFormField, typeof i3.MatHint, typeof i4.MatLabel, typeof i5.MatPlaceholder, typeof i6.MatPrefix, typeof i7.MatSuffix]>;
 }
 
 export declare class MatHint {


### PR DESCRIPTION
We seem to miss the `MatCommonModule` in the form-field. This came up
when doing size comparison between the MDC-based form-field.

It's unclear to me if there is any reason why we didn't add it to the form-field
in the past. Maybe it was just an oversight.