### PR TITLE
build: snapshot builds incorrectly modify semver versions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,15 +37,19 @@ query --output=label_kind
 # By default, failing tests don't print any output, it goes to the log file
 test --test_output=errors
 
-#################################
-# Release configuration.        #
-# Run with "--config=release"   #
-#################################
+####################################
+# Stamping configurations.         #
+# Run with "--config=release" or   #
+# "--config=snapshot-build".       #
+####################################
 
 # Configures script to do version stamping.
 # See https://docs.bazel.build/versions/master/user-manual.html#flag--workspace_status_command
 build:release --workspace_status_command="node ./tools/bazel-stamp-vars.js"
 build:release --stamp
+
+build:snapshot-build --workspace_status_command="node ./tools/bazel-stamp-vars.js --snapshot"
+build:snapshot-build --stamp
 
 ################################
 # View Engine / Ivy toggle     #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,12 @@ jobs:
       - *setup_bazel_binary
 
       - run: yarn build
-      - run: yarn check-release-output
+      - run:
+          name: Checking release output
+          command: |
+            pkg_json_version=$(node -pe "require('./package.json').version")
+            expected_version="${pkg_json_version}-sha-$(git rev-parse --short HEAD)"
+            yarn check-release-output ${expected_version}
 
       # TODO(devversion): replace this with bazel tests that run Madge. This is
       # cumbersome and doesn't guarantee no circular deps for other entry-points.
@@ -435,7 +440,7 @@ jobs:
       # The components examples package is not a release package, but we publish it
       # as part of this job to the docs-content repository. It's not contained in the
       # attached release output, so we need to build it here.
-      - run: bazel build src/components-examples:npm_package --config=release
+      - run: bazel build src/components-examples:npm_package --config=snapshot-build
 
       # Ensures that we do not push the snapshot artifacts upstream until all previous
       # snapshot build jobs have completed. This helps avoiding conflicts when multiple

--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -45,11 +45,6 @@ publishPackage() {
   commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
   commitMessage=$(git log --oneline -n 1)
 
-  # Note that we cannot store the commit SHA in its own version segment
-  # as it will not comply with the semver specification. For example:
-  # 1.0.0-00abcdef will break since the SHA starts with zeros. To fix this,
-  # we create a new version segment with the following format: "1.0.0-sha-00abcdef".
-  # See issue: https://jubianchi.github.io/semver-check/#/^8.0.0/8.2.2-0462599
   buildVersionName="${buildVersion}-sha-${commitSha}"
   buildTagName="${branchName}-${commitSha}"
   buildCommitMessage="${branchName} - ${commitMessage}"
@@ -98,12 +93,6 @@ publishPackage() {
     echo "Skipping publish because tag is already published"
     exit 0
   fi
-
-  # Replace the version in every file recursively with a more specific version that also includes
-  # the SHA of the current build job. Normally this "sed" call would just replace the version
-  # placeholder, but the version placeholders have been replaced by "npm_package" already.
-  escapedVersion=$(echo ${buildVersion} | sed 's/[.[\*^$]/\\&/g')
-  sed -i "s/${escapedVersion}/${buildVersionName}/g" $(find . -type f -not -path '*\/.*')
 
   echo "Updated the build version in every file to include the SHA of the latest commit."
 

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -41,11 +41,6 @@ commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)
 commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
 commitMessage=$(git log --oneline -n 1)
 
-# Note that we cannot store the commit SHA in its own version segment
-# as it will not comply with the semver specification. For example:
-# 1.0.0-00abcdef will break since the SHA starts with zeros. To fix this,
-# we create a new version segment with the following format: "1.0.0-sha-00abcdef".
-# See issue: https://jubianchi.github.io/semver-check/#/^8.0.0/8.2.2-0462599
 buildVersionName="${buildVersion}-sha-${commitSha}"
 buildTagName="${branchName}-${commitSha}"
 buildCommitMessage="${branchName} - ${commitMessage}"
@@ -94,12 +89,6 @@ if [[ $(git ls-remote origin "refs/tags/${buildTagName}") ]]; then
   echo "Skipping publish of docs-content because tag is already published. Exiting.."
   exit 0
 fi
-
-# Replace the version in every file recursively with a more specific version that also includes
-# the SHA of the current build job. Normally this "sed" call would just replace the version
-# placeholder, but the version placeholders have been replaced by "npm_package" already.
-escapedVersion=$(echo ${buildVersion} | sed 's/[.[\*^$]/\\&/g')
-sed -i "s/${escapedVersion}/${buildVersionName}/g" $(find . -type f -not -path '*\/.*')
 
 # Setup the Git configuration
 git config user.name "$commitAuthorName"

--- a/tools/release/check-release-output.ts
+++ b/tools/release/check-release-output.ts
@@ -2,17 +2,16 @@ import chalk from 'chalk';
 import {join} from 'path';
 import {checkReleasePackage} from './release-output/check-package';
 import {releasePackages} from './release-output/release-packages';
-import {parseVersionName, Version} from './version-name/parse-version';
 
 /**
  * Checks the release output by running the release-output validations for each
  * release package.
  */
-export function checkReleaseOutput(releaseOutputDir: string, currentVersion: Version) {
+export function checkReleaseOutput(releaseOutputDir: string, expectedVersion: string) {
   let hasFailed = false;
 
   releasePackages.forEach(packageName => {
-    if (!checkReleasePackage(releaseOutputDir, packageName, currentVersion)) {
+    if (!checkReleasePackage(releaseOutputDir, packageName, expectedVersion)) {
       hasFailed = true;
     }
   });
@@ -30,9 +29,10 @@ export function checkReleaseOutput(releaseOutputDir: string, currentVersion: Ver
 
 
 if (require.main === module) {
-  const currentVersion = parseVersionName(require('../../package.json').version);
-  if (currentVersion === null) {
-    throw Error('Version in project "package.json" is invalid.');
+  const [expectedVersion] = process.argv.slice(2);
+  if (expectedVersion === undefined) {
+    console.error('No expected version specified. Please pass one as argument.');
+    process.exit(1);
   }
-  checkReleaseOutput(join(__dirname, '../../dist/releases'), currentVersion);
+  checkReleaseOutput(join(__dirname, '../../dist/releases'), expectedVersion);
 }

--- a/tools/release/publish-release.ts
+++ b/tools/release/publish-release.ts
@@ -16,7 +16,7 @@ import {parseVersionName, Version} from './version-name/parse-version';
 
 // The package builder script is not written in TypeScript and needs to
 // be imported through a CommonJS import.
-const {defaultBuildReleasePackages} = require('../../scripts/build-packages-dist');
+const {performNpmReleaseBuild} = require('../../scripts/build-packages-dist');
 
 /**
  * Class that can be instantiated in order to create a new release. The tasks requires user
@@ -90,11 +90,11 @@ class PublishReleaseTask extends BaseReleaseTask {
       await this._promptStableVersionForNextTag();
     }
 
-    defaultBuildReleasePackages();
+    performNpmReleaseBuild();
     console.info(chalk.green(`  ✓   Built the release output.`));
 
     // Checks all release packages against release output validations before releasing.
-    checkReleaseOutput(this.releaseOutputPath, this.currentVersion);
+    checkReleaseOutput(this.releaseOutputPath, this.currentVersion.format());
 
     // Extract the release notes for the new version from the changelog file.
     const extractedReleaseNotes = extractReleaseNotes(

--- a/tools/release/release-output/check-package.ts
+++ b/tools/release/release-output/check-package.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import {existsSync} from 'fs';
 import {sync as glob} from 'glob';
 import {join} from 'path';
-import {Version} from '../version-name/parse-version';
 
 import {
   checkCdkPackage,
@@ -35,7 +34,7 @@ type PackageFailures = Map<string, string[]>;
  * @returns Whether the package passed all checks or not.
  */
 export function checkReleasePackage(
-    releasesPath: string, packageName: string, currentVersion: Version): boolean {
+    releasesPath: string, packageName: string, expectedVersion: string): boolean {
   const packagePath = join(releasesPath, packageName);
   const failures = new Map() as PackageFailures;
   const addFailure = (message, filePath?) => {
@@ -82,7 +81,7 @@ export function checkReleasePackage(
     addFailure('No "README.md" file found in package output.');
   }
 
-  checkPrimaryPackageJson(join(packagePath, 'package.json'), currentVersion)
+  checkPrimaryPackageJson(join(packagePath, 'package.json'), expectedVersion)
       .forEach(f => addFailure(f));
 
   // In case there are failures for this package, we want to print those


### PR DESCRIPTION
An interesting case that came up in v10.0.0 with the docs-content. The
snapshot release package and docs-content output had various
`@breaking-change` notes in the source code referring to `v10.0.0` as
certain changes are planned to be made at that point.

The snapshot deploy scripts pick up the version from the package.json
file and replace it in the output packages with a more concrete version
that includes the SHA. This meant that we accidentally also overwrote
versions as in the `@breaking-change` notes (ultimately making it
difficult for us to use the latest docs-content for the v10 release as
it was incorrect).

Example snapshot commit: https://github.com/angular/material2-docs-content/commit/e624c7130d90026574b46d12d488e470f0a18c55

We fix this by not including the SHA as part of the deployment, but
rather including the SHA when building the NPM packages. At that point,
we can safely just replace instances of the `0.0.0-PLACEHOLDER` without
having to worry about accidental version overriding.

To achieve this, we update our release stamping script to have two
modes. i.e. snapshot build mode and release mode. Framework does this
by checking the Git tag history but that seems less ideal as it makes
the release output building reliant on external factors while our
stamping is self-contained within the checked out code revision.