### PR TITLE
fix(datepicker): compilation errors with ViewEngine

### DIFF
--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -48,6 +48,10 @@ export interface MatDateRangeInputParent<D> {
   min: D | null;
   max: D | null;
   dateFilter: DateFilterFn<D>;
+  rangePicker: {
+    opened: boolean;
+    id: string;
+  };
   _startInput: MatDateRangeInputPartBase<D>;
   _endInput: MatDateRangeInputPartBase<D>;
   _groupDisabled: boolean;
@@ -138,12 +142,12 @@ abstract class MatDateRangeInputPartBase<D>
   }
 
   /** Gets the minimum date from the range input. */
-  protected _getMinDate() {
+  _getMinDate() {
     return this._rangeInput.min;
   }
 
   /** Gets the maximum date from the range input. */
-  protected _getMaxDate() {
+  _getMaxDate() {
     return this._rangeInput.max;
   }
 

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -174,10 +174,10 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
   }
 
   /** Gets the minimum date for the input. Used for validation. */
-  protected abstract _getMinDate(): D | null;
+  abstract _getMinDate(): D | null;
 
   /** Gets the maximum date for the input. Used for validation. */
-  protected abstract _getMaxDate(): D | null;
+  abstract _getMaxDate(): D | null;
 
   /** Gets the date filter function. Used for validation. */
   protected abstract _getDateFilter(): DateFilterFn<D> | undefined;

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -162,12 +162,12 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
   }
 
   /** Gets the input's minimum date. */
-  protected _getMinDate() {
+  _getMinDate() {
     return this._min;
   }
 
   /** Gets the input's maximum date. */
-  protected _getMaxDate() {
+  _getMaxDate() {
     return this._max;
   }
 

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -217,8 +217,8 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | nu
     constructor(elementRef: ElementRef<HTMLInputElement>, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats, _formField: MatFormField);
     protected _assignValueToModel(value: D | null): void;
     protected _getDateFilter(): DateFilterFn<D | null>;
-    protected _getMaxDate(): D | null;
-    protected _getMinDate(): D | null;
+    _getMaxDate(): D | null;
+    _getMinDate(): D | null;
     protected _getValueFromModel(modelValue: D | null): D | null;
     protected _openPopup(): void;
     getConnectedOverlayOrigin(): ElementRef;


### PR DESCRIPTION
Fixes a few compilation errors that only happen when the date range picker is compiled with `ViewEngine`.