### PR TITLE
docs(material/tab-group): lacks documentation for mat-stretch-tabs

### DIFF
--- a/.vscode/.editorconfig
+++ b/.vscode/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/components-examples/material/tabs/tab-group-stretched/tab-group-stretched-example.html
+++ b/src/components-examples/material/tabs/tab-group-stretched/tab-group-stretched-example.html
@@ -1,4 +1,4 @@
-<mat-tab-group mat-stretch-tabs class="example-stretched-tabs mat-elevation-z4">
+<mat-tab-group [stretchTabs]="true" class="example-stretched-tabs mat-elevation-z4">
   <mat-tab label="First"> Content 1 </mat-tab>
   <mat-tab label="Second"> Content 2 </mat-tab>
   <mat-tab label="Third"> Content 3 </mat-tab>

--- a/src/dev-app/mdc-tabs/mdc-tabs-demo.html
+++ b/src/dev-app/mdc-tabs/mdc-tabs-demo.html
@@ -26,8 +26,8 @@
     <mat-tab label="Fourth" disabled>Content 4</mat-tab>
   </mat-tab-group>
 
-  <h2>Stretched tabs</h2>
-  <mat-tab-group mat-stretch-tabs>
+  <h2>Stretched tabs ( 'mat-stretch-tabs' is deprecated, use stretchTabs property )</h2>
+  <mat-tab-group [stretchTabs]="true">
     <mat-tab label="First">Content 1</mat-tab>
     <mat-tab label="Second">Content 2</mat-tab>
     <mat-tab label="Third">Content 3</mat-tab>

--- a/src/material-experimental/mdc-tabs/tab-group.scss
+++ b/src/material-experimental/mdc-tabs/tab-group.scss
@@ -13,7 +13,8 @@
 
   // Note that we only want to target direct descendant tabs. Also note that
   // `mat-stretch-tabs` is part of the public API so it should not be changed to `mat-mdc-`.
-  .mat-mdc-tab-group[mat-stretch-tabs] > .mat-mdc-tab-header & {
+  .mat-mdc-tab-group[mat-stretch-tabs] > .mat-mdc-tab-header &
+  ,.mat-mdc-tab-group.mat-stretch-tabs > .mat-mdc-tab-header & {
     flex-grow: 1;
   }
 }

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-link.scss
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-link.scss
@@ -24,7 +24,8 @@
 
   // Note that we only want to target direct descendant tabs. Also note that
   // `mat-stretch-tabs` is part of the public API so it should not be changed to `mat-mdc-`.
-  .mat-mdc-tab-header[mat-stretch-tabs] & {
+  .mat-mdc-tab-header[mat-stretch-tabs] &
+  ,.mat-mdc-tab-header.mat-stretch-tabs & {
     flex-grow: 1;
   }
 }

--- a/src/material/tabs/tab-group.scss
+++ b/src/material/tabs/tab-group.scss
@@ -31,7 +31,8 @@
 }
 
 // Note that we only want to target direct descendant tabs.
-.mat-tab-group[mat-stretch-tabs] > .mat-tab-header .mat-tab-label {
+.mat-tab-group[mat-stretch-tabs] > .mat-tab-header .mat-tab-label
+,.mat-tab-group.mat-stretch-tabs > .mat-tab-header .mat-tab-label {
   flex-basis: 0;
   flex-grow: 1;
 }

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -973,7 +973,7 @@ class TabGroupWithIndirectDescendantTabs {
 
 @Component({
   template: `
-    <mat-tab-group [stretchTab]="stretchTab">
+    <mat-tab-group [stretchTabs]="stretchTab">
         <mat-tab label="One">Tab one content</mat-tab>
         <mat-tab label="Two">Tab two content</mat-tab>
     </mat-tab-group>

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -24,6 +24,7 @@ describe('MatTabGroup', () => {
         TabGroupWithAriaInputs,
         TabGroupWithIsActiveBinding,
         NestedTabs,
+        StretchedTabGroup,
         TabGroupWithIndirectDescendantTabs,
       ],
     });
@@ -636,6 +637,29 @@ describe('MatTabGroup', () => {
     }));
   });
 
+  describe('stretch tabs', () => {
+    let fixture: ComponentFixture<StretchedTabGroup>;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(StretchedTabGroup);
+      fixture.detectChanges();
+      element = fixture.debugElement.query(By.css('mat-tab-group')).nativeElement;
+    });
+
+    it('should add mat-stretch-tabs class when stretchTab is true', (() => {
+      fixture.componentInstance.stretchTab = true;
+      fixture.detectChanges();
+      expect(element.classList.contains('.mat-stretch-tabs')).toBe(false);
+    }));
+
+    it('should remove mat-stretch-tabs class when stretchTab is not true', fakeAsync(() => {
+      fixture.componentInstance.stretchTab = false;
+      fixture.detectChanges();
+      expect(element.classList.contains('.mat-stretch-tabs')).toBe(false);
+    }));
+  });
+
   /**
    * Checks that the `selectedIndex` has been updated; checks that the label and body have their
    * respective `active` classes
@@ -944,4 +968,20 @@ class TabsWithCustomAnimationDuration {}
 })
 class TabGroupWithIndirectDescendantTabs {
   @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
+}
+
+
+@Component({
+  template: `
+    <mat-tab-group [stretchTab]="stretchTab">
+        <mat-tab label="One">Tab one content</mat-tab>
+        <mat-tab label="Two">Tab two content</mat-tab>
+    </mat-tab-group>
+  `,
+})
+class StretchedTabGroup {
+
+  @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
+
+  stretchTab = true;
 }

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -650,7 +650,7 @@ describe('MatTabGroup', () => {
     it('should add mat-stretch-tabs class when stretchTab is true', (() => {
       fixture.componentInstance.stretchTab = true;
       fixture.detectChanges();
-      expect(element.classList.contains('.mat-stretch-tabs')).toBe(false);
+      expect(element.classList.contains('.mat-stretch-tabs')).toBe(true);
     }));
 
     it('should remove mat-stretch-tabs class when stretchTab is not true', fakeAsync(() => {

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -650,13 +650,13 @@ describe('MatTabGroup', () => {
     it('should add mat-stretch-tabs class when stretchTab is true', (() => {
       fixture.componentInstance.stretchTab = true;
       fixture.detectChanges();
-      expect(element.classList.contains('.mat-stretch-tabs')).toBe(true);
+      expect(element.classList.contains('mat-stretch-tabs')).toBe(true);
     }));
 
     it('should remove mat-stretch-tabs class when stretchTab is not true', fakeAsync(() => {
       fixture.componentInstance.stretchTab = false;
       fixture.detectChanges();
-      expect(element.classList.contains('.mat-stretch-tabs')).toBe(false);
+      expect(element.classList.contains('mat-stretch-tabs')).toBe(false);
     }));
   });
 

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -30,6 +30,7 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  HostBinding,
 } from '@angular/core';
 import {
   CanColor,
@@ -105,6 +106,13 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
 
   /** Subscription to changes in the tab labels. */
   private _tabLabelSubscription = Subscription.EMPTY;
+
+   /** Whether the tab group should grow to the size of the active tab. */
+   @Input()
+   @HostBinding('class.mat-stretch-tabs')
+   get stretchTabs(): boolean { return this._stretchTabs; }
+   set stretchTabs(value: boolean) { this._stretchTabs = coerceBooleanProperty(value); }
+   private _stretchTabs: boolean = false;
 
   /** Whether the tab group should grow to the size of the active tab. */
   @Input()

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -388,6 +388,8 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
   static ngAcceptInputType_animationDuration: NumberInput;
   static ngAcceptInputType_selectedIndex: NumberInput;
   static ngAcceptInputType_disableRipple: BooleanInput;
+  static ngAcceptInputType_stretchTabs: BooleanInput;
+
 }
 
 /**

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.scss
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.scss
@@ -24,7 +24,8 @@
   overflow: hidden;  // Keeps the ripple from extending outside the element bounds
   -webkit-tap-highlight-color: transparent;
 
-  [mat-stretch-tabs] & {
+  [mat-stretch-tabs] & ,
+  .mat-stretch-tabs & {
     flex-basis: 0;
     flex-grow: 1;
   }

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -50,6 +50,8 @@ export declare abstract class _MatTabGroupBase extends _MatTabGroupMixinBase imp
     set selectedIndex(value: number | null);
     readonly selectedIndexChange: EventEmitter<number>;
     readonly selectedTabChange: EventEmitter<MatTabChangeEvent>;
+    get stretchTabs(): boolean;
+    set stretchTabs(value: boolean);
     constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, defaultConfig?: MatTabsConfig, _animationMode?: string | undefined);
     _focusChanged(index: number): void;
     _getTabContentId(i: number): string;
@@ -66,7 +68,7 @@ export declare abstract class _MatTabGroupBase extends _MatTabGroupMixinBase imp
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_dynamicHeight: BooleanInput;
     static ngAcceptInputType_selectedIndex: NumberInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabGroupBase, never, never, { "dynamicHeight": "dynamicHeight"; "selectedIndex": "selectedIndex"; "headerPosition": "headerPosition"; "animationDuration": "animationDuration"; "disablePagination": "disablePagination"; "backgroundColor": "backgroundColor"; }, { "selectedIndexChange": "selectedIndexChange"; "focusChange": "focusChange"; "animationDone": "animationDone"; "selectedTabChange": "selectedTabChange"; }, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabGroupBase, never, never, { "stretchTabs": "stretchTabs"; "dynamicHeight": "dynamicHeight"; "selectedIndex": "selectedIndex"; "headerPosition": "headerPosition"; "animationDuration": "animationDuration"; "disablePagination": "disablePagination"; "backgroundColor": "backgroundColor"; }, { "selectedIndexChange": "selectedIndexChange"; "focusChange": "focusChange"; "animationDone": "animationDone"; "selectedTabChange": "selectedTabChange"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabGroupBase, [null, null, { optional: true; }, { optional: true; }]>;
 }
 

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -68,6 +68,7 @@ export declare abstract class _MatTabGroupBase extends _MatTabGroupMixinBase imp
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_dynamicHeight: BooleanInput;
     static ngAcceptInputType_selectedIndex: NumberInput;
+    static ngAcceptInputType_stretchTabs: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabGroupBase, never, never, { "stretchTabs": "stretchTabs"; "dynamicHeight": "dynamicHeight"; "selectedIndex": "selectedIndex"; "headerPosition": "headerPosition"; "animationDuration": "animationDuration"; "disablePagination": "disablePagination"; "backgroundColor": "backgroundColor"; }, { "selectedIndexChange": "selectedIndexChange"; "focusChange": "focusChange"; "animationDone": "animationDone"; "selectedTabChange": "selectedTabChange"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabGroupBase, [null, null, { optional: true; }, { optional: true; }]>;
 }


### PR DESCRIPTION
adds input property to tab-group, so mat-stretch-tabs is exposed to public API

Fixes #19263