### PR TITLE
fix(material-experimental/mdc-menu): apply typography to button menu items

### DIFF
--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -44,7 +44,7 @@
   @include mat-using-mdc-typography($config) {
     @include mdc-menu-surface-core-styles($mat-typography-styles-query);
 
-    .mat-mdc-menu-content {
+    .mat-mdc-menu-content, .mat-mdc-menu-item {
       // Note that we include this private mixin, because the public
       // one adds a bunch of styles that we aren't using for the menu.
       @include mdc-list-base_($mat-typography-styles-query);


### PR DESCRIPTION
Button menu items have the default button typography styles applied instead of the inherited typography from `.mat-mdc-menu-content`. You can observe this at https://material2-dev.firebaseapp.com/mdc-menu - see that the menu items are set to `Arial` instead of `Roboto`