### PR TITLE
test: fix listbox spec failing due to keyboard event helper update

### DIFF
--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -335,7 +335,7 @@ describe('CdkOption', () => {
     it('should focus and toggle the next item when pressing SHIFT + DOWN_ARROW', () => {
       let selectedOptions = optionInstances.filter(option => option.selected);
       const downKeyEvent =
-        createKeyboardEvent('keydown', DOWN_ARROW, undefined, undefined, {shift: true});
+        createKeyboardEvent('keydown', DOWN_ARROW, undefined, {shift: true});
 
       expect(selectedOptions.length).toBe(0);
       expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();


### PR DESCRIPTION
We landed two PRs. One that added a new usage of `createKeyboardEvent`
and another one that changed the signature of `createKeyboardEvent`.

This meant that the first PR adding the new instance does not account
for the new function signature and CI/build is failing.