### PR TITLE
build: fix mdc slider demo

### DIFF
--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -9,6 +9,7 @@
 @import '../material-experimental/mdc-theming/all-theme';
 @import '../material-experimental/mdc-typography/all-typography';
 @import '../material-experimental/mdc-density/all-density';
+@import '../material-experimental/mdc-slider/slider-theme';
 @import '../material-experimental/popover-edit/popover-edit';
 
 // Plus imports for other components in your app.
@@ -42,6 +43,9 @@ $candy-app-theme: mat-light-theme((
 @include mat-column-resize-theme($candy-app-theme);
 @include mat-popover-edit-theme($candy-app-theme);
 
+// We add this in manually for now, because it isn't included in `angular-material-mdc-theme`.
+@include mat-mdc-slider-theme($candy-app-theme);
+
 // Define an alternate dark theme.
 $dark-primary: mat-palette($mat-blue-grey);
 $dark-accent: mat-palette($mat-amber, A200, A100, A400);
@@ -69,6 +73,7 @@ $dark-theme: mat-dark-theme((
   @include angular-material-mdc-color($dark-theme);
   @include mat-column-resize-color($dark-theme);
   @include mat-popover-edit-color($dark-theme);
+  @include mat-mdc-slider-color($dark-theme);
 }
 
 // Include the dark theme for focus indicators.


### PR DESCRIPTION
In #19411 the MDC slider theme was dropped from the all themes mixin since the current slider implementation will be replaced eventually which also broke the MDC slider demo. These changes add back the slider theme only to the dev app so that we can still test it since this is still code that we're releasing to npm.