### PR TITLE
fix(material/datepicker): change `MatDateRangeInput` input validation

### DIFF
--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -376,6 +376,34 @@ describe('MatDateRangeInput', () => {
     expect(end.errors?.matDatepickerMin).toBeFalsy();
   });
 
+  it('should not revalidate if minDate is unchanged', () => {
+    const fixture = createComponent(StandardRangePicker);
+    fixture.componentInstance.minDate = new Date(2020, 3, 2);
+    fixture.detectChanges();
+    spyOn(fixture.componentInstance.rangeInput._startInput, '_validatorOnChange').and.callThrough();
+    fixture.componentInstance.minDate = new Date(2020, 3, 2);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.rangeInput._startInput._validatorOnChange)
+      .not.toHaveBeenCalled();
+    fixture.componentInstance.minDate = new Date(2020, 3, 3);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.rangeInput._startInput._validatorOnChange).toHaveBeenCalled();
+  });
+
+  it('should not revalidate if maxDate is unchanged', () => {
+    const fixture = createComponent(StandardRangePicker);
+    fixture.componentInstance.maxDate = new Date(2020, 3, 2);
+    fixture.detectChanges();
+    spyOn(fixture.componentInstance.rangeInput._endInput, '_validatorOnChange').and.callThrough();
+    fixture.componentInstance.maxDate = new Date(2020, 3, 2);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.rangeInput._endInput._validatorOnChange)
+      .not.toHaveBeenCalled();
+    fixture.componentInstance.maxDate = new Date(2020, 3, 3);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.rangeInput._endInput._validatorOnChange).toHaveBeenCalled();
+  });
+
   it('should set the formatted date value as the input value', () => {
     const fixture = createComponent(StandardRangePicker);
     fixture.componentInstance.minDate = new Date(2020, 3, 2);

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -128,8 +128,11 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   @Input()
   get min(): D | null { return this._min; }
   set min(value: D | null) {
-    this._min = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
-    this._revalidate();
+    const min = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
+    if (!this._dateAdapter.sameDate(min, this._min)) {
+      this._min = min;
+      this._revalidate();
+    }
   }
   private _min: D | null;
 
@@ -137,8 +140,11 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   @Input()
   get max(): D | null { return this._max; }
   set max(value: D | null) {
-    this._max = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
-    this._revalidate();
+    const max = this._getValidDateOrNull(this._dateAdapter.deserialize(value));
+    if (!this._dateAdapter.sameDate(max, this._max)) {
+      this._max = max;
+      this._revalidate();
+    }
   }
   private _max: D | null;
 


### PR DESCRIPTION
* Prevent `MatStartDate._validatorOnChange()` from being called when `MatDateRangeInput`'s `minDate` input is updated with the same date.
* Prevent `MatEndDate._validatorOnChange()` from being called when `MatDateRangeInput`'s `maxDate` input is updated with the same date.
* Resolves #19907