### PR TITLE
docs: fix syntax error in doc region

### DIFF
--- a/src/components-examples/material/badge/badge-overview/badge-overview-example.html
+++ b/src/components-examples/material/badge/badge-overview/badge-overview-example.html
@@ -31,7 +31,7 @@
 
 <p>
   Icon with a badge
-<!-- #dorection mat-badge-color -->
+<!-- #docregion mat-badge-color -->
   <mat-icon matBadge="15" matBadgeColor="warn">home</mat-icon>
 <!-- #enddocregion mat-badge-color -->
     <!-- Include text description of the icon's meaning for screen-readers -->


### PR DESCRIPTION
Fixes a syntax error in one of the docs that is breaking the build on master.