### PR TITLE
fix(material-experimental/form-field): fix notch width after appearance change

### DIFF
--- a/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
@@ -56,8 +56,8 @@
   // we do not want to overwrite. *Note*: We need to have increased specificity for this
   // override because the `right` property will be set with higher specificity in RTL mode.
   .mat-mdc-text-field-wrapper .mat-mdc-form-field-infix .mdc-floating-label {
-    left: 0;
-    right: 0;
+    left: initial;
+    right: initial;
   }
 
   // MDC sets the input elements in outline appearance to "display: flex". There seems to

--- a/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
@@ -56,8 +56,8 @@
   // we do not want to overwrite. *Note*: We need to have increased specificity for this
   // override because the `right` property will be set with higher specificity in RTL mode.
   .mat-mdc-text-field-wrapper .mat-mdc-form-field-infix .mdc-floating-label {
-    left: initial;
-    right: initial;
+    left: auto;
+    right: auto;
   }
 
   // MDC sets the input elements in outline appearance to "display: flex". There seems to

--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -9,7 +9,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {Platform} from '@angular/cdk/platform';
 import {
   AfterContentChecked,
-  AfterContentInit, AfterViewChecked,
+  AfterContentInit,
   AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,

--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -127,7 +127,7 @@ const FLOATING_LABEL_DEFAULT_DOCKED_TRANSFORM = `translateY(-50%)`;
   ]
 })
 export class MatFormField implements AfterViewInit, OnDestroy, AfterContentChecked,
-    AfterContentInit, AfterViewChecked {
+    AfterContentInit {
   @ViewChild('textField') _textField: ElementRef<HTMLElement>;
   @ViewChild('prefixContainer') _prefixContainer: ElementRef<HTMLElement>;
   @ViewChild(MatFormFieldFloatingLabel) _floatingLabel: MatFormFieldFloatingLabel|undefined;
@@ -173,9 +173,7 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
     const oldValue = this._appearance;
     this._appearance = value || (this._defaults && this._defaults.appearance) || DEFAULT_APPEARANCE;
     if (this._appearance === 'outline' && this._appearance !== oldValue) {
-      // After the view changes the appearance to outline, the label's width should be measured
-      // so that it can be provided to the notched outline.
-      this._needsOutlineNotchWidthRefresh = true;
+      this._refreshOutlineNotchWidth();
 
       // If the appearance has been switched to `outline`, the label offset needs to be updated.
       // The update can happen once the view has been re-checked, but not immediately because
@@ -217,7 +215,6 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
   private _explicitFormFieldControl: MatFormFieldControl<any>;
   private _foundation: MDCTextFieldFoundation;
   private _needsOutlineLabelOffsetUpdateOnStable = false;
-  private _needsOutlineNotchWidthRefresh = false;
   private _adapter: MDCTextFieldAdapter = {
     addClass: className => this._textField.nativeElement.classList.add(className),
     removeClass: className => this._textField.nativeElement.classList.remove(className),
@@ -354,16 +351,6 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
 
   ngAfterContentChecked() {
     this._assertFormFieldControl();
-  }
-
-  ngAfterViewChecked() {
-    // After the appearance changes to `outline`, measure the size of the label and provide it
-    // to the notched outline.
-    if (this._needsOutlineNotchWidthRefresh) {
-      this._refreshOutlineNotchWidth();
-      this._changeDetectorRef.detectChanges();
-      this._needsOutlineNotchWidthRefresh = false;
-    }
   }
 
   ngOnDestroy() {

--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -1104,7 +1104,7 @@ describe('MatMdcInput with forms', () => {
     fixture.detectChanges();
 
     let notch = fixture.nativeElement.querySelector('.mdc-notched-outline__notch')! as HTMLElement;
-    expect(notch.style.width).toBe('');
+    expect(notch.style.width).toBeFalsy();
 
     fixture.nativeElement.querySelector('input')!.focus();
     fixture.detectChanges();

--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -1094,6 +1094,23 @@ describe('MatMdcInput with forms', () => {
     expect(formField._control.empty).toBe(false);
   }));
 
+  it('should update notch size after changing appearance to outline', fakeAsync(() => {
+    const fixture = createComponent(MatInputWithAppearance);
+    fixture.detectChanges();
+
+    expect(document.querySelector('.mdc-notched-outline__notch')).toBe(null);
+
+    fixture.componentInstance.appearance = 'outline';
+    fixture.detectChanges();
+
+    let notch = document.querySelector('.mdc-notched-outline__notch')! as HTMLElement;
+    expect(notch.style.width).toBe('');
+
+    document.querySelector('input')!.focus();
+    fixture.detectChanges();
+
+    expect(notch.style.width).not.toBe('');
+  }));
 });
 
 describe('MatFormField default options', () => {
@@ -1498,6 +1515,7 @@ class MatInputWithLabel {}
 @Component({
   template: `
     <mat-form-field [appearance]="appearance">
+      <mat-label>My Label</mat-label>
       <input matInput placeholder="Placeholder">
     </mat-form-field>
   `

--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -1098,15 +1098,15 @@ describe('MatMdcInput with forms', () => {
     const fixture = createComponent(MatInputWithAppearance);
     fixture.detectChanges();
 
-    expect(document.querySelector('.mdc-notched-outline__notch')).toBe(null);
+    expect(fixture.nativeElement.querySelector('.mdc-notched-outline__notch')).toBe(null);
 
     fixture.componentInstance.appearance = 'outline';
     fixture.detectChanges();
 
-    let notch = document.querySelector('.mdc-notched-outline__notch')! as HTMLElement;
+    let notch = fixture.nativeElement.querySelector('.mdc-notched-outline__notch')! as HTMLElement;
     expect(notch.style.width).toBe('');
 
-    document.querySelector('input')!.focus();
+    fixture.nativeElement.querySelector('input')!.focus();
     fixture.detectChanges();
 
     expect(notch.style.width).toBeTruthy();

--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -1109,7 +1109,7 @@ describe('MatMdcInput with forms', () => {
     document.querySelector('input')!.focus();
     fixture.detectChanges();
 
-    expect(notch.style.width).not.toBe('');
+    expect(notch.style.width).toBeTruthy();
   }));
 });
 


### PR DESCRIPTION
When the form field initializes, it will determine the floating label notch width if it is `outline` appearance. This is done once at initialization.

If the form field initializes with an appearance other than `outline`, it does not determine the correct width.

![Screen Shot 2020-06-17 at 8 33 17 PM](https://user-images.githubusercontent.com/22898577/84975571-a244d300-b0da-11ea-8aad-103ff1236a1f.png)

This change measures the correct width after the appearance is changed to `outline` and provides that input to the notched outline.

![Screen Shot 2020-06-17 at 8 34 09 PM](https://user-images.githubusercontent.com/22898577/84975580-a7a21d80-b0da-11ea-8108-611d40943d6e.png)