### PR TITLE
build: add custom linting for symbol names

### DIFF
--- a/src/material/checkbox/checkbox-module.ts
+++ b/src/material/checkbox/checkbox-module.ts
@@ -17,7 +17,6 @@ import {MatCheckboxRequiredValidator} from './checkbox-required-validator';
   exports: [MatCheckboxRequiredValidator],
   declarations: [MatCheckboxRequiredValidator],
 })
-// tslint:disable-next-line:class-name
 export class _MatCheckboxRequiredValidatorModule {
 }
 

--- a/src/material/menu/menu-module.ts
+++ b/src/material/menu/menu-module.ts
@@ -28,7 +28,6 @@ import {MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER, MatMenuTrigger} from './menu-
   ],
   providers: [MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER]
 })
-// tslint:disable-next-line:class-name
 export class _MatMenuDirectivesModule {}
 
 @NgModule({

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -97,7 +97,6 @@ let menuPanelUid = 0;
 
 /** Base class with all of the `MatMenu` functionality. */
 @Directive()
-// tslint:disable-next-line:class-name
 export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit,
   OnDestroy {
   private _keyManager: FocusKeyManager<MatMenuItem>;
@@ -519,9 +518,7 @@ export class MatMenu extends _MatMenuBase {}
     {provide: MatMenu, useExisting: _MatMenu}
   ]
 })
-// tslint:disable-next-line:class-name
 export class _MatMenu extends MatMenu {
-
   constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone,
       @Inject(MAT_MENU_DEFAULT_OPTIONS) defaultOptions: MatMenuDefaultOptions) {
     super(elementRef, ngZone, defaultOptions);

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -96,7 +96,6 @@ export const MAT_RADIO_GROUP =
  * @docs-private
  */
 @Directive()
-// tslint:disable-next-line:class-name
 export abstract class _MatRadioGroupBase<T extends _MatRadioButtonBase> implements AfterContentInit,
   ControlValueAccessor {
   /** Selected value for the radio group. */
@@ -354,7 +353,6 @@ const _MatRadioButtonMixinBase:
  * @docs-private
  */
 @Directive()
-// tslint:disable-next-line:class-name
 export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase implements OnInit,
   AfterViewInit, OnDestroy, CanDisableRipple, HasTabIndex {
 

--- a/src/material/slide-toggle/slide-toggle-module.ts
+++ b/src/material/slide-toggle/slide-toggle-module.ts
@@ -17,9 +17,7 @@ import {MatSlideToggleRequiredValidator} from './slide-toggle-required-validator
   exports: [MatSlideToggleRequiredValidator],
   declarations: [MatSlideToggleRequiredValidator],
 })
-// tslint:disable-next-line:class-name
-export class _MatSlideToggleRequiredValidatorModule {
-}
+export class _MatSlideToggleRequiredValidatorModule {}
 
 @NgModule({
   imports: [

--- a/src/material/tabs/ink-bar.ts
+++ b/src/material/tabs/ink-bar.ts
@@ -14,7 +14,6 @@ import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
  * Interface for a a MatInkBar positioner method, defining the positioning and width of the ink
  * bar in a set of tabs.
  */
-// tslint:disable-next-line class-name Using leading underscore to denote internal interface.
 export interface _MatInkBarPositioner {
   (element: HTMLElement): { left: string, width: string };
 }

--- a/src/material/tabs/tab-body.ts
+++ b/src/material/tabs/tab-body.ts
@@ -109,7 +109,6 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
  * @docs-private
  */
 @Directive()
-// tslint:disable-next-line:class-name
 export abstract class _MatTabBodyBase implements OnInit, OnDestroy {
   /** Current position of the tab-body in the tab-group. Zero means that the tab is visible. */
   private _positionIndex: number;

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -79,7 +79,6 @@ interface MatTabGroupBaseHeader {
  * @docs-private
  */
 @Directive()
-// tslint:disable-next-line:class-name
 export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements AfterContentInit,
     AfterContentChecked, OnDestroy, CanColor, CanDisableRipple {
 

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -39,7 +39,6 @@ import {MatPaginatedTabHeader} from './paginated-tab-header';
  * @docs-private
  */
 @Directive()
-// tslint:disable-next-line:class-name
 export abstract class _MatTabHeaderBase extends MatPaginatedTabHeader implements
   AfterContentChecked, AfterContentInit, AfterViewInit, OnDestroy {
 

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -54,7 +54,6 @@ import {startWith, takeUntil} from 'rxjs/operators';
  * @docs-private
  */
 @Directive()
-// tslint:disable-next-line:class-name
 export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements AfterContentChecked,
   AfterContentInit, OnDestroy {
 
@@ -192,7 +191,6 @@ const _MatTabLinkMixinBase:
 
 /** Base class with all of the `MatTabLink` functionality. */
 @Directive()
-// tslint:disable-next-line:class-name
 export class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewInit, OnDestroy,
   CanDisable, CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {
 

--- a/tools/tslint-rules/symbolNamingRule.ts
+++ b/tools/tslint-rules/symbolNamingRule.ts
@@ -1,0 +1,28 @@
+import * as ts from 'typescript';
+import * as Lint from 'tslint';
+
+/** Lint rule that checks the names of classes and interfaces against a pattern. */
+export class Rule extends Lint.Rules.AbstractRule {
+  /** Pattern that we should validate against. */
+  private _pattern: RegExp;
+
+  constructor(options: Lint.IOptions) {
+    super(options);
+    this._pattern = new RegExp(options.ruleArguments[0] || '.*');
+  }
+
+  apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithFunction(sourceFile, checkSourceFile, this._pattern);
+  }
+}
+
+function checkSourceFile(context: Lint.WalkContext<RegExp>) {
+  context.sourceFile.forEachChild(function walk(node) {
+    if ((ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node)) && node.name && !context.options.test(node.name.text)) {
+      context.addFailureAtNode(node.name, `Symbol name must match pattern ${context.options}`);
+    }
+
+    node.forEachChild(walk);
+  });
+}

--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,6 @@
     // TSLint now shows warnings if types for properties are inferred. This rule needs to be
     // disabled because all properties need to have explicit types set to work for Dgeni.
     "no-inferrable-types": false,
-    "class-name": true,
     "comment-format": [
       true,
       "check-space"
@@ -143,6 +142,7 @@
     "member-naming": [true, {
       "private": "^_"
     }],
+    "symbol-naming": [true, "^_?[A-Z][a-zA-Z0-9]*$"],
     "validate-decorators": [true, {
       "Component": {
         "argument": 0,


### PR DESCRIPTION
As discussed, we want to prefix some exported class names with an underscore so it's more obvious that they're private. The problem is that our current class naming rule doesn't allow for a class to start with an underscore. These changes add a custom rule that can use a regex to validate the class name. Having our own rule allows us to validate more types of nodes as well (e.g. `type` nodes which tslint doesn't check).