### PR TITLE
fix: focus monitor-based styles not working in some cases inside shadow dom

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -18,6 +18,7 @@ import {
   OnDestroy,
   Optional,
   Output,
+  AfterViewInit,
 } from '@angular/core';
 import {Observable, of as observableOf, Subject, Subscription} from 'rxjs';
 import {coerceElement} from '@angular/cdk/coercion';
@@ -562,19 +563,24 @@ function getTarget(event: Event): HTMLElement|null {
 @Directive({
   selector: '[cdkMonitorElementFocus], [cdkMonitorSubtreeFocus]',
 })
-export class CdkMonitorFocus implements OnDestroy {
+export class CdkMonitorFocus implements AfterViewInit, OnDestroy {
   private _monitorSubscription: Subscription;
   @Output() cdkFocusChange = new EventEmitter<FocusOrigin>();
 
-  constructor(private _elementRef: ElementRef<HTMLElement>, private _focusMonitor: FocusMonitor) {
+  constructor(private _elementRef: ElementRef<HTMLElement>, private _focusMonitor: FocusMonitor) {}
+
+  ngAfterViewInit() {
     this._monitorSubscription = this._focusMonitor.monitor(
-        this._elementRef,
-        this._elementRef.nativeElement.hasAttribute('cdkMonitorSubtreeFocus'))
-        .subscribe(origin => this.cdkFocusChange.emit(origin));
+      this._elementRef,
+      this._elementRef.nativeElement.hasAttribute('cdkMonitorSubtreeFocus'))
+      .subscribe(origin => this.cdkFocusChange.emit(origin));
   }
 
   ngOnDestroy() {
     this._focusMonitor.stopMonitoring(this._elementRef);
-    this._monitorSubscription.unsubscribe();
+
+    if (this._monitorSubscription) {
+      this._monitorSubscription.unsubscribe();
+    }
   }
 }

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -30,6 +30,7 @@ import {
   ViewEncapsulation,
   InjectionToken,
   Inject,
+  AfterViewInit,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
@@ -394,7 +395,7 @@ const _MatButtonToggleMixinBase: CanDisableRippleCtor & typeof MatButtonToggleBa
     '(focus)': 'focus()',
   }
 })
-export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit,
+export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit, AfterViewInit,
   CanDisableRipple, OnDestroy {
 
   private _isSingleSelector = false;
@@ -512,7 +513,9 @@ export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit
         group._syncButtonToggle(this, this._checked);
       }
     }
+  }
 
+  ngAfterViewInit() {
     this._focusMonitor.monitor(this._elementRef, true);
   }
 

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -72,6 +72,7 @@ describe('MatButton', () => {
 
   it('should be able to focus button with a specific focus origin', () => {
     const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
     const buttonDebugEl = fixture.debugElement.query(By.css('button'));
     const buttonInstance = buttonDebugEl.componentInstance as MatButton;
 

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -18,6 +18,7 @@ import {
   Optional,
   Inject,
   Input,
+  AfterViewInit,
 } from '@angular/core';
 import {
   CanColor,
@@ -79,7 +80,7 @@ const _MatButtonMixinBase: CanDisableRippleCtor & CanDisableCtor & CanColorCtor 
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatButton extends _MatButtonMixinBase
-    implements OnDestroy, CanDisable, CanColor, CanDisableRipple, FocusableOption {
+    implements AfterViewInit, OnDestroy, CanDisable, CanColor, CanDisableRipple, FocusableOption {
 
   /** Whether the button is round. */
   readonly isRoundButton: boolean = this._hasHostAttributes('mat-fab', 'mat-mini-fab');
@@ -108,11 +109,13 @@ export class MatButton extends _MatButtonMixinBase
     // the class is applied to derived classes.
     elementRef.nativeElement.classList.add('mat-button-base');
 
-    this._focusMonitor.monitor(this._elementRef, true);
-
     if (this.isRoundButton) {
       this.color = DEFAULT_ROUND_BUTTON_COLOR;
     }
+  }
+
+  ngAfterViewInit() {
+    this._focusMonitor.monitor(this._elementRef, true);
   }
 
   ngOnDestroy() {

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -221,7 +221,12 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
 
     this.tabIndex = parseInt(tabIndex) || 0;
 
-    this._focusMonitor.monitor(elementRef, true).subscribe(focusOrigin => {
+    // TODO: Remove this after the `_clickAction` parameter is removed as an injection parameter.
+    this._clickAction = this._clickAction || this._options.clickAction;
+  }
+
+  ngAfterViewInit() {
+    this._focusMonitor.monitor(this._elementRef, true).subscribe(focusOrigin => {
       if (!focusOrigin) {
         // When a focused element becomes disabled, the browser *immediately* fires a blur event.
         // Angular does not expect events to be raised during change detection, so any state change
@@ -230,16 +235,11 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
         // telling the form control it has been touched until the next tick.
         Promise.resolve().then(() => {
           this._onTouched();
-          _changeDetectorRef.markForCheck();
+          this._changeDetectorRef.markForCheck();
         });
       }
     });
 
-    // TODO: Remove this after the `_clickAction` parameter is removed as an injection parameter.
-    this._clickAction = this._clickAction || this._options.clickAction;
-  }
-
-  ngAfterViewInit() {
     this._syncIndeterminate(this._indeterminate);
   }
 

--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -20,6 +20,7 @@ import {
   ViewEncapsulation,
   Optional,
   Inject,
+  AfterViewInit,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {merge, Subscription, EMPTY} from 'rxjs';
@@ -64,7 +65,7 @@ import {MatAccordionTogglePosition} from './accordion-base';
     '(keydown)': '_keydown($event)',
   },
 })
-export class MatExpansionPanelHeader implements OnDestroy, FocusableOption {
+export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, FocusableOption {
   private _parentChangeSubscription = Subscription.EMPTY;
 
   constructor(
@@ -98,12 +99,6 @@ export class MatExpansionPanelHeader implements OnDestroy, FocusableOption {
     panel.closed
       .pipe(filter(() => panel._containsFocus()))
       .subscribe(() => _focusMonitor.focusVia(_element, 'program'));
-
-    _focusMonitor.monitor(_element).subscribe(origin => {
-      if (origin && panel.accordion) {
-        panel.accordion._handleHeaderFocus(this);
-      }
-    });
 
     if (defaultOptions) {
       this.expandedHeight = defaultOptions.expandedHeight;
@@ -199,6 +194,14 @@ export class MatExpansionPanelHeader implements OnDestroy, FocusableOption {
    */
   focus(origin: FocusOrigin = 'program', options?: FocusOptions) {
     this._focusMonitor.focusVia(this._element, origin, options);
+  }
+
+  ngAfterViewInit() {
+    this._focusMonitor.monitor(this._element).subscribe(origin => {
+      if (origin && this.panel.accordion) {
+        this.panel.accordion._handleHeaderFocus(this);
+      }
+    });
   }
 
   ngOnDestroy() {

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -18,10 +18,10 @@ import {
   NgZone,
   OnChanges,
   OnDestroy,
-  OnInit,
   Optional,
   Self,
   HostListener,
+  AfterViewInit,
 } from '@angular/core';
 import {FormGroupDirective, NgControl, NgForm} from '@angular/forms';
 import {
@@ -88,7 +88,7 @@ const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase =
   providers: [{provide: MatFormFieldControl, useExisting: MatInput}],
 })
 export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges,
-    OnDestroy, OnInit, DoCheck, CanUpdateErrorState {
+    OnDestroy, AfterViewInit, DoCheck, CanUpdateErrorState {
   protected _uid = `mat-input-${nextUniqueId++}`;
   protected _previousNativeValue: any;
   private _inputValueAccessor: {value: any};
@@ -277,7 +277,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     }
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     if (this._platform.isBrowser) {
       this._autofillMonitor.monitor(this._elementRef.nativeElement).subscribe(event => {
         this.autofilled = event.isAutofilled;

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -18,6 +18,7 @@ import {
   Optional,
   Input,
   HostListener,
+  AfterViewInit,
 } from '@angular/core';
 import {
   CanDisable, CanDisableCtor,
@@ -57,7 +58,7 @@ const _MatMenuItemMixinBase: CanDisableRippleCtor & CanDisableCtor & typeof MatM
   templateUrl: 'menu-item.html',
 })
 export class MatMenuItem extends _MatMenuItemMixinBase
-    implements FocusableOption, CanDisable, CanDisableRipple, OnDestroy {
+    implements FocusableOption, CanDisable, CanDisableRipple, AfterViewInit, OnDestroy {
 
   /** ARIA role for the menu item. */
   @Input() role: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox' = 'menuitem';
@@ -85,13 +86,6 @@ export class MatMenuItem extends _MatMenuItemMixinBase
     // @breaking-change 8.0.0 make `_focusMonitor` and `document` required params.
     super();
 
-    if (_focusMonitor) {
-      // Start monitoring the element so it gets the appropriate focused classes. We want
-      // to show the focus style for menu items only when the focus was not caused by a
-      // mouse or touch interaction.
-      _focusMonitor.monitor(this._elementRef, false);
-    }
-
     if (_parentMenu && _parentMenu.addItem) {
       _parentMenu.addItem(this);
     }
@@ -108,6 +102,15 @@ export class MatMenuItem extends _MatMenuItemMixinBase
     }
 
     this._focused.next(this);
+  }
+
+  ngAfterViewInit() {
+    if (this._focusMonitor) {
+      // Start monitoring the element so it gets the appropriate focused classes. We want
+      // to show the focus style for menu items only when the focus was not caused by a
+      // mouse or touch interaction.
+      this._focusMonitor.monitor(this._elementRef, false);
+    }
   }
 
   ngOnDestroy() {

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -36,12 +36,12 @@ import {
   Inject,
   Input,
   OnDestroy,
-  OnInit,
   Optional,
   Output,
   ViewChild,
   ViewEncapsulation,
   NgZone,
+  AfterViewInit,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
@@ -156,7 +156,7 @@ const _MatSliderMixinBase:
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatSlider extends _MatSliderMixinBase
-    implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, OnInit, HasTabIndex {
+    implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, AfterViewInit, HasTabIndex {
   /** Whether the slider is inverted. */
   @Input()
   get invert(): boolean { return this._invert; }
@@ -511,7 +511,7 @@ export class MatSlider extends _MatSliderMixinBase
     });
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this._focusMonitor
         .monitor(this._elementRef, true)
         .subscribe((origin: FocusOrigin) => {

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -18,6 +18,7 @@ import {
   ViewEncapsulation,
   Inject,
   ElementRef,
+  AfterViewInit,
 } from '@angular/core';
 import {CanDisable, CanDisableCtor, mixinDisabled} from '@angular/material/core';
 import {FocusMonitor} from '@angular/cdk/a11y';
@@ -95,7 +96,7 @@ interface MatSortHeaderColumnDef {
   ]
 })
 export class MatSortHeader extends _MatSortHeaderMixinBase
-    implements CanDisable, MatSortable, OnDestroy, OnInit {
+    implements CanDisable, MatSortable, OnDestroy, OnInit, AfterViewInit {
   private _rerenderSubscription: Subscription;
 
   /**
@@ -168,11 +169,6 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
 
           changeDetectorRef.markForCheck();
         });
-
-    // We use the focus monitor because we also want to style
-    // things differently based on the focus origin.
-    _focusMonitor.monitor(_elementRef, true)
-        .subscribe(origin => this._setIndicatorHintVisible(!!origin));
   }
 
   ngOnInit() {
@@ -186,6 +182,13 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
         {toState: this._isSorted() ? 'active' : this._arrowDirection});
 
     this._sort.register(this);
+  }
+
+  ngAfterViewInit() {
+    // We use the focus monitor because we also want to style
+    // things differently based on the focus origin.
+    this._focusMonitor.monitor(this._elementRef, true)
+        .subscribe(origin => this._setIndicatorHintVisible(!!origin));
   }
 
   ngOnDestroy() {

--- a/src/material/stepper/step-header.ts
+++ b/src/material/stepper/step-header.ts
@@ -16,6 +16,7 @@ import {
   OnDestroy,
   ViewEncapsulation,
   TemplateRef,
+  AfterViewInit,
 } from '@angular/core';
 import {Subscription} from 'rxjs';
 import {MatStepLabel} from './step-label';
@@ -35,7 +36,7 @@ import {CdkStepHeader, StepState} from '@angular/cdk/stepper';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatStepHeader extends CdkStepHeader implements OnDestroy {
+export class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDestroy {
   private _intlSubscription: Subscription;
 
   /** State of the given step. */
@@ -71,8 +72,11 @@ export class MatStepHeader extends CdkStepHeader implements OnDestroy {
     _elementRef: ElementRef<HTMLElement>,
     changeDetectorRef: ChangeDetectorRef) {
     super(_elementRef);
-    _focusMonitor.monitor(_elementRef, true);
     this._intlSubscription = _intl.changes.subscribe(() => changeDetectorRef.markForCheck());
+  }
+
+  ngAfterViewInit() {
+    this._focusMonitor.monitor(this._elementRef, true);
   }
 
   ngOnDestroy() {

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -27,6 +27,7 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
+  AfterViewInit,
 } from '@angular/core';
 import {
   CanDisable, CanDisableCtor,
@@ -192,8 +193,8 @@ const _MatTabLinkMixinBase:
 /** Base class with all of the `MatTabLink` functionality. */
 @Directive()
 // tslint:disable-next-line:class-name
-export class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnDestroy, CanDisable,
-  CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {
+export class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewInit, OnDestroy,
+  CanDisable, CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {
 
   /** Whether the tab link is active or not. */
   protected _isActive: boolean = false;
@@ -238,12 +239,14 @@ export class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnDestroy, 
     if (animationMode === 'NoopAnimations') {
       this.rippleConfig.animation = {enterDuration: 0, exitDuration: 0};
     }
-
-    _focusMonitor.monitor(elementRef);
   }
 
   focus() {
     this.elementRef.nativeElement.focus();
+  }
+
+  ngAfterViewInit() {
+    this._focusMonitor.monitor(this.elementRef);
   }
 
   ngOnDestroy() {

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -35,10 +35,10 @@ import {
   Input,
   NgZone,
   OnDestroy,
-  OnInit,
   Optional,
   ViewContainerRef,
   ViewEncapsulation,
+  AfterViewInit,
 } from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
@@ -135,7 +135,7 @@ export function MAT_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): MatTooltipDefaultOptions 
     'class': 'mat-tooltip-trigger'
   }
 })
-export class MatTooltip implements OnDestroy, OnInit {
+export class MatTooltip implements OnDestroy, AfterViewInit {
   _overlayRef: OverlayRef | null;
   _tooltipInstance: TooltipComponent | null;
 
@@ -269,28 +269,25 @@ export class MatTooltip implements OnDestroy, OnInit {
       }
     }
 
-    _focusMonitor.monitor(_elementRef)
-      .pipe(takeUntil(this._destroyed))
-      .subscribe(origin => {
-        // Note that the focus monitor runs outside the Angular zone.
-        if (!origin) {
-          _ngZone.run(() => this.hide(0));
-        } else if (origin === 'keyboard') {
-          _ngZone.run(() => this.show());
-        }
-    });
-
     _ngZone.runOutsideAngular(() => {
       _elementRef.nativeElement.addEventListener('keydown', this._handleKeydown);
     });
   }
 
-  /**
-   * Setup styling-specific things
-   */
-  ngOnInit() {
-    // This needs to happen in `ngOnInit` so the initial values for all inputs have been set.
+  ngAfterViewInit() {
+    // This needs to happen after view init so the initial values for all inputs have been set.
     this._setupPointerEvents();
+
+    this._focusMonitor.monitor(this._elementRef)
+      .pipe(takeUntil(this._destroyed))
+      .subscribe(origin => {
+        // Note that the focus monitor runs outside the Angular zone.
+        if (!origin) {
+          this._ngZone.run(() => this.hide(0));
+        } else if (origin === 'keyboard') {
+          this._ngZone.run(() => this.show());
+        }
+    });
   }
 
   /**

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -33,9 +33,10 @@ export declare class CdkAriaLive implements OnDestroy {
     static ɵfac: i0.ɵɵFactoryDef<CdkAriaLive, never>;
 }
 
-export declare class CdkMonitorFocus implements OnDestroy {
+export declare class CdkMonitorFocus implements AfterViewInit, OnDestroy {
     cdkFocusChange: EventEmitter<FocusOrigin>;
     constructor(_elementRef: ElementRef<HTMLElement>, _focusMonitor: FocusMonitor);
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkMonitorFocus, "[cdkMonitorElementFocus], [cdkMonitorSubtreeFocus]", never, {}, { "cdkFocusChange": "cdkFocusChange"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkMonitorFocus, never>;

--- a/tools/public_api_guard/material/button-toggle.d.ts
+++ b/tools/public_api_guard/material/button-toggle.d.ts
@@ -2,7 +2,7 @@ export declare const MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS: InjectionToken<MatButton
 
 export declare const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any;
 
-export declare class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit, CanDisableRipple, OnDestroy {
+export declare class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit, AfterViewInit, CanDisableRipple, OnDestroy {
     _buttonElement: ElementRef<HTMLButtonElement>;
     _type: ToggleType;
     get appearance(): MatButtonToggleAppearance;
@@ -24,6 +24,7 @@ export declare class MatButtonToggle extends _MatButtonToggleMixinBase implement
     _markForCheck(): void;
     _onButtonClick(): void;
     focus(options?: FocusOptions): void;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
     static ngAcceptInputType_checked: BooleanInput;

--- a/tools/public_api_guard/material/button.d.ts
+++ b/tools/public_api_guard/material/button.d.ts
@@ -6,7 +6,7 @@ export declare class MatAnchor extends MatButton {
     static ɵfac: i0.ɵɵFactoryDef<MatAnchor, [null, null, { optional: true; }]>;
 }
 
-export declare class MatButton extends _MatButtonMixinBase implements OnDestroy, CanDisable, CanColor, CanDisableRipple, FocusableOption {
+export declare class MatButton extends _MatButtonMixinBase implements AfterViewInit, OnDestroy, CanDisable, CanColor, CanDisableRipple, FocusableOption {
     _animationMode: string;
     readonly isIconButton: boolean;
     readonly isRoundButton: boolean;
@@ -16,6 +16,7 @@ export declare class MatButton extends _MatButtonMixinBase implements OnDestroy,
     _hasHostAttributes(...attributes: string[]): boolean;
     _isRippleDisabled(): boolean;
     focus(origin?: FocusOrigin, options?: FocusOptions): void;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;

--- a/tools/public_api_guard/material/expansion.d.ts
+++ b/tools/public_api_guard/material/expansion.d.ts
@@ -95,7 +95,7 @@ export declare class MatExpansionPanelDescription {
     static ɵfac: i0.ɵɵFactoryDef<MatExpansionPanelDescription, never>;
 }
 
-export declare class MatExpansionPanelHeader implements OnDestroy, FocusableOption {
+export declare class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, FocusableOption {
     _animationMode?: string | undefined;
     collapsedHeight: string;
     get disabled(): any;
@@ -111,6 +111,7 @@ export declare class MatExpansionPanelHeader implements OnDestroy, FocusableOpti
     _showToggle(): boolean;
     _toggle(): void;
     focus(origin?: FocusOrigin, options?: FocusOptions): void;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatExpansionPanelHeader, "mat-expansion-panel-header", never, { "expandedHeight": "expandedHeight"; "collapsedHeight": "collapsedHeight"; }, {}, never, ["mat-panel-title", "mat-panel-description", "*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatExpansionPanelHeader, [{ host: true; }, null, null, null, { optional: true; }, { optional: true; }]>;

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -4,7 +4,7 @@ export declare const MAT_INPUT_VALUE_ACCESSOR: InjectionToken<{
     value: any;
 }>;
 
-export declare class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges, OnDestroy, OnInit, DoCheck, CanUpdateErrorState {
+export declare class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck, CanUpdateErrorState {
     _ariaDescribedby: string;
     protected _disabled: boolean;
     protected _elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
@@ -48,10 +48,10 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     _onInput(): void;
     protected _validateType(): void;
     focus(options?: FocusOptions): void;
+    ngAfterViewInit(): void;
     ngDoCheck(): void;
     ngOnChanges(): void;
     ngOnDestroy(): void;
-    ngOnInit(): void;
     onContainerClick(): void;
     setDescribedByIds(ids: string[]): void;
     static ngAcceptInputType_disabled: BooleanInput;

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -98,7 +98,7 @@ export interface MatMenuDefaultOptions {
     yPosition: MenuPositionY;
 }
 
-export declare class MatMenuItem extends _MatMenuItemMixinBase implements FocusableOption, CanDisable, CanDisableRipple, OnDestroy {
+export declare class MatMenuItem extends _MatMenuItemMixinBase implements FocusableOption, CanDisable, CanDisableRipple, AfterViewInit, OnDestroy {
     readonly _focused: Subject<MatMenuItem>;
     _highlighted: boolean;
     readonly _hovered: Subject<MatMenuItem>;
@@ -112,6 +112,7 @@ export declare class MatMenuItem extends _MatMenuItemMixinBase implements Focusa
     _handleMouseEnter(): void;
     focus(origin?: FocusOrigin, options?: FocusOptions): void;
     getLabel(): string;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;

--- a/tools/public_api_guard/material/slider.d.ts
+++ b/tools/public_api_guard/material/slider.d.ts
@@ -1,6 +1,6 @@
 export declare const MAT_SLIDER_VALUE_ACCESSOR: any;
 
-export declare class MatSlider extends _MatSliderMixinBase implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, OnInit, HasTabIndex {
+export declare class MatSlider extends _MatSliderMixinBase implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, AfterViewInit, HasTabIndex {
     _animationMode?: string | undefined;
     protected _document: Document;
     get _invertAxis(): boolean;
@@ -55,8 +55,8 @@ export declare class MatSlider extends _MatSliderMixinBase implements ControlVal
     _shouldInvertMouseCoords(): boolean;
     blur(): void;
     focus(options?: FocusOptions): void;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
-    ngOnInit(): void;
     registerOnChange(fn: (value: any) => void): void;
     registerOnTouched(fn: any): void;
     setDisabledState(isDisabled: boolean): void;

--- a/tools/public_api_guard/material/sort.d.ts
+++ b/tools/public_api_guard/material/sort.d.ts
@@ -51,7 +51,7 @@ export declare const matSortAnimations: {
     readonly allowChildren: AnimationTriggerMetadata;
 };
 
-export declare class MatSortHeader extends _MatSortHeaderMixinBase implements CanDisable, MatSortable, OnDestroy, OnInit {
+export declare class MatSortHeader extends _MatSortHeaderMixinBase implements CanDisable, MatSortable, OnDestroy, OnInit, AfterViewInit {
     _arrowDirection: SortDirection;
     _columnDef: MatSortHeaderColumnDef;
     _disableViewStateAnimation: boolean;
@@ -75,6 +75,7 @@ export declare class MatSortHeader extends _MatSortHeaderMixinBase implements Ca
     _setAnimationTransitionState(viewState: ArrowViewStateTransition): void;
     _setIndicatorHintVisible(visible: boolean): void;
     _updateArrowDirection(): void;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
     static ngAcceptInputType_disableClear: BooleanInput;

--- a/tools/public_api_guard/material/stepper.d.ts
+++ b/tools/public_api_guard/material/stepper.d.ts
@@ -24,7 +24,7 @@ export declare class MatStep extends CdkStep implements ErrorStateMatcher {
     static ɵfac: i0.ɵɵFactoryDef<MatStep, [null, { skipSelf: true; }, { optional: true; }]>;
 }
 
-export declare class MatStepHeader extends CdkStepHeader implements OnDestroy {
+export declare class MatStepHeader extends CdkStepHeader implements AfterViewInit, OnDestroy {
     _intl: MatStepperIntl;
     active: boolean;
     disableRipple: boolean;
@@ -44,6 +44,7 @@ export declare class MatStepHeader extends CdkStepHeader implements OnDestroy {
     _stringLabel(): string | null;
     _templateLabel(): MatStepLabel | null;
     focus(): void;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatStepHeader, "mat-step-header", never, { "state": "state"; "label": "label"; "errorMessage": "errorMessage"; "iconOverrides": "iconOverrides"; "index": "index"; "selected": "selected"; "active": "active"; "optional": "optional"; "disableRipple": "disableRipple"; }, {}, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatStepHeader, never>;

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -79,7 +79,7 @@ export declare abstract class _MatTabHeaderBase extends MatPaginatedTabHeader im
     static ɵfac: i0.ɵɵFactoryDef<_MatTabHeaderBase, [null, null, null, { optional: true; }, null, null, { optional: true; }]>;
 }
 
-export declare class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnDestroy, CanDisable, CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {
+export declare class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewInit, OnDestroy, CanDisable, CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {
     protected _isActive: boolean;
     get active(): boolean;
     set active(value: boolean);
@@ -88,6 +88,7 @@ export declare class _MatTabLinkBase extends _MatTabLinkMixinBase implements OnD
     get rippleDisabled(): boolean;
     constructor(_tabNavBar: _MatTabNavBase, elementRef: ElementRef, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string, _focusMonitor: FocusMonitor, animationMode?: string);
     focus(): void;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;

--- a/tools/public_api_guard/material/tooltip.d.ts
+++ b/tools/public_api_guard/material/tooltip.d.ts
@@ -14,7 +14,7 @@ export declare const MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER: {
     useFactory: typeof MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY;
 };
 
-export declare class MatTooltip implements OnDestroy, OnInit {
+export declare class MatTooltip implements OnDestroy, AfterViewInit {
     _overlayRef: OverlayRef | null;
     _tooltipInstance: TooltipComponent | null;
     get disabled(): boolean;
@@ -43,8 +43,8 @@ export declare class MatTooltip implements OnDestroy, OnInit {
     };
     _isTooltipVisible(): boolean;
     hide(delay?: number): void;
+    ngAfterViewInit(): void;
     ngOnDestroy(): void;
-    ngOnInit(): void;
     show(delay?: number): void;
     toggle(): void;
     static ngAcceptInputType_disabled: BooleanInput;


### PR DESCRIPTION
A while ago event delegation was implemented for the focus monitor which has some special behavior where it has to bind its events to the closest shadow root in order for them to work correctly. The problem is that a lot of our `FocusMonitor.focus` calls are very early in the component lifecycle which means that might not have been put into the shadow DOM yet. These changes move the `monitor` calls to `ngAfterViewInit` to resolve the issue.

Fixes #19414.