### PR TITLE
fix(cdk-experimental/menu): re-open menu on hover after click to close on trigger

### DIFF
--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -1026,6 +1026,21 @@ describe('MenuBar', () => {
         expect(document.querySelector(':focus')).toEqual(fileMenuNativeItems[1]);
       }
     );
+
+    it(
+      'should not re-open a menu when hovering over the trigger in the menubar after clicking to ' +
+        'open and then close it',
+      () => {
+        openFileMenu();
+        dispatchMouseEvent(menuBarNativeItems[0], 'click');
+        detectChanges();
+
+        dispatchMouseEvent(menuBarNativeItems[0], 'mouseenter');
+        detectChanges();
+
+        expect(nativeMenus.length).toBe(0);
+      }
+    );
   });
 });
 

--- a/src/cdk-experimental/menu/menu-item-trigger.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.ts
@@ -113,7 +113,7 @@ export class CdkMenuItemTrigger implements OnDestroy {
 
       this._overlayRef!.detach();
     }
-    this._getMenuStack().closeSubMenuOf(this._parentMenu);
+    this._closeSiblingTriggers();
   }
 
   /** Return true if the trigger has an attached menu */
@@ -141,16 +141,7 @@ export class CdkMenuItemTrigger implements OnDestroy {
   _toggleOnMouseEnter() {
     const menuStack = this._getMenuStack();
     if (!menuStack.isEmpty() && !this.isMenuOpen()) {
-      // If nothing was removed from the stack and the last element is not the parent item
-      // that means that the parent menu is a menu bar since we don't put the menu bar on the
-      // stack
-      const isParentMenuBar =
-        !menuStack.closeSubMenuOf(this._parentMenu) && menuStack.peek() !== this._parentMenu;
-
-      if (isParentMenuBar) {
-        menuStack.closeAll();
-      }
-
+      this._closeSiblingTriggers();
       this.openMenu();
     }
   }
@@ -204,6 +195,21 @@ export class CdkMenuItemTrigger implements OnDestroy {
             : this.menuPanel?._menu?.focusLastItem('keyboard');
         }
         break;
+    }
+  }
+
+  /** Close out any sibling menu trigger menus. */
+  private _closeSiblingTriggers() {
+    const menuStack = this._getMenuStack();
+
+    // If nothing was removed from the stack and the last element is not the parent item
+    // that means that the parent menu is a menu bar since we don't put the menu bar on the
+    // stack
+    const isParentMenuBar =
+      !menuStack.closeSubMenuOf(this._parentMenu) && menuStack.peek() !== this._parentMenu;
+
+    if (isParentMenuBar) {
+      menuStack.closeAll();
     }
   }
 


### PR DESCRIPTION
When hovering back over a menu item trigger in a menu bar which was clicked to open then closed, it
opens the submenu. This ensures that a menu attached to a trigger in a menu bar only opens on hover
if it has a sibling open.