### PR TITLE
Cdk listbox key management

### DIFF
--- a/src/cdk-experimental/listbox/BUILD.bazel
+++ b/src/cdk-experimental/listbox/BUILD.bazel
@@ -10,26 +10,26 @@ ng_module(
     ),
     module_name = "@angular/cdk-experimental/listbox",
     deps = [
+        "//src/cdk/a11y",
         "//src/cdk/keycodes",
-        "//src/cdk/a11y"
-    ]
+    ],
 )
 
 ng_test_library(
-     name = "unit_test_sources",
-     srcs = glob(
-         ["**/*.spec.ts"],
-         exclude = ["**/*.e2e.spec.ts"],
-     ),
-     deps = [
-         ":listbox",
-         "@npm//@angular/platform-browser",
-         "//src/cdk/keycodes",
-         "//src/cdk/testing/private"
-     ],
+    name = "unit_test_sources",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["**/*.e2e.spec.ts"],
+    ),
+    deps = [
+        ":listbox",
+        "//src/cdk/keycodes",
+        "//src/cdk/testing/private",
+        "@npm//@angular/platform-browser",
+    ],
 )
 
 ng_web_test_suite(
-     name = "unit_tests",
-     deps = [":unit_test_sources"]
+    name = "unit_tests",
+    deps = [":unit_test_sources"],
 )

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -66,7 +66,7 @@ describe('CdkOption', () => {
     });
 
     it('should update aria-selected when selected is changed programmatically', () => {
-      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();
       optionInstances[1].selected = true;
       fixture.detectChanges();
 
@@ -77,7 +77,7 @@ describe('CdkOption', () => {
       let selectedOptions = optionInstances.filter(option => option.selected);
 
       expect(selectedOptions.length).toBe(0);
-      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();
       expect(optionInstances[0].selected).toBeFalse();
       expect(fixture.componentInstance.changedOption).toBeUndefined();
 
@@ -96,7 +96,7 @@ describe('CdkOption', () => {
       let selectedOptions = optionInstances.filter(option => option.selected);
 
       expect(selectedOptions.length).toBe(0);
-      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();
       expect(optionInstances[0].selected).toBeFalse();
       expect(fixture.componentInstance.changedOption).toBeUndefined();
 
@@ -127,31 +127,20 @@ describe('CdkOption', () => {
       expect(optionInstances[0].disabled).toBeFalse();
       expect(optionElements[0].getAttribute('aria-disabled')).toBe('false');
 
-      testComponent.isVoidDisabled = true;
+      testComponent.isPurpleDisabled = true;
       fixture.detectChanges();
 
       expect(optionInstances[0].disabled).toBeTrue();
       expect(optionElements[0].getAttribute('aria-disabled')).toBe('true');
     });
 
-    it('should toggle option disabled state programmatically via listbox', () => {
-      expect(optionInstances[1].disabled).toBeFalse();
-      expect(optionElements[1].getAttribute('aria-disabled')).toBe('false');
-
-      listboxInstance.setDisabledOption(true, optionInstances[1]);
-      fixture.detectChanges();
-
-      expect(optionInstances[1].disabled).toBeTrue();
-      expect(optionElements[1].getAttribute('aria-disabled')).toBe('true');
-    });
-
     it('should toggle option aria-disabled state on listbox disabled state change', () => {
-      listboxInstance.setDisabledOption(true, optionInstances[0]);
+      optionInstances[0].disabled = true;
       fixture.detectChanges();
 
       expect(listboxInstance.disabled).toBeFalse();
       expect(optionInstances[0].disabled).toBeTrue();
-      expect(optionElements[0].getAttribute('tabindex')).toBeNull();
+      expect(optionElements[0].hasAttribute('tabindex')).toBeFalse();
       expect(optionElements[1].getAttribute('aria-disabled')).toBe('false');
       expect(optionElements[1].getAttribute('tabindex')).toBe('-1');
 
@@ -160,27 +149,27 @@ describe('CdkOption', () => {
 
       expect(listboxInstance.disabled).toBeTrue();
       expect(optionInstances[0].disabled).toBeTrue();
-      expect(optionElements[0].getAttribute('tabindex')).toBeNull();
+      expect(optionElements[0].hasAttribute('tabindex')).toBeFalse();
       expect(optionElements[1].getAttribute('aria-disabled')).toBe('true');
-      expect(optionElements[1].getAttribute('tabindex')).toBeNull();
+      expect(optionElements[1].hasAttribute('tabindex')).toBeFalse();
     });
 
     it('should not toggle selected on click of a disabled option', () => {
       let selectedOptions = optionInstances.filter(option => option.selected);
 
       expect(selectedOptions.length).toBe(0);
-      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();
       expect(optionInstances[0].selected).toBeFalse();
       expect(fixture.componentInstance.changedOption).toBeUndefined();
 
-      testComponent.isVoidDisabled = true;
+      testComponent.isPurpleDisabled = true;
       fixture.detectChanges();
       dispatchMouseEvent(optionElements[0], 'click');
       fixture.detectChanges();
 
       selectedOptions = optionInstances.filter(option => option.selected);
       expect(selectedOptions.length).toBe(0);
-      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();
       expect(optionInstances[0].selected).toBeFalse();
       expect(fixture.componentInstance.changedOption).toBeUndefined();
     });
@@ -189,7 +178,7 @@ describe('CdkOption', () => {
       let selectedOptions = optionInstances.filter(option => option.selected);
 
       expect(selectedOptions.length).toBe(0);
-      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();
       expect(optionInstances[0].selected).toBeFalse();
       expect(fixture.componentInstance.changedOption).toBeUndefined();
 
@@ -200,7 +189,7 @@ describe('CdkOption', () => {
 
       selectedOptions = optionInstances.filter(option => option.selected);
       expect(selectedOptions.length).toBe(0);
-      expect(optionElements[0].getAttribute('aria-selected')).toBeNull();
+      expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();
       expect(optionInstances[0].selected).toBeFalse();
       expect(fixture.componentInstance.changedOption).toBeUndefined();
     });
@@ -257,7 +246,7 @@ describe('CdkOption', () => {
       expect(fixture.componentInstance.changedOption).toBeUndefined();
 
       listboxInstance.setActiveOption(optionInstances[0]);
-      testComponent.isVoidDisabled = true;
+      testComponent.isPurpleDisabled = true;
       fixture.detectChanges();
 
       dispatchKeyboardEvent(listboxElement, 'keydown', SPACE);
@@ -312,8 +301,8 @@ describe('CdkOption', () => {
         [disabled]="isListboxDisabled"
         (selectionChange)="onSelectionChange($event)">
       <div cdkOption
-          [disabled]="isVoidDisabled">
-        Void</div>
+          [disabled]="isPurpleDisabled">
+        Purple</div>
       <div cdkOption
            [disabled]="isSolarDisabled">
         Solar</div>
@@ -324,7 +313,7 @@ describe('CdkOption', () => {
 class ListboxWithOptions {
   changedOption: CdkOption;
   isListboxDisabled: boolean = false;
-  isVoidDisabled: boolean = false;
+  isPurpleDisabled: boolean = false;
   isSolarDisabled: boolean = false;
 
   onSelectionChange(event: ListboxSelectionChangeEvent) {

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -9,8 +9,8 @@ import {
   CdkOption,
   CdkListboxModule, ListboxSelectionChangeEvent, CdkListbox
 } from './index';
-import {createKeyboardEvent, dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
-import {A, DOWN_ARROW, SPACE} from "@angular/cdk/keycodes";
+import {dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
+import {A, DOWN_ARROW, SPACE} from '@angular/cdk/keycodes';
 
 describe('CdkOption', () => {
 
@@ -308,7 +308,7 @@ describe('CdkOption', () => {
 
 @Component({
   template: `
-    <div cdkListbox 
+    <div cdkListbox
         [disabled]="isListboxDisabled"
         (selectionChange)="onSelectionChange($event)">
       <div cdkOption

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -10,7 +10,7 @@ import {
   CdkListboxModule, ListboxSelectionChangeEvent, CdkListbox
 } from './index';
 import {dispatchKeyboardEvent, dispatchMouseEvent} from '@angular/cdk/testing/private';
-import {A, DOWN_ARROW, SPACE} from '@angular/cdk/keycodes';
+import {A, DOWN_ARROW, END, HOME, SPACE} from '@angular/cdk/keycodes';
 
 describe('CdkOption', () => {
 
@@ -110,6 +110,23 @@ describe('CdkOption', () => {
       expect(optionInstances[0].selected).toBeTrue();
       expect(fixture.componentInstance.changedOption).toBeDefined();
       expect(fixture.componentInstance.changedOption.id).toBe(optionInstances[0].id);
+    });
+
+    it('should update active option on home and end key press', () => {
+      listboxInstance.setActiveOption(optionInstances[1]);
+      fixture.detectChanges();
+
+      expect(listboxInstance._listKeyManager.activeItem).toBe(optionInstances[1]);
+
+      dispatchKeyboardEvent(listboxElement, 'keydown', HOME);
+      fixture.detectChanges();
+
+      expect(listboxInstance._listKeyManager.activeItem).toBe(optionInstances[0]);
+
+      dispatchKeyboardEvent(listboxElement, 'keydown', END);
+      fixture.detectChanges();
+
+      expect(listboxInstance._listKeyManager.activeItem).toBe(optionInstances[3]);
     });
 
     it('should be able to toggle listbox disabled state', () => {

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -25,12 +25,12 @@ let nextId = 0;
   selector: '[cdkOption]',
   exportAs: 'cdkOption',
   host: {
-    role: 'option',
+    'role': 'option',
     '(click)': 'toggle()',
-    '(focus)': 'activateOption()',
-    '(blur)': 'deactivateOption()',
-    '[attr.aria-selected]': '_selected || null',
+    '(focus)': 'activate()',
+    '(blur)': 'deactivate()',
     '[id]': 'id',
+    '[attr.aria-selected]': '_selected || null',
     '[attr.tabindex]': '_getTabIndex()',
     '[attr.aria-disabled]': '_isInteractionDisabled()',
     '[class.cdk-option-disabled]': '_isInteractionDisabled()',
@@ -53,7 +53,7 @@ export class CdkOption implements ListKeyManagerOption, Highlightable {
     }
   }
 
-  /** The id of the option, set to a uniqueid if the user does not provide one */
+  /** The id of the option, set to a uniqueid if the user does not provide one. */
   @Input() id = `cdk-option-${nextId++}`;
 
   @Input()
@@ -68,7 +68,7 @@ export class CdkOption implements ListKeyManagerOption, Highlightable {
               @Inject(forwardRef(() => CdkListbox)) public listbox: CdkListbox) {
   }
 
-  /** Toggles the selected state, emits a change event through the injected listbox */
+  /** Toggles the selected state, emits a change event through the injected listbox. */
   toggle() {
     if (!this._isInteractionDisabled()) {
       this.selected = !this.selected;
@@ -76,21 +76,25 @@ export class CdkOption implements ListKeyManagerOption, Highlightable {
     }
   }
 
-  activateOption() {
+  /** Sets the active property true if the option and listbox aren't disabled. */
+  activate() {
     if (!this._isInteractionDisabled()) {
       this._active = true;
       this.listbox.setActiveOption(this);
     }
   }
 
-  deactivateOption() {
+  /** Sets the active property false. */
+  deactivate() {
     this._active = false;
   }
 
+  /** Returns true if the option or listbox are disabled, and false otherwise. */
   _isInteractionDisabled(): boolean {
     return (this.listbox.disabled || this._disabled);
   }
 
+  /** Returns the tab index which depends on the disabled property. */
   _getTabIndex(): string | null {
     return (this.listbox.disabled || this._disabled) ? null : '-1';
   }
@@ -116,7 +120,7 @@ export class CdkOption implements ListKeyManagerOption, Highlightable {
     selector: '[cdkListbox]',
     exportAs: 'cdkListbox',
     host: {
-      role: 'listbox',
+      'role': 'listbox',
       '(keydown)': '_keydown($event)',
       '[attr.aria-disabled]': '_disabled',
     }
@@ -171,7 +175,7 @@ export class CdkListbox implements AfterContentInit, OnDestroy {
 
   }
 
-  /** Emits a selection change event, called when an option has its selected state changed */
+  /** Emits a selection change event, called when an option has its selected state changed. */
   _emitChangeEvent(option: CdkOption) {
     this.selectionChange.emit(new ListboxSelectionChangeEvent(this, option));
   }
@@ -184,18 +188,21 @@ export class CdkListbox implements AfterContentInit, OnDestroy {
     }
   }
 
+  /** Selects the given option if the option and listbox aren't disabled. */
   select(option: CdkOption) {
-    if (!this.disabled && option.disabled) {
+    if (!this.disabled && !option.disabled) {
       option.selected = true;
     }
   }
 
+  /** Deselects the given option if the option and listbox aren't disabled. */
   deselect(option: CdkOption) {
-    if (!this.disabled && option.disabled) {
+    if (!this.disabled && !option.disabled) {
       option.selected = false;
     }
   }
 
+  /** Updates the key manager's active item to the given option. */
   setActiveOption(option: CdkOption) {
     this._listKeyManager.updateActiveItem(option);
   }

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -15,7 +15,7 @@ import {
   QueryList
 } from '@angular/core';
 import {ActiveDescendantKeyManager, Highlightable, ListKeyManagerOption} from '@angular/cdk/a11y';
-import {DOWN_ARROW, ENTER, SPACE, UP_ARROW} from '@angular/cdk/keycodes';
+import {ENTER, SPACE} from '@angular/cdk/keycodes';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 
 let nextId = 0;


### PR DESCRIPTION
Updated listbox to include disabled logic and keyboard interaction management. The listbox still is by default multi-selectable, and in a future PR that handles multi-select I will update the keyboard logic to deal with this.