### PR TITLE
build: update to typescript v3.9.5 [patch backport]

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "tsickle": "0.38.1",
     "tslint": "^6.1.0",
     "tsutils": "^3.17.1",
-    "typescript": "3.9.2",
+    "typescript": "3.9.5",
     "typescript-3.6": "npm:typescript@~3.6.4",
     "typescript-3.7": "npm:typescript@~3.7.0",
     "typescript-3.8": "npm:typescript@~3.8.0",
@@ -173,7 +173,7 @@
     "yargs": "15.3.0"
   },
   "resolutions": {
-    "dgeni-packages/typescript": "3.9.2",
+    "dgeni-packages/typescript": "3.9.5",
     "**/graceful-fs": "4.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12035,10 +12035,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
-typescript@3.9.2, typescript@^3.2.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
-  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
+typescript@3.9.5, typescript@^3.2.2:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 typescript@^3.0.3, typescript@^3.4.5:
   version "3.5.3"


### PR DESCRIPTION
Backport of #19646 for the patch branch.

**Caretaker note**: please manually merge this into the `10.0.x` branch through the Github UI.