### PR TITLE
fix(google-maps): avoid re-initializing info window for same marker

### DIFF
--- a/src/google-maps/map-info-window/map-info-window.spec.ts
+++ b/src/google-maps/map-info-window/map-info-window.spec.ts
@@ -129,6 +129,31 @@ describe('MapInfoWindow', () => {
     expect(infoWindowSpy.open).toHaveBeenCalledWith(mapSpy, fakeMarker);
   });
 
+  it('should not try to reopen info window multiple times for the same marker', () => {
+    const fakeMarker = {} as unknown as google.maps.Marker;
+    const fakeMarkerComponent = {
+      marker: fakeMarker,
+      getAnchor: () => fakeMarker
+    } as unknown as MapMarker;
+    const infoWindowSpy = createInfoWindowSpy({});
+    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    const infoWindowComponent = fixture.debugElement.query(By.directive(
+        MapInfoWindow))!.injector.get<MapInfoWindow>(MapInfoWindow);
+    fixture.detectChanges();
+
+    infoWindowComponent.open(fakeMarkerComponent);
+    expect(infoWindowSpy.open).toHaveBeenCalledTimes(1);
+
+    infoWindowComponent.open(fakeMarkerComponent);
+    expect(infoWindowSpy.open).toHaveBeenCalledTimes(1);
+
+    infoWindowComponent.close();
+    infoWindowComponent.open(fakeMarkerComponent);
+    expect(infoWindowSpy.open).toHaveBeenCalledTimes(2);
+  });
+
   it('exposes methods that provide information about the info window', () => {
     const infoWindowSpy = createInfoWindowSpy({});
     createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -173,8 +173,13 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    */
   open(anchor?: MapAnchorPoint) {
     this._assertInitialized();
-    this._elementRef.nativeElement.style.display = '';
-    this.infoWindow.open(this._googleMap.googleMap, anchor ? anchor.getAnchor() : undefined);
+    const anchorObject = anchor ? anchor.getAnchor() : undefined;
+
+    // Prevent the info window from initializing if trying to reopen on the same anchor.
+    if (this.infoWindow.get('anchor') !== anchorObject) {
+      this._elementRef.nativeElement.style.display = '';
+      this.infoWindow.open(this._googleMap.googleMap, anchorObject);
+    }
   }
 
   private _combineOptions(): Observable<google.maps.InfoWindowOptions> {

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -92,10 +92,14 @@ export function createMarkerConstructorSpy(markerSpy: jasmine.SpyObj<google.maps
 /** Creates a jasmine.SpyObj for a google.maps.InfoWindow */
 export function createInfoWindowSpy(options: google.maps.InfoWindowOptions):
     jasmine.SpyObj<google.maps.InfoWindow> {
+  let anchor: any;
   const infoWindowSpy = jasmine.createSpyObj(
       'google.maps.InfoWindow',
-      ['addListener', 'close', 'getContent', 'getPosition', 'getZIndex', 'open']);
+      ['addListener', 'close', 'getContent', 'getPosition', 'getZIndex', 'open', 'get']);
   infoWindowSpy.addListener.and.returnValue({remove: () => {}});
+  infoWindowSpy.open.and.callFake((_map: any, target: any) => anchor = target);
+  infoWindowSpy.close.and.callFake(() => anchor = null);
+  infoWindowSpy.get.and.callFake((key: string) => key === 'anchor' ? anchor : null);
   return infoWindowSpy;
 }
 


### PR DESCRIPTION
Currently if `open` is called multiple times for the same object, we keep re-initializing the info window. This can be seen in the dev app, because Chrome keeps logging warnings for some event listeners. These changes add a check that keeps the existing info window.

cc @mbehrlich 