### PR TITLE
refactor: use light-weight token for optgroup to optimize bundle size

### DIFF
--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -4,3 +4,4 @@ material/menu/without-lazy-content: 210751
 material/datepicker/range-picker/without-form-field: 330101
 material/button-toggle/standalone: 119400
 material/autocomplete/without-optgroup: 210332
+material/select/without-optgroup: 257988

--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -3,5 +3,5 @@ material/radio/without-group: 121448
 material/menu/without-lazy-content: 210751
 material/datepicker/range-picker/without-form-field: 330101
 material/button-toggle/standalone: 119400
-material/autocomplete/without-optgroup: 210332
-material/select/without-optgroup: 257988
+material/autocomplete/without-optgroup: 208091
+material/select/without-optgroup: 256564

--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -3,3 +3,4 @@ material/radio/without-group: 121448
 material/menu/without-lazy-content: 210751
 material/datepicker/range-picker/without-form-field: 330101
 material/button-toggle/standalone: 119400
+material/autocomplete/without-optgroup: 210332

--- a/integration/size-test/material/autocomplete/BUILD.bazel
+++ b/integration/size-test/material/autocomplete/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//integration/size-test:index.bzl", "size_test")
+
+size_test(
+    name = "without-optgroup",
+    file = "without-optgroup.ts",
+    deps = ["//src/material/autocomplete"],
+)

--- a/integration/size-test/material/autocomplete/without-optgroup.ts
+++ b/integration/size-test/material/autocomplete/without-optgroup.ts
@@ -1,0 +1,26 @@
+import {Component, NgModule} from '@angular/core';
+import {platformBrowser} from '@angular/platform-browser';
+import {MatAutocompleteModule} from '@angular/material/autocomplete';
+
+/**
+ * Basic component using `MatAutocomplete` and `MatOption`. Other supported parts of the
+ * autocomplete like `MatOptgroup` are not used and should be tree-shaken away.
+ */
+@Component({
+  template: `
+    <input [matAutocomplete]="myAutocomplete">
+    <mat-autocomplete #myAutocomplete>
+      <mat-option value="First">First</mat-option>
+    </mat-autocomplete>
+  `,
+})
+export class TestComponent {}
+
+@NgModule({
+  imports: [MatAutocompleteModule],
+  declarations: [TestComponent],
+  bootstrap: [TestComponent],
+})
+export class AppModule {}
+
+platformBrowser().bootstrapModule(AppModule);

--- a/integration/size-test/material/select/BUILD.bazel
+++ b/integration/size-test/material/select/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//integration/size-test:index.bzl", "size_test")
+
+size_test(
+    name = "without-optgroup",
+    file = "without-optgroup.ts",
+    deps = ["//src/material/select"],
+)

--- a/integration/size-test/material/select/without-optgroup.ts
+++ b/integration/size-test/material/select/without-optgroup.ts
@@ -1,0 +1,25 @@
+import {Component, NgModule} from '@angular/core';
+import {platformBrowser} from '@angular/platform-browser';
+import {MatSelectModule} from '@angular/material/select';
+
+/**
+ * Basic component using `MatSelect` and `MatOption`. Other supported parts of the
+ * select like `MatOptgroup` are not used and should be tree-shaken away.
+ */
+@Component({
+  template: `
+    <mat-select>
+      <mat-option value="First">First</mat-option>
+    </mat-select>
+  `,
+})
+export class TestComponent {}
+
+@NgModule({
+  imports: [MatSelectModule],
+  declarations: [TestComponent],
+  bootstrap: [TestComponent],
+})
+export class AppModule {}
+
+platformBrowser().bootstrapModule(AppModule);

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -29,6 +29,7 @@ import {
 import {
   CanDisableRipple,
   CanDisableRippleCtor,
+  MAT_OPTGROUP,
   MAT_OPTION_PARENT_COMPONENT,
   MatOptgroup,
   MatOption,
@@ -127,8 +128,9 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   /** @docs-private */
   @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
 
+  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** @docs-private */
-  @ContentChildren(MatOptgroup, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  @ContentChildren(MAT_OPTGROUP as any, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
 
   /** Function that maps an option's control value to its display value in the trigger. */
   @Input() displayWith: ((value: any) => string) | null = null;

--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -7,7 +7,13 @@
  */
 
 import {BooleanInput} from '@angular/cdk/coercion';
-import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  InjectionToken,
+  Input,
+  ViewEncapsulation
+} from '@angular/core';
 import {CanDisable, CanDisableCtor, mixinDisabled} from '../common-behaviors/disabled';
 
 
@@ -19,6 +25,13 @@ const _MatOptgroupMixinBase: CanDisableCtor & typeof MatOptgroupBase =
 
 // Counter for unique group ids.
 let _uniqueOptgroupIdCounter = 0;
+
+/**
+ * Injection token that can be used to reference instances of `MatOptgroup`. It serves as
+ * alternative token to the actual `MatOptgroup` class which could cause unnecessary
+ * retention of the class and its component metadata.
+ */
+export const MAT_OPTGROUP = new InjectionToken<MatOptgroup>('MatOptgroup');
 
 /**
  * Component that is used to group instances of `mat-option`.
@@ -37,7 +50,8 @@ let _uniqueOptgroupIdCounter = 0;
     '[class.mat-optgroup-disabled]': 'disabled',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-labelledby]': '_labelId',
-  }
+  },
+  providers: [{provide: MAT_OPTGROUP, useExisting: MatOptgroup}],
 })
 export class MatOptgroup extends _MatOptgroupMixinBase implements CanDisable {
   /** Label for the option group. */

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -26,7 +26,7 @@ import {
 } from '@angular/core';
 import {FocusOptions, FocusableOption, FocusOrigin} from '@angular/cdk/a11y';
 import {Subject} from 'rxjs';
-import {MatOptgroup} from './optgroup';
+import {MAT_OPTGROUP, MatOptgroup} from './optgroup';
 
 /**
  * Option IDs need to be unique across components, so this counter exists outside of
@@ -121,7 +121,7 @@ export class MatOption implements FocusableOption, AfterViewChecked, OnDestroy {
     private _element: ElementRef<HTMLElement>,
     private _changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) private _parent: MatOptionParentComponent,
-    @Optional() readonly group: MatOptgroup) {}
+    @Optional() @Inject(MAT_OPTGROUP) readonly group: MatOptgroup) {}
 
   /**
    * Whether or not the option is currently active and ready to be selected.

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -75,6 +75,7 @@ import {
   ErrorStateMatcher,
   HasTabIndex,
   HasTabIndexCtor,
+  MAT_OPTGROUP,
   MAT_OPTION_PARENT_COMPONENT,
   MatOptgroup,
   MatOption,
@@ -364,8 +365,9 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** All of the defined select options. */
   @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
 
+  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** All of the defined groups of options. */
-  @ContentChildren(MatOptgroup, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  @ContentChildren(MAT_OPTGROUP as any, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
 
   /** Classes to be passed to the select panel. Supports the same syntax as `ngClass`. */
   @Input() panelClass: string|string[]|Set<string>|{[key: string]: any};

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -143,6 +143,8 @@ export declare const MAT_LABEL_GLOBAL_OPTIONS: InjectionToken<LabelOptions>;
 
 export declare const MAT_NATIVE_DATE_FORMATS: MatDateFormats;
 
+export declare const MAT_OPTGROUP: InjectionToken<MatOptgroup>;
+
 export declare const MAT_OPTION_PARENT_COMPONENT: InjectionToken<MatOptionParentComponent>;
 
 export declare const MAT_RIPPLE_GLOBAL_OPTIONS: InjectionToken<RippleGlobalOptions>;


### PR DESCRIPTION
The `MatOptgroup` component is not always used in applications. e.g.
it's an optional part of the autocomplete or select. Currently though,
we always reference the `MatOpgroup` component directly at runtime,
and it will be retained in applications regardless of the usage.

We can improve this by providing a light-weight injection token for
the optgroup that we can then use in queries or optional DI injection.

This obviously was already an issue in View Engine too, but it became
significantly worse in Ivy as factories are now directly attached to
the component class.

Related to: #19576.