### PR TITLE
fix(material/card): not clearing margin on last button in end alignment

### DIFF
--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -203,10 +203,23 @@ $mat-card-header-size: 40px !default;
 // actions panel should always be 8px from sides,
 // so the first button in the actions panel can't add its own margins
 .mat-card-actions {
+  &:not(.mat-card-actions-align-end) {
+    .mat-button,
+    .mat-raised-button,
+    .mat-stroked-button {
+      &:first-child {
+        margin-left: 0;
+        margin-right: 0;
+      }
+    }
+  }
+}
+
+.mat-card-actions-align-end {
   .mat-button,
   .mat-raised-button,
   .mat-stroked-button {
-    &:first-child {
+    &:last-child {
       margin-left: 0;
       margin-right: 0;
     }


### PR DESCRIPTION
We have some styles that clear the margin from the first button, but we didn't apply the same to the last button if the card actions are aligned towards the end.

Fixes #20024.