### PR TITLE
fix(datepicker): set color on range separator

### DIFF
--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -67,12 +67,14 @@ $mat-calendar-weekday-table-font-size: 11px !default;
     color: mat-color($foreground, secondary-text);
   }
 
-  .mat-calendar-body-cell-content {
+  .mat-calendar-body-cell-content,
+  .mat-date-range-input-separator {
     color: mat-color($foreground, text);
     border-color: transparent;
   }
 
-  .mat-calendar-body-disabled > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
+  .mat-calendar-body-disabled > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected),
+  .mat-form-field-disabled .mat-date-range-input-separator {
     color: mat-color($foreground, disabled-text);
   }
 
@@ -151,7 +153,7 @@ $mat-calendar-weekday-table-font-size: 11px !default;
     }
   }
 
-  .mat-date-range-input-inner:disabled {
+  .mat-date-range-input-inner[disabled] {
     color: mat-color($foreground, disabled-text);
   }
 }


### PR DESCRIPTION
Currently the date range input separator inherits its color which may not always be correct. These changes set the color explicitly based on the theme.