### PR TITLE
docs(input): Broken link fragments in input documentation.

### DIFF
--- a/src/material/input/input.md
+++ b/src/material/input/input.md
@@ -75,13 +75,13 @@ globally cause input errors to show when the input is dirty and invalid.
 ### Auto-resizing `<textarea>` elements
 
 `<textarea>` elements can be made to automatically resize by using the
-[`cdkTextareaAutosize` directive](https://material.angular.io/components/input/overview#auto-resizing-code-lt-textarea-gt-code-elements)
+[`cdkTextareaAutosize` directive](https://material.angular.io/components/input/overview#auto-resizing-textarea-elements)
 available in the CDK.
 
 ### Responding to changes in the autofill state of an `<input>`
 
 The CDK provides
-[utilities](https://material.angular.io/cdk/text-field/overview#monitoring-the-autofill-state-of-an-code-lt-input-gt-code-)
+[utilities](https://material.angular.io/cdk/text-field/overview#monitoring-the-autofill-state-of-an-input)
 for detecting when an input becomes autofilled and changing the appearance of the autofilled state.
 
 ### Accessibility


### PR DESCRIPTION
Fixes document link fragment, it was using additional chars like lt-code, gt-code

Fixes #11473