### PR TITLE
refactor(cdk-experimental/menu): export Menu interface injection token and MenuStack

### DIFF
--- a/src/cdk-experimental/menu/public-api.ts
+++ b/src/cdk-experimental/menu/public-api.ts
@@ -15,3 +15,6 @@ export * from './menu-item-radio';
 export * from './menu-item-trigger';
 export * from './menu-panel';
 export * from './menu-group';
+
+export * from './menu-stack';
+export {CDK_MENU} from './menu-interface';


### PR DESCRIPTION
Any third-party wanting to extend CdkMenu or CdkMenuBar will need to update the providers array
with the concrete component to inject for the Menu interface as well as act as a provider for the
MenuStack therefore requiring access to the injection token and MenuStack instance.