### PR TITLE
feat(cdk-experimental/menu): Implement grouping logic for menuitems

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -4,11 +4,6 @@
     "src/cdk-experimental/dialog/dialog-container.ts"
   ],
   [
-    "src/cdk-experimental/menu/menu-item.ts",
-    "src/cdk-experimental/menu/menu-panel.ts",
-    "src/cdk-experimental/menu/menu.ts"
-  ],
-  [
     "src/cdk-experimental/popover-edit/edit-event-dispatcher.ts",
     "src/cdk-experimental/popover-edit/edit-ref.ts"
   ],

--- a/src/cdk-experimental/menu/BUILD.bazel
+++ b/src/cdk-experimental/menu/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,4 +14,21 @@ ng_module(
         "@npm//@angular/core",
         "@npm//rxjs",
     ],
+)
+
+ng_test_library(
+    name = "unit_test_sources",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["**/*.e2e.spec.ts"],
+    ),
+    deps = [
+        ":menu",
+        "@npm//@angular/platform-browser",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [":unit_test_sources"],
 )

--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -137,7 +137,6 @@ describe('MenuBar', () => {
 });
 
 @Component({
-  selector: 'menubar-as-radio-group',
   template: `
     <ul cdkMenuBar>
       <li role="none">
@@ -156,7 +155,6 @@ describe('MenuBar', () => {
 class MenuBarRadioGroup {}
 
 @Component({
-  selector: 'menubar-as-checkbox-group',
   template: `
     <ul cdkMenuBar>
       <li role="none">

--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -1,0 +1,175 @@
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {CdkMenuBar} from './menu-bar';
+import {CdkMenuModule} from './menu-module';
+import {CdkMenuItem} from './menu-item';
+import {By} from '@angular/platform-browser';
+
+describe('MenuBar', () => {
+  describe('as radio group', () => {
+    let fixture: ComponentFixture<MenuBarRadioGroup>;
+    let menuBar: CdkMenuBar;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuBarRadioGroup],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuBarRadioGroup);
+      fixture.detectChanges();
+
+      menuBar = fixture.debugElement.query(By.directive(CdkMenuBar)).injector.get(CdkMenuBar);
+
+      menuItems = menuBar._allItems.toArray();
+    }));
+
+    it('should toggle menuitemradio items', () => {
+      expect(menuItems[0].checked).toBeTrue();
+      expect(menuItems[1].checked).toBeFalse();
+
+      menuItems[1].trigger();
+
+      expect(menuItems[0].checked).toBeFalse();
+      expect(menuItems[1].checked).toBeTrue();
+    });
+  });
+
+  describe('as checkbox group', () => {
+    let fixture: ComponentFixture<MenuBarCheckboxGroup>;
+    let menuBar: CdkMenuBar;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuBarCheckboxGroup],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuBarCheckboxGroup);
+
+      menuBar = fixture.debugElement.query(By.directive(CdkMenuBar)).injector.get(CdkMenuBar);
+      fixture.detectChanges();
+
+      menuItems = menuBar._allItems.toArray();
+    }));
+
+    it('should toggle menuitemcheckbox', () => {
+      expect(menuItems[0].checked).toBeTrue();
+      expect(menuItems[1].checked).toBeFalse();
+
+      menuItems[1].trigger();
+      expect(menuItems[0].checked).toBeTrue(); // checkbox should not change
+
+      menuItems[0].trigger();
+
+      expect(menuItems[0].checked).toBeFalse();
+      expect(menuItems[1].checked).toBeTrue();
+    });
+  });
+
+  describe('checkbox change events', () => {
+    let fixture: ComponentFixture<MenuBarCheckboxGroup>;
+    let menu: CdkMenuBar;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuBarCheckboxGroup],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuBarCheckboxGroup);
+
+      menu = fixture.debugElement.query(By.directive(CdkMenuBar)).injector.get(CdkMenuBar);
+      fixture.detectChanges();
+
+      menuItems = menu._allItems.toArray();
+    }));
+
+    it('should emit on click', () => {
+      const spy = jasmine.createSpy('cdkMenu change spy');
+      fixture.debugElement
+        .query(By.directive(CdkMenuBar))
+        .injector.get(CdkMenuBar)
+        .change.subscribe(spy);
+
+      menuItems[0].trigger();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(menuItems[0]);
+    });
+  });
+
+  describe('radiogroup change events', () => {
+    let fixture: ComponentFixture<MenuBarRadioGroup>;
+    let menu: CdkMenuBar;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuBarRadioGroup],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuBarRadioGroup);
+
+      menu = fixture.debugElement.query(By.directive(CdkMenuBar)).injector.get(CdkMenuBar);
+      fixture.detectChanges();
+
+      menuItems = menu._allItems.toArray();
+    }));
+
+    it('should emit on click', () => {
+      const spy = jasmine.createSpy('cdkMenu change spy');
+      fixture.debugElement
+        .query(By.directive(CdkMenuBar))
+        .injector.get(CdkMenuBar)
+        .change.subscribe(spy);
+
+      menuItems[0].trigger();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(menuItems[0]);
+    });
+  });
+});
+
+@Component({
+  selector: 'menubar-as-radio-group',
+  template: `
+    <ul cdkMenuBar>
+      <li role="none">
+        <button checked="true" role="menuitemradio" cdkMenuItem>
+          first
+        </button>
+      </li>
+      <li role="none">
+        <button role="menuitemradio" cdkMenuItem>
+          second
+        </button>
+      </li>
+    </ul>
+  `,
+})
+class MenuBarRadioGroup {}
+
+@Component({
+  selector: 'menubar-as-checkbox-group',
+  template: `
+    <ul cdkMenuBar>
+      <li role="none">
+        <button checked="true" role="menuitemcheckbox" cdkMenuItem>
+          first
+        </button>
+      </li>
+      <li role="none">
+        <button role="menuitemcheckbox" cdkMenuItem>
+          second
+        </button>
+      </li>
+    </ul>
+  `,
+})
+class MenuBarCheckboxGroup {}

--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -8,7 +8,6 @@ import {By} from '@angular/platform-browser';
 describe('MenuBar', () => {
   describe('as radio group', () => {
     let fixture: ComponentFixture<MenuBarRadioGroup>;
-    let menuBar: CdkMenuBar;
     let menuItems: Array<CdkMenuItem>;
 
     beforeEach(async(() => {
@@ -20,9 +19,9 @@ describe('MenuBar', () => {
       fixture = TestBed.createComponent(MenuBarRadioGroup);
       fixture.detectChanges();
 
-      menuBar = fixture.debugElement.query(By.directive(CdkMenuBar)).injector.get(CdkMenuBar);
-
-      menuItems = menuBar._allItems.toArray();
+      menuItems = fixture.debugElement
+        .queryAll(By.directive(CdkMenuItem))
+        .map((element) => element.injector.get(CdkMenuItem));
     }));
 
     it('should toggle menuitemradio items', () => {
@@ -38,7 +37,6 @@ describe('MenuBar', () => {
 
   describe('radiogroup change events', () => {
     let fixture: ComponentFixture<MenuBarRadioGroup>;
-    let menu: CdkMenuBar;
     let menuItems: Array<CdkMenuItem>;
 
     beforeEach(async(() => {
@@ -49,10 +47,11 @@ describe('MenuBar', () => {
 
       fixture = TestBed.createComponent(MenuBarRadioGroup);
 
-      menu = fixture.debugElement.query(By.directive(CdkMenuBar)).injector.get(CdkMenuBar);
       fixture.detectChanges();
 
-      menuItems = menu._allItems.toArray();
+      menuItems = fixture.debugElement
+        .queryAll(By.directive(CdkMenuItem))
+        .map((element) => element.injector.get(CdkMenuItem));
     }));
 
     it('should emit on click', () => {

--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -36,72 +36,6 @@ describe('MenuBar', () => {
     });
   });
 
-  describe('as checkbox group', () => {
-    let fixture: ComponentFixture<MenuBarCheckboxGroup>;
-    let menuBar: CdkMenuBar;
-    let menuItems: Array<CdkMenuItem>;
-
-    beforeEach(async(() => {
-      TestBed.configureTestingModule({
-        imports: [CdkMenuModule],
-        declarations: [MenuBarCheckboxGroup],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(MenuBarCheckboxGroup);
-
-      menuBar = fixture.debugElement.query(By.directive(CdkMenuBar)).injector.get(CdkMenuBar);
-      fixture.detectChanges();
-
-      menuItems = menuBar._allItems.toArray();
-    }));
-
-    it('should toggle menuitemcheckbox', () => {
-      expect(menuItems[0].checked).toBeTrue();
-      expect(menuItems[1].checked).toBeFalse();
-
-      menuItems[1].trigger();
-      expect(menuItems[0].checked).toBeTrue(); // checkbox should not change
-
-      menuItems[0].trigger();
-
-      expect(menuItems[0].checked).toBeFalse();
-      expect(menuItems[1].checked).toBeTrue();
-    });
-  });
-
-  describe('checkbox change events', () => {
-    let fixture: ComponentFixture<MenuBarCheckboxGroup>;
-    let menu: CdkMenuBar;
-    let menuItems: Array<CdkMenuItem>;
-
-    beforeEach(async(() => {
-      TestBed.configureTestingModule({
-        imports: [CdkMenuModule],
-        declarations: [MenuBarCheckboxGroup],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(MenuBarCheckboxGroup);
-
-      menu = fixture.debugElement.query(By.directive(CdkMenuBar)).injector.get(CdkMenuBar);
-      fixture.detectChanges();
-
-      menuItems = menu._allItems.toArray();
-    }));
-
-    it('should emit on click', () => {
-      const spy = jasmine.createSpy('cdkMenu change spy');
-      fixture.debugElement
-        .query(By.directive(CdkMenuBar))
-        .injector.get(CdkMenuBar)
-        .change.subscribe(spy);
-
-      menuItems[0].trigger();
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(menuItems[0]);
-    });
-  });
-
   describe('radiogroup change events', () => {
     let fixture: ComponentFixture<MenuBarRadioGroup>;
     let menu: CdkMenuBar;
@@ -153,21 +87,3 @@ describe('MenuBar', () => {
   `,
 })
 class MenuBarRadioGroup {}
-
-@Component({
-  template: `
-    <ul cdkMenuBar>
-      <li role="none">
-        <button checked="true" role="menuitemcheckbox" cdkMenuItem>
-          first
-        </button>
-      </li>
-      <li role="none">
-        <button role="menuitemcheckbox" cdkMenuItem>
-          second
-        </button>
-      </li>
-    </ul>
-  `,
-})
-class MenuBarCheckboxGroup {}

--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -8,7 +8,7 @@ import {By} from '@angular/platform-browser';
 describe('MenuBar', () => {
   describe('as radio group', () => {
     let fixture: ComponentFixture<MenuBarRadioGroup>;
-    let menuItems: Array<CdkMenuItem>;
+    let menuItems: CdkMenuItem[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -21,7 +21,7 @@ describe('MenuBar', () => {
 
       menuItems = fixture.debugElement
         .queryAll(By.directive(CdkMenuItem))
-        .map((element) => element.injector.get(CdkMenuItem));
+        .map(element => element.injector.get(CdkMenuItem));
     }));
 
     it('should toggle menuitemradio items', () => {
@@ -37,7 +37,7 @@ describe('MenuBar', () => {
 
   describe('radiogroup change events', () => {
     let fixture: ComponentFixture<MenuBarRadioGroup>;
-    let menuItems: Array<CdkMenuItem>;
+    let menuItems: CdkMenuItem[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -51,7 +51,7 @@ describe('MenuBar', () => {
 
       menuItems = fixture.debugElement
         .queryAll(By.directive(CdkMenuItem))
-        .map((element) => element.injector.get(CdkMenuItem));
+        .map(element => element.injector.get(CdkMenuItem));
     }));
 
     it('should emit on click', () => {

--- a/src/cdk-experimental/menu/menu-bar.ts
+++ b/src/cdk-experimental/menu/menu-bar.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input, ContentChildren, QueryList} from '@angular/core';
+import {Directive, Input} from '@angular/core';
 import {CdkMenuGroup} from './menu-group';
-import {CdkMenuItem} from './menu-item';
 
 /**
  * Directive applied to an element which configures it as a MenuBar by setting the appropriate
@@ -31,8 +30,4 @@ export class CdkMenuBar extends CdkMenuGroup {
    * Does not affect styling/layout.
    */
   @Input('cdkMenuBarOrientation') orientation: 'horizontal' | 'vertical' = 'horizontal';
-
-  /** All the child MenuItem components which this directive wraps including descendants */
-  @ContentChildren(CdkMenuItem, {descendants: true})
-  readonly _allItems: QueryList<CdkMenuItem>;
 }

--- a/src/cdk-experimental/menu/menu-bar.ts
+++ b/src/cdk-experimental/menu/menu-bar.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input} from '@angular/core';
+import {Directive, Input, ContentChildren, QueryList} from '@angular/core';
+import {CdkMenuGroup} from './menu-group';
+import {CdkMenuItem} from './menu-item';
 
 /**
  * Directive applied to an element which configures it as a MenuBar by setting the appropriate
@@ -21,11 +23,16 @@ import {Directive, Input} from '@angular/core';
     'role': 'menubar',
     '[attr.aria-orientation]': 'orientation',
   },
+  providers: [{provide: CdkMenuGroup, useExisting: CdkMenuBar}],
 })
-export class CdkMenuBar {
+export class CdkMenuBar extends CdkMenuGroup {
   /**
    * Sets the aria-orientation attribute and determines where sub-menus will be opened.
    * Does not affect styling/layout.
    */
   @Input('cdkMenuBarOrientation') orientation: 'horizontal' | 'vertical' = 'horizontal';
+
+  /** All the child MenuItem components which this directive wraps including descendants */
+  @ContentChildren(CdkMenuItem, {descendants: true})
+  readonly _allItems: QueryList<CdkMenuItem>;
 }

--- a/src/cdk-experimental/menu/menu-group.spec.ts
+++ b/src/cdk-experimental/menu/menu-group.spec.ts
@@ -1,0 +1,218 @@
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {CdkMenuModule} from './menu-module';
+import {CdkMenuGroup} from './menu-group';
+import {CdkMenuItem} from './menu-item';
+import {CdkMenu} from './menu';
+import {By} from '@angular/platform-browser';
+
+describe('MenuGroup', () => {
+  describe('MenuItem', () => {
+    let fixture: ComponentFixture<MenuGroups>;
+    let menu: CdkMenu;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuGroups],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuGroups);
+      fixture.detectChanges();
+
+      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
+
+      menuItems = menu._allItems.toArray();
+    }));
+
+    it('should not change state of sibling menuitemcheckbox', () => {
+      menuItems[1].trigger();
+
+      expect(menuItems[0].checked).toBeTrue(); // default state true
+    });
+
+    it('should change state of sibling menuitemradio in same group', () => {
+      menuItems[3].trigger();
+
+      expect(menuItems[3].checked).toBeTrue();
+      expect(menuItems[2].checked).toBeFalse();
+    });
+
+    it('should not change state of menuitemradio in sibling group', () => {
+      menuItems[4].trigger();
+
+      expect(menuItems[4].checked).toBeTrue();
+      expect(menuItems[2].checked).toBeTrue();
+    });
+
+    it('should not change radiogroup state with disabled button', () => {
+      menuItems[3].disabled = true;
+
+      menuItems[3].trigger();
+
+      expect(menuItems[2].checked).toBeTrue();
+      expect(menuItems[3].checked).toBeFalse();
+    });
+  });
+
+  describe('change events', () => {
+    let fixture: ComponentFixture<MenuGroups>;
+    let menu: CdkMenu;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuGroups],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuGroups);
+      fixture.detectChanges();
+
+      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
+
+      menuItems = menu._allItems.toArray();
+    }));
+
+    it('should not emit from root menu with nested groups', () => {
+      const spy = jasmine.createSpy('changeSpy for root menu');
+      menu.change.subscribe(spy);
+
+      menuItems.forEach((menuItem) => menuItem.trigger());
+
+      expect(spy).toHaveBeenCalledTimes(0);
+    });
+
+    it('should emit from groups with clicked menu items', () => {
+      const spies: Array<jasmine.Spy> = [];
+
+      fixture.debugElement.queryAll(By.directive(CdkMenuGroup)).forEach((group, index) => {
+        const spy = jasmine.createSpy(`cdkMenuGroup ${index} change spy`);
+        spies.push(spy);
+        group.injector.get(CdkMenuGroup).change.subscribe(spy);
+      });
+
+      menuItems[2].trigger();
+      menuItems[4].trigger();
+
+      expect(spies[1]).toHaveBeenCalledTimes(0);
+      expect(spies[2]).toHaveBeenCalledTimes(1);
+      expect(spies[2]).toHaveBeenCalledWith(menuItems[2]);
+      expect(spies[3]).toHaveBeenCalledTimes(1);
+      expect(spies[3]).toHaveBeenCalledWith(menuItems[4]);
+    });
+
+    it('should not emit with click on disabled button', () => {
+      const spy = jasmine.createSpy('cdkMenuGroup change spy');
+
+      fixture.debugElement
+        .queryAll(By.directive(CdkMenuGroup))[3]
+        .injector.get(CdkMenuGroup)
+        .change.subscribe(spy);
+      menuItems[4].disabled = true;
+
+      menuItems[4].trigger();
+
+      expect(spy).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not emit from sibling groups', () => {
+      const spies: Array<jasmine.Spy> = [];
+
+      fixture.debugElement.queryAll(By.directive(CdkMenuGroup)).forEach((group, index) => {
+        const spy = jasmine.createSpy(`cdkMenuGroup ${index} change spy`);
+        spies.push(spy);
+        group.injector.get(CdkMenuGroup).change.subscribe(spy);
+      });
+
+      menuItems[0].trigger();
+
+      expect(spies[1]).toHaveBeenCalledTimes(1);
+      expect(spies[2]).toHaveBeenCalledTimes(0);
+      expect(spies[3]).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not emit on menuitem click', () => {
+      const spies: Array<jasmine.Spy> = [];
+
+      fixture.debugElement.queryAll(By.directive(CdkMenuGroup)).forEach((group, index) => {
+        const spy = jasmine.createSpy(`cdkMenuGroup ${index} change spy`);
+        spies.push(spy);
+        group.injector.get(CdkMenuGroup).change.subscribe(spy);
+      });
+
+      menuItems[7].trigger();
+
+      spies.forEach((spy) => expect(spy).toHaveBeenCalledTimes(0));
+    });
+  });
+});
+
+@Component({
+  selector: 'menu-with-groups',
+  template: `
+    <ul cdkMenu>
+      <!-- Checkbox group -->
+      <li role="none">
+        <ul cdkMenuGroup>
+          <li #first role="none">
+            <button checked="true" role="menuitemcheckbox" cdkMenuItem>
+              one
+            </button>
+          </li>
+          <li role="none">
+            <button role="menuitemcheckbox" cdkMenuItem>
+              two
+            </button>
+          </li>
+        </ul>
+      </li>
+      <!-- Radio group -->
+      <li role="none">
+        <ul cdkMenuGroup>
+          <li role="none">
+            <button checked="true" role="menuitemradio" cdkMenuItem>
+              three
+            </button>
+          </li>
+          <li role="none">
+            <button role="menuitemradio" cdkMenuItem>
+              four
+            </button>
+          </li>
+        </ul>
+      </li>
+      <!-- Radio group -->
+      <li role="none">
+        <ul cdkMenuGroup>
+          <li role="none">
+            <button role="menuitemradio" cdkMenuItem>
+              five
+            </button>
+          </li>
+          <li role="none">
+            <button role="menuitemradio" cdkMenuItem>
+              six
+            </button>
+          </li>
+        </ul>
+      </li>
+      <li role="none">
+        <ul cdkMenuGroup>
+          <li role="none">
+            <button cdkMenuItem>
+              seven
+            </button>
+          </li>
+          <li role="none">
+            <button cdkMenuItem>
+              eight
+            </button>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  `,
+})
+class MenuGroups {}

--- a/src/cdk-experimental/menu/menu-group.spec.ts
+++ b/src/cdk-experimental/menu/menu-group.spec.ts
@@ -150,7 +150,6 @@ describe('MenuGroup', () => {
 });
 
 @Component({
-  selector: 'menu-with-groups',
   template: `
     <ul cdkMenu>
       <!-- Checkbox group -->

--- a/src/cdk-experimental/menu/menu-group.spec.ts
+++ b/src/cdk-experimental/menu/menu-group.spec.ts
@@ -7,17 +7,17 @@ import {CdkMenu} from './menu';
 import {By} from '@angular/platform-browser';
 
 describe('MenuGroup', () => {
-  describe('MenuItem', () => {
-    let fixture: ComponentFixture<MenuGroups>;
+  describe('with MenuItems as checkbox', () => {
+    let fixture: ComponentFixture<CheckboxMenu>;
     let menuItems: Array<CdkMenuItem>;
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
-        declarations: [MenuGroups],
+        declarations: [CheckboxMenu],
       }).compileComponents();
 
-      fixture = TestBed.createComponent(MenuGroups);
+      fixture = TestBed.createComponent(CheckboxMenu);
       fixture.detectChanges();
 
       menuItems = fixture.debugElement
@@ -25,48 +25,67 @@ describe('MenuGroup', () => {
         .map(e => e.injector.get(CdkMenuItem));
     }));
 
-    it('should not change state of sibling menuitemcheckbox', () => {
+    it('should not change state of sibling checked menuitemcheckbox', () => {
       menuItems[1].trigger();
 
-      expect(menuItems[0].checked).toBeTrue(); // default state true
+      expect(menuItems[0].checked).toBeTrue();
     });
+  });
+
+  describe('with MenuItems as radio button', () => {
+    let fixture: ComponentFixture<MenuWithMultipleRadioGroups>;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuWithMultipleRadioGroups],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuWithMultipleRadioGroups);
+      fixture.detectChanges();
+
+      menuItems = fixture.debugElement
+        .queryAll(By.directive(CdkMenuItem))
+        .map(e => e.injector.get(CdkMenuItem));
+    }));
 
     it('should change state of sibling menuitemradio in same group', () => {
-      menuItems[3].trigger();
+      menuItems[1].trigger();
 
-      expect(menuItems[3].checked).toBeTrue();
-      expect(menuItems[2].checked).toBeFalse();
+      expect(menuItems[1].checked).toBeTrue();
+      expect(menuItems[0].checked).toBeFalse();
     });
 
     it('should not change state of menuitemradio in sibling group', () => {
-      menuItems[4].trigger();
+      menuItems[3].trigger();
 
-      expect(menuItems[4].checked).toBeTrue();
-      expect(menuItems[2].checked).toBeTrue();
+      expect(menuItems[3].checked).toBeTrue();
+      expect(menuItems[0].checked).toBeTrue();
     });
 
     it('should not change radiogroup state with disabled button', () => {
-      menuItems[3].disabled = true;
+      menuItems[1].disabled = true;
 
-      menuItems[3].trigger();
+      menuItems[1].trigger();
 
-      expect(menuItems[2].checked).toBeTrue();
-      expect(menuItems[3].checked).toBeFalse();
+      expect(menuItems[0].checked).toBeTrue();
+      expect(menuItems[1].checked).toBeFalse();
     });
   });
 
   describe('change events', () => {
-    let fixture: ComponentFixture<MenuGroups>;
+    let fixture: ComponentFixture<MenuWithMenuItemsAndRadioGroups>;
     let menu: CdkMenu;
     let menuItems: Array<CdkMenuItem>;
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
-        declarations: [MenuGroups],
+        declarations: [MenuWithMenuItemsAndRadioGroups],
       }).compileComponents();
 
-      fixture = TestBed.createComponent(MenuGroups);
+      fixture = TestBed.createComponent(MenuWithMenuItemsAndRadioGroups);
       fixture.detectChanges();
 
       menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
@@ -85,40 +104,7 @@ describe('MenuGroup', () => {
       expect(spy).toHaveBeenCalledTimes(0);
     });
 
-    it('should emit from groups with clicked menu items', () => {
-      const spies: Array<jasmine.Spy> = [];
-
-      fixture.debugElement.queryAll(By.directive(CdkMenuGroup)).forEach((group, index) => {
-        const spy = jasmine.createSpy(`cdkMenuGroup ${index} change spy`);
-        spies.push(spy);
-        group.injector.get(CdkMenuGroup).change.subscribe(spy);
-      });
-
-      menuItems[2].trigger();
-      menuItems[4].trigger();
-
-      expect(spies[1]).toHaveBeenCalledTimes(0);
-      expect(spies[2]).toHaveBeenCalledTimes(1);
-      expect(spies[2]).toHaveBeenCalledWith(menuItems[2]);
-      expect(spies[3]).toHaveBeenCalledTimes(1);
-      expect(spies[3]).toHaveBeenCalledWith(menuItems[4]);
-    });
-
-    it('should not emit with click on disabled button', () => {
-      const spy = jasmine.createSpy('cdkMenuGroup change spy');
-
-      fixture.debugElement
-        .queryAll(By.directive(CdkMenuGroup))[3]
-        .injector.get(CdkMenuGroup)
-        .change.subscribe(spy);
-      menuItems[4].disabled = true;
-
-      menuItems[4].trigger();
-
-      expect(spy).toHaveBeenCalledTimes(0);
-    });
-
-    it('should not emit from sibling groups', () => {
+    it('should emit from enclosing radio group only', () => {
       const spies: Array<jasmine.Spy> = [];
 
       fixture.debugElement.queryAll(By.directive(CdkMenuGroup)).forEach((group, index) => {
@@ -130,8 +116,23 @@ describe('MenuGroup', () => {
       menuItems[0].trigger();
 
       expect(spies[1]).toHaveBeenCalledTimes(1);
+      expect(spies[1]).toHaveBeenCalledWith(menuItems[0]);
       expect(spies[2]).toHaveBeenCalledTimes(0);
       expect(spies[3]).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not emit with click on disabled button', () => {
+      const spy = jasmine.createSpy('cdkMenuGroup change spy');
+
+      fixture.debugElement
+        .queryAll(By.directive(CdkMenuGroup))[1]
+        .injector.get(CdkMenuGroup)
+        .change.subscribe(spy);
+      menuItems[0].disabled = true;
+
+      menuItems[0].trigger();
+
+      expect(spy).toHaveBeenCalledTimes(0);
     });
 
     it('should not emit on menuitem click', () => {
@@ -143,7 +144,7 @@ describe('MenuGroup', () => {
         group.injector.get(CdkMenuGroup).change.subscribe(spy);
       });
 
-      menuItems[7].trigger();
+      menuItems[2].trigger();
 
       spies.forEach(spy => expect(spy).toHaveBeenCalledTimes(0));
     });
@@ -153,7 +154,6 @@ describe('MenuGroup', () => {
 @Component({
   template: `
     <ul cdkMenu>
-      <!-- Checkbox group -->
       <li role="none">
         <ul cdkMenuGroup>
           <li #first role="none">
@@ -168,11 +168,32 @@ describe('MenuGroup', () => {
           </li>
         </ul>
       </li>
-      <!-- Radio group -->
+    </ul>
+  `,
+})
+class CheckboxMenu {}
+
+@Component({
+  template: `
+    <ul cdkMenu>
       <li role="none">
         <ul cdkMenuGroup>
           <li role="none">
             <button checked="true" role="menuitemradio" cdkMenuItem>
+              one
+            </button>
+          </li>
+          <li role="none">
+            <button role="menuitemradio" cdkMenuItem>
+              two
+            </button>
+          </li>
+        </ul>
+      </li>
+      <li role="none">
+        <ul cdkMenuGroup>
+          <li role="none">
+            <button role="menuitemradio" cdkMenuItem>
               three
             </button>
           </li>
@@ -183,17 +204,28 @@ describe('MenuGroup', () => {
           </li>
         </ul>
       </li>
-      <!-- Radio group -->
+    </ul>
+  `,
+})
+class MenuWithMultipleRadioGroups {}
+
+@Component({
+  template: `
+    <ul cdkMenu>
       <li role="none">
         <ul cdkMenuGroup>
           <li role="none">
             <button role="menuitemradio" cdkMenuItem>
-              five
+              one
             </button>
           </li>
+        </ul>
+      </li>
+      <li role="none">
+        <ul cdkMenuGroup>
           <li role="none">
             <button role="menuitemradio" cdkMenuItem>
-              six
+              two
             </button>
           </li>
         </ul>
@@ -202,12 +234,7 @@ describe('MenuGroup', () => {
         <ul cdkMenuGroup>
           <li role="none">
             <button cdkMenuItem>
-              seven
-            </button>
-          </li>
-          <li role="none">
-            <button cdkMenuItem>
-              eight
+              three
             </button>
           </li>
         </ul>
@@ -215,4 +242,4 @@ describe('MenuGroup', () => {
     </ul>
   `,
 })
-class MenuGroups {}
+class MenuWithMenuItemsAndRadioGroups {}

--- a/src/cdk-experimental/menu/menu-group.spec.ts
+++ b/src/cdk-experimental/menu/menu-group.spec.ts
@@ -9,7 +9,6 @@ import {By} from '@angular/platform-browser';
 describe('MenuGroup', () => {
   describe('MenuItem', () => {
     let fixture: ComponentFixture<MenuGroups>;
-    let menu: CdkMenu;
     let menuItems: Array<CdkMenuItem>;
 
     beforeEach(async(() => {
@@ -21,9 +20,9 @@ describe('MenuGroup', () => {
       fixture = TestBed.createComponent(MenuGroups);
       fixture.detectChanges();
 
-      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
-
-      menuItems = menu._allItems.toArray();
+      menuItems = fixture.debugElement
+        .queryAll(By.directive(CdkMenuItem))
+        .map((element) => element.injector.get(CdkMenuItem));
     }));
 
     it('should not change state of sibling menuitemcheckbox', () => {
@@ -72,7 +71,9 @@ describe('MenuGroup', () => {
 
       menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
 
-      menuItems = menu._allItems.toArray();
+      menuItems = fixture.debugElement
+        .queryAll(By.directive(CdkMenuItem))
+        .map((element) => element.injector.get(CdkMenuItem));
     }));
 
     it('should not emit from root menu with nested groups', () => {

--- a/src/cdk-experimental/menu/menu-group.spec.ts
+++ b/src/cdk-experimental/menu/menu-group.spec.ts
@@ -9,7 +9,7 @@ import {By} from '@angular/platform-browser';
 describe('MenuGroup', () => {
   describe('with MenuItems as checkbox', () => {
     let fixture: ComponentFixture<CheckboxMenu>;
-    let menuItems: Array<CdkMenuItem>;
+    let menuItems: CdkMenuItem[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -34,7 +34,7 @@ describe('MenuGroup', () => {
 
   describe('with MenuItems as radio button', () => {
     let fixture: ComponentFixture<MenuWithMultipleRadioGroups>;
-    let menuItems: Array<CdkMenuItem>;
+    let menuItems: CdkMenuItem[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -77,7 +77,7 @@ describe('MenuGroup', () => {
   describe('change events', () => {
     let fixture: ComponentFixture<MenuWithMenuItemsAndRadioGroups>;
     let menu: CdkMenu;
-    let menuItems: Array<CdkMenuItem>;
+    let menuItems: CdkMenuItem[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -105,7 +105,7 @@ describe('MenuGroup', () => {
     });
 
     it('should emit from enclosing radio group only', () => {
-      const spies: Array<jasmine.Spy> = [];
+      const spies: jasmine.Spy[] = [];
 
       fixture.debugElement.queryAll(By.directive(CdkMenuGroup)).forEach((group, index) => {
         const spy = jasmine.createSpy(`cdkMenuGroup ${index} change spy`);
@@ -136,7 +136,7 @@ describe('MenuGroup', () => {
     });
 
     it('should not emit on menuitem click', () => {
-      const spies: Array<jasmine.Spy> = [];
+      const spies: jasmine.Spy[] = [];
 
       fixture.debugElement.queryAll(By.directive(CdkMenuGroup)).forEach((group, index) => {
         const spy = jasmine.createSpy(`cdkMenuGroup ${index} change spy`);

--- a/src/cdk-experimental/menu/menu-group.spec.ts
+++ b/src/cdk-experimental/menu/menu-group.spec.ts
@@ -22,7 +22,7 @@ describe('MenuGroup', () => {
 
       menuItems = fixture.debugElement
         .queryAll(By.directive(CdkMenuItem))
-        .map((element) => element.injector.get(CdkMenuItem));
+        .map(e => e.injector.get(CdkMenuItem));
     }));
 
     it('should not change state of sibling menuitemcheckbox', () => {
@@ -73,14 +73,14 @@ describe('MenuGroup', () => {
 
       menuItems = fixture.debugElement
         .queryAll(By.directive(CdkMenuItem))
-        .map((element) => element.injector.get(CdkMenuItem));
+        .map(element => element.injector.get(CdkMenuItem));
     }));
 
     it('should not emit from root menu with nested groups', () => {
       const spy = jasmine.createSpy('changeSpy for root menu');
       menu.change.subscribe(spy);
 
-      menuItems.forEach((menuItem) => menuItem.trigger());
+      menuItems.forEach(menuItem => menuItem.trigger());
 
       expect(spy).toHaveBeenCalledTimes(0);
     });
@@ -145,7 +145,7 @@ describe('MenuGroup', () => {
 
       menuItems[7].trigger();
 
-      spies.forEach((spy) => expect(spy).toHaveBeenCalledTimes(0));
+      spies.forEach(spy => expect(spy).toHaveBeenCalledTimes(0));
     });
   });
 });

--- a/src/cdk-experimental/menu/menu-group.ts
+++ b/src/cdk-experimental/menu/menu-group.ts
@@ -23,4 +23,14 @@ import {MenuItem} from './menu-item-interface';
 export class CdkMenuGroup {
   /** Emits the element when checkbox or radiobutton state changed  */
   @Output() change: EventEmitter<MenuItem> = new EventEmitter();
+
+  /**
+   * Emits events for the clicked MenuItem
+   * @param menuItem The clicked MenuItem to handle
+   */
+  _registerTriggeredItem(menuItem: MenuItem) {
+    if (menuItem.role !== 'menuitem') {
+      this.change.emit(menuItem);
+    }
+  }
 }

--- a/src/cdk-experimental/menu/menu-group.ts
+++ b/src/cdk-experimental/menu/menu-group.ts
@@ -7,7 +7,7 @@
  */
 
 import {Directive, Output, EventEmitter} from '@angular/core';
-import {CdkMenuItem} from './menu-item';
+import {MenuItem} from './menu-item-interface';
 
 /**
  * Directive which acts as a grouping container for `CdkMenuItem` instances with
@@ -22,5 +22,5 @@ import {CdkMenuItem} from './menu-item';
 })
 export class CdkMenuGroup {
   /** Emits the element when checkbox or radiobutton state changed  */
-  @Output() change: EventEmitter<CdkMenuItem> = new EventEmitter();
+  @Output() change: EventEmitter<MenuItem> = new EventEmitter();
 }

--- a/src/cdk-experimental/menu/menu-item-interface.ts
+++ b/src/cdk-experimental/menu/menu-item-interface.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {EventEmitter} from '@angular/core';
+
+/**
+ * An element within a Menu or MenuBar which:
+ *  - performs some user defined action
+ *  - opens up a submenu
+ *  - acts as a checkbox or radio button
+ */
+export interface MenuItem {
+  /** ARIA role for the menu item. */
+  role: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox';
+
+  /** Whether the checkbox or radiobutton is checked */
+  checked: boolean;
+
+  /**  Whether the MenuItem is disabled - defaults to false */
+  disabled: boolean;
+
+  /** Emits when the attached submenu is opened */
+  opened: EventEmitter<void>;
+
+  /** Whether the menu item opens a menu */
+  hasSubmenu(): boolean;
+}

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -37,7 +37,7 @@ import {CdkMenuGroup} from './menu-group';
 })
 export class CdkMenuItem implements AfterContentInit {
   /** Template reference variable to the menu this trigger opens */
-  @Input('cdkMenuTriggerFor') _menuPanel: CdkMenuPanel;
+  @Input('cdkMenuTriggerFor') _menuPanel?: CdkMenuPanel;
 
   /** ARIA role for the menu item. */
   @Input() role: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox' = 'menuitem';

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -67,7 +67,7 @@ export class CdkMenuItem implements AfterContentInit {
 
   constructor(
     /** reference a parent CdkMenuGroup component */
-    private _menuGroup: CdkMenuGroup
+    private readonly _menuGroup: CdkMenuGroup
   ) {}
 
   /** Configure event subscriptions */

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -89,9 +89,8 @@ export class CdkMenuItem implements AfterContentInit, MenuItem {
 
     if (this.hasSubmenu()) {
       // TODO(andy): open the menu
-    } else if (this.role !== 'menuitem') {
-      this._menuGroup.change.next(this);
     }
+    this._menuGroup._registerTriggeredItem(this);
   }
 
   /** Whether the menu item opens a menu */

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -10,6 +10,7 @@ import {Directive, Output, Input, AfterContentInit, EventEmitter} from '@angular
 import {coerceBooleanProperty, BooleanInput} from '@angular/cdk/coercion';
 import {CdkMenuPanel} from './menu-panel';
 import {CdkMenuGroup} from './menu-group';
+import {MenuItem} from './menu-item-interface';
 
 /**
  * Directive which provides behavior for an element which when clicked:
@@ -35,7 +36,7 @@ import {CdkMenuGroup} from './menu-group';
     '[attr.aria-disabled]': 'disabled || null',
   },
 })
-export class CdkMenuItem implements AfterContentInit {
+export class CdkMenuItem implements AfterContentInit, MenuItem {
   /** Template reference variable to the menu this trigger opens */
   @Input('cdkMenuTriggerFor') _menuPanel?: CdkMenuPanel;
 

--- a/src/cdk-experimental/menu/menu.spec.ts
+++ b/src/cdk-experimental/menu/menu.spec.ts
@@ -6,36 +6,6 @@ import {CdkMenuItem} from './menu-item';
 import {By} from '@angular/platform-browser';
 
 describe('Menu', () => {
-  describe('as radio group', () => {
-    let fixture: ComponentFixture<MenuRadioGroup>;
-    let menu: CdkMenu;
-    let menuItems: Array<CdkMenuItem>;
-
-    beforeEach(async(() => {
-      TestBed.configureTestingModule({
-        imports: [CdkMenuModule],
-        declarations: [MenuRadioGroup],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(MenuRadioGroup);
-      fixture.detectChanges();
-
-      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
-
-      menuItems = menu._allItems.toArray();
-    }));
-
-    it('should toggle menuitemradio items', () => {
-      expect(menuItems[0].checked).toBeTrue();
-      expect(menuItems[1].checked).toBeFalse();
-
-      menuItems[1].trigger();
-
-      expect(menuItems[0].checked).toBeFalse();
-      expect(menuItems[1].checked).toBeTrue();
-    });
-  });
-
   describe('as checkbox group', () => {
     let fixture: ComponentFixture<MenuCheckboxGroup>;
     let menu: CdkMenu;
@@ -98,55 +68,7 @@ describe('Menu', () => {
       expect(spy).toHaveBeenCalledWith(menuItems[0]);
     });
   });
-
-  describe('radiogroup change events', () => {
-    let fixture: ComponentFixture<MenuRadioGroup>;
-    let menu: CdkMenu;
-    let menuItems: Array<CdkMenuItem>;
-
-    beforeEach(async(() => {
-      TestBed.configureTestingModule({
-        imports: [CdkMenuModule],
-        declarations: [MenuRadioGroup],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(MenuRadioGroup);
-
-      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
-      fixture.detectChanges();
-
-      menuItems = menu._allItems.toArray();
-    }));
-
-    it('should emit on click', () => {
-      const spy = jasmine.createSpy('cdkMenu change spy');
-      fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu).change.subscribe(spy);
-
-      menuItems[0].trigger();
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(menuItems[0]);
-    });
-  });
 });
-
-@Component({
-  template: `
-    <ul cdkMenu>
-      <li role="none">
-        <button checked="true" role="menuitemradio" cdkMenuItem>
-          first
-        </button>
-      </li>
-      <li role="none">
-        <button role="menuitemradio" cdkMenuItem>
-          second
-        </button>
-      </li>
-    </ul>
-  `,
-})
-class MenuRadioGroup {}
 
 @Component({
   template: `

--- a/src/cdk-experimental/menu/menu.spec.ts
+++ b/src/cdk-experimental/menu/menu.spec.ts
@@ -8,7 +8,6 @@ import {By} from '@angular/platform-browser';
 describe('Menu', () => {
   describe('as checkbox group', () => {
     let fixture: ComponentFixture<MenuCheckboxGroup>;
-    let menu: CdkMenu;
     let menuItems: Array<CdkMenuItem>;
 
     beforeEach(async(() => {
@@ -19,10 +18,11 @@ describe('Menu', () => {
 
       fixture = TestBed.createComponent(MenuCheckboxGroup);
 
-      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
       fixture.detectChanges();
 
-      menuItems = menu._allItems.toArray();
+      menuItems = fixture.debugElement
+        .queryAll(By.directive(CdkMenuItem))
+        .map((element) => element.injector.get(CdkMenuItem));
     }));
 
     it('should toggle menuitemcheckbox', () => {
@@ -41,7 +41,6 @@ describe('Menu', () => {
 
   describe('checkbox change events', () => {
     let fixture: ComponentFixture<MenuCheckboxGroup>;
-    let menu: CdkMenu;
     let menuItems: Array<CdkMenuItem>;
 
     beforeEach(async(() => {
@@ -52,10 +51,11 @@ describe('Menu', () => {
 
       fixture = TestBed.createComponent(MenuCheckboxGroup);
 
-      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
       fixture.detectChanges();
 
-      menuItems = menu._allItems.toArray();
+      menuItems = fixture.debugElement
+        .queryAll(By.directive(CdkMenuItem))
+        .map((element) => element.injector.get(CdkMenuItem));
     }));
 
     it('should emit on click', () => {

--- a/src/cdk-experimental/menu/menu.spec.ts
+++ b/src/cdk-experimental/menu/menu.spec.ts
@@ -1,0 +1,169 @@
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {CdkMenu} from './menu';
+import {CdkMenuModule} from './menu-module';
+import {CdkMenuItem} from './menu-item';
+import {By} from '@angular/platform-browser';
+
+describe('Menu', () => {
+  describe('as radio group', () => {
+    let fixture: ComponentFixture<MenuRadioGroup>;
+    let menu: CdkMenu;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuRadioGroup],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuRadioGroup);
+      fixture.detectChanges();
+
+      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
+
+      menuItems = menu._allItems.toArray();
+    }));
+
+    it('should toggle menuitemradio items', () => {
+      expect(menuItems[0].checked).toBeTrue();
+      expect(menuItems[1].checked).toBeFalse();
+
+      menuItems[1].trigger();
+
+      expect(menuItems[0].checked).toBeFalse();
+      expect(menuItems[1].checked).toBeTrue();
+    });
+  });
+
+  describe('as checkbox group', () => {
+    let fixture: ComponentFixture<MenuCheckboxGroup>;
+    let menu: CdkMenu;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuCheckboxGroup],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuCheckboxGroup);
+
+      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
+      fixture.detectChanges();
+
+      menuItems = menu._allItems.toArray();
+    }));
+
+    it('should toggle menuitemcheckbox', () => {
+      expect(menuItems[0].checked).toBeTrue();
+      expect(menuItems[1].checked).toBeFalse();
+
+      menuItems[1].trigger();
+      expect(menuItems[0].checked).toBeTrue(); // checkbox should not change
+
+      menuItems[0].trigger();
+
+      expect(menuItems[0].checked).toBeFalse();
+      expect(menuItems[1].checked).toBeTrue();
+    });
+  });
+
+  describe('checkbox change events', () => {
+    let fixture: ComponentFixture<MenuCheckboxGroup>;
+    let menu: CdkMenu;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuCheckboxGroup],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuCheckboxGroup);
+
+      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
+      fixture.detectChanges();
+
+      menuItems = menu._allItems.toArray();
+    }));
+
+    it('should emit on click', () => {
+      const spy = jasmine.createSpy('cdkMenu change spy');
+      fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu).change.subscribe(spy);
+
+      menuItems[0].trigger();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(menuItems[0]);
+    });
+  });
+
+  describe('radiogroup change events', () => {
+    let fixture: ComponentFixture<MenuRadioGroup>;
+    let menu: CdkMenu;
+    let menuItems: Array<CdkMenuItem>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuRadioGroup],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(MenuRadioGroup);
+
+      menu = fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu);
+      fixture.detectChanges();
+
+      menuItems = menu._allItems.toArray();
+    }));
+
+    it('should emit on click', () => {
+      const spy = jasmine.createSpy('cdkMenu change spy');
+      fixture.debugElement.query(By.directive(CdkMenu)).injector.get(CdkMenu).change.subscribe(spy);
+
+      menuItems[0].trigger();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(menuItems[0]);
+    });
+  });
+});
+
+@Component({
+  selector: 'menu-as-radio-group',
+  template: `
+    <ul cdkMenu>
+      <li role="none">
+        <button checked="true" role="menuitemradio" cdkMenuItem>
+          first
+        </button>
+      </li>
+      <li role="none">
+        <button role="menuitemradio" cdkMenuItem>
+          second
+        </button>
+      </li>
+    </ul>
+  `,
+})
+class MenuRadioGroup {}
+
+@Component({
+  selector: 'menu-as-checkbox-group',
+  template: `
+    <ul cdkMenu>
+      <li role="none">
+        <button checked="true" role="menuitemcheckbox" cdkMenuItem>
+          first
+        </button>
+      </li>
+      <li role="none">
+        <button role="menuitemcheckbox" cdkMenuItem>
+          second
+        </button>
+      </li>
+    </ul>
+  `,
+})
+class MenuCheckboxGroup {}

--- a/src/cdk-experimental/menu/menu.spec.ts
+++ b/src/cdk-experimental/menu/menu.spec.ts
@@ -131,7 +131,6 @@ describe('Menu', () => {
 });
 
 @Component({
-  selector: 'menu-as-radio-group',
   template: `
     <ul cdkMenu>
       <li role="none">
@@ -150,7 +149,6 @@ describe('Menu', () => {
 class MenuRadioGroup {}
 
 @Component({
-  selector: 'menu-as-checkbox-group',
   template: `
     <ul cdkMenu>
       <li role="none">

--- a/src/cdk-experimental/menu/menu.spec.ts
+++ b/src/cdk-experimental/menu/menu.spec.ts
@@ -8,7 +8,7 @@ import {By} from '@angular/platform-browser';
 describe('Menu', () => {
   describe('as checkbox group', () => {
     let fixture: ComponentFixture<MenuCheckboxGroup>;
-    let menuItems: Array<CdkMenuItem>;
+    let menuItems: CdkMenuItem[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -22,7 +22,7 @@ describe('Menu', () => {
 
       menuItems = fixture.debugElement
         .queryAll(By.directive(CdkMenuItem))
-        .map((element) => element.injector.get(CdkMenuItem));
+        .map(element => element.injector.get(CdkMenuItem));
     }));
 
     it('should toggle menuitemcheckbox', () => {
@@ -41,7 +41,7 @@ describe('Menu', () => {
 
   describe('checkbox change events', () => {
     let fixture: ComponentFixture<MenuCheckboxGroup>;
-    let menuItems: Array<CdkMenuItem>;
+    let menuItems: CdkMenuItem[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -55,7 +55,7 @@ describe('Menu', () => {
 
       menuItems = fixture.debugElement
         .queryAll(By.directive(CdkMenuItem))
-        .map((element) => element.injector.get(CdkMenuItem));
+        .map(element => element.injector.get(CdkMenuItem));
     }));
 
     it('should emit on click', () => {

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input, Output, EventEmitter} from '@angular/core';
+import {Directive, Input, Output, ContentChildren, QueryList, EventEmitter} from '@angular/core';
 import {CdkMenuItem} from './menu-item';
+import {CdkMenuGroup} from './menu-group';
 
 /**
  * Directive which configures the element as a Menu which should contain child elements marked as
@@ -20,11 +21,12 @@ import {CdkMenuItem} from './menu-item';
   selector: '[cdkMenu]',
   exportAs: 'cdkMenu',
   host: {
-    'role': 'menubar',
+    'role': 'menu',
     '[attr.aria-orientation]': 'orientation',
   },
+  providers: [{provide: CdkMenuGroup, useExisting: CdkMenu}],
 })
-export class CdkMenu {
+export class CdkMenu extends CdkMenuGroup {
   /**
    * Sets the aria-orientation attribute and determines where sub-menus will be opened.
    * Does not affect styling/layout.
@@ -34,6 +36,7 @@ export class CdkMenu {
   /** Event emitted when the menu is closed. */
   @Output() readonly closed: EventEmitter<void | 'click' | 'tab' | 'escape'> = new EventEmitter();
 
-  /** Emits the activated element when checkbox or radiobutton state changed  */
-  @Output() change: EventEmitter<CdkMenuItem>;
+  /** All the child MenuItem components which this directive wraps including descendants */
+  @ContentChildren(CdkMenuItem, {descendants: true})
+  readonly _allItems: QueryList<CdkMenuItem>;
 }

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input, Output, ContentChildren, QueryList, EventEmitter} from '@angular/core';
-import {CdkMenuItem} from './menu-item';
+import {Directive, Input, Output, EventEmitter} from '@angular/core';
 import {CdkMenuGroup} from './menu-group';
 
 /**
@@ -35,8 +34,4 @@ export class CdkMenu extends CdkMenuGroup {
 
   /** Event emitted when the menu is closed. */
   @Output() readonly closed: EventEmitter<void | 'click' | 'tab' | 'escape'> = new EventEmitter();
-
-  /** All the child MenuItem components which this directive wraps including descendants */
-  @ContentChildren(CdkMenuItem, {descendants: true})
-  readonly _allItems: QueryList<CdkMenuItem>;
 }


### PR DESCRIPTION
The MenuBar and Menu pattern allows for MenuItems which have the
menuitemcheckbox or menuitemradio roles. This implements the grouping
logic for, menuitemradio which ensures that sibling items within a
CdkMenu or CdkMenGroup are logically connected and only one can be
checked. It also implements the logic for menuitemcheckbox. Further it
implements the logic for emitting checked events for elements marked
menuitemcheckbox and menuitemradio from their enclosing groups.


-----

Note that I opted not to allow the disabled property on `CdkMenu` and `CdkMenuGroup` since this follows more in line with `mat-menu`, and how I interpreted the pattern. However if we decide to implement this functionality it can be easily added with a followup pr. 