### PR TITLE
refactor(clipboard): remove deprecated APIs for version 10

### DIFF
--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -56,14 +56,6 @@ export class CdkCopyToClipboard implements OnDestroy {
    */
   @Output('cdkCopyToClipboardCopied') copied = new EventEmitter<boolean>();
 
-  /**
-   * Emits when some text is copied to the clipboard. The
-   * emitted value indicates whether copying was successful.
-   * @deprecated Use `cdkCopyToClipboardCopied` instead.
-   * @breaking-change 10.0.0
-   */
-  @Output('copied') _deprecatedCopied = this.copied;
-
   /** Copies that are currently being attempted. */
   private _pending = new Set<PendingCopy>();
 
@@ -75,11 +67,7 @@ export class CdkCopyToClipboard implements OnDestroy {
 
   constructor(
     private _clipboard: Clipboard,
-    /**
-     * @deprecated _ngZone parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    private _ngZone?: NgZone,
+    private _ngZone: NgZone,
     @Optional() @Inject(CKD_COPY_TO_CLIPBOARD_CONFIG) config?: CdkCopyToClipboardConfig) {
 
     if (config && config.attempts != null) {
@@ -97,13 +85,8 @@ export class CdkCopyToClipboard implements OnDestroy {
       const attempt = () => {
         const successful = pending.copy();
         if (!successful && --remainingAttempts && !this._destroyed) {
-          // @breaking-change 10.0.0 Remove null check for `_ngZone`.
-          if (this._ngZone) {
-            this._currentTimeout = this._ngZone.runOutsideAngular(() => setTimeout(attempt, 1));
-          } else {
-            // We use 1 for the timeout since it's more predictable when flushing in unit tests.
-            this._currentTimeout = setTimeout(attempt, 1);
-          }
+          // We use 1 for the timeout since it's more predictable when flushing in unit tests.
+          this._currentTimeout = this._ngZone.runOutsideAngular(() => setTimeout(attempt, 1));
         } else {
           this._currentTimeout = null;
           this._pending.delete(pending);

--- a/src/cdk/schematics/ng-update/data/output-names.ts
+++ b/src/cdk/schematics/ng-update/data/output-names.ts
@@ -24,5 +24,17 @@ export interface OutputNameUpgradeData {
 }
 
 export const outputNames: VersionChanges<OutputNameUpgradeData> = {
+  [TargetVersion.V10]: [
+    {
+      pr: 'https://github.com/angular/components/pull/19362',
+      changes: [{
+        replace: 'copied',
+        replaceWith: 'cdkCopyToClipboardCopied',
+        whitelist: {
+          attributes: ['cdkCopyToClipboard']
+        }
+      }]
+    }
+  ],
   [TargetVersion.V6]: [],
 };

--- a/tools/public_api_guard/cdk/clipboard.d.ts
+++ b/tools/public_api_guard/cdk/clipboard.d.ts
@@ -1,13 +1,11 @@
 export declare class CdkCopyToClipboard implements OnDestroy {
-    _deprecatedCopied: EventEmitter<boolean>;
     attempts: number;
     copied: EventEmitter<boolean>;
     text: string;
-    constructor(_clipboard: Clipboard,
-    _ngZone?: NgZone | undefined, config?: CdkCopyToClipboardConfig);
+    constructor(_clipboard: Clipboard, _ngZone: NgZone, config?: CdkCopyToClipboardConfig);
     copy(attempts?: number): void;
     ngOnDestroy(): void;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkCopyToClipboard, "[cdkCopyToClipboard]", never, { "text": "cdkCopyToClipboard"; "attempts": "cdkCopyToClipboardAttempts"; }, { "copied": "cdkCopyToClipboardCopied"; "_deprecatedCopied": "copied"; }, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkCopyToClipboard, "[cdkCopyToClipboard]", never, { "text": "cdkCopyToClipboard"; "attempts": "cdkCopyToClipboardAttempts"; }, { "copied": "cdkCopyToClipboardCopied"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkCopyToClipboard, [null, null, { optional: true; }]>;
 }
 


### PR DESCRIPTION
Changes the APIs that have been marked as deprecated for v10.

BREAKING CHANGES:
* The `copied` event from `cdkCopyToClipboard` has been renamed to `cdkCopyToClipboardCopied`.
* The `_ngZone` parameter in the `CdkCopyToClipboard` constructor is now required.