### PR TITLE
build: fix ci failures in patch branch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,10 +88,7 @@ web_test_repositories()
 load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
 
 browser_repositories(
-    # Chrome is brought in by `@npm_dev_infra_private` for better version control and
-    # RBE experience where individual browser archives per platform are provided.
-    # TODO: Do the same for Firefox (but it is not used for local development): DEV-114
-    chromium = False,
+    chromium = True,
     firefox = True,
 )
 

--- a/scripts/run-component-tests.js
+++ b/scripts/run-component-tests.js
@@ -61,7 +61,7 @@ if (local && (components.length > 1 || all)) {
   process.exit(1);
 }
 
-const browserName = firefox ? 'firefox-local' : 'chromium';
+const browserName = firefox ? 'firefox-local' : 'chromium-local';
 const bazelBinary = `yarn -s ${watch ? 'ibazel' : 'bazel'}`;
 const configFlag = viewEngine ? '--config=view-engine' : '';
 

--- a/src/material-experimental/mdc-menu/menu.scss
+++ b/src/material-experimental/mdc-menu/menu.scss
@@ -38,8 +38,6 @@
   // Note that we include this private mixin, because the public
   // one adds a bunch of styles that we aren't using for the menu.
   @include mdc-list-item-base_;
-  @include mdc-list-list-item-padding-variant(
-    $mdc-list-textual-variant-config, $query: $mat-base-styles-query);
 
   // MDC's menu items are `<li>` nodes which don't need resets, however ours
   // can be anything, including buttons, so we need to do the reset ourselves.

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -163,16 +163,6 @@ def karma_web_test_suite(name, **kwargs):
     kwargs["srcs"] = ["@npm//:node_modules/tslib/tslib.js"] + getAngularUmdTargets() + kwargs.get("srcs", [])
     kwargs["deps"] = ["//tools/rxjs:rxjs_umd_modules"] + kwargs.get("deps", [])
 
-    # Set up default browsers if no explicit `browsers` have been specified.
-    if not hasattr(kwargs, "browsers"):
-        kwargs["tags"] = ["native"] + kwargs.get("tags", [])
-        kwargs["browsers"] = [
-            # Note: when changing the browser names here, also update the "yarn test"
-            # script to reflect the new browser names.
-            "@npm_angular_dev_infra_private//browsers:chromium",
-            "@io_bazel_rules_webtesting//browsers:firefox-local",
-        ]
-
     for opt_name in kwargs.keys():
         # Filter out options which are specific to "karma_web_test" targets. We cannot
         # pass options like "browsers" to the local web test target.
@@ -208,11 +198,10 @@ def karma_web_test_suite(name, **kwargs):
 def protractor_web_test_suite(flaky = True, **kwargs):
     _protractor_web_test_suite(
         flaky = flaky,
-        browsers = ["@npm_angular_dev_infra_private//browsers:chromium"],
         **kwargs
     )
 
-def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], **kwargs):
+def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], tags = [], **kwargs):
     # Always include a prebuilt theme in the test suite because otherwise tests, which depend on CSS
     # that is needed for measuring, will unexpectedly fail. Also always adding a prebuilt theme
     # reduces the amount of setup that is needed to create a test suite Bazel target. Note that the
@@ -256,6 +245,12 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], **kwargs):
         deps = [
             "//test:angular_test_init",
         ] + deps,
+        browsers = [
+            # Note: when changing the browser names here, also update the "yarn test"
+            # script to reflect the new browser names.
+            "@io_bazel_rules_webtesting//browsers:chromium-local",
+            "@io_bazel_rules_webtesting//browsers:firefox-local",
+        ],
         bootstrap = [
             # This matches the ZoneJS bundles used in default CLI projects. See:
             # https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/application/files/src/polyfills.ts.template#L58
@@ -269,5 +264,6 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], **kwargs):
             "@npm//:node_modules/zone.js/dist/zone-testing.js",
             "@npm//:node_modules/reflect-metadata/Reflect.js",
         ] + bootstrap,
+        tags = ["native"] + tags,
         **kwargs
     )


### PR DESCRIPTION
This reverts commit b4d085240f0b5eca2675cbddc93c405cfd099ded in the `9.2.x` branch. This commit relied on a more recent version of the dev-infra package that is currently not installed in `9.2.x`. i.e. the new browser repositories for the dev-infra package are not configured or available in the installed dev-infra package version.

Also reverts https://github.com/angular/components/commit/771b4ba14d28fd4f8adc65790b566396f3e87b84 as that one relied on a MDC version update that is not part of the patch branch.