### PR TITLE
fix(material-experimental/chips): fix empty check when no chips

### DIFF
--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -154,7 +154,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  get empty(): boolean { return this._chipInput.empty && this._chips.length === 0; }
+  get empty(): boolean { return this._chipInput.empty && (!this._chips || this._chips.length === 0); }
 
     /** The ARIA role applied to the chip grid. */
   get role(): string | null { return this.empty ? null : 'grid'; }

--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -154,7 +154,10 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  get empty(): boolean { return this._chipInput.empty && (!this._chips || this._chips.length === 0); }
+  get empty(): boolean {
+    return (!this._chipInput || this._chipInput.empty) &&
+        (!this._chips || this._chips.length === 0);
+  }
 
     /** The ARIA role applied to the chip grid. */
   get role(): string | null { return this.empty ? null : 'grid'; }

--- a/src/material-experimental/mdc-chips/chip-set.ts
+++ b/src/material-experimental/mdc-chips/chip-set.ts
@@ -193,7 +193,7 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterContentInit
 
   /** Checks whether any of the chips is focused. */
   protected _hasFocusedChip() {
-    return this._chips.some(chip => chip._hasFocus);
+    return this._chips && this._chips.some(chip => chip._hasFocus);
   }
 
   /** Syncs the chip-set's state with the individual chips. */


### PR DESCRIPTION
Similar check that was necessitated from PR #10466 - due to changes in the change detection cycle from input, its possible that `empty` is called earlier and should account for when there are no `chips` picked up yet