### PR TITLE
build: run tslint for integration tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,8 +36,8 @@
     }
   },
   "include": [
+    "integration/**/*.ts",
     "src/**/*.ts",
-    "e2e/**/*.ts",
     "test/**/*.ts",
     "tools/**/*.ts"
   ],


### PR DESCRIPTION
We added a integration test folder a couple of weeks ago. We should
start linting it as we now start adding TypeScript files into it.

Note: We should experiment with incremental linting at some point. I feel like we are slowing down local development a lot with tslint currently. Linting is slow since we lint a super
large TS program w/ type checking enabled.