### PR TITLE
refactor(cdk-experimental/menu): change from submenu to menu naming

### DIFF
--- a/src/cdk-experimental/menu/menu-bar.ts
+++ b/src/cdk-experimental/menu/menu-bar.ts
@@ -30,7 +30,7 @@ import {CDK_MENU, Menu} from './menu-interface';
 })
 export class CdkMenuBar extends CdkMenuGroup implements Menu {
   /**
-   * Sets the aria-orientation attribute and determines where sub-menus will be opened.
+   * Sets the aria-orientation attribute and determines where menus will be opened.
    * Does not affect styling/layout.
    */
   @Input('cdkMenuBarOrientation') orientation: 'horizontal' | 'vertical' = 'horizontal';

--- a/src/cdk-experimental/menu/menu-item-checkbox.spec.ts
+++ b/src/cdk-experimental/menu/menu-item-checkbox.spec.ts
@@ -43,8 +43,8 @@ describe('MenuItemCheckbox', () => {
     expect(checkboxElement.getAttribute('type')).toBe('button');
   });
 
-  it('should not have a submenu', () => {
-    expect(checkbox.hasSubmenu()).toBeFalse();
+  it('should not have a menu', () => {
+    expect(checkbox.hasMenu()).toBeFalse();
   });
 
   it('should toggle the aria checked attribute', () => {

--- a/src/cdk-experimental/menu/menu-item-radio.spec.ts
+++ b/src/cdk-experimental/menu/menu-item-radio.spec.ts
@@ -56,8 +56,8 @@ describe('MenuItemRadio', () => {
     expect(radioElement.getAttribute('type')).toBe('button');
   });
 
-  it('should not have a submenu', () => {
-    expect(radioButton.hasSubmenu()).toBeFalse();
+  it('should not have a menu', () => {
+    expect(radioButton.hasMenu()).toBeFalse();
   });
 
   it('should not toggle checked state when disabled', () => {

--- a/src/cdk-experimental/menu/menu-item-trigger.spec.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.spec.ts
@@ -49,8 +49,8 @@ describe('MenuItemTrigger', () => {
       expect(menuItemElement.getAttribute('type')).toBe('button');
     });
 
-    it('should  have a submenu', () => {
-      expect(menuItem.hasSubmenu()).toBeTrue();
+    it('should  have a menu', () => {
+      expect(menuItem.hasMenu()).toBeTrue();
     });
   });
 
@@ -108,11 +108,11 @@ describe('MenuItemTrigger', () => {
       expect(nativeTriggers[0].getAttribute('aria-expanded')).toEqual('false');
     });
 
-    it('should hide sub-menus on initial load', () => {
+    it('should hide menus on initial load', () => {
       expect(menus.length).toEqual(0);
     });
 
-    it('should only open the attached submenu', () => {
+    it('should only open the attached menu', () => {
       triggers[0].toggle();
       detectChanges();
 
@@ -120,7 +120,7 @@ describe('MenuItemTrigger', () => {
       expect(menus[0] as Menu).toEqual(triggers[0]._menuPanel!._menu!);
     });
 
-    it('should not open the submenu when menu item disabled', () => {
+    it('should not open the menu when menu item disabled', () => {
       menuItems[0].disabled = true;
 
       menuItems[0].trigger();
@@ -129,7 +129,7 @@ describe('MenuItemTrigger', () => {
       expect(menus.length).toBe(0);
     });
 
-    it('should toggle the attached submenu', () => {
+    it('should toggle the attached menu', () => {
       triggers[0].toggle();
       detectChanges();
       expect(menus.length).toEqual(1);
@@ -149,7 +149,7 @@ describe('MenuItemTrigger', () => {
       expect(menus.length).toEqual(2);
     });
 
-    it('should close all sub-menus when root menu is closed', () => {
+    it('should close all menus when root menu is closed', () => {
       triggers[0].toggle();
       detectChanges();
       triggers[1].toggle();
@@ -178,7 +178,7 @@ describe('MenuItemTrigger', () => {
       expect(triggers[0]._menuPanel!._menu).toEqual(menus[0]);
     });
 
-    it('should emit request to open event on submenu open', () => {
+    it('should emit request to open event on menu open', () => {
       const triggerSpy = jasmine.createSpy('cdkMenuItem open request emitter');
       triggers[0].opened.subscribe(triggerSpy);
 
@@ -187,7 +187,7 @@ describe('MenuItemTrigger', () => {
       expect(triggerSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should emit request to close event on submenu close', () => {
+    it('should emit request to close event on menu close', () => {
       const triggerSpy = jasmine.createSpy('cdkMeuItem close request emitter');
       const closedSpy = jasmine.createSpy('cdkMenu closed emitter');
       triggers[0].closed.subscribe(triggerSpy);

--- a/src/cdk-experimental/menu/menu-item-trigger.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.ts
@@ -42,20 +42,20 @@ import {Menu, CDK_MENU} from './menu-interface';
   exportAs: 'cdkMenuTriggerFor',
   host: {
     'aria-haspopup': 'menu',
-    '[attr.aria-expanded]': 'isSubmenuOpen()',
+    '[attr.aria-expanded]': 'isMenuOpen()',
   },
 })
 export class CdkMenuItemTrigger implements OnDestroy {
   /** Template reference variable to the menu this trigger opens */
   @Input('cdkMenuTriggerFor') _menuPanel?: CdkMenuPanel;
 
-  /** Emits when the attached submenu is requested to open */
+  /** Emits when the attached menu is requested to open */
   @Output('cdkMenuOpened') readonly opened: EventEmitter<void> = new EventEmitter();
 
-  /** Emits when the attached submenu is requested to close  */
+  /** Emits when the attached menu is requested to close */
   @Output('cdkMenuClosed') readonly closed: EventEmitter<void> = new EventEmitter();
 
-  /** A reference to the overlay which manages the triggered submenu */
+  /** A reference to the overlay which manages the triggered menu */
   private _overlayRef: OverlayRef | null = null;
 
   /** The content of the menu panel opened by this trigger. */
@@ -69,34 +69,34 @@ export class CdkMenuItemTrigger implements OnDestroy {
     @Inject(CDK_MENU) private readonly _parentMenu: Menu
   ) {}
 
-  /** Open/close the attached submenu if the trigger has been configured with one */
+  /** Open/close the attached menu if the trigger has been configured with one */
   toggle() {
-    if (this.hasSubmenu()) {
-      this.isSubmenuOpen() ? this._closeSubmenu() : this._openSubmenu();
+    if (this.hasMenu()) {
+      this.isMenuOpen() ? this._closeMenu() : this._openMenu();
     }
   }
 
   /** Return true if the trigger has an attached menu */
-  hasSubmenu() {
+  hasMenu() {
     return !!this._menuPanel;
   }
 
-  /** Whether the submenu this button is a trigger for is open */
-  isSubmenuOpen() {
+  /** Whether the menu this button is a trigger for is open */
+  isMenuOpen() {
     return this._overlayRef ? this._overlayRef.hasAttached() : false;
   }
 
-  /** Open the attached submenu */
-  private _openSubmenu() {
+  /** Open the attached menu */
+  private _openMenu() {
     this.opened.next();
 
     this._overlayRef = this._overlay.create(this._getOverlayConfig());
     this._overlayRef.attach(this._getPortal());
   }
 
-  /** Close the opened submenu */
-  private _closeSubmenu() {
-    if (this.isSubmenuOpen()) {
+  /** Close the opened menu */
+  private _closeMenu() {
+    if (this.isMenuOpen()) {
       this.closed.next();
 
       this._overlayRef!.detach();
@@ -112,7 +112,7 @@ export class CdkMenuItemTrigger implements OnDestroy {
     });
   }
 
-  /** Build the position strategy for the overlay which specifies where to place the submenu */
+  /** Build the position strategy for the overlay which specifies where to place the menu */
   private _getOverlayPositionStrategy(): FlexibleConnectedPositionStrategy {
     return this._overlay
       .position()
@@ -120,7 +120,7 @@ export class CdkMenuItemTrigger implements OnDestroy {
       .withPositions(this._getOverlayPositions());
   }
 
-  /** Determine and return where to position the submenu relative to the menu item */
+  /** Determine and return where to position the opened menu relative to the menu item */
   private _getOverlayPositions(): ConnectedPosition[] {
     // TODO: use a common positioning config from (possibly) cdk/overlay
     return this._parentMenu.orientation === 'horizontal'

--- a/src/cdk-experimental/menu/menu-item.spec.ts
+++ b/src/cdk-experimental/menu/menu-item.spec.ts
@@ -51,8 +51,8 @@ describe('MenuItem', () => {
     expect(nativeButton.getAttribute('type')).toBe('button');
   });
 
-  it('should not have a submenu', () => {
-    expect(button.hasSubmenu()).toBeFalse();
+  it('should not have a menu', () => {
+    expect(button.hasMenu()).toBeFalse();
   });
 });
 

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -40,16 +40,16 @@ export class CdkMenuItem {
     @Self() @Optional() private readonly _menuTrigger?: CdkMenuItemTrigger
   ) {}
 
-  /** Open the submenu if one is attached */
+  /** Open the menu if one is attached */
   trigger() {
-    if (!this.disabled && this.hasSubmenu()) {
+    if (!this.disabled && this.hasMenu()) {
       this._menuTrigger!.toggle();
     }
   }
 
   /** Whether the menu item opens a menu. */
-  hasSubmenu() {
-    return !!this._menuTrigger && this._menuTrigger.hasSubmenu();
+  hasMenu() {
+    return !!this._menuTrigger && this._menuTrigger.hasMenu();
   }
 
   static ngAcceptInputType_disabled: BooleanInput;

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -44,7 +44,7 @@ import {throwMissingMenuPanelError} from './menu-errors';
 })
 export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnDestroy {
   /**
-   * Sets the aria-orientation attribute and determines where sub-menus will be opened.
+   * Sets the aria-orientation attribute and determines where menus will be opened.
    * Does not affect styling/layout.
    */
   @Input('cdkMenuOrientation') orientation: 'horizontal' | 'vertical' = 'vertical';


### PR DESCRIPTION
A menu may be a top level menu or a nested menu (submenu) however in the context of a menu item and
menu trigger it is just a menu. This changes the naming scheme to reflect the fact that a menu is
separate from where it opens.