### PR TITLE
build: fix lint failure in MDC option

### DIFF
--- a/src/material-experimental/mdc-core/option/option.ts
+++ b/src/material-experimental/mdc-core/option/option.ts
@@ -19,6 +19,7 @@ import {
   _MatOptionBase,
   MAT_OPTION_PARENT_COMPONENT,
   MatOptionParentComponent,
+  MAT_OPTGROUP,
 } from '@angular/material/core';
 import {MatOptgroup} from './optgroup';
 
@@ -52,7 +53,7 @@ export class MatOption extends _MatOptionBase {
     element: ElementRef<HTMLElement>,
     changeDetectorRef: ChangeDetectorRef,
     @Optional() @Inject(MAT_OPTION_PARENT_COMPONENT) parent: MatOptionParentComponent,
-    @Optional() group: MatOptgroup) {
+    @Optional() @Inject(MAT_OPTGROUP) group: MatOptgroup) {
     super(element, changeDetectorRef, parent, group);
   }
 }


### PR DESCRIPTION
The lint rule for lightweight tokens was introduced in parallel to the MDC option which lead to a failure in master. These changes resolve the failure.