### PR TITLE
perf(table): Reduce calls to updateStickyColumnStyles

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -376,6 +376,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     // this setter will be invoked before the row outlet has been defined hence the null check.
     if (this._rowOutlet && this._rowOutlet.viewContainer.length) {
       this._forceRenderDataRows();
+      this.updateStickyColumnStyles();
     }
   }
   _multiTemplateDataRows: boolean = false;
@@ -459,24 +460,28 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     }
 
     // Render updates if the list of columns have been changed for the header, row, or footer defs.
-    this._renderUpdatedColumns();
+    let forced = this._renderUpdatedColumns();
 
     // If the header row definition has been changed, trigger a render to the header row.
     if (this._headerRowDefChanged) {
       this._forceRenderHeaderRows();
       this._headerRowDefChanged = false;
+      forced = true;
     }
 
     // If the footer row definition has been changed, trigger a render to the footer row.
     if (this._footerRowDefChanged) {
       this._forceRenderFooterRows();
       this._footerRowDefChanged = false;
+      forced = true;
     }
 
     // If there is a data source and row definitions, connect to the data source unless a
     // connection has already been made.
     if (this.dataSource && this._rowDefs.length > 0 && !this._renderChangeSubscription) {
       this._observeRenderChanges();
+    } else if (forced) {
+      this.updateStickyColumnStyles();
     }
 
     this._checkStickyStates();
@@ -785,20 +790,26 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
    */
   private _renderUpdatedColumns() {
     const columnsDiffReducer = (acc: boolean, def: BaseRowDef) => acc || !!def.getColumnsDiff();
+    let forced = false;
 
     // Force re-render data rows if the list of column definitions have changed.
     if (this._rowDefs.reduce(columnsDiffReducer, false)) {
       this._forceRenderDataRows();
+      forced = true;
     }
 
     // Force re-render header/footer rows if the list of column definitions have changed..
     if (this._headerRowDefs.reduce(columnsDiffReducer, false)) {
       this._forceRenderHeaderRows();
+      forced = true;
     }
 
     if (this._footerRowDefs.reduce(columnsDiffReducer, false)) {
       this._forceRenderFooterRows();
+      forced = true;
     }
+
+    return forced;
   }
 
   /**
@@ -868,7 +879,6 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
 
     this._headerRowDefs.forEach((def, i) => this._renderRow(this._headerRowOutlet, def, i));
     this.updateStickyHeaderRowStyles();
-    this.updateStickyColumnStyles();
   }
   /**
    * Clears any existing content in the footer row outlet and creates a new embedded view
@@ -882,7 +892,6 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
 
     this._footerRowDefs.forEach((def, i) => this._renderRow(this._footerRowOutlet, def, i));
     this.updateStickyFooterRowStyles();
-    this.updateStickyColumnStyles();
   }
 
   /** Adds the sticky column styles for the rows according to the columns' stick states. */
@@ -1042,7 +1051,6 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     this._dataDiffer.diff([]);
     this._rowOutlet.viewContainer.clear();
     this.renderRows();
-    this.updateStickyColumnStyles();
   }
 
   /**


### PR DESCRIPTION
Tested with the dev app, clicking "add table" in the "Table with sticky headers, footers and columns" example.

Before:
![image](https://user-images.githubusercontent.com/923677/85492960-06b4d600-b5a4-11ea-8df5-2b2b12441abf.png)
100ms scripting + 59ms rendering

After:
![image](https://user-images.githubusercontent.com/923677/85493056-3368ed80-b5a4-11ea-9663-d65e01f1f13c.png)
75ms scripting + 39ms rendering

The effect is greater in more complex tables. More optimization PRs to come.