### PR TITLE
docs(stepper): error state example not set up correctly

### DIFF
--- a/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
+++ b/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
@@ -1,4 +1,4 @@
-<mat-horizontal-stepper linear #stepper>
+<mat-horizontal-stepper #stepper>
   <mat-step [stepControl]="firstFormGroup" errorMessage="Name is required.">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
@@ -7,6 +7,7 @@
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
       <div>
+        <p>Go to a different step to see the error state</p>
         <button mat-button matStepperNext>Next</button>
       </div>
     </form>
@@ -20,6 +21,7 @@
                required>
       </mat-form-field>
       <div>
+        <p>Go to a different step to see the error state</p>
         <button mat-button matStepperPrevious>Back</button>
         <button mat-button matStepperNext>Next</button>
       </div>

--- a/src/material/stepper/stepper.md
+++ b/src/material/stepper/stepper.md
@@ -215,8 +215,11 @@ the global default stepper options which can be specified by providing a value f
 
 ### Error State
 
-The stepper can now show error states by simply providing the `showError` option to the
-`STEPPER_GLOBAL_OPTIONS` in your application's root module as mentioned above.
+If you want to show an error when the user moved past a step that hasn't been filled out correctly,
+you can set the error message through the `errorMessage` input and configure the stepper to show
+errors via the `showError` option in the `STEPPER_GLOBAL_OPTIONS` injection token. Note that since
+`linear` steppers prevent a user from advancing past an invalid step to begin with, this setting
+will not affect steppers marked as `linear`.
 
 ```ts
 @NgModule({


### PR DESCRIPTION
The `stepper-errors` example was set up using a linear stepper which doesn't allow users to move to a different step if the current one is invalid which means that the user doesn't have a way of seeing the error state.

These changes make the stepper non-linear, expand the example description to explain how the error state works, and add some text so users know what to do in order to see the error state.

Fixes #19407.