### PR TITLE
fix(form-field): error in newer sass versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "run-sequence": "^1.2.2",
-    "sass": "^1.24.4",
+    "sass": "^1.26.3",
     "scss-bundle": "^3.0.2",
     "selenium-webdriver": "^3.6.0",
     "semver": "^6.3.0",

--- a/src/material/form-field/_form-field-outline-theme.scss
+++ b/src/material/form-field/_form-field-outline-theme.scss
@@ -75,7 +75,7 @@ $mat-form-field-outline-dedupe: 0;
   scale($font-scale);
   width: 100% / $font-scale + $mat-form-field-outline-dedupe;
 
-  $mat-form-field-outline-dedupe: $mat-form-field-outline-dedupe + 0.00001 !global;
+  $mat-form-field-outline-dedupe: $mat-form-field-outline-dedupe + 0.00001;
 }
 
 @mixin mat-form-field-outline-typography($config) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10161,10 +10161,10 @@ sass@^1.22.9:
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
 
-sass@^1.24.4:
-  version "1.24.4"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.24.4.tgz#aa50575a9ed2b9e9645b5599156fd149bdad9eaa"
-  integrity sha512-SqizkIEEcVPzmK1tYdlNRl/RSXMEwGcifL9GD+S2p9rEPdj6ycRbk4PWZs0jwlajNSyBPo/SXRB81i22SG0jmw==
+sass@^1.26.3:
+  version "1.26.3"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.26.3.tgz#412df54486143b76b5a65cdf7569e86f44659f46"
+  integrity sha512-5NMHI1+YFYw4sN3yfKjpLuV9B5l7MqQ6FlkTcC4FT+oHbBRUZoSjHrrt/mE0nFXJyY2kQtU9ou9HxvFVjLFuuw==
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
 


### PR DESCRIPTION
One internal Sass mixin was referring to the `$mat-form-field-outline-dedupe` as if it's a global, however the variable is local to the file. In previous Sass version this created a global variable silently, but in the newer ones it's a warning and it'll eventually become an error.

Also bumps our local version of Sass.

Fixes #19122.