### PR TITLE
build: fix unexpected bazel cache discarding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -128,7 +128,3 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 # Load any settings which are specific to the current user. Needs to be *last* statement
 # in this config, as the user configuration should be able to overwrite flags from this file.
 try-import .bazelrc.user
-
-# TODO: check if we can enable these deprecations.
-build --incompatible_new_actions_api=false
-build --incompatible_no_support_tools_in_action_inputs=false


### PR DESCRIPTION
A long-standing issue with our Bazel setup was that the switch
between `ibazel` and `bazel` always resulted a slow down.

It was difficult to debug this because Bazel did not print
anything about what is going on. i.e. it was not clear whether
the analysis cache, or repositories have been discarded. After
investigation it turns out that we set Bazel starlark semantic options
that are applied on to `build` while technically this option also is
relevant for Bazel's first processing phase (i.e. `loading phase`) that runs
for `query`. See how the `QueryCommand` processes the semantic options:

1. https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/runtime/commands/QueryEnvironmentBasedCommand.java;l=103;drc=dcead939ba5fe39d61da6a18a6f83d75e1117f46
2. https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java;l=611;drc=dcead939ba5fe39d61da6a18a6f83d75e1117f46

Due to this option difference (that Bazel detects) , the cache is discarded for the first processing phase, and node modules had to be re-installed and other repositories were fetched again.

This is now fixed by removing these options as they aren't needed
anymore. Alternatively, we could have changed the option target to
`common` so that they also apply to `query`.