### PR TITLE
build: fix ngcc compatibility check execution in CI

### DIFF
--- a/scripts/circleci/ngcc-compatibility-check.sh
+++ b/scripts/circleci/ngcc-compatibility-check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script should fail if one of the individual publish scripts fails.
+set -e
+
+packages=""
+
+for f in ./dist/releases/*; do
+  if [ -d "$f" ]; then
+    packages+=" file:$f"
+  fi
+done
+
+yarn add $packages
+yarn ngcc


### PR DESCRIPTION
ngcc compatibility check was never run against built packages cause they are not included in yarn lockfile

close #19157 