### PR TITLE
fix(material/slider): ignore value assignments while dragging

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -764,6 +764,16 @@ describe('MatSlider', () => {
       expect(sliderInstance.value).toBe(75);
       expect(trackFillElement.style.transform).toContain('scale3d(0.75, 1, 1)');
     });
+
+    it('should not overwrite the value while the user is dragging', () => {
+      dispatchMousedownEventSequence(sliderNativeElement, 0.25);
+      fixture.detectChanges();
+      expect(sliderInstance.value).toBe(25);
+
+      fixture.componentInstance.val = 100;
+      fixture.detectChanges();
+      expect(sliderInstance.value).toBe(25);
+    });
   });
 
   describe('slider with set min and max and a value smaller than min', () => {
@@ -1518,7 +1528,7 @@ describe('MatSlider', () => {
       expect(testComponent.value).toBe(0);
       expect(testComponent.slider.value).toBe(0);
 
-      dispatchMousedownEventSequence(sliderNativeElement, 0.1);
+      dispatchSlideEventSequence(sliderNativeElement, 0, 0.1);
       fixture.detectChanges();
       dispatchSlideEndEvent(sliderNativeElement, 0.1);
 


### PR DESCRIPTION
If the `value` of a slider changes while the user is dragging, their selection will jump around and it won't follow the pointer anymore. These changes make it so that we don't override the user's value while they're dragging.

Fixes #19842.