### PR TITLE
build: remove devmode tsickle decorator processing workaround

### DIFF
--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -35,12 +35,6 @@
     // Note: We can remove this once we fully switched away from Gulp. Currently we still set
     // some options here just in favor of the standard tsconfig's which extending this one.
     "suppressTsconfigOverrideWarnings": true,
-
-    // Enable tsickle so that decorators are processed by tsickle. This is necessary because
-    // we don't want to ship JavaScript files that contain references to DOM elements. This
-    // breaks server-side rendering for non-CLI projects: see: angular#30586.
-    "tsickle": true,
-
     // See https://github.com/angular/angular/issues/29107
     "devmodeTargetOverride": "es5"
   }

--- a/src/bazel-tsconfig-test.json
+++ b/src/bazel-tsconfig-test.json
@@ -9,11 +9,6 @@
   },
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true,
-
-    // Disable tsickle. Tsickle is only needed for building library code that will be
-    // shipped through npm packages. This should speed up compilation for tests.
-    "tsickle": false,
-
     // See https://github.com/angular/angular/issues/29107
     "devmodeTargetOverride": "es5"
   }

--- a/src/universal-app/prerender.ts
+++ b/src/universal-app/prerender.ts
@@ -1,6 +1,15 @@
 import 'reflect-metadata';
 import 'zone.js';
 
+// We need to mock a few native DOM globals as those are not present on the server, but they
+// are required for decorator metadata. The View Engine compiler preserves Angular decorator
+// metadata in the JS output. This could mean for example that inputs which are typed to
+// `HTMLElement` break on the server, as the `__decorate` call requires the `HTMLElement`
+// global to be present. More details: https://github.com/angular/angular/issues/30586.
+(global as any).HTMLElement = {};
+(global as any).Event = {};
+(global as any).TransitionEvent = {};
+
 import {renderModuleFactory} from '@angular/platform-server';
 import {readFileSync, writeFileSync} from 'fs';
 import {join} from 'path';

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,24 +1,9 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "system-config-tmpl.js",
     "system-rxjs-operators.js",
 ])
-
-# Custom "tsc_wrapped" binary that has "tsickle" available as runtime dependency.
-# This is needed as the default compiler for a "ts_library" does not have a dependency
-# on "tsickle" by default.
-nodejs_binary(
-    name = "tsc_wrapped_with_tsickle",
-    data = [
-        "@npm//@bazel/typescript",
-        "@npm//tsickle",
-    ],
-    entry_point = "@npm//:node_modules/@bazel/typescript/internal/tsc_wrapped/tsc_wrapped.js",
-    install_source_map_support = False,
-)
 
 # Workaround for https://github.com/bazelbuild/bazel-toolchains/issues/356. We need the
 # "SYS_ADMIN" capability in order to run browsers with sandbox enabled.

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -41,10 +41,6 @@ def ts_library(tsconfig = None, deps = [], testonly = False, **kwargs):
     _ts_library(
         tsconfig = tsconfig,
         testonly = testonly,
-        # The default "ts_library" compiler does not come with "tsickle" available. Since
-        # we have targets that use "tsickle" decorator processing, we need to ensure that
-        # the compiler could load "tsickle" if needed.
-        compiler = "//tools:tsc_wrapped_with_tsickle",
         deps = local_deps,
         **kwargs
     )

--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -29,20 +29,6 @@ shelljs.cd(projectDir);
 // Workaround for https://github.com/angular/angular/issues/18810.
 shelljs.exec('ngc -p angular-tsconfig.json');
 
-// Workaround for https://github.com/angular/angular/issues/30586. It's not possible to
-// enable tsickle decorator processing without enabling import rewriting to closure.
-// This replacement allows us to enable decorator processing without rewriting imports.
-searchAndReplace(
-    /(this\.transformTypesToClosure) = bazelOpts\.tsickle;/, '$1 = false;',
-    'node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js');
-
-// Workaround for https://github.com/angular/angular/issues/32389. We need to ensure
-// that tsickle is available for esm5 output re-compilations.
-searchAndReplace(
-    '@npm//@bazel/typescript/bin:tsc_wrapped',
-    '@angular_material//tools:tsc_wrapped_with_tsickle',
-    'node_modules/@angular/bazel/src/esm5.bzl');
-
 // Workaround for: https://github.com/angular/angular/issues/32651. We just do not
 // generate re-exports for secondary entry-points. Similar to what "ng-packagr" does.
 searchAndReplace(


### PR DESCRIPTION
In the past, we added a workaround for https://github.com/angular/angular/issues/30586,
so that tsickle actually runs on the devmode output. We can remove this since there
is a more simpler workaround until View Engine is completely gone. Ivy is supposed
to fix this unless the output format is modified to preserve TS decorator calls.

If that would be the case (it's not at time of writing), then we can
still use the global mocking (which is not that unreasonable), or wire
up build optimizer (which would be quite complicated in Bazel).

This is a preparation change for https://github.com/angular/angular/pull/37221, but generally is useful as it simplifies the workaround.