### PR TITLE
build: enable license header linting for benchmark tests

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -169,7 +169,8 @@
     }, "src/!(e2e-app|components-examples|universal-app|dev-app)/**/!(*.spec).ts"],
     "require-license-banner": [
       true,
-      "src/!(e2e-app|components-examples|universal-app)/**/!(*.spec).ts"
+      "src/!(e2e-app|components-examples|universal-app)/**/!(*.spec).ts",
+      "test/benchmarks/**/*.ts"
     ],
     "no-cross-entry-point-relative-imports": [
       true,


### PR DESCRIPTION
Enables license header linting for the benchmark tests
folder. This seems needed because in order to sync these files
into g3, the license header must be correct/added.

Related to #19596.