### PR TITLE
refactor(platform): change deprecated APIs for version 10

### DIFF
--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -1,5 +1,5 @@
 import {Platform} from '@angular/cdk/platform';
-import {Component, PLATFORM_ID, ViewChild} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {A11yModule, FocusTrap, CdkTrapFocus} from '../index';
 
@@ -48,9 +48,9 @@ describe('FocusTrap', () => {
       // focus event handler directly.
       const result = focusTrapInstance.focusLastTabbableElement();
 
-      const platformId = TestBed.inject(PLATFORM_ID);
+      const platform = TestBed.inject(Platform);
       // In iOS button elements are never tabbable, so the last element will be the input.
-      const lastElement = new Platform(platformId).IOS ? 'input' : 'button';
+      const lastElement = platform.IOS ? 'input' : 'button';
 
       expect(document.activeElement!.nodeName.toLowerCase())
           .toBe(lastElement, `Expected ${lastElement} element to be focused`);

--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.spec.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.spec.ts
@@ -5,14 +5,15 @@ import {
   HighContrastModeDetector, WHITE_ON_BLACK_CSS_CLASS,
 } from './high-contrast-mode-detector';
 import {Platform} from '@angular/cdk/platform';
+import {inject} from '@angular/core/testing';
 
 
 describe('HighContrastModeDetector', () => {
   let fakePlatform: Platform;
 
-  beforeEach(() => {
-    fakePlatform = new Platform();
-  });
+  beforeEach(inject([Platform], (p: Platform) => {
+    fakePlatform = p;
+  }));
 
   it('should detect NONE for non-browser platforms', () => {
     fakePlatform.isBrowser = false;

--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
@@ -1,18 +1,18 @@
 import {Platform} from '@angular/cdk/platform';
+import {inject} from '@angular/core/testing';
 import {InteractivityChecker} from './interactivity-checker';
 
 describe('InteractivityChecker', () => {
-  const platform: Platform = new Platform();
-
+  let platform: Platform;
   let testContainerElement: HTMLElement;
   let checker: InteractivityChecker;
 
-  beforeEach(() => {
+  beforeEach(inject([Platform, InteractivityChecker], (p: Platform, i: InteractivityChecker) => {
     testContainerElement = document.createElement('div');
     document.body.appendChild(testContainerElement);
-
-    checker = new InteractivityChecker(platform);
-  });
+    platform = p;
+    checker = i;
+  }));
 
   afterEach(() => {
     document.body.removeChild(testContainerElement);
@@ -21,7 +21,7 @@ describe('InteractivityChecker', () => {
 
   describe('isDisabled', () => {
     it('should return true for disabled elements', () => {
-      let elements = createElements('input', 'textarea', 'select', 'button', 'mat-checkbox');
+      const elements = createElements('input', 'textarea', 'select', 'button', 'mat-checkbox');
       elements.forEach(el => el.setAttribute('disabled', ''));
       appendElements(elements);
 
@@ -32,7 +32,7 @@ describe('InteractivityChecker', () => {
     });
 
     it('should return false for elements without disabled', () => {
-      let elements = createElements('input', 'textarea', 'select', 'button', 'mat-checkbox');
+      const elements = createElements('input', 'textarea', 'select', 'button', 'mat-checkbox');
       appendElements(elements);
 
       elements.forEach(el => {
@@ -46,7 +46,7 @@ describe('InteractivityChecker', () => {
     it('should return false for a `display: none` element', () => {
       testContainerElement.innerHTML =
           `<input style="display: none;">`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isVisible(input))
           .toBe(false, 'Expected element with `display: none` to not be visible');
@@ -57,7 +57,7 @@ describe('InteractivityChecker', () => {
         `<div style="display: none;">
            <input>
          </div>`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isVisible(input))
           .toBe(false, 'Expected element with `display: none` parent to not be visible');
@@ -66,7 +66,7 @@ describe('InteractivityChecker', () => {
     it('should return false for a `visibility: hidden` element', () => {
       testContainerElement.innerHTML =
           `<input style="visibility: hidden;">`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isVisible(input))
           .toBe(false, 'Expected element with `visibility: hidden` to not be visible');
@@ -77,7 +77,7 @@ describe('InteractivityChecker', () => {
         `<div style="visibility: hidden;">
            <input>
          </div>`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isVisible(input))
           .toBe(false, 'Expected element with `visibility: hidden` parent to not be visible');
@@ -91,7 +91,7 @@ describe('InteractivityChecker', () => {
              <input>
            </div>
          </div>`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isVisible(input))
           .toBe(true, 'Expected element with `visibility: hidden` ancestor and closer ' +
@@ -99,7 +99,7 @@ describe('InteractivityChecker', () => {
     });
 
     it('should return true for an element without visibility modifiers', () => {
-      let input = document.createElement('input');
+      const input = document.createElement('input');
       testContainerElement.appendChild(input);
 
       expect(checker.isVisible(input))
@@ -109,7 +109,7 @@ describe('InteractivityChecker', () => {
 
   describe('isFocusable', () => {
     it('should return true for native form controls', () => {
-      let elements = createElements('input', 'textarea', 'select', 'button');
+      const elements = createElements('input', 'textarea', 'select', 'button');
       appendElements(elements);
 
       elements.forEach(el => {
@@ -118,7 +118,7 @@ describe('InteractivityChecker', () => {
     });
 
     it('should return true for an anchor with an href', () => {
-      let anchor = document.createElement('a');
+      const anchor = document.createElement('a');
       anchor.href = 'google.com';
       testContainerElement.appendChild(anchor);
 
@@ -126,7 +126,7 @@ describe('InteractivityChecker', () => {
     });
 
     it('should return false for an anchor without an href', () => {
-      let anchor = document.createElement('a');
+      const anchor = document.createElement('a');
       testContainerElement.appendChild(anchor);
 
       expect(checker.isFocusable(anchor))
@@ -134,7 +134,7 @@ describe('InteractivityChecker', () => {
     });
 
     it('should return false for disabled form controls', () => {
-      let elements = createElements('input', 'textarea', 'select', 'button');
+      const elements = createElements('input', 'textarea', 'select', 'button');
       elements.forEach(el => el.setAttribute('disabled', ''));
       appendElements(elements);
 
@@ -147,7 +147,7 @@ describe('InteractivityChecker', () => {
     it('should return false for a `display: none` element', () => {
       testContainerElement.innerHTML =
           `<input style="display: none;">`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isFocusable(input))
           .toBe(false, 'Expected element with `display: none` to not be visible');
@@ -158,7 +158,7 @@ describe('InteractivityChecker', () => {
         `<div style="display: none;">
            <input>
          </div>`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isFocusable(input))
           .toBe(false, 'Expected element with `display: none` parent to not be visible');
@@ -167,7 +167,7 @@ describe('InteractivityChecker', () => {
     it('should return false for a `visibility: hidden` element', () => {
       testContainerElement.innerHTML =
           `<input style="visibility: hidden;">`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isFocusable(input))
           .toBe(false, 'Expected element with `visibility: hidden` not to be focusable');
@@ -178,7 +178,7 @@ describe('InteractivityChecker', () => {
         `<div style="visibility: hidden;">
            <input>
          </div>`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isFocusable(input))
           .toBe(false, 'Expected element with `visibility: hidden` parent not to be focusable');
@@ -192,7 +192,7 @@ describe('InteractivityChecker', () => {
              <input>
            </div>
          </div>`;
-      let input = testContainerElement.querySelector('input') as HTMLElement;
+      const input = testContainerElement.querySelector('input') as HTMLElement;
 
       expect(checker.isFocusable(input))
           .toBe(true, 'Expected element with `visibility: hidden` ancestor and closer ' +
@@ -200,7 +200,7 @@ describe('InteractivityChecker', () => {
     });
 
     it('should return false for an element with an empty tabindex', () => {
-      let element = document.createElement('div');
+      const element = document.createElement('div');
       element.setAttribute('tabindex', '');
       testContainerElement.appendChild(element);
 
@@ -209,7 +209,7 @@ describe('InteractivityChecker', () => {
     });
 
     it('should return false for an element with a non-numeric tabindex', () => {
-      let element = document.createElement('div');
+      const element = document.createElement('div');
       element.setAttribute('tabindex', 'abba');
       testContainerElement.appendChild(element);
 
@@ -218,7 +218,7 @@ describe('InteractivityChecker', () => {
     });
 
     it('should return true for an element with contenteditable', () => {
-      let element = document.createElement('div');
+      const element = document.createElement('div');
       element.setAttribute('contenteditable', '');
       testContainerElement.appendChild(element);
 
@@ -228,7 +228,7 @@ describe('InteractivityChecker', () => {
 
 
     it('should return false for inert div and span', () => {
-      let elements = createElements('div', 'span');
+      const elements = createElements('div', 'span');
       appendElements(elements);
 
       elements.forEach(el => {
@@ -242,40 +242,53 @@ describe('InteractivityChecker', () => {
 
   describe('isTabbable', () => {
 
-    it('should respect the tabindex for video elements with controls',
+    it('should respect the tabindex for video elements with controls', () => {
       // Do not run for Blink, Firefox and iOS because those treat video elements
       // with controls different and are covered in other tests.
-      runIf(!platform.BLINK && !platform.FIREFOX && !platform.IOS, () => {
-        let video = createFromTemplate('<video controls>', true);
+      if (platform.BLINK || platform.FIREFOX || platform.IOS) {
+        return;
+      }
 
-        expect(checker.isTabbable(video)).toBe(true);
+      const video = createFromTemplate('<video controls>', true);
 
-        video.tabIndex = -1;
+      expect(checker.isTabbable(video)).toBe(true);
 
-        expect(checker.isTabbable(video)).toBe(false);
-      })
-    );
+      video.tabIndex = -1;
 
-    it('should always mark video elements with controls as tabbable (BLINK & FIREFOX)',
+      expect(checker.isTabbable(video)).toBe(false);
+    });
+
+    it('should always mark video elements with controls as tabbable (BLINK & FIREFOX)', () => {
       // Only run this spec for Blink and Firefox, because those always treat video
       // elements with controls as tabbable.
-      runIf(platform.BLINK || platform.FIREFOX, () => {
-        let video = createFromTemplate('<video controls>', true);
+      if (!platform.BLINK && !platform.FIREFOX) {
+        return;
+      }
 
-        expect(checker.isTabbable(video)).toBe(true);
+      const video = createFromTemplate('<video controls>', true);
 
-        video.tabIndex = -1;
+      expect(checker.isTabbable(video)).toBe(true);
 
-        expect(checker.isTabbable(video)).toBe(true);
-      })
-    );
+      video.tabIndex = -1;
+
+      expect(checker.isTabbable(video)).toBe(true);
+    });
 
     // Some tests should not run inside of iOS browsers, because those only allow specific
     // elements to be tabbable and cause the tests to always fail.
-    describe('for non-iOS browsers', runIf(!platform.IOS, () => {
+    describe('for non-iOS browsers', () => {
+      let shouldSkip: boolean;
+
+      beforeEach(() => {
+        shouldSkip = platform.IOS;
+      });
 
       it('should mark form controls and anchors without tabindex attribute as tabbable', () => {
-        let elements = createElements('input', 'textarea', 'select', 'button', 'a');
+        if (shouldSkip) {
+          return;
+        }
+
+        const elements = createElements('input', 'textarea', 'select', 'button', 'a');
         appendElements(elements);
 
         elements.forEach(el => {
@@ -284,7 +297,11 @@ describe('InteractivityChecker', () => {
       });
 
       it('should return true for div and span with tabindex == 0', () => {
-        let elements = createElements('div', 'span');
+        if (shouldSkip) {
+          return;
+        }
+
+        const elements = createElements('div', 'span');
 
         elements.forEach(el => el.setAttribute('tabindex', '0'));
         appendElements(elements);
@@ -296,7 +313,11 @@ describe('InteractivityChecker', () => {
       });
 
       it('should return false for native form controls and anchor with tabindex == -1', () => {
-        let elements = createElements('input', 'textarea', 'select', 'button', 'a');
+        if (shouldSkip) {
+          return;
+        }
+
+        const elements = createElements('input', 'textarea', 'select', 'button', 'a');
 
         elements.forEach(el => el.setAttribute('tabindex', '-1'));
         appendElements(elements);
@@ -308,7 +329,11 @@ describe('InteractivityChecker', () => {
       });
 
       it('should return true for div and span with tabindex == 0', () => {
-        let elements = createElements('div', 'span');
+        if (shouldSkip) {
+          return;
+        }
+
+        const elements = createElements('div', 'span');
 
         elements.forEach(el => el.setAttribute('tabindex', '0'));
         appendElements(elements);
@@ -320,8 +345,12 @@ describe('InteractivityChecker', () => {
       });
 
       it('should respect the inherited tabindex inside of frame elements', () => {
-        let iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
-        let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+        if (shouldSkip) {
+          return;
+        }
+
+        const iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
+        const button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
 
         appendElements([iframe]);
 
@@ -338,6 +367,10 @@ describe('InteractivityChecker', () => {
       });
 
       it('should carefully try to access the frame element of an elements window', () => {
+        if (shouldSkip) {
+          return;
+        }
+
         const iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
         const button = createFromTemplate('<button tabindex="1">Not Tabbable</button>');
 
@@ -357,7 +390,11 @@ describe('InteractivityChecker', () => {
       });
 
       it('should mark elements which are contentEditable as tabbable', () => {
-        let editableEl = createFromTemplate('<div contenteditable="true">', true);
+        if (shouldSkip) {
+          return;
+        }
+
+        const editableEl = createFromTemplate('<div contenteditable="true">', true);
 
         expect(checker.isTabbable(editableEl)).toBe(true);
 
@@ -367,26 +404,39 @@ describe('InteractivityChecker', () => {
       });
 
       it('should never mark iframe elements as tabbable', () => {
-        let iframe = createFromTemplate('<iframe>', true);
+        if (!shouldSkip) {
+          const iframe = createFromTemplate('<iframe>', true);
 
-        // iFrame elements will be never marked as tabbable, because it depends on the content
-        // which is mostly not detectable due to CORS and also the checks will be not reliable.
-        expect(checker.isTabbable(iframe)).toBe(false);
+          // iFrame elements will be never marked as tabbable, because it depends on the content
+          // which is mostly not detectable due to CORS and also the checks will be not reliable.
+          expect(checker.isTabbable(iframe)).toBe(false);
+        }
       });
 
       it('should always mark audio elements without controls as not tabbable', () => {
-        let audio = createFromTemplate('<audio>', true);
+        if (!shouldSkip) {
+          const audio = createFromTemplate('<audio>', true);
 
-        expect(checker.isTabbable(audio)).toBe(false);
+          expect(checker.isTabbable(audio)).toBe(false);
+        }
       });
 
-    }));
+    });
 
-    describe('for Blink and Webkit browsers', runIf(platform.BLINK || platform.WEBKIT, () => {
+    describe('for Blink and Webkit browsers', () => {
+      let shouldSkip: boolean;
+
+      beforeEach(() => {
+        shouldSkip = !platform.BLINK && !platform.WEBKIT;
+      });
 
       it('should not mark elements inside of object frames as tabbable', () => {
-        let objectEl = createFromTemplate('<object>', true) as HTMLObjectElement;
-        let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+        if (shouldSkip) {
+          return;
+        }
+
+        const objectEl = createFromTemplate('<object>', true) as HTMLObjectElement;
+        const button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
 
         appendElements([objectEl]);
 
@@ -399,8 +449,12 @@ describe('InteractivityChecker', () => {
       });
 
       it('should not mark elements inside of invisible frames as tabbable', () => {
-        let iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
-        let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+        if (shouldSkip) {
+          return;
+        }
+
+        const iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
+        const button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
 
         appendElements([iframe]);
 
@@ -412,17 +466,27 @@ describe('InteractivityChecker', () => {
       });
 
       it('should never mark object frame elements as tabbable', () => {
-        let objectEl = createFromTemplate('<object>', true);
-
-        expect(checker.isTabbable(objectEl)).toBe(false);
+        if (!shouldSkip) {
+          const objectEl = createFromTemplate('<object>', true);
+          expect(checker.isTabbable(objectEl)).toBe(false);
+        }
       });
 
-    }));
+    });
 
-    describe('for Blink browsers', runIf(platform.BLINK, () => {
+    describe('for Blink browsers', () => {
+      let shouldSkip: boolean;
+
+      beforeEach(() => {
+        shouldSkip = !platform.BLINK;
+      });
 
       it('should always mark audio elements with controls as tabbable', () => {
-        let audio = createFromTemplate('<audio controls>', true);
+        if (shouldSkip) {
+          return;
+        }
+
+        const audio = createFromTemplate('<audio controls>', true);
 
         expect(checker.isTabbable(audio)).toBe(true);
 
@@ -433,13 +497,22 @@ describe('InteractivityChecker', () => {
         expect(checker.isTabbable(audio)).toBe(true);
       });
 
-    }));
+    });
 
-    describe('for Internet Explorer', runIf(platform.TRIDENT, () => {
+    describe('for Internet Explorer', () => {
+      let shouldSkip: boolean;
+
+      beforeEach(() => {
+        shouldSkip = !platform.TRIDENT;
+      });
 
       it('should never mark video elements without controls as tabbable', () => {
+        if (shouldSkip) {
+          return;
+        }
+
         // In Internet Explorer video elements without controls are never tabbable.
-        let video = createFromTemplate('<video>', true);
+        const video = createFromTemplate('<video>', true);
 
         expect(checker.isTabbable(video)).toBe(false);
 
@@ -449,35 +522,44 @@ describe('InteractivityChecker', () => {
 
       });
 
-    }));
+    });
 
-    describe('for iOS browsers', runIf(platform.IOS && platform.WEBKIT, () => {
+    describe('for iOS browsers', () => {
+      let shouldSkip: boolean;
+
+      beforeEach(() => {
+        shouldSkip = !platform.IOS || !platform.WEBKIT;
+      });
 
       it('should never allow div elements to be tabbable', () => {
-        let divEl = createFromTemplate('<div tabindex="0">', true);
-
-        expect(checker.isTabbable(divEl)).toBe(false);
+        if (!shouldSkip) {
+          const divEl = createFromTemplate('<div tabindex="0">', true);
+          expect(checker.isTabbable(divEl)).toBe(false);
+        }
       });
 
       it('should never allow span elements to be tabbable', () => {
-        let spanEl = createFromTemplate('<span tabindex="0">Text</span>', true);
-
-        expect(checker.isTabbable(spanEl)).toBe(false);
+        if (!shouldSkip) {
+          const spanEl = createFromTemplate('<span tabindex="0">Text</span>', true);
+          expect(checker.isTabbable(spanEl)).toBe(false);
+        }
       });
 
       it('should never allow button elements to be tabbable', () => {
-        let buttonEl = createFromTemplate('<button tabindex="0">', true);
-
-        expect(checker.isTabbable(buttonEl)).toBe(false);
+        if (!shouldSkip) {
+          const buttonEl = createFromTemplate('<button tabindex="0">', true);
+          expect(checker.isTabbable(buttonEl)).toBe(false);
+        }
       });
 
       it('should never allow anchor elements to be tabbable', () => {
-        let anchorEl = createFromTemplate('<a tabindex="0">Link</a>', true);
-
-        expect(checker.isTabbable(anchorEl)).toBe(false);
+        if (!shouldSkip) {
+          const anchorEl = createFromTemplate('<a tabindex="0">Link</a>', true);
+          expect(checker.isTabbable(anchorEl)).toBe(false);
+        }
       });
 
-    }));
+    });
 
 
   });
@@ -488,10 +570,10 @@ describe('InteractivityChecker', () => {
   }
 
   function createFromTemplate(template: string, append = false) {
-    let tmpRoot = document.createElement('div');
+    const tmpRoot = document.createElement('div');
     tmpRoot.innerHTML = template;
 
-    let element = tmpRoot.firstElementChild!;
+    const element = tmpRoot.firstElementChild!;
 
     tmpRoot.removeChild(element);
 
@@ -504,17 +586,9 @@ describe('InteractivityChecker', () => {
 
   /** Appends elements to the testContainerElement. */
   function appendElements(elements: Element[]) {
-    for (let e of elements) {
+    for (const e of elements) {
       testContainerElement.appendChild(e);
     }
-  }
-
-  function runIf(this: any, condition: boolean, runFn: Function): () => void {
-    return (...args: any[]) => {
-      if (condition) {
-        runFn.apply(this, args);
-      }
-    };
   }
 
 });

--- a/src/cdk/platform/platform.ts
+++ b/src/cdk/platform/platform.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, Optional, PLATFORM_ID} from '@angular/core';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
 
 // Whether the current platform supports the V8 Break Iterator. The V8 check
@@ -75,9 +75,6 @@ export class Platform {
   /** Whether the current browser is Safari. */
   SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
 
-  /**
-   * @breaking-change 8.0.0 remove optional decorator
-   */
-  constructor(@Optional() @Inject(PLATFORM_ID) private _platformId?: Object) {}
+  constructor(@Inject(PLATFORM_ID) private _platformId: Object) {}
 }
 

--- a/src/cdk/schematics/ng-update/data/constructor-checks.ts
+++ b/src/cdk/schematics/ng-update/data/constructor-checks.ts
@@ -17,6 +17,12 @@ export type ConstructorChecksUpgradeData = string;
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V10]: [
+    {
+      pr: 'https://github.com/angular/components/pull/19347',
+      changes: ['Platform']
+    }
+  ],
   [TargetVersion.V9]: [{
     pr: 'https://github.com/angular/components/pull/17084',
     changes: ['DropListRef']

--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -60,11 +60,11 @@ describe('MatMdcInput without forms', () => {
   }));
 
   it('should not be treated as empty if type is date', fakeAsync(() => {
-    const platform = new Platform();
+    const fixture = createComponent(MatInputDateTestController);
+    const platform = TestBed.inject(Platform);
+    fixture.detectChanges();
 
     if (!(platform.TRIDENT || (platform.SAFARI && !platform.IOS))) {
-      const fixture = createComponent(MatInputDateTestController);
-      fixture.detectChanges();
       const formField = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
       expect(formField).toBeTruthy();
@@ -74,12 +74,11 @@ describe('MatMdcInput without forms', () => {
 
   // Safari Desktop and IE don't support type="date" and fallback to type="text".
   it('should be treated as empty if type is date in Safari Desktop or IE', fakeAsync(() => {
-    const platform = new Platform();
+    const fixture = createComponent(MatInputDateTestController);
+    const platform = TestBed.inject(Platform);
+    fixture.detectChanges();
 
     if (platform.TRIDENT || (platform.SAFARI && !platform.IOS)) {
-      let fixture = createComponent(MatInputDateTestController);
-      fixture.detectChanges();
-
       const formField = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
       expect(formField).toBeTruthy();

--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -21,14 +21,12 @@ import {
   dispatchMouseEvent,
 } from '@angular/cdk/testing/private';
 import {Component, DebugElement, Type, ViewChild} from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, TestBed, tick, inject} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {MatSlider, MatSliderModule} from './index';
 
 describe('MDC-based MatSlider', () => {
-  const platform = new Platform();
-
   function createComponent<T>(component: Type<T>): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [MatSliderModule, ReactiveFormsModule, FormsModule, BidiModule],
@@ -187,14 +185,14 @@ describe('MDC-based MatSlider', () => {
       expect(sliderNativeElement.classList).not.toContain('mat-slider-active');
     });
 
-    it('should disable tabbing to the slider', () => {
+    it('should disable tabbing to the slider', inject([Platform], (platform: Platform) => {
       expect(sliderNativeElement.hasAttribute('tabindex')).toBe(false);
       // The "tabIndex" property returns an incorrect value in Edge 17.
       // See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4365703/
       if (!platform.EDGE) {
         expect(sliderNativeElement.tabIndex).toBe(-1);
       }
-    });
+    }));
   });
 
   describe('slider with set min and max', () => {

--- a/src/material/checkbox/testing/shared.spec.ts
+++ b/src/material/checkbox/testing/shared.spec.ts
@@ -13,7 +13,7 @@ import {MatCheckboxHarness} from '@angular/material/checkbox/testing/checkbox-ha
  */
 export function runHarnessTests(
     checkboxModule: typeof MatCheckboxModule, checkboxHarness: typeof MatCheckboxHarness) {
-  const platform = new Platform();
+  let platform: Platform;
   let fixture: ComponentFixture<CheckboxHarnessTest>;
   let loader: HarnessLoader;
 
@@ -25,6 +25,7 @@ export function runHarnessTests(
         })
         .compileComponents();
 
+    platform = TestBed.inject(Platform);
     fixture = TestBed.createComponent(CheckboxHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -86,13 +86,12 @@ describe('MatInput without forms', () => {
   }));
 
   it('should not be treated as empty if type is date', fakeAsync(() => {
-    const platform = new Platform();
+    const fixture = createComponent(MatInputDateTestController);
+    const platform = TestBed.inject(Platform);
+    fixture.detectChanges();
 
     if (!(platform.TRIDENT || (platform.SAFARI && !platform.IOS))) {
-      let fixture = createComponent(MatInputDateTestController);
-      fixture.detectChanges();
-
-      let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
+      const el = fixture.debugElement.query(By.css('label'))!.nativeElement;
       expect(el).not.toBeNull();
       expect(el.classList.contains('mat-form-field-empty')).toBe(false);
     }
@@ -100,13 +99,12 @@ describe('MatInput without forms', () => {
 
   // Safari Desktop and IE don't support type="date" and fallback to type="text".
   it('should be treated as empty if type is date in Safari Desktop or IE', fakeAsync(() => {
-    const platform = new Platform();
+    const fixture = createComponent(MatInputDateTestController);
+    const platform = TestBed.inject(Platform);
+    fixture.detectChanges();
 
     if (platform.TRIDENT || (platform.SAFARI && !platform.IOS)) {
-      let fixture = createComponent(MatInputDateTestController);
-      fixture.detectChanges();
-
-      let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
+      const el = fixture.debugElement.query(By.css('label'))!.nativeElement;
       expect(el).not.toBeNull();
       expect(el.classList.contains('mat-form-field-empty')).toBe(true);
     }

--- a/src/material/radio/testing/shared.spec.ts
+++ b/src/material/radio/testing/shared.spec.ts
@@ -11,7 +11,7 @@ import {MatRadioButtonHarness, MatRadioGroupHarness} from './radio-harness';
 export function runHarnessTests(radioModule: typeof MatRadioModule,
                                 radioGroupHarness: typeof MatRadioGroupHarness,
                                 radioButtonHarness: typeof MatRadioButtonHarness) {
-  const platform = new Platform();
+  let platform: Platform;
   let fixture: ComponentFixture<MultipleRadioButtonsHarnessTest>;
   let loader: HarnessLoader;
 
@@ -23,6 +23,7 @@ export function runHarnessTests(radioModule: typeof MatRadioModule,
         })
         .compileComponents();
 
+    platform = TestBed.inject(Platform);
     fixture = TestBed.createComponent(MultipleRadioButtonsHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/material/slide-toggle/testing/shared.spec.ts
+++ b/src/material/slide-toggle/testing/shared.spec.ts
@@ -11,7 +11,7 @@ import {MatSlideToggleHarness} from '@angular/material/slide-toggle/testing/slid
 export function runHarnessTests(
     slideToggleModule: typeof MatSlideToggleModule,
     slideToggleHarness: typeof MatSlideToggleHarness) {
-  const platform = new Platform();
+  let platform: Platform;
   let fixture: ComponentFixture<SlideToggleHarnessTest>;
   let loader: HarnessLoader;
 
@@ -21,6 +21,7 @@ export function runHarnessTests(
       declarations: [SlideToggleHarnessTest],
     }).compileComponents();
 
+    platform = TestBed.inject(Platform);
     fixture = TestBed.createComponent(SlideToggleHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/tools/public_api_guard/cdk/platform.d.ts
+++ b/tools/public_api_guard/cdk/platform.d.ts
@@ -18,8 +18,8 @@ export declare class Platform {
     TRIDENT: boolean;
     WEBKIT: boolean;
     isBrowser: boolean;
-    constructor(_platformId?: Object | undefined);
-    static ɵfac: i0.ɵɵFactoryDef<Platform, [{ optional: true; }]>;
+    constructor(_platformId: Object);
+    static ɵfac: i0.ɵɵFactoryDef<Platform, never>;
     static ɵprov: i0.ɵɵInjectableDef<Platform>;
 }
 


### PR DESCRIPTION
Changes the APIs that were deprecated for v10 in the `cdk/platform` module.

BREAKING CHANGES:
* The `_platformId` parameter in the `Platform` constructor is now required.