### PR TITLE
fix(select): indicating programmatic value change as user interaction in some cases

### DIFF
--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -1660,6 +1660,19 @@ describe('MatSelect', () => {
           subscription!.unsubscribe();
         }));
 
+        it('should not indicate programmatic value changes as user interactions', () => {
+          const events: MatOptionSelectionChange[] = [];
+          const subscription = fixture.componentInstance.select.optionSelectionChanges
+            .subscribe((event: MatOptionSelectionChange) => events.push(event));
+
+          fixture.componentInstance.control.setValue('eggs-5');
+          fixture.detectChanges();
+
+          expect(events.map(event => event.isUserInput)).toEqual([false]);
+
+          subscription.unsubscribe();
+        });
+
     });
 
     describe('forms integration', () => {

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -903,11 +903,11 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
       // Shift focus to the active item. Note that we shouldn't do this in multiple
       // mode, because we don't know what option the user interacted with last.
       if (correspondingOption) {
-        this._keyManager.setActiveItem(correspondingOption);
+        this._keyManager.updateActiveItem(correspondingOption);
       } else if (!this.panelOpen) {
         // Otherwise reset the highlighted option. Note that we only want to do this while
         // closed, because doing it while open can shift the user's focus unnecessarily.
-        this._keyManager.setActiveItem(-1);
+        this._keyManager.updateActiveItem(-1);
       }
     }
 


### PR DESCRIPTION
We were using `ListKeyManager.setActiveItem` to change the active item when a value is assigned through a `FormControl`, in order to have it be highlighted if the user opens the panel. The problem is that `setActiveItem` emits a change event as if it's coming from the user, causing us to dispatch an event object with `isUserInput: true`.

These changes use `updateActiveItem` instead which only updates the item, but doesn't emit any events.

Fixes #19967.