### PR TITLE
build: fix ngcc compatibility jobs not running against packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,8 +405,15 @@ jobs:
       - *attach_release_output
       - *yarn_install
 
+      # Copy the release packages into the node modules so that ngcc can process them.
       - run: cp -R dist/releases/* node_modules/@angular/
-      - run: yarn ngcc
+      # Delete existing ngcc manifests that would prevent the copied packages
+      # from being discovered.
+      - run: rm -f node_modules/__ngcc_entry_points__.json
+      # Ensure that the job fails if an entry-point cannot be compiled. Also disable
+      # tsconfig parsing as that causes the release packages to be incorrectly resolved
+      # to the sources due to path mapping.
+      - run: yarn ngcc --error-on-failed-entry-point --no-tsconfig
 
   # -----------------------------------------------------------------
   # Job that ensures that the release output is compatible with the
@@ -422,8 +429,15 @@ jobs:
       - *setup_snapshot_builds
       - *yarn_install_loose_lockfile
 
+      # Copy the release packages into the node modules so that ngcc can process them.
       - run: cp -R dist/releases/* node_modules/@angular/
-      - run: yarn ngcc
+      # Delete existing ngcc manifests that would prevent the copied packages
+      # from being discovered.
+      - run: rm -f node_modules/__ngcc_entry_points__.json
+      # Ensure that the job fails if an entry-point cannot be compiled. Also disable
+      # tsconfig parsing as that causes the release packages to be incorrectly resolved
+      # to the sources due to path mapping.
+      - run: yarn ngcc --error-on-failed-entry-point --no-tsconfig
 
   # ----------------------------------------------------------------------------
   # Job that runs the local browser tests against the Angular Github snapshots


### PR DESCRIPTION
Ngcc changed how entry points are detected. In the current state,
they store a manifest of discovered packages and entry-points
in the node modules. This means that ngcc won't run for packages
we manually copy into the `node_modules` while a manifest exists.

To fix this for our job, we delete the manifest file. Also it looks
like MDC now has support for path mapping. This means that it will
use the tsconfig from the project root. This causes the release
packages to be resolved to the actual sources. We fix this by
disabling tsconfig parsing. Also it seems like we need to pass
a flag now so that ngcc will fail if compilation of an entry-point
did not complete successfully.

Fixes #19157