### PR TITLE
fix,perf(column-resize): Coalesce style updates along with sticky styler

### DIFF
--- a/src/cdk-experimental/column-resize/column-resize-directives/column-resize-flex.ts
+++ b/src/cdk-experimental/column-resize/column-resize-directives/column-resize-flex.ts
@@ -7,6 +7,7 @@
  */
 
 import {Directive, ElementRef, NgZone} from '@angular/core';
+import {CdkTable} from '@angular/cdk/table';
 
 import {ColumnResize} from '../column-resize';
 import {ColumnResizeNotifier, ColumnResizeNotifierSource} from '../column-resize-notifier';
@@ -30,7 +31,8 @@ export class CdkColumnResizeFlex extends ColumnResize {
       readonly elementRef: ElementRef<HTMLElement>,
       protected readonly eventDispatcher: HeaderRowEventDispatcher,
       protected readonly ngZone: NgZone,
-      protected readonly notifier: ColumnResizeNotifierSource) {
+      protected readonly notifier: ColumnResizeNotifierSource,
+      protected readonly table: CdkTable<unknown>) {
     super();
   }
 }

--- a/src/cdk-experimental/column-resize/column-resize-directives/column-resize.ts
+++ b/src/cdk-experimental/column-resize/column-resize-directives/column-resize.ts
@@ -7,6 +7,7 @@
  */
 
 import {Directive, ElementRef, NgZone} from '@angular/core';
+import {CdkTable} from '@angular/cdk/table';
 
 import {ColumnResize} from '../column-resize';
 import {ColumnResizeNotifier, ColumnResizeNotifierSource} from '../column-resize-notifier';
@@ -30,7 +31,8 @@ export class CdkColumnResize extends ColumnResize {
       readonly elementRef: ElementRef<HTMLElement>,
       protected readonly eventDispatcher: HeaderRowEventDispatcher,
       protected readonly ngZone: NgZone,
-      protected readonly notifier: ColumnResizeNotifierSource) {
+      protected readonly notifier: ColumnResizeNotifierSource,
+      protected readonly table: CdkTable<unknown>) {
     super();
   }
 }

--- a/src/cdk-experimental/column-resize/column-resize-directives/default-enabled-column-resize-flex.ts
+++ b/src/cdk-experimental/column-resize/column-resize-directives/default-enabled-column-resize-flex.ts
@@ -7,6 +7,7 @@
  */
 
 import {Directive, ElementRef, NgZone} from '@angular/core';
+import {CdkTable} from '@angular/cdk/table';
 
 import {ColumnResize} from '../column-resize';
 import {ColumnResizeNotifier, ColumnResizeNotifierSource} from '../column-resize-notifier';
@@ -30,7 +31,8 @@ export class CdkDefaultEnabledColumnResizeFlex extends ColumnResize {
       readonly elementRef: ElementRef<HTMLElement>,
       protected readonly eventDispatcher: HeaderRowEventDispatcher,
       protected readonly ngZone: NgZone,
-      protected readonly notifier: ColumnResizeNotifierSource) {
+      protected readonly notifier: ColumnResizeNotifierSource,
+      protected readonly table: CdkTable<unknown>) {
     super();
   }
 }

--- a/src/cdk-experimental/column-resize/column-resize-directives/default-enabled-column-resize.ts
+++ b/src/cdk-experimental/column-resize/column-resize-directives/default-enabled-column-resize.ts
@@ -7,6 +7,7 @@
  */
 
 import {Directive, ElementRef, NgZone} from '@angular/core';
+import {CdkTable} from '@angular/cdk/table';
 
 import {ColumnResize} from '../column-resize';
 import {ColumnResizeNotifier, ColumnResizeNotifierSource} from '../column-resize-notifier';
@@ -30,7 +31,8 @@ export class CdkDefaultEnabledColumnResize extends ColumnResize {
       readonly elementRef: ElementRef<HTMLElement>,
       protected readonly eventDispatcher: HeaderRowEventDispatcher,
       protected readonly ngZone: NgZone,
-      protected readonly notifier: ColumnResizeNotifierSource) {
+      protected readonly notifier: ColumnResizeNotifierSource,
+      protected readonly table: CdkTable<unknown>) {
     super();
   }
 }

--- a/src/cdk-experimental/column-resize/column-resize-notifier.ts
+++ b/src/cdk-experimental/column-resize/column-resize-notifier.ts
@@ -29,6 +29,11 @@ export interface ColumnSizeAction extends ColumnSize {
    * for all programatically triggered resizes.
    */
   readonly completeImmediately?: boolean;
+
+  /**
+   * Whether the resize action is being applied to a sticky/stickyEnd column.
+   */
+  readonly isStickyColumn?: boolean;
 }
 
 /**
@@ -57,6 +62,7 @@ export class ColumnResizeNotifier {
 
   /** Instantly resizes the specified column. */
   resize(columnId: string, size: number): void {
-    this._source.triggerResize.next({columnId, size, completeImmediately: true});
+    this._source.triggerResize.next(
+        {columnId, size, completeImmediately: true, isStickyColumn: true});
   }
 }

--- a/src/cdk/table/coalesced-style-scheduler.ts
+++ b/src/cdk/table/coalesced-style-scheduler.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injectable, NgZone, OnDestroy} from '@angular/core';
-import {Subject} from 'rxjs';
+import {from, Subject} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
 
 /**
@@ -62,19 +62,33 @@ export class _CoalescedStyleScheduler implements OnDestroy {
 
     this._currentSchedule = new _Schedule();
 
-    this._ngZone.onStable.pipe(
-        take(1),
+    this._getScheduleObservable().pipe(
         takeUntil(this._destroyed),
     ).subscribe(() => {
-      const schedule = this._currentSchedule!;
-      this._currentSchedule = null;
+      while (this._currentSchedule!.tasks.length || this._currentSchedule!.endTasks.length) {
+        const schedule = this._currentSchedule!;
 
-      for (const task of schedule.tasks) {
-        task();
+        // Capture new tasks scheduled by the current set of tasks.
+        this._currentSchedule = new _Schedule();
+
+        for (const task of schedule.tasks) {
+          task();
+        }
+
+        for (const task of schedule.endTasks) {
+          task();
+        }
       }
-      for (const task of schedule.endTasks) {
-        task();
-      }
+
+      this._currentSchedule = null;
     });
+  }
+
+  private _getScheduleObservable() {
+    // Use onStable when in the context of an ongoing change detection cycle so that we
+    // do not accidentally trigger additional cycles.
+    return this._ngZone.isStable ?
+        from(Promise.resolve(undefined)) :
+        this._ngZone.onStable.pipe(take(1));
   }
 }

--- a/src/components-examples/material-experimental/column-resize/default-enabled-column-resize-flex/default-enabled-column-resize-flex-example.html
+++ b/src/components-examples/material-experimental/column-resize/default-enabled-column-resize-flex/default-enabled-column-resize-flex-example.html
@@ -1,12 +1,12 @@
 <mat-table [dataSource]="dataSource" class="mat-elevation-z8 example-table">
   <!-- Position Column -->
-  <ng-container matColumnDef="position">
+  <ng-container matColumnDef="position" sticky>
     <mat-header-cell *matHeaderCellDef [matResizableMaxWidthPx]="100"> No. </mat-header-cell>
     <mat-cell *matCellDef="let element"> {{element.position}} </mat-cell>
   </ng-container>
 
   <!-- Name Column -->
-  <ng-container matColumnDef="name">
+  <ng-container matColumnDef="name" sticky>
     <mat-header-cell *matHeaderCellDef [matResizableMinWidthPx]="150"> Name </mat-header-cell>
     <mat-cell *matCellDef="let element"> {{element.name}} </mat-cell>
   </ng-container>

--- a/src/components-examples/material-experimental/column-resize/default-enabled-column-resize/default-enabled-column-resize-example.html
+++ b/src/components-examples/material-experimental/column-resize/default-enabled-column-resize/default-enabled-column-resize-example.html
@@ -1,12 +1,12 @@
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8 example-table">
   <!-- Position Column -->
-  <ng-container matColumnDef="position">
+  <ng-container matColumnDef="position" sticky>
     <th mat-header-cell *matHeaderCellDef [matResizableMaxWidthPx]="100"> No. </th>
     <td mat-cell *matCellDef="let element"> {{element.position}} </td>
   </ng-container>
 
   <!-- Name Column -->
-  <ng-container matColumnDef="name">
+  <ng-container matColumnDef="name" sticky>
     <th mat-header-cell *matHeaderCellDef [matResizableMinWidthPx]="150"> Name </th>
     <td mat-cell *matCellDef="let element"> {{element.name}} </td>
   </ng-container>

--- a/src/components-examples/material-experimental/column-resize/opt-in-column-resize/opt-in-column-resize-example.html
+++ b/src/components-examples/material-experimental/column-resize/opt-in-column-resize/opt-in-column-resize-example.html
@@ -1,12 +1,12 @@
 <table mat-table columnResize [dataSource]="dataSource" class="mat-elevation-z8 example-table">
   <!-- Position Column -->
-  <ng-container matColumnDef="position">
+  <ng-container matColumnDef="position" sticky>
     <th mat-header-cell *matHeaderCellDef resizable [matResizableMaxWidthPx]="100"> No. </th>
     <td mat-cell *matCellDef="let element"> {{element.position}} </td>
   </ng-container>
 
   <!-- Name Column -->
-  <ng-container matColumnDef="name">
+  <ng-container matColumnDef="name" sticky>
     <th mat-header-cell *matHeaderCellDef resizable [matResizableMinWidthPx]="150"> Name </th>
     <td mat-cell *matCellDef="let element"> {{element.name}} </td>
   </ng-container>

--- a/src/material-experimental/column-resize/BUILD.bazel
+++ b/src/material-experimental/column-resize/BUILD.bazel
@@ -13,6 +13,7 @@ ng_module(
     deps = [
         "//src/cdk-experimental/column-resize",
         "//src/cdk/overlay",
+        "//src/cdk/table",
         "//src/material/table",
         "@npm//@angular/core",
     ],

--- a/src/material-experimental/column-resize/_column-resize.scss
+++ b/src/material-experimental/column-resize/_column-resize.scss
@@ -93,6 +93,7 @@
           transparent, transparent 7px,
           $resizable-active-divider, $resizable-active-divider 1px,
           transparent 8px, transparent);
+      will-change: transform;
     }
   }
 }

--- a/src/material-experimental/column-resize/overlay-handle.ts
+++ b/src/material-experimental/column-resize/overlay-handle.ts
@@ -15,7 +15,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
-import {CdkColumnDef} from '@angular/cdk/table';
+import {CdkColumnDef, _CoalescedStyleScheduler} from '@angular/cdk/table';
 import {Directionality} from '@angular/cdk/bidi';
 import {
   ColumnResize,
@@ -49,6 +49,7 @@ export class MatColumnResizeOverlayHandle extends ResizeOverlayHandle {
       protected readonly ngZone: NgZone,
       protected readonly resizeNotifier: ColumnResizeNotifierSource,
       protected readonly resizeRef: ResizeRef,
+      protected readonly styleScheduler: _CoalescedStyleScheduler,
       @Inject(DOCUMENT) document: any) {
     super();
     this.document = document;

--- a/src/material-experimental/column-resize/resizable-directives/default-enabled-resizable.ts
+++ b/src/material-experimental/column-resize/resizable-directives/default-enabled-resizable.ts
@@ -18,7 +18,7 @@ import {
 import {DOCUMENT} from '@angular/common';
 import {Directionality} from '@angular/cdk/bidi';
 import {Overlay} from '@angular/cdk/overlay';
-import {CdkColumnDef} from '@angular/cdk/table';
+import {CdkColumnDef, _CoalescedStyleScheduler} from '@angular/cdk/table';
 import {
   ColumnResize,
   ColumnResizeNotifierSource,
@@ -52,6 +52,7 @@ export class MatDefaultResizable extends AbstractMatResizable {
       protected readonly overlay: Overlay,
       protected readonly resizeNotifier: ColumnResizeNotifierSource,
       protected readonly resizeStrategy: ResizeStrategy,
+      protected readonly styleScheduler: _CoalescedStyleScheduler,
       protected readonly viewContainerRef: ViewContainerRef,
       protected readonly changeDetectorRef: ChangeDetectorRef) {
     super();

--- a/src/material-experimental/column-resize/resizable-directives/resizable.ts
+++ b/src/material-experimental/column-resize/resizable-directives/resizable.ts
@@ -18,7 +18,7 @@ import {
 import {DOCUMENT} from '@angular/common';
 import {Directionality} from '@angular/cdk/bidi';
 import {Overlay} from '@angular/cdk/overlay';
-import {CdkColumnDef} from '@angular/cdk/table';
+import {CdkColumnDef, _CoalescedStyleScheduler} from '@angular/cdk/table';
 import {
   ColumnResize,
   ColumnResizeNotifierSource,
@@ -51,6 +51,7 @@ export class MatResizable extends AbstractMatResizable {
       protected readonly overlay: Overlay,
       protected readonly resizeNotifier: ColumnResizeNotifierSource,
       protected readonly resizeStrategy: ResizeStrategy,
+      protected readonly styleScheduler: _CoalescedStyleScheduler,
       protected readonly viewContainerRef: ViewContainerRef,
       protected readonly changeDetectorRef: ChangeDetectorRef) {
     super();

--- a/src/material-experimental/column-resize/resize-strategy.ts
+++ b/src/material-experimental/column-resize/resize-strategy.ts
@@ -8,6 +8,7 @@
 
 import {Inject, Injectable, Provider} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
+import {CdkTable, _CoalescedStyleScheduler} from '@angular/cdk/table';
 
 import {
   ColumnResize,
@@ -25,8 +26,10 @@ export {TABLE_LAYOUT_FIXED_RESIZE_STRATEGY_PROVIDER};
 export class MatFlexTableResizeStrategy extends CdkFlexTableResizeStrategy {
   constructor(
       columnResize: ColumnResize,
+      styleScheduler: _CoalescedStyleScheduler,
+      table: CdkTable<unknown>,
       @Inject(DOCUMENT) document: any) {
-    super(columnResize, document);
+    super(columnResize, styleScheduler, table, document);
   }
 
   protected getColumnCssClass(cssFriendlyColumnName: string): string {


### PR DESCRIPTION
Coalesces style updates triggered by the column resize system to trigger less layout thrashing. Also updates sticky column styles when resizing a column.

The net effect is a substantial improvement when applying min/max sizes at startup and a bit of a wash when actively resizing. The gains in active resize performance are mostly offset by the additional cost of recomputing sticky styles (but it was a bug before that they were not being recomputed). Should be much better for tables without sticky columns though.