### PR TITLE
refactor: use lightweight token in CDK drag-drop

### DIFF
--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -5,5 +5,5 @@ material/datepicker/range-picker/without-form-field: 330101
 material/button-toggle/standalone: 119400
 material/autocomplete/without-optgroup: 208091
 material/select/without-optgroup: 256564
-cdk/drag-drop/all-directives: 152732
-cdk/drag-drop/basic: 151593
+cdk/drag-drop/all-directives: 153063
+cdk/drag-drop/basic: 150321

--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -5,3 +5,5 @@ material/datepicker/range-picker/without-form-field: 330101
 material/button-toggle/standalone: 119400
 material/autocomplete/without-optgroup: 208091
 material/select/without-optgroup: 256564
+cdk/drag-drop/all-directives: 152732
+cdk/drag-drop/basic: 151593

--- a/integration/size-test/cdk/drag-drop/BUILD.bazel
+++ b/integration/size-test/cdk/drag-drop/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//integration/size-test:index.bzl", "size_test")
+
+size_test(
+    name = "basic",
+    file = "basic.ts",
+    deps = ["//src/cdk/drag-drop"],
+)
+
+size_test(
+    name = "all-directives",
+    file = "all-directives.ts",
+    deps = ["//src/cdk/drag-drop"],
+)

--- a/integration/size-test/cdk/drag-drop/all-directives.ts
+++ b/integration/size-test/cdk/drag-drop/all-directives.ts
@@ -1,0 +1,26 @@
+import {DragDropModule} from '@angular/cdk/drag-drop';
+import {Component, NgModule} from '@angular/core';
+
+
+/** Component using all parts of the drag-drop module. All directives should be preserved. */
+@Component({
+  template: `
+    <div cdkDropListGroup>
+      <div cdkDropList>
+        <div cdkDrag>
+          <span cdkDragHandle>handle</span>
+          <ng-template cdkDragPlaceholder>Placeholder</ng-template>
+          <ng-template cdkDragPreview>Preview</ng-template>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class TestComponent {}
+
+@NgModule({
+  imports: [DragDropModule],
+  declarations: [TestComponent],
+  bootstrap: [TestComponent],
+})
+export class AppModule {}

--- a/integration/size-test/cdk/drag-drop/basic.ts
+++ b/integration/size-test/cdk/drag-drop/basic.ts
@@ -1,0 +1,23 @@
+import {DragDropModule} from '@angular/cdk/drag-drop';
+import {Component, NgModule} from '@angular/core';
+
+/**
+ * Basic component using `CdkDropList` and `CdkDrag`. Other parts of the drag-drop
+ * module such as `CdkDropListGroup`, `CdkDragPlaceholder`, `CdkDragPreview` or
+ * `CdkDragHandle` are not used and should be tree-shaken away.
+ */
+@Component({
+  template: `
+    <div cdkDropList>
+      <div cdkDrag></div>
+    </div>
+  `,
+})
+export class TestComponent {}
+
+@NgModule({
+  imports: [DragDropModule],
+  declarations: [TestComponent],
+  bootstrap: [TestComponent],
+})
+export class AppModule {}

--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -6,18 +6,34 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Inject, Optional, Input, OnDestroy} from '@angular/core';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {
+  Directive,
+  ElementRef,
+  Inject,
+  InjectionToken,
+  Input,
+  OnDestroy,
+  Optional
+} from '@angular/core';
 import {Subject} from 'rxjs';
 import {CDK_DRAG_PARENT} from '../drag-parent';
 import {toggleNativeDragInteractions} from '../drag-styling';
+
+/**
+ * Injection token that can be used to reference instances of `CdkDragHandle`. It serves as
+ * alternative token to the actual `CdkDragHandle` class which could cause unnecessary
+ * retention of the class and its directive metadata.
+ */
+export const CDK_DRAG_HANDLE = new InjectionToken<CdkDragHandle>('CdkDragHandle');
 
 /** Handle that can be used to drag and CdkDrag instance. */
 @Directive({
   selector: '[cdkDragHandle]',
   host: {
     'class': 'cdk-drag-handle'
-  }
+  },
+  providers: [{provide: CDK_DRAG_HANDLE, useExisting: CdkDragHandle}],
 })
 export class CdkDragHandle implements OnDestroy {
   /** Closest parent draggable instance. */

--- a/src/cdk/drag-drop/directives/drag-placeholder.ts
+++ b/src/cdk/drag-drop/directives/drag-placeholder.ts
@@ -6,14 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, TemplateRef, Input} from '@angular/core';
+import {Directive, TemplateRef, Input, InjectionToken} from '@angular/core';
+
+/**
+ * Injection token that can be used to reference instances of `CdkDragPlaceholder`. It serves as
+ * alternative token to the actual `CdkDragPlaceholder` class which could cause unnecessary
+ * retention of the class and its directive metadata.
+ */
+export const CDK_DRAG_PLACEHOLDER = new InjectionToken<CdkDragPlaceholder>('CdkDragPlaceholder');
 
 /**
  * Element that will be used as a template for the placeholder of a CdkDrag when
  * it is being dragged. The placeholder is displayed in place of the element being dragged.
  */
 @Directive({
-  selector: 'ng-template[cdkDragPlaceholder]'
+  selector: 'ng-template[cdkDragPlaceholder]',
+  providers: [{provide: CDK_DRAG_PLACEHOLDER, useExisting: CdkDragPlaceholder}],
 })
 export class CdkDragPlaceholder<T = any> {
   /** Context data to be added to the placeholder template instance. */

--- a/src/cdk/drag-drop/directives/drag-preview.ts
+++ b/src/cdk/drag-drop/directives/drag-preview.ts
@@ -6,15 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, TemplateRef, Input} from '@angular/core';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {Directive, InjectionToken, Input, TemplateRef} from '@angular/core';
+
+/**
+ * Injection token that can be used to reference instances of `CdkDragPreview`. It serves as
+ * alternative token to the actual `CdkDragPreview` class which could cause unnecessary
+ * retention of the class and its directive metadata.
+ */
+export const CDK_DRAG_PREVIEW = new InjectionToken<CdkDragPreview>('CdkDragPreview');
 
 /**
  * Element that will be used as a template for the preview
  * of a CdkDrag when it is being dragged.
  */
 @Directive({
-  selector: 'ng-template[cdkDragPreview]'
+  selector: 'ng-template[cdkDragPreview]',
+  providers: [{provide: CDK_DRAG_PREVIEW, useExisting: CdkDragPreview}],
 })
 export class CdkDragPreview<T = any> {
   /** Context data to be added to the preview template instance. */

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -16,7 +16,6 @@ import {
   ElementRef,
   EventEmitter,
   Inject,
-  InjectionToken,
   Input,
   NgZone,
   OnDestroy,
@@ -47,20 +46,14 @@ import {
   CdkDragStart,
   CdkDragRelease,
 } from '../drag-events';
-import {CdkDragHandle} from './drag-handle';
-import {CdkDragPlaceholder} from './drag-placeholder';
-import {CdkDragPreview} from './drag-preview';
+import {CDK_DRAG_HANDLE, CdkDragHandle} from './drag-handle';
+import {CDK_DRAG_PLACEHOLDER, CdkDragPlaceholder} from './drag-placeholder';
+import {CDK_DRAG_PREVIEW, CdkDragPreview} from './drag-preview';
 import {CDK_DRAG_PARENT} from '../drag-parent';
 import {DragRef, Point} from '../drag-ref';
-import {CdkDropListInternal as CdkDropList} from './drop-list';
+import {CDK_DROP_LIST, CdkDropListInternal as CdkDropList} from './drop-list';
 import {DragDrop} from '../drag-drop';
 import {CDK_DRAG_CONFIG, DragDropConfig, DragStartDelay, DragAxis} from './config';
-
-/**
- * Injection token that is used to provide a CdkDropList instance to CdkDrag.
- * Used for avoiding circular imports.
- */
-export const CDK_DROP_LIST = new InjectionToken<CdkDropList>('CDK_DROP_LIST');
 
 /** Element that can be moved inside a CdkDropList container. */
 @Directive({
@@ -79,14 +72,17 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   /** Reference to the underlying drag instance. */
   _dragRef: DragRef<CdkDrag<T>>;
 
+  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** Elements that can be used to drag the draggable item. */
-  @ContentChildren(CdkDragHandle, {descendants: true}) _handles: QueryList<CdkDragHandle>;
+  @ContentChildren(CDK_DRAG_HANDLE as any, {descendants: true}) _handles: QueryList<CdkDragHandle>;
 
+  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** Element that will be used as a template to create the draggable item's preview. */
-  @ContentChild(CdkDragPreview) _previewTemplate: CdkDragPreview;
+  @ContentChild(CDK_DRAG_PREVIEW as any) _previewTemplate: CdkDragPreview;
 
+  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** Template for placeholder element rendered to show where a draggable would be dropped. */
-  @ContentChild(CdkDragPlaceholder) _placeholderTemplate: CdkDragPlaceholder;
+  @ContentChild(CDK_DRAG_PLACEHOLDER as any) _placeholderTemplate: CdkDragPlaceholder;
 
   /** Arbitrary data to attach to this drag instance. */
   @Input('cdkDragData') data: T;

--- a/src/cdk/drag-drop/directives/drop-list-group.ts
+++ b/src/cdk/drag-drop/directives/drop-list-group.ts
@@ -6,8 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, OnDestroy, Input} from '@angular/core';
+import {Directive, OnDestroy, Input, InjectionToken} from '@angular/core';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+
+/**
+ * Injection token that can be used to reference instances of `CdkDropListGroup`. It serves as
+ * alternative token to the actual `CdkDropListGroup` class which could cause unnecessary
+ * retention of the class and its directive metadata.
+ */
+export const CDK_DROP_LIST_GROUP =
+    new InjectionToken<CdkDropListGroup<unknown>>('CdkDropListGroup');
 
 /**
  * Declaratively connects sibling `cdkDropList` instances together. All of the `cdkDropList`
@@ -18,6 +26,7 @@ import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 @Directive({
   selector: '[cdkDropListGroup]',
   exportAs: 'cdkDropListGroup',
+  providers: [{provide: CDK_DROP_LIST_GROUP, useExisting: CdkDropListGroup}],
 })
 export class CdkDropListGroup<T> implements OnDestroy {
   /** Drop lists registered inside the group. */

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -18,12 +18,13 @@ import {
   ChangeDetectorRef,
   SkipSelf,
   Inject,
+  InjectionToken,
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
-import {CdkDrag, CDK_DROP_LIST} from './drag';
+import {CdkDrag} from './drag';
 import {CdkDragDrop, CdkDragEnter, CdkDragExit, CdkDragSortEvent} from '../drag-events';
-import {CdkDropListGroup} from './drop-list-group';
+import {CDK_DROP_LIST_GROUP, CdkDropListGroup} from './drop-list-group';
 import {DropListRef} from '../drop-list-ref';
 import {DragRef} from '../drag-ref';
 import {DragDrop} from '../drag-drop';
@@ -41,13 +42,20 @@ let _uniqueIdCounter = 0;
  */
 export interface CdkDropListInternal extends CdkDropList {}
 
+/**
+ * Injection token that can be used to reference instances of `CdkDropList`. It serves as
+ * alternative token to the actual `CdkDropList` class which could cause unnecessary
+ * retention of the class and its directive metadata.
+ */
+export const CDK_DROP_LIST = new InjectionToken<CdkDropList>('CdkDropList');
+
 /** Container that wraps a set of draggable items. */
 @Directive({
   selector: '[cdkDropList], cdk-drop-list',
   exportAs: 'cdkDropList',
   providers: [
     // Prevent child drop lists from picking up the same group as their parent.
-    {provide: CdkDropListGroup, useValue: undefined},
+    {provide: CDK_DROP_LIST_GROUP, useValue: undefined},
     {provide: CDK_DROP_LIST, useExisting: CdkDropList},
   ],
   host: {
@@ -157,7 +165,8 @@ export class CdkDropList<T = any> implements OnDestroy {
       /** Element that the drop list is attached to. */
       public element: ElementRef<HTMLElement>, dragDrop: DragDrop,
       private _changeDetectorRef: ChangeDetectorRef, @Optional() private _dir?: Directionality,
-      @Optional() @SkipSelf() private _group?: CdkDropListGroup<CdkDropList>,
+      @Optional() @Inject(CDK_DROP_LIST_GROUP) @SkipSelf()
+      private _group?: CdkDropListGroup<CdkDropList>,
 
       /**
        * @deprecated _scrollDispatcher parameter to become required.

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -1,6 +1,12 @@
 export declare const CDK_DRAG_CONFIG: InjectionToken<DragDropConfig>;
 
-export declare const CDK_DROP_LIST: InjectionToken<CdkDropList>;
+export declare const CDK_DRAG_HANDLE: InjectionToken<CdkDragHandle>;
+
+export declare const CDK_DRAG_PLACEHOLDER: InjectionToken<CdkDragPlaceholder<any>>;
+
+export declare const CDK_DRAG_PREVIEW: InjectionToken<CdkDragPreview<any>>;
+
+export declare const CDK_DROP_LIST_GROUP: InjectionToken<CdkDropListGroup<unknown>>;
 
 export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     _dragRef: DragRef<CdkDrag<T>>;


### PR DESCRIPTION
Currently the `CdkDropList` directive always retains the `CdkDropListGroup`
directive. This is not desired as the drop list group is not necessarily
always used in combination with a drop list.

Additionally, the `CdkDrag` directive always retains the `CdkDragHandle`,
`CdkDragPlaceholder` and `CdkDragPreview` directives. This is neither
desired because a handle, placeholder or preview can be consumed
optionally. We should only bring those directives into applications
when actually needed.

Size measurements show that this saves around ~1.3kb if only a drop
list and `cdkDrag` is used. The downside is that we add up ~200b if
_all_ directives of the drag-drop module are used. Given the drag-drop
has a compressed size of around 45kb, the 1.3kb size improvement in
the common case should be good enough to move forward (~3% reduction).

@crisbeto Would be interesting to see what you think here. I think it's low-effort to
maintain these tokens here. The individual classes don't seem large in TS source,
but 3% in the common case can quickly cause apps to grow, so I think it would be valuable.

Related to #19576.