### PR TITLE
build: set dev app density class on body

### DIFF
--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -159,9 +159,9 @@ export class DevAppLayout {
     for (let i = 0; i < this.densityScales.length; i++) {
       const className = `demo-density-${this.densityScales[i]}`;
       if (i === this.currentDensityIndex) {
-        this._element.nativeElement.classList.add(className);
+        document.body.classList.add(className);
       } else {
-        this._element.nativeElement.classList.remove(className);
+        document.body.classList.remove(className);
       }
     }
   }


### PR DESCRIPTION
Sets the desnity class on the body, rather than the layout element. We'll need this for overlay-based components that implement the density system.