### PR TITLE
refactor: use lightweight token for CDK accordion 

### DIFF
--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -7,3 +7,4 @@ material/autocomplete/without-optgroup: 208091
 material/select/without-optgroup: 256564
 cdk/drag-drop/all-directives: 153063
 cdk/drag-drop/basic: 150321
+material/expansion/without-accordion: 131135

--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -7,4 +7,4 @@ material/autocomplete/without-optgroup: 208091
 material/select/without-optgroup: 256564
 cdk/drag-drop/all-directives: 153063
 cdk/drag-drop/basic: 150321
-material/expansion/without-accordion: 131135
+material/expansion/without-accordion: 130562

--- a/integration/size-test/material/expansion/BUILD.bazel
+++ b/integration/size-test/material/expansion/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//integration/size-test:index.bzl", "size_test")
+
+size_test(
+    name = "without-accordion",
+    file = "without-accordion.ts",
+    deps = ["//src/material/expansion"],
+)

--- a/integration/size-test/material/expansion/without-accordion.ts
+++ b/integration/size-test/material/expansion/without-accordion.ts
@@ -1,0 +1,23 @@
+import {Component, NgModule} from '@angular/core';
+import {MatExpansionModule} from '@angular/material/expansion';
+
+/**
+ * Basic component using `MatExpansionPanel` and `MatExpansionPanelHeader`. Other parts of
+ * the module such as `MatAccordion` or `CdkAccordion` should be tree-shaken away.
+ */
+@Component({
+  template: `
+    <mat-expansion-panel>
+      <mat-expansion-panel-header>Title</mat-expansion-panel-header>
+      Content
+    </mat-expansion-panel>
+  `,
+})
+export class TestComponent {}
+
+@NgModule({
+  imports: [MatExpansionModule],
+  declarations: [TestComponent],
+  bootstrap: [TestComponent],
+})
+export class AppModule {}

--- a/src/cdk/accordion/accordion-item.ts
+++ b/src/cdk/accordion/accordion-item.ts
@@ -15,9 +15,10 @@ import {
   Optional,
   ChangeDetectorRef,
   SkipSelf,
+  Inject,
 } from '@angular/core';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
-import {CdkAccordion} from './accordion';
+import {CDK_ACCORDION, CdkAccordion} from './accordion';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Subscription} from 'rxjs';
 
@@ -32,9 +33,9 @@ let nextId = 0;
   selector: 'cdk-accordion-item, [cdkAccordionItem]',
   exportAs: 'cdkAccordionItem',
   providers: [
-    // Provide CdkAccordion as undefined to prevent nested accordion items from registering
-    // to the same accordion.
-    {provide: CdkAccordion, useValue: undefined},
+    // Provide `CDK_ACCORDION` as undefined to prevent nested accordion items from
+    // registering to the same accordion.
+    {provide: CDK_ACCORDION, useValue: undefined},
   ],
 })
 export class CdkAccordionItem implements OnDestroy {
@@ -96,7 +97,7 @@ export class CdkAccordionItem implements OnDestroy {
   /** Unregister function for _expansionDispatcher. */
   private _removeUniqueSelectionListener: () => void = () => {};
 
-  constructor(@Optional() @SkipSelf() public accordion: CdkAccordion,
+  constructor(@Optional() @Inject(CDK_ACCORDION) @SkipSelf() public accordion: CdkAccordion,
               private _changeDetectorRef: ChangeDetectorRef,
               protected _expansionDispatcher: UniqueSelectionDispatcher) {
     this._removeUniqueSelectionListener =

--- a/src/cdk/accordion/accordion.ts
+++ b/src/cdk/accordion/accordion.ts
@@ -7,11 +7,18 @@
  */
 
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
-import {Directive, Input, OnChanges, OnDestroy, SimpleChanges} from '@angular/core';
+import {Directive, InjectionToken, Input, OnChanges, OnDestroy, SimpleChanges} from '@angular/core';
 import {Subject} from 'rxjs';
 
 /** Used to generate unique ID for each accordion. */
 let nextId = 0;
+
+/**
+ * Injection token that can be used to reference instances of `CdkAccordion`. It serves
+ * as alternative token to the actual `CdkAccordion` class which could cause unnecessary
+ * retention of the class and its directive metadata.
+ */
+export const CDK_ACCORDION = new InjectionToken<CdkAccordion>('CdkAccordion');
 
 /**
  * Directive whose purpose is to manage the expanded state of CdkAccordionItem children.
@@ -19,6 +26,7 @@ let nextId = 0;
 @Directive({
   selector: 'cdk-accordion, [cdkAccordion]',
   exportAs: 'cdkAccordion',
+  providers: [{provide: CDK_ACCORDION, useExisting: CdkAccordion}],
 })
 export class CdkAccordion implements OnDestroy, OnChanges {
   /** Emits when the state of the accordion changes */


### PR DESCRIPTION
The `CdkAccordionItem` currently always brings in the `CdkAccordion`
class. This is not desired as an accordion item could be used
outside of a `<cdk-accordion>`. In those cases, we do not want
to retain the accordion class w/ metadata unnecessarily.

This also affects the `MatExpansionPanel` as it extends
from the `CdkAccordionItem` and therefore always brings in
the `CdkAccordion` list unnecessarily right now.

Related to #19576.