### PR TITLE
build: bump tooling packages to rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "zone.js": "~0.10.2"
   },
   "devDependencies": {
-    "@angular-devkit/core": "^10.0.0-next.6",
-    "@angular-devkit/schematics": "^10.0.0-next.6",
+    "@angular-devkit/core": "^10.0.0-rc.0",
+    "@angular-devkit/schematics": "^10.0.0-rc.0",
     "@angular/bazel": "^10.0.0-rc.0",
     "@angular/compiler-cli": "^10.0.0-rc.0",
     "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#2ac83eb462cb25c46a761d34dec030e360055016",
@@ -83,7 +83,7 @@
     "@bazel/typescript": "^1.6.0",
     "@firebase/app-types": "^0.3.2",
     "@octokit/rest": "16.28.7",
-    "@schematics/angular": "^10.0.0-next.6",
+    "@schematics/angular": "^10.0.0-rc.0",
     "@types/autoprefixer": "^9.7.2",
     "@types/browser-sync": "^2.26.1",
     "@types/fs-extra": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@angular-devkit/core@10.0.0-next.6", "@angular-devkit/core@^10.0.0-next.6":
-  version "10.0.0-next.6"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-10.0.0-next.6.tgz#4f3d99eecbb0959fdab169b58b2ba5573a3bf248"
-  integrity sha512-4V89t5lLys5mUNKLJqY+JGVYwZrS/SXzAUF34/3PxxZ7WNInvcbP2Ut5FtyDdW5d20r/Wp6seWLuL4AnzI+tDw==
+"@angular-devkit/core@10.0.0-rc.0", "@angular-devkit/core@^10.0.0-rc.0":
+  version "10.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-10.0.0-rc.0.tgz#de44330d2ac6810e958fc8df516b56171577f803"
+  integrity sha512-3hHDdWEVhUPzJPHCwV7KyAwPiKBo0SR6nTRxiF6mgR8d87+X+DGhJwB8+g5a7cumRVm8b8CrziCxosQCOR7z+g==
   dependencies:
     ajv "6.12.2"
     fast-json-stable-stringify "2.1.0"
@@ -13,12 +13,12 @@
     rxjs "6.5.5"
     source-map "0.7.3"
 
-"@angular-devkit/schematics@10.0.0-next.6", "@angular-devkit/schematics@^10.0.0-next.6":
-  version "10.0.0-next.6"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics/-/schematics-10.0.0-next.6.tgz#a017166eaf81835b8c1cbc98674bb524329ba714"
-  integrity sha512-DXSccR9VMyrBq18pDyJASaZ9qn3xkdewxzH76K5Fc3kk1bGfilat2osGSzrIS+L5/boeJknzjIW2wGVI0LNoUw==
+"@angular-devkit/schematics@10.0.0-rc.0", "@angular-devkit/schematics@^10.0.0-rc.0":
+  version "10.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics/-/schematics-10.0.0-rc.0.tgz#77f45a5511f285bcd00704b3e05b40dfb3f20c30"
+  integrity sha512-7H8VsJkN4ySykCKgHhVp744V43FhSfJMf3+3MPDngZBOTVS7TNk6F8wxAvMCT3gqEOKPc8gN0JyDWLflzhTL4A==
   dependencies:
-    "@angular-devkit/core" "10.0.0-next.6"
+    "@angular-devkit/core" "10.0.0-rc.0"
     ora "4.0.4"
     rxjs "6.5.5"
 
@@ -1205,13 +1205,13 @@
     argparse "~1.0.9"
     colors "~1.2.1"
 
-"@schematics/angular@^10.0.0-next.6":
-  version "10.0.0-next.6"
-  resolved "https://registry.yarnpkg.com/@schematics/angular/-/angular-10.0.0-next.6.tgz#acbcb351b6103e3af223e2cccc6805129f0df198"
-  integrity sha512-rKqSe2pl21RJ2aelJptCEqw25cg+pFq1L0Gkq5wuNgSwmXtmZijxRXXlgwgRE0HvWsDfAZdhfs71T8q3IFXChQ==
+"@schematics/angular@^10.0.0-rc.0":
+  version "10.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@schematics/angular/-/angular-10.0.0-rc.0.tgz#eb63e123d54d8ce4c9ad665a20bcb914d5db9245"
+  integrity sha512-ZclGbqbWb/ZpjfD/QgzA0lny8CU5eiJDm3Z+JT97MZ9bTCbfNPjk4A6UQV2ra8w47vSUuNYQgh1ecfN+E5OKXQ==
   dependencies:
-    "@angular-devkit/core" "10.0.0-next.6"
-    "@angular-devkit/schematics" "10.0.0-next.6"
+    "@angular-devkit/core" "10.0.0-rc.0"
+    "@angular-devkit/schematics" "10.0.0-rc.0"
 
 "@stylelint/postcss-css-in-js@^0.37.0":
   version "0.37.0"
@@ -1338,9 +1338,9 @@
     "@types/node" "*"
 
 "@types/googlemaps@^3.39.3":
-  version "3.39.3"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.39.3.tgz#8664e424f335802c8aa46a94676666b0a0f31d97"
-  integrity sha512-L8O9HAVFZj0TuiS8h5ORthiMsrrhjxTC8XUusp5k47oXCst4VTm+qWKvrAvmYMybZVokbp4Udco1mNwJrTNZPQ==
+  version "3.39.6"
+  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.39.6.tgz#ca76df823fb4a8bd78bf47bd215fc70417a9ae51"
+  integrity sha512-O2joRmShgUcGBSyjp0pYFIP0Kv3y6jl8UXokEkcTI4D8FinTYsSt8OaHGQ/tI7WUF2eZTXKVJg6jQuEQS4d30w==
 
 "@types/gulp@*":
   version "4.0.5"


### PR DESCRIPTION
All of the core packages were at 10.0.0-rc.0, but the tooling ones were still on `next`. These changes align the version.