### PR TITLE
refactor(material/progress-spinner): remove separate MatSpinner class

### DIFF
--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -104,7 +104,7 @@ const INDETERMINATE_ANIMATION_TEMPLATE = `
  * `<mat-progress-spinner>` component.
  */
 @Component({
-  selector: 'mat-progress-spinner',
+  selector: 'mat-progress-spinner, mat-spinner',
   exportAs: 'matProgressSpinner',
   host: {
     'role': 'progressbar',
@@ -169,7 +169,8 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
   }
 
   /** Mode of the progress circle */
-  @Input() mode: ProgressSpinnerMode = 'determinate';
+  @Input() mode: ProgressSpinnerMode = this._elementRef.nativeElement.nodeName.toLowerCase() ===
+  'mat-spinner' ? 'indeterminate' : 'determinate';
 
   /** Value of the progress circle. */
   @Input()
@@ -307,29 +308,4 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
  * This is a component definition to be used as a convenience reference to create an
  * indeterminate `<mat-progress-spinner>` instance.
  */
-@Component({
-  selector: 'mat-spinner',
-  host: {
-    'role': 'progressbar',
-    'mode': 'indeterminate',
-    'class': 'mat-spinner mat-progress-spinner',
-    '[class._mat-animation-noopable]': `_noopAnimations`,
-    '[style.width.px]': 'diameter',
-    '[style.height.px]': 'diameter',
-  },
-  inputs: ['color'],
-  templateUrl: 'progress-spinner.html',
-  styleUrls: ['progress-spinner.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
-})
-export class MatSpinner extends MatProgressSpinner {
-  constructor(elementRef: ElementRef<HTMLElement>, platform: Platform,
-              @Optional() @Inject(DOCUMENT) document: any,
-              @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string,
-              @Inject(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS)
-                  defaults?: MatProgressSpinnerDefaultOptions) {
-    super(elementRef, platform, document, animationMode, defaults);
-    this.mode = 'indeterminate';
-  }
-}
+export {MatProgressSpinner as MatSpinner}


### PR DESCRIPTION
Having a separate MatSpinner class generates more code than necessary. 
We can omit the class by adding `mat-spinner` to the MatProgressSpinner selector and modifying the `mode` initialization.