### PR TITLE
fix(benchmark): fix license header and correct test descriptions

### DIFF
--- a/test/benchmarks/material/checkbox/checkbox.perf-spec.ts
+++ b/test/benchmarks/material/checkbox/checkbox.perf-spec.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
@@ -9,14 +9,14 @@
 import {$, browser} from 'protractor';
 import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilities';
 
-describe('checkbox overview performance benchmarks', () => {
+describe('checkbox performance benchmarks', () => {
   beforeAll(() => {
     browser.rootEl = '#root';
   });
 
   it('renders a checked checkbox', async() => {
     await runBenchmark({
-      id: 'checkbox-overview-render-checked',
+      id: 'checkbox-render-checked',
       url: '',
       ignoreBrowserSynchronization: true,
       params: [],
@@ -35,7 +35,7 @@ describe('checkbox overview performance benchmarks', () => {
 
   it('renders an unchecked checkbox', async() => {
     await runBenchmark({
-      id: 'checkbox-overview-render-unchecked',
+      id: 'checkbox-render-unchecked',
       url: '',
       ignoreBrowserSynchronization: true,
       params: [],
@@ -51,7 +51,7 @@ describe('checkbox overview performance benchmarks', () => {
 
   it('renders an indeterminate checkbox', async() => {
     await runBenchmark({
-      id: 'checkbox-overview-render-indeterminate',
+      id: 'checkbox-render-indeterminate',
       url: '',
       ignoreBrowserSynchronization: true,
       params: [],
@@ -70,7 +70,7 @@ describe('checkbox overview performance benchmarks', () => {
 
   it('updates from unchecked to checked', async() => {
     await runBenchmark({
-      id: 'checkbox-overview-click-unchecked-to-checked',
+      id: 'checkbox-click-unchecked-to-checked',
       url: '',
       ignoreBrowserSynchronization: true,
       params: [],
@@ -89,7 +89,7 @@ describe('checkbox overview performance benchmarks', () => {
 
   it('updates from checked to unchecked', async() => {
     await runBenchmark({
-      id: 'checkbox-overview-click-checked-to-unchecked',
+      id: 'checkbox-click-checked-to-unchecked',
       url: '',
       ignoreBrowserSynchronization: true,
       params: [],


### PR DESCRIPTION
### Fix
* Fix license header so that we can copybara sync this into google3
### Cleanup
* Remove use of the word "overview. This was a remnant from when we thought we would use the `checkbox-overview-example`. Since this is no longer the case (and since I'm already making a small change here), it would be good to remove it.