### PR TITLE
refactor(google-maps): use assert functions to avoid casting to non-nullable value

### DIFF
--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -290,7 +290,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
       bounds: google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral,
       padding?: number|google.maps.Padding) {
     this._assertInitialized();
-    this.googleMap!.fitBounds(bounds, padding);
+    this.googleMap.fitBounds(bounds, padding);
   }
 
   /**
@@ -299,7 +299,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   panBy(x: number, y: number) {
     this._assertInitialized();
-    this.googleMap!.panBy(x, y);
+    this.googleMap.panBy(x, y);
   }
 
   /**
@@ -308,7 +308,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   panTo(latLng: google.maps.LatLng|google.maps.LatLngLiteral) {
     this._assertInitialized();
-    this.googleMap!.panTo(latLng);
+    this.googleMap.panTo(latLng);
   }
 
   /**
@@ -319,7 +319,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
       latLngBounds: google.maps.LatLngBounds|google.maps.LatLngBoundsLiteral,
       padding?: number|google.maps.Padding) {
     this._assertInitialized();
-    this.googleMap!.panToBounds(latLngBounds, padding);
+    this.googleMap.panToBounds(latLngBounds, padding);
   }
 
   /**
@@ -328,7 +328,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getBounds(): google.maps.LatLngBounds|null {
     this._assertInitialized();
-    return this.googleMap!.getBounds() || null;
+    return this.googleMap.getBounds() || null;
   }
 
   /**
@@ -337,7 +337,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getCenter(): google.maps.LatLng {
     this._assertInitialized();
-    return this.googleMap!.getCenter();
+    return this.googleMap.getCenter();
   }
 
   /**
@@ -346,7 +346,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getClickableIcons(): boolean {
     this._assertInitialized();
-    return this.googleMap!.getClickableIcons();
+    return this.googleMap.getClickableIcons();
   }
 
   /**
@@ -355,7 +355,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getHeading(): number {
     this._assertInitialized();
-    return this.googleMap!.getHeading();
+    return this.googleMap.getHeading();
   }
 
   /**
@@ -364,7 +364,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getMapTypeId(): google.maps.MapTypeId|string {
     this._assertInitialized();
-    return this.googleMap!.getMapTypeId();
+    return this.googleMap.getMapTypeId();
   }
 
   /**
@@ -373,7 +373,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getProjection(): google.maps.Projection|null {
     this._assertInitialized();
-    return this.googleMap!.getProjection();
+    return this.googleMap.getProjection();
   }
 
   /**
@@ -382,7 +382,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getStreetView(): google.maps.StreetViewPanorama {
     this._assertInitialized();
-    return this.googleMap!.getStreetView();
+    return this.googleMap.getStreetView();
   }
 
   /**
@@ -391,7 +391,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getTilt(): number {
     this._assertInitialized();
-    return this.googleMap!.getTilt();
+    return this.googleMap.getTilt();
   }
 
   /**
@@ -400,7 +400,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   getZoom(): number {
     this._assertInitialized();
-    return this.googleMap!.getZoom();
+    return this.googleMap.getZoom();
   }
 
   /**
@@ -409,7 +409,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   get controls(): Array<google.maps.MVCArray<Node>> {
     this._assertInitialized();
-    return this.googleMap!.controls;
+    return this.googleMap.controls;
   }
 
   /**
@@ -418,7 +418,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   get data(): google.maps.Data {
     this._assertInitialized();
-    return this.googleMap!.data;
+    return this.googleMap.data;
   }
 
   /**
@@ -427,7 +427,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   get mapTypes(): google.maps.MapTypeRegistry {
     this._assertInitialized();
-    return this.googleMap!.mapTypes;
+    return this.googleMap.mapTypes;
   }
 
   /**
@@ -436,7 +436,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    */
   get overlayMapTypes(): google.maps.MVCArray<google.maps.MapType> {
     this._assertInitialized();
-    return this.googleMap!.overlayMapTypes;
+    return this.googleMap.overlayMapTypes;
   }
 
   private _setSize() {
@@ -503,7 +503,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
   }
 
   /** Asserts that the map has been initialized. */
-  private _assertInitialized() {
+  private _assertInitialized(): asserts this is {googleMap: google.maps.Map} {
     if (!this.googleMap) {
       throw Error('Cannot access Google Map information before the API has been initialized. ' +
                   'Please wait for the API to load before trying to interact with it.');

--- a/src/google-maps/map-circle/map-circle.ts
+++ b/src/google-maps/map-circle/map-circle.ts
@@ -168,7 +168,7 @@ export class MapCircle implements OnInit, OnDestroy {
           this.circle = new google.maps.Circle(options);
         });
         this._assertInitialized();
-        this.circle!.setMap(this._map.googleMap!);
+        this.circle.setMap(this._map.googleMap!);
         this._eventManager.setTarget(this.circle);
       });
 
@@ -193,7 +193,7 @@ export class MapCircle implements OnInit, OnDestroy {
    */
   getBounds(): google.maps.LatLngBounds {
     this._assertInitialized();
-    return this.circle!.getBounds();
+    return this.circle.getBounds();
   }
 
   /**
@@ -202,7 +202,7 @@ export class MapCircle implements OnInit, OnDestroy {
    */
   getCenter(): google.maps.LatLng {
     this._assertInitialized();
-    return this.circle!.getCenter();
+    return this.circle.getCenter();
   }
 
   /**
@@ -211,7 +211,7 @@ export class MapCircle implements OnInit, OnDestroy {
    */
   getDraggable(): boolean {
     this._assertInitialized();
-    return this.circle!.getDraggable();
+    return this.circle.getDraggable();
   }
 
   /**
@@ -220,7 +220,7 @@ export class MapCircle implements OnInit, OnDestroy {
    */
   getEditable(): boolean {
     this._assertInitialized();
-    return this.circle!.getEditable();
+    return this.circle.getEditable();
   }
 
   /**
@@ -229,7 +229,7 @@ export class MapCircle implements OnInit, OnDestroy {
    */
   getRadius(): number {
     this._assertInitialized();
-    return this.circle!.getRadius();
+    return this.circle.getRadius();
   }
 
   /**
@@ -238,7 +238,7 @@ export class MapCircle implements OnInit, OnDestroy {
    */
   getVisible(): boolean {
     this._assertInitialized();
-    return this.circle!.getVisible();
+    return this.circle.getVisible();
   }
 
   private _combineOptions(): Observable<google.maps.CircleOptions> {
@@ -256,7 +256,7 @@ export class MapCircle implements OnInit, OnDestroy {
   private _watchForOptionsChanges() {
     this._options.pipe(takeUntil(this._destroyed)).subscribe(options => {
       this._assertInitialized();
-      this.circle!.setOptions(options);
+      this.circle.setOptions(options);
     });
   }
 
@@ -264,7 +264,7 @@ export class MapCircle implements OnInit, OnDestroy {
     this._center.pipe(takeUntil(this._destroyed)).subscribe(center => {
       if (center) {
         this._assertInitialized();
-        this.circle!.setCenter(center);
+        this.circle.setCenter(center);
       }
     });
   }
@@ -273,12 +273,12 @@ export class MapCircle implements OnInit, OnDestroy {
     this._radius.pipe(takeUntil(this._destroyed)).subscribe(radius => {
       if (radius !== undefined) {
         this._assertInitialized();
-        this.circle!.setRadius(radius);
+        this.circle.setRadius(radius);
       }
     });
   }
 
-  private _assertInitialized() {
+  private _assertInitialized(): asserts this is {circle: google.maps.Circle} {
     if (!this._map.googleMap) {
       throw Error(
         'Cannot access Google Map information before the API has been initialized. ' +

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.ts
@@ -84,7 +84,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
           this.groundOverlay = new google.maps.GroundOverlay(this.url, this.bounds, options);
         });
         this._assertInitialized();
-        this.groundOverlay!.setMap(this._map.googleMap!);
+        this.groundOverlay.setMap(this._map.googleMap!);
         this._eventManager.setTarget(this.groundOverlay);
       });
 
@@ -108,7 +108,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
    */
   getBounds(): google.maps.LatLngBounds {
     this._assertInitialized();
-    return this.groundOverlay!.getBounds();
+    return this.groundOverlay.getBounds();
   }
 
   /**
@@ -118,7 +118,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
    */
   getOpacity(): number {
     this._assertInitialized();
-    return this.groundOverlay!.getOpacity();
+    return this.groundOverlay.getOpacity();
   }
 
   /**
@@ -128,7 +128,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
    */
   getUrl(): string {
     this._assertInitialized();
-    return this.groundOverlay!.getUrl();
+    return this.groundOverlay.getUrl();
   }
 
   private _combineOptions(): Observable<google.maps.GroundOverlayOptions> {
@@ -145,12 +145,12 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
     this._opacity.pipe(takeUntil(this._destroyed)).subscribe(opacity => {
       if (opacity) {
         this._assertInitialized();
-        this.groundOverlay!.setOpacity(opacity);
+        this.groundOverlay.setOpacity(opacity);
       }
     });
   }
 
-  private _assertInitialized() {
+  private _assertInitialized(): asserts this is {groundOverlay: google.maps.GroundOverlay} {
     if (!this._map.googleMap) {
       throw Error(
           'Cannot access Google Map information before the API has been initialized. ' +

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -135,7 +135,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    */
   close() {
     this._assertInitialized();
-    this.infoWindow!.close();
+    this.infoWindow.close();
   }
 
   /**
@@ -144,7 +144,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    */
   getContent(): string|Node {
     this._assertInitialized();
-    return this.infoWindow!.getContent();
+    return this.infoWindow.getContent();
   }
 
   /**
@@ -154,7 +154,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    */
   getPosition(): google.maps.LatLng|null {
     this._assertInitialized();
-    return this.infoWindow!.getPosition();
+    return this.infoWindow.getPosition();
   }
 
   /**
@@ -163,7 +163,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    */
   getZIndex(): number {
     this._assertInitialized();
-    return this.infoWindow!.getZIndex();
+    return this.infoWindow.getZIndex();
   }
 
   /**
@@ -174,7 +174,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     this._assertInitialized();
     const marker = anchor ? anchor.marker : undefined;
     this._elementRef.nativeElement.style.display = '';
-    this.infoWindow!.open(this._googleMap.googleMap, marker);
+    this.infoWindow.open(this._googleMap.googleMap, marker);
   }
 
   private _combineOptions(): Observable<google.maps.InfoWindowOptions> {
@@ -191,7 +191,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
   private _watchForOptionsChanges() {
     this._options.pipe(takeUntil(this._destroy)).subscribe(options => {
       this._assertInitialized();
-      this.infoWindow!.setOptions(options);
+      this.infoWindow.setOptions(options);
     });
   }
 
@@ -199,12 +199,12 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     this._position.pipe(takeUntil(this._destroy)).subscribe(position => {
       if (position) {
         this._assertInitialized();
-        this.infoWindow!.setPosition(position);
+        this.infoWindow.setPosition(position);
       }
     });
   }
 
-  private _assertInitialized() {
+  private _assertInitialized(): asserts this is {infoWindow: google.maps.InfoWindow} {
     if (!this._googleMap.googleMap) {
       throw Error(
           'Cannot access Google Map information before the API has been initialized. ' +

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -255,7 +255,7 @@ export class MapMarker implements OnInit, OnDestroy {
         // user has subscribed to.
         this._ngZone.runOutsideAngular(() => this.marker = new google.maps.Marker(options));
         this._assertInitialized();
-        this.marker!.setMap(this._googleMap.googleMap!);
+        this.marker.setMap(this._googleMap.googleMap!);
         this._eventManager.setTarget(this.marker);
       });
 
@@ -282,7 +282,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getAnimation(): google.maps.Animation|null {
     this._assertInitialized();
-    return this.marker!.getAnimation() || null;
+    return this.marker.getAnimation() || null;
   }
 
   /**
@@ -291,7 +291,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getClickable(): boolean {
     this._assertInitialized();
-    return this.marker!.getClickable();
+    return this.marker.getClickable();
   }
 
   /**
@@ -300,7 +300,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getCursor(): string|null {
     this._assertInitialized();
-    return this.marker!.getCursor() || null;
+    return this.marker.getCursor() || null;
   }
 
   /**
@@ -309,7 +309,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getDraggable(): boolean {
     this._assertInitialized();
-    return !!this.marker!.getDraggable();
+    return !!this.marker.getDraggable();
   }
 
   /**
@@ -318,7 +318,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getIcon(): string|google.maps.Icon|google.maps.Symbol|null {
     this._assertInitialized();
-    return this.marker!.getIcon() || null;
+    return this.marker.getIcon() || null;
   }
 
   /**
@@ -327,7 +327,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getLabel(): google.maps.MarkerLabel|null {
     this._assertInitialized();
-    return this.marker!.getLabel() || null;
+    return this.marker.getLabel() || null;
   }
 
   /**
@@ -336,7 +336,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getOpacity(): number|null {
     this._assertInitialized();
-    return this.marker!.getOpacity() || null;
+    return this.marker.getOpacity() || null;
   }
 
   /**
@@ -345,7 +345,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getPosition(): google.maps.LatLng|null {
     this._assertInitialized();
-    return this.marker!.getPosition() || null;
+    return this.marker.getPosition() || null;
   }
 
   /**
@@ -354,7 +354,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getShape(): google.maps.MarkerShape|null {
     this._assertInitialized();
-    return this.marker!.getShape() || null;
+    return this.marker.getShape() || null;
   }
 
   /**
@@ -363,7 +363,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getTitle(): string|null {
     this._assertInitialized();
-    return this.marker!.getTitle() || null;
+    return this.marker.getTitle() || null;
   }
 
   /**
@@ -372,7 +372,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getVisible(): boolean {
     this._assertInitialized();
-    return this.marker!.getVisible();
+    return this.marker.getVisible();
   }
 
   /**
@@ -381,7 +381,7 @@ export class MapMarker implements OnInit, OnDestroy {
    */
   getZIndex(): number|null {
     this._assertInitialized();
-    return this.marker!.getZIndex() || null;
+    return this.marker.getZIndex() || null;
   }
 
   private _combineOptions(): Observable<google.maps.MarkerOptions> {
@@ -444,7 +444,7 @@ export class MapMarker implements OnInit, OnDestroy {
     });
   }
 
-  private _assertInitialized() {
+  private _assertInitialized(): asserts this is {marker: google.maps.Marker} {
     if (!this._googleMap.googleMap) {
       throw Error(
           'Cannot access Google Map information before the API has been initialized. ' +

--- a/src/google-maps/map-polygon/map-polygon.ts
+++ b/src/google-maps/map-polygon/map-polygon.ts
@@ -149,7 +149,7 @@ export class MapPolygon implements OnInit, OnDestroy {
           this.polygon = new google.maps.Polygon(options);
         });
         this._assertInitialized();
-        this.polygon!.setMap(this._map.googleMap!);
+        this.polygon.setMap(this._map.googleMap!);
         this._eventManager.setTarget(this.polygon);
       });
 
@@ -173,7 +173,7 @@ export class MapPolygon implements OnInit, OnDestroy {
    */
   getDraggable(): boolean {
     this._assertInitialized();
-    return this.polygon!.getDraggable();
+    return this.polygon.getDraggable();
   }
 
   /**
@@ -181,7 +181,7 @@ export class MapPolygon implements OnInit, OnDestroy {
    */
   getEditable(): boolean {
     this._assertInitialized();
-    return this.polygon!.getEditable();
+    return this.polygon.getEditable();
   }
 
   /**
@@ -189,7 +189,7 @@ export class MapPolygon implements OnInit, OnDestroy {
    */
   getPath(): google.maps.MVCArray<google.maps.LatLng> {
     this._assertInitialized();
-    return this.polygon!.getPath();
+    return this.polygon.getPath();
   }
 
   /**
@@ -197,7 +197,7 @@ export class MapPolygon implements OnInit, OnDestroy {
    */
   getPaths(): google.maps.MVCArray<google.maps.MVCArray<google.maps.LatLng>> {
     this._assertInitialized();
-    return this.polygon!.getPaths();
+    return this.polygon.getPaths();
   }
 
   /**
@@ -205,7 +205,7 @@ export class MapPolygon implements OnInit, OnDestroy {
    */
   getVisible(): boolean {
     this._assertInitialized();
-    return this.polygon!.getVisible();
+    return this.polygon.getVisible();
   }
 
   private _combineOptions(): Observable<google.maps.PolygonOptions> {
@@ -221,7 +221,7 @@ export class MapPolygon implements OnInit, OnDestroy {
   private _watchForOptionsChanges() {
     this._options.pipe(takeUntil(this._destroyed)).subscribe(options => {
       this._assertInitialized();
-      this.polygon!.setOptions(options);
+      this.polygon.setOptions(options);
     });
   }
 
@@ -229,12 +229,12 @@ export class MapPolygon implements OnInit, OnDestroy {
     this._paths.pipe(takeUntil(this._destroyed)).subscribe(paths => {
       if (paths) {
         this._assertInitialized();
-        this.polygon!.setPaths(paths);
+        this.polygon.setPaths(paths);
       }
     });
   }
 
-  private _assertInitialized() {
+  private _assertInitialized(): asserts this is {polygon: google.maps.Polygon} {
     if (!this._map.googleMap) {
       throw Error(
           'Cannot access Google Map information before the API has been initialized. ' +

--- a/src/google-maps/map-polyline/map-polyline.ts
+++ b/src/google-maps/map-polyline/map-polyline.ts
@@ -147,7 +147,7 @@ export class MapPolyline implements OnInit, OnDestroy {
         // user has subscribed to.
         this._ngZone.runOutsideAngular(() => this.polyline = new google.maps.Polyline(options));
         this._assertInitialized();
-        this.polyline!.setMap(this._map.googleMap!);
+        this.polyline.setMap(this._map.googleMap!);
         this._eventManager.setTarget(this.polyline);
       });
 
@@ -171,7 +171,7 @@ export class MapPolyline implements OnInit, OnDestroy {
    */
   getDraggable(): boolean {
     this._assertInitialized();
-    return this.polyline!.getDraggable();
+    return this.polyline.getDraggable();
   }
 
   /**
@@ -179,7 +179,7 @@ export class MapPolyline implements OnInit, OnDestroy {
    */
   getEditable(): boolean {
     this._assertInitialized();
-    return this.polyline!.getEditable();
+    return this.polyline.getEditable();
   }
 
   /**
@@ -188,7 +188,7 @@ export class MapPolyline implements OnInit, OnDestroy {
   getPath(): google.maps.MVCArray<google.maps.LatLng> {
     this._assertInitialized();
     // @breaking-change 11.0.0 Make the return value nullable.
-    return this.polyline!.getPath();
+    return this.polyline.getPath();
   }
 
   /**
@@ -196,7 +196,7 @@ export class MapPolyline implements OnInit, OnDestroy {
    */
   getVisible(): boolean {
     this._assertInitialized();
-    return this.polyline!.getVisible();
+    return this.polyline.getVisible();
   }
 
   private _combineOptions(): Observable<google.maps.PolylineOptions> {
@@ -211,23 +211,21 @@ export class MapPolyline implements OnInit, OnDestroy {
 
   private _watchForOptionsChanges() {
     this._options.pipe(takeUntil(this._destroyed)).subscribe(options => {
-      if (this.polyline) {
-        this._assertInitialized();
-        this.polyline.setOptions(options);
-      }
+      this._assertInitialized();
+      this.polyline.setOptions(options);
     });
   }
 
   private _watchForPathChanges() {
     this._path.pipe(takeUntil(this._destroyed)).subscribe(path => {
-      if (path && this.polyline) {
+      if (path) {
         this._assertInitialized();
         this.polyline.setPath(path);
       }
     });
   }
 
-  private _assertInitialized() {
+  private _assertInitialized(): asserts this is {polyline: google.maps.Polyline} {
     if (!this._map.googleMap) {
       throw Error(
           'Cannot access Google Map information before the API has been initialized. ' +

--- a/src/google-maps/map-rectangle/map-rectangle.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.ts
@@ -157,7 +157,7 @@ export class MapRectangle implements OnInit, OnDestroy {
           this.rectangle = new google.maps.Rectangle(options);
         });
         this._assertInitialized();
-        this.rectangle!.setMap(this._map.googleMap!);
+        this.rectangle.setMap(this._map.googleMap!);
         this._eventManager.setTarget(this.rectangle);
       });
 
@@ -181,7 +181,7 @@ export class MapRectangle implements OnInit, OnDestroy {
    */
   getBounds(): google.maps.LatLngBounds {
     this._assertInitialized();
-    return this.rectangle!.getBounds();
+    return this.rectangle.getBounds();
   }
 
   /**
@@ -190,7 +190,7 @@ export class MapRectangle implements OnInit, OnDestroy {
    */
   getDraggable(): boolean {
     this._assertInitialized();
-    return this.rectangle!.getDraggable();
+    return this.rectangle.getDraggable();
   }
 
   /**
@@ -199,7 +199,7 @@ export class MapRectangle implements OnInit, OnDestroy {
    */
   getEditable(): boolean {
     this._assertInitialized();
-    return this.rectangle!.getEditable();
+    return this.rectangle.getEditable();
   }
 
   /**
@@ -208,7 +208,7 @@ export class MapRectangle implements OnInit, OnDestroy {
    */
   getVisible(): boolean {
     this._assertInitialized();
-    return this.rectangle!.getVisible();
+    return this.rectangle.getVisible();
   }
 
   private _combineOptions(): Observable<google.maps.RectangleOptions> {
@@ -224,7 +224,7 @@ export class MapRectangle implements OnInit, OnDestroy {
   private _watchForOptionsChanges() {
     this._options.pipe(takeUntil(this._destroyed)).subscribe(options => {
       this._assertInitialized();
-      this.rectangle!.setOptions(options);
+      this.rectangle.setOptions(options);
     });
   }
 
@@ -232,12 +232,12 @@ export class MapRectangle implements OnInit, OnDestroy {
     this._bounds.pipe(takeUntil(this._destroyed)).subscribe(bounds => {
       if (bounds) {
         this._assertInitialized();
-        this.rectangle!.setBounds(bounds);
+        this.rectangle.setBounds(bounds);
       }
     });
   }
 
-  private _assertInitialized() {
+  private _assertInitialized(): asserts this is {rectangle: google.maps.Rectangle} {
     if (!this._map.googleMap) {
       throw Error(
           'Cannot access Google Map information before the API has been initialized. ' +


### PR DESCRIPTION
We can take advantage of TypeScript's `asserts` keyword so that we don't have to cast values to be non-nullable, when we've already asserted that they exist.