### PR TITLE
refactor(icon): change deprecated APIs for version 10

### DIFF
--- a/src/material/icon/icon-registry.ts
+++ b/src/material/icon/icon-registry.ts
@@ -137,8 +137,7 @@ export class MatIconRegistry implements OnDestroy {
     @Optional() private _httpClient: HttpClient,
     private _sanitizer: DomSanitizer,
     @Optional() @Inject(DOCUMENT) document: any,
-    // @breaking-change 9.0.0 _errorHandler parameter to be made required
-    @Optional() private readonly _errorHandler?: ErrorHandler) {
+    private readonly _errorHandler: ErrorHandler) {
       this._document = document;
     }
 
@@ -380,12 +379,7 @@ export class MatIconRegistry implements OnDestroy {
             // Swallow errors fetching individual URLs so the
             // combined Observable won't necessarily fail.
             const errorMessage = `Loading icon set URL: ${url} failed: ${err.message}`;
-            // @breaking-change 9.0.0 _errorHandler parameter to be made required
-            if (this._errorHandler) {
-              this._errorHandler.handleError(new Error(errorMessage));
-            } else {
-              console.error(errorMessage);
-            }
+            this._errorHandler.handleError(new Error(errorMessage));
             return observableOf(null);
           })
         );
@@ -641,8 +635,8 @@ export function ICON_REGISTRY_PROVIDER_FACTORY(
   parentRegistry: MatIconRegistry,
   httpClient: HttpClient,
   sanitizer: DomSanitizer,
-  document?: any,
-  errorHandler?: ErrorHandler) {
+  errorHandler: ErrorHandler,
+  document?: any) {
   return parentRegistry || new MatIconRegistry(httpClient, sanitizer, document, errorHandler);
 }
 
@@ -654,7 +648,7 @@ export const ICON_REGISTRY_PROVIDER = {
     [new Optional(), new SkipSelf(), MatIconRegistry],
     [new Optional(), HttpClient],
     DomSanitizer,
-    [new Optional(), ErrorHandler],
+    ErrorHandler,
     [new Optional(), DOCUMENT as InjectionToken<any>],
   ],
   useFactory: ICON_REGISTRY_PROVIDER_FACTORY,

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -22,7 +22,6 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
-  Optional,
   SimpleChanges,
   ViewEncapsulation,
 } from '@angular/core';
@@ -185,13 +184,8 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Aft
   constructor(
       elementRef: ElementRef<HTMLElement>, private _iconRegistry: MatIconRegistry,
       @Attribute('aria-hidden') ariaHidden: string,
-      /**
-       * @deprecated `location` parameter to be made required.
-       * @breaking-change 8.0.0
-       */
-      @Optional() @Inject(MAT_ICON_LOCATION) private _location?: MatIconLocation,
-      // @breaking-change 9.0.0 _errorHandler parameter to be made required
-      @Optional() private readonly _errorHandler?: ErrorHandler) {
+      @Inject(MAT_ICON_LOCATION) private _location: MatIconLocation,
+      private readonly _errorHandler: ErrorHandler) {
     super(elementRef);
 
     // If the user has not explicitly set aria-hidden, mark the icon as hidden, as this is
@@ -240,12 +234,7 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Aft
             .pipe(take(1))
             .subscribe(svg => this._setSvgElement(svg), (err: Error) => {
               const errorMessage = `Error retrieving icon ${namespace}:${iconName}! ${err.message}`;
-              // @breaking-change 9.0.0 _errorHandler parameter to be made required.
-              if (this._errorHandler) {
-                this._errorHandler.handleError(new Error(errorMessage));
-              } else {
-                console.error(errorMessage);
-              }
+              this._errorHandler.handleError(new Error(errorMessage));
             });
       } else if (svgIconChanges.previousValue) {
         this._clearSvgElement();
@@ -268,7 +257,7 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Aft
   ngAfterViewChecked() {
     const cachedElements = this._elementsWithExternalReferences;
 
-    if (cachedElements && this._location && cachedElements.size) {
+    if (cachedElements && cachedElements.size) {
       const newPath = this._location.getPathname();
 
       // We need to check whether the URL has changed on each change detection since
@@ -310,13 +299,10 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Aft
 
     // Note: we do this fix here, rather than the icon registry, because the
     // references have to point to the URL at the time that the icon was created.
-    if (this._location) {
-      const path = this._location.getPathname();
-      this._previousPath = path;
-      this._cacheChildrenWithExternalReferences(svg);
-      this._prependPathToReferences(path);
-    }
-
+    const path = this._location.getPathname();
+    this._previousPath = path;
+    this._cacheChildrenWithExternalReferences(svg);
+    this._prependPathToReferences(path);
     this._elementRef.nativeElement.appendChild(svg);
   }
 

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -34,6 +34,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/19363',
       changes: ['MatTooltip']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/19323',
+      changes: ['MatIcon', 'MatIconRegistry']
     }
   ],
   [TargetVersion.V9]: [

--- a/tools/public_api_guard/material/icon.d.ts
+++ b/tools/public_api_guard/material/icon.d.ts
@@ -8,11 +8,11 @@ export declare function getMatIconNoHttpProviderError(): Error;
 
 export declare const ICON_REGISTRY_PROVIDER: {
     provide: typeof MatIconRegistry;
-    deps: (Optional[] | typeof DomSanitizer)[];
+    deps: (Optional[] | typeof DomSanitizer | typeof ErrorHandler)[];
     useFactory: typeof ICON_REGISTRY_PROVIDER_FACTORY;
 };
 
-export declare function ICON_REGISTRY_PROVIDER_FACTORY(parentRegistry: MatIconRegistry, httpClient: HttpClient, sanitizer: DomSanitizer, document?: any, errorHandler?: ErrorHandler): MatIconRegistry;
+export declare function ICON_REGISTRY_PROVIDER_FACTORY(parentRegistry: MatIconRegistry, httpClient: HttpClient, sanitizer: DomSanitizer, errorHandler: ErrorHandler, document?: any): MatIconRegistry;
 
 export interface IconOptions {
     viewBox?: string;
@@ -31,15 +31,14 @@ export declare class MatIcon extends _MatIconMixinBase implements OnChanges, OnI
     get inline(): boolean;
     set inline(inline: boolean);
     svgIcon: string;
-    constructor(elementRef: ElementRef<HTMLElement>, _iconRegistry: MatIconRegistry, ariaHidden: string,
-    _location?: MatIconLocation | undefined, _errorHandler?: ErrorHandler | undefined);
+    constructor(elementRef: ElementRef<HTMLElement>, _iconRegistry: MatIconRegistry, ariaHidden: string, _location: MatIconLocation, _errorHandler: ErrorHandler);
     ngAfterViewChecked(): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
     static ngAcceptInputType_inline: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatIcon, "mat-icon", ["matIcon"], { "color": "color"; "inline": "inline"; "svgIcon": "svgIcon"; "fontSet": "fontSet"; "fontIcon": "fontIcon"; }, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<MatIcon, [null, null, { attribute: "aria-hidden"; }, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatIcon, [null, null, { attribute: "aria-hidden"; }, null, null]>;
 }
 
 export interface MatIconLocation {
@@ -52,7 +51,7 @@ export declare class MatIconModule {
 }
 
 export declare class MatIconRegistry implements OnDestroy {
-    constructor(_httpClient: HttpClient, _sanitizer: DomSanitizer, document: any, _errorHandler?: ErrorHandler | undefined);
+    constructor(_httpClient: HttpClient, _sanitizer: DomSanitizer, document: any, _errorHandler: ErrorHandler);
     addSvgIcon(iconName: string, url: SafeResourceUrl, options?: IconOptions): this;
     addSvgIconInNamespace(namespace: string, iconName: string, url: SafeResourceUrl, options?: IconOptions): this;
     addSvgIconLiteral(iconName: string, literal: SafeHtml, options?: IconOptions): this;
@@ -68,6 +67,6 @@ export declare class MatIconRegistry implements OnDestroy {
     ngOnDestroy(): void;
     registerFontClassAlias(alias: string, className?: string): this;
     setDefaultFontSetClass(className: string): this;
-    static ɵfac: i0.ɵɵFactoryDef<MatIconRegistry, [{ optional: true; }, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatIconRegistry, [{ optional: true; }, null, { optional: true; }, null]>;
     static ɵprov: i0.ɵɵInjectableDef<MatIconRegistry>;
 }


### PR DESCRIPTION
Changes the APIs that were marked as deprecated for v10.

BREAKING CHANGES:
* The `_location` and `_errorHandler` parameters in the `MatIcon` constructor are now required.
* The `_errorHandler` parameter in the `MatIconRegistry` constructor is now required.