### PR TITLE
docs(cdk/scrolling): make ScrollingModule the primary export (#20112)

### DIFF
--- a/src/cdk/scrolling/scrolling-module.ts
+++ b/src/cdk/scrolling/scrolling-module.ts
@@ -20,6 +20,9 @@ import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
 })
 export class CdkScrollableModule {}
 
+/**
+ * @docs-primary-export
+ */
 @NgModule({
   imports: [
     BidiModule,


### PR DESCRIPTION
This designates ScrollingModule as the primary module for cdk/scrolling.

Fixes #20112

Screenshot: 
![image](https://user-images.githubusercontent.com/831651/89372792-15b79980-d6b5-11ea-8f3d-28cc80da01ea.png)
