### PR TITLE
fix(overlay): resolve circular dependency

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -25,10 +25,6 @@
     "src/cdk/drag-drop/drop-list-ref.ts"
   ],
   [
-    "src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts",
-    "src/cdk/overlay/overlay-ref.ts"
-  ],
-  [
     "src/cdk/schematics/testing/index.ts",
     "src/cdk/schematics/testing/test-case-setup.ts"
   ],

--- a/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/keyboard/overlay-keyboard-dispatcher.ts
@@ -15,7 +15,7 @@ import {
   Optional,
   SkipSelf,
 } from '@angular/core';
-import {OverlayRef} from '../overlay-ref';
+import {OverlayReference} from '../overlay-reference';
 
 
 /**
@@ -27,7 +27,7 @@ import {OverlayRef} from '../overlay-ref';
 export class OverlayKeyboardDispatcher implements OnDestroy {
 
   /** Currently attached overlays in the order they were attached. */
-  _attachedOverlays: OverlayRef[] = [];
+  _attachedOverlays: OverlayReference[] = [];
 
   private _document: Document;
   private _isAttached: boolean;
@@ -41,7 +41,7 @@ export class OverlayKeyboardDispatcher implements OnDestroy {
   }
 
   /** Add a new overlay to the list of attached overlay refs. */
-  add(overlayRef: OverlayRef): void {
+  add(overlayRef: OverlayReference): void {
     // Ensure that we don't get the same overlay multiple times.
     this.remove(overlayRef);
 
@@ -55,7 +55,7 @@ export class OverlayKeyboardDispatcher implements OnDestroy {
   }
 
   /** Remove an overlay from the list of attached overlay refs. */
-  remove(overlayRef: OverlayRef): void {
+  remove(overlayRef: OverlayReference): void {
     const index = this._attachedOverlays.indexOf(overlayRef);
 
     if (index > -1) {

--- a/src/cdk/overlay/overlay-reference.ts
+++ b/src/cdk/overlay/overlay-reference.ts
@@ -8,6 +8,7 @@
 
 import {Portal} from '@angular/cdk/portal';
 import {Direction, Directionality} from '@angular/cdk/bidi';
+import {Subject} from 'rxjs';
 
 /**
  * Basic interface for an overlay. Used to avoid circular type references between
@@ -26,4 +27,5 @@ export interface OverlayReference {
   updatePosition: () => void;
   getDirection: () => Direction;
   setDirection: (dir: Direction | Directionality) => void;
+  _keydownEvents: Subject<KeyboardEvent>;
 }

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -236,11 +236,11 @@ export declare class OverlayContainer implements OnDestroy {
 }
 
 export declare class OverlayKeyboardDispatcher implements OnDestroy {
-    _attachedOverlays: OverlayRef[];
+    _attachedOverlays: OverlayReference[];
     constructor(document: any);
-    add(overlayRef: OverlayRef): void;
+    add(overlayRef: OverlayReference): void;
     ngOnDestroy(): void;
-    remove(overlayRef: OverlayRef): void;
+    remove(overlayRef: OverlayReference): void;
     static ɵfac: i0.ɵɵFactoryDef<OverlayKeyboardDispatcher, never>;
     static ɵprov: i0.ɵɵInjectableDef<OverlayKeyboardDispatcher>;
 }


### PR DESCRIPTION
Resolves a circular dependency between a couple of the classes in `cdk/overlay`.