### PR TITLE
fix(material/chips): don't stop propagation on all click events

### DIFF
--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -378,8 +378,6 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   _handleClick(event: Event) {
     if (this.disabled) {
       event.preventDefault();
-    } else {
-      event.stopPropagation();
     }
   }
 


### PR DESCRIPTION
Historically we've had to stop propagation on clicks so that clicking on a chip won't move focus to the first chip once the event bubbles up to the list. This isn't necessary as of #12856 which changes how we detect clicks from inside a chip. These changes remove the call since it can prevent people's global click listeners from firing.

Fixes #19759.