### PR TITLE
build: enforce consistent spaces between colons

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -66,6 +66,7 @@
     "declaration-block-semicolon-space-after": "always-single-line",
     "declaration-block-semicolon-newline-before": "never-multi-line",
     "declaration-block-semicolon-newline-after": "always-multi-line",
+    "declaration-colon-space-after": "always-single-line",
     "declaration-property-value-blacklist": [
         {"/.*/": ["initial"]},
         {"message": "The `initial` value is not supported in IE."}

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -242,8 +242,8 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
   @extend %mat-checkbox-outer-box;
 
   background-color: transparent;
-  transition:
-      border-color $mat-checkbox-transition-duration $mat-linear-out-slow-in-timing-function;
+  transition: border-color $mat-checkbox-transition-duration
+      $mat-linear-out-slow-in-timing-function;
   border: {
     width: $mat-checkbox-border-width;
     style: solid;
@@ -437,8 +437,8 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
     }
 
     .mat-checkbox-mixedmark {
-      animation:
-        $mat-checkbox-transition-duration linear 0ms mat-checkbox-unchecked-indeterminate-mixedmark;
+      animation: $mat-checkbox-transition-duration linear 0ms
+          mat-checkbox-unchecked-indeterminate-mixedmark;
     }
   }
 
@@ -448,32 +448,32 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
     }
 
     .mat-checkbox-checkmark-path {
-      animation:
-        $mat-checkbox-transition-duration linear 0ms mat-checkbox-checked-unchecked-checkmark-path;
+      animation: $mat-checkbox-transition-duration linear 0ms
+          mat-checkbox-checked-unchecked-checkmark-path;
     }
   }
 
   &-checked-indeterminate {
     .mat-checkbox-checkmark {
-      animation:
-        $mat-checkbox-transition-duration linear 0ms mat-checkbox-checked-indeterminate-checkmark;
+      animation: $mat-checkbox-transition-duration linear 0ms
+          mat-checkbox-checked-indeterminate-checkmark;
     }
 
     .mat-checkbox-mixedmark {
-      animation:
-        $mat-checkbox-transition-duration linear 0ms mat-checkbox-checked-indeterminate-mixedmark;
+      animation: $mat-checkbox-transition-duration linear 0ms
+          mat-checkbox-checked-indeterminate-mixedmark;
     }
   }
 
   &-indeterminate-checked {
     .mat-checkbox-checkmark {
-      animation:
-        $indeterminate-change-duration linear 0ms mat-checkbox-indeterminate-checked-checkmark;
+      animation: $indeterminate-change-duration linear 0ms
+          mat-checkbox-indeterminate-checked-checkmark;
     }
 
     .mat-checkbox-mixedmark {
-      animation:
-        $indeterminate-change-duration linear 0ms mat-checkbox-indeterminate-checked-mixedmark;
+      animation: $indeterminate-change-duration linear 0ms
+          mat-checkbox-indeterminate-checked-mixedmark;
     }
   }
 
@@ -483,9 +483,8 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
     }
 
     .mat-checkbox-mixedmark {
-      animation:
-        $indeterminate-change-duration * 0.6 linear 0ms
-        mat-checkbox-indeterminate-unchecked-mixedmark;
+      animation: $indeterminate-change-duration * 0.6 linear 0ms
+          mat-checkbox-indeterminate-unchecked-mixedmark;
     }
   }
 }

--- a/src/material/grid-list/grid-list.scss
+++ b/src/material/grid-list/grid-list.scss
@@ -75,7 +75,7 @@ $mat-grid-list-text-padding: 16px;
     }
 
     &:empty {
-      display:none;
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Enables a lint rule that enforces that we have consistent spaces around the colon which prevents things like `display:none`.