### PR TITLE
refactor(button-toggle): remove deprecated APIs for version 10

### DIFF
--- a/src/material/button-toggle/button-toggle.spec.ts
+++ b/src/material/button-toggle/button-toggle.spec.ts
@@ -8,7 +8,6 @@ import {
   MatButtonToggle,
   MatButtonToggleChange,
   MatButtonToggleGroup,
-  MatButtonToggleGroupMultiple,
   MatButtonToggleModule,
 } from './index';
 
@@ -645,10 +644,6 @@ describe('MatButtonToggle without forms', () => {
       expect(() => {
         groupInstance.value = 'not-an-array';
       }).toThrowError(/Value must be an array/);
-    });
-
-    it('should be able to query for the deprecated `MatButtonToggleGroupMultiple`', () => {
-      expect(fixture.debugElement.query(By.directive(MatButtonToggleGroupMultiple))).toBeTruthy();
     });
 
   });

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -73,12 +73,6 @@ export const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any = {
   multi: true
 };
 
-/**
- * @deprecated Use `MatButtonToggleGroup` instead.
- * @breaking-change 8.0.0
- */
-export class MatButtonToggleGroupMultiple {}
-
 let _uniqueIdCounter = 0;
 
 /** Change event object emitted by MatButtonToggle. */
@@ -94,10 +88,7 @@ export class MatButtonToggleChange {
 /** Exclusive selection button toggle group that behaves like a radio-button group. */
 @Directive({
   selector: 'mat-button-toggle-group',
-  providers: [
-    MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR,
-    {provide: MatButtonToggleGroupMultiple, useExisting: MatButtonToggleGroup},
-  ],
+  providers: [MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR],
   host: {
     'role': 'group',
     'class': 'mat-button-toggle-group',
@@ -488,7 +479,6 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
               private _changeDetectorRef: ChangeDetectorRef,
               private _elementRef: ElementRef<HTMLElement>,
               private _focusMonitor: FocusMonitor,
-              // @breaking-change 8.0.0 `defaultTabIndex` to be made a required parameter.
               @Attribute('tabindex') defaultTabIndex: string,
               @Optional() @Inject(MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS)
                   defaultOptions?: MatButtonToggleDefaultOptions) {

--- a/src/material/schematics/ng-update/data/class-names.ts
+++ b/src/material/schematics/ng-update/data/class-names.ts
@@ -9,6 +9,14 @@
 import {ClassNameUpgradeData, TargetVersion, VersionChanges} from '@angular/cdk/schematics';
 
 export const classNames: VersionChanges<ClassNameUpgradeData> = {
+  [TargetVersion.V10]: [
+    {
+      pr: 'https://github.com/angular/components/pull/19289',
+      changes: [
+        {replace: 'MatButtonToggleGroupMultiple', replaceWith: 'MatButtonToggleGroup'}
+      ]
+    }
+  ],
   [TargetVersion.V6]: [
     {
       pr: 'https://github.com/angular/components/pull/10291',

--- a/tools/public_api_guard/material/button-toggle.d.ts
+++ b/tools/public_api_guard/material/button-toggle.d.ts
@@ -85,9 +85,6 @@ export declare class MatButtonToggleGroup implements ControlValueAccessor, OnIni
     static ɵfac: i0.ɵɵFactoryDef<MatButtonToggleGroup, [null, { optional: true; }]>;
 }
 
-export declare class MatButtonToggleGroupMultiple {
-}
-
 export declare class MatButtonToggleModule {
     static ɵinj: i0.ɵɵInjectorDef<MatButtonToggleModule>;
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatButtonToggleModule, [typeof i1.MatButtonToggleGroup, typeof i1.MatButtonToggle], [typeof i2.MatCommonModule, typeof i2.MatRippleModule], [typeof i2.MatCommonModule, typeof i1.MatButtonToggleGroup, typeof i1.MatButtonToggle]>;


### PR DESCRIPTION
Removes the `button-toggle` APIs that were deprecated back in 8, but were never removed.

BREAKING CHANGES:
* `MatButtonToggleGroupMultiple` has been removed. Use `MatButtonToggleGroup` instead.