### PR TITLE
fix(material-experimental/mdc-snack-bar): blending in with background in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.scss
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.scss
@@ -1,5 +1,6 @@
 @import '@material/snackbar/mixins.import';
 @import '../mdc-helpers/mdc-helpers';
+@import '../../cdk/a11y/a11y';
 
 @include mdc-snackbar-core-styles($query: $mat-base-styles-query);
 
@@ -8,6 +9,10 @@
 // of positions, so we'll defer logic there.
 .mat-mdc-snack-bar-container {
   position: static;
+
+  @include cdk-high-contrast(active, off) {
+    border: solid 1px;
+  }
 }
 
 // These elements need to have full width using flex layout.


### PR DESCRIPTION
The MDC snack bar doesn't have a border which causes it to blend in with the background in high contrast mode.