### PR TITLE
fix(material/progress-spinner): progress-spinners with diameter less than or equal to 10

### DIFF
--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -156,6 +156,19 @@ describe('MatProgressSpinner', () => {
         .toBe('0 0 25.2 25.2', 'Expected the custom diameter to be applied to the svg viewBox.');
   });
 
+  it('should allow a custom diameter value of 10 or lower', () => {
+    const fixture = TestBed.createComponent(ProgressSpinnerCustomDiameter);
+
+    fixture.componentInstance.diameter = 8;
+    fixture.detectChanges();
+
+    const circleElement = fixture.nativeElement.querySelector('circle');
+    const svgElement = fixture.nativeElement.querySelector('svg');
+
+    expect(circleElement.getAttribute('r')).toEqual('0.36');
+    expect(svgElement.getAttribute('viewBox')).toBe('0 0 1.52 1.52');
+  });
+
   it('should add a style tag with the indeterminate animation to the document head when using a ' +
     'non-default diameter', inject([Platform], (platform: Platform) => {
       // On Edge and IE we use a fallback animation because the

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -231,7 +231,9 @@ export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements 
 
   /** The radius of the spinner, adjusted for stroke width. */
   _getCircleRadius() {
-    return (this.diameter - BASE_STROKE_WIDTH) / 2;
+    // In the general case adjust the diameter by the base stroke width.
+    // For small diameters adjust by a diameter percentage so that the radius is greater than 0.
+    return Math.max(this.diameter - BASE_STROKE_WIDTH, this.diameter * 0.09) / 2;
   }
 
   /** The view box of the spinner's svg element. */


### PR DESCRIPTION
As @paulferaud pointed out in #19469, using `BASE_STROKE_WIDTH` when calculating the spinner circle radius is causing issues, such as the progress spinner becoming invisible if the diameter is less than or equal to 10.

One solution is to change the radius calculation for diameters less than 11 and subtract a fraction of the diameter instead of `BASE_STROKE_WIDTH`. 

This also maintains the current behaviour for any diameters above 10, so shouldn’t cause breaking screenshot tests.

Fixes #19469