### PR TITLE
feat(material/core): allow theme overriding for background and foreground

### DIFF
--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -122,16 +122,8 @@ $_mat-theme-generate-default-density: true !default;
     accent: $accent,
     warn: if($warn != null, $warn, mat-palette($mat-red)),
     is-dark: false,
-    foreground: if(
-      $foreground != null,
-      map_merge($mat-light-theme-foreground, $foreground),
-      $mat-light-theme-foreground
-    ),
-    background: if(
-      $background != null,
-      map_merge($mat-light-theme-background, $background),
-      $mat-light-theme-background
-    ),
+    foreground: if($foreground != null, $foreground, $mat-light-theme-foreground),
+    background: if($background != null, $background, $mat-light-theme-background),
   );
 }
 
@@ -148,16 +140,8 @@ $_mat-theme-generate-default-density: true !default;
     accent: $accent,
     warn: if($warn != null, $warn, mat-palette($mat-red)),
     is-dark: true,
-    foreground: if(
-      $foreground != null,
-      map_merge($mat-dark-theme-foreground, $foreground),
-      $mat-dark-theme-foreground
-    ),
-    background: if(
-      $background != null,
-      map_merge($mat-dark-theme-background, $background),
-      $mat-dark-theme-background
-    ),
+    foreground: if($foreground != null, $foreground, $mat-dark-theme-foreground),
+    background: if($background != null, $background, $mat-dark-theme-background),
   );
 }
 

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -111,27 +111,53 @@ $_mat-theme-generate-default-density: true !default;
 
 // Creates a light-themed color configuration from the specified
 // primary, accent and warn palettes.
-@function _mat-create-light-color-config($primary, $accent, $warn: null) {
+@function _mat-create-light-color-config(
+  $primary,
+  $accent,
+  $warn: null,
+  $foreground: null,
+  $background: null) {
   @return (
     primary: $primary,
     accent: $accent,
     warn: if($warn != null, $warn, mat-palette($mat-red)),
     is-dark: false,
-    foreground: $mat-light-theme-foreground,
-    background: $mat-light-theme-background,
+    foreground: if(
+      $foreground != null,
+      map_merge($mat-light-theme-foreground, $foreground),
+      $mat-light-theme-foreground
+    ),
+    background: if(
+      $background != null,
+      map_merge($mat-light-theme-background, $background),
+      $mat-light-theme-background
+    ),
   );
 }
 
 // Creates a dark-themed color configuration from the specified
 // primary, accent and warn palettes.
-@function _mat-create-dark-color-config($primary, $accent, $warn: null) {
+@function _mat-create-dark-color-config(
+  $primary,
+  $accent,
+  $warn: null,
+  $foreground: null,
+  $background: null) {
   @return (
     primary: $primary,
     accent: $accent,
     warn: if($warn != null, $warn, mat-palette($mat-red)),
     is-dark: true,
-    foreground: $mat-dark-theme-foreground,
-    background: $mat-dark-theme-background,
+    foreground: if(
+      $foreground != null,
+      map_merge($mat-dark-theme-foreground, $foreground),
+      $mat-dark-theme-foreground
+    ),
+    background: if(
+      $background != null,
+      map_merge($mat-dark-theme-background, $background),
+      $mat-dark-theme-background
+    ),
   );
 }
 
@@ -167,7 +193,12 @@ $_mat-theme-generate-default-density: true !default;
     $primary: map_get($color-settings, primary);
     $accent: map_get($color-settings, accent);
     $warn: map_get($color-settings, warn);
-    $result: map_merge($result, (color: _mat-create-light-color-config($primary, $accent, $warn)));
+    $foreground: map_get($color-settings, foreground);
+    $background: map_get($color-settings, background);
+    $result: map_merge(
+      $result,
+      (color: _mat-create-light-color-config($primary, $accent, $warn, $foreground, $background))
+    );
   }
   @return _mat-create-backwards-compatibility-theme(_mat-validate-theme($result));
 }
@@ -204,7 +235,12 @@ $_mat-theme-generate-default-density: true !default;
     $primary: map_get($color-settings, primary);
     $accent: map_get($color-settings, accent);
     $warn: map_get($color-settings, warn);
-    $result: map_merge($result, (color: _mat-create-dark-color-config($primary, $accent, $warn)));
+    $foreground: map_get($color-settings, foreground);
+    $background: map_get($color-settings, background);
+    $result: map_merge(
+      $result,
+      (color: _mat-create-dark-color-config($primary, $accent, $warn, $foreground, $background))
+    );
   }
   @return _mat-create-backwards-compatibility-theme(_mat-validate-theme($result));
 }


### PR DESCRIPTION
Fixes #19935 

With the new color map it's quite verbose to override background/foreground in a custom theme.
This pull request attempts to solve that by allowing the following to override any background/foreground properties.

```sass
$candy-app-theme: mat-light-theme((
  color: (
    primary: $candy-app-primary,
    accent: $candy-app-accent,
    background: (
      background: #000
    )
  )
));
``` 

Another solution could be `background: if($background != null, $background, $mat-dark-theme-background)` and let the user provide the map_merge on their own as no other property allow partial maps.

```sass
$candy-app-theme: mat-light-theme((
  color: (
    primary: $candy-app-primary,
    accent: $candy-app-accent,
    background: map_merge(
      $mat-dark-theme-background,
      (background: #000)
    )
  )
));
``` 