### PR TITLE
Update datepicker-formats-example.ts

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-formats/datepicker-formats-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-formats/datepicker-formats-example.ts
@@ -8,7 +8,7 @@ import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/
 // syntax. However, rollup creates a synthetic default module and we thus need to import it using
 // the `default as` syntax.
 import * as _moment from 'moment';
-// tslint:disable-next-line:no-duplicate-imports
+// @ts-ignore
 import {default as _rollupMoment} from 'moment';
 
 const moment = _rollupMoment || _moment;


### PR DESCRIPTION
the line below was supposed to have ts ignore any errors, but it wasn't working. 
// tslint:disable-next-line:no-duplicate-imports

Found the fix here
https://github.com/Microsoft/vscode-tslint/issues/368