### PR TITLE
refactor(material/menu): explicitly set aria-expanded to true/false

### DIFF
--- a/src/material/legacy-menu/menu.spec.ts
+++ b/src/material/legacy-menu/menu.spec.ts
@@ -879,7 +879,7 @@ describe('MatMenu', () => {
     fixture.detectChanges();
     const triggerEl = fixture.componentInstance.triggerEl.nativeElement;
 
-    expect(triggerEl.hasAttribute('aria-expanded')).toBe(false);
+    expect(triggerEl.getAttribute('aria-expanded')).toBe('false');
 
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
@@ -891,7 +891,7 @@ describe('MatMenu', () => {
     fixture.detectChanges();
     tick(500);
 
-    expect(triggerEl.hasAttribute('aria-expanded')).toBe(false);
+    expect(triggerEl.getAttribute('aria-expanded')).toBe('false');
   }));
 
   it('should throw if assigning a menu that contains the trigger', fakeAsync(() => {

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -78,7 +78,7 @@ export const MENU_PANEL_TOP_PADDING = 8;
 @Directive({
   host: {
     '[attr.aria-haspopup]': 'menu ? "menu" : null',
-    '[attr.aria-expanded]': 'menuOpen || null',
+    '[attr.aria-expanded]': 'menuOpen',
     '[attr.aria-controls]': 'menuOpen ? menu.panelId : null',
     '(click)': '_handleClick($event)',
     '(mousedown)': '_handleMousedown($event)',

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -882,7 +882,7 @@ describe('MDC-based MatMenu', () => {
     fixture.detectChanges();
     const triggerEl = fixture.componentInstance.triggerEl.nativeElement;
 
-    expect(triggerEl.hasAttribute('aria-expanded')).toBe(false);
+    expect(triggerEl.getAttribute('aria-expanded')).toBe('false');
 
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
@@ -894,7 +894,7 @@ describe('MDC-based MatMenu', () => {
     fixture.detectChanges();
     tick(500);
 
-    expect(triggerEl.hasAttribute('aria-expanded')).toBe(false);
+    expect(triggerEl.getAttribute('aria-expanded')).toBe('false');
   }));
 
   it('should throw if assigning a menu that contains the trigger', fakeAsync(() => {


### PR DESCRIPTION
In the context of a submenu trigger it is useful for a screen reader user to
know whether a submenu is open or closed. By specifying the
`aria-expanded` attribute as either true or false it provides an
additional "collapsed" announcement to the user informing them of the
state of the menu trigger when closed.