### PR TITLE
build: include mdc-color and mdc-density entry-points in release

### DIFF
--- a/src/material-experimental/BUILD.bazel
+++ b/src/material-experimental/BUILD.bazel
@@ -24,6 +24,8 @@ ng_package(
     name = "npm_package",
     srcs = ["package.json"],
     data = MATERIAL_EXPERIMENTAL_SCSS_LIBS + [
+        "//src/material-experimental/mdc-color",
+        "//src/material-experimental/mdc-density",
         "//src/material-experimental/mdc-helpers",
         "//src/material-experimental/mdc-theming",
         "//src/material-experimental/mdc-typography",

--- a/src/material-experimental/mdc-color/BUILD.bazel
+++ b/src/material-experimental/mdc-color/BUILD.bazel
@@ -2,6 +2,11 @@ load("//tools:defaults.bzl", "sass_library")
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "mdc-color",
+    srcs = [":all_color"],
+)
+
 sass_library(
     name = "all_color",
     srcs = ["_all-color.scss"],

--- a/src/material-experimental/mdc-density/BUILD.bazel
+++ b/src/material-experimental/mdc-density/BUILD.bazel
@@ -2,6 +2,11 @@ load("//tools:defaults.bzl", "sass_library")
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "mdc-density",
+    srcs = [":all_density"],
+)
+
 sass_library(
     name = "all_density",
     srcs = ["_all-density.scss"],


### PR DESCRIPTION
The new `mdc-color` and `mdc-density` entry-points should be
included in the `@angular/material-experimental` package.