### PR TITLE
build: update merge script temporarily to merge into rc branch

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -9,7 +9,13 @@ export const merge = (): MergeConfig => {
   const currentVersion = require('../package.json').version;
   // We use the `@angular/cdk` as source of truth for the latest published version in NPM.
   // Any package from the monorepo could technically work and result in the same version.
-  const {minor, patch} = determineMergeBranches(currentVersion, '@angular/cdk');
+  let {minor, patch} = determineMergeBranches(currentVersion, '@angular/cdk');
+
+  // TODO(devversion) Clean this up once the label/branching has been finalized.
+  if (currentVersion.startsWith('10.0.0-rc')) {
+    patch = '10.0.x';
+    minor = 'master';
+  }
 
   return {
     // By default, the merge script merges locally with `git cherry-pick` and autosquash.
@@ -32,7 +38,8 @@ export const merge = (): MergeConfig => {
       },
       {
         pattern: 'target: minor',
-        branches: ['master', minor],
+        // TODO: Clean this up after the labels/branching has been finalized.
+        branches: minor === 'master' ? ['master'] : ['master', minor],
       },
       {
         pattern: 'target: major',


### PR DESCRIPTION
Updates the merge script temporarily so that `target: patch`
PRs are merged into the RC branch. We are currently revisiting
labeling/branching, and once this is finalized, we can clean
this up. For now though, we want to not put the burden of
manually cherry-picking onto the caretaker.