### PR TITLE
fix(expansion): fix expansion `.mat-expansion-panel-header` styles

### DIFF
--- a/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.css
+++ b/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.css
@@ -2,11 +2,6 @@
   padding-bottom: 20px;
 }
 
-.example-headers-align .mat-expansion-panel-header-title,
-.example-headers-align .mat-expansion-panel-header-description {
-  flex-basis: 0;
-}
-
 .example-headers-align .mat-expansion-panel-header-description {
   justify-content: space-between;
   align-items: center;

--- a/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.css
+++ b/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.css
@@ -1,8 +1,3 @@
-.example-headers-align .mat-expansion-panel-header-title,
-.example-headers-align .mat-expansion-panel-header-description {
-  flex-basis: 0;
-}
-
 .example-headers-align .mat-expansion-panel-header-description {
   justify-content: space-between;
   align-items: center;

--- a/src/material/expansion/expansion-panel-header.html
+++ b/src/material/expansion/expansion-panel-header.html
@@ -1,4 +1,4 @@
-<span class="mat-content">
+<span class="mat-content" [class.mat-content-hide-toggle]="!_showToggle()">
   <ng-content select="mat-panel-title"></ng-content>
   <ng-content select="mat-panel-description"></ng-content>
   <ng-content></ng-content>

--- a/src/material/expansion/expansion-panel-header.scss
+++ b/src/material/expansion/expansion-panel-header.scss
@@ -48,12 +48,33 @@
   flex: 1;
   flex-direction: row;
   overflow: hidden;
+
+  // width of .mat-expansion-indicator::after element
+  &.mat-content-hide-toggle {
+    margin-right: 8px;
+
+    [dir='rtl'] & {
+      margin-right: 0;
+      margin-left: 8px;
+    }
+
+    .mat-expansion-toggle-indicator-before & {
+      margin-left: 24px;
+      margin-right: 0;
+
+      [dir='rtl'] & {
+        margin-right: 24px;
+        margin-left: 0;
+      }
+    }
+  }
 }
 
 .mat-expansion-panel-header-title,
 .mat-expansion-panel-header-description {
   display: flex;
   flex-grow: 1;
+  flex-basis: 0;
   margin-right: 16px;
   align-items: center;
 

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -63,9 +63,8 @@ describe('MatExpansionPanel', () => {
 
   it('should be able to render panel content lazily', fakeAsync(() => {
     const fixture = TestBed.createComponent(LazyPanelWithContent);
-    const content = fixture.debugElement.query(
-      By.css('.mat-expansion-panel-content'),
-    )!.nativeElement;
+    const content = fixture.debugElement.query(By.css('.mat-expansion-panel-content'))!
+      .nativeElement;
     fixture.detectChanges();
 
     expect(content.textContent.trim())
@@ -82,9 +81,8 @@ describe('MatExpansionPanel', () => {
 
   it('should render the content for a lazy-loaded panel that is opened on init', fakeAsync(() => {
     const fixture = TestBed.createComponent(LazyPanelOpenOnLoad);
-    const content = fixture.debugElement.query(
-      By.css('.mat-expansion-panel-content'),
-    )!.nativeElement;
+    const content = fixture.debugElement.query(By.css('.mat-expansion-panel-content'))!
+      .nativeElement;
     fixture.detectChanges();
 
     expect(content.textContent.trim())
@@ -314,12 +312,14 @@ describe('MatExpansionPanel', () => {
   it('should be able to hide the toggle', () => {
     const fixture = TestBed.createComponent(PanelWithContent);
     const header = fixture.debugElement.query(By.css('.mat-expansion-panel-header'))!.nativeElement;
+    const content = fixture.debugElement.query(By.css('.mat-content'))!.nativeElement;
 
     fixture.detectChanges();
 
     expect(header.querySelector('.mat-expansion-indicator'))
       .withContext('Expected indicator to be shown.')
       .toBeTruthy();
+    expect(content.classList).not.toContain('mat-content-hide-toggle');
 
     fixture.componentInstance.hideToggle = true;
     fixture.detectChanges();
@@ -327,6 +327,7 @@ describe('MatExpansionPanel', () => {
     expect(header.querySelector('.mat-expansion-indicator'))
       .withContext('Expected indicator to be hidden.')
       .toBeFalsy();
+    expect(content.classList).toContain('mat-content-hide-toggle');
   });
 
   it('should update the indicator rotation when the expanded state is toggled programmatically', fakeAsync(() => {


### PR DESCRIPTION
* Add margin to `.mat-content` element to account for consumer using
  `mat-expansion-panel` components with the toggle hidden alongside
  `mat-expansion-panel` components where the toggle is visible
* Adjust sizing of `.mat-expansion-panel-header-title` and
  `.mat-expansion-panel-header-description` elements so that the width
  of each respective element is uniform across multiple adjacent
  `mat-expansion-panel` elements
* Fixes #20002

**LTR**

![image](https://user-images.githubusercontent.com/18009315/87737102-16d96300-c7a8-11ea-83ec-014c7dee1537.png)

**RTL**

![image](https://user-images.githubusercontent.com/18009315/87737164-3a9ca900-c7a8-11ea-9488-c8618cd06a23.png)

Caretaker Note (andrewseguin, 2022-04): Breaks ~50 screenshot tests. Text in expansion panels are getting shifted over maybe 10 - 15px