### PR TITLE
feat(cdk-experimental/menu): add the ability to open/close menus on mouse click and hover

### DIFF
--- a/src/cdk-experimental/menu/BUILD.bazel
+++ b/src/cdk-experimental/menu/BUILD.bazel
@@ -33,6 +33,7 @@ ng_test_library(
         "//src/cdk/keycodes",
         "//src/cdk/testing/private",
         "@npm//@angular/platform-browser",
+        "@npm//rxjs",
     ],
 )
 

--- a/src/cdk-experimental/menu/item-pointer-entries.spec.ts
+++ b/src/cdk-experimental/menu/item-pointer-entries.spec.ts
@@ -1,0 +1,103 @@
+import {Component, QueryList, ElementRef, ViewChildren, AfterViewInit} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {createMouseEvent, dispatchEvent} from '@angular/cdk/testing/private';
+import {Observable} from 'rxjs';
+import {FocusableElement, getItemPointerEntries} from './item-pointer-entries';
+
+describe('FocusMouseManger', () => {
+  let fixture: ComponentFixture<MultiElementWithConditionalComponent>;
+  let mouseFocusChanged: Observable<MockWrapper>;
+  let mockElements: MockWrapper[];
+
+  /** Get the components under test from the fixture. */
+  function getComponentsForTesting() {
+    mouseFocusChanged = fixture.componentInstance.mouseFocusChanged;
+    mockElements = fixture.componentInstance._allItems.toArray();
+  }
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [MultiElementWithConditionalComponent, MockWrapper],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MultiElementWithConditionalComponent);
+    fixture.detectChanges();
+
+    getComponentsForTesting();
+  });
+
+  it('should emit on mouseEnter observable when mouse enters a tracked element', () => {
+    const spy = jasmine.createSpy('mouse enter spy');
+    mouseFocusChanged.subscribe(spy);
+
+    const event = createMouseEvent('mouseenter');
+    dispatchEvent(mockElements[0]._elementRef.nativeElement, event);
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(mockElements[0]);
+  });
+
+  it('should be aware of newly created/added components and track them', () => {
+    const spy = jasmine.createSpy('mouse enter spy');
+    mouseFocusChanged.subscribe(spy);
+
+    expect(mockElements.length).toBe(2);
+    fixture.componentInstance.showThird = true;
+    fixture.detectChanges();
+    getComponentsForTesting();
+
+    const mouseEnter = createMouseEvent('mouseenter');
+    dispatchEvent(mockElements[2]._elementRef.nativeElement, mouseEnter);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(mockElements[2]);
+  });
+
+  it('should toggle focused items when hovering from one to another', () => {
+    const spy = jasmine.createSpy('focus toggle spy');
+    mouseFocusChanged.subscribe(spy);
+
+    const mouseEnter = createMouseEvent('mouseenter');
+    dispatchEvent(mockElements[0]._elementRef.nativeElement, mouseEnter);
+    dispatchEvent(mockElements[1]._elementRef.nativeElement, mouseEnter);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.calls.argsFor(0)[0]).toEqual(mockElements[0]);
+    expect(spy.calls.argsFor(1)[0]).toEqual(mockElements[1]);
+  });
+});
+
+@Component({
+  selector: 'wrapper',
+  template: `<ng-content></ng-content>`,
+})
+class MockWrapper implements FocusableElement {
+  constructor(readonly _elementRef: ElementRef<HTMLElement>) {}
+}
+
+@Component({
+  template: `
+    <div>
+      <wrapper>First</wrapper>
+      <wrapper>Second</wrapper>
+      <wrapper *ngIf="showThird">Third</wrapper>
+    </div>
+  `,
+})
+class MultiElementWithConditionalComponent implements AfterViewInit {
+  /** Whether the third element should be displayed. */
+  showThird = false;
+
+  /** All mock elements. */
+  @ViewChildren(MockWrapper) readonly _allItems: QueryList<MockWrapper>;
+
+  /** Manages elements under mouse focus. */
+  mouseFocusChanged: Observable<MockWrapper>;
+
+  ngAfterViewInit() {
+    this.mouseFocusChanged = getItemPointerEntries(this._allItems);
+  }
+}

--- a/src/cdk-experimental/menu/item-pointer-entries.ts
+++ b/src/cdk-experimental/menu/item-pointer-entries.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {QueryList, ElementRef} from '@angular/core';
+import {fromEvent, Observable, defer} from 'rxjs';
+import {mapTo, mergeAll, takeUntil, startWith, mergeMap} from 'rxjs/operators';
+
+/** Item to track for mouse focus events. */
+export interface FocusableElement {
+  /** A reference to the element to be tracked. */
+  _elementRef: ElementRef<HTMLElement>;
+}
+
+/**
+ * Gets a stream of pointer (mouse) entries into the given items.
+ * This should typically run outside the Angular zone.
+ */
+export function getItemPointerEntries<T extends FocusableElement>(
+  items: QueryList<T>
+): Observable<T> {
+  return defer(() =>
+    items.changes.pipe(
+      startWith(items),
+      mergeMap((list: QueryList<T>) =>
+        list.map(element =>
+          fromEvent(element._elementRef.nativeElement, 'mouseenter').pipe(
+            mapTo(element),
+            takeUntil(items.changes)
+          )
+        )
+      ),
+      mergeAll()
+    )
+  );
+}

--- a/src/cdk-experimental/menu/menu-item-radio.ts
+++ b/src/cdk-experimental/menu/menu-item-radio.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
-import {Directive, OnDestroy, ElementRef, Self, Optional, Inject} from '@angular/core';
+import {Directive, OnDestroy, ElementRef, Self, Optional, Inject, NgZone} from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {CdkMenuItemSelectable} from './menu-item-selectable';
 import {CdkMenuItem} from './menu-item';
@@ -40,6 +40,7 @@ export class CdkMenuItemRadio extends CdkMenuItemSelectable implements OnDestroy
   constructor(
     private readonly _selectionDispatcher: UniqueSelectionDispatcher,
     element: ElementRef<HTMLElement>,
+    ngZone: NgZone,
     @Inject(CDK_MENU) parentMenu: Menu,
     @Optional() dir?: Directionality,
     /** Reference to the CdkMenuItemTrigger directive if one is added to the same element */
@@ -47,7 +48,7 @@ export class CdkMenuItemRadio extends CdkMenuItemSelectable implements OnDestroy
     // tslint:disable-next-line: lightweight-tokens
     @Self() @Optional() menuTrigger?: CdkMenuItemTrigger
   ) {
-    super(element, parentMenu, dir, menuTrigger);
+    super(element, parentMenu, ngZone, dir, menuTrigger);
 
     this._registerDispatcherListener();
   }
@@ -69,6 +70,7 @@ export class CdkMenuItemRadio extends CdkMenuItemSelectable implements OnDestroy
   }
 
   ngOnDestroy() {
+    super.ngOnDestroy();
     this._removeDispatcherListener();
   }
 }

--- a/src/cdk-experimental/menu/menu-item-trigger.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.ts
@@ -45,6 +45,8 @@ import {FocusNext} from './menu-stack';
   exportAs: 'cdkMenuTriggerFor',
   host: {
     '(keydown)': '_toggleOnKeydown($event)',
+    '(mouseenter)': '_toggleOnMouseEnter()',
+    '(click)': 'toggle()',
     'tabindex': '-1',
     'aria-haspopup': 'menu',
     '[attr.aria-expanded]': 'isMenuOpen()',
@@ -130,6 +132,27 @@ export class CdkMenuItemTrigger implements OnDestroy {
    */
   getMenu(): Menu | undefined {
     return this.menuPanel?._menu;
+  }
+
+  /**
+   * If there are existing open menus and this menu is not open, close sibling menus and open
+   * this one.
+   */
+  _toggleOnMouseEnter() {
+    const menuStack = this._getMenuStack();
+    if (!menuStack.isEmpty() && !this.isMenuOpen()) {
+      // If nothing was removed from the stack and the last element is not the parent item
+      // that means that the parent menu is a menu bar since we don't put the menu bar on the
+      // stack
+      const isParentMenuBar =
+        !menuStack.closeSubMenuOf(this._parentMenu) && menuStack.peek() !== this._parentMenu;
+
+      if (isParentMenuBar) {
+        menuStack.closeAll();
+      }
+
+      this.openMenu();
+    }
   }
 
   /**

--- a/src/cdk-experimental/menu/menu-stack.ts
+++ b/src/cdk-experimental/menu/menu-stack.ts
@@ -40,14 +40,14 @@ export class MenuStack {
   private readonly _empty: Subject<FocusNext> = new Subject();
 
   /** Observable which emits the MenuStackItem which has been requested to close. */
-  readonly closed: Observable<MenuStackItem> = this._close.asObservable();
+  readonly closed: Observable<MenuStackItem> = this._close;
 
   /**
    * Observable which emits when the MenuStack is empty after popping off the last element. It
    * emits a FocusNext event which specifies the action the closer has requested the listener
    * perform.
    */
-  readonly emptied: Observable<FocusNext> = this._empty.asObservable();
+  readonly emptied: Observable<FocusNext> = this._empty;
 
   /** @param menu the MenuStackItem to put on the stack. */
   push(menu: MenuStackItem) {
@@ -80,13 +80,17 @@ export class MenuStack {
    * Pop items off of the stack up to but excluding `lastItem` and emit each on the close
    * observable. If the stack is empty or `lastItem` is not on the stack it does nothing.
    * @param lastItem the element which should be left on the stack
+   * @return whether or not an item was removed from the stack
    */
   closeSubMenuOf(lastItem: MenuStackItem) {
+    let removed = false;
     if (this._elements.indexOf(lastItem) >= 0) {
+      removed = this.peek() !== lastItem;
       while (this.peek() !== lastItem) {
         this._close.next(this._elements.pop());
       }
     }
+    return removed;
   }
 
   /**


### PR DESCRIPTION
Add the ability to open/close a menu when a user clicks a menu trigger and when a user hovers over
menu items. Additionally, keep track of hovered menu items and sync them with the FocusKeyManager
allowing a user to continue with a keyboard where they left off with their mouse.