### PR TITLE
build: bazel_build CI check to also build docs-content and examples-highlighted

### DIFF
--- a/src/components-examples/BUILD.bazel
+++ b/src/components-examples/BUILD.bazel
@@ -75,7 +75,6 @@ filegroup(
 highlight_files(
     name = "examples-highlighted",
     srcs = [":example-source-files"],
-    tags = ["docs-package"],
 )
 
 package_docs_content(
@@ -102,7 +101,6 @@ package_docs_content(
         # in the docs-content. Hence there is no target section name.
         ":examples-highlighted": "",
     },
-    tags = ["docs-package"],
 )
 
 ng_package(


### PR DESCRIPTION
Syntax/spelling errors when adding comments to components examples to mark out regions aren't caught until after the PR is merged. 
To build `examples-highlighted` and `docs-content` on CI the `docs-package` tag has to be removed as `build_bazel` filters them out.