### PR TITLE
fix(cdk/testing): emit pointer events on hover and mouseAway

### DIFF
--- a/src/cdk/testing/testbed/unit-test-element.ts
+++ b/src/cdk/testing/testbed/unit-test-element.ts
@@ -81,19 +81,9 @@ export class UnitTestElement implements TestElement {
     const clientX = Math.round(left + relativeX);
     const clientY = Math.round(top + relativeY);
 
-    // The latest versions of all browsers we support have the new `PointerEvent` API.
-    // Though since we capture the two most recent versions of these browsers, we also
-    // need to support Safari 12 at time of writing. Safari 12 does not have support for this,
-    // so we need to conditionally create and dispatch these events based on feature detection.
-    const emitPointerEvents = window.PointerEvent !== undefined;
-
-    if (emitPointerEvents) {
-      dispatchPointerEvent(this.element, 'pointerdown', clientX, clientY);
-    }
+    this._dispatchPointerEventIfSupported('pointerdown', clientX, clientY);
     dispatchMouseEvent(this.element, 'mousedown', clientX, clientY);
-    if (emitPointerEvents) {
-      dispatchMouseEvent(this.element, 'pointerup', clientX, clientY);
-    }
+    this._dispatchPointerEventIfSupported('pointerup', clientX, clientY);
     dispatchMouseEvent(this.element, 'mouseup', clientX, clientY);
     dispatchMouseEvent(this.element, 'click', clientX, clientY);
 
@@ -115,12 +105,14 @@ export class UnitTestElement implements TestElement {
 
   async hover(): Promise<void> {
     await this._stabilize();
+    this._dispatchPointerEventIfSupported('pointerenter');
     dispatchMouseEvent(this.element, 'mouseenter');
     await this._stabilize();
   }
 
   async mouseAway(): Promise<void> {
     await this._stabilize();
+    this._dispatchPointerEventIfSupported('pointerleave');
     dispatchMouseEvent(this.element, 'mouseleave');
     await this._stabilize();
   }
@@ -174,5 +166,21 @@ export class UnitTestElement implements TestElement {
   async isFocused(): Promise<boolean> {
     await this._stabilize();
     return document.activeElement === this.element;
+  }
+
+  /**
+   * Dispatches a pointer event on the current element if the browser supports it.
+   * @param name Name of the pointer event to be dispatched.
+   * @param clientX Coordinate of the user's pointer along the X axis.
+   * @param clientY Coordinate of the user's pointer along the Y axis.
+   */
+  private _dispatchPointerEventIfSupported(name: string, clientX?: number, clientY?: number) {
+    // The latest versions of all browsers we support have the new `PointerEvent` API.
+    // Though since we capture the two most recent versions of these browsers, we also
+    // need to support Safari 12 at time of writing. Safari 12 does not have support for this,
+    // so we need to conditionally create and dispatch these events based on feature detection.
+    if (typeof PointerEvent !== 'undefined' && PointerEvent) {
+      dispatchPointerEvent(this.element, name, clientX, clientY);
+    }
   }
 }


### PR DESCRIPTION
In 9cd18911d40084b6a01a9c93ec45370f03e3ad76 pointer event simulation was added to `UnitTestElement.click` to closer simulate the events that happen inside the browser. These changes expand the coverage to the `hover` and `mouseAway` methods since they can dispatch pointer events too.