### PR TITLE
build: remove unused bootstrap calls in size tests

### DIFF
--- a/integration/size-test/cdk/drag-drop/all-directives.ts
+++ b/integration/size-test/cdk/drag-drop/all-directives.ts
@@ -1,7 +1,6 @@
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import {Component, NgModule} from '@angular/core';
 
-
 /** Component using all parts of the drag-drop module. All directives should be preserved. */
 @Component({
   template: `

--- a/integration/size-test/material/autocomplete/without-optgroup.ts
+++ b/integration/size-test/material/autocomplete/without-optgroup.ts
@@ -1,5 +1,4 @@
 import {Component, NgModule} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 
 /**
@@ -22,5 +21,3 @@ export class TestComponent {}
   bootstrap: [TestComponent],
 })
 export class AppModule {}
-
-platformBrowser().bootstrapModule(AppModule);

--- a/integration/size-test/material/button-toggle/standalone.ts
+++ b/integration/size-test/material/button-toggle/standalone.ts
@@ -1,5 +1,4 @@
 import {Component, NgModule} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 
 /**
@@ -19,5 +18,3 @@ export class TestComponent {}
   bootstrap: [TestComponent],
 })
 export class AppModule {}
-
-platformBrowser().bootstrapModule(AppModule);

--- a/integration/size-test/material/datepicker/range-picker/without-form-field.ts
+++ b/integration/size-test/material/datepicker/range-picker/without-form-field.ts
@@ -1,5 +1,4 @@
 import {Component, NgModule} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 
 /**
@@ -26,5 +25,3 @@ export class TestComponent {}
   bootstrap: [TestComponent],
 })
 export class AppModule {}
-
-platformBrowser().bootstrapModule(AppModule);

--- a/integration/size-test/material/menu/without-lazy-content.ts
+++ b/integration/size-test/material/menu/without-lazy-content.ts
@@ -1,6 +1,5 @@
 import {Component, NgModule} from '@angular/core';
 import {MatMenuModule} from '@angular/material/menu';
-import {platformBrowser} from '@angular/platform-browser';
 
 /**
  * Basic component using `MatMenu` and `MatMenuTrigger`. No lazy `MatMenuContent` is
@@ -20,5 +19,3 @@ export class TestComponent {}
   bootstrap: [TestComponent],
 })
 export class AppModule {}
-
-platformBrowser().bootstrapModule(AppModule);

--- a/integration/size-test/material/radio/without-group.ts
+++ b/integration/size-test/material/radio/without-group.ts
@@ -1,6 +1,5 @@
 import {Component, NgModule} from '@angular/core';
 import {MatRadioModule} from '@angular/material/radio';
-import {platformBrowser} from '@angular/platform-browser';
 
 /**
  * Basic component using `MatRadioButton`. Doesn't use a `MatRadioGroup`, so the class
@@ -19,5 +18,3 @@ export class TestComponent {}
   bootstrap: [TestComponent],
 })
 export class AppModule {}
-
-platformBrowser().bootstrapModule(AppModule);

--- a/integration/size-test/material/select/without-optgroup.ts
+++ b/integration/size-test/material/select/without-optgroup.ts
@@ -1,5 +1,4 @@
 import {Component, NgModule} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
 import {MatSelectModule} from '@angular/material/select';
 
 /**
@@ -21,5 +20,3 @@ export class TestComponent {}
   bootstrap: [TestComponent],
 })
 export class AppModule {}
-
-platformBrowser().bootstrapModule(AppModule);


### PR DESCRIPTION
The size tests automatically will include a bootstrap module
call. The boostrap calls in those test files are noop and
will be removed by rollup as build optimizer considers it as
a side-effect free call that is unused.