### PR TITLE
refactor(cdk/schematics): remove circular dependency

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -25,10 +25,6 @@
     "src/cdk/drag-drop/drop-list-ref.ts"
   ],
   [
-    "src/cdk/schematics/testing/index.ts",
-    "src/cdk/schematics/testing/test-case-setup.ts"
-  ],
-  [
     "src/cdk/scrolling/scroll-dispatcher.ts",
     "src/cdk/scrolling/scrollable.ts"
   ],

--- a/src/cdk/schematics/testing/test-case-setup.ts
+++ b/src/cdk/schematics/testing/test-case-setup.ts
@@ -14,7 +14,7 @@ import {readFileSync, removeSync} from 'fs-extra';
 import {sync as globSync} from 'glob';
 import {basename, extname, join, relative, sep} from 'path';
 import {EMPTY} from 'rxjs';
-import {createTestApp} from '../testing';
+import {createTestApp} from './test-app';
 
 /** Suffix that indicates whether a given file is a test case input. */
 const TEST_CASE_INPUT_SUFFIX = '_input.ts';


### PR DESCRIPTION
Changes an import in order to avoid a ciruclar dependency.