### PR TITLE
build: increase timeout for resultstore build uploads

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,7 +94,7 @@ build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
 
 # Setup Build Event Service
 build:remote --bes_backend=buildeventservice.googleapis.com
-build:remote --bes_timeout=30s
+build:remote --bes_timeout=60s
 build:remote --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # Set remote caching settings


### PR DESCRIPTION
We upload build results to Google Cloud `ResultStore`. Sometimes this
seems to fail though and Bazel CI jobs exit red. This could be due to
BES servers being slow, or servers being unreliably. Given that remote
executors from GCP are behaving fine though, we try increasing the
timeout first. We can disable the uploading if it doesn't get better.

For context: We upload to result store / source.cloud.google.com so that
CI builds with Bazel can be debugged better. e.g. 

https://source.cloud.google.com/results/invocations/410a5790-54eb-43e8-96eb-c3cfa0f8960d