### PR TITLE
build: some scripts not being linted

### DIFF
--- a/scripts/caretaking/resync-caretaker-app-prs.ts
+++ b/scripts/caretaking/resync-caretaker-app-prs.ts
@@ -1,6 +1,7 @@
 import * as Octokit from '@octokit/rest';
 import * as fetch from 'node-fetch';
 
+const apiBaseUrl = 'https://test-jperrott.firebaseio.com/pulls';
 const github = new Octokit({auth: process.env.TOKEN});
 
 async function resync() {
@@ -22,7 +23,7 @@ async function resync() {
   let syncedCount = 0;
   for (let pull of pulls) {
     await fetch.default(
-      `https://test-jperrott.firebaseio.com/pulls/${pull.base.repo.full_name}/${pull.number}/github.json`,
+      `${apiBaseUrl}/${pull.base.repo.full_name}/${pull.number}/github.json`,
       {
         method: 'patch',
         body: JSON.stringify({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,8 @@
     "e2e/**/*.ts",
     "test/**/*.ts",
     "tools/**/*.ts",
-    "integration/**/*.ts"
+    "integration/**/*.ts",
+    "scripts/**/*.ts"
   ],
   "exclude": [
     // Exclude files that depend on Node APIs because those depend on the Node types and therefore


### PR DESCRIPTION
The files under `./scripts` were being linted. Also fixes a lint error that got through.