### PR TITLE
docs(slide-toggle): fix typo for mat button

### DIFF
--- a/src/components-examples/material/slide-toggle/slide-toggle-forms/slide-toggle-forms-example.html
+++ b/src/components-examples/material/slide-toggle/slide-toggle-forms/slide-toggle-forms-example.html
@@ -21,5 +21,5 @@
 
   <p>Form Group Status: {{formGroup.status}}</p>
 
-  <button mat-rasied-button type="submit">Save Settings</button>
+  <button mat-raised-button type="submit">Save Settings</button>
 </form>


### PR DESCRIPTION
fixes type for Save Settings button in Slide toggle example
<img width="729" alt="Screenshot 2020-06-27 at 2 15 11 AM" src="https://user-images.githubusercontent.com/856090/85899745-2e15d800-b81c-11ea-97cf-67cc5ad89593.png">
