### PR TITLE
fix(cdk-experimental/menu): ensure context menu is closed out with other menu elements on page

### DIFF
--- a/src/cdk-experimental/menu/context-menu.ts
+++ b/src/cdk-experimental/menu/context-menu.ts
@@ -41,7 +41,7 @@ import {MenuStack, MenuStackItem} from './menu-stack';
  */
 function isWithinMenuElement(target: Element | null) {
   while (target instanceof Element) {
-    if (target.className.indexOf('cdk-menu') !== -1) {
+    if (target.classList.contains('cdk-menu') && !target.classList.contains('cdk-menu-inline')) {
       return true;
     }
     target = target.parentElement;

--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -779,7 +779,10 @@ describe('MenuBar', () => {
       openMenu();
       expect(menus.length).toBe(1);
 
-      fixture.debugElement.query(By.css('#container')).nativeElement.click();
+      dispatchMouseEvent(
+        fixture.debugElement.query(By.css('#container')).nativeElement,
+        'mousedown'
+      );
       detectChanges();
 
       expect(menus.length).toBe(0);

--- a/src/cdk-experimental/menu/menu-bar.ts
+++ b/src/cdk-experimental/menu/menu-bar.ts
@@ -260,7 +260,7 @@ export class CdkMenuBar extends CdkMenuGroup implements Menu, AfterContentInit, 
   // to avoid double event listeners, we need to use `HostListener`. Once Ivy is the default, we
   // can move this back into `host`.
   // tslint:disable:no-host-decorator-in-concrete
-  @HostListener('document:click', ['$event'])
+  @HostListener('document:mousedown', ['$event'])
   /** Close any open submenu if there was a click event which occurred outside the menu stack. */
   _closeOnBackgroundClick(event: MouseEvent) {
     if (this._hasOpenSubmenu()) {

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -54,6 +54,7 @@ import {getItemPointerEntries} from './item-pointer-entries';
     '[tabindex]': '_isInline() ? 0 : null',
     'role': 'menu',
     'class': 'cdk-menu',
+    '[class.cdk-menu-inline]': '_isInline()',
     '[attr.aria-orientation]': 'orientation',
   },
   providers: [


### PR DESCRIPTION
Fixes an issue which prevents an open context menu from closing out if clicked on a menu bar
element or on an inline menu. Further fixes an issue where opening a context menu does not close
out any open menu.