### PR TITLE
feature(cdk/testing) emulate selection in testbed environment

### DIFF
--- a/guides/using-component-harnesses.md
+++ b/guides/using-component-harnesses.md
@@ -8,7 +8,7 @@ idea for component harnesses comes from the
 [PageObject](https://martinfowler.com/bliki/PageObject.html) pattern commonly used for integration
 testing.
 
-Angular Material offers test harnesses for many of its components. The Angular team strongly
+Angular Material offers test harnesses for most of its components. The Angular team strongly
 encourages developers to use these harnesses for testing to avoid creating brittle tests that rely
 on a component's internals.
 
@@ -262,3 +262,23 @@ When tests depend on the implementation details, they become a common source of 
 library changes. Angular CDK's test harnesses makes component library updates easier for both
 application authors and the Angular team, as the Angular team only has to update the harness once
 for everyone.
+
+## Differences between Testbed and real browser testing (Protractor)
+
+Writing test for both environments is very similar now. But even thought we do our best to get the
+behavior as close as possible, it's a low priority task and there are still some slight differences
+in the result of sending keys you should be arware of:
+
+* **All keys** will send keydown, keypress and keyup events.
+* **Normal characters** will change the value of text inputs at the cursor position or replace
+    selection.
+* **Arrow keys**
+  * **in text inputs** will emulate cursor movement or, if send with modifier ```{ shift: true }```,
+    seletion. But in textareas arrow up and down will just use col count and won't hit exactly one
+    line beacuse font measures and width and line wrapping.
+  * **in select inputs** might change the selected option.
+* **Page-Up/-Down** won't do anything but sending the key events.
+* **Backspace/Delete** won't delete anything.
+* **Enter** in inputs won't submit forms or insert a new line in multiline inputs. But of course it
+    may sometimes select an option, if the component listens to the keydown event.
+* **Tab** won't change focus to the next or previous input, nor select it's text value.

--- a/src/cdk/testing/testbed/fake-events/emulate-arrow-in-text-input.ts
+++ b/src/cdk/testing/testbed/fake-events/emulate-arrow-in-text-input.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  TextInputElement, getSelectionStart, getValueLength, getSelectionEnd,
+} from './text-input-element';
+
+type ArrowKey = 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight';
+export function isArrowKey(key: string): key is ArrowKey {
+  return key.startsWith('Arrow');
+}
+
+/**
+ * will move cursor and/or change selection of text value
+ */
+export function emulateArrowInTextInput(
+  modifiers: { shift?: boolean }, key: ArrowKey, element: TextInputElement,
+) {
+  if (modifiers.shift) {
+    switch (key) {
+      case 'ArrowUp': return emulateShiftArrowUp(element);
+      case 'ArrowRight': return emulateShiftArrowRight(element);
+      case 'ArrowDown': return emulateShiftArrowDown(element);
+      case 'ArrowLeft': return emulateShiftArrowLeft(element);
+    }
+  } else {
+    switch (key) {
+      case 'ArrowUp': return emulateArrowUp(element);
+      case 'ArrowRight': return emulateArrowRight(element);
+      case 'ArrowDown': return emulateArrowDown(element);
+      case 'ArrowLeft': return emulateArrowLeft(element);
+    }
+  }
+}
+
+function emulateArrowUp(target: TextInputElement) {
+  const lineLength = getLineLength(target);
+  const selectionStart = getSelectionStart(target);
+
+  setCursor(target, Math.max(selectionStart - lineLength, 0));
+}
+
+function setCursor(target: TextInputElement, position: number) {
+  target.setSelectionRange(position, position, 'none');
+}
+
+function getLineLength(target: TextInputElement, valueLength = getValueLength(target)) {
+  return target instanceof HTMLTextAreaElement ? target.cols : valueLength;
+}
+
+function emulateArrowRight(target: TextInputElement) {
+  if (target.selectionStart !== target.selectionEnd) {
+    setCursor(target, getSelectionEnd(target));
+    return;
+  }
+
+  const valueLength = getValueLength(target);
+  const selectionEnd = target.selectionEnd;
+  if (selectionEnd && selectionEnd < valueLength) {
+    setCursor(target, selectionEnd + 1);
+  } else {
+    setCursor(target, valueLength);
+  }
+}
+
+function emulateArrowDown(target: TextInputElement) {
+  const valueLength = getValueLength(target);
+  const lineLength = getLineLength(target, valueLength);
+  const selectionEnd = getSelectionEnd(target);
+  setCursor(target, Math.min(selectionEnd + lineLength, valueLength));
+}
+
+function emulateArrowLeft(target: TextInputElement) {
+  if (target.selectionStart !== target.selectionEnd) {
+    setCursor(target, getSelectionStart(target));
+    target.selectionEnd = target.selectionStart;
+    return;
+  }
+
+  const selectionStart = getSelectionStart(target);
+  if (selectionStart && selectionStart > 0) {
+    setCursor(target, selectionStart - 1);
+    return;
+  }
+
+  const valueLength = getValueLength(target);
+  if (valueLength > 0) {
+    setCursor(target, valueLength - 1);
+    return;
+  }
+
+  setCursor(target, 0);
+}
+
+function emulateShiftArrowUp(target: TextInputElement) {
+  const lineLength = getLineLength(target);
+
+  if (isSelectionDirectionOf(target, 'forward')) {
+    reduceSelectionAtSelectionEnd(target, lineLength);
+  } else {
+    extendSelectionAtSelectionStart(target, lineLength);
+  }
+}
+
+function isSelectionDirectionOf(target: TextInputElement, direction: 'forward' | 'backward') {
+  return target.selectionDirection === direction && (target.selectionStart !== target.selectionEnd);
+}
+
+function extendSelectionAtSelectionStart(target: TextInputElement, lengthToExtend: number) {
+  const selectionStart = getSelectionStart(target);
+  const newSelectionStart = Math.max(selectionStart - lengthToExtend, 0);
+  target.selectionStart = newSelectionStart;
+  if (target.selectionDirection !== 'backward') {
+    target.selectionDirection = 'backward';
+  }
+}
+
+function reduceSelectionAtSelectionEnd(target: TextInputElement, lengthToReduce: number) {
+  const selectionStart = getSelectionStart(target);
+  const selectionEnd = getSelectionEnd(target);
+  const newSelectionEnd = selectionEnd - lengthToReduce;
+
+  if (selectionStart < newSelectionEnd) {
+    target.selectionEnd = newSelectionEnd;
+  } else {
+    target.selectionEnd = selectionStart;
+    target.selectionDirection = 'none';
+    // there's a different behavior in firefox, which would move selection end:
+    // target.selectionEnd = selectionStart;
+    // target.selectionStart = newSelectionEnd;
+    // target.selectionDirection = 'backward';
+  }
+}
+
+function emulateShiftArrowRight(target: TextInputElement) {
+  if (isSelectionDirectionOf(target, 'backward')) {
+    reduceSelectionAtSelectionStart(target, 1);
+  } else {
+    extendSelectionAtSelectionEnd(target, 1);
+  }
+}
+
+function extendSelectionAtSelectionEnd(target: TextInputElement, lengthToExtend: number) {
+  const valueLength = getValueLength(target);
+  const selectionEnd = getSelectionEnd(target);
+  target.selectionEnd = Math.min(selectionEnd + lengthToExtend, valueLength);
+  if (target.selectionDirection !== 'forward') {
+    target.selectionDirection = 'forward';
+  }
+}
+
+function reduceSelectionAtSelectionStart(target: TextInputElement, lengthToReduce: number) {
+  const selectionStart = getSelectionStart(target);
+  const selectionEnd = getSelectionEnd(target);
+  const newSelectionStart = selectionStart + lengthToReduce;
+
+  if (newSelectionStart < selectionEnd) {
+    target.selectionStart = newSelectionStart;
+  } else {
+    target.selectionStart = selectionEnd;
+    target.selectionDirection = 'none';
+    // there's a different behavior in firefox, which would move selection end:
+    // target.selectionStart = selectionEnd;
+    // target.selectionEnd = newSelectionStart;
+    // target.selectionDirection = 'forward';
+  }
+}
+
+function emulateShiftArrowDown(target: TextInputElement) {
+  const lineLength = getLineLength(target);
+
+  if (isSelectionDirectionOf(target, 'backward')) {
+    reduceSelectionAtSelectionStart(target, lineLength);
+  } else {
+    extendSelectionAtSelectionEnd(target, lineLength);
+  }
+}
+
+function emulateShiftArrowLeft(target: TextInputElement) {
+  if (isSelectionDirectionOf(target, 'forward')) {
+    reduceSelectionAtSelectionEnd(target, 1);
+  } else {
+    extendSelectionAtSelectionStart(target, 1);
+  }
+}

--- a/src/cdk/testing/testbed/fake-events/emulate-char-in-text-input.ts
+++ b/src/cdk/testing/testbed/fake-events/emulate-char-in-text-input.ts
@@ -30,8 +30,18 @@ export function writeCharacter(element: TextInputElement, key: string) {
   dispatchFakeEvent(element, 'input');
 }
 
+const knownInputTypesWithSelectionIssues = ['color'];
 function hasToRespectSelection(element: TextInputElement): boolean {
-  return typeof element.value === 'string' && element.value.length > 0
-    && typeof element.selectionStart === 'number' && element.selectionStart < element.value.length
-  ;
+  try {
+    return typeof element.value === 'string' && element.value.length > 0
+      && typeof element.selectionStart === 'number' && element.selectionStart < element.value.length
+    ;
+  } catch (e) {
+    // Safari will throw 'type error' on input[type=color].selectionStart.get().
+    if (knownInputTypesWithSelectionIssues.indexOf(element.type) < 0) {
+      console.warn('could not detect selection of ', element);
+    }
+    // In general we can't respect selection if we can't detect selection so this will return false.
+    return false;
+  }
 }

--- a/src/cdk/testing/testbed/fake-events/emulate-char-in-text-input.ts
+++ b/src/cdk/testing/testbed/fake-events/emulate-char-in-text-input.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {dispatchFakeEvent} from './dispatch-events';
+import {getSelectionEnd, getSelectionStart, TextInputElement} from './text-input-element';
+
+/**
+ * emulate writing characters into text input fields.
+ * @docs-private
+ */
+export function writeCharacter(element: TextInputElement, key: string) {
+  if (!hasToRespectSelection(element)) {
+    element.value += key;
+  } else {
+    const value = element.value;
+    const selectionStart = getSelectionStart(element);
+    const valueBeforeSelection = value.substr(0, selectionStart);
+    const selectionEnd = getSelectionEnd(element);
+    const valueAfterSelection = value.substr(selectionEnd);
+    element.value = valueBeforeSelection + key + valueAfterSelection;
+
+    const cursor = selectionStart + key.length;
+    element.setSelectionRange(cursor, cursor, 'none');
+  }
+  dispatchFakeEvent(element, 'input');
+}
+
+function hasToRespectSelection(element: TextInputElement): boolean {
+  return typeof element.value === 'string' && element.value.length > 0
+    && typeof element.selectionStart === 'number' && element.selectionStart < element.value.length
+  ;
+}

--- a/src/cdk/testing/testbed/fake-events/emulate-text-input-behavior.spec.ts
+++ b/src/cdk/testing/testbed/fake-events/emulate-text-input-behavior.spec.ts
@@ -1,0 +1,401 @@
+import {emulateKeyInTextInput} from './emulate-text-input-behavior';
+import {isTextInput, TextInputElement} from './text-input-element';
+
+describe('type in text input', () => {
+  describe('in general', () => {
+    let input: TextInputElement;
+
+    beforeEach(() => input = document.createElement('input'));
+
+    it('should be a TextInput', () => {
+      expect(isTextInput(input)).toBe(true);
+    });
+
+    it('should change value on character input', () => {
+      emulateKeyInTextInput({}, 'a', input);
+      emulateKeyInTextInput({}, 'b', input);
+      emulateKeyInTextInput({}, 'c', input);
+
+      expect(input.value).toBe('abc');
+    });
+
+    describe('simulate selection', () => {
+      it('should select last character on Shift + ArrowLeft', () => {
+        input.value = 'abc';
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+
+        expect(input.selectionStart).toBe(2, 'start');
+        expect(input.selectionEnd).toBe(3, 'end');
+        expect(input.selectionDirection).toBe('backward', 'direction');
+      });
+
+      it('should extend selection backward', () => {
+        input.value = 'abc';
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+
+        expect(input.selectionStart).toBe(1, 'start');
+        expect(input.selectionEnd).toBe(3, 'end');
+        expect(input.selectionDirection).toBe('backward', 'direction');
+      });
+
+      it('should stop extending selection backward at the beginning of the input', () => {
+        input.value = 'abc';
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+
+        expect(input.selectionStart).toBe(0, 'start');
+        expect(input.selectionEnd).toBe(3, 'end');
+        expect(input.selectionDirection).toBe('backward', 'direction');
+      });
+
+      it('should reduce selection backward', () => {
+        input.value = 'abc';
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+
+        expect(input.selectionStart).toBe(2, 'start');
+        expect(input.selectionEnd).toBe(3, 'end');
+        expect(input.selectionDirection).toBe('backward', 'direction');
+      });
+
+      it('should move cursor without shift', () => {
+        input.value = 'abc';
+
+        emulateKeyInTextInput({}, 'ArrowLeft', input);
+
+        expect(input.selectionStart).toBe(2, 'start');
+        expect(input.selectionEnd).toBe(2, 'end');
+        expect(input.selectionDirection).toEqual(
+          jasmine.stringMatching(/none|forward/), 'direction',
+        );
+      });
+
+      it('should start selection from cursor position', () => {
+        input.value = 'abc';
+
+        emulateKeyInTextInput({}, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+
+        expect(input.selectionStart).toBe(1, 'start');
+        expect(input.selectionEnd).toBe(2, 'end');
+        expect(input.selectionDirection).toBe('backward', 'direction');
+      });
+
+      it('should type at cursor position', () => {
+        emulateKeyInTextInput({}, 'a', input);
+        emulateKeyInTextInput({}, 'b', input);
+        emulateKeyInTextInput({}, 'ArrowLeft', input);
+        emulateKeyInTextInput({}, 'c', input);
+
+        expect(input.value).toBe('acb');
+        expect(input.selectionStart).toBe(2, 'start');
+        expect(input.selectionEnd).toBe(2, 'end');
+        expect(input.selectionDirection).toEqual(
+          jasmine.stringMatching(/none|forward/), 'direction',
+        );
+      });
+
+      it('should change selection direction from backwards to none', () => {
+        input.value = 'abcd';
+        emulateKeyInTextInput({}, 'ArrowLeft', input);
+        emulateKeyInTextInput({}, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+
+        expect(input.selectionStart).toBe(2, 'start');
+        expect(input.selectionEnd).toBe(2, 'end');
+        expect(input.selectionDirection).toEqual(
+          jasmine.stringMatching(/none|forward/), 'direction',
+        );
+      });
+
+      it('should change selection direction from backwards to forwards', () => {
+        input.value = 'abcd';
+        emulateKeyInTextInput({}, 'ArrowLeft', input);
+        emulateKeyInTextInput({}, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+
+        expect(input.selectionStart).toBe(2, 'start');
+        expect(input.selectionEnd).toBe(3, 'end');
+        expect(input.selectionDirection).toBe('forward', 'direction');
+      });
+
+      it('should extend selection forward', () => {
+        input.value = 'abc';
+        input.selectionStart = input.selectionEnd = 0;
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+
+        expect(input.selectionStart).toBe(0, 'start');
+        expect(input.selectionEnd).toBe(2, 'end');
+        expect(input.selectionDirection).toBe('forward', 'direction');
+      });
+
+      it('should stop extending selection forward at the end of the input', () => {
+        input.value = 'abc';
+        input.selectionStart = input.selectionEnd = 0;
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+
+        expect(input.selectionStart).toBe(0, 'start');
+        expect(input.selectionEnd).toBe(3, 'end');
+        expect(input.selectionDirection).toBe('forward', 'direction');
+      });
+
+      it('should reduce selection forward', () => {
+        input.value = 'abc';
+        input.selectionStart = input.selectionEnd = 0;
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+
+        expect(input.selectionStart).toBe(0, 'start');
+        expect(input.selectionEnd).toBe(1, 'end');
+        expect(input.selectionDirection).toBe('forward', 'direction');
+      });
+
+      it('should change selection direction from forward to none', () => {
+        input.value = 'abcd';
+        input.selectionStart = input.selectionEnd = 2;
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+
+        expect(input.selectionStart).toBe(2, 'start');
+        expect(input.selectionEnd).toBe(2, 'end');
+        expect(input.selectionDirection).toEqual(
+          jasmine.stringMatching(/none|forward/), 'direction',
+        );
+      });
+
+      it('should change selection direction from forward to backward', () => {
+        input.value = 'abcd';
+        input.selectionStart = input.selectionEnd = 2;
+
+        emulateKeyInTextInput({ shift: true }, 'ArrowRight', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+        emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+
+        expect(input.selectionStart).toBe(1, 'start');
+        expect(input.selectionEnd).toBe(2, 'end');
+        expect(input.selectionDirection).toBe('backward', 'direction');
+      });
+    });
+
+    // describe('simulate backspace', () => {
+    //   pending('backspace not implemented yet');
+    //   it('should delete last character', () => {
+    //     input.value = 'abcd';
+
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+
+    //     expect(input.value).toBe('abc', 'value');
+    //     expect(input.selectionStart).toBe(3, 'start');
+    //     expect(input.selectionEnd).toBe(3, 'end');
+    //     expect(input.selectionDirection).toEqual(
+    //       jasmine.stringMatching(/none|forward/), 'direction',
+    //     );
+    //   });
+
+    //   it('should delete all characters', () => {
+    //     input.value = 'abcd';
+
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+
+    //     expect(input.value).toBe('', 'value');
+    //     expect(input.selectionStart).toBe(0, 'start');
+    //     expect(input.selectionEnd).toBe(0, 'end');
+    //     expect(input.selectionDirection).toEqual(
+    //       jasmine.stringMatching(/none|forward/), 'direction',
+    //     );
+    //   });
+
+    //   it('should not trigger events after deleting all characters', () => {
+    //     input.value = 'abcd';
+    //     const eventSpy = spyOn(input, 'dispatchEvent');
+
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+
+    //     expect(eventSpy).toHaveBeenCalledTimes(4);
+    //     expect(input.value).toBe('', 'value');
+    //     expect(input.selectionStart).toBe(0, 'start');
+    //     expect(input.selectionEnd).toBe(0, 'end');
+    //     expect(input.selectionDirection).toEqual(
+    //       jasmine.stringMatching(/none|forward/), 'direction',
+    //     );
+    //   });
+
+    //   it('should delete at cursor position', () => {
+    //     input.value = 'abc';
+    //     emulateKeyInTextInput({}, 'ArrowLeft', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+    //     emulateKeyInTextInput({}, 'd', input);
+
+    //     expect(input.value).toBe('adc');
+    //     expect(input.selectionStart).toBe(2, 'start');
+    //     expect(input.selectionEnd).toBe(2, 'end');
+    //     expect(input.selectionDirection).toEqual(
+    //       jasmine.stringMatching(/none|forward/), 'direction',
+    //     );
+    //   });
+
+    //   it('should delete all selected characters', () => {
+    //     input.value = 'abcd';
+    //     emulateKeyInTextInput({}, 'ArrowLeft', input);
+    //     emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+    //     emulateKeyInTextInput({ shift: true }, 'ArrowLeft', input);
+    //     emulateKeyInTextInput({}, 'Backspace', input);
+
+    //     expect(input.value).toBe('ad', 'value');
+    //     expect(input.selectionStart).toBe(1, 'start');
+    //     expect(input.selectionEnd).toBe(1, 'end');
+    //     expect(input.selectionDirection).toEqual(
+    //       jasmine.stringMatching(/none|forward/), 'direction',
+    //     );
+    //   });
+    // });
+  });
+
+  describe('HTMLInputElement', () => {
+    let input: HTMLInputElement;
+
+    beforeEach(() => input = document.createElement('input'));
+
+    it('should be a TextInput', () => {
+      expect(isTextInput(input)).toBe(true);
+    });
+
+    // it('should not append new line on "Enter"', () => {
+    //   pending('enter not implemented yet');
+    //   emulateKeyInTextInput({}, 'a', input);
+    //   emulateKeyInTextInput({}, 'Enter', input);
+    //   emulateKeyInTextInput({}, 'c', input);
+
+    //   expect(input.value).toBe('ac');
+    // });
+
+    it('on arrow up key should select value until it\'s start', () => {
+      input.value = 'abcd';
+
+      emulateKeyInTextInput({}, 'ArrowLeft', input);
+      emulateKeyInTextInput({ shift: true }, 'ArrowUp', input);
+
+      expect(input.selectionStart).toBe(0, 'start');
+      expect(input.selectionEnd).toBe(3, 'end');
+      expect(input.selectionDirection).toBe('backward', 'direction');
+    });
+
+    it('on arrow down key should select value until it\'s start', () => {
+      input.value = 'abcd';
+      input.selectionStart = input.selectionEnd = 1;
+
+      emulateKeyInTextInput({ shift: true }, 'ArrowDown', input);
+
+      expect(input.selectionStart).toBe(1, 'start');
+      expect(input.selectionEnd).toBe(4, 'end');
+      expect(input.selectionDirection).toBe('forward', 'direction');
+    });
+
+    it('on arrow up then down key should remove selection', () => {
+      input.value = 'abcd';
+      input.selectionStart = input.selectionEnd = 2;
+
+      emulateKeyInTextInput({ shift: true }, 'ArrowUp', input);
+      emulateKeyInTextInput({ shift: true }, 'ArrowDown', input);
+
+      expect(input.selectionStart).toBe(2, 'start');
+      expect(input.selectionEnd).toBe(2, 'end');
+      expect(input.selectionDirection).toEqual(
+        jasmine.stringMatching(/none|forward/), 'direction',
+      );
+    });
+
+    it('on arrow up then twice down key should select from cursor to end', () => {
+      input.value = 'abcd';
+      input.selectionStart = input.selectionEnd = 2;
+
+      emulateKeyInTextInput({ shift: true }, 'ArrowUp', input);
+      emulateKeyInTextInput({ shift: true }, 'ArrowDown', input);
+      emulateKeyInTextInput({ shift: true }, 'ArrowDown', input);
+
+      expect(input.selectionStart).toBe(2, 'start');
+      expect(input.selectionEnd).toBe(4, 'end');
+      expect(input.selectionDirection).toBe('forward', 'direction');
+    });
+
+    it('on arrow down then up key should remove selection', () => {
+      input.value = 'abcd';
+      input.selectionStart = input.selectionEnd = 2;
+
+      emulateKeyInTextInput({ shift: true }, 'ArrowDown', input);
+      emulateKeyInTextInput({ shift: true }, 'ArrowUp', input);
+
+      expect(input.selectionStart).toBe(2, 'start');
+      expect(input.selectionEnd).toBe(2, 'end');
+      expect(input.selectionDirection).toEqual(
+        jasmine.stringMatching(/none|forward/), 'direction',
+      );
+    });
+
+    it('on arrow down then twice up key should select from start to cursor', () => {
+      input.value = 'abcd';
+      input.selectionStart = input.selectionEnd = 2;
+
+      emulateKeyInTextInput({ shift: true }, 'ArrowDown', input);
+      emulateKeyInTextInput({ shift: true }, 'ArrowUp', input);
+      emulateKeyInTextInput({ shift: true }, 'ArrowUp', input);
+
+      expect(input.selectionStart).toBe(0, 'start');
+      expect(input.selectionEnd).toBe(2, 'end');
+      expect(input.selectionDirection).toBe('backward', 'direction');
+    });
+  });
+
+  describe('HTMLTextAreaElement', () => {
+    let textarea: HTMLTextAreaElement;
+
+    beforeEach(() => textarea = document.createElement('textarea'));
+
+    it('should be a TextInput', () => {
+      expect(isTextInput(textarea)).toBe(true);
+    });
+
+    // it('should append new line on "Enter"', () => {
+    //   pending('enter not implemented yet');
+    //   emulateKeyInTextInput({}, 'a', textarea);
+    //   emulateKeyInTextInput({}, 'Enter', textarea);
+    //   emulateKeyInTextInput({}, 'c', textarea);
+
+    //   expect(textarea.value).toBe('a\nc');
+    // });
+  });
+
+  describe('HTMLButtonElement', () => {
+    it('should not be a TextInput', () => {
+      expect(isTextInput(document.createElement('button'))).toBe(false);
+    });
+  });
+});

--- a/src/cdk/testing/testbed/fake-events/emulate-text-input-behavior.ts
+++ b/src/cdk/testing/testbed/fake-events/emulate-text-input-behavior.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ModifierKeys} from '@angular/cdk/testing';
+import {dispatchFakeEvent} from './dispatch-events';
+import {TextInputElement} from './text-input-element';
+import {emulateArrowInTextInput, isArrowKey} from './emulate-arrow-in-text-input';
+import {writeCharacter} from './emulate-char-in-text-input';
+
+/**
+ * Emulate browser behavior of keys in text inputs.
+ *
+ * will not send key events themself but:
+ * - Change the value on character input at cursor position
+ *
+ * @param modifiers ModifierKeys that may change behavior
+ * @param key to emulate
+ * @param element TextInputElement
+ * @see to send key events use {@linkcode file://./type-in-element.ts#typeInElement}
+ *
+ * @docs-private
+ */
+export function emulateKeyInTextInput(
+  modifiers: ModifierKeys, key: string, element: TextInputElement,
+) {
+  if (key.length === 1) {
+    writeCharacter(element, key);
+  } else if (isArrowKey(key)) {
+    emulateArrowInTextInput(modifiers, key, element);
+  }
+}
+
+/**
+ * Clears the text of a TextInputElement.
+ * @docs-private
+ */
+export function clearTextElement(element: TextInputElement) {
+  element.value = '';
+  dispatchFakeEvent(element, 'input');
+}

--- a/src/cdk/testing/testbed/fake-events/text-input-element.ts
+++ b/src/cdk/testing/testbed/fake-events/text-input-element.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Checks whether the given Element is a TextInputElement.
+ * @docs-private
+ */
+export function isTextInput(element: Element): element is TextInputElement {
+  return isTextArea(element) || isInputWithText(element);
+}
+
+function isTextArea(element: Element): element is HTMLTextAreaElement {
+  return element.nodeName.toLowerCase() === 'textarea';
+}
+
+const inputsTypesWithoutText = ['checkbox', 'radio'];
+function isInputWithText(element: Element): element is HTMLInputElement {
+  return element.nodeName.toLowerCase() === 'input'
+    && (inputsTypesWithoutText.indexOf((element as HTMLInputElement).type) < 0)
+  ;
+}
+
+/**
+ * Inputs that contains editable text values.
+ * @docs-private
+ */
+export type TextInputElement = HTMLInputElement | HTMLTextAreaElement;
+
+/**
+ * get selection start with fallbacks
+ * @docs-private
+ */
+export function getSelectionStart(element: TextInputElement): number {
+  if (typeof element.selectionStart === 'number') {
+    return element.selectionStart;
+  } else if (typeof element.selectionEnd === 'number') {
+    return element.selectionEnd;
+  } else {
+    return getValueLength(element);
+  }
+}
+
+/**
+ * get selection end with fallbacks
+ * @docs-private
+ */
+export function getSelectionEnd(element: TextInputElement): number {
+  if (typeof element.selectionEnd === 'number') {
+    return element.selectionEnd;
+  } else if (typeof element.selectionStart === 'number') {
+    return element.selectionStart;
+  } else {
+    return getValueLength(element);
+  }
+}
+
+/**
+ * get value length with fallbacks
+ * @docs-private
+ */
+export function getValueLength(element: TextInputElement): number {
+  if (typeof element.value === 'string') {
+    return element.value.length;
+  } else {
+    return 0;
+  }
+}

--- a/src/cdk/testing/testbed/fake-events/type-in-element.spec.ts
+++ b/src/cdk/testing/testbed/fake-events/type-in-element.spec.ts
@@ -1,0 +1,108 @@
+import {typeInElement} from './type-in-element';
+
+describe('type in elements', () => {
+  describe('type in input', () => {
+    it('should send keydown event', () => {
+      // given
+      const input = document.createElement('input');
+
+      const keydownSpy = jasmine.createSpy();
+      input.addEventListener('keydown', keydownSpy);
+
+      // when
+      typeInElement(input, 'a');
+
+      // then
+      expect(keydownSpy).toHaveBeenCalledTimes(1);
+      expect(keydownSpy).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'a' }));
+    });
+
+    it('should send keypress event', () => {
+      // given
+      const input = document.createElement('input');
+
+      const keypressSpy = jasmine.createSpy();
+      input.addEventListener('keypress', keypressSpy);
+
+      // when
+      typeInElement(input, 'a');
+
+      // then
+      expect(keypressSpy).toHaveBeenCalledTimes(1);
+      expect(keypressSpy).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'a' }));
+    });
+
+    it('should send keyup event', () => {
+      // given
+      const input = document.createElement('input');
+
+      const keyupSpy = jasmine.createSpy();
+      input.addEventListener('keyup', keyupSpy);
+
+      // when
+      typeInElement(input, 'a');
+
+      // then
+      expect(keyupSpy).toHaveBeenCalledTimes(1);
+      expect(keyupSpy).toHaveBeenCalledWith(jasmine.objectContaining({ key: 'a' }));
+    });
+
+    it('should send input event', () => {
+      // given
+      const input = document.createElement('input');
+
+      const inputEventSpy = jasmine.createSpy();
+      input.addEventListener('input', inputEventSpy);
+
+      // when
+      typeInElement(input, 'a');
+
+      // then
+      expect(inputEventSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should send events in order', () => {
+      // given
+      const input = document.createElement('input');
+
+      const eventSpy = jasmine.createSpy();
+      input.addEventListener('input', eventSpy);
+      input.addEventListener('keydown', eventSpy);
+      input.addEventListener('keyup', eventSpy);
+      input.addEventListener('keypress', eventSpy);
+
+      // when
+      typeInElement(input, 'a');
+
+      // then
+      expect(eventSpy.calls.all().map((call: any) => call.args[0].type)).toEqual([
+        'keydown', 'keypress', 'input', 'keyup',
+      ]);
+    });
+
+    it('should change value of inputs', () => {
+      // given
+      const input = document.createElement('input');
+
+      // when
+      typeInElement(input, 'a');
+
+      // then
+      expect(input.value).toEqual('a');
+    });
+
+    it('should not execute default action if prevented', () => {
+      // given
+      const input = document.createElement('input');
+      input.addEventListener('keypress', (event) => {
+        event.preventDefault();
+      });
+
+      // when
+      typeInElement(input, 'a');
+
+      // then
+      expect(input.value).toEqual('');
+    });
+  });
+});

--- a/src/cdk/testing/testbed/fake-events/type-in-element.ts
+++ b/src/cdk/testing/testbed/fake-events/type-in-element.ts
@@ -62,8 +62,10 @@ export function typeInElement(element: HTMLElement, ...modifiersAndKeys: any) {
   triggerFocus(element);
   for (const key of keys) {
     dispatchKeyboardEvent(element, 'keydown', key.keyCode, key.key, modifiers);
-    dispatchKeyboardEvent(element, 'keypress', key.keyCode, key.key, modifiers);
-    if (isTextInput(element) && key.key) {
+    const keypresss = dispatchKeyboardEvent(
+      element, 'keypress', key.keyCode, key.key, modifiers,
+    );
+    if (!keypresss.defaultPrevented && isTextInput(element) && key.key) {
       emulateKeyInTextInput(modifiers, key.key, element);
     }
     dispatchKeyboardEvent(element, 'keyup', key.keyCode, key.key, modifiers);

--- a/src/cdk/testing/testbed/unit-test-element.ts
+++ b/src/cdk/testing/testbed/unit-test-element.ts
@@ -12,7 +12,6 @@ import {
   clearElement,
   dispatchMouseEvent,
   dispatchPointerEvent,
-  isTextInput,
   triggerBlur,
   triggerFocus,
   typeInElement,
@@ -64,9 +63,6 @@ export class UnitTestElement implements TestElement {
 
   async clear(): Promise<void> {
     await this._stabilize();
-    if (!isTextInput(this.element)) {
-      throw Error('Attempting to clear an invalid element');
-    }
     clearElement(this.element);
     await this._stabilize();
   }

--- a/src/cdk/testing/tests/harnesses/main-component-harness.ts
+++ b/src/cdk/testing/tests/harnesses/main-component-harness.ts
@@ -26,6 +26,7 @@ export class MainComponentHarness extends ComponentHarness {
   readonly allLabels = this.locatorForAll('label');
   readonly allLists = this.locatorForAll(SubComponentHarness);
   readonly memo = this.locatorFor('textarea');
+  readonly checkbox = this.locatorFor('input[type=checkbox]');
   readonly clickTest = this.locatorFor('.click-test');
   readonly clickTestResult = this.locatorFor('.click-test-result');
   // Allow null for element
@@ -110,6 +111,10 @@ export class MainComponentHarness extends ComponentHarness {
 
   async sendAltJ(): Promise<void> {
     return (await this.input()).sendKeys({alt: true}, 'j');
+  }
+
+  async getInputValue(): Promise<string> {
+    return (await this.input()).getProperty('value');
   }
 
   async getTaskStateResult(): Promise<string> {

--- a/src/cdk/testing/tests/test-main-component.html
+++ b/src/cdk/testing/tests/test-main-component.html
@@ -17,6 +17,7 @@
   <span class="special-key">{{specialKey}}</span>
   <div id="value">Input: {{input}}</div>
   <textarea id="memo" aria-label="memo">{{memo}}</textarea>
+  <input id="checkbox" aria-label="checkbox" type="checkbox">
 </div>
 <div class="subcomponents">
   <test-sub class="test-special" title="test tools" [items]="testTools"></test-sub>


### PR DESCRIPTION
Currently arrow keys have no effect in TestbedEnvironment and sending keys does not respect cursor position or selections.

This adjusts behavior in TestbedEnvironment to get closer to the behavior of ProtractorEnvironment (real browsers).

It's a prerequisite to #19709 (will need select on tab into input with text). But in fact this is the larger part because selection handling is much more than emulating tab.