### PR TITLE
fix(material-experimental/mdc-mdc): menu items missing padding

### DIFF
--- a/src/material-experimental/mdc-menu/menu.scss
+++ b/src/material-experimental/mdc-menu/menu.scss
@@ -38,6 +38,8 @@
   // Note that we include this private mixin, because the public
   // one adds a bunch of styles that we aren't using for the menu.
   @include mdc-list-item-base_;
+  @include mdc-list-list-item-padding-variant(
+    $mdc-list-textual-variant-config, $query: $mat-base-styles-query);
 
   // MDC's menu items are `<li>` nodes which don't need resets, however ours
   // can be anything, including buttons, so we need to do the reset ourselves.


### PR DESCRIPTION
Fixes the MDC menu items not having the proper padding. This was fixed initially in #19548 and reverted by https://github.com/devversion/material2/commit/b2517961098ad93f2bbfa4f2ffe1d9a5085181a7, but it was never re-fixed.