### PR TITLE
chore: change examples codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -131,7 +131,7 @@
 
 # Docs examples & guides
 /guides/**                                         @jelbourn
-/src/components-examples/**                        @andrewjs
+/src/components-examples/**                        @andrewseguin
 
 # Dev-app
 /src/dev-app/*                                     @jelbourn

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -131,7 +131,7 @@
 
 # Docs examples & guides
 /guides/**                                         @jelbourn
-/src/components-examples/**                        @jelbourn
+/src/components-examples/**                        @andrewjs
 
 # Dev-app
 /src/dev-app/*                                     @jelbourn


### PR DESCRIPTION
Changing codeowner for components-examples/ to @andrewseguin to delegate
some reviews