### PR TITLE
fix(cdk/a11y): not picking up some events inside the shadow DOM

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
@@ -44,6 +44,7 @@ describe('FocusMonitor', () => {
 
     changeHandler = jasmine.createSpy('focus origin change handler');
     focusMonitor.monitor(buttonElement).subscribe(changeHandler);
+    registerPendingEvents();
     patchElementFocus(buttonElement);
   }));
 
@@ -283,6 +284,7 @@ describe('FocusMonitor', () => {
 
     focusMonitor.monitor(parent, true);
     focusMonitor.monitor(parent, false);
+    registerPendingEvents();
 
     // Simulate focus via mouse.
     dispatchMouseEvent(buttonElement, 'mousedown');
@@ -328,6 +330,7 @@ describe('FocusMonitor with "eventual" detection', () => {
 
     changeHandler = jasmine.createSpy('focus origin change handler');
     focusMonitor.monitor(buttonElement).subscribe(changeHandler);
+    registerPendingEvents();
     patchElementFocus(buttonElement);
   }));
 
@@ -364,6 +367,7 @@ describe('cdkMonitorFocus', () => {
       fixture = TestBed.createComponent(ButtonWithFocusClasses);
       fixture.detectChanges();
 
+      registerPendingEvents();
       spyOn(fixture.componentInstance, 'focusChanged');
       buttonElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
       patchElementFocus(buttonElement);
@@ -468,6 +472,7 @@ describe('cdkMonitorFocus', () => {
 
       patchElementFocus(parentElement);
       patchElementFocus(childElement);
+      registerPendingEvents();
     });
 
     it('should add focus classes on parent focus', fakeAsync(() => {
@@ -501,6 +506,7 @@ describe('cdkMonitorFocus', () => {
 
       patchElementFocus(parentElement);
       patchElementFocus(childElement);
+      registerPendingEvents();
     });
 
     it('should add focus classes on parent focus', fakeAsync(() => {
@@ -537,6 +543,7 @@ describe('cdkMonitorFocus', () => {
 
       patchElementFocus(parentElement);
       patchElementFocus(childElement);
+      registerPendingEvents();
     }));
 
     it('should add keyboard focus classes on both elements when child is focused via keyboard',
@@ -584,6 +591,7 @@ describe('FocusMonitor observable stream', () => {
   it('should emit inside the NgZone', fakeAsync(() => {
     const spy = jasmine.createSpy('zone spy');
     focusMonitor.monitor(buttonElement).subscribe(() => spy(NgZone.isInAngularZone()));
+    registerPendingEvents();
     expect(spy).not.toHaveBeenCalled();
 
     buttonElement.focus();
@@ -593,6 +601,10 @@ describe('FocusMonitor observable stream', () => {
   }));
 });
 
+
+function registerPendingEvents() {
+  dispatchFakeEvent(document, 'mousemove');
+}
 
 @Component({
   template: `<div class="parent"><button>focus me!</button></div>`

--- a/src/material-experimental/mdc-dialog/dialog.spec.ts
+++ b/src/material-experimental/mdc-dialog/dialog.spec.ts
@@ -6,6 +6,7 @@ import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
   createKeyboardEvent,
   dispatchEvent,
+  dispatchFakeEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent,
   patchElementFocus
@@ -1028,6 +1029,7 @@ describe('MDC-based MatDialog', () => {
          let button = document.createElement('button');
          button.id = 'dialog-trigger';
          document.body.appendChild(button);
+         dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
          button.focus();
 
          let dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
@@ -1065,6 +1067,7 @@ describe('MDC-based MatDialog', () => {
              .subscribe(focusOrigin => lastFocusOrigin = focusOrigin);
 
          document.body.appendChild(button);
+         dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
          button.focus();
 
          // Patch the element focus after the initial and real focus, because otherwise the
@@ -1099,6 +1102,7 @@ describe('MDC-based MatDialog', () => {
              .subscribe(focusOrigin => lastFocusOrigin = focusOrigin);
 
          document.body.appendChild(button);
+         dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
          button.focus();
 
          // Patch the element focus after the initial and real focus, because otherwise the
@@ -1135,6 +1139,7 @@ describe('MDC-based MatDialog', () => {
              .subscribe(focusOrigin => lastFocusOrigin = focusOrigin);
 
          document.body.appendChild(button);
+         dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
          button.focus();
 
          // Patch the element focus after the initial and real focus, because otherwise the
@@ -1173,6 +1178,7 @@ describe('MDC-based MatDialog', () => {
              .subscribe(focusOrigin => lastFocusOrigin = focusOrigin);
 
          document.body.appendChild(button);
+         dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
          button.focus();
 
          // Patch the element focus after the initial and real focus, because otherwise the

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -56,6 +56,7 @@ describe('MDC-based MatSelectionList without forms', () => {
 
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption));
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
+      dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
     }));
 
     function getFocusIndex() {

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -343,6 +343,7 @@ describe('MDC-based MatMenu', () => {
 
       patchElementFocus(triggerEl);
       focusMonitor.monitor(triggerEl, false);
+      dispatchFakeEvent(document, 'mousemove');
       triggerEl.click(); // A click without a mousedown before it is considered a keyboard open.
       fixture.detectChanges();
       fixture.componentInstance.trigger.closeMenu();
@@ -365,6 +366,7 @@ describe('MDC-based MatMenu', () => {
       fixture.detectChanges();
       patchElementFocus(triggerEl);
       focusMonitor.monitor(triggerEl, false);
+      dispatchFakeEvent(document, 'mousemove');
       fixture.componentInstance.trigger.closeMenu();
       fixture.detectChanges();
       tick(500);
@@ -382,6 +384,7 @@ describe('MDC-based MatMenu', () => {
 
       patchElementFocus(triggerEl);
       focusMonitor.monitor(triggerEl, false);
+      dispatchFakeEvent(document, 'mousemove');
 
       // Trigger a fake right click.
       dispatchEvent(triggerEl, createMouseEvent('mousedown', 50, 100, 2));
@@ -410,6 +413,7 @@ describe('MDC-based MatMenu', () => {
         fixture.detectChanges();
         patchElementFocus(triggerEl);
         focusMonitor.monitor(triggerEl, false);
+        dispatchFakeEvent(document, 'mousemove');
         fixture.componentInstance.trigger.closeMenu();
         fixture.detectChanges();
         tick(500);

--- a/src/material-experimental/mdc-radio/radio.spec.ts
+++ b/src/material-experimental/mdc-radio/radio.spec.ts
@@ -418,6 +418,7 @@ describe('MDC-based MatRadio', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(RadioGroupWithNgModel);
       fixture.detectChanges();
+      dispatchFakeEvent(document, 'mousemove');
 
       testComponent = fixture.debugElement.componentInstance;
 

--- a/src/material/button/BUILD.bazel
+++ b/src/material/button/BUILD.bazel
@@ -53,6 +53,7 @@ ng_test_library(
     ),
     deps = [
         ":button",
+        "//src/cdk/testing/private",
         "//src/material/core",
         "@npm//@angular/platform-browser",
     ],

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -3,6 +3,7 @@ import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MatButtonModule, MatButton} from './index';
 import {MatRipple, ThemePalette} from '@angular/material/core';
+import {dispatchFakeEvent} from '@angular/cdk/testing/private';
 
 
 describe('MatButton', () => {
@@ -73,6 +74,8 @@ describe('MatButton', () => {
   it('should be able to focus button with a specific focus origin', () => {
     const fixture = TestBed.createComponent(TestApp);
     fixture.detectChanges();
+    dispatchFakeEvent(document, 'mousemove');
+
     const buttonDebugEl = fixture.debugElement.query(By.css('button'));
     const buttonInstance = buttonDebugEl.componentInstance as MatButton;
 

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -923,6 +923,7 @@ describe('MatCheckbox', () => {
 
       fixture.componentInstance.isRequired = false;
       fixture.detectChanges();
+      dispatchFakeEvent(document, 'mousemove');
 
       checkboxDebugElement = fixture.debugElement.query(By.directive(MatCheckbox))!;
       checkboxNativeElement = checkboxDebugElement.nativeElement;
@@ -972,6 +973,7 @@ describe('MatCheckbox', () => {
 
       inputElement.click();
       fixture.detectChanges();
+      dispatchFakeEvent(document, 'mousemove');
       flush();
 
       expect(checkboxNativeElement.classList).not.toContain('ng-touched');

--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -200,6 +200,7 @@ describe('MatDateRangeInput', () => {
   it('should float the form field label when either input is focused', () => {
     const fixture = createComponent(StandardRangePicker);
     fixture.detectChanges();
+    dispatchFakeEvent(document, 'mousemove');
     const {rangeInput, end} = fixture.componentInstance;
     let focusMonitor: FocusMonitor;
 

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -34,7 +34,7 @@ import {
   createKeyboardEvent,
   dispatchEvent,
   patchElementFocus,
-  dispatchMouseEvent
+  dispatchMouseEvent, dispatchFakeEvent
 } from '@angular/cdk/testing/private';
 import {
   MAT_DIALOG_DATA,
@@ -1123,6 +1123,7 @@ describe('MatDialog', () => {
       let button = document.createElement('button');
       button.id = 'dialog-trigger';
       document.body.appendChild(button);
+      dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
       button.focus();
 
       let dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
@@ -1156,6 +1157,7 @@ describe('MatDialog', () => {
         .subscribe(focusOrigin => lastFocusOrigin = focusOrigin);
 
       document.body.appendChild(button);
+      dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
       button.focus();
 
       // Patch the element focus after the initial and real focus, because otherwise the
@@ -1189,6 +1191,7 @@ describe('MatDialog', () => {
         .subscribe(focusOrigin => lastFocusOrigin = focusOrigin);
 
       document.body.appendChild(button);
+      dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
       button.focus();
 
       // Patch the element focus after the initial and real focus, because otherwise the
@@ -1225,6 +1228,7 @@ describe('MatDialog', () => {
         .subscribe(focusOrigin => lastFocusOrigin = focusOrigin);
 
       document.body.appendChild(button);
+      dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
       button.focus();
 
       // Patch the element focus after the initial and real focus, because otherwise the
@@ -1262,6 +1266,7 @@ describe('MatDialog', () => {
         .subscribe(focusOrigin => lastFocusOrigin = focusOrigin);
 
       document.body.appendChild(button);
+      dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
       button.focus();
 
       // Patch the element focus after the initial and real focus, because otherwise the

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -12,6 +12,7 @@ import {
   dispatchKeyboardEvent,
   createKeyboardEvent,
   dispatchEvent,
+  dispatchFakeEvent,
 } from '@angular/cdk/testing/private';
 import {DOWN_ARROW, UP_ARROW, HOME, END} from '@angular/cdk/keycodes';
 import {FocusMonitor} from '@angular/cdk/a11y';
@@ -162,6 +163,7 @@ describe('MatAccordion', () => {
   it('should move focus to the next header when pressing the down arrow', () => {
     const fixture = TestBed.createComponent(SetOfItems);
     fixture.detectChanges();
+    dispatchFakeEvent(document, 'mousemove');
 
     const headerElements = fixture.debugElement.queryAll(By.css('mat-expansion-panel-header'));
     const headers = fixture.componentInstance.headers.toArray();
@@ -180,6 +182,7 @@ describe('MatAccordion', () => {
   it('should not move focus into nested accordions', () => {
     const fixture = TestBed.createComponent(NestedAccordions);
     fixture.detectChanges();
+    dispatchFakeEvent(document, 'mousemove');
 
     const headerElements = fixture.debugElement.queryAll(By.css('mat-expansion-panel-header'));
     const headers = fixture.componentInstance.headers.toArray();
@@ -197,6 +200,7 @@ describe('MatAccordion', () => {
   it('should move focus to the next header when pressing the up arrow', () => {
     const fixture = TestBed.createComponent(SetOfItems);
     fixture.detectChanges();
+    dispatchFakeEvent(document, 'mousemove');
 
     const headerElements = fixture.debugElement.queryAll(By.css('mat-expansion-panel-header'));
     const headers = fixture.componentInstance.headers.toArray();
@@ -215,6 +219,7 @@ describe('MatAccordion', () => {
   it('should skip disabled items when moving focus with the keyboard', () => {
     const fixture = TestBed.createComponent(SetOfItems);
     fixture.detectChanges();
+    dispatchFakeEvent(document, 'mousemove');
 
     const headerElements = fixture.debugElement.queryAll(By.css('mat-expansion-panel-header'));
     const panels = fixture.componentInstance.panels.toArray();

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -63,6 +63,7 @@ describe('MatSelectionList without forms', () => {
 
       listOptions = fixture.debugElement.queryAll(By.directive(MatListOption));
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
+      dispatchFakeEvent(document, 'mousemove'); // Trigger the focus monitor event registration.
     }));
 
     it('should be able to set a value on a list option', () => {

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -343,6 +343,7 @@ describe('MatMenu', () => {
 
       patchElementFocus(triggerEl);
       focusMonitor.monitor(triggerEl, false);
+      dispatchFakeEvent(document, 'mousemove');
       triggerEl.click(); // A click without a mousedown before it is considered a keyboard open.
       fixture.detectChanges();
       fixture.componentInstance.trigger.closeMenu();
@@ -365,6 +366,7 @@ describe('MatMenu', () => {
       fixture.detectChanges();
       patchElementFocus(triggerEl);
       focusMonitor.monitor(triggerEl, false);
+      dispatchFakeEvent(document, 'mousemove');
       fixture.componentInstance.trigger.closeMenu();
       fixture.detectChanges();
       tick(500);
@@ -382,6 +384,7 @@ describe('MatMenu', () => {
 
       patchElementFocus(triggerEl);
       focusMonitor.monitor(triggerEl, false);
+      dispatchFakeEvent(document, 'mousemove');
 
       // Trigger a fake right click.
       dispatchEvent(triggerEl, createMouseEvent('mousedown', 50, 100, 2));
@@ -410,6 +413,7 @@ describe('MatMenu', () => {
         fixture.detectChanges();
         patchElementFocus(triggerEl);
         focusMonitor.monitor(triggerEl, false);
+        dispatchFakeEvent(document, 'mousemove');
         fixture.componentInstance.trigger.closeMenu();
         fixture.detectChanges();
         tick(500);

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -411,6 +411,7 @@ describe('MatRadio', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(RadioGroupWithNgModel);
       fixture.detectChanges();
+      dispatchFakeEvent(document, 'mousemove');
 
       testComponent = fixture.debugElement.componentInstance;
 

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -68,6 +68,7 @@ describe('MatSlideToggle without forms', () => {
 
       // Initialize the slide-toggle component, by triggering the first change detection cycle.
       fixture.detectChanges();
+      dispatchFakeEvent(document, 'mousemove');
 
       const slideToggleDebug = fixture.debugElement.query(By.css('mat-slide-toggle'))!;
 
@@ -558,6 +559,7 @@ describe('MatSlideToggle with forms', () => {
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(SlideToggleWithModel);
       fixture.detectChanges();
+      dispatchFakeEvent(document, 'mousemove');
 
       const slideToggleDebug = fixture.debugElement.query(By.directive(MatSlideToggle))!;
 

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -44,6 +44,7 @@ describe('MatSlider', () => {
     beforeEach(() => {
       fixture = createComponent(StandardSlider);
       fixture.detectChanges();
+      dispatchFakeEvent(document, 'mousemove');
 
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -5,6 +5,7 @@ import {
   createMouseEvent,
   dispatchMouseEvent,
   wrappedErrorMessage,
+  dispatchFakeEvent,
 } from '@angular/cdk/testing/private';
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
@@ -51,6 +52,7 @@ describe('MatSort', () => {
     fixture = TestBed.createComponent(SimpleMatSortApp);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    dispatchFakeEvent(document, 'mousemove');
   });
 
   it('should have the sort headers register and deregister themselves', () => {


### PR DESCRIPTION
When an element inside the shadow is monitored via the `FocusMonitor`, we have to bind the global events on the shadow root, rather than the document, in order to be able to figure out when it receives focus. The problem is that if we try to look up the element too early, it might not be inside the shadow DOM yet.

These changes address the issue by deferring the event registration until the next time the user interacts with the page.

Fixes #19760.