### PR TITLE
fix(components/youtube-player): Pending commands, e.g. play video, are lost if issued before the YouTube iFrame API is available

### DIFF
--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -399,6 +399,20 @@ describe('YoutubePlayer', () => {
 
       expect(spy).toHaveBeenCalled();
     });
+
+    it('should play on init if playVideo was called before the API has loaded', () => {
+      fixture = TestBed.createComponent(TestApp);
+      testComponent = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+
+      testComponent.youtubePlayer.playVideo();
+
+      window.YT = api!;
+      window.onYouTubeIframeAPIReady!();
+      events.onReady({target: playerSpy});
+
+      expect(playerSpy.playVideo).toHaveBeenCalled();
+    });
   });
 
   it('should pick up static startSeconds and endSeconds values', () => {

--- a/src/youtube-player/youtube-player.ts
+++ b/src/youtube-player/youtube-player.ts
@@ -244,14 +244,15 @@ export class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
 
     // Set up side effects to bind inputs to the player.
     playerObs.subscribe(player => {
+      if (!player) {
+        return;
+      }
       this._player = player;
       this._playerChanges.next(player);
-
-      if (player && this._pendingPlayerState) {
+      if (this._pendingPlayerState) {
         this._initializePlayer(player, this._pendingPlayerState);
+        this._pendingPlayerState = undefined;
       }
-
-      this._pendingPlayerState = undefined;
     });
 
     bindSizeToPlayer(playerObs, this._width, this._height);


### PR DESCRIPTION
When commands like YouTubePlayer.playVideo() are issued before _player is set, they get saved in
_pendingPlayerState to be passed on to the player when it is initialized. However, if the player
observable emits undefined before the initialized player, _pendingPlayerState is unset, and the
pending commands are lost. The player observable emits undefined if the iframe API is not yet
available.