### PR TITLE
perf(list-base): convert list-base adapter to class object

### DIFF
--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -37,28 +37,38 @@ function toggleClass(el: Element, className: string, on: boolean) {
 class ListAdapter implements MDCListAdapter {
   constructor(private _delegate: MatInteractiveListBase) {}
 
-  getListItemCount = () => this._delegate._items.length;
-  listItemAtIndexHasClass =
-      (index: number, className: string) =>
-        this._delegate._elementAtIndex(index).classList.contains(className)
-  addClassForElementIndex =
-      (index: number, className: string) =>
-        this._delegate._elementAtIndex(index).classList.add(className)
-  removeClassForElementIndex =
-      (index: number, className: string) =>
-        this._delegate._elementAtIndex(index).classList.remove(className)
-  getAttributeForElementIndex = (index: number, attr: string) =>
-    this._delegate._elementAtIndex(index).getAttribute(attr)
-  setAttributeForElementIndex =
-      (index: number, attr: string, value: string) =>
-        this._delegate._elementAtIndex(index).setAttribute(attr, value)
-  getFocusedElementIndex = () =>
-    this._delegate._indexForElement(this._delegate.getDocument()?.activeElement)
-  isFocusInsideList = () =>
-    this._delegate.getElement().nativeElement.contains(this._delegate.getDocument()?.activeElement)
-  isRootFocused = () =>
-    this._delegate.getElement().nativeElement === this._delegate.getDocument()?.activeElement
-  focusItemAtIndex = (index: number) =>  this._delegate._elementAtIndex(index).focus();
+  getListItemCount() {
+    return this._delegate._items.length;
+  }
+  listItemAtIndexHasClass(index: number, className: string) {
+    return this._delegate._elementAtIndex(index).classList.contains(className);
+  }
+  addClassForElementIndex(index: number, className: string) {
+    return this._delegate._elementAtIndex(index).classList.add(className);
+  }
+  removeClassForElementIndex(index: number, className: string) {
+    return this._delegate._elementAtIndex(index).classList.remove(className);
+  }
+  getAttributeForElementIndex(index: number, attr: string) {
+    return this._delegate._elementAtIndex(index).getAttribute(attr);
+  }
+  setAttributeForElementIndex(index: number, attr: string, value: string) {
+    return this._delegate._elementAtIndex(index).setAttribute(attr, value);
+  }
+  getFocusedElementIndex() {
+    return this._delegate._indexForElement(this._delegate.getDocument()?.activeElement);
+  }
+  isFocusInsideList() {
+    return this._delegate.getElement().nativeElement.contains(
+      this._delegate.getDocument()?.activeElement);
+  }
+  isRootFocused() {
+    return this._delegate.getElement().nativeElement ===
+      this._delegate.getDocument()?.activeElement;
+  }
+  focusItemAtIndex(index: number) {
+    return this._delegate._elementAtIndex(index).focus();
+  }
 
   // MDC uses this method to disable focusable children of list items. However, we believe that
   // this is not an accessible pattern and should be avoided, therefore we intentionally do not
@@ -67,19 +77,27 @@ class ListAdapter implements MDCListAdapter {
   // A user who feels they really need this feature can simply listen to the `(focus)` and
   // `(blur)` events on the list item and enable/disable focus on the children themselves as
   // appropriate.
-  setTabIndexForListItemChildren = () => {};
+  setTabIndexForListItemChildren() {}
 
   // The following methods have a dummy implementation in the base class because they are only
   // applicable to certain types of lists. They should be implemented for the concrete classes
   // where they are applicable.
-  hasCheckboxAtIndex = () => false;
-  hasRadioAtIndex = () => false;
-  setCheckedCheckboxOrRadioAtIndex = () => {};
-  isCheckboxCheckedAtIndex = () => false;
+  hasCheckboxAtIndex() {
+    return false;
+  }
+  hasRadioAtIndex() {
+    return false;
+  }
+  setCheckedCheckboxOrRadioAtIndex() {}
+  isCheckboxCheckedAtIndex() {
+    return false;
+  }
 
   // TODO(mmalerba): Determine if we need to implement these.
-  getPrimaryTextAtIndex = () => '';
-  notifyAction = () => {};
+  getPrimaryTextAtIndex() {
+    return '';
+  }
+  notifyAction() {}
 }
 
 @Directive()

--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -40,32 +40,41 @@ class ListAdapter implements MDCListAdapter {
   getListItemCount() {
     return this._delegate._items.length;
   }
+
   listItemAtIndexHasClass(index: number, className: string) {
     return this._delegate._elementAtIndex(index).classList.contains(className);
   }
+
   addClassForElementIndex(index: number, className: string) {
     return this._delegate._elementAtIndex(index).classList.add(className);
   }
+
   removeClassForElementIndex(index: number, className: string) {
     return this._delegate._elementAtIndex(index).classList.remove(className);
   }
+
   getAttributeForElementIndex(index: number, attr: string) {
     return this._delegate._elementAtIndex(index).getAttribute(attr);
   }
+
   setAttributeForElementIndex(index: number, attr: string, value: string) {
     return this._delegate._elementAtIndex(index).setAttribute(attr, value);
   }
+
   getFocusedElementIndex() {
-    return this._delegate._indexForElement(this._delegate.getDocument()?.activeElement);
+    return this._delegate._indexForElement(this._delegate._document?.activeElement);
   }
+
   isFocusInsideList() {
-    return this._delegate.getElement().nativeElement.contains(
-      this._delegate.getDocument()?.activeElement);
+    return this._delegate._element.nativeElement.contains(
+      this._delegate._document?.activeElement);
   }
+
   isRootFocused() {
-    return this._delegate.getElement().nativeElement ===
-      this._delegate.getDocument()?.activeElement;
+    return this._delegate._element.nativeElement ===
+      this._delegate._document?.activeElement;
   }
+
   focusItemAtIndex(index: number) {
     return this._delegate._elementAtIndex(index).focus();
   }
@@ -204,13 +213,13 @@ export abstract class MatInteractiveListBase extends MatListBase
 
   protected _foundation: MDCListFoundation;
 
-  protected _document: Document;
+  _document: Document;
 
   private _itemsArr: MatListItemBase[] = [];
 
   private _subscriptions = new Subscription();
 
-  constructor(protected _element: ElementRef<HTMLElement>, @Inject(DOCUMENT) document: any) {
+  constructor(public _element: ElementRef<HTMLElement>, @Inject(DOCUMENT) document: any) {
     super();
     this._document = document;
     this._isNonInteractive = false;
@@ -227,18 +236,6 @@ export abstract class MatInteractiveListBase extends MatListBase
   ngOnDestroy() {
     this._foundation.destroy();
     this._subscriptions.unsubscribe();
-  }
-
-  getItems() {
-    return this._items;
-  }
-
-  getDocument() {
-    return this._document;
-  }
-
-  getElement() {
-    return this._element;
   }
 
   private _initItems() {

--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -34,6 +34,7 @@ function toggleClass(el: Element, className: string, on: boolean) {
   }
 }
 
+/** @docs-private */
 class ListAdapter implements MDCListAdapter {
   constructor(private _delegate: MatInteractiveListBase) {}
 


### PR DESCRIPTION
Converts list-base adapter to class object to hopefully memory usage and increase performance

Test failures hopefully should be resolved after this PR is merged:
https://github.com/material-components/material-components-web/pull/6256