### PR TITLE
chore: update caretaker resyncing script to include new fields

### DIFF
--- a/scripts/caretaking/resync-caretaker-app-prs.ts
+++ b/scripts/caretaking/resync-caretaker-app-prs.ts
@@ -33,7 +33,9 @@ async function resync() {
           'state': pull.state,
           'commit_sha': pull.head.sha,
           'author': pull.user,
-          'labels': pull.labels
+          'labels': pull.labels,
+          'created_at': pull.created_at,
+          'updated_at': pull.updated_at,
         })
       });
     syncedCount++;


### PR DESCRIPTION
New fields have been added to the synced information from each PR
in the caretaker application.  This change updates the resync script
to also include these new fields.