### PR TITLE
feat(cdk-experimental/menu): add ability to close menus when clicking outside the menu tree

### DIFF
--- a/src/cdk-experimental/menu/BUILD.bazel
+++ b/src/cdk-experimental/menu/BUILD.bazel
@@ -14,6 +14,7 @@ ng_module(
         "//src/cdk/coercion",
         "//src/cdk/collections",
         "//src/cdk/overlay",
+        "//src/cdk/platform",
         "@npm//@angular/core",
         "@npm//rxjs",
     ],

--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -1,9 +1,12 @@
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
-import {Component} from '@angular/core';
+import {Component, ViewChildren, QueryList} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {CdkMenuBar} from './menu-bar';
 import {CdkMenuModule} from './menu-module';
 import {CdkMenuItemRadio} from './menu-item-radio';
+import {CdkMenu} from './menu';
+import {CdkMenuItemTrigger} from './menu-item-trigger';
+import {CdkMenuGroup} from './menu-group';
 
 describe('MenuBar', () => {
   describe('as radio group', () => {
@@ -67,6 +70,78 @@ describe('MenuBar', () => {
       expect(spy).toHaveBeenCalledWith(menuItems[0]);
     });
   });
+
+  describe('with submenu', () => {
+    let fixture: ComponentFixture<MenuBarWithMenus>;
+
+    let menus: CdkMenu[];
+    let triggers: CdkMenuItemTrigger[];
+
+    /** open the attached menu */
+    const openMenu = () => {
+      triggers[0].toggle();
+      detectChanges();
+    };
+
+    const grabElementsForTesting = () => {
+      menus = fixture.componentInstance.menus.toArray();
+      triggers = fixture.componentInstance.triggers.toArray();
+    };
+
+    /** run change detection and, extract and set the rendered elements */
+    const detectChanges = () => {
+      fixture.detectChanges();
+      grabElementsForTesting();
+    };
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuBarWithMenus],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MenuBarWithMenus);
+      detectChanges();
+    });
+
+    it('should close out all open menus when clicked outside the menu tree', () => {
+      openMenu();
+      expect(menus.length).toEqual(1);
+
+      fixture.debugElement.query(By.css('#container')).nativeElement.click();
+      detectChanges();
+
+      expect(menus.length).toEqual(0);
+    });
+
+    it('should not close open menus when clicking on menu or menu bar elements', () => {
+      openMenu();
+      expect(menus.length).toEqual(1);
+
+      fixture.debugElement
+        .queryAll(By.directive(CdkMenuGroup)) // Menu and MenuBar inherit from MenuGroup
+        .forEach(element => element.nativeElement.click());
+      detectChanges();
+
+      expect(menus.length)
+        .withContext('menu should stay open if clicking on any menu element')
+        .toEqual(1);
+    });
+
+    it('should not close when clicking on a non-menu element inside menu', () => {
+      openMenu();
+      expect(menus.length).toEqual(1);
+
+      fixture.debugElement.query(By.css('#inner-element')).nativeElement.click();
+      detectChanges();
+
+      expect(menus.length)
+        .withContext('menu should stay open if clicking on an inner span element')
+        .toEqual(1);
+    });
+  });
 });
 
 @Component({
@@ -86,3 +161,23 @@ describe('MenuBar', () => {
   `,
 })
 class MenuBarRadioGroup {}
+
+@Component({
+  template: `
+    <div id="container">
+      <div cdkMenuBar>
+        <button cdkMenuItem [cdkMenuTriggerFor]="sub1">Trigger</button>
+      </div>
+
+      <ng-template cdkMenuPanel #sub1="cdkMenuPanel">
+        <div cdkMenu [cdkMenuPanel]="sub1">
+          <span id="inner-element">A nested non-menuitem element</span>
+        </div>
+      </ng-template>
+    </div>
+  `,
+})
+class MenuBarWithMenus {
+  @ViewChildren(CdkMenu) menus: QueryList<CdkMenu>;
+  @ViewChildren(CdkMenuItemTrigger) triggers: QueryList<CdkMenuItemTrigger>;
+}

--- a/src/cdk-experimental/menu/menu-bar.ts
+++ b/src/cdk-experimental/menu/menu-bar.ts
@@ -6,9 +6,25 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input} from '@angular/core';
+import {
+  Directive,
+  Input,
+  ElementRef,
+  ContentChildren,
+  QueryList,
+  AfterContentInit,
+  Inject,
+  EventEmitter,
+  OnDestroy,
+} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
+import {_getShadowRoot} from '@angular/cdk/platform';
+import {fromEvent, Observable, merge} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 import {CdkMenuGroup} from './menu-group';
 import {CDK_MENU, Menu} from './menu-interface';
+import {CdkMenuItem} from './menu-item';
+import {CloseEventCause} from './menu-item-trigger';
 
 /**
  * Directive applied to an element which configures it as a MenuBar by setting the appropriate
@@ -28,10 +44,143 @@ import {CDK_MENU, Menu} from './menu-interface';
     {provide: CDK_MENU, useExisting: CdkMenuBar},
   ],
 })
-export class CdkMenuBar extends CdkMenuGroup implements Menu {
+export class CdkMenuBar extends CdkMenuGroup implements Menu, AfterContentInit, OnDestroy {
   /**
    * Sets the aria-orientation attribute and determines where menus will be opened.
    * Does not affect styling/layout.
    */
   @Input('cdkMenuBarOrientation') orientation: 'horizontal' | 'vertical' = 'horizontal';
+
+  /** All child MenuItem elements nested in this MenuBar. */
+  @ContentChildren(CdkMenuItem, {descendants: true})
+  private readonly _allItems: QueryList<CdkMenuItem>;
+
+  /** Event emitter used to end the subscription to document click events. */
+  private readonly _destroyDocumentSubscription: EventEmitter<void> = new EventEmitter();
+
+  /** A reference to the document. */
+  private readonly _document: Document;
+
+  /** Whether the element is inside of a ShadowRoot component. */
+  private _isInsideShadowRoot: boolean;
+
+  constructor(
+    private readonly _elementRef: ElementRef<HTMLElement>,
+    @Inject(DOCUMENT) document: any
+  ) {
+    super();
+
+    this._document = document;
+  }
+
+  ngAfterContentInit() {
+    super.ngAfterContentInit();
+
+    this._configChildSubscriptions();
+  }
+
+  /**
+   * Returns true if this MenuBar, or any open Menu triggered by a MenuItem in this MenuBar,
+   * contains the given HTMLElement.
+   * @param element the element to search for.
+   */
+  _contains(element: HTMLElement) {
+    return (
+      this._elementRef.nativeElement.contains(element) ||
+      this._allItems
+        .filter(menuItem => menuItem.hasMenu() && menuItem._menuTrigger!.isMenuOpen())
+        .some(menuItem => menuItem._menuTrigger!._menuPanel!._menu!._contains(element))
+    );
+  }
+
+  /**
+   * Configure child MenuItem subscriptions and ensure that future child elements are also
+   * subscribed to.
+   */
+  private _configChildSubscriptions() {
+    this._allItems
+      .filter(menuItem => menuItem.hasMenu())
+      .forEach(menuItem => this._subscribeToTriggers(menuItem));
+
+    this._allItems.changes.subscribe((menuItems: QueryList<CdkMenuItem>) => {
+      menuItems
+        .filter(menuItem => menuItem.hasMenu())
+        .forEach(menuItem => this._subscribeToTriggers(menuItem));
+    });
+  }
+
+  /**
+   * Subscribe to the MenuItem open and close event emitters which toggle the subscription to
+   * document click events.
+   * @param menuItem the MenuItem to subscribe to.
+   */
+  private _subscribeToTriggers(menuItem: CdkMenuItem) {
+    menuItem._menuTrigger!.opened.subscribe(() => this._requestDocumentSubscription(menuItem));
+    menuItem._menuTrigger!.closed.subscribe((eventType: CloseEventCause) =>
+      this._requestDocumentSubscriptionEnd(eventType)
+    );
+  }
+
+  /**
+   * Start listening to Document click events if there is no document click event listener
+   * registered. The listener will close out the open menu when a click occurs outside the
+   * menu tree.
+   * @param menuItem the MenuItem which opened the menu.
+   */
+  private _requestDocumentSubscription(menuItem: CdkMenuItem) {
+    if (!this._isListeningToDocument()) {
+      merge(
+        fromEvent(this._document, 'click') as Observable<MouseEvent>,
+        fromEvent(this._document, 'touchend') as Observable<TouchEvent>
+      )
+        .pipe(takeUntil(this._destroyDocumentSubscription))
+        .subscribe(event => {
+          // we need to consider whether or not the outside click event occurred while the
+          // element is in the Shadow DOM when fetching the click target.
+          const clickTarget = (this._isShadowRoot() && event.composedPath
+            ? event.composedPath()[0]
+            : event.target) as HTMLElement;
+
+          if (!this._contains(clickTarget)) {
+            menuItem.trigger();
+          }
+        });
+    }
+  }
+
+  /**
+   * Stop the document click listener if one is configured.
+   * @param eventType the type of event which closed the menu.
+   */
+  private _requestDocumentSubscriptionEnd(eventType: CloseEventCause) {
+    // Since a hover from one MenuItemTrigger to another will cause the first menu to close and
+    // second menu to open we ignore hover close events in order to prevent unnecessary
+    /// re-subscriptions. We only want to unsubscribe when all menus are fully closed.
+    if (eventType !== 'hover') {
+      this._destroyDocumentSubscription.next();
+    }
+  }
+
+  /** Return true if there is an active document click listener. */
+  private _isListeningToDocument() {
+    return this._destroyDocumentSubscription.observers.length > 0;
+  }
+
+  /**
+   * Determine once whether the element is in the Shadow DOM and return the result. Note that the
+   * result is cached and will be the same on subsequent calls to this method.
+   */
+  private _isShadowRoot() {
+    if (this._isInsideShadowRoot === undefined) {
+      this._isInsideShadowRoot = !!_getShadowRoot(this._elementRef.nativeElement);
+    }
+    return this._isInsideShadowRoot;
+  }
+
+  ngOnDestroy() {
+    super.ngOnDestroy();
+
+    this._destroyDocumentSubscription.next();
+    this._destroyDocumentSubscription.complete();
+  }
 }

--- a/src/cdk-experimental/menu/menu-interface.ts
+++ b/src/cdk-experimental/menu/menu-interface.ts
@@ -15,4 +15,7 @@ export const CDK_MENU = new InjectionToken<Menu>('cdk-menu');
 export interface Menu {
   /** The orientation of the menu */
   orientation: 'horizontal' | 'vertical';
+
+  /** Whether the menu contains the given element */
+  _contains(element: HTMLElement): boolean;
 }

--- a/src/cdk-experimental/menu/menu-item-trigger.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.ts
@@ -28,6 +28,12 @@ import {
 import {CdkMenuPanel} from './menu-panel';
 import {Menu, CDK_MENU} from './menu-interface';
 
+/** Types of actions which may cause a menu to open */
+export type OpenEventCause = void | 'hover' | 'keydown' | 'click';
+
+/** Types of actions which may cause a menu to close */
+export type CloseEventCause = OpenEventCause | 'tab' | 'escape';
+
 /**
  * A directive to be combined with CdkMenuItem which opens the Menu it is bound to. If the
  * element is in a top level MenuBar it will open the menu on click, or if a sibling is already
@@ -50,10 +56,10 @@ export class CdkMenuItemTrigger implements OnDestroy {
   @Input('cdkMenuTriggerFor') _menuPanel?: CdkMenuPanel;
 
   /** Emits when the attached menu is requested to open */
-  @Output('cdkMenuOpened') readonly opened: EventEmitter<void> = new EventEmitter();
+  @Output('cdkMenuOpened') readonly opened: EventEmitter<OpenEventCause> = new EventEmitter();
 
   /** Emits when the attached menu is requested to close */
-  @Output('cdkMenuClosed') readonly closed: EventEmitter<void> = new EventEmitter();
+  @Output('cdkMenuClosed') readonly closed: EventEmitter<CloseEventCause> = new EventEmitter();
 
   /** A reference to the overlay which manages the triggered menu */
   private _overlayRef: OverlayRef | null = null;

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -37,7 +37,7 @@ export class CdkMenuItem {
 
   constructor(
     /** Reference to the CdkMenuItemTrigger directive if one is added to the same element */
-    @Self() @Optional() private readonly _menuTrigger?: CdkMenuItemTrigger
+    @Self() @Optional() readonly _menuTrigger?: CdkMenuItemTrigger
   ) {}
 
   /** Open the menu if one is attached */


### PR DESCRIPTION
Add functionality to close any open menus (and submenus) when a user clicks on an element outside
the open menu tree and the menu bar.