### PR TITLE
build: docs generation script adding extra file extension

### DIFF
--- a/tools/example-module/generate-example-module.ts
+++ b/tools/example-module/generate-example-module.ts
@@ -50,7 +50,7 @@ function inlineExampleModuleTemplate(parsedData: AnalyzedExamples): string {
       files: data.files,
       selector: data.selector,
       additionalComponents: data.additionalComponents,
-      primaryFile: path.basename(data.sourcePath),
+      primaryFile: path.basename(data.sourcePath, path.extname(data.sourcePath)),
       module: {
         name: data.module.name,
         importSpecifier: data.module.packagePath,


### PR DESCRIPTION
The `indexFilename` in the `ExampleData` that we were publishing to npm includes the file extension, but because material.angular.io assumes that it's just the filename, we end up adding the extension twice when we generate a Stackblitz example (see https://github.com/angular/material.angular.io/blob/master/src/app/shared/stack-blitz/stack-blitz-writer.ts#L91). This doesn't seem to break the example, but it gets highlighted as invalid in the editor.

The error seems to be a side-effect of d00cb12582ab1265d38bb0f3012b7bd1adced97f where some things were cleaned up. I've fixed the issue by stripping away the extension like before.

Fixes #20061.