### PR TITLE
build: enforce consistent array types

### DIFF
--- a/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
+++ b/src/cdk-experimental/popover-edit/edit-event-dispatcher.ts
@@ -274,7 +274,7 @@ export class EditEventDispatcher {
   }
 }
 
-function computeHoverContentState([firstRow, lastRow, activeRow, hoverRow]: Array<Element|null>):
+function computeHoverContentState([firstRow, lastRow, activeRow, hoverRow]: (Element|null)[]):
      Map<Element, HoverContentState> {
   const hoverContentState = new Map<Element, HoverContentState>();
 

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap.spec.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, ElementRef, Type, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, Type, ViewChild, Provider} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   A11yModule,
@@ -11,7 +11,7 @@ import {
 import {FocusTrapManager} from './focus-trap-manager';
 
 describe('ConfigurableFocusTrap', () => {
-    let providers: Array<Object>;
+    let providers: Provider[];
 
     describe('with FocusTrapInertStrategy', () => {
       let mockInertStrategy: FocusTrapInertStrategy;
@@ -88,8 +88,8 @@ describe('ConfigurableFocusTrap', () => {
     });
 });
 
-function createComponent<T>(componentType: Type<T>, providers: Array<Object> = []
-  ): ComponentFixture<T> {
+function createComponent<T>(componentType: Type<T>, providers: Provider[] = []):
+  ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [A11yModule],
       declarations: [componentType],

--- a/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
+++ b/src/cdk/a11y/focus-trap/event-listener-inert-strategy.spec.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, ElementRef, Type, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, Type, ViewChild, Provider} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {patchElementFocus} from '@angular/cdk/testing/private';
 import {
@@ -58,8 +58,8 @@ describe('EventListenerFocusTrapInertStrategy', () => {
 
 });
 
-function createComponent<T>(componentType: Type<T>, providers: Array<Object> = []
-  ): ComponentFixture<T> {
+function createComponent<T>(componentType: Type<T>, providers: Provider[] = []):
+  ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [A11yModule],
       declarations: [componentType],

--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -65,7 +65,7 @@ export class OverlayConfig {
       // loses the array generic type in the `for of`. But we *also* have to use `Array` because
       // typescript won't iterate over an `Iterable` unless you compile with `--downlevelIteration`
       const configKeys =
-          Object.keys(config) as Iterable<keyof OverlayConfig> & Array<keyof OverlayConfig>;
+          Object.keys(config) as Iterable<keyof OverlayConfig> & (keyof OverlayConfig)[];
       for (const key of configKeys) {
         if (config[key] !== undefined) {
           // TypeScript, as of version 3.5, sees the left-hand-side of this expression

--- a/src/cdk/table/sticky-styler.ts
+++ b/src/cdk/table/sticky-styler.ts
@@ -224,7 +224,7 @@ export class StickyStyler {
     // Use `Iterable` instead of `Array` because TypeScript, as of 3.6.3,
     // loses the array generic type in the `for of`. But we *also* have to use `Array` because
     // typescript won't iterate over an `Iterable` unless you compile with `--downlevelIteration`
-    for (const dir of STICKY_DIRECTIONS as Iterable<StickyDirection> & Array<StickyDirection>) {
+    for (const dir of STICKY_DIRECTIONS as Iterable<StickyDirection> & StickyDirection[]) {
       if (element.style[dir]) {
         zIndex += zIndexIncrements[dir];
       }

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -408,7 +408,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.controls
    */
-  get controls(): Array<google.maps.MVCArray<Node>> {
+  get controls(): google.maps.MVCArray<Node>[] {
     this._assertInitialized();
     return this.googleMap.controls;
   }

--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -204,7 +204,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   set value(value: any) {
     this._value = value;
   }
-  protected _value: Array<any> = [];
+  protected _value: any[] = [];
 
   /** An object used to control when error messages are shown. */
   @Input() errorStateMatcher: ErrorStateMatcher;

--- a/src/material-experimental/mdc-progress-bar/progress-bar.spec.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.spec.ts
@@ -8,7 +8,7 @@ import {MatProgressBar} from './progress-bar';
 
 describe('MDC-based MatProgressBar', () => {
   function createComponent<T>(componentType: Type<T>,
-                              imports?: Array<Type<{}>>): ComponentFixture<T> {
+                              imports?: Type<{}>[]): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: imports || [MatProgressBarModule],
       declarations: [componentType]

--- a/src/material/progress-bar/progress-bar.spec.ts
+++ b/src/material/progress-bar/progress-bar.spec.ts
@@ -10,7 +10,7 @@ describe('MatProgressBar', () => {
   let fakePath: string;
 
   function createComponent<T>(componentType: Type<T>,
-                              imports?: Array<Type<{}>>): ComponentFixture<T> {
+                              imports?: Type<{}>[]): ComponentFixture<T> {
     fakePath = '/fake-path';
 
     TestBed.configureTestingModule({

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -941,7 +941,7 @@ describe('MatSelect', () => {
       describe('for options', () => {
         let fixture: ComponentFixture<BasicSelect>;
         let trigger: HTMLElement;
-        let options: Array<HTMLElement>;
+        let options: HTMLElement[];
 
         beforeEach(fakeAsync(() => {
           fixture = TestBed.createComponent(BasicSelect);

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -1168,7 +1168,7 @@ class OnPushTooltipDemo {
     </button>`,
 })
 class DynamicTooltipsDemo {
-  tooltips: Array<string> = [];
+  tooltips: string[] = [];
 }
 
 @Component({

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -3,7 +3,7 @@ export declare class GoogleMap implements OnChanges, OnInit, OnDestroy {
     boundsChanged: Observable<void>;
     set center(center: google.maps.LatLngLiteral | google.maps.LatLng);
     centerChanged: Observable<void>;
-    get controls(): Array<google.maps.MVCArray<Node>>;
+    get controls(): google.maps.MVCArray<Node>[];
     get data(): google.maps.Data;
     googleMap?: google.maps.Map;
     headingChanged: Observable<void>;

--- a/tslint.json
+++ b/tslint.json
@@ -97,6 +97,7 @@
     "jsdoc-format": [true, "check-multiline-start"],
     "no-duplicate-imports": true,
     "await-promise": true,
+    "array-type": [true, "array"],
 
     // Codelyzer
     "template-banana-in-box": true,


### PR DESCRIPTION
Adds some linting that we consistently use `T[]` instead of `Array<T>`.