### PR TITLE
fix(a11y): list key manager not emitting change event if new item is added to active index

### DIFF
--- a/src/cdk/a11y/key-manager/list-key-manager.spec.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.spec.ts
@@ -143,6 +143,18 @@ describe('Key managers', () => {
         subscription.unsubscribe();
       });
 
+      it('should emit if the active item changed, but not the active index', () => {
+        const spy = jasmine.createSpy('change spy');
+        const subscription = keyManager.change.subscribe(spy);
+
+        keyManager.setActiveItem(0);
+        itemList.items.unshift(new FakeFocusable('zero'));
+        keyManager.setActiveItem(0);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        subscription.unsubscribe();
+      });
+
       it('should activate the first item when pressing down on a clean key manager', () => {
         keyManager = new ListKeyManager<FakeFocusable>(itemList);
 

--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -187,11 +187,11 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
   setActiveItem(item: T): void;
 
   setActiveItem(item: any): void {
-    const previousIndex = this._activeItemIndex;
+    const previousActiveItem = this._activeItem;
 
     this.updateActiveItem(item);
 
-    if (this._activeItemIndex !== previousIndex) {
+    if (this._activeItem !== previousActiveItem) {
       this.change.next(this._activeItemIndex);
     }
   }


### PR DESCRIPTION
Currently we emit the `ListKeyManager.change` event if the active index changes, but the problem is that the list could be swapped out, resulting in a new item at the same index. These changes switch to using the item reference to determine whether we need to emit the event.

Fixes #19661.