### PR TITLE
build: remove deleted script from lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "node ./scripts/run-component-tests.js",
     "test-local": "yarn -s test --local",
     "test-firefox": "yarn -s test --firefox",
-    "lint": "yarn -s tslint && yarn -s stylelint && yarn -s bazel:format-lint && yarn -s ownerslint",
+    "lint": "yarn -s tslint && yarn -s stylelint && yarn -s ownerslint && yarn -s ng-dev format changed --check",
     "e2e": "bazel test //src/... --test_tag_filters=e2e",
     "deploy-dev-app": "node ./scripts/deploy-dev-app.js",
     "breaking-changes": "ts-node --project scripts/tsconfig.json scripts/breaking-changes.ts",


### PR DESCRIPTION
The `bazel:format-lint` script was removed, but it's still referenced in the `lint` script.