### PR TITLE
fix(google-maps): allow for ground overlay image to be changed

### DIFF
--- a/src/dev-app/google-map/google-map-demo.html
+++ b/src/dev-app/google-map/google-map-demo.html
@@ -101,4 +101,16 @@
     </label>
   </div>
 
+  <div>
+    <label for="ground-overlay-image">
+      Ground Overlay image
+
+      <select id="ground-overlay-image" (change)="groundOverlayUrlChanged($event)">
+        <option
+          *ngFor="let image of groundOverlayImages"
+          [value]="image.url">{{image.title}}</option>
+      </select>
+    </label>
+  </div>
+
 </div>

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -66,7 +66,17 @@ export class GoogleMapDemo {
   circleOptions: google.maps.CircleOptions =
       {center: CIRCLE_CENTER, radius: CIRCLE_RADIUS, strokeColor: 'grey', strokeOpacity: 0.8};
   isGroundOverlayDisplayed = false;
-  groundOverlayUrl = 'https://angular.io/assets/images/logos/angular/angular.svg';
+  groundOverlayImages = [
+    {
+      title: 'Red logo',
+      url: 'https://angular.io/assets/images/logos/angular/angular.svg'
+    },
+    {
+      title: 'Black logo',
+      url: 'https://angular.io/assets/images/logos/angular/angular_solidBlack.svg'
+    }
+  ];
+  groundOverlayUrl = this.groundOverlayImages[0].url;
   groundOverlayBounds = RECTANGLE_BOUNDS;
 
   mapTypeId: google.maps.MapTypeId;
@@ -148,5 +158,9 @@ export class GoogleMapDemo {
 
   toggleGroundOverlayDisplay() {
     this.isGroundOverlayDisplayed = !this.isGroundOverlayDisplayed;
+  }
+
+  groundOverlayUrlChanged(event: Event) {
+    this.groundOverlayUrl = (event.target as HTMLSelectElement).value;
   }
 }

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
@@ -57,11 +57,11 @@ describe('MapGroundOverlay', () => {
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
   });
 
-  it('has an error if required url or bounds are not provided', () => {
+  it('has an error if required bounds are not provided', () => {
     expect(() => {
       const fixture = TestBed.createComponent(TestApp);
       fixture.detectChanges();
-    }).toThrow(new Error('An image url is required'));
+    }).toThrow(new Error('Image bounds are required'));
   });
 
   it('exposes methods that provide information about the Ground Overlay', () => {
@@ -119,6 +119,32 @@ describe('MapGroundOverlay', () => {
     expect(addSpy).toHaveBeenCalledWith('dblclick', jasmine.any(Function));
     subscription.unsubscribe();
   });
+
+  it('should be able to change the image after init', () => {
+    const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
+    const groundOverlayConstructorSpy =
+        createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.componentInstance.url = url;
+    fixture.componentInstance.bounds = bounds;
+    fixture.componentInstance.clickable = clickable;
+    fixture.componentInstance.opacity = opacity;
+    fixture.detectChanges();
+
+    expect(groundOverlayConstructorSpy).toHaveBeenCalledWith(url, bounds, groundOverlayOptions);
+    expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
+
+    groundOverlaySpy.setMap.calls.reset();
+    fixture.componentInstance.url = 'foo.png';
+    fixture.detectChanges();
+
+    expect(groundOverlaySpy.set).toHaveBeenCalledWith('url', 'foo.png');
+    expect(groundOverlaySpy.setMap).toHaveBeenCalledTimes(2);
+    expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(null);
+    expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
+  });
+
 });
 
 @Component({

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -241,6 +241,7 @@ export function createCircleConstructorSpy(circleSpy: jasmine.SpyObj<google.maps
 export function createGroundOverlaySpy(
     url: string, bounds: google.maps.LatLngBoundsLiteral,
     options?: google.maps.GroundOverlayOptions): jasmine.SpyObj<google.maps.GroundOverlay> {
+  const values: {[key: string]: any} = {url};
   const groundOverlaySpy = jasmine.createSpyObj('google.maps.GroundOverlay', [
     'addListener',
     'getBounds',
@@ -248,8 +249,10 @@ export function createGroundOverlaySpy(
     'getUrl',
     'setMap',
     'setOpacity',
+    'set',
   ]);
   groundOverlaySpy.addListener.and.returnValue({remove: () => {}});
+  groundOverlaySpy.set.and.callFake((key: string, value: any) => values[key] = value);
   return groundOverlaySpy;
 }
 

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -94,7 +94,7 @@ export declare class MapGroundOverlay implements OnInit, OnDestroy {
     mapClick: Observable<google.maps.MouseEvent>;
     mapDblclick: Observable<google.maps.MouseEvent>;
     set opacity(opacity: number);
-    url: string;
+    set url(url: string);
     constructor(_map: GoogleMap, _ngZone: NgZone);
     getBounds(): google.maps.LatLngBounds;
     getOpacity(): number;


### PR DESCRIPTION
As things are set up at the moment, changing the ground overlay's `url` won't do anything. These changes add some extra logic to update the URL and to tell the map to re-render.

cc @mbehrlich 