### PR TITLE
test: fix failing MDC snackbar test

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
@@ -192,18 +192,16 @@ describe('MatSnackBar', () => {
   }));
 
 
-  it('should default to the passed message for the announcement message', fakeAsync(() => {
+  it('should clear the announcement message if it is the same as main message', fakeAsync(() => {
     spyOn(liveAnnouncer, 'announce');
 
-    snackBar.open(simpleMessage);
+    snackBar.open(simpleMessage, undefined, {announcementMessage: simpleMessage});
     viewContainerFixture.detectChanges();
 
     expect(overlayContainerElement.childElementCount)
         .toBe(1, 'Expected the overlay with the default announcement message to be added');
 
-    // Expect the live announcer to have been called with the display message and some
-    // string for the politeness. We do not want to test for the default politeness here.
-    expect(liveAnnouncer.announce).toHaveBeenCalledWith(simpleMessage, jasmine.any(String));
+    expect(liveAnnouncer.announce).not.toHaveBeenCalled();
   }));
 
   it('should be able to specify a custom announcement message', fakeAsync(() => {


### PR DESCRIPTION
The MDC-based snackbar tests are currently failing because we landed
a change in the non-MDC snackbar that propagates to the MDC-based
snack bar. That is expected, but the test for the MDC-based snackbar
have not been updated accordingly.

See: https://github.com/angular/components/commit/1bbfcf40958b7b31e69dc9e19fc2acd237dde1dd.