### PR TITLE
fix(dialog): focus recapturing not accounting for autoFocus option

### DIFF
--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -151,9 +151,9 @@ export class MatDialogContainer extends BasePortalOutlet {
   /** Moves focus back into the dialog if it was moved out. */
   _recaptureFocus() {
     if (!this._containsFocus()) {
-      const focusWasTrapped = this._focusTrap.focusInitialElement();
+      const focusContainer = !this._config.autoFocus || !this._focusTrap.focusInitialElement();
 
-      if (!focusWasTrapped) {
+      if (focusContainer) {
         this._elementRef.nativeElement.focus();
       }
     }

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -983,6 +983,33 @@ describe('MatDialog', () => {
       expect(document.activeElement).toBe(input, 'Expected input to stay focused after click');
     }));
 
+    it('should recapture focus to the container when clicking on the backdrop with ' +
+      'autoFocus disabled', fakeAsync(() => {
+        dialog.open(PizzaMsg, {
+          disableClose: true,
+          viewContainerRef: testViewContainerRef,
+          autoFocus: false
+        });
+
+        viewContainerFixture.detectChanges();
+        flushMicrotasks();
+
+        let backdrop =
+          overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+        let container =
+          overlayContainerElement.querySelector('.mat-dialog-container') as HTMLInputElement;
+
+        expect(document.activeElement).toBe(container, 'Expected container to be focused on open');
+
+        container.blur(); // Programmatic clicks might not move focus so we simulate it.
+        backdrop.click();
+        viewContainerFixture.detectChanges();
+        flush();
+
+        expect(document.activeElement)
+            .toBe(container, 'Expected container to stay focused after click');
+      }));
+
   });
 
   describe('hasBackdrop option', () => {


### PR DESCRIPTION
In #18826 we added some logic to recapture focus if the user clicks on a disabled backdrop. The problem is that we didn't account for the `autoFocus` config option.

Fixes #19350.