### PR TITLE
fix(list): single selection list selected state not shown on touch devices

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -350,7 +350,7 @@ mat-action-list {
 // enhancement and not all desktop browsers support this kind of media query, we can't
 // use something like `@media (hover)`.
 @media (hover: none) {
-  .mat-list-option,
+  .mat-list-option:not(.mat-list-single-selected-option),
   .mat-nav-list .mat-list-item,
   .mat-action-list .mat-list-item {
     &:not(.mat-list-item-disabled):hover {


### PR DESCRIPTION
We have some extra CSS rules to prevent sticky hover states on touch devices. The problem is that we use the hover style to indicate a selected item in a single selection list and it breaks in a way that prevents the selected state from showing up for touch devices. These changes make the selector more specific to avoid the issue.

Fixes #19876.