### PR TITLE
chore: enable strictPropertyInitialization check in TS.

### DIFF
--- a/src/cdk-experimental/popover-edit/edit-ref.ts
+++ b/src/cdk-experimental/popover-edit/edit-ref.ts
@@ -28,7 +28,8 @@ export class EditRef<FormValue> implements OnDestroy {
   readonly blurred: Observable<void> = this._blurredSubject.asObservable();
 
   /** The value to set the form back to on revert. */
-  private _revertFormValue: FormValue;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _revertFormValue!: FormValue;
 
   constructor(
       @Self() private readonly _form: ControlContainer,

--- a/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
+++ b/src/cdk-experimental/scrolling/auto-size-virtual-scroll.ts
@@ -89,13 +89,16 @@ export class AutoSizeVirtualScrollStrategy implements VirtualScrollStrategy {
   private _averager: ItemSizeAverager;
 
   /** The last measured scroll offset of the viewport. */
-  private _lastScrollOffset: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastScrollOffset!: number;
 
   /** The last measured size of the rendered content in the viewport. */
-  private _lastRenderedContentSize: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastRenderedContentSize!: number;
 
   /** The last measured size of the rendered content in the viewport. */
-  private _lastRenderedContentOffset: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastRenderedContentOffset!: number;
 
   /**
    * The number of consecutive cycles where removing extra items has failed. Failure here means that

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -88,22 +88,27 @@ export class FocusMonitor implements OnDestroy {
   private _origin: FocusOrigin = null;
 
   /** The FocusOrigin of the last focus event tracked by the FocusMonitor. */
-  private _lastFocusOrigin: FocusOrigin;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastFocusOrigin!: FocusOrigin;
 
   /** Whether the window has just been focused. */
   private _windowFocused = false;
 
   /** The target of the last touch event. */
-  private _lastTouchTarget: EventTarget | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastTouchTarget!: EventTarget | null;
 
   /** The timeout id of the touch timeout, used to cancel timeout later. */
-  private _touchTimeoutId: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _touchTimeoutId!: number;
 
   /** The timeout id of the window focus timeout. */
-  private _windowFocusTimeoutId: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _windowFocusTimeoutId!: number;
 
   /** The timeout id of the origin clearing timeout. */
-  private _originTimeoutId: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _originTimeoutId!: number;
 
   /** Map of elements being monitored to their info. */
   private _elementInfo = new Map<HTMLElement, MonitoredElementInfo>();

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -35,8 +35,10 @@ import {InteractivityChecker} from '../interactivity-checker/interactivity-check
  * @breaking-change for 11.0.0 Remove this class.
  */
 export class FocusTrap {
-  private _startAnchor: HTMLElement | null;
-  private _endAnchor: HTMLElement | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _startAnchor!: HTMLElement | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _endAnchor!: HTMLElement | null;
   private _hasAttached = false;
 
   // Event listeners for the anchors. Need to be regular functions so that we can unbind them later.
@@ -399,7 +401,8 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit, DoCheck {
   @Input('cdkTrapFocusAutoCapture')
   get autoCapture(): boolean { return this._autoCapture; }
   set autoCapture(value: boolean) { this._autoCapture = coerceBooleanProperty(value); }
-  private _autoCapture: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _autoCapture!: boolean;
 
   constructor(
       private _elementRef: ElementRef<HTMLElement>,

--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -45,7 +45,8 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
   private _letterKeyStream = new Subject<string>();
   private _typeaheadSubscription = Subscription.EMPTY;
   private _vertical = true;
-  private _horizontal: 'ltr' | 'rtl' | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _horizontal!: 'ltr' | 'rtl' | null;
   private _allowedModifierKeys: ListKeyManagerModifierKey[] = [];
 
   /**

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -213,7 +213,8 @@ export class CdkAriaLive implements OnDestroy {
   private _politeness: AriaLivePoliteness = 'off';
 
   private _previousAnnouncedText?: string;
-  private _subscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _subscription!: Subscription | null;
 
   constructor(private _elementRef: ElementRef, private _liveAnnouncer: LiveAnnouncer,
               private _contentObserver: ContentObserver, private _ngZone: NgZone) {}

--- a/src/cdk/bidi/dir.ts
+++ b/src/cdk/bidi/dir.ts
@@ -37,7 +37,8 @@ export class Dir implements Directionality, AfterContentInit, OnDestroy {
   private _isInitialized: boolean = false;
 
   /** Direction as passed in by the consumer. */
-  _rawDir: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _rawDir!: string;
 
   /** Event emitted when the direction changes. */
   @Output('dirChange') change = new EventEmitter<Direction>();

--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -68,7 +68,8 @@ export class CdkCopyToClipboard implements OnDestroy {
   private _pending = new Set<PendingCopy>();
 
   /** Whether the directive has been destroyed. */
-  private _destroyed: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _destroyed!: boolean;
 
   /** Timeout for the current copy attempt. */
   private _currentTimeout: any;

--- a/src/cdk/collections/selection-model.ts
+++ b/src/cdk/collections/selection-model.ts
@@ -22,7 +22,8 @@ export class SelectionModel<T> {
   private _selectedToEmit: T[] = [];
 
   /** Cache for the array value of the selected items. */
-  private _selected: T[] | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _selected!: T[] | null;
 
   /** Selected values. */
   get selected(): T[] {

--- a/src/cdk/drag-drop/directives/drag-placeholder.ts
+++ b/src/cdk/drag-drop/directives/drag-placeholder.ts
@@ -17,6 +17,7 @@ import {Directive, TemplateRef, Input} from '@angular/core';
 })
 export class CdkDragPlaceholder<T = any> {
   /** Context data to be added to the placeholder template instance. */
-  @Input() data: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() data!: T;
   constructor(public templateRef: TemplateRef<T>) {}
 }

--- a/src/cdk/drag-drop/directives/drag-preview.ts
+++ b/src/cdk/drag-drop/directives/drag-preview.ts
@@ -18,7 +18,8 @@ import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 })
 export class CdkDragPreview<T = any> {
   /** Context data to be added to the preview template instance. */
-  @Input() data: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() data!: T;
 
   /** Whether the preview should preserve the same size as the item that is being dragged. */
   @Input()

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -80,26 +80,32 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   _dragRef: DragRef<CdkDrag<T>>;
 
   /** Elements that can be used to drag the draggable item. */
-  @ContentChildren(CdkDragHandle, {descendants: true}) _handles: QueryList<CdkDragHandle>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(CdkDragHandle, {descendants: true}) _handles!: QueryList<CdkDragHandle>;
 
   /** Element that will be used as a template to create the draggable item's preview. */
-  @ContentChild(CdkDragPreview) _previewTemplate: CdkDragPreview;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(CdkDragPreview) _previewTemplate!: CdkDragPreview;
 
   /** Template for placeholder element rendered to show where a draggable would be dropped. */
-  @ContentChild(CdkDragPlaceholder) _placeholderTemplate: CdkDragPlaceholder;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(CdkDragPlaceholder) _placeholderTemplate!: CdkDragPlaceholder;
 
   /** Arbitrary data to attach to this drag instance. */
-  @Input('cdkDragData') data: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDragData') data!: T;
 
   /** Locks the position of the dragged element along the specified axis. */
-  @Input('cdkDragLockAxis') lockAxis: DragAxis;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDragLockAxis') lockAxis!: DragAxis;
 
   /**
    * Selector that will be used to determine the root draggable element, starting from
    * the `cdkDrag` element and going up the DOM. Passing an alternate root element is useful
    * when trying to enable dragging on an element that you might not have access to.
    */
-  @Input('cdkDragRootElement') rootElementSelector: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDragRootElement') rootElementSelector!: string;
 
   /**
    * Node or selector that will be used to determine the element to which the draggable's
@@ -107,19 +113,22 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
    * will be matched starting from the element's parent and going up the DOM until a match
    * has been found.
    */
-  @Input('cdkDragBoundary') boundaryElement: string | ElementRef<HTMLElement> | HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDragBoundary') boundaryElement!: string | ElementRef<HTMLElement> | HTMLElement;
 
   /**
    * Amount of milliseconds to wait after the user has put their
    * pointer down before starting to drag the element.
    */
-  @Input('cdkDragStartDelay') dragStartDelay: DragStartDelay;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDragStartDelay') dragStartDelay!: DragStartDelay;
 
   /**
    * Sets the position of a `CdkDrag` that is outside of a drop container.
    * Can be used to restore the element's position for a returning user.
    */
-  @Input('cdkDragFreeDragPosition') freeDragPosition: {x: number, y: number};
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDragFreeDragPosition') freeDragPosition!: {x: number, y: number};
 
   /** Whether starting to drag this element is disabled. */
   @Input('cdkDragDisabled')
@@ -130,7 +139,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     this._disabled = coerceBooleanProperty(value);
     this._dragRef.disabled = this._disabled;
   }
-  private _disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disabled!: boolean;
 
   /**
    * Function that can be used to customize the logic of how the position of the drag item
@@ -141,7 +151,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   @Input('cdkDragConstrainPosition') constrainPosition?: (point: Point, dragRef: DragRef) => Point;
 
   /** Class to be added to the preview element. */
-  @Input('cdkDragPreviewClass') previewClass: string | string[];
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDragPreviewClass') previewClass!: string | string[];
 
   /** Emits when the user starts dragging the item. */
   @Output('cdkDragStarted') started: EventEmitter<CdkDragStart> = new EventEmitter<CdkDragStart>();

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -63,7 +63,8 @@ export class CdkDropList<T = any> implements OnDestroy {
   private _destroyed = new Subject<void>();
 
   /** Whether the element's scrollable parents have been resolved. */
-  private _scrollableParentsResolved: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _scrollableParentsResolved!: boolean;
 
   /** Keeps track of the drop lists that are currently on the page. */
   private static _dropLists: CdkDropList[] = [];
@@ -80,10 +81,12 @@ export class CdkDropList<T = any> implements OnDestroy {
   connectedTo: (CdkDropList | string)[] | CdkDropList | string = [];
 
   /** Arbitrary data to attach to this container. */
-  @Input('cdkDropListData') data: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDropListData') data!: T;
 
   /** Direction in which the list is oriented. */
-  @Input('cdkDropListOrientation') orientation: DropListOrientation;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDropListOrientation') orientation!: DropListOrientation;
 
   /**
    * Unique ID for the drop zone. Can be used as a reference
@@ -92,7 +95,8 @@ export class CdkDropList<T = any> implements OnDestroy {
   @Input() id: string = `cdk-drop-list-${_uniqueIdCounter++}`;
 
   /** Locks the position of the draggable elements inside the container along the specified axis. */
-  @Input('cdkDropListLockAxis') lockAxis: DragAxis;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkDropListLockAxis') lockAxis!: DragAxis;
 
   /** Whether starting a dragging sequence from this container is disabled. */
   @Input('cdkDropListDisabled')
@@ -106,11 +110,13 @@ export class CdkDropList<T = any> implements OnDestroy {
     // the user in a disabled state, so we also need to sync it as it's being set.
     this._dropListRef.disabled = this._disabled = coerceBooleanProperty(value);
   }
-  private _disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disabled!: boolean;
 
   /** Whether sorting within this drop list is disabled. */
+  // TODO(issue/13329): Attempt to remove "!".
   @Input('cdkDropListSortingDisabled')
-  sortingDisabled: boolean;
+  sortingDisabled!: boolean;
 
   /**
    * Function that is used to determine whether an item
@@ -120,8 +126,9 @@ export class CdkDropList<T = any> implements OnDestroy {
   enterPredicate: (drag: CdkDrag, drop: CdkDropList) => boolean = () => true
 
   /** Whether to auto-scroll the view when the user moves their pointer close to the edges. */
+  // TODO(issue/13329): Attempt to remove "!".
   @Input('cdkDropListAutoScrollDisabled')
-  autoScrollDisabled: boolean;
+  autoScrollDisabled!: boolean;
 
   /** Emits when the user drops an item inside the container. */
   @Output('cdkDropListDropped')

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -84,28 +84,35 @@ export interface Point {
  */
 export class DragRef<T = any> {
   /** Element displayed next to the user's pointer while the element is dragged. */
-  private _preview: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _preview!: HTMLElement;
 
   /** Reference to the view of the preview element. */
-  private _previewRef: EmbeddedViewRef<any> | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _previewRef!: EmbeddedViewRef<any> | null;
 
   /** Reference to the view of the placeholder element. */
-  private _placeholderRef: EmbeddedViewRef<any> | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _placeholderRef!: EmbeddedViewRef<any> | null;
 
   /** Element that is rendered instead of the draggable item while it is being sorted. */
-  private _placeholder: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _placeholder!: HTMLElement;
 
   /** Coordinates within the element at which the user picked up the element. */
-  private _pickupPositionInElement: Point;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _pickupPositionInElement!: Point;
 
   /** Coordinates on the page at which the user picked up the element. */
-  private _pickupPositionOnPage: Point;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _pickupPositionOnPage!: Point;
 
   /**
    * Anchor node used to save the place in the DOM where the element was
    * picked up so that it can be restored at the end of the drag sequence.
    */
-  private _anchor: Comment;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _anchor!: Comment;
 
   /**
    * CSS `transform` applied to the element when it isn't being dragged. We need a
@@ -125,16 +132,20 @@ export class DragRef<T = any> {
    * Whether the dragging sequence has been started. Doesn't
    * necessarily mean that the element has been moved.
    */
-  private _hasStartedDragging: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _hasStartedDragging!: boolean;
 
   /** Whether the element has moved since the user started dragging it. */
-  private _hasMoved: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _hasMoved!: boolean;
 
   /** Drop container in which the DragRef resided when dragging began. */
-  private _initialContainer: DropListRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _initialContainer!: DropListRef;
 
   /** Index at which the item started in its initial container. */
-  private _initialIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _initialIndex!: number;
 
   /** Cached positions of scrollable parent elements. */
   private _parentPositions: ParentPositionTracker;
@@ -149,22 +160,26 @@ export class DragRef<T = any> {
   }>();
 
   /** Keeps track of the direction in which the user is dragging along each axis. */
-  private _pointerDirectionDelta: {x: -1 | 0 | 1, y: -1 | 0 | 1};
+  // TODO(issue/13329): Attempt to remove "!".
+  private _pointerDirectionDelta!: {x: -1 | 0 | 1, y: -1 | 0 | 1};
 
   /** Pointer position at which the last change in the delta occurred. */
-  private _pointerPositionAtLastDirectionChange: Point;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _pointerPositionAtLastDirectionChange!: Point;
 
   /**
    * Root DOM node of the drag instance. This is the element that will
    * be moved around as the user is dragging.
    */
-  private _rootElement: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _rootElement!: HTMLElement;
 
   /**
    * Inline style value of `-webkit-tap-highlight-color` at the time the
    * dragging was started. Used to restore the value once we're done dragging.
    */
-  private _rootElementTapHighlight: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _rootElementTapHighlight!: string;
 
   /** Subscription to pointer movement events. */
   private _pointerMoveSubscription = Subscription.EMPTY;
@@ -183,10 +198,12 @@ export class DragRef<T = any> {
    * events multiple times on touch devices where the browser will fire a fake
    * mouse event for each touch event, after a certain time.
    */
-  private _lastTouchEventTime: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastTouchEventTime!: number;
 
   /** Time at which the last dragging sequence was started. */
-  private _dragStartTime: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dragStartTime!: number;
 
   /** Cached reference to the boundary element. */
   private _boundaryElement: HTMLElement | null = null;
@@ -219,7 +236,8 @@ export class DragRef<T = any> {
   private _direction: Direction = 'ltr';
 
   /** Axis along which dragging is locked. */
-  lockAxis: 'x' | 'y';
+  // TODO(issue/13329): Attempt to remove "!".
+  lockAxis!: 'x' | 'y';
 
   /**
    * Amount of milliseconds to wait after the user has put their
@@ -286,7 +304,8 @@ export class DragRef<T = any> {
   }> = this._moveEvents.asObservable();
 
   /** Arbitrary data that can be attached to the drag item. */
-  data: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  data!: T;
 
   /**
    * Function that can be used to customize the logic of how the position of the drag item

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -83,7 +83,8 @@ export class DropListRef<T = any> {
   sortingDisabled: boolean = false;
 
   /** Locks the position of the draggable elements inside the container along the specified axis. */
-  lockAxis: 'x' | 'y';
+  // TODO(issue/13329): Attempt to remove "!".
+  lockAxis!: 'x' | 'y';
 
   /**
    * Whether auto-scrolling the view when the user
@@ -131,7 +132,8 @@ export class DropListRef<T = any> {
   }>();
 
   /** Arbitrary data that can be attached to the drop list. */
-  data: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  data!: T;
 
   /** Whether an item in the list is being dragged. */
   private _isDragging = false;
@@ -143,14 +145,16 @@ export class DropListRef<T = any> {
   private _parentPositions: ParentPositionTracker;
 
   /** Cached `ClientRect` of the drop list. */
-  private _clientRect: ClientRect;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _clientRect!: ClientRect;
 
   /**
    * Draggable items that are currently active inside the container. Includes the items
    * from `_draggables`, as well as any items that have been dragged in, but haven't
    * been dropped yet.
    */
-  private _activeDraggables: DragRef[];
+  // TODO(issue/13329): Attempt to remove "!".
+  private _activeDraggables!: DragRef[];
 
   /**
    * Keeps track of the item that was last swapped with the dragged item, as
@@ -159,7 +163,8 @@ export class DropListRef<T = any> {
   private _previousSwap = {drag: null as DragRef | null, delta: 0};
 
   /** Draggable items in the container. */
-  private _draggables: ReadonlyArray<DragRef>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _draggables!: ReadonlyArray<DragRef>;
 
   /** Drop lists that are connected to the current one. */
   private _siblings: ReadonlyArray<DropListRef> = [];
@@ -183,7 +188,8 @@ export class DropListRef<T = any> {
   private _horizontalScrollDirection = AutoScrollHorizontalDirection.NONE;
 
   /** Node that is being auto-scrolled. */
-  private _scrollNode: HTMLElement | Window;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _scrollNode!: HTMLElement | Window;
 
   /** Used to signal to the current auto-scroll sequence when to stop. */
   private _stopScrollTimers = new Subject<void>();
@@ -195,10 +201,12 @@ export class DropListRef<T = any> {
   private _document: Document;
 
   /** Elements that can be scrolled while the user is dragging. */
-  private _scrollableElements: HTMLElement[];
+  // TODO(issue/13329): Attempt to remove "!".
+  private _scrollableElements!: HTMLElement[];
 
   /** Initial value for the element's `scroll-snap-type` style. */
-  private _initialScrollSnap: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _initialScrollSnap!: string;
 
   constructor(
     element: ElementRef<HTMLElement> | HTMLElement,

--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -161,7 +161,8 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
     this._debounce = coerceNumberProperty(value);
     this._subscribe();
   }
-  private _debounce: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _debounce!: number;
 
   private _currentSubscription: Subscription | null = null;
 

--- a/src/cdk/overlay/fullscreen-overlay-container.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.ts
@@ -22,7 +22,8 @@ import {Platform} from '@angular/cdk/platform';
 @Injectable({providedIn: 'root'})
 export class FullscreenOverlayContainer extends OverlayContainer implements OnDestroy {
   private _fullScreenEventName: string | undefined;
-  private _fullScreenListener: () => void;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _fullScreenListener!: () => void;
 
   constructor(
     @Inject(DOCUMENT) _document: any,

--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
@@ -30,7 +30,8 @@ export class OverlayKeyboardDispatcher implements OnDestroy {
   _attachedOverlays: OverlayRef[] = [];
 
   private _document: Document;
-  private _isAttached: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _isAttached!: boolean;
 
   constructor(@Inject(DOCUMENT) document: any) {
     this._document = document;

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -27,7 +27,8 @@ const isTestEnvironment: boolean = typeof window !== 'undefined' && !!window &&
 /** Container inside which all overlays will render. */
 @Injectable({providedIn: 'root'})
 export class OverlayContainer implements OnDestroy {
-  protected _containerElement: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _containerElement!: HTMLElement;
   protected _document: Document;
 
   constructor(

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -103,7 +103,8 @@ export class CdkOverlayOrigin {
   exportAs: 'cdkConnectedOverlay'
 })
 export class CdkConnectedOverlay implements OnDestroy, OnChanges {
-  private _overlayRef: OverlayRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _overlayRef!: OverlayRef;
   private _templatePortal: TemplatePortal;
   private _hasBackdrop = false;
   private _lockPosition = false;
@@ -111,22 +112,28 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   private _flexibleDimensions = false;
   private _push = false;
   private _backdropSubscription = Subscription.EMPTY;
-  private _offsetX: number;
-  private _offsetY: number;
-  private _position: FlexibleConnectedPositionStrategy;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _offsetX!: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _offsetY!: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _position!: FlexibleConnectedPositionStrategy;
   private _scrollStrategyFactory: () => ScrollStrategy;
 
   /** Origin for the connected overlay. */
-  @Input('cdkConnectedOverlayOrigin') origin: CdkOverlayOrigin;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayOrigin') origin!: CdkOverlayOrigin;
 
   /** Registered connected position pairs. */
-  @Input('cdkConnectedOverlayPositions') positions: ConnectedPosition[];
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayPositions') positions!: ConnectedPosition[];
 
   /**
    * This input overrides the positions input if specified. It lets users pass
    * in arbitrary positioning strategies.
    */
-  @Input('cdkConnectedOverlayPositionStrategy') positionStrategy: FlexibleConnectedPositionStrategy;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayPositionStrategy') positionStrategy!: FlexibleConnectedPositionStrategy;
 
   /** The offset in pixels for the overlay connection point on the x-axis */
   @Input('cdkConnectedOverlayOffsetX')
@@ -151,22 +158,28 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   }
 
   /** The width of the overlay panel. */
-  @Input('cdkConnectedOverlayWidth') width: number | string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayWidth') width!: number | string;
 
   /** The height of the overlay panel. */
-  @Input('cdkConnectedOverlayHeight') height: number | string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayHeight') height!: number | string;
 
   /** The min width of the overlay panel. */
-  @Input('cdkConnectedOverlayMinWidth') minWidth: number | string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayMinWidth') minWidth!: number | string;
 
   /** The min height of the overlay panel. */
-  @Input('cdkConnectedOverlayMinHeight') minHeight: number | string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayMinHeight') minHeight!: number | string;
 
   /** The custom class to be set on the backdrop element. */
-  @Input('cdkConnectedOverlayBackdropClass') backdropClass: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayBackdropClass') backdropClass!: string;
 
   /** The custom class to add to the overlay pane element. */
-  @Input('cdkConnectedOverlayPanelClass') panelClass: string | string[];
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayPanelClass') panelClass!: string | string[];
 
   /** Margin between the overlay and the viewport edges. */
   @Input('cdkConnectedOverlayViewportMargin') viewportMargin: number = 0;
@@ -178,7 +191,8 @@ export class CdkConnectedOverlay implements OnDestroy, OnChanges {
   @Input('cdkConnectedOverlayOpen') open: boolean = false;
 
   /** CSS selector which to set the transform origin. */
-  @Input('cdkConnectedOverlayTransformOriginOn') transformOriginSelector: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('cdkConnectedOverlayTransformOriginOn') transformOriginSelector!: string;
 
   /** Whether or not the overlay should attach a backdrop. */
   @Input('cdkConnectedOverlayHasBackdrop')

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -43,7 +43,8 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
    * Reference to the parent of the `_host` at the time it was detached. Used to restore
    * the `_host` to its original position in the DOM when it gets re-attached.
    */
-  private _previousHostParent: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _previousHostParent!: HTMLElement;
 
   /** Stream of keydown events dispatched to this overlay. */
   _keydownEvents = new Subject<KeyboardEvent>();

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -42,7 +42,8 @@ let nextUniqueId = 0;
  */
 @Injectable()
 export class Overlay {
-  private _appRef: ApplicationRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _appRef!: ApplicationRef;
 
   constructor(
               /** Scrolling strategies that can be used when creating an overlay. */

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -41,9 +41,11 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   _positionStrategy: FlexibleConnectedPositionStrategy;
 
   /** The overlay to which this strategy is attached. */
-  private _overlayRef: OverlayReference;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _overlayRef!: OverlayReference;
 
-  private _direction: Direction | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _direction!: Direction | null;
 
   /** Whether the we're dealing with an RTL context */
   get _isRtl() {

--- a/src/cdk/overlay/position/connected-position.ts
+++ b/src/cdk/overlay/position/connected-position.ts
@@ -80,10 +80,14 @@ export class ConnectionPositionPair {
  *  @docs-private
  */
 export class ScrollingVisibility {
-  isOriginClipped: boolean;
-  isOriginOutsideView: boolean;
-  isOverlayClipped: boolean;
-  isOverlayOutsideView: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  isOriginClipped!: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  isOriginOutsideView!: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  isOverlayClipped!: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  isOverlayOutsideView!: boolean;
 }
 
 /** The change event emitted by the strategy when a fallback position is used. */

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -47,10 +47,12 @@ export type FlexibleConnectedPositionStrategyOrigin = ElementRef | Element | Poi
  */
 export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   /** The overlay to which this strategy is attached. */
-  private _overlayRef: OverlayReference;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _overlayRef!: OverlayReference;
 
   /** Whether we're performing the very first positioning of the overlay. */
-  private _isInitialRender: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _isInitialRender!: boolean;
 
   /** Last size used for the bounding box. Used to avoid resizing the overlay after open. */
   private _lastBoundingBoxSize = {width: 0, height: 0};
@@ -71,13 +73,16 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   private _positionLocked = false;
 
   /** Cached origin dimensions */
-  private _originRect: ClientRect;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _originRect!: ClientRect;
 
   /** Cached overlay dimensions */
-  private _overlayRect: ClientRect;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _overlayRect!: ClientRect;
 
   /** Cached viewport dimensions */
-  private _viewportRect: ClientRect;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _viewportRect!: ClientRect;
 
   /** Amount of space that must be maintained between the overlay and the edge of the viewport. */
   private _viewportMargin = 0;
@@ -89,22 +94,27 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   _preferredPositions: ConnectionPositionPair[] = [];
 
   /** The origin element against which the overlay will be positioned. */
-  private _origin: FlexibleConnectedPositionStrategyOrigin;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _origin!: FlexibleConnectedPositionStrategyOrigin;
 
   /** The overlay pane element. */
-  private _pane: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _pane!: HTMLElement;
 
   /** Whether the strategy has been disposed of already. */
-  private _isDisposed: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _isDisposed!: boolean;
 
   /**
    * Parent element for the overlay panel used to constrain the overlay panel's size to fit
    * within the viewport.
    */
-  private _boundingBox: HTMLElement | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _boundingBox!: HTMLElement | null;
 
   /** The last position to have been calculated as the best fit position. */
-  private _lastPosition: ConnectedPosition | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastPosition!: ConnectedPosition | null;
 
   /** Subject that emits whenever the position changes. */
   private _positionChanges = new Subject<ConnectedOverlayPositionChange>();
@@ -119,13 +129,15 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   private _offsetY = 0;
 
   /** Selector to be used when finding the elements on which to set the transform origin. */
-  private _transformOriginSelector: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _transformOriginSelector!: string;
 
   /** Keeps track of the CSS classes that the position strategy has applied on the overlay panel. */
   private _appliedPanelClasses: string[] = [];
 
   /** Amount by which the overlay was pushed in each axis during the last time it was positioned. */
-  private _previousPushAmount: {x: number, y: number} | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _previousPushAmount!: {x: number, y: number} | null;
 
   /** Observable sequence of position changes. */
   positionChanges: Observable<ConnectedOverlayPositionChange> =

--- a/src/cdk/overlay/position/global-position-strategy.ts
+++ b/src/cdk/overlay/position/global-position-strategy.ts
@@ -20,7 +20,8 @@ const wrapperClass = 'cdk-global-overlay-wrapper';
  */
 export class GlobalPositionStrategy implements PositionStrategy {
   /** The overlay to which this strategy is attached. */
-  private _overlayRef: OverlayReference;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _overlayRef!: OverlayReference;
   private _cssPosition: string = 'static';
   private _topOffset: string = '';
   private _bottomOffset: string = '';
@@ -30,7 +31,8 @@ export class GlobalPositionStrategy implements PositionStrategy {
   private _justifyContent: string = '';
   private _width: string = '';
   private _height: string = '';
-  private _isDisposed: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _isDisposed!: boolean;
 
   attach(overlayRef: OverlayReference): void {
     const config = overlayRef.getConfig();

--- a/src/cdk/overlay/scroll/block-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.ts
@@ -22,7 +22,8 @@ type ScrollBehaviorCSSStyleDeclaration = CSSStyleDeclaration & {scrollBehavior: 
  */
 export class BlockScrollStrategy implements ScrollStrategy {
   private _previousHTMLStyles = {top: '', left: ''};
-  private _previousScrollPosition: { top: number, left: number };
+  // TODO(issue/13329): Attempt to remove "!".
+  private _previousScrollPosition!: { top: number, left: number };
   private _isEnabled = false;
   private _document: Document;
 

--- a/src/cdk/overlay/scroll/close-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.ts
@@ -24,8 +24,10 @@ export interface CloseScrollStrategyConfig {
  */
 export class CloseScrollStrategy implements ScrollStrategy {
   private _scrollSubscription: Subscription|null = null;
-  private _overlayRef: OverlayReference;
-  private _initialScrollPosition: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _overlayRef!: OverlayReference;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _initialScrollPosition!: number;
 
   constructor(
     private _scrollDispatcher: ScrollDispatcher,

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.ts
@@ -29,7 +29,8 @@ export interface RepositionScrollStrategyConfig {
  */
 export class RepositionScrollStrategy implements ScrollStrategy {
   private _scrollSubscription: Subscription|null = null;
-  private _overlayRef: OverlayReference;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _overlayRef!: OverlayReference;
 
   constructor(
     private _scrollDispatcher: ScrollDispatcher,

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -77,7 +77,8 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
   private _isInitialized = false;
 
   /** Reference to the currently-attached component/view ref. */
-  private _attachedRef: CdkPortalOutletAttachedRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _attachedRef!: CdkPortalOutletAttachedRef;
 
   constructor(
       private _componentFactoryResolver: ComponentFactoryResolver,

--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -34,7 +34,8 @@ export interface ComponentType<T> {
  * It can be attach to / detached from a `PortalOutlet`.
  */
 export abstract class Portal<T> {
-  private _attachedHost: PortalOutlet | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _attachedHost!: PortalOutlet | null;
 
   /** Attach this portal to a host. */
   attach(host: PortalOutlet): T {
@@ -196,10 +197,12 @@ export type PortalHost = PortalOutlet;
  */
 export abstract class BasePortalOutlet implements PortalOutlet {
   /** The portal currently attached to the host. */
-  protected _attachedPortal: Portal<any> | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _attachedPortal!: Portal<any> | null;
 
   /** A function that will permanently dispose this host. */
-  private _disposeFn: (() => void) | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disposeFn!: (() => void) | null;
 
   /** Whether this host has already been permanently disposed. */
   private _isDisposed: boolean = false;

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -28,13 +28,16 @@ export interface ViewportScrollPosition {
 @Injectable({providedIn: 'root'})
 export class ViewportRuler implements OnDestroy {
   /** Cached viewport dimensions. */
-  private _viewportSize: {width: number; height: number};
+  // TODO(issue/13329): Attempt to remove "!".
+  private _viewportSize!: {width: number; height: number};
 
   /** Stream of viewport change events. */
-  private _change: Observable<Event>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _change!: Observable<Event>;
 
   /** Subscription to streams that invalidate the cached viewport dimensions. */
-  private _invalidateCache: Subscription;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _invalidateCache!: Subscription;
 
   /** Used to reference correct document/window */
   protected _document?: Document;

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -147,13 +147,16 @@ export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy 
   private _differ: IterableDiffer<T> | null = null;
 
   /** The most recent data emitted from the DataSource. */
-  private _data: T[] | ReadonlyArray<T>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _data!: T[] | ReadonlyArray<T>;
 
   /** The currently rendered items. */
-  private _renderedItems: T[];
+  // TODO(issue/13329): Attempt to remove "!".
+  private _renderedItems!: T[];
 
   /** The currently rendered range of indices. */
-  private _renderedRange: ListRange;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _renderedRange!: ListRange;
 
   /**
    * The template cache used to hold on ot template instancess that have been stamped out, but don't

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -100,7 +100,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
             Promise.resolve().then(() => this.ngZone.run(() => observer.next(index)))));
 
   /** The element that wraps the rendered content. */
-  @ViewChild('contentWrapper', {static: true}) _contentWrapper: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('contentWrapper', {static: true}) _contentWrapper!: ElementRef<HTMLElement>;
 
   /** A stream that emits whenever the rendered range changes. */
   renderedRangeStream: Observable<ListRange> = this._renderedRangeSubject.asObservable();
@@ -120,7 +121,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
    * The CSS transform applied to the rendered subset of items so that they appear within the bounds
    * of the visible viewport.
    */
-  private _renderedContentTransform: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _renderedContentTransform!: string;
 
   /** The currently rendered range of indices. */
   private _renderedRange: ListRange = {start: 0, end: 0};
@@ -132,7 +134,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   private _viewportSize = 0;
 
   /** the currently attached CdkVirtualForOf. */
-  private _forOf: CdkVirtualForOf<any> | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _forOf!: CdkVirtualForOf<any> | null;
 
   /** The last rendered content offset that was set. */
   private _renderedContentOffset = 0;

--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -60,16 +60,20 @@ export type StepperOrientation = 'horizontal'|'vertical';
 /** Change event emitted on selection changes. */
 export class StepperSelectionEvent {
   /** Index of the step now selected. */
-  selectedIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  selectedIndex!: number;
 
   /** Index of the step previously selected. */
-  previouslySelectedIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  previouslySelectedIndex!: number;
 
   /** The step instance now selected. */
-  selectedStep: CdkStep;
+  // TODO(issue/13329): Attempt to remove "!".
+  selectedStep!: CdkStep;
 
   /** The step instance previously selected. */
-  previouslySelectedStep: CdkStep;
+  // TODO(issue/13329): Attempt to remove "!".
+  previouslySelectedStep!: CdkStep;
 }
 
 /** The state of each step. */
@@ -122,34 +126,42 @@ export class CdkStep implements OnChanges {
   _displayDefaultIndicatorType: boolean;
 
   /** Template for step label if it exists. */
-  @ContentChild(CdkStepLabel) stepLabel: CdkStepLabel;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(CdkStepLabel) stepLabel!: CdkStepLabel;
 
   /** Template for step content. */
-  @ViewChild(TemplateRef, {static: true}) content: TemplateRef<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(TemplateRef, {static: true}) content!: TemplateRef<any>;
 
   /** The top level abstract control of the step. */
-  @Input() stepControl: AbstractControlLike;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() stepControl!: AbstractControlLike;
 
   /** Whether user has seen the expanded step content or not. */
   interacted = false;
 
   /** Plain text label of the step. */
-  @Input() label: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() label!: string;
 
   /** Error message to display when there's an error. */
-  @Input() errorMessage: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() errorMessage!: string;
 
   /** Aria label for the tab. */
-  @Input('aria-label') ariaLabel: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-label') ariaLabel!: string;
 
   /**
    * Reference to the element that the tab is labelled by.
    * Will be cleared if `aria-label` is set at the same time.
    */
-  @Input('aria-labelledby') ariaLabelledby: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-labelledby') ariaLabelledby!: string;
 
   /** State of the step. */
-  @Input() state: StepState;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() state!: StepState;
 
   /** Whether the user can return to this step once it has been marked as completed. */
   @Input()
@@ -251,7 +263,8 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
   protected _destroyed = new Subject<void>();
 
   /** Used for managing keyboard focus. */
-  private _keyManager: FocusKeyManager<FocusableOption>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _keyManager!: FocusKeyManager<FocusableOption>;
 
   /**
    * @breaking-change 8.0.0 Remove `| undefined` once the `_document`
@@ -264,7 +277,8 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
    * @deprecated use `steps` instead
    * @breaking-change 9.0.0 remove this property
    */
-  @ContentChildren(CdkStep, {descendants: true}) _steps: QueryList<CdkStep>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(CdkStep, {descendants: true}) _steps!: QueryList<CdkStep>;
 
   /** The list of step components that the stepper is holding. */
   get steps(): QueryList<CdkStep> {
@@ -276,7 +290,8 @@ export class CdkStepper implements AfterViewInit, OnDestroy {
    * @deprecated Type to be changed to `QueryList<CdkStepHeader>`.
    * @breaking-change 8.0.0
    */
-  @ContentChildren(CdkStepHeader, {descendants: true}) _stepHeader: QueryList<FocusableOption>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(CdkStepHeader, {descendants: true}) _stepHeader!: QueryList<FocusableOption>;
 
   /** Whether the validity of previous steps should be checked or not. */
   @Input()

--- a/src/cdk/table/cell.ts
+++ b/src/cdk/table/cell.ts
@@ -100,13 +100,16 @@ export class CdkColumnDef extends _CdkColumnDefBase implements CanStick {
   _stickyEnd: boolean = false;
 
   /** @docs-private */
-  @ContentChild(CdkCellDef) cell: CdkCellDef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(CdkCellDef) cell!: CdkCellDef;
 
   /** @docs-private */
-  @ContentChild(CdkHeaderCellDef) headerCell: CdkHeaderCellDef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(CdkHeaderCellDef) headerCell!: CdkHeaderCellDef;
 
   /** @docs-private */
-  @ContentChild(CdkFooterCellDef) footerCell: CdkFooterCellDef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(CdkFooterCellDef) footerCell!: CdkFooterCellDef;
 
   /**
    * Transformed version of the column name that can be used as part of a CSS classname. Excludes

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -40,10 +40,12 @@ export const CDK_ROW_TEMPLATE = `<ng-container cdkCellOutlet></ng-container>`;
 @Directive()
 export abstract class BaseRowDef implements OnChanges {
   /** The columns to be displayed on this row. */
-  columns: Iterable<string>;
+  // TODO(issue/13329): Attempt to remove "!".
+  columns!: Iterable<string>;
 
   /** Differ used to check if any changes were made to the columns. */
-  protected _columnsDiffer: IterableDiffer<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _columnsDiffer!: IterableDiffer<any>;
 
   constructor(
       /** @docs-private */ public template: TemplateRef<any>, protected _differs: IterableDiffers) {
@@ -158,7 +160,8 @@ export class CdkRowDef<T> extends BaseRowDef {
    * when no other when functions return true for the data.
    * For every row, there must be at least one when function that passes or an undefined to default.
    */
-  when: (index: number, rowData: T) => boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  when!: (index: number, rowData: T) => boolean;
 
   // TODO(andrewseguin): Add an input for providing a switch function to determine
   //   if this template should be used.
@@ -232,7 +235,8 @@ export interface CdkCellOutletMultiRowContext<T> {
 @Directive({selector: '[cdkCellOutlet]'})
 export class CdkCellOutlet implements OnDestroy {
   /** The ordered list of cells to render within this outlet's view container */
-  cells: CdkCellDef[];
+  // TODO(issue/13329): Attempt to remove "!".
+  cells!: CdkCellDef[];
 
   /** The data context to be provided to each cell */
   context: any;

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -192,16 +192,19 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   private _document: Document;
 
   /** Latest data provided by the data source. */
-  protected _data: T[]|ReadonlyArray<T>;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _data!: T[]|ReadonlyArray<T>;
 
   /** Subject that emits when the component has been destroyed. */
   private _onDestroy = new Subject<void>();
 
   /** List of the rendered rows as identified by their `RenderRow` object. */
-  private _renderRows: RenderRow<T>[];
+  // TODO(issue/13329): Attempt to remove "!".
+  private _renderRows!: RenderRow<T>[];
 
   /** Subscription that listens for the data provided by the data source. */
-  private _renderChangeSubscription: Subscription|null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _renderChangeSubscription!: Subscription|null;
 
   /**
    * Map of all the user's defined columns (header, data, and footer cell template) identified by
@@ -214,27 +217,32 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
    * Set of all row definitions that can be used by this table. Populated by the rows gathered by
    * using `ContentChildren` as well as any custom row definitions added to `_customRowDefs`.
    */
-  private _rowDefs: CdkRowDef<T>[];
+  // TODO(issue/13329): Attempt to remove "!".
+  private _rowDefs!: CdkRowDef<T>[];
 
   /**
    * Set of all header row definitions that can be used by this table. Populated by the rows
    * gathered by using `ContentChildren` as well as any custom row definitions added to
    * `_customHeaderRowDefs`.
    */
-  private _headerRowDefs: CdkHeaderRowDef[];
+  // TODO(issue/13329): Attempt to remove "!".
+  private _headerRowDefs!: CdkHeaderRowDef[];
 
   /**
    * Set of all row definitions that can be used by this table. Populated by the rows gathered by
    * using `ContentChildren` as well as any custom row definitions added to
    * `_customFooterRowDefs`.
    */
-  private _footerRowDefs: CdkFooterRowDef[];
+  // TODO(issue/13329): Attempt to remove "!".
+  private _footerRowDefs!: CdkFooterRowDef[];
 
   /** Differ used to find the changes in the data provided by the data source. */
-  private _dataDiffer: IterableDiffer<RenderRow<T>>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dataDiffer!: IterableDiffer<RenderRow<T>>;
 
   /** Stores the row definition that does not have a when predicate. */
-  private _defaultRowDef: CdkRowDef<T>|null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _defaultRowDef!: CdkRowDef<T>|null;
 
   /**
    * Column definitions that were defined outside of the direct content children of the table.
@@ -298,7 +306,8 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
    * Utility class that is responsible for applying the appropriate sticky positioning styles to
    * the table's rows and cells.
    */
-  private _stickyStyler: StickyStyler;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _stickyStyler!: StickyStyler;
 
   /**
    * CSS class added to any row or cell that has sticky positioning applied. May be overriden by
@@ -326,7 +335,8 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     }
     this._trackByFn = fn;
   }
-  private _trackByFn: TrackByFunction<T>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _trackByFn!: TrackByFunction<T>;
 
   /**
    * The table's source of data, which can be provided in three ways (in order of complexity):
@@ -357,7 +367,8 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
       this._switchDataSource(dataSource);
     }
   }
-  private _dataSource: CdkTableDataSourceInput<T>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dataSource!: CdkTableDataSourceInput<T>;
 
   /**
    * Whether to allow multiple rows per data object by evaluating which rows evaluate their 'when'
@@ -392,32 +403,41 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
       new BehaviorSubject<{start: number, end: number}>({start: 0, end: Number.MAX_VALUE});
 
   // Outlets in the table's template where the header, data rows, and footer will be inserted.
-  @ViewChild(DataRowOutlet, {static: true}) _rowOutlet: DataRowOutlet;
-  @ViewChild(HeaderRowOutlet, {static: true}) _headerRowOutlet: HeaderRowOutlet;
-  @ViewChild(FooterRowOutlet, {static: true}) _footerRowOutlet: FooterRowOutlet;
-  @ViewChild(NoDataRowOutlet, {static: true}) _noDataRowOutlet: NoDataRowOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(DataRowOutlet, {static: true}) _rowOutlet!: DataRowOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(HeaderRowOutlet, {static: true}) _headerRowOutlet!: HeaderRowOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(FooterRowOutlet, {static: true}) _footerRowOutlet!: FooterRowOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(NoDataRowOutlet, {static: true}) _noDataRowOutlet!: NoDataRowOutlet;
 
   /**
    * The column definitions provided by the user that contain what the header, data, and footer
    * cells should render for each column.
    */
-  @ContentChildren(CdkColumnDef, {descendants: true}) _contentColumnDefs: QueryList<CdkColumnDef>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(CdkColumnDef, {descendants: true}) _contentColumnDefs!: QueryList<CdkColumnDef>;
 
   /** Set of data row definitions that were provided to the table as content children. */
-  @ContentChildren(CdkRowDef, {descendants: true}) _contentRowDefs: QueryList<CdkRowDef<T>>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(CdkRowDef, {descendants: true}) _contentRowDefs!: QueryList<CdkRowDef<T>>;
 
   /** Set of header row definitions that were provided to the table as content children. */
+  // TODO(issue/13329): Attempt to remove "!".
   @ContentChildren(CdkHeaderRowDef, {
     descendants: true
-  }) _contentHeaderRowDefs: QueryList<CdkHeaderRowDef>;
+  }) _contentHeaderRowDefs!: QueryList<CdkHeaderRowDef>;
 
   /** Set of footer row definitions that were provided to the table as content children. */
+  // TODO(issue/13329): Attempt to remove "!".
   @ContentChildren(CdkFooterRowDef, {
     descendants: true
-  }) _contentFooterRowDefs: QueryList<CdkFooterRowDef>;
+  }) _contentFooterRowDefs!: QueryList<CdkFooterRowDef>;
 
   /** Row definition that will only be rendered if there's no data in the table. */
-  @ContentChild(CdkNoDataRow) _noDataRow: CdkNoDataRow;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(CdkNoDataRow) _noDataRow!: CdkNoDataRow;
 
   constructor(
       protected readonly _differs: IterableDiffers,

--- a/src/cdk/table/text-column.ts
+++ b/src/cdk/table/text-column.ts
@@ -76,7 +76,8 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
    * Text label that should be used for the column header. If this property is not
    * set, the header text will default to the column name with its first letter capitalized.
    */
-  @Input() headerText: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() headerText!: string;
 
   /**
    * Accessor function to retrieve the data rendered for each cell. If this
@@ -84,7 +85,8 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
    * the column's name. For example, if the column is named `id`, then the rendered value will be
    * value defined by the data's `id` property.
    */
-  @Input() dataAccessor: (data: T, name: string) => string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() dataAccessor!: (data: T, name: string) => string;
 
   /** Alignment of the cell values. */
   @Input() justify: 'start'|'end' = 'start';

--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -399,7 +399,8 @@ export interface BaseHarnessFilters {
 export class HarnessPredicate<T extends ComponentHarness> {
   private _predicates: AsyncPredicate<T>[] = [];
   private _descriptions: string[] = [];
-  private _ancestor: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _ancestor!: string;
 
   constructor(public harnessType: ComponentHarnessConstructor<T>, options: BaseHarnessFilters) {
     this._addBaseOptions(options);

--- a/src/cdk/testing/tests/test-main-component.ts
+++ b/src/cdk/testing/tests/test-main-component.ts
@@ -35,18 +35,23 @@ export class TestMainComponent implements OnDestroy {
   username: string;
   counter: number;
   asyncCounter: number;
-  input: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  input!: string;
   memo: string;
   testTools: string[];
   testMethods: string[];
-  _isHovering: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  _isHovering!: boolean;
   specialKey = '';
   relativeX = 0;
   relativeY = 0;
   _shadowDomSupported = _supportsShadowDom();
 
-  @ViewChild('clickTestElement') clickTestElement: ElementRef<HTMLElement>;
-  @ViewChild('taskStateResult') taskStateResultElement: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('clickTestElement') clickTestElement!: ElementRef<HTMLElement>;
+
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('taskStateResult') taskStateResultElement!: ElementRef<HTMLElement>;
 
   private _fakeOverlayElement: HTMLElement;
 

--- a/src/cdk/testing/tests/test-sub-component.ts
+++ b/src/cdk/testing/tests/test-sub-component.ts
@@ -19,6 +19,8 @@ import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@ang
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TestSubComponent {
-  @Input() title: string;
-  @Input() items: string[];
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() title!: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() items!: string[];
 }

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -46,8 +46,10 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   private _initialHeight: string | undefined;
   private readonly _destroyed = new Subject<void>();
 
-  private _minRows: number;
-  private _maxRows: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _minRows!: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _maxRows!: number;
   private _enabled: boolean = true;
 
   /**
@@ -89,7 +91,8 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   }
 
   /** Cached height of a textarea with a single row. */
-  private _cachedLineHeight: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _cachedLineHeight!: number;
 
   /** Used to reference correct document/window */
   protected _document?: Document;

--- a/src/cdk/tree/control/base-tree-control.ts
+++ b/src/cdk/tree/control/base-tree-control.ts
@@ -19,7 +19,8 @@ export abstract class BaseTreeControl<T, K = T> implements TreeControl<T, K> {
   abstract expandAll(): void;
 
   /** Saved data node for `expandAll` action. */
-  dataNodes: T[];
+  // TODO(issue/13329): Attempt to remove "!".
+  dataNodes!: T[];
 
   /** A selection model with multi-selection to track expansion status. */
   expansionModel: SelectionModel<K> = new SelectionModel<K>(true);
@@ -33,16 +34,19 @@ export abstract class BaseTreeControl<T, K = T> implements TreeControl<T, K> {
   trackBy?: (dataNode: T) => K;
 
   /** Get depth of a given data node, return the level number. This is for flat tree node. */
-  getLevel: (dataNode: T) => number;
+  // TODO(issue/13329): Attempt to remove "!".
+  getLevel!: (dataNode: T) => number;
 
   /**
    * Whether the data node is expandable. Returns true if expandable.
    * This is for flat tree node.
    */
-  isExpandable: (dataNode: T) => boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  isExpandable!: (dataNode: T) => boolean;
 
   /** Gets a stream that emits whenever the given data node's children change. */
-  getChildren: (dataNode: T) => (Observable<T[]> | T[] | undefined | null);
+  // TODO(issue/13329): Attempt to remove "!".
+  getChildren!: (dataNode: T) => (Observable<T[]> | T[] | undefined | null);
 
   /** Toggles one single data node's expanded/collapsed state. */
   toggle(dataNode: T): void {

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -43,10 +43,12 @@ import {getTreeControlFunctionsMissingError} from './tree-errors';
 })
 export class CdkNestedTreeNode<T> extends CdkTreeNode<T> implements AfterContentInit, OnDestroy {
   /** Differ used to find the changes in the data provided by the data source. */
-  private _dataDiffer: IterableDiffer<T>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dataDiffer!: IterableDiffer<T>;
 
   /** The children data dataNodes of current node. They will be placed in `CdkTreeNodeOutlet`. */
-  protected _children: T[];
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _children!: T[];
 
   /** The children node placeholder. */
   @ContentChildren(CdkTreeNodeOutlet, {
@@ -54,7 +56,8 @@ export class CdkNestedTreeNode<T> extends CdkTreeNode<T> implements AfterContent
     // indirect descendants if it's left as false.
     descendants: true
   })
-  nodeOutlet: QueryList<CdkTreeNodeOutlet>;
+  // TODO(issue/13329): Attempt to remove "!".
+  nodeOutlet!: QueryList<CdkTreeNodeOutlet>;
 
   constructor(protected _elementRef: ElementRef<HTMLElement>,
               protected _tree: CdkTree<T>,

--- a/src/cdk/tree/node.ts
+++ b/src/cdk/tree/node.ts
@@ -15,7 +15,8 @@ export class CdkTreeNodeOutletContext<T> {
   $implicit: T;
 
   /** Depth of the node. */
-  level: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  level!: number;
 
   /** Index location of the node. */
   index?: number;
@@ -46,7 +47,8 @@ export class CdkTreeNodeDef<T> {
    * For every node, there must be at least one when function that passes or an undefined to
    * default.
    */
-  when: (index: number, nodeData: T) => boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  when!: (index: number, nodeData: T) => boolean;
 
   /** @docs-private */
   constructor(public template: TemplateRef<any>) {}

--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -25,7 +25,8 @@ const cssUnitPattern = /([A-Za-z%]+)$/;
 })
 export class CdkTreeNodePadding<T> implements OnDestroy {
   /** Current padding value applied to the element. Used to avoid unnecessarily hitting the DOM. */
-  private _currentPadding: string|null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _currentPadding!: string|null;
 
   /** Subject that emits when the component has been destroyed. */
   private _destroyed = new Subject<void>();
@@ -43,7 +44,8 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
     this._level = coerceNumberProperty(value, null)!;
     this._setPadding();
   }
-  _level: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  _level!: number;
 
   /**
    * The indent for each level. Can be a number or a CSS string.

--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -72,13 +72,16 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
   private _onDestroy = new Subject<void>();
 
   /** Differ used to find the changes in the data provided by the data source. */
-  private _dataDiffer: IterableDiffer<T>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dataDiffer!: IterableDiffer<T>;
 
   /** Stores the node definition that does not have a when predicate. */
-  private _defaultNodeDef: CdkTreeNodeDef<T> | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _defaultNodeDef!: CdkTreeNodeDef<T> | null;
 
   /** Data subscription */
-  private _dataSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dataSubscription!: Subscription | null;
 
   /** Level of nodes */
   private _levels: Map<T, number> = new Map<T, number>();
@@ -95,10 +98,12 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
       this._switchDataSource(dataSource);
     }
   }
-  private _dataSource: DataSource<T> | Observable<T[]> | T[];
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dataSource!: DataSource<T> | Observable<T[]> | T[];
 
   /** The tree controller */
-  @Input() treeControl: TreeControl<T>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() treeControl!: TreeControl<T>;
 
   /**
    * Tracking function that will be used to check the differences in data changes. Used similarly
@@ -106,17 +111,20 @@ export class CdkTree<T> implements AfterContentChecked, CollectionViewer, OnDest
    * relative to the function to know if a node should be added/removed/moved.
    * Accepts a function that takes two parameters, `index` and `item`.
    */
-  @Input() trackBy: TrackByFunction<T>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() trackBy!: TrackByFunction<T>;
 
   // Outlets within the tree's template where the dataNodes will be inserted.
-  @ViewChild(CdkTreeNodeOutlet, {static: true}) _nodeOutlet: CdkTreeNodeOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(CdkTreeNodeOutlet, {static: true}) _nodeOutlet!: CdkTreeNodeOutlet;
 
   /** The tree node template for the tree */
   @ContentChildren(CdkTreeNodeDef, {
     // We need to use `descendants: true`, because Ivy will no longer match
     // indirect descendants if it's left as false.
     descendants: true
-  }) _nodeDefs: QueryList<CdkTreeNodeDef<T>>;
+  // TODO(issue/13329): Attempt to remove "!".
+  }) _nodeDefs!: QueryList<CdkTreeNodeDef<T>>;
 
   // TODO(tinayuangao): Setup a listener for scrolling, emit the calculated view to viewChange.
   //     Remove the MAX_VALUE in viewChange
@@ -326,7 +334,8 @@ export class CdkTreeNode<T> implements FocusableOption, OnDestroy {
       this._dataChanges.next();
     }
   }
-  protected _data: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _data!: T;
 
   get isExpanded(): boolean {
     return this._tree.treeControl.isExpanded(this._data);

--- a/src/material-experimental/mdc-button/button-base.ts
+++ b/src/material-experimental/mdc-button/button-base.ts
@@ -98,7 +98,8 @@ export class MatButtonBase extends _MatButtonBaseMixin implements CanDisable, Ca
   _isRippleCentered = false;
 
   /** Reference to the MatRipple instance of the button. */
-  @ViewChild(MatRipple) ripple: MatRipple;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatRipple) ripple!: MatRipple;
 
   constructor(
       elementRef: ElementRef, public _platform: Platform, public _ngZone: NgZone,
@@ -163,7 +164,8 @@ export const MAT_ANCHOR_HOST = {
  */
 @Directive()
 export class MatAnchorBase extends MatButtonBase {
-  tabIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  tabIndex!: number;
 
   constructor(elementRef: ElementRef, platform: Platform, ngZone: NgZone,
               animationMode?: string) {

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -46,9 +46,11 @@ export const MAT_CHECKBOX_CONTROL_VALUE_ACCESSOR: any = {
 /** Change event object emitted by MatCheckbox. */
 export class MatCheckboxChange {
   /** The source MatCheckbox of the event. */
-  source: MatCheckbox;
+  // TODO(issue/13329): Attempt to remove "!".
+  source!: MatCheckbox;
   /** The new `checked` value of the checkbox. */
-  checked: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  checked!: boolean;
 }
 
 /** Configuration for the ripple animation. */
@@ -99,7 +101,8 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
   @Input() tabIndex: number;
 
   /** The `value` attribute to use for the input element */
-  @Input() value: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() value!: string;
 
   private _uniqueId = `mat-mdc-checkbox-${++nextUniqueId}`;
 
@@ -170,13 +173,16 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
   @Output() readonly indeterminateChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   /** The root element for the `MDCCheckbox`. */
-  @ViewChild('checkbox') _checkbox: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('checkbox') _checkbox!: ElementRef<HTMLElement>;
 
   /** The native input element. */
-  @ViewChild('nativeCheckbox') _nativeCheckbox: ElementRef<HTMLInputElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('nativeCheckbox') _nativeCheckbox!: ElementRef<HTMLInputElement>;
 
   /** The native label element. */
-  @ViewChild('label') _label: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('label') _label!: ElementRef<HTMLElement>;
 
   /** Returns the unique id for the visual hidden input. */
   get inputId(): string {

--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -110,13 +110,16 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   readonly controlType: string = 'mat-chip-grid';
 
   /** Subscription to blur changes in the chips. */
-  private _chipBlurSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipBlurSubscription!: Subscription | null;
 
   /** Subscription to focus changes in the chips. */
-  private _chipFocusSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipFocusSubscription!: Subscription | null;
 
   /** The chip input to add more chips */
-  protected _chipInput: MatChipTextControl;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _chipInput!: MatChipTextControl;
 
   /**
    * Function when touched. Set as part of ControlValueAccessor implementation.
@@ -131,7 +134,8 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   _onChange: (value: any) => void = () => {};
 
   /** The GridFocusKeyManager which handles focus. */
-  _keyManager: GridFocusKeyManager;
+  // TODO(issue/13329): Attempt to remove "!".
+  _keyManager!: GridFocusKeyManager;
 
   /**
    * Implemented as part of MatFormFieldControl.
@@ -172,7 +176,8 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     this._placeholder = value;
     this.stateChanges.next();
   }
-  protected _placeholder: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _placeholder!: string;
 
   /** Whether any chips or the matChipInput inside of this chip-grid has focus. */
   get focused(): boolean { return this._chipInput.focused || this._hasFocusedChip(); }
@@ -207,7 +212,8 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   protected _value: Array<any> = [];
 
   /** An object used to control when error messages are shown. */
-  @Input() errorStateMatcher: ErrorStateMatcher;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() errorStateMatcher!: ErrorStateMatcher;
 
   /** Combined stream of all of the child chips' blur events. */
   get chipBlurChanges(): Observable<MatChipEvent> {
@@ -235,7 +241,8 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     // indirect descendants if it's left as false.
     descendants: true
   })
-  _chips: QueryList<MatChipRow>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _chips!: QueryList<MatChipRow>;
 
   constructor(_elementRef: ElementRef,
               _changeDetectorRef: ChangeDetectorRef,

--- a/src/material-experimental/mdc-chips/chip-input.ts
+++ b/src/material-experimental/mdc-chips/chip-input.ts
@@ -49,7 +49,8 @@ let nextUniqueId = 0;
 export class MatChipInput implements MatChipTextControl, OnChanges {
   /** Whether the control is focused. */
   focused: boolean = false;
-  _chipGrid: MatChipGrid;
+  // TODO(issue/13329): Attempt to remove "!".
+  _chipGrid!: MatChipGrid;
 
   /** Register input for chip list */
   @Input('matChipInputFor')

--- a/src/material-experimental/mdc-chips/chip-listbox.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.ts
@@ -87,16 +87,20 @@ export const MAT_CHIP_LISTBOX_CONTROL_VALUE_ACCESSOR: any = {
 export class MatChipListbox extends MatChipSet implements AfterContentInit, ControlValueAccessor {
 
   /** Subscription to selection changes in the chips. */
-  private _chipSelectionSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipSelectionSubscription!: Subscription | null;
 
   /** Subscription to blur changes in the chips. */
-  private _chipBlurSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipBlurSubscription!: Subscription | null;
 
   /** Subscription to focus changes in the chips. */
-  private _chipFocusSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipFocusSubscription!: Subscription | null;
 
   /** The FocusKeyManager which handles focus. */
-  _keyManager: FocusKeyManager<MatChip>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _keyManager!: FocusKeyManager<MatChip>;
 
   /**
    * Function when touched. Set as part of ControlValueAccessor implementation.
@@ -197,12 +201,13 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
   @Output() readonly change: EventEmitter<MatChipListboxChange> =
       new EventEmitter<MatChipListboxChange>();
 
+  // TODO(issue/13329): Attempt to remove "!".
   @ContentChildren(MatChipOption, {
     // We need to use `descendants: true`, because Ivy will no longer match
     // indirect descendants if it's left as false.
     descendants: true
   })
-  _chips: QueryList<MatChipOption>;
+  _chips!: QueryList<MatChipOption>;
 
   constructor(protected _elementRef: ElementRef,
               _changeDetectorRef: ChangeDetectorRef,

--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -56,7 +56,8 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
    * The focusable wrapper element in the first gridcell, which contains all
    * chip content other than the remove icon.
    */
-  @ViewChild('chipContent') chipContent: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('chipContent') chipContent!: ElementRef;
 
   /** The focusable grid cells for this row. Implemented as part of GridKeyManagerRow. */
   cells!: HTMLElement[];

--- a/src/material-experimental/mdc-chips/chip-set.ts
+++ b/src/material-experimental/mdc-chips/chip-set.ts
@@ -65,13 +65,16 @@ const _MatChipSetMixinBase: HasTabIndexCtor & typeof MatChipSetBase =
 export class MatChipSet extends _MatChipSetMixinBase implements AfterContentInit, AfterViewInit,
   HasTabIndex, OnDestroy {
   /** Subscription to remove changes in chips. */
-  private _chipRemoveSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipRemoveSubscription!: Subscription | null;
 
   /** Subscription to destroyed events in chips. */
-  private _chipDestroyedSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipDestroyedSubscription!: Subscription | null;
 
   /** Subscription to chip interactions. */
-  private _chipInteractionSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipInteractionSubscription!: Subscription | null;
 
   /**
    * When a chip is destroyed, we store the index of the destroyed chip until the chips
@@ -108,7 +111,8 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterContentInit
   };
 
   /** The aria-describedby attribute on the chip list for improved a11y. */
-  _ariaDescribedby: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _ariaDescribedby!: string;
 
   /** Uid of the chip set */
   _uid: string = `mat-mdc-chip-set-${uid++}`;
@@ -153,11 +157,12 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterContentInit
   }
 
   /** The chips that are part of this chip set. */
+  // TODO(issue/13329): Attempt to remove "!".
   @ContentChildren(MatChip, {
     // We need to use `descendants: true`, because Ivy will no longer match
     // indirect descendants if it's left as false.
     descendants: true
-  }) _chips: QueryList<MatChip>;
+  }) _chips!: QueryList<MatChip>;
 
   constructor(protected _elementRef: ElementRef,
               protected _changeDetectorRef: ChangeDetectorRef,

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -227,16 +227,20 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
   protected _destroyed = new Subject<void>();
 
   /** The chip's leading icon. */
-  @ContentChild(MatChipAvatar) leadingIcon: MatChipAvatar;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatChipAvatar) leadingIcon!: MatChipAvatar;
 
   /** The chip's trailing icon. */
-  @ContentChild(MatChipTrailingIcon) trailingIcon: MatChipTrailingIcon;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatChipTrailingIcon) trailingIcon!: MatChipTrailingIcon;
 
   /** The chip's trailing remove icon. */
-  @ContentChild(MatChipRemove) removeIcon: MatChipRemove;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatChipRemove) removeIcon!: MatChipRemove;
 
   /** Reference to the MatRipple instance of the chip. */
-  @ViewChild(MatRipple) ripple: MatRipple;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatRipple) ripple!: MatRipple;
 
  /**
   * Implementation of the MDC chip adapter interface.

--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -128,19 +128,26 @@ const FLOATING_LABEL_DEFAULT_DOCKED_TRANSFORM = `translateY(-50%)`;
 })
 export class MatFormField implements AfterViewInit, OnDestroy, AfterContentChecked,
     AfterContentInit {
-  @ViewChild('textField') _textField: ElementRef<HTMLElement>;
-  @ViewChild('prefixContainer') _prefixContainer: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('textField') _textField!: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('prefixContainer') _prefixContainer!: ElementRef<HTMLElement>;
   @ViewChild(MatFormFieldFloatingLabel) _floatingLabel: MatFormFieldFloatingLabel|undefined;
   @ViewChild(MatFormFieldNotchedOutline) _notchedOutline: MatFormFieldNotchedOutline|undefined;
   @ViewChild(MatFormFieldLineRipple) _lineRipple: MatFormFieldLineRipple|undefined;
 
   @ContentChild(MatLabel) _labelChildNonStatic: MatLabel|undefined;
   @ContentChild(MatLabel, {static: true}) _labelChildStatic: MatLabel|undefined;
-  @ContentChild(MatFormFieldControl) _formFieldControl: MatFormFieldControl<any>;
-  @ContentChildren(MatPrefix, {descendants: true}) _prefixChildren: QueryList<MatPrefix>;
-  @ContentChildren(MatSuffix, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
-  @ContentChildren(MatError, {descendants: true}) _errorChildren: QueryList<MatError>;
-  @ContentChildren(MatHint, {descendants: true}) _hintChildren: QueryList<MatHint>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatFormFieldControl) _formFieldControl!: MatFormFieldControl<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatPrefix, {descendants: true}) _prefixChildren!: QueryList<MatPrefix>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatSuffix, {descendants: true}) _suffixChildren!: QueryList<MatSuffix>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatError, {descendants: true}) _errorChildren!: QueryList<MatError>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatHint, {descendants: true}) _hintChildren!: QueryList<MatHint>;
 
   /** Whether the required marker should be hidden. */
   @Input() hideRequiredMarker: boolean = false;
@@ -164,7 +171,8 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
       this._changeDetectorRef.markForCheck();
     }
   }
-  private _floatLabel: FloatLabelType;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _floatLabel!: FloatLabelType;
 
   /** The form-field appearance style. */
   @Input()
@@ -200,7 +208,8 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
   _subscriptAnimationState = '';
 
   /** Width of the outline notch. */
-  _outlineNotchWidth: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  _outlineNotchWidth!: number;
 
   /** Gets the current form field control */
   get _control(): MatFormFieldControl<any> {
@@ -210,8 +219,10 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
 
   private _destroyed = new Subject<void>();
   private _isFocused: boolean|null = null;
-  private _explicitFormFieldControl: MatFormFieldControl<any>;
-  private _foundation: MDCTextFieldFoundation;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _explicitFormFieldControl!: MatFormFieldControl<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _foundation!: MDCTextFieldFoundation;
   private _needsOutlineLabelOffsetUpdateOnStable = false;
   private _adapter: MDCTextFieldAdapter = {
     addClass: className => this._textField.nativeElement.classList.add(className),

--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -26,13 +26,15 @@ export class MatListBase {
   // metadata is not inherited by child classes, instead the host binding data is defined in a way
   // that can be inherited.
   // tslint:disable-next-line:no-host-decorator-in-concrete
+  // TODO(issue/13329): Attempt to remove "!".
   @HostBinding('class.mdc-list--non-interactive')
-  _isNonInteractive: boolean;
+  _isNonInteractive!: boolean;
 }
 
 @Directive()
 export abstract class MatListItemBase implements AfterContentInit, OnDestroy, RippleTarget {
-  lines: QueryList<ElementRef<Element>>;
+  // TODO(issue/13329): Attempt to remove "!".
+  lines!: QueryList<ElementRef<Element>>;
 
   rippleConfig: RippleConfig = {};
 

--- a/src/material-experimental/mdc-list/list.ts
+++ b/src/material-experimental/mdc-list/list.ts
@@ -81,7 +81,8 @@ export class MatList extends MatListBase {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatListItem extends MatListItemBase {
-  @ContentChildren(MatLine, {read: ElementRef, descendants: true}) lines:
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatLine, {read: ElementRef, descendants: true}) lines!:
       QueryList<ElementRef<Element>>;
 
   constructor(element: ElementRef, ngZone: NgZone, listBase: MatListBase, platform: Platform) {

--- a/src/material-experimental/mdc-list/selection-list.ts
+++ b/src/material-experimental/mdc-list/selection-list.ts
@@ -64,7 +64,8 @@ export class MatSelectionList extends MatListBase {}
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatListOption extends MatListItemBase {
-  @ContentChildren(MatLine, {read: ElementRef, descendants: true}) lines:
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatLine, {read: ElementRef, descendants: true}) lines!:
       QueryList<ElementRef<Element>>;
 
   constructor(element: ElementRef, ngZone: NgZone, listBase: MatListBase, platform: Platform) {

--- a/src/material-experimental/mdc-progress-bar/progress-bar.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.ts
@@ -111,9 +111,12 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements AfterVie
   }
   private _bufferValue = 0;
 
-  private _rootElement: HTMLElement;
-  private _primaryBar: HTMLElement;
-  private _bufferBar: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _rootElement!: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _primaryBar!: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _bufferBar!: HTMLElement;
 
   /**
    * Event emitted when animation of the primary progress bar completes. This event will not

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -71,8 +71,9 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
 })
 export class MatRadioGroup extends BaseMatRadioGroup {
   /** Child radio buttons. */
+  // TODO(issue/13329): Attempt to remove "!".
   @ContentChildren(forwardRef(() => MatRadioButton), {descendants: true})
-      _radios: QueryList<_MatRadioButtonBase>;
+      _radios!: QueryList<_MatRadioButtonBase>;
 }
 
 @Component({

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
@@ -95,7 +95,8 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
   private _uniqueId: string = `mat-mdc-slide-toggle-${++nextUniqueId}`;
   private _required: boolean = false;
   private _checked: boolean = false;
-  private _foundation: MDCSwitchFoundation;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _foundation!: MDCSwitchFoundation;
   private _adapter: MDCSwitchAdapter = {
     addClass: className => this._switchElement.nativeElement.classList.add(className),
     removeClass: className => this._switchElement.nativeElement.classList.remove(className),
@@ -107,7 +108,8 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
   };
 
   /** Whether the slide toggle is currently focused. */
-  _focused: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  _focused!: boolean;
 
   /** Configuration for the underlying ripple. */
   _rippleAnimation: RippleAnimationConfig = RIPPLE_ANIMATION_CONFIG;
@@ -127,7 +129,8 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
   set tabIndex(value: number) {
     this._tabIndex = coerceNumberProperty(value);
   }
-  private _tabIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _tabIndex!: number;
 
   /** Whether the label should appear after or before the slide-toggle. Defaults to 'after'. */
   @Input() labelPosition: 'before' | 'after' = 'after';
@@ -199,10 +202,12 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 
   /** Reference to the underlying input element. */
-  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('input') _inputElement!: ElementRef<HTMLInputElement>;
 
   /** Reference to the MDC switch element. */
-  @ViewChild('switch') _switchElement: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('switch') _switchElement!: ElementRef<HTMLElement>;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               @Attribute('tabindex') tabIndex: string,

--- a/src/material-experimental/mdc-table/cell.ts
+++ b/src/material-experimental/mdc-table/cell.ts
@@ -60,7 +60,8 @@ export class MatFooterCellDef extends CdkFooterCellDef {}
 })
 export class MatColumnDef extends CdkColumnDef {
   /** Unique name for this column. */
-  @Input('matColumnDef') name: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matColumnDef') name!: string;
 
   static ngAcceptInputType_sticky: BooleanInput;
 }

--- a/src/material-experimental/mdc-tabs/ink-bar.ts
+++ b/src/material-experimental/mdc-tabs/ink-bar.ts
@@ -62,10 +62,13 @@ export class MatInkBar {
  * @docs-private
  */
 export class MatInkBarFoundation {
-  private _destroyed: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _destroyed!: boolean;
   private _foundation: MDCTabIndicatorFoundation;
-  private _inkBarElement: HTMLElement;
-  private _inkBarContentElement: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _inkBarElement!: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _inkBarContentElement!: HTMLElement;
   private _fitToContent = false;
   private _adapter: MDCTabIndicatorAdapter = {
     addClass: className => {

--- a/src/material-experimental/mdc-tabs/tab-body.ts
+++ b/src/material-experimental/mdc-tabs/tab-body.ts
@@ -60,7 +60,8 @@ export class MatTabBodyPortal extends BaseMatTabBodyPortal {
   },
 })
 export class MatTabBody extends _MatTabBodyBase {
-  @ViewChild(PortalHostDirective) _portalHost: PortalHostDirective;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(PortalHostDirective) _portalHost!: PortalHostDirective;
 
   constructor(elementRef: ElementRef<HTMLElement>,
     @Optional() dir: Directionality,

--- a/src/material-experimental/mdc-tabs/tab-group.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.ts
@@ -54,9 +54,12 @@ import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coe
   },
 })
 export class MatTabGroup extends _MatTabGroupBase {
-  @ContentChildren(MatTab, {descendants: true}) _allTabs: QueryList<MatTab>;
-  @ViewChild('tabBodyWrapper') _tabBodyWrapper: ElementRef;
-  @ViewChild('tabHeader') _tabHeader: MatTabHeader;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatTab, {descendants: true}) _allTabs!: QueryList<MatTab>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabBodyWrapper') _tabBodyWrapper!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabHeader') _tabHeader!: MatTabHeader;
 
   /** Whether the ink bar should fit its width to the size of the tab label content. */
   @Input()

--- a/src/material-experimental/mdc-tabs/tab-header.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.ts
@@ -51,12 +51,18 @@ import {MatInkBar} from './ink-bar';
   },
 })
 export class MatTabHeader extends _MatTabHeaderBase implements AfterContentInit {
-  @ContentChildren(MatTabLabelWrapper, {descendants: false}) _items: QueryList<MatTabLabelWrapper>;
-  @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
-  @ViewChild('tabList', {static: true}) _tabList: ElementRef;
-  @ViewChild('nextPaginator') _nextPaginator: ElementRef<HTMLElement>;
-  @ViewChild('previousPaginator') _previousPaginator: ElementRef<HTMLElement>;
-  _inkBar: MatInkBar;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatTabLabelWrapper, {descendants: false}) _items!: QueryList<MatTabLabelWrapper>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabListContainer', {static: true}) _tabListContainer!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabList', {static: true}) _tabList!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('nextPaginator') _nextPaginator!: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('previousPaginator') _previousPaginator!: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _inkBar!: MatInkBar;
 
   constructor(elementRef: ElementRef,
               changeDetectorRef: ChangeDetectorRef,

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -73,12 +73,18 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
   }
   _fitInkBarToContent = new BehaviorSubject(false);
 
-  @ContentChildren(forwardRef(() => MatTabLink), {descendants: true}) _items: QueryList<MatTabLink>;
-  @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
-  @ViewChild('tabList', {static: true}) _tabList: ElementRef;
-  @ViewChild('nextPaginator') _nextPaginator: ElementRef<HTMLElement>;
-  @ViewChild('previousPaginator') _previousPaginator: ElementRef<HTMLElement>;
-  _inkBar: MatInkBar;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(forwardRef(() => MatTabLink), {descendants: true}) _items!: QueryList<MatTabLink>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabListContainer', {static: true}) _tabListContainer!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabList', {static: true}) _tabList!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('nextPaginator') _nextPaginator!: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('previousPaginator') _previousPaginator!: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _inkBar!: MatInkBar;
 
   constructor(elementRef: ElementRef,
               @Optional() dir: Directionality,

--- a/src/material-experimental/mdc-tabs/tab.ts
+++ b/src/material-experimental/mdc-tabs/tab.ts
@@ -34,8 +34,10 @@ export class MatTab extends BaseMatTab {
    * Template provided in the tab content that will be used if present, used to enable lazy-loading
    */
   @ContentChild(MatTabContent, {read: TemplateRef, static: true})
-  _explicitContent: TemplateRef<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _explicitContent!: TemplateRef<any>;
 
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
-  @ContentChild(MatTabLabel) templateLabel: MatTabLabel;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatTabLabel) templateLabel!: MatTabLabel;
 }

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -125,23 +125,28 @@ export function getMatAutocompleteMissingPanelError(): Error {
 })
 export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewInit, OnChanges,
   OnDestroy {
-  private _overlayRef: OverlayRef | null;
-  private _portal: TemplatePortal;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _overlayRef!: OverlayRef | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _portal!: TemplatePortal;
   private _componentDestroyed = false;
   private _autocompleteDisabled = false;
   private _scrollStrategy: () => ScrollStrategy;
 
   /** Old value of the native input. Used to work around issues with the `input` event on IE. */
-  private _previousValue: string | number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _previousValue!: string | number | null;
 
   /** Strategy that is used to position the panel. */
-  private _positionStrategy: FlexibleConnectedPositionStrategy;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _positionStrategy!: FlexibleConnectedPositionStrategy;
 
   /** Whether or not the label state is being overridden. */
   private _manuallyFloatingLabel = false;
 
   /** The subscription for closing actions (some are bound to document). */
-  private _closingActionsSubscription: Subscription;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _closingActionsSubscription!: Subscription;
 
   /** Subscription to viewport size changes. */
   private _viewportSubscription = Subscription.EMPTY;
@@ -154,7 +159,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
   private _canOpenOnNextFocus = true;
 
   /** Whether the element is inside of a ShadowRoot component. */
-  private _isInsideShadowRoot: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _isInsideShadowRoot!: boolean;
 
   /** Stream of keyboard events that can close the panel. */
   private readonly _closeKeyEventStream = new Subject<void>();
@@ -178,7 +184,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
   _onTouched = () => {};
 
   /** The autocomplete panel to be attached to this trigger. */
-  @Input('matAutocomplete') autocomplete: MatAutocomplete;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matAutocomplete') autocomplete!: MatAutocomplete;
 
   /**
    * Position of the autocomplete panel relative to the trigger element. A position of `auto`
@@ -193,7 +200,8 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
    * Reference relative to which to position the autocomplete panel.
    * Defaults to the autocomplete trigger element.
    */
-  @Input('matAutocompleteConnectedTo') connectedTo: MatAutocompleteOrigin;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matAutocompleteConnectedTo') connectedTo!: MatAutocompleteOrigin;
 
   /**
    * `autocomplete` attribute to be set on the input element.

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -119,16 +119,20 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   // Notably, another component may trigger `focus` on the autocomplete-trigger.
 
   /** @docs-private */
-  @ViewChild(TemplateRef, {static: true}) template: TemplateRef<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(TemplateRef, {static: true}) template!: TemplateRef<any>;
 
   /** Element for the panel containing the autocomplete options. */
-  @ViewChild('panel') panel: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('panel') panel!: ElementRef;
 
   /** @docs-private */
-  @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatOption, {descendants: true}) options!: QueryList<MatOption>;
 
   /** @docs-private */
-  @ContentChildren(MatOptgroup, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatOptgroup, {descendants: true}) optionGroups!: QueryList<MatOptgroup>;
 
   /** Function that maps an option's control value to its display value in the trigger. */
   @Input() displayWith: ((value: any) => string) | null = null;
@@ -142,13 +146,15 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   set autoActiveFirstOption(value: boolean) {
     this._autoActiveFirstOption = coerceBooleanProperty(value);
   }
-  private _autoActiveFirstOption: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _autoActiveFirstOption!: boolean;
 
   /**
    * Specify the width of the autocomplete panel.  Can be any CSS sizing value, otherwise it will
    * match the width of its host.
    */
-  @Input() panelWidth: string | number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() panelWidth!: string | number;
 
   /** Event that is emitted whenever an option from the list is selected. */
   @Output() readonly optionSelected: EventEmitter<MatAutocompleteSelectedEvent> =

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -88,7 +88,8 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
   @Input('matBadgePosition') position: MatBadgePosition = 'above after';
 
   /** The content for the badge */
-  @Input('matBadge') content: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matBadge') content!: string;
 
   /** Message used to describe the decorated element via aria-describedby */
   @Input('matBadgeDescription')
@@ -105,7 +106,8 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
       }
     }
   }
-  private _description: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _description!: string;
 
   /** Size of the badge. Can be 'small', 'medium', or 'large'. */
   @Input('matBadgeSize') size: MatBadgeSize = 'medium';
@@ -116,7 +118,8 @@ export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges
   set hidden(val: boolean) {
     this._hidden = coerceBooleanProperty(val);
   }
-  private _hidden: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _hidden!: boolean;
 
   /** Unique id for the badge */
   _id: number = nextId++;

--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -63,7 +63,8 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
   private _breakpointSubscription: Subscription;
 
   /** The portal outlet inside of this container into which the content will be loaded. */
-  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet: CdkPortalOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet!: CdkPortalOutlet;
 
   /** The state of the bottom sheet animations. */
   _animationState: 'void' | 'visible' | 'hidden' = 'void';
@@ -72,7 +73,8 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
   _animationStateChanged = new EventEmitter<AnimationEvent>();
 
   /** The class that traps and manages focus within the bottom sheet. */
-  private _focusTrap: FocusTrap;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _focusTrap!: FocusTrap;
 
   /** Element that was focused before the bottom sheet was opened. */
   private _elementFocusedBeforeOpened: HTMLElement | null = null;
@@ -81,7 +83,8 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
   private _document: Document;
 
   /** Whether the component has been destroyed. */
-  private _destroyed: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _destroyed!: boolean;
 
   constructor(
     private _elementRef: ElementRef<HTMLElement>,

--- a/src/material/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/material/bottom-sheet/bottom-sheet-ref.ts
@@ -19,7 +19,8 @@ import {MatBottomSheetContainer} from './bottom-sheet-container';
  */
 export class MatBottomSheetRef<T = any, R = any> {
   /** Instance of the component making up the content of the bottom sheet. */
-  instance: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  instance!: T;
 
   /**
    * Instance of the component into which the bottom sheet content is projected.
@@ -40,7 +41,8 @@ export class MatBottomSheetRef<T = any, R = any> {
   private _result: R | undefined;
 
   /** Handle to the timeout that's running as a fallback in case the exit animation doesn't fire. */
-  private _closeFallbackTimeout: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _closeFallbackTimeout!: number;
 
   constructor(
     containerInstance: MatBottomSheetContainer,

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -111,7 +111,8 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
   private _vertical = false;
   private _multiple = false;
   private _disabled = false;
-  private _selectionModel: SelectionModel<MatButtonToggle>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _selectionModel!: SelectionModel<MatButtonToggle>;
 
   /**
    * Reference to the raw value that the consumer tried to assign. The real
@@ -131,11 +132,12 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
   _onTouched: () => any = () => {};
 
   /** Child button toggle buttons. */
+  // TODO(issue/13329): Attempt to remove "!".
   @ContentChildren(forwardRef(() => MatButtonToggle), {
     // Note that this would technically pick up toggles
     // from nested groups, but that's not a case that we support.
     descendants: true
-  }) _buttonToggles: QueryList<MatButtonToggle>;
+  }) _buttonToggles!: QueryList<MatButtonToggle>;
 
   /** The appearance for all the buttons in the group. */
   @Input() appearance: MatButtonToggleAppearance;
@@ -413,7 +415,8 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
    * Attached to the aria-label attribute of the host element. In most cases, aria-labelledby will
    * take precedence so this may be omitted.
    */
-  @Input('aria-label') ariaLabel: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-label') ariaLabel!: string;
 
   /**
    * Users can specify the `aria-labelledby` attribute which will be forwarded to the input element
@@ -421,9 +424,11 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
   @Input('aria-labelledby') ariaLabelledby: string | null = null;
 
   /** Type of the button toggle. Either 'radio' or 'checkbox'. */
-  _type: ToggleType;
+  // TODO(issue/13329): Attempt to remove "!".
+  _type!: ToggleType;
 
-  @ViewChild('button') _buttonElement: ElementRef<HTMLButtonElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('button') _buttonElement!: ElementRef<HTMLButtonElement>;
 
   /** The parent button toggle group (exclusive selection). Optional. */
   buttonToggleGroup: MatButtonToggleGroup;
@@ -432,10 +437,12 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
   get buttonId(): string { return `${this.id}-button`; }
 
   /** The unique ID for this button toggle. */
-  @Input() id: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() id!: string;
 
   /** HTML's 'name' attribute used to group radios for unique selection. */
-  @Input() name: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() name!: string;
 
   /** MatButtonToggleGroup reads this to assign its own value. */
   @Input() value: any;
@@ -451,7 +458,8 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
   set appearance(value: MatButtonToggleAppearance) {
     this._appearance = value;
   }
-  private _appearance: MatButtonToggleAppearance;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _appearance!: MatButtonToggleAppearance;
 
   /** Whether the button is checked. */
   @Input()

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -88,7 +88,8 @@ export class MatButton extends _MatButtonMixinBase
   readonly isIconButton: boolean = this._hasHostAttributes('mat-icon-button');
 
   /** Reference to the MatRipple instance of the button. */
-  @ViewChild(MatRipple) ripple: MatRipple;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatRipple) ripple!: MatRipple;
 
   constructor(elementRef: ElementRef,
               private _focusMonitor: FocusMonitor,
@@ -167,7 +168,8 @@ export class MatButton extends _MatButtonMixinBase
 })
 export class MatAnchor extends MatButton {
   /** Tabindex of the button. */
-  @Input() tabIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() tabIndex!: number;
 
   constructor(
     focusMonitor: FocusMonitor,

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -84,9 +84,11 @@ export const enum TransitionCheckState {
 /** Change event object emitted by MatCheckbox. */
 export class MatCheckboxChange {
   /** The source MatCheckbox of the event. */
-  source: MatCheckbox;
+  // TODO(issue/13329): Attempt to remove "!".
+  source!: MatCheckbox;
   /** The new `checked` value of the checkbox. */
-  checked: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  checked!: boolean;
 }
 
 // Boilerplate for applying mixins to MatCheckbox.
@@ -158,7 +160,8 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   @Input()
   get required(): boolean { return this._required; }
   set required(value: boolean) { this._required = coerceBooleanProperty(value); }
-  private _required: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _required!: boolean;
 
   /** Whether the label should appear after or before the checkbox. Defaults to 'after' */
   @Input() labelPosition: 'before' | 'after' = 'after';
@@ -174,13 +177,16 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   @Output() readonly indeterminateChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   /** The value attribute of the native input element */
-  @Input() value: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() value!: string;
 
   /** The native `<input type="checkbox">` element */
-  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('input') _inputElement!: ElementRef<HTMLInputElement>;
 
   /** Reference to the ripple instance of the checkbox. */
-  @ViewChild(MatRipple) ripple: MatRipple;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatRipple) ripple!: MatRipple;
 
   /**
    * Called when the checkbox is blurred. Needed to properly implement ControlValueAccessor.

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -49,7 +49,8 @@ let nextUniqueId = 0;
 export class MatChipInput implements MatChipTextControl, OnChanges {
   /** Whether the control is focused. */
   focused: boolean = false;
-  _chipList: MatChipList;
+  // TODO(issue/13329): Attempt to remove "!".
+  _chipList!: MatChipList;
 
   /** Register input for chip list */
   @Input('matChipInputFor')

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -118,25 +118,31 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   private _destroyed = new Subject<void>();
 
   /** Subscription to focus changes in the chips. */
-  private _chipFocusSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipFocusSubscription!: Subscription | null;
 
   /** Subscription to blur changes in the chips. */
-  private _chipBlurSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipBlurSubscription!: Subscription | null;
 
   /** Subscription to selection changes in chips. */
-  private _chipSelectionSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipSelectionSubscription!: Subscription | null;
 
   /** Subscription to remove changes in chips. */
-  private _chipRemoveSubscription: Subscription | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _chipRemoveSubscription!: Subscription | null;
 
   /** The chip input to add more chips */
-  protected _chipInput: MatChipTextControl;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _chipInput!: MatChipTextControl;
 
   /** Uid of the chip list */
   _uid: string = `mat-chip-list-${nextUniqueId++}`;
 
   /** The aria-describedby attribute on the chip list for improved a11y. */
-  _ariaDescribedby: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _ariaDescribedby!: string;
 
   /** Tab index for the chip list. */
   _tabIndex = 0;
@@ -148,7 +154,8 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   _userTabIndex: number | null = null;
 
   /** The FocusKeyManager which handles focus. */
-  _keyManager: FocusKeyManager<MatChip>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _keyManager!: FocusKeyManager<MatChip>;
 
   /** Function when touched */
   _onTouched = () => {};
@@ -156,7 +163,8 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   /** Function when changed */
   _onChange: (value: any) => void = () => {};
 
-  _selectionModel: SelectionModel<MatChip>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _selectionModel!: SelectionModel<MatChip>;
 
   /** The array of selected chips inside chip list. */
   get selected(): MatChip[] | MatChip {
@@ -167,7 +175,8 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   get role(): string | null { return this.empty ? null : 'listbox'; }
 
   /** An object used to control when error messages are shown. */
-  @Input() errorStateMatcher: ErrorStateMatcher;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() errorStateMatcher!: ErrorStateMatcher;
 
   /** Whether the user should be allowed to select multiple chips. */
   @Input()
@@ -238,7 +247,8 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
     this._placeholder = value;
     this.stateChanges.next();
   }
-  protected _placeholder: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _placeholder!: string;
 
   /** Whether any chips or the matChipInput inside of this chip-list has focus. */
   get focused(): boolean {
@@ -327,11 +337,12 @@ export class MatChipList extends _MatChipListMixinBase implements MatFormFieldCo
   @Output() readonly valueChange: EventEmitter<any> = new EventEmitter<any>();
 
   /** The chip components contained within this chip list. */
+  // TODO(issue/13329): Attempt to remove "!".
   @ContentChildren(MatChip, {
     // We need to use `descendants: true`, because Ivy will no longer match
     // indirect descendants if it's left as false.
     descendants: true
-  }) chips: QueryList<MatChip>;
+  }) chips!: QueryList<MatChip>;
 
   constructor(protected _elementRef: ElementRef<HTMLElement>,
               private _changeDetectorRef: ChangeDetectorRef,

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -68,7 +68,8 @@ export class MatChipSelectionChange {
 // Boilerplate for applying mixins to MatChip.
 /** @docs-private */
 class MatChipBase {
-  disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  disabled!: boolean;
   constructor(public _elementRef: ElementRef) {}
 }
 
@@ -166,13 +167,16 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   _chipListDisabled: boolean = false;
 
   /** The chip avatar */
-  @ContentChild(MatChipAvatar) avatar: MatChipAvatar;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatChipAvatar) avatar!: MatChipAvatar;
 
   /** The chip's trailing icon. */
-  @ContentChild(MatChipTrailingIcon) trailingIcon: MatChipTrailingIcon;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatChipTrailingIcon) trailingIcon!: MatChipTrailingIcon;
 
   /** The chip's remove toggler. */
-  @ContentChild(forwardRef(() => MatChipRemove)) removeIcon: MatChipRemove;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(forwardRef(() => MatChipRemove)) removeIcon!: MatChipRemove;
 
   /** Whether the chip is selected. */
   @Input()

--- a/src/material/core/common-behaviors/error-state.ts
+++ b/src/material/core/common-behaviors/error-state.ts
@@ -47,7 +47,8 @@ export function mixinErrorState<T extends Constructor<HasErrorState>>(base: T)
      */
     readonly stateChanges = new Subject<void>();
 
-    errorStateMatcher: ErrorStateMatcher;
+  // TODO(issue/13329): Attempt to remove "!".
+  errorStateMatcher!: ErrorStateMatcher;
 
     updateErrorState() {
       const oldState = this.errorState;

--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -41,7 +41,8 @@ let _uniqueOptgroupIdCounter = 0;
 })
 export class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
   /** Label for the option group. */
-  @Input() label: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() label!: string;
 
   /** Unique id for the underlying label. */
   _labelId: string = `mat-optgroup-label-${_uniqueOptgroupIdCounter++}`;

--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -76,10 +76,12 @@ const pointerUpEvents = ['mouseup', 'mouseleave', 'touchend', 'touchcancel'];
  */
 export class RippleRenderer implements EventListenerObject {
   /** Element where the ripples are being added to. */
-  private _containerElement: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _containerElement!: HTMLElement;
 
   /** Element which triggers the ripple elements on mouse events. */
-  private _triggerElement: HTMLElement | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _triggerElement!: HTMLElement | null;
 
   /** Whether the pointer is currently down or not. */
   private _isPointerDown = false;
@@ -88,10 +90,12 @@ export class RippleRenderer implements EventListenerObject {
   private _activeRipples = new Set<RippleRef>();
 
   /** Latest non-persistent ripple that was triggered. */
-  private _mostRecentTransientRipple: RippleRef | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _mostRecentTransientRipple!: RippleRef | null;
 
   /** Time in milliseconds when the last touchstart event happened. */
-  private _lastTouchStartEvent: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastTouchStartEvent!: number;
 
   /** Whether pointer-up event listeners have been registered. */
   private _pointerUpEventsRegistered = false;
@@ -100,7 +104,8 @@ export class RippleRenderer implements EventListenerObject {
    * Cached dimensions of the ripple container. Set when the first
    * ripple is shown and cleared once no more ripples are visible.
    */
-  private _containerRect: ClientRect | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _containerRect!: ClientRect | null;
 
   constructor(private _target: RippleTarget,
               private _ngZone: NgZone,

--- a/src/material/core/ripple/ripple.ts
+++ b/src/material/core/ripple/ripple.ts
@@ -59,16 +59,19 @@ export const MAT_RIPPLE_GLOBAL_OPTIONS =
 export class MatRipple implements OnInit, OnDestroy, RippleTarget {
 
   /** Custom color for all ripples. */
-  @Input('matRippleColor') color: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matRippleColor') color!: string;
 
   /** Whether the ripples should be visible outside the component's bounds. */
-  @Input('matRippleUnbounded') unbounded: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matRippleUnbounded') unbounded!: boolean;
 
   /**
    * Whether the ripple always originates from the center of the host element's bounds, rather
    * than originating from the location of the click event.
    */
-  @Input('matRippleCentered') centered: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matRippleCentered') centered!: boolean;
 
   /**
    * If set, the radius in pixels of foreground ripples when fully expanded. If unset, the radius
@@ -82,7 +85,8 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
    * duration of the ripples. The animation durations will be overwritten if the
    * `NoopAnimationsModule` is being used.
    */
-  @Input('matRippleAnimation') animation: RippleAnimationConfig;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matRippleAnimation') animation!: RippleAnimationConfig;
 
   /**
    * Whether click events will not trigger the ripple. Ripples can be still launched manually
@@ -106,7 +110,8 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
     this._trigger = trigger;
     this._setupTriggerEventsIfEnabled();
   }
-  private _trigger: HTMLElement;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _trigger!: HTMLElement;
 
   /** Renderer for the ripple DOM manipulations. */
   private _rippleRenderer: RippleRenderer;

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -68,25 +68,32 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
    * Used to skip the next focus event when rendering the preview range.
    * We need a flag like this, because some browsers fire focus events asynchronously.
    */
-  private _skipNextFocus: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _skipNextFocus!: boolean;
 
   /** The label for the table. (e.g. "Jan 2017"). */
-  @Input() label: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() label!: string;
 
   /** The cells to display in the table. */
-  @Input() rows: MatCalendarCell[][];
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() rows!: MatCalendarCell[][];
 
   /** The value in the table that corresponds to today. */
-  @Input() todayValue: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() todayValue!: number;
 
   /** Start value of the selected date range. */
-  @Input() startValue: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() startValue!: number;
 
   /** End value of the selected date range. */
-  @Input() endValue: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() endValue!: number;
 
   /** The minimum number of free cells needed to fit the label in the first row. */
-  @Input() labelMinRequiredCells: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() labelMinRequiredCells!: number;
 
   /** The number of columns in the table. */
   @Input() numCols: number = 7;
@@ -104,10 +111,12 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
   @Input() cellAspectRatio: number = 1;
 
   /** Start of the comparison range. */
-  @Input() comparisonStart: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() comparisonStart!: number | null;
 
   /** End of the comparison range. */
-  @Input() comparisonEnd: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() comparisonEnd!: number | null;
 
   /** Start of the preview range. */
   @Input() previewStart: number | null = null;
@@ -123,13 +132,16 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
   @Output() previewChange = new EventEmitter<MatCalendarUserEvent<MatCalendarCell | null>>();
 
   /** The number of blank cells to put at the beginning for the first row. */
-  _firstRowOffset: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  _firstRowOffset!: number;
 
   /** Padding for the individual date cells. */
-  _cellPadding: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _cellPadding!: string;
 
   /** Width of an individual cell. */
-  _cellWidth: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _cellWidth!: string;
 
   constructor(private _elementRef: ElementRef<HTMLElement>, private _ngZone: NgZone) {
     _ngZone.runOutsideAngular(() => {

--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -188,10 +188,12 @@ export class MatCalendarHeader<D> {
 })
 export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDestroy, OnChanges {
   /** An input indicating the type of the header component, if set. */
-  @Input() headerComponent: ComponentType<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() headerComponent!: ComponentType<any>;
 
   /** A portal containing the header component type for this calendar. */
-  _calendarHeaderPortal: Portal<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _calendarHeaderPortal!: Portal<any>;
 
   private _intlChanges: Subscription;
 
@@ -208,7 +210,8 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   set startAt(value: D | null) {
     this._startAt = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _startAt: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _startAt!: D | null;
 
   /** Whether the calendar should be started in month or year view. */
   @Input() startView: MatCalendarView = 'month';
@@ -223,7 +226,8 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
       this._selected = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
     }
   }
-  private _selected: DateRange<D> | D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _selected!: DateRange<D> | D | null;
 
   /** The minimum selectable date. */
   @Input()
@@ -231,7 +235,8 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   set minDate(value: D | null) {
     this._minDate = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _minDate: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _minDate!: D | null;
 
   /** The maximum selectable date. */
   @Input()
@@ -239,19 +244,24 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   set maxDate(value: D | null) {
     this._maxDate = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _maxDate: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _maxDate!: D | null;
 
   /** Function used to filter which dates are selectable. */
-  @Input() dateFilter: (date: D) => boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() dateFilter!: (date: D) => boolean;
 
   /** Function that can be used to add custom CSS classes to dates. */
-  @Input() dateClass: (date: D) => MatCalendarCellCssClasses;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() dateClass!: (date: D) => MatCalendarCellCssClasses;
 
   /** Start of the comparison range. */
-  @Input() comparisonStart: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() comparisonStart!: D | null;
 
   /** End of the comparison range. */
-  @Input() comparisonEnd: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() comparisonEnd!: D | null;
 
   /**
    * Emits when the currently selected date changes.
@@ -276,13 +286,16 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
       new EventEmitter<MatCalendarUserEvent<D | null>>();
 
   /** Reference to the current month view component. */
-  @ViewChild(MatMonthView) monthView: MatMonthView<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatMonthView) monthView!: MatMonthView<D>;
 
   /** Reference to the current year view component. */
-  @ViewChild(MatYearView) yearView: MatYearView<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatYearView) yearView!: MatYearView<D>;
 
   /** Reference to the current multi-year view component. */
-  @ViewChild(MatMultiYearView) multiYearView: MatMultiYearView<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatMultiYearView) multiYearView!: MatMultiYearView<D>;
 
   /**
    * The current active date. This determines which time period is shown and which date is
@@ -294,7 +307,8 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     this.stateChanges.next();
     this._changeDetectorRef.markForCheck();
   }
-  private _clampedActiveDate: D;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _clampedActiveDate!: D;
 
   /** Whether the calendar is in month view. */
   get currentView(): MatCalendarView { return this._currentView; }
@@ -303,7 +317,8 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     this._moveFocusOnNextTick = true;
     this._changeDetectorRef.markForCheck();
   }
-  private _currentView: MatCalendarView;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _currentView!: MatCalendarView;
 
   /**
    * Emits whenever there is a state change that the header may need to respond to.

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -72,7 +72,8 @@ abstract class MatDateRangeInputPartBase<D>
   extends MatDatepickerInputBase<DateRange<D>> implements OnInit, DoCheck {
 
   /** @docs-private */
-  ngControl: NgControl;
+  // TODO(issue/13329): Attempt to remove "!".
+  ngControl!: NgControl;
 
   /** @docs-private */
   abstract updateErrorState(): void;

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -84,7 +84,8 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
    * Set the placeholder attribute on `matStartDate` and `matEndDate`.
    * @docs-private
    */
-  placeholder: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  placeholder!: string;
 
   /** The range picker that this input is associated with. */
   @Input()
@@ -96,7 +97,8 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
       this._registerModel(this._model!);
     }
   }
-  private _rangePicker: MatDateRangePicker<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _rangePicker!: MatDateRangePicker<D>;
 
   /** Whether the input is required. */
   @Input()
@@ -104,7 +106,8 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   set required(value: boolean) {
     this._required = coerceBooleanProperty(value);
   }
-  private _required: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _required!: boolean;
 
   /** Function that can be used to filter out dates within the date range picker. */
   @Input()
@@ -113,7 +116,8 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
     this._dateFilter = value;
     this._revalidate();
   }
-  private _dateFilter: DateFilterFn<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dateFilter!: DateFilterFn<D>;
 
   /** The minimum valid date. */
   @Input()
@@ -122,7 +126,8 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
     this._min = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
     this._revalidate();
   }
-  private _min: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _min!: D | null;
 
   /** The maximum valid date. */
   @Input()
@@ -131,7 +136,8 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
     this._max = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
     this._revalidate();
   }
-  private _max: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _max!: D | null;
 
   /** Whether the input is disabled. */
   @Input()
@@ -184,8 +190,10 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   /** End of the comparison range that should be shown in the calendar. */
   @Input() comparisonEnd: D | null = null;
 
-  @ContentChild(MatStartDate) _startInput: MatStartDate<D>;
-  @ContentChild(MatEndDate) _endInput: MatEndDate<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatStartDate) _startInput!: MatStartDate<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatEndDate) _endInput!: MatEndDate<D>;
 
   /**
    * Implemented as a part of `MatFormFieldControl`.

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -128,19 +128,24 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
   extends _MatDatepickerContentMixinBase implements AfterViewInit, OnDestroy, CanColor {
 
   /** Reference to the internal calendar component. */
-  @ViewChild(MatCalendar) _calendar: MatCalendar<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatCalendar) _calendar!: MatCalendar<D>;
 
   /** Reference to the datepicker that created the overlay. */
-  datepicker: MatDatepickerBase<any, S, D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  datepicker!: MatDatepickerBase<any, S, D>;
 
   /** Start of the comparison range. */
-  comparisonStart: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  comparisonStart!: D | null;
 
   /** End of the comparison range. */
-  comparisonEnd: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  comparisonEnd!: D | null;
 
   /** Whether the datepicker is above or below the input. */
-  _isAbove: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  _isAbove!: boolean;
 
   /** Current state of the animation. */
   _animationState: 'enter' | 'void' = 'enter';
@@ -233,7 +238,8 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
   private _scrollStrategy: () => ScrollStrategy;
 
   /** An input indicating the type of the custom header component for the calendar, if set. */
-  @Input() calendarHeaderComponent: ComponentType<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() calendarHeaderComponent!: ComponentType<any>;
 
   /** The date to open the calendar to initially. */
   @Input()
@@ -245,7 +251,8 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
   set startAt(value: D | null) {
     this._startAt = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _startAt: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _startAt!: D | null;
 
   /** The view that the calendar should start in. */
   @Input() startView: 'month' | 'year' | 'multi-year' = 'month';
@@ -286,7 +293,8 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
       this._disabledChange.next(newValue);
     }
   }
-  private _disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disabled!: boolean;
 
   /** Preferred position of the datepicker in the X axis. */
   @Input()
@@ -309,10 +317,12 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
   @Output() readonly monthSelected: EventEmitter<D> = new EventEmitter<D>();
 
   /** Classes to be passed to the date picker panel. Supports the same syntax as `ngClass`. */
-  @Input() panelClass: string | string[];
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() panelClass!: string | string[];
 
   /** Function that can be used to add custom CSS classes to dates. */
-  @Input() dateClass: (date: D) => MatCalendarCellCssClasses;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() dateClass!: (date: D) => MatCalendarCellCssClasses;
 
   /** Emits when the datepicker has been opened. */
   @Output('opened') openedStream: EventEmitter<void> = new EventEmitter<void>();
@@ -345,19 +355,23 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
   }
 
   /** A reference to the overlay when the calendar is opened as a popup. */
-  private _popupRef: OverlayRef | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _popupRef!: OverlayRef | null;
 
   /** A reference to the dialog when the calendar is opened as a dialog. */
-  private _dialogRef: MatDialogRef<MatDatepickerContent<S, D>> | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dialogRef!: MatDialogRef<MatDatepickerContent<S, D>> | null;
 
   /** Reference to the component instantiated in popup mode. */
-  private _popupComponentRef: ComponentRef<MatDatepickerContent<S, D>> | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _popupComponentRef!: ComponentRef<MatDatepickerContent<S, D>> | null;
 
   /** The element that was focused before the datepicker was opened. */
   private _focusedElementBeforeOpen: HTMLElement | null = null;
 
   /** The input element this datepicker is associated with. */
-  _datepickerInput: C;
+  // TODO(issue/13329): Attempt to remove "!".
+  _datepickerInput!: C;
 
   /** Emits when the datepicker is disabled. */
   readonly _disabledChange = new Subject<boolean>();

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -62,7 +62,8 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
   implements ControlValueAccessor, AfterViewInit, OnDestroy, Validator {
 
   /** Whether the component has been initialized. */
-  private _isInitialized: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _isInitialized!: boolean;
 
   /** The value of the input. */
   @Input()
@@ -106,7 +107,8 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
       element.blur();
     }
   }
-  private _disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disabled!: boolean;
 
   /** Emits when a `change` event is fired on this `<input>`. */
   @Output() readonly dateChange: EventEmitter<MatDatepickerInputEvent<D, S>> =
@@ -134,7 +136,8 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
    * we might get a value before we have a model. This property keeps track
    * of the value until we have somewhere to assign it.
    */
-  private _pendingValue: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _pendingValue!: D | null;
 
   /** The form control validator for whether the input parses. */
   private _parseValidator: ValidatorFn = (): ValidationErrors | null => {

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -77,7 +77,8 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
       this._registerModel(datepicker._registerInput(this));
     }
   }
-  _datepicker: MatDatepicker<D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _datepicker!: MatDatepicker<D>;
 
   /** The minimum valid date. */
   @Input()
@@ -86,7 +87,8 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
     this._min = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
     this._validatorOnChange();
   }
-  private _min: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _min!: D | null;
 
   /** The maximum valid date. */
   @Input()
@@ -95,7 +97,8 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
     this._max = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
     this._validatorOnChange();
   }
-  private _max: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _max!: D | null;
 
   /** Function that can be used to filter out dates within the datepicker. */
   @Input('matDatepickerFilter')
@@ -104,7 +107,8 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
     this._dateFilter = value;
     this._validatorOnChange();
   }
-  private _dateFilter: DateFilterFn<D | null>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _dateFilter!: DateFilterFn<D | null>;
 
   /** The combined form control validator for this input. */
   protected _validator: ValidatorFn | null;

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -57,7 +57,8 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   private _stateChanges = Subscription.EMPTY;
 
   /** Datepicker instance that the button will toggle. */
-  @Input('for') datepicker: MatDatepickerBase<MatDatepickerControl<any>, D>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('for') datepicker!: MatDatepickerBase<MatDatepickerControl<any>, D>;
 
   /** Tabindex for the toggle. */
   @Input() tabIndex: number | null;
@@ -74,16 +75,20 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);
   }
-  private _disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disabled!: boolean;
 
   /** Whether ripples on the toggle should be disabled. */
-  @Input() disableRipple: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() disableRipple!: boolean;
 
   /** Custom icon set by the consumer. */
-  @ContentChild(MatDatepickerToggleIcon) _customIcon: MatDatepickerToggleIcon;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatDatepickerToggleIcon) _customIcon!: MatDatepickerToggleIcon;
 
   /** Underlying button element. */
-  @ViewChild('button') _button: MatButton;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('button') _button!: MatButton;
 
   constructor(
     public _intl: MatDatepickerIntl,

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -96,7 +96,8 @@ export class MatMonthView<D> implements AfterContentInit, OnDestroy {
 
     this._setRanges(this._selected);
   }
-  private _selected: DateRange<D> | D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _selected!: DateRange<D> | D | null;
 
   /** The minimum selectable date. */
   @Input()
@@ -104,7 +105,8 @@ export class MatMonthView<D> implements AfterContentInit, OnDestroy {
   set minDate(value: D | null) {
     this._minDate = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _minDate: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _minDate!: D | null;
 
   /** The maximum selectable date. */
   @Input()
@@ -112,19 +114,24 @@ export class MatMonthView<D> implements AfterContentInit, OnDestroy {
   set maxDate(value: D | null) {
     this._maxDate = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _maxDate: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _maxDate!: D | null;
 
   /** Function used to filter which dates are selectable. */
-  @Input() dateFilter: (date: D) => boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() dateFilter!: (date: D) => boolean;
 
   /** Function that can be used to add custom CSS classes to dates. */
-  @Input() dateClass: (date: D) => MatCalendarCellCssClasses;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() dateClass!: (date: D) => MatCalendarCellCssClasses;
 
   /** Start of the comparison range. */
-  @Input() comparisonStart: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() comparisonStart!: D | null;
 
   /** End of the comparison range. */
-  @Input() comparisonEnd: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() comparisonEnd!: D | null;
 
   /** Emits when a new date is selected. */
   @Output() readonly selectedChange: EventEmitter<D | null> = new EventEmitter<D | null>();
@@ -137,43 +144,56 @@ export class MatMonthView<D> implements AfterContentInit, OnDestroy {
   @Output() readonly activeDateChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatCalendarBody) _matCalendarBody!: MatCalendarBody;
 
   /** The label for this month (e.g. "January 2017"). */
-  _monthLabel: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _monthLabel!: string;
 
   /** Grid of calendar cells representing the dates of the month. */
-  _weeks: MatCalendarCell[][];
+  // TODO(issue/13329): Attempt to remove "!".
+  _weeks!: MatCalendarCell[][];
 
   /** The number of blank cells in the first row before the 1st of the month. */
-  _firstWeekOffset: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  _firstWeekOffset!: number;
 
   /** Start value of the currently-shown date range. */
-  _rangeStart: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _rangeStart!: number | null;
 
   /** End value of the currently-shown date range. */
-  _rangeEnd: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _rangeEnd!: number | null;
 
   /** Start value of the currently-shown comparison date range. */
-  _comparisonRangeStart: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _comparisonRangeStart!: number | null;
 
   /** End value of the currently-shown comparison date range. */
-  _comparisonRangeEnd: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _comparisonRangeEnd!: number | null;
 
   /** Start of the preview range. */
-  _previewStart: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _previewStart!: number | null;
 
   /** End of the preview range. */
-  _previewEnd: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _previewEnd!: number | null;
 
   /** Whether the user is currently selecting a range of dates. */
-  _isRange: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  _isRange!: boolean;
 
   /** The date of the month that today falls on. Null if today is in another month. */
-  _todayDate: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _todayDate!: number | null;
 
   /** The names of the weekdays. */
-  _weekdays: {long: string, narrow: string}[];
+  // TODO(issue/13329): Attempt to remove "!".
+  _weekdays!: {long: string, narrow: string}[];
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,

--- a/src/material/datepicker/multi-year-view.ts
+++ b/src/material/datepicker/multi-year-view.ts
@@ -85,7 +85,8 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
 
     this._setSelectedYear(value);
   }
-  private _selected: DateRange<D> | D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _selected!: DateRange<D> | D | null;
 
 
   /** The minimum selectable date. */
@@ -94,7 +95,8 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
   set minDate(value: D | null) {
     this._minDate = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _minDate: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _minDate!: D | null;
 
   /** The maximum selectable date. */
   @Input()
@@ -102,10 +104,12 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
   set maxDate(value: D | null) {
     this._maxDate = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _maxDate: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _maxDate!: D | null;
 
   /** A function used to filter which dates are selectable. */
-  @Input() dateFilter: (date: D) => boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() dateFilter!: (date: D) => boolean;
 
   /** Emits when a new year is selected. */
   @Output() readonly selectedChange: EventEmitter<D> = new EventEmitter<D>();
@@ -117,16 +121,20 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
   @Output() readonly activeDateChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatCalendarBody) _matCalendarBody!: MatCalendarBody;
 
   /** Grid of calendar cells representing the currently displayed years. */
-  _years: MatCalendarCell[][];
+  // TODO(issue/13329): Attempt to remove "!".
+  _years!: MatCalendarCell[][];
 
   /** The year that today falls on. */
-  _todayYear: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  _todayYear!: number;
 
   /** The year of the selected date. Null if the selected date is null. */
-  _selectedYear: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _selectedYear!: number | null;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               @Optional() public _dateAdapter: DateAdapter<D>,

--- a/src/material/datepicker/year-view.ts
+++ b/src/material/datepicker/year-view.ts
@@ -80,7 +80,8 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
 
     this._setSelectedMonth(value);
   }
-  private _selected: DateRange<D> | D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _selected!: DateRange<D> | D | null;
 
   /** The minimum selectable date. */
   @Input()
@@ -88,7 +89,8 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
   set minDate(value: D | null) {
     this._minDate = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _minDate: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _minDate!: D | null;
 
   /** The maximum selectable date. */
   @Input()
@@ -96,10 +98,12 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
   set maxDate(value: D | null) {
     this._maxDate = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
   }
-  private _maxDate: D | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _maxDate!: D | null;
 
   /** A function used to filter which dates are selectable. */
-  @Input() dateFilter: (date: D) => boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() dateFilter!: (date: D) => boolean;
 
   /** Emits when a new month is selected. */
   @Output() readonly selectedChange: EventEmitter<D> = new EventEmitter<D>();
@@ -111,22 +115,27 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
   @Output() readonly activeDateChange: EventEmitter<D> = new EventEmitter<D>();
 
   /** The body of calendar table */
-  @ViewChild(MatCalendarBody) _matCalendarBody: MatCalendarBody;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatCalendarBody) _matCalendarBody!: MatCalendarBody;
 
   /** Grid of calendar cells representing the months of the year. */
-  _months: MatCalendarCell[][];
+  // TODO(issue/13329): Attempt to remove "!".
+  _months!: MatCalendarCell[][];
 
   /** The label for this year (e.g. "2017"). */
-  _yearLabel: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _yearLabel!: string;
 
   /** The month in this year that today falls on. Null if today is in a different year. */
-  _todayMonth: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _todayMonth!: number | null;
 
   /**
    * The month in this year that the selected Date falls on.
    * Null if the selected Date is in a different year.
    */
-  _selectedMonth: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _selectedMonth!: number | null;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -74,10 +74,12 @@ export class MatDialogContainer extends BasePortalOutlet {
   private _document: Document;
 
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
-  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet: CdkPortalOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet!: CdkPortalOutlet;
 
   /** The class that traps and manages focus within the dialog. */
-  private _focusTrap: FocusTrap;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _focusTrap!: FocusTrap;
 
   /** Element that was focused before the dialog was opened. Save this to restore upon close. */
   private _elementFocusedBeforeDialogWasOpened: HTMLElement | null = null;
@@ -92,7 +94,8 @@ export class MatDialogContainer extends BasePortalOutlet {
   _ariaLabelledBy: string | null;
 
   /** ID for the container DOM element. */
-  _id: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _id!: string;
 
   constructor(
     private _elementRef: ElementRef,

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -35,7 +35,8 @@ let dialogElementUid = 0;
 })
 export class MatDialogClose implements OnInit, OnChanges {
   /** Screenreader label for the button. */
-  @Input('aria-label') ariaLabel: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-label') ariaLabel!: string;
 
   /** Default to "button" to prevents accidental form submits. */
   @Input() type: 'submit' | 'button' | 'reset' = 'button';

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -27,7 +27,8 @@ export const enum MatDialogState {OPEN, CLOSING, CLOSED}
  */
 export class MatDialogRef<T, R = any> {
   /** The instance of component opened into the dialog. */
-  componentInstance: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  componentInstance!: T;
 
   /** Whether the user is allowed to close the dialog. */
   disableClose: boolean | undefined = this._containerInstance._config.disableClose;
@@ -45,7 +46,8 @@ export class MatDialogRef<T, R = any> {
   private _result: R | undefined;
 
   /** Handle to the timeout that's running as a fallback in case the exit animation doesn't fire. */
-  private _closeFallbackTimeout: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _closeFallbackTimeout!: number;
 
   /** Current state of the dialog. */
   private _state = MatDialogState.OPEN;

--- a/src/material/expansion/accordion.ts
+++ b/src/material/expansion/accordion.ts
@@ -39,14 +39,16 @@ import {MatExpansionPanelHeader} from './expansion-panel-header';
   }
 })
 export class MatAccordion extends CdkAccordion implements MatAccordionBase, AfterContentInit {
-  private _keyManager: FocusKeyManager<MatExpansionPanelHeader>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _keyManager!: FocusKeyManager<MatExpansionPanelHeader>;
 
   /** Headers belonging to this accordion. */
   private _ownHeaders = new QueryList<MatExpansionPanelHeader>();
 
   /** All headers inside the accordion. Includes headers inside nested accordions. */
+  // TODO(issue/13329): Attempt to remove "!".
   @ContentChildren(MatExpansionPanelHeader, {descendants: true})
-  _headers: QueryList<MatExpansionPanelHeader>;
+  _headers!: QueryList<MatExpansionPanelHeader>;
 
   /** Whether the expansion indicator should be hidden. */
   @Input()

--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -133,10 +133,12 @@ export class MatExpansionPanelHeader implements OnDestroy, FocusableOption {
   }
 
   /** Height of the header while the panel is expanded. */
-  @Input() expandedHeight: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() expandedHeight!: string;
 
   /** Height of the header while the panel is collapsed. */
-  @Input() collapsedHeight: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() collapsedHeight!: string;
 
   /**
    * Whether the associated panel is disabled. Implemented as a part of `FocusableOption`.

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -101,7 +101,8 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
   OnDestroy {
   private _document: Document;
   private _hideToggle = false;
-  private _togglePosition: MatAccordionTogglePosition;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _togglePosition!: MatAccordionTogglePosition;
 
   /** Whether the toggle indicator should be hidden. */
   @Input()
@@ -134,13 +135,16 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
   accordion: MatAccordionBase;
 
   /** Content that will be rendered lazily. */
-  @ContentChild(MatExpansionPanelContent) _lazyContent: MatExpansionPanelContent;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatExpansionPanelContent) _lazyContent!: MatExpansionPanelContent;
 
   /** Element containing the panel's user-provided content. */
-  @ViewChild('body') _body: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('body') _body!: ElementRef<HTMLElement>;
 
   /** Portal holding the user's content. */
-  _portal: TemplatePortal;
+  // TODO(issue/13329): Attempt to remove "!".
+  _portal!: TemplatePortal;
 
   /** ID for the associated header element. Used for a11y labelling. */
   _headerId = `mat-expansion-panel-header-${uniqueId++}`;

--- a/src/material/form-field/form-field-control.ts
+++ b/src/material/form-field/form-field-control.ts
@@ -15,40 +15,51 @@ import {Directive} from '@angular/core';
 @Directive()
 export abstract class MatFormFieldControl<T> {
   /** The value of the control. */
-  value: T | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  value!: T | null;
 
   /**
    * Stream that emits whenever the state of the control changes such that the parent `MatFormField`
    * needs to run change detection.
    */
-  readonly stateChanges: Observable<void>;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly stateChanges!: Observable<void>;
 
   /** The element ID for this control. */
-  readonly id: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly id!: string;
 
   /** The placeholder for this control. */
-  readonly placeholder: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly placeholder!: string;
 
   /** Gets the NgControl for this control. */
-  readonly ngControl: NgControl | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly ngControl!: NgControl | null;
 
   /** Whether the control is focused. */
-  readonly focused: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly focused!: boolean;
 
   /** Whether the control is empty. */
-  readonly empty: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly empty!: boolean;
 
   /** Whether the `MatFormField` label should try to float. */
-  readonly shouldLabelFloat: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly shouldLabelFloat!: boolean;
 
   /** Whether the control is required. */
-  readonly required: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly required!: boolean;
 
   /** Whether the control is disabled. */
-  readonly disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly disabled!: boolean;
 
   /** Whether the control is in an error state. */
-  readonly errorState: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  readonly errorState!: boolean;
 
   /**
    * An optional name for the control type that can be used to distinguish `mat-form-field` elements

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -185,7 +185,8 @@ export class MatFormField extends _MatFormFieldMixinBase
       this._outlineGapCalculationNeededOnStable = true;
     }
   }
-  _appearance: MatFormFieldAppearance;
+  // TODO(issue/13329): Attempt to remove "!".
+  _appearance!: MatFormFieldAppearance;
 
   /** Whether the required marker should be hidden. */
   @Input()
@@ -242,7 +243,8 @@ export class MatFormField extends _MatFormFieldMixinBase
       this._changeDetectorRef.markForCheck();
     }
   }
-  private _floatLabel: FloatLabelType;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _floatLabel!: FloatLabelType;
 
   /** Whether the Angular animations are enabled. */
   _animationsEnabled: boolean;
@@ -251,14 +253,20 @@ export class MatFormField extends _MatFormFieldMixinBase
    * @deprecated
    * @breaking-change 8.0.0
    */
-  @ViewChild('underline') underlineRef: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('underline') underlineRef!: ElementRef;
 
-  @ViewChild('connectionContainer', {static: true}) _connectionContainerRef: ElementRef;
-  @ViewChild('inputContainer') _inputContainerRef: ElementRef;
-  @ViewChild('label') private _label: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('connectionContainer', {static: true}) _connectionContainerRef!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('inputContainer') _inputContainerRef!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('label') private _label!: ElementRef;
 
-  @ContentChild(MatFormFieldControl) _controlNonStatic: MatFormFieldControl<any>;
-  @ContentChild(MatFormFieldControl, {static: true}) _controlStatic: MatFormFieldControl<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatFormFieldControl) _controlNonStatic!: MatFormFieldControl<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatFormFieldControl, {static: true}) _controlStatic!: MatFormFieldControl<any>;
   get _control() {
     // TODO(crisbeto): we need this workaround in order to support both Ivy and ViewEngine.
     //  We should clean this up once Ivy is the default renderer.
@@ -267,19 +275,27 @@ export class MatFormField extends _MatFormFieldMixinBase
   set _control(value) {
     this._explicitFormFieldControl = value;
   }
-  private _explicitFormFieldControl: MatFormFieldControl<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _explicitFormFieldControl!: MatFormFieldControl<any>;
 
-  @ContentChild(MatLabel) _labelChildNonStatic: MatLabel;
-  @ContentChild(MatLabel, {static: true}) _labelChildStatic: MatLabel;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatLabel) _labelChildNonStatic!: MatLabel;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatLabel, {static: true}) _labelChildStatic!: MatLabel;
   get _labelChild() {
     return this._labelChildNonStatic || this._labelChildStatic;
   }
 
-  @ContentChild(MatPlaceholder) _placeholderChild: MatPlaceholder;
-  @ContentChildren(MatError, {descendants: true}) _errorChildren: QueryList<MatError>;
-  @ContentChildren(MatHint, {descendants: true}) _hintChildren: QueryList<MatHint>;
-  @ContentChildren(MatPrefix, {descendants: true}) _prefixChildren: QueryList<MatPrefix>;
-  @ContentChildren(MatSuffix, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatPlaceholder) _placeholderChild!: MatPlaceholder;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatError, {descendants: true}) _errorChildren!: QueryList<MatError>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatHint, {descendants: true}) _hintChildren!: QueryList<MatHint>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatPrefix, {descendants: true}) _prefixChildren!: QueryList<MatPrefix>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatSuffix, {descendants: true}) _suffixChildren!: QueryList<MatSuffix>;
 
   constructor(
       public _elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef,

--- a/src/material/grid-list/grid-list.ts
+++ b/src/material/grid-list/grid-list.ts
@@ -52,10 +52,12 @@ const MAT_FIT_MODE = 'fit';
 })
 export class MatGridList implements MatGridListBase, OnInit, AfterContentChecked {
   /** Number of columns being rendered. */
-  private _cols: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _cols!: number;
 
   /** Used for determiningthe position of each tile in the grid. */
-  private _tileCoordinator: TileCoordinator;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _tileCoordinator!: TileCoordinator;
 
   /**
    * Row height value passed in by user. This can be one of three types:
@@ -63,16 +65,19 @@ export class MatGridList implements MatGridListBase, OnInit, AfterContentChecked
    * - Ratio value (ex: "4:3"): sets the row height based on width:height ratio
    * - "Fit" mode (ex: "fit"): sets the row height to total height divided by number of rows
    */
-  private _rowHeight: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _rowHeight!: string;
 
   /** The amount of space between tiles. This will be something like '5px' or '2em'. */
   private _gutter: string = '1px';
 
   /** Sets position and size styles for a tile */
-  private _tileStyler: TileStyler;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _tileStyler!: TileStyler;
 
   /** Query list of tiles that are being rendered. */
-  @ContentChildren(MatGridTile, {descendants: true}) _tiles: QueryList<MatGridTile>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatGridTile, {descendants: true}) _tiles!: QueryList<MatGridTile>;
 
   constructor(private _element: ElementRef<HTMLElement>,
               @Optional() private _dir: Directionality) {}

--- a/src/material/grid-list/grid-tile.ts
+++ b/src/material/grid-list/grid-tile.ts
@@ -75,7 +75,8 @@ export class MatGridTile {
   encapsulation: ViewEncapsulation.None,
 })
 export class MatGridTileText implements AfterContentInit {
-  @ContentChildren(MatLine, {descendants: true}) _lines: QueryList<MatLine>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatLine, {descendants: true}) _lines!: QueryList<MatLine>;
 
   constructor(private _element: ElementRef<HTMLElement>) {}
 

--- a/src/material/grid-list/tile-coordinator.ts
+++ b/src/material/grid-list/tile-coordinator.ts
@@ -36,7 +36,8 @@ export interface Tile {
  */
 export class TileCoordinator {
   /** Tracking array (see class description). */
-  tracker: number[];
+  // TODO(issue/13329): Attempt to remove "!".
+  tracker!: number[];
 
   /** Index at which the search for the next gap will start. */
   columnIndex: number = 0;
@@ -59,7 +60,8 @@ export class TileCoordinator {
   }
 
   /** The computed (row, col) position of each tile (the output). */
-  positions: TilePosition[];
+  // TODO(issue/13329): Attempt to remove "!".
+  positions!: TilePosition[];
 
   /**
    * Updates the tile positions.

--- a/src/material/grid-list/tile-styler.ts
+++ b/src/material/grid-list/tile-styler.ts
@@ -22,11 +22,14 @@ const cssCalcAllowedValue = /^-?\d+((\.\d+)?[A-Za-z%$]?)+$/;
  * @docs-private
  */
 export abstract class TileStyler {
-  _gutterSize: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _gutterSize!: string;
   _rows: number = 0;
   _rowspan: number = 0;
-  _cols: number;
-  _direction: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _cols!: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  _direction!: string;
 
   /**
    * Adds grid-list layout info once it is available. Cannot be processed in the constructor
@@ -206,8 +209,10 @@ export class FixedTileStyler extends TileStyler {
 export class RatioTileStyler extends TileStyler {
 
   /** Ratio width:height given by user to determine row height. */
-  rowHeightRatio: number;
-  baseTileHeight: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  rowHeightRatio!: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  baseTileHeight!: string;
 
   constructor(value: string) {
     super();

--- a/src/material/icon/icon-registry.ts
+++ b/src/material/icon/icon-registry.ts
@@ -79,8 +79,10 @@ export interface IconOptions {
  * @docs-private
  */
 class SvgIconConfig {
-  url: SafeResourceUrl | null;
-  svgElement: SVGElement | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  url!: SafeResourceUrl | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  svgElement!: SVGElement | null;
 
   constructor(url: SafeResourceUrl, options?: IconOptions);
   constructor(svgElement: SVGElement, options?: IconOptions);

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -151,7 +151,8 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Aft
   private _inline: boolean = false;
 
   /** Name of the icon in the SVG icon set. */
-  @Input() svgIcon: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() svgIcon!: string;
 
   /** Font set that the icon is a part of. */
   @Input()
@@ -159,7 +160,8 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Aft
   set fontSet(value: string) {
     this._fontSet = this._cleanupFontValue(value);
   }
-  private _fontSet: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _fontSet!: string;
 
   /** Name of an icon within a font set. */
   @Input()
@@ -167,10 +169,13 @@ export class MatIcon extends _MatIconMixinBase implements OnChanges, OnInit, Aft
   set fontIcon(value: string) {
     this._fontIcon = this._cleanupFontValue(value);
   }
-  private _fontIcon: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _fontIcon!: string;
 
-  private _previousFontSetClass: string;
-  private _previousFontIconClass: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _previousFontSetClass!: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _previousFontIconClass!: string;
 
   /** Keeps track of the current page path. */
   private _previousPath?: string;

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -158,13 +158,15 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   @Input()
   get id(): string { return this._id; }
   set id(value: string) { this._id = value || this._uid; }
-  protected _id: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _id!: string;
 
   /**
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  @Input() placeholder: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() placeholder!: string;
 
   /**
    * Implemented as part of MatFormFieldControl.
@@ -192,7 +194,8 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
   protected _type = 'text';
 
   /** An object used to control when error messages are shown. */
-  @Input() errorStateMatcher: ErrorStateMatcher;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() errorStateMatcher!: ErrorStateMatcher;
 
   /**
    * Implemented as part of MatFormFieldControl.

--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -181,9 +181,12 @@ export class MatListItem extends _MatListItemMixinBase implements AfterContentIn
   private _list?: MatNavList | MatList;
   private _destroyed = new Subject<void>();
 
-  @ContentChildren(MatLine, {descendants: true}) _lines: QueryList<MatLine>;
-  @ContentChild(MatListAvatarCssMatStyler) _avatar: MatListAvatarCssMatStyler;
-  @ContentChild(MatListIconCssMatStyler) _icon: MatListIconCssMatStyler;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatLine, {descendants: true}) _lines!: QueryList<MatLine>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatListAvatarCssMatStyler) _avatar!: MatListAvatarCssMatStyler;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatListIconCssMatStyler) _icon!: MatListIconCssMatStyler;
 
   constructor(private _element: ElementRef<HTMLElement>,
               _changeDetectorRef: ChangeDetectorRef,

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -125,12 +125,16 @@ export class MatListOption extends _MatListOptionMixinBase implements AfterConte
   private _disabled = false;
   private _hasFocus = false;
 
-  @ContentChild(MatListAvatarCssMatStyler) _avatar: MatListAvatarCssMatStyler;
-  @ContentChild(MatListIconCssMatStyler) _icon: MatListIconCssMatStyler;
-  @ContentChildren(MatLine, {descendants: true}) _lines: QueryList<MatLine>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatListAvatarCssMatStyler) _avatar!: MatListAvatarCssMatStyler;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatListIconCssMatStyler) _icon!: MatListIconCssMatStyler;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatLine, {descendants: true}) _lines!: QueryList<MatLine>;
 
   /** DOM element containing the item's text. */
-  @ViewChild('text') _text: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('text') _text!: ElementRef;
 
   /** Whether the label should appear before or after the checkbox. Defaults to 'after' */
   @Input() checkboxPosition: 'before' | 'after' = 'after';
@@ -342,10 +346,12 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
   private _contentInitialized = false;
 
   /** The FocusKeyManager which handles focus. */
-  _keyManager: FocusKeyManager<MatListOption>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _keyManager!: FocusKeyManager<MatListOption>;
 
   /** The option components contained within this selection-list. */
-  @ContentChildren(MatListOption, {descendants: true}) options: QueryList<MatListOption>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatListOption, {descendants: true}) options!: QueryList<MatListOption>;
 
   /** Emits a change event whenever the selected state of an option changes. */
   @Output() readonly selectionChange: EventEmitter<MatSelectionListChange> =
@@ -408,7 +414,8 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
   private _onChange: (value: any) => void = (_: any) => {};
 
   /** Keeps track of the currently-selected value. */
-  _value: string[]|null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _value!: string[]|null;
 
   /** Emits when the list has been destroyed. */
   private _destroyed = new Subject<void>();
@@ -417,7 +424,8 @@ export class MatSelectionList extends _MatSelectionListMixinBase implements CanD
   _onTouched: () => void = () => {};
 
   /** Whether the list has been destroyed. */
-  private _isDestroyed: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _isDestroyed!: boolean;
 
   constructor(private _element: ElementRef<HTMLElement>,
     // @breaking-change 11.0.0 Remove `tabIndex` parameter.

--- a/src/material/list/testing/list-harness-base.ts
+++ b/src/material/list/testing/list-harness-base.ts
@@ -37,7 +37,8 @@ export class MatListHarnessBase
       C extends ComponentHarness,
       F extends BaseListItemHarnessFilters
     > extends ComponentHarness {
-  protected _itemHarness: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  protected _itemHarness!: T;
 
   /**
    * Gets a list of harnesses representing the items in this list.

--- a/src/material/menu/menu-content.ts
+++ b/src/material/menu/menu-content.ts
@@ -28,8 +28,10 @@ import {Subject} from 'rxjs';
   selector: 'ng-template[matMenuContent]'
 })
 export class MatMenuContent implements OnDestroy {
-  private _portal: TemplatePortal<any>;
-  private _outlet: DomPortalOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _portal!: TemplatePortal<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _outlet!: DomPortalOutlet;
 
   /** Emits when the menu content has been attached. */
   _attached = new Subject<void>();

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -81,7 +81,8 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({passive: tr
   exportAs: 'matMenuTrigger'
 })
 export class MatMenuTrigger implements AfterContentInit, OnDestroy {
-  private _portal: TemplatePortal;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _portal!: TemplatePortal;
   private _overlayRef: OverlayRef | null = null;
   private _menuOpen: boolean = false;
   private _closingActionsSubscription = Subscription.EMPTY;
@@ -131,7 +132,8 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
       });
     }
   }
-  private _menu: MatMenuPanel;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _menu!: MatMenuPanel;
 
   /** Data to be passed along to any lazily-rendered content. */
   @Input('matMenuTriggerData') menuData: any;

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -164,20 +164,23 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
   }
 
   /** @docs-private */
-  @ViewChild(TemplateRef) templateRef: TemplateRef<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(TemplateRef) templateRef!: TemplateRef<any>;
 
   /**
    * List of the items inside of a menu.
    * @deprecated
    * @breaking-change 8.0.0
    */
-  @ContentChildren(MatMenuItem, {descendants: false}) items: QueryList<MatMenuItem>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatMenuItem, {descendants: false}) items!: QueryList<MatMenuItem>;
 
   /**
    * Menu content that will be rendered lazily.
    * @docs-private
    */
-  @ContentChild(MatMenuContent) lazyContent: MatMenuContent;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatMenuContent) lazyContent!: MatMenuContent;
 
   /** Whether the menu should overlap its trigger. */
   @Input()
@@ -221,7 +224,8 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
       this._elementRef.nativeElement.className = '';
     }
   }
-  private _previousPanelClass: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _previousPanelClass!: string;
 
   /**
    * This method takes classes set on the host mat-menu element and applies them on the

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -47,7 +47,8 @@ const DEFAULT_PAGE_SIZE = 50;
  */
 export class PageEvent {
   /** The current page index. */
-  pageIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  pageIndex!: number;
 
   /**
    * Index of the page that was selected previously.
@@ -56,10 +57,12 @@ export class PageEvent {
   previousPageIndex?: number;
 
   /** The current page size */
-  pageSize: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  pageSize!: number;
 
   /** The current total number of items being paged */
-  length: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  length!: number;
 }
 
 
@@ -107,7 +110,8 @@ const _MatPaginatorBase: CanDisableCtor & HasInitializedCtor & typeof MatPaginat
 })
 export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy, CanDisable,
   HasInitialized {
-  private _initialized: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _initialized!: boolean;
   private _intlChanges: Subscription;
 
   /** Theme color to be used for the underlying form controls. */
@@ -138,7 +142,8 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
     this._pageSize = Math.max(coerceNumberProperty(value), 0);
     this._updateDisplayedPageSizeOptions();
   }
-  private _pageSize: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _pageSize!: number;
 
   /** The set of provided page size options to display to the user. */
   @Input()
@@ -170,7 +175,8 @@ export class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy
   @Output() readonly page: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
 
   /** Displayed set of page size options. Will be sorted and include current page size. */
-  _displayedPageSizeOptions: number[];
+  // TODO(issue/13329): Attempt to remove "!".
+  _displayedPageSizeOptions!: number[];
 
   constructor(public _intl: MatPaginatorIntl,
               private _changeDetectorRef: ChangeDetectorRef,

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -143,7 +143,8 @@ export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor
   set bufferValue(v: number) { this._bufferValue = clamp(v || 0); }
   private _bufferValue: number = 0;
 
-  @ViewChild('primaryValueBar') _primaryValueBar: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('primaryValueBar') _primaryValueBar!: ElementRef;
 
   /**
    * Event emitted when animation of the primary progress bar completes. This event will not

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -126,7 +126,8 @@ const INDETERMINATE_ANIMATION_TEMPLATE = `
 export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements OnInit, CanColor {
   private _diameter = BASE_SIZE;
   private _value = 0;
-  private _strokeWidth: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _strokeWidth!: number;
   private _fallbackAnimation = false;
 
   /**
@@ -134,7 +135,8 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
    * For most elements this is the document, but for the ones in the Shadow DOM we need to
    * use the shadow root.
    */
-  private _styleRoot: Node;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _styleRoot!: Node;
 
   /**
    * Tracks diameters of existing instances to de-dupe generated styles (default d = 100).

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -135,7 +135,8 @@ export class MatRadioGroup implements AfterContentInit, ControlValueAccessor {
 
   /** Child radio buttons. */
   @ContentChildren(forwardRef(() => MatRadioButton), { descendants: true })
-  _radios: QueryList<MatRadioButton>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _radios!: QueryList<MatRadioButton>;
 
   /** Theme color for all of the radio buttons in the group. */
   @Input() color: ThemePalette;
@@ -317,7 +318,8 @@ class MatRadioButtonBase {
   // Since the disabled property is manually defined for the MatRadioButton and isn't set up in
   // the mixin base class. To be able to use the tabindex mixin, a disabled property must be
   // defined to properly work.
-  disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  disabled!: boolean;
 
   constructor(public _elementRef: ElementRef) {}
 }
@@ -342,16 +344,20 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
   @Input() id: string = this._uniqueId;
 
   /** Analog to HTML 'name' attribute used to group radios for unique selection. */
-  @Input() name: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() name!: string;
 
   /** Used to set the 'aria-label' attribute on the underlying input element. */
-  @Input('aria-label') ariaLabel: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-label') ariaLabel!: string;
 
   /** The 'aria-labelledby' attribute takes precedence as the element's text alternative. */
-  @Input('aria-labelledby') ariaLabelledby: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-labelledby') ariaLabelledby!: string;
 
   /** The 'aria-describedby' attribute is read after the element's label and field type. */
-  @Input('aria-describedby') ariaDescribedby: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-describedby') ariaDescribedby!: string;
 
   /** Whether this radio button is checked. */
   @Input()
@@ -403,7 +409,8 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
   set labelPosition(value) {
     this._labelPosition = value;
   }
-  private _labelPosition: 'before' | 'after';
+  // TODO(issue/13329): Attempt to remove "!".
+  private _labelPosition!: 'before' | 'after';
 
   /** Whether the radio button is disabled. */
   @Input()
@@ -431,7 +438,8 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
       this._providerOverride && this._providerOverride.color || 'accent';
   }
   set color(newValue: ThemePalette) { this._color = newValue; }
-  private _color: ThemePalette;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _color!: ThemePalette;
 
   /**
    * Event emitted when the checked state of this radio button changes.
@@ -450,10 +458,12 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
   private _checked: boolean = false;
 
   /** Whether this radio is disabled. */
-  private _disabled: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disabled!: boolean;
 
   /** Whether this radio is required. */
-  private _required: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _required!: boolean;
 
   /** Value assigned to this radio. */
   private _value: any = null;
@@ -462,7 +472,8 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
   private _removeUniqueSelectionListener: () => void = () => {};
 
   /** The native `<input type=radio>` element */
-  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('input') _inputElement!: ElementRef<HTMLInputElement>;
 
   constructor(@Optional() radioGroup: MatRadioGroup,
               elementRef: ElementRef,

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -260,7 +260,8 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   private _scrollTop = 0;
 
   /** The placeholder displayed in the trigger of the select. */
-  private _placeholder: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _placeholder!: string;
 
   /** Whether the component is in multiple selection mode. */
   private _multiple: boolean = false;
@@ -275,19 +276,23 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   private readonly _destroy = new Subject<void>();
 
   /** The last measured value for the trigger's client bounding rect. */
-  _triggerRect: ClientRect;
+  // TODO(issue/13329): Attempt to remove "!".
+  _triggerRect!: ClientRect;
 
   /** The aria-describedby attribute on the select for improved a11y. */
-  _ariaDescribedby: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  _ariaDescribedby!: string;
 
   /** The cached font-size of the trigger element. */
   _triggerFontSize = 0;
 
   /** Deals with the selection logic. */
-  _selectionModel: SelectionModel<MatOption>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _selectionModel!: SelectionModel<MatOption>;
 
   /** Manages keyboard events for options in the panel. */
-  _keyManager: ActiveDescendantKeyManager<MatOption>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _keyManager!: ActiveDescendantKeyManager<MatOption>;
 
   /** `View -> model callback called when value changes` */
   _onChange: (value: any) => void = () => {};
@@ -348,10 +353,12 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   controlType = 'mat-select';
 
   /** Trigger that opens the select. */
-  @ViewChild('trigger') trigger: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('trigger') trigger!: ElementRef;
 
   /** Panel containing the select options. */
-  @ViewChild('panel') panel: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('panel') panel!: ElementRef;
 
   /**
    * Overlay pane containing the options.
@@ -359,19 +366,24 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
    * @breaking-change 10.0.0
    * @docs-private
    */
-  @ViewChild(CdkConnectedOverlay) overlayDir: CdkConnectedOverlay;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(CdkConnectedOverlay) overlayDir!: CdkConnectedOverlay;
 
   /** All of the defined select options. */
-  @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatOption, {descendants: true}) options!: QueryList<MatOption>;
 
   /** All of the defined groups of options. */
-  @ContentChildren(MatOptgroup, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatOptgroup, {descendants: true}) optionGroups!: QueryList<MatOptgroup>;
 
   /** Classes to be passed to the select panel. Supports the same syntax as `ngClass`. */
-  @Input() panelClass: string|string[]|Set<string>|{[key: string]: any};
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() panelClass!: string|string[]|Set<string>|{[key: string]: any};
 
   /** User-supplied override of the trigger element. */
-  @ContentChild(MatSelectTrigger) customTrigger: MatSelectTrigger;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatSelectTrigger) customTrigger!: MatSelectTrigger;
 
   /** Placeholder to be shown if no value has been selected. */
   @Input()
@@ -440,10 +452,12 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   @Input('aria-label') ariaLabel: string = '';
 
   /** Input that can be used to specify the `aria-labelledby` attribute. */
-  @Input('aria-labelledby') ariaLabelledby: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-labelledby') ariaLabelledby!: string;
 
   /** Object used to control when error messages are shown. */
-  @Input() errorStateMatcher: ErrorStateMatcher;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() errorStateMatcher!: ErrorStateMatcher;
 
   /** Time to wait in milliseconds after the last keystroke before moving focus to an item. */
   @Input()
@@ -451,13 +465,15 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   set typeaheadDebounceInterval(value: number) {
     this._typeaheadDebounceInterval = coerceNumberProperty(value);
   }
-  private _typeaheadDebounceInterval: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _typeaheadDebounceInterval!: number;
 
   /**
    * Function used to sort the values in a select in multiple mode.
    * Follows the same logic as `Array.prototype.sort`.
    */
-  @Input() sortComparator: (a: MatOption, b: MatOption, options: MatOption[]) => number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() sortComparator!: (a: MatOption, b: MatOption, options: MatOption[]) => number;
 
   /** Unique id of the element. */
   @Input()
@@ -466,7 +482,8 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     this._id = value || this._uid;
     this.stateChanges.next();
   }
-  private _id: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _id!: string;
 
   /** Combined stream of all of the child options' change events. */
   readonly optionSelectionChanges: Observable<MatOptionSelectionChange> = defer(() => {

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -138,7 +138,8 @@ export class MatDrawerContent extends CdkScrollable implements AfterContentInit 
   encapsulation: ViewEncapsulation.None,
 })
 export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestroy {
-  private _focusTrap: FocusTrap;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _focusTrap!: FocusTrap;
   private _elementFocusedBeforeDrawerWasOpened: HTMLElement | null = null;
 
   /** Whether the drawer is initialized. Used for disabling the initial animation. */
@@ -200,7 +201,8 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
   private _opened: boolean = false;
 
   /** How the sidenav was opened (keypress, mouse click etc.) */
-  private _openedVia: FocusOrigin | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _openedVia!: FocusOrigin | null;
 
   /** Emits whenever the drawer has started animating. */
   _animationStarted = new Subject<AnimationEvent>();
@@ -496,13 +498,16 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
     // indirect descendants if it's left as false.
     descendants: true
   })
-  _allDrawers: QueryList<MatDrawer>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _allDrawers!: QueryList<MatDrawer>;
 
   /** Drawers that belong to this container. */
   _drawers = new QueryList<MatDrawer>();
 
-  @ContentChild(MatDrawerContent) _content: MatDrawerContent;
-  @ViewChild(MatDrawerContent) _userContent: MatDrawerContent;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatDrawerContent) _content!: MatDrawerContent;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatDrawerContent) _userContent!: MatDrawerContent;
 
   /** The drawer child with the `start` position. */
   get start(): MatDrawer | null { return this._start; }
@@ -539,14 +544,17 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
   set hasBackdrop(value: any) {
     this._backdropOverride = value == null ? null : coerceBooleanProperty(value);
   }
-  _backdropOverride: boolean | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _backdropOverride!: boolean | null;
 
   /** Event emitted when the drawer backdrop is clicked. */
   @Output() readonly backdropClick: EventEmitter<void> = new EventEmitter<void>();
 
   /** The drawer at the start/end position, independent of direction. */
-  private _start: MatDrawer | null;
-  private _end: MatDrawer | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _start!: MatDrawer | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _end!: MatDrawer | null;
 
   /**
    * The drawer at the left/right. When direction changes, these will change as well.
@@ -554,8 +562,10 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
    * In LTR, _left == _start and _right == _end.
    * In RTL, _left == _end and _right == _start.
    */
-  private _left: MatDrawer | null;
-  private _right: MatDrawer | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _left!: MatDrawer | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _right!: MatDrawer | null;
 
   /** Emits when the component is destroyed. */
   private readonly _destroyed = new Subject<void>();

--- a/src/material/sidenav/sidenav.ts
+++ b/src/material/sidenav/sidenav.ts
@@ -130,8 +130,10 @@ export class MatSidenavContainer extends MatDrawerContainer {
     // indirect descendants if it's left as false.
     descendants: true
   })
-  _allDrawers: QueryList<MatSidenav>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _allDrawers!: QueryList<MatSidenav>;
 
-  @ContentChild(MatSidenavContent) _content: MatSidenavContent;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatSidenavContent) _content!: MatSidenavContent;
   static ngAcceptInputType_hasBackdrop: BooleanInput;
 }

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -112,10 +112,12 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   private _checked: boolean = false;
 
   /** Reference to the thumb HTMLElement. */
-  @ViewChild('thumbContainer') _thumbEl: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('thumbContainer') _thumbEl!: ElementRef;
 
   /** Reference to the thumb bar HTMLElement. */
-  @ViewChild('toggleBar') _thumbBarEl: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('toggleBar') _thumbBarEl!: ElementRef;
 
   /** Name value will be applied to the input element if present. */
   @Input() name: string | null = null;
@@ -169,7 +171,8 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   get inputId(): string { return `${this.id || this._uniqueId}-input`; }
 
   /** Reference to the underlying input element. */
-  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('input') _inputElement!: ElementRef<HTMLInputElement>;
 
   constructor(elementRef: ElementRef,
               private _focusMonitor: FocusMonitor,

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -91,10 +91,12 @@ export const MAT_SLIDER_VALUE_ACCESSOR: any = {
 /** A simple change event emitted by the MatSlider component. */
 export class MatSliderChange {
   /** The MatSlider that changed. */
-  source: MatSlider;
+  // TODO(issue/13329): Attempt to remove "!".
+  source!: MatSlider;
 
   /** The new value of the source slider. */
-  value: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  value!: number | null;
 }
 
 // Boilerplate for applying mixins to MatSlider.
@@ -265,7 +267,8 @@ export class MatSlider extends _MatSliderMixinBase
    * in the thumb label. Can be used to format very large number in order
    * for them to fit into the slider thumb.
    */
-  @Input() displayWith: (value: number) => string | number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() displayWith!: (value: number) => string | number;
 
   /** Whether the slider is vertical. */
   @Input()
@@ -459,19 +462,23 @@ export class MatSlider extends _MatSliderMixinBase
   private _controlValueAccessorChangeFn: (value: any) => void = () => {};
 
   /** Decimal places to round to, based on the step amount. */
-  private _roundToDecimal: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _roundToDecimal!: number;
 
   /** Subscription to the Directionality change EventEmitter. */
   private _dirChangeSubscription = Subscription.EMPTY;
 
   /** The value of the slider when the slide start event fires. */
-  private _valueOnSlideStart: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _valueOnSlideStart!: number | null;
 
   /** Position of the pointer when the dragging started. */
-  private _pointerPositionOnStart: {x: number, y: number} | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _pointerPositionOnStart!: {x: number, y: number} | null;
 
   /** Reference to the inner slider wrapper element. */
-  @ViewChild('sliderWrapper') private _sliderWrapper: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('sliderWrapper') private _sliderWrapper!: ElementRef;
 
   /**
    * Whether mouse events should be converted to a slider position by calculating their distance
@@ -487,7 +494,8 @@ export class MatSlider extends _MatSliderMixinBase
   }
 
   /** Keeps track of the last pointer event that was captured by the slider. */
-  private _lastPointerEvent: MouseEvent | TouchEvent | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _lastPointerEvent!: MouseEvent | TouchEvent | null;
 
   /** Used to subscribe to global move and end events */
   protected _document?: Document;

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -59,7 +59,8 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
   private _destroyed = false;
 
   /** The portal outlet inside of this container into which the snack bar content will be loaded. */
-  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet: CdkPortalOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet!: CdkPortalOutlet;
 
   /** Subject for notifying that the snack bar has exited from view. */
   readonly _onExit: Subject<any> = new Subject();

--- a/src/material/snack-bar/snack-bar-ref.ts
+++ b/src/material/snack-bar/snack-bar-ref.ts
@@ -25,7 +25,8 @@ const MAX_TIMEOUT = Math.pow(2, 31) - 1;
  */
 export class MatSnackBarRef<T> {
   /** The instance of the component making up the content of the snack bar. */
-  instance: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  instance!: T;
 
   /**
    * The instance of the component making up the content of the snack bar.
@@ -46,7 +47,8 @@ export class MatSnackBarRef<T> {
    * Timeout ID for the duration setTimeout call. Used to clear the timeout if the snackbar is
    * dismissed before the duration passes.
    */
-  private _durationTimeoutId: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _durationTimeoutId!: number;
 
   /** Whether the snack bar was dismissed using the action button. */
   private _dismissedByAction = false;

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -109,7 +109,8 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
    * position through the animation. If animations are currently disabled, the fromState is removed
    * so that there is no animation displayed.
    */
-  _viewState: ArrowViewStateTransition;
+  // TODO(issue/13329): Attempt to remove "!".
+  _viewState!: ArrowViewStateTransition;
 
   /** The direction the arrow should be facing according to the current state. */
   _arrowDirection: SortDirection = '';
@@ -123,19 +124,22 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
    * ID of this sort header. If used within the context of a CdkColumnDef, this will default to
    * the column's name.
    */
-  @Input('mat-sort-header') id: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('mat-sort-header') id!: string;
 
   /** Sets the position of the arrow that displays when sorted. */
   @Input() arrowPosition: 'before' | 'after' = 'after';
 
   /** Overrides the sort start value of the containing MatSort for this MatSortable. */
-  @Input() start: 'asc' | 'desc';
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() start!: 'asc' | 'desc';
 
   /** Overrides the disable clear value of the containing MatSort for this MatSortable. */
   @Input()
   get disableClear(): boolean { return this._disableClear; }
   set disableClear(v) { this._disableClear = coerceBooleanProperty(v); }
-  private _disableClear: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disableClear!: boolean;
 
   constructor(public _intl: MatSortHeaderIntl,
               changeDetectorRef: ChangeDetectorRef,

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -76,7 +76,8 @@ export class MatSort extends _MatSortMixinBase
   readonly _stateChanges = new Subject<void>();
 
   /** The id of the most recently sorted MatSortable. */
-  @Input('matSortActive') active: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matSortActive') active!: string;
 
   /**
    * The direction to set when an MatSortable is initially sorted.
@@ -102,7 +103,8 @@ export class MatSort extends _MatSortMixinBase
   @Input('matSortDisableClear')
   get disableClear(): boolean { return this._disableClear; }
   set disableClear(v: boolean) { this._disableClear = coerceBooleanProperty(v); }
-  private _disableClear: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _disableClear!: boolean;
 
   /** Event emitted when the user changes either the active sort or sort direction. */
   @Output('matSortChange') readonly sortChange: EventEmitter<Sort> = new EventEmitter<Sort>();

--- a/src/material/stepper/step-header.ts
+++ b/src/material/stepper/step-header.ts
@@ -39,31 +39,40 @@ export class MatStepHeader extends CdkStepHeader implements OnDestroy {
   private _intlSubscription: Subscription;
 
   /** State of the given step. */
-  @Input() state: StepState;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() state!: StepState;
 
   /** Label of the given step. */
-  @Input() label: MatStepLabel | string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() label!: MatStepLabel | string;
 
   /** Error message to display when there's an error. */
-  @Input() errorMessage: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() errorMessage!: string;
 
   /** Overrides for the header icons, passed in via the stepper. */
-  @Input() iconOverrides: {[key: string]: TemplateRef<MatStepperIconContext>};
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() iconOverrides!: {[key: string]: TemplateRef<MatStepperIconContext>};
 
   /** Index of the given step. */
-  @Input() index: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() index!: number;
 
   /** Whether the given step is selected. */
-  @Input() selected: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() selected!: boolean;
 
   /** Whether the given step label is active. */
-  @Input() active: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() active!: boolean;
 
   /** Whether the given step is optional. */
-  @Input() optional: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() optional!: boolean;
 
   /** Whether the ripple should be disabled. */
-  @Input() disableRipple: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() disableRipple!: boolean;
 
   constructor(
     public _intl: MatStepperIntl,

--- a/src/material/stepper/stepper-icon.ts
+++ b/src/material/stepper/stepper-icon.ts
@@ -27,7 +27,8 @@ export interface MatStepperIconContext {
 })
 export class MatStepperIcon {
   /** Name of the icon to be overridden. */
-  @Input('matStepperIcon') name: StepState;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matStepperIcon') name!: StepState;
 
   constructor(public templateRef: TemplateRef<MatStepperIconContext>) {}
 }

--- a/src/material/stepper/stepper.ts
+++ b/src/material/stepper/stepper.ts
@@ -61,7 +61,8 @@ import {MatStepperIcon, MatStepperIconContext} from './stepper-icon';
 })
 export class MatStep extends CdkStep implements ErrorStateMatcher {
   /** Content for step label given by `<ng-template matStepLabel>`. */
-  @ContentChild(MatStepLabel) stepLabel: MatStepLabel;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChild(MatStepLabel) stepLabel!: MatStepLabel;
 
   /** @breaking-change 8.0.0 remove the `?` after `stepperOptions` */
   constructor(@Inject(forwardRef(() => MatStepper)) stepper: MatStepper,
@@ -87,19 +88,23 @@ export class MatStep extends CdkStep implements ErrorStateMatcher {
 @Directive({selector: '[matStepper]', providers: [{provide: CdkStepper, useExisting: MatStepper}]})
 export class MatStepper extends CdkStepper implements AfterContentInit {
   /** The list of step headers of the steps in the stepper. */
-  @ViewChildren(MatStepHeader) _stepHeader: QueryList<MatStepHeader>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChildren(MatStepHeader) _stepHeader!: QueryList<MatStepHeader>;
 
   /** Steps that the stepper holds. */
-  @ContentChildren(MatStep, {descendants: true}) _steps: QueryList<MatStep>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatStep, {descendants: true}) _steps!: QueryList<MatStep>;
 
   /** Custom icon overrides passed in by the consumer. */
-  @ContentChildren(MatStepperIcon, {descendants: true}) _icons: QueryList<MatStepperIcon>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatStepperIcon, {descendants: true}) _icons!: QueryList<MatStepperIcon>;
 
   /** Event emitted when the current step is done transitioning in. */
   @Output() readonly animationDone: EventEmitter<void> = new EventEmitter<void>();
 
   /** Whether ripples should be disabled for the step headers. */
-  @Input() disableRipple: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() disableRipple!: boolean;
 
   /** Consumer-specified template-refs to be used to override the header icons. */
   _iconOverrides: {[key: string]: TemplateRef<MatStepperIconContext>} = {};

--- a/src/material/table/cell.ts
+++ b/src/material/table/cell.ts
@@ -60,7 +60,8 @@ export class MatFooterCellDef extends CdkFooterCellDef {}
 })
 export class MatColumnDef extends CdkColumnDef {
   /** Unique name for this column. */
-  @Input('matColumnDef') name: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matColumnDef') name!: string;
 
   static ngAcceptInputType_sticky: BooleanInput;
 }

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -65,7 +65,8 @@ export class MatTableDataSource<T> extends DataSource<T> {
    * For example, a 'selectAll()' function would likely want to select the set of filtered data
    * shown to the user rather than all the data.
    */
-  filteredData: T[];
+  // TODO(issue/13329): Attempt to remove "!".
+  filteredData!: T[];
 
   /** Array of data that should be rendered by the table, where each object represents one row. */
   get data() { return this._data.value; }
@@ -87,7 +88,8 @@ export class MatTableDataSource<T> extends DataSource<T> {
     this._sort = sort;
     this._updateChangeSubscription();
   }
-  private _sort: MatSort|null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _sort!: MatSort|null;
 
   /**
    * Instance of the MatPaginator component used by the table to control what page of the data is
@@ -104,7 +106,8 @@ export class MatTableDataSource<T> extends DataSource<T> {
     this._paginator = paginator;
     this._updateChangeSubscription();
   }
-  private _paginator: MatPaginator|null;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _paginator!: MatPaginator|null;
 
   /**
    * Data accessor function that is used for accessing data properties for sorting through

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -100,16 +100,20 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
    * The number of tab labels that are displayed on the header. When this changes, the header
    * should re-evaluate the scroll position.
    */
-  private _tabLabelCount: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _tabLabelCount!: number;
 
   /** Whether the scroll distance has changed and should be applied after the view is checked. */
-  private _scrollDistanceChanged: boolean;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _scrollDistanceChanged!: boolean;
 
   /** Used to manage focus between the tabs. */
-  private _keyManager: FocusKeyManager<MatPaginatedTabHeaderItem>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _keyManager!: FocusKeyManager<MatPaginatedTabHeaderItem>;
 
   /** Cached text content of the header. */
-  private _currentTextContent: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _currentTextContent!: string;
 
   /** Stream that will stop the automated scrolling. */
   private _stopScrolling = new Subject<void>();

--- a/src/material/tabs/tab-body.ts
+++ b/src/material/tabs/tab-body.ts
@@ -112,13 +112,15 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
 // tslint:disable-next-line:class-name
 export abstract class _MatTabBodyBase implements OnInit, OnDestroy {
   /** Current position of the tab-body in the tab-group. Zero means that the tab is visible. */
-  private _positionIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _positionIndex!: number;
 
   /** Subscription to the directionality change observable. */
   private _dirChangeSubscription = Subscription.EMPTY;
 
   /** Tab body position state. Used by the animation trigger for the current state. */
-  _position: MatTabBodyPositionState;
+  // TODO(issue/13329): Attempt to remove "!".
+  _position!: MatTabBodyPositionState;
 
   /** Emits when an animation on the tab is complete. */
   _translateTabComplete = new Subject<AnimationEvent>();
@@ -139,10 +141,12 @@ export abstract class _MatTabBodyBase implements OnInit, OnDestroy {
   abstract _portalHost: PortalHostDirective;
 
   /** The tab body content to display. */
-  @Input('content') _content: TemplatePortal;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('content') _content!: TemplatePortal;
 
   /** Position that will be used when the tab is immediately becoming visible after creation. */
-  @Input() origin: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input() origin!: number | null;
 
   // Note that the default value will always be overwritten by `MatTabBody`, but we need one
   // anyway to prevent the animations module from throwing an error if the body is used on its own.
@@ -261,7 +265,8 @@ export abstract class _MatTabBodyBase implements OnInit, OnDestroy {
   }
 })
 export class MatTabBody extends _MatTabBodyBase {
-  @ViewChild(PortalHostDirective) _portalHost: PortalHostDirective;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(PortalHostDirective) _portalHost!: PortalHostDirective;
 
   constructor(elementRef: ElementRef<HTMLElement>,
               @Optional() dir: Directionality,

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -53,9 +53,11 @@ let nextId = 0;
 /** A simple change event emitted on focus or selection changes. */
 export class MatTabChangeEvent {
   /** Index of the currently-selected tab. */
-  index: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  index!: number;
   /** Reference to the currently-selected tab. */
-  tab: MatTab;
+  // TODO(issue/13329): Attempt to remove "!".
+  tab!: MatTab;
 }
 
 /** Possible positions for the tab header. */
@@ -129,7 +131,8 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
   set animationDuration(value: string) {
     this._animationDuration = /^\d+$/.test(value) ? value + 'ms' : value;
   }
-  private _animationDuration: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _animationDuration!: string;
 
   /**
    * Whether pagination should be disabled. This can be used to avoid unnecessary
@@ -407,9 +410,12 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
   },
 })
 export class MatTabGroup extends _MatTabGroupBase {
-  @ContentChildren(MatTab, {descendants: true}) _allTabs: QueryList<MatTab>;
-  @ViewChild('tabBodyWrapper') _tabBodyWrapper: ElementRef;
-  @ViewChild('tabHeader') _tabHeader: MatTabGroupBaseHeader;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatTab, {descendants: true}) _allTabs!: QueryList<MatTab>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabBodyWrapper') _tabBodyWrapper!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabHeader') _tabHeader!: MatTabGroupBaseHeader;
 
   constructor(elementRef: ElementRef,
               changeDetectorRef: ChangeDetectorRef,

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -88,12 +88,18 @@ export abstract class _MatTabHeaderBase extends MatPaginatedTabHeader implements
   },
 })
 export class MatTabHeader extends _MatTabHeaderBase {
-  @ContentChildren(MatTabLabelWrapper, {descendants: false}) _items: QueryList<MatTabLabelWrapper>;
-  @ViewChild(MatInkBar, {static: true}) _inkBar: MatInkBar;
-  @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
-  @ViewChild('tabList', {static: true}) _tabList: ElementRef;
-  @ViewChild('nextPaginator') _nextPaginator: ElementRef<HTMLElement>;
-  @ViewChild('previousPaginator') _previousPaginator: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatTabLabelWrapper, {descendants: false}) _items!: QueryList<MatTabLabelWrapper>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatInkBar, {static: true}) _inkBar!: MatInkBar;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabListContainer', {static: true}) _tabListContainer!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabList', {static: true}) _tabList!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('nextPaginator') _nextPaginator!: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('previousPaginator') _previousPaginator!: ElementRef<HTMLElement>;
 
   constructor(elementRef: ElementRef,
               changeDetectorRef: ChangeDetectorRef,

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -160,12 +160,18 @@ export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements Af
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class MatTabNav extends _MatTabNavBase {
-  @ContentChildren(forwardRef(() => MatTabLink), {descendants: true}) _items: QueryList<MatTabLink>;
-  @ViewChild(MatInkBar, {static: true}) _inkBar: MatInkBar;
-  @ViewChild('tabListContainer', {static: true}) _tabListContainer: ElementRef;
-  @ViewChild('tabList', {static: true}) _tabList: ElementRef;
-  @ViewChild('nextPaginator') _nextPaginator: ElementRef<HTMLElement>;
-  @ViewChild('previousPaginator') _previousPaginator: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(forwardRef(() => MatTabLink), {descendants: true}) _items!: QueryList<MatTabLink>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatInkBar, {static: true}) _inkBar!: MatInkBar;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabListContainer', {static: true}) _tabListContainer!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('tabList', {static: true}) _tabList!: ElementRef;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('nextPaginator') _nextPaginator!: ElementRef<HTMLElement>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild('previousPaginator') _previousPaginator!: ElementRef<HTMLElement>;
 
   constructor(elementRef: ElementRef,
     @Optional() dir: Directionality,

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -65,28 +65,33 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
       this._templateLabel = value;
     }
   }
-  private _templateLabel: MatTabLabel;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _templateLabel!: MatTabLabel;
 
   /**
    * Template provided in the tab content that will be used if present, used to enable lazy-loading
    */
   @ContentChild(MatTabContent, {read: TemplateRef, static: true})
-  _explicitContent: TemplateRef<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  _explicitContent!: TemplateRef<any>;
 
   /** Template inside the MatTab view that contains an `<ng-content>`. */
-  @ViewChild(TemplateRef, {static: true}) _implicitContent: TemplateRef<any>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(TemplateRef, {static: true}) _implicitContent!: TemplateRef<any>;
 
   /** Plain text label for the tab, used when there is no template label. */
   @Input('label') textLabel: string = '';
 
   /** Aria label for the tab. */
-  @Input('aria-label') ariaLabel: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-label') ariaLabel!: string;
 
   /**
    * Reference to the element that the tab is labelled by.
    * Will be cleared if `aria-label` is set at the same time.
    */
-  @Input('aria-labelledby') ariaLabelledby: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('aria-labelledby') ariaLabelledby!: string;
 
   /** Portal that will be the hosted content of the tab */
   private _contentPortal: TemplatePortal | null = null;

--- a/src/material/toolbar/toolbar.ts
+++ b/src/material/toolbar/toolbar.ts
@@ -55,7 +55,8 @@ export class MatToolbar extends _MatToolbarMixinBase implements CanColor, AfterV
   private _document: Document;
 
   /** Reference to all toolbar row elements that have been projected. */
-  @ContentChildren(MatToolbarRow, {descendants: true}) _toolbarRows: QueryList<MatToolbarRow>;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ContentChildren(MatToolbarRow, {descendants: true}) _toolbarRows!: QueryList<MatToolbarRow>;
 
   constructor(
     elementRef: ElementRef,

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -133,13 +133,17 @@ export function MAT_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): MatTooltipDefaultOptions 
   exportAs: 'matTooltip',
 })
 export class MatTooltip implements OnDestroy, OnInit {
-  _overlayRef: OverlayRef | null;
-  _tooltipInstance: TooltipComponent | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _overlayRef!: OverlayRef | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _tooltipInstance!: TooltipComponent | null;
 
-  private _portal: ComponentPortal<TooltipComponent>;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _portal!: ComponentPortal<TooltipComponent>;
   private _position: TooltipPosition = 'below';
   private _disabled: boolean = false;
-  private _tooltipClass: string|string[]|Set<string>|{[key: string]: any};
+  // TODO(issue/13329): Attempt to remove "!".
+  private _tooltipClass!: string|string[]|Set<string>|{[key: string]: any};
   private _scrollStrategy: () => ScrollStrategy;
 
   /** Allows the user to define the position of the tooltip relative to the parent element */
@@ -235,7 +239,8 @@ export class MatTooltip implements OnDestroy, OnInit {
   private _passiveListeners = new Map<string, EventListenerOrEventListenerObject>();
 
   /** Timer started at the last `touchstart` event. */
-  private _touchstartTimeout: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _touchstartTimeout!: number;
 
   /** Emits when the component is destroyed. */
   private readonly _destroyed = new Subject<void>();
@@ -630,16 +635,20 @@ export class MatTooltip implements OnDestroy, OnInit {
 })
 export class TooltipComponent implements OnDestroy {
   /** Message to display in the tooltip */
-  message: string;
+  // TODO(issue/13329): Attempt to remove "!".
+  message!: string;
 
   /** Classes to be added to the tooltip. Supports the same syntax as `ngClass`. */
-  tooltipClass: string|string[]|Set<string>|{[key: string]: any};
+  // TODO(issue/13329): Attempt to remove "!".
+  tooltipClass!: string|string[]|Set<string>|{[key: string]: any};
 
   /** The timeout ID of any current timer set to show the tooltip */
-  _showTimeoutId: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _showTimeoutId!: number | null;
 
   /** The timeout ID of any current timer set to hide the tooltip */
-  _hideTimeoutId: number | null;
+  // TODO(issue/13329): Attempt to remove "!".
+  _hideTimeoutId!: number | null;
 
   /** Property watched by the animation framework to show or hide the tooltip */
   _visibility: TooltipVisibility = 'initial';

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -76,7 +76,8 @@ export class MatTreeNode<T> extends _MatTreeNodeMixinBase<T>
   providers: [{provide: CdkTreeNodeDef, useExisting: MatTreeNodeDef}]
 })
 export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
-  @Input('matTreeNode') data: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matTreeNode') data!: T;
 }
 
 /**
@@ -98,7 +99,8 @@ export class MatTreeNodeDef<T> extends CdkTreeNodeDef<T> {
 })
 export class MatNestedTreeNode<T> extends CdkNestedTreeNode<T> implements AfterContentInit,
   OnDestroy {
-  @Input('matNestedTreeNode') node: T;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matNestedTreeNode') node!: T;
 
   /** Whether the node is disabled. */
   @Input()
@@ -113,7 +115,8 @@ export class MatNestedTreeNode<T> extends CdkNestedTreeNode<T> implements AfterC
     // If the specified tabIndex value is null or undefined, fall back to the default value.
     this._tabIndex = value != null ? value : 0;
   }
-  private _tabIndex: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  private _tabIndex!: number;
 
   constructor(protected _elementRef: ElementRef<HTMLElement>,
               protected _tree: CdkTree<T>,

--- a/src/material/tree/padding.ts
+++ b/src/material/tree/padding.ts
@@ -18,8 +18,10 @@ import {Directive, Input} from '@angular/core';
 export class MatTreeNodePadding<T> extends CdkTreeNodePadding<T> {
 
   /** The level of depth of the tree node. The padding will be `level * indent` pixels. */
-  @Input('matTreeNodePadding') level: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matTreeNodePadding') level!: number;
 
   /** The indent for each level. Default number 40px from material design menu sub-menu spec. */
-  @Input('matTreeNodePaddingIndent') indent: number;
+  // TODO(issue/13329): Attempt to remove "!".
+  @Input('matTreeNodePaddingIndent') indent!: number;
 }

--- a/src/material/tree/tree.ts
+++ b/src/material/tree/tree.ts
@@ -30,5 +30,6 @@ import {MatTreeNodeOutlet} from './outlet';
 })
 export class MatTree<T> extends CdkTree<T> {
   // Outlets within the tree's template where the dataNodes will be inserted.
-  @ViewChild(MatTreeNodeOutlet, {static: true}) _nodeOutlet: MatTreeNodeOutlet;
+  // TODO(issue/13329): Attempt to remove "!".
+  @ViewChild(MatTreeNodeOutlet, {static: true}) _nodeOutlet!: MatTreeNodeOutlet;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "strictNullChecks": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This is generally a recommended check for all TS projects and part of
--strict checks. Properly fixing all instances is a hard task and there
are 200+ failures with this check.

Luckily, there is a suppression - putting ! on the property name, and I
had an auto-fixer handy, so this PR suppresses all old instances.

This will allow new code to be written to be conforming while the old
code will continue to work as expected.

Each suppression has a comment added to remind the owners to revisit the
decision to use ! (as it is unsafe). This separates the intentional
usage of !, from the auto-inserted ones.

see issue #13329