### PR TITLE
test(material-experimental/mdc-card): remove stub for unit test

### DIFF
--- a/src/material-experimental/mdc-card/card.spec.ts
+++ b/src/material-experimental/mdc-card/card.spec.ts
@@ -1,1 +1,0 @@
-// TODO: copy tests from existing mat-card, update as necessary to fix.


### PR DESCRIPTION
Doesn't exist in the current card since its just a bunch of directives. Any issues should come up from the e2e tests