### PR TITLE
fix(material-experimental/mdc-snack-bar): error during server-side rendering

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
@@ -25,6 +25,7 @@ import {
 } from '@angular/core';
 import {MatSnackBarConfig, _SnackBarContainer} from '@angular/material/snack-bar';
 import {MDCSnackbarAdapter, MDCSnackbarFoundation} from '@material/snackbar';
+import {Platform} from '@angular/cdk/platform';
 import {Observable, Subject} from 'rxjs';
 
 /**
@@ -101,7 +102,8 @@ export class MatSnackBarContainer extends BasePortalOutlet
 
   constructor(
       private _elementRef: ElementRef<HTMLElement>,
-      public snackBarConfig: MatSnackBarConfig) {
+      public snackBarConfig: MatSnackBarConfig,
+      private _platform: Platform) {
     super();
 
     // Based on the ARIA spec, `alert` and `status` roles have an
@@ -136,7 +138,10 @@ export class MatSnackBarContainer extends BasePortalOutlet
   }
 
   enter() {
-    this._mdcFoundation.open();
+    // MDC uses some browser APIs that will throw during server-side rendering.
+    if (this._platform.isBrowser) {
+      this._mdcFoundation.open();
+    }
   }
 
   exit(): Observable<void> {

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
@@ -12,6 +12,7 @@ import {MatSlideToggleModule} from '@angular/material-experimental/mdc-slide-tog
 import {MatSliderModule} from '@angular/material-experimental/mdc-slider';
 import {MatTabsModule} from '@angular/material-experimental/mdc-tabs';
 import {MatIconModule} from '@angular/material/icon';
+import {MatSnackBarModule, MatSnackBar} from '@angular/material-experimental/mdc-snack-bar';
 
 @Component({
   selector: 'kitchen-sink-mdc',
@@ -35,6 +36,7 @@ export class KitchenSinkMdc {
     MatSliderModule,
     MatTabsModule,
     MatProgressBarModule,
+    MatSnackBarModule,
   ],
   declarations: [KitchenSinkMdc],
   exports: [KitchenSinkMdc],
@@ -47,6 +49,9 @@ export class KitchenSinkMdc {
   }]
 })
 export class KitchenSinkMdcModule {
+  constructor(snackBar: MatSnackBar) {
+    snackBar.open('Hello there');
+  }
 }
 
 export function ERROR_HANDLER(error: Error) {


### PR DESCRIPTION
Fixes an error that the MDC snack bar throws during server-side rendering, because MDC is using some browser APIs. Also sets up SSR testing for the new module.