### PR TITLE
fix(table): filter predicate not called for falsy values

### DIFF
--- a/src/material-experimental/mdc-table/table.spec.ts
+++ b/src/material-experimental/mdc-table/table.spec.ts
@@ -283,6 +283,14 @@ describe('MDC-based MatTable', () => {
         ['a_2', 'b_2', 'c_2'],
         ['Footer A', 'Footer B', 'Footer C'],
       ]);
+
+      // Change the filter to a falsy value that might come in from the view.
+      dataSource.filter = 0 as any;
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
     }));
 
     it('should not match concatenated words', fakeAsync(() => {

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -250,8 +250,8 @@ export class MatTableDataSource<T> extends DataSource<T> {
     // If there is a filter string, filter out data that does not contain it.
     // Each data object is converted to a string using the function defined by filterTermAccessor.
     // May be overridden for customization.
-    this.filteredData =
-        !this.filter ? data : data.filter(obj => this.filterPredicate(obj, this.filter));
+    this.filteredData = (this.filter == null || this.filter === '') ? data :
+        data.filter(obj => this.filterPredicate(obj, this.filter));
 
     if (this.paginator) { this._updatePaginator(this.filteredData.length); }
 

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -300,6 +300,14 @@ describe('MatTable', () => {
         ['a_2', 'b_2', 'c_2'],
         ['Footer A', 'Footer B', 'Footer C'],
       ]);
+
+      // Change the filter to a falsy value that might come in from the view.
+      dataSource.filter = 0 as any;
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
     }));
 
     it('should not match concatenated words', fakeAsync(() => {


### PR DESCRIPTION
We had a simple falsy check to determine whether to call the filter predicate. I'm guessing it was written this way so that if somebody were to clear a filter input, all items will be shown. This seems a bit too loose since it could catch things like 0 which technically aren't allowed due to the `string` type, but could still end up inside the data source if values are proxied in directly through the view.

Ideally we'd just call the predicate for all values and let it decide whether or not to filter, but I left in special cases for undefined, null and empty strings, because I expect a lot of apps to be broken if we were to change the behavior.

Fixes #19092.
Fixes #9967.