### PR TITLE
fix(mat-stepper): .mat-stepper-label should be a consistent size 

### DIFF
--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -87,7 +87,7 @@
   .mat-step-label {
     font: {
       size: mat-font-size($config, body-2);
-      weight: mat-font-weight($config, body-2);;
+      weight: normal;
     };
   }
 

--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -86,8 +86,8 @@
 
   .mat-step-label {
     font: {
-      size: mat-font-size($config, body-1);
-      weight: mat-font-weight($config, body-1);
+      size: mat-font-size($config, body-2);
+      weight: mat-font-weight($config, body-2);;
     };
   }
 
@@ -95,15 +95,8 @@
     font-weight: normal;
   }
 
-  .mat-step-label-error {
-    font-size: mat-font-size($config, body-2);
-  }
-
   .mat-step-label-selected {
-    font: {
-      size: mat-font-size($config, body-2);
-      weight: mat-font-weight($config, body-2);
-    };
+    font-weight: bolder;
   }
 }
 


### PR DESCRIPTION
Provide a consistent font-size for `.mat-stepper-label` when `body-1` and `body-2` are different sizes.

With the Material Design (v1) typography, `body-1` and `body-2` are the same size, so this change is a noop; however this fixes a CSS bug in GMat when the sizes diverge.