### PR TITLE
fix(datepicker): not updating calendar state if input changes while open

### DIFF
--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -18,6 +18,7 @@ import {
   Optional,
   Output,
   AfterViewInit,
+  OnChanges,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -31,7 +32,7 @@ import {
   MAT_DATE_FORMATS,
   MatDateFormats,
 } from '@angular/material/core';
-import {Subscription} from 'rxjs';
+import {Subscription, Subject} from 'rxjs';
 import {createMissingDateImplError} from './datepicker-errors';
 import {ExtractDateTypeFromSelection, MatDateSelectionModel} from './date-selection-model';
 
@@ -59,7 +60,7 @@ export type DateFilterFn<D> = (date: D | null) => boolean;
 /** Base class for datepicker inputs. */
 @Directive()
 export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection<S>>
-  implements ControlValueAccessor, AfterViewInit, OnDestroy, Validator {
+  implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy, Validator {
 
   /** Whether the component has been initialized. */
   private _isInitialized: boolean;
@@ -92,7 +93,7 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
 
     if (this._disabled !== newValue) {
       this._disabled = newValue;
-      this._disabledChange.emit(newValue);
+      this._stateChanges.next(undefined);
     }
 
     // We need to null check the `blur` method, because it's undefined during SSR.
@@ -119,8 +120,8 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
   /** Emits when the value changes (either due to user input or programmatic change). */
   _valueChange = new EventEmitter<D | null>();
 
-  /** Emits when the disabled state has changed */
-  _disabledChange = new EventEmitter<boolean>();
+  /** Emits when the internal state has changed */
+  _stateChanges = new Subject<void>();
 
   _onTouched = () => {};
   _validatorOnChange = () => {};
@@ -250,11 +251,15 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
     this._isInitialized = true;
   }
 
+  ngOnChanges() {
+    this._stateChanges.next(undefined);
+  }
+
   ngOnDestroy() {
     this._valueChangesSubscription.unsubscribe();
     this._localeSubscription.unsubscribe();
     this._valueChange.complete();
-    this._disabledChange.complete();
+    this._stateChanges.complete();
   }
 
   /** @docs-private */

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -116,9 +116,9 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   }
 
   private _watchStateChanges() {
-    const datepickerDisabled = this.datepicker ? this.datepicker._disabledChange : observableOf();
-    const inputDisabled = this.datepicker && this.datepicker._datepickerInput ?
-        this.datepicker._datepickerInput._disabledChange : observableOf();
+    const datepickerStateChanged = this.datepicker ? this.datepicker._stateChanges : observableOf();
+    const inputStateChanged = this.datepicker && this.datepicker._datepickerInput ?
+        this.datepicker._datepickerInput._stateChanges : observableOf();
     const datepickerToggled = this.datepicker ?
         merge(this.datepicker.openedStream, this.datepicker.closedStream) :
         observableOf();
@@ -126,8 +126,8 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
     this._stateChanges.unsubscribe();
     this._stateChanges = merge(
       this._intl.changes,
-      datepickerDisabled,
-      inputDisabled,
+      datepickerStateChanged,
+      inputStateChanged,
       datepickerToggled
     ).subscribe(() => this._changeDetectorRef.markForCheck());
   }

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -1262,6 +1262,7 @@ describe('MatDatepicker', () => {
       afterEach(fakeAsync(() => {
         testComponent.datepicker.close();
         fixture.detectChanges();
+        flush();
       }));
 
       it('should use min and max dates specified by the input', () => {
@@ -1354,6 +1355,37 @@ describe('MatDatepicker', () => {
 
         expect(testComponent.model.valid).toBe(true);
         expect(testComponent.date).toBe(validDate);
+      }));
+
+      it('should update the calendar when the min/max dates change', fakeAsync(() => {
+        const getDisabledCells = () => {
+          return document.querySelectorAll('.mat-calendar-body-disabled').length;
+        };
+
+        testComponent.date = new Date(2020, JAN, 5);
+        fixture.detectChanges();
+
+        testComponent.minDate = new Date(2020, JAN, 3);
+        testComponent.maxDate = new Date(2020, JAN, 7);
+        fixture.detectChanges();
+
+        testComponent.datepicker.open();
+        fixture.detectChanges();
+        flush();
+
+        let disabledCellCount = getDisabledCells();
+        expect(disabledCellCount).not.toBe(0);
+
+        testComponent.minDate = new Date(2020, JAN, 1);
+        fixture.detectChanges();
+
+        expect(getDisabledCells()).not.toBe(disabledCellCount);
+        disabledCellCount = getDisabledCells();
+
+        testComponent.maxDate = new Date(2020, JAN, 10);
+        fixture.detectChanges();
+
+        expect(getDisabledCells()).not.toBe(disabledCellCount);
       }));
 
     });

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -285,12 +285,12 @@ export declare class MatDatepickerToggleIcon {
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerToggleIcon, never>;
 }
 
-export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, MatDatepickerControl<D>, MatDateRangeInputParent<D>, MatDateRangePickerInput<D>, AfterContentInit, OnDestroy {
+export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>, MatDatepickerControl<D>, MatDateRangeInputParent<D>, MatDateRangePickerInput<D>, AfterContentInit, OnChanges, OnDestroy {
     _ariaDescribedBy: string | null;
-    _disabledChange: Subject<boolean>;
     _endInput: MatEndDate<D>;
     _groupDisabled: boolean;
     _startInput: MatStartDate<D>;
+    _stateChanges: Subject<void>;
     comparisonEnd: D | null;
     comparisonStart: D | null;
     controlType: string;
@@ -327,6 +327,7 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     getStartValue(): D | null;
     getThemePalette(): ThemePalette;
     ngAfterContentInit(): void;
+    ngOnChanges(): void;
     ngOnDestroy(): void;
     onContainerClick(): void;
     setDescribedByIds(ids: string[]): void;


### PR DESCRIPTION
The datepicker was only updating the calendar state that depends on the input when we open and close. I've reworked it so we do it any time one of the input's inputs changes. I also renamed the various `_disabledChange` streams to `_stateChanges` which aligns with what we're doing in other components.

Fixes #19959.