### PR TITLE
feat(material-experimental/mdc-form-field): expose `MAT_FORM_FIELD` injection token

### DIFF
--- a/src/material-experimental/mdc-form-field/public-api.ts
+++ b/src/material-experimental/mdc-form-field/public-api.ts
@@ -7,6 +7,7 @@
  */
 
 export {
+  MAT_FORM_FIELD,
   MatFormFieldControl,
   getMatFormFieldDuplicatedHintError,
   getMatFormFieldMissingControlError,


### PR DESCRIPTION
We recently added a new injection token called `MAT_FORM_FIELD`. This
token should allow form control implementers to inject the form-field
without having to bring in the actual `MatFormField` as a side-effect.

We should expose that token from the MDC form-field entry-point too,
as that will ease the migration. Also it would be unexpected if an
application switches to the MDC-based form field, but would still need
to import from the non-MDC form field entry-point.