### PR TITLE
fix(datepicker): label state not being updated in some cases

### DIFF
--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -527,6 +527,21 @@ describe('MatDateRangeInput', () => {
     expect(fixture.componentInstance.rangeInput.placeholder).toBe('Start date – End date');
   });
 
+  it('should emit to the stateChanges stream when typing a value into an input', () => {
+    const fixture = createComponent(StandardRangePicker);
+    fixture.detectChanges();
+    const {start, rangeInput} = fixture.componentInstance;
+    const spy = jasmine.createSpy('stateChanges spy');
+    const subscription = rangeInput.stateChanges.subscribe(spy);
+
+    start.nativeElement.value = '10/10/2020';
+    dispatchFakeEvent(start.nativeElement, 'input');
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
+
 });
 
 @Component({

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -291,6 +291,7 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
 
   /** Handles the value in one of the child inputs changing. */
   _handleChildValueChange() {
+    this.stateChanges.next();
     this._changeDetectorRef.markForCheck();
   }
 


### PR DESCRIPTION
The date range input wasn't emitting to its `stateChanges` stream when typing in the sub-inputs which meant that in some cases the view state was out of sync. These changes add an extra call to ensure that everything is synced up.

The issue manifests itself in one of the live examples:
![demo](https://user-images.githubusercontent.com/4450522/85766204-199be780-b717-11ea-90ba-d476ead7908d.gif)
