### PR TITLE
refactor: convert new theme-mixin-api stylelint rule to typescript

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,7 +7,7 @@
     "./tools/stylelint/no-nested-mixin.ts",
     "./tools/stylelint/no-concrete-rules.ts",
     "./tools/stylelint/no-top-level-ampersand-in-mixin.ts",
-    "./tools/stylelint/theme-mixin-api.js"
+    "./tools/stylelint/theme-mixin-api.ts"
   ],
   "rules": {
     "material/no-prefixes": [true, {


### PR DESCRIPTION
We recently refactored all stylelint rules to TypeScript. Similarly
we should migrate the new rule that has been added in the density
feature branch.