### PR TITLE
feat(cdk/tree): add trackBy functionality to NestedTreeControl

### DIFF
--- a/src/cdk/tree/control/nested-tree-control.spec.ts
+++ b/src/cdk/tree/control/nested-tree-control.spec.ts
@@ -196,6 +196,24 @@ describe('CdkNestedTreeControl', () => {
       });
     });
   });
+
+  it('maintains node expansion state based on trackBy function, if provided', () => {
+    const treeControl = new NestedTreeControl<TestData, string>(getChildren);
+
+    const nodes = generateData(2, 2);
+    const secondNode = nodes[1];
+    treeControl.dataNodes = nodes;
+    treeControl.trackBy = (node: TestData) => `${node.a} ${node.b} ${node.c}`;
+
+    treeControl.expand(secondNode);
+    expect(treeControl.isExpanded(secondNode)).toBeTruthy('Expect second node to be expanded');
+
+    // Replace the second node with a brand new instance with same hash
+    nodes[1] = new TestData(
+        secondNode.a, secondNode.b, secondNode.c, secondNode.level, secondNode.children);
+    expect(treeControl.isExpanded(nodes[1])).toBeTruthy('Expect second node to still be expanded');
+  });
+
 });
 
 export class TestData {

--- a/src/cdk/tree/control/nested-tree-control.spec.ts
+++ b/src/cdk/tree/control/nested-tree-control.spec.ts
@@ -4,14 +4,15 @@ import {NestedTreeControl} from './nested-tree-control';
 
 
 describe('CdkNestedTreeControl', () => {
-  let treeControl: NestedTreeControl<TestData>;
   let getChildren = (node: TestData) => observableOf(node.children);
 
-  beforeEach(() => {
-    treeControl = new NestedTreeControl<TestData>(getChildren);
-  });
-
   describe('base tree control actions', () => {
+    let treeControl: NestedTreeControl<TestData>;
+
+    beforeEach(() => {
+      treeControl = new NestedTreeControl<TestData>(getChildren);
+    });
+
     it('should be able to expand and collapse dataNodes', () => {
       const nodes = generateData(10, 4);
       const node = nodes[1];

--- a/src/cdk/tree/control/nested-tree-control.spec.ts
+++ b/src/cdk/tree/control/nested-tree-control.spec.ts
@@ -199,12 +199,12 @@ describe('CdkNestedTreeControl', () => {
   });
 
   it('maintains node expansion state based on trackBy function, if provided', () => {
-    const treeControl = new NestedTreeControl<TestData, string>(getChildren);
+    const treeControl = new NestedTreeControl<TestData, string>(
+        getChildren, {trackBy: (node: TestData) => `${node.a} ${node.b} ${node.c}`});
 
     const nodes = generateData(2, 2);
     const secondNode = nodes[1];
     treeControl.dataNodes = nodes;
-    treeControl.trackBy = (node: TestData) => `${node.a} ${node.b} ${node.c}`;
 
     treeControl.expand(secondNode);
     expect(treeControl.isExpanded(secondNode)).toBeTruthy('Expect second node to be expanded');

--- a/tools/public_api_guard/cdk/tree.d.ts
+++ b/tools/public_api_guard/cdk/tree.d.ts
@@ -161,12 +161,17 @@ export declare function getTreeMultipleDefaultNodeDefsError(): Error;
 
 export declare function getTreeNoValidDataSourceError(): Error;
 
-export declare class NestedTreeControl<T> extends BaseTreeControl<T> {
+export declare class NestedTreeControl<T, K = T> extends BaseTreeControl<T, K> {
     getChildren: (dataNode: T) => (Observable<T[]> | T[] | undefined | null);
-    constructor(getChildren: (dataNode: T) => (Observable<T[]> | T[] | undefined | null));
+    options?: NestedTreeControlOptions<T, K> | undefined;
+    constructor(getChildren: (dataNode: T) => (Observable<T[]> | T[] | undefined | null), options?: NestedTreeControlOptions<T, K> | undefined);
     protected _getDescendants(descendants: T[], dataNode: T): void;
     expandAll(): void;
     getDescendants(dataNode: T): T[];
+}
+
+export interface NestedTreeControlOptions<T, K> {
+    trackBy?: (dataNode: T) => K;
 }
 
 export interface TreeControl<T, K = T> {


### PR DESCRIPTION
The ability to track tree-node expansion via a trackBy function was added to FlatTreeControl in #18708. This PR adds the same functionality to NestedTreeControl to allow nested trees the ability to also specify an alternative method of tracking a node's expansion status. 