### PR TITLE
docs: responsiveness of form examples tab

### DIFF
--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/example-tel-input-example.html
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/example-tel-input-example.html
@@ -1,10 +1,21 @@
 <div [formGroup]="parts" class="example-tel-input-container">
-  <input class="example-tel-input-element" formControlName="area" size="3"
-         aria-label="Area code" (input)="_handleInput()">
+  <input
+    class="example-tel-input-element"
+    formControlName="area" size="3"
+    aria-label="Area code"
+    (input)="_handleInput()">
   <span class="example-tel-input-spacer">&ndash;</span>
-  <input class="example-tel-input-element" formControlName="exchange" size="3"
-         aria-label="Exchange code" (input)="_handleInput()">
+  <input
+    class="example-tel-input-element"
+    formControlName="exchange"
+    size="3"
+    aria-label="Exchange code"
+    (input)="_handleInput()">
   <span class="example-tel-input-spacer">&ndash;</span>
-  <input class="example-tel-input-element" formControlName="subscriber" size="4"
-         aria-label="Subscriber number" (input)="_handleInput()">
+  <input
+    class="example-tel-input-element"
+    formControlName="subscriber"
+    size="4"
+    aria-label="Subscriber number"
+    (input)="_handleInput()">
 </div>

--- a/src/components-examples/material/form-field/form-field-custom-control/example-tel-input-example.html
+++ b/src/components-examples/material/form-field/form-field-custom-control/example-tel-input-example.html
@@ -1,7 +1,10 @@
 <div [formGroup]="parts" class="example-tel-input-container">
-  <input class="example-tel-input-element" formControlName="area" size="3" aria-label="Area code" (input)="_handleInput()">
+  <input class="example-tel-input-element" formControlName="area"
+         size="3" aria-label="Area code" (input)="_handleInput()">
   <span class="example-tel-input-spacer">&ndash;</span>
-  <input class="example-tel-input-element" formControlName="exchange" size="3" aria-label="Exchange code" (input)="_handleInput()">
+  <input class="example-tel-input-element" formControlName="exchange"
+         size="3" aria-label="Exchange code" (input)="_handleInput()">
   <span class="example-tel-input-spacer">&ndash;</span>
-  <input class="example-tel-input-element" formControlName="subscriber" size="4" aria-label="Subscriber number" (input)="_handleInput()">
+  <input class="example-tel-input-element" formControlName="subscriber"
+         size="4" aria-label="Subscriber number" (input)="_handleInput()">
 </div>

--- a/src/components-examples/material/form-field/form-field-custom-control/example-tel-input-example.html
+++ b/src/components-examples/material/form-field/form-field-custom-control/example-tel-input-example.html
@@ -1,10 +1,22 @@
 <div [formGroup]="parts" class="example-tel-input-container">
-  <input class="example-tel-input-element" formControlName="area"
-         size="3" aria-label="Area code" (input)="_handleInput()">
+  <input
+    class="example-tel-input-element"
+    formControlName="area"
+    size="3"
+    aria-label="Area code"
+    (input)="_handleInput()">
   <span class="example-tel-input-spacer">&ndash;</span>
-  <input class="example-tel-input-element" formControlName="exchange"
-         size="3" aria-label="Exchange code" (input)="_handleInput()">
+  <input
+    class="example-tel-input-element"
+    formControlName="exchange"
+    size="3"
+    aria-label="Exchange code"
+    (input)="_handleInput()">
   <span class="example-tel-input-spacer">&ndash;</span>
-  <input class="example-tel-input-element" formControlName="subscriber"
-         size="4" aria-label="Subscriber number" (input)="_handleInput()">
+  <input
+    class="example-tel-input-element"
+    formControlName="subscriber"
+    size="4"
+    aria-label="Subscriber number"
+    (input)="_handleInput()">
 </div>


### PR DESCRIPTION
![Screenshot from 2020-06-16 17-32-46](https://user-images.githubusercontent.com/15893684/84771664-71d83880-aff7-11ea-9993-f044deccd3b0.png)

The above issue is resolved directly on https://material.angular.io/components/form-field/examples