### PR TITLE
fix(tabs): don't prevent default space/enter action if active tab doesn't change

### DIFF
--- a/src/material-experimental/mdc-tabs/tab-header.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.spec.ts
@@ -148,6 +148,19 @@ describe('MDC-based MatTabHeader', () => {
       expect(spaceEvent.defaultPrevented).toBe(true);
     });
 
+    it('should not prevent the default space/enter action if the current is selected', () => {
+      appComponent.tabHeader.focusIndex = appComponent.tabHeader.selectedIndex = 0;
+      fixture.detectChanges();
+
+      const spaceEvent = dispatchKeyboardEvent(tabListContainer, 'keydown', SPACE);
+      fixture.detectChanges();
+      expect(spaceEvent.defaultPrevented).toBe(false);
+
+      const enterEvent = dispatchKeyboardEvent(tabListContainer, 'keydown', ENTER);
+      fixture.detectChanges();
+      expect(enterEvent.defaultPrevented).toBe(false);
+    });
+
     it('should move focus to the first tab when pressing HOME', () => {
       appComponent.tabHeader.focusIndex = 3;
       fixture.detectChanges();

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -269,8 +269,10 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
         break;
       case ENTER:
       case SPACE:
-        this.selectFocusedIndex.emit(this.focusIndex);
-        this._itemSelected(event);
+        if (this.focusIndex !== this.selectedIndex) {
+          this.selectFocusedIndex.emit(this.focusIndex);
+          this._itemSelected(event);
+        }
         break;
       default:
         this._keyManager.onKeydown(event);

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -150,6 +150,19 @@ describe('MatTabHeader', () => {
       expect(spaceEvent.defaultPrevented).toBe(true);
     });
 
+    it('should not prevent the default space/enter action if the current is selected', () => {
+      appComponent.tabHeader.focusIndex = appComponent.tabHeader.selectedIndex = 0;
+      fixture.detectChanges();
+
+      const spaceEvent = dispatchKeyboardEvent(tabListContainer, 'keydown', SPACE);
+      fixture.detectChanges();
+      expect(spaceEvent.defaultPrevented).toBe(false);
+
+      const enterEvent = dispatchKeyboardEvent(tabListContainer, 'keydown', ENTER);
+      fixture.detectChanges();
+      expect(enterEvent.defaultPrevented).toBe(false);
+    });
+
     it('should move focus to the first tab when pressing HOME', () => {
       appComponent.tabHeader.focusIndex = 3;
       fixture.detectChanges();


### PR DESCRIPTION
Switches to only preventing the default enter/space action if we did something with the event, otherwise we risk interfering with other user events.

Fixes #19190.