### PR TITLE
test(tooltip/testing): disable tests on touch devices

### DIFF
--- a/src/material/tooltip/testing/BUILD.bazel
+++ b/src/material/tooltip/testing/BUILD.bazel
@@ -24,6 +24,7 @@ ng_test_library(
     srcs = ["shared.spec.ts"],
     deps = [
         ":testing",
+        "//src/cdk/platform",
         "//src/cdk/testing",
         "//src/cdk/testing/testbed",
         "//src/material/tooltip",

--- a/src/material/tooltip/testing/shared.spec.ts
+++ b/src/material/tooltip/testing/shared.spec.ts
@@ -5,10 +5,15 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {MatTooltipHarness} from '@angular/material/tooltip/testing/tooltip-harness';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Platform} from '@angular/cdk/platform';
 
 /** Shared tests to run on both the original and MDC-based tooltips. */
 export function runHarnessTests(
     tooltipModule: typeof MatTooltipModule, tooltipHarness: typeof MatTooltipHarness) {
+  // TODO(COMP-322): whether the current test device is supported by the harness. At the time of
+  // writing, we have to skip these tests on touch devices, because we don't have a way of
+  // simulating touch events. This variable should be removed once the issue is resolved.
+  let isSupported: boolean;
   let fixture: ComponentFixture<TooltipHarnessTest>;
   let loader: HarnessLoader;
 
@@ -21,14 +26,25 @@ export function runHarnessTests(
     fixture = TestBed.createComponent(TooltipHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);
+
+    const platform = TestBed.inject(Platform);
+    isSupported = !platform.IOS && !platform.ANDROID;
   });
 
   it('should load all tooltip harnesses', async () => {
+    if (!isSupported) {
+      return;
+    }
+
     const tooltips = await loader.getAllHarnesses(tooltipHarness);
     expect(tooltips.length).toBe(2);
   });
 
   it('should be able to show a tooltip', async () => {
+    if (!isSupported) {
+      return;
+    }
+
     const tooltip = await loader.getHarness(tooltipHarness.with({selector: '#one'}));
     expect(await tooltip.isOpen()).toBe(false);
     await tooltip.show();
@@ -36,6 +52,10 @@ export function runHarnessTests(
   });
 
   it('should be able to hide a tooltip', async () => {
+    if (!isSupported) {
+      return;
+    }
+
     const tooltip = await loader.getHarness(tooltipHarness.with({selector: '#one'}));
     expect(await tooltip.isOpen()).toBe(false);
     await tooltip.show();
@@ -45,12 +65,20 @@ export function runHarnessTests(
   });
 
   it('should be able to get the text of a tooltip', async () => {
+    if (!isSupported) {
+      return;
+    }
+
     const tooltip = await loader.getHarness(tooltipHarness.with({selector: '#one'}));
     await tooltip.show();
     expect(await tooltip.getTooltipText()).toBe('Tooltip message');
   });
 
   it('should return empty when getting the tooltip text while closed', async () => {
+    if (!isSupported) {
+      return;
+    }
+
     const tooltip = await loader.getHarness(tooltipHarness.with({selector: '#one'}));
     expect(await tooltip.getTooltipText()).toBe('');
   });


### PR DESCRIPTION
Currently the tooltip harness won't work on touch devices, because we don't simulate touch events. These changes temporarily disable the tests on unsupported devices until we can update the harness APIs.