### PR TITLE
fix(material-experimental/mdc-chips) adjust margins

### DIFF
--- a/src/material-experimental/mdc-chips/chips.scss
+++ b/src/material-experimental/mdc-chips/chips.scss
@@ -100,6 +100,19 @@ input.mat-mdc-chip-input {
   flex: 1 0 $mat-chip-input-width;
 }
 
+// The margin value is set in MDC.
+$mat-mdc-chip-margin: 4px;
+
+// Don't let the chip margin increase the mat-form-field height.
+.mat-mdc-chip-grid {
+  margin: -$mat-mdc-chip-margin;
+
+  // Keep the mat-chip-grid height the same even when there are no chips.
+  input.mat-input-element {
+    margin: $mat-mdc-chip-margin;
+  }
+}
+
 .mdc-chip__checkmark-path {
   ._mat-animation-noopable & {
     transition: none;


### PR DESCRIPTION
mat-chip-grid goes inside a mat-form-field, and the 4px margin on the
individual chips is causing the mat-chip-grid element to be too tall,
and thus the form field is also too tall. Give the mat-chip-grid a
negative margin so that it fits in the form field. The same thing was
done for non-mdc chips:
https://github.com/angular/components/blob/master/src/material/chips/chips.scss#L195