### PR TITLE
test(mdc-slide-toggle): add performance tests for mdc-slide-toggle

### DIFF
--- a/test/benchmarks/mdc/slide-toggle/BUILD.bazel
+++ b/test/benchmarks/mdc/slide-toggle/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@npm_angular_dev_infra_private//benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+
+# TODO(wagnermaciel): Update this target to provide indigo-pink in a way that doesn't require having to import it with
+# stylesUrls inside the components once `component_benchmark` supports asset injection.
+
+component_benchmark(
+    name = "benchmark",
+    driver = ":slide-toggle.perf-spec.ts",
+    driver_deps = [
+        "@npm//@angular/dev-infra-private",
+        "@npm//protractor",
+        "@npm//@types/jasmine",
+    ],
+    ng_deps = [
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "//src/material-experimental/mdc-slide-toggle",
+    ],
+    ng_srcs = [":app.module.ts"],
+    prefix = "",
+    styles = ["//src/material-experimental/mdc-theming:indigo_pink_prebuilt"],
+)

--- a/test/benchmarks/mdc/slide-toggle/app.module.ts
+++ b/test/benchmarks/mdc/slide-toggle/app.module.ts
@@ -38,7 +38,6 @@ export class SlideToggleBenchmarkApp {
     BrowserModule,
     MatSlideToggleModule,
   ],
-  providers: [],
   bootstrap: [SlideToggleBenchmarkApp]
 })
 export class AppModule {}

--- a/test/benchmarks/mdc/slide-toggle/app.module.ts
+++ b/test/benchmarks/mdc/slide-toggle/app.module.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, NgModule, ViewEncapsulation} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {MatSlideToggleModule} from '@angular/material-experimental/mdc-slide-toggle';
+
+/** component: mdc-slide-toggle */
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <button id="show" (click)="show()">Show</button>
+    <button id="hide" (click)="hide()">Hide</button>
+
+    <ng-container *ngIf="isVisible">
+      <mat-slide-toggle>Slide me!</mat-slide-toggle>
+    </ng-container>
+  `,
+  encapsulation: ViewEncapsulation.None,
+  styleUrls: ['//src/material-experimental/mdc-theming/prebuilt/indigo-pink.css'],
+})
+export class SlideToggleBenchmarkApp {
+  isVisible = false;
+  show() { this.isVisible = true; }
+  hide() { this.isVisible = false; }
+}
+
+
+@NgModule({
+  declarations: [SlideToggleBenchmarkApp],
+  imports: [
+    BrowserModule,
+    MatSlideToggleModule,
+  ],
+  providers: [],
+  bootstrap: [SlideToggleBenchmarkApp]
+})
+export class AppModule {}

--- a/test/benchmarks/mdc/slide-toggle/slide-toggle.perf-spec.ts
+++ b/test/benchmarks/mdc/slide-toggle/slide-toggle.perf-spec.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {$, browser} from 'protractor';
+import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilities';
+
+describe('slide toggle performance benchmarks', () => {
+  beforeAll(() => {
+    browser.rootEl = '#root';
+  });
+
+  it('renders a slide toggle', async() => {
+    await runBenchmark({
+      id: 'slide-toggle-render',
+      url: '',
+      ignoreBrowserSynchronization: true,
+      params: [],
+      prepare: async () => await $('#hide').click(),
+      work: async () => await $('#show').click(),
+    });
+  });
+
+  it('clicks a slide toggle', async() => {
+    await runBenchmark({
+      id: 'slide-toggle-click',
+      url: '',
+      ignoreBrowserSynchronization: true,
+      params: [],
+      setup: async () => await $('#show').click(),
+      work: async () => await $('.mat-mdc-slide-toggle label').click(),
+    });
+  });
+});


### PR DESCRIPTION
### Context

This branch is checked out of https://github.com/angular/components/pull/20032 because it needs the changes to material-experimental's indigo-pink theme.