### PR TITLE
refactor: assert value for RxJS v7 compatibility

### DIFF
--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -45,7 +45,7 @@ export type ExtendedScrollToOptions = _XAxis & _YAxis & ScrollOptions;
   selector: '[cdk-scrollable], [cdkScrollable]'
 })
 export class CdkScrollable implements OnInit, OnDestroy {
-  private _destroyed = new Subject();
+  private _destroyed = new Subject<void>();
 
   private _elementScrolled: Observable<Event> = new Observable((observer: Observer<Event>) =>
       this.ngZone.runOutsideAngular(() =>

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -240,7 +240,7 @@ export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy 
   ngOnDestroy() {
     this._viewport.detach();
 
-    this._dataSourceChanges.next();
+    this._dataSourceChanges.next(undefined!);
     this._dataSourceChanges.complete();
     this.viewChange.complete();
 

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -62,10 +62,10 @@ export class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy 
   @ViewChild(CdkPortalOutlet, {static: true}) _portalOutlet: CdkPortalOutlet;
 
   /** Subject for notifying that the snack bar has exited from view. */
-  readonly _onExit: Subject<any> = new Subject();
+  readonly _onExit: Subject<void> = new Subject();
 
   /** Subject for notifying that the snack bar has finished entering the view. */
-  readonly _onEnter: Subject<any> = new Subject();
+  readonly _onEnter: Subject<void> = new Subject();
 
   /** The state of the snack bar animations. */
   _animationState = 'void';

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -641,7 +641,7 @@ export class TooltipComponent implements OnDestroy {
   private _closeOnInteraction: boolean = false;
 
   /** Subject for notifying that the tooltip has been hidden from the view */
-  private readonly _onHide: Subject<any> = new Subject();
+  private readonly _onHide: Subject<void> = new Subject();
 
   /** Stream that emits whether the user has a handset-sized display.  */
   _isHandset: Observable<BreakpointState> = this._breakpointObserver.observe(Breakpoints.Handset);

--- a/tools/public_api_guard/material/snack-bar.d.ts
+++ b/tools/public_api_guard/material/snack-bar.d.ts
@@ -35,8 +35,8 @@ export declare class MatSnackBarConfig<D = any> {
 
 export declare class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy {
     _animationState: string;
-    readonly _onEnter: Subject<any>;
-    readonly _onExit: Subject<any>;
+    readonly _onEnter: Subject<void>;
+    readonly _onExit: Subject<void>;
     _portalOutlet: CdkPortalOutlet;
     _role: 'alert' | 'status' | null;
     attachDomPortal: (portal: DomPortal) => void;


### PR DESCRIPTION
In RxJS v7, the type of `Subject.next()` will change from `next(value?: T)` to `next(value: T)` ([change](https://github.com/ReactiveX/rxjs/commit/33561526d2c893fdb2a7c5552a3c86806cb0e9a9#diff-54b18fdea0a03178c258be326d16f566L61)). No runtime behavior is affected, but this change will break users who build from source. This PR corrects types to ensure projects build successfully.

### Changes
- asserts `T|undefined|null` values to `T` where appropriate.
- refactor instances of `Subject<any>` to `Subject<void>` so the `next()` method can be called without passing an argument.