### PR TITLE
fix(tests): update tests to use new _c- prefix

### DIFF
--- a/src/material/badge/badge.spec.ts
+++ b/src/material/badge/badge.spec.ts
@@ -147,7 +147,8 @@ describe('MatBadge', () => {
     let encapsulationAttr: Attr | undefined;
 
     for (let i = 0; i < badge.attributes.length; i++) {
-      if (badge.attributes[i].name.startsWith('_ngcontent-')) {
+      if (badge.attributes[i].name.startsWith('_c-') ||
+          badge.attributes[i].name.startsWith('_ngcontent-')) {
         encapsulationAttr = badge.attributes[i];
         break;
       }


### PR DESCRIPTION
Updates badge.spec.ts to also detect the new minified _c- angular prefix.

This change is to reflect https://github.com/angular/angular/pull/37786.