### PR TITLE
fix(cdk/schematics): errors when attempting to read some files

### DIFF
--- a/src/cdk/schematics/update-tool/file-system.ts
+++ b/src/cdk/schematics/update-tool/file-system.ts
@@ -52,11 +52,11 @@ export abstract class FileSystem<T = WorkspacePath> {
   /** Applies all changes which have been recorded in update recorders. */
   abstract commitEdits(): void;
   /** Creates a new file with the given content. */
-  abstract create(filePath: T, content: string);
+  abstract create(filePath: T, content: string): void;
   /** Overwrites an existing file with the given content. */
-  abstract overwrite(filePath: T, content: string);
+  abstract overwrite(filePath: T, content: string): void;
   /** Deletes the given file. */
-  abstract delete(filePath: T);
+  abstract delete(filePath: T): void;
   /**
    * Resolves given paths to a resolved path in the file system. For example, the devkit
    * tree considers the actual workspace directory as file system root.

--- a/src/cdk/schematics/update-tool/index.ts
+++ b/src/cdk/schematics/update-tool/index.ts
@@ -102,15 +102,17 @@ export class UpdateProject<Context> {
     // specified in any Angular component. Therefore we allow for additional stylesheets
     // being specified. We visit them in each migration unless they have been already
     // discovered before as actual component resource.
-    additionalStylesheetPaths.forEach(filePath => {
-      const resolvedPath = this._fileSystem.resolve(filePath);
-      const stylesheet = resourceCollector.resolveExternalStylesheet(resolvedPath, null);
-      // Do not visit stylesheets which have been referenced from a component.
-      if (!this._analyzedFiles.has(resolvedPath)) {
-        migrations.forEach(r => r.visitStylesheet(stylesheet));
-        this._analyzedFiles.add(resolvedPath);
-      }
-    });
+    if (additionalStylesheetPaths) {
+      additionalStylesheetPaths.forEach(filePath => {
+        const resolvedPath = this._fileSystem.resolve(filePath);
+        const stylesheet = resourceCollector.resolveExternalStylesheet(resolvedPath, null);
+        // Do not visit stylesheets which have been referenced from a component.
+        if (!this._analyzedFiles.has(resolvedPath) && stylesheet) {
+          migrations.forEach(r => r.visitStylesheet(stylesheet));
+          this._analyzedFiles.add(resolvedPath);
+        }
+      });
+    }
 
     // Call the "postAnalysis" method for each migration.
     migrations.forEach(r => r.postAnalysis());

--- a/src/cdk/schematics/update-tool/target-version.ts
+++ b/src/cdk/schematics/update-tool/target-version.ts
@@ -22,6 +22,7 @@ export enum TargetVersion {
  * based on the "TargetVersion" enum.
  */
 export function getAllVersionNames(): string[] {
-  return Object.keys(TargetVersion)
-      .filter(enumValue => typeof TargetVersion[enumValue] === 'string');
+  return Object.keys(TargetVersion).filter(enumValue => {
+    return typeof (TargetVersion as Record<string, string|undefined>)[enumValue] === 'string';
+  });
 }

--- a/src/cdk/schematics/update-tool/tsconfig.json
+++ b/src/cdk/schematics/update-tool/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "lib": ["es2015"],
     "types": ["node", "glob"]
   }

--- a/src/cdk/schematics/update-tool/version-changes.ts
+++ b/src/cdk/schematics/update-tool/version-changes.ts
@@ -29,15 +29,11 @@ export type ValueOfChanges<T> = T extends VersionChanges<infer X>? X : null;
  */
 export function getChangesForTarget<T>(target: TargetVersion, data: VersionChanges<T>): T[] {
   if (!data) {
-    throw new Error(
-        `No data could be found for target version: ${TargetVersion[target]}`);
+    const version = (TargetVersion as Record<string, string>)[target];
+    throw new Error(`No data could be found for target version: ${version}`);
   }
 
-  if (!data[target]) {
-    return [];
-  }
-
-  return data[target]!.reduce((result, prData) => result.concat(prData.changes), [] as T[]);
+  return (data[target] || []).reduce((result, prData) => result.concat(prData.changes), [] as T[]);
 }
 
 /**


### PR DESCRIPTION
In some cases the schematics fail to read a file which results in an error, because we weren't guarding against it properly. We had the correct types in place, but the tsconfig didn't have `strictNullChecks` enabled which prevented the compiler from reporting the errors.

Fixes #19779.