### PR TITLE
fix(material-experimental): strong focus indicator clipped in checkbox and radio button

### DIFF
--- a/src/material-experimental/mdc-helpers/_focus-indicators.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators.scss
@@ -58,6 +58,13 @@
     margin: 5px;
   }
 
+  // These components have to set `border-radius: 50%` in order to support density scaling
+  // which will clip a square focus indicator so we have to turn it into a circle.
+  .mat-mdc-checkbox-ripple.mat-mdc-focus-indicator::before,
+  .mat-radio-ripple.mat-mdc-focus-indicator::before {
+    border-radius: 50%;
+  }
+
   // Render the focus indicator on focus. Defining a pseudo element's
   // content will cause it to render.
 


### PR DESCRIPTION
In order to support density scaling, the MDC checkbox and radio button have `border-radius: 50%` on their ripple element which is also used as the strong focus indicator. Since the indicator is a square, it'll be clipped, unless we also make it into a circle.

For reference, here's what the circular indicators look like:
![Angular_Material_-_Google_Chrome_2020-05-22_17-41-26](https://user-images.githubusercontent.com/4450522/82685460-845b8e00-9c54-11ea-9115-eaa3662690e5.png)
![Angular_Material_-_Google_Chrome_2020-05-22_17-43-54](https://user-images.githubusercontent.com/4450522/82685467-84f42480-9c54-11ea-98b2-7eab042001ea.png)

cc @zelliott 