### PR TITLE
build: ensure project version is set correctly in NPM package output

### DIFF
--- a/tools/release/release-output/check-package.ts
+++ b/tools/release/release-output/check-package.ts
@@ -6,10 +6,10 @@ import {Version} from '../version-name/parse-version';
 
 import {
   checkCdkPackage,
-  checkMaterialPackage,
-  checkPackageJsonFile,
-  checkPackageJsonMigrations,
+  checkEntryPointPackageJsonFile,
   checkJavaScriptOutput,
+  checkMaterialPackage,
+  checkPrimaryPackageJson,
   checkTypeDefinitionFile
 } from './output-validations';
 
@@ -64,7 +64,7 @@ export function checkReleasePackage(
   // Check each "package.json" file in the release output. We want to ensure
   // that there are no invalid file references in the entry-point definitions.
   packageJsonFiles.forEach(filePath => {
-    checkPackageJsonFile(filePath).forEach(message => addFailure(message, filePath));
+    checkEntryPointPackageJsonFile(filePath).forEach(message => addFailure(message, filePath));
   });
 
   // Special release validation checks for the "material" release package.
@@ -82,7 +82,7 @@ export function checkReleasePackage(
     addFailure('No "README.md" file found in package output.');
   }
 
-  checkPackageJsonMigrations(join(packagePath, 'package.json'), currentVersion)
+  checkPrimaryPackageJson(join(packagePath, 'package.json'), currentVersion)
       .forEach(f => addFailure(f));
 
   // In case there are failures for this package, we want to print those


### PR DESCRIPTION
In framework, the version placeholder computation was incorrect
in some situations. i.e. the release packages used a version that
indicates local changes like `x.x.x-local-changes`. We should ensure
that the release output matches the expected version.

This is especially becoming relevant when we switch to a shared
Bazel workspace status command from the dev-infra package. The
workspace status command is responsible for determining the version
placeholder value when building with `--config=release`.