### PR TITLE
fix(progress-spinner) add theme for mdc-progress-spinner

### DIFF
--- a/src/material-experimental/mdc-theming/_all-theme.scss
+++ b/src/material-experimental/mdc-theming/_all-theme.scss
@@ -11,6 +11,7 @@
 @import '../mdc-tabs/tabs-theme';
 @import '../mdc-table/table-theme';
 @import '../mdc-progress-bar/progress-bar-theme';
+@import '../mdc-progress-spinner/progress-spinner-theme';
 @import '../mdc-input/input-theme';
 @import '../mdc-form-field/form-field-theme';
 @import '../../material/core/theming/check-duplicate-styles';
@@ -27,6 +28,7 @@
     @include mat-mdc-list-theme($theme-or-color-config);
     @include mat-mdc-menu-theme($theme-or-color-config);
     @include mat-mdc-progress-bar-theme($theme-or-color-config);
+    @include mat-mdc-progress-spinner-theme($theme-or-color-config);
     @include mat-mdc-radio-theme($theme-or-color-config);
     @include mat-mdc-slide-toggle-theme($theme-or-color-config);
     @include mat-mdc-snack-bar-theme($theme-or-color-config);


### PR DESCRIPTION
previously excluded in https://github.com/angular/components/pull/20048 to keep it merge safe