### PR TITLE
refactor: add missing abstract directive decorators

### DIFF
--- a/src/cdk-experimental/column-resize/resizable.ts
+++ b/src/cdk-experimental/column-resize/resizable.ts
@@ -8,6 +8,7 @@
 
 import {
   AfterViewInit,
+  Directive,
   ElementRef,
   Injector,
   NgZone,
@@ -38,6 +39,7 @@ const OVERLAY_ACTIVE_CLASS = 'cdk-resizable-overlay-thumb-active';
  * Base class for Resizable directives which are applied to column headers to make those columns
  * resizable.
  */
+@Directive()
 export abstract class Resizable<HandleComponent extends ResizeOverlayHandle>
     implements AfterViewInit, OnDestroy {
   protected minWidthPxInternal: number = 0;

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -37,6 +37,7 @@ export const CDK_ROW_TEMPLATE = `<ng-container cdkCellOutlet></ng-container>`;
  * Base class for the CdkHeaderRowDef and CdkRowDef that handles checking their columns inputs
  * for changes and notifying the table.
  */
+@Directive()
 export abstract class BaseRowDef implements OnChanges {
   /** The columns to be displayed on this row. */
   columns: Iterable<string>;

--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -6,14 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentInit, ElementRef, NgZone, OnDestroy, QueryList} from '@angular/core';
+import {AfterContentInit, Directive, ElementRef, NgZone, OnDestroy, QueryList} from '@angular/core';
 import {setLines} from '@angular/material/core';
 import {Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
 
 export class MatListBase {}
 
-export class MatListItemBase implements AfterContentInit, OnDestroy {
+@Directive()
+export abstract class MatListItemBase implements AfterContentInit, OnDestroy {
   lines: QueryList<ElementRef<Element>>;
 
   private _subscriptions = new Subscription();

--- a/tslint.json
+++ b/tslint.json
@@ -112,7 +112,7 @@
     "no-import-export-spacing": true,
     "no-private-getters": true,
     "no-undecorated-base-class-di": true,
-    "no-undecorated-class-with-ng-fields": true,
+    "no-undecorated-class-with-angular-features": true,
     "setters-after-getters": true,
     "ng-on-changes-property-access": true,
     "require-breaking-change-version": true,


### PR DESCRIPTION
In version 10 of Angular, undecorated base classes using Angular
features (including the use of lifecycle hooks) are no longer supported.

Needed for https://github.com/angular/angular/pull/36921