### PR TITLE
refactor: do not manually modify properties of keyboard events in tests

### DIFF
--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -170,7 +170,7 @@ describe('MenuBar', () => {
         it('should not focus the last item when pressing end with modifier', () => {
           focusMenuBar();
 
-          const event = createKeyboardEvent('keydown', END, '', undefined, {control: true});
+          const event = createKeyboardEvent('keydown', END, '', {control: true});
           dispatchEvent(nativeMenuBar, event);
           detectChanges();
 
@@ -182,7 +182,7 @@ describe('MenuBar', () => {
           dispatchKeyboardEvent(nativeMenuBar, 'keydown', END);
           detectChanges();
 
-          let event = createKeyboardEvent('keydown', HOME, '', undefined, {control: true});
+          let event = createKeyboardEvent('keydown', HOME, '', {control: true});
           dispatchEvent(nativeMenuBar, event);
           detectChanges();
 
@@ -328,7 +328,7 @@ describe('MenuBar', () => {
         it('should not focus the last item when pressing end with modifier', () => {
           openFileMenu();
 
-          const event = createKeyboardEvent('keydown', END, '', undefined, {control: true});
+          const event = createKeyboardEvent('keydown', END, '', {control: true});
           dispatchEvent(nativeMenus[0], event);
           detectChanges();
 
@@ -340,7 +340,7 @@ describe('MenuBar', () => {
           dispatchKeyboardEvent(nativeMenus[0], 'keydown', END);
           detectChanges();
 
-          const event = createKeyboardEvent('keydown', HOME, '', undefined, {control: true});
+          const event = createKeyboardEvent('keydown', HOME, '', {control: true});
           dispatchEvent(nativeMenus[0], event);
           detectChanges();
 
@@ -422,7 +422,7 @@ describe('MenuBar', () => {
         it('should not close submenu and focus parent on escape with modifier', () => {
           openFileMenu();
           openShareMenu();
-          const event = createKeyboardEvent('keydown', ESCAPE, '', undefined, {control: true});
+          const event = createKeyboardEvent('keydown', ESCAPE, '', {control: true});
 
           dispatchEvent(nativeMenus[1], event);
           detectChanges();

--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -563,7 +563,7 @@ describe('CDK Popover Edit', () => {
 
         describe('arrow keys', () => {
           const dispatchKey = (cell: HTMLElement, keyCode: number) =>
-              dispatchKeyboardEvent(cell, 'keydown', keyCode, undefined, cell);
+              dispatchKeyboardEvent(cell, 'keydown', keyCode);
 
           it('moves focus up/down/left/right and prevents default', () => {
             const rowCells = getRowCells();

--- a/src/cdk/a11y/key-manager/list-key-manager.spec.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.spec.ts
@@ -723,8 +723,7 @@ describe('Key managers', () => {
       }));
 
       it('should not move focus if a modifier, that is not allowed, is pressed', fakeAsync(() => {
-        const tEvent = createKeyboardEvent('keydown', 84, 't');
-        Object.defineProperty(tEvent, 'ctrlKey', {get: () => true});
+        const tEvent = createKeyboardEvent('keydown', 84, 't', {control: true});
 
         expect(keyManager.activeItem).toBeFalsy();
 
@@ -735,8 +734,7 @@ describe('Key managers', () => {
       }));
 
       it('should always allow the shift key', fakeAsync(() => {
-        const tEvent = createKeyboardEvent('keydown', 84, 't');
-        Object.defineProperty(tEvent, 'shiftKey', {get: () => true});
+        const tEvent = createKeyboardEvent('keydown', 84, 't', {shift: true});
 
         expect(keyManager.activeItem).toBeFalsy();
 

--- a/src/cdk/keycodes/modifiers.spec.ts
+++ b/src/cdk/keycodes/modifiers.spec.ts
@@ -4,7 +4,7 @@ import {hasModifierKey} from './modifiers';
 describe('keyboard modifiers', () => {
   it('should check whether the alt key is pressed', () => {
     const event = createKeyboardEvent('keydown', 0);
-    const altEvent = createKeyboardEvent('keydown', 0, '', undefined, {alt: true});
+    const altEvent = createKeyboardEvent('keydown', 0, '',  {alt: true});
 
     expect(hasModifierKey(event)).toBe(false);
     expect(hasModifierKey(altEvent)).toBe(true);
@@ -12,7 +12,7 @@ describe('keyboard modifiers', () => {
 
   it('should check whether the shift key is pressed', () => {
     const event = createKeyboardEvent('keydown', 0);
-    const shiftEvent = createKeyboardEvent('keydown', 0, '', undefined, {shift: true});
+    const shiftEvent = createKeyboardEvent('keydown', 0, '', {shift: true});
 
     expect(hasModifierKey(event)).toBe(false);
     expect(hasModifierKey(shiftEvent)).toBe(true);
@@ -20,7 +20,7 @@ describe('keyboard modifiers', () => {
 
   it('should check whether the meta key is pressed', () => {
     const event = createKeyboardEvent('keydown', 0);
-    const metaEvent = createKeyboardEvent('keydown', 0, '', undefined, {meta: true});
+    const metaEvent = createKeyboardEvent('keydown', 0, '', {meta: true});
 
     expect(hasModifierKey(event)).toBe(false);
     expect(hasModifierKey(metaEvent)).toBe(true);
@@ -28,25 +28,25 @@ describe('keyboard modifiers', () => {
 
   it('should check whether the ctrl key is pressed', () => {
     const event = createKeyboardEvent('keydown', 0);
-    const ctrlEvent = createKeyboardEvent('keydown', 0, '', undefined, {control: true});
+    const ctrlEvent = createKeyboardEvent('keydown', 0, '', {control: true});
 
     expect(hasModifierKey(event)).toBe(false);
     expect(hasModifierKey(ctrlEvent)).toBe(true);
   });
 
   it('should check if a particular modifier key is pressed', () => {
-    const ctrlEvent = createKeyboardEvent('keydown', 0, '', undefined, {control: true});
+    const ctrlEvent = createKeyboardEvent('keydown', 0, '', {control: true});
     const ctrlAltEvent = createKeyboardEvent(
-        'keydown', 0, '', undefined, {control: true, alt: true});
+        'keydown', 0, '', {control: true, alt: true});
 
     expect(hasModifierKey(ctrlEvent, 'altKey')).toBe(false);
     expect(hasModifierKey(ctrlAltEvent, 'altKey')).toBe(true);
   });
 
   it('should check if multiple specific modifier keys are pressed', () => {
-    const ctrlEvent = createKeyboardEvent('keydown', 0, '', undefined, {control: true});
+    const ctrlEvent = createKeyboardEvent('keydown', 0, '', {control: true});
     const ctrlAltShiftEvent = createKeyboardEvent(
-        'keydown', 0, '', undefined, {control: true, alt: true, shift: true});
+        'keydown', 0, '', {control: true, alt: true, shift: true});
 
     expect(hasModifierKey(ctrlEvent, 'altKey', 'shiftKey')).toBe(false);
     expect(hasModifierKey(ctrlAltShiftEvent, 'altKey', 'shiftKey')).toBe(true);

--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
@@ -104,11 +104,11 @@ describe('OverlayKeyboardDispatcher', () => {
     instance.attach(new ComponentPortal(TestComponent));
     instance.keydownEvents().subscribe(spy);
 
-    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE, undefined, instance.overlayElement);
+    dispatchKeyboardEvent(instance.overlayElement, 'keydown', ESCAPE);
     expect(spy).toHaveBeenCalledTimes(1);
 
     instance.detach();
-    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE, undefined, instance.overlayElement);
+    dispatchKeyboardEvent(instance.overlayElement, 'keydown', ESCAPE);
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -120,11 +120,11 @@ describe('OverlayKeyboardDispatcher', () => {
     instance.attach(new ComponentPortal(TestComponent));
     instance.keydownEvents().subscribe(spy);
 
-    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE, undefined, instance.overlayElement);
+    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
     expect(spy).toHaveBeenCalledTimes(1);
 
     instance.dispose();
-    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE, undefined, instance.overlayElement);
+    dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
 
     expect(spy).toHaveBeenCalledTimes(1);
   });

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -161,8 +161,7 @@ describe('Overlay directives', () => {
     fixture.componentInstance.isOpen = true;
     fixture.detectChanges();
 
-    const event = createKeyboardEvent('keydown', ESCAPE);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', ESCAPE, undefined, {alt: true});
     dispatchEvent(document.body, event);
     fixture.detectChanges();
 

--- a/src/cdk/testing/testbed/fake-events/dispatch-events.ts
+++ b/src/cdk/testing/testbed/fake-events/dispatch-events.ts
@@ -33,13 +33,14 @@ export function dispatchFakeEvent(node: Node | Window, type: string, canBubble?:
 }
 
 /**
- * Shorthand to dispatch a keyboard event with a specified key code.
+ * Shorthand to dispatch a keyboard event with a specified key code and
+ * optional modifiers.
  * @docs-private
  */
 export function dispatchKeyboardEvent(node: Node, type: string, keyCode?: number, key?: string,
-                                      target?: Element, modifiers?: ModifierKeys): KeyboardEvent {
+                                      modifiers?: ModifierKeys): KeyboardEvent {
   return dispatchEvent(node,
-      createKeyboardEvent(type, keyCode, key, target, modifiers));
+      createKeyboardEvent(type, keyCode, key, modifiers));
 }
 
 /**

--- a/src/cdk/testing/testbed/fake-events/event-objects.ts
+++ b/src/cdk/testing/testbed/fake-events/event-objects.ts
@@ -174,14 +174,6 @@ export function createFakeEvent(type: string, canBubble = false, cancelable = tr
 }
 
 /**
- * Sets the `target` of a given event. This method provides a convenient way to update
- * the target of a event as the `target` property is usually considered `readonly`.
- */
-export function setEventTarget(event: Event, target: Element) {
-  defineReadonlyEventProperty(event, 'target', target);
-}
-
-/**
  * Defines a readonly property on the given event object. Readonly properties on an event object
  * are always set as configurable as that matches default readonly properties for DOM event objects.
  */

--- a/src/cdk/testing/testbed/fake-events/event-objects.ts
+++ b/src/cdk/testing/testbed/fake-events/event-objects.ts
@@ -97,18 +97,19 @@ export function createTouchEvent(type: string, pageX = 0, pageY = 0) {
 }
 
 /**
- * Dispatches a keydown event from an element.
+ * Creates a keyboard event with the specified key and modifiers.
  * @docs-private
  */
 export function createKeyboardEvent(type: string, keyCode: number = 0, key: string = '',
-                                    target?: Element, modifiers: ModifierKeys = {}) {
-  const event = document.createEvent('KeyboardEvent') as any;
-  const originalPreventDefault = event.preventDefault;
+                                    modifiers: ModifierKeys = {}) {
+  const event = document.createEvent('KeyboardEvent');
+  const originalPreventDefault = event.preventDefault.bind(event);
 
   // Firefox does not support `initKeyboardEvent`, but supports `initKeyEvent`.
-  if (event.initKeyEvent) {
-    event.initKeyEvent(type, true, true, window, modifiers.control, modifiers.alt, modifiers.shift,
-        modifiers.meta, keyCode);
+  // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyEvent.
+  if ((event as any).initKeyEvent !== undefined) {
+    (event as any).initKeyEvent(type, true, true, window, modifiers.control, modifiers.alt,
+        modifiers.shift, modifiers.meta, keyCode);
   } else {
     // `initKeyboardEvent` expects to receive modifiers as a whitespace-delimited string
     // See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyboardEvent
@@ -130,7 +131,10 @@ export function createKeyboardEvent(type: string, keyCode: number = 0, key: stri
       modifiersList += 'Meta ';
     }
 
-    event.initKeyboardEvent(type,
+    // TS3.6 removed the `initKeyboardEvent` method and suggested porting to
+    // `new KeyboardEvent()` constructor. We cannot use that as we support IE11.
+    // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyboardEvent.
+    (event as any).initKeyboardEvent(type,
         true, /* canBubble */
         true, /* cancelable */
         window, /* view */
@@ -145,7 +149,6 @@ export function createKeyboardEvent(type: string, keyCode: number = 0, key: stri
   // See related bug https://bugs.webkit.org/show_bug.cgi?id=16735
   defineReadonlyEventProperty(event, 'keyCode', keyCode);
   defineReadonlyEventProperty(event, 'key', key);
-  defineReadonlyEventProperty(event, 'target', target);
   defineReadonlyEventProperty(event, 'ctrlKey', !!modifiers.control);
   defineReadonlyEventProperty(event, 'altKey', !!modifiers.alt);
   defineReadonlyEventProperty(event, 'shiftKey', !!modifiers.shift);
@@ -154,7 +157,7 @@ export function createKeyboardEvent(type: string, keyCode: number = 0, key: stri
   // IE won't set `defaultPrevented` on synthetic events so we need to do it manually.
   event.preventDefault = function() {
     defineReadonlyEventProperty(event, 'defaultPrevented', true);
-    return originalPreventDefault.apply(this, arguments);
+    return originalPreventDefault();
   };
 
   return event;
@@ -168,6 +171,14 @@ export function createFakeEvent(type: string, canBubble = false, cancelable = tr
   const event = document.createEvent('Event');
   event.initEvent(type, canBubble, cancelable);
   return event;
+}
+
+/**
+ * Sets the `target` of a given event. This method provides a convenient way to update
+ * the target of a event as the `target` property is usually considered `readonly`.
+ */
+export function setEventTarget(event: Event, target: Element) {
+  defineReadonlyEventProperty(event, 'target', target);
 }
 
 /**

--- a/src/cdk/testing/testbed/fake-events/type-in-element.ts
+++ b/src/cdk/testing/testbed/fake-events/type-in-element.ts
@@ -58,13 +58,13 @@ export function typeInElement(element: HTMLElement, ...modifiersAndKeys: any) {
 
   triggerFocus(element);
   for (const key of keys) {
-    dispatchKeyboardEvent(element, 'keydown', key.keyCode, key.key, element, modifiers);
-    dispatchKeyboardEvent(element, 'keypress', key.keyCode, key.key, element, modifiers);
+    dispatchKeyboardEvent(element, 'keydown', key.keyCode, key.key, modifiers);
+    dispatchKeyboardEvent(element, 'keypress', key.keyCode, key.key, modifiers);
     if (isTextInput(element) && key.key && key.key.length === 1) {
       element.value += key.key;
       dispatchFakeEvent(element, 'input');
     }
-    dispatchKeyboardEvent(element, 'keyup', key.keyCode, key.key, element, modifiers);
+    dispatchKeyboardEvent(element, 'keyup', key.keyCode, key.key, modifiers);
   }
 }
 

--- a/src/material-experimental/mdc-chips/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/BUILD.bazel
@@ -65,6 +65,7 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/platform",
+        "//src/cdk/testing",
         "//src/cdk/testing/private",
         "//src/material/core",
         "//src/material/form-field",

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -1,26 +1,25 @@
 import {animate, style, transition, trigger} from '@angular/animations';
-import {Directionality, Direction} from '@angular/cdk/bidi';
+import {Direction, Directionality} from '@angular/cdk/bidi';
 import {
   BACKSPACE,
   DELETE,
+  END,
   ENTER,
+  HOME,
   LEFT_ARROW,
   RIGHT_ARROW,
   SPACE,
-  TAB,
-  HOME,
-  END
+  TAB
 } from '@angular/cdk/keycodes';
-import {ModifierKeys} from '@angular/cdk/testing';
 import {
   createFakeEvent,
   createKeyboardEvent,
+  dispatchEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent,
-  setEventTarget,
-  typeInElement,
   MockNgZone,
+  typeInElement,
 } from '@angular/cdk/testing/private';
 import {
   Component,
@@ -32,7 +31,7 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
-import {fakeAsync, ComponentFixture, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, NgForm, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
@@ -270,7 +269,6 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastRowIndex = array.length - 1;
           let lastChip = array[lastRowIndex];
@@ -281,7 +279,8 @@ describe('MDC-based MatChipGrid', () => {
           expect(manager.activeColumnIndex).toEqual(0);
 
           // Press the LEFT arrow
-          chipGridInstance._keydown(LEFT_EVENT);
+          dispatchKeyboardEvent(lastNativeChip, 'keydown', LEFT_ARROW);
+
           chipGridInstance._blur(); // Simulate focus leaving the list and going to the chip.
           fixture.detectChanges();
 
@@ -294,7 +293,6 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -304,7 +302,7 @@ describe('MDC-based MatChipGrid', () => {
           expect(manager.activeColumnIndex).toEqual(0);
 
           // Press the RIGHT arrow
-          chipGridInstance._keydown(RIGHT_EVENT);
+          dispatchKeyboardEvent(firstNativeChip, 'keydown', RIGHT_ARROW);
           chipGridInstance._blur(); // Simulate focus leaving the list and going to the chip.
           fixture.detectChanges();
 
@@ -314,10 +312,9 @@ describe('MDC-based MatChipGrid', () => {
         });
 
         it('should not handle arrow key events from non-chip elements', () => {
-          const event = createKeydownEvent(RIGHT_ARROW, chipGridNativeElement);
           const initialActiveIndex = manager.activeRowIndex;
 
-          chipGridInstance._keydown(event);
+          dispatchKeyboardEvent(chipGridNativeElement, 'keydown', RIGHT_ARROW);
           fixture.detectChanges();
 
           expect(manager.activeRowIndex)
@@ -335,7 +332,6 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastRowIndex = array.length - 1;
           let lastItem = array[lastRowIndex];
@@ -347,7 +343,7 @@ describe('MDC-based MatChipGrid', () => {
 
 
           // Press the RIGHT arrow
-          chipGridInstance._keydown(RIGHT_EVENT);
+          dispatchKeyboardEvent(lastNativeChip, 'keydown', RIGHT_ARROW);
           chipGridInstance._blur(); // Simulate focus leaving the list and going to the chip.
           fixture.detectChanges();
 
@@ -360,7 +356,6 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -371,7 +366,7 @@ describe('MDC-based MatChipGrid', () => {
 
 
           // Press the LEFT arrow
-          chipGridInstance._keydown(LEFT_EVENT);
+          dispatchKeyboardEvent(firstNativeChip, 'keydown', LEFT_ARROW);
           chipGridInstance._blur(); // Simulate focus leaving the list and going to the chip.
           fixture.detectChanges();
 
@@ -384,7 +379,7 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          chipGridInstance._keydown(createKeydownEvent(TAB, firstNativeChip));
+          dispatchKeyboardEvent(firstNativeChip, 'keydown', TAB);
 
           expect(chipGridInstance.tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -405,8 +400,7 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          chipGridInstance._keydown(createKeydownEvent(TAB, firstNativeChip));
-
+          dispatchKeyboardEvent(firstNativeChip, 'keydown', TAB);
           expect(chipGridInstance.tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
 
@@ -423,7 +417,7 @@ describe('MDC-based MatChipGrid', () => {
         let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
         let firstNativeChip = nativeChips[0] as HTMLElement;
 
-        let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
+        let RIGHT_EVENT = createKeyboardEvent('keydown', RIGHT_ARROW);
         let array = chips.toArray();
         let firstItem = array[0];
 
@@ -431,7 +425,7 @@ describe('MDC-based MatChipGrid', () => {
         expect(manager.activeRowIndex).toBe(0);
         expect(manager.activeColumnIndex).toBe(0);
 
-        chipGridInstance._keydown(RIGHT_EVENT);
+        dispatchEvent(firstNativeChip, RIGHT_EVENT);
         chipGridInstance._blur();
         fixture.detectChanges();
 
@@ -456,7 +450,7 @@ describe('MDC-based MatChipGrid', () => {
         const nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
         const lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-        const HOME_EVENT = createKeydownEvent(HOME, lastNativeChip);
+        const HOME_EVENT = createKeyboardEvent('keydown', HOME);
         const array = chips.toArray();
         const lastItem = array[array.length - 1];
 
@@ -464,7 +458,7 @@ describe('MDC-based MatChipGrid', () => {
         expect(manager.activeRowIndex).toBe(4);
         expect(manager.activeColumnIndex).toBe(0);
 
-        chipGridInstance._keydown(HOME_EVENT);
+        dispatchEvent(lastNativeChip, HOME_EVENT);
         fixture.detectChanges();
 
         expect(HOME_EVENT.defaultPrevented).toBe(true);
@@ -479,7 +473,7 @@ describe('MDC-based MatChipGrid', () => {
         const nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
         const firstNativeChip = nativeChips[0] as HTMLElement;
 
-        const END_EVENT = createKeydownEvent(END, firstNativeChip);
+        const END_EVENT = createKeyboardEvent('keydown', END);
         const array = chips.toArray();
         const firstItem = array[0];
 
@@ -487,7 +481,7 @@ describe('MDC-based MatChipGrid', () => {
         expect(manager.activeRowIndex).toBe(0);
         expect(manager.activeColumnIndex).toBe(0);
 
-        chipGridInstance._keydown(END_EVENT);
+        dispatchEvent(firstNativeChip, END_EVENT);
         fixture.detectChanges();
 
         expect(END_EVENT.defaultPrevented).toBe(true);
@@ -505,7 +499,7 @@ describe('MDC-based MatChipGrid', () => {
         const firstItem = array[0];
 
         firstItem.focus();
-        firstItem._keydown(createKeydownEvent(ENTER, document.activeElement!, undefined, 'Enter'));
+        dispatchKeyboardEvent(document.activeElement!, 'keydown', ENTER, 'Enter');
         fixture.detectChanges();
 
         const activeRowIndex = manager.activeRowIndex;
@@ -513,7 +507,7 @@ describe('MDC-based MatChipGrid', () => {
 
         const KEYS_TO_IGNORE = [HOME, END, LEFT_ARROW, RIGHT_ARROW];
         for (const key of KEYS_TO_IGNORE) {
-          chipGridInstance._keydown(createKeydownEvent(key, document.activeElement!));
+          dispatchKeyboardEvent(document.activeElement!, 'keydown', key);
           fixture.detectChanges();
 
           expect(manager.activeRowIndex).toBe(activeRowIndex);
@@ -551,7 +545,6 @@ describe('MDC-based MatChipGrid', () => {
 
         it('should not focus the last chip when press DELETE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let DELETE_EVENT = createKeydownEvent(DELETE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
@@ -559,7 +552,7 @@ describe('MDC-based MatChipGrid', () => {
           expect(manager.activeColumnIndex).toBe(-1);
 
           // Press the DELETE key
-          chipGridInstance._keydown(DELETE_EVENT);
+          dispatchKeyboardEvent(nativeInput, 'keydown', DELETE);
           fixture.detectChanges();
 
           // It doesn't focus the last chip
@@ -569,7 +562,6 @@ describe('MDC-based MatChipGrid', () => {
 
         it('should focus the last chip when press BACKSPACE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let BACKSPACE_EVENT = createKeydownEvent(BACKSPACE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
@@ -577,7 +569,7 @@ describe('MDC-based MatChipGrid', () => {
           expect(manager.activeColumnIndex).toBe(-1);
 
           // Press the BACKSPACE key
-          chipGridInstance._keydown(BACKSPACE_EVENT);
+          dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
           fixture.detectChanges();
 
           // It focuses the last chip
@@ -1003,16 +995,6 @@ describe('MDC-based MatChipGrid', () => {
     chips = chipGridInstance._chips;
   }
 });
-
-/** Creates a keydown event with the given key and an optional target element. */
-function createKeydownEvent(keyCode: number, target?: Element, modifiers?: ModifierKeys,
-                            keyName?: string) {
-  const event = createKeyboardEvent('keydown', keyCode, keyName, modifiers);
-  if (target !== undefined) {
-    setEventTarget(event, target);
-  }
-  return event;
-}
 
 @Component({
   template: `

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -11,12 +11,14 @@ import {
   HOME,
   END
 } from '@angular/cdk/keycodes';
+import {ModifierKeys} from '@angular/cdk/testing';
 import {
   createFakeEvent,
   createKeyboardEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent,
+  setEventTarget,
   typeInElement,
   MockNgZone,
 } from '@angular/cdk/testing/private';
@@ -268,7 +270,7 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let LEFT_EVENT = createKeyboardEvent('keydown', LEFT_ARROW, undefined, lastNativeChip);
+          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastRowIndex = array.length - 1;
           let lastChip = array[lastRowIndex];
@@ -292,8 +294,7 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let RIGHT_EVENT: KeyboardEvent =
-            createKeyboardEvent('keydown', RIGHT_ARROW, undefined, firstNativeChip);
+          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -313,8 +314,7 @@ describe('MDC-based MatChipGrid', () => {
         });
 
         it('should not handle arrow key events from non-chip elements', () => {
-          const event: KeyboardEvent =
-              createKeyboardEvent('keydown', RIGHT_ARROW, undefined, chipGridNativeElement);
+          const event = createKeydownEvent(RIGHT_ARROW, chipGridNativeElement);
           const initialActiveIndex = manager.activeRowIndex;
 
           chipGridInstance._keydown(event);
@@ -335,8 +335,7 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let RIGHT_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', RIGHT_ARROW, undefined, lastNativeChip);
+          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastRowIndex = array.length - 1;
           let lastItem = array[lastRowIndex];
@@ -361,8 +360,7 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let LEFT_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', LEFT_ARROW, undefined, firstNativeChip);
+          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -386,8 +384,7 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          chipGridInstance._keydown(
-              createKeyboardEvent('keydown', TAB, undefined, firstNativeChip));
+          chipGridInstance._keydown(createKeydownEvent(TAB, firstNativeChip));
 
           expect(chipGridInstance.tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -408,8 +405,7 @@ describe('MDC-based MatChipGrid', () => {
           let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          chipGridInstance._keydown(
-              createKeyboardEvent('keydown', TAB, undefined, firstNativeChip));
+          chipGridInstance._keydown(createKeydownEvent(TAB, firstNativeChip));
 
           expect(chipGridInstance.tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -427,8 +423,7 @@ describe('MDC-based MatChipGrid', () => {
         let nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
         let firstNativeChip = nativeChips[0] as HTMLElement;
 
-        let RIGHT_EVENT: KeyboardEvent =
-          createKeyboardEvent('keydown', RIGHT_ARROW, undefined, firstNativeChip);
+        let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
         let array = chips.toArray();
         let firstItem = array[0];
 
@@ -461,8 +456,7 @@ describe('MDC-based MatChipGrid', () => {
         const nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
         const lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-        const HOME_EVENT: KeyboardEvent =
-          createKeyboardEvent('keydown', HOME, undefined, lastNativeChip);
+        const HOME_EVENT = createKeydownEvent(HOME, lastNativeChip);
         const array = chips.toArray();
         const lastItem = array[array.length - 1];
 
@@ -485,8 +479,7 @@ describe('MDC-based MatChipGrid', () => {
         const nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
         const firstNativeChip = nativeChips[0] as HTMLElement;
 
-        const END_EVENT: KeyboardEvent =
-          createKeyboardEvent('keydown', END, undefined, firstNativeChip);
+        const END_EVENT = createKeydownEvent(END, firstNativeChip);
         const array = chips.toArray();
         const firstItem = array[0];
 
@@ -510,8 +503,9 @@ describe('MDC-based MatChipGrid', () => {
 
         const array = chips.toArray();
         const firstItem = array[0];
+
         firstItem.focus();
-        firstItem._keydown(createKeyboardEvent('keydown', ENTER, 'Enter', document.activeElement!));
+        firstItem._keydown(createKeydownEvent(ENTER, document.activeElement!, undefined, 'Enter'));
         fixture.detectChanges();
 
         const activeRowIndex = manager.activeRowIndex;
@@ -519,9 +513,7 @@ describe('MDC-based MatChipGrid', () => {
 
         const KEYS_TO_IGNORE = [HOME, END, LEFT_ARROW, RIGHT_ARROW];
         for (const key of KEYS_TO_IGNORE) {
-          const event: KeyboardEvent =
-              createKeyboardEvent('keydown', key, undefined, document.activeElement!);
-          chipGridInstance._keydown(event);
+          chipGridInstance._keydown(createKeydownEvent(key, document.activeElement!));
           fixture.detectChanges();
 
           expect(manager.activeRowIndex).toBe(activeRowIndex);
@@ -559,8 +551,7 @@ describe('MDC-based MatChipGrid', () => {
 
         it('should not focus the last chip when press DELETE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let DELETE_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', DELETE, nativeInput);
+          let DELETE_EVENT = createKeydownEvent(DELETE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
@@ -578,8 +569,7 @@ describe('MDC-based MatChipGrid', () => {
 
         it('should focus the last chip when press BACKSPACE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let BACKSPACE_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', BACKSPACE, undefined, nativeInput);
+          let BACKSPACE_EVENT = createKeydownEvent(BACKSPACE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
@@ -1013,6 +1003,16 @@ describe('MDC-based MatChipGrid', () => {
     chips = chipGridInstance._chips;
   }
 });
+
+/** Creates a keydown event with the given key and an optional target element. */
+function createKeydownEvent(keyCode: number, target?: Element, modifiers?: ModifierKeys,
+                            keyName?: string) {
+  const event = createKeyboardEvent('keydown', keyCode, keyName, modifiers);
+  if (target !== undefined) {
+    setEventTarget(event, target);
+  }
+  return event;
+}
 
 @Component({
   template: `

--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -1,24 +1,18 @@
 import {Directionality} from '@angular/cdk/bidi';
-import {ENTER, COMMA, TAB} from '@angular/cdk/keycodes';
+import {COMMA, ENTER, TAB} from '@angular/cdk/keycodes';
 import {PlatformModule} from '@angular/cdk/platform';
-import {ModifierKeys} from '@angular/cdk/testing';
-import {
-  createKeyboardEvent,
-  dispatchKeyboardEvent,
-  dispatchEvent,
-  setEventTarget,
-} from '@angular/cdk/testing/private';
+import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatFormFieldModule} from '@angular/material/form-field';
 import {Subject} from 'rxjs';
 import {
   MAT_CHIPS_DEFAULT_OPTIONS,
+  MatChipGrid,
   MatChipInput,
   MatChipInputEvent,
-  MatChipGrid,
   MatChipsDefaultOptions,
   MatChipsModule
 } from './index';
@@ -61,11 +55,9 @@ describe('MDC-based MatChipInput', () => {
 
   describe('basic behavior', () => {
     it('emits the (chipEnd) on enter keyup', () => {
-      let ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement);
-
       spyOn(testChipInput, 'add');
 
-      chipInputDirective._keydown(ENTER_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', ENTER);
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
@@ -137,11 +129,10 @@ describe('MDC-based MatChipInput', () => {
 
     it('should not allow focus to escape when tabbing backwards', fakeAsync(() => {
       const gridElement: HTMLElement = fixture.nativeElement.querySelector('mat-chip-grid');
-      const event = createKeydownEvent(TAB, inputNativeElement, {shift: true});
 
       expect(gridElement.getAttribute('tabindex')).toBe('0');
 
-      dispatchEvent(inputNativeElement, event);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', TAB, undefined, {shift: true});
       fixture.detectChanges();
 
       expect(gridElement.getAttribute('tabindex')).toBe('0', 'Expected tabindex to remain 0');
@@ -178,35 +169,32 @@ describe('MDC-based MatChipInput', () => {
 
   describe('[separatorKeyCodes]', () => {
     it('does not emit (chipEnd) when a non-separator key is pressed', () => {
-      let ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [COMMA];
       fixture.detectChanges();
 
-      chipInputDirective._keydown(ENTER_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', ENTER);
       expect(testChipInput.add).not.toHaveBeenCalled();
     });
 
     it('emits (chipEnd) when a custom separator keys is pressed', () => {
-      let COMMA_EVENT = createKeydownEvent(COMMA, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [COMMA];
       fixture.detectChanges();
 
-      chipInputDirective._keydown(COMMA_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA);
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
     it('emits accepts the custom separator keys in a Set', () => {
-      let COMMA_EVENT = createKeydownEvent(COMMA, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = new Set([COMMA]);
       fixture.detectChanges();
 
-      chipInputDirective._keydown(COMMA_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA);
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
@@ -236,32 +224,22 @@ describe('MDC-based MatChipInput', () => {
       spyOn(testChipInput, 'add');
       fixture.detectChanges();
 
-      chipInputDirective._keydown(createKeydownEvent(COMMA, inputNativeElement));
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA);
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
     it('should not emit the chipEnd event if a separator is pressed with a modifier key', () => {
-      const ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement, {shift: true});
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [ENTER];
       fixture.detectChanges();
 
-      chipInputDirective._keydown(ENTER_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', ENTER, undefined, {shift: true});
       expect(testChipInput.add).not.toHaveBeenCalled();
     });
 
   });
 });
-
-/** Creates a keydown event with the given key and an optional target element. */
-function createKeydownEvent(keyCode: number, target?: Element, modifiers?: ModifierKeys) {
-  const event = createKeyboardEvent('keydown', keyCode, undefined, modifiers);
-  if (target !== undefined) {
-    setEventTarget(event, target);
-  }
-  return event;
-}
 
 @Component({
   template: `

--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -1,10 +1,12 @@
 import {Directionality} from '@angular/cdk/bidi';
 import {ENTER, COMMA, TAB} from '@angular/cdk/keycodes';
 import {PlatformModule} from '@angular/cdk/platform';
+import {ModifierKeys} from '@angular/cdk/testing';
 import {
   createKeyboardEvent,
   dispatchKeyboardEvent,
   dispatchEvent,
+  setEventTarget,
 } from '@angular/cdk/testing/private';
 import {Component, DebugElement, ViewChild} from '@angular/core';
 import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
@@ -59,7 +61,7 @@ describe('MDC-based MatChipInput', () => {
 
   describe('basic behavior', () => {
     it('emits the (chipEnd) on enter keyup', () => {
-      let ENTER_EVENT = createKeyboardEvent('keydown', ENTER, undefined, inputNativeElement);
+      let ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement);
 
       spyOn(testChipInput, 'add');
 
@@ -120,7 +122,7 @@ describe('MDC-based MatChipInput', () => {
 
       expect(gridElement.getAttribute('tabindex')).toBe('0');
 
-      dispatchKeyboardEvent(inputNativeElement, 'keydown', TAB, undefined, inputNativeElement);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', TAB);
       fixture.detectChanges();
 
       expect(gridElement.getAttribute('tabindex'))
@@ -135,8 +137,7 @@ describe('MDC-based MatChipInput', () => {
 
     it('should not allow focus to escape when tabbing backwards', fakeAsync(() => {
       const gridElement: HTMLElement = fixture.nativeElement.querySelector('mat-chip-grid');
-      const event = createKeyboardEvent('keydown', TAB, undefined, inputNativeElement);
-      Object.defineProperty(event, 'shiftKey', {get: () => true});
+      const event = createKeydownEvent(TAB, inputNativeElement, {shift: true});
 
       expect(gridElement.getAttribute('tabindex')).toBe('0');
 
@@ -177,7 +178,7 @@ describe('MDC-based MatChipInput', () => {
 
   describe('[separatorKeyCodes]', () => {
     it('does not emit (chipEnd) when a non-separator key is pressed', () => {
-      let ENTER_EVENT = createKeyboardEvent('keydown', ENTER, undefined, inputNativeElement);
+      let ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [COMMA];
@@ -188,7 +189,7 @@ describe('MDC-based MatChipInput', () => {
     });
 
     it('emits (chipEnd) when a custom separator keys is pressed', () => {
-      let COMMA_EVENT = createKeyboardEvent('keydown', COMMA, undefined, inputNativeElement);
+      let COMMA_EVENT = createKeydownEvent(COMMA, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [COMMA];
@@ -199,7 +200,7 @@ describe('MDC-based MatChipInput', () => {
     });
 
     it('emits accepts the custom separator keys in a Set', () => {
-      let COMMA_EVENT = createKeyboardEvent('keydown', COMMA, undefined, inputNativeElement);
+      let COMMA_EVENT = createKeydownEvent(COMMA, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = new Set([COMMA]);
@@ -235,14 +236,12 @@ describe('MDC-based MatChipInput', () => {
       spyOn(testChipInput, 'add');
       fixture.detectChanges();
 
-      chipInputDirective._keydown(
-          createKeyboardEvent('keydown', COMMA, undefined, inputNativeElement));
+      chipInputDirective._keydown(createKeydownEvent(COMMA, inputNativeElement));
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
     it('should not emit the chipEnd event if a separator is pressed with a modifier key', () => {
-      const ENTER_EVENT = createKeyboardEvent('keydown', ENTER, undefined, inputNativeElement);
-      Object.defineProperty(ENTER_EVENT, 'shiftKey', {get: () => true});
+      const ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement, {shift: true});
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [ENTER];
@@ -254,6 +253,15 @@ describe('MDC-based MatChipInput', () => {
 
   });
 });
+
+/** Creates a keydown event with the given key and an optional target element. */
+function createKeydownEvent(keyCode: number, target?: Element, modifiers?: ModifierKeys) {
+  const event = createKeyboardEvent('keydown', keyCode, undefined, modifiers);
+  if (target !== undefined) {
+    setEventTarget(event, target);
+  }
+  return event;
+}
 
 @Component({
   template: `

--- a/src/material-experimental/mdc-chips/chip-listbox.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.spec.ts
@@ -12,6 +12,7 @@ import {
   createKeyboardEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
+  setEventTarget,
   MockNgZone,
 } from '@angular/cdk/testing/private';
 import {
@@ -261,7 +262,7 @@ describe('MDC-based MatChipListbox', () => {
           let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let LEFT_EVENT = createKeyboardEvent('keydown', LEFT_ARROW, undefined, lastNativeChip);
+          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastIndex = array.length - 1;
           let lastItem = array[lastIndex];
@@ -283,8 +284,7 @@ describe('MDC-based MatChipListbox', () => {
           let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let RIGHT_EVENT: KeyboardEvent =
-            createKeyboardEvent('keydown', RIGHT_ARROW, undefined, firstNativeChip);
+          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -302,8 +302,7 @@ describe('MDC-based MatChipListbox', () => {
         });
 
         it('should not handle arrow key events from non-chip elements', () => {
-          const event: KeyboardEvent =
-              createKeyboardEvent('keydown', RIGHT_ARROW, undefined, chipListboxNativeElement);
+          const event: KeyboardEvent = createKeydownEvent(RIGHT_ARROW, chipListboxNativeElement);
           const initialActiveIndex = manager.activeItemIndex;
 
           chipListboxInstance._keydown(event);
@@ -316,7 +315,7 @@ describe('MDC-based MatChipListbox', () => {
         it('should focus the first item when pressing HOME', () => {
           const nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           const lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
-          const HOME_EVENT = createKeyboardEvent('keydown', HOME, undefined, lastNativeChip);
+          const HOME_EVENT = createKeydownEvent(HOME, lastNativeChip);
           const array = chips.toArray();
           const lastItem = array[array.length - 1];
 
@@ -332,7 +331,7 @@ describe('MDC-based MatChipListbox', () => {
 
         it('should focus the last item when pressing END', () => {
           const nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
-          const END_EVENT = createKeyboardEvent('keydown', END, undefined, nativeChips[0]);
+          const END_EVENT = createKeydownEvent(END, nativeChips[0]);
 
           expect(manager.activeItemIndex).toBe(-1);
 
@@ -354,8 +353,7 @@ describe('MDC-based MatChipListbox', () => {
           let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let RIGHT_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', RIGHT_ARROW, undefined, lastNativeChip);
+          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastIndex = array.length - 1;
           let lastItem = array[lastIndex];
@@ -377,8 +375,7 @@ describe('MDC-based MatChipListbox', () => {
           let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let LEFT_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', LEFT_ARROW, undefined, firstNativeChip);
+          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -396,7 +393,7 @@ describe('MDC-based MatChipListbox', () => {
         });
 
         it('should allow focus to escape when tabbing away', fakeAsync(() => {
-          chipListboxInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
+          chipListboxInstance._keyManager.onKeydown(createKeydownEvent(TAB));
 
           expect(chipListboxInstance.tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -414,7 +411,7 @@ describe('MDC-based MatChipListbox', () => {
           expect(chipListboxInstance.tabIndex)
             .toBe(4, 'Expected tabIndex to be set to user defined value 4.');
 
-          chipListboxInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
+          chipListboxInstance._keyManager.onKeydown(createKeydownEvent(TAB));
 
           expect(chipListboxInstance.tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -432,8 +429,7 @@ describe('MDC-based MatChipListbox', () => {
         let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
         let firstNativeChip = nativeChips[0] as HTMLElement;
 
-        let RIGHT_EVENT: KeyboardEvent =
-          createKeyboardEvent('keydown', RIGHT_ARROW, undefined, firstNativeChip);
+        let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
         let array = chips.toArray();
         let firstItem = array[0];
 
@@ -799,6 +795,15 @@ describe('MDC-based MatChipListbox', () => {
     chips = chipListboxInstance._chips;
   }
 });
+
+/** Creates a keydown event with the given key and an optional target element. */
+function createKeydownEvent(keyCode: number, target?: Element): KeyboardEvent {
+  const event = createKeyboardEvent('keydown', keyCode, undefined);
+  if (target !== undefined) {
+    setEventTarget(event, target);
+  }
+  return event;
+}
 
 @Component({
   template: `

--- a/src/material-experimental/mdc-chips/chip-listbox.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.spec.ts
@@ -1,18 +1,11 @@
 import {FocusKeyManager} from '@angular/cdk/a11y';
-import {Directionality, Direction} from '@angular/cdk/bidi';
-import {
-  END,
-  HOME,
-  LEFT_ARROW,
-  RIGHT_ARROW,
-  SPACE,
-  TAB,
-} from '@angular/cdk/keycodes';
+import {Direction, Directionality} from '@angular/cdk/bidi';
+import {END, HOME, LEFT_ARROW, RIGHT_ARROW, SPACE, TAB} from '@angular/cdk/keycodes';
 import {
   createKeyboardEvent,
+  dispatchEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
-  setEventTarget,
   MockNgZone,
 } from '@angular/cdk/testing/private';
 import {
@@ -262,7 +255,6 @@ describe('MDC-based MatChipListbox', () => {
           let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastIndex = array.length - 1;
           let lastItem = array[lastIndex];
@@ -272,7 +264,7 @@ describe('MDC-based MatChipListbox', () => {
           expect(manager.activeItemIndex).toEqual(lastIndex);
 
           // Press the LEFT arrow
-          chipListboxInstance._keydown(LEFT_EVENT);
+          dispatchKeyboardEvent(lastNativeChip, 'keydown', LEFT_ARROW);
           chipListboxInstance._blur(); // Simulate focus leaving the listbox and going to the chip.
           fixture.detectChanges();
 
@@ -284,7 +276,6 @@ describe('MDC-based MatChipListbox', () => {
           let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -293,7 +284,7 @@ describe('MDC-based MatChipListbox', () => {
           expect(manager.activeItemIndex).toEqual(0);
 
           // Press the RIGHT arrow
-          chipListboxInstance._keydown(RIGHT_EVENT);
+          dispatchKeyboardEvent(firstNativeChip, 'keydown', RIGHT_ARROW);
           chipListboxInstance._blur(); // Simulate focus leaving the listbox and going to the chip.
           fixture.detectChanges();
 
@@ -302,10 +293,9 @@ describe('MDC-based MatChipListbox', () => {
         });
 
         it('should not handle arrow key events from non-chip elements', () => {
-          const event: KeyboardEvent = createKeydownEvent(RIGHT_ARROW, chipListboxNativeElement);
           const initialActiveIndex = manager.activeItemIndex;
 
-          chipListboxInstance._keydown(event);
+          dispatchKeyboardEvent(chipListboxNativeElement, 'keydown', RIGHT_ARROW);
           fixture.detectChanges();
 
           expect(manager.activeItemIndex)
@@ -315,14 +305,14 @@ describe('MDC-based MatChipListbox', () => {
         it('should focus the first item when pressing HOME', () => {
           const nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           const lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
-          const HOME_EVENT = createKeydownEvent(HOME, lastNativeChip);
+          const HOME_EVENT = createKeyboardEvent('keydown', HOME);
           const array = chips.toArray();
           const lastItem = array[array.length - 1];
 
           lastItem.focus();
           expect(manager.activeItemIndex).toBe(array.length - 1);
 
-          chipListboxInstance._keydown(HOME_EVENT);
+          dispatchEvent(lastNativeChip, HOME_EVENT);
           fixture.detectChanges();
 
           expect(manager.activeItemIndex).toBe(0);
@@ -331,11 +321,11 @@ describe('MDC-based MatChipListbox', () => {
 
         it('should focus the last item when pressing END', () => {
           const nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
-          const END_EVENT = createKeydownEvent(END, nativeChips[0]);
+          const END_EVENT = createKeyboardEvent('keydown', END);
 
           expect(manager.activeItemIndex).toBe(-1);
 
-          chipListboxInstance._keydown(END_EVENT);
+          dispatchEvent(nativeChips[0], END_EVENT);
           fixture.detectChanges();
 
           expect(manager.activeItemIndex).toBe(chips.length - 1);
@@ -353,7 +343,6 @@ describe('MDC-based MatChipListbox', () => {
           let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastIndex = array.length - 1;
           let lastItem = array[lastIndex];
@@ -363,7 +352,7 @@ describe('MDC-based MatChipListbox', () => {
           expect(manager.activeItemIndex).toEqual(lastIndex);
 
           // Press the RIGHT arrow
-          chipListboxInstance._keydown(RIGHT_EVENT);
+          dispatchKeyboardEvent(lastNativeChip, 'keydown', RIGHT_ARROW);
           chipListboxInstance._blur(); // Simulate focus leaving the listbox and going to the chip.
           fixture.detectChanges();
 
@@ -375,7 +364,6 @@ describe('MDC-based MatChipListbox', () => {
           let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -384,7 +372,7 @@ describe('MDC-based MatChipListbox', () => {
           expect(manager.activeItemIndex).toEqual(0);
 
           // Press the LEFT arrow
-          chipListboxInstance._keydown(LEFT_EVENT);
+          dispatchKeyboardEvent(firstNativeChip, 'keydown', LEFT_ARROW);
           chipListboxInstance._blur(); // Simulate focus leaving the listbox and going to the chip.
           fixture.detectChanges();
 
@@ -393,7 +381,7 @@ describe('MDC-based MatChipListbox', () => {
         });
 
         it('should allow focus to escape when tabbing away', fakeAsync(() => {
-          chipListboxInstance._keyManager.onKeydown(createKeydownEvent(TAB));
+          chipListboxInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
 
           expect(chipListboxInstance.tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -411,7 +399,7 @@ describe('MDC-based MatChipListbox', () => {
           expect(chipListboxInstance.tabIndex)
             .toBe(4, 'Expected tabIndex to be set to user defined value 4.');
 
-          chipListboxInstance._keyManager.onKeydown(createKeydownEvent(TAB));
+          chipListboxInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
 
           expect(chipListboxInstance.tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -429,14 +417,13 @@ describe('MDC-based MatChipListbox', () => {
         let nativeChips = chipListboxNativeElement.querySelectorAll('mat-chip-option');
         let firstNativeChip = nativeChips[0] as HTMLElement;
 
-        let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
         let array = chips.toArray();
         let firstItem = array[0];
 
         firstItem.focus();
         expect(manager.activeItemIndex).toBe(0);
 
-        chipListboxInstance._keydown(RIGHT_EVENT);
+        dispatchKeyboardEvent(firstNativeChip, 'keydown', RIGHT_ARROW);
         chipListboxInstance._blur();
         fixture.detectChanges();
 
@@ -445,7 +432,7 @@ describe('MDC-based MatChipListbox', () => {
         dirChange.next('rtl');
         fixture.detectChanges();
 
-        chipListboxInstance._keydown(RIGHT_EVENT);
+        dispatchKeyboardEvent(firstNativeChip, 'keydown', RIGHT_ARROW);
         chipListboxInstance._blur();
         fixture.detectChanges();
 
@@ -795,15 +782,6 @@ describe('MDC-based MatChipListbox', () => {
     chips = chipListboxInstance._chips;
   }
 });
-
-/** Creates a keydown event with the given key and an optional target element. */
-function createKeydownEvent(keyCode: number, target?: Element): KeyboardEvent {
-  const event = createKeyboardEvent('keydown', keyCode, undefined);
-  if (target !== undefined) {
-    setEventTarget(event, target);
-  }
-  return event;
-}
 
 @Component({
   template: `

--- a/src/material-experimental/mdc-chips/chip-option.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-option.spec.ts
@@ -178,7 +178,7 @@ describe('MDC-based Option Chips', () => {
         });
 
         it('should selects/deselects the currently focused chip on SPACE', () => {
-          const SPACE_EVENT: KeyboardEvent = createKeyboardEvent('keydown', SPACE) as KeyboardEvent;
+          const SPACE_EVENT = createKeyboardEvent('keydown', SPACE);
           const CHIP_SELECTED_EVENT: MatChipSelectionChange = {
             source: chipInstance,
             isUserInput: true,
@@ -250,7 +250,7 @@ describe('MDC-based Option Chips', () => {
         });
 
         it('SPACE ignores selection', () => {
-          const SPACE_EVENT: KeyboardEvent = createKeyboardEvent('keydown', SPACE) as KeyboardEvent;
+          const SPACE_EVENT = createKeyboardEvent('keydown', SPACE);
 
           spyOn(testComponent, 'chipSelectionChange');
 

--- a/src/material-experimental/mdc-chips/chip-remove.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-remove.spec.ts
@@ -122,8 +122,7 @@ describe('MDC-based Chip Remove', () => {
       testChip.removable = true;
       fixture.detectChanges();
 
-      const event = createKeyboardEvent('keydown', SPACE);
-      Object.defineProperty(event, 'shiftKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', SPACE, undefined, {shift: true});
       dispatchEvent(buttonElement, event);
       fixture.detectChanges();
 
@@ -148,8 +147,7 @@ describe('MDC-based Chip Remove', () => {
       testChip.removable = true;
       fixture.detectChanges();
 
-      const event = createKeyboardEvent('keydown', ENTER);
-      Object.defineProperty(event, 'shiftKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', ENTER, undefined, {shift: true});
       dispatchEvent(buttonElement, event);
       fixture.detectChanges();
 

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -120,7 +120,7 @@ describe('MDC-based Row Chips', () => {
         });
 
         it('DELETE emits the (removed) event', () => {
-          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE) as KeyboardEvent;
+          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE);
 
           spyOn(testComponent, 'chipRemove');
 
@@ -135,7 +135,7 @@ describe('MDC-based Row Chips', () => {
         });
 
         it('BACKSPACE emits the (removed) event', () => {
-          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE) as KeyboardEvent;
+          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE);
 
           spyOn(testComponent, 'chipRemove');
 
@@ -150,7 +150,7 @@ describe('MDC-based Row Chips', () => {
         });
 
         it('arrow key navigation does not emit the (removed) event', () => {
-          const ARROW_KEY_EVENT = createKeyboardEvent('keydown', RIGHT_ARROW) as KeyboardEvent;
+          const ARROW_KEY_EVENT = createKeyboardEvent('keydown', RIGHT_ARROW);
 
           spyOn(testComponent, 'chipRemove');
 
@@ -172,7 +172,7 @@ describe('MDC-based Row Chips', () => {
         });
 
         it('DELETE does not emit the (removed) event', () => {
-          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE) as KeyboardEvent;
+          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE);
 
           spyOn(testComponent, 'chipRemove');
 
@@ -187,7 +187,7 @@ describe('MDC-based Row Chips', () => {
         });
 
         it('BACKSPACE does not emit the (removed) event', () => {
-          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE) as KeyboardEvent;
+          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE);
 
           spyOn(testComponent, 'chipRemove');
 
@@ -253,7 +253,7 @@ describe('MDC-based Row Chips', () => {
       it('should begin editing on ENTER', () => {
         chipInstance.focus();
         const primaryActionElement = chipNativeElement.querySelector('.mdc-chip__primary-action')!;
-        const enterEvent = createKeyboardEvent('keydown', ENTER, 'Enter', primaryActionElement);
+        const enterEvent = createKeyboardEvent('keydown', ENTER, 'Enter');
         dispatchEvent(primaryActionElement, enterEvent);
         expect(chipNativeElement.classList).toContain('mdc-chip--editing');
       });
@@ -279,7 +279,7 @@ describe('MDC-based Row Chips', () => {
 
       function keyDownOnPrimaryAction(keyCode: number, key: string) {
         const primaryActionElement = chipNativeElement.querySelector('.mdc-chip__primary-action')!;
-        const keyDownEvent = createKeyboardEvent('keydown', keyCode, key, primaryActionElement);
+        const keyDownEvent = createKeyboardEvent('keydown', keyCode, key);
         dispatchEvent(primaryActionElement, keyDownEvent);
       }
 

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -405,9 +405,8 @@ describe('MDC-based MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
 
     const panel = overlayContainerElement.querySelector('.mat-mdc-menu-panel')!;
-    const event = createKeyboardEvent('keydown', ESCAPE);
+    const event = createKeyboardEvent('keydown', ESCAPE, undefined, {alt: true});
 
-    Object.defineProperty(event, 'altKey', {get: () => true});
     dispatchEvent(panel, event);
     fixture.detectChanges();
     tick(500);
@@ -788,8 +787,7 @@ describe('MDC-based MatMenu', () => {
 
     spyOn(items[0], 'focus').and.callThrough();
 
-    const event = createKeyboardEvent('keydown', HOME);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', HOME, undefined, {alt: true});
 
     dispatchEvent(panel, event);
     fixture.detectChanges();
@@ -833,8 +831,7 @@ describe('MDC-based MatMenu', () => {
 
     spyOn(items[items.length - 1], 'focus').and.callThrough();
 
-    const event = createKeyboardEvent('keydown', END);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', END, undefined, {alt: true});
 
     dispatchEvent(panel, event);
     fixture.detectChanges();

--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -928,8 +928,7 @@ describe('MDC-based MatSlider', () => {
         UP_ARROW, DOWN_ARROW, RIGHT_ARROW,
         LEFT_ARROW, PAGE_DOWN, PAGE_UP, HOME, END
       ].forEach(key => {
-        const event = createKeyboardEvent('keydown', key);
-        Object.defineProperty(event, 'altKey', {get: () => true});
+        const event = createKeyboardEvent('keydown', key, undefined, {alt: true});
         dispatchEvent(sliderNativeElement, event);
         fixture.detectChanges();
         expect(event.defaultPrevented).toBe(false);

--- a/src/material-experimental/mdc-tabs/tab-header.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.spec.ts
@@ -211,12 +211,8 @@ describe('MDC-based MatTabHeader', () => {
     });
 
     it('should not do anything if a modifier key is pressed', () => {
-      const rightArrowEvent = createKeyboardEvent('keydown', RIGHT_ARROW);
-      const enterEvent = createKeyboardEvent('keydown', ENTER);
-
-      [rightArrowEvent, enterEvent].forEach(event => {
-        Object.defineProperty(event, 'shiftKey', {get: () => true});
-      });
+      const rightArrowEvent = createKeyboardEvent('keydown', RIGHT_ARROW, undefined, {shift: true});
+      const enterEvent = createKeyboardEvent('keydown', ENTER, undefined, {shift: true});
 
       appComponent.tabHeader.focusIndex = 0;
       fixture.detectChanges();

--- a/src/material-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/material-experimental/popover-edit/popover-edit.spec.ts
@@ -444,7 +444,7 @@ describe('Material Popover Edit', () => {
 
         describe('arrow keys', () => {
           const dispatchKey = (cell: HTMLElement, keyCode: number) =>
-              dispatchKeyboardEvent(cell, 'keydown', keyCode, undefined, cell);
+              dispatchKeyboardEvent(cell, 'keydown', keyCode);
 
           it('moves focus up/down/left/right and prevents default', () => {
             const rowCells = getRowCells();

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1160,8 +1160,7 @@ describe('MatAutocomplete', () => {
 
     it('should close the panel when pressing ALT + UP_ARROW', fakeAsync(() => {
       const trigger = fixture.componentInstance.trigger;
-      const upArrowEvent = createKeyboardEvent('keydown', UP_ARROW);
-      Object.defineProperty(upArrowEvent, 'altKey', {get: () => true});
+      const upArrowEvent = createKeyboardEvent('keydown', UP_ARROW, undefined, {alt: true});
       spyOn(upArrowEvent, 'stopPropagation').and.callThrough();
 
       input.focus();

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -170,8 +170,7 @@ describe('MatBottomSheet', () => {
   it('should not close a bottom sheet via the escape key with a modifier', fakeAsync(() => {
     bottomSheet.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
 
-    const event = createKeyboardEvent('keydown', ESCAPE);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', ESCAPE, undefined, {alt: true});
     dispatchEvent(document.body, event);
     viewContainerFixture.detectChanges();
     flush();
@@ -239,8 +238,8 @@ describe('MatBottomSheet', () => {
     const container =
         overlayContainerElement.querySelector('mat-bottom-sheet-container') as HTMLElement;
     dispatchKeyboardEvent(document.body, 'keydown', A);
-    dispatchKeyboardEvent(document.body, 'keydown', A, undefined, backdrop);
-    dispatchKeyboardEvent(document.body, 'keydown', A, undefined, container);
+    dispatchKeyboardEvent(backdrop, 'keydown', A);
+    dispatchKeyboardEvent(container, 'keydown', A);
 
     expect(spy).toHaveBeenCalledTimes(3);
   }));

--- a/src/material/chips/BUILD.bazel
+++ b/src/material/chips/BUILD.bazel
@@ -60,6 +60,7 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/platform",
+        "//src/cdk/testing",
         "//src/cdk/testing/private",
         "//src/material/core",
         "//src/material/form-field",

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -1,22 +1,17 @@
 import {Directionality} from '@angular/cdk/bidi';
-import {ENTER, COMMA, TAB} from '@angular/cdk/keycodes';
+import {COMMA, ENTER, TAB} from '@angular/cdk/keycodes';
 import {PlatformModule} from '@angular/cdk/platform';
-import {ModifierKeys} from '@angular/cdk/testing';
-import {
-  createKeyboardEvent,
-  dispatchKeyboardEvent,
-  dispatchEvent, setEventTarget,
-} from '@angular/cdk/testing/private';
+import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {MatFormFieldModule} from '@angular/material/form-field';
 import {Subject} from 'rxjs';
-import {MatChipInput, MatChipInputEvent} from './chip-input';
-import {MatChipsModule} from './index';
 import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
+import {MatChipInput, MatChipInputEvent} from './chip-input';
 import {MatChipList} from './chip-list';
+import {MatChipsModule} from './index';
 
 
 describe('MatChipInput', () => {
@@ -56,11 +51,9 @@ describe('MatChipInput', () => {
 
   describe('basic behavior', () => {
     it('emits the (chipEnd) on enter keyup', () => {
-      let ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement);
-
       spyOn(testChipInput, 'add');
 
-      chipInputDirective._keydown(ENTER_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', ENTER);
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
@@ -123,11 +116,10 @@ describe('MatChipInput', () => {
 
     it('should not allow focus to escape when tabbing backwards', fakeAsync(() => {
       const listElement: HTMLElement = fixture.nativeElement.querySelector('.mat-chip-list');
-      const event = createKeydownEvent(TAB, undefined, {shift: true});
 
       expect(listElement.getAttribute('tabindex')).toBe('0');
 
-      dispatchEvent(inputNativeElement, event);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', TAB, undefined, {shift: true});
       fixture.detectChanges();
 
       expect(listElement.getAttribute('tabindex')).toBe('0', 'Expected tabindex to remain 0');
@@ -173,35 +165,32 @@ describe('MatChipInput', () => {
 
   describe('[separatorKeyCodes]', () => {
     it('does not emit (chipEnd) when a non-separator key is pressed', () => {
-      let ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [COMMA];
       fixture.detectChanges();
 
-      chipInputDirective._keydown(ENTER_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', ENTER);
       expect(testChipInput.add).not.toHaveBeenCalled();
     });
 
     it('emits (chipEnd) when a custom separator keys is pressed', () => {
-      let COMMA_EVENT = createKeydownEvent(COMMA, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [COMMA];
       fixture.detectChanges();
 
-      chipInputDirective._keydown(COMMA_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA);
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
     it('emits accepts the custom separator keys in a Set', () => {
-      let COMMA_EVENT = createKeydownEvent(COMMA, inputNativeElement);
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = new Set([COMMA]);
       fixture.detectChanges();
 
-      chipInputDirective._keydown(COMMA_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA);
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
@@ -231,32 +220,22 @@ describe('MatChipInput', () => {
       spyOn(testChipInput, 'add');
       fixture.detectChanges();
 
-      chipInputDirective._keydown(createKeydownEvent(COMMA, inputNativeElement));
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', COMMA);
       expect(testChipInput.add).toHaveBeenCalled();
     });
 
     it('should not emit the chipEnd event if a separator is pressed with a modifier key', () => {
-      const ENTER_EVENT = createKeydownEvent(ENTER, inputNativeElement, {shift: true});
       spyOn(testChipInput, 'add');
 
       chipInputDirective.separatorKeyCodes = [ENTER];
       fixture.detectChanges();
 
-      chipInputDirective._keydown(ENTER_EVENT);
+      dispatchKeyboardEvent(inputNativeElement, 'keydown', ENTER, undefined, {shift: true});
       expect(testChipInput.add).not.toHaveBeenCalled();
     });
 
   });
 });
-
-/** Creates a keydown event with the given key and an optional target element. */
-function createKeydownEvent(keyCode: number, target?: Element, modifiers?: ModifierKeys) {
-  const event = createKeyboardEvent('keydown', keyCode, undefined, modifiers);
-  if (target !== undefined) {
-    setEventTarget(event, target);
-  }
-  return event;
-}
 
 @Component({
   template: `

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -1,26 +1,28 @@
 import {animate, style, transition, trigger} from '@angular/animations';
 import {FocusKeyManager} from '@angular/cdk/a11y';
-import {Directionality, Direction} from '@angular/cdk/bidi';
+import {Direction, Directionality} from '@angular/cdk/bidi';
 import {
   BACKSPACE,
   DELETE,
+  END,
   ENTER,
+  HOME,
   LEFT_ARROW,
   RIGHT_ARROW,
   SPACE,
   TAB,
-  HOME,
-  END,
 } from '@angular/cdk/keycodes';
 import {
   createKeyboardEvent,
+  dispatchEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent,
+  MockNgZone,
   typeInElement,
-  MockNgZone, setEventTarget,
 } from '@angular/cdk/testing/private';
 import {
+  ChangeDetectionStrategy,
   Component,
   DebugElement,
   NgZone,
@@ -29,17 +31,16 @@ import {
   Type,
   ViewChild,
   ViewChildren,
-  ChangeDetectionStrategy,
 } from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {
+  FormBuilder,
   FormControl,
+  FormGroup,
   FormsModule,
   NgForm,
   ReactiveFormsModule,
   Validators,
-  FormGroup,
-  FormBuilder,
 } from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
@@ -318,7 +319,6 @@ describe('MatChipList', () => {
           let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastIndex = array.length - 1;
           let lastItem = array[lastIndex];
@@ -328,7 +328,7 @@ describe('MatChipList', () => {
           expect(manager.activeItemIndex).toEqual(lastIndex);
 
           // Press the LEFT arrow
-          chipListInstance._keydown(LEFT_EVENT);
+          dispatchKeyboardEvent(lastNativeChip, 'keydown', LEFT_ARROW);
           chipListInstance._blur(); // Simulate focus leaving the list and going to the chip.
           fixture.detectChanges();
 
@@ -340,7 +340,6 @@ describe('MatChipList', () => {
           let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -349,7 +348,7 @@ describe('MatChipList', () => {
           expect(manager.activeItemIndex).toEqual(0);
 
           // Press the RIGHT arrow
-          chipListInstance._keydown(RIGHT_EVENT);
+          dispatchKeyboardEvent(firstNativeChip, 'keydown', RIGHT_ARROW);
           chipListInstance._blur(); // Simulate focus leaving the list and going to the chip.
           fixture.detectChanges();
 
@@ -358,10 +357,9 @@ describe('MatChipList', () => {
         });
 
         it('should not handle arrow key events from non-chip elements', () => {
-          const event = createKeydownEvent(RIGHT_ARROW, chipListNativeElement);
           const initialActiveIndex = manager.activeItemIndex;
 
-          chipListInstance._keydown(event);
+          dispatchKeyboardEvent(chipListNativeElement, 'keydown', RIGHT_ARROW);
           fixture.detectChanges();
 
           expect(manager.activeItemIndex)
@@ -371,14 +369,14 @@ describe('MatChipList', () => {
         it('should focus the first item when pressing HOME', () => {
           const nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           const lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
-          const HOME_EVENT = createKeydownEvent(HOME, lastNativeChip);
+          const HOME_EVENT = createKeyboardEvent('keydown', HOME);
           const array = chips.toArray();
           const lastItem = array[array.length - 1];
 
           lastItem.focus();
           expect(manager.activeItemIndex).toBe(array.length - 1);
 
-          chipListInstance._keydown(HOME_EVENT);
+          dispatchEvent(lastNativeChip, HOME_EVENT);
           fixture.detectChanges();
 
           expect(manager.activeItemIndex).toBe(0);
@@ -387,11 +385,11 @@ describe('MatChipList', () => {
 
         it('should focus the last item when pressing END', () => {
           const nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
-          const END_EVENT = createKeydownEvent(END, nativeChips[0]);
+          const END_EVENT = createKeyboardEvent('keydown', END);
 
           expect(manager.activeItemIndex).toBe(-1);
 
-          chipListInstance._keydown(END_EVENT);
+          dispatchEvent(nativeChips[0], END_EVENT);
           fixture.detectChanges();
 
           expect(manager.activeItemIndex).toBe(chips.length - 1);
@@ -410,7 +408,6 @@ describe('MatChipList', () => {
           let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastIndex = array.length - 1;
           let lastItem = array[lastIndex];
@@ -420,7 +417,7 @@ describe('MatChipList', () => {
           expect(manager.activeItemIndex).toEqual(lastIndex);
 
           // Press the RIGHT arrow
-          chipListInstance._keydown(RIGHT_EVENT);
+          dispatchKeyboardEvent(lastNativeChip, 'keydown', RIGHT_ARROW);
           chipListInstance._blur(); // Simulate focus leaving the list and going to the chip.
           fixture.detectChanges();
 
@@ -432,7 +429,6 @@ describe('MatChipList', () => {
           let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -441,7 +437,7 @@ describe('MatChipList', () => {
           expect(manager.activeItemIndex).toEqual(0);
 
           // Press the LEFT arrow
-          chipListInstance._keydown(LEFT_EVENT);
+          dispatchKeyboardEvent(firstNativeChip, 'keydown', LEFT_ARROW);
           chipListInstance._blur(); // Simulate focus leaving the list and going to the chip.
           fixture.detectChanges();
 
@@ -450,7 +446,7 @@ describe('MatChipList', () => {
         });
 
         it('should allow focus to escape when tabbing away', fakeAsync(() => {
-          chipListInstance._keyManager.onKeydown(createKeydownEvent(TAB));
+          chipListInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
 
           expect(chipListInstance._tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -468,7 +464,7 @@ describe('MatChipList', () => {
           expect(chipListInstance._tabIndex)
             .toBe(4, 'Expected tabIndex to be set to user defined value 4.');
 
-          chipListInstance._keyManager.onKeydown(createKeydownEvent(TAB));
+          chipListInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
 
           expect(chipListInstance._tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -486,14 +482,14 @@ describe('MatChipList', () => {
         let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
         let firstNativeChip = nativeChips[0] as HTMLElement;
 
-        let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
+        let RIGHT_EVENT = createKeyboardEvent('keydown', RIGHT_ARROW);
         let array = chips.toArray();
         let firstItem = array[0];
 
         firstItem.focus();
         expect(manager.activeItemIndex).toBe(0);
 
-        chipListInstance._keydown(RIGHT_EVENT);
+        dispatchEvent(firstNativeChip, RIGHT_EVENT);
         chipListInstance._blur();
         fixture.detectChanges();
 
@@ -541,14 +537,13 @@ describe('MatChipList', () => {
 
         it('should not focus the last chip when press DELETE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let DELETE_EVENT = createKeydownEvent(DELETE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
           expect(manager.activeItemIndex).toBe(-1);
 
           // Press the DELETE key
-          chipListInstance._keydown(DELETE_EVENT);
+          dispatchKeyboardEvent(nativeInput, 'keydown', DELETE);
           fixture.detectChanges();
 
           // It doesn't focus the last chip
@@ -557,14 +552,13 @@ describe('MatChipList', () => {
 
         it('should focus the last chip when press BACKSPACE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let BACKSPACE_EVENT = createKeydownEvent(BACKSPACE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
           expect(manager.activeItemIndex).toBe(-1);
 
           // Press the BACKSPACE key
-          chipListInstance._keydown(BACKSPACE_EVENT);
+          dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
           fixture.detectChanges();
 
           // It focuses the last chip
@@ -1168,14 +1162,13 @@ describe('MatChipList', () => {
 
         it('should not focus the last chip when press DELETE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let DELETE_EVENT = createKeydownEvent(DELETE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
           expect(manager.activeItemIndex).toBe(-1);
 
           // Press the DELETE key
-          chipListInstance._keydown(DELETE_EVENT);
+          dispatchKeyboardEvent(nativeInput, 'keydown', DELETE);
           fixture.detectChanges();
 
           // It doesn't focus the last chip
@@ -1184,14 +1177,13 @@ describe('MatChipList', () => {
 
         it('should focus the last chip when press BACKSPACE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let BACKSPACE_EVENT = createKeydownEvent(BACKSPACE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
           expect(manager.activeItemIndex).toBe(-1);
 
           // Press the BACKSPACE key
-          chipListInstance._keydown(BACKSPACE_EVENT);
+          dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
           fixture.detectChanges();
 
           // It focuses the last chip
@@ -1378,15 +1370,6 @@ describe('MatChipList', () => {
   }
 
 });
-
-/** Creates a keydown event with the given key and an optional target element. */
-function createKeydownEvent(keyCode: number, target?: Element): KeyboardEvent {
-  const event = createKeyboardEvent('keydown', keyCode, undefined);
-  if (target !== undefined) {
-    setEventTarget(event, target);
-  }
-  return event;
-}
 
 @Component({
   template: `

--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -18,7 +18,7 @@ import {
   dispatchKeyboardEvent,
   dispatchMouseEvent,
   typeInElement,
-  MockNgZone,
+  MockNgZone, setEventTarget,
 } from '@angular/cdk/testing/private';
 import {
   Component,
@@ -318,7 +318,7 @@ describe('MatChipList', () => {
           let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let LEFT_EVENT = createKeyboardEvent('keydown', LEFT_ARROW, undefined, lastNativeChip);
+          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastIndex = array.length - 1;
           let lastItem = array[lastIndex];
@@ -340,8 +340,7 @@ describe('MatChipList', () => {
           let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let RIGHT_EVENT: KeyboardEvent =
-            createKeyboardEvent('keydown', RIGHT_ARROW, undefined, firstNativeChip);
+          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -359,8 +358,7 @@ describe('MatChipList', () => {
         });
 
         it('should not handle arrow key events from non-chip elements', () => {
-          const event: KeyboardEvent =
-              createKeyboardEvent('keydown', RIGHT_ARROW, undefined, chipListNativeElement);
+          const event = createKeydownEvent(RIGHT_ARROW, chipListNativeElement);
           const initialActiveIndex = manager.activeItemIndex;
 
           chipListInstance._keydown(event);
@@ -373,7 +371,7 @@ describe('MatChipList', () => {
         it('should focus the first item when pressing HOME', () => {
           const nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           const lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
-          const HOME_EVENT = createKeyboardEvent('keydown', HOME, undefined, lastNativeChip);
+          const HOME_EVENT = createKeydownEvent(HOME, lastNativeChip);
           const array = chips.toArray();
           const lastItem = array[array.length - 1];
 
@@ -389,7 +387,7 @@ describe('MatChipList', () => {
 
         it('should focus the last item when pressing END', () => {
           const nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
-          const END_EVENT = createKeyboardEvent('keydown', END, undefined, nativeChips[0]);
+          const END_EVENT = createKeydownEvent(END, nativeChips[0]);
 
           expect(manager.activeItemIndex).toBe(-1);
 
@@ -412,8 +410,7 @@ describe('MatChipList', () => {
           let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           let lastNativeChip = nativeChips[nativeChips.length - 1] as HTMLElement;
 
-          let RIGHT_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', RIGHT_ARROW, undefined, lastNativeChip);
+          let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, lastNativeChip);
           let array = chips.toArray();
           let lastIndex = array.length - 1;
           let lastItem = array[lastIndex];
@@ -435,8 +432,7 @@ describe('MatChipList', () => {
           let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
           let firstNativeChip = nativeChips[0] as HTMLElement;
 
-          let LEFT_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', LEFT_ARROW, undefined, firstNativeChip);
+          let LEFT_EVENT = createKeydownEvent(LEFT_ARROW, firstNativeChip);
           let array = chips.toArray();
           let firstItem = array[0];
 
@@ -454,7 +450,7 @@ describe('MatChipList', () => {
         });
 
         it('should allow focus to escape when tabbing away', fakeAsync(() => {
-          chipListInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
+          chipListInstance._keyManager.onKeydown(createKeydownEvent(TAB));
 
           expect(chipListInstance._tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -472,7 +468,7 @@ describe('MatChipList', () => {
           expect(chipListInstance._tabIndex)
             .toBe(4, 'Expected tabIndex to be set to user defined value 4.');
 
-          chipListInstance._keyManager.onKeydown(createKeyboardEvent('keydown', TAB));
+          chipListInstance._keyManager.onKeydown(createKeydownEvent(TAB));
 
           expect(chipListInstance._tabIndex)
             .toBe(-1, 'Expected tabIndex to be set to -1 temporarily.');
@@ -490,8 +486,7 @@ describe('MatChipList', () => {
         let nativeChips = chipListNativeElement.querySelectorAll('mat-chip');
         let firstNativeChip = nativeChips[0] as HTMLElement;
 
-        let RIGHT_EVENT: KeyboardEvent =
-          createKeyboardEvent('keydown', RIGHT_ARROW, undefined, firstNativeChip);
+        let RIGHT_EVENT = createKeydownEvent(RIGHT_ARROW, firstNativeChip);
         let array = chips.toArray();
         let firstItem = array[0];
 
@@ -546,8 +541,7 @@ describe('MatChipList', () => {
 
         it('should not focus the last chip when press DELETE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let DELETE_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', DELETE, nativeInput);
+          let DELETE_EVENT = createKeydownEvent(DELETE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
@@ -563,8 +557,7 @@ describe('MatChipList', () => {
 
         it('should focus the last chip when press BACKSPACE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let BACKSPACE_EVENT: KeyboardEvent =
-              createKeyboardEvent('keydown', BACKSPACE, undefined, nativeInput);
+          let BACKSPACE_EVENT = createKeydownEvent(BACKSPACE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
@@ -1175,8 +1168,7 @@ describe('MatChipList', () => {
 
         it('should not focus the last chip when press DELETE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let DELETE_EVENT: KeyboardEvent =
-            createKeyboardEvent('keydown', DELETE, nativeInput);
+          let DELETE_EVENT = createKeydownEvent(DELETE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
@@ -1192,8 +1184,7 @@ describe('MatChipList', () => {
 
         it('should focus the last chip when press BACKSPACE', () => {
           let nativeInput = fixture.nativeElement.querySelector('input');
-          let BACKSPACE_EVENT: KeyboardEvent =
-            createKeyboardEvent('keydown', BACKSPACE, undefined, nativeInput);
+          let BACKSPACE_EVENT = createKeydownEvent(BACKSPACE, nativeInput);
 
           // Focus the input
           nativeInput.focus();
@@ -1387,6 +1378,15 @@ describe('MatChipList', () => {
   }
 
 });
+
+/** Creates a keydown event with the given key and an optional target element. */
+function createKeydownEvent(keyCode: number, target?: Element): KeyboardEvent {
+  const event = createKeyboardEvent('keydown', keyCode, undefined);
+  if (target !== undefined) {
+    setEventTarget(event, target);
+  }
+  return event;
+}
 
 @Component({
   template: `

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -251,7 +251,7 @@ describe('MatChip', () => {
         });
 
         it('should selects/deselects the currently focused chip on SPACE', () => {
-          const SPACE_EVENT: KeyboardEvent = createKeyboardEvent('keydown', SPACE) as KeyboardEvent;
+          const SPACE_EVENT = createKeyboardEvent('keydown', SPACE);
           const CHIP_SELECTED_EVENT: MatChipSelectionChange = {
             source: chipInstance,
             isUserInput: true,
@@ -313,7 +313,7 @@ describe('MatChip', () => {
         });
 
         it('SPACE ignores selection', () => {
-          const SPACE_EVENT: KeyboardEvent = createKeyboardEvent('keydown', SPACE) as KeyboardEvent;
+          const SPACE_EVENT = createKeyboardEvent('keydown', SPACE);
 
           spyOn(testComponent, 'chipSelectionChange');
 
@@ -337,7 +337,7 @@ describe('MatChip', () => {
         });
 
         it('DELETE emits the (removed) event', () => {
-          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE) as KeyboardEvent;
+          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE);
 
           spyOn(testComponent, 'chipRemove');
 
@@ -349,7 +349,7 @@ describe('MatChip', () => {
         });
 
         it('BACKSPACE emits the (removed) event', () => {
-          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE) as KeyboardEvent;
+          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE);
 
           spyOn(testComponent, 'chipRemove');
 
@@ -368,7 +368,7 @@ describe('MatChip', () => {
         });
 
         it('DELETE does not emit the (removed) event', () => {
-          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE) as KeyboardEvent;
+          const DELETE_EVENT = createKeyboardEvent('keydown', DELETE);
 
           spyOn(testComponent, 'chipRemove');
 
@@ -380,7 +380,7 @@ describe('MatChip', () => {
         });
 
         it('BACKSPACE does not emit the (removed) event', () => {
-          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE) as KeyboardEvent;
+          const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE);
 
           spyOn(testComponent, 'chipRemove');
 

--- a/src/material/core/option/option.spec.ts
+++ b/src/material/core/option/option.spec.ts
@@ -135,8 +135,7 @@ describe('MatOption component', () => {
     const subscription = optionInstance.onSelectionChange.subscribe(spy);
 
     [ENTER, SPACE].forEach(key => {
-      const event = createKeyboardEvent('keydown', key);
-      Object.defineProperty(event, 'shiftKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', key, undefined, {shift: true});
       dispatchEvent(optionNativeElement, event);
       fixture.detectChanges();
 

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -454,8 +454,7 @@ describe('MatDatepicker', () => {
 
         expect(testComponent.datepicker.opened).toBe(true);
 
-        const event = createKeyboardEvent('keydown', UP_ARROW);
-        Object.defineProperty(event, 'altKey', {get: () => true});
+        const event = createKeyboardEvent('keydown', UP_ARROW, undefined, {alt: true});
 
         dispatchEvent(document.body, event);
         fixture.detectChanges();
@@ -467,8 +466,7 @@ describe('MatDatepicker', () => {
       it('should open the datepicker using ALT + DOWN_ARROW', fakeAsync(() => {
         expect(testComponent.datepicker.opened).toBe(false);
 
-        const event = createKeyboardEvent('keydown', DOWN_ARROW);
-        Object.defineProperty(event, 'altKey', {get: () => true});
+        const event = createKeyboardEvent('keydown', DOWN_ARROW, undefined, {alt: true});
 
         dispatchEvent(fixture.nativeElement.querySelector('input'), event);
         fixture.detectChanges();
@@ -485,8 +483,7 @@ describe('MatDatepicker', () => {
 
         input.setAttribute('readonly', 'true');
 
-        const event = createKeyboardEvent('keydown', DOWN_ARROW);
-        Object.defineProperty(event, 'altKey', {get: () => true});
+        const event = createKeyboardEvent('keydown', DOWN_ARROW, undefined, {alt: true});
 
         dispatchEvent(input, event);
         fixture.detectChanges();
@@ -511,8 +508,7 @@ describe('MatDatepicker', () => {
         fixture.detectChanges();
 
         expect(() => {
-          const event = createKeyboardEvent('keydown', DOWN_ARROW);
-          Object.defineProperty(event, 'altKey', {get: () => true});
+          const event = createKeyboardEvent('keydown', DOWN_ARROW, undefined, {alt: true});
           dispatchEvent(fixture.nativeElement.querySelector('input'), event);
           fixture.detectChanges();
           flush();

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -317,7 +317,7 @@ describe('MatMonthView', () => {
           expect(monthViewNativeElement.querySelectorAll('.mat-calendar-body-preview-end').length)
               .toBeGreaterThan(0);
 
-          const event = createKeyboardEvent('keydown', ESCAPE, 'Escape', calendarBodyEl);
+          const event = createKeyboardEvent('keydown', ESCAPE, 'Escape');
           spyOn(event, 'stopPropagation');
           dispatchEvent(calendarBodyEl, event);
           fixture.detectChanges();

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -274,8 +274,7 @@ describe('MatDialog', () => {
       viewContainerRef: testViewContainerRef
     });
 
-    const event = createKeyboardEvent('keydown', ESCAPE);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', ESCAPE, undefined, {alt: true});
     dispatchEvent(document.body, event);
     viewContainerFixture.detectChanges();
     flush();
@@ -359,8 +358,8 @@ describe('MatDialog', () => {
     let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
     let container = overlayContainerElement.querySelector('mat-dialog-container') as HTMLElement;
     dispatchKeyboardEvent(document.body, 'keydown', A);
-    dispatchKeyboardEvent(document.body, 'keydown', A, undefined, backdrop);
-    dispatchKeyboardEvent(document.body, 'keydown', A, undefined, container);
+    dispatchKeyboardEvent(backdrop, 'keydown', A);
+    dispatchKeyboardEvent(container, 'keydown', A);
 
     expect(spy).toHaveBeenCalledTimes(3);
   }));

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -257,8 +257,7 @@ describe('MatAccordion', () => {
 
     headers.forEach(header => spyOn(header, 'focus'));
     const eventTarget = headerElements[headerElements.length - 1].nativeElement;
-    const event = createKeyboardEvent('keydown', HOME, eventTarget);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', HOME, undefined, {alt: true});
 
     dispatchEvent(eventTarget, event);
     fixture.detectChanges();
@@ -292,8 +291,7 @@ describe('MatAccordion', () => {
     headers.forEach(header => spyOn(header, 'focus'));
 
     const eventTarget = headerElements[0].nativeElement;
-    const event = createKeyboardEvent('keydown', END, eventTarget);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', END, undefined, {alt: true});
 
     dispatchEvent(eventTarget, event);
     fixture.detectChanges();

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -225,7 +225,7 @@ describe('MatSelectionList without forms', () => {
 
     it('should be able to use keyboard select with SPACE', () => {
       const testListItem = listOptions[1].nativeElement as HTMLElement;
-      const SPACE_EVENT = createKeyboardEvent('keydown', SPACE, undefined, testListItem);
+      const SPACE_EVENT = createKeyboardEvent('keydown', SPACE);
       const selectList =
           selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
       expect(selectList.selected.length).toBe(0);
@@ -241,7 +241,7 @@ describe('MatSelectionList without forms', () => {
 
     it('should be able to select an item using ENTER', () => {
       const testListItem = listOptions[1].nativeElement as HTMLElement;
-      const ENTER_EVENT = createKeyboardEvent('keydown', ENTER, undefined, testListItem);
+      const ENTER_EVENT = createKeyboardEvent('keydown', ENTER);
       const selectList =
           selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
       expect(selectList.selected.length).toBe(0);
@@ -263,8 +263,7 @@ describe('MatSelectionList without forms', () => {
       expect(selectList.selected.length).toBe(0);
 
       [ENTER, SPACE].forEach(key => {
-        const event = createKeyboardEvent('keydown', key, undefined, testListItem);
-        Object.defineProperty(event, 'ctrlKey', { get: () => true });
+        const event = createKeyboardEvent('keydown', key, undefined, {control: true});
 
         dispatchFakeEvent(testListItem, 'focus');
         selectionList.componentInstance._keydown(event);
@@ -284,8 +283,7 @@ describe('MatSelectionList without forms', () => {
       listOptions[1].componentInstance.disabled = true;
 
       dispatchFakeEvent(testListItem, 'focus');
-      selectionList.componentInstance._keydown(
-          createKeyboardEvent('keydown', SPACE, undefined, testListItem));
+      selectionList.componentInstance._keydown(createKeyboardEvent('keydown', SPACE));
       fixture.detectChanges();
 
       expect(selectionModel.selected.length).toBe(0);
@@ -369,8 +367,7 @@ describe('MatSelectionList without forms', () => {
       });
 
     it('should focus previous item when press UP ARROW', () => {
-      let testListItem = listOptions[2].nativeElement as HTMLElement;
-      let UP_EVENT = createKeyboardEvent('keydown', UP_ARROW, undefined, testListItem);
+      let UP_EVENT = createKeyboardEvent('keydown', UP_ARROW);
       let manager = selectionList.componentInstance._keyManager;
 
       dispatchFakeEvent(listOptions[2].nativeElement, 'focus');
@@ -385,8 +382,7 @@ describe('MatSelectionList without forms', () => {
 
     it('should focus and toggle the next item when pressing SHIFT + UP_ARROW', () => {
       const manager = selectionList.componentInstance._keyManager;
-      const upKeyEvent = createKeyboardEvent('keydown', UP_ARROW);
-      Object.defineProperty(upKeyEvent, 'shiftKey', {get: () => true});
+      const upKeyEvent = createKeyboardEvent('keydown', UP_ARROW, undefined, {shift: true});
 
       dispatchFakeEvent(listOptions[3].nativeElement, 'focus');
       expect(manager.activeItemIndex).toBe(3);
@@ -421,8 +417,7 @@ describe('MatSelectionList without forms', () => {
 
     it('should focus and toggle the next item when pressing SHIFT + DOWN_ARROW', () => {
       const manager = selectionList.componentInstance._keyManager;
-      const downKeyEvent = createKeyboardEvent('keydown', DOWN_ARROW);
-      Object.defineProperty(downKeyEvent, 'shiftKey', {get: () => true});
+      const downKeyEvent = createKeyboardEvent('keydown', DOWN_ARROW, undefined, {shift: true});
 
       dispatchFakeEvent(listOptions[0].nativeElement, 'focus');
       expect(manager.activeItemIndex).toBe(0);
@@ -458,8 +453,7 @@ describe('MatSelectionList without forms', () => {
       const manager = selectionList.componentInstance._keyManager;
       expect(manager.activeItemIndex).toBe(-1);
 
-      const event = createKeyboardEvent('keydown', HOME);
-      Object.defineProperty(event, 'shiftKey', { get: () => true });
+      const event = createKeyboardEvent('keydown', HOME, undefined, {shift: true});
 
       dispatchEvent(selectionList.nativeElement, event);
       fixture.detectChanges();
@@ -483,8 +477,7 @@ describe('MatSelectionList without forms', () => {
       const manager = selectionList.componentInstance._keyManager;
       expect(manager.activeItemIndex).toBe(-1);
 
-      const event = createKeyboardEvent('keydown', END);
-      Object.defineProperty(event, 'shiftKey', { get: () => true });
+      const event = createKeyboardEvent('keydown', END, undefined, {shift: true});
 
       dispatchEvent(selectionList.nativeElement, event);
       fixture.detectChanges();
@@ -495,8 +488,7 @@ describe('MatSelectionList without forms', () => {
 
     it('should select all items using ctrl + a', () => {
       listOptions.forEach(option => option.componentInstance.disabled = false);
-      const event = createKeyboardEvent('keydown', A, selectionList.nativeElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
 
       expect(listOptions.some(option => option.componentInstance.selected)).toBe(false);
 
@@ -507,8 +499,7 @@ describe('MatSelectionList without forms', () => {
     });
 
     it('should not select disabled items when pressing ctrl + a', () => {
-      const event = createKeyboardEvent('keydown', A, selectionList.nativeElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
 
       listOptions.slice(0, 2).forEach(option => option.componentInstance.disabled = true);
       fixture.detectChanges();
@@ -524,8 +515,7 @@ describe('MatSelectionList without forms', () => {
     });
 
     it('should select all items using ctrl + a if some items are selected', () => {
-      const event = createKeyboardEvent('keydown', A, selectionList.nativeElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
 
       listOptions.slice(0, 2).forEach(option => option.componentInstance.selected = true);
       fixture.detectChanges();
@@ -539,8 +529,7 @@ describe('MatSelectionList without forms', () => {
     });
 
     it('should deselect all with ctrl + a if all options are selected', () => {
-      const event = createKeyboardEvent('keydown', A, selectionList.nativeElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
 
       listOptions.forEach(option => option.componentInstance.selected = true);
       fixture.detectChanges();
@@ -615,8 +604,7 @@ describe('MatSelectionList without forms', () => {
       fixture.detectChanges();
       tick(100); // Tick only half the typeahead timeout.
 
-      selectionList.componentInstance._keydown(
-        createKeyboardEvent('keydown', SPACE, undefined, testListItem));
+      selectionList.componentInstance._keydown(createKeyboardEvent('keydown', SPACE));
       fixture.detectChanges();
       tick(100); // Tick the rest of the timeout.
 
@@ -1035,8 +1023,7 @@ describe('MatSelectionList without forms', () => {
     });
 
     it('should do nothing when pressing ctrl + a', () => {
-      const event = createKeyboardEvent('keydown', A, selectionList.nativeElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
 
       expect(listOptions.every(option => !option.componentInstance.selected)).toBe(true);
 
@@ -1049,8 +1036,7 @@ describe('MatSelectionList without forms', () => {
     it('should focus, but not toggle, the next item when pressing SHIFT + UP_ARROW in single ' +
       'selection mode', () => {
         const manager = selectionList.componentInstance._keyManager;
-        const upKeyEvent = createKeyboardEvent('keydown', UP_ARROW);
-        Object.defineProperty(upKeyEvent, 'shiftKey', {get: () => true});
+        const upKeyEvent = createKeyboardEvent('keydown', UP_ARROW, undefined, {shift: true});
 
         dispatchFakeEvent(listOptions[3].nativeElement, 'focus');
         expect(manager.activeItemIndex).toBe(3);
@@ -1068,8 +1054,7 @@ describe('MatSelectionList without forms', () => {
     it('should focus, but not toggle, the next item when pressing SHIFT + DOWN_ARROW ' +
       'in single selection mode', () => {
         const manager = selectionList.componentInstance._keyManager;
-        const downKeyEvent = createKeyboardEvent('keydown', DOWN_ARROW);
-        Object.defineProperty(downKeyEvent, 'shiftKey', {get: () => true});
+        const downKeyEvent = createKeyboardEvent('keydown', DOWN_ARROW, undefined, {shift: true});
 
         dispatchFakeEvent(listOptions[0].nativeElement, 'focus');
         expect(manager.activeItemIndex).toBe(0);

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -442,9 +442,8 @@ describe('MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
 
     const panel = overlayContainerElement.querySelector('.mat-menu-panel')!;
-    const event = createKeyboardEvent('keydown', ESCAPE);
+    const event = createKeyboardEvent('keydown', ESCAPE, undefined, {alt: true});
 
-    Object.defineProperty(event, 'altKey', {get: () => true});
     dispatchEvent(panel, event);
     fixture.detectChanges();
     tick(500);
@@ -823,8 +822,7 @@ describe('MatMenu', () => {
 
     spyOn(items[0], 'focus').and.callThrough();
 
-    const event = createKeyboardEvent('keydown', HOME);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', HOME, undefined, {alt: true});
 
     dispatchEvent(panel, event);
     fixture.detectChanges();
@@ -868,8 +866,7 @@ describe('MatMenu', () => {
 
     spyOn(items[items.length - 1], 'focus').and.callThrough();
 
-    const event = createKeyboardEvent('keydown', END);
-    Object.defineProperty(event, 'altKey', {get: () => true});
+    const event = createKeyboardEvent('keydown', END, undefined, {alt: true});
 
     dispatchEvent(panel, event);
     fixture.detectChanges();

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -435,8 +435,7 @@ describe('MatSelect', () => {
           expect(selectInstance.panelOpen).toBe(false, 'Expected select to be closed.');
           expect(formControl.value).toBeFalsy('Expected no initial value.');
 
-          const event = createKeyboardEvent('keydown', DOWN_ARROW);
-          Object.defineProperty(event, 'altKey', {get: () => true});
+          const event = createKeyboardEvent('keydown', DOWN_ARROW, undefined, {alt: true});
 
           dispatchEvent(select, event);
 
@@ -450,8 +449,7 @@ describe('MatSelect', () => {
           expect(selectInstance.panelOpen).toBe(false, 'Expected select to be closed.');
           expect(formControl.value).toBeFalsy('Expected no initial value.');
 
-          const event = createKeyboardEvent('keydown', UP_ARROW);
-          Object.defineProperty(event, 'altKey', {get: () => true});
+          const event = createKeyboardEvent('keydown', UP_ARROW, undefined, {alt: true});
 
           dispatchEvent(select, event);
 
@@ -467,8 +465,7 @@ describe('MatSelect', () => {
 
           expect(selectInstance.panelOpen).toBe(true, 'Expected select to be open.');
 
-          const event = createKeyboardEvent('keydown', DOWN_ARROW);
-          Object.defineProperty(event, 'altKey', {get: () => true});
+          const event = createKeyboardEvent('keydown', DOWN_ARROW, undefined, {alt: true});
 
           dispatchEvent(select, event);
 
@@ -484,8 +481,7 @@ describe('MatSelect', () => {
 
           expect(selectInstance.panelOpen).toBe(true, 'Expected select to be open.');
 
-          const event = createKeyboardEvent('keydown', UP_ARROW);
-          Object.defineProperty(event, 'altKey', {get: () => true});
+          const event = createKeyboardEvent('keydown', UP_ARROW, undefined, {alt: true});
 
           dispatchEvent(select, event);
 
@@ -721,8 +717,7 @@ describe('MatSelect', () => {
             fixture.destroy();
 
             const multiFixture = TestBed.createComponent(MultiSelect);
-            const event = createKeyboardEvent('keydown', DOWN_ARROW);
-            Object.defineProperty(event, 'shiftKey', {get: () => true});
+            const event = createKeyboardEvent('keydown', DOWN_ARROW, undefined, {shift: true});
 
             multiFixture.detectChanges();
             select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
@@ -749,8 +744,7 @@ describe('MatSelect', () => {
             fixture.destroy();
 
             const multiFixture = TestBed.createComponent(MultiSelect);
-            const event = createKeyboardEvent('keydown', UP_ARROW);
-            Object.defineProperty(event, 'shiftKey', {get: () => true});
+            const event = createKeyboardEvent('keydown', UP_ARROW, undefined, {shift: true});
 
             multiFixture.detectChanges();
             select = multiFixture.debugElement.query(By.css('mat-select'))!.nativeElement;
@@ -791,8 +785,7 @@ describe('MatSelect', () => {
         it('should not prevent the default actions on selection keys when pressing a modifier',
           fakeAsync(() => {
             [ENTER, SPACE].forEach(key => {
-              const event = createKeyboardEvent('keydown', key);
-              Object.defineProperty(event, 'shiftKey', {get: () => true});
+              const event = createKeyboardEvent('keydown', key, undefined, {shift: true});
               expect(event.defaultPrevented).toBe(false);
             });
 
@@ -4357,8 +4350,7 @@ describe('MatSelect', () => {
       fixture.componentInstance.select.open();
       fixture.detectChanges();
 
-      const event = createKeyboardEvent('keydown', A, selectElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
       dispatchEvent(selectElement, event);
       fixture.detectChanges();
 
@@ -4388,8 +4380,7 @@ describe('MatSelect', () => {
       fixture.componentInstance.select.open();
       fixture.detectChanges();
 
-      const event = createKeyboardEvent('keydown', A, selectElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
       dispatchEvent(selectElement, event);
       fixture.detectChanges();
 
@@ -4415,8 +4406,7 @@ describe('MatSelect', () => {
       fixture.componentInstance.select.open();
       fixture.detectChanges();
 
-      const event = createKeyboardEvent('keydown', A, selectElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
       dispatchEvent(selectElement, event);
       fixture.detectChanges();
 
@@ -4455,8 +4445,7 @@ describe('MatSelect', () => {
       fixture.componentInstance.select.open();
       fixture.detectChanges();
 
-      const event = createKeyboardEvent('keydown', A, selectElement);
-      Object.defineProperty(event, 'ctrlKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
       dispatchEvent(selectElement, event);
       fixture.detectChanges();
 

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -228,8 +228,7 @@ describe('MatDrawer', () => {
       expect(testComponent.closeCount).toBe(0, 'Expected no close events.');
       expect(testComponent.closeStartCount).toBe(0, 'Expected no close start events.');
 
-      const event = createKeyboardEvent('keydown', ESCAPE);
-      Object.defineProperty(event, 'altKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', ESCAPE, undefined, {alt: true});
       dispatchEvent(drawer.nativeElement, event);
       fixture.detectChanges();
       flush();

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -1012,8 +1012,7 @@ describe('MatSlider', () => {
         UP_ARROW, DOWN_ARROW, RIGHT_ARROW,
         LEFT_ARROW, PAGE_DOWN, PAGE_UP, HOME, END
       ].forEach(key => {
-        const event = createKeyboardEvent('keydown', key);
-        Object.defineProperty(event, 'altKey', {get: () => true});
+        const event = createKeyboardEvent('keydown', key, undefined, {alt: true});
         dispatchEvent(sliderNativeElement, event);
         fixture.detectChanges();
         expect(event.defaultPrevented).toBe(false);

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -1310,7 +1310,7 @@ function assertSelectKeyWithModifierInteraction(fixture: ComponentFixture<any>,
       .toBe(0, 'Expected index of selected step to remain unchanged after pressing the next key.');
 
   modifiers.forEach(modifier => {
-    const event: KeyboardEvent = createKeyboardEvent('keydown', selectionKey);
+    const event = createKeyboardEvent('keydown', selectionKey);
     Object.defineProperty(event, modifier, {get: () => true});
     dispatchEvent(stepHeaders[1].nativeElement, event);
     fixture.detectChanges();

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -213,12 +213,9 @@ describe('MatTabHeader', () => {
     });
 
     it('should not do anything if a modifier key is pressed', () => {
-      const rightArrowEvent = createKeyboardEvent('keydown', RIGHT_ARROW);
-      const enterEvent = createKeyboardEvent('keydown', ENTER);
-
-      [rightArrowEvent, enterEvent].forEach(event => {
-        Object.defineProperty(event, 'shiftKey', {get: () => true});
-      });
+      const rightArrowEvent = createKeyboardEvent(
+          'keydown', RIGHT_ARROW, undefined, {shift: true});
+      const enterEvent = createKeyboardEvent('keydown', ENTER, undefined, {shift: true});
 
       appComponent.tabHeader.focusIndex = 0;
       fixture.detectChanges();

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -667,8 +667,7 @@ describe('MatTooltip', () => {
       tick(0);
       fixture.detectChanges();
 
-      const event = createKeyboardEvent('keydown', ESCAPE);
-      Object.defineProperty(event, 'altKey', {get: () => true});
+      const event = createKeyboardEvent('keydown', ESCAPE, undefined, {alt: true});
       dispatchEvent(buttonElement, event);
       fixture.detectChanges();
       flush();


### PR DESCRIPTION
We have common helpers for dealing with events. In the past, the
keyboard event helpers did not support modifier keys, but we added
such functionality. Existing tests should not use `Object.defineProperty`,
to set modifier keys. Instead tests should just pass the desired
modifier keys to the `createKeyboardEvent` helper call.

This commit cleans this up. Additionally, it fixes an incorrect method
description for the `createKeyboardEvent` helper while also cleaning up
that the helper undesirably accepts a `target` element. The event target
is always automatically set when the event is dispatched on a given
element. If this is not desired in some situations (as with the chips
tests), then the event target needs to be manually set. It's not typical
to do this though, so the helper should not have this API (as it also
complicates the keyboard event tests of other components; plus it's
inconsistent with other event helpers we expose).