### PR TITLE
refactor(cdk-experimental/menu): remove selector restriction on trigger forcing a menu item

### DIFF
--- a/src/cdk-experimental/menu/menu-item-trigger.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.ts
@@ -41,7 +41,7 @@ import {FocusNext} from './menu-stack';
  * functionality.
  */
 @Directive({
-  selector: '[cdkMenuItem][cdkMenuTriggerFor]',
+  selector: '[cdkMenuTriggerFor]',
   exportAs: 'cdkMenuTriggerFor',
   host: {
     '(keydown)': '_toggleOnKeydown($event)',


### PR DESCRIPTION
Remove the restriction on the CdkMenuItemTriggers selector forcing it to be placed alongside a
CdkMenuItem. This allows for more customization when the Cdk directives are extended.