### PR TITLE
fix(google-maps): incorrect variable access for server-side rendering check

### DIFF
--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -117,7 +117,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
 
     // If no info window has been created on the server, we do not try closing it.
     // On the server, an info window cannot be created and this would cause errors.
-    if (this.infoWindow) {
+    if (this._infoWindow) {
       this.close();
     }
   }


### PR DESCRIPTION
We added a SSR check to the google-maps window info directive, but when
this PR landed in the patch branch, the variable names no longer matched.

The variable for the `_infoWindow` has been made public with 3e00f4c5fca48c2c62e8b2279449e73bba898579, but
this change did not land in the patch branch as it targets a next minor release.