### PR TITLE
refactor(slide-toggle): remove deprecated APIs for version 10

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle-config.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle-config.ts
@@ -12,12 +12,6 @@ import {InjectionToken} from '@angular/core';
 export interface MatSlideToggleDefaultOptions {
   /** Whether toggle action triggers value changes in slide toggle. */
   disableToggleValue?: boolean;
-  /**
-   * Whether drag action triggers value changes in slide toggle.
-   * @deprecated No longer being used.
-   * @breaking-change 9.0.0.
-   */
-  disableDragValue?: boolean;
 }
 
 /** Injection token to be used to override the default options for `mat-slide-toggle`. */

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
@@ -185,16 +185,6 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
   /** Event will be dispatched each time the slide-toggle input is toggled. */
   @Output() readonly toggleChange: EventEmitter<void> = new EventEmitter<void>();
 
-  /**
-   * An event will be dispatched each time the slide-toggle is dragged.
-   * This event is always emitted when the user drags the slide toggle to make a change greater
-   * than 50%. It does not mean the slide toggle's value is changed. The event is not emitted when
-   * the user toggles the slide toggle to change its value.
-   * @deprecated No longer being used.
-   * @breaking-change 9.0.0
-   */
-  @Output() readonly dragChange: EventEmitter<void> = new EventEmitter<void>();
-
   /** Returns the unique id for the visual hidden input. */
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -14,6 +14,12 @@ import {ConstructorChecksUpgradeData, TargetVersion, VersionChanges} from '@angu
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V10]: [
+    {
+      pr: 'https://github.com/angular/components/pull/19307',
+      changes: ['MatSlideToggle']
+    }
+  ],
   [TargetVersion.V9]: [
     {
       pr: 'https://github.com/angular/components/pull/17230',

--- a/src/material/slide-toggle/BUILD.bazel
+++ b/src/material/slide-toggle/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
     module_name = "@angular/material/slide-toggle",
     deps = [
         "//src/cdk/a11y",
-        "//src/cdk/bidi",
         "//src/cdk/coercion",
         "//src/cdk/observers",
         "//src/material/core",
@@ -57,7 +56,6 @@ ng_test_library(
     deps = [
         ":slide-toggle",
         "//src/cdk/a11y",
-        "//src/cdk/bidi",
         "//src/cdk/observers",
         "//src/cdk/testing/private",
         "//src/material/testing",

--- a/src/material/slide-toggle/slide-toggle-config.ts
+++ b/src/material/slide-toggle/slide-toggle-config.ts
@@ -12,12 +12,6 @@ import {InjectionToken} from '@angular/core';
 export interface MatSlideToggleDefaultOptions {
   /** Whether toggle action triggers value changes in slide toggle. */
   disableToggleValue?: boolean;
-  /**
-   * Whether drag action triggers value changes in slide toggle.
-   * @deprecated No longer being used.
-   * @breaking-change 10.0.0
-   */
-  disableDragValue?: boolean;
 }
 
 /** Injection token to be used to override the default options for `mat-slide-toggle`. */

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -1,4 +1,3 @@
-import {BidiModule, Direction} from '@angular/cdk/bidi';
 import {MutationObserverFactory} from '@angular/cdk/observers';
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
 import {Component} from '@angular/core';
@@ -25,7 +24,7 @@ describe('MatSlideToggle without forms', () => {
     mutationObserverCallbacks = [];
 
     TestBed.configureTestingModule({
-      imports: [MatSlideToggleModule, BidiModule],
+      imports: [MatSlideToggleModule],
       declarations: [
         SlideToggleBasic,
         SlideToggleWithTabindexAttr,
@@ -850,7 +849,7 @@ describe('MatSlideToggle with forms', () => {
 
 @Component({
   template: `
-    <mat-slide-toggle [dir]="direction" [required]="isRequired"
+    <mat-slide-toggle [required]="isRequired"
                      [disabled]="isDisabled"
                      [color]="slideColor"
                      [id]="slideId"
@@ -883,7 +882,6 @@ class SlideToggleBasic {
   labelPosition: string;
   toggleTriggered: number = 0;
   dragTriggered: number = 0;
-  direction: Direction = 'ltr';
 
   onSlideClick: (event?: Event) => void = () => {};
   onSlideChange = (event: MatSlideToggleChange) => this.lastEvent = event;

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -7,7 +7,6 @@
  */
 
 import {FocusMonitor} from '@angular/cdk/a11y';
-import {Directionality} from '@angular/cdk/bidi';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   AfterContentInit,
@@ -23,7 +22,6 @@ import {
   Output,
   ViewChild,
   ViewEncapsulation,
-  NgZone,
   Optional,
   Inject,
 } from '@angular/core';
@@ -155,16 +153,6 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
    */
   @Output() readonly toggleChange: EventEmitter<void> = new EventEmitter<void>();
 
-  /**
-   * An event will be dispatched each time the slide-toggle is dragged.
-   * This event is always emitted when the user drags the slide toggle to make a change greater
-   * than 50%. It does not mean the slide toggle's value is changed. The event is not emitted when
-   * the user toggles the slide toggle to change its value.
-   * @deprecated No longer being used. To be removed.
-   * @breaking-change 10.0.0
-   */
-  @Output() readonly dragChange: EventEmitter<void> = new EventEmitter<void>();
-
   /** Returns the unique id for the visual hidden input. */
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 
@@ -175,15 +163,9 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
               private _focusMonitor: FocusMonitor,
               private _changeDetectorRef: ChangeDetectorRef,
               @Attribute('tabindex') tabIndex: string,
-                /**
-                 * @deprecated `_ngZone` and `_dir` parameters to be removed.
-                 * @breaking-change 10.0.0
-                 */
-              _ngZone: NgZone,
               @Inject(MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS)
                   public defaults: MatSlideToggleDefaultOptions,
-              @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,
-              @Optional() _dir?: Directionality) {
+              @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
     super(elementRef);
     this.tabIndex = parseInt(tabIndex) || 0;
   }

--- a/tools/public_api_guard/material/slide-toggle.d.ts
+++ b/tools/public_api_guard/material/slide-toggle.d.ts
@@ -20,7 +20,6 @@ export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements 
     get checked(): boolean;
     set checked(value: boolean);
     defaults: MatSlideToggleDefaultOptions;
-    readonly dragChange: EventEmitter<void>;
     id: string;
     get inputId(): string;
     labelPosition: 'before' | 'after';
@@ -28,8 +27,7 @@ export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements 
     get required(): boolean;
     set required(value: boolean);
     readonly toggleChange: EventEmitter<void>;
-    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string,
-    _ngZone: NgZone, defaults: MatSlideToggleDefaultOptions, _animationMode?: string | undefined, _dir?: Directionality);
+    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, defaults: MatSlideToggleDefaultOptions, _animationMode?: string | undefined);
     _onChangeEvent(event: Event): void;
     _onInputClick(event: Event): void;
     _onLabelTextChange(): void;
@@ -45,8 +43,8 @@ export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements 
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_required: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSlideToggle, "mat-slide-toggle", ["matSlideToggle"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "color": "color"; "tabIndex": "tabIndex"; "name": "name"; "id": "id"; "labelPosition": "labelPosition"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; "required": "required"; "checked": "checked"; }, { "change": "change"; "toggleChange": "toggleChange"; "dragChange": "dragChange"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<MatSlideToggle, [null, null, null, { attribute: "tabindex"; }, null, null, { optional: true; }, { optional: true; }]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatSlideToggle, "mat-slide-toggle", ["matSlideToggle"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "color": "color"; "tabIndex": "tabIndex"; "name": "name"; "id": "id"; "labelPosition": "labelPosition"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; "required": "required"; "checked": "checked"; }, { "change": "change"; "toggleChange": "toggleChange"; }, never, ["*"]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatSlideToggle, [null, null, null, { attribute: "tabindex"; }, null, { optional: true; }]>;
 }
 
 export declare class MatSlideToggleChange {
@@ -58,7 +56,6 @@ export declare class MatSlideToggleChange {
 }
 
 export interface MatSlideToggleDefaultOptions {
-    disableDragValue?: boolean;
     disableToggleValue?: boolean;
 }
 


### PR DESCRIPTION
Removes the APIs that were marked as deprecated for v10.

BREAKING CHANGES:
* `MatSlideToggleDefaultOptions.disableDragValue` has been removed.
* `MatSlideToggle.dragChange` has been removed.
* The `_ngZone` and `_dir` parameters have been removed from the `MatSlideToggle` constructor.