### PR TITLE
fix(markdown-to-html): use regex to match new API

### DIFF
--- a/tools/markdown-to-html/docs-marked-renderer.spec.ts
+++ b/tools/markdown-to-html/docs-marked-renderer.spec.ts
@@ -49,11 +49,9 @@ describe('DocsMarkdownRenderer', () => {
          {
           "example": "exampleName",
           "file": "example-html.html",
-          "region": "some-region",
+          "region": "some-region"
          }
         ) -->`);
-
-    // TODO(annieyw): I think DocsMarkedRenderer#html needs to be fixed for the new API?
     expectEqualIgnoreLeadingWhitespace(result, `<div material-docs-example="
          {
           "example": "exampleName",

--- a/tools/markdown-to-html/docs-marked-renderer.ts
+++ b/tools/markdown-to-html/docs-marked-renderer.ts
@@ -64,7 +64,7 @@ export class DocsMarkdownRenderer extends Renderer {
    *   {
    *    "example": "exampleName",
    *    "file": "example-html.html",
-   *    "region": "some-region",
+   *    "region": "some-region"
    *   }
    *  ) -->`
    *  turns into
@@ -78,20 +78,21 @@ export class DocsMarkdownRenderer extends Renderer {
    *  `<div material-docs-example="name"></div>`
    */
   html(html: string) {
-        html = html.replace(exampleCommentRegex, (_match: string, content: string) => {
-              if (content.startsWith('{')) {
-                  const {example, file, region} = JSON.parse(content);
-                  return `<div material-docs-example="${example}"
-                               file="${file}"
-                               region="${region}"></div>`;
-              } else {
-                  return `<div material-docs-example="${content}"></div>`;
-              }
-          }
-        );
+    html = html.replace(exampleCommentRegex, (_match: string, content: string) => {
+        if (content.match(/\{[\s\S]*\}/g)) {
+          // using [\s\S]* because .* does not match line breaks
+          const {example, file, region} = JSON.parse(content);
+          return `<div material-docs-example="${example}"
+                             file="${file}"
+                             region="${region}"></div>`;
+        } else {
+          return `<div material-docs-example="${content}"></div>`;
+        }
+      }
+    );
 
-        return super.html(html);
-    }
+    return super.html(html);
+  }
 
   /**
    * Method that will be called after a markdown file has been transformed to HTML. This method

--- a/tools/markdown-to-html/docs-marked-renderer.ts
+++ b/tools/markdown-to-html/docs-marked-renderer.ts
@@ -79,8 +79,8 @@ export class DocsMarkdownRenderer extends Renderer {
    */
   html(html: string) {
     html = html.replace(exampleCommentRegex, (_match: string, content: string) => {
+        // using [\s\S]* because .* does not match line breaks
         if (content.match(/\{[\s\S]*\}/g)) {
-          // using [\s\S]* because .* does not match line breaks
           const {example, file, region} = JSON.parse(content);
           return `<div material-docs-example="${example}"
                              file="${file}"


### PR DESCRIPTION
Remove trailing comma in example comment. 
Replace differentiating between new and old API with regex match instead of `.startsWith('{')`