### PR TITLE
feat(cdk-experimental/menu): add functionality to navigate a Menu and MenuBar with a keyboard

### DIFF
--- a/src/cdk-experimental/menu/BUILD.bazel
+++ b/src/cdk-experimental/menu/BUILD.bazel
@@ -10,9 +10,11 @@ ng_module(
     ),
     module_name = "@angular/cdk-experimental/menu",
     deps = [
+        "//src/cdk/a11y",
         "//src/cdk/bidi",
         "//src/cdk/coercion",
         "//src/cdk/collections",
+        "//src/cdk/keycodes",
         "//src/cdk/overlay",
         "@npm//@angular/core",
         "@npm//rxjs",
@@ -28,6 +30,8 @@ ng_test_library(
     deps = [
         ":menu",
         "//src/cdk/collections",
+        "//src/cdk/keycodes",
+        "//src/cdk/testing/private",
         "@npm//@angular/platform-browser",
     ],
 )

--- a/src/cdk-experimental/menu/menu-bar.ts
+++ b/src/cdk-experimental/menu/menu-bar.ts
@@ -6,9 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input} from '@angular/core';
+import {
+  Directive,
+  Input,
+  ContentChildren,
+  QueryList,
+  AfterContentInit,
+  OnDestroy,
+  Inject,
+} from '@angular/core';
+import {Directionality} from '@angular/cdk/bidi';
+import {_getShadowRoot} from '@angular/cdk/platform';
+import {Subject} from 'rxjs';
 import {CdkMenuGroup} from './menu-group';
 import {CDK_MENU, Menu} from './menu-interface';
+import {CdkMenuItem} from './menu-item';
+import {MenuKeyManager, TYPE_AHEAD_DEBOUNCE} from './menu-key-manager';
 
 /**
  * Directive applied to an element which configures it as a MenuBar by setting the appropriate
@@ -20,7 +33,10 @@ import {CDK_MENU, Menu} from './menu-interface';
   selector: '[cdkMenuBar]',
   exportAs: 'cdkMenuBar',
   host: {
+    '(keydown)': '_handleKeyEvent($event)',
+    '(focus)': 'focusFirstItem()',
     'role': 'menubar',
+    'tabindex': '0',
     '[attr.aria-orientation]': 'orientation',
   },
   providers: [
@@ -28,10 +44,64 @@ import {CDK_MENU, Menu} from './menu-interface';
     {provide: CDK_MENU, useExisting: CdkMenuBar},
   ],
 })
-export class CdkMenuBar extends CdkMenuGroup implements Menu {
+export class CdkMenuBar extends CdkMenuGroup implements Menu, OnDestroy, AfterContentInit {
   /**
    * Sets the aria-orientation attribute and determines where menus will be opened.
    * Does not affect styling/layout.
    */
   @Input('cdkMenuBarOrientation') orientation: 'horizontal' | 'vertical' = 'horizontal';
+
+  /** Handles keyboard events for the MenuBar. */
+  private _keyManager?: MenuKeyManager;
+
+  /** All child MenuItem elements nested in this MenuBar. */
+  @ContentChildren(CdkMenuItem, {descendants: true})
+  private readonly _allItems: QueryList<CdkMenuItem>;
+
+  constructor(
+    private readonly _dir: Directionality,
+    @Inject(TYPE_AHEAD_DEBOUNCE) private readonly _debounceInterval: number
+  ) {
+    super();
+  }
+
+  ngAfterContentInit() {
+    super.ngAfterContentInit();
+
+    this._keyManager = new MenuKeyManager(this._allItems, {
+      directionality: this._dir,
+      menuOrientation: this.orientation,
+      typeAheadDebounce: this._debounceInterval,
+    });
+  }
+
+  /** Place focus on the first MenuItem in the menu. */
+  focusFirstItem() {
+    this._keyManager?.focusFirstItem();
+  }
+
+  /** Place focus on the last MenuItem in the menu. */
+  focusLastItem() {
+    this._keyManager?.focusLastItem();
+  }
+
+  /** Place focus on the given MenuItem in the menu. */
+  focusItem(child: CdkMenuItem) {
+    this._keyManager?.focusItem(child);
+  }
+
+  /** Get an emitter which emits bubbled-up keyboard events from the keyboard manager. */
+  _getBubbledKeyboardEvents(): Subject<KeyboardEvent> | undefined {
+    return this._keyManager?._bubbledEvents;
+  }
+
+  /** Direct the MenuKeyManager to handle the keyboard event. */
+  _handleKeyEvent(event: KeyboardEvent) {
+    this._keyManager?.onKeydown(event);
+  }
+
+  ngOnDestroy() {
+    super.ngOnDestroy();
+    this._keyManager!.destroy();
+  }
 }

--- a/src/cdk-experimental/menu/menu-interface.ts
+++ b/src/cdk-experimental/menu/menu-interface.ts
@@ -7,6 +7,8 @@
  */
 
 import {InjectionToken} from '@angular/core';
+import {FocusableOption} from '@angular/cdk/a11y';
+import {Subject} from 'rxjs';
 
 /** Injection token used to return classes implementing the Menu interface */
 export const CDK_MENU = new InjectionToken<Menu>('cdk-menu');
@@ -15,4 +17,16 @@ export const CDK_MENU = new InjectionToken<Menu>('cdk-menu');
 export interface Menu {
   /** The orientation of the menu */
   orientation: 'horizontal' | 'vertical';
+
+  /** Place focus on the first MenuItem in the menu. */
+  focusFirstItem(): void;
+
+  /** Place focus on the last MenuItem in the menu. */
+  focusLastItem(): void;
+
+  /** Place focus on the given MenuItem in the menu. */
+  focusItem(child: FocusableOption): void;
+
+  /** Get an emitter which emits bubbled-up keyboard events from the keyboard manager. */
+  _getBubbledKeyboardEvents(): Subject<KeyboardEvent> | undefined;
 }

--- a/src/cdk-experimental/menu/menu-item-checkbox.ts
+++ b/src/cdk-experimental/menu/menu-item-checkbox.ts
@@ -8,6 +8,7 @@
 
 import {Directive} from '@angular/core';
 import {CdkMenuItemSelectable} from './menu-item-selectable';
+import {CdkMenuItem} from './menu-item';
 
 /**
  * A directive providing behavior for the "menuitemcheckbox" ARIA role, which behaves similarly to a
@@ -23,7 +24,10 @@ import {CdkMenuItemSelectable} from './menu-item-selectable';
     '[attr.aria-checked]': 'checked || null',
     '[attr.aria-disabled]': 'disabled || null',
   },
-  providers: [{provide: CdkMenuItemSelectable, useExisting: CdkMenuItemCheckbox}],
+  providers: [
+    {provide: CdkMenuItemSelectable, useExisting: CdkMenuItemCheckbox},
+    {provide: CdkMenuItem, useExisting: CdkMenuItemSelectable},
+  ],
 })
 export class CdkMenuItemCheckbox extends CdkMenuItemSelectable {
   trigger() {

--- a/src/cdk-experimental/menu/menu-item-radio.ts
+++ b/src/cdk-experimental/menu/menu-item-radio.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
-import {Directive, OnDestroy} from '@angular/core';
+import {Directive, OnDestroy, ElementRef, Self, Optional} from '@angular/core';
 import {CdkMenuItemSelectable} from './menu-item-selectable';
+import {CdkMenuItem} from './menu-item';
+import {CdkMenuItemTrigger} from './menu-item-trigger';
 
 /**
  * A directive providing behavior for the the "menuitemradio" ARIA role, which behaves similarly to
@@ -24,14 +26,22 @@ import {CdkMenuItemSelectable} from './menu-item-selectable';
     '[attr.aria-checked]': 'checked || null',
     '[attr.aria-disabled]': 'disabled || null',
   },
-  providers: [{provide: CdkMenuItemSelectable, useExisting: CdkMenuItemRadio}],
+  providers: [
+    {provide: CdkMenuItemSelectable, useExisting: CdkMenuItemRadio},
+    {provide: CdkMenuItem, useExisting: CdkMenuItemSelectable},
+  ],
 })
 export class CdkMenuItemRadio extends CdkMenuItemSelectable implements OnDestroy {
   /** Function to unregister the selection dispatcher */
   private _removeDispatcherListener: () => void;
 
-  constructor(private readonly _selectionDispatcher: UniqueSelectionDispatcher) {
-    super();
+  constructor(
+    private readonly _selectionDispatcher: UniqueSelectionDispatcher,
+    element: ElementRef<HTMLElement>,
+    /** Reference to the CdkMenuItemTrigger directive if one is added to the same element */
+    @Self() @Optional() menuTrigger?: CdkMenuItemTrigger
+  ) {
+    super(element, menuTrigger);
 
     this._registerDispatcherListener();
   }

--- a/src/cdk-experimental/menu/menu-item-trigger.spec.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.spec.ts
@@ -117,7 +117,7 @@ describe('MenuItemTrigger', () => {
       detectChanges();
 
       expect(menus.length).toEqual(1);
-      expect(menus[0] as Menu).toEqual(triggers[0]._menuPanel!._menu!);
+      expect(menus[0] as Menu).toEqual(triggers[0].getMenu()!);
     });
 
     it('should not open the menu when menu item disabled', () => {
@@ -175,7 +175,7 @@ describe('MenuItemTrigger', () => {
       detectChanges();
 
       expect(menus.length).withContext('first level menu should stay open').toEqual(1);
-      expect(triggers[0]._menuPanel!._menu).toEqual(menus[0]);
+      expect(triggers[0].getMenu()).toEqual(menus[0]);
     });
 
     it('should emit request to open event on menu open', () => {

--- a/src/cdk-experimental/menu/menu-item-trigger.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.ts
@@ -47,7 +47,7 @@ import {Menu, CDK_MENU} from './menu-interface';
 })
 export class CdkMenuItemTrigger implements OnDestroy {
   /** Template reference variable to the menu this trigger opens */
-  @Input('cdkMenuTriggerFor') _menuPanel?: CdkMenuPanel;
+  @Input('cdkMenuTriggerFor') private readonly _menuPanel?: CdkMenuPanel;
 
   /** Emits when the attached menu is requested to open */
   @Output('cdkMenuOpened') readonly opened: EventEmitter<void> = new EventEmitter();
@@ -86,20 +86,28 @@ export class CdkMenuItemTrigger implements OnDestroy {
     return this._overlayRef ? this._overlayRef.hasAttached() : false;
   }
 
+  /**
+   * Get a reference to the rendered Menu if the Menu is open and it is visible in the DOM.
+   * @return the menu if it is open, otherwise undefined.
+   */
+  getMenu(): Menu | undefined {
+    return this._menuPanel?._menu;
+  }
+
   /** Open the attached menu */
   private _openMenu() {
-    this.opened.next();
-
     this._overlayRef = this._overlay.create(this._getOverlayConfig());
     this._overlayRef.attach(this._getPortal());
+
+    this.opened.next();
   }
 
   /** Close the opened menu */
   private _closeMenu() {
     if (this.isMenuOpen()) {
-      this.closed.next();
-
       this._overlayRef!.detach();
+
+      this.closed.next();
     }
   }
 
@@ -143,11 +151,10 @@ export class CdkMenuItemTrigger implements OnDestroy {
    * content to change dynamically and be reflected in the application.
    */
   private _getPortal() {
-    if (!this._panelContent || this._panelContent.templateRef !== this._menuPanel?._templateRef) {
-      this._panelContent = new TemplatePortal(
-        this._menuPanel!._templateRef,
-        this._viewContainerRef
-      );
+    const hasMenuContentChanged = this._menuPanel?._templateRef !== this._panelContent?.templateRef;
+
+    if (this._menuPanel && (!this._panelContent || hasMenuContentChanged)) {
+      this._panelContent = new TemplatePortal(this._menuPanel._templateRef, this._viewContainerRef);
     }
     return this._panelContent;
   }

--- a/src/cdk-experimental/menu/menu-item.spec.ts
+++ b/src/cdk-experimental/menu/menu-item.spec.ts
@@ -5,54 +5,79 @@ import {CdkMenuModule} from './menu-module';
 import {CdkMenuItem} from './menu-item';
 
 describe('MenuItem', () => {
-  let fixture: ComponentFixture<SingleMenuItem>;
-  let button: CdkMenuItem;
-  let nativeButton: HTMLButtonElement;
+  describe('without enclosing elements', () => {
+    let fixture: ComponentFixture<SingleMenuItem>;
+    let menuItem: CdkMenuItem;
+    let nativeButton: HTMLButtonElement;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [CdkMenuModule],
-      declarations: [SingleMenuItem],
-    }).compileComponents();
-  }));
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [SingleMenuItem],
+      }).compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SingleMenuItem);
-    fixture.detectChanges();
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SingleMenuItem);
+      fixture.detectChanges();
 
-    button = fixture.debugElement.query(By.directive(CdkMenuItem)).injector.get(CdkMenuItem);
-    nativeButton = fixture.debugElement.query(By.directive(CdkMenuItem)).nativeElement;
+      menuItem = fixture.debugElement.query(By.directive(CdkMenuItem)).injector.get(CdkMenuItem);
+      nativeButton = fixture.debugElement.query(By.directive(CdkMenuItem)).nativeElement;
+    });
+
+    it('should have the menuitem role', () => {
+      expect(nativeButton.getAttribute('role')).toBe('menuitem');
+    });
+
+    it('should coerce the disabled property', () => {
+      (menuItem as any).disabled = '';
+      expect(menuItem.disabled).toBeTrue();
+    });
+
+    it('should toggle the aria disabled attribute', () => {
+      expect(nativeButton.hasAttribute('aria-disabled')).toBeFalse();
+
+      menuItem.disabled = true;
+      fixture.detectChanges();
+
+      expect(nativeButton.getAttribute('aria-disabled')).toBe('true');
+
+      menuItem.disabled = false;
+      fixture.detectChanges();
+
+      expect(nativeButton.hasAttribute('aria-disabled')).toBeFalse();
+    });
+
+    it('should be a button type', () => {
+      expect(nativeButton.getAttribute('type')).toBe('button');
+    });
+
+    it('should not have a menu', () => {
+      expect(menuItem.hasMenu()).toBeFalse();
+    });
   });
 
-  it('should have the menuitem role', () => {
-    expect(nativeButton.getAttribute('role')).toBe('menuitem');
-  });
+  describe('with complex inner elements', () => {
+    let fixture: ComponentFixture<ComplexMenuItem>;
+    let menuItem: CdkMenuItem;
 
-  it('should coerce the disabled property', () => {
-    (button as any).disabled = '';
-    expect(button.disabled).toBeTrue();
-  });
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [ComplexMenuItem],
+      }).compileComponents();
+    }));
 
-  it('should toggle the aria disabled attribute', () => {
-    expect(nativeButton.getAttribute('aria-disabled')).toBeNull();
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ComplexMenuItem);
+      fixture.detectChanges();
 
-    button.disabled = true;
-    fixture.detectChanges();
+      menuItem = fixture.debugElement.query(By.directive(CdkMenuItem)).injector.get(CdkMenuItem);
+    });
 
-    expect(nativeButton.getAttribute('aria-disabled')).toBe('true');
-
-    button.disabled = false;
-    fixture.detectChanges();
-
-    expect(nativeButton.getAttribute('aria-disabled')).toBeNull();
-  });
-
-  it('should be a button type', () => {
-    expect(nativeButton.getAttribute('type')).toBe('button');
-  });
-
-  it('should not have a menu', () => {
-    expect(button.hasMenu()).toBeFalse();
+    it('should be able to extract the label text, with text nested in bold tag', () => {
+      expect(menuItem.getLabel()).toBe('Click me!');
+    });
   });
 });
 
@@ -60,3 +85,8 @@ describe('MenuItem', () => {
   template: `<button cdkMenuItem>Click me!</button>`,
 })
 class SingleMenuItem {}
+
+@Component({
+  template: ` <button cdkMenuItem>Click <b>me!</b></button> `,
+})
+class ComplexMenuItem {}

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -6,9 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input, Optional, Self} from '@angular/core';
+import {Directive, Input, Optional, Self, ElementRef, Output, EventEmitter} from '@angular/core';
 import {coerceBooleanProperty, BooleanInput} from '@angular/cdk/coercion';
+import {FocusableOption} from '@angular/cdk/a11y';
 import {CdkMenuItemTrigger} from './menu-item-trigger';
+import {Menu} from './menu-interface';
 
 /**
  * Directive which provides the ability for an element to be focused and navigated to using the
@@ -24,7 +26,7 @@ import {CdkMenuItemTrigger} from './menu-item-trigger';
     '[attr.aria-disabled]': 'disabled || null',
   },
 })
-export class CdkMenuItem {
+export class CdkMenuItem implements FocusableOption {
   /**  Whether the CdkMenuItem is disabled - defaults to false */
   @Input()
   get disabled(): boolean {
@@ -35,21 +37,63 @@ export class CdkMenuItem {
   }
   private _disabled = false;
 
+  /**
+   * If this MenuItem is a regular MenuItem, outputs when it is triggered by a keyboard or mouse
+   * event.
+   */
+  @Output('cdkMenuItemTriggered') triggered: EventEmitter<void> = new EventEmitter();
+
   constructor(
+    private readonly _elementRef: ElementRef<HTMLElement>,
     /** Reference to the CdkMenuItemTrigger directive if one is added to the same element */
     @Self() @Optional() private readonly _menuTrigger?: CdkMenuItemTrigger
   ) {}
 
-  /** Open the menu if one is attached */
+  /** Place focus on the element. */
+  focus() {
+    this._elementRef.nativeElement.focus();
+  }
+
+  /** If not disabled, toggle the menu if one is attached otherwise emits the OnTrigger event. */
   trigger() {
-    if (!this.disabled && this.hasMenu()) {
+    if (this.disabled) {
+      return;
+    }
+
+    if (this.hasMenu()) {
       this._menuTrigger!.toggle();
+    } else {
+      this.triggered.next();
     }
   }
 
   /** Whether the menu item opens a menu. */
   hasMenu() {
-    return !!this._menuTrigger && this._menuTrigger.hasMenu();
+    return !!this._menuTrigger?.hasMenu();
+  }
+
+  /** Return true if this MenuItem has an attached menu and it is open. */
+  isMenuOpen() {
+    return !!this._menuTrigger?.isMenuOpen();
+  }
+
+  /**
+   * Get a reference to the rendered Menu if the Menu is open and it is visible in the DOM.
+   * @return the menu if it is open, otherwise undefined.
+   */
+  getMenu(): Menu | undefined {
+    return this._menuTrigger?.getMenu();
+  }
+
+  /** Get the MenuItemTrigger associated with this element. */
+  getMenuTrigger(): CdkMenuItemTrigger | undefined {
+    return this._menuTrigger;
+  }
+
+  /** Get the label for this element which is required by the FocusableOption interface. */
+  getLabel(): string {
+    // TODO(andy): implement a more robust algorithm for determining nested text
+    return this._elementRef.nativeElement.innerText;
   }
 
   static ngAcceptInputType_disabled: BooleanInput;

--- a/src/cdk-experimental/menu/menu-key-manager.spec.ts
+++ b/src/cdk-experimental/menu/menu-key-manager.spec.ts
@@ -1,0 +1,752 @@
+import {
+  Component,
+  EventEmitter,
+  ViewChildren,
+  QueryList,
+  ElementRef,
+  ViewChild,
+} from '@angular/core';
+import {async, TestBed, ComponentFixture, tick, fakeAsync} from '@angular/core/testing';
+import {
+  dispatchKeyboardEvent,
+  createKeyboardEvent,
+  dispatchEvent,
+} from '@angular/cdk/testing/private';
+import {
+  TAB,
+  RIGHT_ARROW,
+  LEFT_ARROW,
+  DOWN_ARROW,
+  UP_ARROW,
+  SPACE,
+  HOME,
+  END,
+  E,
+  D,
+  ESCAPE,
+  S,
+  H,
+} from '@angular/cdk/keycodes';
+import {CdkMenuModule} from './menu-module';
+import {CdkMenuItem} from './menu-item';
+import {CdkMenuBar} from './menu-bar';
+import {CdkMenu} from './menu';
+import {defaultTypeAheadDebounce} from './menu-key-manager';
+import {CdkMenuItemCheckbox} from './menu-item-checkbox';
+import {CdkMenuItemRadio} from './menu-item-radio';
+
+describe('Keyboard Manager', () => {
+  describe('(with ltr layout)', () => {
+    let fixture: ComponentFixture<MultiMenuWithSubmenu>;
+    let nativeMenuBar: HTMLElement;
+    let nativeMenus: HTMLElement[];
+    let menuBarNativeItems: HTMLButtonElement[];
+    let fileMenuNativeItems: HTMLButtonElement[];
+
+    function grabElementsForTesting() {
+      nativeMenuBar = fixture.componentInstance.nativeMenuBar.nativeElement;
+
+      nativeMenus = fixture.componentInstance.nativeMenus.map(e => e.nativeElement);
+
+      menuBarNativeItems = fixture.componentInstance.nativeItems
+        .map(e => e.nativeElement)
+        .slice(0, 2); // menu bar has the first 2 menu items
+
+      if (nativeMenus.length > 0) {
+        fileMenuNativeItems = fixture.componentInstance.nativeItems
+          .map(e => e.nativeElement)
+          .slice(2, 5); // file menu has the next 3 menu items
+      }
+    }
+
+    /** Run change detection and extract then set the rendered elements. */
+    function detectChanges() {
+      fixture.detectChanges();
+      grabElementsForTesting();
+    }
+
+    /** Set focus to the MenuBar and run change detection. */
+    function focusMenuBar() {
+      dispatchKeyboardEvent(document, 'keydown', TAB);
+      nativeMenuBar.focus();
+
+      detectChanges();
+    }
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MultiMenuWithSubmenu],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MultiMenuWithSubmenu);
+      detectChanges();
+    });
+
+    describe('for MenuBar', () => {
+      it('should focus the first menu item when the menubar gets tabbed in', () => {
+        focusMenuBar();
+
+        expect(document.activeElement).toEqual(menuBarNativeItems[0]);
+      });
+
+      it('should toggle the last/first menu item on end/home key press', () => {
+        focusMenuBar();
+        dispatchKeyboardEvent(nativeMenuBar, 'keydown', END);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(menuBarNativeItems[menuBarNativeItems.length - 1]);
+
+        focusMenuBar();
+        dispatchKeyboardEvent(nativeMenuBar, 'keydown', HOME);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(menuBarNativeItems[0]);
+      });
+
+      it('should not focus the last item when pressing end with modifier', () => {
+        focusMenuBar();
+
+        const event = createKeyboardEvent('keydown', END, '', undefined, {control: true});
+        dispatchEvent(nativeMenuBar, event);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(menuBarNativeItems[0]);
+      });
+
+      it('should not focus the first item when pressing home with modifier', () => {
+        focusMenuBar();
+        dispatchKeyboardEvent(nativeMenuBar, 'keydown', END);
+        detectChanges();
+
+        let event = createKeyboardEvent('keydown', HOME, '', undefined, {control: true});
+        dispatchEvent(nativeMenuBar, event);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(menuBarNativeItems[menuBarNativeItems.length - 1]);
+      });
+
+      it('should focus the edit MenuItem on E, D character keys', fakeAsync(() => {
+        focusMenuBar();
+        dispatchKeyboardEvent(nativeMenuBar, 'keydown', E);
+        dispatchKeyboardEvent(nativeMenuBar, 'keydown', D);
+        tick(defaultTypeAheadDebounce + 100);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(menuBarNativeItems[1]);
+      }));
+
+      it(
+        'should toggle and wrap when cycling the right/left arrow keys on menu bar ' +
+          'without toggling menus',
+        () => {
+          focusMenuBar();
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', RIGHT_ARROW);
+          detectChanges();
+          expect(document.activeElement).toEqual(menuBarNativeItems[1]);
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', RIGHT_ARROW);
+          detectChanges();
+          expect(document.activeElement).toEqual(menuBarNativeItems[0]);
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', LEFT_ARROW);
+          detectChanges();
+          expect(document.activeElement).toEqual(menuBarNativeItems[1]);
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', LEFT_ARROW);
+          detectChanges();
+          expect(document.activeElement).toEqual(menuBarNativeItems[0]);
+
+          expect(nativeMenus.length).toBe(0);
+        }
+      );
+
+      it(
+        "should open the focused menu item's menu and focus the first submenu" +
+          ' item on the down key',
+        () => {
+          focusMenuBar();
+
+          dispatchKeyboardEvent(menuBarNativeItems[0], 'keydown', DOWN_ARROW);
+          detectChanges();
+
+          expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
+        }
+      );
+
+      it(
+        "should open the focused menu item's menu and focus the last submenu" +
+          ' item on the up key',
+        () => {
+          focusMenuBar();
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', UP_ARROW);
+          detectChanges();
+
+          expect(document.activeElement).toEqual(
+            fileMenuNativeItems[fileMenuNativeItems.length - 1]
+          );
+        }
+      );
+
+      it('should open the focused menu items menu and focus first submenu item on space', () => {
+        focusMenuBar();
+
+        dispatchKeyboardEvent(nativeMenuBar, 'keydown', SPACE);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
+      });
+    });
+
+    describe('for Menu', () => {
+      function openFileMenu() {
+        if (nativeMenus.length === 0) {
+          focusMenuBar();
+          dispatchKeyboardEvent(menuBarNativeItems[0], 'keydown', SPACE);
+          detectChanges();
+        }
+      }
+
+      function openShareMenu() {
+        openFileMenu();
+        if (nativeMenus.length === 1) {
+          dispatchKeyboardEvent(nativeMenus[0], 'keydown', DOWN_ARROW);
+          dispatchKeyboardEvent(nativeMenus[0], 'keydown', RIGHT_ARROW);
+          detectChanges();
+        }
+      }
+
+      it('should open the submenu with focus on item with menu on right arrow press', () => {
+        openFileMenu();
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', DOWN_ARROW);
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', RIGHT_ARROW);
+        detectChanges();
+
+        expect(nativeMenus.length).withContext('menu bar, menu and submenu').toBe(2);
+        expect(nativeMenus[0].id).toBe('file_menu');
+        expect(nativeMenus[1].id).toBe('share_menu');
+      });
+
+      it('should cycle focus on down/up arrow without toggling menus', () => {
+        openFileMenu();
+        expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', DOWN_ARROW);
+        expect(document.activeElement).toEqual(fileMenuNativeItems[1]);
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', DOWN_ARROW);
+        expect(document.activeElement).toEqual(fileMenuNativeItems[2]);
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', UP_ARROW);
+        expect(document.activeElement).toEqual(fileMenuNativeItems[1]);
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', UP_ARROW);
+        expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', UP_ARROW);
+        expect(document.activeElement).toEqual(fileMenuNativeItems[2]);
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', DOWN_ARROW);
+        expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
+
+        expect(nativeMenus.length).toBe(1);
+      });
+
+      it('should focus the first/last item on home/end keys', () => {
+        openFileMenu();
+        expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', END);
+        expect(document.activeElement).toEqual(fileMenuNativeItems[fileMenuNativeItems.length - 1]);
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', HOME);
+        expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
+      });
+
+      it('should not focus the last item when pressing end with modifier', () => {
+        openFileMenu();
+
+        const event = createKeyboardEvent('keydown', END, '', undefined, {control: true});
+        dispatchEvent(nativeMenus[0], event);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
+      });
+
+      it('should not focus the first item when pressing home with modifier', () => {
+        openFileMenu();
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', END);
+        detectChanges();
+
+        const event = createKeyboardEvent('keydown', HOME, '', undefined, {control: true});
+        dispatchEvent(nativeMenus[0], event);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(fileMenuNativeItems[fileMenuNativeItems.length - 1]);
+      });
+
+      it(
+        'should call user defined function and close out menus on space key on a non-trigger ' +
+          'menu item',
+        () => {
+          openShareMenu();
+          const spy = jasmine.createSpy('user defined callback spy');
+          fixture.componentInstance.clickEmitter.subscribe(spy);
+
+          dispatchKeyboardEvent(nativeMenus[1], 'keydown', SPACE);
+          detectChanges();
+
+          expect(nativeMenus.length).toBe(0);
+          expect(spy).toHaveBeenCalledTimes(1);
+        }
+      );
+
+      it('should close the submenu on left arrow and place focus back on its trigger', () => {
+        openShareMenu();
+
+        dispatchKeyboardEvent(nativeMenus[1], 'keydown', LEFT_ARROW);
+        detectChanges();
+
+        expect(nativeMenus.length).toBe(1);
+        expect(nativeMenus[0].id).toBe('file_menu');
+        expect(document.activeElement).toEqual(fileMenuNativeItems[1]);
+      });
+
+      it(
+        'should close menu tree, focus next menu bar item and open its menu on right arrow when ' +
+          "currently focused item doesn't trigger a menu",
+        () => {
+          openShareMenu();
+
+          dispatchKeyboardEvent(nativeMenus[1], 'keydown', RIGHT_ARROW);
+          detectChanges();
+
+          expect(nativeMenus.length).toBe(1);
+          expect(nativeMenus[0].id).toBe('edit_menu');
+          expect(document.activeElement).toEqual(menuBarNativeItems[1]);
+        }
+      );
+
+      it('should close first level menu and focus previous menubar item on left arrow', () => {
+        openFileMenu();
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', LEFT_ARROW);
+        detectChanges();
+
+        expect(nativeMenus.length).toBe(1);
+        expect(nativeMenus[0].id).toBe('edit_menu');
+        expect(document.activeElement).toEqual(menuBarNativeItems[1]);
+      });
+
+      it('should close the open submenu and focus its trigger on escape press', () => {
+        openShareMenu();
+
+        dispatchKeyboardEvent(nativeMenus[1], 'keydown', ESCAPE);
+        detectChanges();
+
+        expect(nativeMenus.length).toBe(1);
+        expect(nativeMenus[0].id).toBe('file_menu');
+        expect(document.activeElement)
+          .withContext('re-focus trigger')
+          .toEqual(fileMenuNativeItems[1]);
+      });
+
+      it('should not close submenu and focus parent on escape with modifier', () => {
+        openShareMenu();
+        const event = createKeyboardEvent('keydown', ESCAPE, '', undefined, {control: true});
+
+        dispatchEvent(nativeMenus[1], event);
+        detectChanges();
+
+        expect(nativeMenus.length).withContext('menu bar, file menu, share menu').toBe(2);
+        expect(nativeMenus[0].id).toBe('file_menu');
+        expect(nativeMenus[1].id).toBe('share_menu');
+      });
+
+      it('should close out all menus on tab', () => {
+        openShareMenu();
+
+        dispatchKeyboardEvent(nativeMenus[1], 'keydown', TAB);
+        detectChanges();
+
+        expect(nativeMenus.length).toBe(0);
+      });
+
+      it('should focus share MenuItem on S, H character key press', fakeAsync(() => {
+        openFileMenu();
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', S);
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', H);
+        tick(defaultTypeAheadDebounce + 100);
+        detectChanges();
+
+        expect(document.activeElement).toEqual(fileMenuNativeItems[1]);
+      }));
+    });
+  });
+
+  describe('(with rtl layout)', () => {
+    let fixture: ComponentFixture<MultiMenuWithSubmenu>;
+    let nativeMenuBar: HTMLElement;
+    let nativeMenus: HTMLElement[];
+    let menuBarNativeItems: HTMLButtonElement[];
+    let fileMenuNativeItems: HTMLButtonElement[];
+
+    function grabElementsForTesting() {
+      nativeMenuBar = fixture.componentInstance.nativeMenuBar.nativeElement;
+
+      nativeMenus = fixture.componentInstance.nativeMenus.map(e => e.nativeElement);
+
+      menuBarNativeItems = fixture.componentInstance.nativeItems
+        .map(e => e.nativeElement)
+        .slice(0, 2); // menu bar has the first 2 menu items
+
+      if (nativeMenus.length > 0) {
+        fileMenuNativeItems = fixture.componentInstance.nativeItems
+          .map(e => e.nativeElement)
+          .slice(2, 5); // file menu has the next 3 menu items
+      }
+    }
+
+    /** Run change detection and extract then set the rendered elements. */
+    function detectChanges() {
+      fixture.detectChanges();
+      grabElementsForTesting();
+    }
+
+    /** Place focus on the MenuBar and run change detection. */
+    function focusMenuBar() {
+      dispatchKeyboardEvent(document, 'keydown', TAB);
+      nativeMenuBar.focus();
+
+      detectChanges();
+    }
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MultiMenuWithSubmenu],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MultiMenuWithSubmenu);
+      detectChanges();
+    });
+
+    beforeAll(() => {
+      document.dir = 'rtl';
+    });
+
+    afterAll(() => {
+      document.dir = 'ltr';
+    });
+
+    describe('for Menu', () => {
+      function openFileMenu() {
+        if (nativeMenus.length === 0) {
+          focusMenuBar();
+          dispatchKeyboardEvent(menuBarNativeItems[0], 'keydown', SPACE);
+          detectChanges();
+        }
+      }
+
+      function openShareMenu() {
+        openFileMenu();
+        if (nativeMenus.length === 1) {
+          dispatchKeyboardEvent(nativeMenus[0], 'keydown', DOWN_ARROW);
+          dispatchKeyboardEvent(nativeMenus[0], 'keydown', LEFT_ARROW);
+          detectChanges();
+        }
+      }
+
+      it('should open the submenu for menu item with menu on left arrow', () => {
+        openFileMenu();
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', DOWN_ARROW);
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', LEFT_ARROW);
+        detectChanges();
+
+        expect(nativeMenus.length).withContext('menu and submenu').toBe(2);
+        expect(nativeMenus[0].id).toBe('file_menu');
+        expect(nativeMenus[1].id).toBe('share_menu');
+      });
+
+      it('should close the submenu and focus its trigger on right arrow', () => {
+        openShareMenu();
+
+        dispatchKeyboardEvent(nativeMenus[1], 'keydown', RIGHT_ARROW);
+        detectChanges();
+
+        expect(nativeMenus.length).toBe(1);
+        expect(nativeMenus[0].id).toBe('file_menu');
+        expect(document.activeElement).toEqual(fileMenuNativeItems[1]);
+      });
+
+      it(
+        'should close menu tree, focus next menu bar item and open its menu on left arrow when ' +
+          "focused item doesn't have a menu",
+        () => {
+          openShareMenu();
+
+          dispatchKeyboardEvent(nativeMenus[1], 'keydown', LEFT_ARROW);
+          detectChanges();
+
+          expect(nativeMenus.length).toBe(1);
+          expect(nativeMenus[0].id).toBe('edit_menu');
+          expect(document.activeElement).toEqual(menuBarNativeItems[1]);
+        }
+      );
+
+      it('should close first level menu and focus the previous menubar item on right arrow', () => {
+        openFileMenu();
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', RIGHT_ARROW);
+        detectChanges();
+
+        expect(nativeMenus.length).toBe(1);
+        expect(nativeMenus[0].id).toBe('edit_menu');
+        expect(document.activeElement).toEqual(menuBarNativeItems[1]);
+      });
+    });
+  });
+
+  describe('with menuitemcheckbox components', () => {
+    let fixture: ComponentFixture<MenuWithCheckboxes>;
+    let nativeMenuBar: HTMLElement;
+    let nativeMenus: HTMLElement[];
+    let menuBarNativeItems: HTMLButtonElement[];
+    let fontMenuItems: CdkMenuItemCheckbox[];
+
+    function grabElementsForTesting() {
+      nativeMenuBar = fixture.componentInstance.nativeMenuBar.nativeElement;
+
+      nativeMenus = fixture.componentInstance.nativeMenus.map(e => e.nativeElement);
+
+      menuBarNativeItems = fixture.componentInstance.nativeItems
+        .map(e => e.nativeElement)
+        .slice(0, 2); // menu bar has the first 2 menu items
+
+      if (nativeMenus.length > 0) {
+        fontMenuItems = fixture.componentInstance.checkboxItems.toArray();
+      }
+    }
+
+    /** Run change detection and extract then set the rendered elements. */
+    function detectChanges() {
+      fixture.detectChanges();
+      grabElementsForTesting();
+    }
+
+    /** Place focus on the menu bar and run change detection. */
+    function focusMenuBar() {
+      dispatchKeyboardEvent(document, 'keydown', TAB);
+      nativeMenuBar.focus();
+
+      detectChanges();
+    }
+
+    function openFontMenu() {
+      if (nativeMenus.length === 0) {
+        focusMenuBar();
+        dispatchKeyboardEvent(menuBarNativeItems[0], 'keydown', SPACE);
+        detectChanges();
+      }
+    }
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuWithCheckboxes],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MenuWithCheckboxes);
+      detectChanges();
+    });
+
+    it(
+      'should set the checked state on the focused checkbox on space key and keep the' +
+        ' menu open',
+      () => {
+        openFontMenu();
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', SPACE);
+        detectChanges();
+
+        expect(fontMenuItems[0].checked).toBeTrue();
+        expect(nativeMenus.length).toBe(1);
+        expect(nativeMenus[0].id).toBe('font_menu');
+      }
+    );
+  });
+
+  describe('with menuitemradio components', () => {
+    let fixture: ComponentFixture<MenuWithRadioButtons>;
+    let nativeMenuBar: HTMLElement;
+    let nativeMenus: HTMLElement[];
+    let menuBarNativeItems: HTMLButtonElement[];
+    let fontMenuItems: CdkMenuItemRadio[];
+
+    function grabElementsForTesting() {
+      nativeMenuBar = fixture.componentInstance.nativeMenuBar.nativeElement;
+
+      nativeMenus = fixture.componentInstance.nativeMenus.map(e => e.nativeElement);
+
+      menuBarNativeItems = fixture.componentInstance.nativeItems
+        .map(e => e.nativeElement)
+        .slice(0, 1); // menu bar only has a single item
+
+      if (nativeMenus.length > 0) {
+        fontMenuItems = fixture.componentInstance.radioItems.toArray();
+      }
+    }
+
+    /** run change detection and, extract and set the rendered elements. */
+    function detectChanges() {
+      fixture.detectChanges();
+      grabElementsForTesting();
+    }
+
+    /** set focus the the MenuBar and run change detection. */
+    function focusMenuBar() {
+      dispatchKeyboardEvent(document, 'keydown', TAB);
+      nativeMenuBar.focus();
+
+      detectChanges();
+    }
+
+    function openFontMenu() {
+      if (nativeMenus.length === 0) {
+        focusMenuBar();
+        dispatchKeyboardEvent(menuBarNativeItems[0], 'keydown', SPACE);
+        detectChanges();
+      }
+    }
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [CdkMenuModule],
+        declarations: [MenuWithRadioButtons],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MenuWithRadioButtons);
+      detectChanges();
+    });
+
+    it(
+      'should set the checked state on the active radio button on space key and keep the' +
+        ' menu open',
+      () => {
+        openFontMenu();
+
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', DOWN_ARROW);
+        dispatchKeyboardEvent(nativeMenus[0], 'keydown', SPACE);
+        detectChanges();
+
+        expect(fontMenuItems[1].checked).toBeTrue();
+        expect(nativeMenus.length).toBe(1);
+        expect(nativeMenus[0].id).toBe('text_menu');
+      }
+    );
+  });
+});
+
+@Component({
+  template: `
+    <div>
+      <div cdkMenuBar id="menu_bar">
+        <button cdkMenuItem [cdkMenuTriggerFor]="file">File</button>
+        <button cdkMenuItem [cdkMenuTriggerFor]="edit">Edit</button>
+      </div>
+
+      <ng-template cdkMenuPanel #file="cdkMenuPanel">
+        <div cdkMenu id="file_menu" [cdkMenuPanel]="file">
+          <button cdkMenuItem>Save</button>
+          <button cdkMenuItem [cdkMenuTriggerFor]="share">Share</button>
+          <button cdkMenuItem>Open</button>
+        </div>
+      </ng-template>
+
+      <ng-template cdkMenuPanel #share="cdkMenuPanel">
+        <div cdkMenu id="share_menu" [cdkMenuPanel]="share">
+          <button (cdkMenuItemTriggered)="clickEmitter.next()" cdkMenuItem>Email</button>
+          <button cdkMenuItem>Chat</button>
+        </div>
+      </ng-template>
+
+      <ng-template cdkMenuPanel #edit="cdkMenuPanel">
+        <div cdkMenu id="edit_menu" [cdkMenuPanel]="edit">
+          <button cdkMenuItem>Undo</button>
+          <button cdkMenuItem>Redo</button>
+        </div>
+      </ng-template>
+    </div>
+  `,
+})
+class MultiMenuWithSubmenu {
+  clickEmitter = new EventEmitter<void>();
+  @ViewChild(CdkMenuBar, {read: ElementRef}) nativeMenuBar: ElementRef;
+
+  @ViewChildren(CdkMenu, {read: ElementRef}) nativeMenus: QueryList<ElementRef>;
+
+  @ViewChildren(CdkMenuItem, {read: ElementRef}) nativeItems: QueryList<ElementRef>;
+}
+
+@Component({
+  template: `
+    <div>
+      <div cdkMenuBar id="menu_bar">
+        <button cdkMenuItem [cdkMenuTriggerFor]="font">Font size</button>
+      </div>
+
+      <ng-template cdkMenuPanel #font="cdkMenuPanel">
+        <div cdkMenu id="font_menu" [cdkMenuPanel]="font">
+          <button cdkMenuItemCheckbox>Small</button>
+          <button cdkMenuItemCheckbox>Large</button>
+        </div>
+      </ng-template>
+    </div>
+  `,
+})
+class MenuWithCheckboxes {
+  @ViewChild(CdkMenuBar, {read: ElementRef}) nativeMenuBar: ElementRef;
+
+  @ViewChildren(CdkMenu, {read: ElementRef}) nativeMenus: QueryList<ElementRef>;
+
+  @ViewChildren(CdkMenuItem, {read: ElementRef}) nativeItems: QueryList<ElementRef>;
+
+  @ViewChildren(CdkMenuItemCheckbox) checkboxItems: QueryList<CdkMenuItemCheckbox>;
+}
+
+@Component({
+  template: `
+    <div>
+      <div cdkMenuBar id="menu_bar">
+        <button cdkMenuItem [cdkMenuTriggerFor]="text">Text</button>
+      </div>
+
+      <ng-template cdkMenuPanel #text="cdkMenuPanel">
+        <div cdkMenu id="text_menu" [cdkMenuPanel]="text">
+          <button cdkMenuItemRadio>Bold</button>
+          <button cdkMenuItemRadio>Italic</button>
+        </div>
+      </ng-template>
+    </div>
+  `,
+})
+class MenuWithRadioButtons {
+  @ViewChild(CdkMenuBar, {read: ElementRef}) nativeMenuBar: ElementRef;
+
+  @ViewChildren(CdkMenu, {read: ElementRef}) nativeMenus: QueryList<ElementRef>;
+
+  @ViewChildren(CdkMenuItem, {read: ElementRef}) nativeItems: QueryList<ElementRef>;
+
+  @ViewChildren(CdkMenuItemRadio) radioItems: QueryList<CdkMenuItemRadio>;
+}

--- a/src/cdk-experimental/menu/menu-key-manager.ts
+++ b/src/cdk-experimental/menu/menu-key-manager.ts
@@ -1,0 +1,339 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {FocusKeyManager} from '@angular/cdk/a11y';
+import {QueryList, InjectionToken} from '@angular/core';
+import {Directionality} from '@angular/cdk/bidi';
+import {
+  SPACE,
+  ENTER,
+  LEFT_ARROW,
+  RIGHT_ARROW,
+  UP_ARROW,
+  DOWN_ARROW,
+  END,
+  HOME,
+  ESCAPE,
+  TAB,
+  hasModifierKey,
+} from '@angular/cdk/keycodes';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+import {CdkMenuItemSelectable} from './menu-item-selectable';
+import {CdkMenuItem} from './menu-item';
+
+/**
+ * How long to wait in ms after the last character keystroke before reacting and changing the
+ * focused element.
+ */
+export const defaultTypeAheadDebounce = 200;
+
+/** Injection token used to customize the TypeAhead debounce interval. */
+export const TYPE_AHEAD_DEBOUNCE = new InjectionToken('cdk-menu-typeahead-debounce');
+
+/** Specifies the configuration options for the MenuKeyManager. */
+export type MenuKeyManagerConfig = {
+  /** Specifies the layout direction. */
+  directionality: Directionality;
+  /** Layout of the menu using the MenuKeyManager. */
+  menuOrientation: 'horizontal' | 'vertical';
+  /** Delay in milliseconds before handling character keys. */
+  typeAheadDebounce: number;
+};
+
+/**
+ * Handles Keyboard Events by setting focus to the appropriate MenuItems and/or triggering focused
+ * MenuItems based on the outlined behavior in the aria spec
+ * (https://www.w3.org/TR/wai-aria-practices-1.2/#menu) for the given key codes. It emits events
+ * which should be handled by parent Menu's MenuKeyManagers and internally hooks into submenu
+ * events.
+ *
+ * The MenuKeyManager handles both horizontal and vertical Menu orientation along with support for
+ * ltr and rtl layouts.
+ *
+ */
+export class MenuKeyManager {
+  /**
+   * Emits events which should be processed by the next Keyboard Manager. These may be events which
+   * are processed by this MenuKeyManager and should also be processed by the parent menus
+   * MenuKeyManager, or they may be events which cannot be processed by this MenuKeyManager.
+   */
+  readonly _bubbledEvents = new Subject<KeyboardEvent>();
+
+  /** End subscriptions to any open submenu's Keyboard Manager bubbled events emitter. */
+  private readonly _destroyKeyManagerListener = new Subject<void>();
+
+  /** Handles focus for the managed menu items. */
+  private readonly _keyManager: FocusKeyManager<CdkMenuItem>;
+
+  constructor(children: QueryList<CdkMenuItem>, private readonly _config: MenuKeyManagerConfig) {
+    this._keyManager = new FocusKeyManager(children)
+      .withWrap()
+      .withTypeAhead(_config.typeAheadDebounce);
+
+    if (this._isHorizontal()) {
+      this._keyManager.withHorizontalOrientation(_config.directionality.value);
+    } else {
+      this._keyManager.withVerticalOrientation();
+    }
+
+    this._keyManager.change.subscribe(() =>
+      this._subscribeToBubbledEvents(this._keyManager.activeItem!)
+    );
+  }
+
+  /**
+   * If the MenuItem opens a menu, subscribe to that menu's bubbled keyboard events emitter.
+   * @param menuItem the triggering menu item whose attached menu's Keyboard Manager it subscribes
+   * to.
+   */
+  private _subscribeToBubbledEvents(menuItem: CdkMenuItem) {
+    // Stop any existing subscriptions since the focus has changed and any open menu has closed.
+    this._destroyKeyManagerListener.next();
+
+    if (menuItem.hasMenu()) {
+      // If the provided menu item has a menu, when the menu opens subscribe to its
+      // bubbled events emitter allowing this Keyboard Manager to react to events which
+      // occurred in the submenu. For example, a TAB key event should close out the entire
+      // menu tree therefore when TAB is detected in a submenu, its Keyboard Manager emits the
+      // TAB event along with closing its open menu. Next, the listening Keyboard Managers higher
+      // up in the chain can react to this event by closing out its open menus and further
+      // bubbling up the event. In essence mimicking the default event bubbling behavior provided by
+      // nesting elements.
+      menuItem
+        .getMenuTrigger()!
+        .opened.pipe(takeUntil(this._destroyKeyManagerListener))
+        .subscribe(() => {
+          const menu = menuItem.getMenu();
+          if (menu?._getBubbledKeyboardEvents()) {
+            menu
+              ._getBubbledKeyboardEvents()!
+              .pipe(takeUntil(this._destroyKeyManagerListener))
+              .subscribe((keyboardEvent: KeyboardEvent) => this.onKeydown(keyboardEvent, true));
+          }
+        });
+    }
+  }
+
+  /** Place focus on the first menu item. */
+  focusFirstItem() {
+    this._keyManager.setFirstItemActive();
+  }
+
+  /** Place focus on the last menu item. */
+  focusLastItem() {
+    this._keyManager.setLastItemActive();
+  }
+
+  /**
+   * Place focus on the given menu item.
+   * @param item the menu item to focus.
+   */
+  focusItem(item: CdkMenuItem) {
+    this._keyManager.setActiveItem(item);
+  }
+
+  /**
+   * Process the given KeyboardEvent which may result in a Menu being open/closed and/or focus
+   * changing between the managed MenuItems.
+   *
+   * @param event the KeyboardEvent to process
+   * @param bubbled whether or not the KeyboardEvent has bubbled up from a submenu
+   */
+  onKeydown(event: KeyboardEvent, bubbled = false) {
+    let activeItem = this._keyManager.activeItem;
+
+    switch (event.keyCode) {
+      case ENTER:
+      case SPACE:
+        if (activeItem && !bubbled) {
+          if (activeItem.hasMenu()) {
+            this._openActiveMenu();
+            this._focusFirstSubmenuItem();
+          } else {
+            activeItem.trigger();
+
+            // Triggering a CdkMenuitemSelectable should not close the menu tree
+            if (!(activeItem instanceof CdkMenuItemSelectable)) {
+              this._bubbledEvents.next(event);
+            }
+          }
+        } else {
+          this._closeActiveMenu();
+          this._bubbledEvents.next(event);
+        }
+        break;
+
+      case LEFT_ARROW:
+        if (this._isHorizontal()) {
+          this._focusNext(event);
+        } else if (this._config.directionality.value === 'ltr') {
+          this._closeOnHorizontalArrow(event);
+        } else {
+          this._openOnHorizontalArrow(event, bubbled);
+        }
+        break;
+
+      case RIGHT_ARROW:
+        if (this._isHorizontal()) {
+          this._focusNext(event);
+        } else if (this._config.directionality.value === 'ltr') {
+          this._openOnHorizontalArrow(event, bubbled);
+        } else {
+          this._closeOnHorizontalArrow(event);
+        }
+        break;
+
+      case UP_ARROW:
+      case DOWN_ARROW:
+        if (this._isHorizontal() && activeItem?.hasMenu()) {
+          event.preventDefault();
+
+          this._openActiveMenu();
+          event.keyCode === DOWN_ARROW
+            ? this._focusFirstSubmenuItem()
+            : this._focusLastSubmenuItem();
+        } else {
+          this._keyManager.onKeydown(event);
+        }
+        break;
+
+      case HOME:
+      case END:
+        if (!hasModifierKey(event)) {
+          event.keyCode === HOME ? this.focusFirstItem() : this.focusLastItem();
+          event.preventDefault();
+        }
+        break;
+
+      case ESCAPE:
+        if (hasModifierKey(event)) {
+          break;
+        } else if (this._isActiveMenuOpen()) {
+          this._closeActiveMenu();
+        } else {
+          this._bubbledEvents.next(event);
+        }
+        event.preventDefault();
+        break;
+
+      case TAB:
+        this._closeActiveMenu();
+        this._bubbledEvents.next(event);
+        this._keyManager.onKeydown(event);
+        break;
+
+      default:
+        this._keyManager.onKeydown(event);
+    }
+  }
+
+  /**
+   * If the key is of type LEFT or RIGHT arrow, open the current active item if it has a menu and
+   * this is the primary event handler. Otherwise bubble up the event to the next handler.
+   * @param event the keyboard event to handle.
+   * @param bubbled whether or not the event has bubbled up from a child.
+   */
+  private _openOnHorizontalArrow(event: KeyboardEvent, bubbled: boolean) {
+    const keycode = event.keyCode;
+    if (keycode === LEFT_ARROW || keycode === RIGHT_ARROW) {
+      const activeItem = this._keyManager.activeItem;
+      if (activeItem?.hasMenu() && !bubbled) {
+        this._openActiveMenu();
+        this._focusFirstSubmenuItem();
+      } else {
+        this._closeActiveMenu();
+        this._bubbledEvents.next(event);
+      }
+    }
+  }
+
+  /**
+   * If the key is of type LEFT or RIGHT arrow, close the active items menu if the active item has
+   * an open menu, otherwise bubble up the event to the next handler.
+   * @param event the keyboard event to handle.
+   */
+  private _closeOnHorizontalArrow(event: KeyboardEvent) {
+    const keycode = event.keyCode;
+    if (keycode === LEFT_ARROW || keycode === RIGHT_ARROW) {
+      this._isActiveMenuOpen() ? this._closeActiveMenu() : this._bubbledEvents.next(event);
+    }
+  }
+
+  /** Close the active items menu and place focus on it if its menu is open. */
+  private _closeActiveMenu() {
+    const activeItem = this._keyManager.activeItem;
+    if (activeItem?.isMenuOpen()) {
+      activeItem.trigger();
+      this.focusItem(activeItem);
+    }
+  }
+
+  /** Open the active items menu if it has a menu and it's currently closed. */
+  private _openActiveMenu() {
+    const activeItem = this._keyManager.activeItem;
+    if (activeItem?.hasMenu() && !activeItem.isMenuOpen()) {
+      activeItem.trigger();
+    }
+  }
+
+  /** Place focus on the first item in the current active items menu. */
+  private _focusFirstSubmenuItem() {
+    const activeItem = this._keyManager.activeItem;
+    if (activeItem?.isMenuOpen()) {
+      activeItem.getMenu()?.focusFirstItem();
+    }
+  }
+
+  /** Place focus on the last item in the current active items menu. */
+  private _focusLastSubmenuItem() {
+    const activeItem = this._keyManager.activeItem;
+    if (activeItem?.isMenuOpen()) {
+      activeItem.getMenu()?.focusLastItem();
+    }
+  }
+
+  /** Return true if the current active item has a menu and it's open. */
+  private _isActiveMenuOpen() {
+    const activeItem = this._keyManager.activeItem;
+    return !!(activeItem?.hasMenu() && activeItem.isMenuOpen());
+  }
+
+  /**
+   * Place focus on the next element. If the currently focused element is open, close it and open
+   * the next element, otherwise do nothing else.
+   * @param event the keyboard event which trigged the focus action.
+   */
+  private _focusNext(event: KeyboardEvent) {
+    const previous = this._keyManager.activeItem;
+    this._keyManager.onKeydown(event);
+    const current = this._keyManager.activeItem;
+
+    if (previous !== current && previous?.isMenuOpen()) {
+      // close the previous menu and since previous was open, open the next one if it has one
+      previous.trigger();
+      this._openActiveMenu();
+    }
+  }
+
+  /**
+   * Return true if the menu for which this manager is enabled is configured in a horizontal
+   * orientation.
+   */
+  private _isHorizontal() {
+    return this._config.menuOrientation === 'horizontal';
+  }
+
+  /** Cleanup all subscriptions */
+  destroy() {
+    this._destroyKeyManagerListener.next();
+    this._destroyKeyManagerListener.complete();
+
+    this._bubbledEvents.complete();
+  }
+}

--- a/src/cdk-experimental/menu/menu-module.ts
+++ b/src/cdk-experimental/menu/menu-module.ts
@@ -16,6 +16,7 @@ import {CdkMenuGroup} from './menu-group';
 import {CdkMenuItemRadio} from './menu-item-radio';
 import {CdkMenuItemCheckbox} from './menu-item-checkbox';
 import {CdkMenuItemTrigger} from './menu-item-trigger';
+import {TYPE_AHEAD_DEBOUNCE, defaultTypeAheadDebounce} from './menu-key-manager';
 
 const EXPORTED_DECLARATIONS = [
   CdkMenuBar,
@@ -31,5 +32,6 @@ const EXPORTED_DECLARATIONS = [
   imports: [OverlayModule],
   exports: EXPORTED_DECLARATIONS,
   declarations: EXPORTED_DECLARATIONS,
+  providers: [{provide: TYPE_AHEAD_DEBOUNCE, useValue: defaultTypeAheadDebounce}],
 })
 export class CdkMenuModule {}

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -16,12 +16,17 @@ import {
   AfterContentInit,
   OnDestroy,
   Optional,
+  Inject,
 } from '@angular/core';
+import {Directionality} from '@angular/cdk/bidi';
+import {Subject} from 'rxjs';
 import {take} from 'rxjs/operators';
 import {CdkMenuGroup} from './menu-group';
 import {CdkMenuPanel} from './menu-panel';
 import {Menu, CDK_MENU} from './menu-interface';
 import {throwMissingMenuPanelError} from './menu-errors';
+import {CdkMenuItem} from './menu-item';
+import {MenuKeyManager, TYPE_AHEAD_DEBOUNCE} from './menu-key-manager';
 
 /**
  * Directive which configures the element as a Menu which should contain child elements marked as
@@ -34,6 +39,7 @@ import {throwMissingMenuPanelError} from './menu-errors';
   selector: '[cdkMenu]',
   exportAs: 'cdkMenu',
   host: {
+    '(keydown)': '_handleKeyEvent($event)',
     'role': 'menu',
     '[attr.aria-orientation]': 'orientation',
   },
@@ -52,9 +58,16 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnD
   /** Event emitted when the menu is closed. */
   @Output() readonly closed: EventEmitter<void | 'click' | 'tab' | 'escape'> = new EventEmitter();
 
+  /** Handles keyboard events for the menu. */
+  private _keyManager?: MenuKeyManager;
+
   /** List of nested CdkMenuGroup elements */
   @ContentChildren(CdkMenuGroup, {descendants: true})
   private readonly _nestedGroups: QueryList<CdkMenuGroup>;
+
+  /** All child MenuItem elements nested in this Menu. */
+  @ContentChildren(CdkMenuItem, {descendants: true})
+  private readonly _allItems: QueryList<CdkMenuItem>;
 
   /**
    * A reference to the enclosing parent menu panel.
@@ -65,7 +78,11 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnD
    */
   @Input('cdkMenuPanel') private readonly _explicitPanel?: CdkMenuPanel;
 
-  constructor(@Optional() private readonly _menuPanel?: CdkMenuPanel) {
+  constructor(
+    private readonly _dir: Directionality,
+    @Inject(TYPE_AHEAD_DEBOUNCE) private readonly _debounceInterval: number,
+    @Optional() private readonly _menuPanel?: CdkMenuPanel
+  ) {
     super();
   }
 
@@ -74,6 +91,40 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnD
 
     this._completeChangeEmitter();
     this._registerWithParentPanel();
+
+    this._keyManager = new MenuKeyManager(this._allItems, {
+      directionality: this._dir,
+      menuOrientation: this.orientation,
+      typeAheadDebounce: this._debounceInterval,
+    });
+  }
+
+  /** Place focus on the first MenuItem in the menu. */
+  focusFirstItem() {
+    this._keyManager?.focusFirstItem();
+  }
+
+  /** Place focus on the last MenuItem in the menu. */
+  focusLastItem() {
+    this._keyManager?.focusLastItem();
+  }
+
+  /**
+   * Place focus on the given MenuItem in the menu.
+   * @param child the MenuItem to place focus on
+   */
+  focusItem(child: CdkMenuItem) {
+    this._keyManager?.focusItem(child);
+  }
+
+  /** Get an emitter which emits bubbled-up keyboard events from the keyboard manager. */
+  _getBubbledKeyboardEvents(): Subject<KeyboardEvent> | undefined {
+    return this._keyManager?._bubbledEvents;
+  }
+
+  /** Direct the MenuKeyManager to handle the keyboard event. */
+  _handleKeyEvent(event: KeyboardEvent) {
+    this._keyManager?.onKeydown(event);
   }
 
   /** Register this menu with its enclosing parent menu panel */
@@ -117,6 +168,7 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnD
 
   ngOnDestroy() {
     this._emitClosedEvent();
+    this._keyManager!.destroy();
   }
 
   /** Emit and complete the closed event emitter */


### PR DESCRIPTION
The aria spec for Menu and MenuBar describes a robust set of instructions for navigating the Menu
using a keyboard. This implements the full aria spec for vertical and horizontal Menus along with
support for left-to-right and right-to-left layouts. Some liberty is taken with handling keyboard
events with modifier keys (home/end and escape) in order to match the existing mat-menu
implementation for those keys.