### PR TITLE
fix(cdk/scrolling): fixed-size-virtual-scroll wrong range and position when items length changes and current scroll is greater than new data length

### DIFF
--- a/src/cdk/scrolling/fixed-size-virtual-scroll.ts
+++ b/src/cdk/scrolling/fixed-size-virtual-scroll.ts
@@ -121,11 +121,18 @@ export class FixedSizeVirtualScrollStrategy implements VirtualScrollStrategy {
     }
 
     const scrollOffset = this._viewport.measureScrollOffset();
-    const firstVisibleIndex = scrollOffset / this._itemSize;
     const renderedRange = this._viewport.getRenderedRange();
     const newRange = {start: renderedRange.start, end: renderedRange.end};
     const viewportSize = this._viewport.getViewportSize();
     const dataLength = this._viewport.getDataLength();
+    let firstVisibleIndex = scrollOffset / this._itemSize;
+
+    if (newRange.end >= dataLength) {
+      const maxVisibleItems = Math.ceil(viewportSize / this._itemSize);
+      firstVisibleIndex = Math.max(0, Math.min(firstVisibleIndex, dataLength - maxVisibleItems));
+      newRange.start = Math.floor(firstVisibleIndex);
+      newRange.end = Math.max(0, Math.min(dataLength - 1, newRange.start + maxVisibleItems));
+    }
 
     const startBuffer = scrollOffset - newRange.start * this._itemSize;
     if (startBuffer < this._minBufferPx && newRange.start != 0) {

--- a/src/cdk/scrolling/fixed-size-virtual-scroll.ts
+++ b/src/cdk/scrolling/fixed-size-virtual-scroll.ts
@@ -120,18 +120,29 @@ export class FixedSizeVirtualScrollStrategy implements VirtualScrollStrategy {
       return;
     }
 
-    const scrollOffset = this._viewport.measureScrollOffset();
     const renderedRange = this._viewport.getRenderedRange();
     const newRange = {start: renderedRange.start, end: renderedRange.end};
     const viewportSize = this._viewport.getViewportSize();
     const dataLength = this._viewport.getDataLength();
+    let scrollOffset = this._viewport.measureScrollOffset();
     let firstVisibleIndex = scrollOffset / this._itemSize;
 
-    if (newRange.end >= dataLength) {
+    // If user scrolls to the bottom of the list and data changes to a smaller list
+    if (newRange.end > dataLength) {
+      // We have to recalculate the first visible index based on new data length and viewport size.
       const maxVisibleItems = Math.ceil(viewportSize / this._itemSize);
-      firstVisibleIndex = Math.max(0, Math.min(firstVisibleIndex, dataLength - maxVisibleItems));
-      newRange.start = Math.floor(firstVisibleIndex);
-      newRange.end = Math.max(0, Math.min(dataLength - 1, newRange.start + maxVisibleItems));
+      const newVisibleIndex = Math.max(0,
+          Math.min(firstVisibleIndex, dataLength - maxVisibleItems));
+
+      // If first visible index changed we must update scroll offset to handle start/end buffers
+      // Current range must also be adjusted to cover the new position (bottom of new list).
+      if (firstVisibleIndex != newVisibleIndex) {
+        firstVisibleIndex = newVisibleIndex;
+        scrollOffset = newVisibleIndex * this._itemSize;
+        newRange.start = Math.floor(firstVisibleIndex);
+      }
+
+      newRange.end = Math.max(0, Math.min(dataLength, newRange.start + maxVisibleItems));
     }
 
     const startBuffer = scrollOffset - newRange.start * this._itemSize;

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -412,12 +412,26 @@ describe('CdkVirtualScrollViewport', () => {
       fixture.detectChanges();
       flush();
 
-      triggerScroll(viewport);
+      expect(viewport.getOffsetToRenderedContentStart())
+          .toBe(testComponent.itemSize, 'should be scrolled to bottom of 5 item list');
+    }));
+
+    it('should handle dynamic item array keeping position when possibile', fakeAsync(() => {
+      testComponent.items = Array(100).fill(0);
+      finishInit(fixture);
+      triggerScroll(viewport, testComponent.itemSize * 50);
       fixture.detectChanges();
       flush();
 
       expect(viewport.getOffsetToRenderedContentStart())
-          .toBe(testComponent.itemSize, 'should be scrolled to bottom of 5 item list');
+          .toBe(testComponent.itemSize * 50, 'should be scrolled to index 50 item list');
+
+      testComponent.items = Array(54).fill(0);
+      fixture.detectChanges();
+      flush();
+
+      expect(viewport.getOffsetToRenderedContentStart())
+          .toBe(testComponent.itemSize * 50, 'should be kept the scroll position');
     }));
 
     it('should update viewport as user scrolls right in horizontal mode', fakeAsync(() => {
@@ -900,6 +914,15 @@ function triggerScroll(viewport: CdkVirtualScrollViewport, offset?: number) {
     .cdk-virtual-scroll-orientation-horizontal .cdk-virtual-scroll-content-wrapper {
       flex-direction: row;
     }
+
+    .cdk-virtual-scroll-viewport {
+      background-color: #f5f5f5;
+    }
+
+    .item {
+      box-sizing: border-box;
+      border: 1px dashed #ccc;
+    }
   `],
   encapsulation: ViewEncapsulation.None,
 })
@@ -952,6 +975,15 @@ class FixedSizeVirtualScroll {
     .cdk-virtual-scroll-orientation-horizontal .cdk-virtual-scroll-content-wrapper {
       flex-direction: row;
     }
+
+    .cdk-virtual-scroll-viewport {
+      background-color: #f5f5f5;
+    }
+
+    .item {
+      box-sizing: border-box;
+      border: 1px dashed #ccc;
+    }
   `],
   encapsulation: ViewEncapsulation.None,
 })
@@ -982,9 +1014,19 @@ class FixedSizeVirtualScrollWithRtlDirection {
 @Component({
   template: `
     <cdk-virtual-scroll-viewport>
-      <div *cdkVirtualFor="let item of items">{{item}}</div>
+      <div class="item" *cdkVirtualFor="let item of items">{{item}}</div>
     </cdk-virtual-scroll-viewport>
-  `
+  `,
+  styles: [`
+    .cdk-virtual-scroll-viewport {
+      background-color: #f5f5f5;
+    }
+
+    .item {
+      box-sizing: border-box;
+      border: 1px dashed #ccc;
+    }
+  `]
 })
 class VirtualScrollWithNoStrategy {
   items = [];
@@ -1013,11 +1055,14 @@ class InjectsViewContainer {
     .cdk-virtual-scroll-viewport {
       width: 200px;
       height: 200px;
+      background-color: #f5f5f5;
     }
 
     .item {
       width: 100%;
       height: 50px;
+      box-sizing: border-box;
+      border: 1px dashed #ccc;
     }
   `],
   encapsulation: ViewEncapsulation.None

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -416,6 +416,26 @@ describe('CdkVirtualScrollViewport', () => {
           .toBe(testComponent.itemSize, 'should be scrolled to bottom of 5 item list');
     }));
 
+    it('should handle dynamic item array with dynamic buffer', fakeAsync(() => {
+      finishInit(fixture);
+      triggerScroll(viewport, testComponent.itemSize * 6);
+      fixture.detectChanges();
+      flush();
+
+      expect(viewport.getOffsetToRenderedContentStart())
+          .toBe(testComponent.itemSize * 6, 'should be scrolled to bottom of 10 item list');
+
+      testComponent.items = Array(5).fill(0);
+      testComponent.minBufferPx = testComponent.itemSize;
+      testComponent.maxBufferPx = testComponent.itemSize;
+
+      fixture.detectChanges();
+      flush();
+
+      expect(viewport.getOffsetToRenderedContentStart())
+          .toBe(0, 'should render from first item');
+    }));
+
     it('should handle dynamic item array keeping position when possibile', fakeAsync(() => {
       testComponent.items = Array(100).fill(0);
       finishInit(fixture);


### PR DESCRIPTION
FixedSizeVirtualScroll rendered range is not correct when going from a large list to a smaller list.

![ezgif-4-afef96a7a7ff](https://user-images.githubusercontent.com/1423005/84161368-7f2d7a00-aa6f-11ea-8331-3bb4eab7b167.gif)

I've checked MR #19030 by @crisbeto with the modified test case but it fails anyway.

One of the main problems is in `firstVisibleIndex` that it's not correct anymore when the list shrinks to a size smaller then the current scroll position, in fact the following code causes `newRange.end` < `newRange.start`:

```ts
        if (expandEnd > 0) {
          newRange.end = Math.min(dataLength, newRange.end + expandEnd);
          newRange.start = Math.max(0,
              Math.floor(firstVisibleIndex - this._minBufferPx / this._itemSize));
        }
```

Unit test changes:
- Removed a wrong `triggerScroll(viewport)` on `should handle dynamic item array`: user doesn't need to scroll the view to see what changed
- Added some style to test cases to debug easily
- Added a test to check no-regression with the new code

Fixes #19029