### PR TITLE
build: increase timeout for legacy saucelabs tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -90,7 +90,7 @@ module.exports = config => {
       startConnect: false,
       recordVideo: false,
       recordScreenshots: false,
-      idleTimeout: 600,
+      idleTimeout: 1000,
       commandTimeout: 600,
       maxDuration: 5400,
     },


### PR DESCRIPTION
We keep adding more tests to our codebase, but browsers
on Saucelabs generally run slow. During the last couple of
weeks unit tests on Saucelabs sometimes failed due to the default 10min
timeout. e.g. https://app.saucelabs.com/tests/bfb7ade4b0fc4e7e9ff7237074baac80

We bump the timeout so that tests can complete without us relaunching
another instance of a browser (which might pass; but will increase CI
duration even more). We use the maximum value of 1000seconds.

Ideally we'll fix this in the future by having incremental test runs.
I'm working on this with a Bazel setup as a side project. See:
https://github.com/angular/components/pull/19409