### PR TITLE
refactor: ensure paths are safely passed around in ng-update

### DIFF
--- a/src/cdk/schematics/ng-update/devkit-migration-rule.ts
+++ b/src/cdk/schematics/ng-update/devkit-migration-rule.ts
@@ -15,6 +15,7 @@ import {join} from 'path';
 import {UpdateProject} from '../update-tool';
 import {MigrationCtor} from '../update-tool/migration';
 import {TargetVersion} from '../update-tool/target-version';
+import {WorkspacePath} from '../update-tool/file-system';
 import {getTargetTsconfigPath, getWorkspaceConfigGracefully} from '../utils/project-tsconfig-paths';
 
 import {DevkitFileSystem} from './devkit-file-system';
@@ -72,7 +73,7 @@ export function createMigrationSchematicRule(
     // Keep track of all project source files which have been checked/migrated. This is
     // necessary because multiple TypeScript projects can contain the same source file and
     // we don't want to check these again, as this would result in duplicated failure messages.
-    const analyzedFiles = new Set<string>();
+    const analyzedFiles = new Set<WorkspacePath>();
     // The CLI uses the working directory as the base directory for the virtual file system tree.
     const workspaceFsPath = process.cwd();
     const fileSystem = new DevkitFileSystem(tree, workspaceFsPath);

--- a/src/cdk/schematics/ng-update/migrations/attribute-selectors.ts
+++ b/src/cdk/schematics/ng-update/migrations/attribute-selectors.ts
@@ -7,6 +7,7 @@
  */
 
 import * as ts from 'typescript';
+import {WorkspacePath} from '../../update-tool/file-system';
 import {ResolvedResource} from '../../update-tool/component-resource-collector';
 import {Migration} from '../../update-tool/migration';
 import {AttributeSelectorUpgradeData} from '../data/attribute-selectors';
@@ -63,11 +64,13 @@ export class AttributeSelectorsMigration extends Migration<UpgradeData> {
     this.data.forEach(selector => {
       findAllSubstringIndices(literalText, selector.replace)
           .map(offset => literal.getStart() + offset)
-          .forEach(start => this._replaceSelector(filePath, start, selector));
+          .forEach(start => this._replaceSelector(
+              this.fileSystem.resolve(filePath), start, selector));
     });
   }
 
-  private _replaceSelector(filePath: string, start: number, data: AttributeSelectorUpgradeData) {
+  private _replaceSelector(filePath: WorkspacePath, start: number,
+                           data: AttributeSelectorUpgradeData) {
     this.fileSystem.edit(filePath)
       .remove(start, data.replace.length)
       .insertRight(start, data.replaceWith);

--- a/src/cdk/schematics/ng-update/migrations/class-names.ts
+++ b/src/cdk/schematics/ng-update/migrations/class-names.ts
@@ -97,8 +97,9 @@ export class ClassNamesMigration extends Migration<UpgradeData> {
   /** Creates a failure and replacement for the specified identifier. */
   private _createFailureWithReplacement(identifier: ts.Identifier) {
     const classData = this.data.find(data => data.replace === identifier.text)!;
+    const filePath = this.fileSystem.resolve(identifier.getSourceFile().fileName);
 
-    this.fileSystem.edit(identifier.getSourceFile().fileName)
+    this.fileSystem.edit(filePath)
       .remove(identifier.getStart(), identifier.getWidth())
       .insertRight(identifier.getStart(), classData.replaceWith);
   }

--- a/src/cdk/schematics/ng-update/migrations/css-selectors.ts
+++ b/src/cdk/schematics/ng-update/migrations/css-selectors.ts
@@ -7,6 +7,7 @@
  */
 
 import * as ts from 'typescript';
+import {WorkspacePath} from '../../update-tool/file-system';
 import {ResolvedResource} from '../../update-tool/component-resource-collector';
 import {Migration} from '../../update-tool/migration';
 import {CssSelectorUpgradeData} from '../data/css-selectors';
@@ -69,11 +70,11 @@ export class CssSelectorsMigration extends Migration<UpgradeData> {
 
       findAllSubstringIndices(textContent, data.replace)
           .map(offset => node.getStart() + offset)
-          .forEach(start => this._replaceSelector(filePath, start, data));
+          .forEach(start => this._replaceSelector(this.fileSystem.resolve(filePath), start, data));
     });
   }
 
-  private _replaceSelector(filePath: string, start: number, data: CssSelectorUpgradeData) {
+  private _replaceSelector(filePath: WorkspacePath, start: number, data: CssSelectorUpgradeData) {
     this.fileSystem.edit(filePath)
       .remove(start, data.replace.length)
       .insertRight(start, data.replaceWith);

--- a/src/cdk/schematics/ng-update/migrations/element-selectors.ts
+++ b/src/cdk/schematics/ng-update/migrations/element-selectors.ts
@@ -8,6 +8,7 @@
 
 import * as ts from 'typescript';
 import {ResolvedResource} from '../../update-tool/component-resource-collector';
+import {WorkspacePath} from '../../update-tool/file-system';
 import {Migration} from '../../update-tool/migration';
 import {ElementSelectorUpgradeData} from '../data/element-selectors';
 import {findAllSubstringIndices} from '../typescript/literal';
@@ -57,11 +58,13 @@ export class ElementSelectorsMigration extends Migration<UpgradeData> {
     this.data.forEach(selector => {
       findAllSubstringIndices(textContent, selector.replace)
           .map(offset => node.getStart() + offset)
-          .forEach(start => this._replaceSelector(filePath, start, selector));
+          .forEach(start => this._replaceSelector(
+              this.fileSystem.resolve(filePath), start, selector));
     });
   }
 
-  private _replaceSelector(filePath: string, start: number, data: ElementSelectorUpgradeData) {
+  private _replaceSelector(filePath: WorkspacePath, start: number,
+                           data: ElementSelectorUpgradeData) {
     this.fileSystem.edit(filePath)
       .remove(start, data.replace.length)
       .insertRight(start, data.replaceWith);

--- a/src/cdk/schematics/ng-update/migrations/input-names.ts
+++ b/src/cdk/schematics/ng-update/migrations/input-names.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {WorkspacePath} from '../../update-tool/file-system';
 import {findInputsOnElementWithAttr, findInputsOnElementWithTag} from '../html-parsing/angular';
 import {ResolvedResource} from '../../update-tool/component-resource-collector';
 import {Migration} from '../../update-tool/migration';
@@ -63,7 +64,8 @@ export class InputNamesMigration extends Migration<UpgradeData> {
     });
   }
 
-  private _replaceInputName(filePath: string, start: number, width: number, newName: string) {
+  private _replaceInputName(filePath: WorkspacePath, start: number, width: number,
+                            newName: string) {
     this.fileSystem.edit(filePath)
       .remove(start, width)
       .insertRight(start, newName);

--- a/src/cdk/schematics/ng-update/migrations/output-names.ts
+++ b/src/cdk/schematics/ng-update/migrations/output-names.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {WorkspacePath} from '../../update-tool/file-system';
 import {ResolvedResource} from '../../update-tool/component-resource-collector';
 import {Migration} from '../../update-tool/migration';
 
@@ -49,7 +50,8 @@ export class OutputNamesMigration extends Migration<UpgradeData> {
     });
   }
 
-  private _replaceOutputName(filePath: string, start: number, width: number, newName: string) {
+  private _replaceOutputName(filePath: WorkspacePath, start: number, width: number,
+                             newName: string) {
     this.fileSystem.edit(filePath)
       .remove(start, width)
       .insertRight(start, newName);

--- a/src/cdk/schematics/ng-update/migrations/property-names.ts
+++ b/src/cdk/schematics/ng-update/migrations/property-names.ts
@@ -39,7 +39,7 @@ export class PropertyNamesMigration extends Migration<UpgradeData> {
       }
 
       if (!data.whitelist || data.whitelist.classes.includes(typeName)) {
-        this.fileSystem.edit(node.getSourceFile().fileName)
+        this.fileSystem.edit(this.fileSystem.resolve(node.getSourceFile().fileName))
           .remove(node.name.getStart(), node.name.getWidth())
           .insertRight(node.name.getStart(), data.replaceWith);
       }

--- a/src/cdk/schematics/ng-update/test-cases/misc/external-resource-resolution.spec.ts
+++ b/src/cdk/schematics/ng-update/test-cases/misc/external-resource-resolution.spec.ts
@@ -1,0 +1,30 @@
+import {resolveBazelPath} from '@angular/cdk/schematics/testing';
+import {MIGRATION_PATH} from '../../../index.spec';
+import {createTestCaseSetup} from '../../../testing';
+
+describe('ng-update external resource resolution', () => {
+
+  it('should properly resolve referenced resources in components', async () => {
+    const {runFixers, writeFile, removeTempDir, appTree} = await createTestCaseSetup(
+      'migration-v6', MIGRATION_PATH,
+      [resolveBazelPath(__dirname, './external-resource-resolution_input.ts')]);
+
+    const testContent = `<div cdk-connected-overlay [origin]="test"></div>`;
+    const expected = `<div cdk-connected-overlay [cdkConnectedOverlayOrigin]="test"></div>`;
+
+    writeFile('/projects/material/test.html', testContent);
+    writeFile('/projects/cdk-testing/src/some-tmpl.html', testContent);
+    writeFile('/projects/cdk-testing/src/test-cases/local.html', testContent);
+
+    await runFixers();
+
+    expect(appTree.readContent('/projects/material/test.html'))
+        .toBe(expected, 'Expected absolute devkit tree paths to work.');
+    expect(appTree.readContent('/projects/cdk-testing/src/some-tmpl.html'))
+        .toBe(expected, 'Expected relative paths with parent segments to work.');
+    expect(appTree.readContent('/projects/cdk-testing/src/test-cases/local.html'))
+        .toBe(expected, 'Expected relative paths without explicit dot to work.');
+
+    removeTempDir();
+  });
+});

--- a/src/cdk/schematics/ng-update/test-cases/misc/external-resource-resolution_input.ts
+++ b/src/cdk/schematics/ng-update/test-cases/misc/external-resource-resolution_input.ts
@@ -1,0 +1,19 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'test-cmp',
+  templateUrl: '/projects/material/test.html',
+})
+export class MyTestComp {}
+
+@Component({
+  selector: 'test-cmp2',
+  templateUrl: '../some-tmpl.html',
+})
+export class MyTestComp2 {}
+
+@Component({
+  selector: 'test-cmp3',
+  templateUrl: 'local.html',
+})
+export class MyTestComp3 {}

--- a/src/cdk/schematics/testing/test-case-setup.ts
+++ b/src/cdk/schematics/testing/test-case-setup.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {getSystemPath, normalize} from '@angular-devkit/core';
+import {getSystemPath, normalize, Path} from '@angular-devkit/core';
 import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
 import * as virtualFs from '@angular-devkit/core/src/virtual-fs/host';
 import {HostTree, Tree} from '@angular-devkit/schematics';
@@ -224,13 +224,13 @@ export function defineJasmineTestCases(versionName: string, collectionFile: stri
  */
 export function _patchTypeScriptDefaultLib(tree: Tree) {
   const _originalRead = tree.read;
-  tree.read = function(filePath: string) {
+  tree.read = function(filePath: Path) {
     // In case a file within the TypeScript package is requested, we read the file from
     // the real file system. This is necessary because within unit tests, the "typeScript"
     // package from within the Bazel "@npm" repository  is used. The virtual tree can't be
     // used because the "@npm" repository directory is not part of the virtual file system.
     if (filePath.match(/node_modules[/\\]typescript/)) {
-      return readFileSync(filePath);
+      return readFileSync(getSystemPath(filePath));
     } else {
       return _originalRead.apply(this, arguments);
     }

--- a/src/cdk/schematics/update-tool/file-system.ts
+++ b/src/cdk/schematics/update-tool/file-system.ts
@@ -9,31 +9,62 @@
 import {UpdateRecorder} from './update-recorder';
 
 /**
+ * A workspace path semantically is equivalent to the `Path` type provided by the
+ * Angular devkit. Paths denoted with such a type are guaranteed to be representing
+ * paths of a given virtual file system. This means that the root of a path can be
+ * different, and does not necessarily need to match the root in the real file system.
+ *
+ * For example: Consider we have a project in `/home/<..>/my-project`. Then a path
+ * like `/package.json` could actually refer to the `package.json` file in `my-project`.
+ * Note that in the real file system this would not match though.
+ *
+ * One wonder why another type has been declared for such paths, when there already
+ * is the `Path` type provided by the devkit. We do this for a couple of reasons:
+ *
+ *   1. The update-tool cannot have a dependency on the Angular devkit as that one
+ *      is not synced into g3. We want to be able to run migrations in g3 if needed.
+ *   2. `WorkspacePath` is stricter than `Path` because it does not intersect with `string`.
+ *      That helps ensuring that workspace paths are not accidentally passed to native
+ *      path manipulation functions (like `path.resolve`). This complicates the use of
+ *      workspace paths, but it's a trade off for more predictable path manipulations.
+ */
+export type WorkspacePath = {
+  // Brand signature matches the devkit paths so that existing path
+  // utilities from the Angular devkit can be conveniently used.
+  __PRIVATE_DEVKIT_PATH: void;
+};
+
+/**
  * Abstraction of the file system that migrations can use to record and apply
  * changes. This is necessary to support virtual file systems as used in the CLI devkit.
  */
-export interface FileSystem {
-  /**
-   * Resolves an absolute path to a unique path in the file system. For example,
-   * the devkit tree considers the workspace as disk root in paths.
-   */
-  resolve(fsFilePath: string): string;
+export abstract class FileSystem<T = WorkspacePath> {
   /** Checks whether a given file exists. */
-  exists(fsFilePath: string): boolean;
+  abstract exists(filePath: T): boolean;
   /** Gets the contents of the given file. */
-  read(fsFilePath: string): string|null;
+  abstract read(filePath: T): string|null;
   /**
    * Creates an update recorder for the given file. Edits can be recorded and
    * committed in batches. Changes are not applied automatically because otherwise
    * migrations would need to re-read files, or account for shifted file contents.
    */
-  edit(fsFilePath: string): UpdateRecorder;
+  abstract edit(filePath: T): UpdateRecorder;
   /** Applies all changes which have been recorded in update recorders. */
-  commitEdits(): void;
+  abstract commitEdits(): void;
   /** Creates a new file with the given content. */
-  create(fsFilePath: string, content: string);
+  abstract create(filePath: T, content: string);
   /** Overwrites an existing file with the given content. */
-  overwrite(fsFilePath: string, content: string);
+  abstract overwrite(filePath: T, content: string);
   /** Deletes the given file. */
-  delete(fsFilePath: string);
+  abstract delete(filePath: T);
+  /**
+   * Resolves given paths to a resolved path in the file system. For example, the devkit
+   * tree considers the actual workspace directory as file system root.
+   *
+   * Follows the same semantics as the native path `resolve` method. i.e. segments
+   * are processed in reverse. The last segment is considered the target and the
+   * function will iterate from the target through other segments until it finds an
+   * absolute path segment.
+   */
+  abstract resolve(...segments: string[]): T;
 }

--- a/src/cdk/schematics/update-tool/migration.ts
+++ b/src/cdk/schematics/update-tool/migration.ts
@@ -8,13 +8,13 @@
 
 import * as ts from 'typescript';
 import {ResolvedResource} from './component-resource-collector';
-import {FileSystem} from './file-system';
+import {FileSystem, WorkspacePath} from './file-system';
 import {UpdateLogger} from './logger';
 import {TargetVersion} from './target-version';
 import {LineAndCharacter} from './utils/line-mappings';
 
 export interface MigrationFailure {
-  filePath: string;
+  filePath: WorkspacePath;
   message: string;
   position?: LineAndCharacter;
 }
@@ -79,7 +79,7 @@ export abstract class Migration<Data, Context = never> {
   protected createFailureAtNode(node: ts.Node, message: string) {
     const sourceFile = node.getSourceFile();
     this.failures.push({
-      filePath: sourceFile.fileName,
+      filePath: this.fileSystem.resolve(sourceFile.fileName),
       position: ts.getLineAndCharacterOfPosition(sourceFile, node.getStart()),
       message: message,
     });

--- a/src/cdk/schematics/utils/project-index-file.ts
+++ b/src/cdk/schematics/utils/project-index-file.ts
@@ -6,16 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Path} from '@angular-devkit/core';
 import {WorkspaceProject} from '@angular-devkit/core/src/experimental/workspace';
 import {BrowserBuilderTarget} from '@schematics/angular/utility/workspace-models';
 import {defaultTargetBuilders, getTargetsByBuilderName} from './project-targets';
 
 /** Gets the path of the index file in the given project. */
-export function getProjectIndexFiles(project: WorkspaceProject): string[] {
+export function getProjectIndexFiles(project: WorkspaceProject): Path[] {
   // Use a set to remove duplicate index files referenced in multiple build targets
   // of a project.
   return [...new Set(
       (getTargetsByBuilderName(project, defaultTargetBuilders.build) as BrowserBuilderTarget[])
           .filter(t => t.options.index)
-          .map(t => t.options.index!))];
+          .map(t => t.options.index! as Path))];
 }

--- a/src/cdk/schematics/utils/project-main-file.ts
+++ b/src/cdk/schematics/utils/project-main-file.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Path} from '@angular-devkit/core';
 import {WorkspaceProject} from '@angular-devkit/core/src/experimental/workspace';
 import {SchematicsException} from '@angular-devkit/schematics';
 import {getProjectTargetOptions} from './project-targets';
 
 /** Looks for the main TypeScript file in the given project and returns its path. */
-export function getProjectMainFile(project: WorkspaceProject): string {
+export function getProjectMainFile(project: WorkspaceProject): Path {
   const buildOptions = getProjectTargetOptions(project, 'build');
 
   if (!buildOptions.main) {

--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/import-manager.ts
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/import-manager.ts
@@ -288,7 +288,7 @@ export class ImportManager {
    */
   recordChanges() {
     this._importCache.forEach((fileImports, sourceFile) => {
-      const recorder = this._fileSystem.edit(sourceFile.fileName);
+      const recorder = this._fileSystem.edit(this._fileSystem.resolve(sourceFile.fileName));
       const lastUnmodifiedImport =
           fileImports.reverse().find(i => i.state === ImportState.UNMODIFIED);
       const importStartIndex =

--- a/src/material/schematics/ng-update/migrations/misc-ripples-v7/ripple-speed-factor-migration.ts
+++ b/src/material/schematics/ng-update/migrations/misc-ripples-v7/ripple-speed-factor-migration.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Migration, ResolvedResource, TargetVersion} from '@angular/cdk/schematics';
+import {Migration, ResolvedResource, TargetVersion, WorkspacePath} from '@angular/cdk/schematics';
 import * as ts from 'typescript';
 import {
   convertSpeedFactorToDuration,
@@ -80,7 +80,7 @@ export class RippleSpeedFactorMigration extends Migration<null> {
 
     const targetTypeName = targetTypeNode.symbol.getName();
     const propertyName = leftExpression.name.getText();
-    const filePath = leftExpression.getSourceFile().fileName;
+    const filePath = this.fileSystem.resolve(leftExpression.getSourceFile().fileName);
 
     if (targetTypeName === 'MatRipple' && propertyName === 'speedFactor') {
       if (ts.isNumericLiteral(expression.right)) {
@@ -137,7 +137,7 @@ export class RippleSpeedFactorMigration extends Migration<null> {
     // config from a separate file).
 
     const {initializer, name} = assignment;
-    const filePath = assignment.getSourceFile().fileName;
+    const filePath = this.fileSystem.resolve(assignment.getSourceFile().fileName);
 
     if (ts.isNumericLiteral(initializer)) {
       const numericValue = parseFloat(initializer.text);
@@ -165,7 +165,7 @@ export class RippleSpeedFactorMigration extends Migration<null> {
     }
   }
 
-  private _replaceText(filePath: string, start: number, width: number, newText: string) {
+  private _replaceText(filePath: WorkspacePath, start: number, width: number, newText: string) {
     const recorder = this.fileSystem.edit(filePath);
     recorder.remove(start, width);
     recorder.insertRight(start, newText);

--- a/src/material/schematics/ng-update/migrations/package-imports-v8/secondary-entry-points-migration.ts
+++ b/src/material/schematics/ng-update/migrations/package-imports-v8/secondary-entry-points-migration.ts
@@ -131,7 +131,9 @@ export class SecondaryEntryPointsMigration extends Migration<null> {
       return;
     }
 
-    const recorder = this.fileSystem.edit(declaration.moduleSpecifier.getSourceFile().fileName);
+    const filePath = this.fileSystem.resolve(
+        declaration.moduleSpecifier.getSourceFile().fileName);
+    const recorder = this.fileSystem.edit(filePath);
 
     // Perform the replacement that switches the primary entry-point import to
     // the individual secondary entry-point imports.


### PR DESCRIPTION
Schematics using the TypeScript compiler API have a significant issue
with paths. The problem is that the TypeScript compiler API intends to
rely fully on absolute paths, while ng-update and the devkit tree intend
to rely on project-scoped/relative paths.

This is problematic as it is straightforward to mix paths up, leading to
unexpected errors. For example, computing a relative path between a devkit
path and an absolute disk path results in a non-existent path.

To fix this ambiguity, we improve type safety of paths by using branded
primitives such as the `@angular-devkit/core` `Path` or an even more
strict type called `WorkspacePath`. A normal string is considered an
unresolved path and cannot be assigned to a `WorkspacePath`. Similarly a
`WorkspacePath` cannot be assigned to a `string`. This ensures that
resolved paths are not accidentally mixed with unresolved paths, and
that we can safely pass around unresolved and resolved paths without
loss of their semantics.

This fixes a case (and potentially more) where a devkit path and an absolute disk
path result in an incorrectly resolved resource. In CLI apps it's possible to reference
resources through absolute project-scoped paths. e.g. `/src/app/app.component.html`. This has been fixed, and tests have been added (this might be the fix for #19354)

**Note**: Long-term it would be ideal to implement a TypeScript compiler host that only deals with resolved workspace paths, but this is not possible yet as implementing TypeScript's `readDirectory` host method with a virtual tree is complex (and TS doesn't expose its helpers here).