### PR TITLE
build: remove workaround for decorator metadata in universal-app

### DIFF
--- a/src/universal-app/prerender.ts
+++ b/src/universal-app/prerender.ts
@@ -1,15 +1,6 @@
 import 'reflect-metadata';
 import 'zone.js';
 
-// We need to mock a few native DOM globals as those are not present on the server, but they
-// are required for decorator metadata. The View Engine compiler preserves Angular decorator
-// metadata in the JS output. This could mean for example that inputs which are typed to
-// `HTMLElement` break on the server, as the `__decorate` call requires the `HTMLElement`
-// global to be present. More details: https://github.com/angular/angular/issues/30586.
-(global as any).HTMLElement = {};
-(global as any).Event = {};
-(global as any).TransitionEvent = {};
-
 import {renderModuleFactory} from '@angular/platform-server';
 import {readFileSync, writeFileSync} from 'fs';
 import {join} from 'path';


### PR DESCRIPTION
In the past, Angular removed tsickle from the build pipeline. This meant
that decorators were not downleveled, and executed immediately. This
caused errors in SSR as parameters or input types are accessed on
file load as runtime values. e.g. consider an input that used
`HTMLElement` as type. The TypeScript decorator output would access
`HTMLElement` on file load directly. This breaks on the server as such
DOM specific globals do not exist there.

We worked around this by providing global mocks for these symbols. Now
with Angular v10 though, Angular processes decorators by default without
requiring tsickle. This means that we can remove the workaround.