### PR TITLE
feat(tabs): allow for dynamicHeight to be configured through MAT_TABS_CONFIG

### DIFF
--- a/src/material-experimental/mdc-tabs/tab-group.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.spec.ts
@@ -749,7 +749,7 @@ describe('MatTabNavBar with a default config', () => {
       imports: [MatTabsModule, BrowserAnimationsModule],
       declarations: [SimpleTabsTestApp],
       providers: [
-        {provide: MAT_TABS_CONFIG, useValue: {fitInkBarToContent: true}}
+        {provide: MAT_TABS_CONFIG, useValue: {fitInkBarToContent: true, dynamicHeight: true}}
       ]
     });
 
@@ -767,6 +767,10 @@ describe('MatTabNavBar with a default config', () => {
     const indicatorElement = tabElement.querySelector('.mdc-tab-indicator');
     expect(indicatorElement.parentElement).toBeTruthy();
     expect(indicatorElement.parentElement).toBe(contentElement);
+  });
+
+  it('should set whether the height of the tab group is dynamic', () => {
+    expect(fixture.componentInstance.tabGroup.dynamicHeight).toBe(true);
   });
 });
 
@@ -796,6 +800,7 @@ describe('MatTabNavBar with a default config', () => {
   `
 })
 class SimpleTabsTestApp {
+  @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
   @ViewChildren(MatTab) tabs: QueryList<MatTab>;
   selectedIndex: number = 1;
   focusEvent: any;

--- a/src/material/tabs/tab-config.ts
+++ b/src/material/tabs/tab-config.ts
@@ -23,6 +23,9 @@ export interface MatTabsConfig {
    * This only applies to the MDC-based tabs.
    */
   fitInkBarToContent?: boolean;
+
+  /** Whether the tab group should grow to the size of the active tab. */
+  dynamicHeight?: boolean;
 }
 
 /** Injection token that can be used to provide the default options the tabs module. */

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -6,7 +6,7 @@ import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {CommonModule} from '@angular/common';
 import {Observable} from 'rxjs';
-import {MatTab, MatTabGroup, MatTabHeaderPosition, MatTabsModule} from './index';
+import {MatTab, MatTabGroup, MatTabHeaderPosition, MatTabsModule, MAT_TABS_CONFIG} from './index';
 
 
 describe('MatTabGroup', () => {
@@ -665,6 +665,30 @@ describe('MatTabGroup', () => {
   }
 });
 
+describe('MatTabNavBar with a default config', () => {
+  let fixture: ComponentFixture<SimpleTabsTestApp>;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [MatTabsModule, BrowserAnimationsModule],
+      declarations: [SimpleTabsTestApp],
+      providers: [
+        {provide: MAT_TABS_CONFIG, useValue: {dynamicHeight: true}}
+      ]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SimpleTabsTestApp);
+    fixture.detectChanges();
+  });
+
+  it('should set whether the height of the tab group is dynamic', () => {
+    expect(fixture.componentInstance.tabGroup.dynamicHeight).toBe(true);
+  });
+});
 
 describe('nested MatTabGroup with enabled animations', () => {
   beforeEach(fakeAsync(() => {
@@ -719,6 +743,7 @@ describe('nested MatTabGroup with enabled animations', () => {
   `
 })
 class SimpleTabsTestApp {
+  @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
   @ViewChildren(MatTab) tabs: QueryList<MatTab>;
   selectedIndex: number = 1;
   focusEvent: any;

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -110,7 +110,7 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
   @Input()
   get dynamicHeight(): boolean { return this._dynamicHeight; }
   set dynamicHeight(value: boolean) { this._dynamicHeight = coerceBooleanProperty(value); }
-  private _dynamicHeight: boolean = false;
+  private _dynamicHeight: boolean;
 
   /** The index of the active tab. */
   @Input()
@@ -180,6 +180,8 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
         defaultConfig.animationDuration : '500ms';
     this.disablePagination = defaultConfig && defaultConfig.disablePagination != null ?
         defaultConfig.disablePagination : false;
+    this.dynamicHeight = defaultConfig && defaultConfig.dynamicHeight != null ?
+        defaultConfig.dynamicHeight : false;
   }
 
   /**

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -252,6 +252,7 @@ export declare const matTabsAnimations: {
 export interface MatTabsConfig {
     animationDuration?: string;
     disablePagination?: boolean;
+    dynamicHeight?: boolean;
     fitInkBarToContent?: boolean;
 }
 


### PR DESCRIPTION
Makes it possible for consumers to configure the `dynamicHeight` default value through the `MAT_TABS_CONFIG` injection token.

Fixes #19662.