### PR TITLE
feat(table/testing): allow filtering by column name

### DIFF
--- a/src/material/table/testing/cell-harness.ts
+++ b/src/material/table/testing/cell-harness.ts
@@ -88,5 +88,7 @@ function getCellPredicate<T extends MatCellHarness>(
   options: CellHarnessFilters): HarnessPredicate<T> {
   return new HarnessPredicate(type, options)
     .addOption('text', options.text,
-        (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text));
+        (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text))
+    .addOption('columnName', options.columnName,
+        (harness, name) => HarnessPredicate.stringMatches(harness.getColumnName(), name));
 }

--- a/src/material/table/testing/shared.spec.ts
+++ b/src/material/table/testing/shared.spec.ts
@@ -79,6 +79,14 @@ export function runHarnessTests(
     expect(cellTexts).toEqual(['1.0079']);
   });
 
+  it('should be able to filter cells by column name', async () => {
+    const table = await loader.getHarness(tableHarness);
+    const firstRow = (await table.getRows())[0];
+    const cells = await firstRow.getCells({columnName: 'symbol'});
+    const cellTexts = await Promise.all(cells.map(cell => cell.getText()));
+    expect(cellTexts).toEqual(['H']);
+  });
+
   it('should be able to filter cells by regex', async () => {
     const table = await loader.getHarness(tableHarness);
     const firstRow = (await table.getRows())[0];

--- a/src/material/table/testing/table-harness-filters.ts
+++ b/src/material/table/testing/table-harness-filters.ts
@@ -11,6 +11,9 @@ import {BaseHarnessFilters} from '@angular/cdk/testing';
 export interface CellHarnessFilters extends BaseHarnessFilters {
   /** Only find instances whose text matches the given value. */
   text?: string | RegExp;
+
+  /** Only find instances whose column name matches the given value. */
+  columnName?: string | RegExp;
 }
 
 /** A set of criteria that can be used to filter a list of row harness instances. */

--- a/tools/public_api_guard/material/table/testing.d.ts
+++ b/tools/public_api_guard/material/table/testing.d.ts
@@ -1,4 +1,5 @@
 export interface CellHarnessFilters extends BaseHarnessFilters {
+    columnName?: string | RegExp;
     text?: string | RegExp;
 }
 


### PR DESCRIPTION
Adds an extra filter to the column harness to allow cells to be picked out by column name.

Fixes #19172.

**Note:** even though this is marked as a `feat`, I'm setting it for `patch`, because it's pretty minor and all of the parts for it were already in place. I don't feel strongly against bumping it up to a `minor` though.