### PR TITLE
fix(material/sort): view not updated when sort state is changed through binding

### DIFF
--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -198,6 +198,16 @@ describe('MatSort', () => {
         component.dispatchMouseEvent('defaultA', 'mouseenter');
         component.expectViewAndDirectionStates(expectedStates);
       });
+
+      it('should be correct when sorting programmatically', () => {
+        component.active = 'defaultB';
+        component.direction = 'asc';
+        fixture.detectChanges();
+
+        expectedStates.set('defaultB', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+      });
+
     });
 
     it('should be able to cycle from asc -> desc from either start point', () => {


### PR DESCRIPTION
Fixes the visible state of the sort header not being updated if it gets changed through the `matSortActive` binding.

Fixes #19467.