### PR TITLE
fix(material/sidenav): mark sidenav content as scrollable

### DIFF
--- a/src/material/sidenav/drawer.html
+++ b/src/material/sidenav/drawer.html
@@ -1,3 +1,3 @@
-<div class="mat-drawer-inner-container">
+<div class="mat-drawer-inner-container" cdkScrollable>
   <ng-content></ng-content>
 </div>

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -642,6 +642,17 @@ describe('MatDrawer', () => {
     }));
 
   });
+
+  it('should mark the drawer content as scrollable', () => {
+    const fixture = TestBed.createComponent(BasicTestApp);
+    fixture.detectChanges();
+
+    const content = fixture.debugElement.query(By.css('.mat-drawer-inner-container'));
+    const scrollable = content.injector.get(CdkScrollable);
+    expect(scrollable).toBeTruthy();
+    expect(scrollable.getElementRef().nativeElement).toBe(content.nativeElement);
+  });
+
 });
 
 describe('MatDrawerContainer', () => {


### PR DESCRIPTION
Marks the sidenav's inner scrollable element as `cdkScrollable` so any overlays placed inside of it can update.

Fixes #19846.
Fixes #18453.