### PR TITLE
chore: clean up unnecessary providers arrays from existing code

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -75,7 +75,6 @@ inside your `NgModule`.
     ExampleBottomSheetComponent
   ],
 
-  providers: [],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -64,7 +64,6 @@ the `ComponentFactory` for it.
     ExampleDialogComponent
   ],
 
-  providers: [],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/test/benchmarks/material/button/app.module.ts
+++ b/test/benchmarks/material/button/app.module.ts
@@ -38,7 +38,6 @@ export class ButtonBenchmarkApp {
     BrowserModule,
     MatButtonModule,
   ],
-  providers: [],
   bootstrap: [ButtonBenchmarkApp],
 })
 export class AppModule {}

--- a/test/benchmarks/material/card/app.module.ts
+++ b/test/benchmarks/material/card/app.module.ts
@@ -37,7 +37,6 @@ export class CardBenchmarkApp {
     BrowserModule,
     MatCardModule,
   ],
-  providers: [],
   bootstrap: [CardBenchmarkApp],
 })
 export class AppModule {}

--- a/test/benchmarks/material/checkbox/app.module.ts
+++ b/test/benchmarks/material/checkbox/app.module.ts
@@ -46,7 +46,6 @@ export class CheckboxBenchmarkApp {
     BrowserModule,
     MatCheckboxModule,
   ],
-  providers: [],
   bootstrap: [CheckboxBenchmarkApp],
 })
 export class AppModule {}

--- a/test/benchmarks/material/chips/app.module.ts
+++ b/test/benchmarks/material/chips/app.module.ts
@@ -53,7 +53,6 @@ export class ChipsBenchmarkApp {
     BrowserModule,
     MatChipsModule,
   ],
-  providers: [],
   bootstrap: [ChipsBenchmarkApp],
 })
 export class AppModule {}

--- a/test/benchmarks/material/form-field/app.module.ts
+++ b/test/benchmarks/material/form-field/app.module.ts
@@ -68,7 +68,6 @@ export class FormFieldBenchmarkApp {
     MatSelectModule,
     MatInputModule,
   ],
-  providers: [],
   bootstrap: [FormFieldBenchmarkApp],
 })
 export class AppModule {}

--- a/test/benchmarks/material/radio/app.module.ts
+++ b/test/benchmarks/material/radio/app.module.ts
@@ -60,7 +60,6 @@ export class RadioBenchmarkApp {
     BrowserModule,
     MatRadioModule,
   ],
-  providers: [],
   bootstrap: [RadioBenchmarkApp],
 })
 export class AppModule {}

--- a/test/benchmarks/material/slide-toggle/app.module.ts
+++ b/test/benchmarks/material/slide-toggle/app.module.ts
@@ -38,7 +38,6 @@ export class SlideToggleBenchmarkApp {
     BrowserModule,
     MatSlideToggleModule,
   ],
-  providers: [],
   bootstrap: [SlideToggleBenchmarkApp]
 })
 export class AppModule {}

--- a/test/benchmarks/material/table/app.module.ts
+++ b/test/benchmarks/material/table/app.module.ts
@@ -75,7 +75,6 @@ export class TableBenchmarkApp {
     BrowserModule,
     MatTableModule,
   ],
-  providers: [],
   bootstrap: [TableBenchmarkApp],
 })
 export class AppModule {}

--- a/test/benchmarks/mdc/card/app.module.ts
+++ b/test/benchmarks/mdc/card/app.module.ts
@@ -37,7 +37,6 @@ export class CardBenchmarkApp {
     BrowserModule,
     MatCardModule,
   ],
-  providers: [],
   bootstrap: [CardBenchmarkApp],
 })
 export class AppModule {}


### PR DESCRIPTION
Passing in `providers: []` isn't necessary so these changes clean up the existing code.