### PR TITLE
feat(cdk/drag-drop): support configurable propagation of mousedown and touchstart events.

### DIFF
--- a/src/cdk/drag-drop/directives/config.ts
+++ b/src/cdk/drag-drop/directives/config.ts
@@ -42,6 +42,7 @@ export interface DragDropConfig extends Partial<DragRefConfig> {
   sortingDisabled?: boolean;
   listAutoScrollDisabled?: boolean;
   listOrientation?: DropListOrientation;
+  propagateEvents?: boolean;
   zIndex?: number;
 }
 

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -199,6 +199,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
           config.dragStartThreshold : 5,
       pointerDirectionChangeThreshold: config && config.pointerDirectionChangeThreshold != null ?
           config.pointerDirectionChangeThreshold : 5,
+      propagateEvents: config && config.propagateEvents,
       zIndex: config?.zIndex
     });
     this._dragRef.data = this;

--- a/src/cdk/drag-drop/drag-drop.ts
+++ b/src/cdk/drag-drop/drag-drop.ts
@@ -16,7 +16,8 @@ import {DragDropRegistry} from './drag-drop-registry';
 /** Default configuration to be used when creating a `DragRef`. */
 const DEFAULT_CONFIG = {
   dragStartThreshold: 5,
-  pointerDirectionChangeThreshold: 5
+  pointerDirectionChangeThreshold: 5,
+  propagateEvents: false
 };
 
 /**

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -38,7 +38,7 @@ export interface DragRefConfig {
    * parent elements in the DOM when CDK initiates a drag 
    * sequence.
    */
-  propagateEvents: boolean;
+  propagateEvents?: boolean;
 
   /** `z-index` for the absolutely-positioned elements that are created by the drag item. */
   zIndex?: number;

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -33,6 +33,13 @@ export interface DragRefConfig {
    */
   pointerDirectionChangeThreshold: number;
 
+  /**
+   * Whether touch/mouse begin events should propagate to
+   * parent elements in the DOM when CDK initiates a drag 
+   * sequence.
+   */
+  propagateEvents: boolean;
+
   /** `z-index` for the absolutely-positioned elements that are created by the drag item. */
   zIndex?: number;
 }
@@ -744,7 +751,9 @@ export class DragRef<T = any> {
     // Always stop propagation for the event that initializes
     // the dragging sequence, in order to prevent it from potentially
     // starting another sequence for a draggable parent somewhere up the DOM tree.
-    event.stopPropagation();
+    if (!this._config.propagateEvents) {
+      event.stopPropagation();
+    }
 
     const isDragging = this.isDragging();
     const isTouchSequence = isTouchEvent(event);

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -35,7 +35,7 @@ export interface DragRefConfig {
 
   /**
    * Whether touch/mouse begin events should propagate to
-   * parent elements in the DOM when CDK initiates a drag 
+   * parent elements in the DOM when CDK initiates a drag
    * sequence.
    */
   propagateEvents?: boolean;

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -214,6 +214,7 @@ export interface DragDropConfig extends Partial<DragRefConfig> {
     listOrientation?: DropListOrientation;
     lockAxis?: DragAxis;
     previewClass?: string | string[];
+    propagateEvents?: boolean;
     rootElementSelector?: string;
     sortingDisabled?: boolean;
     zIndex?: number;

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -318,6 +318,7 @@ export declare class DragRef<T = any> {
 export interface DragRefConfig {
     dragStartThreshold: number;
     pointerDirectionChangeThreshold: number;
+    propagateEvents?: boolean;
     zIndex?: number;
 }
 


### PR DESCRIPTION
fix for: [#19334](https://github.com/angular/components/pull/19334)