### PR TITLE
fix(ng-update): properly handle update from different working directory

### DIFF
--- a/src/cdk/schematics/ng-update/test-cases/misc/working-directory.spec.ts
+++ b/src/cdk/schematics/ng-update/test-cases/misc/working-directory.spec.ts
@@ -1,0 +1,30 @@
+import {join} from 'path';
+import {MIGRATION_PATH} from '../../../index.spec';
+import {createTestCaseSetup} from '../../../testing';
+
+describe('ng-update working directory', () => {
+
+  it('should migrate project if working directory is not workspace root', async () => {
+    const {runFixers, writeFile, removeTempDir, tempPath, appTree} = await createTestCaseSetup(
+      'migration-v6', MIGRATION_PATH, []);
+    const stylesheetPath = 'projects/cdk-testing/src/test-cases/global-stylesheets-test.scss';
+
+    // Write a stylesheet that will be captured by the migration.
+    writeFile(stylesheetPath, `
+      [cdkPortalHost] {
+        color: red;
+      }
+    `);
+
+    // We want to switch into a given project directory. This means that the devkit
+    // file system tree is at workspace root while the working directory is not the
+    // workspace directory as previously assumed. See the following issue for more details:
+    // https://github.com/angular/components/issues/19779
+    await runFixers(join(tempPath, 'projects/cdk-testing'));
+
+    expect(appTree.readContent(stylesheetPath)).not
+      .toContain('[cdkPortalHost]', 'Expected migration to change stylesheet contents.');
+
+    removeTempDir();
+  });
+});

--- a/src/cdk/schematics/testing/test-case-setup.ts
+++ b/src/cdk/schematics/testing/test-case-setup.ts
@@ -104,10 +104,10 @@ export async function createTestCaseSetup(migrationName: string, collectionPath:
 
   writeFile(testAppTsconfigPath, JSON.stringify(testAppTsconfig, null, 2));
 
-  const runFixers = async function() {
-    // Switch to the new temporary directory to simulate that "ng update" is ran
-    // from within the project.
-    process.chdir(tempPath);
+  const runFixers = async function(workingDir = tempPath) {
+    // Switch to the given working directory. By default, switches to the workspace
+    // root to simulate the common `ng update` usage pattern.
+    process.chdir(workingDir);
 
     // Patch "executePostTasks" to do nothing. This is necessary since
     // we cannot run the node install task in unit tests. Rather we just

--- a/src/cdk/schematics/utils/workspace-fs-path.ts
+++ b/src/cdk/schematics/utils/workspace-fs-path.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath} from '@angular-devkit/core';
+import {HostDirEntry, HostTree, Tree} from '@angular-devkit/schematics';
+
+/**
+ * Gets the workspace file system path from the given tree. Returns
+ * `null` if the path could not be determined.
+ */
+// TODO: Remove this once we have a fully virtual TypeScript compiler host: COMP-387
+export function getWorkspaceFileSystemPath(tree: Tree): string|null {
+  if (!(tree.root instanceof HostDirEntry)) {
+    return null;
+  }
+  const hostTree = tree.root['_tree'];
+  if (!(hostTree instanceof HostTree) || hostTree['_backend'] === undefined) {
+    return null;
+  }
+  const backend = hostTree['_backend'];
+  if (backend['_root'] !== undefined) {
+    return getSystemPath(backend['_root']);
+  }
+  return null;
+}


### PR DESCRIPTION
In some situations, developers will run `ng update` from a sub directory
of the project. This currently results in a noop migration as file
system paths were computed incorrectly. This is because ng-update
always assumed that the CWD is the workspace root in the real file
system. This is not the case and therefore threw off path resolution.

We can fix this by determining the workspace file system path from
the virtual file system host tree's. This is not ideal, but best
solution for now until we can parse/resolve TypeScript projects
purely from within the virtual file system. This is currently
not easy to implement and requires helpers from TS which are
not exposed yet. See: https://github.com/microsoft/TypeScript/issues/13793.

This is tracked with: COMP-387.

Fixes #19779.