### PR TITLE
test(material-experimental/mdc-form-field): remove e2e file

### DIFF
--- a/src/material-experimental/mdc-form-field/BUILD.bazel
+++ b/src/material-experimental/mdc-form-field/BUILD.bazel
@@ -1,7 +1,5 @@
-load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
 load(
     "//tools:defaults.bzl",
-    "ng_e2e_test_library",
     "ng_module",
     "sass_binary",
     "sass_library",

--- a/src/material-experimental/mdc-form-field/BUILD.bazel
+++ b/src/material-experimental/mdc-form-field/BUILD.bazel
@@ -90,23 +90,3 @@ sass_library(
         "//src/material/core:core_scss_lib",
     ],
 )
-
-###########
-# Testing
-###########
-
-ng_e2e_test_library(
-    name = "e2e_test_sources",
-    srcs = glob(["**/*.e2e.spec.ts"]),
-    deps = [
-        "//src/cdk/testing/private/e2e",
-    ],
-)
-
-e2e_test_suite(
-    name = "e2e_tests",
-    deps = [
-        ":e2e_test_sources",
-        "//src/cdk/testing/private/e2e",
-    ],
-)


### PR DESCRIPTION
Our form field doesn't have an e2e test, probably since all the other components indirectly test it (input, select, etc)