### PR TITLE
feat(youtube-player): support passing in the playerVars parameter

### DIFF
--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -49,6 +49,7 @@ describe('YoutubePlayer', () => {
           videoId: VIDEO_ID,
           width: DEFAULT_PLAYER_WIDTH,
           height: DEFAULT_PLAYER_HEIGHT,
+          playerVars: undefined
         }));
     });
 
@@ -129,6 +130,21 @@ describe('YoutubePlayer', () => {
       expect(playerSpy.setSize).toHaveBeenCalledWith(DEFAULT_PLAYER_WIDTH, DEFAULT_PLAYER_HEIGHT);
       expect(testComponent.youtubePlayer.width).toBe(DEFAULT_PLAYER_WIDTH);
       expect(testComponent.youtubePlayer.height).toBe(DEFAULT_PLAYER_HEIGHT);
+    });
+
+    it('passes the configured playerVars to the player', () => {
+      const playerVars: YT.PlayerVars = { modestbranding: YT.ModestBranding.Modest };
+      fixture.componentInstance.playerVars = playerVars;
+      fixture.detectChanges();
+
+      events.onReady({target: playerSpy});
+      const calls = playerCtorSpy.calls.all();
+
+      // We expect 2 calls since the first one is run on init and the
+      // second one happens after the `playerVars` have changed.
+      expect(calls.length).toBe(2);
+      expect(calls[0].args[1]).toEqual(jasmine.objectContaining({playerVars: undefined}));
+      expect(calls[1].args[1]).toEqual(jasmine.objectContaining({playerVars}));
     });
 
     it('initializes the player with start and end seconds', () => {
@@ -462,6 +478,7 @@ describe('YoutubePlayer', () => {
   template: `
     <youtube-player #player [videoId]="videoId" *ngIf="visible" [width]="width" [height]="height"
       [startSeconds]="startSeconds" [endSeconds]="endSeconds" [suggestedQuality]="suggestedQuality"
+      [playerVars]="playerVars"
       (ready)="onReady($event)"
       (stateChange)="onStateChange($event)"
       (playbackQualityChange)="onPlaybackQualityChange($event)"
@@ -479,6 +496,7 @@ class TestApp {
   startSeconds: number | undefined;
   endSeconds: number | undefined;
   suggestedQuality: YT.SuggestedVideoQuality | undefined;
+  playerVars: YT.PlayerVars | undefined;
   onReady = jasmine.createSpy('onReady');
   onStateChange = jasmine.createSpy('onStateChange');
   onPlaybackQualityChange = jasmine.createSpy('onPlaybackQualityChange');

--- a/tools/public_api_guard/youtube-player/youtube-player.d.ts
+++ b/tools/public_api_guard/youtube-player/youtube-player.d.ts
@@ -6,6 +6,8 @@ export declare class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     set height(height: number | undefined);
     playbackQualityChange: Observable<YT.OnPlaybackQualityChangeEvent>;
     playbackRateChange: Observable<YT.OnPlaybackRateChangeEvent>;
+    get playerVars(): YT.PlayerVars | undefined;
+    set playerVars(playerVars: YT.PlayerVars | undefined);
     ready: Observable<YT.PlayerEvent>;
     showBeforeIframeApiLoads: boolean | undefined;
     set startSeconds(startSeconds: number | undefined);
@@ -41,7 +43,7 @@ export declare class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     setVolume(volume: number): void;
     stopVideo(): void;
     unMute(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<YouTubePlayer, "youtube-player", never, { "videoId": "videoId"; "height": "height"; "width": "width"; "startSeconds": "startSeconds"; "endSeconds": "endSeconds"; "suggestedQuality": "suggestedQuality"; "showBeforeIframeApiLoads": "showBeforeIframeApiLoads"; }, { "ready": "ready"; "stateChange": "stateChange"; "error": "error"; "apiChange": "apiChange"; "playbackQualityChange": "playbackQualityChange"; "playbackRateChange": "playbackRateChange"; }, never, never>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<YouTubePlayer, "youtube-player", never, { "videoId": "videoId"; "height": "height"; "width": "width"; "startSeconds": "startSeconds"; "endSeconds": "endSeconds"; "suggestedQuality": "suggestedQuality"; "playerVars": "playerVars"; "showBeforeIframeApiLoads": "showBeforeIframeApiLoads"; }, { "ready": "ready"; "stateChange": "stateChange"; "error": "error"; "apiChange": "apiChange"; "playbackQualityChange": "playbackQualityChange"; "playbackRateChange": "playbackRateChange"; }, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<YouTubePlayer, never>;
 }
 


### PR DESCRIPTION
We tried doing this before in #17672, but we never managed to wrap it up. These changes add support for passing in the `playerVars` parameter to the YouTube API which has some settings like autoplay and hiding the video controls.

**Note:** I'm setting it to P2, because it's something that we should've supported from the beginning and it comes up in issues once in a while.

Fixes #19267.