### PR TITLE
fix(material/list): use flexbox to size mat-line elements (#19809)

### DIFF
--- a/src/material/core/style/_list-common.scss
+++ b/src/material/core/style/_list-common.scss
@@ -37,7 +37,7 @@
 
   display: flex;
   flex-direction: column;
-  width: 100%;
+  flex: auto;
   box-sizing: border-box;
   overflow: hidden;
 


### PR DESCRIPTION
* use `flex: auto` instead of `width: 100%` to allow `.mat-list-text` element to take up the available space

[stackblitz demonstrating issue](https://stackblitz.com/edit/angular-sawwqj)

**Before**
![image](https://user-images.githubusercontent.com/18009315/86241127-61d06500-bb70-11ea-9f6e-f339b4f97fc9.png)

**After**
![image](https://user-images.githubusercontent.com/18009315/86240819-deaf0f00-bb6f-11ea-97b7-9c6317466869.png)
