### PR TITLE
feat(cdk-experimental/menu): add roving tab index to menu items

### DIFF
--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -228,6 +228,32 @@ describe('MenuBar', () => {
           }
         );
 
+        it('should toggle tabindex of menu bar items with left/right arrow keys', () => {
+          focusMenuBar();
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', RIGHT_ARROW);
+          detectChanges();
+          expect(menuBarNativeItems[0].tabIndex).toEqual(-1);
+          expect(menuBarNativeItems[1].tabIndex).toEqual(0);
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', RIGHT_ARROW);
+          detectChanges();
+          expect(menuBarNativeItems[0].tabIndex).toEqual(0);
+          expect(menuBarNativeItems[1].tabIndex).toEqual(-1);
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', LEFT_ARROW);
+          detectChanges();
+          expect(menuBarNativeItems[0].tabIndex).toEqual(-1);
+          expect(menuBarNativeItems[1].tabIndex).toEqual(0);
+
+          dispatchKeyboardEvent(nativeMenuBar, 'keydown', LEFT_ARROW);
+          detectChanges();
+          expect(menuBarNativeItems[0].tabIndex).toEqual(0);
+          expect(menuBarNativeItems[1].tabIndex).toEqual(-1);
+
+          expect(nativeMenus.length).toBe(0);
+        });
+
         it(
           "should open the focused menu item's menu and focus the first submenu" +
             ' item on the down key',
@@ -264,6 +290,28 @@ describe('MenuBar', () => {
 
           expect(document.activeElement).toEqual(fileMenuNativeItems[0]);
         });
+
+        it(
+          'should set the tabindex to 0 on the active item and reset the previous active items ' +
+            'to -1 when navigating down to a submenu and within it using the arrow keys',
+          () => {
+            focusMenuBar();
+
+            expect(menuBarNativeItems[0].tabIndex).toEqual(0);
+
+            dispatchKeyboardEvent(menuBarNativeItems[0], 'keydown', SPACE);
+            detectChanges();
+
+            expect(menuBarNativeItems[0].tabIndex).toEqual(-1);
+            expect(fileMenuNativeItems[0].tabIndex).toEqual(0);
+
+            dispatchKeyboardEvent(fileMenuNativeItems[0], 'keydown', DOWN_ARROW);
+            detectChanges();
+
+            expect(fileMenuNativeItems[0].tabIndex).toEqual(-1);
+            expect(fileMenuNativeItems[1].tabIndex).toEqual(0);
+          }
+        );
       });
 
       describe('for Menu', () => {
@@ -873,6 +921,7 @@ describe('MenuBar', () => {
     function openFileMenu() {
       dispatchMouseEvent(menuBarNativeItems[0], 'mouseenter');
       dispatchMouseEvent(menuBarNativeItems[0], 'click');
+      dispatchMouseEvent(menuBarNativeItems[0], 'mouseenter');
       detectChanges();
     }
 
@@ -1039,6 +1088,61 @@ describe('MenuBar', () => {
         detectChanges();
 
         expect(nativeMenus.length).toBe(0);
+      }
+    );
+
+    it(
+      'should not set the tabindex when hovering over menubar item and there is no open' +
+        ' sibling menu',
+      () => {
+        dispatchMouseEvent(menuBarNativeItems[0], 'mouseenter');
+        detectChanges();
+
+        expect(menuBarNativeItems[0].tabIndex).toBe(-1);
+      }
+    );
+
+    it(
+      'should set the tabindex of the opened trigger to 0 and toggle tabindex' +
+        ' when hovering between items',
+      () => {
+        openFileMenu();
+
+        expect(menuBarNativeItems[0].tabIndex).toBe(0);
+
+        dispatchMouseEvent(menuBarNativeItems[1], 'mouseenter');
+        detectChanges();
+
+        expect(menuBarNativeItems[0].tabIndex).toBe(-1);
+        expect(menuBarNativeItems[1].tabIndex).toBe(0);
+
+        dispatchMouseEvent(menuBarNativeItems[0], 'mouseenter');
+        detectChanges();
+
+        expect(menuBarNativeItems[0].tabIndex).toBe(0);
+        expect(menuBarNativeItems[1].tabIndex).toBe(-1);
+      }
+    );
+
+    it(
+      'should set the tabindex to 0 on the active item and reset the previous active items ' +
+        'to -1 when navigating down to a submenu and within it using a mouse',
+      () => {
+        openFileMenu();
+        expect(menuBarNativeItems[0].tabIndex).toBe(0);
+
+        dispatchMouseEvent(fileMenuNativeItems[0], 'mouseenter');
+        dispatchMouseEvent(menuBarNativeItems[0], 'mouseout');
+        detectChanges();
+
+        expect(menuBarNativeItems[0].tabIndex).toBe(-1);
+        expect(fileMenuNativeItems[0].tabIndex).toBe(0);
+
+        dispatchMouseEvent(fileMenuNativeItems[1], 'mouseenter');
+        detectChanges();
+
+        expect(fileMenuNativeItems[0].tabIndex).toBe(-1);
+        expect(fileMenuNativeItems[1].tabIndex).toBe(0);
       }
     );
   });

--- a/src/cdk-experimental/menu/menu-item-checkbox.ts
+++ b/src/cdk-experimental/menu/menu-item-checkbox.ts
@@ -18,6 +18,7 @@ import {CdkMenuItem} from './menu-item';
   selector: '[cdkMenuItemCheckbox]',
   exportAs: 'cdkMenuItemCheckbox',
   host: {
+    '[tabindex]': '_tabindex',
     'type': 'button',
     'role': 'menuitemcheckbox',
     '[attr.aria-checked]': 'checked || null',

--- a/src/cdk-experimental/menu/menu-item-radio.ts
+++ b/src/cdk-experimental/menu/menu-item-radio.ts
@@ -31,6 +31,7 @@ import {CDK_MENU, Menu} from './menu-interface';
   selector: '[cdkMenuItemRadio]',
   exportAs: 'cdkMenuItemRadio',
   host: {
+    '[tabindex]': '_tabindex',
     'type': 'button',
     'role': 'menuitemradio',
     '[attr.aria-checked]': 'checked || null',


### PR DESCRIPTION
The element under focus has a tab index of 0 while all others are set to -1. As other elements come
into focus, the previous elements tab index is reset to -1 and the newly focused element has a tab
index set to 0.