### PR TITLE
build: set up boilerplate for v11 schematics

### DIFF
--- a/src/cdk/schematics/migration.json
+++ b/src/cdk/schematics/migration.json
@@ -26,6 +26,11 @@
       "description": "Updates the Angular CDK to v10",
       "factory": "./ng-update/index#updateToV10"
     },
+    "migration-v11": {
+      "version": "11.0.0-0",
+      "description": "Updates the Angular CDK to v11",
+      "factory": "./ng-update/index#updateToV11"
+    },
     "ng-post-update": {
       "description": "Prints out results after ng-update.",
       "factory": "./ng-update/index#postUpdate",

--- a/src/cdk/schematics/ng-update/index.ts
+++ b/src/cdk/schematics/ng-update/index.ts
@@ -36,6 +36,11 @@ export function updateToV10(): Rule {
   return createMigrationSchematicRule(TargetVersion.V10, [], cdkUpgradeData, onMigrationComplete);
 }
 
+/** Entry point for the migration schematics with target of Angular CDK 11.0.0 */
+export function updateToV11(): Rule {
+  return createMigrationSchematicRule(TargetVersion.V11, [], cdkUpgradeData, onMigrationComplete);
+}
+
 /** Function that will be called when the migration completed. */
 function onMigrationComplete(context: SchematicContext, targetVersion: TargetVersion,
                              hasFailures: boolean) {

--- a/src/cdk/schematics/update-tool/target-version.ts
+++ b/src/cdk/schematics/update-tool/target-version.ts
@@ -15,6 +15,7 @@ export enum TargetVersion {
   V8 = 'version 8',
   V9 = 'version 9',
   V10 = 'version 10',
+  V11 = 'version 11',
 }
 
 /**

--- a/src/material/schematics/migration.json
+++ b/src/material/schematics/migration.json
@@ -26,6 +26,11 @@
       "description": "Updates Angular Material to v10",
       "factory": "./ng-update/index#updateToV10"
     },
+    "migration-v11": {
+      "version": "11.0.0-0",
+      "description": "Updates Angular Material to v11",
+      "factory": "./ng-update/index#updateToV11"
+    },
     "ng-post-update": {
       "description": "Prints out results after ng-update.",
       "factory": "./ng-update/index#postUpdate",

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -68,6 +68,12 @@ export function updateToV10(): Rule {
       TargetVersion.V10, materialMigrations, materialUpgradeData, onMigrationComplete);
 }
 
+/** Entry point for the migration schematics with target of Angular Material v11 */
+export function updateToV11(): Rule {
+  return createMigrationSchematicRule(
+      TargetVersion.V11, materialMigrations, materialUpgradeData, onMigrationComplete);
+}
+
 /** Function that will be called when the migration completed. */
 function onMigrationComplete(context: SchematicContext, targetVersion: TargetVersion,
                              hasFailures: boolean) {


### PR DESCRIPTION
Usually we leave it until the last moment to set up the schematics for a new major version and we inevitably get blocked by the fact that the boilerplate isn't set up. These changes add it ahead of time so we aren't blocked by it in a few months.