### PR TITLE
refactor(cdk/table): remove deprecated APIs for version 10

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -544,32 +544,6 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     this.updateStickyColumnStyles();
   }
 
-  /**
-   * Sets the header row definition to be used. Overrides the header row definition gathered by
-   * using `ContentChild`, if one exists. Sets a flag that will re-render the header row after the
-   * table's content is checked.
-   * @docs-private
-   * @deprecated Use `addHeaderRowDef` and `removeHeaderRowDef` instead
-   * @breaking-change 8.0.0
-   */
-  setHeaderRowDef(headerRowDef: CdkHeaderRowDef) {
-    this._customHeaderRowDefs = new Set([headerRowDef]);
-    this._headerRowDefChanged = true;
-  }
-
-  /**
-   * Sets the footer row definition to be used. Overrides the footer row definition gathered by
-   * using `ContentChild`, if one exists. Sets a flag that will re-render the footer row after the
-   * table's content is checked.
-   * @docs-private
-   * @deprecated Use `addFooterRowDef` and `removeFooterRowDef` instead
-   * @breaking-change 8.0.0
-   */
-  setFooterRowDef(footerRowDef: CdkFooterRowDef) {
-    this._customFooterRowDefs = new Set([footerRowDef]);
-    this._footerRowDefChanged = true;
-  }
-
   /** Adds a column definition that was not included as part of the content children. */
   addColumnDef(columnDef: CdkColumnDef) {
     this._customColumnDefs.add(columnDef);

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -209,8 +209,6 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
     removeHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
     removeRowDef(rowDef: CdkRowDef<T>): void;
     renderRows(): void;
-    setFooterRowDef(footerRowDef: CdkFooterRowDef): void;
-    setHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
     updateStickyColumnStyles(): void;
     updateStickyFooterRowStyles(): void;
     updateStickyHeaderRowStyles(): void;


### PR DESCRIPTION
Removes the APIs that have been deprecated for v10.

BREAKING CHANGES:
* `CdkTable.setHeaderRowDef` has been removed. Use `CdkTable.addHeaderRowDef` and `CdkTable.removeHeaderRowDef` instead.
* `CdkTable.setFooterRowDef` has been removed. Use `CdkTable.addFooterRowDef` and `CdkTable.removeFooterRowDef` instead.