### PR TITLE
build: switch to dev-infra configuration directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -315,6 +315,7 @@
 
 # Misc
 /*                                                 @angular/dev-infra-components @jelbourn
+/.ng-dev/**                                        @angular/dev-infra-components
 /.github/**                                        @angular/dev-infra-components @jelbourn
 /.vscode/**                                        @angular/dev-infra-components @mmalerba
 /src/*                                             @jelbourn

--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -1,0 +1,7 @@
+import {github} from './github';
+import {merge} from './merge';
+
+module.exports = {
+  github,
+  merge,
+};

--- a/.ng-dev/github.ts
+++ b/.ng-dev/github.ts
@@ -1,0 +1,10 @@
+import {GithubConfig} from '@angular/dev-infra-private/utils/config';
+
+/**
+ * Github configuration for the ng-dev command. This repository is
+ * uses as remote for the merge script.
+ */
+export const github: GithubConfig = {
+  owner: 'angular',
+  name: 'components'
+};

--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -1,22 +1,12 @@
 import {MergeConfig} from '@angular/dev-infra-private/pr/merge/config';
 import {determineMergeBranches} from '@angular/dev-infra-private/pr/merge/determine-merge-branches';
-import {GithubConfig} from '@angular/dev-infra-private/utils/config';
-
-/**
- * Github configuration for the ng-dev command. This repository is
- * uses as remote for the merge script.
- */
-const github: GithubConfig = {
-  owner: 'angular',
-  name: 'components'
-};
 
 /**
  * Configuration for the merge tool in `ng-dev`. This sets up the labels which
  * are respected by the merge script (e.g. the target labels).
  */
-const merge = (): MergeConfig => {
-  const currentVersion = require('./package.json').version;
+export const merge = (): MergeConfig => {
+  const currentVersion = require('../package.json').version;
   // We use the `@angular/cdk` as source of truth for the latest published version in NPM.
   // Any package from the monorepo could technically work and result in the same version.
   const {minor, patch} = determineMergeBranches(currentVersion, '@angular/cdk');
@@ -56,9 +46,4 @@ const merge = (): MergeConfig => {
       }
     ],
   };
-};
-
-module.exports = {
-  github,
-  merge,
 };


### PR DESCRIPTION
We recently updated the shared dev-infra package to the latest
version (in order to bring in the benchmark utils), but this
actually broke the merge script because dev-infra landed a change
on how the configuration is loaded.

Previously, the configuration has been loaded from a single file
at project root, but now dev-infra loads it from a dedicated
dev-infra folder. This has been done that way to allow for dedicated
configuration files for individual `ng-dev` command parts.