### PR TITLE
fix(drag-drop): error during device emulation on firefox

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1187,6 +1187,27 @@ describe('CdkDrag', () => {
       expect(drag.rootElementSelector).toBe('.root');
     }));
 
+    it('should not throw if touches and changedTouches are empty', fakeAsync(() => {
+      const fixture = createComponent(StandaloneDraggable);
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+      startDraggingViaTouch(fixture, dragElement);
+      continueDraggingViaTouch(fixture, 50, 100);
+
+      const event = createTouchEvent('touchend', 50, 100);
+      Object.defineProperties(event, {
+        touches: {get: () => []},
+        changedTouches: {get: () => []}
+      });
+
+      expect(() => {
+        dispatchEvent(document, event);
+        fixture.detectChanges();
+        tick();
+      }).not.toThrow();
+    }));
+
   });
 
   describe('draggable with a handle', () => {

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -1034,9 +1034,16 @@ export class DragRef<T = any> {
 
   /** Determines the point of the page that was touched by the user. */
   private _getPointerPositionOnPage(event: MouseEvent | TouchEvent): Point {
-    // `touches` will be empty for start/end events so we have to fall back to `changedTouches`.
-    const point = isTouchEvent(event) ? (event.touches[0] || event.changedTouches[0]) : event;
     const scrollPosition = this._getViewportScrollPosition();
+    const point = isTouchEvent(event) ?
+        // `touches` will be empty for start/end events so we have to fall back to `changedTouches`.
+        // Also note that on real devices we're guaranteed for either `touches` or `changedTouches`
+        // to have a value, but Firefox in device emulation mode has a bug where both can be empty
+        // for `touchstart` and `touchend` so we fall back to a dummy object in order to avoid
+        // throwing an error. The value returned here will be incorrect, but since this only
+        // breaks inside a developer tool and the value is only used for secondary information,
+        // we can get away with it. See https://bugzilla.mozilla.org/show_bug.cgi?id=1615824.
+        (event.touches[0] || event.changedTouches[0] || {pageX: 0, pageY: 0}) : event;
 
     return {
       x: point.pageX - scrollPosition.left,


### PR DESCRIPTION
The events that Firefox emits when it emulates a mobile device in the dev tools are incomplete which causes an error to be thrown at the end of a drag seequence. These changes add a bit of extra logic so everything doesn't break down.

Fixes #19385.