### PR TITLE
fix(cdk-experimental/menu): fix bug preventing keyboard event handling if opened programmatically

### DIFF
--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -452,6 +452,27 @@ describe('MenuBar', () => {
 
           expect(document.activeElement).toEqual(fileMenuNativeItems[1]);
         }));
+
+        it('should handle keyboard actions if initial menu is opened programmatically', () => {
+          fixture.debugElement
+              .queryAll(By.directive(CdkMenuItem))[0]
+              .injector.get(CdkMenuItem)
+              .getMenuTrigger()!
+              .openMenu();
+          detectChanges();
+          fixture.debugElement
+              .queryAll(By.directive(CdkMenuItem))[2]
+              .injector.get(CdkMenuItem)
+              .getMenuTrigger()!
+              .openMenu();
+          detectChanges();
+
+          fileMenuNativeItems[0].focus();
+          dispatchKeyboardEvent(fileMenuNativeItems[0], 'keydown', TAB);
+          detectChanges();
+
+          expect(nativeMenus.length).toBe(0);
+        });
       });
     });
 


### PR DESCRIPTION
If a menu is opened programmatically, subsequent keyboard events to close it out are not handled.
This fixes the issue by tracking the open sub-menu regardless of how it was opened up.