### PR TITLE
refactor(datepicker): remove circular dependencies

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -41,14 +41,6 @@
     "src/cdk/testing/private/e2e/query.ts"
   ],
   [
-    "src/material/datepicker/date-range-input.ts",
-    "src/material/datepicker/date-range-picker.ts"
-  ],
-  [
-    "src/material/datepicker/datepicker-input.ts",
-    "src/material/datepicker/datepicker.ts"
-  ],
-  [
     "src/material/grid-list/grid-list.ts",
     "src/material/grid-list/tile-styler.ts"
   ]

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -34,7 +34,7 @@ import {
 import {MatDatepickerControl} from './datepicker-base';
 import {createMissingDateImplError} from './datepicker-errors';
 import {DateFilterFn} from './datepicker-input-base';
-import {MatDateRangePicker} from './date-range-picker';
+import {MatDateRangePicker, MatDateRangePickerInput} from './date-range-picker';
 import {DateRange, MatDateSelectionModel} from './date-selection-model';
 
 let nextUniqueId = 0;
@@ -60,7 +60,8 @@ let nextUniqueId = 0;
   ]
 })
 export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
-  MatDatepickerControl<D>, MatDateRangeInputParent<D>, AfterContentInit, OnDestroy {
+  MatDatepickerControl<D>, MatDateRangeInputParent<D>, MatDateRangePickerInput<D>,
+  AfterContentInit, OnDestroy {
   /** Current value of the range input. */
   get value() {
     return this._model ? this._model.selection : null;

--- a/src/material/datepicker/date-range-picker.ts
+++ b/src/material/datepicker/date-range-picker.ts
@@ -7,9 +7,17 @@
  */
 
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-import {MatDatepickerBase, MatDatepickerContent} from './datepicker-base';
-import {MatDateRangeInput} from './date-range-input';
+import {MatDatepickerBase, MatDatepickerContent, MatDatepickerControl} from './datepicker-base';
 import {MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER, DateRange} from './date-selection-model';
+
+/**
+ * Input that can be associated with a date range picker.
+ * @docs-private
+ */
+export interface MatDateRangePickerInput<D> extends MatDatepickerControl<D> {
+  comparisonStart: D|null;
+  comparisonEnd: D|null;
+}
 
 // TODO(mmalerba): We use a component instead of a directive here so the user can use implicit
 // template reference variables (e.g. #d vs #d="matDateRangePicker"). We can change this to a
@@ -23,9 +31,8 @@ import {MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER, DateRange} from './date-selecti
   encapsulation: ViewEncapsulation.None,
   providers: [MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER]
 })
-export class MatDateRangePicker<D>
-  extends MatDatepickerBase<MatDateRangeInput<D>, DateRange<D>, D> {
-
+export class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRangePickerInput<D>,
+  DateRange<D>, D> {
   protected _forwardContentValues(instance: MatDatepickerContent<DateRange<D>, D>) {
     super._forwardContentValues(instance);
 

--- a/src/material/datepicker/datepicker.ts
+++ b/src/material/datepicker/datepicker.ts
@@ -7,8 +7,7 @@
  */
 
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-import {MatDatepickerBase} from './datepicker-base';
-import {MatDatepickerInput} from './datepicker-input';
+import {MatDatepickerBase, MatDatepickerControl} from './datepicker-base';
 import {MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER} from './date-selection-model';
 
 // TODO(mmalerba): We use a component instead of a directive here so the user can use implicit
@@ -23,5 +22,5 @@ import {MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER} from './date-selection-model';
   encapsulation: ViewEncapsulation.None,
   providers: [MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER]
 })
-export class MatDatepicker<D> extends MatDatepickerBase<MatDatepickerInput<D>, D | null, D> {
+export class MatDatepicker<D> extends MatDatepickerBase<MatDatepickerControl<D>, D | null, D> {
 }

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -31,7 +31,7 @@ export * from './datepicker-toggle';
 export * from './month-view';
 export * from './year-view';
 export * from './date-range-input';
-export * from './date-range-picker';
+export {MatDateRangePicker} from './date-range-picker';
 export * from './date-selection-model';
 export {MatStartDate, MatEndDate} from './date-range-input-parts';
 export {MatMultiYearView, yearsPerPage, yearsPerRow} from './multi-year-view';

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -174,7 +174,7 @@ export interface MatCalendarUserEvent<D> {
 
 export declare type MatCalendarView = 'month' | 'year' | 'multi-year';
 
-export declare class MatDatepicker<D> extends MatDatepickerBase<MatDatepickerInput<D>, D | null, D> {
+export declare class MatDatepicker<D> extends MatDatepickerBase<MatDatepickerControl<D>, D | null, D> {
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDatepicker<any>, "mat-datepicker", ["matDatepicker"], {}, {}, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepicker<any>, never>;
 }
@@ -285,7 +285,7 @@ export declare class MatDatepickerToggleIcon {
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerToggleIcon, never>;
 }
 
-export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, MatDatepickerControl<D>, MatDateRangeInputParent<D>, AfterContentInit, OnDestroy {
+export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, MatDatepickerControl<D>, MatDateRangeInputParent<D>, MatDateRangePickerInput<D>, AfterContentInit, OnDestroy {
     _ariaDescribedBy: string | null;
     _ariaLabelledBy: string | null;
     _disabledChange: Subject<boolean>;
@@ -336,7 +336,7 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     static ɵfac: i0.ɵɵFactoryDef<MatDateRangeInput<any>, [null, null, { optional: true; self: true; }, { optional: true; }, { optional: true; }]>;
 }
 
-export declare class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRangeInput<D>, DateRange<D>, D> {
+export declare class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRangePickerInput<D>, DateRange<D>, D> {
     protected _forwardContentValues(instance: MatDatepickerContent<DateRange<D>, D>): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDateRangePicker<any>, "mat-date-range-picker", ["matDateRangePicker"], {}, {}, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDateRangePicker<any>, never>;


### PR DESCRIPTION
Adjusts a couple of types in order to avoid circular dependencies.