### PR TITLE
feat(cdk-experimental/menu): add ability to close menus when clicking outside the menu tree

### DIFF
--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -1,9 +1,12 @@
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
-import {Component} from '@angular/core';
+import {Component, ViewChildren, QueryList} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {CdkMenuBar} from './menu-bar';
 import {CdkMenuModule} from './menu-module';
 import {CdkMenuItemRadio} from './menu-item-radio';
+import {CdkMenu} from './menu';
+import {CdkMenuItemTrigger} from './menu-item-trigger';
+import {CdkMenuGroup} from './menu-group';
 
 describe('MenuBar', () => {
   describe('as radio group', () => {
@@ -67,6 +70,79 @@ describe('MenuBar', () => {
       expect(spy).toHaveBeenCalledWith(menuItems[0]);
     });
   });
+
+  describe('with submenu', () => {
+    let fixture: ComponentFixture<MenuBarWithMenus>;
+
+    let menus: CdkMenu[];
+    let triggers: CdkMenuItemTrigger[];
+
+    /** open the attached menu. */
+    const openMenu = () => {
+      triggers[0].toggle();
+      detectChanges();
+    };
+
+    /** set the menus and triggers arrays. */
+    const grabElementsForTesting = () => {
+      menus = fixture.componentInstance.menus.toArray();
+      triggers = fixture.componentInstance.triggers.toArray();
+    };
+
+    /** run change detection and, extract and set the rendered elements. */
+    const detectChanges = () => {
+      fixture.detectChanges();
+      grabElementsForTesting();
+    };
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuBarWithMenus],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MenuBarWithMenus);
+      detectChanges();
+    });
+
+    it('should close out all open menus when clicked outside the menu tree', () => {
+      openMenu();
+      expect(menus.length).toEqual(1);
+
+      fixture.debugElement.query(By.css('#container')).nativeElement.click();
+      detectChanges();
+
+      expect(menus.length).toEqual(0);
+    });
+
+    it('should not close open menus when clicking on menu or menu bar elements', () => {
+      openMenu();
+      expect(menus.length).toEqual(1);
+
+      fixture.debugElement
+        .queryAll(By.directive(CdkMenuGroup)) // Menu and MenuBar inherit from MenuGroup
+        .forEach(element => element.nativeElement.click());
+      detectChanges();
+
+      expect(menus.length)
+        .withContext('menu should stay open if clicking on any menu element')
+        .toEqual(1);
+    });
+
+    it('should not close when clicking on a non-menu element inside menu', () => {
+      openMenu();
+      expect(menus.length).toEqual(1);
+
+      fixture.debugElement.query(By.css('#inner-element')).nativeElement.click();
+      detectChanges();
+
+      expect(menus.length)
+        .withContext('menu should stay open if clicking on an inner span element')
+        .toEqual(1);
+    });
+  });
 });
 
 @Component({
@@ -86,3 +162,23 @@ describe('MenuBar', () => {
   `,
 })
 class MenuBarRadioGroup {}
+
+@Component({
+  template: `
+    <div id="container">
+      <div cdkMenuBar>
+        <button cdkMenuItem [cdkMenuTriggerFor]="sub1">Trigger</button>
+      </div>
+
+      <ng-template cdkMenuPanel #sub1="cdkMenuPanel">
+        <div cdkMenu [cdkMenuPanel]="sub1">
+          <span id="inner-element">A nested non-menuitem element</span>
+        </div>
+      </ng-template>
+    </div>
+  `,
+})
+class MenuBarWithMenus {
+  @ViewChildren(CdkMenu) menus: QueryList<CdkMenu>;
+  @ViewChildren(CdkMenuItemTrigger) triggers: QueryList<CdkMenuItemTrigger>;
+}

--- a/src/cdk-experimental/menu/menu-bar.ts
+++ b/src/cdk-experimental/menu/menu-bar.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input} from '@angular/core';
+import {Directive, Input, ElementRef, OnDestroy} from '@angular/core';
 import {CdkMenuGroup} from './menu-group';
 import {CDK_MENU, Menu} from './menu-interface';
+import {OpenMenuTracker} from './menu-tree-service';
 
 /**
  * Directive applied to an element which configures it as a MenuBar by setting the appropriate
@@ -28,10 +29,19 @@ import {CDK_MENU, Menu} from './menu-interface';
     {provide: CDK_MENU, useExisting: CdkMenuBar},
   ],
 })
-export class CdkMenuBar extends CdkMenuGroup implements Menu {
+export class CdkMenuBar extends CdkMenuGroup implements Menu, OnDestroy {
   /**
    * Sets the aria-orientation attribute and determines where menus will be opened.
    * Does not affect styling/layout.
    */
   @Input('cdkMenuBarOrientation') orientation: 'horizontal' | 'vertical' = 'horizontal';
+
+  /** Keep track of the open menus in the menu tree. */
+  _openMenuTracker = new OpenMenuTracker();
+
+  constructor(elementRef: ElementRef<HTMLElement>) {
+    super();
+
+    this._openMenuTracker.push(elementRef.nativeElement);
+  }
 }

--- a/src/cdk-experimental/menu/menu-interface.ts
+++ b/src/cdk-experimental/menu/menu-interface.ts
@@ -7,6 +7,7 @@
  */
 
 import {InjectionToken} from '@angular/core';
+import {OpenMenuTracker} from './menu-tree-service';
 
 /** Injection token used to return classes implementing the Menu interface */
 export const CDK_MENU = new InjectionToken<Menu>('cdk-menu');
@@ -15,4 +16,7 @@ export const CDK_MENU = new InjectionToken<Menu>('cdk-menu');
 export interface Menu {
   /** The orientation of the menu */
   orientation: 'horizontal' | 'vertical';
+
+  /** Keep track of the open menus in the menu tree. */
+  _openMenuTracker: OpenMenuTracker;
 }

--- a/src/cdk-experimental/menu/menu-tree-service.ts
+++ b/src/cdk-experimental/menu/menu-tree-service.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Track the open menu HTML elements in order to handle click events outside the menu tree when the
+ * menus aren't logically nested.
+ */
+export class OpenMenuTracker {
+  /** Array of the HTMLElements in the open menu tree starting from the root Menu Bar. */
+  readonly openMenus: HTMLElement[] = [];
+
+  /** Add a menus native element to the tracker. */
+  push(menuElement: HTMLElement) {
+    this.openMenus.push(menuElement);
+  }
+
+  /** Add the given given trackers open menu elements to this tracker. */
+  extend(tracker: OpenMenuTracker) {
+    this.openMenus.push(...tracker.openMenus);
+  }
+}

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -16,12 +16,14 @@ import {
   AfterContentInit,
   OnDestroy,
   Optional,
+  ElementRef,
 } from '@angular/core';
 import {take} from 'rxjs/operators';
 import {CdkMenuGroup} from './menu-group';
 import {CdkMenuPanel} from './menu-panel';
 import {Menu, CDK_MENU} from './menu-interface';
 import {throwMissingMenuPanelError} from './menu-errors';
+import {OpenMenuTracker} from './menu-tree-service';
 
 /**
  * Directive which configures the element as a Menu which should contain child elements marked as
@@ -56,6 +58,9 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnD
   @ContentChildren(CdkMenuGroup, {descendants: true})
   private readonly _nestedGroups: QueryList<CdkMenuGroup>;
 
+  /** Keep track of the open menus in the menu tree. */
+  _openMenuTracker = new OpenMenuTracker();
+
   /**
    * A reference to the enclosing parent menu panel.
    *
@@ -65,8 +70,13 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnD
    */
   @Input('cdkMenuPanel') private readonly _explicitPanel?: CdkMenuPanel;
 
-  constructor(@Optional() private readonly _menuPanel?: CdkMenuPanel) {
+  constructor(
+    elementRef: ElementRef<HTMLElement>,
+    @Optional() private readonly _menuPanel?: CdkMenuPanel
+  ) {
     super();
+
+    this._openMenuTracker.push(elementRef.nativeElement);
   }
 
   ngAfterContentInit() {


### PR DESCRIPTION
Add functionality to close any open menus (and submenus) when a user clicks on an element outside
the open menu tree and the menu bar.