### PR TITLE
feat(material-experimental): add MDC-based mat-option and mdc-core entry point

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,6 +100,7 @@
 /src/material-experimental/mdc-checkbox/**         @mmalerba
 /src/material-experimental/mdc-chips/**            @mmalerba
 /src/material-experimental/mdc-color/**            @jelbourn @devversion
+/src/material-experimental/mdc-core/**             @crisbeto
 /src/material-experimental/mdc-density/**          @devversion
 /src/material-experimental/mdc-dialog/**           @devversion
 /src/material-experimental/mdc-form-field/**       @devversion @mmalerba

--- a/src/material-experimental/config.bzl
+++ b/src/material-experimental/config.bzl
@@ -8,6 +8,7 @@ entryPoints = [
     "mdc-checkbox/testing",
     "mdc-chips",
     "mdc-chips/testing",
+    "mdc-core",
     "mdc-form-field",
     "mdc-form-field/testing",
     "mdc-input",

--- a/src/material-experimental/mdc-core/BUILD.bazel
+++ b/src/material-experimental/mdc-core/BUILD.bazel
@@ -1,0 +1,80 @@
+load(
+    "//tools:defaults.bzl",
+    "ng_module",
+    "ng_test_library",
+    "ng_web_test_suite",
+    "sass_binary",
+    "sass_library",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "mdc-core",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    assets = [
+        ":option/option.css",
+        ":option/optgroup.css",
+    ] + glob(["**/*.html"]),
+    module_name = "@angular/material-experimental/mdc-core",
+    deps = [
+        "//src/material/core",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//rxjs",
+    ],
+)
+
+sass_library(
+    name = "mdc_core_scss_lib",
+    srcs = glob(["**/_*.scss"]),
+)
+
+sass_binary(
+    name = "option_scss",
+    src = "option/option.scss",
+    include_paths = [
+        "external/npm/node_modules",
+    ],
+    deps = [
+        "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
+        "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
+    ],
+)
+
+sass_binary(
+    name = "optgroup_scss",
+    src = "option/optgroup.scss",
+    include_paths = [
+        "external/npm/node_modules",
+    ],
+    deps = [
+        "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
+        "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
+    ],
+)
+
+#################
+#  Test targets
+#################
+
+ng_test_library(
+    name = "unit_test_sources",
+    srcs = glob(
+        ["**/*.spec.ts"],
+    ),
+    deps = [
+        ":mdc-core",
+        "//src/cdk/keycodes",
+        "//src/cdk/testing/private",
+        "@npm//@angular/platform-browser",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [":unit_test_sources"],
+)

--- a/src/material-experimental/mdc-core/_core.scss
+++ b/src/material-experimental/mdc-core/_core.scss
@@ -1,0 +1,15 @@
+@import '../../material/core/theming/check-duplicate-styles';
+@import './option/option-theme';
+@import './option/optgroup-theme';
+
+// Mixin that renders all of the core styles that depend on the theme.
+@mixin mat-mdc-core-theme($theme-or-color-config) {
+  $theme: _mat-legacy-get-theme($theme-or-color-config);
+  // Wrap the sub-theme includes in the duplicate theme styles mixin. This ensures that
+  // there won't be multiple warnings. e.g. if `mat-mdc-core-theme` reports a warning, then
+  // the imported themes (such as `mat-ripple-theme`) should not report again.
+  @include _mat-check-duplicate-theme-styles($theme, 'mat-mdc-core') {
+    @include mat-mdc-option-theme($theme);
+    @include mat-mdc-optgroup-theme($theme);
+  }
+}

--- a/src/material-experimental/mdc-core/index.ts
+++ b/src/material-experimental/mdc-core/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-core/option/_optgroup-theme.scss
+++ b/src/material-experimental/mdc-core/option/_optgroup-theme.scss
@@ -1,0 +1,46 @@
+@import '@material/list/mixins.import';
+@import '@material/list/variables.import';
+@import '@material/theme/functions.import';
+@import '../../mdc-helpers/mdc-helpers';
+@import '../../../material/core/theming/check-duplicate-styles';
+
+@mixin mat-mdc-optgroup-color($config-or-theme) {
+  $config: mat-get-color-config($config-or-theme);
+
+  @include mat-using-mdc-theme($config) {
+    .mat-mdc-optgroup-label {
+      // Since this will usually be rendered in an overlay,
+      // we have explicitly set the default color.
+      @include mdc-theme-prop(color, text-primary-on-background);
+      @include mdc-list-item-disabled-text-color($mdc-list-text-disabled-color,
+        $query: $mat-theme-styles-query);
+    }
+  }
+}
+
+@mixin mat-mdc-optgroup-typography($config-or-theme) {
+  $config: mat-get-typography-config($config-or-theme);
+}
+
+@mixin mat-mdc-optgroup-density($config-or-theme) {
+  $density-scale: mat-get-density-config($config-or-theme);
+}
+
+@mixin mat-mdc-optgroup-theme($theme-or-color-config) {
+  $theme: _mat-legacy-get-theme($theme-or-color-config);
+  @include _mat-check-duplicate-theme-styles($theme, 'mat-mdc-optgroup') {
+    $color: mat-get-color-config($theme);
+    $density: mat-get-density-config($theme);
+    $typography: mat-get-typography-config($theme);
+
+    @if $color != null {
+      @include mat-mdc-optgroup-color($color);
+    }
+    @if $density != null {
+      @include mat-mdc-optgroup-density($density);
+    }
+    @if $typography != null {
+      @include mat-mdc-optgroup-typography($typography);
+    }
+  }
+}

--- a/src/material-experimental/mdc-core/option/_option-theme.scss
+++ b/src/material-experimental/mdc-core/option/_option-theme.scss
@@ -1,0 +1,68 @@
+@import '@material/list/mixins.import';
+@import '@material/list/variables.import';
+@import '@material/theme/functions.import';
+@import '../../mdc-helpers/mdc-helpers';
+@import '../../../material/core/theming/check-duplicate-styles';
+
+@mixin mat-mdc-option-color($config-or-theme) {
+  $config: mat-get-color-config($config-or-theme);
+
+  @include mat-using-mdc-theme($config) {
+    .mat-mdc-option {
+      // Since this will usually be rendered in an overlay,
+      // we have explicitly set the default color.
+      @include mdc-theme-prop(color, text-primary-on-background);
+      @include mdc-list-item-disabled-text-color($mdc-list-text-disabled-color,
+        $query: $mat-theme-styles-query);
+
+      &:hover:not(.mdc-list-item--disabled),
+      &:focus:not(.mdc-list-item--disabled),
+      &.mat-mdc-option-active,
+
+      // In multiple mode there is a checkbox to show that the option is selected.
+      &.mdc-list-item--selected:not(.mat-mdc-option-multiple):not(.mdc-list-item--disabled) {
+        $color: $mdc-theme-on-surface;
+        background: rgba($color, mdc-states-opacity($color, hover));
+      }
+    }
+
+    .mat-primary .mat-mdc-option.mdc-list-item--selected:not(.mdc-list-item--disabled) {
+      @include mdc-list-item-primary-text-ink-color(primary, $query: $mat-theme-styles-query);
+    }
+
+    .mat-accent .mat-mdc-option.mdc-list-item--selected:not(.mdc-list-item--disabled) {
+      @include mdc-list-item-primary-text-ink-color(secondary, $query: $mat-theme-styles-query);
+    }
+
+    .mat-warn .mat-mdc-option.mdc-list-item--selected:not(.mdc-list-item--disabled) {
+      @include mdc-list-item-primary-text-ink-color(error, $query: $mat-theme-styles-query);
+    }
+  }
+}
+
+@mixin mat-mdc-option-typography($config-or-theme) {
+  $config: mat-get-typography-config($config-or-theme);
+}
+
+@mixin mat-mdc-option-density($config-or-theme) {
+  $density-scale: mat-get-density-config($config-or-theme);
+}
+
+@mixin mat-mdc-option-theme($theme-or-color-config) {
+  $theme: _mat-legacy-get-theme($theme-or-color-config);
+  @include _mat-check-duplicate-theme-styles($theme, 'mat-mdc-option') {
+    $color: mat-get-color-config($theme);
+    $density: mat-get-density-config($theme);
+    $typography: mat-get-typography-config($theme);
+
+    @if $color != null {
+      @include mat-mdc-option-color($color);
+    }
+    @if $density != null {
+      @include mat-mdc-option-density($density);
+    }
+    @if $typography != null {
+      @include mat-mdc-option-typography($typography);
+    }
+  }
+}

--- a/src/material-experimental/mdc-core/option/index.ts
+++ b/src/material-experimental/mdc-core/option/index.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MatRippleModule, MatPseudoCheckboxModule} from '@angular/material/core';
+import {MatOption} from './option';
+import {MatOptgroup} from './optgroup';
+
+
+@NgModule({
+  imports: [MatRippleModule, CommonModule, MatPseudoCheckboxModule],
+  exports: [MatOption, MatOptgroup],
+  declarations: [MatOption, MatOptgroup]
+})
+export class MatOptionModule {}
+
+
+export * from './option';
+export * from './optgroup';
+export {
+  MatOptionSelectionChange,
+  MatOptionParentComponent,
+  MAT_OPTION_PARENT_COMPONENT,
+  _countGroupLabelsBeforeOption,
+  _getOptionScrollPosition
+} from '@angular/material/core';

--- a/src/material-experimental/mdc-core/option/optgroup.html
+++ b/src/material-experimental/mdc-core/option/optgroup.html
@@ -1,0 +1,8 @@
+<label
+  class="mat-mdc-optgroup-label"
+  [class.mdc-list-item--disabled]="disabled"
+  [id]="_labelId">
+  <span class="mdc-list-item__text">{{ label }} <ng-content></ng-content></span>
+</label>
+
+<ng-content select="mat-option, ng-container"></ng-content>

--- a/src/material-experimental/mdc-core/option/optgroup.scss
+++ b/src/material-experimental/mdc-core/option/optgroup.scss
@@ -1,0 +1,13 @@
+@import '@material/list/mixins.import';
+@import '@material/list/variables.import';
+@import '../../mdc-helpers/mdc-helpers';
+
+.mat-mdc-optgroup-label {
+  @include mdc-list-item-base_;
+  @include mdc-list-list-item-padding-variant(
+    $mdc-list-textual-variant-config, $query: $mat-base-styles-query);
+  @include mdc-list-list-item-height-variant(
+    $mdc-list-textual-variant-config, $query: $mat-base-styles-query);
+  @include mdc-list-item-disabled-text-opacity($mdc-list-text-disabled-opacity,
+    $query: $mat-base-styles-query);
+}

--- a/src/material-experimental/mdc-core/option/optgroup.ts
+++ b/src/material-experimental/mdc-core/option/optgroup.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ViewEncapsulation, ChangeDetectionStrategy} from '@angular/core';
+import {_MatOptgroupBase} from '@angular/material/core';
+
+
+/**
+ * Component that is used to group instances of `mat-option`.
+ */
+@Component({
+  selector: 'mat-optgroup',
+  exportAs: 'matOptgroup',
+  templateUrl: 'optgroup.html',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  inputs: ['disabled'],
+  styleUrls: ['optgroup.css'],
+  host: {
+    'class': 'mat-mdc-optgroup',
+    'role': 'group',
+    '[attr.aria-disabled]': 'disabled.toString()',
+    '[attr.aria-labelledby]': '_labelId',
+  }
+})
+export class MatOptgroup extends _MatOptgroupBase {
+}

--- a/src/material-experimental/mdc-core/option/option.html
+++ b/src/material-experimental/mdc-core/option/option.html
@@ -1,0 +1,9 @@
+<mat-pseudo-checkbox *ngIf="multiple" class="mat-mdc-option-pseudo-checkbox"
+    [state]="selected ? 'checked' : 'unchecked'" [disabled]="disabled"></mat-pseudo-checkbox>
+
+<span class="mdc-list-item__text"><ng-content></ng-content></span>
+
+<div class="mat-mdc-option-ripple" mat-ripple
+     [matRippleTrigger]="_getHostElement()"
+     [matRippleDisabled]="disabled || disableRipple">
+</div>

--- a/src/material-experimental/mdc-core/option/option.scss
+++ b/src/material-experimental/mdc-core/option/option.scss
@@ -1,0 +1,58 @@
+@import '@material/list/mixins.import';
+@import '@material/list/variables.import';
+@import '../../mdc-helpers/mdc-helpers';
+@import '../../../material/core/style/vendor-prefixes';
+@import '../../../cdk/a11y/a11y';
+
+.mat-mdc-option {
+  // Note that we include this private mixin, because the public
+  // one adds a bunch of styles that we aren't using for the menu.
+  @include mdc-list-item-base_;
+  @include mdc-list-list-item-padding-variant(
+    $mdc-list-textual-variant-config, $query: $mat-base-styles-query);
+  @include mdc-list-list-item-height-variant(
+    $mdc-list-textual-variant-config, $query: $mat-base-styles-query);
+  @include mdc-list-item-disabled-text-opacity($mdc-list-text-disabled-opacity,
+    $query: $mat-base-styles-query);
+  @include user-select(none);
+
+  &:not(.mdc-list-item--disabled) {
+    cursor: pointer;
+  }
+
+  // Note that we bump the padding here, rather than padding inside the
+  // group so that ripples still reach to the edges of the panel.
+  .mat-mdc-optgroup &:not(.mat-mdc-option-multiple) {
+    padding-left: $mdc-list-side-padding * 2;
+
+    [dir='rtl'] & {
+      padding-left: $mdc-list-side-padding;
+      padding-right: $mdc-list-side-padding * 2;
+    }
+  }
+
+  .mat-pseudo-checkbox {
+    margin-right: $mdc-list-side-padding;
+
+    [dir='rtl'] & {
+      margin-right: 0;
+      margin-left: $mdc-list-side-padding;
+    }
+  }
+
+  // Increase specificity because ripple styles are part of the `mat-core` mixin and can
+  // potentially overwrite the absolute position of the container.
+  .mat-mdc-option-ripple {
+    @include mat-fill;
+
+    // Disable pointer events for the ripple container because the container will overlay the
+    // user content and we don't want to disable mouse events on the user content.
+    // Pointer events can be safely disabled because the ripple trigger element is the host element.
+    pointer-events: none;
+
+    // Prevents the ripple from completely covering the option in high contrast mode.
+    @include cdk-high-contrast(active, off) {
+      opacity: 0.5;
+    }
+  }
+}

--- a/src/material-experimental/mdc-core/option/option.spec.ts
+++ b/src/material-experimental/mdc-core/option/option.spec.ts
@@ -1,0 +1,208 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component, DebugElement} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {
+  dispatchFakeEvent,
+  dispatchKeyboardEvent,
+  createKeyboardEvent,
+  dispatchEvent,
+} from '@angular/cdk/testing/private';
+import {SPACE, ENTER} from '@angular/cdk/keycodes';
+import {MatOption, MatOptionModule} from './index';
+
+describe('MatOption component', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [MatOptionModule],
+      declarations: [BasicOption]
+    }).compileComponents();
+  }));
+
+  it('should complete the `stateChanges` stream on destroy', () => {
+    const fixture = TestBed.createComponent(BasicOption);
+    fixture.detectChanges();
+
+    const optionInstance: MatOption =
+        fixture.debugElement.query(By.directive(MatOption))!.componentInstance;
+    const completeSpy = jasmine.createSpy('complete spy');
+    const subscription = optionInstance._stateChanges.subscribe({complete: completeSpy});
+
+    fixture.destroy();
+    expect(completeSpy).toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
+
+  it('should not emit to `onSelectionChange` if selecting an already-selected option', () => {
+    const fixture = TestBed.createComponent(BasicOption);
+    fixture.detectChanges();
+
+    const optionInstance: MatOption =
+        fixture.debugElement.query(By.directive(MatOption))!.componentInstance;
+
+    optionInstance.select();
+    expect(optionInstance.selected).toBe(true);
+
+    const spy = jasmine.createSpy('selection change spy');
+    const subscription = optionInstance.onSelectionChange.subscribe(spy);
+
+    optionInstance.select();
+    fixture.detectChanges();
+
+    expect(optionInstance.selected).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+
+    subscription.unsubscribe();
+  });
+
+  it('should not emit to `onSelectionChange` if deselecting an unselected option', () => {
+    const fixture = TestBed.createComponent(BasicOption);
+    fixture.detectChanges();
+
+    const optionInstance: MatOption =
+        fixture.debugElement.query(By.directive(MatOption))!.componentInstance;
+
+    optionInstance.deselect();
+    expect(optionInstance.selected).toBe(false);
+
+    const spy = jasmine.createSpy('selection change spy');
+    const subscription = optionInstance.onSelectionChange.subscribe(spy);
+
+    optionInstance.deselect();
+    fixture.detectChanges();
+
+    expect(optionInstance.selected).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+
+    subscription.unsubscribe();
+  });
+
+  it('should be able to set a custom id', () => {
+    const fixture = TestBed.createComponent(BasicOption);
+
+    fixture.componentInstance.id = 'custom-option';
+    fixture.detectChanges();
+
+    const optionInstance = fixture.debugElement.query(By.directive(MatOption))!.componentInstance;
+
+    expect(optionInstance.id).toBe('custom-option');
+  });
+
+  it('should select the option when pressing space', () => {
+    const fixture = TestBed.createComponent(BasicOption);
+    fixture.detectChanges();
+
+    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption))!;
+    const optionNativeElement: HTMLElement = optionDebugElement.nativeElement;
+    const optionInstance: MatOption = optionDebugElement.componentInstance;
+    const spy = jasmine.createSpy('selection change spy');
+    const subscription = optionInstance.onSelectionChange.subscribe(spy);
+
+    const event = dispatchKeyboardEvent(optionNativeElement, 'keydown', SPACE);
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    subscription.unsubscribe();
+  });
+
+  it('should select the option when pressing enter', () => {
+    const fixture = TestBed.createComponent(BasicOption);
+    fixture.detectChanges();
+
+    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption))!;
+    const optionNativeElement: HTMLElement = optionDebugElement.nativeElement;
+    const optionInstance: MatOption = optionDebugElement.componentInstance;
+    const spy = jasmine.createSpy('selection change spy');
+    const subscription = optionInstance.onSelectionChange.subscribe(spy);
+
+    const event = dispatchKeyboardEvent(optionNativeElement, 'keydown', ENTER);
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    subscription.unsubscribe();
+  });
+
+  it('should not do anything when pressing the selection keys with a modifier', () => {
+    const fixture = TestBed.createComponent(BasicOption);
+    fixture.detectChanges();
+
+    const optionDebugElement = fixture.debugElement.query(By.directive(MatOption))!;
+    const optionNativeElement: HTMLElement = optionDebugElement.nativeElement;
+    const optionInstance: MatOption = optionDebugElement.componentInstance;
+    const spy = jasmine.createSpy('selection change spy');
+    const subscription = optionInstance.onSelectionChange.subscribe(spy);
+
+    [ENTER, SPACE].forEach(key => {
+      const event = createKeyboardEvent('keydown', key);
+      Object.defineProperty(event, 'shiftKey', {get: () => true});
+      dispatchEvent(optionNativeElement, event);
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
+
+  describe('ripples', () => {
+    let fixture: ComponentFixture<BasicOption>;
+    let optionDebugElement: DebugElement;
+    let optionNativeElement: HTMLElement;
+    let optionInstance: MatOption;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(BasicOption);
+      fixture.detectChanges();
+
+      optionDebugElement = fixture.debugElement.query(By.directive(MatOption))!;
+      optionNativeElement = optionDebugElement.nativeElement;
+      optionInstance = optionDebugElement.componentInstance;
+    });
+
+    it('should show ripples by default', () => {
+      expect(optionInstance.disableRipple).toBeFalsy('Expected ripples to be enabled by default');
+      expect(optionNativeElement.querySelectorAll('.mat-ripple-element').length)
+        .toBe(0, 'Expected no ripples to show up initially');
+
+      dispatchFakeEvent(optionNativeElement, 'mousedown');
+      dispatchFakeEvent(optionNativeElement, 'mouseup');
+
+      expect(optionNativeElement.querySelectorAll('.mat-ripple-element').length)
+        .toBe(1, 'Expected one ripple to show up after a fake click.');
+    });
+
+    it('should not show ripples if the option is disabled', () => {
+      expect(optionNativeElement.querySelectorAll('.mat-ripple-element').length)
+        .toBe(0, 'Expected no ripples to show up initially');
+
+      fixture.componentInstance.disabled = true;
+      fixture.detectChanges();
+
+      dispatchFakeEvent(optionNativeElement, 'mousedown');
+      dispatchFakeEvent(optionNativeElement, 'mouseup');
+
+      expect(optionNativeElement.querySelectorAll('.mat-ripple-element').length)
+        .toBe(0, 'Expected no ripples to show up after click on a disabled option.');
+    });
+
+  });
+
+  it('should have a focus indicator', () => {
+    const fixture = TestBed.createComponent(BasicOption);
+    const optionNativeElement = fixture.debugElement.query(By.directive(MatOption))!.nativeElement;
+
+    expect(optionNativeElement.classList.contains('mat-mdc-focus-indicator')).toBe(true);
+  });
+
+});
+
+@Component({
+  template: `<mat-option [id]="id" [disabled]="disabled"></mat-option>`
+})
+class BasicOption {
+  disabled: boolean;
+  id: string;
+}

--- a/src/material-experimental/mdc-core/option/option.ts
+++ b/src/material-experimental/mdc-core/option/option.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  Component,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+  ElementRef,
+  ChangeDetectorRef,
+  Optional,
+  Inject,
+} from '@angular/core';
+import {
+  _MatOptionBase,
+  MAT_OPTION_PARENT_COMPONENT,
+  MatOptionParentComponent,
+} from '@angular/material/core';
+import {MatOptgroup} from './optgroup';
+
+/**
+ * Single option inside of a `<mat-select>` element.
+ */
+@Component({
+  selector: 'mat-option',
+  exportAs: 'matOption',
+  host: {
+    'role': 'option',
+    '[attr.tabindex]': '_getTabIndex()',
+    '[class.mdc-list-item--selected]': 'selected',
+    '[class.mat-mdc-option-multiple]': 'multiple',
+    '[class.mat-mdc-option-active]': 'active',
+    '[class.mdc-list-item--disabled]': 'disabled',
+    '[id]': 'id',
+    '[attr.aria-selected]': '_getAriaSelected()',
+    '[attr.aria-disabled]': 'disabled.toString()',
+    '(click)': '_selectViaInteraction()',
+    '(keydown)': '_handleKeydown($event)',
+    'class': 'mat-mdc-option mat-mdc-focus-indicator',
+  },
+  styleUrls: ['option.css'],
+  templateUrl: 'option.html',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MatOption extends _MatOptionBase {
+  constructor(
+    element: ElementRef<HTMLElement>,
+    changeDetectorRef: ChangeDetectorRef,
+    @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) parent: MatOptionParentComponent,
+    @Optional() group: MatOptgroup) {
+    super(element, changeDetectorRef, parent, group);
+  }
+}

--- a/src/material-experimental/mdc-core/public-api.ts
+++ b/src/material-experimental/mdc-core/public-api.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './option/index';

--- a/src/material-experimental/mdc-theming/BUILD.bazel
+++ b/src/material-experimental/mdc-theming/BUILD.bazel
@@ -20,6 +20,7 @@ sass_library(
         "//src/material-experimental/mdc-card:mdc_card_scss_lib",
         "//src/material-experimental/mdc-checkbox:mdc_checkbox_scss_lib",
         "//src/material-experimental/mdc-chips:mdc_chips_scss_lib",
+        "//src/material-experimental/mdc-core:mdc_core_scss_lib",
         "//src/material-experimental/mdc-form-field:mdc_form_field_scss_lib",
         "//src/material-experimental/mdc-input:mdc_input_scss_lib",
         "//src/material-experimental/mdc-list:mdc_list_scss_lib",

--- a/src/material-experimental/mdc-theming/_all-theme.scss
+++ b/src/material-experimental/mdc-theming/_all-theme.scss
@@ -1,3 +1,4 @@
+@import '../mdc-core/core';
 @import '../mdc-button/button-theme';
 @import '../mdc-card/card-theme';
 @import '../mdc-checkbox/checkbox-theme';
@@ -16,6 +17,7 @@
 
 @mixin angular-material-mdc-theme($theme-or-color-config) {
   @include _mat-check-duplicate-theme-styles($theme-or-color-config, 'angular-material-mdc-theme') {
+    @include mat-mdc-core-theme($theme-or-color-config);
     @include mat-mdc-button-theme($theme-or-color-config);
     @include mat-mdc-fab-theme($theme-or-color-config);
     @include mat-mdc-icon-button-theme($theme-or-color-config);

--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -12,7 +12,8 @@ import {
   Component,
   InjectionToken,
   Input,
-  ViewEncapsulation
+  ViewEncapsulation,
+  Directive
 } from '@angular/core';
 import {CanDisable, CanDisableCtor, mixinDisabled} from '../common-behaviors/disabled';
 
@@ -25,6 +26,18 @@ const _MatOptgroupMixinBase: CanDisableCtor & typeof MatOptgroupBase =
 
 // Counter for unique group ids.
 let _uniqueOptgroupIdCounter = 0;
+
+@Directive()
+// tslint:disable-next-line:class-name
+export class _MatOptgroupBase extends _MatOptgroupMixinBase implements CanDisable {
+  /** Label for the option group. */
+  @Input() label: string;
+
+  /** Unique id for the underlying label. */
+  _labelId: string = `mat-optgroup-label-${_uniqueOptgroupIdCounter++}`;
+
+  static ngAcceptInputType_disabled: BooleanInput;
+}
 
 /**
  * Injection token that can be used to reference instances of `MatOptgroup`. It serves as
@@ -53,12 +66,5 @@ export const MAT_OPTGROUP = new InjectionToken<MatOptgroup>('MatOptgroup');
   },
   providers: [{provide: MAT_OPTGROUP, useExisting: MatOptgroup}],
 })
-export class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
-  /** Label for the option group. */
-  @Input() label: string;
-
-  /** Unique id for the underlying label. */
-  _labelId: string = `mat-optgroup-label-${_uniqueOptgroupIdCounter++}`;
-
-  static ngAcceptInputType_disabled: BooleanInput;
+export class MatOptgroup extends _MatOptgroupBase {
 }

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -23,10 +23,11 @@ import {
   Output,
   QueryList,
   ViewEncapsulation,
+  Directive,
 } from '@angular/core';
 import {FocusOptions, FocusableOption, FocusOrigin} from '@angular/cdk/a11y';
 import {Subject} from 'rxjs';
-import {MAT_OPTGROUP, MatOptgroup} from './optgroup';
+import {MatOptgroup, _MatOptgroupBase, MAT_OPTGROUP} from './optgroup';
 
 /**
  * Option IDs need to be unique across components, so this counter exists outside of
@@ -59,32 +60,10 @@ export interface MatOptionParentComponent {
 export const MAT_OPTION_PARENT_COMPONENT =
     new InjectionToken<MatOptionParentComponent>('MAT_OPTION_PARENT_COMPONENT');
 
-/**
- * Single option inside of a `<mat-select>` element.
- */
-@Component({
-  selector: 'mat-option',
-  exportAs: 'matOption',
-  host: {
-    'role': 'option',
-    '[attr.tabindex]': '_getTabIndex()',
-    '[class.mat-selected]': 'selected',
-    '[class.mat-option-multiple]': 'multiple',
-    '[class.mat-active]': 'active',
-    '[id]': 'id',
-    '[attr.aria-selected]': '_getAriaSelected()',
-    '[attr.aria-disabled]': 'disabled.toString()',
-    '[class.mat-option-disabled]': 'disabled',
-    '(click)': '_selectViaInteraction()',
-    '(keydown)': '_handleKeydown($event)',
-    'class': 'mat-option mat-focus-indicator',
-  },
-  styleUrls: ['option.css'],
-  templateUrl: 'option.html',
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-export class MatOption implements FocusableOption, AfterViewChecked, OnDestroy {
+
+@Directive()
+// tslint:disable-next-line:class-name
+export class _MatOptionBase implements FocusableOption, AfterViewChecked, OnDestroy {
   private _selected = false;
   private _active = false;
   private _disabled = false;
@@ -120,8 +99,8 @@ export class MatOption implements FocusableOption, AfterViewChecked, OnDestroy {
   constructor(
     private _element: ElementRef<HTMLElement>,
     private _changeDetectorRef: ChangeDetectorRef,
-    @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) private _parent: MatOptionParentComponent,
-    @Optional() @Inject(MAT_OPTGROUP) readonly group: MatOptgroup) {}
+    private _parent: MatOptionParentComponent,
+    readonly group: _MatOptgroupBase) {}
 
   /**
    * Whether or not the option is currently active and ready to be selected.
@@ -268,6 +247,41 @@ export class MatOption implements FocusableOption, AfterViewChecked, OnDestroy {
   }
 
   static ngAcceptInputType_disabled: BooleanInput;
+}
+
+/**
+ * Single option inside of a `<mat-select>` element.
+ */
+@Component({
+  selector: 'mat-option',
+  exportAs: 'matOption',
+  host: {
+    'role': 'option',
+    '[attr.tabindex]': '_getTabIndex()',
+    '[class.mat-selected]': 'selected',
+    '[class.mat-option-multiple]': 'multiple',
+    '[class.mat-active]': 'active',
+    '[id]': 'id',
+    '[attr.aria-selected]': '_getAriaSelected()',
+    '[attr.aria-disabled]': 'disabled.toString()',
+    '[class.mat-option-disabled]': 'disabled',
+    '(click)': '_selectViaInteraction()',
+    '(keydown)': '_handleKeydown($event)',
+    'class': 'mat-option mat-focus-indicator',
+  },
+  styleUrls: ['option.css'],
+  templateUrl: 'option.html',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MatOption extends _MatOptionBase {
+  constructor(
+    element: ElementRef<HTMLElement>,
+    changeDetectorRef: ChangeDetectorRef,
+    @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) parent: MatOptionParentComponent,
+    @Optional() @Inject(MAT_OPTGROUP) group: MatOptgroup) {
+    super(element, changeDetectorRef, parent, group);
+  }
 }
 
 /**

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -2,6 +2,46 @@ export declare function _countGroupLabelsBeforeOption(optionIndex: number, optio
 
 export declare function _getOptionScrollPosition(optionIndex: number, optionHeight: number, currentScrollPosition: number, panelHeight: number): number;
 
+export declare class _MatOptgroupBase extends _MatOptgroupMixinBase implements CanDisable {
+    _labelId: string;
+    label: string;
+    static ngAcceptInputType_disabled: BooleanInput;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatOptgroupBase, never, never, { "label": "label"; }, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<_MatOptgroupBase, never>;
+}
+
+export declare class _MatOptionBase implements FocusableOption, AfterViewChecked, OnDestroy {
+    readonly _stateChanges: Subject<void>;
+    get active(): boolean;
+    get disableRipple(): boolean | undefined;
+    get disabled(): any;
+    set disabled(value: any);
+    readonly group: _MatOptgroupBase;
+    id: string;
+    get multiple(): boolean | undefined;
+    readonly onSelectionChange: EventEmitter<MatOptionSelectionChange>;
+    get selected(): boolean;
+    value: any;
+    get viewValue(): string;
+    constructor(_element: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _parent: MatOptionParentComponent, group: _MatOptgroupBase);
+    _getAriaSelected(): boolean | null;
+    _getHostElement(): HTMLElement;
+    _getTabIndex(): string;
+    _handleKeydown(event: KeyboardEvent): void;
+    _selectViaInteraction(): void;
+    deselect(): void;
+    focus(_origin?: FocusOrigin, options?: FocusOptions): void;
+    getLabel(): string;
+    ngAfterViewChecked(): void;
+    ngOnDestroy(): void;
+    select(): void;
+    setActiveStyles(): void;
+    setInactiveStyles(): void;
+    static ngAcceptInputType_disabled: BooleanInput;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatOptionBase, never, never, { "value": "value"; "id": "id"; "disabled": "disabled"; }, { "onSelectionChange": "onSelectionChange"; }, never>;
+    static ɵfac: i0.ɵɵFactoryDef<_MatOptionBase, never>;
+}
+
 export declare class AnimationCurves {
     static ACCELERATION_CURVE: string;
     static DECELERATION_CURVE: string;
@@ -190,43 +230,14 @@ export declare class MatNativeDateModule {
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatNativeDateModule, never, [typeof NativeDateModule], never>;
 }
 
-export declare class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
-    _labelId: string;
-    label: string;
-    static ngAcceptInputType_disabled: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatOptgroup, "mat-optgroup", ["matOptgroup"], { "disabled": "disabled"; "label": "label"; }, {}, never, ["*", "mat-option, ng-container"]>;
+export declare class MatOptgroup extends _MatOptgroupBase {
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatOptgroup, "mat-optgroup", ["matOptgroup"], { "disabled": "disabled"; }, {}, never, ["*", "mat-option, ng-container"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatOptgroup, never>;
 }
 
-export declare class MatOption implements FocusableOption, AfterViewChecked, OnDestroy {
-    readonly _stateChanges: Subject<void>;
-    get active(): boolean;
-    get disableRipple(): boolean | undefined;
-    get disabled(): any;
-    set disabled(value: any);
-    readonly group: MatOptgroup;
-    id: string;
-    get multiple(): boolean | undefined;
-    readonly onSelectionChange: EventEmitter<MatOptionSelectionChange>;
-    get selected(): boolean;
-    value: any;
-    get viewValue(): string;
-    constructor(_element: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _parent: MatOptionParentComponent, group: MatOptgroup);
-    _getAriaSelected(): boolean | null;
-    _getHostElement(): HTMLElement;
-    _getTabIndex(): string;
-    _handleKeydown(event: KeyboardEvent): void;
-    _selectViaInteraction(): void;
-    deselect(): void;
-    focus(_origin?: FocusOrigin, options?: FocusOptions): void;
-    getLabel(): string;
-    ngAfterViewChecked(): void;
-    ngOnDestroy(): void;
-    select(): void;
-    setActiveStyles(): void;
-    setInactiveStyles(): void;
-    static ngAcceptInputType_disabled: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatOption, "mat-option", ["matOption"], { "value": "value"; "id": "id"; "disabled": "disabled"; }, { "onSelectionChange": "onSelectionChange"; }, never, ["*"]>;
+export declare class MatOption extends _MatOptionBase {
+    constructor(element: ElementRef<HTMLElement>, changeDetectorRef: ChangeDetectorRef, parent: MatOptionParentComponent, group: MatOptgroup);
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatOption, "mat-option", ["matOption"], {}, {}, never, ["*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatOption, [null, null, { optional: true; }, { optional: true; }]>;
 }
 


### PR DESCRIPTION
- Sets up the MDC-based `mat-option` and `mat-optgroup` which are a prerequisite for the MDC-based `mat-select` and `mat-autocomplete`.
- Adds a new `mdc-core` entry point which is the equivalent of `material/core`. We'll need this in the future for other things like an MDC-based `mat-core-theme` and for the elevation styles.