### PR TITLE
feat(cdk-experimental/menu): add ability to close menus when clicking outside the menu tree

### DIFF
--- a/src/cdk-experimental/menu/menu-group.ts
+++ b/src/cdk-experimental/menu/menu-group.ts
@@ -29,6 +29,7 @@ import {CdkMenuItem} from './menu-item';
   exportAs: 'cdkMenuGroup',
   host: {
     'role': 'group',
+    'class': 'cdk-menu-group',
   },
   providers: [{provide: UniqueSelectionDispatcher, useClass: UniqueSelectionDispatcher}],
 })

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -45,6 +45,7 @@ function removeIcons(element: Element) {
     'tabindex': '-1',
     'type': 'button',
     'role': 'menuitem',
+    'class': 'cdk-menu-item',
     '[attr.aria-disabled]': 'disabled || null',
   },
 })

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -51,6 +51,7 @@ import {MenuStack, MenuStackItem, FocusNext} from './menu-stack';
   host: {
     '(keydown)': '_handleKeyEvent($event)',
     'role': 'menu',
+    'class': 'cdk-menu',
     '[attr.aria-orientation]': 'orientation',
   },
   providers: [


### PR DESCRIPTION
Add functionality to close any open menus (and submenus) when a user clicks on an element outside
the open menu tree and the menu bar components.