### PR TITLE
fix(material/datepicker) : value change without blur when the date st…

### DIFF
--- a/src/material-moment-adapter/adapter/moment-date-formats.ts
+++ b/src/material-moment-adapter/adapter/moment-date-formats.ts
@@ -11,7 +11,7 @@ import {MatDateFormats} from '@angular/material/core';
 
 export const MAT_MOMENT_DATE_FORMATS: MatDateFormats = {
   parse: {
-    dateInput: 'l',
+    dateInput: 'HTML5_FMT.DATE',
   },
   display: {
     dateInput: 'l',


### PR DESCRIPTION
…arts with 0

Fix a bug in the moment datepicker component that triggers valueChange without the blur event
when the date starts with 0 and the 0 is removed. This is due to the fact that in the
library moment.js 0 with the format 'L' is considered invalid.
One way to bypass this issue and not impact the `_onInput` function of `datepicker-input-base.ts` is to change the format, with for example `HTML5_FMT.DATE` only in the `moment-date-adapter`.

Fixes #19613