### PR TITLE
feat(cdk/testing): add base class for harnesses that may contain other harnesses

### DIFF
--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -375,6 +375,31 @@ export abstract class ComponentHarness {
   }
 }
 
+
+/**
+ * Base class for component harnesses that authors should extend if they anticipate that consumers
+ * of the harness may want to access other harnesses within the `<ng-content>` of the component.
+ */
+export abstract class ContentContainerComponentHarness<S extends string = string>
+  extends ComponentHarness implements HarnessLoader {
+
+  getChildLoader(selector: S): Promise<HarnessLoader> {
+    return this.locatorFactory.harnessLoaderFor(selector);
+  }
+
+  getAllChildLoaders(selector: S): Promise<HarnessLoader[]> {
+    return this.locatorFactory.harnessLoaderForAll(selector);
+  }
+
+  getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
+    return this.locatorFor(query)();
+  }
+
+  getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
+    return this.locatorForAll(query)();
+  }
+}
+
 /** Constructor for a ComponentHarness subclass. */
 export interface ComponentHarnessConstructor<T extends ComponentHarness> {
   new(locatorFactory: LocatorFactory): T;

--- a/src/material/card/testing/card-harness.ts
+++ b/src/material/card/testing/card-harness.ts
@@ -6,12 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  ComponentHarness,
-  HarnessLoader,
-  HarnessPredicate,
-  HarnessQuery
-} from '@angular/cdk/testing';
+import {HarnessPredicate, ContentContainerComponentHarness} from '@angular/cdk/testing';
 import {CardHarnessFilters} from './card-harness-filters';
 
 /** Selectors for different sections of the mat-card that can container user content. */
@@ -23,7 +18,7 @@ export const enum MatCardSection {
 }
 
 /** Harness for interacting with a standard mat-card in tests. */
-export class MatCardHarness extends ComponentHarness implements HarnessLoader {
+export class MatCardHarness extends ContentContainerComponentHarness<MatCardSection> {
   /** The selector for the host element of a `MatCard` instance. */
   static hostSelector = 'mat-card';
 
@@ -60,21 +55,5 @@ export class MatCardHarness extends ComponentHarness implements HarnessLoader {
   /** Gets the cards's subtitle text. */
   async getSubtitleText(): Promise<string> {
     return (await this._subtitle())?.text() ?? '';
-  }
-
-  async getChildLoader(selector: string): Promise<HarnessLoader> {
-    return (await this.locatorFactory.rootHarnessLoader()).getChildLoader(selector);
-  }
-
-  async getAllChildLoaders(selector: string): Promise<HarnessLoader[]> {
-    return (await this.locatorFactory.rootHarnessLoader()).getAllChildLoaders(selector);
-  }
-
-  async getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
-    return (await this.locatorFactory.rootHarnessLoader()).getHarness(query);
-  }
-
-  async getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
-    return (await this.locatorFactory.rootHarnessLoader()).getAllHarnesses(query);
   }
 }

--- a/tools/public_api_guard/cdk/testing.d.ts
+++ b/tools/public_api_guard/cdk/testing.d.ts
@@ -26,6 +26,13 @@ export interface ComponentHarnessConstructor<T extends ComponentHarness> {
     new (locatorFactory: LocatorFactory): T;
 }
 
+export declare abstract class ContentContainerComponentHarness<S extends string = string> extends ComponentHarness implements HarnessLoader {
+    getAllChildLoaders(selector: S): Promise<HarnessLoader[]>;
+    getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
+    getChildLoader(selector: S): Promise<HarnessLoader>;
+    getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
+}
+
 export interface ElementDimensions {
     height: number;
     left: number;

--- a/tools/public_api_guard/material/card/testing.d.ts
+++ b/tools/public_api_guard/material/card/testing.d.ts
@@ -4,11 +4,7 @@ export interface CardHarnessFilters extends BaseHarnessFilters {
     title?: string | RegExp;
 }
 
-export declare class MatCardHarness extends ComponentHarness implements HarnessLoader {
-    getAllChildLoaders(selector: string): Promise<HarnessLoader[]>;
-    getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
-    getChildLoader(selector: string): Promise<HarnessLoader>;
-    getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
+export declare class MatCardHarness extends ContentContainerComponentHarness<MatCardSection> {
     getSubtitleText(): Promise<string>;
     getText(): Promise<string>;
     getTitleText(): Promise<string>;


### PR DESCRIPTION
Adds a variant of the `ComponentHarness` base class that implements `HarnessLoader` and allows for child loaders to be queried off of the current harness. Applies it to the card harness to illustrate the consumption.

**Note:** marking as P2, because it's blocking further work on applying this to other harnesses.