### PR TITLE
docs: fix incorrect template reference to map marker

### DIFF
--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -109,7 +109,7 @@ export class GoogleMapDemo {
             (mapClick)="addMarker($event)"
             (mapMousemove)="move($event)"
             (mapRightclick)="removeLastMarker()">
-  <map-marker #marker
+  <map-marker #marker="mapMarker"
               *ngFor="let markerPosition of markerPositions"
               [position]="markerPosition"
               [options]="markerOptions"


### PR DESCRIPTION
The readme file for google-maps serves as basic documentation for the
google-maps package. Currently it suggests an invalid template reference
since we switched from a component to a directive.

Directives do not provide the `$implicit` context, so we'd
need to use the explicit directive `exportAs` name.

Fixes #19807.