### PR TITLE
fix(material/select): have form control disabled state take precedence over disabled binding

### DIFF
--- a/src/material-experimental/mdc-select/select.spec.ts
+++ b/src/material-experimental/mdc-select/select.spec.ts
@@ -124,6 +124,7 @@ describe('MDC-based MatSelect', () => {
         SelectWithFormFieldLabel,
         SelectWithChangeEvent,
         SelectInsideDynamicFormGroup,
+        SelectWithFormControlAndDisabledBinding,
       ]);
     }));
 
@@ -2221,6 +2222,18 @@ describe('MDC-based MatSelect', () => {
           expect(instance.select.disabled).toBe(true);
         }),
       );
+
+      it('should pick the form control disabled state over its property binding', () => {
+        const fixture = TestBed.createComponent(SelectWithFormControlAndDisabledBinding);
+        fixture.detectChanges();
+
+        fixture.componentInstance.control.enable();
+        fixture.detectChanges();
+        fixture.componentInstance.isDisabled = true;
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.select.disabled).toBe(false);
+      });
     });
 
     describe('keyboard scrolling', () => {
@@ -5073,4 +5086,17 @@ class SelectInsideDynamicFormGroup {
       control: {value: '', disabled: isDisabled},
     });
   }
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-select [disabled]="isDisabled" [formControl]="control"></mat-select>
+    </mat-form-field>
+  `,
+})
+class SelectWithFormControlAndDisabledBinding {
+  @ViewChild(MatSelect) select: MatSelect;
+  control = new FormControl();
+  isDisabled: boolean;
 }

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -123,6 +123,7 @@ describe('MatSelect', () => {
         SelectWithFormFieldLabel,
         SelectWithChangeEvent,
         SelectInsideDynamicFormGroup,
+        SelectWithFormControlAndDisabledBinding,
       ]);
     }));
 
@@ -2236,6 +2237,18 @@ describe('MatSelect', () => {
           expect(instance.select.disabled).toBe(true);
         }),
       );
+
+      it('should pick the form control disabled state over its property binding', () => {
+        const fixture = TestBed.createComponent(SelectWithFormControlAndDisabledBinding);
+        fixture.detectChanges();
+
+        fixture.componentInstance.control.enable();
+        fixture.detectChanges();
+        fixture.componentInstance.isDisabled = true;
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.select.disabled).toBe(false);
+      });
     });
 
     describe('animations', () => {
@@ -6051,4 +6064,17 @@ class SelectInsideDynamicFormGroup {
       control: {value: '', disabled: isDisabled},
     });
   }
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-select [disabled]="isDisabled" [formControl]="control"></mat-select>
+    </mat-form-field>
+  `,
+})
+class SelectWithFormControlAndDisabledBinding {
+  @ViewChild(MatSelect) select: MatSelect;
+  control = new FormControl();
+  isDisabled: boolean;
 }

--- a/tools/public_api_guard/material/select.md
+++ b/tools/public_api_guard/material/select.md
@@ -9,7 +9,6 @@ import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { AfterContentInit } from '@angular/core';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { BooleanInput } from '@angular/cdk/coercion';
-import { CanDisable } from '@angular/material/core';
 import { CanDisableRipple } from '@angular/material/core';
 import { CanUpdateErrorState } from '@angular/material/core';
 import { CdkConnectedOverlay } from '@angular/cdk/overlay';
@@ -112,7 +111,7 @@ export const matSelectAnimations: {
 };
 
 // @public
-export abstract class _MatSelectBase<C> extends _MatSelectMixinBase implements AfterContentInit, OnChanges, OnDestroy, OnInit, DoCheck, ControlValueAccessor, CanDisable, HasTabIndex, MatFormFieldControl<any>, CanUpdateErrorState, CanDisableRipple {
+export abstract class _MatSelectBase<C> extends _MatSelectMixinBase implements AfterContentInit, OnChanges, OnDestroy, OnInit, DoCheck, ControlValueAccessor, HasTabIndex, MatFormFieldControl<any>, CanUpdateErrorState, CanDisableRipple {
     constructor(_viewportRuler: ViewportRuler, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, _defaultErrorStateMatcher: ErrorStateMatcher, elementRef: ElementRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any, _liveAnnouncer: LiveAnnouncer, _defaultOptions?: MatSelectConfig | undefined);
     _ariaDescribedby: string;
     ariaLabel: string;
@@ -127,6 +126,10 @@ export abstract class _MatSelectBase<C> extends _MatSelectMixinBase implements A
     controlType: string;
     abstract customTrigger: {};
     protected readonly _destroy: Subject<void>;
+    get disabled(): boolean;
+    set disabled(value: boolean);
+    // (undocumented)
+    protected _disabled: boolean;
     get disableOptionCentering(): boolean;
     set disableOptionCentering(value: BooleanInput);
     get empty(): boolean;
@@ -211,7 +214,7 @@ export abstract class _MatSelectBase<C> extends _MatSelectMixinBase implements A
     protected _viewportRuler: ViewportRuler;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<_MatSelectBase<any>, never, never, { "panelClass": "panelClass"; "placeholder": "placeholder"; "required": "required"; "multiple": "multiple"; "disableOptionCentering": "disableOptionCentering"; "compareWith": "compareWith"; "value": "value"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; "errorStateMatcher": "errorStateMatcher"; "typeaheadDebounceInterval": "typeaheadDebounceInterval"; "sortComparator": "sortComparator"; "id": "id"; }, { "openedChange": "openedChange"; "_openedStream": "opened"; "_closedStream": "closed"; "selectionChange": "selectionChange"; "valueChange": "valueChange"; }, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<_MatSelectBase<any>, never, never, { "panelClass": "panelClass"; "placeholder": "placeholder"; "required": "required"; "multiple": "multiple"; "disableOptionCentering": "disableOptionCentering"; "compareWith": "compareWith"; "value": "value"; "disabled": "disabled"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; "errorStateMatcher": "errorStateMatcher"; "typeaheadDebounceInterval": "typeaheadDebounceInterval"; "sortComparator": "sortComparator"; "id": "id"; }, { "openedChange": "openedChange"; "_openedStream": "opened"; "_closedStream": "closed"; "selectionChange": "selectionChange"; "valueChange": "valueChange"; }, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<_MatSelectBase<any>, [null, null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; self: true; }, { attribute: "tabindex"; }, null, null, { optional: true; }]>;
 }


### PR DESCRIPTION
`MatSelect` can be disabled either through the `disabled` property or via a `ControlValueAccessor`, but currently it's inconsistent if the two values conflict with each other since we take the value of the last one that was set. These changes make it so that the value from the CVA has precedence. This is consistent with how we handle the disabled state in `MatInput`.

Fixes #19437.