### PR TITLE
test(mdc-card): add performance tests for mdc-card

### DIFF
--- a/test/benchmarks/mdc/card/BUILD.bazel
+++ b/test/benchmarks/mdc/card/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@npm_angular_dev_infra_private//benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+
+# TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
+# stylesUrls inside the components once `component_benchmark` supports asset injection.
+
+component_benchmark(
+    name = "benchmark",
+    driver = ":card.perf-spec.ts",
+    driver_deps = [
+        "@npm//@angular/dev-infra-private",
+        "@npm//protractor",
+        "@npm//@types/jasmine",
+    ],
+    ng_deps = [
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "//src/material-experimental/mdc-card",
+    ],
+    ng_srcs = [":app.module.ts"],
+    prefix = "",
+    styles = ["//src/material-experimental/mdc-theming:indigo_pink_prebuilt"],
+)

--- a/test/benchmarks/mdc/card/app.module.ts
+++ b/test/benchmarks/mdc/card/app.module.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, NgModule, ViewEncapsulation} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {MatCardModule} from '@angular/material-experimental/mdc-card';
+
+/** component: mdc-card */
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <button id="show" (click)="show()">Show</button>
+    <button id="hide" (click)="hide()">Hide</button>
+
+    <mat-card *ngIf="isVisible">Simple card</mat-card>
+  `,
+  encapsulation: ViewEncapsulation.None,
+  styleUrls: ['//src/material-experimental/mdc-theming/prebuilt/indigo-pink.css'],
+})
+export class CardBenchmarkApp {
+  isVisible = false;
+
+  show() { this.isVisible = true; }
+  hide() { this.isVisible = false; }
+}
+
+
+@NgModule({
+  declarations: [CardBenchmarkApp],
+  imports: [
+    BrowserModule,
+    MatCardModule,
+  ],
+  providers: [],
+  bootstrap: [CardBenchmarkApp],
+})
+export class AppModule {}

--- a/test/benchmarks/mdc/card/card.perf-spec.ts
+++ b/test/benchmarks/mdc/card/card.perf-spec.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {$, browser} from 'protractor';
+import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilities';
+
+describe('card performance benchmarks', () => {
+  beforeAll(() => {
+    browser.rootEl = '#root';
+  });
+
+  it('renders a simple card', async() => {
+    await runBenchmark({
+      id: 'card-render',
+      url: '',
+      ignoreBrowserSynchronization: true,
+      params: [],
+      prepare: async () => await $('#hide').click(),
+      work: async () => await $('#show').click()
+    });
+  });
+});


### PR DESCRIPTION
This benchmark is identical to the one in `//src/test/benchmarks/material/card` except that it uses the mdc version of the component.