### PR TITLE
test: clean up remaining dynamic query usages

### DIFF
--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -345,8 +345,8 @@ class FocusTrapWithoutFocusableElements {
   `,
 })
 class FocusTrapInsidePortal {
-  @ViewChild('template', {static: false}) template: TemplateRef<any>;
-  @ViewChild(CdkPortalOutlet, {static: false}) portalOutlet: CdkPortalOutlet;
+  @ViewChild('template') template: TemplateRef<any>;
+  @ViewChild(CdkPortalOutlet) portalOutlet: CdkPortalOutlet;
 
   constructor(public viewContainerRef: ViewContainerRef) {}
 }

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -5449,9 +5449,9 @@ class StandaloneDraggableWithHandle {
   `
 })
 class StandaloneDraggableWithPreDisabledHandle {
-  @ViewChild('dragElement', {static: false}) dragElement: ElementRef<HTMLElement>;
-  @ViewChild('handleElement', {static: false}) handleElement: ElementRef<HTMLElement>;
-  @ViewChild(CdkDrag, {static: false}) dragInstance: CdkDrag;
+  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
+  @ViewChild('handleElement') handleElement: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag) dragInstance: CdkDrag;
   disableHandle = true;
 }
 

--- a/src/cdk/portal/portal.md
+++ b/src/cdk/portal/portal.md
@@ -88,7 +88,7 @@ Usage:
 ```
 
 ```ts
-@ViewChild('domPortalContent', {static: false}) domPortalContent: ElementRef<HTMLElement>;
+@ViewChild('domPortalContent') domPortalContent: ElementRef<HTMLElement>;
 ngAfterViewInit() {
   this.domPortal = new DomPortal(this.domPortalContent);
 }

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -678,8 +678,8 @@ class SaveParentNodeOnInit implements AfterViewInit {
   `
 })
 class ArbitraryViewContainerRefComponent {
-  @ViewChild('template', {static: false}) template: TemplateRef<any>;
-  @ViewChild(SaveParentNodeOnInit, {static: false}) saveParentNodeOnInit: SaveParentNodeOnInit;
+  @ViewChild('template') template: TemplateRef<any>;
+  @ViewChild(SaveParentNodeOnInit) saveParentNodeOnInit: SaveParentNodeOnInit;
 
   constructor(public viewContainerRef: ViewContainerRef, public injector: Injector) { }
 }

--- a/src/dev-app/portal/portal-demo.ts
+++ b/src/dev-app/portal/portal-demo.ts
@@ -17,7 +17,7 @@ import {Component, QueryList, ViewChildren, ElementRef, ViewChild} from '@angula
 })
 export class PortalDemo {
   @ViewChildren(CdkPortal) templatePortals: QueryList<Portal<any>>;
-  @ViewChild('domPortalSource', {static: false}) domPortalSource: ElementRef<HTMLElement>;
+  @ViewChild('domPortalSource') domPortalSource: ElementRef<HTMLElement>;
 
   selectedPortal: Portal<any>;
 

--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -66,7 +66,7 @@ import {MapInfoWindow, MapMarker} from '@angular/google-maps';
   templateUrl: 'google-map-demo.html',
 })
 export class GoogleMapDemo {
-  @ViewChild(MapInfoWindow, {static: false}) infoWindow: MapInfoWindow;
+  @ViewChild(MapInfoWindow) infoWindow: MapInfoWindow;
 
   center = {lat: 24, lng: 12};
   markerOptions = {draggable: false};

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -157,7 +157,7 @@ const MOUSE_START_OFFSET = 1000;
 
 @Directive()
 abstract class BaseTestComponent {
-  @ViewChild('table', {static: false}) table: ElementRef;
+  @ViewChild('table') table: ElementRef;
 
   abstract columnResize: AbstractMatColumnResize;
 

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -2582,8 +2582,8 @@ class SimpleMenuWithRepeater {
   `
 })
 class SimpleMenuWithRepeaterInLazyContent {
-  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
-  @ViewChild(MatMenu, {static: false}) menu: MatMenu;
+  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
+  @ViewChild(MatMenu) menu: MatMenu;
   items = [{label: 'Pizza', disabled: false}, {label: 'Pasta', disabled: false}];
 }
 

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -337,8 +337,8 @@ class SetOfItems {
   </mat-accordion>`})
 class NestedAccordions {
   @ViewChildren(MatExpansionPanelHeader) headers: QueryList<MatExpansionPanelHeader>;
-  @ViewChild('secondOuterHeader', {static: false}) secondOuterHeader: MatExpansionPanelHeader;
-  @ViewChild('firstInnerHeader', {static: false}) firstInnerHeader: MatExpansionPanelHeader;
+  @ViewChild('secondOuterHeader') secondOuterHeader: MatExpansionPanelHeader;
+  @ViewChild('firstInnerHeader') firstInnerHeader: MatExpansionPanelHeader;
 }
 
 @Component({template: `

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -2602,8 +2602,8 @@ class SimpleMenuWithRepeater {
   `
 })
 class SimpleMenuWithRepeaterInLazyContent {
-  @ViewChild(MatMenuTrigger, {static: false}) trigger: MatMenuTrigger;
-  @ViewChild(MatMenu, {static: false}) menu: MatMenu;
+  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
+  @ViewChild(MatMenu) menu: MatMenu;
   items = [{label: 'Pizza', disabled: false}, {label: 'Pasta', disabled: false}];
 }
 


### PR DESCRIPTION
For a while we had linting to explicitly specify the `static` flag on queries and we eventually removed it in ece800463a6fdb02cc622e964eccd41599c9b5a0, but there are still some PRs going in that were written while the restriction was in place. These changes clean up the remaining instances.