### PR TITLE
feat(datepicker/testing): add test harnesses for the datepicker module

### DIFF
--- a/src/material/config.bzl
+++ b/src/material/config.bzl
@@ -18,6 +18,7 @@ entryPoints = [
     "core",
     "core/testing",
     "datepicker",
+    "datepicker/testing",
     "dialog",
     "dialog/testing",
     "divider",

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -179,7 +179,7 @@ const _MatDateRangeInputBase:
 @Directive({
   selector: 'input[matStartDate]',
   host: {
-    'class': 'mat-date-range-input-inner',
+    'class': 'mat-start-date mat-date-range-input-inner',
     '[disabled]': 'disabled',
     '(input)': '_onInput($event.target.value)',
     '(change)': '_onChange()',
@@ -265,7 +265,7 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpd
 @Directive({
   selector: 'input[matEndDate]',
   host: {
-    'class': 'mat-date-range-input-inner',
+    'class': 'mat-end-date mat-date-range-input-inner',
     '[disabled]': 'disabled',
     '(input)': '_onInput($event.target.value)',
     '(change)': '_onChange()',

--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -48,10 +48,14 @@ let nextUniqueId = 0;
   host: {
     'class': 'mat-date-range-input',
     '[class.mat-date-range-input-hide-placeholders]': '_shouldHidePlaceholders()',
+    '[class.mat-date-range-input-required]': 'required',
     '[attr.id]': 'null',
     'role': 'group',
     '[attr.aria-labelledby]': '_getAriaLabelledby()',
     '[attr.aria-describedby]': '_ariaDescribedBy',
+    // Used by the test harness to tie this input to its calendar. We can't depend on
+    // `aria-owns` for this, because it's only defined while the calendar is open.
+    '[attr.data-mat-calendar]': 'rangePicker ? rangePicker.id : null',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -366,6 +366,9 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
   /** The element that was focused before the datepicker was opened. */
   private _focusedElementBeforeOpen: HTMLElement | null = null;
 
+  /** Unique class that will be added to the backdrop so that the test harnesses can look it up. */
+  private _backdropHarnessClass = `${this.id}-backdrop`;
+
   /** The input element this datepicker is associated with. */
   _datepickerInput: C;
 
@@ -516,6 +519,7 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
       // datepicker dialog behaves consistently even if the user changed the defaults.
       hasBackdrop: true,
       disableClose: false,
+      backdropClass: ['cdk-overlay-dark-backdrop', this._backdropHarnessClass],
       width: '',
       height: '',
       minWidth: '',
@@ -572,7 +576,7 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
     const overlayConfig = new OverlayConfig({
       positionStrategy: this._setConnectedPositions(positionStrategy),
       hasBackdrop: true,
-      backdropClass: 'mat-overlay-transparent-backdrop',
+      backdropClass: ['mat-overlay-transparent-backdrop', this._backdropHarnessClass],
       direction: this._dir,
       scrollStrategy: this._scrollStrategy(),
       panelClass: 'mat-datepicker-popup',

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -55,10 +55,14 @@ export const MAT_DATEPICKER_VALIDATORS: any = {
     {provide: MAT_INPUT_VALUE_ACCESSOR, useExisting: MatDatepickerInput},
   ],
   host: {
+    'class': 'mat-datepicker-input',
     '[attr.aria-haspopup]': '_datepicker ? "dialog" : null',
     '[attr.aria-owns]': '(_datepicker?.opened && _datepicker.id) || null',
     '[attr.min]': 'min ? _dateAdapter.toIso8601(min) : null',
     '[attr.max]': 'max ? _dateAdapter.toIso8601(max) : null',
+    // Used by the test harness to tie this input to its calendar. We can't depend on
+    // `aria-owns` for this, because it's only defined while the calendar is open.
+    '[attr.data-mat-calendar]': '_datepicker ? _datepicker.id : null',
     '[disabled]': 'disabled',
     '(input)': '_onInput($event.target.value)',
     '(change)': '_onChange()',

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -47,6 +47,8 @@ export class MatDatepickerToggleIcon {}
     '[class.mat-datepicker-toggle-active]': 'datepicker && datepicker.opened',
     '[class.mat-accent]': 'datepicker && datepicker.color === "accent"',
     '[class.mat-warn]': 'datepicker && datepicker.color === "warn"',
+    // Used by the test harness to tie this toggle to its datepicker.
+    '[attr.data-mat-calendar]': 'datepicker ? datepicker.id : null',
     '(focus)': '_button.focus()',
   },
   exportAs: 'matDatepickerToggle',

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -32,6 +32,8 @@ import {
   ViewEncapsulation,
   ViewChild,
   OnDestroy,
+  SimpleChanges,
+  OnChanges,
 } from '@angular/core';
 import {DateAdapter, MAT_DATE_FORMATS, MatDateFormats} from '@angular/material/core';
 import {Directionality} from '@angular/cdk/bidi';
@@ -65,7 +67,7 @@ const DAYS_PER_WEEK = 7;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MatMonthView<D> implements AfterContentInit, OnDestroy {
+export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
   private _rerenderSubscription = Subscription.EMPTY;
 
   /**
@@ -197,6 +199,14 @@ export class MatMonthView<D> implements AfterContentInit, OnDestroy {
     this._rerenderSubscription = this._dateAdapter.localeChanges
       .pipe(startWith(null))
       .subscribe(() => this._init());
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    const comparisonChange = changes['comparisonStart'] || changes['comparisonEnd'];
+
+    if (comparisonChange && !comparisonChange.firstChange) {
+      this._setRanges(this.selected);
+    }
   }
 
   ngOnDestroy() {

--- a/src/material/datepicker/testing/BUILD.bazel
+++ b/src/material/datepicker/testing/BUILD.bazel
@@ -1,0 +1,63 @@
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material/datepicker/testing",
+    deps = [
+        "//src/cdk/coercion",
+        "//src/cdk/testing",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob(["**/*.ts"]),
+)
+
+ng_test_library(
+    name = "harness_tests_lib",
+    srcs = [
+        "calendar-harness-shared.spec.ts",
+        "date-range-input-harness-shared.spec.ts",
+        "datepicker-input-harness-shared.spec.ts",
+        "datepicker-toggle-harness-shared.spec.ts",
+    ],
+    deps = [
+        ":testing",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/core",
+        "//src/material/datepicker",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+    ],
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = [
+            "date-range-input-harness-shared.spec.ts",
+            "datepicker-input-harness-shared.spec.ts",
+            "datepicker-toggle-harness-shared.spec.ts",
+            "calendar-harness-shared.spec.ts",
+        ],
+    ),
+    deps = [
+        ":harness_tests_lib",
+        ":testing",
+        "//src/material/datepicker",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [":unit_tests_lib"],
+)

--- a/src/material/datepicker/testing/calendar-cell-harness.ts
+++ b/src/material/datepicker/testing/calendar-cell-harness.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate, ComponentHarness} from '@angular/cdk/testing';
+import {CalendarCellHarnessFilters} from './datepicker-harness-filters';
+
+/** Harness for interacting with a standard Material calendar cell in tests. */
+export class MatCalendarCellHarness extends ComponentHarness {
+  static hostSelector = '.mat-calendar-body-cell';
+
+  /** Reference to the inner content element inside the cell. */
+  private _content = this.locatorFor('.mat-calendar-body-cell-content');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatCalendarCellHarness`
+   * that meets certain criteria.
+   * @param options Options for filtering which cell instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: CalendarCellHarnessFilters = {}): HarnessPredicate<MatCalendarCellHarness> {
+    return new HarnessPredicate(MatCalendarCellHarness, options)
+      .addOption('text', options.text, (harness, text) => {
+        return HarnessPredicate.stringMatches(harness.getText(), text);
+      })
+      .addOption('selected', options.selected, async (harness, selected) => {
+        return (await harness.isSelected()) === selected;
+      })
+      .addOption('active', options.active, async (harness, active) => {
+        return (await harness.isActive()) === active;
+      })
+      .addOption('disabled', options.disabled, async (harness, disabled) => {
+        return (await harness.isDisabled()) === disabled;
+      })
+      .addOption('today', options.today, async (harness, today) => {
+        return (await harness.isToday()) === today;
+      })
+      .addOption('inRange', options.inRange, async (harness, inRange) => {
+        return (await harness.isInRange()) === inRange;
+      })
+      .addOption('inComparisonRange', options.inComparisonRange,
+          async (harness, inComparisonRange) => {
+            return (await harness.isInComparisonRange()) === inComparisonRange;
+          })
+      .addOption('inPreviewRange', options.inPreviewRange, async (harness, inPreviewRange) => {
+        return (await harness.isInPreviewRange()) === inPreviewRange;
+      });
+  }
+
+  /** Gets the text of the calendar cell. */
+  async getText(): Promise<string> {
+    return (await this._content()).text();
+  }
+
+  /** Gets the aria-label of the calendar cell. */
+  async getAriaLabel(): Promise<string> {
+    // We're guaranteed for the `aria-label` to be defined
+    // since this is a private element that we control.
+    return (await this.host()).getAttribute('aria-label') as Promise<string>;
+  }
+
+  /** Whether the cell is selected. */
+  async isSelected(): Promise<boolean> {
+    const host = await this.host();
+    return (await host.getAttribute('aria-selected')) === 'true';
+  }
+
+  /** Whether the cell is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return this._hasState('disabled');
+  }
+
+  /** Whether the cell is currently activated using keyboard navigation. */
+  async isActive(): Promise<boolean> {
+    return this._hasState('active');
+  }
+
+  /** Whether the cell represents today's date. */
+  async isToday(): Promise<boolean> {
+    return (await this._content()).hasClass('mat-calendar-body-today');
+  }
+
+  /** Selects the calendar cell. Won't do anything if the cell is disabled. */
+  async select(): Promise<void> {
+    return (await this.host()).click();
+  }
+
+  /** Hovers over the calendar cell. */
+  async hover(): Promise<void> {
+    return (await this.host()).hover();
+  }
+
+  /** Moves the mouse away from the calendar cell. */
+  async mouseAway(): Promise<void> {
+    return (await this.host()).mouseAway();
+  }
+
+  /** Focuses the calendar cell. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Removes focus from the calendar cell. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the cell is the start of the main range. */
+  async isRangeStart(): Promise<boolean> {
+    return this._hasState('range-start');
+  }
+
+  /** Whether the cell is the end of the main range. */
+  async isRangeEnd(): Promise<boolean> {
+    return this._hasState('range-end');
+  }
+
+  /** Whether the cell is part of the main range. */
+  async isInRange(): Promise<boolean> {
+    return this._hasState('in-range');
+  }
+
+  /** Whether the cell is the start of the comparison range. */
+  async isComparisonRangeStart(): Promise<boolean> {
+    return this._hasState('comparison-start');
+  }
+
+  /** Whether the cell is the end of the comparison range. */
+  async isComparisonRangeEnd(): Promise<boolean> {
+    return this._hasState('comparison-end');
+  }
+
+  /** Whether the cell is inside of the comparison range. */
+  async isInComparisonRange(): Promise<boolean> {
+    return this._hasState('in-comparison-range');
+  }
+
+  /** Whether the cell is the start of the preview range. */
+  async isPreviewRangeStart(): Promise<boolean> {
+    return this._hasState('preview-start');
+  }
+
+  /** Whether the cell is the end of the preview range. */
+  async isPreviewRangeEnd(): Promise<boolean> {
+    return this._hasState('preview-end');
+  }
+
+  /** Whether the cell is inside of the preview range. */
+  async isInPreviewRange(): Promise<boolean> {
+    return this._hasState('in-preview');
+  }
+
+  /** Returns whether the cell has a particular CSS class-based state. */
+  private async _hasState(name: string): Promise<boolean> {
+    return (await this.host()).hasClass(`mat-calendar-body-${name}`);
+  }
+}

--- a/src/material/datepicker/testing/calendar-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/calendar-harness-shared.spec.ts
@@ -1,0 +1,324 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatDatepickerModule, DateRange} from '@angular/material/datepicker';
+import {MatNativeDateModule} from '@angular/material/core';
+import {MatCalendarHarness, CalendarView} from './calendar-harness';
+
+/** Date at which the calendars are set. */
+const calendarDate = new Date(2020, 7, 1);
+
+/** Shared tests to run on both the original and MDC-based calendars. */
+export function runCalendarHarnessTests(
+    datepickerModule: typeof MatDatepickerModule,
+    calendarHarness: typeof MatCalendarHarness) {
+  let fixture: ComponentFixture<CalendarHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatNativeDateModule, datepickerModule],
+      declarations: [CalendarHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CalendarHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load all calendar harnesses', async () => {
+    const calendars = await loader.getAllHarnesses(calendarHarness);
+    expect(calendars.length).toBe(2);
+  });
+
+  it('should go to a different view', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    expect(await calendar.getCurrentView()).toBe(CalendarView.MONTH);
+
+    await calendar.changeView();
+    expect(await calendar.getCurrentView()).toBe(CalendarView.MULTI_YEAR);
+  });
+
+  it('should get the current view label', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    expect(await calendar.getCurrentViewLabel()).toBe('AUG 2020');
+
+    await calendar.changeView();
+    expect(await calendar.getCurrentViewLabel()).toBe('2016 – 2039');
+  });
+
+  it('should go to the next page in the view', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    expect(await calendar.getCurrentViewLabel()).toBe('AUG 2020');
+
+    await calendar.next();
+    expect(await calendar.getCurrentViewLabel()).toBe('SEP 2020');
+  });
+
+  it('should go to the previous page in the view', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    expect(await calendar.getCurrentViewLabel()).toBe('AUG 2020');
+
+    await calendar.previous();
+    expect(await calendar.getCurrentViewLabel()).toBe('JUL 2020');
+  });
+
+  it('should get all of the date cells inside the calendar', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    expect((await calendar.getCells()).length).toBe(31);
+  });
+
+  it('should get the text of a calendar cell', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const cells = await calendar.getCells();
+
+    expect(await cells[0].getText()).toBe('1');
+    expect(await cells[15].getText()).toBe('16');
+    expect(await cells[30].getText()).toBe('31');
+  });
+
+  it('should be able to select a specific cell through the calendar', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const targetCell = (await calendar.getCells({text: '16'}))[0];
+    expect(await targetCell.isSelected()).toBe(false);
+
+    await calendar.selectCell({text: '16'});
+    expect(await targetCell.isSelected()).toBe(true);
+  });
+
+  it('should get the aria-label of a cell', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const cells = await calendar.getCells();
+
+    expect(await cells[0].getAriaLabel()).toBe('August 1, 2020');
+    expect(await cells[15].getAriaLabel()).toBe('August 16, 2020');
+    expect(await cells[30].getAriaLabel()).toBe('August 31, 2020');
+  });
+
+  it('should get the disabled state of a cell', async () => {
+    fixture.componentInstance.minDate =
+        new Date(calendarDate.getFullYear(), calendarDate.getMonth(), 20);
+
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const cells = await calendar.getCells();
+
+    expect(await cells[0].isDisabled()).toBe(true);
+    expect(await cells[15].isDisabled()).toBe(true);
+    expect(await cells[30].isDisabled()).toBe(false);
+  });
+
+  it('should select a cell', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const cell = (await calendar.getCells())[10];
+    expect(await cell.isSelected()).toBe(false);
+
+    await cell.select();
+    expect(await cell.isSelected()).toBe(true);
+  });
+
+  it('should get whether a cell is active', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const cells = await calendar.getCells();
+
+    expect(await cells[0].isActive()).toBe(true);
+    expect(await cells[15].isActive()).toBe(false);
+  });
+
+  it('should get the state of the cell within the main range', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#range'}));
+    const allCells = await calendar.getCells();
+    const [initialStartStates, initialInRangeStates, initialEndStates] = await Promise.all([
+      Promise.all(allCells.map(cell => cell.isRangeStart())),
+      Promise.all(allCells.map(cell => cell.isInRange())),
+      Promise.all(allCells.map(cell => cell.isRangeEnd()))
+    ]);
+
+    expect(initialStartStates.every(state => state === false)).toBe(true);
+    expect(initialInRangeStates.every(state => state === false)).toBe(true);
+    expect(initialEndStates.every(state => state === false)).toBe(true);
+
+    await (await calendar.getCells({text: '5'}))[0].select();
+    await (await calendar.getCells({text: '8'}))[0].select();
+
+    expect(await allCells[4].isRangeStart()).toBe(true);
+    expect(await allCells[4].isInRange()).toBe(true);
+    expect(await allCells[4].isRangeEnd()).toBe(false);
+
+    expect(await allCells[5].isRangeStart()).toBe(false);
+    expect(await allCells[5].isInRange()).toBe(true);
+    expect(await allCells[5].isRangeEnd()).toBe(false);
+
+    expect(await allCells[6].isRangeStart()).toBe(false);
+    expect(await allCells[6].isInRange()).toBe(true);
+    expect(await allCells[6].isRangeEnd()).toBe(false);
+
+    expect(await allCells[7].isRangeStart()).toBe(false);
+    expect(await allCells[7].isInRange()).toBe(true);
+    expect(await allCells[7].isRangeEnd()).toBe(true);
+  });
+
+  it('should get the state of the cell within the comparison range', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#range'}));
+    const allCells = await calendar.getCells();
+    const [initialStartStates, initialInRangeStates, initialEndStates] = await Promise.all([
+      Promise.all(allCells.map(cell => cell.isComparisonRangeStart())),
+      Promise.all(allCells.map(cell => cell.isInComparisonRange())),
+      Promise.all(allCells.map(cell => cell.isComparisonRangeEnd()))
+    ]);
+
+    expect(initialStartStates.every(state => state === false)).toBe(true);
+    expect(initialInRangeStates.every(state => state === false)).toBe(true);
+    expect(initialEndStates.every(state => state === false)).toBe(true);
+
+    fixture.componentInstance.comparisonStart =
+        new Date(calendarDate.getFullYear(), calendarDate.getMonth(), 5);
+    fixture.componentInstance.comparisonEnd =
+        new Date(calendarDate.getFullYear(), calendarDate.getMonth(), 8);
+
+    expect(await allCells[4].isComparisonRangeStart()).toBe(true);
+    expect(await allCells[4].isInComparisonRange()).toBe(true);
+    expect(await allCells[4].isComparisonRangeEnd()).toBe(false);
+
+    expect(await allCells[5].isComparisonRangeStart()).toBe(false);
+    expect(await allCells[5].isInComparisonRange()).toBe(true);
+    expect(await allCells[5].isComparisonRangeEnd()).toBe(false);
+
+    expect(await allCells[6].isComparisonRangeStart()).toBe(false);
+    expect(await allCells[6].isInComparisonRange()).toBe(true);
+    expect(await allCells[6].isComparisonRangeEnd()).toBe(false);
+
+    expect(await allCells[7].isComparisonRangeStart()).toBe(false);
+    expect(await allCells[7].isInComparisonRange()).toBe(true);
+    expect(await allCells[7].isComparisonRangeEnd()).toBe(true);
+  });
+
+  it('should get the state of the cell within the preview range', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#range'}));
+    const allCells = await calendar.getCells();
+    const [initialStartStates, initialInRangeStates, initialEndStates] = await Promise.all([
+      Promise.all(allCells.map(cell => cell.isPreviewRangeStart())),
+      Promise.all(allCells.map(cell => cell.isInPreviewRange())),
+      Promise.all(allCells.map(cell => cell.isPreviewRangeEnd()))
+    ]);
+
+    expect(initialStartStates.every(state => state === false)).toBe(true);
+    expect(initialInRangeStates.every(state => state === false)).toBe(true);
+    expect(initialEndStates.every(state => state === false)).toBe(true);
+
+    await (await calendar.getCells({text: '5'}))[0].select();
+    await (await calendar.getCells({text: '8'}))[0].hover();
+
+    expect(await allCells[4].isPreviewRangeStart()).toBe(true);
+    expect(await allCells[4].isInPreviewRange()).toBe(true);
+    expect(await allCells[4].isPreviewRangeEnd()).toBe(false);
+
+    expect(await allCells[5].isPreviewRangeStart()).toBe(false);
+    expect(await allCells[5].isInPreviewRange()).toBe(true);
+    expect(await allCells[5].isPreviewRangeEnd()).toBe(false);
+
+    expect(await allCells[6].isPreviewRangeStart()).toBe(false);
+    expect(await allCells[6].isInPreviewRange()).toBe(true);
+    expect(await allCells[6].isPreviewRangeEnd()).toBe(false);
+
+    expect(await allCells[7].isPreviewRangeStart()).toBe(false);
+    expect(await allCells[7].isInPreviewRange()).toBe(true);
+    expect(await allCells[7].isPreviewRangeEnd()).toBe(true);
+  });
+
+  it('should filter cells by their text', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const cells = await calendar.getCells({text: /^3/});
+    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['3', '30', '31']);
+  });
+
+  it('should filter cells by their selected state', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const allCells = await calendar.getCells();
+
+    await allCells[0].select();
+
+    const selectedCells = await calendar.getCells({selected: true});
+    expect(await Promise.all(selectedCells.map(cell => cell.getText()))).toEqual(['1']);
+  });
+
+  it('should filter cells by their active state', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const cells = await calendar.getCells({active: true});
+    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['1']);
+  });
+
+  it('should filter cells by their disabled state', async () => {
+    fixture.componentInstance.minDate =
+        new Date(calendarDate.getFullYear(), calendarDate.getMonth(), 3);
+
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
+    const cells = await calendar.getCells({disabled: true});
+    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['1', '2']);
+  });
+
+  it('should filter cells based on whether they are inside the comparison range', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#range'}));
+
+    fixture.componentInstance.comparisonStart =
+        new Date(calendarDate.getFullYear(), calendarDate.getMonth(), 5);
+    fixture.componentInstance.comparisonEnd =
+        new Date(calendarDate.getFullYear(), calendarDate.getMonth(), 8);
+
+    const cells = await calendar.getCells({inComparisonRange: true});
+    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['5', '6', '7', '8']);
+  });
+
+  it('should filter cells based on whether they are inside the preview range', async () => {
+    const calendar = await loader.getHarness(calendarHarness.with({selector: '#range'}));
+
+    await (await calendar.getCells({text: '5'}))[0].select();
+    await (await calendar.getCells({text: '8'}))[0].hover();
+
+    const cells = await calendar.getCells({inPreviewRange: true});
+    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['5', '6', '7', '8']);
+  });
+
+}
+
+@Component({
+  template: `
+    <mat-calendar
+      id="single"
+      [startAt]="startAt"
+      [minDate]="minDate"
+      [selected]="singleValue"
+      (selectedChange)="singleValue = $event"></mat-calendar>
+
+    <mat-calendar
+      id="range"
+      [startAt]="startAt"
+      [minDate]="minDate"
+      [selected]="rangeValue"
+      [comparisonStart]="comparisonStart"
+      [comparisonEnd]="comparisonEnd"
+      (selectedChange)="rangeChanged($event)"></mat-calendar>
+  `
+})
+class CalendarHarnessTest {
+  // Start the datepickers off at a specific date so tests
+  // run consistently no matter what the current date is.
+  readonly startAt = new Date(calendarDate);
+  minDate: Date|null;
+  singleValue: Date|null = null;
+  rangeValue = new DateRange<Date>(null, null);
+  comparisonStart: Date|null = null;
+  comparisonEnd: Date|null = null;
+
+  rangeChanged(selectedDate: Date) {
+    let {start, end} = this.rangeValue;
+
+    if (start == null || end != null) {
+      start = selectedDate;
+    } else if (end == null) {
+      end = selectedDate;
+    }
+
+    this.rangeValue = new DateRange<Date>(start, end);
+  }
+}

--- a/src/material/datepicker/testing/calendar-harness.spec.ts
+++ b/src/material/datepicker/testing/calendar-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {runCalendarHarnessTests} from './calendar-harness-shared.spec';
+import {MatCalendarHarness} from './calendar-harness';
+
+describe('Non-MDC-based calendar harness', () => {
+  runCalendarHarnessTests(MatDatepickerModule, MatCalendarHarness);
+});

--- a/src/material/datepicker/testing/calendar-harness.ts
+++ b/src/material/datepicker/testing/calendar-harness.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate, ComponentHarness} from '@angular/cdk/testing';
+import {CalendarHarnessFilters, CalendarCellHarnessFilters} from './datepicker-harness-filters';
+import {MatCalendarCellHarness} from './calendar-cell-harness';
+
+/** Possible views of a `MatCalendarHarness`. */
+export const enum CalendarView {MONTH, YEAR, MULTI_YEAR}
+
+/** Harness for interacting with a standard Material calendar in tests. */
+export class MatCalendarHarness extends ComponentHarness {
+  static hostSelector = '.mat-calendar';
+
+  /** Queries for the calendar's period toggle button. */
+  private _periodButton = this.locatorFor('.mat-calendar-period-button');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatCalendarHarness`
+   * that meets certain criteria.
+   * @param options Options for filtering which calendar instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: CalendarHarnessFilters = {}): HarnessPredicate<MatCalendarHarness> {
+    return new HarnessPredicate(MatCalendarHarness, options);
+  }
+
+  /**
+   * Gets a list of cells inside the calendar.
+   * @param filter Optionally filters which cells are included.
+   */
+  async getCells(filter: CalendarCellHarnessFilters = {}): Promise<MatCalendarCellHarness[]> {
+    return this.locatorForAll(MatCalendarCellHarness.with(filter))();
+  }
+
+  /** Gets the current view that is being shown inside the calendar. */
+  async getCurrentView(): Promise<CalendarView> {
+    if (await this.locatorForOptional('mat-multi-year-view')()) {
+      return CalendarView.MULTI_YEAR;
+    }
+
+    if (await this.locatorForOptional('mat-year-view')()) {
+      return CalendarView.YEAR;
+    }
+
+    return CalendarView.MONTH;
+  }
+
+  /** Gets the label of the current calendar view. */
+  async getCurrentViewLabel(): Promise<string> {
+    return (await this._periodButton()).text();
+  }
+
+  /** Changes the calendar view by clicking on the view toggle button. */
+  async changeView(): Promise<void> {
+    return (await this._periodButton()).click();
+  }
+
+  /** Goes to the next page of the current view (e.g. next month when inside the month view). */
+  async next(): Promise<void> {
+    return (await this.locatorFor('.mat-calendar-next-button')()).click();
+  }
+
+  /**
+   * Goes to the previous page of the current view
+   * (e.g. previous month when inside the month view).
+   */
+  async previous(): Promise<void> {
+    return (await this.locatorFor('.mat-calendar-previous-button')()).click();
+  }
+
+  /**
+   * Selects a cell in the current calendar view.
+   * @param filter An optional filter to apply to the cells. The first cell matching the filter
+   *     will be selected.
+   */
+  async selectCell(filter: CalendarCellHarnessFilters = {}): Promise<void> {
+    const cells = await this.getCells(filter);
+    if (!cells.length) {
+      throw Error(`Cannot find calendar cell matching filter ${JSON.stringify(filter)}`);
+    }
+    await cells[0].select();
+  }
+}

--- a/src/material/datepicker/testing/date-range-input-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/date-range-input-harness-shared.spec.ts
@@ -1,0 +1,240 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {MatNativeDateModule} from '@angular/material/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatCalendarHarness} from './calendar-harness';
+import {
+  MatDateRangeInputHarness,
+  MatStartDateHarness,
+  MatEndDateHarness,
+} from './date-range-input-harness';
+
+/** Shared tests to run on both the original and MDC-based date range inputs. */
+export function runDateRangeInputHarnessTests(
+    datepickerModule: typeof MatDatepickerModule,
+    dateRangeInputHarness: typeof MatDateRangeInputHarness,
+    startInputHarness: typeof MatStartDateHarness,
+    endInputHarness: typeof MatEndDateHarness,
+    calendarHarness: typeof MatCalendarHarness) {
+  let fixture: ComponentFixture<DateRangeInputHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, MatNativeDateModule, datepickerModule, FormsModule],
+      declarations: [DateRangeInputHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DateRangeInputHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load all date range input harnesses', async () => {
+    const inputs = await loader.getAllHarnesses(dateRangeInputHarness);
+    expect(inputs.length).toBe(2);
+  });
+
+  it('should get whether the input is disabled', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    expect(await input.isDisabled()).toBe(false);
+
+    fixture.componentInstance.disabled = true;
+    expect(await input.isDisabled()).toBe(true);
+  });
+
+  it('should get whether the input is required', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    expect(await input.isRequired()).toBe(false);
+
+    fixture.componentInstance.required = true;
+    expect(await input.isRequired()).toBe(true);
+  });
+
+  it('should get the input separator', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    expect(await input.getSeparator()).toBe('–');
+  });
+
+  it('should get the combined input value including the separator', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+
+    fixture.componentInstance.startDate = new Date(2020, 0, 1, 12, 0, 0);
+    fixture.componentInstance.endDate = new Date(2020, 1, 2, 12, 0, 0);
+
+    expect(await input.getValue()).toBe('1/1/2020 – 2/2/2020');
+  });
+
+  it('should get harnesses for the inner inputs', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    expect(start).toBeInstanceOf(startInputHarness);
+    expect(end).toBeInstanceOf(endInputHarness);
+  });
+
+  it('should be able to open and close a calendar in popup mode', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    expect(await input.isCalendarOpen()).toBe(false);
+
+    await input.openCalendar();
+    expect(await input.isCalendarOpen()).toBe(true);
+
+    await input.closeCalendar();
+    expect(await input.isCalendarOpen()).toBe(false);
+  });
+
+  it('should be able to open and close a calendar in touch mode', async () => {
+    fixture.componentInstance.touchUi = true;
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    expect(await input.isCalendarOpen()).toBe(false);
+
+    await input.openCalendar();
+    expect(await input.isCalendarOpen()).toBe(true);
+
+    await input.closeCalendar();
+    expect(await input.isCalendarOpen()).toBe(false);
+  });
+
+  it('should be able to get the harness for the associated calendar', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    await input.openCalendar();
+    expect(await input.getCalendar()).toBeInstanceOf(calendarHarness);
+  });
+
+  /////
+
+  it('should get whether the inner inputs are disabled', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+
+    expect(await Promise.all([start.isDisabled(), end.isDisabled()])).toEqual([false, false]);
+
+    fixture.componentInstance.subInputsDisabled = true;
+    expect(await Promise.all([start.isDisabled(), end.isDisabled()])).toEqual([true, true]);
+  });
+
+  it('should get whether the inner inputs are required', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+
+    expect(await Promise.all([start.isRequired(), end.isRequired()])).toEqual([false, false]);
+
+    fixture.componentInstance.subInputsRequired = true;
+    expect(await Promise.all([start.isRequired(), end.isRequired()])).toEqual([true, true]);
+  });
+
+  it('should get the values of the inner inputs', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+
+    fixture.componentInstance.startDate = new Date(2020, 0, 1, 12, 0, 0);
+    fixture.componentInstance.endDate = new Date(2020, 1, 2, 12, 0, 0);
+
+    expect(await Promise.all([start.getValue(), end.getValue()])).toEqual(['1/1/2020', '2/2/2020']);
+  });
+
+  it('should set the values of the inner inputs', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+
+    expect(await Promise.all([start.getValue(), end.getValue()])).toEqual(['', '']);
+
+    await Promise.all([start.setValue('1/1/2020'), end.setValue('2/2/2020')]);
+
+    expect(await Promise.all([start.getValue(), end.getValue()])).toEqual(['1/1/2020', '2/2/2020']);
+  });
+
+  it('should get the placeholders of the inner inputs', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+
+    expect(await Promise.all([start.getPlaceholder(), end.getPlaceholder()])).toEqual([
+      'Start date',
+      'End date'
+    ]);
+  });
+
+  it('should be able to change the inner input focused state', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+
+    expect(await start.isFocused()).toBe(false);
+    await start.focus();
+    expect(await start.isFocused()).toBe(true);
+    await start.blur();
+    expect(await start.isFocused()).toBe(false);
+
+    expect(await end.isFocused()).toBe(false);
+    await end.focus();
+    expect(await end.isFocused()).toBe(true);
+    await end.blur();
+    expect(await end.isFocused()).toBe(false);
+  });
+
+  it('should get the minimum date of the inner inputs', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+
+    expect(await Promise.all([start.getMin(), end.getMin()])).toEqual([null, null]);
+
+    fixture.componentInstance.minDate = new Date(2020, 0, 1, 12, 0, 0);
+    expect(await Promise.all([start.getMin(), end.getMin()])).toEqual(['2020-01-01', '2020-01-01']);
+  });
+
+  it('should get the maximum date of the inner inputs', async () => {
+    const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
+    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+
+    expect(await Promise.all([start.getMax(), end.getMax()])).toEqual([null, null]);
+
+    fixture.componentInstance.maxDate = new Date(2020, 0, 1, 12, 0, 0);
+
+    expect(await Promise.all([start.getMax(), end.getMax()])).toEqual(['2020-01-01', '2020-01-01']);
+  });
+}
+
+@Component({
+  template: `
+    <mat-date-range-input
+      basic
+      [disabled]="disabled"
+      [required]="required"
+      [min]="minDate"
+      [max]="maxDate"
+      [rangePicker]="picker">
+      <input
+        matStartDate
+        [(ngModel)]="startDate"
+        [disabled]="subInputsDisabled"
+        [required]="subInputsRequired"
+        placeholder="Start date">
+      <input
+        matEndDate
+        [(ngModel)]="endDate"
+        [disabled]="subInputsDisabled"
+        [required]="subInputsRequired"
+        placeholder="End date">
+    </mat-date-range-input>
+    <mat-date-range-picker #picker [touchUi]="touchUi"></mat-date-range-picker>
+
+    <mat-date-range-input no-range-picker>
+      <input matStartDate>
+      <input matEndDate>
+    </mat-date-range-input>
+  `
+})
+class DateRangeInputHarnessTest {
+  startDate: Date|null = null;
+  endDate: Date|null = null;
+  minDate: Date|null = null;
+  maxDate: Date|null = null;
+  touchUi = false;
+  disabled = false;
+  required = false;
+  subInputsDisabled = false;
+  subInputsRequired = false;
+}

--- a/src/material/datepicker/testing/date-range-input-harness.spec.ts
+++ b/src/material/datepicker/testing/date-range-input-harness.spec.ts
@@ -1,0 +1,18 @@
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {
+  MatDateRangeInputHarness,
+  MatStartDateHarness,
+  MatEndDateHarness,
+} from './date-range-input-harness';
+import {runDateRangeInputHarnessTests} from './date-range-input-harness-shared.spec';
+import {MatCalendarHarness} from './calendar-harness';
+
+describe('Non-MDC-based date range input harness', () => {
+  runDateRangeInputHarnessTests(
+    MatDatepickerModule,
+    MatDateRangeInputHarness,
+    MatStartDateHarness,
+    MatEndDateHarness,
+    MatCalendarHarness,
+  );
+});

--- a/src/material/datepicker/testing/date-range-input-harness.ts
+++ b/src/material/datepicker/testing/date-range-input-harness.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate, TestKey} from '@angular/cdk/testing';
+import {MatDatepickerInputHarnessBase, getInputPredicate} from './datepicker-input-harness-base';
+import {DatepickerTriggerHarnessBase} from './datepicker-trigger-harness-base';
+import {
+  DatepickerInputHarnessFilters,
+  DateRangeInputHarnessFilters,
+} from './datepicker-harness-filters';
+
+/** Harness for interacting with a standard Material date range start input in tests. */
+export class MatStartDateHarness extends MatDatepickerInputHarnessBase {
+  static hostSelector = '.mat-start-date';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatStartDateHarness`
+   * that meets certain criteria.
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: DatepickerInputHarnessFilters = {}):
+    HarnessPredicate<MatStartDateHarness> {
+    return getInputPredicate(MatStartDateHarness, options);
+  }
+}
+
+/** Harness for interacting with a standard Material date range end input in tests. */
+export class MatEndDateHarness extends MatDatepickerInputHarnessBase {
+  static hostSelector = '.mat-end-date';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatEndDateHarness`
+   * that meets certain criteria.
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: DatepickerInputHarnessFilters = {}):
+    HarnessPredicate<MatEndDateHarness> {
+    return getInputPredicate(MatEndDateHarness, options);
+  }
+}
+
+
+/** Harness for interacting with a standard Material date range input in tests. */
+export class MatDateRangeInputHarness extends DatepickerTriggerHarnessBase {
+  static hostSelector = '.mat-date-range-input';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatDateRangeInputHarness`
+   * that meets certain criteria.
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: DateRangeInputHarnessFilters = {}):
+    HarnessPredicate<MatDateRangeInputHarness> {
+      return new HarnessPredicate(MatDateRangeInputHarness, options)
+        .addOption('value', options.value,
+            (harness, value) => HarnessPredicate.stringMatches(harness.getValue(), value));
+  }
+
+  /** Gets the combined value of the start and end inputs, including the separator. */
+  async getValue(): Promise<string> {
+    const [start, end, separator] = await Promise.all([
+      this.getStartInput().then(input => input.getValue()),
+      this.getEndInput().then(input => input.getValue()),
+      this.getSeparator()
+    ]);
+
+    return start + `${end ? ` ${separator} ${end}` : ''}`;
+  }
+
+  /** Gets the inner start date input inside the range input. */
+  async getStartInput(): Promise<MatStartDateHarness> {
+    // Don't pass in filters here since the start input is required and there can only be one.
+    return this.locatorFor(MatStartDateHarness)();
+  }
+
+  /** Gets the inner start date input inside the range input. */
+  async getEndInput(): Promise<MatEndDateHarness> {
+    // Don't pass in filters here since the end input is required and there can only be one.
+    return this.locatorFor(MatEndDateHarness)();
+  }
+
+  /** Gets the separator text between the values of the two inputs. */
+  async getSeparator(): Promise<string> {
+    return (await this.locatorFor('.mat-date-range-input-separator')()).text();
+  }
+
+  /** Gets whether the range input is disabled. */
+  async isDisabled(): Promise<boolean> {
+    // We consider the input as disabled if both of the sub-inputs are disabled.
+    const [startDisabled, endDisabled] = await Promise.all([
+      this.getStartInput().then(input => input.isDisabled()),
+      this.getEndInput().then(input => input.isDisabled())
+    ]);
+
+    return startDisabled && endDisabled;
+  }
+
+  /** Gets whether the range input is required. */
+  async isRequired(): Promise<boolean> {
+    return (await this.host()).hasClass('mat-date-range-input-required');
+  }
+
+  /** Opens the calendar associated with the input. */
+  async isCalendarOpen(): Promise<boolean> {
+    // `aria-owns` is set on both inputs only if there's an
+    // open range picker so we can use it as an indicator.
+    const startHost = await (await this.getStartInput()).host();
+    return (await startHost.getAttribute('aria-owns')) != null;
+  }
+
+  protected async _openCalendar(): Promise<void> {
+    // Alt + down arrow is the combination for opening the calendar with the keyboard.
+    const startHost = await (await this.getStartInput()).host();
+    return startHost.sendKeys({alt: true}, TestKey.DOWN_ARROW);
+  }
+}

--- a/src/material/datepicker/testing/datepicker-harness-filters.ts
+++ b/src/material/datepicker/testing/datepicker-harness-filters.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+/** A set of criteria that can be used to filter a list of datepicker input instances. */
+export interface DatepickerInputHarnessFilters extends BaseHarnessFilters {
+  /** Filters based on the value of the input. */
+  value?: string | RegExp;
+  /** Filters based on the placeholder text of the input. */
+  placeholder?: string | RegExp;
+}
+
+/** A set of criteria that can be used to filter a list of datepicker toggle instances. */
+export interface DatepickerToggleHarnessFilters extends BaseHarnessFilters {}
+
+/** A set of criteria that can be used to filter a list of calendar instances. */
+export interface CalendarHarnessFilters extends BaseHarnessFilters {}
+
+/** A set of criteria that can be used to filter a list of calendar cell instances. */
+export interface CalendarCellHarnessFilters extends BaseHarnessFilters {
+  /** Filters based on the text of the cell. */
+  text?: string | RegExp;
+  /** Filters based on whether the cell is selected. */
+  selected?: boolean;
+  /** Filters based on whether the cell is activated using keyboard navigation */
+  active?: boolean;
+  /** Filters based on whether the cell is disabled. */
+  disabled?: boolean;
+  /** Filters based on whether the cell represents today's date. */
+  today?: boolean;
+  /** Filters based on whether the cell is inside of the main range. */
+  inRange?: boolean;
+  /** Filters based on whether the cell is inside of the comparison range. */
+  inComparisonRange?: boolean;
+  /** Filters based on whether the cell is inside of the preview range. */
+  inPreviewRange?: boolean;
+}
+
+/** A set of criteria that can be used to filter a list of date range input instances. */
+export interface DateRangeInputHarnessFilters extends BaseHarnessFilters {
+  /** Filters based on the value of the input. */
+  value?: string | RegExp;
+}

--- a/src/material/datepicker/testing/datepicker-input-harness-base.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness-base.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+  ComponentHarness,
+} from '@angular/cdk/testing';
+import {DatepickerInputHarnessFilters} from './datepicker-harness-filters';
+
+/** Sets up the filter predicates for a datepicker input harness. */
+export function getInputPredicate<T extends MatDatepickerInputHarnessBase>(
+  type: ComponentHarnessConstructor<T>,
+  options: DatepickerInputHarnessFilters): HarnessPredicate<T> {
+
+  return new HarnessPredicate(type, options)
+    .addOption('value', options.value, (harness, value) => {
+      return HarnessPredicate.stringMatches(harness.getValue(), value);
+    })
+    .addOption('placeholder', options.placeholder, (harness, placeholder) => {
+      return HarnessPredicate.stringMatches(harness.getPlaceholder(), placeholder);
+    });
+}
+
+/** Base class for datepicker input harnesses. */
+export abstract class MatDatepickerInputHarnessBase extends ComponentHarness {
+  /** Whether the input is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return (await this.host()).getProperty('disabled')!;
+  }
+
+  /** Whether the input is required. */
+  async isRequired(): Promise<boolean> {
+    return (await this.host()).getProperty('required')!;
+  }
+
+  /** Gets the value of the input. */
+  async getValue(): Promise<string> {
+    // The "value" property of the native input is always defined.
+    return (await (await this.host()).getProperty('value'))!;
+  }
+
+  /**
+   * Sets the value of the input. The value will be set by simulating
+   * keypresses that correspond to the given value.
+   */
+  async setValue(newValue: string): Promise<void> {
+    const inputEl = await this.host();
+    await inputEl.clear();
+
+    // We don't want to send keys for the value if the value is an empty
+    // string in order to clear the value. Sending keys with an empty string
+    // still results in unnecessary focus events.
+    if (newValue) {
+      await inputEl.sendKeys(newValue);
+    }
+  }
+
+  /** Gets the placeholder of the input. */
+  async getPlaceholder(): Promise<string> {
+    return (await (await this.host()).getProperty('placeholder'));
+  }
+
+  /**
+   * Focuses the input and returns a promise that indicates when the
+   * action is complete.
+   */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /**
+   * Blurs the input and returns a promise that indicates when the
+   * action is complete.
+   */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the input is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
+  /** Gets the formatted minimum date for the input's value. */
+  async getMin(): Promise<string | null> {
+    return (await this.host()).getAttribute('min');
+  }
+
+  /** Gets the formatted maximum date for the input's value. */
+  async getMax(): Promise<string | null> {
+    return (await this.host()).getAttribute('max');
+  }
+}

--- a/src/material/datepicker/testing/datepicker-input-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness-shared.spec.ts
@@ -1,0 +1,169 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {MatNativeDateModule} from '@angular/material/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatDatepickerInputHarness} from './datepicker-input-harness';
+import {MatCalendarHarness} from './calendar-harness';
+
+/** Shared tests to run on both the original and MDC-based datepicker inputs. */
+export function runDatepickerInputHarnessTests(
+    datepickerModule: typeof MatDatepickerModule,
+    datepickerInputHarness: typeof MatDatepickerInputHarness,
+    calendarHarness: typeof MatCalendarHarness) {
+  let fixture: ComponentFixture<DatepickerInputHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, MatNativeDateModule, datepickerModule, FormsModule],
+      declarations: [DatepickerInputHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatepickerInputHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load all datepicker input harnesses', async () => {
+    const inputs = await loader.getAllHarnesses(datepickerInputHarness);
+    expect(inputs.length).toBe(2);
+  });
+
+  it('should filter inputs based on their value', async () => {
+    fixture.componentInstance.date = new Date(2020, 0, 1, 12, 0, 0);
+    const inputs = await loader.getAllHarnesses(datepickerInputHarness.with({value: /2020/}));
+    expect(inputs.length).toBe(1);
+  });
+
+  it('should filter inputs based on their placeholder', async () => {
+    const inputs = await loader.getAllHarnesses(datepickerInputHarness.with({
+      placeholder: /^Type/
+    }));
+
+    expect(inputs.length).toBe(1);
+  });
+
+  it('should get whether the input has an associated calendar', async () => {
+    const inputs = await loader.getAllHarnesses(datepickerInputHarness);
+    expect(await Promise.all(inputs.map(input => input.hasCalendar()))).toEqual([true, false]);
+  });
+
+  it('should get whether the input is disabled', async () => {
+    const input = await loader.getHarness(datepickerInputHarness.with({selector: '#basic'}));
+    expect(await input.isDisabled()).toBe(false);
+
+    fixture.componentInstance.disabled = true;
+    expect(await input.isDisabled()).toBe(true);
+  });
+
+  it('should get whether the input is required', async () => {
+    const input = await loader.getHarness(datepickerInputHarness.with({selector: '#basic'}));
+    expect(await input.isRequired()).toBe(false);
+
+    fixture.componentInstance.required = true;
+    expect(await input.isRequired()).toBe(true);
+  });
+
+  it('should get the input value', async () => {
+    const input = await loader.getHarness(datepickerInputHarness.with({selector: '#basic'}));
+    fixture.componentInstance.date = new Date(2020, 0, 1, 12, 0, 0);
+
+    expect(await input.getValue()).toBe('1/1/2020');
+  });
+
+  it('should set the input value', async () => {
+    const input = await loader.getHarness(datepickerInputHarness.with({selector: '#basic'}));
+    expect(await input.getValue()).toBeFalsy();
+
+    await input.setValue('1/1/2020');
+    expect(await input.getValue()).toBe('1/1/2020');
+  });
+
+  it('should get the input placeholder', async () => {
+    const inputs = await loader.getAllHarnesses(datepickerInputHarness);
+    expect(await Promise.all(inputs.map(input => {
+      return input.getPlaceholder();
+    }))).toEqual(['Type a date', '']);
+  });
+
+  it('should be able to change the input focused state', async () => {
+    const input = await loader.getHarness(datepickerInputHarness.with({selector: '#basic'}));
+    expect(await input.isFocused()).toBe(false);
+
+    await input.focus();
+    expect(await input.isFocused()).toBe(true);
+
+    await input.blur();
+    expect(await input.isFocused()).toBe(false);
+  });
+
+  it('should get the minimum date of the input', async () => {
+    const inputs = await loader.getAllHarnesses(datepickerInputHarness);
+    fixture.componentInstance.minDate = new Date(2020, 0, 1, 12, 0, 0);
+    expect(await Promise.all(inputs.map(input => input.getMin()))).toEqual(['2020-01-01', null]);
+  });
+
+  it('should get the maximum date of the input', async () => {
+    const inputs = await loader.getAllHarnesses(datepickerInputHarness);
+    fixture.componentInstance.maxDate = new Date(2020, 0, 1, 12, 0, 0);
+    expect(await Promise.all(inputs.map(input => input.getMax()))).toEqual(['2020-01-01', null]);
+  });
+
+  it('should be able to open and close a calendar in popup mode', async () => {
+    const input = await loader.getHarness(datepickerInputHarness.with({selector: '#basic'}));
+    expect(await input.isCalendarOpen()).toBe(false);
+
+    await input.openCalendar();
+    expect(await input.isCalendarOpen()).toBe(true);
+
+    await input.closeCalendar();
+    expect(await input.isCalendarOpen()).toBe(false);
+  });
+
+  it('should be able to open and close a calendar in touch mode', async () => {
+    fixture.componentInstance.touchUi = true;
+    const input = await loader.getHarness(datepickerInputHarness.with({selector: '#basic'}));
+    expect(await input.isCalendarOpen()).toBe(false);
+
+    await input.openCalendar();
+    expect(await input.isCalendarOpen()).toBe(true);
+
+    await input.closeCalendar();
+    expect(await input.isCalendarOpen()).toBe(false);
+  });
+
+  it('should be able to get the harness for the associated calendar', async () => {
+    const input = await loader.getHarness(datepickerInputHarness.with({selector: '#basic'}));
+    await input.openCalendar();
+    expect(await input.getCalendar()).toBeInstanceOf(calendarHarness);
+  });
+}
+
+@Component({
+  template: `
+    <input
+      id="basic"
+      matInput
+      [matDatepicker]="picker"
+      [(ngModel)]="date"
+      [min]="minDate"
+      [max]="maxDate"
+      [disabled]="disabled"
+      [required]="required"
+      placeholder="Type a date">
+    <mat-datepicker #picker [touchUi]="touchUi"></mat-datepicker>
+    <input id="no-datepicker" matDatepicker>
+  `
+})
+class DatepickerInputHarnessTest {
+  date: Date|null = null;
+  minDate: Date|null = null;
+  maxDate: Date|null = null;
+  touchUi = false;
+  disabled = false;
+  required = false;
+}

--- a/src/material/datepicker/testing/datepicker-input-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness.spec.ts
@@ -1,0 +1,12 @@
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {MatDatepickerInputHarness} from './datepicker-input-harness';
+import {runDatepickerInputHarnessTests} from './datepicker-input-harness-shared.spec';
+import {MatCalendarHarness} from './calendar-harness';
+
+describe('Non-MDC-based datepicker input harness', () => {
+  runDatepickerInputHarnessTests(
+    MatDatepickerModule,
+    MatDatepickerInputHarness,
+    MatCalendarHarness
+  );
+});

--- a/src/material/datepicker/testing/datepicker-input-harness.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate, TestKey} from '@angular/cdk/testing';
+import {DatepickerInputHarnessFilters, CalendarHarnessFilters} from './datepicker-harness-filters';
+import {MatDatepickerInputHarnessBase, getInputPredicate} from './datepicker-input-harness-base';
+import {MatCalendarHarness} from './calendar-harness';
+import {
+  DatepickerTrigger,
+  closeCalendar,
+  getCalendarId,
+  getCalendar,
+} from './datepicker-trigger-harness-base';
+
+/** Harness for interacting with a standard Material datepicker inputs in tests. */
+export class MatDatepickerInputHarness extends MatDatepickerInputHarnessBase implements
+  DatepickerTrigger {
+  static hostSelector = '.mat-datepicker-input';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatDatepickerInputHarness`
+   * that meets certain criteria.
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: DatepickerInputHarnessFilters = {}):
+    HarnessPredicate<MatDatepickerInputHarness> {
+    return getInputPredicate(MatDatepickerInputHarness, options);
+  }
+
+  /** Gets whether the calendar associated with the input is open. */
+  async isCalendarOpen(): Promise<boolean> {
+    // `aria-owns` is set only if there's an open datepicker so we can use it as an indicator.
+    const host = await this.host();
+    return (await host.getAttribute('aria-owns')) != null;
+  }
+
+  /** Opens the calendar associated with the input. */
+  async openCalendar(): Promise<void> {
+    const [isDisabled, hasCalendar] = await Promise.all([this.isDisabled(), this.hasCalendar()]);
+
+    if (!isDisabled && hasCalendar) {
+      // Alt + down arrow is the combination for opening the calendar with the keyboard.
+      const host = await this.host();
+      return host.sendKeys({alt: true}, TestKey.DOWN_ARROW);
+    }
+  }
+
+  /** Closes the calendar associated with the input. */
+  async closeCalendar(): Promise<void> {
+    if (await this.isCalendarOpen()) {
+      await closeCalendar(getCalendarId(this.host()), this.documentRootLocatorFactory());
+      // This is necessary so that we wait for the closing animation to finish in touch UI mode.
+      await this.forceStabilize();
+    }
+  }
+
+  /** Whether a calendar is associated with the input. */
+  async hasCalendar(): Promise<boolean> {
+    return (await getCalendarId(this.host())) != null;
+  }
+
+  /**
+   * Gets the `MatCalendarHarness` that is associated with the trigger.
+   * @param filter Optionally filters which calendar is included.
+   */
+  async getCalendar(filter: CalendarHarnessFilters = {}): Promise<MatCalendarHarness> {
+    return getCalendar(filter, this.host(), this.documentRootLocatorFactory());
+  }
+}

--- a/src/material/datepicker/testing/datepicker-toggle-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/datepicker-toggle-harness-shared.spec.ts
@@ -1,0 +1,91 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {MatNativeDateModule} from '@angular/material/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatDatepickerToggleHarness} from './datepicker-toggle-harness';
+import {MatCalendarHarness} from './calendar-harness';
+
+/** Shared tests to run on both the original and MDC-based datepicker toggles. */
+export function runDatepickerToggleHarnessTests(
+    datepickerModule: typeof MatDatepickerModule,
+    datepickerToggleHarness: typeof MatDatepickerToggleHarness,
+    calendarHarness: typeof MatCalendarHarness) {
+  let fixture: ComponentFixture<DatepickerToggleHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, MatNativeDateModule, datepickerModule],
+      declarations: [DatepickerToggleHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatepickerToggleHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load all toggle harnesses', async () => {
+    const toggles = await loader.getAllHarnesses(datepickerToggleHarness);
+    expect(toggles.length).toBe(2);
+  });
+
+  it('should get whether the toggle is disabled', async () => {
+    const toggle = await loader.getHarness(datepickerToggleHarness.with({selector: '#basic'}));
+    expect(await toggle.isDisabled()).toBe(false);
+
+    fixture.componentInstance.disabled = true;
+    expect(await toggle.isDisabled()).toBe(true);
+  });
+
+  it('should get whether the toggle has a calendar associated with it', async () => {
+    const toggles = await loader.getAllHarnesses(datepickerToggleHarness);
+    expect(await Promise.all(toggles.map(toggle => toggle.hasCalendar()))).toEqual([true, false]);
+  });
+
+  it('should be able to open and close a calendar in popup mode', async () => {
+    const toggle = await loader.getHarness(datepickerToggleHarness.with({selector: '#basic'}));
+    expect(await toggle.isCalendarOpen()).toBe(false);
+
+    await toggle.openCalendar();
+    expect(await toggle.isCalendarOpen()).toBe(true);
+
+    await toggle.closeCalendar();
+    expect(await toggle.isCalendarOpen()).toBe(false);
+  });
+
+  it('should be able to open and close a calendar in touch mode', async () => {
+    fixture.componentInstance.touchUi = true;
+    const toggle = await loader.getHarness(datepickerToggleHarness.with({selector: '#basic'}));
+    expect(await toggle.isCalendarOpen()).toBe(false);
+
+    await toggle.openCalendar();
+    expect(await toggle.isCalendarOpen()).toBe(true);
+
+    await toggle.closeCalendar();
+    expect(await toggle.isCalendarOpen()).toBe(false);
+  });
+
+  it('should be able to get the harness for the associated calendar', async () => {
+    const toggle = await loader.getHarness(datepickerToggleHarness.with({selector: '#basic'}));
+    await toggle.openCalendar();
+    expect(await toggle.getCalendar()).toBeInstanceOf(calendarHarness);
+  });
+
+}
+
+@Component({
+  template: `
+    <input [matDatepicker]="picker">
+    <mat-datepicker-toggle id="basic" [for]="picker" [disabled]="disabled"></mat-datepicker-toggle>
+    <mat-datepicker #picker [touchUi]="touchUi"></mat-datepicker>
+
+    <mat-datepicker-toggle id="no-calendar"></mat-datepicker-toggle>
+  `
+})
+class DatepickerToggleHarnessTest {
+  touchUi = false;
+  disabled = false;
+}

--- a/src/material/datepicker/testing/datepicker-toggle-harness.spec.ts
+++ b/src/material/datepicker/testing/datepicker-toggle-harness.spec.ts
@@ -1,0 +1,12 @@
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {runDatepickerToggleHarnessTests} from './datepicker-toggle-harness-shared.spec';
+import {MatDatepickerToggleHarness} from './datepicker-toggle-harness';
+import {MatCalendarHarness} from './calendar-harness';
+
+describe('Non-MDC-based datepicker toggle harness', () => {
+  runDatepickerToggleHarnessTests(
+    MatDatepickerModule,
+    MatDatepickerToggleHarness,
+    MatCalendarHarness
+  );
+});

--- a/src/material/datepicker/testing/datepicker-toggle-harness.ts
+++ b/src/material/datepicker/testing/datepicker-toggle-harness.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate} from '@angular/cdk/testing';
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {DatepickerToggleHarnessFilters} from './datepicker-harness-filters';
+import {DatepickerTriggerHarnessBase} from './datepicker-trigger-harness-base';
+
+
+/** Harness for interacting with a standard Material datepicker toggle in tests. */
+export class MatDatepickerToggleHarness extends DatepickerTriggerHarnessBase {
+  static hostSelector = '.mat-datepicker-toggle';
+
+  /** The clickable button inside the toggle. */
+  private _button = this.locatorFor('button');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatDatepickerToggleHarness` that
+   * meets certain criteria.
+   * @param options Options for filtering which datepicker toggle instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: DatepickerToggleHarnessFilters = {}):
+    HarnessPredicate<MatDatepickerToggleHarness> {
+    return new HarnessPredicate(MatDatepickerToggleHarness, options);
+  }
+
+  /** Gets whether the calendar associated with the toggle is open. */
+  async isCalendarOpen(): Promise<boolean> {
+    return (await this.host()).hasClass('mat-datepicker-toggle-active');
+  }
+
+  /** Whether the toggle is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const button = await this._button();
+    return coerceBooleanProperty(await button.getAttribute('disabled'));
+  }
+
+  protected async _openCalendar(): Promise<void> {
+    return (await this._button()).click();
+  }
+}

--- a/src/material/datepicker/testing/datepicker-trigger-harness-base.ts
+++ b/src/material/datepicker/testing/datepicker-trigger-harness-base.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, LocatorFactory, TestElement} from '@angular/cdk/testing';
+import {CalendarHarnessFilters} from './datepicker-harness-filters';
+import {MatCalendarHarness} from './calendar-harness';
+
+/** Interface for a test harness that can open and close a calendar. */
+export interface DatepickerTrigger {
+  isCalendarOpen(): Promise<boolean>;
+  openCalendar(): Promise<void>;
+  closeCalendar(): Promise<void>;
+  hasCalendar(): Promise<boolean>;
+  getCalendar(filter?: CalendarHarnessFilters): Promise<MatCalendarHarness>;
+}
+
+/** Base class for harnesses that can trigger a calendar. */
+export abstract class DatepickerTriggerHarnessBase extends ComponentHarness implements
+  DatepickerTrigger {
+  /** Whether the trigger is disabled. */
+  abstract isDisabled(): Promise<boolean>;
+
+  /** Whether the calendar associated with the trigger is open. */
+  abstract isCalendarOpen(): Promise<boolean>;
+
+  /** Opens the calendar associated with the trigger. */
+  protected abstract _openCalendar(): Promise<void>;
+
+  /** Opens the calendar if the trigger is enabled and it has a calendar. */
+  async openCalendar(): Promise<void> {
+    const [isDisabled, hasCalendar] = await Promise.all([this.isDisabled(), this.hasCalendar()]);
+
+    if (!isDisabled && hasCalendar) {
+      return this._openCalendar();
+    }
+  }
+
+  /** Closes the calendar if it is open. */
+  async closeCalendar(): Promise<void> {
+    if (await this.isCalendarOpen()) {
+      await closeCalendar(getCalendarId(this.host()), this.documentRootLocatorFactory());
+      // This is necessary so that we wait for the closing animation to finish in touch UI mode.
+      await this.forceStabilize();
+    }
+  }
+
+  /** Gets whether there is a calendar associated with the trigger. */
+  async hasCalendar(): Promise<boolean> {
+    return (await getCalendarId(this.host())) != null;
+  }
+
+  /**
+   * Gets the `MatCalendarHarness` that is associated with the trigger.
+   * @param filter Optionally filters which calendar is included.
+   */
+  async getCalendar(filter: CalendarHarnessFilters = {}): Promise<MatCalendarHarness> {
+    return getCalendar(filter, this.host(), this.documentRootLocatorFactory());
+  }
+}
+
+/** Gets the ID of the calendar that a particular test element can trigger. */
+export async function getCalendarId(host: Promise<TestElement>): Promise<string | null> {
+  return (await host).getAttribute('data-mat-calendar');
+}
+
+/** Closes the calendar with a specific ID. */
+export async function closeCalendar(
+  calendarId: Promise<string | null>,
+  documentLocator: LocatorFactory) {
+  // We close the calendar by clicking on the backdrop, even though all datepicker variants
+  // have the ability to close by pressing escape. The backdrop is preferrable, because the
+  // escape key has multiple functions inside a range picker (either cancel the current range
+  // or close the calendar). Since we don't have access to set the ID on the backdrop in all
+  // cases, we set a unique class instead which is the same as the calendar's ID and suffixed
+  // with `-backdrop`.
+  const backdropSelector = `.${await calendarId}-backdrop`;
+  return (await documentLocator.locatorFor(backdropSelector)()).click();
+}
+
+/** Gets the test harness for a calendar associated with a particular host. */
+export async function getCalendar(
+  filter: CalendarHarnessFilters,
+  host: Promise<TestElement>,
+  documentLocator: LocatorFactory): Promise<MatCalendarHarness> {
+  const calendarId = await getCalendarId(host);
+
+  if (!calendarId) {
+    throw Error(`Element is not associated with a calendar`);
+  }
+
+  return documentLocator.locatorFor(MatCalendarHarness.with({
+    ...filter,
+    selector: `#${calendarId}`
+  }))();
+}

--- a/src/material/datepicker/testing/index.ts
+++ b/src/material/datepicker/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material/datepicker/testing/public-api.ts
+++ b/src/material/datepicker/testing/public-api.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './datepicker-harness-filters';
+export * from './datepicker-input-harness';
+export * from './datepicker-toggle-harness';
+export * from './date-range-input-harness';
+export * from './calendar-harness';
+export * from './calendar-cell-harness';

--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -54,7 +54,7 @@ export class MatDialogConfig<D = any> {
   hasBackdrop?: boolean = true;
 
   /** Custom class for the backdrop. */
-  backdropClass?: string = '';
+  backdropClass?: string | string[] = '';
 
   /** Whether the user can use escape or clicking on the backdrop to close the modal. */
   disableClose?: boolean = false;

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -377,7 +377,7 @@ export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements 
     static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
 
-export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
+export declare class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
     _comparisonRangeEnd: number | null;
     _comparisonRangeStart: number | null;
     _dateAdapter: DateAdapter<D>;
@@ -417,6 +417,7 @@ export declare class MatMonthView<D> implements AfterContentInit, OnDestroy {
     _init(): void;
     _previewChanged({ event, value: cell }: MatCalendarUserEvent<MatCalendarCell<D> | null>): void;
     ngAfterContentInit(): void;
+    ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatMonthView<any>, "mat-month-view", ["matMonthView"], { "activeDate": "activeDate"; "selected": "selected"; "minDate": "minDate"; "maxDate": "maxDate"; "dateFilter": "dateFilter"; "dateClass": "dateClass"; "comparisonStart": "comparisonStart"; "comparisonEnd": "comparisonEnd"; }, { "selectedChange": "selectedChange"; "_userSelection": "_userSelection"; "activeDateChange": "activeDateChange"; }, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatMonthView<any>, [null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;

--- a/tools/public_api_guard/material/datepicker/testing.d.ts
+++ b/tools/public_api_guard/material/datepicker/testing.d.ts
@@ -1,0 +1,109 @@
+export interface CalendarCellHarnessFilters extends BaseHarnessFilters {
+    active?: boolean;
+    disabled?: boolean;
+    inComparisonRange?: boolean;
+    inPreviewRange?: boolean;
+    inRange?: boolean;
+    selected?: boolean;
+    text?: string | RegExp;
+    today?: boolean;
+}
+
+export interface CalendarHarnessFilters extends BaseHarnessFilters {
+}
+
+export declare const enum CalendarView {
+    MONTH = 0,
+    YEAR = 1,
+    MULTI_YEAR = 2
+}
+
+export interface DatepickerInputHarnessFilters extends BaseHarnessFilters {
+    placeholder?: string | RegExp;
+    value?: string | RegExp;
+}
+
+export interface DatepickerToggleHarnessFilters extends BaseHarnessFilters {
+}
+
+export interface DateRangeInputHarnessFilters extends BaseHarnessFilters {
+    value?: string | RegExp;
+}
+
+export declare class MatCalendarCellHarness extends ComponentHarness {
+    blur(): Promise<void>;
+    focus(): Promise<void>;
+    getAriaLabel(): Promise<string>;
+    getText(): Promise<string>;
+    hover(): Promise<void>;
+    isActive(): Promise<boolean>;
+    isComparisonRangeEnd(): Promise<boolean>;
+    isComparisonRangeStart(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    isInComparisonRange(): Promise<boolean>;
+    isInPreviewRange(): Promise<boolean>;
+    isInRange(): Promise<boolean>;
+    isPreviewRangeEnd(): Promise<boolean>;
+    isPreviewRangeStart(): Promise<boolean>;
+    isRangeEnd(): Promise<boolean>;
+    isRangeStart(): Promise<boolean>;
+    isSelected(): Promise<boolean>;
+    isToday(): Promise<boolean>;
+    mouseAway(): Promise<void>;
+    select(): Promise<void>;
+    static hostSelector: string;
+    static with(options?: CalendarCellHarnessFilters): HarnessPredicate<MatCalendarCellHarness>;
+}
+
+export declare class MatCalendarHarness extends ComponentHarness {
+    changeView(): Promise<void>;
+    getCells(filter?: CalendarCellHarnessFilters): Promise<MatCalendarCellHarness[]>;
+    getCurrentView(): Promise<CalendarView>;
+    getCurrentViewLabel(): Promise<string>;
+    next(): Promise<void>;
+    previous(): Promise<void>;
+    selectCell(filter?: CalendarCellHarnessFilters): Promise<void>;
+    static hostSelector: string;
+    static with(options?: CalendarHarnessFilters): HarnessPredicate<MatCalendarHarness>;
+}
+
+export declare class MatDatepickerInputHarness extends MatDatepickerInputHarnessBase implements DatepickerTrigger {
+    closeCalendar(): Promise<void>;
+    getCalendar(filter?: CalendarHarnessFilters): Promise<MatCalendarHarness>;
+    hasCalendar(): Promise<boolean>;
+    isCalendarOpen(): Promise<boolean>;
+    openCalendar(): Promise<void>;
+    static hostSelector: string;
+    static with(options?: DatepickerInputHarnessFilters): HarnessPredicate<MatDatepickerInputHarness>;
+}
+
+export declare class MatDatepickerToggleHarness extends DatepickerTriggerHarnessBase {
+    protected _openCalendar(): Promise<void>;
+    isCalendarOpen(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: DatepickerToggleHarnessFilters): HarnessPredicate<MatDatepickerToggleHarness>;
+}
+
+export declare class MatDateRangeInputHarness extends DatepickerTriggerHarnessBase {
+    protected _openCalendar(): Promise<void>;
+    getEndInput(): Promise<MatEndDateHarness>;
+    getSeparator(): Promise<string>;
+    getStartInput(): Promise<MatStartDateHarness>;
+    getValue(): Promise<string>;
+    isCalendarOpen(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    isRequired(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: DateRangeInputHarnessFilters): HarnessPredicate<MatDateRangeInputHarness>;
+}
+
+export declare class MatEndDateHarness extends MatDatepickerInputHarnessBase {
+    static hostSelector: string;
+    static with(options?: DatepickerInputHarnessFilters): HarnessPredicate<MatEndDateHarness>;
+}
+
+export declare class MatStartDateHarness extends MatDatepickerInputHarnessBase {
+    static hostSelector: string;
+    static with(options?: DatepickerInputHarnessFilters): HarnessPredicate<MatStartDateHarness>;
+}

--- a/tools/public_api_guard/material/dialog.d.ts
+++ b/tools/public_api_guard/material/dialog.d.ts
@@ -68,7 +68,7 @@ export declare class MatDialogConfig<D = any> {
     ariaLabel?: string | null;
     ariaLabelledBy?: string | null;
     autoFocus?: boolean;
-    backdropClass?: string;
+    backdropClass?: string | string[];
     closeOnNavigation?: boolean;
     componentFactoryResolver?: ComponentFactoryResolver;
     data?: D | null;


### PR DESCRIPTION
* Sets up test harnesses for the components in the datepicker module. Includes datepicker input, datepicker toggle, calendar, calendar cell, date range input, date range input start/end sub-inputs.
* Fixes an issue in `mat-calendar` that showed up while adding unit tests for the harnesses. The standalone calendar wasn't picking up changes to the comparison range after init.
* Expands the dialog `backdropClass` signature to allow `string[]`. This was necessary for the harness so that we can tie a harness to a particular backdrop.