### PR TITLE
fix(select): use combobox pattern for accessibility

### DIFF
--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -1,10 +1,9 @@
 <div cdk-overlay-origin
      class="mat-select-trigger"
-     aria-hidden="true"
      (click)="toggle()"
      #origin="cdkOverlayOrigin"
      #trigger>
-  <div class="mat-select-value" [ngSwitch]="empty">
+  <div class="mat-select-value" [ngSwitch]="empty" [attr.id]="_valueId">
     <span class="mat-select-placeholder" *ngSwitchCase="true">{{placeholder || '\u00A0'}}</span>
     <span class="mat-select-value-text" *ngSwitchCase="false" [ngSwitch]="!!customTrigger">
       <span *ngSwitchDefault>{{triggerValue || '\u00A0'}}</span>
@@ -32,8 +31,13 @@
   <div class="mat-select-panel-wrap" [@transformPanelWrap]>
     <div
       #panel
-      [attr.id]="id + '-panel'"
+      role="listbox"
+      tabindex="-1"
       class="mat-select-panel {{ _getPanelTheme() }}"
+      [attr.id]="id + '-panel'"
+      [attr.aria-multiselectable]="multiple"
+      [attr.aria-label]="ariaLabel || null"
+      [attr.aria-labelledby]="_getPanelAriaLabelledby()"
       [ngClass]="panelClass"
       [@transformPanel]="multiple ? 'showing-multiple' : 'showing'"
       (@transformPanel.done)="_panelDoneAnimatingStream.next($event.toState)"

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -215,7 +215,6 @@ export const MAT_SELECT_TRIGGER = new InjectionToken<MatSelectTrigger>('MatSelec
 })
 export class MatSelectTrigger {}
 
-
 @Component({
   selector: 'mat-select',
   exportAs: 'matSelect',
@@ -225,23 +224,29 @@ export class MatSelectTrigger {}
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    'role': 'listbox',
+    'role': 'combobox',
+    'aria-autocomplete': 'none',
+    // TODO(crisbeto): the value for aria-haspopup should be `listbox`, but currently it's difficult
+    // to sync into g3, because of an outdated automated a11y check which flags it as an invalid
+    // value. At some point we should try to switch it back to being `listbox`. When doing the
+    // MDC-based `mat-select`, we can get away with starting it off as `listbox`.
+    'aria-haspopup': 'true',
+    'class': 'mat-select',
     '[attr.id]': 'id',
     '[attr.tabindex]': 'tabIndex',
-    '[attr.aria-label]': '_getAriaLabel()',
-    '[attr.aria-labelledby]': '_getAriaLabelledby()',
+    '[attr.aria-controls]': 'panelOpen ? id + "-panel" : null',
+    '[attr.aria-expanded]': 'panelOpen',
+    '[attr.aria-label]': 'ariaLabel || null',
     '[attr.aria-required]': 'required.toString()',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-invalid]': 'errorState',
-    '[attr.aria-owns]': 'panelOpen ? _optionIds : null',
-    '[attr.aria-multiselectable]': 'multiple',
     '[attr.aria-describedby]': '_ariaDescribedby || null',
     '[attr.aria-activedescendant]': '_getAriaActiveDescendant()',
     '[class.mat-select-disabled]': 'disabled',
     '[class.mat-select-invalid]': 'errorState',
     '[class.mat-select-required]': 'required',
     '[class.mat-select-empty]': 'empty',
-    'class': 'mat-select',
+    '[class.mat-select-multiple]': 'multiple',
     '(keydown)': '_handleKeydown($event)',
     '(focus)': '_onFocus()',
     '(blur)': '_onBlur()',
@@ -281,6 +286,9 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** Unique id for this input. */
   private _uid = `mat-select-${nextUniqueId++}`;
 
+  /** Current `ariar-labelledby` value for the select trigger. */
+  private _triggerAriaLabelledBy: string | null = null;
+
   /** Emits whenever the component is destroyed. */
   private readonly _destroy = new Subject<void>();
 
@@ -305,8 +313,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** `View -> model callback called when select has been touched` */
   _onTouched = () => {};
 
-  /** The IDs of child options to be passed to the aria-owns attribute. */
-  _optionIds: string = '';
+  _valueId = `mat-select-value-${nextUniqueId++}`;
 
   /** The value of the select panel's transform-origin property. */
   _transformOrigin: string = 'top';
@@ -607,6 +614,21 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   }
 
   ngDoCheck() {
+    const newAriaLabelledby = this._getTriggerAriaLabelledby();
+
+    // We have to manage setting the `aria-labelledby` ourselves, because part of its value
+    // is computed as a result of a content query which can cause this binding to trigger a
+    // "changed after checked" error.
+    if (newAriaLabelledby !== this._triggerAriaLabelledBy) {
+      const element: HTMLElement = this._elementRef.nativeElement;
+      this._triggerAriaLabelledBy = newAriaLabelledby;
+      if (newAriaLabelledby) {
+        element.setAttribute('aria-labelledby', newAriaLabelledby);
+      } else {
+        element.removeAttribute('aria-labelledby');
+      }
+    }
+
     if (this.ngControl) {
       this.updateErrorState();
     }
@@ -992,8 +1014,6 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
         this._changeDetectorRef.markForCheck();
         this.stateChanges.next();
       });
-
-    this._setOptionIds();
   }
 
   /** Invoked when an option is clicked. */
@@ -1065,11 +1085,6 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     this._onChange(valueToEmit);
     this.selectionChange.emit(new MatSelectChange(this, valueToEmit));
     this._changeDetectorRef.markForCheck();
-  }
-
-  /** Records option IDs to pass to the aria-owns property. */
-  private _setOptionIds() {
-    this._optionIds = this.options.map(option => option.id).join(' ');
   }
 
   /**
@@ -1164,27 +1179,14 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     return Math.min(Math.max(0, optimalScrollPosition), maxScroll);
   }
 
-  /** Returns the aria-label of the select component. */
-  _getAriaLabel(): string | null {
-    // If an ariaLabelledby value has been set by the consumer, the select should not overwrite the
-    // `aria-labelledby` value by setting the ariaLabel to the placeholder.
-    return this.ariaLabelledby ? null : this.ariaLabel || this.placeholder;
-  }
-
-  /** Returns the aria-labelledby of the select component. */
-  _getAriaLabelledby(): string | null {
-    if (this.ariaLabelledby) {
-      return this.ariaLabelledby;
-    }
-
-    // Note: we use `_getAriaLabel` here, because we want to check whether there's a
-    // computed label. `this.ariaLabel` is only the user-specified label.
-    if (!this._parentFormField || !this._parentFormField._hasFloatingLabel() ||
-      this._getAriaLabel()) {
+  /** Gets the aria-labelledby for the select panel. */
+  _getPanelAriaLabelledby(): string | null {
+    if (this.ariaLabel) {
       return null;
     }
 
-    return this._parentFormField.getLabelId();
+    const labelId = this._getLabelId();
+    return this.ariaLabelledby ? labelId + ' ' + this.ariaLabelledby : labelId;
   }
 
   /** Determines the `aria-activedescendant` to be set on the host. */
@@ -1194,6 +1196,11 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     }
 
     return null;
+  }
+
+  /** Gets the ID of the element that is labelling the select. */
+  private _getLabelId(): string {
+    return this._parentFormField?.getLabelId() || '';
   }
 
   /**
@@ -1377,6 +1384,21 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** Calculates the height of the select's options. */
   private _getItemHeight(): number {
     return this._triggerFontSize * SELECT_ITEM_HEIGHT_EM;
+  }
+
+  /** Gets the aria-labelledby of the select component trigger. */
+  private _getTriggerAriaLabelledby(): string | null {
+    if (this.ariaLabel) {
+      return null;
+    }
+
+    let value = this._getLabelId() + ' ' + this._valueId;
+
+    if (this.ariaLabelledby) {
+      value += ' ' + this.ariaLabelledby;
+    }
+
+    return value;
   }
 
   /**

--- a/src/material/select/testing/select-harness.ts
+++ b/src/material/select/testing/select-harness.ts
@@ -58,8 +58,7 @@ export class MatSelectHarness extends MatFormFieldControlHarness {
 
   /** Gets a boolean promise indicating if the select is in multi-selection mode. */
   async isMultiple(): Promise<boolean> {
-    const ariaMultiselectable = (await this.host()).getAttribute('aria-multiselectable');
-    return (await ariaMultiselectable) === 'true';
+    return (await this.host()).hasClass('mat-select-multiple');
   }
 
   /** Gets a promise for the select's value text. */

--- a/tools/public_api_guard/material/select.d.ts
+++ b/tools/public_api_guard/material/select.d.ts
@@ -20,7 +20,6 @@ export declare class MatSelect extends _MatSelectMixinBase implements AfterConte
     _onChange: (value: any) => void;
     _onTouched: () => void;
     readonly _openedStream: Observable<void>;
-    _optionIds: string;
     _panelDoneAnimatingStream: Subject<string>;
     _positions: ConnectedPosition[];
     _scrollStrategy: ScrollStrategy;
@@ -28,6 +27,7 @@ export declare class MatSelect extends _MatSelectMixinBase implements AfterConte
     _transformOrigin: string;
     _triggerFontSize: number;
     _triggerRect: ClientRect;
+    _valueId: string;
     ariaLabel: string;
     ariaLabelledby: string;
     get compareWith(): (o1: any, o2: any) => boolean;
@@ -72,8 +72,7 @@ export declare class MatSelect extends _MatSelectMixinBase implements AfterConte
     constructor(_viewportRuler: ViewportRuler, _changeDetectorRef: ChangeDetectorRef, _ngZone: NgZone, _defaultErrorStateMatcher: ErrorStateMatcher, elementRef: ElementRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _parentFormField: MatFormField, ngControl: NgControl, tabIndex: string, scrollStrategyFactory: any, _liveAnnouncer: LiveAnnouncer, defaults?: MatSelectConfig);
     _calculateOverlayScroll(selectedIndex: number, scrollBuffer: number, maxScroll: number): number;
     _getAriaActiveDescendant(): string | null;
-    _getAriaLabel(): string | null;
-    _getAriaLabelledby(): string | null;
+    _getPanelAriaLabelledby(): string | null;
     _getPanelTheme(): string;
     _handleKeydown(event: KeyboardEvent): void;
     _isRtl(): boolean;


### PR DESCRIPTION
Applies some of our recent learnings on how to handle the accessibility of a custom select to `mat-select`. Includes switching the trigger to be a `combobox` and the panel to a `listbox`.

Fixes #11083.