### PR TITLE
refactor(material-experimental): expose whether harness elements are focused

### DIFF
--- a/src/material-experimental/mdc-button/testing/button-harness.ts
+++ b/src/material-experimental/mdc-button/testing/button-harness.ts
@@ -62,4 +62,9 @@ export class MatButtonHarness extends ComponentHarness {
   async blur(): Promise<void> {
     return (await this.host()).blur();
   }
+
+  /** Whether the button is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
 }

--- a/src/material-experimental/mdc-checkbox/testing/checkbox-harness.ts
+++ b/src/material-experimental/mdc-checkbox/testing/checkbox-harness.ts
@@ -102,6 +102,11 @@ export class MatCheckboxHarness extends ComponentHarness {
     return (await this._input()).blur();
   }
 
+  /** Whether the checkbox is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this._input()).isFocused();
+  }
+
   /**
    * Toggle the checked state of the checkbox and returns a void promise that indicates when the
    * action is complete.

--- a/src/material-experimental/mdc-menu/testing/menu-harness.ts
+++ b/src/material-experimental/mdc-menu/testing/menu-harness.ts
@@ -56,6 +56,11 @@ export class MatMenuHarness extends ComponentHarness {
     return (await this.host()).blur();
   }
 
+  /** Whether the menu is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   async open(): Promise<void> {
     throw Error('not implemented');
   }
@@ -105,14 +110,21 @@ export class MatMenuItemHarness extends ComponentHarness {
     return (await this.host()).text();
   }
 
-  /** Focuses the menu and returns a void promise that indicates when the action is complete. */
+  /**
+   * Focuses the menu item and returns a void promise that indicates when the action is complete.
+   */
   async focus(): Promise<void> {
     return (await this.host()).focus();
   }
 
-  /** Blurs the menu and returns a void promise that indicates when the action is complete. */
+  /** Blurs the menu item and returns a void promise that indicates when the action is complete. */
   async blur(): Promise<void> {
     return (await this.host()).blur();
+  }
+
+  /** Whether the menu item is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
   }
 
   async click(): Promise<void> {

--- a/src/material-experimental/mdc-slide-toggle/testing/slide-toggle-harness.ts
+++ b/src/material-experimental/mdc-slide-toggle/testing/slide-toggle-harness.ts
@@ -90,6 +90,11 @@ export class MatSlideToggleHarness extends ComponentHarness {
     return (await this._input()).blur();
   }
 
+  /** Whether the slide-toggle is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this._input()).isFocused();
+  }
+
   /**
    * Toggle the checked state of the slide-toggle and returns a void promise that indicates when the
    * action is complete.

--- a/src/material-experimental/mdc-slider/testing/slider-harness.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-harness.ts
@@ -126,6 +126,11 @@ export class MatSliderHarness extends ComponentHarness {
     return (await this.host()).blur();
   }
 
+  /** Whether the slider is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   /** Calculates the percentage of the given value. */
   private async _calculatePercentage(value: number) {
     const [min, max] = await Promise.all([this.getMinValue(), this.getMaxValue()]);

--- a/src/material/autocomplete/testing/autocomplete-harness.ts
+++ b/src/material/autocomplete/testing/autocomplete-harness.ts
@@ -56,6 +56,11 @@ export class MatAutocompleteHarness extends ComponentHarness {
     return (await this.host()).blur();
   }
 
+  /** Whether the autocomplete input is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   /** Enters text into the autocomplete. */
   async enterText(value: string): Promise<void> {
     return (await this.host()).sendKeys(value);

--- a/src/material/autocomplete/testing/shared.spec.ts
+++ b/src/material/autocomplete/testing/shared.spec.ts
@@ -63,11 +63,11 @@ export function runHarnessTests(
 
   it('should focus and blur an input', async () => {
     const input = await loader.getHarness(autocompleteHarness.with({selector: '#plain'}));
-    expect(getActiveElementId()).not.toBe('plain');
+    expect(await input.isFocused()).toBe(false);
     await input.focus();
-    expect(getActiveElementId()).toBe('plain');
+    expect(await input.isFocused()).toBe(true);
     await input.blur();
-    expect(getActiveElementId()).not.toBe('plain');
+    expect(await input.isFocused()).toBe(false);
   });
 
   it('should be able to type in an input', async () => {
@@ -147,10 +147,6 @@ export function runHarnessTests(
     await expectAsync(input.selectOption({text: 'Texas'})).toBeRejectedWithError(
         /Could not find a mat-option matching {"text":"Texas"}/);
   });
-}
-
-function getActiveElementId() {
-  return document.activeElement ? document.activeElement.id : '';
 }
 
 @Component({

--- a/src/material/button-toggle/testing/button-toggle-harness.ts
+++ b/src/material/button-toggle/testing/button-toggle-harness.ts
@@ -85,6 +85,11 @@ export class MatButtonToggleHarness extends ComponentHarness {
     return (await this._button()).blur();
   }
 
+  /** Whether the toggle is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this._button()).isFocused();
+  }
+
   /** Toggle the checked state of the buttons toggle. */
   async toggle(): Promise<void> {
     return (await this._button()).click();

--- a/src/material/button-toggle/testing/button-toggle-shared.spec.ts
+++ b/src/material/button-toggle/testing/button-toggle-shared.spec.ts
@@ -81,17 +81,17 @@ export function runHarnessTests(
 
   it('should focus the button toggle', async () => {
     const toggle = await loader.getHarness(buttonToggleHarness.with({text: 'First'}));
-    expect(getActiveElementTagName()).not.toBe('button');
+    expect(await toggle.isFocused()).toBe(false);
     await toggle.focus();
-    expect(getActiveElementTagName()).toBe('button');
+    expect(await toggle.isFocused()).toBe(true);
   });
 
   it('should blur the button toggle', async () => {
     const toggle = await loader.getHarness(buttonToggleHarness.with({text: 'First'}));
     await toggle.focus();
-    expect(getActiveElementTagName()).toBe('button');
+    expect(await toggle.isFocused()).toBe(true);
     await toggle.blur();
-    expect(getActiveElementTagName()).not.toBe('button');
+    expect(await toggle.isFocused()).toBe(false);
   });
 
   it('should toggle the button value', async () => {
@@ -120,10 +120,6 @@ export function runHarnessTests(
     expect(await checkedToggle.isChecked()).toBe(false);
     expect(await uncheckedToggle.isChecked()).toBe(false);
   });
-}
-
-function getActiveElementTagName() {
-  return document.activeElement ? document.activeElement.tagName.toLowerCase() : '';
 }
 
 @Component({

--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -62,4 +62,9 @@ export class MatButtonHarness extends ComponentHarness {
   async blur(): Promise<void> {
     return (await this.host()).blur();
   }
+
+  /** Whether the button is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
 }

--- a/src/material/button/testing/shared.spec.ts
+++ b/src/material/button/testing/shared.spec.ts
@@ -67,11 +67,11 @@ export function runHarnessTests(
 
   it('should focus and blur a button', async () => {
     const button = await loader.getHarness(buttonHarness.with({text: 'Basic button'}));
-    expect(getActiveElementId()).not.toBe('basic');
+    expect(await button.isFocused()).toBe(false);
     await button.focus();
-    expect(getActiveElementId()).toBe('basic');
+    expect(await button.isFocused()).toBe(true);
     await button.blur();
-    expect(getActiveElementId()).not.toBe('basic');
+    expect(await button.isFocused()).toBe(false);
   });
 
   it('should click a button', async () => {
@@ -96,10 +96,6 @@ export function runHarnessTests(
 
     expect(fixture.componentInstance.clicked).toBe(false);
   });
-}
-
-function getActiveElementId() {
-  return document.activeElement ? document.activeElement.id : '';
 }
 
 @Component({

--- a/src/material/checkbox/testing/checkbox-harness.ts
+++ b/src/material/checkbox/testing/checkbox-harness.ts
@@ -101,6 +101,11 @@ export class MatCheckboxHarness extends ComponentHarness {
     return (await this._input()).blur();
   }
 
+  /** Whether the checkbox is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this._input()).isFocused();
+  }
+
   /**
    * Toggles the checked state of the checkbox.
    *

--- a/src/material/checkbox/testing/shared.spec.ts
+++ b/src/material/checkbox/testing/shared.spec.ts
@@ -114,17 +114,17 @@ export function runHarnessTests(
 
   it('should focus checkbox', async () => {
     const checkbox = await loader.getHarness(checkboxHarness.with({label: 'First'}));
-    expect(getActiveElementTagName()).not.toBe('input');
+    expect(await checkbox.isFocused()).toBe(false);
     await checkbox.focus();
-    expect(getActiveElementTagName()).toBe('input');
+    expect(await checkbox.isFocused()).toBe(true);
   });
 
   it('should blur checkbox', async () => {
     const checkbox = await loader.getHarness(checkboxHarness.with({label: 'First'}));
     await checkbox.focus();
-    expect(getActiveElementTagName()).toBe('input');
+    expect(await checkbox.isFocused()).toBe(true);
     await checkbox.blur();
-    expect(getActiveElementTagName()).not.toBe('input');
+    expect(await checkbox.isFocused()).toBe(false);
   });
 
   it('should toggle checkbox', async () => {
@@ -165,10 +165,6 @@ export function runHarnessTests(
     await disabledCheckbox.toggle();
     expect(await disabledCheckbox.isChecked()).toBe(false);
   });
-}
-
-function getActiveElementTagName() {
-  return document.activeElement ? document.activeElement.tagName.toLowerCase() : '';
 }
 
 @Component({

--- a/src/material/expansion/testing/expansion-harness.ts
+++ b/src/material/expansion/testing/expansion-harness.ts
@@ -125,6 +125,11 @@ export class MatExpansionPanelHarness extends ComponentHarness {
     return (await this._header()).blur();
   }
 
+  /** Whether the panel is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this._header()).isFocused();
+  }
+
   /** Whether the panel has a toggle indicator displayed. */
   async hasToggleIndicator(): Promise<boolean> {
     return (await this._expansionIndicator()) !== null;

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -98,6 +98,11 @@ export class MatInputHarness extends MatFormFieldControlHarness {
     return (await this.host()).blur();
   }
 
+  /** Whether the input is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   /**
    * Sets the value of the input. The value will be set by simulating
    * keypresses that correspond to the given value.

--- a/src/material/input/testing/shared.spec.ts
+++ b/src/material/input/testing/shared.spec.ts
@@ -168,18 +168,18 @@ export function runHarnessTests(
 
   it('should be able to focus input', async () => {
     const input = await loader.getHarness(inputHarness.with({selector: '[name="favorite-food"]'}));
-    expect(getActiveElementTagName()).not.toBe('input');
+    expect(await input.isFocused()).toBe(false);
     await input.focus();
-    expect(getActiveElementTagName()).toBe('input');
+    expect(await input.isFocused()).toBe(true);
   });
 
   it('should be able to blur input', async () => {
     const input = await loader.getHarness(inputHarness.with({selector: '[name="favorite-food"]'}));
-    expect(getActiveElementTagName()).not.toBe('input');
+    expect(await input.isFocused()).toBe(false);
     await input.focus();
-    expect(getActiveElementTagName()).toBe('input');
+    expect(await input.isFocused()).toBe(true);
     await input.blur();
-    expect(getActiveElementTagName()).not.toBe('input');
+    expect(await input.isFocused()).toBe(false);
   });
 
   it('should be able to set the value of a control that cannot be typed in', async () => {
@@ -193,10 +193,6 @@ export function runHarnessTests(
     await input.setValue('#00ff00');
     expect((await input.getValue()).toLowerCase()).toBe('#00ff00');
   });
-}
-
-function getActiveElementTagName() {
-  return document.activeElement ? document.activeElement.tagName.toLowerCase() : '';
 }
 
 @Component({

--- a/src/material/list/testing/action-list-harness.ts
+++ b/src/material/list/testing/action-list-harness.ts
@@ -62,4 +62,9 @@ export class MatActionListItemHarness extends MatListItemHarnessBase {
   async blur(): Promise<void> {
     return (await this.host()).blur();
   }
+
+  /** Whether the action list item is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
 }

--- a/src/material/list/testing/nav-list-harness.ts
+++ b/src/material/list/testing/nav-list-harness.ts
@@ -68,4 +68,9 @@ export class MatNavListItemHarness extends MatListItemHarnessBase {
   async blur(): Promise<void> {
     return (await this.host()).blur();
   }
+
+  /** Whether the nav list item is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
 }

--- a/src/material/list/testing/selection-list-harness.ts
+++ b/src/material/list/testing/selection-list-harness.ts
@@ -112,6 +112,11 @@ export class MatListOptionHarness extends MatListItemHarnessBase {
     return (await this.host()).blur();
   }
 
+  /** Whether the list option is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   /** Toggles the checked state of the checkbox. */
   async toggle() {
     return (await this.host()).click();

--- a/src/material/menu/testing/menu-harness.ts
+++ b/src/material/menu/testing/menu-harness.ts
@@ -57,6 +57,11 @@ export class MatMenuHarness extends ComponentHarness {
     return (await this.host()).blur();
   }
 
+  /** Whether the menu is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   /** Opens the menu. */
   async open(): Promise<void> {
     if (!await this.isOpen()) {
@@ -166,6 +171,11 @@ export class MatMenuItemHarness extends ComponentHarness {
   /** Blurs the menu item. */
   async blur(): Promise<void> {
     return (await this.host()).blur();
+  }
+
+  /** Whether the menu item is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
   }
 
   /** Clicks the menu item. */

--- a/src/material/menu/testing/shared.spec.ts
+++ b/src/material/menu/testing/shared.spec.ts
@@ -62,11 +62,11 @@ export function runHarnessTests(
 
     it('should focus and blur a menu', async () => {
       const menu = await loader.getHarness(menuHarness.with({triggerText: 'Settings'}));
-      expect(getActiveElementId()).not.toBe('settings');
+      expect(await menu.isFocused()).toBe(false);
       await menu.focus();
-      expect(getActiveElementId()).toBe('settings');
+      expect(await menu.isFocused()).toBe(true);
       await menu.blur();
-      expect(getActiveElementId()).not.toBe('settings');
+      expect(await menu.isFocused()).toBe(false);
     });
 
     it('should open and close', async () => {
@@ -170,10 +170,6 @@ export function runHarnessTests(
           /Item matching {"text":"Leaf Item 1"} does not have a submenu/);
     });
   });
-}
-
-function getActiveElementId() {
-  return document.activeElement ? document.activeElement.id : '';
 }
 
 @Component({

--- a/src/material/radio/testing/radio-harness.ts
+++ b/src/material/radio/testing/radio-harness.ts
@@ -230,6 +230,11 @@ export class MatRadioButtonHarness extends ComponentHarness {
     return (await this._input()).blur();
   }
 
+  /** Whether the radio-button is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this._input()).isFocused();
+  }
+
   /**
    * Puts the radio-button in a checked state by clicking it if it is currently unchecked,
    * or doing nothing if it is already checked.

--- a/src/material/radio/testing/shared.spec.ts
+++ b/src/material/radio/testing/shared.spec.ts
@@ -212,17 +212,17 @@ export function runHarnessTests(radioModule: typeof MatRadioModule,
 
     it('should focus radio-button', async () => {
       const radioButton = await loader.getHarness(radioButtonHarness.with({selector: '#opt2'}));
-      expect(getActiveElementTagName()).not.toBe('input');
+      expect(await radioButton.isFocused()).toBe(false);
       await radioButton.focus();
-      expect(getActiveElementTagName()).toBe('input');
+      expect(await radioButton.isFocused()).toBe(true);
     });
 
     it('should blur radio-button', async () => {
       const radioButton = await loader.getHarness(radioButtonHarness.with({selector: '#opt2'}));
       await radioButton.focus();
-      expect(getActiveElementTagName()).toBe('input');
+      expect(await radioButton.isFocused()).toBe(true);
       await radioButton.blur();
-      expect(getActiveElementTagName()).not.toBe('input');
+      expect(await radioButton.isFocused()).toBe(false);
     });
 
     it('should check radio-button', async () => {
@@ -264,10 +264,6 @@ export function runHarnessTests(radioModule: typeof MatRadioModule,
       expect(await radioButton.isRequired()).toBe(true);
     });
   });
-}
-
-function getActiveElementTagName() {
-  return document.activeElement ? document.activeElement.tagName.toLowerCase() : '';
 }
 
 @Component({

--- a/src/material/select/testing/select-harness.ts
+++ b/src/material/select/testing/select-harness.ts
@@ -77,6 +77,11 @@ export class MatSelectHarness extends MatFormFieldControlHarness {
     return (await this.host()).blur();
   }
 
+  /** Whether the select is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   /** Gets the options inside the select panel. */
   async getOptions(filter: Omit<OptionHarnessFilters, 'ancestor'> = {}):
     Promise<MatOptionHarness[]> {

--- a/src/material/select/testing/shared.spec.ts
+++ b/src/material/select/testing/shared.spec.ts
@@ -105,11 +105,11 @@ export function runHarnessTests(
 
   it('should focus and blur a select', async () => {
     const select = await loader.getHarness(selectHarness.with({selector: '#single-selection'}));
-    expect(getActiveElementId()).not.toBe('single-selection');
+    expect(await select.isFocused()).toBe(false);
     await select.focus();
-    expect(getActiveElementId()).toBe('single-selection');
+    expect(await select.isFocused()).toBe(true);
     await select.blur();
-    expect(getActiveElementId()).not.toBe('single-selection');
+    expect(await select.isFocused()).toBe(false);
   });
 
   it('should be able to open and close a single-selection select', async () => {
@@ -234,10 +234,6 @@ export function runHarnessTests(
     expect(control.value).toBe('CA');
   });
 
-}
-
-function getActiveElementId() {
-  return document.activeElement ? document.activeElement.id : '';
 }
 
 @Component({

--- a/src/material/slide-toggle/testing/shared.spec.ts
+++ b/src/material/slide-toggle/testing/shared.spec.ts
@@ -102,17 +102,17 @@ export function runHarnessTests(
 
   it('should focus slide-toggle', async () => {
     const slideToggle = await loader.getHarness(slideToggleHarness.with({label: 'First'}));
-    expect(getActiveElementTagName()).not.toBe('input');
+    expect(await slideToggle.isFocused()).toBe(false);
     await slideToggle.focus();
-    expect(getActiveElementTagName()).toBe('input');
+    expect(await slideToggle.isFocused()).toBe(true);
   });
 
   it('should blur slide-toggle', async () => {
     const slideToggle = await loader.getHarness(slideToggleHarness.with({label: 'First'}));
     await slideToggle.focus();
-    expect(getActiveElementTagName()).toBe('input');
+    expect(await slideToggle.isFocused()).toBe(true);
     await slideToggle.blur();
-    expect(getActiveElementTagName()).not.toBe('input');
+    expect(await slideToggle.isFocused()).toBe(false);
   });
 
   it('should toggle slide-toggle', async () => {
@@ -155,10 +155,6 @@ export function runHarnessTests(
     await disabledToggle.toggle();
     expect(await disabledToggle.isChecked()).toBe(false);
   });
-}
-
-function getActiveElementTagName() {
-  return document.activeElement ? document.activeElement.tagName.toLowerCase() : '';
 }
 
 @Component({

--- a/src/material/slide-toggle/testing/slide-toggle-harness.ts
+++ b/src/material/slide-toggle/testing/slide-toggle-harness.ts
@@ -90,6 +90,11 @@ export class MatSlideToggleHarness extends ComponentHarness {
     return (await this._input()).blur();
   }
 
+  /** Whether the slide-toggle is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this._input()).isFocused();
+  }
+
   /** Toggle the checked state of the slide-toggle. */
   async toggle(): Promise<void> {
     return (await this._inputContainer()).click();

--- a/src/material/slider/testing/shared.spec.ts
+++ b/src/material/slider/testing/shared.spec.ts
@@ -93,19 +93,19 @@ export function runHarnessTests(
   it('should be able to focus slider', async () => {
     // the first slider is disabled.
     const slider = (await loader.getAllHarnesses(sliderHarness))[1];
-    expect(getActiveElementTagName()).not.toBe('mat-slider');
+    expect(await slider.isFocused()).toBe(false);
     await slider.focus();
-    expect(getActiveElementTagName()).toBe('mat-slider');
+    expect(await slider.isFocused()).toBe(true);
   });
 
   it('should be able to blur slider', async () => {
     // the first slider is disabled.
     const slider = (await loader.getAllHarnesses(sliderHarness))[1];
-    expect(getActiveElementTagName()).not.toBe('mat-slider');
+    expect(await slider.isFocused()).toBe(false);
     await slider.focus();
-    expect(getActiveElementTagName()).toBe('mat-slider');
+    expect(await slider.isFocused()).toBe(true);
     await slider.blur();
-    expect(getActiveElementTagName()).not.toBe('mat-slider');
+    expect(await slider.isFocused()).toBe(false);
   });
 
   it('should be able to set value of slider', async () => {
@@ -174,10 +174,6 @@ export function runHarnessTests(
       expect(await sliders[2].getValue()).toBe(210);
     });
   }
-}
-
-function getActiveElementTagName() {
-  return document.activeElement ? document.activeElement.tagName.toLowerCase() : '';
 }
 
 @Component({

--- a/src/material/slider/testing/slider-harness.ts
+++ b/src/material/slider/testing/slider-harness.ts
@@ -119,6 +119,11 @@ export class MatSliderHarness extends ComponentHarness {
     return (await this.host()).blur();
   }
 
+  /** Whether the slider is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
   /** Calculates the percentage of the given value. */
   private async _calculatePercentage(value: number) {
     const [min, max] = await Promise.all([this.getMinValue(), this.getMaxValue()]);

--- a/tools/public_api_guard/material/autocomplete/testing.d.ts
+++ b/tools/public_api_guard/material/autocomplete/testing.d.ts
@@ -10,6 +10,7 @@ export declare class MatAutocompleteHarness extends ComponentHarness {
     getOptions(filters?: Omit<OptionHarnessFilters, 'ancestor'>): Promise<MatOptionHarness[]>;
     getValue(): Promise<string>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isOpen(): Promise<boolean>;
     selectOption(filters: OptionHarnessFilters): Promise<void>;
     static hostSelector: string;

--- a/tools/public_api_guard/material/button-toggle/testing.d.ts
+++ b/tools/public_api_guard/material/button-toggle/testing.d.ts
@@ -27,6 +27,7 @@ export declare class MatButtonToggleHarness extends ComponentHarness {
     getText(): Promise<string>;
     isChecked(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     toggle(): Promise<void>;
     uncheck(): Promise<void>;
     static hostSelector: string;

--- a/tools/public_api_guard/material/button/testing.d.ts
+++ b/tools/public_api_guard/material/button/testing.d.ts
@@ -8,6 +8,7 @@ export declare class MatButtonHarness extends ComponentHarness {
     focus(): Promise<void>;
     getText(): Promise<string>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     static hostSelector: string;
     static with(options?: ButtonHarnessFilters): HarnessPredicate<MatButtonHarness>;
 }

--- a/tools/public_api_guard/material/checkbox/testing.d.ts
+++ b/tools/public_api_guard/material/checkbox/testing.d.ts
@@ -14,6 +14,7 @@ export declare class MatCheckboxHarness extends ComponentHarness {
     getValue(): Promise<string | null>;
     isChecked(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isIndeterminate(): Promise<boolean>;
     isRequired(): Promise<boolean>;
     isValid(): Promise<boolean>;

--- a/tools/public_api_guard/material/expansion/testing.d.ts
+++ b/tools/public_api_guard/material/expansion/testing.d.ts
@@ -29,6 +29,7 @@ export declare class MatExpansionPanelHarness extends ComponentHarness {
     hasToggleIndicator(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
     isExpanded(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     toggle(): Promise<void>;
     static hostSelector: string;
     static with(options?: ExpansionPanelHarnessFilters): HarnessPredicate<MatExpansionPanelHarness>;

--- a/tools/public_api_guard/material/input/testing.d.ts
+++ b/tools/public_api_guard/material/input/testing.d.ts
@@ -12,6 +12,7 @@ export declare class MatInputHarness extends MatFormFieldControlHarness {
     getType(): Promise<string>;
     getValue(): Promise<string>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isReadonly(): Promise<boolean>;
     isRequired(): Promise<boolean>;
     setValue(newValue: string): Promise<void>;

--- a/tools/public_api_guard/material/list/testing.d.ts
+++ b/tools/public_api_guard/material/list/testing.d.ts
@@ -28,6 +28,7 @@ export declare class MatActionListItemHarness extends MatListItemHarnessBase {
     blur(): Promise<void>;
     click(): Promise<void>;
     focus(): Promise<void>;
+    isFocused(): Promise<boolean>;
     static hostSelector: string;
     static with(options?: ActionListItemHarnessFilters): HarnessPredicate<MatActionListItemHarness>;
 }
@@ -49,6 +50,7 @@ export declare class MatListOptionHarness extends MatListItemHarnessBase {
     focus(): Promise<void>;
     getCheckboxPosition(): Promise<'before' | 'after'>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isSelected(): Promise<boolean>;
     select(): Promise<void>;
     toggle(): Promise<void>;
@@ -67,6 +69,7 @@ export declare class MatNavListItemHarness extends MatListItemHarnessBase {
     click(): Promise<void>;
     focus(): Promise<void>;
     getHref(): Promise<string | null>;
+    isFocused(): Promise<boolean>;
     static hostSelector: string;
     static with(options?: NavListItemHarnessFilters): HarnessPredicate<MatNavListItemHarness>;
 }

--- a/tools/public_api_guard/material/menu/testing.d.ts
+++ b/tools/public_api_guard/material/menu/testing.d.ts
@@ -6,6 +6,7 @@ export declare class MatMenuHarness extends ComponentHarness {
     getItems(filters?: Omit<MenuItemHarnessFilters, 'ancestor'>): Promise<MatMenuItemHarness[]>;
     getTriggerText(): Promise<string>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isOpen(): Promise<boolean>;
     open(): Promise<void>;
     static hostSelector: string;
@@ -20,6 +21,7 @@ export declare class MatMenuItemHarness extends ComponentHarness {
     getText(): Promise<string>;
     hasSubmenu(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     static hostSelector: string;
     static with(options?: MenuItemHarnessFilters): HarnessPredicate<MatMenuItemHarness>;
 }

--- a/tools/public_api_guard/material/radio/testing.d.ts
+++ b/tools/public_api_guard/material/radio/testing.d.ts
@@ -8,6 +8,7 @@ export declare class MatRadioButtonHarness extends ComponentHarness {
     getValue(): Promise<string | null>;
     isChecked(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isRequired(): Promise<boolean>;
     static hostSelector: string;
     static with(options?: RadioButtonHarnessFilters): HarnessPredicate<MatRadioButtonHarness>;

--- a/tools/public_api_guard/material/select/testing.d.ts
+++ b/tools/public_api_guard/material/select/testing.d.ts
@@ -8,6 +8,7 @@ export declare class MatSelectHarness extends MatFormFieldControlHarness {
     getValueText(): Promise<string>;
     isDisabled(): Promise<boolean>;
     isEmpty(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isMultiple(): Promise<boolean>;
     isOpen(): Promise<boolean>;
     isRequired(): Promise<boolean>;

--- a/tools/public_api_guard/material/slide-toggle/testing.d.ts
+++ b/tools/public_api_guard/material/slide-toggle/testing.d.ts
@@ -8,6 +8,7 @@ export declare class MatSlideToggleHarness extends ComponentHarness {
     getName(): Promise<string | null>;
     isChecked(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     isRequired(): Promise<boolean>;
     isValid(): Promise<boolean>;
     toggle(): Promise<void>;

--- a/tools/public_api_guard/material/slider/testing.d.ts
+++ b/tools/public_api_guard/material/slider/testing.d.ts
@@ -9,6 +9,7 @@ export declare class MatSliderHarness extends ComponentHarness {
     getPercentage(): Promise<number>;
     getValue(): Promise<number>;
     isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
     setValue(value: number): Promise<void>;
     static hostSelector: string;
     static with(options?: SliderHarnessFilters): HarnessPredicate<MatSliderHarness>;


### PR DESCRIPTION
Currently we have a bunch of test harnesses that have methods for blurring and focusing the underlying element, but they don't expose whether it currently has focus. These changes add `isFocused` methods to all of the harnesses so they're consistent between each other.

Fixes #19702.