### PR TITLE
build: ci failure notifications accidentally skipped

### DIFF
--- a/scripts/circleci/notify-slack-job-failure.sh
+++ b/scripts/circleci/notify-slack-job-failure.sh
@@ -3,7 +3,7 @@
 # Script that notifies Slack about the currently failing job. This script
 # will be a noop when running for forked builds (i.e. PRs).
 
-if [[ -z "${CIRCLE_PR_NUMBER}" ]]; then
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
   echo "Skipping notification for pull request."
   exit 0
 fi


### PR DESCRIPTION
Looks like we currently incorrectly skip notifications when the `CIRCLE_PR_NUMBER`
variable is _not_ defined. It should be the other way around though, and we want
to only skip notifications when this variable is defined/not-null (i.e. skip notifications for PRs that don't have access to the webhook secret variable anyway).