### PR TITLE
Configure dialog content font

### DIFF
--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -22,6 +22,9 @@
   .mat-dialog-title {
     @include mat-typography-level-to-styles($config, title);
   }
+  .mat-dialog-content {
+    @include mat-typography-level-to-styles($config, body-1);
+  }
 }
 
 @mixin _mat-dialog-density($config-or-theme) {}


### PR DESCRIPTION
The contents of the font is currently unconfigured which yields inconsistent dialogs by default.