### PR TITLE
build: remove wombot proxy registry from package.jsons for release

### DIFF
--- a/src/cdk-experimental/package.json
+++ b/src/cdk-experimental/package.json
@@ -18,8 +18,5 @@
   "dependencies": {
     "tslib": "0.0.0-TSLIB"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -32,8 +32,5 @@
   "ng-update": {
     "migrations": "./schematics/migration.json"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/src/google-maps/package.json
+++ b/src/google-maps/package.json
@@ -24,8 +24,5 @@
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG"
   },
-  "sideEffects": false,
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/src/material-experimental/package.json
+++ b/src/material-experimental/package.json
@@ -19,8 +19,5 @@
   "dependencies": {
     "tslib": "0.0.0-TSLIB"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/src/material-moment-adapter/package.json
+++ b/src/material-moment-adapter/package.json
@@ -26,8 +26,5 @@
       "@angular/material-moment-adapter"
     ]
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -36,9 +36,5 @@
       "@angular/material-moment-adapter"
     ]
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }
-

--- a/src/youtube-player/package.json
+++ b/src/youtube-player/package.json
@@ -24,8 +24,5 @@
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }


### PR DESCRIPTION
Due to an outage with the proxy we rely on for publishing, we need
to temporarily directly publish to NPM using our own angular
credentials again.