### PR TITLE
refactor(autocomplete): change deprecated APIs for version 10

### DIFF
--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -219,8 +219,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
               @Optional() private _dir: Directionality,
               @Optional() @Inject(MAT_FORM_FIELD) @Host() private _formField: MatFormField,
               @Optional() @Inject(DOCUMENT) private _document: any,
-              // @breaking-change 8.0.0 Make `_viewportRuler` required.
-              private _viewportRuler?: ViewportRuler) {
+              private _viewportRuler: ViewportRuler) {
     this._scrollStrategy = scrollStrategy;
   }
 
@@ -644,13 +643,11 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
         }
       });
 
-      if (this._viewportRuler) {
-        this._viewportSubscription = this._viewportRuler.change().subscribe(() => {
-          if (this.panelOpen && overlayRef) {
-            overlayRef.updateSize({width: this._getPanelWidth()});
-          }
-        });
-      }
+      this._viewportSubscription = this._viewportRuler.change().subscribe(() => {
+        if (this.panelOpen && overlayRef) {
+          overlayRef.updateSize({width: this._getPanelWidth()});
+        }
+      });
     } else {
       // Update the trigger, panel width and direction, in case anything has changed.
       this._positionStrategy.setOrigin(this._getConnectedElement());

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -26,6 +26,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/19372',
       changes: ['MatSortHeader']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/19324',
+      changes: ['MatAutocompleteTrigger']
     }
   ],
   [TargetVersion.V9]: [

--- a/tools/public_api_guard/material/autocomplete.d.ts
+++ b/tools/public_api_guard/material/autocomplete.d.ts
@@ -98,7 +98,7 @@ export declare class MatAutocompleteTrigger implements ControlValueAccessor, Aft
     get panelClosingActions(): Observable<MatOptionSelectionChange | null>;
     get panelOpen(): boolean;
     position: 'auto' | 'above' | 'below';
-    constructor(_element: ElementRef<HTMLInputElement>, _overlay: Overlay, _viewContainerRef: ViewContainerRef, _zone: NgZone, _changeDetectorRef: ChangeDetectorRef, scrollStrategy: any, _dir: Directionality, _formField: MatFormField, _document: any, _viewportRuler?: ViewportRuler | undefined);
+    constructor(_element: ElementRef<HTMLInputElement>, _overlay: Overlay, _viewContainerRef: ViewContainerRef, _zone: NgZone, _changeDetectorRef: ChangeDetectorRef, scrollStrategy: any, _dir: Directionality, _formField: MatFormField, _document: any, _viewportRuler: ViewportRuler);
     _handleFocus(): void;
     _handleInput(event: KeyboardEvent): void;
     _handleKeydown(event: KeyboardEvent): void;


### PR DESCRIPTION
Changes the APIs that were marked as deprecated for v10.

BREAKING CHANGES:
* The `_viewportRuler` parameter in the `MatAutocompleteTrigger` constructor is now required.