### PR TITLE
fix(datepicker): don't render invalid ranges and clean up range display logic

### DIFF
--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -336,22 +336,24 @@ describe('MatCalendarBody', () => {
       expect(cells[27].classList).toContain(inRangeClass);
     });
 
-    it('should be able to mark a date both as the range start and end', () => {
+    it('should not to mark a date as both the start and end', () => {
       testComponent.startValue = 1;
       testComponent.endValue = 1;
       fixture.detectChanges();
 
-      expect(cells[0].classList).toContain(startClass);
-      expect(cells[0].classList).toContain(endClass);
+      expect(cells[0].classList).not.toContain(startClass);
+      expect(cells[0].classList).not.toContain(inRangeClass);
+      expect(cells[0].classList).not.toContain(endClass);
     });
 
-    it('should be able to mark a date both as the comparison range start and end', () => {
+    it('should not mark a date as both the comparison start and end', () => {
       testComponent.comparisonStart = 1;
       testComponent.comparisonEnd = 1;
       fixture.detectChanges();
 
-      expect(cells[0].classList).toContain(comparisonStartClass);
-      expect(cells[0].classList).toContain(comparisonEndClass);
+      expect(cells[0].classList).not.toContain(comparisonStartClass);
+      expect(cells[0].classList).not.toContain(inComparisonClass);
+      expect(cells[0].classList).not.toContain(comparisonEndClass);
     });
 
     it('should not mark a date as the range end if it comes before the start', () => {
@@ -361,7 +363,7 @@ describe('MatCalendarBody', () => {
 
       expect(cells[0].classList).not.toContain(endClass);
       expect(cells[0].classList).not.toContain(inRangeClass);
-      expect(cells[1].classList).toContain(startClass);
+      expect(cells[1].classList).not.toContain(startClass);
     });
 
     it('should not mark a date as the comparison range end if it comes before the start', () => {
@@ -371,7 +373,7 @@ describe('MatCalendarBody', () => {
 
       expect(cells[0].classList).not.toContain(comparisonEndClass);
       expect(cells[0].classList).not.toContain(inComparisonClass);
-      expect(cells[1].classList).toContain(comparisonStartClass);
+      expect(cells[1].classList).not.toContain(comparisonStartClass);
     });
 
     it('should not show a range if there is no start', () => {
@@ -473,7 +475,7 @@ describe('MatCalendarBody', () => {
       dispatchMouseEvent(cells[2], 'mouseenter');
       fixture.detectChanges();
 
-      expect(cells[5].classList).toContain(startClass);
+      expect(cells[5].classList).not.toContain(startClass);
       expect(cells[5].classList).not.toContain(previewStartClass);
       expect(cells.some(cell => cell.classList.contains(inPreviewClass))).toBe(false);
     });

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -215,23 +215,22 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
 
   /** Gets whether a value is the start of the main range. */
   _isRangeStart(value: number) {
-    return value === this.startValue;
+    return isStart(value, this.startValue, this.endValue);
   }
 
   /** Gets whether a value is the end of the main range. */
   _isRangeEnd(value: number) {
-    return this.startValue && value >= this.startValue && value === this.endValue;
+    return isEnd(value, this.startValue, this.endValue);
   }
 
   /** Gets whether a value is within the currently-selected range. */
   _isInRange(value: number): boolean {
-    return this.isRange && this.startValue !== null && this.endValue !== null &&
-           value >= this.startValue && value <= this.endValue;
+    return isInRange(value, this.startValue, this.endValue, this.isRange);
   }
 
   /** Gets whether a value is the start of the comparison range. */
   _isComparisonStart(value: number) {
-    return value === this.comparisonStart;
+    return isStart(value, this.comparisonStart, this.comparisonEnd);
   }
 
   /** Whether the cell is a start bridge cell between the main and comparison ranges. */
@@ -268,36 +267,27 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
 
   /** Gets whether a value is the end of the comparison range. */
   _isComparisonEnd(value: number) {
-    return this.comparisonStart && value >= this.comparisonStart &&
-           value === this.comparisonEnd;
+    return isEnd(value, this.comparisonStart, this.comparisonEnd);
   }
 
   /** Gets whether a value is within the current comparison range. */
   _isInComparisonRange(value: number) {
-    return this.comparisonStart && this.comparisonEnd &&
-           value >= this.comparisonStart &&
-           value <= this.comparisonEnd;
+    return isInRange(value, this.comparisonStart, this.comparisonEnd, this.isRange);
   }
 
   /** Gets whether a value is the start of the preview range. */
   _isPreviewStart(value: number) {
-    return value === this.previewStart && this.previewEnd && value < this.previewEnd;
+    return isStart(value, this.previewStart, this.previewEnd);
   }
 
   /** Gets whether a value is the end of the preview range. */
   _isPreviewEnd(value: number) {
-    return value === this.previewEnd && this.previewStart && value > this.previewStart;
+    return isEnd(value, this.previewStart, this.previewEnd);
   }
 
   /** Gets whether a value is inside the preview range. */
   _isInPreview(value: number) {
-    if (!this.isRange) {
-      return false;
-    }
-
-    const {previewStart, previewEnd} = this;
-    return previewStart !== null && previewEnd !== null && previewStart !== previewEnd &&
-           value >= previewStart && value <= previewEnd;
+    return isInRange(value, this.previewStart, this.previewEnd, this.isRange);
   }
 
   /**
@@ -371,4 +361,23 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
 /** Checks whether a node is a table cell element. */
 function isTableCell(node: Node): node is HTMLTableCellElement {
   return node.nodeName === 'TD';
+}
+
+/** Checks whether a value is the start of a range. */
+function isStart(value: number, start: number | null, end: number | null): boolean {
+  return end !== null && start !== end && value < end && value === start;
+}
+
+/** Checks whether a value is the end of a range. */
+function isEnd(value: number, start: number | null, end: number | null): boolean {
+  return start !== null && start !== end && value >= start && value === end;
+}
+
+/** Checks whether a value is inside of a range. */
+function isInRange(value: number,
+                   start: number | null,
+                   end: number | null,
+                   rangeEnabled: boolean): boolean {
+  return rangeEnabled && start !== null && end !== null && start !== end &&
+         value >= start && value <= end;
 }

--- a/src/material/datepicker/calendar.html
+++ b/src/material/datepicker/calendar.html
@@ -4,7 +4,7 @@
   <mat-month-view
       *ngSwitchCase="'month'"
       [(activeDate)]="activeDate"
-      [selected]="selected"
+      [selected]="_getDisplaySelection()"
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"
@@ -17,7 +17,7 @@
   <mat-year-view
       *ngSwitchCase="'year'"
       [(activeDate)]="activeDate"
-      [selected]="selected"
+      [selected]="_getDisplaySelection()"
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"
@@ -28,7 +28,7 @@
   <mat-multi-year-view
       *ngSwitchCase="'multi-year'"
       [(activeDate)]="activeDate"
-      [selected]="selected"
+      [selected]="_getDisplaySelection()"
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -446,6 +446,11 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     this.currentView = view;
   }
 
+  /** Gets the selection that should be displayed to the user. */
+  _getDisplaySelection(): DateRange<D> | D | null {
+    return this._model.isValid() ? this._model.selection : null;
+  }
+
   /**
    * @param obj The object to check.
    * @returns The given object if it is both a date instance and valid, otherwise null.

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -39,11 +39,11 @@ export declare const MAT_DATEPICKER_VALIDATORS: any;
 
 export declare const MAT_DATEPICKER_VALUE_ACCESSOR: any;
 
-export declare function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>): MatSingleDateSelectionModel<unknown>;
+export declare function MAT_RANGE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
 
 export declare const MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
-export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>): MatSingleDateSelectionModel<unknown>;
+export declare function MAT_SINGLE_DATE_SELECTION_MODEL_FACTORY(parent: MatSingleDateSelectionModel<unknown>, adapter: DateAdapter<unknown>): MatSingleDateSelectionModel<unknown>;
 
 export declare const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
@@ -77,6 +77,7 @@ export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecke
     yearView: MatYearView<D>;
     constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef, _model: MatDateSelectionModel<DateRange<D> | D | null>, _rangeSelectionStrategy?: MatCalendarRangeSelectionStrategy<D> | undefined);
     _dateSelected(event: MatCalendarUserEvent<D | null>): void;
+    _getDisplaySelection(): DateRange<D> | D | null;
     _goToDateInView(date: D, view: 'month' | 'year' | 'multi-year'): void;
     _monthSelectedInYearView(normalizedMonth: D): void;
     _yearSelectedInMultiYearView(normalizedYear: D): void;
@@ -116,14 +117,14 @@ export declare class MatCalendarBody implements OnChanges, OnDestroy {
     _isActiveCell(rowIndex: number, colIndex: number): boolean;
     _isComparisonBridgeEnd(value: number, rowIndex: number, colIndex: number): boolean;
     _isComparisonBridgeStart(value: number, rowIndex: number, colIndex: number): boolean;
-    _isComparisonEnd(value: number): boolean | 0 | null;
+    _isComparisonEnd(value: number): boolean;
     _isComparisonStart(value: number): boolean;
-    _isInComparisonRange(value: number): boolean | 0 | null;
+    _isInComparisonRange(value: number): boolean;
     _isInPreview(value: number): boolean;
     _isInRange(value: number): boolean;
-    _isPreviewEnd(value: number): boolean | 0 | null;
-    _isPreviewStart(value: number): boolean | 0 | null;
-    _isRangeEnd(value: number): boolean | 0;
+    _isPreviewEnd(value: number): boolean;
+    _isPreviewStart(value: number): boolean;
+    _isRangeEnd(value: number): boolean;
     _isRangeStart(value: number): boolean;
     _isSelected(cell: MatCalendarCell): boolean;
     ngOnChanges(changes: SimpleChanges): void;
@@ -342,12 +343,15 @@ export declare class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRang
 }
 
 export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>> implements OnDestroy {
+    protected _adapter: DateAdapter<D>;
     readonly selection: S;
     selectionChanged: Observable<DateSelectionModelChange<S>>;
     protected constructor(
-    selection: S);
+    selection: S, _adapter: DateAdapter<D>);
+    protected _isValidDateInstance(date: D): boolean;
     abstract add(date: D | null): void;
     abstract isComplete(): boolean;
+    abstract isValid(): boolean;
     ngOnDestroy(): void;
     updateSelection(value: S, source: unknown): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDateSelectionModel<any, any>, never, never, {}, {}, never>;
@@ -440,17 +444,19 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
 }
 
 export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
-    constructor();
+    constructor(adapter: DateAdapter<D>);
     add(date: D | null): void;
     isComplete(): boolean;
+    isValid(): boolean;
     static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>, never>;
     static ɵprov: i0.ɵɵInjectableDef<MatRangeDateSelectionModel<any>>;
 }
 
 export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
-    constructor();
+    constructor(adapter: DateAdapter<D>);
     add(date: D | null): void;
     isComplete(): boolean;
+    isValid(): boolean;
     static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>, never>;
     static ɵprov: i0.ɵɵInjectableDef<MatSingleDateSelectionModel<any>>;
 }


### PR DESCRIPTION
No longer shows dates on the calendar if the range is invalid. Also moves out some common range logic that was being repeated in multiple places.