### PR TITLE
docs: prevent form submission in examples

### DIFF
--- a/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.html
@@ -1,4 +1,4 @@
-<form>
+<form (submit)="$event.preventDefault()">
   <mat-form-field>
     <mat-label>First name</mat-label>
     <input matInput (cdkAutofill)="firstNameAutofilled = $event.isAutofilled">

--- a/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.html
@@ -1,4 +1,4 @@
-<form>
+<form (submit)="$event.preventDefault()">
   <mat-form-field>
     <mat-label>First name</mat-label>
     <input matInput #first>


### PR DESCRIPTION
There were a couple of examples which would trigger a page refresh if the user pressed one of the buttons, because we were using a form without preventing its default action.