### PR TITLE
build: lint integration test files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,8 @@
     "src/**/*.ts",
     "e2e/**/*.ts",
     "test/**/*.ts",
-    "tools/**/*.ts"
+    "tools/**/*.ts",
+    "integration/**/*.ts"
   ],
   "exclude": [
     // Exclude files that depend on Node APIs because those depend on the Node types and therefore


### PR DESCRIPTION
Includes the integration test files under the lint rules so we can catch things like unused imports.