### PR TITLE
build: fix breaking changes script compilation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "ts-node": "^3.0.4",
     "tsickle": "0.38.1",
     "tslint": "^6.1.0",
-    "tsutils": "^3.0.0",
+    "tsutils": "^3.17.1",
     "typescript": "3.9.1-rc",
     "typescript-3.6": "npm:typescript@~3.6.4",
     "typescript-3.7": "npm:typescript@~3.7.0",

--- a/scripts/breaking-changes.ts
+++ b/scripts/breaking-changes.ts
@@ -1,7 +1,7 @@
 import {join, relative} from 'path';
 import {readFileSync} from 'fs';
 import chalk from 'chalk';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.8'; // TODO(crisbeto): switch back to `typescript` once 3.9 is out
 import * as tsutils from 'tsutils';
 
 const projectRoot = process.cwd();
@@ -19,7 +19,7 @@ const parsedConfig = ts.parseJsonSourceFileConfigFileContent(configFile, ts.sys,
 const summary: {[version: string]: string[]} = {};
 
 // Go through all the TS files in the project.
-parsedConfig.fileNames.forEach(fileName => {
+parsedConfig.fileNames.forEach((fileName: string) => {
   const sourceFile = ts.createSourceFile(fileName, readFileSync(fileName, 'utf8'),
       configFile.languageVersion);
   const lineRanges = tsutils.getLineRanges(sourceFile);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11717,10 +11717,10 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-tsutils@^3.0.0:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.5.2.tgz#6fd3c2d5a731e83bb21b070a173ec0faf3a8f6d3"
-  integrity sha512-qIlklNuI/1Dzfm+G+kJV5gg3gimZIX5haYtIVQe7qGyKd7eu8T1t1DY6pz4Sc2CGXAj9s1izycctm9Zfl9sRuQ==
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
It seems like using the RC of TS 3.9 causes a typing mismatch which breaks the `breaking-changes` script. Temporarily switches to using 3.8.