### PR TITLE
fix(input/testing): filtering by regex not working

### DIFF
--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -25,11 +25,11 @@ export class MatInputHarness extends MatFormFieldControlHarness {
    */
   static with(options: InputHarnessFilters = {}): HarnessPredicate<MatInputHarness> {
     return new HarnessPredicate(MatInputHarness, options)
-        .addOption('value', options.value, async (harness, value) => {
-          return (await harness.getValue()) === value;
+        .addOption('value', options.value, (harness, value) => {
+          return HarnessPredicate.stringMatches(harness.getValue(), value);
         })
-        .addOption('placeholder', options.placeholder, async (harness, placeholder) => {
-          return (await harness.getPlaceholder()) === placeholder;
+        .addOption('placeholder', options.placeholder, (harness, placeholder) => {
+          return HarnessPredicate.stringMatches(harness.getPlaceholder(), placeholder);
         });
   }
 

--- a/src/material/input/testing/shared.spec.ts
+++ b/src/material/input/testing/shared.spec.ts
@@ -43,9 +43,26 @@ export function runHarnessTests(
     expect(inputs.length).toBe(1);
   });
 
-  it('should load input with specific value', async () => {
+  it('should load input with a specific value', async () => {
     const inputs = await loader.getAllHarnesses(inputHarness.with({value: 'Sushi'}));
     expect(inputs.length).toBe(1);
+  });
+
+  it('should load input with a value that matches a regex', async () => {
+    const inputs = await loader.getAllHarnesses(inputHarness.with({value: /shi$/}));
+    expect(inputs.length).toBe(1);
+    expect(await inputs[0].getValue()).toBe('Sushi');
+  });
+
+  it('should load input with a specific placeholder', async () => {
+    const inputs = await loader.getAllHarnesses(inputHarness.with({placeholder: 'Favorite food'}));
+    expect(inputs.length).toBe(1);
+  });
+
+  it('should load input with a placeholder that matches a regex', async () => {
+    const inputs = await loader.getAllHarnesses(inputHarness.with({placeholder: / food$/}));
+    expect(inputs.length).toBe(1);
+    expect(await inputs[0].getPlaceholder()).toBe('Favorite food');
   });
 
   it('should be able to get id of input', async () => {


### PR DESCRIPTION
The types of the `value` and `placeholder` filters allow both a string and a regex, but passing in a regex doesn't actually work because we were comparing the values directly instead of going through `stringMatches`.