### PR TITLE
docs(tree): fix typo in tree template

### DIFF
--- a/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.html
@@ -12,7 +12,7 @@
                  [style.display]="shouldRender(node) ? 'flex' : 'none'"
                  class="example-tree-node">
     <button mat-icon-button cdkTreeNodeToggle
-            [attr.aria-label]="'toggle ' + node.filename"
+            [attr.aria-label]="'Toggle ' + node.name"
             (click)="node.isExpanded = !node.isExpanded"
             [style.visibility]="node.expandable ? 'visible' : 'hidden'">
       <mat-icon class="mat-icon-rtl-mirror">

--- a/src/components-examples/cdk/tree/cdk-tree-nested/cdk-tree-nested-example.html
+++ b/src/components-examples/cdk/tree/cdk-tree-nested/cdk-tree-nested-example.html
@@ -7,7 +7,7 @@
   </cdk-nested-tree-node>
   <!-- This is the tree node template for expandable nodes -->
   <cdk-nested-tree-node *cdkTreeNodeDef="let node; when: hasChild" class="example-tree-node">
-    <button mat-icon-button [attr.aria-label]="'toggle ' + node.name" cdkTreeNodeToggle>
+    <button mat-icon-button [attr.aria-label]="'Toggle ' + node.name" cdkTreeNodeToggle>
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
       </mat-icon>

--- a/src/components-examples/material/tree/tree-checklist/tree-checklist-example.html
+++ b/src/components-examples/material/tree/tree-checklist/tree-checklist-example.html
@@ -17,7 +17,7 @@
 
   <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
     <button mat-icon-button matTreeNodeToggle
-            [attr.aria-label]="'toggle ' + node.filename">
+            [attr.aria-label]="'Toggle ' + node.item">
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
       </mat-icon>

--- a/src/components-examples/material/tree/tree-dynamic/tree-dynamic-example.html
+++ b/src/components-examples/material/tree/tree-dynamic/tree-dynamic-example.html
@@ -5,7 +5,7 @@
   </mat-tree-node>
   <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
     <button mat-icon-button
-            [attr.aria-label]="'toggle ' + node.filename" matTreeNodeToggle>
+            [attr.aria-label]="'Toggle ' + node.item" matTreeNodeToggle>
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
       </mat-icon>

--- a/src/components-examples/material/tree/tree-flat-overview/tree-flat-overview-example.html
+++ b/src/components-examples/material/tree/tree-flat-overview/tree-flat-overview-example.html
@@ -8,7 +8,7 @@
   <!-- This is the tree node template for expandable nodes -->
   <mat-tree-node *matTreeNodeDef="let node;when: hasChild" matTreeNodePadding>
     <button mat-icon-button matTreeNodeToggle
-            [attr.aria-label]="'toggle ' + node.name">
+            [attr.aria-label]="'Toggle ' + node.name">
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
       </mat-icon>

--- a/src/components-examples/material/tree/tree-loadmore/tree-loadmore-example.html
+++ b/src/components-examples/material/tree/tree-loadmore/tree-loadmore-example.html
@@ -8,7 +8,7 @@
   <!-- expandable node -->
   <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
     <button mat-icon-button
-            [attr.aria-label]="'toggle ' + node.filename"
+            [attr.aria-label]="'Toggle ' + node.item"
             (click)="loadChildren(node)"
             matTreeNodeToggle>
       <mat-icon class="mat-icon-rtl-mirror">

--- a/src/components-examples/material/tree/tree-nested-overview/tree-nested-overview-example.html
+++ b/src/components-examples/material/tree/tree-nested-overview/tree-nested-overview-example.html
@@ -12,7 +12,7 @@
     <li>
       <div class="mat-tree-node">
         <button mat-icon-button matTreeNodeToggle
-                [attr.aria-label]="'toggle ' + node.name">
+                [attr.aria-label]="'Toggle ' + node.name">
           <mat-icon class="mat-icon-rtl-mirror">
             {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
           </mat-icon>

--- a/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -9,7 +9,7 @@
 
   <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
     <button mat-icon-button matTreeNodeToggle
-            [attr.aria-label]="'toggle ' + node.name">
+            [attr.aria-label]="'Toggle ' + node.name">
       <mat-icon class="mat-icon-rtl-mirror">
         {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
       </mat-icon>


### PR DESCRIPTION
A bunch of tree examples were copied off of each other and were referecing a non-existent property which resulted in an incorrect `aria-label`.

Fixes #20216.