### PR TITLE
build: fix release output containing invalid imports sometimes

### DIFF
--- a/tools/postinstall/@bazel_typescript_tsc_wrapped_worker_cache_fix.patch
+++ b/tools/postinstall/@bazel_typescript_tsc_wrapped_worker_cache_fix.patch
@@ -1,0 +1,34 @@
+diff --git node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js
+index 031d9dad1..a7fe9b79b 100644
+--- node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js
++++ node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js
+@@ -377,10 +377,27 @@ class CompilerHost {
+                         `which would be overwritten with ${moduleName} ` +
+                         `by Bazel's TypeScript compiler.`);
+                 }
+-                // Setting the moduleName is equivalent to the original source having a
+-                // ///<amd-module name="some/name"/> directive
++
++                // Setting the moduleName is equivalent to the original source having the triple
++                // slash `///<amd-module name="some/name"/>` directive. Also note that we tag
++                // source files for which we assigned a generated module name. This is necessary
++                // so that we can reset the module name when the same source file is loaded from
++                // a cache, but with a different module format where the auto-generated module
++                // names are not desirable. The module name should not leak from previous
++                // compilations through a potential source file cache.
++                sf._hasGeneratedAmdModuleName = true;
+                 sf.moduleName = moduleName;
++                return sf;
+             }
++
++            // If the loaded source file has a generated amd module name applied from
++            // previous compilations (in worker mode), reset the file module name
++            // as neither the UMD or AMD module format is used (for which we generate
++            // the AMD module names automatically).
++            if (sf._hasGeneratedAmdModuleName) {
++                sf.moduleName = undefined;
++            }
++
+             return sf;
+         });
+     }

--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -14,7 +14,7 @@ const chalk = require('chalk');
  * Version of the post install patch. Needs to be incremented when
  * existing patches or edits have been modified.
  */
-const PATCH_VERSION = 6;
+const PATCH_VERSION = 9;
 
 /** Path to the project directory. */
 const projectDir = path.join(__dirname, '../..');
@@ -109,6 +109,9 @@ function applyPatches() {
 
   // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1208.
   applyPatch(path.join(__dirname, './manifest_externs_hermeticity.patch'));
+
+  // Patches the changes from: https://github.com/bazelbuild/rules_typescript/pull/504.
+  applyPatch(path.join(__dirname, './@bazel_typescript_tsc_wrapped_worker_cache_fix.patch'));
 
   // Workaround for https://github.com/angular/angular/issues/33452:
   searchAndReplace(


### PR DESCRIPTION
Resubmit of #20201 with an updated patch. Still not 100% confident why the TS compilation failed, but investigation
showed that the previous patch using a `Proxy` meant that TS sometimes is unable to read the `moduleName`
compared to it being an actual property on the source file object. Most likely TS internally tries to read
the module name, but it's not defined on the source file, but in the actual `Proxy` object.  