### PR TITLE
docs(a11y): add note about cdkFocusInitial inside focus trap directive

### DIFF
--- a/src/cdk/a11y/a11y.md
+++ b/src/cdk/a11y/a11y.md
@@ -84,6 +84,9 @@ For example:
 <a mat-list-item routerLink cdkFocusRegionEnd>Focus region end</a>
 ```
 
+**Note:** If you're using `cdkFocusInitial` together with the `CdkTrapFocus` directive, nothing
+will happen unless you've enabled the `cdkTrapFocusAutoCapture` option as well. This is due to
+`CdkTrapFocus` not capturing focus on initialization by default.
 
 ## InteractivityChecker
 `InteractivityChecker` is used to check the interactivity of an element, capturing disabled,


### PR DESCRIPTION
Adds a note to the docs mentioning that `cdkFocusInitial` won't do anything inside the focus trap directive, unless `cdkTrapFocusAutoCapture` is enabled.

Fixes #19475.