### PR TITLE
fix(drag-drop): drop-list wrong enter position

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -3916,9 +3916,11 @@ describe('CdkDrag', () => {
       const groups = fixture.componentInstance.groupedDragItems.slice();
       const element = groups[0][1].element.nativeElement;
       const dropInstances = fixture.componentInstance.dropInstances.toArray();
-      const targetRect = groups[1][2].element.nativeElement.getBoundingClientRect();
+      const targetRect = groups[1][1].element.nativeElement.getBoundingClientRect();
 
-      dragElementViaMouse(fixture, element, targetRect.left + 1, targetRect.top + 1);
+      // Use coordinates of [1] item corresponding to [2] item
+      // after dragged item is removed from first container
+      dragElementViaMouse(fixture, element, targetRect.left + 1, targetRect.top);
       flush();
       fixture.detectChanges();
 
@@ -3927,7 +3929,7 @@ describe('CdkDrag', () => {
       expect(event).toBeTruthy();
       expect(event).toEqual({
         previousIndex: 1,
-        currentIndex: 3,
+        currentIndex: 2, // dragged item should replace the [2] item (see comment above)
         item: groups[0][1],
         container: dropInstances[1],
         previousContainer: dropInstances[0],
@@ -4104,6 +4106,132 @@ describe('CdkDrag', () => {
       fixture.detectChanges();
 
       expect(fixture.componentInstance.droppedSpy).not.toHaveBeenCalled();
+    }));
+
+    it('should update drop zone after element has entered', fakeAsync(() => {
+      const fixture = createComponent(ConnectedDropZones);
+
+      // Make sure there's only one item in the first list.
+      fixture.componentInstance.todo = ['things'];
+      fixture.detectChanges();
+
+      const dropInstances = fixture.componentInstance.dropInstances.toArray();
+      const groups = fixture.componentInstance.groupedDragItems;
+      const dropZones = dropInstances.map(d => d.element.nativeElement);
+      const item = groups[0][0];
+      const initialTargetZoneRect = dropZones[1].getBoundingClientRect();
+      const targetElement = groups[1][groups[1].length - 1].element.nativeElement;
+      let targetRect = targetElement.getBoundingClientRect();
+
+      startDraggingViaMouse(fixture, item.element.nativeElement);
+
+      const placeholder = dropZones[0].querySelector('.cdk-drag-placeholder')!;
+
+      expect(placeholder).toBeTruthy();
+
+      dispatchMouseEvent(document, 'mousemove', targetRect.left + 1, targetRect.top + 1);
+      fixture.detectChanges();
+
+      expect(targetElement.previousSibling === placeholder)
+          .toBe(true, 'Expected placeholder to be inside second container before last item.');
+
+      // Update target rect
+      targetRect = targetElement.getBoundingClientRect();
+      expect(initialTargetZoneRect.bottom <= targetRect.top)
+        .toBe(true, 'Expected target rect to be outside of initial target zone rect');
+
+        // Swap with target
+      dispatchMouseEvent(document, 'mousemove', targetRect.left + 1, targetRect.bottom - 1);
+      fixture.detectChanges();
+
+      // Drop and verify item drop positon and coontainer
+      dispatchMouseEvent(document, 'mouseup', targetRect.left + 1, targetRect.bottom - 1);
+      flush();
+      fixture.detectChanges();
+
+      const event = fixture.componentInstance.droppedSpy.calls.mostRecent().args[0];
+
+      expect(event).toBeTruthy();
+      expect(event).toEqual({
+        previousIndex: 0,
+        currentIndex: 3,
+        item: item,
+        container: dropInstances[1],
+        previousContainer: dropInstances[0],
+        isPointerOverContainer: true,
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+      });
+    }));
+
+    it('should enter as first child if entering from top', fakeAsync(() => {
+      const fixture = createComponent(ConnectedDropZones);
+
+      // Make sure there's only one item in the first list.
+      fixture.componentInstance.todo = ['things'];
+      fixture.detectChanges();
+
+      const groups = fixture.componentInstance.groupedDragItems;
+      const dropZones = fixture.componentInstance.dropInstances.map(d => d.element.nativeElement);
+      const item = groups[0][0];
+
+      // Add some initial padding as the target drop zone
+      dropZones[1].style.paddingTop = '10px';
+
+      const targetRect = dropZones[1].getBoundingClientRect();
+
+      startDraggingViaMouse(fixture, item.element.nativeElement);
+
+      const placeholder = dropZones[0].querySelector('.cdk-drag-placeholder')!;
+
+      expect(placeholder).toBeTruthy();
+
+      expect(dropZones[0].contains(placeholder))
+          .toBe(true, 'Expected placeholder to be inside the first container.');
+
+      dispatchMouseEvent(document, 'mousemove', targetRect.left, targetRect.top);
+      fixture.detectChanges();
+
+      expect(dropZones[1].firstChild === placeholder)
+          .toBe(true, 'Expected placeholder to be first child inside second container.');
+
+      dispatchMouseEvent(document, 'mouseup');
+    }));
+
+    it('should enter as last child if entering from top in reversed container', fakeAsync(() => {
+      const fixture = createComponent(ConnectedDropZones);
+
+      // Make sure there's only one item in the first list.
+      fixture.componentInstance.todo = ['things'];
+      fixture.detectChanges();
+
+      const groups = fixture.componentInstance.groupedDragItems;
+      const dropZones = fixture.componentInstance.dropInstances.map(d => d.element.nativeElement);
+      const item = groups[0][0];
+
+      // Add some initial padding as the target drop zone
+      const targetDropZoneStyle = dropZones[1].style;
+      targetDropZoneStyle.paddingTop = '10px';
+      targetDropZoneStyle.display = 'flex';
+      targetDropZoneStyle.flexDirection = 'column-reverse';
+
+      const targetRect = dropZones[1].getBoundingClientRect();
+
+      startDraggingViaMouse(fixture, item.element.nativeElement);
+
+      const placeholder = dropZones[0].querySelector('.cdk-drag-placeholder')!;
+
+      expect(placeholder).toBeTruthy();
+
+      expect(dropZones[0].contains(placeholder))
+          .toBe(true, 'Expected placeholder to be inside the first container.');
+
+      dispatchMouseEvent(document, 'mousemove', targetRect.left, targetRect.top);
+      fixture.detectChanges();
+
+      expect(dropZones[1].lastChild === placeholder)
+          .toBe(true, 'Expected placeholder to be last child inside second container.');
+
+      dispatchMouseEvent(document, 'mouseup');
     }));
 
     it('should assign a default id on each drop zone', fakeAsync(() => {

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -4191,7 +4191,7 @@ describe('CdkDrag', () => {
       dispatchMouseEvent(document, 'mousemove', targetRect.left, targetRect.top);
       fixture.detectChanges();
 
-      expect(dropZones[1].firstChild === placeholder)
+      expect(dropZones[1].firstElementChild === placeholder)
           .toBe(true, 'Expected placeholder to be first child inside second container.');
 
       dispatchMouseEvent(document, 'mouseup');

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -310,7 +310,7 @@ export class DropListRef<T = any> {
       activeDraggables.splice(newIndex, 0, item);
     } else {
       const element = coerceElement(this.element);
-      if (this._isEnteringFromStart(pointerX, pointerY)) {
+      if (activeDraggables.length && this._isEnteringFromStart(pointerX, pointerY)) {
         element.insertBefore(placeholder, activeDraggables[0].getRootElement());
         activeDraggables.unshift(item);
       } else {
@@ -712,9 +712,9 @@ export class DropListRef<T = any> {
     const firstItemPosition = this._itemPositions[0];
     const isHorizontal = this._orientation === 'horizontal';
 
-    return firstItemPosition && (isHorizontal ?
+    return isHorizontal ?
       pointerX <= firstItemPosition.clientRect.left :
-      pointerY <= firstItemPosition.clientRect.top);
+      pointerY <= firstItemPosition.clientRect.top;
   }
 
   /**

--- a/src/dev-app/drag-drop/drag-drop-demo.html
+++ b/src/dev-app/drag-drop/drag-drop-demo.html
@@ -29,16 +29,31 @@
   </div>
 </div>
 
-<div>
+<div cdkDropListGroup>
   <div class="demo-list demo-list-horizontal">
-    <h2>Horizontal list</h2>
+    <h2>Ages</h2>
     <div
       cdkDropList
       cdkDropListOrientation="horizontal"
       (cdkDropListDropped)="drop($event)"
       [cdkDropListLockAxis]="axisLock"
-      [cdkDropListData]="horizontalData">
-      <div *ngFor="let item of horizontalData" cdkDrag>
+      [cdkDropListData]="ages">
+      <div *ngFor="let item of ages" cdkDrag>
+        {{item}}
+        <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-list demo-list-horizontal" style="text-align: right">
+    <h2>Preferred Ages</h2>
+    <div
+      cdkDropList
+      cdkDropListOrientation="horizontal"
+      (cdkDropListDropped)="drop($event)"
+      [cdkDropListLockAxis]="axisLock"
+      [cdkDropListData]="preferredAges">
+      <div *ngFor="let item of preferredAges" cdkDrag>
         {{item}}
         <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
       </div>
@@ -55,7 +70,8 @@
   <h2>Data</h2>
   <pre>{{todo.join(', ')}}</pre>
   <pre>{{done.join(', ')}}</pre>
-  <pre>{{horizontalData.join(', ')}}</pre>
+  <pre>{{ages.join(', ')}}</pre>
+  <pre>{{preferredAges.join(', ')}}</pre>
 </div>
 
 <div>

--- a/src/dev-app/drag-drop/drag-drop-demo.scss
+++ b/src/dev-app/drag-drop/drag-drop-demo.scss
@@ -24,7 +24,8 @@
   display: block;
 
   .demo-list-horizontal & {
-    display: flex;
+    padding: 0 24px;
+    display: inline-flex;
     flex-direction: row;
   }
 }
@@ -49,8 +50,9 @@
   .demo-list-horizontal & {
     border: none;
     border-right: solid 1px #ccc;
-    flex-grow: 1;
-    flex-basis: 0;
+    flex: 1 1;
+    white-space: nowrap;
+    background-color: #fff;
 
     [dir='rtl'] & {
       border-right: none;

--- a/src/dev-app/drag-drop/drag-drop-demo.ts
+++ b/src/dev-app/drag-drop/drag-drop-demo.ts
@@ -35,12 +35,15 @@ export class DragAndDropDemo {
     'Check reddit'
   ];
 
-  horizontalData = [
+  ages = [
+    'Stone age',
     'Bronze age',
     'Iron age',
     'Middle ages',
-    'Early modern period',
-    'Long nineteenth century'
+  ];
+  preferredAges = [
+    'Modern period',
+    'Renaissance'
   ];
 
   constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {


### PR DESCRIPTION
Parent rect should be cached again when the new item has been added.
![issue video](https://user-images.githubusercontent.com/1423005/79694947-1813f600-8274-11ea-838e-0d1e4468a7f5.gif)

If item is entering from start (left/top) it should be inserted in the first position from the beginning to avoid "jump effect"
![issue video](https://user-images.githubusercontent.com/1423005/79694962-32e66a80-8274-11ea-8314-72fdd4e763f1.gif)

When looking for item index from pointer position exclude right/bottom pixel: that pixel is external.
![issue video](https://user-images.githubusercontent.com/1423005/79694970-4d204880-8274-11ea-9828-4bf24eb34ae8.gif)