### PR TITLE
refactor(cdk-experimental/dialog): sync with recent material dialog changes

### DIFF
--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -10,14 +10,13 @@ import {animate, AnimationEvent, state, style, transition, trigger} from '@angul
 import {FocusTrapFactory} from '@angular/cdk/a11y';
 import {
   BasePortalOutlet,
-  ComponentPortal,
   CdkPortalOutlet,
-  TemplatePortal,
+  ComponentPortal,
   DomPortal,
+  TemplatePortal,
 } from '@angular/cdk/portal';
 import {DOCUMENT} from '@angular/common';
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -73,7 +72,7 @@ export function throwDialogContentAlreadyAttachedError() {
     '(@dialog.done)': '_animationDone.next($event)',
   },
 })
-export class CdkDialogContainer extends BasePortalOutlet implements OnDestroy, AfterViewInit {
+export class CdkDialogContainer extends BasePortalOutlet implements OnDestroy {
   private readonly _document: Document;
 
   /** State of the dialog animation. */
@@ -151,8 +150,8 @@ export class CdkDialogContainer extends BasePortalOutlet implements OnDestroy, A
     });
   }
 
-  /** If the dialog view completes initialization, the open animation starts. */
-  ngAfterViewInit() {
+  /** Initializes the dialog container with the attached content. */
+  _initializeWithAttachedContent() {
     // Save the previously focused element. This element will be re-focused
     // when the dialog closes.
     this._savePreviouslyFocusedElement();

--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -116,6 +116,8 @@ export class Dialog implements OnDestroy {
       overlayRef, config);
 
     this._registerDialogRef(dialogRef);
+    dialogContainer._initializeWithAttachedContent();
+
     return dialogRef;
   }
 
@@ -133,6 +135,8 @@ export class Dialog implements OnDestroy {
       overlayRef, config);
 
     this._registerDialogRef(dialogRef);
+    dialogContainer._initializeWithAttachedContent();
+
     return dialogRef;
   }
 


### PR DESCRIPTION
We recently landed the MDC-based dialog. For this one, we changed
how the dialog initializes the focus trap, saves the previously
focused element, focuses the dialog container.

Previously, all of this this has been performed before the content
has been attached. The dialog used `Promise.resolve` to wait for
the content to be attached. This has been cleaned up now so that the
container is initialized properly (without the `Promise.resolve` trick)
after the content has been attached.

We initially did this in the MDC-based dialog PR through the
`ngAfterViewInit` lifecycle hook, but that unveiled issues
in g3 where the focus is moved too early to the container. We
fixed this in the Material dialog by having an explicit
`_initializeWithAttachedContent` method on the container.

The change has just not been applied to the CDK dialog. This
commit syncs the CDK dialog with the latest changes.