### PR TITLE
build: postinstall patches not failing on compilation errors

### DIFF
--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -39,7 +39,12 @@ async function main() {
   registry = await readAndValidatePatchMarker();
 
   // Apply all patches synchronously.
-  applyPatches();
+  try {
+    applyPatches();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
 
   // Write the patch marker file so that we don't accidentally re-apply patches
   // in subsequent Yarn installations.


### PR DESCRIPTION
Since the postinstall patches and the `ngc` call were inside an `async` function, we were getting uncaught promise rejection logs, instead of exiting the process with an error code, which allowed the subsequent scripts in the postinstall chain to run. These changes add a try/catch so we can exit correctly.