### PR TITLE
build: do not upload results to cloud result-store by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -92,10 +92,18 @@ build:remote --host_platform=//tools:rbe_platform
 build:remote --platforms=//tools:rbe_platform
 build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
 
-# Setup Build Event Service
-build:remote --bes_backend=buildeventservice.googleapis.com
-build:remote --bes_timeout=60s
-build:remote --bes_results_url="https://source.cloud.google.com/results/invocations/"
+################################
+# --config=build-results       #
+################################
+
+# Sets up Build Event Service if the `builds-results` configuration is used. We
+# do not upload build results by default as this makes us reliant on external servers
+# that could cause builds to fail unnecessarily. If desired, build result uploading
+# can be manually uploaded, but given that the build event service server has been
+# less stable than the remote executors, we do not want to degrade CI stability.
+build:build-results --bes_backend=buildeventservice.googleapis.com
+build:build-results --bes_timeout=60s
+build:build-results --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # Set remote caching settings
 build:remote --remote_accept_cached=true


### PR DESCRIPTION
We currently always upload build results to `source.cloud.google.com`.
Though past has proven that servers for the Build Event Service are
rather unstable compared to the remote execution workers we acquire
for CI builds. To avoid that these servers and the non-build relevant
result uploading degrades CI stability, we do not run them by default,
unless one explicitly opts-in through a Bazel build configuration.

The uploaded build results were useful to inspect output of individual
targets that ran on CI, but the need for this is limited, and if someone
cannot see given output for an action, he could easily connect to the CI
container and run the command manually. Usually the output for failed
actions is printed to the CI output anyway.

Motivation for this change: As explained, instability of these servers. I have
noticed such failures frequently over the past months (not often; but noticeable).
Today it's significantly impeding PR statuses, most likely due to a larger GCP outage.