### PR TITLE
build: sort integration size test golden lexicographically

### DIFF
--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -1,10 +1,10 @@
-material/list/nav-list: 130473
-material/radio/without-group: 121448
-material/menu/without-lazy-content: 210751
-material/datepicker/range-picker/without-form-field: 330101
-material/button-toggle/standalone: 119400
-material/autocomplete/without-optgroup: 208091
-material/select/without-optgroup: 256564
 cdk/drag-drop/all-directives: 153063
 cdk/drag-drop/basic: 150321
+material/autocomplete/without-optgroup: 208091
+material/button-toggle/standalone: 119400
+material/datepicker/range-picker/without-form-field: 330101
 material/expansion/without-accordion: 130562
+material/list/nav-list: 130473
+material/menu/without-lazy-content: 210751
+material/radio/without-group: 121448
+material/select/without-optgroup: 256564


### PR DESCRIPTION
Sorts the integration size-test golden lexicographically. This
should make the golden more readable.