### PR TITLE
fix(cdk/drag-drop): preserve checked state for grouped radio inputs

### DIFF
--- a/src/cdk/drag-drop/clone-node.ts
+++ b/src/cdk/drag-drop/clone-node.ts
@@ -44,9 +44,19 @@ function transferData<T extends Element>(selector: string, node: HTMLElement, cl
   }
 }
 
+// Counter for unique cloned radio button names.
+let cloneUniqueId = 0;
+
 /** Transfers the data of one input element to another. */
-function transferInputData(source: Element & {value: string}, clone: Element & {value: string}) {
+function transferInputData(source: Element & {value: string},
+                           clone: Element & {value: string; name: string; type: string}) {
   clone.value = source.value;
+  // Radio button `name` attributes must be unique for radio button groups
+  // otherwise original radio buttons can lose their checked state
+  // once the clone is inserted in the DOM.
+  if (clone.type === 'radio' && clone.name) {
+    clone.name = `mat-clone-${clone.name}-${cloneUniqueId++}`;
+  }
 }
 
 /** Transfers the data of one canvas element to another. */


### PR DESCRIPTION
We transfer input `value` property while cloning draggable element, but
with several radio inputs that have the same `name` attribute we can face an
issue when checked state moves to cloned radio input element and we can't restore it
when dropping element.

These changes add unique name for all cloned elements: radio inputs
inside preview and placeholder. This makes sure that original input
won't lose its checked state once the clone is inserted in the DOM.

Fixes #20236