### PR TITLE
feat(cdk-experimental/listbox): selection logic and testing for listbox.

### DIFF
--- a/src/cdk-experimental/listbox/BUILD.bazel
+++ b/src/cdk-experimental/listbox/BUILD.bazel
@@ -11,7 +11,7 @@ ng_module(
     module_name = "@angular/cdk-experimental/listbox",
     deps = [
         "//src/cdk/coercion",
-    ]
+    ],
 )
 
 ng_test_library(

--- a/src/cdk-experimental/listbox/BUILD.bazel
+++ b/src/cdk-experimental/listbox/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -9,4 +9,22 @@ ng_module(
         exclude = ["**/*.spec.ts"],
     ),
     module_name = "@angular/cdk-experimental/listbox",
+)
+
+ng_test_library(
+     name = "unit_test_sources",
+     srcs = glob(
+         ["**/*.spec.ts"],
+         exclude = ["**/*.e2e.spec.ts"],
+     ),
+     deps = [
+         ":listbox",
+         "@npm//@angular/platform-browser",
+         "//src/cdk/testing/private"
+     ],
+)
+
+ng_web_test_suite(
+     name = "unit_tests",
+     deps = [":unit_test_sources"]
 )

--- a/src/cdk-experimental/listbox/BUILD.bazel
+++ b/src/cdk-experimental/listbox/BUILD.bazel
@@ -12,19 +12,19 @@ ng_module(
 )
 
 ng_test_library(
-     name = "unit_test_sources",
-     srcs = glob(
-         ["**/*.spec.ts"],
-         exclude = ["**/*.e2e.spec.ts"],
-     ),
-     deps = [
-         ":listbox",
-         "@npm//@angular/platform-browser",
-         "//src/cdk/testing/private"
-     ],
+    name = "unit_test_sources",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["**/*.e2e.spec.ts"],
+    ),
+    deps = [
+        ":listbox",
+        "//src/cdk/testing/private",
+        "@npm//@angular/platform-browser",
+    ],
 )
 
 ng_web_test_suite(
-     name = "unit_tests",
-     deps = [":unit_test_sources"]
+    name = "unit_tests",
+    deps = [":unit_test_sources"],
 )

--- a/src/cdk-experimental/listbox/BUILD.bazel
+++ b/src/cdk-experimental/listbox/BUILD.bazel
@@ -9,6 +9,9 @@ ng_module(
         exclude = ["**/*.spec.ts"],
     ),
     module_name = "@angular/cdk-experimental/listbox",
+    deps = [
+        "//src/cdk/coercion",
+    ]
 )
 
 ng_test_library(

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -43,7 +43,7 @@ describe('CdkOption', () => {
     it('should generate a unique optionId for each option', () => {
       let optionIds: string[] = [];
       for (const instance of optionInstances) {
-        const id = instance.getOptionId();
+        const id = instance._optionid;
 
         expect(optionIds.indexOf(id)).toBe(-1);
         optionIds.push(id);

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -59,7 +59,7 @@ describe('CdkOption', () => {
       const selectedOptions = listboxInstance.getSelectedOptions();
 
       expect(selectedOptions.length).toBe(1);
-      expect(selectedOptions[0].selected).toBeTruthy();
+      expect(selectedOptions[0].selected).toBeTrue();
     });
 
     it('should update selected option on click event', () => {
@@ -72,7 +72,7 @@ describe('CdkOption', () => {
 
       expect(listboxInstance.getSelectedOptions().length).toBe(1);
       expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBe('true');
-      expect(options[0].selected).toBeTruthy();
+      expect(options[0].selected).toBeTrue();
     });
   });
 

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -15,7 +15,6 @@ describe('CdkOption', () => {
 
   describe('selection state change', () => {
     let fixture: ComponentFixture<ListboxWithOptions>;
-    let listbox: DebugElement;
     let options: DebugElement[];
     let optionInstances: CdkOption[];
     let optionElements: HTMLElement[];
@@ -30,8 +29,6 @@ describe('CdkOption', () => {
     beforeEach(async(() => {
       fixture = TestBed.createComponent(ListboxWithOptions);
       fixture.detectChanges();
-
-      listbox = fixture.debugElement.query(By.directive(CdkListbox));
 
       options = fixture.debugElement.queryAll(By.directive(CdkOption));
       optionInstances = options.map(o => o.injector.get<CdkOption>(CdkOption));

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -27,12 +27,12 @@ describe('CdkOption', () => {
 
       fixture = TestBed.createComponent(CdkListboxWithCdkOptions);
       fixture.detectChanges();
-      listboxInstance = fixture.debugElement.query(By.directive(CdkListbox))
-          .injector.get(CdkListbox);
+      listboxInstance =
+          fixture.debugElement.query(By.directive(CdkListbox)).injector.get(CdkListbox);
       options = listboxInstance._options.toArray();
     }));
 
-    it('should generate a unique optionid for each option', () => {
+    it('should generate a unique optionId for each option', () => {
       options.forEach(option => {
         expect(option.getOptionId()).toMatch(/cdk-option-\d+/);
       });
@@ -40,16 +40,16 @@ describe('CdkOption', () => {
 
     it('should have set the selected input of the options to null by default', () => {
       options.forEach(option => {
-        expect(option.selected).toBe(null);
+        expect(option.selected).toBeFalse();
       });
     });
 
     it('should update aria-selected when selected is changed programmatically', () => {
-      expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBe(null);
+      expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBeNull();
       options[1].selected = true;
       fixture.detectChanges();
 
-      expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBeTrue();
     });
 
     it('should be able to return the currently selected options', () => {
@@ -64,14 +64,14 @@ describe('CdkOption', () => {
 
     it('should update selected option on click event', () => {
       expect(listboxInstance.getSelectedOptions().length).toBe(0);
-      expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBe(null);
-      expect(options[0].selected).toBeFalsy();
+      expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBeNull();
+      expect(options[0].selected).toBeFalse();
 
       dispatchMouseEvent(options[0].getElementRef().nativeElement, 'click');
       fixture.detectChanges();
 
       expect(listboxInstance.getSelectedOptions().length).toBe(1);
-      expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBeTrue();
       expect(options[0].selected).toBeTrue();
     });
   });

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -33,15 +33,15 @@ describe('CdkOption', () => {
     }));
 
     it('should generate a unique optionId for each option', () => {
-      options.forEach(option => {
+      for (const option of options) {
         expect(option.getOptionId()).toMatch(/cdk-option-\d+/);
-      });
+      }
     });
 
     it('should have set the selected input of the options to null by default', () => {
-      options.forEach(option => {
+      for (const option of options) {
         expect(option.selected).toBeFalse();
-      });
+      }
     });
 
     it('should update aria-selected when selected is changed programmatically', () => {
@@ -50,16 +50,6 @@ describe('CdkOption', () => {
       fixture.detectChanges();
 
       expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBeTrue();
-    });
-
-    it('should be able to return the currently selected options', () => {
-      expect(listboxInstance.getSelectedOptions().length).toBe(0);
-      options[0].selected = true;
-      fixture.detectChanges();
-      const selectedOptions = listboxInstance.getSelectedOptions();
-
-      expect(selectedOptions.length).toBe(1);
-      expect(selectedOptions[0].selected).toBeTrue();
     });
 
     it('should update selected option on click event', () => {

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -3,7 +3,7 @@ import {
   async,
   TestBed,
 } from '@angular/core/testing';
-import {Component} from '@angular/core';
+import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
   CdkOption,
@@ -16,8 +16,8 @@ describe('CdkOption', () => {
 
   describe('selection state change', () => {
     let fixture: ComponentFixture<CdkListboxWithCdkOptions>;
-    let listboxInstance: CdkListbox;
-    let options: CdkOption[];
+    let listboxInstance: DebugElement;
+    let options: DebugElement[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -29,42 +29,43 @@ describe('CdkOption', () => {
     beforeEach(async(() => {
       fixture = TestBed.createComponent(CdkListboxWithCdkOptions);
       fixture.detectChanges();
-      listboxInstance =
-          fixture.debugElement.query(By.directive(CdkListbox)).injector.get(CdkListbox);
-      options = listboxInstance._options.toArray();
+      listboxInstance = fixture.debugElement.query(By.directive(CdkListbox));
+      options = fixture.debugElement.queryAll(By.directive(CdkOption));
     }));
 
     it('should generate a unique optionId for each option', () => {
       for (const option of options) {
-        expect(option.getOptionId()).toMatch(/cdk-option-\d+/);
+        expect(option.injector.get<CdkOption>(CdkOption).getOptionId()).toMatch(/cdk-option-\d+/);
       }
     });
 
     it('should have set the selected input of the options to null by default', () => {
       for (const option of options) {
-        expect(option.selected).toBeFalse();
+        expect(option.injector.get<CdkOption>(CdkOption).selected).toBeFalse();
       }
     });
 
     it('should update aria-selected when selected is changed programmatically', () => {
-      expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBeNull();
-      options[1].selected = true;
+      expect(options[1].nativeElement.getAttribute('aria-selected')).toBeNull();
+      options[1].injector.get<CdkOption>(CdkOption).selected = true;
       fixture.detectChanges();
 
-      expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBeTrue();
+      expect(options[1].nativeElement.getAttribute('aria-selected')).toBe('true');
     });
 
     it('should update selected option on click event', () => {
-      expect(listboxInstance.getSelectedOptions().length).toBe(0);
-      expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBeNull();
-      expect(options[0].selected).toBeFalse();
+      let selectedOptions = options.filter(option => option.injector.get<CdkOption>(CdkOption).selected);
+      expect(selectedOptions.length).toBe(0);
+      expect(options[0].nativeElement.getAttribute('aria-selected')).toBeNull();
+      expect(options[0].injector.get<CdkOption>(CdkOption).selected).toBeFalse();
 
-      dispatchMouseEvent(options[0].getElementRef().nativeElement, 'click');
+      dispatchMouseEvent(options[0].nativeElement, 'click');
       fixture.detectChanges();
 
-      expect(listboxInstance.getSelectedOptions().length).toBe(1);
-      expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBeTrue();
-      expect(options[0].selected).toBeTrue();
+      selectedOptions = options.filter(option => option.injector.get<CdkOption>(CdkOption).selected);
+      expect(selectedOptions.length).toBe(1);
+      expect(options[0].nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(options[0].injector.get<CdkOption>(CdkOption).selected).toBeTrue();
     });
   });
 

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -7,7 +7,6 @@ import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
   CdkOption,
-  CdkListbox,
   CdkListboxModule
 } from './index';
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -14,22 +14,22 @@ import {dispatchMouseEvent} from '@angular/cdk/testing/private';
 describe('CdkOption', () => {
 
   describe('selection state change', () => {
-    let fixture: ComponentFixture<ListboxWithCdkOptions>;
+    let fixture: ComponentFixture<ListboxWithOptions>;
     let listbox: DebugElement;
     let listboxInstance: CdkListbox;
     let options: DebugElement[];
     let optionInstances: CdkOption[];
-    let optionElements: Element[];
+    let optionElements: HTMLElement[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
         imports: [CdkListboxModule],
-        declarations: [ListboxWithCdkOptions],
+        declarations: [ListboxWithOptions],
       }).compileComponents();
     }));
 
     beforeEach(async(() => {
-      fixture = TestBed.createComponent(ListboxWithCdkOptions);
+      fixture = TestBed.createComponent(ListboxWithOptions);
       fixture.detectChanges();
 
       listbox = fixture.debugElement.query(By.directive(CdkListbox));
@@ -43,12 +43,10 @@ describe('CdkOption', () => {
     it('should generate a unique optionId for each option', () => {
       let optionIds: string[] = [];
       for (const instance of optionInstances) {
-        const id = instance._optionid;
+        expect(optionIds.indexOf(instance.id)).toBe(-1);
+        optionIds.push(instance.id);
 
-        expect(optionIds.indexOf(id)).toBe(-1);
-        optionIds.push(id);
-
-        expect(id).toMatch(/cdk-option-\d+/);
+        expect(instance.id).toMatch(/cdk-option-\d+/);
       }
     });
 
@@ -68,12 +66,12 @@ describe('CdkOption', () => {
 
     it('should update selected option on click event', () => {
       let selectedOptions = optionInstances.filter(option => option.selected);
-      spyOn(listboxInstance, '_emitChangeEvent');
+      spyOn(fixture.componentInstance, 'onSelectionChange');
 
       expect(selectedOptions.length).toBe(0);
       expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
       expect(optionInstances[0].selected).toBeFalse();
-      expect(listboxInstance._emitChangeEvent).toHaveBeenCalledTimes(0);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(0);
 
       dispatchMouseEvent(optionElements[0], 'click');
       fixture.detectChanges();
@@ -82,21 +80,21 @@ describe('CdkOption', () => {
       expect(selectedOptions.length).toBe(1);
       expect(optionElements[0].getAttribute('aria-selected')).toBe('true');
       expect(optionInstances[0].selected).toBeTrue();
-      expect(listboxInstance._emitChangeEvent).toHaveBeenCalledTimes(1);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(1);
     });
   });
 
 });
 
 @Component({
-    template: `
-    <div cdkListbox>
-      <div cdkOption>Void</div>
-      <div cdkOption>Solar</div>
-      <div cdkOption>Arc</div>
-      <div cdkOption>Stasis</div>
-    </div>`
+  template: `
+  <div cdkListbox (selectionChange)="onSelectionChange($event)">
+    <div cdkOption>Void</div>
+    <div cdkOption>Solar</div>
+    <div cdkOption>Arc</div>
+    <div cdkOption>Stasis</div>
+  </div>`
 })
-class ListboxWithCdkOptions {
-
+class ListboxWithOptions {
+  onSelectionChange(_option: CdkOption) {}
 }

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -68,7 +68,7 @@ describe('CdkOption', () => {
 
     it('should update selected option on click event', () => {
       let selectedOptions = optionInstances.filter(option => option.selected);
-      spyOn(listboxInstance, "_emitChangeEvent");
+      spyOn(listboxInstance, '_emitChangeEvent');
 
       expect(selectedOptions.length).toBe(0);
       expect(optionElements[0].getAttribute('aria-selected')).toBeNull();

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -16,7 +16,6 @@ describe('CdkOption', () => {
   describe('selection state change', () => {
     let fixture: ComponentFixture<ListboxWithOptions>;
     let listbox: DebugElement;
-    let listboxInstance: CdkListbox;
     let options: DebugElement[];
     let optionInstances: CdkOption[];
     let optionElements: HTMLElement[];
@@ -33,7 +32,6 @@ describe('CdkOption', () => {
       fixture.detectChanges();
 
       listbox = fixture.debugElement.query(By.directive(CdkListbox));
-      listboxInstance = listbox.injector.get<CdkListbox>(CdkListbox);
 
       options = fixture.debugElement.queryAll(By.directive(CdkOption));
       optionInstances = options.map(o => o.injector.get<CdkOption>(CdkOption));

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -1,0 +1,91 @@
+import {
+  ComponentFixture,
+  async,
+  TestBed,
+} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {
+  CdkOption,
+  CdkListbox,
+  CdkListboxModule
+} from './index';
+import {dispatchMouseEvent} from '@angular/cdk/testing/private';
+
+describe('CdkOption', () => {
+
+  describe('selection state change', () => {
+    let fixture: ComponentFixture<CdkListboxWithCdkOptions>;
+    let listboxInstance: CdkListbox;
+    let options: Array<CdkOption>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkListboxModule],
+        declarations: [CdkListboxWithCdkOptions],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(CdkListboxWithCdkOptions);
+      fixture.detectChanges();
+      listboxInstance = fixture.debugElement.query(By.directive(CdkListbox)).injector.get(CdkListbox);
+      options = listboxInstance._options.toArray();
+    }));
+
+    it('should generate a unique optionid for each option', () => {
+      options.forEach(option => {
+        expect(option.getOptionId()).toMatch(/cdk-option-\d+/);
+      });
+    });
+
+    it('should have set the selected input of the options to null by default', () => {
+      options.forEach(option => {
+        expect(option.selected).toBe(null);
+      });
+    });
+
+    it('should update aria-selected when selected is changed programmatically', () => {
+      expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBe(null);
+      options[1].selected = true;
+      fixture.detectChanges();
+
+      expect(options[1].getElementRef().nativeElement.getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('should be able to return the currently selected options', () => {
+      expect(listboxInstance.getSelectedOptions().length).toBe(0);
+      options[0].selected = true;
+      fixture.detectChanges();
+      const selectedOptions = listboxInstance.getSelectedOptions();
+
+      expect(selectedOptions.length).toBe(1);
+      expect(selectedOptions[0].selected).toBeTruthy();
+    });
+
+    it('should update selected option on click event', () => {
+      expect(listboxInstance.getSelectedOptions().length).toBe(0);
+      expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBe(null);
+      expect(options[0].selected).toBeFalsy();
+
+      dispatchMouseEvent(options[0].getElementRef().nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(listboxInstance.getSelectedOptions().length).toBe(1);
+      expect(options[0].getElementRef().nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(options[0].selected).toBeTruthy();
+    });
+  });
+
+});
+
+@Component({
+    template:`
+    <div cdkListbox>
+      <div cdkOption></div>
+      <div cdkOption></div>
+      <div cdkOption></div>
+      <div cdkOption></div> 
+    </div>`
+})
+class CdkListboxWithCdkOptions {
+
+}

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -27,7 +27,8 @@ describe('CdkOption', () => {
 
       fixture = TestBed.createComponent(CdkListboxWithCdkOptions);
       fixture.detectChanges();
-      listboxInstance = fixture.debugElement.query(By.directive(CdkListbox)).injector.get(CdkListbox);
+      listboxInstance = fixture.debugElement.query(By.directive(CdkListbox))
+          .injector.get(CdkListbox);
       options = listboxInstance._options.toArray();
     }));
 

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -17,7 +17,7 @@ describe('CdkOption', () => {
   describe('selection state change', () => {
     let fixture: ComponentFixture<CdkListboxWithCdkOptions>;
     let listboxInstance: CdkListbox;
-    let options: Array<CdkOption>;
+    let options: CdkOption[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -78,12 +78,12 @@ describe('CdkOption', () => {
 });
 
 @Component({
-    template:`
+    template: `
     <div cdkListbox>
       <div cdkOption></div>
       <div cdkOption></div>
       <div cdkOption></div>
-      <div cdkOption></div> 
+      <div cdkOption></div>
     </div>`
 })
 class CdkListboxWithCdkOptions {

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -16,7 +16,6 @@ describe('CdkOption', () => {
 
   describe('selection state change', () => {
     let fixture: ComponentFixture<CdkListboxWithCdkOptions>;
-    let listboxInstance: DebugElement;
     let options: DebugElement[];
 
     beforeEach(async(() => {
@@ -29,7 +28,6 @@ describe('CdkOption', () => {
     beforeEach(async(() => {
       fixture = TestBed.createComponent(CdkListboxWithCdkOptions);
       fixture.detectChanges();
-      listboxInstance = fixture.debugElement.query(By.directive(CdkListbox));
       options = fixture.debugElement.queryAll(By.directive(CdkOption));
     }));
 
@@ -54,7 +52,8 @@ describe('CdkOption', () => {
     });
 
     it('should update selected option on click event', () => {
-      let selectedOptions = options.filter(option => option.injector.get<CdkOption>(CdkOption).selected);
+      let selectedOptions =
+          options.filter(option => option.injector.get<CdkOption>(CdkOption).selected);
       expect(selectedOptions.length).toBe(0);
       expect(options[0].nativeElement.getAttribute('aria-selected')).toBeNull();
       expect(options[0].injector.get<CdkOption>(CdkOption).selected).toBeFalse();
@@ -62,7 +61,8 @@ describe('CdkOption', () => {
       dispatchMouseEvent(options[0].nativeElement, 'click');
       fixture.detectChanges();
 
-      selectedOptions = options.filter(option => option.injector.get<CdkOption>(CdkOption).selected);
+      selectedOptions =
+          options.filter(option => option.injector.get<CdkOption>(CdkOption).selected);
       expect(selectedOptions.length).toBe(1);
       expect(options[0].nativeElement.getAttribute('aria-selected')).toBe('true');
       expect(options[0].injector.get<CdkOption>(CdkOption).selected).toBeTrue();

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -24,7 +24,9 @@ describe('CdkOption', () => {
         imports: [CdkListboxModule],
         declarations: [CdkListboxWithCdkOptions],
       }).compileComponents();
+    }));
 
+    beforeEach(async(() => {
       fixture = TestBed.createComponent(CdkListboxWithCdkOptions);
       fixture.detectChanges();
       listboxInstance =

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -7,64 +7,82 @@ import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
   CdkOption,
-  CdkListboxModule
+  CdkListboxModule, CdkListbox
 } from './index';
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
 
 describe('CdkOption', () => {
 
   describe('selection state change', () => {
-    let fixture: ComponentFixture<CdkListboxWithCdkOptions>;
+    let fixture: ComponentFixture<ListboxWithCdkOptions>;
+    let listbox: DebugElement;
+    let listboxInstance: CdkListbox;
     let options: DebugElement[];
+    let optionInstances: CdkOption[];
+    let optionElements: Element[];
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
         imports: [CdkListboxModule],
-        declarations: [CdkListboxWithCdkOptions],
+        declarations: [ListboxWithCdkOptions],
       }).compileComponents();
     }));
 
     beforeEach(async(() => {
-      fixture = TestBed.createComponent(CdkListboxWithCdkOptions);
+      fixture = TestBed.createComponent(ListboxWithCdkOptions);
       fixture.detectChanges();
+
+      listbox = fixture.debugElement.query(By.directive(CdkListbox));
+      listboxInstance = listbox.injector.get<CdkListbox>(CdkListbox);
+
       options = fixture.debugElement.queryAll(By.directive(CdkOption));
+      optionInstances = options.map(o => o.injector.get<CdkOption>(CdkOption));
+      optionElements = options.map(o => o.nativeElement);
     }));
 
     it('should generate a unique optionId for each option', () => {
-      for (const option of options) {
-        expect(option.injector.get<CdkOption>(CdkOption).getOptionId()).toMatch(/cdk-option-\d+/);
+      let optionIds: string[] = [];
+      for (const instance of optionInstances) {
+        const id = instance.getOptionId();
+
+        expect(optionIds.indexOf(id)).toBe(-1);
+        optionIds.push(id);
+
+        expect(id).toMatch(/cdk-option-\d+/);
       }
     });
 
     it('should have set the selected input of the options to null by default', () => {
-      for (const option of options) {
-        expect(option.injector.get<CdkOption>(CdkOption).selected).toBeFalse();
+      for (const instance of optionInstances) {
+        expect(instance.selected).toBeFalse();
       }
     });
 
     it('should update aria-selected when selected is changed programmatically', () => {
-      expect(options[1].nativeElement.getAttribute('aria-selected')).toBeNull();
-      options[1].injector.get<CdkOption>(CdkOption).selected = true;
+      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      optionInstances[1].selected = true;
       fixture.detectChanges();
 
-      expect(options[1].nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(optionElements[1].getAttribute('aria-selected')).toBe('true');
     });
 
     it('should update selected option on click event', () => {
-      let selectedOptions =
-          options.filter(option => option.injector.get<CdkOption>(CdkOption).selected);
-      expect(selectedOptions.length).toBe(0);
-      expect(options[0].nativeElement.getAttribute('aria-selected')).toBeNull();
-      expect(options[0].injector.get<CdkOption>(CdkOption).selected).toBeFalse();
+      let selectedOptions = optionInstances.filter(option => option.selected);
+      spyOn(listboxInstance, "_emitChangeEvent");
 
-      dispatchMouseEvent(options[0].nativeElement, 'click');
+      expect(selectedOptions.length).toBe(0);
+      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      expect(optionInstances[0].selected).toBeFalse();
+      expect(listboxInstance._emitChangeEvent).toHaveBeenCalledTimes(0);
+
+      dispatchMouseEvent(optionElements[0], 'click');
       fixture.detectChanges();
 
-      selectedOptions =
-          options.filter(option => option.injector.get<CdkOption>(CdkOption).selected);
+      selectedOptions = optionInstances.filter(option => option.selected);
       expect(selectedOptions.length).toBe(1);
-      expect(options[0].nativeElement.getAttribute('aria-selected')).toBe('true');
-      expect(options[0].injector.get<CdkOption>(CdkOption).selected).toBeTrue();
+      expect(optionElements[0].getAttribute('aria-selected')).toBe('true');
+      expect(optionInstances[0].selected).toBeTrue();
+      expect(listboxInstance._emitChangeEvent).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -73,12 +91,12 @@ describe('CdkOption', () => {
 @Component({
     template: `
     <div cdkListbox>
-      <div cdkOption></div>
-      <div cdkOption></div>
-      <div cdkOption></div>
-      <div cdkOption></div>
+      <div cdkOption>Void</div>
+      <div cdkOption>Solar</div>
+      <div cdkOption>Arc</div>
+      <div cdkOption>Stasis</div>
     </div>`
 })
-class CdkListboxWithCdkOptions {
+class ListboxWithCdkOptions {
 
 }

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -7,7 +7,7 @@ import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
   CdkOption,
-  CdkListboxModule, CdkListbox
+  CdkListboxModule
 } from './index';
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
 

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -7,7 +7,7 @@ import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
   CdkOption,
-  CdkListboxModule
+  CdkListboxModule, ListboxSelectionChangeEvent
 } from './index';
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
 
@@ -61,12 +61,11 @@ describe('CdkOption', () => {
 
     it('should update selected option on click event', () => {
       let selectedOptions = optionInstances.filter(option => option.selected);
-      spyOn(fixture.componentInstance, 'onSelectionChange');
 
       expect(selectedOptions.length).toBe(0);
       expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
       expect(optionInstances[0].selected).toBeFalse();
-      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(0);
+      expect(fixture.componentInstance.changedOption).toBeUndefined();
 
       dispatchMouseEvent(optionElements[0], 'click');
       fixture.detectChanges();
@@ -75,7 +74,8 @@ describe('CdkOption', () => {
       expect(selectedOptions.length).toBe(1);
       expect(optionElements[0].getAttribute('aria-selected')).toBe('true');
       expect(optionInstances[0].selected).toBeTrue();
-      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(1);
+      expect(fixture.componentInstance.changedOption).toBeDefined();
+      expect(fixture.componentInstance.changedOption.id).toBe(optionInstances[0].id);
     });
   });
 
@@ -91,5 +91,9 @@ describe('CdkOption', () => {
   </div>`
 })
 class ListboxWithOptions {
-  onSelectionChange(_option: CdkOption) {}
+  changedOption: CdkOption;
+
+  onSelectionChange(event: ListboxSelectionChangeEvent) {
+    this.changedOption = event.option;
+  }
 }

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -61,6 +61,11 @@ export class CdkOption {
   getOptionId(): string {
     return this._optionId;
   }
+
+  /** Returns an ElementRef of this option */
+  getElementRef(): ElementRef {
+    return this._elementRef;
+  }
 }
 
 let _uniqueIdCounter = 0;

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -6,19 +6,68 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive} from '@angular/core';
+import {
+  ContentChildren,
+  Directive,
+  ElementRef,
+  HostListener,
+  Input,
+  QueryList
+} from '@angular/core';
 
+/**
+ * Directive that applies interaction patterns to an element following the aria role of option.
+ * Typically meant to be placed inside a listbox. Logic handling selection, disabled state, and
+ * value is built in.
+ */
 @Directive({
   selector: '[cdkOption]',
   exportAs: 'cdkOption',
   host: {
     role: 'option',
+    '[attr.aria-selected]': '_selected',
+    '[attr.data-optionid]': '_optionId',
   }
 })
 export class CdkOption {
+  private _selected: boolean | null = null;
+  private _optionId: string;
 
+  /** Whether the option is selected or not */
+  @Input()
+  get selected(): boolean | null {
+    return this._selected;
+  }
+  set selected(value: boolean | null) {
+    this._selected = value;
+  }
+
+  constructor(private el: ElementRef) {
+  }
+
+  /** Sets the optionId to the given id */
+  setOptionId(id: string): void {
+    this._optionId = id;
+  }
+
+  /** Returns the optionId of this option */
+  getOptionId(): string {
+    return this._optionId;
+  }
+
+  /** Returns an ElementRef of this option */
+  getElementRef(): ElementRef {
+    return this.el;
+  }
 }
 
+let _uniqueIdCounter = 0;
+
+/**
+ * Directive that applies interaction patterns to an element following the aria role of listbox.
+ * Typically CdkOption elements are placed inside the listbox. Logic to handle keyboard navigation,
+ * selection of options, active options, and disabled states is built in.
+ */
 @Directive({
   selector: '[cdkListbox]',
   exportAs: 'cdkListbox',
@@ -28,4 +77,57 @@ export class CdkOption {
 })
 export class CdkListbox {
 
+  constructor(private el: ElementRef) {
+  }
+
+  /** A query list containing all CdkOption elements within this listbox */
+  @ContentChildren(CdkOption) _options: QueryList<CdkOption>;
+
+  /** Listener activated on click of this listbox */
+  @HostListener('click', ['$event']) onClickUpdateSelectedOption($event: MouseEvent) {
+    console.log('in listbox click event');
+    console.log($event.target);
+    this._options.toArray().forEach(option => {
+      const optionId = option.getOptionId();
+      if ($event.target instanceof Element && optionId === $event.target?.getAttribute('data-optionid')) {
+        this.updateSelectedOption(option);
+      }
+    });
+  }
+
+  ngAfterContentInit() {
+    this._options.forEach(option => {
+      option.setOptionId(`cdk-option-${_uniqueIdCounter++}`);
+    });
+  }
+
+  private updateSelectedOption(option: CdkOption): void {
+    if (option.selected) {
+      this.deselectOption(option);
+    } else {
+      this.selectOption(option);
+    }
+  }
+
+  /** Sets the given option's selected state to true */
+  selectOption(option: CdkOption): void {
+    option.selected = true;
+  }
+
+  /** Sets the given option's selected state to null. Null is preferable to false for screen readers */
+  deselectOption(option: CdkOption): void {
+    option.selected = null;
+  }
+
+  /** Returns an array of all options that are currently selected */
+  getSelectedOptions(): Array<CdkOption> {
+    const selectedOptions = new Array<CdkOption>();
+    this._options.toArray().forEach(option => {
+      if (option.selected) {
+        selectedOptions.push(option);
+      }
+    });
+
+    return selectedOptions;
+  }
 }

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -24,7 +24,7 @@ import {
   exportAs: 'cdkOption',
   host: {
     role: 'option',
-    '(click)': '_onClickUpdateSelected()',
+    '(click)': 'toggle()',
     '[attr.aria-selected]': '_selected || null',
     '[attr.data-optionid]': '_optionId',
   }
@@ -47,13 +47,9 @@ export class CdkOption {
     this.setOptionId(`cdk-option-${_uniqueIdCounter++}`);
   }
 
-  _onClickUpdateSelected() {
-    this.toggleSelected();
-    this.listbox._emitChangeEvent(this);
-  }
-
-  toggleSelected() {
+  toggle() {
     this.selected = !this.selected;
+    this.listbox._emitChangeEvent(this);
   }
 
   /** Sets the optionId to the given id */

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -86,7 +86,8 @@ export class CdkListbox {
   /** A query list containing all CdkOption elements within this listbox */
   @ContentChildren(CdkOption, {descendants: true}) _options: QueryList<CdkOption>;
 
-  @Output() readonly selectionChange: EventEmitter<ListboxSelectionChangeEvent> = new EventEmitter<ListboxSelectionChangeEvent>();
+  @Output() readonly selectionChange: EventEmitter<ListboxSelectionChangeEvent> =
+      new EventEmitter<ListboxSelectionChangeEvent>();
 
   /** Emits a selection change event, called when an option has its selected state changed */
   _emitChangeEvent(option: CdkOption) {

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -48,7 +48,12 @@ export class CdkOption {
   }
 
   _onClickUpdateSelected() {
+    this.toggleSelected();
     this.listbox._emitChangeEvent(this);
+  }
+
+  toggleSelected() {
+    this.selected = !this.selected;
   }
 
   /** Sets the optionId to the given id */

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -13,6 +13,7 @@ import {
   Input, Output,
   QueryList
 } from '@angular/core';
+import {coerceBooleanProperty} from "@angular/cdk/coercion";
 
 /**
  * Directive that applies interaction patterns to an element following the aria role of option.
@@ -26,7 +27,7 @@ import {
     role: 'option',
     '(click)': 'toggle()',
     '[attr.aria-selected]': '_selected || null',
-    '[attr.data-optionid]': '_optionId',
+    '[attr.optionid]': '_optionId',
   }
 })
 export class CdkOption {
@@ -39,12 +40,12 @@ export class CdkOption {
     return this._selected;
   }
   set selected(value: boolean) {
-    this._selected = value;
+    this._selected = coerceBooleanProperty(value);
   }
 
   constructor(private readonly _elementRef: ElementRef,
               @Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {
-    this.setOptionId(`cdk-option-${_uniqueIdCounter++}`);
+    this.setOptionId(`cdk-option-${nextId++}`);
   }
 
   toggle() {
@@ -63,12 +64,12 @@ export class CdkOption {
   }
 
   /** Returns an ElementRef of this option */
-  getElementRef(): ElementRef {
+  private getElementRef(): ElementRef {
     return this._elementRef;
   }
 }
 
-let _uniqueIdCounter = 0;
+let nextId = 0;
 
 /**
  * Directive that applies interaction patterns to an element following the aria role of listbox.

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -26,13 +26,14 @@ import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
   host: {
     role: 'option',
     '(click)': 'toggle()',
-    '[attr.aria-selected]': '_selected || null',
-    '[attr.optionid]': '_optionid',
+    '[attr.aria-selected]': 'selected || null',
+    '[attr.id]': 'id',
   }
 })
 export class CdkOption {
   private _selected: boolean = false;
-  readonly _optionid: string;
+  readonly _uniqueid: string;
+  private _id: string;
 
   /** Whether the option is selected or not */
   @Input()
@@ -43,8 +44,18 @@ export class CdkOption {
     this._selected = coerceBooleanProperty(value);
   }
 
+  @Input()
+  get id(): string {
+    return this._id;
+  }
+  set id(value: string) {
+    this._id = value || this._uniqueid;
+  }
+
+
   constructor(@Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {
-    this._optionid = `cdk-option-${nextId++}`;
+    this._uniqueid = `cdk-option-${nextId++}`;
+    this.id = this.id;
   }
 
   toggle() {

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -42,7 +42,8 @@ export class CdkOption {
     this._selected = value;
   }
 
-  constructor(private _el: ElementRef) {
+  constructor(private readonly _el: ElementRef) {
+    this.setOptionId(`cdk-option-${_uniqueIdCounter++}`);
   }
 
   /** Sets the optionId to the given id */
@@ -76,10 +77,7 @@ let _uniqueIdCounter = 0;
     '(click)': 'onClickUpdateSelectedOption($event)'
   }
 })
-export class CdkListbox implements AfterContentInit {
-
-  constructor() {
-  }
+export class CdkListbox {
 
   /** A query list containing all CdkOption elements within this listbox */
   @ContentChildren(CdkOption, {descendants: true}) _options: QueryList<CdkOption>;
@@ -92,12 +90,6 @@ export class CdkListbox implements AfterContentInit {
           optionId === $event.target?.getAttribute('data-optionid')) {
         this._updateSelectedOption(option);
       }
-    });
-  }
-
-  ngAfterContentInit() {
-    this._options.forEach(option => {
-      option.setOptionId(`cdk-option-${_uniqueIdCounter++}`);
     });
   }
 
@@ -121,13 +113,6 @@ export class CdkListbox implements AfterContentInit {
 
   /** Returns an array of all options that are currently selected */
   getSelectedOptions(): CdkOption[] {
-    const selectedOptions = new Array<CdkOption>();
-    this._options.toArray().forEach(option => {
-      if (option.selected) {
-        selectedOptions.push(option);
-      }
-    });
-
-    return selectedOptions;
+    return this._options.toArray().filter(option => option.selected);
   }
 }

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -9,8 +9,8 @@
 import {
   ContentChildren,
   Directive,
-  ElementRef,
-  Input,
+  ElementRef, EventEmitter,
+  Input, Output,
   QueryList
 } from '@angular/core';
 
@@ -24,6 +24,7 @@ import {
   exportAs: 'cdkOption',
   host: {
     role: 'option',
+    '(click)': '_onClickUpdateSelected()',
     '[attr.aria-selected]': '_selected || null',
     '[attr.data-optionid]': '_optionId',
   }
@@ -41,8 +42,14 @@ export class CdkOption {
     this._selected = value;
   }
 
+  @Output() readonly selectionChange: EventEmitter<CdkOption> = new EventEmitter<CdkOption>();
+
   constructor(private readonly _elementRef: ElementRef) {
     this.setOptionId(`cdk-option-${_uniqueIdCounter++}`);
+  }
+
+  _onClickUpdateSelected() {
+
   }
 
   /** Sets the optionId to the given id */

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -24,29 +24,29 @@ import {
   exportAs: 'cdkOption',
   host: {
     role: 'option',
-    '[attr.aria-selected]': '_selected',
+    '[attr.aria-selected]': '_selected || null',
     '[attr.data-optionid]': '_optionId',
   }
 })
 export class CdkOption {
-  private _selected: boolean | null = null;
+  private _selected: boolean;
   private _optionId: string;
 
   /** Whether the option is selected or not */
   @Input()
-  get selected(): boolean | null {
+  get selected(): boolean {
     return this._selected;
   }
-  set selected(value: boolean | null) {
+  set selected(value: boolean) {
     this._selected = value;
   }
 
-  constructor(private readonly _el: ElementRef) {
+  constructor(private readonly _elementRef: ElementRef) {
     this.setOptionId(`cdk-option-${_uniqueIdCounter++}`);
   }
 
   /** Sets the optionId to the given id */
-  setOptionId(id: string): void {
+  setOptionId(id: string) {
     this._optionId = id;
   }
 
@@ -57,7 +57,7 @@ export class CdkOption {
 
   /** Returns an ElementRef of this option */
   getElementRef(): ElementRef {
-    return this._el;
+    return this._elementRef;
   }
 }
 
@@ -82,32 +82,32 @@ export class CdkListbox {
   @ContentChildren(CdkOption, {descendants: true}) _options: QueryList<CdkOption>;
 
   /** On click handler of this listbox, updates selected value of clicked option */
-  onClickUpdateSelectedOption($event: MouseEvent) {
+  onClickUpdateSelectedOption(event: MouseEvent) {
     this._options.toArray().forEach(option => {
       const optionId = option.getOptionId();
-      if ($event.target instanceof Element &&
-          optionId === $event.target?.getAttribute('data-optionid')) {
+      if (event.target instanceof Element &&
+          optionId === event.target?.getAttribute('data-optionid')) {
         this._updateSelectedOption(option);
       }
     });
   }
 
-  private _updateSelectedOption(option: CdkOption): void {
+  private _updateSelectedOption(option: CdkOption) {
     if (option.selected) {
-      this.deselectOption(option);
+      this.deselect(option);
     } else {
-      this.selectOption(option);
+      this.select(option);
     }
   }
 
   /** Sets the given option's selected state to true */
-  selectOption(option: CdkOption): void {
+  select(option: CdkOption) {
     option.selected = true;
   }
 
   /** Sets the given option's selected state to null. Null is preferable for screen readers */
-  deselectOption(option: CdkOption): void {
-    option.selected = null;
+  deselect(option: CdkOption) {
+    option.selected = false;
   }
 
   /** Returns an array of all options that are currently selected */

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -61,11 +61,6 @@ export class CdkOption {
   getOptionId(): string {
     return this._optionId;
   }
-
-  /** Returns an ElementRef of this option */
-  getElementRef(): ElementRef {
-    return this._elementRef;
-  }
 }
 
 let _uniqueIdCounter = 0;

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  AfterContentInit,
   ContentChildren,
   Directive,
   ElementRef,

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -9,7 +9,7 @@
 import {
   ContentChildren,
   Directive,
-  ElementRef, EventEmitter,
+  ElementRef, EventEmitter, forwardRef, Inject,
   Input, Output,
   QueryList
 } from '@angular/core';
@@ -42,14 +42,13 @@ export class CdkOption {
     this._selected = value;
   }
 
-  @Output() readonly selectionChange: EventEmitter<CdkOption> = new EventEmitter<CdkOption>();
-
-  constructor(private readonly _elementRef: ElementRef) {
+  constructor(private readonly _elementRef: ElementRef,
+              @Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {
     this.setOptionId(`cdk-option-${_uniqueIdCounter++}`);
   }
 
   _onClickUpdateSelected() {
-    this.selectionChange.emit(this);
+    this.listbox._emitChangeEvent(this);
   }
 
   /** Sets the optionId to the given id */
@@ -89,21 +88,8 @@ export class CdkListbox {
 
   @Output() readonly selectionChange: EventEmitter<CdkOption> = new EventEmitter<CdkOption>();
 
-  ngAfterContentInit() {
-    for (const option of this._options) {
-      option.selectionChange.subscribe(() => {
-        this._updateSelectedOption(option);
-      })
-    }
-  }
-
-  /** Toggles the selected state of the given option and emits the option in the selectionChange event */
-  private _updateSelectedOption(option: CdkOption) {
-    if (option.selected) {
-      this.deselect(option);
-    } else {
-      this.select(option);
-    }
+  /** Emits a selection change event, called when an option has its selected state changed */
+  _emitChangeEvent(option: CdkOption) {
     this.selectionChange.emit(option);
   }
 

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -42,7 +42,7 @@ export class CdkOption {
     this._selected = value;
   }
 
-  constructor(private el: ElementRef) {
+  constructor(private _el: ElementRef) {
   }
 
   /** Sets the optionId to the given id */
@@ -57,7 +57,7 @@ export class CdkOption {
 
   /** Returns an ElementRef of this option */
   getElementRef(): ElementRef {
-    return this.el;
+    return this._el;
   }
 }
 
@@ -73,24 +73,24 @@ let _uniqueIdCounter = 0;
   exportAs: 'cdkListbox',
   host: {
     role: 'listbox',
+    '(click)': '_onClickUpdateSelectedOption($event)'
   }
 })
 export class CdkListbox {
 
-  constructor(private el: ElementRef) {
+  constructor() {
   }
 
   /** A query list containing all CdkOption elements within this listbox */
   @ContentChildren(CdkOption) _options: QueryList<CdkOption>;
 
-  /** Listener activated on click of this listbox */
-  @HostListener('click', ['$event']) onClickUpdateSelectedOption($event: MouseEvent) {
-    console.log('in listbox click event');
-    console.log($event.target);
+  /** On click handler of this listbox, updates selected value of clicked option */
+  private _onClickUpdateSelectedOption($event: MouseEvent) {
     this._options.toArray().forEach(option => {
       const optionId = option.getOptionId();
-      if ($event.target instanceof Element && optionId === $event.target?.getAttribute('data-optionid')) {
-        this.updateSelectedOption(option);
+      if ($event.target instanceof Element &&
+          optionId === $event.target?.getAttribute('data-optionid')) {
+        this._updateSelectedOption(option);
       }
     });
   }
@@ -101,7 +101,7 @@ export class CdkListbox {
     });
   }
 
-  private updateSelectedOption(option: CdkOption): void {
+  private _updateSelectedOption(option: CdkOption): void {
     if (option.selected) {
       this.deselectOption(option);
     } else {
@@ -120,7 +120,7 @@ export class CdkListbox {
   }
 
   /** Returns an array of all options that are currently selected */
-  getSelectedOptions(): Array<CdkOption> {
+  getSelectedOptions(): CdkOption[] {
     const selectedOptions = new Array<CdkOption>();
     this._options.toArray().forEach(option => {
       if (option.selected) {

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -9,11 +9,11 @@
 import {
   ContentChildren,
   Directive,
-  ElementRef, EventEmitter, forwardRef, Inject,
+  EventEmitter, forwardRef, Inject,
   Input, Output,
   QueryList
 } from '@angular/core';
-import {coerceBooleanProperty} from "@angular/cdk/coercion";
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 
 /**
  * Directive that applies interaction patterns to an element following the aria role of option.
@@ -27,12 +27,12 @@ import {coerceBooleanProperty} from "@angular/cdk/coercion";
     role: 'option',
     '(click)': 'toggle()',
     '[attr.aria-selected]': '_selected || null',
-    '[attr.optionid]': '_optionId',
+    '[attr.optionid]': '_optionid',
   }
 })
 export class CdkOption {
   private _selected: boolean = false;
-  private _optionId: string;
+  readonly _optionid: string;
 
   /** Whether the option is selected or not */
   @Input()
@@ -43,9 +43,8 @@ export class CdkOption {
     this._selected = coerceBooleanProperty(value);
   }
 
-  constructor(private readonly _elementRef: ElementRef,
-              @Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {
-    this.setOptionId(`cdk-option-${nextId++}`);
+  constructor(@Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {
+    this._optionid = `cdk-option-${nextId++}`;
   }
 
   toggle() {
@@ -53,20 +52,7 @@ export class CdkOption {
     this.listbox._emitChangeEvent(this);
   }
 
-  /** Sets the optionId to the given id */
-  setOptionId(id: string) {
-    this._optionId = id;
-  }
-
-  /** Returns the optionId of this option */
-  getOptionId(): string {
-    return this._optionId;
-  }
-
-  /** Returns an ElementRef of this option */
-  private getElementRef(): ElementRef {
-    return this._elementRef;
-  }
+  static ngAcceptInputType_selected: BooleanInput;
 }
 
 let nextId = 0;

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -73,7 +73,7 @@ let _uniqueIdCounter = 0;
   exportAs: 'cdkListbox',
   host: {
     role: 'listbox',
-    '(click)': '_onClickUpdateSelectedOption($event)'
+    '(click)': 'onClickUpdateSelectedOption($event)'
   }
 })
 export class CdkListbox implements AfterContentInit {
@@ -85,7 +85,7 @@ export class CdkListbox implements AfterContentInit {
   @ContentChildren(CdkOption, {descendants: true}) _options: QueryList<CdkOption>;
 
   /** On click handler of this listbox, updates selected value of clicked option */
-  private _onClickUpdateSelectedOption($event: MouseEvent) {
+  onClickUpdateSelectedOption($event: MouseEvent) {
     this._options.toArray().forEach(option => {
       const optionId = option.getOptionId();
       if ($event.target instanceof Element &&

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -49,7 +49,7 @@ export class CdkOption {
   }
 
   _onClickUpdateSelected() {
-
+    this.selectionChange.emit(this);
   }
 
   /** Sets the optionId to the given id */
@@ -80,7 +80,6 @@ let _uniqueIdCounter = 0;
   exportAs: 'cdkListbox',
   host: {
     role: 'listbox',
-    '(click)': 'onClickUpdateSelectedOption($event)'
   }
 })
 export class CdkListbox {
@@ -88,23 +87,24 @@ export class CdkListbox {
   /** A query list containing all CdkOption elements within this listbox */
   @ContentChildren(CdkOption, {descendants: true}) _options: QueryList<CdkOption>;
 
-  /** On click handler of this listbox, updates selected value of clicked option */
-  onClickUpdateSelectedOption(event: MouseEvent) {
-    for (const option of this._options.toArray()) {
-      const optionId = option.getOptionId();
-      if (event.target instanceof Element &&
-          optionId === event.target?.getAttribute('data-optionid')) {
+  @Output() readonly selectionChange: EventEmitter<CdkOption> = new EventEmitter<CdkOption>();
+
+  ngAfterContentInit() {
+    for (const option of this._options) {
+      option.selectionChange.subscribe(() => {
         this._updateSelectedOption(option);
-      }
+      })
     }
   }
 
+  /** Toggles the selected state of the given option and emits the option in the selectionChange event */
   private _updateSelectedOption(option: CdkOption) {
     if (option.selected) {
       this.deselect(option);
     } else {
       this.select(option);
     }
+    this.selectionChange.emit(option);
   }
 
   /** Sets the given option's selected state to true */

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -15,6 +15,8 @@ import {
 } from '@angular/core';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 
+let nextId = 0;
+
 /**
  * Directive that applies interaction patterns to an element following the aria role of option.
  * Typically meant to be placed inside a listbox. Logic handling selection, disabled state, and
@@ -27,13 +29,11 @@ import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
     role: 'option',
     '(click)': 'toggle()',
     '[attr.aria-selected]': 'selected || null',
-    '[attr.id]': 'id',
+    '[id]': 'id',
   }
 })
 export class CdkOption {
   private _selected: boolean = false;
-  readonly _uniqueid: string;
-  private _id: string;
 
   /** Whether the option is selected or not */
   @Input()
@@ -45,18 +45,9 @@ export class CdkOption {
   }
 
   /** The id of the option, set to a uniqueid if the user does not provide one */
-  @Input()
-  get id(): string {
-    return this._id;
-  }
-  set id(value: string) {
-    this._id = value || this._uniqueid;
-  }
+  @Input() id = `cdk-option-${nextId++}`;
 
-  constructor(@Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {
-    this._uniqueid = `cdk-option-${nextId++}`;
-    this.id = this.id;
-  }
+  constructor(@Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {}
 
   /** Toggles the selected state, emits a change event through the injected listbox */
   toggle() {
@@ -66,8 +57,6 @@ export class CdkOption {
 
   static ngAcceptInputType_selected: BooleanInput;
 }
-
-let nextId = 0;
 
 /**
  * Directive that applies interaction patterns to an element following the aria role of listbox.

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -7,10 +7,10 @@
  */
 
 import {
+  AfterContentInit,
   ContentChildren,
   Directive,
   ElementRef,
-  HostListener,
   Input,
   QueryList
 } from '@angular/core';
@@ -76,13 +76,13 @@ let _uniqueIdCounter = 0;
     '(click)': '_onClickUpdateSelectedOption($event)'
   }
 })
-export class CdkListbox {
+export class CdkListbox implements AfterContentInit {
 
   constructor() {
   }
 
   /** A query list containing all CdkOption elements within this listbox */
-  @ContentChildren(CdkOption) _options: QueryList<CdkOption>;
+  @ContentChildren(CdkOption, {descendants: true}) _options: QueryList<CdkOption>;
 
   /** On click handler of this listbox, updates selected value of clicked option */
   private _onClickUpdateSelectedOption($event: MouseEvent) {
@@ -114,7 +114,7 @@ export class CdkListbox {
     option.selected = true;
   }
 
-  /** Sets the given option's selected state to null. Null is preferable to false for screen readers */
+  /** Sets the given option's selected state to null. Null is preferable for screen readers */
   deselectOption(option: CdkOption): void {
     option.selected = null;
   }

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -83,13 +83,13 @@ export class CdkListbox {
 
   /** On click handler of this listbox, updates selected value of clicked option */
   onClickUpdateSelectedOption(event: MouseEvent) {
-    this._options.toArray().forEach(option => {
+    for (const option of this._options.toArray()) {
       const optionId = option.getOptionId();
       if (event.target instanceof Element &&
           optionId === event.target?.getAttribute('data-optionid')) {
         this._updateSelectedOption(option);
       }
-    });
+    }
   }
 
   private _updateSelectedOption(option: CdkOption) {

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -29,7 +29,7 @@ import {
   }
 })
 export class CdkOption {
-  private _selected: boolean;
+  private _selected: boolean = false;
   private _optionId: string;
 
   /** Whether the option is selected or not */
@@ -108,10 +108,5 @@ export class CdkListbox {
   /** Sets the given option's selected state to null. Null is preferable for screen readers */
   deselect(option: CdkOption) {
     option.selected = false;
-  }
-
-  /** Returns an array of all options that are currently selected */
-  getSelectedOptions(): CdkOption[] {
-    return this._options.toArray().filter(option => option.selected);
   }
 }

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -44,6 +44,7 @@ export class CdkOption {
     this._selected = coerceBooleanProperty(value);
   }
 
+  /** The id of the option, set to a uniqueid if the user does not provide one */
   @Input()
   get id(): string {
     return this._id;
@@ -52,12 +53,12 @@ export class CdkOption {
     this._id = value || this._uniqueid;
   }
 
-
   constructor(@Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {
     this._uniqueid = `cdk-option-${nextId++}`;
     this.id = this.id;
   }
 
+  /** Toggles the selected state, emits a change event through the injected listbox */
   toggle() {
     this.selected = !this.selected;
     this.listbox._emitChangeEvent(this);
@@ -85,11 +86,11 @@ export class CdkListbox {
   /** A query list containing all CdkOption elements within this listbox */
   @ContentChildren(CdkOption, {descendants: true}) _options: QueryList<CdkOption>;
 
-  @Output() readonly selectionChange: EventEmitter<CdkOption> = new EventEmitter<CdkOption>();
+  @Output() readonly selectionChange: EventEmitter<ListboxSelectionChangeEvent> = new EventEmitter<ListboxSelectionChangeEvent>();
 
   /** Emits a selection change event, called when an option has its selected state changed */
   _emitChangeEvent(option: CdkOption) {
-    this.selectionChange.emit(option);
+    this.selectionChange.emit(new ListboxSelectionChangeEvent(this, option));
   }
 
   /** Sets the given option's selected state to true */
@@ -101,4 +102,13 @@ export class CdkListbox {
   deselect(option: CdkOption) {
     option.selected = false;
   }
+}
+
+/** Change event that is being fired whenever the selected state of an option changes. */
+export class ListboxSelectionChangeEvent {
+  constructor(
+    /** Reference to the listbox that emitted the event. */
+    public source: CdkListbox,
+    /** Reference to the option that has been changed. */
+    public option: CdkOption) {}
 }


### PR DESCRIPTION
Added the basic logic to keep track of a selected state of options and to toggle that state by clicking on them. The selected state of an option is tied to aria-selected. The CdkListbox also handles providing unique optionIds to its child options. Currently, logic to toggle multi-select in the listbox is not yet included, so by default the listbox has multi-select enabled. Tests were included to listbox. Feedback on testing style is appreciated.