### PR TITLE
docs(datepicker): change input parsing format

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-formats/datepicker-formats-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-formats/datepicker-formats-example.ts
@@ -17,7 +17,7 @@ const moment = _rollupMoment || _moment;
 // https://momentjs.com/docs/#/displaying/format/
 export const MY_FORMATS = {
   parse: {
-    dateInput: 'LL',
+    dateInput: 'L',
   },
   display: {
     dateInput: 'LL',


### PR DESCRIPTION
* use the more intuitive 'L' input parsing format which allows for entering dates in 'MM/DD/YYYY' format (#19758)