### PR TITLE
build: set master as branch for minor label when merging

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -9,13 +9,11 @@ export const merge = (): MergeConfig => {
   const currentVersion = require('../package.json').version;
   // We use the `@angular/cdk` as source of truth for the latest published version in NPM.
   // Any package from the monorepo could technically work and result in the same version.
-  let {minor, patch} = determineMergeBranches(currentVersion, '@angular/cdk');
 
   // TODO(devversion) Clean this up once the label/branching has been finalized.
-  if (currentVersion.startsWith('10.0.0-rc')) {
-    patch = '10.0.x';
-    minor = 'master';
-  }
+  // let {minor, patch} = determineMergeBranches(currentVersion, '@angular/cdk');
+  const patch = '10.0.x';
+  const minor = 'master';
 
   return {
     // By default, the merge script merges locally with `git cherry-pick` and autosquash.


### PR DESCRIPTION
Updates the hard-coded branch logic so that minor
label merges into `master`. We continue using our
hard-coded values as we have not finalized the branching
and labeling yet.