### PR TITLE
build: add lint rule for lightweight tokens pattern

### DIFF
--- a/src/cdk-experimental/menu/menu-item-radio.ts
+++ b/src/cdk-experimental/menu/menu-item-radio.ts
@@ -43,6 +43,8 @@ export class CdkMenuItemRadio extends CdkMenuItemSelectable implements OnDestroy
     @Inject(CDK_MENU) parentMenu: Menu,
     @Optional() dir?: Directionality,
     /** Reference to the CdkMenuItemTrigger directive if one is added to the same element */
+    // `CdkMenuItemRadio` is commonly used in combination with a `CdkMenuItemTrigger`.
+    // tslint:disable-next-line: lightweight-tokens
     @Self() @Optional() menuTrigger?: CdkMenuItemTrigger
   ) {
     super(element, parentMenu, dir, menuTrigger);

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -62,6 +62,8 @@ export class CdkMenuItem implements FocusableOption {
     @Inject(CDK_MENU) private readonly _parentMenu: Menu,
     @Optional() private readonly _dir?: Directionality,
     /** Reference to the CdkMenuItemTrigger directive if one is added to the same element */
+    // `CdkMenuItem` is commonly used in combination with a `CdkMenuItemTrigger`.
+    // tslint:disable-next-line: lightweight-tokens
     @Self() @Optional() private readonly _menuTrigger?: CdkMenuItemTrigger
   ) {}
 

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -92,6 +92,8 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnI
 
   constructor(
     @Optional() private readonly _dir?: Directionality,
+    // `CdkMenuPanel` is always used in combination with a `CdkMenu`.
+    // tslint:disable-next-line: lightweight-tokens
     @Optional() private readonly _menuPanel?: CdkMenuPanel
   ) {
     super();

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -16,7 +16,6 @@ import {
   Injectable,
   Injector,
   NgZone,
-  Optional,
 } from '@angular/core';
 import {OverlayKeyboardDispatcher} from './dispatchers/overlay-keyboard-dispatcher';
 import {OverlayOutsideClickDispatcher} from './dispatchers/overlay-outside-click-dispatcher';
@@ -57,9 +56,9 @@ export class Overlay {
               @Inject(DOCUMENT) private _document: any,
               private _directionality: Directionality,
               // @breaking-change 8.0.0 `_location` parameter to be made required.
-              @Optional() private _location?: Location,
+              private _location?: Location,
               // @breaking-change 9.0.0 `_outsideClickDispatcher` parameter to be made required.
-              @Optional() private _outsideClickDispatcher?: OverlayOutsideClickDispatcher) { }
+              private _outsideClickDispatcher?: OverlayOutsideClickDispatcher) { }
 
   /**
    * Creates an overlay.

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -163,7 +163,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
                * @deprecated `viewportRuler` parameter to become required.
                * @breaking-change 11.0.0
                */
-              @Optional() viewportRuler?: ViewportRuler) {
+              viewportRuler?: ViewportRuler) {
     super(elementRef, scrollDispatcher, ngZone, dir);
 
     if (!_scrollStrategy) {

--- a/src/cdk/table/text-column.ts
+++ b/src/cdk/table/text-column.ts
@@ -111,6 +111,9 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
   @ViewChild(CdkHeaderCellDef, {static: true}) headerCell: CdkHeaderCellDef;
 
   constructor(
+      // `CdkTextColumn` is always requiring a table, but we just assert it manually
+      // for better error reporting.
+      // tslint:disable-next-line: lightweight-tokens
       @Optional() private _table: CdkTable<T>,
       @Optional() @Inject(TEXT_COLUMN_OPTIONS) private _options: TextColumnOptions<T>) {
     this._options = _options || {};

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -88,7 +88,7 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
               /**
                * @deprecated @breaking-change 9.0.0 `platform` parameter to become required.
                */
-              @Optional() platform?: Platform,
+              platform?: Platform,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
               @Optional() @Inject(MAT_TABS_CONFIG) defaultConfig?: MatTabsConfig) {
     super(elementRef, dir, ngZone, changeDetectorRef, viewportRuler, platform, animationMode);

--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -46,6 +46,8 @@ export class MatDialogClose implements OnInit, OnChanges {
   @Input('matDialogClose') _matDialogClose: any;
 
   constructor(
+    // The dialog title directive is always used in combination with a `MatDialogRef`.
+    // tslint:disable-next-line: lightweight-tokens
     @Optional() public dialogRef: MatDialogRef<any>,
     private _elementRef: ElementRef<HTMLElement>,
     private _dialog: MatDialog) {}
@@ -94,6 +96,8 @@ export class MatDialogTitle implements OnInit {
   @Input() id: string = `mat-dialog-title-${dialogElementUid++}`;
 
   constructor(
+    // The dialog title directive is always used in combination with a `MatDialogRef`.
+    // tslint:disable-next-line: lightweight-tokens
     @Optional() private _dialogRef: MatDialogRef<any>,
     private _elementRef: ElementRef<HTMLElement>,
     private _dialog: MatDialog) {}

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -30,7 +30,7 @@ import {
   ErrorStateMatcher,
   mixinErrorState,
 } from '@angular/material/core';
-import {MatFormFieldControl, MatFormField} from '@angular/material/form-field';
+import {MatFormFieldControl, MatFormField, MAT_FORM_FIELD} from '@angular/material/form-field';
 import {Subject} from 'rxjs';
 import {getMatInputUnsupportedTypeError} from './input-errors';
 import {MAT_INPUT_VALUE_ACCESSOR} from './input-value-accessor';
@@ -238,9 +238,9 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     @Optional() @Self() @Inject(MAT_INPUT_VALUE_ACCESSOR) inputValueAccessor: any,
     private _autofillMonitor: AutofillMonitor,
     ngZone: NgZone,
-    // @breaking-change 8.0.0 `_formField` parameter to be made required.
-    // tslint:disable-next-line lightweight-tokens
-    @Optional() private _formField?: MatFormField) {
+    // TODO: Remove this once the legacy appearance has been removed. We only need
+    // to inject the form-field for determining whether the placeholder has been promoted.
+    @Optional() @Inject(MAT_FORM_FIELD) private _formField?: MatFormField) {
     super(_defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl);
 
     const element = this._elementRef.nativeElement;
@@ -366,9 +366,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     // screen readers will read it out twice: once from the label and once from the attribute.
     // TODO: can be removed once we get rid of the `legacy` style for the form field, because it's
     // the only one that supports promoting the placeholder to a label.
-    const formField = this._formField;
-    const placeholder =
-        (!formField || !formField._hideControlPlaceholder()) ? this.placeholder : null;
+    const placeholder = this._formField?._hideControlPlaceholder?.() ? null : this.placeholder;
     if (placeholder !== this._previousPlaceholder) {
       const element = this._elementRef.nativeElement;
       this._previousPlaceholder = placeholder;

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -239,6 +239,7 @@ export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<
     private _autofillMonitor: AutofillMonitor,
     ngZone: NgZone,
     // @breaking-change 8.0.0 `_formField` parameter to be made required.
+    // tslint:disable-next-line lightweight-tokens
     @Optional() private _formField?: MatFormField) {
     super(_defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl);
 

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -169,7 +169,11 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
               private _element: ElementRef<HTMLElement>,
               private _viewContainerRef: ViewContainerRef,
               @Inject(MAT_MENU_SCROLL_STRATEGY) scrollStrategy: any,
+              // `MatMenu` is always used in combination with a `MatMenuTrigger`.
+              // tslint:disable-next-line: lightweight-tokens
               @Optional() private _parentMenu: MatMenu,
+              // `MatMenuTrigger` is commonly used in combination with a `MatMenuItem`.
+              // tslint:disable-next-line: lightweight-tokens
               @Optional() @Self() private _menuItemInstance: MatMenuItem,
               @Optional() private _dir: Directionality,
               // TODO(crisbeto): make the _focusMonitor required when doing breaking changes.

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -142,6 +142,8 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
 
   constructor(public _intl: MatSortHeaderIntl,
               changeDetectorRef: ChangeDetectorRef,
+              // `MatSort` is not optionally injected, but just asserted manually w/ better error.
+              // tslint:disable-next-line: lightweight-tokens
               @Optional() public _sort: MatSort,
               @Inject('MAT_SORT_HEADER_COLUMN_DEF') @Optional()
                   public _columnDef: MatSortHeaderColumnDef,

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -92,7 +92,7 @@ export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements Af
               /**
                * @deprecated @breaking-change 9.0.0 `platform` parameter to become required.
                */
-              @Optional() platform?: Platform,
+              platform?: Platform,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, changeDetectorRef, viewportRuler, dir, ngZone, platform, animationMode);
   }
@@ -175,7 +175,7 @@ export class MatTabNav extends _MatTabNavBase {
     /**
      * @deprecated @breaking-change 9.0.0 `platform` parameter to become required.
      */
-    @Optional() platform?: Platform,
+    platform?: Platform,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, dir, ngZone, changeDetectorRef, viewportRuler, platform, animationMode);
   }

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -195,7 +195,7 @@ export declare class Overlay {
     scrollStrategies: ScrollStrategyOptions, _overlayContainer: OverlayContainer, _componentFactoryResolver: ComponentFactoryResolver, _positionBuilder: OverlayPositionBuilder, _keyboardDispatcher: OverlayKeyboardDispatcher, _injector: Injector, _ngZone: NgZone, _document: any, _directionality: Directionality, _location?: Location | undefined, _outsideClickDispatcher?: OverlayOutsideClickDispatcher | undefined);
     create(config?: OverlayConfig): OverlayRef;
     position(): OverlayPositionBuilder;
-    static ɵfac: i0.ɵɵFactoryDef<Overlay, [null, null, null, null, null, null, null, null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<Overlay, never>;
     static ɵprov: i0.ɵɵInjectableDef<Overlay>;
 }
 

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -141,7 +141,7 @@ export declare class CdkVirtualScrollViewport extends CdkScrollable implements O
     setRenderedRange(range: ListRange): void;
     setTotalContentSize(size: number): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<CdkVirtualScrollViewport, "cdk-virtual-scroll-viewport", never, { "orientation": "orientation"; }, { "scrolledIndexChange": "scrolledIndexChange"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<CdkVirtualScrollViewport, [null, null, null, { optional: true; }, { optional: true; }, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<CdkVirtualScrollViewport, [null, null, null, { optional: true; }, { optional: true; }, null, null]>;
 }
 
 export declare const DEFAULT_RESIZE_TIME = 20;

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -111,7 +111,7 @@ export declare abstract class _MatTabNavBase extends MatPaginatedTabHeader imple
     ngAfterContentInit(): void;
     updateActiveLink(_element?: ElementRef): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabNavBase, never, never, { "backgroundColor": "backgroundColor"; "disableRipple": "disableRipple"; "color": "color"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<_MatTabNavBase, [null, { optional: true; }, null, null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<_MatTabNavBase, [null, { optional: true; }, null, null, null, null, { optional: true; }]>;
 }
 
 export declare const MAT_TAB_GROUP: InjectionToken<any>;
@@ -242,7 +242,7 @@ export declare class MatTabNav extends _MatTabNavBase {
     platform?: Platform, animationMode?: string);
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTabNav, "[mat-tab-nav-bar]", ["matTabNavBar", "matTabNav"], { "color": "color"; }, {}, ["_items"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<MatTabNav, [null, { optional: true; }, null, null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatTabNav, [null, { optional: true; }, null, null, null, null, { optional: true; }]>;
 }
 
 export declare const matTabsAnimations: {

--- a/tools/tslint-rules/lightweightTokensRule.ts
+++ b/tools/tslint-rules/lightweightTokensRule.ts
@@ -1,0 +1,182 @@
+import * as minimatch from 'minimatch';
+import * as path from 'path';
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+/** Arguments this rule supports. */
+type RuleArguments = [
+  /** Glob that matches files which should be checked */
+  string[],
+  /** List of symbols that should be skipped for lightweight tokens. */
+  string[],
+];
+
+/** TSLint walk context for this rule. */
+type Context = Lint.WalkContext<RuleArguments>;
+
+/** Failure message that is used when a heavy token is optionally used. */
+const failureMessage = `Use a lightweight token for optionally injecting. This is necessary as ` +
+  `otherwise the injected symbol is always retained even though it might not be used. ` +
+  `Read more about it: https://next.angular.io/guide/lightweight-injection-tokens`;
+
+/**
+ * Rule that warns if a DI constructor is discovered for which parameters optionally
+ * inject classes without using the lightweight token pattern. The rule intends to help
+ * with optimized source code that works well for tree shakers. Read more about this here:
+ * https://next.angular.io/guide/lightweight-injection-tokens.
+ */
+export class Rule extends Lint.Rules.TypedRule {
+  applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+    return this.applyWithFunction(sourceFile, checkSourceFileForLightweightTokens,
+        this.getOptions().ruleArguments as RuleArguments, program.getTypeChecker());
+  }
+}
+
+
+/**
+ * Checks whether the given source file has classes with DI constructor parameters
+ * for which lightweight tokens are suitable (for optimized tree shaking).
+ */
+function checkSourceFileForLightweightTokens(ctx: Context, typeChecker: ts.TypeChecker): void {
+  // Relative path for the current TypeScript source file. This allows for
+  // relative globs being used in the rule options.
+  const relativeFilePath = path.relative(process.cwd(), ctx.sourceFile.fileName);
+  const [enabledFilesGlobs] = ctx.options;
+  const visitNode = (node: ts.Node) => {
+    if (ts.isClassDeclaration(node)) {
+      checkClassDeclarationForLightweightToken(node, ctx, typeChecker);
+    } else {
+      ts.forEachChild(node, visitNode);
+    }
+  };
+
+  if (enabledFilesGlobs.some(g => minimatch(relativeFilePath, g))) {
+    ts.forEachChild(ctx.sourceFile, visitNode);
+  }
+}
+
+/**
+ * Checks whether the given class declarations has a constructor with parameters
+ * for which lightweight tokens are suitable (for optimized tree shaking).
+ */
+function checkClassDeclarationForLightweightToken(
+    node: ts.ClassDeclaration, ctx: Context, typeChecker: ts.TypeChecker) {
+  // If a class has any decorator, it is assumed to be an Angular decorator.
+  // There are no other decorators available and we do not want to complicate
+  // this lint rule.
+  if (!node.decorators || node.decorators.length === 0) {
+    return;
+  }
+
+  for (const member of node.members) {
+    if (member.kind === ts.SyntaxKind.Constructor) {
+      checkConstructorForLightweightTokens(member as ts.ConstructorDeclaration, ctx, typeChecker);
+    }
+  }
+}
+
+/**
+ * Checks whether the given constructor has parameters where a lightweight
+ * token is suitable.
+ */
+function checkConstructorForLightweightTokens(
+    node: ts.ConstructorDeclaration, ctx: Context, typeChecker: ts.TypeChecker) {
+  for (const param of node.parameters) {
+    // Skip parameters without an explicit type. This should never happen in this
+    // repository but we handle it silently if there are such instances.
+    if (param.type === undefined) {
+      continue;
+    }
+
+    // Skip parameters which already have `@Inject` or are not using `@Optional` at all.
+    const {isOptional, hasInject} = analyzeDecorators(param);
+    if (hasInject || !isOptional) {
+      continue;
+    }
+
+    // Determine the type being used for injection of this parameter.
+    const injectionType = getInjectionType(param.type);
+    if (injectionType === null) {
+      continue;
+    }
+
+    let symbol = typeChecker.getSymbolAtLocation(injectionType);
+    // Symbols can be aliases of the declaration symbol. e.g. in named import specifiers.
+    // We need to resolve the aliased symbol back to the declaration symbol.
+    // tslint:disable-next-line:no-bitwise
+    if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+      symbol = typeChecker.getAliasedSymbol(symbol);
+    }
+
+    if (!symbol || !symbol.valueDeclaration) {
+      continue;
+    }
+
+    // Skip symbols which are explicitly disabled in the rule arguments. Some classes
+    // such as `Directionality` are always retained anyway, so there is no need to
+    // consume them through an optionally lightweight token.
+    if (ctx.options[1].includes(symbol.getName())) {
+      continue;
+    }
+
+    // No lightweight tokens are available for external symbols. Framework might
+    // add tokens in the future, but now there is no way for most symbols.
+    if (symbol.valueDeclaration.getSourceFile().isDeclarationFile) {
+      continue;
+    }
+
+    // If the containing class injects itself, then lightweight tokens will not have
+    // any effect, and we skip the lint.
+    if (symbol.valueDeclaration === node.parent) {
+      continue;
+    }
+
+    ctx.addFailureAtNode(param.type, failureMessage);
+  }
+}
+
+/** Gets an identifier that represents the given type node's resolved value. */
+function getInjectionType(type: ts.TypeNode): ts.Identifier|null {
+  // Unwraps union types with `null`. This is supported in Angular when
+  // `@Optional` is used. The `null` union type is ignored.
+  if (ts.isUnionTypeNode(type)) {
+    const nonNullTypes = type.types.filter(t => t.kind !== ts.SyntaxKind.NullKeyword);
+    return nonNullTypes.length === 1 ? getInjectionType(nonNullTypes[0]) : null;
+  }
+  if (!ts.isTypeReferenceNode(type)) {
+    return null;
+  }
+  const unwrapEntityName = (n: ts.EntityName): ts.Identifier => {
+    if (ts.isQualifiedName(n)) {
+      return unwrapEntityName(n.right);
+    }
+    return n;
+  };
+  return unwrapEntityName(type.typeName);
+}
+
+/**
+ * Analyzes the decorators of the given parameter. Returns whether it has
+ * an `@Inject` or `@Optional` decorator applied.
+ */
+function analyzeDecorators(param: ts.ParameterDeclaration):
+    {hasInject: boolean, isOptional: boolean} {
+  if (!param.decorators) {
+    return {hasInject: false, isOptional: false};
+  }
+  let hasInject = false;
+  let isOptional = false;
+  for (const decorator of param.decorators) {
+    const expr = decorator.expression;
+    if (!ts.isCallExpression(expr) || !ts.isIdentifier(expr.expression)) {
+      continue;
+    }
+    if (expr.expression.text === 'Inject') {
+      hasInject = true;
+    }
+    if (expr.expression.text === 'Optional') {
+      isOptional = true;
+    }
+  }
+  return {hasInject, isOptional};
+}

--- a/tslint.json
+++ b/tslint.json
@@ -127,6 +127,14 @@
     "no-nested-ternary": true,
     "prefer-const-enum": true,
     "no-lifecycle-invocation": [true, "**/!(*.spec).ts"],
+    "lightweight-tokens": [
+      true,
+      ["src/**/!(*.spec).ts"],
+      // Directionality is always used in Angular Material and therefore does not
+      // need a lightweight token. Date Adapter is not very significant and does not
+      // need a dedicated token.
+      ["Directionality", "DateAdapter"]
+    ],
     "coercion-types": [true,
       ["coerceBooleanProperty", "coerceCssPixelValue", "coerceNumberProperty"],
       {


### PR DESCRIPTION
Adds a lint that warns if a DI constructor is discovered for which
parameters optionally inject classes without using the lightweight
token pattern. The rule intends to help with optimized source code
that works well for tree shakers. Read more about this here:

https://next.angular.io/guide/lightweight-injection-tokens.