### PR TITLE
fix(material/radio): incorrect text color when placed inside an overlay with a dark theme

### DIFF
--- a/src/material/radio/_radio-theme.scss
+++ b/src/material/radio/_radio-theme.scss
@@ -28,6 +28,12 @@
     border-color: theming.get-color-from-palette($foreground, secondary-text);
   }
 
+  .mat-radio-label-content {
+    // Explicitly set the text color since the radio button may be
+    // inside an overlay that doesn't have the proper theme text color.
+    color: theming.get-color-from-palette($foreground, 'text');
+  }
+
   .mat-radio-button {
     &.mat-primary {
       @include _color($primary);


### PR DESCRIPTION
Fixes a similar issue to #18742. The radio button inherits its text color from the closest parent which may not be correct once the element is moved out into an overlay.