### PR TITLE
test(material-experimental/mdc-slider): try to reduce test flakes

### DIFF
--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -24,12 +24,19 @@ import {Component, DebugElement, Type, ViewChild} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed, tick, inject} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSlider, MatSliderModule} from './index';
 
 describe('MDC-based MatSlider', () => {
   function createComponent<T>(component: Type<T>): ComponentFixture<T> {
     TestBed.configureTestingModule({
-      imports: [MatSliderModule, ReactiveFormsModule, FormsModule, BidiModule],
+      imports: [
+        MatSliderModule,
+        ReactiveFormsModule,
+        FormsModule,
+        BidiModule,
+        NoopAnimationsModule,
+      ],
       declarations: [component],
     }).compileComponents();
 


### PR DESCRIPTION
We've been seeing more test flakes from the MDC slider recently. These changes try to address them by disabling animations and adding an extra change detection after flushing `requestAnimationFrame`.