### PR TITLE
fix(cdk/platform): rtl scroll axis incorrectly determined in Safari macOS

### DIFF
--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -48,7 +48,6 @@ export function getRtlScrollAxisType(): RtlScrollAxisType {
     const scrollContainer = document.createElement('div');
     const containerStyle = scrollContainer.style;
     scrollContainer.dir = 'rtl';
-    containerStyle.height = '1px';
     containerStyle.width = '1px';
     containerStyle.overflow = 'auto';
     containerStyle.visibility = 'hidden';


### PR DESCRIPTION
In Safari on macOS, the RTL scroll axis is determined incorrectly when
scrollbars are set to `Always Display` as per macOS general system
preferences. Our test element for the scroll axis sets a fixed height.

This is resulting in a vertical scroll bar as the horizontal scroll bar
for testing `scrollLeft` exceeds the scroll containers `1px` height. The
vertical scroll bar then unveils a bug in Webkit where space is acquired
on the right side for the scroll bar (while it's displayed on the left).

This space causes our scroll axis detection to break as the horizontal
`scrollLeft` unexpectedly expands to: `[-scrollWidth, 15px]` while
usually `0px` is the right boundary. We fix this by simply ensuring
that no vertical scroll bar is ever displayed. The vertical scrolling
is not needed for determining the RTL horizontal scroll axis type.

I've reported a bug upstream in Webkit:
https://bugs.webkit.org/show_bug.cgi?id=213851.

I tested manually on Chrome 83.0.4103.116 Windows 10; macOS High Sierra Firefox 77; macOS High Sierra Safari 11.1, macOS Mojave Safari 12.1, macOS Catalina Safari 13.1, Windows 10 IE11.900.18362.0. Unfortunately there are no tests for this feature detection, nor would it be easy to write one for the particular scenario where a macOS setting is required.

Fixes #14609.