### PR TITLE
build: integration size tests should not cause failure in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,7 +570,13 @@ jobs:
       - *setup_bazel_remote_execution
       - *yarn_install
       - *setup_bazel_binary
-      - run: yarn integration-tests
+      # TODO: Re-enable when there are integration tests that should run with Ivy.
+      # Currently this command fails as there are no tests.
+      # - run: yarn integration-tests
+      - run:
+          name: Running size integration tests (failures are reported in Slack only).
+          command: |
+            yarn integration-tests:size-test || ./scripts/circleci/notify-slack-job-failure.sh
       - run: yarn integration-tests:view-engine
       - *slack_notify_on_failure
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,9 @@
     "merge": "ng-dev pr merge",
     "approve-api": "node ./scripts/approve-api-golden.js",
     "approve-size-tests": "node ./scripts/approve-size-golden.js",
-    "integration-tests": "bazel test //integration/... --test_tag_filters=-view-engine-only --build_tests_only",
-    "integration-tests:view-engine": "bazel test //integration/... --test_tag_filters=view-engine-only --build_tests_only --config=view-engine"
+    "integration-tests": "bazel test --test_tag_filters=-view-engine-only --build_tests_only -- //integration/... -//integration/size-test/...",
+    "integration-tests:view-engine": "bazel test --test_tag_filters=view-engine-only --build_tests_only -- //integration/... -//integration/size-test/...",
+    "integration-tests:size-test": "bazel test //integration/size-test/..."
   },
   "version": "10.1.0-next.0",
   "dependencies": {


### PR DESCRIPTION
Disables the size test integration tests until we have a better concept for reporting size regressions. For now we disable them in the CI but report failures to the #components-ci-failures Slack channel. 