### PR TITLE
docs(material/table): fix example overflowing docs site width

### DIFF
--- a/src/components-examples/material/table/table-sticky-columns/table-sticky-columns-example.css
+++ b/src/components-examples/material/table/table-sticky-columns/table-sticky-columns-example.css
@@ -1,6 +1,7 @@
 .example-container {
   height: 400px;
   width: 550px;
+  max-width: 100%;
   overflow: auto;
 }
 


### PR DESCRIPTION
Closes https://github.com/angular/material.angular.io/pull/778

# Before
![localhost_4201_table(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/3506071/88116653-16194600-cb87-11ea-8b42-cce935532d3f.png)

# After
![localhost_4201_table(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/3506071/88116657-187ba000-cb87-11ea-9191-b970c82945ba.png)

