### PR TITLE
build: postinstall should not process dev-infra package

### DIFF
--- a/angular-tsconfig.json
+++ b/angular-tsconfig.json
@@ -26,6 +26,7 @@
     "node_modules/@angular/bazel/**",
     "node_modules/@angular/common/upgrade*",
     "node_modules/@angular/compiler-cli/**",
+    "node_modules/@angular/dev-infra-private/**",
     "node_modules/@angular/router/upgrade*"
   ]
 }


### PR DESCRIPTION
Currently our NGC postinstall for Bazel also runs against the
dev-infra package. This results in a small slow-down and is
simply unnecessary given that this does not represent
a dependency of interest for `ng_module` compilations.