### PR TITLE
perf(mdc-checkbox, mdc-radio): Use class for MDC adapter

### DIFF
--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -90,13 +90,13 @@ class CheckBoxAdapter implements MDCCheckboxAdapter {
   }
 
   removeNativeControlAttr(attr: string)  {
-    if (!this._delegate._getAttrBlocklist().has(attr)) {
+    if (!this._delegate._attrBlocklist.has(attr)) {
       this._delegate._nativeCheckbox.nativeElement.removeAttribute(attr);
     }
   }
 
   setNativeControlAttr(attr: string, value: string)  {
-    if (!this._delegate._getAttrBlocklist().has(attr)) {
+    if (!this._delegate._attrBlocklist.has(attr)) {
       this._delegate._nativeCheckbox.nativeElement.setAttribute(attr, value);
     }
   }
@@ -256,10 +256,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
    * MDC uses animation events to determine when to update `aria-checked` which is unreliable.
    * Therefore we disable it and handle it ourselves.
    */
-  private _attrBlacklist = new Set(['aria-checked']);
-
-  /** The `MDCCheckboxAdapter` instance for this checkbox. */
-  private _adapter: CheckBoxAdapter;
+  readonly _attrBlocklist: ReadonlySet<string> = new Set(['aria-checked']);
 
   constructor(
       private _changeDetectorRef: ChangeDetectorRef,
@@ -276,8 +273,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
     // Note: We don't need to set up the MDCFormFieldFoundation. Its only purpose is to manage the
     // ripple, which we do ourselves instead.
     this.tabIndex = parseInt(tabIndex) || 0;
-    this._adapter = new CheckBoxAdapter(this);
-    this._checkboxFoundation = new MDCCheckboxFoundation(this._adapter);
+    this._checkboxFoundation = new MDCCheckboxFoundation(new CheckBoxAdapter(this));
 
     this._options = this._options || {};
 
@@ -288,11 +284,6 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
     // @breaking-change 10.0.0: Remove this after the `_clickAction` parameter is removed as an
     // injection parameter.
     this._clickAction = this._clickAction || this._options.clickAction;
-    console.log('potato!!!!!!!!!!!!!!!');
-  }
-
-  _getAttrBlocklist() {
-    return this._attrBlacklist;
   }
 
   ngAfterViewInit() {

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -57,41 +57,50 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
   exitDuration: numbers.FG_DEACTIVATION_MS,
 };
 
-/** Singleton check box adapter. */
+/** Check box adapter. */
 class CheckBoxAdapter implements MDCCheckboxAdapter {
   constructor(private readonly _delegate: MatCheckbox) {}
 
   addClass(className: string) {
-    return this._delegate.setClass(className, true);
+    return this._delegate._setClass(className, true);
   }
+
   removeClass(className: string) {
-    return this._delegate.setClass(className, false);
+    return this._delegate._setClass(className, false);
   }
+
   forceLayout() {
     return this._delegate._checkbox.nativeElement.offsetWidth;
   }
+
   hasNativeControl() {
     return !!this._delegate._nativeCheckbox;
   }
+
   isAttachedToDOM() {
     return !!this._delegate._checkbox.nativeElement.parentNode;
   }
+
   isChecked() {
     return this._delegate.checked;
-    }
+  }
+
   isIndeterminate() {
     return this._delegate.indeterminate;
   }
+
   removeNativeControlAttr(attr: string)  {
-    if (!this._delegate.getAttrBlacklist().has(attr)) {
+    if (!this._delegate._getAttrBlocklist().has(attr)) {
       this._delegate._nativeCheckbox.nativeElement.removeAttribute(attr);
     }
   }
+
   setNativeControlAttr(attr: string, value: string)  {
-    if (!this._delegate.getAttrBlacklist().has(attr)) {
+    if (!this._delegate._getAttrBlocklist().has(attr)) {
       this._delegate._nativeCheckbox.nativeElement.setAttribute(attr, value);
     }
   }
+
   setNativeControlDisabled(disabled: boolean) {
     this._delegate.disabled = disabled;
   }
@@ -279,9 +288,10 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
     // @breaking-change 10.0.0: Remove this after the `_clickAction` parameter is removed as an
     // injection parameter.
     this._clickAction = this._clickAction || this._options.clickAction;
+    console.log('potato!!!!!!!!!!!!!!!');
   }
 
-  getAttrBlacklist() {
+  _getAttrBlocklist() {
     return this._attrBlacklist;
   }
 
@@ -399,7 +409,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
   }
 
   /** Sets whether the given CSS class should be applied to the native input. */
-  setClass(cssClass: string, active: boolean) {
+  _setClass(cssClass: string, active: boolean) {
     this._classes[cssClass] = active;
     this._changeDetectorRef.markForCheck();
   }

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -57,8 +57,8 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
   exitDuration: numbers.FG_DEACTIVATION_MS,
 };
 
-/** Check box adapter. */
-class CheckBoxAdapter implements MDCCheckboxAdapter {
+/** @docs-private */
+class CheckboxAdapter implements MDCCheckboxAdapter {
   constructor(private readonly _delegate: MatCheckbox) {}
 
   addClass(className: string) {
@@ -273,7 +273,7 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
     // Note: We don't need to set up the MDCFormFieldFoundation. Its only purpose is to manage the
     // ripple, which we do ourselves instead.
     this.tabIndex = parseInt(tabIndex) || 0;
-    this._checkboxFoundation = new MDCCheckboxFoundation(new CheckBoxAdapter(this));
+    this._checkboxFoundation = new MDCCheckboxFoundation(new CheckboxAdapter(this));
 
     this._options = this._options || {};
 

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -104,12 +104,12 @@ class CheckBoxAdapter implements MDCCheckboxAdapter {
     return this._delegate.indeterminate;
   }
   removeNativeControlAttr(attr)  {
-    if (!this._delegate._attrBlacklist.has(attr)) {
+    if (!this._delegate.getAttrBlacklist().has(attr)) {
       this._delegate._nativeCheckbox.nativeElement.removeAttribute(attr);
     }
   }
   setNativeControlAttr(attr, value)  {
-    if (!this._delegate._attrBlacklist.has(attr)) {
+    if (!this._delegate.getAttrBlacklist().has(attr)) {
       this._delegate._nativeCheckbox.nativeElement.setAttribute(attr, value);
     }
   }
@@ -300,6 +300,10 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
     // @breaking-change 10.0.0: Remove this after the `_clickAction` parameter is removed as an
     // injection parameter.
     this._clickAction = this._clickAction || this._options.clickAction;
+  }
+
+  getAttrBlacklist() {
+    return this._attrBlacklist;
   }
 
   ngAfterViewInit() {

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -59,33 +59,12 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
 
 /** Singleton check box adapter. */
 class CheckBoxAdapter implements MDCCheckboxAdapter {
+  constructor(private readonly _delegate: MatCheckbox) {}
 
-  private static _adapter: CheckBoxAdapter;
-
-  private _delegate: MatCheckbox;
-
-  private constructor(delegate: MatCheckbox) {
-    this._delegate = delegate;
-  }
-
-  useDelegate(delegate: MatCheckbox) {
-    if (!this._delegate) {
-      CheckBoxAdapter._adapter = new CheckBoxAdapter(delegate);
-    } else {
-      this._delegate = delegate;
-    }
-
-    return CheckBoxAdapter.getAdapter();
-  }
-
-  static getAdapter() {
-    return CheckBoxAdapter._adapter;
-  }
-
-  addClass(className) {
+  addClass(className: string) {
     return this._delegate.setClass(className, true);
   }
-  removeClass(className) {
+  removeClass(className: string) {
     return this._delegate.setClass(className, false);
   }
   forceLayout() {
@@ -103,23 +82,20 @@ class CheckBoxAdapter implements MDCCheckboxAdapter {
   isIndeterminate() {
     return this._delegate.indeterminate;
   }
-  removeNativeControlAttr(attr)  {
+  removeNativeControlAttr(attr: string)  {
     if (!this._delegate.getAttrBlacklist().has(attr)) {
       this._delegate._nativeCheckbox.nativeElement.removeAttribute(attr);
     }
   }
-  setNativeControlAttr(attr, value)  {
+  setNativeControlAttr(attr: string, value: string)  {
     if (!this._delegate.getAttrBlacklist().has(attr)) {
       this._delegate._nativeCheckbox.nativeElement.setAttribute(attr, value);
     }
   }
-  setNativeControlDisabled(disabled) {
+  setNativeControlDisabled(disabled: boolean) {
     this._delegate.disabled = disabled;
   }
 }
-
-const _singletonCheckboxAdapter = CheckBoxAdapter.getAdapter();
-
 
 @Component({
   selector: 'mat-checkbox',
@@ -273,6 +249,9 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
    */
   private _attrBlacklist = new Set(['aria-checked']);
 
+  /** The `MDCCheckboxAdapter` instance for this checkbox. */
+  private _adapter: CheckBoxAdapter;
+
   constructor(
       private _changeDetectorRef: ChangeDetectorRef,
       @Attribute('tabindex') tabIndex: string,
@@ -288,8 +267,8 @@ export class MatCheckbox implements AfterViewInit, OnDestroy, ControlValueAccess
     // Note: We don't need to set up the MDCFormFieldFoundation. Its only purpose is to manage the
     // ripple, which we do ourselves instead.
     this.tabIndex = parseInt(tabIndex) || 0;
-    this._checkboxFoundation = new MDCCheckboxFoundation(
-      _singletonCheckboxAdapter.useDelegate(this));
+    this._adapter = new CheckBoxAdapter(this);
+    this._checkboxFoundation = new MDCCheckboxFoundation(this._adapter);
 
     this._options = this._options || {};
 

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -66,29 +66,7 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
 };
 
 class RadioAdapter implements MDCRadioAdapter {
-
-  private static _adapter: RadioAdapter;
-
-  private _delegate: MatRadioButton;
-
-  private constructor(delegate: MatRadioButton) {
-    this._delegate = delegate;
-  }
-
-  useDelegate(delegate: MatRadioButton) {
-    if (!this._delegate) {
-      RadioAdapter._adapter = new RadioAdapter(delegate);
-    } else {
-      this._delegate = delegate;
-    }
-
-    return RadioAdapter.getAdapter();
-  }
-
-  static getAdapter() {
-    return RadioAdapter._adapter;
-  }
-
+  constructor(private readonly _delegate: MatRadioButton) {}
   addClass(className: string) {
     return this._delegate.setClass(className, true);
   }
@@ -103,7 +81,6 @@ class RadioAdapter implements MDCRadioAdapter {
   }
 }
 
-const _singletonRadioAdapter = RadioAdapter.getAdapter();
 
 /**
  * A group of radio buttons. May contain one or more `<mat-radio-button>` elements.
@@ -152,11 +129,12 @@ export class MatRadioGroup extends _MatRadioGroupBase<MatRadioButton> {
 })
 export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit, OnDestroy {
 
+  private _radioAdapter: MDCRadioAdapter;
 
   /** Configuration for the underlying ripple. */
   _rippleAnimation: RippleAnimationConfig = RIPPLE_ANIMATION_CONFIG;
 
-  _radioFoundation = new MDCRadioFoundation(_singletonRadioAdapter.useDelegate(this));
+  _radioFoundation: MDCRadioFoundation;
   _classes: {[key: string]: boolean} = {};
 
   constructor(@Optional() @Inject(MAT_RADIO_GROUP) radioGroup: MatRadioGroup,
@@ -169,6 +147,8 @@ export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit
               _providerOverride?: MatRadioDefaultOptions) {
     super(radioGroup, elementRef, _changeDetector, _focusMonitor,
         _radioDispatcher, _animationMode, _providerOverride);
+    this._radioAdapter = new RadioAdapter(this);
+    this._radioFoundation = new MDCRadioFoundation(this._radioAdapter);
   }
 
   ngAfterViewInit() {

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -65,6 +65,7 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
   exitDuration: numbers.FG_DEACTIVATION_MS
 };
 
+/** @docs-private */
 class RadioAdapter implements MDCRadioAdapter {
   constructor(private readonly _delegate: MatRadioButton) {}
   addClass(className: string) {
@@ -129,8 +130,6 @@ export class MatRadioGroup extends _MatRadioGroupBase<MatRadioButton> {
 })
 export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit, OnDestroy {
 
-  private _radioAdapter: MDCRadioAdapter;
-
   /** Configuration for the underlying ripple. */
   _rippleAnimation: RippleAnimationConfig = RIPPLE_ANIMATION_CONFIG;
 
@@ -147,8 +146,7 @@ export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit
               _providerOverride?: MatRadioDefaultOptions) {
     super(radioGroup, elementRef, _changeDetector, _focusMonitor,
         _radioDispatcher, _animationMode, _providerOverride);
-    this._radioAdapter = new RadioAdapter(this);
-    this._radioFoundation = new MDCRadioFoundation(this._radioAdapter);
+    this._radioFoundation = new MDCRadioFoundation(new RadioAdapter(this));
   }
 
   ngAfterViewInit() {

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -69,15 +69,15 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
 class RadioAdapter implements MDCRadioAdapter {
   constructor(private readonly _delegate: MatRadioButton) {}
   addClass(className: string) {
-    return this._delegate.setClass(className, true);
+    return this._delegate._setClass(className, true);
   }
   removeClass(className: string) {
-    return this._delegate.setClass(className, false);
+    return this._delegate._setClass(className, false);
   }
   setNativeControlDisabled(disabled: boolean) {
     if (this._delegate.disabled !== disabled) {
       this._delegate.disabled = disabled;
-      this._delegate.getChangeDetector().markForCheck();
+      this._delegate._changeDetector.markForCheck();
     }
   }
 }
@@ -138,7 +138,7 @@ export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit
 
   constructor(@Optional() @Inject(MAT_RADIO_GROUP) radioGroup: MatRadioGroup,
               elementRef: ElementRef,
-              _changeDetector: ChangeDetectorRef,
+              readonly _changeDetector: ChangeDetectorRef,
               _focusMonitor: FocusMonitor,
               _radioDispatcher: UniqueSelectionDispatcher,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) _animationMode?: string,
@@ -159,13 +159,9 @@ export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit
     this._radioFoundation.destroy();
   }
 
-  setClass(cssClass: string, active: boolean) {
+  _setClass(cssClass: string, active: boolean) {
     this._classes = {...this._classes, [cssClass]: active};
     this._changeDetector.markForCheck();
-  }
-
-  getChangeDetector() {
-    return this._changeDetector;
   }
 
   /**


### PR DESCRIPTION
Change the adapters in MatCheckbox and MatRadioButton to class objects to (hopefully) reduce memory usage or improve performance.

## The Metrics
A simple test shows that the change to class-based adapter causes a statistically significant difference in performance!

### Before Adapter Optimization
Times to initialize all checkboxes (milliseconds):
0.7299988065
0.7049997803
0.6649994757
0.6749990862
0.6349999458
0.6850000937
0.7099998184
0.6350008771
0.7799998857
0.6700006779
Average: 0.6889998447

### After Adapter Optimization
Times to initialize all checkboxes:
0.6799995899
0.560000306
0.6049999502
0.6849993952
0.6249998696
0.6349999458
0.6699995138
0.6299999077
0.6750009488
0.639999751
Average: 0.6404999178

Overall a 7% initialization performance increase.