### PR TITLE
build: add script for approving public API changes

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -58,3 +58,9 @@ packages locally and test them by either of the following ways:
 1. Update the dependencies in `package.json` to point to the local uncompressed package directories.
 2. Directly copy the local uncompressed package directories into the `node_modules/` directory
    of a project.
+
+
+### Approving public API changes
+If you're making changes to a public API, they need to be propagated to our public API golden files.
+To save the changes you can run `yarn approve-api <target>` and to review the changes, you can look
+at the file under `tools/public_api_guard/<target>.d.ts`.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "resync-caretaker-app": "ts-node --project scripts scripts/caretaking/resync-caretaker-app-prs.ts",
     "ts-circular-deps:check": "yarn -s ts-circular-deps check --config ./src/circular-deps-test.conf.js",
     "ts-circular-deps:approve": "yarn -s ts-circular-deps approve --config ./src/circular-deps-test.conf.js",
-    "merge": "ts-node --project scripts scripts/merge-script/cli.ts --config ./merge-config.js"
+    "merge": "ts-node --project scripts scripts/merge-script/cli.ts --config ./merge-config.js",
+    "approve-api": "node ./scripts/approve-api-golden.js"
   },
   "version": "9.2.1",
   "dependencies": {

--- a/scripts/approve-api-golden.js
+++ b/scripts/approve-api-golden.js
@@ -1,0 +1,14 @@
+const shelljs = require('shelljs');
+const chalk = require('chalk');
+const path = require('path');
+const packageName = process.argv[2];
+
+if (!packageName) {
+  console.error(chalk.red('No package name has been passed in for API golden approval.'));
+  process.exit(1);
+}
+
+// ShellJS should exit if any command fails.
+shelljs.set('-e');
+shelljs.cd(path.join(__dirname, '../'));
+shelljs.exec(`yarn bazel run //tools/public_api_guard:${packageName}.d.ts_api.accept`);


### PR DESCRIPTION
The Bazel targets for approving public API changes are a little convoluted and hard to remember. These changes add a small script to make it easier to manage. E.g. `yarn api:approve material/chips`.