### PR TITLE
build: fix release output containing invalid imports sometimes

### DIFF
--- a/tools/postinstall/@bazel_typescript_tsc_wrapped_worker_cache_fix.patch
+++ b/tools/postinstall/@bazel_typescript_tsc_wrapped_worker_cache_fix.patch
@@ -1,0 +1,64 @@
+diff --git node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js
+index 031d9dad1..b9df57eb4 100644
+--- node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js
++++ node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js
+@@ -38,6 +38,44 @@ function validateBazelOptions(bazelOpts) {
+     }
+ }
+ const SOURCE_EXT = /((\.d)?\.tsx?|\.js)$/;
++
++/** Name of the TypeScript source file property containing the module name. */
++const MODULE_NAME_PROP = 'moduleName';
++
++/**
++ * Updates the given source file with a specified module name at constant time. The module name
++ * is not directly assigned to the source file object, but exposed through a proxy handler that
++ * wraps the source file. This ensures that changing the `moduleName` does not affect the original
++ * source file which originates from a cache and should not be invalidated.
++ */
++function wrapSourceFileWithModuleName(sourceFile, moduleName) {
++  return new Proxy(sourceFile, {
++    has: (target, prop) => prop === MODULE_NAME_PROP || Reflect.has(target, prop),
++    ownKeys: (target) => Reflect.ownKeys(target).concat(MODULE_NAME_PROP),
++    getOwnPropertyDescriptor: (target, prop) => {
++      if (prop === MODULE_NAME_PROP) {
++        // TypeScript sometimes will enumerate through top-level properties of
++        // a source file (e.g. to create a mutable clone). The module name should
++        // not be skipped by accident here.
++        return {configurable: true, enumerable: true};
++      }
++      return Reflect.getOwnPropertyDescriptor(target, prop);
++    },
++    get: function(target, prop, receiver) {
++      if (prop === MODULE_NAME_PROP) {
++        return moduleName;
++      }
++      return Reflect.get(target, prop, receiver);
++    },
++    set: function(target, prop, value, receiver) {
++      if (prop === MODULE_NAME_PROP) {
++        return false;
++      }
++      return Reflect.set(target, prop, value, receiver);
++    },
++  })
++}
++
+ /**
+  * CompilerHost that knows how to cache parsed files to improve compile times.
+  */
+@@ -377,9 +415,11 @@ class CompilerHost {
+                         `which would be overwritten with ${moduleName} ` +
+                         `by Bazel's TypeScript compiler.`);
+                 }
+-                // Setting the moduleName is equivalent to the original source having a
+-                // ///<amd-module name="some/name"/> directive
+-                sf.moduleName = moduleName;
++                // Setting the moduleName is equivalent to the original source having the triple
++                // slash `///<amd-module name="some/name"/>` directive. Also note that we do not
++                // directly modify the source file `moduleName` property as that means that
++                // consecutive compilations using a cache could have an unexpected module name.
++                return wrapSourceFileWithModuleName(sf, moduleName);
+             }
+             return sf;
+         });

--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -14,7 +14,7 @@ const chalk = require('chalk');
  * Version of the post install patch. Needs to be incremented when
  * existing patches or edits have been modified.
  */
-const PATCH_VERSION = 6;
+const PATCH_VERSION = 8;
 
 /** Path to the project directory. */
 const projectDir = path.join(__dirname, '../..');
@@ -109,6 +109,9 @@ function applyPatches() {
 
   // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1208.
   applyPatch(path.join(__dirname, './manifest_externs_hermeticity.patch'));
+
+  // Patches the changes from: https://github.com/bazelbuild/rules_typescript/pull/504.
+  applyPatch(path.join(__dirname, './@bazel_typescript_tsc_wrapped_worker_cache_fix.patch'));
 
   try {
     // Temporary patch pre-req for https://github.com/angular/angular/pull/36333.


### PR DESCRIPTION
A very subtle issue has surfaced in our release output. Based on
previous builds that have been performed locally by the caretaker
performing the release, the release output might differ and contain
invalid module imports that break ES2015 output.

Notably the es2015 output is not primarily used by the CLI. It uses
the flat ES2015 output instead.

The issue surfaces because of a bug in `@bazel/typescript` where the
`moduleName` for source files is leaking between TSC worker runs. This
means that source files are incorrectly referenced by module name,
instead of relative path when the prodmode ES2015 output is built.
Deep paths to source files are not supported as per Angular Package format.

We patch the fix that is pending upstream to ensure our release output
works: https://github.com/bazelbuild/rules_typescript/pull/504. Once the
fix upstream lands (which might take quite some time; given g3 sync and
sync with the rules_nodejs repository), we can remove the patch and
update to the latest version of `@bazel/typescript`.

Fixes #20179.