### PR TITLE
fix(ng-add): ng add @angular/material fails in library projects

### DIFF
--- a/src/cdk/schematics/testing/index.ts
+++ b/src/cdk/schematics/testing/index.ts
@@ -9,5 +9,6 @@
 export * from './post-scheduled-tasks';
 export * from './test-app';
 export * from './test-case-setup';
+export * from './test-library';
 export * from './file-content';
 export * from './resolve-bazel-path';

--- a/src/cdk/schematics/testing/test-library.ts
+++ b/src/cdk/schematics/testing/test-library.ts
@@ -11,8 +11,8 @@ import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/test
 
 import {createTestProject} from './test-project';
 
-/** Create a base app used for testing. */
-export async function createTestApp(runner: SchematicTestRunner, appOptions = {}, tree?: Tree):
+/** Create a base library used for testing. */
+export async function createTestLibrary(runner: SchematicTestRunner, appOptions = {}, tree?: Tree):
     Promise<UnitTestTree> {
-  return createTestProject(runner, 'application', appOptions, tree);
+  return createTestProject(runner, 'library', appOptions, tree);
 }

--- a/src/cdk/schematics/testing/test-project.ts
+++ b/src/cdk/schematics/testing/test-project.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Tree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+
+/** Create a base project used for testing. */
+export async function createTestProject(
+  runner: SchematicTestRunner, projectType: 'application'|'library', appOptions = {}, tree?: Tree):
+    Promise<UnitTestTree> {
+  const workspaceTree = await runner.runExternalSchematicAsync('@schematics/angular', 'workspace', {
+    name: 'workspace',
+    version: '6.0.0',
+    newProjectRoot: 'projects',
+  }, tree).toPromise();
+
+  return runner.runExternalSchematicAsync('@schematics/angular', projectType,
+      {name: 'material', ...appOptions}, workspaceTree).toPromise();
+}

--- a/src/material/schematics/ng-add/index.spec.ts
+++ b/src/material/schematics/ng-add/index.spec.ts
@@ -8,7 +8,7 @@ import {
   getProjectStyleFile,
   getProjectTargetOptions,
 } from '@angular/cdk/schematics';
-import {createTestApp, getFileContent} from '@angular/cdk/schematics/testing';
+import {createTestApp, createTestLibrary, getFileContent} from '@angular/cdk/schematics/testing';
 import {getWorkspace} from '@schematics/angular/utility/config';
 import {COLLECTION_PATH} from '../index.spec';
 import {addPackageToPackageJson} from './package-config';
@@ -417,5 +417,35 @@ describe('ng-add schematic', () => {
       const buffer = tree.read(indexPath)!;
       expect(buffer.toString()).toContain('<body class="one two">');
     });
+  });
+});
+
+describe('ng-add schematic - library project', () => {
+  let runner: SchematicTestRunner;
+  let libraryTree: Tree;
+  let errorOutput: string[];
+  let warnOutput: string[];
+
+  beforeEach(async () => {
+    runner = new SchematicTestRunner('schematics', require.resolve('../collection.json'));
+    libraryTree = await createTestLibrary(runner);
+
+    errorOutput = [];
+    warnOutput = [];
+    runner.logger.subscribe(e => {
+      if (e.level === 'error') {
+        errorOutput.push(e.message);
+      } else if (e.level === 'warn') {
+        warnOutput.push(e.message);
+      }
+    });
+  });
+
+  it('should warn if a library project is targeted', async () => {
+    await runner.runSchematicAsync('ng-add-setup-project', {}, libraryTree).toPromise();
+
+    expect(errorOutput.length).toBe(0);
+    expect(warnOutput.length).toBe(1);
+    expect(warnOutput[0]).toMatch(/There is no additional setup required/);
   });
 });

--- a/src/material/schematics/ng-add/setup-project.ts
+++ b/src/material/schematics/ng-add/setup-project.ts
@@ -33,13 +33,26 @@ const noopAnimationsModuleName = 'NoopAnimationsModule';
  *  - Adds Browser Animation to app.module
  */
 export default function(options: Schema): Rule {
-  return chain([
-    addAnimationsModule(options),
-    addThemeToAppStyles(options),
-    addFontsToIndex(options),
-    addMaterialAppStyles(options),
-    addTypographyClass(options),
-  ]);
+  return (host: Tree, context: SchematicContext) => {
+    const workspace = getWorkspace(host);
+    const project = getProjectFromWorkspace(workspace, options.project);
+
+    if (project.projectType === 'application') {
+      return chain([
+        addAnimationsModule(options),
+        addThemeToAppStyles(options),
+        addFontsToIndex(options),
+        addMaterialAppStyles(options),
+        addTypographyClass(options),
+      ]);
+    }
+    context.logger.warn(
+        'Angular Material has been set up in your workspace. There is no additional setup ' +
+        'required for consuming Angular Material in your library project.\n\n' +
+        'If you intended to run the schematic on a different project, pass the `--project` ' +
+        'option.');
+    return host;
+  };
 }
 
 /**


### PR DESCRIPTION
Skip app related ng-add steps when working with library projects

close #19156 