### PR TITLE
fix(drag-drop): allow handle to be set on drag element if there is a different drag root

### DIFF
--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -1,5 +1,5 @@
 cdk/drag-drop/all-directives: 153594
-cdk/drag-drop/basic: 150852
+cdk/drag-drop/basic: 151498
 material-experimental/mdc-chips/basic: 147607
 material-experimental/mdc-form-field/advanced: 220897
 material-experimental/mdc-form-field/basic: 220060

--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -14,7 +14,8 @@ import {
   InjectionToken,
   Input,
   OnDestroy,
-  Optional
+  Optional,
+  SkipSelf,
 } from '@angular/core';
 import {Subject} from 'rxjs';
 import {CDK_DRAG_PARENT} from '../drag-parent';
@@ -53,7 +54,7 @@ export class CdkDragHandle implements OnDestroy {
 
   constructor(
     public element: ElementRef<HTMLElement>,
-    @Inject(CDK_DRAG_PARENT) @Optional() parentDrag?: any) {
+    @Inject(CDK_DRAG_PARENT) @Optional() @SkipSelf() parentDrag?: any) {
 
     this._parentDrag = parentDrag;
     toggleNativeDragInteractions(element.nativeElement, false);

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -544,6 +544,30 @@ describe('CdkDrag', () => {
       expect(dragElement.style.transform).toBeFalsy();
     }));
 
+    it('should be able to set the cdkDrag element as handle if it has a different root element',
+      fakeAsync(() => {
+        const fixture = createComponent(DraggableWithAlternateRootAndSelfHandle);
+        fixture.detectChanges();
+
+        const dragRoot = fixture.componentInstance.dragRoot.nativeElement;
+        const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+        expect(dragRoot.style.transform).toBeFalsy();
+        expect(dragElement.style.transform).toBeFalsy();
+
+        // Try dragging the root. This should be possible since the drag element is the handle.
+        dragElementViaMouse(fixture, dragRoot, 50, 100);
+
+        expect(dragRoot.style.transform).toBeFalsy();
+        expect(dragElement.style.transform).toBeFalsy();
+
+        // Drag via the drag element which acts as the handle.
+        dragElementViaMouse(fixture, dragElement, 50, 100);
+
+        expect(dragRoot.style.transform).toBe('translate3d(50px, 100px, 0px)');
+        expect(dragElement.style.transform).toBeFalsy();
+      }));
+
     it('should preserve the initial transform if the root element changes', fakeAsync(() => {
       const fixture = createComponent(DraggableWithAlternateRoot);
       fixture.detectChanges();
@@ -6275,6 +6299,25 @@ class DraggableInHorizontalFlexDropZoneWithMatchSizePreview {
   `
 })
 class ConnectedDropZonesWithIntermediateSibling extends ConnectedDropZones {
+}
+
+
+@Component({
+  template: `
+    <div #dragRoot class="alternate-root" style="width: 200px; height: 200px; background: hotpink">
+      <div
+        cdkDrag
+        cdkDragRootElement=".alternate-root"
+        cdkDragHandle
+        #dragElement
+        style="width: 100px; height: 100px; background: red;"></div>
+    </div>
+  `
+})
+class DraggableWithAlternateRootAndSelfHandle {
+  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
+  @ViewChild('dragRoot') dragRoot: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag) dragInstance: CdkDrag;
 }
 
 

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -28,6 +28,7 @@ import {
   SimpleChanges,
   ChangeDetectorRef,
   isDevMode,
+  Self,
 } from '@angular/core';
 import {
   coerceBooleanProperty,
@@ -189,7 +190,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
       private _viewContainerRef: ViewContainerRef,
       @Optional() @Inject(CDK_DRAG_CONFIG) config: DragDropConfig,
       @Optional() private _dir: Directionality, dragDrop: DragDrop,
-      private _changeDetectorRef: ChangeDetectorRef) {
+      private _changeDetectorRef: ChangeDetectorRef,
+      @Optional() @Self() private _selfHandle?: CdkDragHandle) {
     this._dragRef = dragDrop.createDrag(element, {
       dragStartThreshold: config && config.dragStartThreshold != null ?
           config.dragStartThreshold : 5,
@@ -262,6 +264,14 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
             const childHandleElements = handles
               .filter(handle => handle._parentDrag === this)
               .map(handle => handle.element);
+
+            // Usually handles are only allowed to be a descendant of the drag element, but if
+            // the consumer defined a different drag root, we should allow the drag element
+            // itself to be a handle too.
+            if (this._selfHandle && this.rootElementSelector) {
+              childHandleElements.push(this.element);
+            }
+
             this._dragRef.withHandles(childHandleElements);
           }),
           // Listen if the state of any of the handles changes.

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -37,7 +37,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     started: EventEmitter<CdkDragStart>;
     constructor(
     element: ElementRef<HTMLElement>,
-    dropContainer: CdkDropList, _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragDropConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef);
+    dropContainer: CdkDropList, _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragDropConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _selfHandle?: CdkDragHandle | undefined);
     getFreeDragPosition(): {
         readonly x: number;
         readonly y: number;
@@ -50,7 +50,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     reset(): void;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { "data": "cdkDragData"; "lockAxis": "cdkDragLockAxis"; "rootElementSelector": "cdkDragRootElement"; "boundaryElement": "cdkDragBoundary"; "dragStartDelay": "cdkDragStartDelay"; "freeDragPosition": "cdkDragFreeDragPosition"; "disabled": "cdkDragDisabled"; "constrainPosition": "cdkDragConstrainPosition"; "previewClass": "cdkDragPreviewClass"; }, { "started": "cdkDragStarted"; "released": "cdkDragReleased"; "ended": "cdkDragEnded"; "entered": "cdkDragEntered"; "exited": "cdkDragExited"; "dropped": "cdkDragDropped"; "moved": "cdkDragMoved"; }, ["_previewTemplate", "_placeholderTemplate", "_handles"]>;
-    static ɵfac: i0.ɵɵFactoryDef<CdkDrag<any>, [null, { optional: true; skipSelf: true; }, null, null, null, { optional: true; }, { optional: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDef<CdkDrag<any>, [null, { optional: true; skipSelf: true; }, null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; self: true; }]>;
 }
 
 export interface CdkDragDrop<T, O = T> {
@@ -95,7 +95,7 @@ export declare class CdkDragHandle implements OnDestroy {
     ngOnDestroy(): void;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDragHandle, "[cdkDragHandle]", never, { "disabled": "cdkDragHandleDisabled"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<CdkDragHandle, [null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<CdkDragHandle, [null, { optional: true; skipSelf: true; }]>;
 }
 
 export interface CdkDragMove<T = any> {


### PR DESCRIPTION
Currently we only allow the drag handle to be a descendant of the drag element, but this can be inconvenient if the drag root is moved further up the DOM using `cdkDragRootElement`. These changes allow for a handle to be set on the drag element itself, if it has an alternate drag root.

Fixes #19555.