### PR TITLE
build: fix syntax error in docs

### DIFF
--- a/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
+++ b/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
@@ -7,7 +7,7 @@
   <mat-step [stepControl]="firstFormGroup" [editable]="isEditable">
 <!-- #enddocregion editable -->
     <form [formGroup]="firstFormGroup">
-<!-- #edocregion ng-template -->
+<!-- #docregion ng-template -->
       <ng-template matStepLabel>Fill out your name</ng-template>
 <!-- #enddocregion ng-template -->
       <mat-form-field>


### PR DESCRIPTION
Fixes an error that's breaking master, because one of the doc regions was misspelled.