### PR TITLE
refactor(cdk/scrolling): remove circular dependency between scrollable and dispatcher

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -21,10 +21,6 @@
     "src/cdk/drag-drop/drop-list-ref.ts"
   ],
   [
-    "src/cdk/scrolling/scroll-dispatcher.ts",
-    "src/cdk/scrolling/scrollable.ts"
-  ],
-  [
     "src/cdk/scrolling/virtual-scroll-strategy.ts",
     "src/cdk/scrolling/virtual-scroll-viewport.ts"
   ],

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -8,7 +8,7 @@
 
 import {Direction} from '@angular/cdk/bidi';
 import {Platform} from '@angular/cdk/platform';
-import {CdkScrollable, ViewportRuler} from '@angular/cdk/scrolling';
+import {Scrollable, ViewportRuler} from '@angular/cdk/scrolling';
 import {ElementRef} from '@angular/core';
 import {Observable} from 'rxjs';
 
@@ -118,7 +118,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
    * on reposition we can evaluate if it or the overlay has been clipped or outside view. Every
    * Scrollable must be an ancestor element of the strategy's origin element.
    */
-  withScrollableContainers(scrollables: CdkScrollable[]) {
+  withScrollableContainers(scrollables: Scrollable[]) {
     this._positionStrategy.withScrollableContainers(scrollables);
   }
 

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -8,7 +8,7 @@
 
 import {PositionStrategy} from './position-strategy';
 import {ElementRef} from '@angular/core';
-import {ViewportRuler, CdkScrollable, ViewportScrollPosition} from '@angular/cdk/scrolling';
+import {ViewportRuler, ViewportScrollPosition, Scrollable} from '@angular/cdk/scrolling';
 import {
   ConnectedOverlayPositionChange,
   ConnectionPositionPair,
@@ -83,7 +83,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   private _viewportMargin = 0;
 
   /** The Scrollable containers used to check scrollable view properties on position change. */
-  private _scrollables: CdkScrollable[] = [];
+  private _scrollables: Scrollable[] = [];
 
   /** Ordered list of preferred positions, from most to least desirable. */
   _preferredPositions: ConnectionPositionPair[] = [];
@@ -360,7 +360,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
    * on reposition we can evaluate if it or the overlay has been clipped or outside view. Every
    * Scrollable must be an ancestor element of the strategy's origin element.
    */
-  withScrollableContainers(scrollables: CdkScrollable[]): this {
+  withScrollableContainers(scrollables: Scrollable[]): this {
     this._scrollables = scrollables;
     return this;
   }

--- a/src/cdk/scrolling/public-api.ts
+++ b/src/cdk/scrolling/public-api.ts
@@ -15,3 +15,4 @@ export * from './virtual-for-of';
 export * from './virtual-scroll-strategy';
 export * from './virtual-scroll-viewport';
 export * from './virtual-scroll-repeater';
+export * from './scroll-types';

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -8,10 +8,10 @@
 
 import {Platform} from '@angular/cdk/platform';
 import {ElementRef, Injectable, NgZone, OnDestroy, Optional, Inject} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
 import {fromEvent, of as observableOf, Subject, Subscription, Observable, Observer} from 'rxjs';
 import {auditTime, filter} from 'rxjs/operators';
-import {CdkScrollable} from './scrollable';
-import {DOCUMENT} from '@angular/common';
+import {Scrollable} from './scroll-types';
 
 /** Time in ms to throttle the scrolling events by default. */
 export const DEFAULT_SCROLL_TIME = 20;
@@ -32,7 +32,7 @@ export class ScrollDispatcher implements OnDestroy {
   }
 
   /** Subject for notifying that a registered scrollable reference element has been scrolled. */
-  private _scrolled = new Subject<CdkScrollable|void>();
+  private _scrolled = new Subject<Scrollable|void>();
 
   /** Keeps track of the global `scroll` and `resize` subscriptions. */
   _globalSubscription: Subscription | null = null;
@@ -44,14 +44,14 @@ export class ScrollDispatcher implements OnDestroy {
    * Map of all the scrollable references that are registered with the service and their
    * scroll event subscriptions.
    */
-  scrollContainers: Map<CdkScrollable, Subscription> = new Map();
+  scrollContainers: Map<Scrollable, Subscription> = new Map();
 
   /**
    * Registers a scrollable instance with the service and listens for its scrolled events. When the
    * scrollable is scrolled, the service emits the event to its scrolled observable.
    * @param scrollable Scrollable instance to be registered.
    */
-  register(scrollable: CdkScrollable): void {
+  register(scrollable: Scrollable): void {
     if (!this.scrollContainers.has(scrollable)) {
       this.scrollContainers.set(scrollable, scrollable.elementScrolled()
           .subscribe(() => this._scrolled.next(scrollable)));
@@ -62,7 +62,7 @@ export class ScrollDispatcher implements OnDestroy {
    * Deregisters a Scrollable reference and unsubscribes from its scroll event observable.
    * @param scrollable Scrollable instance to be deregistered.
    */
-  deregister(scrollable: CdkScrollable): void {
+  deregister(scrollable: Scrollable): void {
     const scrollableReference = this.scrollContainers.get(scrollable);
 
     if (scrollableReference) {
@@ -81,12 +81,12 @@ export class ScrollDispatcher implements OnDestroy {
    * If you need to update any data bindings as a result of a scroll event, you have
    * to run the callback using `NgZone.run`.
    */
-  scrolled(auditTimeInMs: number = DEFAULT_SCROLL_TIME): Observable<CdkScrollable|void> {
+  scrolled(auditTimeInMs: number = DEFAULT_SCROLL_TIME): Observable<Scrollable|void> {
     if (!this._platform.isBrowser) {
       return observableOf<void>();
     }
 
-    return new Observable((observer: Observer<CdkScrollable|void>) => {
+    return new Observable((observer: Observer<Scrollable|void>) => {
       if (!this._globalSubscription) {
         this._addGlobalListener();
       }
@@ -122,7 +122,7 @@ export class ScrollDispatcher implements OnDestroy {
    * @param elementRef Element whose ancestors to listen for.
    * @param auditTimeInMs Time to throttle the scroll events.
    */
-  ancestorScrolled(elementRef: ElementRef, auditTimeInMs?: number): Observable<CdkScrollable|void> {
+  ancestorScrolled(elementRef: ElementRef, auditTimeInMs?: number): Observable<Scrollable|void> {
     const ancestors = this.getAncestorScrollContainers(elementRef);
 
     return this.scrolled(auditTimeInMs).pipe(filter(target => {
@@ -131,10 +131,10 @@ export class ScrollDispatcher implements OnDestroy {
   }
 
   /** Returns all registered Scrollables that contain the provided element. */
-  getAncestorScrollContainers(elementRef: ElementRef): CdkScrollable[] {
-    const scrollingContainers: CdkScrollable[] = [];
+  getAncestorScrollContainers(elementRef: ElementRef): Scrollable[] {
+    const scrollingContainers: Scrollable[] = [];
 
-    this.scrollContainers.forEach((_subscription: Subscription, scrollable: CdkScrollable) => {
+    this.scrollContainers.forEach((_subscription: Subscription, scrollable: Scrollable) => {
       if (this._scrollableContainsElement(scrollable, elementRef)) {
         scrollingContainers.push(scrollable);
       }
@@ -149,7 +149,7 @@ export class ScrollDispatcher implements OnDestroy {
   }
 
   /** Returns true if the element is contained within the provided Scrollable. */
-  private _scrollableContainsElement(scrollable: CdkScrollable, elementRef: ElementRef): boolean {
+  private _scrollableContainsElement(scrollable: Scrollable, elementRef: ElementRef): boolean {
     let element: HTMLElement | null = elementRef.nativeElement;
     let scrollableElement = scrollable.getElementRef().nativeElement;
 

--- a/src/cdk/scrolling/scroll-types.ts
+++ b/src/cdk/scrolling/scroll-types.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ElementRef} from '@angular/core';
+import {Observable} from 'rxjs';
+
+export type _Without<T> = {[P in keyof T]?: never};
+export type _XOR<T, U> = (_Without<T> & U) | (_Without<U> & T);
+export type _Top = {top?: number};
+export type _Bottom = {bottom?: number};
+export type _Left = {left?: number};
+export type _Right = {right?: number};
+export type _Start = {start?: number};
+export type _End = {end?: number};
+export type _XAxis = _XOR<_XOR<_Left, _Right>, _XOR<_Start, _End>>;
+export type _YAxis = _XOR<_Top, _Bottom>;
+
+/**
+ * An extended version of ScrollToOptions that allows expressing scroll offsets relative to the
+ * top, bottom, left, right, start, or end of the viewport rather than just the top and left.
+ * Please note: the top and bottom properties are mutually exclusive, as are the left, right,
+ * start, and end properties.
+ */
+export type ExtendedScrollToOptions = _XAxis & _YAxis & ScrollOptions;
+
+/** Edge from which a scroll offset can be measured. */
+export type ScrollOffsetEdge = 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end';
+
+/**
+ * Object that can be registered with the `ScrollDispatcher`. Used to avoid a circular
+ * dependencies between the `ScrollDispatcher` and `CdkScrollable.`
+ * @docs-private
+ */
+export interface Scrollable {
+  elementScrolled(): Observable<Event>;
+  getElementRef(): ElementRef<HTMLElement>;
+  measureScrollOffset(from: ScrollOffsetEdge): number;
+  scrollTo(options: ExtendedScrollToOptions): void;
+}

--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -16,25 +16,16 @@ import {Directive, ElementRef, NgZone, OnDestroy, OnInit, Optional} from '@angul
 import {fromEvent, Observable, Subject, Observer} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {ScrollDispatcher} from './scroll-dispatcher';
-
-export type _Without<T> = {[P in keyof T]?: never};
-export type _XOR<T, U> = (_Without<T> & U) | (_Without<U> & T);
-export type _Top = {top?: number};
-export type _Bottom = {bottom?: number};
-export type _Left = {left?: number};
-export type _Right = {right?: number};
-export type _Start = {start?: number};
-export type _End = {end?: number};
-export type _XAxis = _XOR<_XOR<_Left, _Right>, _XOR<_Start, _End>>;
-export type _YAxis = _XOR<_Top, _Bottom>;
-
-/**
- * An extended version of ScrollToOptions that allows expressing scroll offsets relative to the
- * top, bottom, left, right, start, or end of the viewport rather than just the top and left.
- * Please note: the top and bottom properties are mutually exclusive, as are the left, right,
- * start, and end properties.
- */
-export type ExtendedScrollToOptions = _XAxis & _YAxis & ScrollOptions;
+import {
+  ExtendedScrollToOptions,
+  _Without,
+  _Left,
+  _Right,
+  _Bottom,
+  _Top,
+  ScrollOffsetEdge,
+  Scrollable,
+} from './scroll-types';
 
 /**
  * Sends an event when the directive's element is scrolled. Registers itself with the
@@ -44,7 +35,7 @@ export type ExtendedScrollToOptions = _XAxis & _YAxis & ScrollOptions;
 @Directive({
   selector: '[cdk-scrollable], [cdkScrollable]'
 })
-export class CdkScrollable implements OnInit, OnDestroy {
+export class CdkScrollable implements Scrollable, OnInit, OnDestroy {
   private _destroyed = new Subject<void>();
 
   private _elementScrolled: Observable<Event> = new Observable((observer: Observer<Event>) =>
@@ -150,7 +141,7 @@ export class CdkScrollable implements OnInit, OnDestroy {
    * in an RTL context.
    * @param from The edge to measure from.
    */
-  measureScrollOffset(from: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number {
+  measureScrollOffset(from: ScrollOffsetEdge): number {
     const LEFT = 'left';
     const RIGHT = 'right';
     const el = this.elementRef.nativeElement;

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -33,7 +33,8 @@ import {
 } from 'rxjs';
 import {auditTime, startWith, takeUntil} from 'rxjs/operators';
 import {ScrollDispatcher} from './scroll-dispatcher';
-import {CdkScrollable, ExtendedScrollToOptions} from './scrollable';
+import {CdkScrollable} from './scrollable';
+import {ExtendedScrollToOptions} from './scroll-types';
 import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-strategy';
 import {ViewportRuler} from './viewport-ruler';
 import {CdkVirtualScrollRepeater} from './virtual-scroll-repeater';

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -107,7 +107,7 @@ export declare class ConnectedPositionStrategy implements PositionStrategy {
     withOffsetX(offset: number): this;
     withOffsetY(offset: number): this;
     withPositions(positions: ConnectionPositionPair[]): this;
-    withScrollableContainers(scrollables: CdkScrollable[]): void;
+    withScrollableContainers(scrollables: Scrollable[]): void;
 }
 
 export declare class ConnectionPositionPair {
@@ -142,7 +142,7 @@ export declare class FlexibleConnectedPositionStrategy implements PositionStrate
     withLockedPosition(isLocked?: boolean): this;
     withPositions(positions: ConnectedPosition[]): this;
     withPush(canPush?: boolean): this;
-    withScrollableContainers(scrollables: CdkScrollable[]): this;
+    withScrollableContainers(scrollables: Scrollable[]): this;
     withTransformOriginOn(selector: string): this;
     withViewportMargin(margin: number): this;
 }

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -53,7 +53,7 @@ export declare class CdkFixedSizeVirtualScroll implements OnChanges {
     static ɵfac: i0.ɵɵFactoryDef<CdkFixedSizeVirtualScroll, never>;
 }
 
-export declare class CdkScrollable implements OnInit, OnDestroy {
+export declare class CdkScrollable implements Scrollable, OnInit, OnDestroy {
     protected dir?: Directionality | undefined;
     protected elementRef: ElementRef<HTMLElement>;
     protected ngZone: NgZone;
@@ -61,7 +61,7 @@ export declare class CdkScrollable implements OnInit, OnDestroy {
     constructor(elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir?: Directionality | undefined);
     elementScrolled(): Observable<Event>;
     getElementRef(): ElementRef<HTMLElement>;
-    measureScrollOffset(from: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number;
+    measureScrollOffset(from: ScrollOffsetEdge): number;
     ngOnDestroy(): void;
     ngOnInit(): void;
     scrollTo(options: ExtendedScrollToOptions): void;
@@ -165,17 +165,24 @@ export declare class FixedSizeVirtualScrollStrategy implements VirtualScrollStra
     updateItemAndBufferSize(itemSize: number, minBufferPx: number, maxBufferPx: number): void;
 }
 
+export interface Scrollable {
+    elementScrolled(): Observable<Event>;
+    getElementRef(): ElementRef<HTMLElement>;
+    measureScrollOffset(from: ScrollOffsetEdge): number;
+    scrollTo(options: ExtendedScrollToOptions): void;
+}
+
 export declare class ScrollDispatcher implements OnDestroy {
     protected _document: Document;
     _globalSubscription: Subscription | null;
-    scrollContainers: Map<CdkScrollable, Subscription>;
+    scrollContainers: Map<Scrollable, Subscription>;
     constructor(_ngZone: NgZone, _platform: Platform, document: any);
-    ancestorScrolled(elementRef: ElementRef, auditTimeInMs?: number): Observable<CdkScrollable | void>;
-    deregister(scrollable: CdkScrollable): void;
-    getAncestorScrollContainers(elementRef: ElementRef): CdkScrollable[];
+    ancestorScrolled(elementRef: ElementRef, auditTimeInMs?: number): Observable<Scrollable | void>;
+    deregister(scrollable: Scrollable): void;
+    getAncestorScrollContainers(elementRef: ElementRef): Scrollable[];
     ngOnDestroy(): void;
-    register(scrollable: CdkScrollable): void;
-    scrolled(auditTimeInMs?: number): Observable<CdkScrollable | void>;
+    register(scrollable: Scrollable): void;
+    scrolled(auditTimeInMs?: number): Observable<Scrollable | void>;
     static ɵfac: i0.ɵɵFactoryDef<ScrollDispatcher, [null, null, { optional: true; }]>;
     static ɵprov: i0.ɵɵInjectableDef<ScrollDispatcher>;
 }
@@ -184,6 +191,8 @@ export declare class ScrollingModule {
     static ɵinj: i0.ɵɵInjectorDef<ScrollingModule>;
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<ScrollingModule, [typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport], [typeof i5.BidiModule, typeof i6.PlatformModule, typeof CdkScrollableModule], [typeof i5.BidiModule, typeof CdkScrollableModule, typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport]>;
 }
+
+export declare type ScrollOffsetEdge = 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end';
 
 export declare class ViewportRuler implements OnDestroy {
     protected _document: Document;


### PR DESCRIPTION
Moves some code around to remove a circular dependency between `CdkScrollable` and `ScrollDispatcher`.