### PR TITLE
refactor: add virtual scroll repeater interface

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -29,10 +29,6 @@
     "src/cdk/scrolling/scrollable.ts"
   ],
   [
-    "src/cdk/scrolling/virtual-for-of.ts",
-    "src/cdk/scrolling/virtual-scroll-viewport.ts"
-  ],
-  [
     "src/cdk/scrolling/virtual-scroll-strategy.ts",
     "src/cdk/scrolling/virtual-scroll-viewport.ts"
   ],

--- a/src/cdk/scrolling/public-api.ts
+++ b/src/cdk/scrolling/public-api.ts
@@ -14,3 +14,4 @@ export * from './viewport-ruler';
 export * from './virtual-for-of';
 export * from './virtual-scroll-strategy';
 export * from './virtual-scroll-viewport';
+export * from './virtual-scroll-repeater';

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -33,6 +33,7 @@ import {
 import {Observable, Subject, of as observableOf, isObservable} from 'rxjs';
 import {pairwise, shareReplay, startWith, switchMap, takeUntil} from 'rxjs/operators';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
+import {CdkVirtualScrollRepeater} from './virtual-scroll-repeater';
 
 
 /** The context for an item rendered by `CdkVirtualForOf` */
@@ -74,7 +75,8 @@ function getSize(orientation: 'horizontal' | 'vertical', node: Node): number {
 @Directive({
   selector: '[cdkVirtualFor][cdkVirtualForOf]',
 })
-export class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy {
+export class CdkVirtualForOf<T> implements
+    CdkVirtualScrollRepeater<T>, CollectionViewer, DoCheck, OnDestroy {
   /** Emits when the rendered view of the data changes. */
   viewChange = new Subject<ListRange>();
 

--- a/src/cdk/scrolling/virtual-scroll-repeater.ts
+++ b/src/cdk/scrolling/virtual-scroll-repeater.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Observable} from 'rxjs';
+import {ListRange} from '@angular/cdk/collections';
+
+/**
+ * An item to be repeated by the VirtualScrollViewport
+ */
+export interface CdkVirtualScrollRepeater<T> {
+  dataStream: Observable<T[] | ReadonlyArray<T>>;
+  measureRangeSize(range: ListRange, orientation: 'horizontal' | 'vertical'): number;
+}

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -34,9 +34,9 @@ import {
 import {auditTime, startWith, takeUntil} from 'rxjs/operators';
 import {ScrollDispatcher} from './scroll-dispatcher';
 import {CdkScrollable, ExtendedScrollToOptions} from './scrollable';
-import {CdkVirtualForOf} from './virtual-for-of';
 import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-strategy';
 import {ViewportRuler} from './viewport-ruler';
+import {CdkVirtualScrollRepeater} from './virtual-scroll-repeater';
 
 /** Checks if the given ranges are equal. */
 function rangesEqual(r1: ListRange, r2: ListRange): boolean {
@@ -131,8 +131,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   /** The size of the viewport (in pixels). */
   private _viewportSize = 0;
 
-  /** the currently attached CdkVirtualForOf. */
-  private _forOf: CdkVirtualForOf<any> | null;
+  /** the currently attached CdkVirtualScrollRepeater. */
+  private _forOf: CdkVirtualScrollRepeater<any> | null;
 
   /** The last rendered content offset that was set. */
   private _renderedContentOffset = 0;
@@ -215,8 +215,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     super.ngOnDestroy();
   }
 
-  /** Attaches a `CdkVirtualForOf` to this viewport. */
-  attach(forOf: CdkVirtualForOf<any>) {
+  /** Attaches a `CdkVirtualScrollRepeater` to this viewport. */
+  attach(forOf: CdkVirtualScrollRepeater<any>) {
     if (this._forOf) {
       throw Error('CdkVirtualScrollViewport is already attached.');
     }

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -74,7 +74,7 @@ export declare class CdkScrollableModule {
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<CdkScrollableModule, [typeof i1.CdkScrollable], never, [typeof i1.CdkScrollable]>;
 }
 
-export declare class CdkVirtualForOf<T> implements CollectionViewer, DoCheck, OnDestroy {
+export declare class CdkVirtualForOf<T> implements CdkVirtualScrollRepeater<T>, CollectionViewer, DoCheck, OnDestroy {
     _cdkVirtualForOf: DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined;
     get cdkVirtualForOf(): DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined;
     set cdkVirtualForOf(value: DataSource<T> | Observable<T[]> | NgIterable<T> | null | undefined);
@@ -107,6 +107,11 @@ export declare type CdkVirtualForOfContext<T> = {
     odd: boolean;
 };
 
+export interface CdkVirtualScrollRepeater<T> {
+    dataStream: Observable<T[] | ReadonlyArray<T>>;
+    measureRangeSize(range: ListRange, orientation: 'horizontal' | 'vertical'): number;
+}
+
 export declare class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, OnDestroy {
     _contentWrapper: ElementRef<HTMLElement>;
     _totalContentHeight: string;
@@ -118,7 +123,7 @@ export declare class CdkVirtualScrollViewport extends CdkScrollable implements O
     scrolledIndexChange: Observable<number>;
     constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher,
     viewportRuler?: ViewportRuler);
-    attach(forOf: CdkVirtualForOf<any>): void;
+    attach(forOf: CdkVirtualScrollRepeater<any>): void;
     checkViewportSize(): void;
     detach(): void;
     getDataLength(): number;


### PR DESCRIPTION
I originally refactored `virtualForOf` into an interface as part of some ongoing virtual scroll enhancements. After discovering #16412, I decided to use the existing work since it has already been blessed. Prior attempts to merge this change in #14287 and #16412 have gone stale without any recent updates, so I forked the changes and fixed file conflicts.

