### PR TITLE
docs(buttons): fix overflow on mobile (#19741)

### DIFF
--- a/src/components-examples/material/button/button-overview/button-overview-example.css
+++ b/src/components-examples/material/button/button-overview/button-overview-example.css
@@ -1,28 +1,27 @@
 section {
   display: table;
-  margin: 8px;
 }
 
 .example-label {
   display: table-cell;
   font-size: 14px;
   margin-left: 8px;
-  width: 120px;
+  min-width: 120px;
 }
 
 .example-button-row {
   display: table-cell;
+  width: 490px;
 }
 
-.example-button-row button {
-  display: table-cell;
-  margin-right: 8px;
+.example-button-row .mat-button-base {
+  margin: 8px 8px 8px 0;
 }
 
 .example-flex-container {
   display: flex;
   justify-content: space-between;
-  width: 480px;
+  flex-wrap: wrap;
 }
 
 .example-button-container {


### PR DESCRIPTION
* Resolves #19741 

![image](https://user-images.githubusercontent.com/18009315/85566749-4f997880-b5fe-11ea-93c9-f46d13567d74.png)
![image](https://user-images.githubusercontent.com/18009315/85566863-68a22980-b5fe-11ea-9a21-11366cb20623.png)
