### PR TITLE
refactor(youtube-player): change deprecated APIs for version 10

### DIFF
--- a/src/youtube-player/youtube-player.ts
+++ b/src/youtube-player/youtube-player.ts
@@ -21,7 +21,6 @@ import {
   Output,
   ViewChild,
   ViewEncapsulation,
-  Optional,
   Inject,
   PLATFORM_ID,
 } from '@angular/core';
@@ -187,17 +186,8 @@ export class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
   @ViewChild('youtubeContainer')
   youtubeContainer: ElementRef<HTMLElement>;
 
-  constructor(
-    private _ngZone: NgZone,
-    /**
-     * @deprecated `platformId` parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    @Optional() @Inject(PLATFORM_ID) platformId?: Object) {
-
-    // @breaking-change 10.0.0 Remove null check for `platformId`.
-    this._isBrowser =
-        platformId ? isPlatformBrowser(platformId) : typeof window === 'object' && !!window;
+  constructor(private _ngZone: NgZone, @Inject(PLATFORM_ID) platformId: Object) {
+    this._isBrowser = isPlatformBrowser(platformId);
   }
 
   ngOnInit() {

--- a/tools/public_api_guard/youtube-player/youtube-player.d.ts
+++ b/tools/public_api_guard/youtube-player/youtube-player.d.ts
@@ -16,8 +16,7 @@ export declare class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     get width(): number | undefined;
     set width(width: number | undefined);
     youtubeContainer: ElementRef<HTMLElement>;
-    constructor(_ngZone: NgZone,
-    platformId?: Object);
+    constructor(_ngZone: NgZone, platformId: Object);
     createEventsBoundInZone(): YT.Events;
     getAvailablePlaybackRates(): number[];
     getAvailableQualityLevels(): YT.SuggestedVideoQuality[];
@@ -43,7 +42,7 @@ export declare class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     stopVideo(): void;
     unMute(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<YouTubePlayer, "youtube-player", never, { "videoId": "videoId"; "height": "height"; "width": "width"; "startSeconds": "startSeconds"; "endSeconds": "endSeconds"; "suggestedQuality": "suggestedQuality"; "showBeforeIframeApiLoads": "showBeforeIframeApiLoads"; }, { "ready": "ready"; "stateChange": "stateChange"; "error": "error"; "apiChange": "apiChange"; "playbackQualityChange": "playbackQualityChange"; "playbackRateChange": "playbackRateChange"; }, never, never>;
-    static ɵfac: i0.ɵɵFactoryDef<YouTubePlayer, [null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<YouTubePlayer, never>;
 }
 
 export declare class YouTubePlayerModule {


### PR DESCRIPTION
Changes the APIs that were marked as deprecated in the `youtube-player` module.

BREAKING CHANGES:
* The `platformId` parameter of the `YouTubePlayer` constructor is now required.