### PR TITLE
fix(datepicker): clearing completed range when pressing escape

### DIFF
--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -333,6 +333,26 @@ describe('MatMonthView', () => {
           expect(testComponent.selected).toBeFalsy();
         });
 
+        it('should not clear the range when pressing escape while there is no preview', () => {
+          const getRangeElements = () => monthViewNativeElement.querySelectorAll([
+            '.mat-calendar-body-range-start',
+            '.mat-calendar-body-in-range',
+            '.mat-calendar-body-range-end'
+          ].join(','));
+
+          testComponent.selected = new DateRange(new Date(2017, JAN, 10), new Date(2017, JAN, 15));
+          fixture.detectChanges();
+
+          expect(getRangeElements().length)
+              .toBeGreaterThan(0, 'Expected range to be present on init.');
+
+          dispatchKeyboardEvent(calendarBodyEl, 'keydown', ESCAPE);
+          fixture.detectChanges();
+
+          expect(getRangeElements().length)
+              .toBeGreaterThan(0, 'Expected range to be present after pressing the escape key.');
+        });
+
         it('should not fire the selected change event when clicking on an already-selected ' +
           'date while selecting a single date', () => {
             testComponent.selected = new Date(2017, JAN, 10);

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -275,8 +275,8 @@ export class MatMonthView<D> implements AfterContentInit, OnDestroy {
         }
         return;
       case ESCAPE:
-          // Abort the current range selection if the user presses escape mid-selection.
-        if (this._previewEnd !== null) {
+        // Abort the current range selection if the user presses escape mid-selection.
+        if (this._previewEnd != null) {
           this._previewStart = this._previewEnd = null;
           this.selectedChange.emit(null);
           this._userSelection.emit({value: null, event});


### PR DESCRIPTION
The check for when pressing escape should clear a range wasn't quite right which meant that pressing escape would clear a completed range. The intention was to only clear the range if the user has a start, but not an end.