### PR TITLE
refactor(cdk/overlay): remove logic which tracks excluded elements from outside clicks

### DIFF
--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
@@ -125,26 +125,34 @@ describe('OverlayOutsideClickDispatcher', () => {
     overlayTwo.dispose();
   });
 
-  it(`should not dispatch click event when click on element
-      included in excludeFromOutsideClick array`, () => {
+  it('should dispatch the click event when click is on an element outside the overlay', () => {
+    const portal = new ComponentPortal(TestComponent);
     const overlayRef = overlay.create();
+    overlayRef.attach(portal);
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+
+    const spy = jasmine.createSpy('overlay mouse click spy');
+    overlayRef.outsidePointerEvents().subscribe(spy);
+
+    button.click();
+    expect(spy).toHaveBeenCalled();
+
+    button.parentNode!.removeChild(button);
+    overlayRef.dispose();
+  });
+
+  it('should not dispatch the click event when click is on an element inside the overlay', () => {
+    const portal = new ComponentPortal(TestComponent);
+    const overlayRef = overlay.create();
+    overlayRef.attach(portal);
+
     const spy = jasmine.createSpy('overlay mouse click event spy');
     overlayRef.outsidePointerEvents().subscribe(spy);
 
-    const overlayConfig = overlayRef.getConfig();
-    expect(overlayConfig.excludeFromOutsideClick).toBeDefined();
-    expect(overlayConfig.excludeFromOutsideClick!.length).toBe(0);
-
-    overlayRef.attach(new ComponentPortal(TestComponent));
-
-    const buttonShouldNotDetach = document.createElement('button');
-    document.body.appendChild(buttonShouldNotDetach);
-    overlayConfig.excludeFromOutsideClick!.push(buttonShouldNotDetach);
-    buttonShouldNotDetach.click();
-
+    overlayRef.overlayElement.click();
     expect(spy).not.toHaveBeenCalled();
 
-    buttonShouldNotDetach.parentNode!.removeChild(buttonShouldNotDetach);
     overlayRef.dispose();
   });
 });

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.ts
@@ -81,13 +81,9 @@ export class OverlayOutsideClickDispatcher extends BaseOverlayDispatcher {
         continue;
       }
 
-      const config = overlayRef.getConfig();
-      const excludeElements = [...config.excludeFromOutsideClick!, overlayRef.overlayElement];
-      const isInsideClick: boolean = excludeElements.some(e => e.contains(target));
-
-      // If it is inside click just break - we should do nothing
-      // If it is outside click dispatch the mouse event, and proceed with the next overlay
-      if (isInsideClick) {
+      // If it's a click inside the overlay, just break - we should do nothing
+      // If it's an outside click dispatch the mouse event, and proceed with the next overlay
+      if (overlayRef.overlayElement.contains(target as Node)) {
         break;
       }
 

--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -59,11 +59,6 @@ export class OverlayConfig {
    */
   disposeOnNavigation?: boolean = false;
 
-  /**
-   * Array of HTML elements clicking on which should not be considered as outside click
-   */
-  excludeFromOutsideClick?: HTMLElement[] = [];
-
   constructor(config?: OverlayConfig) {
     if (config) {
       // Use `Iterable` instead of `Array` because TypeScript, as of 3.6.3,

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -205,7 +205,6 @@ export declare class OverlayConfig {
     backdropClass?: string | string[];
     direction?: Direction | Directionality;
     disposeOnNavigation?: boolean;
-    excludeFromOutsideClick?: HTMLElement[];
     hasBackdrop?: boolean;
     height?: number | string;
     maxHeight?: number | string;


### PR DESCRIPTION
This removes the ability to track excluded elements from the overlay and only stops outside
click event notifications if the click event occurred within an overlay element itself. The
overlay should not track elements to be excluded from outside click - this should be up
to the developer. This allows for custom closeout logic to be implemented by the developer leaving
the cdk to be unopinionated.