### PR TITLE
fix(material-experimental/mdc-slide-toggle): fix focus indictor position

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
@@ -28,6 +28,14 @@
     }
   }
 
+  // The thumb-underlay element has `mat-mdc-focus-indicator` which sets
+  // a relative position. This element must have absolute positioning. This
+  // has increased specificity than the style set in MDC to guarantee that
+  // it will be absolutely positioned.
+  .mdc-switch__thumb-underlay {
+    position: absolute;
+  }
+
   // The MDC switch styles related to the hover state are intertwined with the MDC ripple styles.
   // We currently don't use the MDC ripple due to size concerns, therefore we need to add some
   // additional styles to restore the hover state.


### PR DESCRIPTION
The MDC slide toggle's element with the focus indicator should always be absolutely positioned. Right now, its a race condition whether it is (currently broken in Google) depending on load order since they have the same specificity