### PR TITLE
chore: clean up leftover tslint disable statements

### DIFF
--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -28,7 +28,6 @@ const _MatOptgroupMixinBase: CanDisableCtor & typeof MatOptgroupBase =
 let _uniqueOptgroupIdCounter = 0;
 
 @Directive()
-// tslint:disable-next-line:class-name
 export class _MatOptgroupBase extends _MatOptgroupMixinBase implements CanDisable {
   /** Label for the option group. */
   @Input() label: string;

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -62,7 +62,6 @@ export const MAT_OPTION_PARENT_COMPONENT =
 
 
 @Directive()
-// tslint:disable-next-line:class-name
 export class _MatOptionBase implements FocusableOption, AfterViewChecked, OnDestroy {
   private _selected = false;
   private _active = false;

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -53,7 +53,6 @@ export function throwMatDialogContentAlreadyAttachedError() {
  * animations as these are left to implementers of the dialog container.
  */
 @Directive()
-// tslint:disable-next-line:class-name
 export abstract class _MatDialogContainerBase extends BasePortalOutlet {
   protected _document: Document;
 

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -70,7 +70,6 @@ export const MAT_DIALOG_SCROLL_STRATEGY_PROVIDER = {
  * for arbitrary dialog refs and dialog container components.
  */
 @Directive()
-// tslint:disable-next-line:class-name
 export abstract class _MatDialogBase<C extends _MatDialogContainerBase> implements OnDestroy {
   private _openDialogsAtThisLevel: MatDialogRef<any>[] = [];
   private readonly _afterAllClosedAtThisLevel = new Subject<void>();

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -35,7 +35,6 @@ import {MatSnackBarConfig} from './snack-bar-config';
  * Internal interface for a snack bar container.
  * @docs-private
  */
-// tslint:disable-next-line:class-name
 export interface _SnackBarContainer {
   snackBarConfig: MatSnackBarConfig;
   _onExit: Subject<any>;


### PR DESCRIPTION
These statements are from PRs that were opened before we added our own rule for validating class names.