### PR TITLE
refactor(core): avoid circular dependency in ripples

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -45,10 +45,6 @@
     "src/cdk/testing/private/e2e/query.ts"
   ],
   [
-    "src/material/core/ripple/ripple-ref.ts",
-    "src/material/core/ripple/ripple-renderer.ts"
-  ],
-  [
     "src/material/datepicker/date-range-input.ts",
     "src/material/datepicker/date-range-picker.ts"
   ],

--- a/src/material/core/ripple/ripple-ref.ts
+++ b/src/material/core/ripple/ripple-ref.ts
@@ -6,11 +6,29 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {RippleConfig, RippleRenderer} from './ripple-renderer';
-
 /** Possible states for a ripple element. */
 export const enum RippleState {
   FADING_IN, VISIBLE, FADING_OUT, HIDDEN
+}
+
+export type RippleConfig = {
+  color?: string;
+  centered?: boolean;
+  radius?: number;
+  persistent?: boolean;
+  animation?: RippleAnimationConfig;
+  terminateOnPointerUp?: boolean;
+};
+
+/**
+ * Interface that describes the configuration for the animation of a ripple.
+ * There are two animation phases with different durations for the ripples.
+ */
+export interface RippleAnimationConfig {
+  /** Duration in milliseconds for the enter animation (expansion from point of contact). */
+  enterDuration?: number;
+  /** Duration in milliseconds for the exit animation (fade-out). */
+  exitDuration?: number;
 }
 
 /**
@@ -22,7 +40,7 @@ export class RippleRef {
   state: RippleState = RippleState.HIDDEN;
 
   constructor(
-    private _renderer: RippleRenderer,
+    private _renderer: {fadeOutRipple(ref: RippleRef): void},
     /** Reference to the ripple HTML element. */
     public element: HTMLElement,
     /** Ripple configuration used for the ripple. */

--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -9,27 +9,7 @@ import {ElementRef, NgZone} from '@angular/core';
 import {Platform, normalizePassiveListenerOptions} from '@angular/cdk/platform';
 import {isFakeMousedownFromScreenReader} from '@angular/cdk/a11y';
 import {coerceElement} from '@angular/cdk/coercion';
-import {RippleRef, RippleState} from './ripple-ref';
-
-export type RippleConfig = {
-  color?: string;
-  centered?: boolean;
-  radius?: number;
-  persistent?: boolean;
-  animation?: RippleAnimationConfig;
-  terminateOnPointerUp?: boolean;
-};
-
-/**
- * Interface that describes the configuration for the animation of a ripple.
- * There are two animation phases with different durations for the ripples.
- */
-export interface RippleAnimationConfig {
-  /** Duration in milliseconds for the enter animation (expansion from point of contact). */
-  enterDuration?: number;
-  /** Duration in milliseconds for the exit animation (fade-out). */
-  exitDuration?: number;
-}
+import {RippleRef, RippleState, RippleConfig} from './ripple-ref';
 
 /**
  * Interface that describes the target for launching ripples.

--- a/src/material/core/ripple/ripple.spec.ts
+++ b/src/material/core/ripple/ripple.spec.ts
@@ -8,9 +8,10 @@ import {
   dispatchTouchEvent,
   createMouseEvent,
 } from '@angular/cdk/testing/private';
-import {defaultRippleAnimationConfig, RippleAnimationConfig} from './ripple-renderer';
+import {defaultRippleAnimationConfig} from './ripple-renderer';
 import {
-  MatRipple, MatRippleModule, MAT_RIPPLE_GLOBAL_OPTIONS, RippleState, RippleGlobalOptions
+  MatRipple, MatRippleModule, MAT_RIPPLE_GLOBAL_OPTIONS, RippleState, RippleGlobalOptions,
+  RippleAnimationConfig
 } from './index';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/src/material/core/ripple/ripple.ts
+++ b/src/material/core/ripple/ripple.ts
@@ -18,8 +18,8 @@ import {
   OnInit,
   Optional,
 } from '@angular/core';
-import {RippleRef} from './ripple-ref';
-import {RippleAnimationConfig, RippleConfig, RippleRenderer, RippleTarget} from './ripple-renderer';
+import {RippleAnimationConfig, RippleConfig, RippleRef} from './ripple-ref';
+import {RippleRenderer, RippleTarget} from './ripple-renderer';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 /** Configurable options for `matRipple`. */

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -366,7 +366,9 @@ export declare class RippleRef {
     config: RippleConfig;
     element: HTMLElement;
     state: RippleState;
-    constructor(_renderer: RippleRenderer,
+    constructor(_renderer: {
+        fadeOutRipple(ref: RippleRef): void;
+    },
     element: HTMLElement,
     config: RippleConfig);
     fadeOut(): void;


### PR DESCRIPTION
Moves some types around in order to avoid a circular dependency between the ripple renderer and ripple ref.