### PR TITLE
refactor(drag-drop): remove deprecated APIs for version 10

### DIFF
--- a/src/cdk/drag-drop/directives/config.ts
+++ b/src/cdk/drag-drop/directives/config.ts
@@ -44,12 +44,3 @@ export interface DragDropConfig extends Partial<DragRefConfig> {
   listOrientation?: DropListOrientation;
   zIndex?: number;
 }
-
-/**
- * @deprecated No longer being used. To be removed.
- * @breaking-change 10.0.0
- * @docs-private
- */
-export function CDK_DRAG_CONFIG_FACTORY(): DragDropConfig {
-  return {dragStartThreshold: 5, pointerDirectionChangeThreshold: 5};
-}

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -226,12 +226,18 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   /**
    * Returns the element that is being used as a placeholder
    * while the current element is being dragged.
+   * @deprecated No longer being used to be removed.
+   * @breaking-change 11.0.0
    */
   getPlaceholderElement(): HTMLElement {
     return this._dragRef.getPlaceholderElement();
   }
 
-  /** Returns the root draggable element. */
+  /**
+   * Returns the root draggable element.
+   * @deprecated No longer being used to be removed.
+   * @breaking-change 11.0.0
+   */
   getRootElement(): HTMLElement {
     return this._dragRef.getRootElement();
   }

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -233,64 +233,6 @@ export class CdkDropList<T = any> implements OnDestroy {
     this._destroyed.complete();
   }
 
-  /**
-   * Starts dragging an item.
-   * @deprecated No longer being used. To be removed.
-   * @breaking-change 10.0.0
-   */
-  start(): void {
-    this._dropListRef.start();
-  }
-
-  /**
-   * Drops an item into this container.
-   * @param item Item being dropped into the container.
-   * @param currentIndex Index at which the item should be inserted.
-   * @param previousContainer Container from which the item got dragged in.
-   * @param isPointerOverContainer Whether the user's pointer was over the
-   *    container when the item was dropped.
-   *
-   * @deprecated No longer being used. To be removed.
-   * @breaking-change 10.0.0
-   */
-  drop(item: CdkDrag, currentIndex: number, previousContainer: CdkDropList,
-    isPointerOverContainer: boolean): void {
-    this._dropListRef.drop(item._dragRef, currentIndex, previousContainer._dropListRef,
-        isPointerOverContainer, {x: 0, y: 0});
-  }
-
-  /**
-   * Emits an event to indicate that the user moved an item into the container.
-   * @param item Item that was moved into the container.
-   * @param pointerX Position of the item along the X axis.
-   * @param pointerY Position of the item along the Y axis.
-   * @deprecated No longer being used. To be removed.
-   * @breaking-change 10.0.0
-   */
-  enter(item: CdkDrag, pointerX: number, pointerY: number): void {
-    this._dropListRef.enter(item._dragRef, pointerX, pointerY);
-  }
-
-  /**
-   * Removes an item from the container after it was dragged into another container by the user.
-   * @param item Item that was dragged out.
-   * @deprecated No longer being used. To be removed.
-   * @breaking-change 10.0.0
-   */
-  exit(item: CdkDrag): void {
-    this._dropListRef.exit(item._dragRef);
-  }
-
-  /**
-   * Figures out the index of an item in the container.
-   * @param item Item whose index should be determined.
-   * @deprecated No longer being used. To be removed.
-   * @breaking-change 10.0.0
-   */
-  getItemIndex(item: CdkDrag): number {
-    return this._dropListRef.getItemIndex(item._dragRef);
-  }
-
   /** Syncs the inputs of the CdkDropList with the options of the underlying DropListRef. */
   private _setupInputSyncSubscription(ref: DropListRef<CdkDropList>) {
     if (this._dir) {

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -1,7 +1,5 @@
 export declare const CDK_DRAG_CONFIG: InjectionToken<DragDropConfig>;
 
-export declare function CDK_DRAG_CONFIG_FACTORY(): DragDropConfig;
-
 export declare const CDK_DROP_LIST: InjectionToken<CdkDropList>;
 
 export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
@@ -166,14 +164,9 @@ export declare class CdkDropList<T = any> implements OnDestroy {
     element: ElementRef<HTMLElement>, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined,
     _scrollDispatcher?: ScrollDispatcher | undefined, config?: DragDropConfig);
     addItem(item: CdkDrag): void;
-    drop(item: CdkDrag, currentIndex: number, previousContainer: CdkDropList, isPointerOverContainer: boolean): void;
-    enter(item: CdkDrag, pointerX: number, pointerY: number): void;
-    exit(item: CdkDrag): void;
-    getItemIndex(item: CdkDrag): number;
     getSortedItems(): CdkDrag[];
     ngOnDestroy(): void;
     removeItem(item: CdkDrag): void;
-    start(): void;
     static ngAcceptInputType_autoScrollDisabled: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_sortingDisabled: BooleanInput;


### PR DESCRIPTION
Removes some deprecated APIs that were marked to be removed in v10. Also marks some more APIs that were supposed to deprecated.

BREAKING CHANGES:
* `CdkDropList.start` has been removed.
* `CdkDropList.drop` has been removed.
* `CdkDropList.enter` has been removed.
* `CdkDropList.exit` has been removed.
* `CdkDropList.getItemIndex` has been removed.
* `CDK_DRAG_CONFIG_FACTORY` has been removed.