### PR TITLE
docs(components/cdk/scrolling): add note about view recycling with dy…

### DIFF
--- a/src/cdk/scrolling/scrolling.md
+++ b/src/cdk/scrolling/scrolling.md
@@ -56,6 +56,9 @@ is reused instead. The size of the view cache can be adjusted via the `templateC
 property; setting this size to `0` disables caching. If your templates are expensive in terms of
 memory you may wish to reduce this number to avoid spending too much memory on the template cache.
 
+Recycled components within the `<cdk-virtual-scroll-viewport>` preserve state like bound parameter values. 
+When rendering dynamic components, you may want to disable caching completely.
+
 <!-- example(cdk-virtual-scroll-template-cache) -->
 
 ##### Specifying data


### PR DESCRIPTION
…namic components

Added a clearer note about the behaviour of view recycling in cdk-virtual-scroll-viewport
containers when rendering dynamic components.

Fixes #15838