### PR TITLE
refactor(cdk/drag-drop): do not always retain drag handle directive 

### DIFF
--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -1,5 +1,5 @@
 cdk/drag-drop/all-directives: 154096
-cdk/drag-drop/basic: 151903
+cdk/drag-drop/basic: 151353
 material-experimental/mdc-chips/basic: 147607
 material-experimental/mdc-form-field/advanced: 220897
 material-experimental/mdc-form-field/basic: 220060

--- a/goldens/size-test.yaml
+++ b/goldens/size-test.yaml
@@ -1,5 +1,5 @@
-cdk/drag-drop/all-directives: 153594
-cdk/drag-drop/basic: 151498
+cdk/drag-drop/all-directives: 154096
+cdk/drag-drop/basic: 151903
 material-experimental/mdc-chips/basic: 147607
 material-experimental/mdc-form-field/advanced: 220897
 material-experimental/mdc-form-field/basic: 220060

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -191,7 +191,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
       @Optional() @Inject(CDK_DRAG_CONFIG) config: DragDropConfig,
       @Optional() private _dir: Directionality, dragDrop: DragDrop,
       private _changeDetectorRef: ChangeDetectorRef,
-      @Optional() @Self() private _selfHandle?: CdkDragHandle) {
+      @Optional() @Self() @Inject(CDK_DRAG_HANDLE) private _selfHandle?: CdkDragHandle) {
     this._dragRef = dragDrop.createDrag(element, {
       dragStartThreshold: config && config.dragStartThreshold != null ?
           config.dragStartThreshold : 5,


### PR DESCRIPTION
See individual commits. 

Marking as P2 to fix the size regression as soon as possible (low-effort), and since lightweight token work was P2 too.