### PR TITLE
fix(slider): focus ring not matching theme color

### DIFF
--- a/src/material/slider/_slider-theme.scss
+++ b/src/material/slider/_slider-theme.scss
@@ -13,6 +13,18 @@
   .mat-slider-thumb-label-text {
     color: mat-color($palette, default-contrast);
   }
+
+  .mat-slider-focus-ring {
+    $opacity: 0.2;
+    $color: mat-color($palette, default, $opacity);
+    background-color: $color;
+
+    // `mat-color` uses `rgba` for the opacity which won't work with
+    // CSS variables so we need to use `opacity` as a fallback.
+    @if (type-of($color) != color) {
+      opacity: $opacity;
+    }
+  }
 }
 
 @mixin mat-slider-color($config-or-theme) {
@@ -46,18 +58,6 @@
 
   .mat-warn {
     @include _mat-slider-inner-content-theme($warn);
-  }
-
-  .mat-slider-focus-ring {
-    $opacity: 0.2;
-    $color: mat-color($accent, default, $opacity);
-    background-color: $color;
-
-    // `mat-color` uses `rgba` for the opacity which won't work with
-    // CSS variables so we need to use `opacity` as a fallback.
-    @if (type-of($color) != color) {
-      opacity: $opacity;
-    }
   }
 
   .mat-slider:hover,


### PR DESCRIPTION
Fixes the slider's focus ring always using the accent color, instead of matching the current theme palette.

Fixes #19507.