### PR TITLE
build: do not print github auth token if merge script fails

### DIFF
--- a/scripts/merge-script/failures.ts
+++ b/scripts/merge-script/failures.ts
@@ -70,4 +70,9 @@ export class PullRequestFailure {
   static notFound() {
     return new this(`Pull request could not be found upstream.`);
   }
+
+  static insufficientPermissionsToMerge() {
+    return new this(`Insufficient Github API permissions to merge pull request. Please ` +
+        `ensure that your auth token has write access.`);
+  }
 }

--- a/scripts/merge-script/git.ts
+++ b/scripts/merge-script/git.ts
@@ -10,10 +10,20 @@ import * as Octokit from '@octokit/rest';
 import {spawnSync, SpawnSyncOptions, SpawnSyncReturns} from 'child_process';
 import {Config} from './config';
 
+/** Error for failed Github API requests. */
+export class GithubApiRequestError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+  }
+}
+
 /** Error for failed Git commands. */
 export class GitCommandError extends Error {
-  constructor(public commandArgs: string[]) {
-    super(`Command failed: git ${commandArgs.join(' ')}`);
+  constructor(client: GitClient, public args: string[]) {
+    // Errors are not guaranteed to be caught. To ensure that we don't
+    // accidentally leak the Github token that might be used in a command,
+    // we sanitize the command that will be part of the error message.
+    super(`Command failed: git ${client.omitGithubTokenFromMessage(args.join(' '))}`);
   }
 }
 
@@ -29,15 +39,23 @@ export class GitClient {
   /** Instance of the authenticated Github octokit API. */
   api: Octokit;
 
+  /** Regular expression that matches the provided Github token. */
+  private _tokenRegex = new RegExp(this._githubToken, 'g');
+
   constructor(private _githubToken: string, private _config: Config) {
     this.api = new Octokit({auth: _githubToken});
+    this.api.hook.error('request', error => {
+      // Wrap API errors in a known error class. This allows us to
+      // expect Github API errors better and in a non-ambiguous way.
+      throw new GithubApiRequestError(error.status, error.message);
+    });
   }
 
   /** Executes the given git command. Throws if the command fails. */
   run(args: string[], options?: SpawnSyncOptions): Omit<SpawnSyncReturns<string>, 'status'> {
     const result = this.runGraceful(args, options);
     if (result.status !== 0) {
-      throw new GitCommandError(args);
+      throw new GitCommandError(this, args);
     }
     // Omit `status` from the type so that it's obvious that the status is never
     // non-zero as explained in the method description.
@@ -46,21 +64,32 @@ export class GitClient {
 
   /**
    * Spawns a given Git command process. Does not throw if the command fails. Additionally,
-   * the "stderr" output is inherited and will be printed in case of errors. This makes it
-   * easier to debug failed commands.
+   * if there is any stderr output, the output will be printed. This makes it easier to
+   * debug failed commands.
    */
   runGraceful(args: string[], options: SpawnSyncOptions = {}): SpawnSyncReturns<string> {
-    // To improve the debugging experience in case something fails, we print
-    // all executed Git commands.
-    console.info('Executing: git', ...args);
-    return spawnSync('git', args, {
+    // To improve the debugging experience in case something fails, we print all executed
+    // Git commands. Note that we do not want to print the token if is contained in the
+    // command. It's common to share errors with others if the tool failed.
+    console.info('Executing: git', this.omitGithubTokenFromMessage(args.join(' ')));
+
+    const result = spawnSync('git', args, {
       cwd: this._config.projectRoot,
-      stdio: ['pipe', 'pipe', 'inherit'],
+      stdio: 'pipe',
       ...options,
       // Encoding is always `utf8` and not overridable. This ensures that this method
       // always returns `string` as output instead of buffers.
       encoding: 'utf8',
     });
+
+    if (result.stderr !== null) {
+      // Git sometimes prints the command if it failed. This means that it could
+      // potentially leak the Github token used for accessing the remote. To avoid
+      // printing a token, we sanitize the string before printing the stderr output.
+      process.stderr.write(this.omitGithubTokenFromMessage(result.stderr));
+    }
+
+    return result;
   }
 
   /** Whether the given branch contains the specified SHA. */
@@ -76,5 +105,10 @@ export class GitClient {
   /** Gets whether the current Git repository has uncommitted changes. */
   hasUncommittedChanges(): boolean {
     return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
+  }
+
+  /** Sanitizes a given message by omitting the provided Github token if present. */
+  omitGithubTokenFromMessage(value: string): string {
+    return value.replace(this._tokenRegex, '<TOKEN>');
   }
 }

--- a/scripts/merge-script/pull-request.ts
+++ b/scripts/merge-script/pull-request.ts
@@ -94,8 +94,13 @@ async function fetchPullRequestFromGithub(
   try {
     const result = await git.api.pulls.get({...git.repoParams, pull_number: prNumber});
     return result.data;
-  } catch {
-    return null;
+  } catch (e) {
+    // If the pull request could not be found, we want to return `null` so
+    // that the error can be handled gracefully.
+    if (e.status === 404) {
+      return null;
+    }
+    throw e;
   }
 }
 


### PR DESCRIPTION
Various improvements to the merge script:

1. No longer print Github auth token if a command fails.
2. No longer print Github auth token when verbose-printing executed git commands.
3. Better error if token does not have required permissions for merging
pull request (api-merge strategy)