### PR TITLE
build: set up caretaker note label in merge script

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -31,6 +31,7 @@ export const merge = (): MergeConfig => {
     claSignedLabel: 'cla: yes',
     mergeReadyLabel: 'merge ready',
     commitMessageFixupLabel: 'commit message fixup',
+    caretakerNoteLabel: 'caretaker note',
     labels: [
       {
         pattern: 'target: patch',

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@angular/bazel": "^10.0.0",
     "@angular/benchpress": "^0.2.0",
     "@angular/compiler-cli": "^10.0.0",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#54a5865a219e89202d6ca128775e6a2489b9dac1",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#0d806013f9c76bfae91d648fb69fc3cb2bf08758",
     "@angular/platform-browser-dynamic": "^10.0.0",
     "@angular/platform-server": "^10.0.0",
     "@angular/router": "^10.0.0",
@@ -171,8 +171,7 @@
     "typescript-3.7": "npm:typescript@~3.7.0",
     "typescript-3.8": "npm:typescript@~3.8.0",
     "vrsource-tslint-rules": "5.1.1",
-    "yaml": "^1.10.0",
-    "yargs": "15.3.0"
+    "yaml": "^1.10.0"
   },
   "resolutions": {
     "dgeni-packages/typescript": "3.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,7 +48,7 @@
     shelljs "0.8.2"
     tsickle "^0.38.0"
 
-"@angular/benchpress@^0.2.0":
+"@angular/benchpress@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@angular/benchpress/-/benchpress-0.2.0.tgz#964d9b474317fed425eec11eb724b8e3b7d6d73b"
   integrity sha512-m+RwR5NGQ7yP8oVk2RPJHKjJHCXK+2kmm8Ow0Z98elO2svT4Azbweo71zBgz3bikVEdSC8zYtx8fi8+pap5Sqg==
@@ -60,6 +60,14 @@
     q "^1.5.1"
     reflect-metadata "^0.1.2"
     selenium-webdriver "^2.53.3"
+
+"@angular/benchpress@^0.2.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@angular/benchpress/-/benchpress-0.2.1.tgz#f8b58d9acfda0d29959b87dcb8082b1c33735db5"
+  integrity sha512-ojHCP96ZunHBZpt08USSEdLJsuXnEEdJtfzl+9oTdMXbooKkzSVO7N6bVdjefbGRNAleAuSAo3gVrdPqumLznA==
+  dependencies:
+    "@angular/core" "^10.0.0-0 || ^11.0.0"
+    reflect-metadata "^0.1.13"
 
 "@angular/common@^10.0.0":
   version "10.0.0"
@@ -101,17 +109,17 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/core@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-10.0.0.tgz#b199450576f8acc0549d2836cfa04294fa3a585e"
-  integrity sha512-N1m6op428ktgcsnXqqspb1xGZ9gp664Jmb4JoVajCD3JXucRfidw+vt3kPOldbWA6M4pIu5ZtZY3IZc2GrK5UQ==
+"@angular/core@^10.0.0", "@angular/core@^10.0.0-0 || ^11.0.0":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-10.0.2.tgz#d2d2c2dd4a9e80dcccc63c274f13ab7397ee5a3b"
+  integrity sha512-r4M1D2NOdkmmFyvYLHRYSIBKTGNXQarZHDZcm5oEq2eTsRVe2u9MYIeOpHKeVQCQK7XKQVB13IZQP3XpUvljFg==
   dependencies:
     tslib "^2.0.0"
 
 "@angular/core@^9.0.0":
-  version "9.1.9"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-9.1.9.tgz#db4241f867d6e14b81ed6e7c50334813c6ebfc10"
-  integrity sha512-q/DERgVU6vK2LtTcdVCGGBcoO424WsEfImh3Vcuy+P/ZVmthlDUC/+q+tSKt8MMf4hLpxFDQJE8vUSkktj7QEw==
+  version "9.1.11"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-9.1.11.tgz#7a92d27292212ed381be15f9000d4019867f1c7c"
+  integrity sha512-KAlEedBo761O1aeoTJVziOSHi8Fttk9ipvbDZXYT/o0W/KdVwubxP34g9t5aD8LCcF8+L0z4VLw++HjdJAUpwg==
 
 "@angular/core@~8.2.14":
   version "8.2.14"
@@ -120,11 +128,13 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#54a5865a219e89202d6ca128775e6a2489b9dac1":
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#0d806013f9c76bfae91d648fb69fc3cb2bf08758":
   version "0.0.0"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#54a5865a219e89202d6ca128775e6a2489b9dac1"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#0d806013f9c76bfae91d648fb69fc3cb2bf08758"
   dependencies:
+    "@angular/benchpress" "0.2.0"
     "@octokit/graphql" "^4.3.1"
+    brotli "^1.3.2"
     chalk "^2.3.1"
     cli-progress "^3.7.0"
     glob "7.1.2"
@@ -134,6 +144,7 @@
     node-uuid "1.4.8"
     semver "^6.3.0"
     shelljs "^0.8.3"
+    tslib "^2.0.0"
     typed-graphqlify "^2.3.0"
     yaml "^1.7.2"
     yargs "15.3.0"
@@ -2289,7 +2300,7 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
-base64-js@^1.2.3:
+base64-js@^1.1.2, base64-js@^1.2.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
@@ -2492,6 +2503,13 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+brotli@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.2.tgz#525a9cad4fcba96475d7d388f6aecb13eed52f46"
+  integrity sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=
+  dependencies:
+    base64-js "^1.1.2"
 
 browser-sync-client@^2.26.6:
   version "2.26.6"
@@ -9898,7 +9916,7 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
-reflect-metadata@^0.1.2:
+reflect-metadata@^0.1.13, reflect-metadata@^0.1.2:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==


### PR DESCRIPTION
Updates to the latest version of the dev-infra package, so
that we could leverage the new caretaker note label prompt.

The script will prompt/warn the caretaker if a note is
set up. This should help with raising awareness for
special attention required by the caretaker.