### PR TITLE
refactor: replace asObservable usages

### DIFF
--- a/src/cdk-experimental/column-resize/column-resize-notifier.ts
+++ b/src/cdk-experimental/column-resize/column-resize-notifier.ts
@@ -51,7 +51,7 @@ export class ColumnResizeNotifierSource {
 @Injectable()
 export class ColumnResizeNotifier {
   /** Emits whenever a column is resized. */
-  readonly resizeCompleted: Observable<ColumnSize> = this._source.resizeCompleted.asObservable();
+  readonly resizeCompleted: Observable<ColumnSize> = this._source.resizeCompleted;
 
   constructor(private readonly _source: ColumnResizeNotifierSource) {}
 

--- a/src/cdk-experimental/dialog/dialog-ref.ts
+++ b/src/cdk-experimental/dialog/dialog-ref.ts
@@ -133,12 +133,12 @@ export class DialogRef<T, R = any> {
 
   /** Gets an observable that emits when dialog begins opening. */
   beforeOpened(): Observable<void> {
-    return this._containerInstance._beforeEnter.asObservable();
+    return this._containerInstance._beforeEnter;
   }
 
   /** Gets an observable that emits when dialog is finished opening. */
   afterOpened(): Observable<void> {
-    return this._containerInstance._afterEnter.asObservable();
+    return this._containerInstance._afterEnter;
   }
 
   /** Gets an observable that emits when dialog begins closing. */

--- a/src/cdk-experimental/popover-edit/edit-ref.ts
+++ b/src/cdk-experimental/popover-edit/edit-ref.ts
@@ -21,11 +21,11 @@ import {EditEventDispatcher} from './edit-event-dispatcher';
 export class EditRef<FormValue> implements OnDestroy {
   /** Emits the final value of this edit instance before closing. */
   private readonly _finalValueSubject = new Subject<FormValue>();
-  readonly finalValue: Observable<FormValue> = this._finalValueSubject.asObservable();
+  readonly finalValue: Observable<FormValue> = this._finalValueSubject;
 
   /** Emits when the user tabs out of this edit lens before closing. */
   private readonly _blurredSubject = new Subject<void>();
-  readonly blurred: Observable<void> = this._blurredSubject.asObservable();
+  readonly blurred: Observable<void> = this._blurredSubject;
 
   /** The value to set the form back to on revert. */
   private _revertFormValue: FormValue;

--- a/src/cdk-experimental/popover-edit/focus-escape-notifier.ts
+++ b/src/cdk-experimental/popover-edit/focus-escape-notifier.ts
@@ -46,7 +46,7 @@ export class FocusEscapeNotifier extends FocusTrap {
   }
 
   escapes(): Observable<FocusEscapeNotifierDirection> {
-    return this._escapeSubject.asObservable();
+    return this._escapeSubject;
   }
 }
 

--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -253,7 +253,7 @@ class ElementDataSource extends DataSource<PeriodicElement> {
 
   /** Connect function called by the table to retrieve one stream containing the data to render. */
   connect() {
-    return this.data.asObservable();
+    return this.data;
   }
 
   disconnect() {}

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -247,7 +247,7 @@ export class FocusMonitor implements OnDestroy {
         cachedInfo.checkChildren = true;
       }
 
-      return cachedInfo.subject.asObservable();
+      return cachedInfo.subject;
     }
 
     // Create monitored element info.
@@ -259,7 +259,7 @@ export class FocusMonitor implements OnDestroy {
     this._elementInfo.set(nativeElement, info);
     this._registerGlobalListeners(info);
 
-    return info.subject.asObservable();
+    return info.subject;
   }
 
   /**

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -341,7 +341,7 @@ export class FocusTrap {
     if (this._ngZone.isStable) {
       fn();
     } else {
-      this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(fn);
+      this._ngZone.onStable.pipe(take(1)).subscribe(fn);
     }
   }
 }

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -2407,7 +2407,7 @@ describe('CdkDrag', () => {
       const itemInstance = fixture.componentInstance.dragItems.toArray()[1];
       const item = itemInstance.element.nativeElement;
       const spy = jasmine.createSpy('dropped spy');
-      const subscription = itemInstance.dropped.asObservable().subscribe(spy);
+      const subscription = itemInstance.dropped.subscribe(spy);
 
       // Do an initial drag and drop sequence.
       dragElementViaMouse(fixture, item, 50, 50);

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -251,7 +251,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     // element to be in the proper place in the DOM. This is mostly relevant
     // for draggable elements inside portals since they get stamped out in
     // their original DOM position and then they get transferred to the portal.
-    this._ngZone.onStable.asObservable()
+    this._ngZone.onStable
       .pipe(take(1), takeUntil(this._destroyed))
       .subscribe(() => {
         this._updateRootElement();

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -292,7 +292,7 @@ export class DragRef<T = any> {
     event: MouseEvent | TouchEvent;
     distance: Point;
     delta: {x: -1 | 0 | 1, y: -1 | 0 | 1};
-  }> = this._moveEvents.asObservable();
+  }> = this._moveEvents;
 
   /** Arbitrary data that can be attached to the drag item. */
   data: T;

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -39,7 +39,7 @@ describe('Overlay directives', () => {
       declarations: [ConnectedOverlayDirectiveTest, ConnectedOverlayPropertyInitOrder],
       providers: [{provide: Directionality, useFactory: () => dir = {value: 'ltr'}},
         {provide: ScrollDispatcher, useFactory: () => ({
-          scrolled: () => scrolledSubject.asObservable()
+          scrolled: () => scrolledSubject
         })}
       ],
     });

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -127,7 +127,6 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     // before attempting to position it, as the position may depend on the size of the rendered
     // content.
     this._ngZone.onStable
-      .asObservable()
       .pipe(take(1))
       .subscribe(() => {
         // The overlay could've been detached before the zone has stabilized.
@@ -258,27 +257,27 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
 
   /** Gets an observable that emits when the backdrop has been clicked. */
   backdropClick(): Observable<MouseEvent> {
-    return this._backdropClick.asObservable();
+    return this._backdropClick;
   }
 
   /** Gets an observable that emits when the overlay has been attached. */
   attachments(): Observable<void> {
-    return this._attachments.asObservable();
+    return this._attachments;
   }
 
   /** Gets an observable that emits when the overlay has been detached. */
   detachments(): Observable<void> {
-    return this._detachments.asObservable();
+    return this._detachments;
   }
 
   /** Gets an observable of keydown events targeted to this overlay. */
   keydownEvents(): Observable<KeyboardEvent> {
-    return this._keydownEvents.asObservable();
+    return this._keydownEvents;
   }
 
   /** Gets an observable of pointer events targeted outside this overlay. */
   outsidePointerEvents(): Observable<MouseEvent> {
-    return this._outsidePointerEvents.asObservable();
+    return this._outsidePointerEvents;
   }
 
   /** Gets the current overlay configuration, which is immutable. */
@@ -510,7 +509,6 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
       // might still be animating. This stream helps us avoid interrupting the animation
       // by waiting for the pane to become empty.
       const subscription = this._ngZone.onStable
-        .asObservable()
         .pipe(takeUntil(merge(this._attachments, this._detachments)))
         .subscribe(() => {
           // Needs a couple of checks for the pane and host, because

--- a/src/cdk/overlay/position/connected-position-strategy.ts
+++ b/src/cdk/overlay/position/connected-position-strategy.ts
@@ -49,9 +49,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
   _preferredPositions: ConnectionPositionPair[] = [];
 
   /** Emits an event when the connection point changes. */
-  get onPositionChange(): Observable<ConnectedOverlayPositionChange> {
-    return this._positionStrategy.positionChanges;
-  }
+  readonly onPositionChange: Observable<ConnectedOverlayPositionChange>;
 
   constructor(
       originPos: OriginConnectionPosition, overlayPos: OverlayConnectionPosition,
@@ -68,6 +66,7 @@ export class ConnectedPositionStrategy implements PositionStrategy {
                                  .withViewportMargin(0);
 
     this.withFallbackPosition(originPos, overlayPos);
+    this.onPositionChange = this._positionStrategy.positionChanges;
   }
 
   /** Ordered list of preferred positions, from most to least desirable. */

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -128,8 +128,7 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
   private _previousPushAmount: {x: number, y: number} | null;
 
   /** Observable sequence of position changes. */
-  positionChanges: Observable<ConnectedOverlayPositionChange> =
-      this._positionChanges.asObservable();
+  positionChanges: Observable<ConnectedOverlayPositionChange> = this._positionChanges;
 
   /** Ordered list of preferred positions, from most to least desirable. */
   get positions(): ConnectionPositionPair[] {

--- a/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
@@ -25,7 +25,7 @@ describe('CloseScrollStrategy', () => {
       imports: [OverlayModule, PortalModule, OverlayTestModule],
       providers: [
         {provide: ScrollDispatcher, useFactory: () => ({
-          scrolled: () => scrolledSubject.asObservable()
+          scrolled: () => scrolledSubject
         })},
         {provide: ViewportRuler, useFactory: () => ({
           getViewportScrollPosition: () => ({top: scrollPosition})

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -23,7 +23,7 @@ describe('RepositionScrollStrategy', () => {
       imports: [OverlayModule, PortalModule, OverlayTestModule],
       providers: [
         {provide: ScrollDispatcher, useFactory: () => ({
-          scrolled: () => scrolledSubject.asObservable()
+          scrolled: () => scrolledSubject
         })}
       ]
     });

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -103,7 +103,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   @ViewChild('contentWrapper', {static: true}) _contentWrapper: ElementRef<HTMLElement>;
 
   /** A stream that emits whenever the rendered range changes. */
-  renderedRangeStream: Observable<ListRange> = this._renderedRangeSubject.asObservable();
+  renderedRangeStream: Observable<ListRange> = this._renderedRangeSubject;
 
   /**
    * The total size of all content (in pixels), including content that is not currently rendered.

--- a/src/cdk/testing/testbed/task-state-zone-interceptor.ts
+++ b/src/cdk/testing/testbed/task-state-zone-interceptor.ts
@@ -35,7 +35,7 @@ export class TaskStateZoneInterceptor {
       this._lastState ? this._getTaskStateFromInternalZoneState(this._lastState) : {stable: true});
 
   /** Public observable that emits whenever the task state changes. */
-  readonly state: Observable<TaskState> = this._stateSubject.asObservable();
+  readonly state: Observable<TaskState> = this._stateSubject;
 
   constructor(private _lastState: HasTaskState|null) {}
 

--- a/src/cdk/text-field/autofill.ts
+++ b/src/cdk/text-field/autofill.ts
@@ -75,7 +75,7 @@ export class AutofillMonitor implements OnDestroy {
     const info = this._monitoredElements.get(element);
 
     if (info) {
-      return info.subject.asObservable();
+      return info.subject;
     }
 
     const result = new Subject<AutofillEvent>();
@@ -107,7 +107,7 @@ export class AutofillMonitor implements OnDestroy {
       }
     });
 
-    return result.asObservable();
+    return result;
   }
 
   /**

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -297,7 +297,7 @@ class ElementDataSource extends DataSource<PeriodicElement> {
 
   /** Connect function called by the table to retrieve one stream containing the data to render. */
   connect() {
-    return this.data.asObservable();
+    return this.data;
   }
 
   disconnect() {}

--- a/src/material-experimental/mdc-chips/chip-option.ts
+++ b/src/material-experimental/mdc-chips/chip-option.ts
@@ -197,7 +197,6 @@ export class MatChipOption extends MatChip implements AfterContentInit {
     // that moves focus not the next item. To work around the issue, we defer marking the chip
     // as not focused until the next time the zone stabilizes.
     this._ngZone.onStable
-      .asObservable()
       .pipe(take(1))
       .subscribe(() => {
         this._ngZone.run(() => {

--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -481,7 +481,7 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
     // Note that we have to run outside of the `NgZone` explicitly, in order to avoid
     // throwing users into an infinite loop if `zone-patch-rxjs` is included.
     this._ngZone.runOutsideAngular(() => {
-      this._ngZone.onStable.asObservable().pipe(takeUntil(this._destroyed)).subscribe(() => {
+      this._ngZone.onStable.pipe(takeUntil(this._destroyed)).subscribe(() => {
         if (this._needsOutlineLabelOffsetUpdateOnStable) {
           this._needsOutlineLabelOffsetUpdateOnStable = false;
           this._updateOutlineLabelOffset();

--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
@@ -147,7 +147,7 @@ export class MatSnackBarContainer extends BasePortalOutlet
   exit(): Observable<void> {
     this._exiting = true;
     this._mdcFoundation.close();
-    return this._onExit.asObservable();
+    return this._onExit;
   }
 
   /** Attach a component portal as content to this snack bar container. */

--- a/src/material-experimental/mdc-tabs/tab-header.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.spec.ts
@@ -44,7 +44,7 @@ describe('MDC-based MatTabHeader', () => {
       ],
       providers: [
         ViewportRuler,
-        {provide: Directionality, useFactory: () => ({value: dir, change: change.asObservable()})},
+        {provide: Directionality, useFactory: () => ({value: dir, change: change})},
       ]
     });
 

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -31,7 +31,7 @@ describe('MDC-based MatTabNavBar', () => {
       providers: [
         {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useFactory: () => globalRippleOptions},
         {provide: Directionality, useFactory: () =>
-            ({value: dir, change: dirChange.asObservable()})},
+            ({value: dir, change: dirChange})},
       ]
     });
 

--- a/src/material-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/material-experimental/popover-edit/popover-edit.spec.ts
@@ -174,7 +174,7 @@ class ElementDataSource extends DataSource<PeriodicElement> {
 
   /** Connect function called by the table to retrieve one stream containing the data to render. */
   connect() {
-    return this.data.asObservable();
+    return this.data;
   }
 
   disconnect() {}

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -335,7 +335,6 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
     // If there are any subscribers before `ngAfterViewInit`, the `autocomplete` will be undefined.
     // Return a stream that we'll replace with the real one once everything is in place.
     return this._zone.onStable
-        .asObservable()
         .pipe(take(1), switchMap(() => this.optionSelections));
   }) as Observable<MatOptionSelectionChange>;
 
@@ -516,7 +515,7 @@ export class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewIn
    * stream every time the option list changes.
    */
   private _subscribeToClosingActions(): Subscription {
-    const firstStable = this._zone.onStable.asObservable().pipe(take(1));
+    const firstStable = this._zone.onStable.pipe(take(1));
     const optionChanges = this.autocomplete.options.changes.pipe(
       tap(() => this._positionStrategy.reapplyLastPosition()),
       // Defer emitting to the stream until the next tick, because changing

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1559,7 +1559,7 @@ describe('MatAutocomplete', () => {
       let spacer = document.createElement('div');
       let fixture = createComponent(SimpleAutocomplete, [{
         provide: ScrollDispatcher,
-        useValue: {scrolled: () => scrolledSubject.asObservable()}
+        useValue: {scrolled: () => scrolledSubject}
       }]);
 
       fixture.detectChanges();
@@ -2242,7 +2242,7 @@ describe('MatAutocomplete', () => {
       const fixture = createComponent(SimpleAutocomplete, [
         {
           provide: ScrollDispatcher,
-          useValue: {scrolled: () => scrolledSubject.asObservable()}
+          useValue: {scrolled: () => scrolledSubject}
         },
         {
           provide: MAT_AUTOCOMPLETE_SCROLL_STRATEGY,

--- a/src/material/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/material/bottom-sheet/bottom-sheet-ref.ts
@@ -115,12 +115,12 @@ export class MatBottomSheetRef<T = any, R = any> {
 
   /** Gets an observable that is notified when the bottom sheet is finished closing. */
   afterDismissed(): Observable<R | undefined> {
-    return this._afterDismissed.asObservable();
+    return this._afterDismissed;
   }
 
   /** Gets an observable that is notified when the bottom sheet has opened and appeared. */
   afterOpened(): Observable<void> {
-    return this._afterOpened.asObservable();
+    return this._afterOpened;
   }
 
   /**

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -424,7 +424,6 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     // that moves focus not the next item. To work around the issue, we defer marking the chip
     // as not focused until the next time the zone stabilizes.
     this._ngZone.onStable
-      .asObservable()
       .pipe(take(1))
       .subscribe(() => {
         this._ngZone.run(() => {

--- a/src/material/core/datetime/date-adapter.ts
+++ b/src/material/core/datetime/date-adapter.ts
@@ -32,10 +32,10 @@ export const MAT_DATE_LOCALE_PROVIDER = {provide: MAT_DATE_LOCALE, useExisting: 
 export abstract class DateAdapter<D> {
   /** The locale to use for all dates. */
   protected locale: any;
+  protected _localeChanges = new Subject<void>();
 
   /** A stream that emits when the locale changes. */
-  get localeChanges(): Observable<void> { return this._localeChanges; }
-  protected _localeChanges = new Subject<void>();
+  readonly localeChanges: Observable<void> = this._localeChanges;
 
   /**
    * Gets the year component of the given date.

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -193,7 +193,7 @@ export class MatCalendarBody implements OnChanges, OnDestroy {
   /** Focuses the active cell after the microtask queue is empty. */
   _focusActiveCell(movePreview = true) {
     this._ngZone.runOutsideAngular(() => {
-      this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
+      this._ngZone.onStable.pipe(take(1)).subscribe(() => {
         const activeCell: HTMLElement | null =
             this._elementRef.nativeElement.querySelector('.mat-calendar-body-active');
 

--- a/src/material/datepicker/date-selection-model.ts
+++ b/src/material/datepicker/date-selection-model.ts
@@ -48,7 +48,7 @@ export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<
   private _selectionChanged = new Subject<DateSelectionModelChange<S>>();
 
   /** Emits when the selection has changed. */
-  selectionChanged: Observable<DateSelectionModelChange<S>> = this._selectionChanged.asObservable();
+  selectionChanged: Observable<DateSelectionModelChange<S>> = this._selectionChanged;
 
   protected constructor(
     /** The current selection. */

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -549,7 +549,7 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
     this._forwardContentValues(this._popupComponentRef.instance);
 
     // Update the position once the calendar has rendered.
-    this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
+    this._ngZone.onStable.pipe(take(1)).subscribe(() => {
       this._popupRef!.updatePosition();
     });
   }

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -139,21 +139,21 @@ export class MatDialogRef<T, R = any> {
    * Gets an observable that is notified when the dialog is finished opening.
    */
   afterOpened(): Observable<void> {
-    return this._afterOpened.asObservable();
+    return this._afterOpened;
   }
 
   /**
    * Gets an observable that is notified when the dialog is finished closing.
    */
   afterClosed(): Observable<R | undefined> {
-    return this._afterClosed.asObservable();
+    return this._afterClosed;
   }
 
   /**
    * Gets an observable that is notified when the dialog has started closing.
    */
   beforeClosed(): Observable<R | undefined> {
-    return this._beforeClosed.asObservable();
+    return this._beforeClosed;
   }
 
   /**

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -63,7 +63,7 @@ describe('MatDialog', () => {
       providers: [
         {provide: Location, useClass: SpyLocation},
         {provide: ScrollDispatcher, useFactory: () => ({
-          scrolled: () => scrolledSubject.asObservable()
+          scrolled: () => scrolledSubject
         })},
       ],
     });

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -343,7 +343,7 @@ export class MatFormField extends _MatFormFieldMixinBase
     // in order to avoid throwing users into an infinite loop
     // if `zone-patch-rxjs` is included.
     this._ngZone.runOutsideAngular(() => {
-      this._ngZone.onStable.asObservable().pipe(takeUntil(this._destroyed)).subscribe(() => {
+      this._ngZone.onStable.pipe(takeUntil(this._destroyed)).subscribe(() => {
         if (this._outlineGapCalculationNeededOnStable) {
           this.updateOutlineGap();
         }

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -126,14 +126,15 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
         throwMatMenuRecursiveError();
       }
 
-      this._menuCloseSubscription = menu.close.asObservable().subscribe(reason => {
-        this._destroyMenu();
+      this._menuCloseSubscription = menu.close.subscribe(
+        (reason: 'click' | 'tab' | 'keydown' | undefined) => {
+          this._destroyMenu();
 
-        // If a click closed the menu, we should close the entire chain of nested menus.
-        if ((reason === 'click' || reason === 'tab') && this._parentMenu) {
-          this._parentMenu.closed.emit(reason);
-        }
-      });
+          // If a click closed the menu, we should close the entire chain of nested menus.
+          if ((reason === 'click' || reason === 'tab') && this._parentMenu) {
+            this._parentMenu.closed.emit(reason);
+          }
+        });
     }
   }
   private _menu: MatMenuPanel;

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -354,7 +354,7 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
   focusFirstItem(origin: FocusOrigin = 'program'): void {
     // When the content is rendered lazily, it takes a bit before the items are inside the DOM.
     if (this.lazyContent) {
-      this._ngZone.onStable.asObservable()
+      this._ngZone.onStable
         .pipe(take(1))
         .subscribe(() => this._focusFirstItem(origin));
     } else {

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -104,7 +104,7 @@ describe('MatSelect', () => {
         {provide: Directionality, useFactory: () => dir = {value: 'ltr', change: EMPTY}},
         {
           provide: ScrollDispatcher, useFactory: () => ({
-            scrolled: () => scrolledSubject.asObservable(),
+            scrolled: () => scrolledSubject,
           }),
         },
         ...providers

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -495,7 +495,6 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     }
 
     return this._ngZone.onStable
-      .asObservable()
       .pipe(take(1), switchMap(() => this.optionSelectionChanges));
   }) as Observable<MatOptionSelectionChange>;
 
@@ -654,7 +653,7 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     this._changeDetectorRef.markForCheck();
 
     // Set the font size on the panel element once it exists.
-    this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
+    this._ngZone.onStable.pipe(take(1)).subscribe(() => {
       if (this._triggerFontSize && this.overlayDir.overlayRef &&
           this.overlayDir.overlayRef.overlayElement) {
         this.overlayDir.overlayRef.overlayElement.style.fontSize = `${this._triggerFontSize}px`;

--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -47,6 +47,7 @@ import {
   take,
   takeUntil,
   distinctUntilChanged,
+  mapTo,
 } from 'rxjs/operators';
 import {matDrawerAnimations} from './drawer-animations';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
@@ -227,12 +228,10 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
 
   /** Event emitted when the drawer has started opening. */
   @Output()
-  get openedStart(): Observable<void> {
-    return this._animationStarted.pipe(
-      filter(e => e.fromState !== e.toState && e.toState.indexOf('open') === 0),
-      map(() => {})
-    );
-  }
+  readonly openedStart: Observable<void> = this._animationStarted.pipe(
+    filter(e => e.fromState !== e.toState && e.toState.indexOf('open') === 0),
+    mapTo(undefined)
+  );
 
   /** Event emitted when the drawer has been closed. */
   @Output('closed')
@@ -240,12 +239,10 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
 
   /** Event emitted when the drawer has started closing. */
   @Output()
-  get closedStart(): Observable<void> {
-    return this._animationStarted.pipe(
-      filter(e => e.fromState !== e.toState && e.toState === 'void'),
-      map(() => {})
-    );
-  }
+  readonly closedStart: Observable<void> = this._animationStarted.pipe(
+    filter(e => e.fromState !== e.toState && e.toState === 'void'),
+    mapTo(undefined)
+  );
 
   /** Emits when the component is destroyed. */
   private readonly _destroyed = new Subject<void>();
@@ -775,7 +772,7 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
     // NOTE: We need to wait for the microtask queue to be empty before validating,
     // since both drawers may be swapping positions at the same time.
     drawer.onPositionChanged.pipe(takeUntil(this._drawers.changes)).subscribe(() => {
-      this._ngZone.onMicrotaskEmpty.asObservable().pipe(take(1)).subscribe(() => {
+      this._ngZone.onMicrotaskEmpty.pipe(take(1)).subscribe(() => {
         this._validateDrawers();
       });
     });

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -187,7 +187,7 @@ export class MatSnackBarContainer extends BasePortalOutlet
    * errors where we end up removing an element which is in the middle of an animation.
    */
   private _completeExit() {
-    this._ngZone.onMicrotaskEmpty.asObservable().pipe(take(1)).subscribe(() => {
+    this._ngZone.onMicrotaskEmpty.pipe(take(1)).subscribe(() => {
       this._onExit.next();
       this._onExit.complete();
     });

--- a/src/material/snack-bar/snack-bar-ref.ts
+++ b/src/material/snack-bar/snack-bar-ref.ts
@@ -116,7 +116,7 @@ export class MatSnackBarRef<T> {
 
   /** Gets an observable that is notified when the snack bar is finished closing. */
   afterDismissed(): Observable<MatSnackBarDismiss> {
-    return this._afterDismissed.asObservable();
+    return this._afterDismissed;
   }
 
   /** Gets an observable that is notified when the snack bar has opened and appeared. */
@@ -126,6 +126,6 @@ export class MatSnackBarRef<T> {
 
   /** Gets an observable that is notified when the snack bar action is called. */
   onAction(): Observable<void> {
-    return this._onAction.asObservable();
+    return this._onAction;
   }
 }

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -46,7 +46,7 @@ describe('MatTabHeader', () => {
       ],
       providers: [
         ViewportRuler,
-        {provide: Directionality, useFactory: () => ({value: dir, change: change.asObservable()})},
+        {provide: Directionality, useFactory: () => ({value: dir, change: change})},
       ]
     });
 

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -27,8 +27,7 @@ describe('MatTabNavBar', () => {
       ],
       providers: [
         {provide: MAT_RIPPLE_GLOBAL_OPTIONS, useFactory: () => globalRippleOptions},
-        {provide: Directionality, useFactory: () =>
-            ({value: dir, change: dirChange.asObservable()})},
+        {provide: Directionality, useFactory: () => ({value: dir, change: dirChange})},
       ]
     });
 

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -510,7 +510,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
       this._tooltipInstance.message = this.message;
       this._tooltipInstance._markForCheck();
 
-      this._ngZone.onMicrotaskEmpty.asObservable().pipe(
+      this._ngZone.onMicrotaskEmpty.pipe(
         take(1),
         takeUntil(this._destroyed)
       ).subscribe(() => {
@@ -742,7 +742,7 @@ export class TooltipComponent implements OnDestroy {
 
   /** Returns an observable that notifies when the tooltip has been hidden from view. */
   afterHidden(): Observable<void> {
-    return this._onHide.asObservable();
+    return this._onHide;
   }
 
   /** Whether the tooltip is being displayed. */

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -91,7 +91,7 @@ export interface ConnectedPosition {
 export declare class ConnectedPositionStrategy implements PositionStrategy {
     _positionStrategy: FlexibleConnectedPositionStrategy;
     _preferredPositions: ConnectionPositionPair[];
-    get onPositionChange(): Observable<ConnectedOverlayPositionChange>;
+    readonly onPositionChange: Observable<ConnectedOverlayPositionChange>;
     get positions(): ConnectionPositionPair[];
     constructor(originPos: OriginConnectionPosition, overlayPos: OverlayConnectionPosition, connectedTo: ElementRef<HTMLElement>, viewportRuler: ViewportRuler, document: Document, platform: Platform, overlayContainer: OverlayContainer);
     apply(): void;

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -89,7 +89,7 @@ export declare type CanUpdateErrorStateCtor = Constructor<CanUpdateErrorState>;
 export declare abstract class DateAdapter<D> {
     protected _localeChanges: Subject<void>;
     protected locale: any;
-    get localeChanges(): Observable<void>;
+    readonly localeChanges: Observable<void>;
     abstract addCalendarDays(date: D, days: number): D;
     abstract addCalendarMonths(date: D, months: number): D;
     abstract addCalendarYears(date: D, years: number): D;

--- a/tools/public_api_guard/material/sidenav.d.ts
+++ b/tools/public_api_guard/material/sidenav.d.ts
@@ -12,7 +12,7 @@ export declare class MatDrawer implements AfterContentInit, AfterContentChecked,
     _openedStream: Observable<void>;
     get autoFocus(): boolean;
     set autoFocus(value: boolean);
-    get closedStart(): Observable<void>;
+    readonly closedStart: Observable<void>;
     get disableClose(): boolean;
     set disableClose(value: boolean);
     get mode(): MatDrawerMode;
@@ -21,7 +21,7 @@ export declare class MatDrawer implements AfterContentInit, AfterContentChecked,
     get opened(): boolean;
     set opened(value: boolean);
     readonly openedChange: EventEmitter<boolean>;
-    get openedStart(): Observable<void>;
+    readonly openedStart: Observable<void>;
     get position(): 'start' | 'end';
     set position(value: 'start' | 'end');
     constructor(_elementRef: ElementRef<HTMLElement>, _focusTrapFactory: FocusTrapFactory, _focusMonitor: FocusMonitor, _platform: Platform, _ngZone: NgZone, _doc: any,

--- a/tslint.json
+++ b/tslint.json
@@ -90,7 +90,8 @@
       ["xit"],
       ["xdescribe"],
       {"name": ["first"], "message": "Use take(1) instead."},
-      {"name": ["Object", "assign"], "message": "Use the spread operator instead."}
+      {"name": ["Object", "assign"], "message": "Use the spread operator instead."},
+      {"name": ["*", "asObservable"], "message": "Cast to Observable type instead."}
     ],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.
     "linebreak-style": [true, "LF"],


### PR DESCRIPTION
As discussed, replaces usages of the `asObservable` with a cast to `Observable` since the method is a little pointless, because people can easily get around it if they really want to.

Also cleans up a few getters that were returning observables.