### PR TITLE
fix(google-maps): rendering blank if custom options with no center are provided

### DIFF
--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -169,6 +169,18 @@ describe('GoogleMap', () => {
     expect(mapSpy.setOptions).toHaveBeenCalledWith({...options, heading: 170});
   });
 
+  it('should set a default center if the custom options do not provide one', () => {
+    const options = {zoom: 7};
+    mapSpy = createMapSpy(options);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.componentInstance.options = options;
+    fixture.detectChanges();
+
+    expect(mapConstructorSpy.calls.mostRecent()?.args[1].center).toBeTruthy();
+  });
+
   it('gives precedence to center and zoom over options', () => {
     const inputOptions = {center: {lat: 3, lng: 5}, zoom: 7, heading: 170};
     const correctedOptions = {

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -455,7 +455,9 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
         .pipe(map(([options, center, zoom]) => {
           const combinedOptions: google.maps.MapOptions = {
             ...options,
-            center: center || options.center,
+            // It's important that we set **some** kind of `center`, otherwise
+            // Google Maps will render a blank rectangle which looks broken.
+            center: center || options.center || DEFAULT_OPTIONS.center,
             zoom: zoom !== undefined ? zoom : options.zoom,
             mapTypeId: this.mapTypeId
           };


### PR DESCRIPTION
If an options object without a `center` is passed to the Google Maps API, it'll render a grey rectangle which looks broken. These changes make sure that we always pass in a `center` so something is rendered.

Fixes #19908.