### PR TITLE
refactor(datepicker): move date range selection logic out of calendar

### DIFF
--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -24,8 +24,8 @@ import {
   MatCalendar,
   MatCalendarHeader,
   MatDatepickerInputEvent,
-  MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
-  MatCalendarRangeSelectionStrategy,
+  MAT_DATE_RANGE_SELECTION_STRATEGY,
+  MatDateRangeSelectionStrategy,
   DateRange
 } from '@angular/material/datepicker';
 import {Subject} from 'rxjs';
@@ -86,7 +86,7 @@ export class DatepickerDemo {
 
 /** Range selection strategy that preserves the current range. */
 @Injectable()
-export class PreserveRangeStrategy<D> implements MatCalendarRangeSelectionStrategy<D> {
+export class PreserveRangeStrategy<D> implements MatDateRangeSelectionStrategy<D> {
   constructor(private _dateAdapter: DateAdapter<D>) {}
 
   selectionFinished(date: D, currentRange: DateRange<D>) {
@@ -134,7 +134,7 @@ export class PreserveRangeStrategy<D> implements MatCalendarRangeSelectionStrate
 @Directive({
   selector: '[customRangeStrategy]',
   providers: [{
-    provide: MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+    provide: MAT_DATE_RANGE_SELECTION_STRATEGY,
     useClass: PreserveRangeStrategy
   }]
 })

--- a/src/material/datepicker/calendar.html
+++ b/src/material/datepicker/calendar.html
@@ -4,7 +4,7 @@
   <mat-month-view
       *ngSwitchCase="'month'"
       [(activeDate)]="activeDate"
-      [selected]="_getDisplaySelection()"
+      [selected]="selected"
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"
@@ -17,7 +17,7 @@
   <mat-year-view
       *ngSwitchCase="'year'"
       [(activeDate)]="activeDate"
-      [selected]="_getDisplaySelection()"
+      [selected]="selected"
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"
@@ -28,7 +28,7 @@
   <mat-multi-year-view
       *ngSwitchCase="'multi-year'"
       [(activeDate)]="activeDate"
-      [selected]="_getDisplaySelection()"
+      [selected]="selected"
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"

--- a/src/material/datepicker/date-range-selection-strategy.ts
+++ b/src/material/datepicker/date-range-selection-strategy.ts
@@ -13,12 +13,11 @@ import {DateRange} from './date-selection-model';
 // TODO(crisbeto): this needs to be expanded to allow for the preview range to be customized.
 
 /** Injection token used to customize the date range selection behavior. */
-export const MAT_CALENDAR_RANGE_SELECTION_STRATEGY =
-    new InjectionToken<MatCalendarRangeSelectionStrategy<any>>(
-        'MAT_CALENDAR_RANGE_SELECTION_STRATEGY');
+export const MAT_DATE_RANGE_SELECTION_STRATEGY =
+    new InjectionToken<MatDateRangeSelectionStrategy<any>>('MAT_DATE_RANGE_SELECTION_STRATEGY');
 
 /** Object that can be provided in order to customize the date range selection behavior. */
-export interface MatCalendarRangeSelectionStrategy<D> {
+export interface MatDateRangeSelectionStrategy<D> {
   /**
    * Called when the user has finished selecting a value.
    * @param date Date that was selected. Will be null if the user cleared the selection.
@@ -43,7 +42,7 @@ export interface MatCalendarRangeSelectionStrategy<D> {
 
 /** Provides the default date range selection behavior. */
 @Injectable()
-export class DefaultMatCalendarRangeStrategy<D> implements MatCalendarRangeSelectionStrategy<D> {
+export class DefaultMatCalendarRangeStrategy<D> implements MatDateRangeSelectionStrategy<D> {
   constructor(private _dateAdapter: DateAdapter<D>) {}
 
   selectionFinished(date: D, currentRange: DateRange<D>) {

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -7,11 +7,12 @@
     [maxDate]="datepicker._maxDate"
     [dateFilter]="datepicker._dateFilter"
     [headerComponent]="datepicker.calendarHeaderComponent"
+    [selected]="_getSelected()"
     [dateClass]="datepicker.dateClass"
     [comparisonStart]="comparisonStart"
     [comparisonEnd]="comparisonEnd"
     [@fadeInCalendar]="'enter'"
     (yearSelected)="datepicker._selectYear($event)"
     (monthSelected)="datepicker._selectMonth($event)"
-    (_userSelection)="_handleUserSelection()">
+    (_userSelection)="_handleUserSelection($event)">
 </mat-calendar>

--- a/src/material/datepicker/datepicker-module.ts
+++ b/src/material/datepicker/datepicker-module.ts
@@ -31,9 +31,9 @@ import {MatDateRangeInput} from './date-range-input';
 import {MatStartDate, MatEndDate} from './date-range-input-parts';
 import {MatDateRangePicker} from './date-range-picker';
 import {
-  MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+  MAT_DATE_RANGE_SELECTION_STRATEGY,
   DefaultMatCalendarRangeStrategy
-} from './calendar-range-selection-strategy';
+} from './date-range-selection-strategy';
 
 
 @NgModule({
@@ -84,7 +84,7 @@ import {
     MatDatepickerIntl,
     MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
     {
-      provide: MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+      provide: MAT_DATE_RANGE_SELECTION_STRATEGY,
       useClass: DefaultMatCalendarRangeStrategy
     }
   ],

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -28,9 +28,9 @@ import {MatCalendarBody} from './calendar-body';
 import {MatMonthView} from './month-view';
 import {DateRange} from './date-selection-model';
 import {
-  MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
+  MAT_DATE_RANGE_SELECTION_STRATEGY,
   DefaultMatCalendarRangeStrategy,
-} from './calendar-range-selection-strategy';
+} from './date-range-selection-strategy';
 
 describe('MatMonthView', () => {
   let dir: {value: Direction};
@@ -51,7 +51,7 @@ describe('MatMonthView', () => {
       ],
       providers: [
         {provide: Directionality, useFactory: () => dir = {value: 'ltr'}},
-        {provide: MAT_CALENDAR_RANGE_SELECTION_STRATEGY, useClass: DefaultMatCalendarRangeStrategy}
+        {provide: MAT_DATE_RANGE_SELECTION_STRATEGY, useClass: DefaultMatCalendarRangeStrategy}
       ]
     });
 

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -46,9 +46,9 @@ import {Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
 import {DateRange} from './date-selection-model';
 import {
-  MatCalendarRangeSelectionStrategy,
-  MAT_CALENDAR_RANGE_SELECTION_STRATEGY,
-} from './calendar-range-selection-strategy';
+  MatDateRangeSelectionStrategy,
+  MAT_DATE_RANGE_SELECTION_STRATEGY,
+} from './date-range-selection-strategy';
 
 
 const DAYS_PER_WEEK = 7;
@@ -179,8 +179,8 @@ export class MatMonthView<D> implements AfterContentInit, OnDestroy {
               @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
               @Optional() public _dateAdapter: DateAdapter<D>,
               @Optional() private _dir?: Directionality,
-              @Inject(MAT_CALENDAR_RANGE_SELECTION_STRATEGY) @Optional()
-                  private _rangeStrategy?: MatCalendarRangeSelectionStrategy<D>) {
+              @Inject(MAT_DATE_RANGE_SELECTION_STRATEGY) @Optional()
+                  private _rangeStrategy?: MatDateRangeSelectionStrategy<D>) {
     if (!this._dateAdapter) {
       throw createMissingDateImplError('DateAdapter');
     }

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -10,7 +10,7 @@ export * from './datepicker-module';
 export * from './calendar';
 export * from './calendar-body';
 export * from './datepicker';
-export * from './calendar-range-selection-strategy';
+export * from './date-range-selection-strategy';
 export * from './datepicker-animations';
 export {
   MAT_DATEPICKER_SCROLL_STRATEGY,

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -17,7 +17,7 @@ export interface DateSelectionModelChange<S> {
     source: unknown;
 }
 
-export declare class DefaultMatCalendarRangeStrategy<D> implements MatCalendarRangeSelectionStrategy<D> {
+export declare class DefaultMatCalendarRangeStrategy<D> implements MatDateRangeSelectionStrategy<D> {
     constructor(_dateAdapter: DateAdapter<D>);
     createPreview(activeDate: D | null, currentRange: DateRange<D>): DateRange<D>;
     selectionFinished(date: D, currentRange: DateRange<D>): DateRange<D>;
@@ -27,7 +27,7 @@ export declare class DefaultMatCalendarRangeStrategy<D> implements MatCalendarRa
 
 export declare type ExtractDateTypeFromSelection<T> = T extends DateRange<infer D> ? D : NonNullable<T>;
 
-export declare const MAT_CALENDAR_RANGE_SELECTION_STRATEGY: InjectionToken<MatCalendarRangeSelectionStrategy<any>>;
+export declare const MAT_DATE_RANGE_SELECTION_STRATEGY: InjectionToken<MatDateRangeSelectionStrategy<any>>;
 
 export declare const MAT_DATEPICKER_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
@@ -53,7 +53,7 @@ export declare const MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER: FactoryProvider;
 
 export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDestroy, OnChanges {
     _calendarHeaderPortal: Portal<any>;
-    readonly _userSelection: EventEmitter<void>;
+    readonly _userSelection: EventEmitter<MatCalendarUserEvent<D | null>>;
     get activeDate(): D;
     set activeDate(value: D);
     comparisonEnd: D | null;
@@ -79,9 +79,8 @@ export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecke
     stateChanges: Subject<void>;
     readonly yearSelected: EventEmitter<D>;
     yearView: MatYearView<D>;
-    constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef, _model: MatDateSelectionModel<DateRange<D> | D | null>, _rangeSelectionStrategy?: MatCalendarRangeSelectionStrategy<D> | undefined);
+    constructor(_intl: MatDatepickerIntl, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, _changeDetectorRef: ChangeDetectorRef);
     _dateSelected(event: MatCalendarUserEvent<D | null>): void;
-    _getDisplaySelection(): DateRange<D> | D | null;
     _goToDateInView(date: D, view: 'month' | 'year' | 'multi-year'): void;
     _monthSelectedInYearView(normalizedMonth: D): void;
     _yearSelectedInMultiYearView(normalizedYear: D): void;
@@ -92,7 +91,7 @@ export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecke
     ngOnDestroy(): void;
     updateTodaysDate(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatCalendar<any>, "mat-calendar", ["matCalendar"], { "headerComponent": "headerComponent"; "startAt": "startAt"; "startView": "startView"; "selected": "selected"; "minDate": "minDate"; "maxDate": "maxDate"; "dateFilter": "dateFilter"; "dateClass": "dateClass"; "comparisonStart": "comparisonStart"; "comparisonEnd": "comparisonEnd"; }, { "selectedChange": "selectedChange"; "yearSelected": "yearSelected"; "monthSelected": "monthSelected"; "_userSelection": "_userSelection"; }, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatCalendar<any>, [null, { optional: true; }, { optional: true; }, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatCalendar<any>, [null, { optional: true; }, { optional: true; }, null]>;
 }
 
 export declare class MatCalendarBody implements OnChanges, OnDestroy {
@@ -168,11 +167,6 @@ export declare class MatCalendarHeader<D> {
     static ɵfac: i0.ɵɵFactoryDef<MatCalendarHeader<any>, [null, null, { optional: true; }, { optional: true; }, null]>;
 }
 
-export interface MatCalendarRangeSelectionStrategy<D> {
-    createPreview(activeDate: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
-    selectionFinished(date: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
-}
-
 export interface MatCalendarUserEvent<D> {
     event: Event;
     value: D;
@@ -199,13 +193,14 @@ export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>
     comparisonStart: D | null;
     datepicker: MatDatepickerBase<any, S, D>;
     constructor(elementRef: ElementRef,
-    _changeDetectorRef?: ChangeDetectorRef | undefined, _model?: MatDateSelectionModel<S, D> | undefined);
-    _handleUserSelection(): void;
+    _changeDetectorRef?: ChangeDetectorRef | undefined, _model?: MatDateSelectionModel<S, D> | undefined, _dateAdapter?: DateAdapter<D> | undefined, _rangeSelectionStrategy?: MatDateRangeSelectionStrategy<D> | undefined);
+    _getSelected(): D | DateRange<D> | null;
+    _handleUserSelection(event: MatCalendarUserEvent<D | null>): void;
     _startExitAnimation(): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDatepickerContent<any, any>, "mat-datepicker-content", ["matDatepickerContent"], { "color": "color"; }, {}, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any, any>, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any, any>, [null, null, null, null, { optional: true; }]>;
 }
 
 export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> implements MatDatepickerControl<D | null> {
@@ -346,6 +341,11 @@ export declare class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRang
     static ɵfac: i0.ɵɵFactoryDef<MatDateRangePicker<any>, never>;
 }
 
+export interface MatDateRangeSelectionStrategy<D> {
+    createPreview(activeDate: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
+    selectionFinished(date: D | null, currentRange: DateRange<D>, event: Event): DateRange<D>;
+}
+
 export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<S>> implements OnDestroy {
     protected _adapter: DateAdapter<D>;
     readonly selection: S;
@@ -405,7 +405,7 @@ export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
     get selected(): DateRange<D> | D | null;
     set selected(value: DateRange<D> | D | null);
     readonly selectedChange: EventEmitter<D | null>;
-    constructor(_changeDetectorRef: ChangeDetectorRef, _dateFormats: MatDateFormats, _dateAdapter: DateAdapter<D>, _dir?: Directionality | undefined, _rangeStrategy?: MatCalendarRangeSelectionStrategy<D> | undefined);
+    constructor(_changeDetectorRef: ChangeDetectorRef, _dateFormats: MatDateFormats, _dateAdapter: DateAdapter<D>, _dir?: Directionality | undefined, _rangeStrategy?: MatDateRangeSelectionStrategy<D> | undefined);
     _dateSelected(event: MatCalendarUserEvent<number>): void;
     _focusActiveCell(movePreview?: boolean): void;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;


### PR DESCRIPTION
There are some projects that expect that the `mat-calendar` doesn't assign the value itself, but only renders it out and emits an event when something is selected. These changes move the date selection logic out into the `MatDatepickerContent`.

Also renames the calendar range selection strategy since it doesn't have much to do with the calendar anymore.