### PR TITLE
refactor(input): mirror placeholder in data attribute

### DIFF
--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -78,6 +78,7 @@ const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase =
     // the native input element. Otherwise property bindings for those don't work.
     '[attr.id]': 'id',
     '[attr.placeholder]': 'placeholder',
+    '[attr.data-placeholder]': 'placeholder',
     '[disabled]': 'disabled',
     '[required]': 'required',
     '[attr.readonly]': 'readonly && !_isNativeSelect || null',


### PR DESCRIPTION
This is a prerequisite to make landing #10466 easier in g3. Mirrors the native placeholder value in a data attribute so that we can read it even when it has been removed.