### PR TITLE
fix(input): changed after checked error if input has static placeholder

### DIFF
--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -996,6 +996,12 @@ describe('MatInput without forms', () => {
     }).not.toThrow();
   }));
 
+  it('should not throw when there is a default ngIf on the input element', fakeAsync(() => {
+    expect(() => {
+      createComponent(MatInputWithAnotherNgIf).detectChanges();
+    }).not.toThrow();
+  }));
+
 });
 
 describe('MatInput with forms', () => {
@@ -2251,3 +2257,18 @@ class CustomMatInputAccessor {
   `
 })
 class MatInputWithDefaultNgIf {}
+
+
+// Note that the DOM structure is slightly weird, but it's
+// testing a specific g3 issue. See the discussion on #10466.
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-label>App name</mat-label>
+      <input matInput *ngIf="true" placeholder="My placeholder" [value]="inputValue">
+    </mat-form-field>
+  `
+})
+class MatInputWithAnotherNgIf {
+  inputValue = 'test';
+}

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -43,7 +43,6 @@ export declare class MatInput extends _MatInputMixinBase implements MatFormField
     ngControl: NgControl, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined);
     protected _dirtyCheckNativeValue(): void;
     _focusChanged(isFocused: boolean): void;
-    _getPlaceholderAttribute(): string | undefined;
     protected _isBadInput(): boolean;
     protected _isNeverEmpty(): boolean;
     _onInput(): void;


### PR DESCRIPTION
The placeholder attribute is set based on a child query which is prone to "changed after checked" errors. These changes switch to assigning it ourselves directly to the DOM manually.