### PR TITLE
build: don't flag noop mixins in theme mixin rule

### DIFF
--- a/src/material-experimental/column-resize/_column-resize.scss
+++ b/src/material-experimental/column-resize/_column-resize.scss
@@ -97,13 +97,9 @@
   }
 }
 
-@mixin mat-column-resize-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
-}
+@mixin mat-column-resize-typography($config-or-theme) {}
 
-@mixin mat-column-resize-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-column-resize-density($config-or-theme) {}
 
 @mixin mat-column-resize-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
+++ b/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
@@ -1,22 +1,10 @@
 @import '../mdc-helpers/mdc-helpers';
 
-@mixin mat-mdc-autocomplete-color($config-or-theme) {
-  $config: mat-get-color-config($config-or-theme);
-  @include mat-using-mdc-theme($config) {
-    // TODO: implement MDC-based autocomplete.
-  }
-}
+@mixin mat-mdc-autocomplete-color($config-or-theme) {}
 
-@mixin mat-mdc-autocomplete-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
-  @include mat-using-mdc-typography($config) {
-    // TODO: implement MDC-based autocomplete.
-  }
-}
+@mixin mat-mdc-autocomplete-typography($config-or-theme) {}
 
-@mixin mat-mdc-autocomplete-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-mdc-autocomplete-density($config-or-theme) {}
 
 @mixin mat-mdc-autocomplete-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/mdc-button/_button-theme.scss
+++ b/src/material-experimental/mdc-button/_button-theme.scss
@@ -258,9 +258,7 @@ $mat-button-state-target: '.mdc-button__ripple';
   }
 }
 
-@mixin mat-mdc-fab-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-mdc-fab-density($config-or-theme) {}
 
 @mixin mat-mdc-fab-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/mdc-card/_card-theme.scss
+++ b/src/material-experimental/mdc-card/_card-theme.scss
@@ -48,9 +48,7 @@
   }
 }
 
-@mixin mat-mdc-card-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-mdc-card-density($config-or-theme) {}
 
 @mixin mat-mdc-card-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/mdc-input/_input-theme.scss
+++ b/src/material-experimental/mdc-input/_input-theme.scss
@@ -10,9 +10,7 @@
   @include mat-using-mdc-typography($config) {}
 }
 
-@mixin mat-mdc-input-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-mdc-input-density($config-or-theme) {}
 
 @mixin mat-mdc-input-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -52,9 +52,7 @@
   }
 }
 
-@mixin mat-mdc-menu-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-mdc-menu-density($config-or-theme) {}
 
 @mixin mat-mdc-menu-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
+++ b/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
@@ -29,14 +29,9 @@
   }
 }
 
-@mixin mat-mdc-progress-bar-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme)
-  // No typography for this component.
-}
+@mixin mat-mdc-progress-bar-typography($config-or-theme) {}
 
-@mixin mat-mdc-progress-bar-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-mdc-progress-bar-density($config-or-theme) {}
 
 @mixin mat-mdc-progress-bar-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/mdc-sidenav/_sidenav-theme.scss
+++ b/src/material-experimental/mdc-sidenav/_sidenav-theme.scss
@@ -1,18 +1,8 @@
 @import '../mdc-helpers/mdc-helpers';
 
-@mixin mat-mdc-sidenav-color($config-or-theme) {
-  $config: mat-get-color-config($config-or-theme);
-  @include mat-using-mdc-theme($config) {
-    // TODO: implement MDC-based sidenav.
-  }
-}
+@mixin mat-mdc-sidenav-color($config-or-theme) {}
 
-@mixin mat-mdc-sidenav-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
-  @include mat-using-mdc-typography($config) {
-    // TODO: implement MDC-based sidenav.
-  }
-}
+@mixin mat-mdc-sidenav-typography($config-or-theme) {}
 
 @mixin mat-mdc-sidenav-density($config-or-theme) {
   $density-scale: mat-get-density-config($config-or-theme);

--- a/src/material-experimental/mdc-slider/_slider-theme.scss
+++ b/src/material-experimental/mdc-slider/_slider-theme.scss
@@ -25,9 +25,7 @@
   }
 }
 
-@mixin mat-mdc-slider-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-mdc-slider-density($config-or-theme) {}
 
 @mixin mat-mdc-slider-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/mdc-snackbar/_snackbar-theme.scss
+++ b/src/material-experimental/mdc-snackbar/_snackbar-theme.scss
@@ -1,16 +1,10 @@
 @import '../mdc-helpers/mdc-helpers';
 
-@mixin mat-mdc-snackbar-color($config-or-theme) {
-  $config: mat-get-color-config($config-or-theme);
-}
+@mixin mat-mdc-snackbar-color($config-or-theme) {}
 
-@mixin mat-mdc-snackbar-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
-}
+@mixin mat-mdc-snackbar-typography($config-or-theme) {}
 
-@mixin mat-mdc-snackbar-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-mdc-snackbar-density($config-or-theme) {}
 
 @mixin mat-mdc-snackbar-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material-experimental/popover-edit/_popover-edit.scss
+++ b/src/material-experimental/popover-edit/_popover-edit.scss
@@ -150,9 +150,7 @@
 }
 
 
-@mixin mat-popover-edit-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-popover-edit-density($config-or-theme) {}
 
 @mixin mat-popover-edit-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/autocomplete/_autocomplete-theme.scss
+++ b/src/material/autocomplete/_autocomplete-theme.scss
@@ -27,13 +27,9 @@
   }
 }
 
-@mixin mat-autocomplete-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
- }
+@mixin mat-autocomplete-typography($config-or-theme) {}
 
-@mixin _mat-autocomplete-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
- }
+@mixin _mat-autocomplete-density($config-or-theme) {}
 
 @mixin mat-autocomplete-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/badge/_badge-theme.scss
+++ b/src/material/badge/_badge-theme.scss
@@ -206,10 +206,7 @@ $mat-badge-large-size: $mat-badge-default-size + 6;
   }
 }
 
-@mixin _mat-badge-density($config-or-theme) {
-
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-badge-density($config-or-theme) {}
 
 @mixin mat-badge-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/bottom-sheet/_bottom-sheet-theme.scss
+++ b/src/material/bottom-sheet/_bottom-sheet-theme.scss
@@ -23,9 +23,7 @@
   }
 }
 
-@mixin _mat-bottom-sheet-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-bottom-sheet-density($config-or-theme) {}
 
 @mixin mat-bottom-sheet-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -173,9 +173,7 @@ $_mat-button-ripple-opacity: 0.1;
   }
 }
 
-@mixin _mat-button-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-button-density($config-or-theme) {}
 
 @mixin mat-button-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -49,9 +49,7 @@
   }
 }
 
-@mixin _mat-card-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-card-density($config-or-theme) {}
 
 @mixin mat-card-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -108,9 +108,7 @@
   }
 }
 
-@mixin _mat-checkbox-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-checkbox-density($config-or-theme) {}
 
 @mixin mat-checkbox-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -100,9 +100,7 @@ $mat-chip-remove-font-size: 18px;
   }
 }
 
-@mixin _mat-chips-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-chips-density($config-or-theme) {}
 
 @mixin mat-chips-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/core/option/_optgroup-theme.scss
+++ b/src/material/core/option/_optgroup-theme.scss
@@ -23,9 +23,7 @@
   }
 }
 
-@mixin _mat-optgroup-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-optgroup-density($config-or-theme) {}
 
 @mixin mat-optgroup-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -57,9 +57,7 @@
   }
 }
 
-@mixin _mat-option-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-option-density($config-or-theme) {}
 
 @mixin mat-option-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -59,12 +59,9 @@
   }
 }
 
-@mixin mat-pseudo-checkbox-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
-}
-@mixin _mat-pseudo-checkbox-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin mat-pseudo-checkbox-typography($config-or-theme) {}
+
+@mixin _mat-pseudo-checkbox-density($config-or-theme) {}
 
 @mixin mat-pseudo-checkbox-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -220,9 +220,7 @@ $mat-calendar-weekday-table-font-size: 11px !default;
   }
 }
 
-@mixin _mat-datepicker-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-datepicker-density($config-or-theme) {}
 
 @mixin mat-datepicker-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -24,9 +24,7 @@
   }
 }
 
-@mixin _mat-dialog-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-dialog-density($config-or-theme) {}
 
 @mixin mat-dialog-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/divider/_divider-theme.scss
+++ b/src/material/divider/_divider-theme.scss
@@ -15,13 +15,9 @@
   }
 }
 
-@mixin mat-divider-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
-}
+@mixin mat-divider-typography($config-or-theme) {}
 
-@mixin _mat-divider-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-divider-density($config-or-theme) {}
 
 @mixin mat-divider-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/form-field/_form-field-fill-theme.scss
+++ b/src/material/form-field/_form-field-fill-theme.scss
@@ -102,9 +102,7 @@ $mat-form-field-fill-dedupe: 0;
   }
 }
 
-@mixin _mat-form-field-fill-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-form-field-fill-density($config-or-theme) {}
 
 @mixin mat-form-field-fill-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/form-field/_form-field-legacy-theme.scss
+++ b/src/material/form-field/_form-field-legacy-theme.scss
@@ -175,9 +175,7 @@ $mat-form-field-legacy-dedupe: 0;
   }
 }
 
-@mixin _mat-form-field-legacy-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-form-field-legacy-density($config-or-theme) {}
 
 @mixin mat-form-field-legacy-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/form-field/_form-field-outline-theme.scss
+++ b/src/material/form-field/_form-field-outline-theme.scss
@@ -132,9 +132,7 @@ $mat-form-field-outline-dedupe: 0;
   }
 }
 
-@mixin _mat-form-field-outline-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-form-field-outline-density($config-or-theme) {}
 
 @mixin mat-form-field-outline-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/form-field/_form-field-standard-theme.scss
+++ b/src/material/form-field/_form-field-standard-theme.scss
@@ -25,13 +25,9 @@
   }
 }
 
-@mixin mat-form-field-standard-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
-}
+@mixin mat-form-field-standard-typography($config-or-theme) {}
 
-@mixin _mat-form-field-standard-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-form-field-standard-density($config-or-theme) {}
 
 @mixin mat-form-field-standard-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/grid-list/_grid-list-theme.scss
+++ b/src/material/grid-list/_grid-list-theme.scss
@@ -6,9 +6,7 @@
 
 
 // Include this empty mixin for consistency with the other components.
-@mixin mat-grid-list-color($config-or-theme) {
-  $config: mat-get-color-config($config-or-theme);
- }
+@mixin mat-grid-list-color($config-or-theme) {}
 
 @mixin mat-grid-list-typography($config-or-theme) {
   $config: mat-get-typography-config($config-or-theme);
@@ -19,9 +17,7 @@
   }
 }
 
-@mixin _mat-grid-list-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-grid-list-density($config-or-theme) {}
 
 @mixin mat-grid-list-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/icon/_icon-theme.scss
+++ b/src/material/icon/_icon-theme.scss
@@ -24,13 +24,9 @@
   }
 }
 
-@mixin mat-icon-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
- }
+@mixin mat-icon-typography($config-or-theme) {}
 
-@mixin _mat-icon-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-icon-density($config-or-theme) {}
 
 @mixin mat-icon-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/input/_input-theme.scss
+++ b/src/material/input/_input-theme.scss
@@ -75,9 +75,7 @@
   }
 }
 
-@mixin _mat-input-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-input-density($config-or-theme) {}
 
 @mixin mat-input-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -94,9 +94,7 @@
   }
 }
 
-@mixin _mat-list-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-list-density($config-or-theme) {}
 
 @mixin mat-list-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/menu/_menu-theme.scss
+++ b/src/material/menu/_menu-theme.scss
@@ -52,9 +52,7 @@
   }
 }
 
-@mixin _mat-menu-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-menu-density($config-or-theme) {}
 
 @mixin mat-menu-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -49,13 +49,9 @@
   }
 }
 
-@mixin mat-progress-bar-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
- }
+@mixin mat-progress-bar-typography($config-or-theme) {}
 
-@mixin _mat-progress-bar-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-progress-bar-density($config-or-theme) {}
 
 @mixin mat-progress-bar-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/progress-spinner/_progress-spinner-theme.scss
+++ b/src/material/progress-spinner/_progress-spinner-theme.scss
@@ -23,13 +23,9 @@
   }
 }
 
-@mixin mat-progress-spinner-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
- }
+@mixin mat-progress-spinner-typography($config-or-theme) {}
 
-@mixin _mat-progress-spinner-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-progress-spinner-density($config-or-theme) {}
 
 @mixin mat-progress-spinner-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/radio/_radio-theme.scss
+++ b/src/material/radio/_radio-theme.scss
@@ -75,9 +75,7 @@
   }
 }
 
-@mixin _mat-radio-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-radio-density($config-or-theme) {}
 
 @mixin mat-radio-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/select/_select-theme.scss
+++ b/src/material/select/_select-theme.scss
@@ -78,9 +78,7 @@
   }
 }
 
-@mixin _mat-select-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-select-density($config-or-theme) {}
 
 @mixin mat-select-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/sidenav/_sidenav-theme.scss
+++ b/src/material/sidenav/_sidenav-theme.scss
@@ -74,13 +74,9 @@
   }
 }
 
-@mixin mat-sidenav-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
- }
+@mixin mat-sidenav-typography($config-or-theme) {}
 
-@mixin _mat-sidenav-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-sidenav-density($config-or-theme) {}
 
 @mixin mat-sidenav-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -80,9 +80,7 @@
   }
 }
 
-@mixin _mat-slide-toggle-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-slide-toggle-density($config-or-theme) {}
 
 @mixin mat-slide-toggle-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/slider/_slider-theme.scss
+++ b/src/material/slider/_slider-theme.scss
@@ -175,9 +175,7 @@
   }
 }
 
-@mixin _mat-slider-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-slider-density($config-or-theme) {}
 
 @mixin mat-slider-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/snack-bar/_snack-bar-theme.scss
+++ b/src/material/snack-bar/_snack-bar-theme.scss
@@ -42,9 +42,7 @@
   }
 }
 
-@mixin _mat-snack-bar-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-snack-bar-density($config-or-theme) {}
 
 @mixin mat-snack-bar-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/sort/_sort-theme.scss
+++ b/src/material/sort/_sort-theme.scss
@@ -26,13 +26,9 @@
   }
 }
 
-@mixin mat-sort-typography($config-or-theme) {
-  $config: mat-get-typography-config($config-or-theme);
- }
+@mixin mat-sort-typography($config-or-theme) {}
 
-@mixin _mat-sort-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-sort-density($config-or-theme) {}
 
 @mixin mat-sort-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/table/_table-theme.scss
+++ b/src/material/table/_table-theme.scss
@@ -49,9 +49,7 @@
   }
 }
 
-@mixin _mat-table-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-table-density($config-or-theme) {}
 
 @mixin mat-table-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -142,9 +142,7 @@
   }
 }
 
-@mixin _mat-tabs-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-tabs-density($config-or-theme) {}
 
 @mixin mat-tabs-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);

--- a/src/material/tooltip/_tooltip-theme.scss
+++ b/src/material/tooltip/_tooltip-theme.scss
@@ -37,9 +37,7 @@ $mat-tooltip-handset-vertical-padding:
   }
 }
 
-@mixin _mat-tooltip-density($config-or-theme) {
-  $density-scale: mat-get-density-config($config-or-theme);
-}
+@mixin _mat-tooltip-density($config-or-theme) {}
 
 @mixin mat-tooltip-theme($theme-or-color-config) {
   $theme: _mat-legacy-get-theme($theme-or-color-config);


### PR DESCRIPTION
The `theme-mixin-api` rule flags any mixin that doesn't include a variable that extracts the config. This can be annoying for noop placeholder mixins since we have to declare a variable that won't be used. These changes add an exception for mixins that are empty or only contain comment nodes.