### PR TITLE
fix(datepicker): emitting dateChange event when opposite range input changes

### DIFF
--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -40,7 +40,7 @@ import {
 import {BooleanInput} from '@angular/cdk/coercion';
 import {BACKSPACE} from '@angular/cdk/keycodes';
 import {MatDatepickerInputBase, DateFilterFn} from './datepicker-input-base';
-import {DateRange} from './date-selection-model';
+import {DateRange, DateSelectionModelChange} from './date-selection-model';
 
 /** Parent component that should be wrapped around `MatStartDate` and `MatEndDate`. */
 export interface MatDateRangeInputParent<D> {
@@ -238,6 +238,10 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpd
     }
   }
 
+  protected _canEmitChangeEvent = (event: DateSelectionModelChange<DateRange<D>>): boolean => {
+    return event.source !== this._rangeInput._endInput;
+  }
+
   protected _formatValue(value: D | null) {
     super._formatValue(value);
 
@@ -316,6 +320,10 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdat
       this._model.updateSelection(range, this);
       this._cvaOnChange(value);
     }
+  }
+
+  protected _canEmitChangeEvent = (event: DateSelectionModelChange<DateRange<D>>): boolean => {
+    return event.source !== this._rangeInput._startInput;
   }
 
   _onKeydown(event: KeyboardEvent) {

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -176,6 +176,10 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
     return this._dateFilter;
   }
 
+  protected _canEmitChangeEvent() {
+    return true;
+  }
+
   // Unnecessary when selecting a single date.
   protected _outsideValueChanged: undefined;
 

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -216,6 +216,7 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | nu
     set min(value: D | null);
     constructor(elementRef: ElementRef<HTMLInputElement>, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats, _formField: MatFormField);
     protected _assignValueToModel(value: D | null): void;
+    protected _canEmitChangeEvent(): boolean;
     protected _getDateFilter(): DateFilterFn<D | null>;
     _getMaxDate(): D | null;
     _getMinDate(): D | null;
@@ -364,6 +365,7 @@ export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSe
 }
 
 export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+    protected _canEmitChangeEvent: (event: DateSelectionModelChange<DateRange<D>>) => boolean;
     protected _validator: ValidatorFn | null;
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
     protected _assignValueToModel(value: D | null): void;
@@ -468,6 +470,7 @@ export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionMode
 }
 
 export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+    protected _canEmitChangeEvent: (event: DateSelectionModelChange<DateRange<D>>) => boolean;
     protected _validator: ValidatorFn | null;
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
     protected _assignValueToModel(value: D | null): void;


### PR DESCRIPTION
Adds some logic to prevent date range inputs from emitting their `dateChange` and `dateInput` events when a value is assigned to the opposite input.

Fixes #19968.