### PR TITLE
build: switch to chromium provided in dev-infra package

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,7 +88,10 @@ web_test_repositories()
 load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
 
 browser_repositories(
-    chromium = True,
+    # Chrome is brought in by `@npm_dev_infra_private` for better version control and
+    # RBE experience where individual browser archives per platform are provided.
+    # TODO: Do the same for Firefox (but it is not used for local development): DEV-114
+    chromium = False,
     firefox = True,
 )
 

--- a/scripts/run-component-tests.js
+++ b/scripts/run-component-tests.js
@@ -61,7 +61,7 @@ if (local && (components.length > 1 || all)) {
   process.exit(1);
 }
 
-const browserName = firefox ? 'firefox-local' : 'chromium-local';
+const browserName = firefox ? 'firefox-local' : 'chromium';
 const bazelBinary = `yarn -s ${watch ? 'ibazel' : 'bazel'}`;
 const configFlag = viewEngine ? '--config=view-engine' : '';
 

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -159,6 +159,16 @@ def karma_web_test_suite(name, **kwargs):
     kwargs["srcs"] = ["@npm//:node_modules/tslib/tslib.js"] + getAngularUmdTargets() + kwargs.get("srcs", [])
     kwargs["deps"] = ["//tools/rxjs:rxjs_umd_modules"] + kwargs.get("deps", [])
 
+    # Set up default browsers if no explicit `browsers` have been specified.
+    if not hasattr(kwargs, "browsers"):
+        kwargs["tags"] = ["native"] + kwargs.get("tags", [])
+        kwargs["browsers"] = [
+            # Note: when changing the browser names here, also update the "yarn test"
+            # script to reflect the new browser names.
+            "@npm_angular_dev_infra_private//browsers:chromium",
+            "@io_bazel_rules_webtesting//browsers:firefox-local",
+        ]
+
     for opt_name in kwargs.keys():
         # Filter out options which are specific to "karma_web_test" targets. We cannot
         # pass options like "browsers" to the local web test target.
@@ -194,10 +204,11 @@ def karma_web_test_suite(name, **kwargs):
 def protractor_web_test_suite(flaky = True, **kwargs):
     _protractor_web_test_suite(
         flaky = flaky,
+        browsers = ["@npm_angular_dev_infra_private//browsers:chromium"],
         **kwargs
     )
 
-def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], tags = [], **kwargs):
+def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], **kwargs):
     # Always include a prebuilt theme in the test suite because otherwise tests, which depend on CSS
     # that is needed for measuring, will unexpectedly fail. Also always adding a prebuilt theme
     # reduces the amount of setup that is needed to create a test suite Bazel target. Note that the
@@ -241,12 +252,6 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], tags = [], **k
         deps = [
             "//test:angular_test_init",
         ] + deps,
-        browsers = [
-            # Note: when changing the browser names here, also update the "yarn test"
-            # script to reflect the new browser names.
-            "@io_bazel_rules_webtesting//browsers:chromium-local",
-            "@io_bazel_rules_webtesting//browsers:firefox-local",
-        ],
         bootstrap = [
             # This matches the ZoneJS bundles used in default CLI projects. See:
             # https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/application/files/src/polyfills.ts.template#L58
@@ -260,6 +265,5 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], tags = [], **k
             "@npm//:node_modules/zone.js/dist/zone-testing.js",
             "@npm//:node_modules/reflect-metadata/Reflect.js",
         ] + bootstrap,
-        tags = ["native"] + tags,
         **kwargs
     )


### PR DESCRIPTION
This is a duplicate of #19565 that has been accidentally
reverted as a patch-only PR has been merged into `master`.

See: https://github.com/angular/components/commit/d15f19edb2757050b851b3822bc37e51d135143b