### PR TITLE
fix: unable to set expanded or collapsed height in expansion panel

### DIFF
--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -161,9 +161,9 @@ export class MatExpansionPanelHeader implements OnDestroy, FocusableOption {
   _getHeaderHeight(): string|null {
     const isExpanded = this._isExpanded();
     if (isExpanded && this.expandedHeight) {
-      return `${this.expandedHeight}px`;
+      return this.expandedHeight;
     } else if (!isExpanded && this.collapsedHeight) {
-      return `${this.collapsedHeight}px`;
+      return this.collapsedHeight;
     }
     return null;
   }

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -351,6 +351,11 @@ describe('MatExpansionPanel', () => {
     expect(panel.componentInstance.hideToggle).toBe(true);
     expect(header.componentInstance.expandedHeight).toBe('10px');
     expect(header.componentInstance.collapsedHeight).toBe('16px');
+    expect(header.nativeElement.style.height).toBe('16px');
+
+    fixture.componentInstance.expanded = true;
+    fixture.detectChanges();
+    expect(header.nativeElement.style.height).toBe('10px');
   });
 
   describe('disabled state', () => {


### PR DESCRIPTION
For the density system, we reworked the expansion panel to no longer
rely on Angular animations. Looks like the refactoring missed that units
are already set for the `expandedHeight` and `collapsedHeight` inputs.

This hasn't been catched in any unit test, so tests are updated to catch this now.