### PR TITLE
refactor(sort): change deprecated APIs for version 10

### DIFF
--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -22,6 +22,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/19379',
       changes: ['MatSlider']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/19372',
+      changes: ['MatSortHeader']
     }
   ],
   [TargetVersion.V9]: [

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -142,12 +142,8 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
               @Optional() public _sort: MatSort,
               @Inject('MAT_SORT_HEADER_COLUMN_DEF') @Optional()
                   public _columnDef: MatSortHeaderColumnDef,
-              /**
-               * @deprecated _focusMonitor and _elementRef to become required parameters.
-               * @breaking-change 10.0.0
-               */
-              private _focusMonitor?: FocusMonitor,
-              private _elementRef?: ElementRef<HTMLElement>) {
+              private _focusMonitor: FocusMonitor,
+              private _elementRef: ElementRef<HTMLElement>) {
     // Note that we use a string token for the `_columnDef`, because the value is provided both by
     // `material/table` and `cdk/table` and we can't have the CDK depending on Material,
     // and we want to avoid having the sort header depending on the CDK table because
@@ -173,12 +169,10 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
           changeDetectorRef.markForCheck();
         });
 
-    if (_focusMonitor && _elementRef) {
-      // We use the focus monitor because we also want to style
-      // things differently based on the focus origin.
-      _focusMonitor.monitor(_elementRef, true)
-          .subscribe(origin => this._setIndicatorHintVisible(!!origin));
-    }
+    // We use the focus monitor because we also want to style
+    // things differently based on the focus origin.
+    _focusMonitor.monitor(_elementRef, true)
+        .subscribe(origin => this._setIndicatorHintVisible(!!origin));
   }
 
   ngOnInit() {
@@ -195,11 +189,7 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
   }
 
   ngOnDestroy() {
-    // @breaking-change 10.0.0 Remove null check for _focusMonitor and _elementRef.
-    if (this._focusMonitor && this._elementRef) {
-      this._focusMonitor.stopMonitoring(this._elementRef);
-    }
-
+    this._focusMonitor.stopMonitoring(this._elementRef);
     this._sort.deregister(this);
     this._rerenderSubscription.unsubscribe();
   }

--- a/tools/public_api_guard/material/sort.d.ts
+++ b/tools/public_api_guard/material/sort.d.ts
@@ -64,8 +64,7 @@ export declare class MatSortHeader extends _MatSortHeaderMixinBase implements Ca
     set disableClear(v: boolean);
     id: string;
     start: 'asc' | 'desc';
-    constructor(_intl: MatSortHeaderIntl, changeDetectorRef: ChangeDetectorRef, _sort: MatSort, _columnDef: MatSortHeaderColumnDef,
-    _focusMonitor?: FocusMonitor | undefined, _elementRef?: ElementRef<HTMLElement> | undefined);
+    constructor(_intl: MatSortHeaderIntl, changeDetectorRef: ChangeDetectorRef, _sort: MatSort, _columnDef: MatSortHeaderColumnDef, _focusMonitor: FocusMonitor, _elementRef: ElementRef<HTMLElement>);
     _getAriaSortAttribute(): "ascending" | "descending" | null;
     _getArrowDirectionState(): string;
     _getArrowViewState(): string;


### PR DESCRIPTION
Cleans up the APIs that were marked as deprecated for v10.

BREAKING CHANGES:
* The `_focusMonitor` and `_elementRef` parameters in the `MatSortHeader` constructor are now required.