### PR TITLE
fix(overlay): expand flexible origin type to allow SVG elements

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -33,7 +33,7 @@ const boundingBoxClass = 'cdk-overlay-connected-position-bounding-box';
 const cssUnitPattern = /([A-Za-z%]+)$/;
 
 /** Possible values that can be set as the origin of a FlexibleConnectedPositionStrategy. */
-export type FlexibleConnectedPositionStrategyOrigin = ElementRef | HTMLElement | Point & {
+export type FlexibleConnectedPositionStrategyOrigin = ElementRef | Element | Point & {
   width?: number;
   height?: number;
 };

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -146,7 +146,7 @@ export declare class FlexibleConnectedPositionStrategy implements PositionStrate
     withViewportMargin(margin: number): this;
 }
 
-export declare type FlexibleConnectedPositionStrategyOrigin = ElementRef | HTMLElement | Point & {
+export declare type FlexibleConnectedPositionStrategyOrigin = ElementRef | Element | Point & {
     width?: number;
     height?: number;
 };


### PR DESCRIPTION
The typing of the `FlexibleConnectedPositionStrategyOrigin` is scoped to `HTMLElement` which doesn't cover `SVGElement`, even though we support it. These changes update the type.

Note that this should be a safe change to the public API, because we're widening the type.

Fixes #36381.