### PR TITLE
feat(material-experimental/mdc-autocomplete): implement MDC-based mat-autocomplete

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -144,6 +144,7 @@
 /src/dev-app/baseline/**                           @mmalerba
 /src/dev-app/bottom-sheet/**                       @jelbourn @crisbeto
 /src/dev-app/button-toggle/**                      @jelbourn
+/src/dev-app/mdc-autocomplete/**                   @crisbeto
 /src/dev-app/button/**                             @jelbourn
 /src/dev-app/card/**                               @jelbourn
 /src/dev-app/cdk-experimental-listbox/**           @jelbourn @nielsr98

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -46,6 +46,7 @@ ng_module(
         "//src/dev-app/input",
         "//src/dev-app/list",
         "//src/dev-app/live-announcer",
+        "//src/dev-app/mdc-autocomplete",
         "//src/dev-app/mdc-button",
         "//src/dev-app/mdc-card",
         "//src/dev-app/mdc-checkbox",

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -74,6 +74,7 @@ export class DevAppLayout {
     {name: 'Typography', route: '/typography'},
     {name: 'Virtual Scrolling', route: '/virtual-scroll'},
     {name: 'YouTube Player', route: '/youtube-player'},
+    {name: 'MDC Autocomplete', route: '/mdc-autocomplete'},
     {name: 'MDC Button', route: '/mdc-button'},
     {name: 'MDC Card', route: '/mdc-card'},
     {name: 'MDC Checkbox', route: '/mdc-checkbox'},

--- a/src/dev-app/dev-app/routes.ts
+++ b/src/dev-app/dev-app/routes.ts
@@ -69,6 +69,10 @@ export const DEV_APP_ROUTES: Routes = [
     path: 'menubar',
     loadChildren: 'menubar/mat-menubar-demo-module#MatMenuBarDemoModule'
   },
+  {
+    path: 'mdc-autocomplete',
+    loadChildren: 'mdc-autocomplete/mdc-autocomplete-demo-module#MdcAutocompleteDemoModule'
+  },
   {path: 'mdc-button', loadChildren: 'mdc-button/mdc-button-demo-module#MdcButtonDemoModule'},
   {path: 'mdc-card', loadChildren: 'mdc-card/mdc-card-demo-module#MdcCardDemoModule'},
   {

--- a/src/dev-app/mdc-autocomplete/BUILD.bazel
+++ b/src/dev-app/mdc-autocomplete/BUILD.bazel
@@ -1,0 +1,26 @@
+load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "mdc-autocomplete",
+    srcs = glob(["**/*.ts"]),
+    assets = [
+        "mdc-autocomplete-demo.html",
+        ":mdc_autocomplete_demo_scss",
+    ],
+    deps = [
+        "//src/material-experimental/mdc-autocomplete",
+        "//src/material-experimental/mdc-button",
+        "//src/material-experimental/mdc-card",
+        "//src/material-experimental/mdc-form-field",
+        "//src/material-experimental/mdc-input",
+        "@npm//@angular/forms",
+        "@npm//@angular/router",
+    ],
+)
+
+sass_binary(
+    name = "mdc_autocomplete_demo_scss",
+    src = "mdc-autocomplete-demo.scss",
+)

--- a/src/dev-app/mdc-autocomplete/mdc-autocomplete-demo-module.ts
+++ b/src/dev-app/mdc-autocomplete/mdc-autocomplete-demo-module.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {MatAutocompleteModule} from '@angular/material-experimental/mdc-autocomplete';
+import {MatButtonModule} from '@angular/material-experimental/mdc-button';
+import {MatCardModule} from '@angular/material-experimental/mdc-card';
+import {MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
+import {MatInputModule} from '@angular/material-experimental/mdc-input';
+import {RouterModule} from '@angular/router';
+import {MdcAutocompleteDemo} from './mdc-autocomplete-demo';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    ReactiveFormsModule,
+    RouterModule.forChild([{path: '', component: MdcAutocompleteDemo}]),
+  ],
+  declarations: [MdcAutocompleteDemo],
+})
+export class MdcAutocompleteDemoModule {
+}

--- a/src/dev-app/mdc-autocomplete/mdc-autocomplete-demo.html
+++ b/src/dev-app/mdc-autocomplete/mdc-autocomplete-demo.html
@@ -1,0 +1,76 @@
+Space above cards: <input type="number" [formControl]="topHeightCtrl">
+<div [style.height.px]="topHeightCtrl.value"></div>
+<div class="demo-autocomplete">
+  <mat-card *ngIf="(reactiveStates | async) as tempStates">
+    Reactive length: {{ tempStates?.length }}
+    <div>Reactive value: {{ stateCtrl.value | json }}</div>
+    <div>Reactive dirty: {{ stateCtrl.dirty }}</div>
+
+    <mat-form-field>
+      <mat-label>State</mat-label>
+      <input matInput [matAutocomplete]="reactiveAuto" [formControl]="stateCtrl">
+      <mat-autocomplete #reactiveAuto="matAutocomplete" [displayWith]="displayFn">
+        <mat-option *ngFor="let state of tempStates" [value]="state">
+          <span>{{ state.name }}</span>
+          <span class="demo-secondary-text"> ({{ state.code }}) </span>
+        </mat-option>
+      </mat-autocomplete>
+    </mat-form-field>
+
+    <mat-card-actions>
+      <button mat-button (click)="stateCtrl.reset()">RESET</button>
+      <button mat-button (click)="stateCtrl.setValue(states[10])">SET VALUE</button>
+      <button mat-button (click)="stateCtrl.enabled ? stateCtrl.disable() : stateCtrl.enable()">
+        TOGGLE DISABLED
+      </button>
+    </mat-card-actions>
+
+  </mat-card>
+
+  <mat-card>
+
+    <div>Template-driven value (currentState): {{ currentState }}</div>
+    <div>Template-driven dirty: {{ modelDir ? modelDir.dirty : false }}</div>
+
+    <!-- Added an ngIf below to test that autocomplete works with ngIf -->
+    <mat-form-field *ngIf="true">
+      <mat-label>State</mat-label>
+      <input matInput [matAutocomplete]="tdAuto" [(ngModel)]="currentState"
+        (ngModelChange)="tdStates = filterStates(currentState)" [disabled]="tdDisabled">
+      <mat-autocomplete #tdAuto="matAutocomplete">
+        <mat-option *ngFor="let state of tdStates" [value]="state.name">
+          <span>{{ state.name }}</span>
+        </mat-option>
+      </mat-autocomplete>
+    </mat-form-field>
+
+    <mat-card-actions>
+      <button mat-button (click)="modelDir.reset()">RESET</button>
+      <button mat-button (click)="currentState='California'">SET VALUE</button>
+      <button mat-button (click)="tdDisabled=!tdDisabled">
+        TOGGLE DISABLED
+      </button>
+    </mat-card-actions>
+
+  </mat-card>
+
+  <mat-card>
+    <div>Option groups (currentGroupedState): {{ currentGroupedState }}</div>
+
+    <mat-form-field>
+      <mat-label>State</mat-label>
+      <input
+        matInput
+        [matAutocomplete]="groupedAuto"
+        [(ngModel)]="currentGroupedState"
+        (ngModelChange)="filteredGroupedStates = filterStateGroups(currentGroupedState)">
+    </mat-form-field>
+  </mat-card>
+</div>
+
+<mat-autocomplete #groupedAuto="matAutocomplete">
+  <mat-optgroup *ngFor="let group of filteredGroupedStates"
+    [label]="'States starting with ' + group.letter">
+    <mat-option *ngFor="let state of group.states" [value]="state.name">{{ state.name }}</mat-option>
+  </mat-optgroup>
+</mat-autocomplete>

--- a/src/dev-app/mdc-autocomplete/mdc-autocomplete-demo.scss
+++ b/src/dev-app/mdc-autocomplete/mdc-autocomplete-demo.scss
@@ -1,0 +1,21 @@
+.demo-autocomplete {
+  display: flex;
+  flex-flow: row wrap;
+
+  .mat-mdc-card {
+    width: 400px;
+    margin: 24px;
+    padding: 16px;
+  }
+
+  .mat-mdc-form-field {
+    margin-top: 16px;
+    min-width: 200px;
+    max-width: 100%;
+  }
+}
+
+.demo-secondary-text {
+  color: rgba(0, 0, 0, 0.54);
+  margin-left: 8px;
+}

--- a/src/dev-app/mdc-autocomplete/mdc-autocomplete-demo.ts
+++ b/src/dev-app/mdc-autocomplete/mdc-autocomplete-demo.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ViewChild} from '@angular/core';
+import {FormControl, NgModel} from '@angular/forms';
+import {Observable} from 'rxjs';
+import {map, startWith} from 'rxjs/operators';
+
+
+export interface State {
+  code: string;
+  name: string;
+}
+
+export interface StateGroup {
+  letter: string;
+  states: State[];
+}
+
+@Component({
+  selector: 'mdc-autocomplete-demo',
+  templateUrl: 'mdc-autocomplete-demo.html',
+  styleUrls: ['mdc-autocomplete-demo.css']
+})
+export class MdcAutocompleteDemo {
+  stateCtrl: FormControl;
+  currentState = '';
+  currentGroupedState = '';
+  topHeightCtrl = new FormControl(0);
+
+  reactiveStates: Observable<State[]>;
+  tdStates: State[];
+
+  tdDisabled = false;
+
+  @ViewChild(NgModel) modelDir: NgModel;
+
+  groupedStates: StateGroup[];
+  filteredGroupedStates: StateGroup[];
+  states: State[] = [
+    {code: 'AL', name: 'Alabama'},
+    {code: 'AK', name: 'Alaska'},
+    {code: 'AZ', name: 'Arizona'},
+    {code: 'AR', name: 'Arkansas'},
+    {code: 'CA', name: 'California'},
+    {code: 'CO', name: 'Colorado'},
+    {code: 'CT', name: 'Connecticut'},
+    {code: 'DE', name: 'Delaware'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'GA', name: 'Georgia'},
+    {code: 'HI', name: 'Hawaii'},
+    {code: 'ID', name: 'Idaho'},
+    {code: 'IL', name: 'Illinois'},
+    {code: 'IN', name: 'Indiana'},
+    {code: 'IA', name: 'Iowa'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'KY', name: 'Kentucky'},
+    {code: 'LA', name: 'Louisiana'},
+    {code: 'ME', name: 'Maine'},
+    {code: 'MD', name: 'Maryland'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'MI', name: 'Michigan'},
+    {code: 'MN', name: 'Minnesota'},
+    {code: 'MS', name: 'Mississippi'},
+    {code: 'MO', name: 'Missouri'},
+    {code: 'MT', name: 'Montana'},
+    {code: 'NE', name: 'Nebraska'},
+    {code: 'NV', name: 'Nevada'},
+    {code: 'NH', name: 'New Hampshire'},
+    {code: 'NJ', name: 'New Jersey'},
+    {code: 'NM', name: 'New Mexico'},
+    {code: 'NY', name: 'New York'},
+    {code: 'NC', name: 'North Carolina'},
+    {code: 'ND', name: 'North Dakota'},
+    {code: 'OH', name: 'Ohio'},
+    {code: 'OK', name: 'Oklahoma'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'RI', name: 'Rhode Island'},
+    {code: 'SC', name: 'South Carolina'},
+    {code: 'SD', name: 'South Dakota'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'TX', name: 'Texas'},
+    {code: 'UT', name: 'Utah'},
+    {code: 'VT', name: 'Vermont'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WA', name: 'Washington'},
+    {code: 'WV', name: 'West Virginia'},
+    {code: 'WI', name: 'Wisconsin'},
+    {code: 'WY', name: 'Wyoming'},
+  ];
+
+  constructor() {
+    this.tdStates = this.states;
+    this.stateCtrl = new FormControl({code: 'CA', name: 'California'});
+    this.reactiveStates = this.stateCtrl.valueChanges
+      .pipe(
+        startWith(this.stateCtrl.value),
+        map(val => this.displayFn(val)),
+        map(name => this.filterStates(name))
+      );
+
+    this.filteredGroupedStates = this.groupedStates =
+        this.states.reduce<StateGroup[]>((groups, state) => {
+          let group = groups.find(g => g.letter === state.name[0]);
+
+          if (!group) {
+            group = { letter: state.name[0], states: [] };
+            groups.push(group);
+          }
+
+          group.states.push({ code: state.code, name: state.name });
+
+          return groups;
+        }, []);
+  }
+
+  displayFn(value: any): string {
+    return value && typeof value === 'object' ? value.name : value;
+  }
+
+  filterStates(val: string) {
+    return val ? this._filter(this.states, val) : this.states;
+  }
+
+  filterStateGroups(val: string) {
+    if (val) {
+      return this.groupedStates
+        .map(group => ({ letter: group.letter, states: this._filter(group.states, val) }))
+        .filter(group => group.states.length > 0);
+    }
+
+    return this.groupedStates;
+  }
+
+  private _filter(states: State[], val: string) {
+    const filterValue = val.toLowerCase();
+    return states.filter(state => state.name.toLowerCase().startsWith(filterValue));
+  }
+}

--- a/src/material-experimental/mdc-autocomplete/BUILD.bazel
+++ b/src/material-experimental/mdc-autocomplete/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//src/e2e-app:test_suite.bzl", "e2e_test_suite")
-load("//tools:defaults.bzl", "ng_e2e_test_library", "ng_module", "sass_binary", "sass_library")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite", "sass_binary", "sass_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,7 +15,12 @@ ng_module(
     ] + glob(["**/*.html"]),
     module_name = "@angular/material-experimental/mdc-autocomplete",
     deps = [
+        "//src/cdk/overlay",
+        "//src/cdk/scrolling",
+        "//src/material-experimental/mdc-core",
+        "//src/material/autocomplete",
         "//src/material/core",
+        "@npm//@angular/common",
     ],
 )
 
@@ -25,6 +29,7 @@ sass_library(
     srcs = glob(["**/_*.scss"]),
     deps = [
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
+        "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
     ],
 )
 
@@ -34,21 +39,48 @@ sass_binary(
     include_paths = [
         "external/npm/node_modules",
     ],
-    deps = [],
-)
-
-ng_e2e_test_library(
-    name = "e2e_test_sources",
-    srcs = glob(["**/*.e2e.spec.ts"]),
     deps = [
-        "//src/cdk/testing/private/e2e",
+        "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
+        "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
+        "//src/material/core:core_scss_lib",
     ],
 )
 
-e2e_test_suite(
-    name = "e2e_tests",
+ng_test_library(
+    name = "mdc_autocomplete_tests_lib",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = [
+            "**/*.e2e.spec.ts",
+        ],
+    ),
     deps = [
-        ":e2e_test_sources",
-        "//src/cdk/testing/private/e2e",
+        ":mdc-autocomplete",
+        "//src/cdk/bidi",
+        "//src/cdk/keycodes",
+        "//src/cdk/overlay",
+        "//src/cdk/platform",
+        "//src/cdk/scrolling",
+        "//src/cdk/testing/private",
+        "//src/material-experimental/mdc-core",
+        "//src/material-experimental/mdc-form-field",
+        "//src/material-experimental/mdc-input",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+        "@npm//rxjs",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    static_files = [
+        "@npm//:node_modules/@material/textfield/dist/mdc.textfield.js",
+        "@npm//:node_modules/@material/line-ripple/dist/mdc.lineRipple.js",
+        "@npm//:node_modules/@material/notched-outline/dist/mdc.notchedOutline.js",
+        "@npm//:node_modules/@material/dom/dist/mdc.dom.js",
+    ],
+    deps = [
+        ":mdc_autocomplete_tests_lib",
+        "//src/material-experimental:mdc_require_config.js",
     ],
 )

--- a/src/material-experimental/mdc-autocomplete/README.md
+++ b/src/material-experimental/mdc-autocomplete/README.md
@@ -1,1 +1,98 @@
-<!-- TODO -->
+This is prototype of an alternate version of `<mat-autocomplete>` built on top of
+[MDC Web](https://github.com/material-components/material-components-web). It demonstrates how
+Angular Material could use MDC Web under the hood while still exposing the same API Angular users as
+the existing `<mat-autocomplete>`. This component is experimental and should not be used in production.
+
+## How to use
+Assuming your application is already up and running using Angular Material, you can add this
+component by following these steps:
+
+1. Install Angular Material Experimental & MDC WEB:
+
+   ```bash
+   npm i material-components-web @angular/material-experimental
+   ```
+
+2. In your `angular.json`, make sure `node_modules/` is listed as a Sass include path. This is
+   needed for the Sass compiler to be able to find the MDC Web Sass files.
+
+   ```json
+   ...
+   "styles": [
+     "src/styles.scss"
+   ],
+   "stylePreprocessorOptions": {
+     "includePaths": [
+       "node_modules/"
+     ]
+   },
+   ...
+   ```
+
+3. Import the experimental `MatAutocompleteModule` and add it to the module that declares your
+   component:
+
+   ```ts
+   import {MatAutocompleteModule} from '@angular/material-experimental/mdc-autocomplete';
+
+   @NgModule({
+     declarations: [MyComponent],
+     imports: [MatAutocompleteModule],
+   })
+   export class MyModule {}
+   ```
+
+4. Add use `<mat-autocomplete>` in your component's template, just like you would the normal
+   `<mat-autocomplete>`:
+
+   ```html
+    <input [matAutocomplete]="autocomplete">
+    <mat-autocomplete #autocomplete="matAutocomplete">
+      <mat-option value="1">Option 1</mat-option>
+      <mat-option value="2">Option 2</mat-option>
+    </mat-autocomplete>
+   ```
+
+5. Add the theme and typography mixins to your Sass. (There is currently no pre-built CSS option for
+   the experimental `<mat-autocomplete>`):
+
+   ```scss
+   @import '~@angular/material/theming';
+   @import '~@angular/material-experimental/mdc-autocomplete';
+
+   $my-primary: mat-palette($mat-indigo);
+   $my-accent:  mat-palette($mat-pink, A200, A100, A400);
+   $my-theme:   mat-light-theme((
+     color: (
+       primary: $my-primary,
+       accent: $my-accent
+     )
+   ));
+
+   @include mat-mdc-autocomplete-theme($my-theme);
+   @include mat-mdc-autocomplete-typography();
+   ```
+
+## API differences
+The experimental autocomplete API closely matches the
+[API of the standard autocomplete](https://material.angular.io/components/autocomplete/api).
+`@angular/material-experimental/mdc-autocomplete` exports symbols with the same name and public
+interface as all of the symbols found under `@angular/material/autocomplete`
+
+## Replacing the standard autocomplete in an existing app
+Because the experimental API mirrors the API for the standard autocomplete, it can easily be swapped
+in by just changing the import paths. There is currently no schematic for this, but you can run the
+following string replace across your TypeScript files:
+
+```bash
+grep -lr --include="*.ts" --exclude-dir="node_modules" \
+  --exclude="*.d.ts" "['\"]@angular/material/autocomplete['\"]" | xargs sed -i \
+  "s/['\"]@angular\/material\/autocomplete['\"]/'@angular\/material-experimental\/mdc-autocomplete'/g"
+```
+
+CSS styles and tests that depend on implementation details of `mat-autocomplete` (such as getting
+elements from the template by class name) will need to be manually updated.
+
+There are some small visual differences between this autocomplete and the standard one. This
+autocomplete has a different font size and elevation `box-shadow`, as well as padding at the top
+and bottom of the list.

--- a/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
+++ b/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
@@ -1,8 +1,27 @@
+@import '@material/menu-surface/mixins.import';
+@import '@material/list/mixins.import';
 @import '../mdc-helpers/mdc-helpers';
 
-@mixin mat-mdc-autocomplete-color($config-or-theme) {}
+@mixin mat-mdc-autocomplete-color($config-or-theme) {
+  $config: mat-get-color-config($config-or-theme);
+  @include mat-using-mdc-theme($config) {
+    @include mdc-menu-surface-core-styles($mat-theme-styles-query);
+    @include mdc-list-without-ripple($mat-theme-styles-query);
+  }
+}
 
-@mixin mat-mdc-autocomplete-typography($config-or-theme) {}
+@mixin mat-mdc-autocomplete-typography($config-or-theme) {
+  $config: mat-get-typography-config($config-or-theme);
+  @include mat-using-mdc-typography($config) {
+    @include mdc-menu-surface-core-styles($mat-typography-styles-query);
+
+    .mat-mdc-autocomplete-panel {
+      // Note that we include this private mixin, because the public one adds
+      // a bunch of styles that we aren't using for the autocomplete panel.
+      @include mdc-list-base_($mat-typography-styles-query);
+    }
+  }
+}
 
 @mixin mat-mdc-autocomplete-density($config-or-theme) {}
 

--- a/src/material-experimental/mdc-autocomplete/autocomplete-origin.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete-origin.ts
@@ -6,15 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef} from '@angular/core';
-
-/** Base class containing all of the functionality for `MatAutocompleteOrigin`. */
-@Directive()
-export abstract class _MatAutocompleteOriginBase {
-  constructor(
-    /** Reference to the element on which the directive is applied. */
-    public elementRef: ElementRef<HTMLElement>) {}
-}
+import {Directive} from '@angular/core';
+import {_MatAutocompleteOriginBase} from '@angular/material/autocomplete';
 
 /**
  * Directive applied to an element to make it usable

--- a/src/material-experimental/mdc-autocomplete/autocomplete-trigger.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete-trigger.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directive, forwardRef} from '@angular/core';
+import {NG_VALUE_ACCESSOR} from '@angular/forms';
+import {_MatAutocompleteTriggerBase} from '@angular/material/autocomplete';
+import {_countGroupLabelsBeforeOption, _getOptionScrollPosition} from '@angular/material/core';
+
+/**
+ * Provider that allows the autocomplete to register as a ControlValueAccessor.
+ * @docs-private
+ */
+export const MAT_AUTOCOMPLETE_VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => MatAutocompleteTrigger),
+  multi: true
+};
+
+@Directive({
+  selector: `input[matAutocomplete], textarea[matAutocomplete]`,
+  host: {
+    'class': 'mat-autocomplete-trigger',
+    '[attr.autocomplete]': 'autocompleteAttribute',
+    '[attr.role]': 'autocompleteDisabled ? null : "combobox"',
+    '[attr.aria-autocomplete]': 'autocompleteDisabled ? null : "list"',
+    '[attr.aria-activedescendant]': '(panelOpen && activeOption) ? activeOption.id : null',
+    '[attr.aria-expanded]': 'autocompleteDisabled ? null : panelOpen.toString()',
+    '[attr.aria-owns]': '(autocompleteDisabled || !panelOpen) ? null : autocomplete?.id',
+    '[attr.aria-haspopup]': '!autocompleteDisabled',
+    // Note: we use `focusin`, as opposed to `focus`, in order to open the panel
+    // a little earlier. This avoids issues where IE delays the focusing of the input.
+    '(focusin)': '_handleFocus()',
+    '(blur)': '_onTouched()',
+    '(input)': '_handleInput($event)',
+    '(keydown)': '_handleKeydown($event)',
+  },
+  exportAs: 'matAutocompleteTrigger',
+  providers: [MAT_AUTOCOMPLETE_VALUE_ACCESSOR]
+})
+export class MatAutocompleteTrigger extends _MatAutocompleteTriggerBase {
+  protected _aboveClass = 'mat-mdc-autocomplete-panel-above';
+
+  protected _scrollToOption(index: number): void {
+    // Given that we are not actually focusing active options, we must manually adjust scroll
+    // to reveal options below the fold. First, we find the offset of the option from the top
+    // of the panel. If that offset is below the fold, the new scrollTop will be the offset -
+    // the panel height + the option height, so the active option will be just visible at the
+    // bottom of the panel. If that offset is above the top of the visible panel, the new scrollTop
+    // will become the offset. If that offset is visible within the panel already, the scrollTop is
+    // not adjusted.
+    const autocomplete = this.autocomplete;
+    const labelCount = _countGroupLabelsBeforeOption(index,
+      autocomplete.options, autocomplete.optionGroups);
+
+    if (index === 0 && labelCount === 1) {
+      // If we've got one group label before the option and we're at the top option,
+      // scroll the list to the top. This is better UX than scrolling the list to the
+      // top of the option, because it allows the user to read the top group's label.
+      autocomplete._setScrollTop(0);
+    } else {
+      const option = autocomplete.options.toArray()[index];
+
+      if (option) {
+        const element = option._getHostElement();
+        const newScrollPosition = _getOptionScrollPosition(
+          element.offsetTop,
+          element.offsetHeight,
+          autocomplete._getScrollTop(),
+          autocomplete.panel.nativeElement.offsetHeight
+        );
+
+        autocomplete._setScrollTop(newScrollPosition);
+      }
+    }
+  }
+}

--- a/src/material-experimental/mdc-autocomplete/autocomplete.e2e.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.e2e.spec.ts
@@ -1,1 +1,0 @@
-// TODO: copy tests from existing mat-autocomplete, update as necessary to fix.

--- a/src/material-experimental/mdc-autocomplete/autocomplete.html
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.html
@@ -1,0 +1,10 @@
+<ng-template>
+  <div
+    class="mat-mdc-autocomplete-panel mdc-menu-surface mdc-menu-surface--open"
+    role="listbox"
+    [id]="id"
+    [ngClass]="_classList"
+    #panel>
+    <ng-content></ng-content>
+  </div>
+</ng-template>

--- a/src/material-experimental/mdc-autocomplete/autocomplete.scss
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.scss
@@ -1,1 +1,40 @@
-// TODO: implement MDC-based autocomplete
+@import '@material/menu-surface/mixins.import';
+@import '@material/list/mixins.import';
+@import '@material/list/variables.import';
+@import '../../cdk/a11y/a11y';
+@import '../mdc-helpers/mdc-helpers';
+
+@include mdc-menu-surface-core-styles($query: structure);
+
+.mat-mdc-autocomplete-panel {
+  width: 100%; // Ensures that the panel matches the overlay width.
+  max-height: 256px; // Prevents lists with a lot of option from growing too high.
+  position: static; // MDC uses `absolute` by default which will throw off our positioning.
+  visibility: hidden;
+
+  // Note that we include this private mixin, because the public
+  // one adds a bunch of styles that we aren't using for the menu.
+  @include mdc-list-base_($query: structure);
+  @include cdk-high-contrast(active, off) {
+    outline: solid 1px;
+  }
+
+  .cdk-overlay-pane:not(.mat-mdc-autocomplete-panel-above) & {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  .mat-mdc-autocomplete-panel-above & {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+// These classes are used to toggle the panel's visibility depending on whether it has any options.
+.mat-mdc-autocomplete-visible {
+  visibility: visible;
+}
+
+.mat-mdc-autocomplete-hidden {
+  visibility: hidden;
+}

--- a/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
@@ -1,0 +1,3024 @@
+import {Directionality} from '@angular/cdk/bidi';
+import {DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW} from '@angular/cdk/keycodes';
+import {Overlay, OverlayContainer} from '@angular/cdk/overlay';
+import {_supportsShadowDom} from '@angular/cdk/platform';
+import {ScrollDispatcher} from '@angular/cdk/scrolling';
+import {
+  MockNgZone,
+  clearElement,
+  createKeyboardEvent,
+  dispatchEvent,
+  dispatchFakeEvent,
+  dispatchKeyboardEvent,
+  typeInElement,
+} from '@angular/cdk/testing/private';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  Provider,
+  QueryList,
+  Type,
+  ViewChild,
+  ViewChildren,
+  ViewEncapsulation,
+} from '@angular/core';
+import {
+  async,
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  inject,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {MatOption, MatOptionSelectionChange} from '@angular/material-experimental/mdc-core';
+import {MatFormField, MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
+import {By} from '@angular/platform-browser';
+import {MatInputModule} from '@angular/material-experimental/mdc-input';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {EMPTY, Observable, Subject, Subscription} from 'rxjs';
+import {map, startWith} from 'rxjs/operators';
+
+
+import {
+  getMatAutocompleteMissingPanelError,
+  MAT_AUTOCOMPLETE_DEFAULT_OPTIONS,
+  MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
+  MatAutocomplete,
+  MatAutocompleteModule,
+  MatAutocompleteOrigin,
+  MatAutocompleteSelectedEvent,
+  MatAutocompleteTrigger,
+} from './index';
+
+
+describe('MDC-based MatAutocomplete', () => {
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
+  let zone: MockNgZone;
+
+  // Creates a test component fixture.
+  function createComponent<T>(component: Type<T>, providers: Provider[] = []) {
+    TestBed.configureTestingModule({
+      imports: [
+        MatAutocompleteModule,
+        MatFormFieldModule,
+        MatInputModule,
+        FormsModule,
+        ReactiveFormsModule,
+        NoopAnimationsModule
+      ],
+      declarations: [component],
+      providers: [
+        {provide: NgZone, useFactory: () => zone = new MockNgZone()},
+        ...providers
+      ]
+    });
+
+    TestBed.compileComponents();
+
+    inject([OverlayContainer], (oc: OverlayContainer) => {
+      overlayContainer = oc;
+      overlayContainerElement = oc.getContainerElement();
+    })();
+
+    return TestBed.createComponent<T>(component);
+  }
+
+  afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
+    // Since we're resetting the testing module in some of the tests,
+    // we can potentially have multiple overlay containers.
+    currentOverlayContainer.ngOnDestroy();
+    overlayContainer.ngOnDestroy();
+  }));
+
+  describe('panel toggling', () => {
+    let fixture: ComponentFixture<SimpleAutocomplete>;
+    let input: HTMLInputElement;
+
+    beforeEach(() => {
+      fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    });
+
+    it('should open the panel when the input is focused', () => {
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected panel state to start out closed.`);
+
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(true, `Expected panel state to read open when input is focused.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('Alabama', `Expected panel to display when input is focused.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('California', `Expected panel to display when input is focused.`);
+    });
+
+    it('should not open the panel on focus if the input is readonly', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+      input.readOnly = true;
+      fixture.detectChanges();
+
+      expect(trigger.panelOpen).toBe(false, 'Expected panel state to start out closed.');
+      dispatchFakeEvent(input, 'focusin');
+      flush();
+
+      fixture.detectChanges();
+      expect(trigger.panelOpen).toBe(false, 'Expected panel to stay closed.');
+    }));
+
+    it('should not open using the arrow keys when the input is readonly', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+      input.readOnly = true;
+      fixture.detectChanges();
+
+      expect(trigger.panelOpen).toBe(false, 'Expected panel state to start out closed.');
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      flush();
+
+      fixture.detectChanges();
+      expect(trigger.panelOpen).toBe(false, 'Expected panel to stay closed.');
+    }));
+
+    it('should open the panel programmatically', () => {
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected panel state to start out closed.`);
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(true, `Expected panel state to read open when opened programmatically.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('Alabama', `Expected panel to display when opened programmatically.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('California', `Expected panel to display when opened programmatically.`);
+    });
+
+    it('should show the panel when the first open is after the initial zone stabilization',
+      async(() => {
+        // Note that we're running outside the Angular zone, in order to be able
+        // to test properly without the subscription from `_subscribeToClosingActions`
+        // giving us a false positive.
+        fixture.ngZone!.runOutsideAngular(() => {
+          fixture.componentInstance.trigger.openPanel();
+
+          Promise.resolve().then(() => {
+            expect(fixture.componentInstance.panel.showPanel)
+                .toBe(true, `Expected panel to be visible.`);
+          });
+        });
+      }));
+
+    it('should close the panel when the user clicks away', fakeAsync(() => {
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      dispatchFakeEvent(document, 'click');
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected clicking outside the panel to set its state to closed.`);
+      expect(overlayContainerElement.textContent)
+          .toEqual('', `Expected clicking outside the panel to close the panel.`);
+    }));
+
+    it('should close the panel when the user taps away on a touch device', fakeAsync(() => {
+      dispatchFakeEvent(input, 'focus');
+      fixture.detectChanges();
+      flush();
+      dispatchFakeEvent(document, 'touchend');
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected tapping outside the panel to set its state to closed.`);
+      expect(overlayContainerElement.textContent)
+          .toEqual('', `Expected tapping outside the panel to close the panel.`);
+    }));
+
+    it('should close the panel when an option is clicked', fakeAsync(() => {
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const option = overlayContainerElement.querySelector('mat-option') as HTMLElement;
+      option.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected clicking an option to set the panel state to closed.`);
+      expect(overlayContainerElement.textContent)
+          .toEqual('', `Expected clicking an option to close the panel.`);
+    }));
+
+    it('should close the panel when a newly created option is clicked', fakeAsync(() => {
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      // Filter down the option list to a subset of original options ('Alabama', 'California')
+      typeInElement(input, 'al');
+      fixture.detectChanges();
+      tick();
+
+      let options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[0].click();
+
+      // Changing value from 'Alabama' to 'al' to re-populate the option list,
+      // ensuring that 'California' is created new.
+      dispatchFakeEvent(input, 'focusin');
+      clearElement(input);
+      typeInElement(input, 'al');
+      fixture.detectChanges();
+      tick();
+
+      options = overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected clicking a new option to set the panel state to closed.`);
+      expect(overlayContainerElement.textContent)
+          .toEqual('', `Expected clicking a new option to close the panel.`);
+    }));
+
+    it('should close the panel programmatically', () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.closePanel();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected closing programmatically to set the panel state to closed.`);
+      expect(overlayContainerElement.textContent)
+          .toEqual('', `Expected closing programmatically to close the panel.`);
+    });
+
+    it('should not throw when attempting to close the panel of a destroyed autocomplete', () => {
+      const trigger = fixture.componentInstance.trigger;
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      fixture.destroy();
+
+      expect(() => trigger.closePanel()).not.toThrow();
+    });
+
+    it('should hide the panel when the options list is empty', fakeAsync(() => {
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+
+      const panel =
+          overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel') as HTMLElement;
+
+      expect(panel.classList)
+          .toContain('mat-mdc-autocomplete-visible', `Expected panel to start out visible.`);
+
+      // Filter down the option list such that no options match the value
+      typeInElement(input, 'af');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(panel.classList)
+          .toContain('mat-mdc-autocomplete-hidden', `Expected panel to hide itself when empty.`);
+    }));
+
+    it('should keep the label floating until the panel closes', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      expect(fixture.componentInstance.formField.floatLabel)
+          .toEqual('always', 'Expected label to float as soon as panel opens.');
+
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      const options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.formField.floatLabel)
+          .toEqual('auto', 'Expected label to return to auto state after panel closes.');
+    }));
+
+    it('should not open the panel when the `input` event is invoked on a non-focused input', () => {
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected panel state to start out closed.`);
+
+      input.value = 'Alabama';
+      dispatchFakeEvent(input, 'input');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected panel state to stay closed.`);
+    });
+
+   it('should not mess with label placement if set to never', fakeAsync(() => {
+      fixture.componentInstance.floatLabel = 'never';
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      expect(fixture.componentInstance.formField.floatLabel)
+          .toEqual('never', 'Expected label to stay static.');
+      flush();
+      fixture.detectChanges();
+
+      const options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.formField.floatLabel)
+          .toEqual('never', 'Expected label to stay in static state after close.');
+    }));
+
+    it('should not mess with label placement if set to always', fakeAsync(() => {
+      fixture.componentInstance.floatLabel = 'always';
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      expect(fixture.componentInstance.formField.floatLabel)
+          .toEqual('always', 'Expected label to stay elevated on open.');
+      flush();
+      fixture.detectChanges();
+
+      const options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.formField.floatLabel)
+          .toEqual('always', 'Expected label to stay elevated after close.');
+    }));
+
+    it('should toggle the visibility when typing and closing the panel', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      tick();
+      fixture.detectChanges();
+
+      expect(overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!.classList)
+          .toContain('mat-mdc-autocomplete-visible', 'Expected panel to be visible.');
+
+      typeInElement(input, 'x');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!.classList)
+          .toContain('mat-mdc-autocomplete-hidden', 'Expected panel to be hidden.');
+
+      fixture.componentInstance.trigger.closePanel();
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      clearElement(input);
+      typeInElement(input, 'al');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!.classList)
+          .toContain('mat-mdc-autocomplete-visible', 'Expected panel to be visible.');
+    }));
+
+    it('should animate the label when the input is focused', () => {
+      const inputContainer = fixture.componentInstance.formField;
+
+      spyOn(inputContainer, '_animateAndLockLabel');
+      expect(inputContainer._animateAndLockLabel).not.toHaveBeenCalled();
+
+      dispatchFakeEvent(fixture.debugElement.query(By.css('input'))!.nativeElement, 'focusin');
+      expect(inputContainer._animateAndLockLabel).toHaveBeenCalled();
+    });
+
+    it('should provide the open state of the panel', fakeAsync(() => {
+      expect(fixture.componentInstance.panel.isOpen).toBeFalsy(
+        `Expected the panel to be unopened initially.`);
+
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+      flush();
+
+      expect(fixture.componentInstance.panel.isOpen).toBeTruthy(
+        `Expected the panel to be opened on focus.`);
+    }));
+
+    it('should emit an event when the panel is opened', () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.openedSpy).toHaveBeenCalled();
+    });
+
+    it('should not emit the `opened` event when no options are being shown', () => {
+      fixture.componentInstance.filteredStates = fixture.componentInstance.states = [];
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.openedSpy).not.toHaveBeenCalled();
+    });
+
+    it('should emit the `opened` event if the options come in after the panel is shown',
+       fakeAsync(() => {
+         fixture.componentInstance.filteredStates = fixture.componentInstance.states = [];
+         fixture.detectChanges();
+
+         fixture.componentInstance.trigger.openPanel();
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.openedSpy).not.toHaveBeenCalled();
+
+         fixture.componentInstance.filteredStates = fixture.componentInstance.states =
+             [{name: 'California', code: 'CA'}];
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.openedSpy).toHaveBeenCalled();
+       }));
+
+    it('should not emit the opened event multiple times while typing', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.openedSpy).toHaveBeenCalledTimes(1);
+
+      typeInElement(input, 'Alabam');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.openedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('should emit an event when the panel is closed', () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.closePanel();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.closedSpy).toHaveBeenCalled();
+    });
+
+    it('should not emit the `closed` event when no options were shown', () => {
+      fixture.componentInstance.filteredStates = fixture.componentInstance.states = [];
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.closePanel();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.closedSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not be able to open the panel if the autocomplete is disabled', () => {
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected panel state to start out closed.`);
+
+      fixture.componentInstance.autocompleteDisabled = true;
+      fixture.detectChanges();
+
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected panel to remain closed.`);
+    });
+
+    it('should continue to update the model if the autocomplete is disabled', () => {
+      fixture.componentInstance.autocompleteDisabled = true;
+      fixture.detectChanges();
+
+      typeInElement(input, 'hello');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.value).toBe('hello');
+    });
+
+    it('should set aria-haspopup depending on whether the autocomplete is disabled', () => {
+      expect(input.getAttribute('aria-haspopup')).toBe('true');
+
+      fixture.componentInstance.autocompleteDisabled = true;
+      fixture.detectChanges();
+
+      expect(input.getAttribute('aria-haspopup')).toBe('false');
+    });
+
+  });
+
+  it('should not close the panel when clicking on the input', fakeAsync(() => {
+       const fixture = createComponent(SimpleAutocomplete);
+       fixture.detectChanges();
+       const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+
+       dispatchFakeEvent(input, 'focusin');
+       fixture.detectChanges();
+       zone.simulateZoneExit();
+
+       expect(fixture.componentInstance.trigger.panelOpen)
+           .toBe(true, 'Expected panel to be opened on focus.');
+
+       input.click();
+       fixture.detectChanges();
+
+       expect(fixture.componentInstance.trigger.panelOpen)
+           .toBe(true, 'Expected panel to remain opened after clicking on the input.');
+     }));
+
+  it('should not close the panel when clicking on the input inside shadow DOM', fakeAsync(() => {
+       // This test is only relevant for Shadow DOM-capable browsers.
+       if (!_supportsShadowDom()) {
+         return;
+       }
+
+       const fixture = createComponent(SimpleAutocompleteShadowDom);
+       fixture.detectChanges();
+       const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+
+       dispatchFakeEvent(input, 'focusin');
+       fixture.detectChanges();
+       zone.simulateZoneExit();
+
+       expect(fixture.componentInstance.trigger.panelOpen)
+           .toBe(true, 'Expected panel to be opened on focus.');
+
+       input.click();
+       fixture.detectChanges();
+
+       expect(fixture.componentInstance.trigger.panelOpen)
+           .toBe(true, 'Expected panel to remain opened after clicking on the input.');
+     }));
+
+  it('should have the correct text direction in RTL', () => {
+    const rtlFixture = createComponent(SimpleAutocomplete, [
+      {provide: Directionality, useFactory: () => ({value: 'rtl', change: EMPTY})},
+    ]);
+
+    rtlFixture.detectChanges();
+    rtlFixture.componentInstance.trigger.openPanel();
+    rtlFixture.detectChanges();
+
+    const boundingBox =
+        overlayContainerElement.querySelector('.cdk-overlay-connected-position-bounding-box')!;
+    expect(boundingBox.getAttribute('dir')).toEqual('rtl');
+  });
+
+  it('should update the panel direction if it changes for the trigger', () => {
+    const dirProvider = {value: 'rtl', change: EMPTY};
+    const rtlFixture = createComponent(SimpleAutocomplete, [
+      {provide: Directionality, useFactory: () => dirProvider},
+    ]);
+
+    rtlFixture.detectChanges();
+    rtlFixture.componentInstance.trigger.openPanel();
+    rtlFixture.detectChanges();
+
+    let boundingBox =
+        overlayContainerElement.querySelector('.cdk-overlay-connected-position-bounding-box')!;
+    expect(boundingBox.getAttribute('dir')).toEqual('rtl');
+
+    rtlFixture.componentInstance.trigger.closePanel();
+    rtlFixture.detectChanges();
+
+    dirProvider.value = 'ltr';
+    rtlFixture.componentInstance.trigger.openPanel();
+    rtlFixture.detectChanges();
+
+    boundingBox =
+        overlayContainerElement.querySelector('.cdk-overlay-connected-position-bounding-box')!;
+    expect(boundingBox.getAttribute('dir')).toEqual('ltr');
+  });
+
+  it('should be able to set a custom value for the `autocomplete` attribute', () => {
+    const fixture = createComponent(AutocompleteWithNativeAutocompleteAttribute);
+    const input = fixture.nativeElement.querySelector('input');
+
+    fixture.detectChanges();
+
+    expect(input.getAttribute('autocomplete')).toBe('changed');
+  });
+
+  it('should not throw when typing in an element with a null and disabled autocomplete', () => {
+    const fixture = createComponent(InputWithoutAutocompleteAndDisabled);
+    fixture.detectChanges();
+
+    expect(() => {
+      dispatchKeyboardEvent(fixture.nativeElement.querySelector('input'), 'keydown', SPACE);
+      fixture.detectChanges();
+    }).not.toThrow();
+  });
+
+  describe('forms integration', () => {
+    let fixture: ComponentFixture<SimpleAutocomplete>;
+    let input: HTMLInputElement;
+
+    beforeEach(() => {
+      fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    });
+
+    it('should update control value as user types with input value', () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      typeInElement(input, 'a');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.value)
+          .toEqual('a', 'Expected control value to be updated as user types.');
+
+      typeInElement(input, 'l');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.value)
+          .toEqual('al', 'Expected control value to be updated as user types.');
+    });
+
+    it('should update control value when autofilling', () => {
+      // Simulate the browser autofilling the input by setting a value and
+      // dispatching an `input` event while the input is out of focus.
+      expect(document.activeElement).not.toBe(input, 'Expected input not to have focus.');
+      input.value = 'Alabama';
+      dispatchFakeEvent(input, 'input');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.value)
+          .toBe('Alabama', 'Expected value to be propagated to the form control.');
+    });
+
+    it('should update control value when option is selected with option value', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.value)
+          .toEqual({code: 'CA', name: 'California'},
+              'Expected control value to equal the selected option value.');
+    }));
+
+    it('should update the control back to a string if user types after an option is selected',
+      fakeAsync(() => {
+        fixture.componentInstance.trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+
+        const options =
+            overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+        options[1].click();
+        fixture.detectChanges();
+
+        clearElement(input);
+        typeInElement(input, 'Californi');
+        fixture.detectChanges();
+        tick();
+
+        expect(fixture.componentInstance.stateCtrl.value)
+            .toEqual('Californi', 'Expected control value to revert back to string.');
+      }));
+
+    it('should fill the text field with display value when an option is selected', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(input.value)
+          .toContain('California', `Expected text field to fill with selected value.`);
+    }));
+
+    it('should fill the text field with value if displayWith is not set', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      fixture.componentInstance.panel.displayWith = null;
+      fixture.componentInstance.options.toArray()[1].value = 'test value';
+      fixture.detectChanges();
+
+      const options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+
+      fixture.detectChanges();
+      expect(input.value)
+          .toContain('test value', `Expected input to fall back to selected option's value.`);
+    }));
+
+    it('should fill the text field correctly if value is set to obj programmatically',
+      fakeAsync(() => {
+        fixture.componentInstance.stateCtrl.setValue({code: 'AL', name: 'Alabama'});
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        expect(input.value)
+            .toContain('Alabama', `Expected input to fill with matching option's viewValue.`);
+      }));
+
+    it('should clear the text field if value is reset programmatically', fakeAsync(() => {
+      typeInElement(input, 'Alabama');
+      fixture.detectChanges();
+      tick();
+
+      fixture.componentInstance.stateCtrl.reset();
+      tick();
+
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toEqual('', `Expected input value to be empty after reset.`);
+    }));
+
+    it('should disable input in view when disabled programmatically', () => {
+      const formFieldElement =
+          fixture.debugElement.query(By.css('.mat-mdc-form-field'))!.nativeElement;
+
+      expect(input.disabled)
+          .toBe(false, `Expected input to start out enabled in view.`);
+      expect(formFieldElement.classList.contains('mat-form-field-disabled'))
+          .toBe(false, `Expected input underline to start out with normal styles.`);
+
+      fixture.componentInstance.stateCtrl.disable();
+      fixture.detectChanges();
+
+      expect(input.disabled)
+          .toBe(true, `Expected input to be disabled in view when disabled programmatically.`);
+      expect(formFieldElement.classList.contains('mat-form-field-disabled'))
+          .toBe(true, `Expected input underline to display disabled styles.`);
+    });
+
+    it('should mark the autocomplete control as dirty as user types', () => {
+      expect(fixture.componentInstance.stateCtrl.dirty)
+          .toBe(false, `Expected control to start out pristine.`);
+
+      typeInElement(input, 'a');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.dirty)
+          .toBe(true, `Expected control to become dirty when the user types into the input.`);
+    });
+
+    it('should mark the autocomplete control as dirty when an option is selected', fakeAsync(() => {
+      expect(fixture.componentInstance.stateCtrl.dirty)
+          .toBe(false, `Expected control to start out pristine.`);
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.dirty)
+          .toBe(true, `Expected control to become dirty when an option was selected.`);
+    }));
+
+    it('should not mark the control dirty when the value is set programmatically', () => {
+      expect(fixture.componentInstance.stateCtrl.dirty)
+          .toBe(false, `Expected control to start out pristine.`);
+
+      fixture.componentInstance.stateCtrl.setValue('AL');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.dirty)
+          .toBe(false, `Expected control to stay pristine if value is set programmatically.`);
+    });
+
+    it('should mark the autocomplete control as touched on blur', () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.stateCtrl.touched)
+          .toBe(false, `Expected control to start out untouched.`);
+
+      dispatchFakeEvent(input, 'blur');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.touched)
+          .toBe(true, `Expected control to become touched on blur.`);
+    });
+
+    it('should disable the input when used with a value accessor and without `matInput`', () => {
+      overlayContainer.ngOnDestroy();
+      fixture.destroy();
+      TestBed.resetTestingModule();
+
+      const plainFixture = createComponent(PlainAutocompleteInputWithFormControl);
+      plainFixture.detectChanges();
+      input = plainFixture.nativeElement.querySelector('input');
+
+      expect(input.disabled).toBe(false);
+
+      plainFixture.componentInstance.formControl.disable();
+      plainFixture.detectChanges();
+
+      expect(input.disabled).toBe(true);
+    });
+
+  });
+
+  describe('keyboard events', () => {
+    let fixture: ComponentFixture<SimpleAutocomplete>;
+    let input: HTMLInputElement;
+    let DOWN_ARROW_EVENT: KeyboardEvent;
+    let UP_ARROW_EVENT: KeyboardEvent;
+    let ENTER_EVENT: KeyboardEvent;
+
+    beforeEach(fakeAsync(() => {
+      fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      DOWN_ARROW_EVENT = createKeyboardEvent('keydown', DOWN_ARROW);
+      UP_ARROW_EVENT = createKeyboardEvent('keydown', UP_ARROW);
+      ENTER_EVENT = createKeyboardEvent('keydown', ENTER);
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+    }));
+
+    it('should not focus the option when DOWN key is pressed', () => {
+      spyOn(fixture.componentInstance.options.first, 'focus');
+
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      expect(fixture.componentInstance.options.first.focus).not.toHaveBeenCalled();
+    });
+
+    it('should not close the panel when DOWN key is pressed', () => {
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(true, `Expected panel state to stay open when DOWN key is pressed.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('Alabama', `Expected panel to keep displaying when DOWN key is pressed.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('California', `Expected panel to keep displaying when DOWN key is pressed.`);
+    });
+
+    it('should set the active item to the first option when DOWN key is pressed', () => {
+      const componentInstance = fixture.componentInstance;
+      const optionEls =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+
+      expect(componentInstance.trigger.panelOpen)
+          .toBe(true, 'Expected first down press to open the pane.');
+
+      componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(componentInstance.trigger.activeOption === componentInstance.options.first)
+          .toBe(true, 'Expected first option to be active.');
+      expect(optionEls[0].classList).toContain('mat-mdc-option-active');
+      expect(optionEls[1].classList).not.toContain('mat-mdc-option-active');
+
+      componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(componentInstance.trigger.activeOption === componentInstance.options.toArray()[1])
+          .toBe(true, 'Expected second option to be active.');
+      expect(optionEls[0].classList).not.toContain('mat-mdc-option-active');
+      expect(optionEls[1].classList).toContain('mat-mdc-option-active');
+    });
+
+    it('should set the active item to the last option when UP key is pressed', () => {
+      const componentInstance = fixture.componentInstance;
+      const optionEls =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+
+      expect(componentInstance.trigger.panelOpen)
+          .toBe(true, 'Expected first up press to open the pane.');
+
+      componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(componentInstance.trigger.activeOption === componentInstance.options.last)
+          .toBe(true, 'Expected last option to be active.');
+      expect(optionEls[10].classList).toContain('mat-mdc-option-active');
+      expect(optionEls[0].classList).not.toContain('mat-mdc-option-active');
+
+      componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(componentInstance.trigger.activeOption === componentInstance.options.first)
+          .toBe(true, 'Expected first option to be active.');
+      expect(optionEls[0].classList).toContain('mat-mdc-option-active');
+    });
+
+    it('should set the active item properly after filtering', fakeAsync(() => {
+      const componentInstance = fixture.componentInstance;
+
+      componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      tick();
+      fixture.detectChanges();
+    }));
+
+    it('should set the active item properly after filtering', () => {
+      const componentInstance = fixture.componentInstance;
+
+      typeInElement(input, 'o');
+      fixture.detectChanges();
+
+      componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      const optionEls =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+
+      expect(componentInstance.trigger.activeOption === componentInstance.options.first)
+          .toBe(true, 'Expected first option to be active.');
+      expect(optionEls[0].classList).toContain('mat-mdc-option-active');
+      expect(optionEls[1].classList).not.toContain('mat-mdc-option-active');
+    });
+
+    it('should fill the text field when an option is selected with ENTER', fakeAsync(() => {
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      flush();
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+      fixture.detectChanges();
+      expect(input.value)
+          .toContain('Alabama', `Expected text field to fill with selected value on ENTER.`);
+    }));
+
+    it('should prevent the default enter key action', fakeAsync(() => {
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      flush();
+
+      fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+
+      expect(ENTER_EVENT.defaultPrevented)
+          .toBe(true, 'Expected the default action to have been prevented.');
+    }));
+
+    it('should not prevent the default enter action for a closed panel after a user action', () => {
+      fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.closePanel();
+      fixture.detectChanges();
+      fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+
+      expect(ENTER_EVENT.defaultPrevented).toBe(false, 'Default action should not be prevented.');
+    });
+
+    it('should fill the text field, not select an option, when SPACE is entered', () => {
+      typeInElement(input, 'New');
+      fixture.detectChanges();
+
+      const SPACE_EVENT = createKeyboardEvent('keydown', SPACE);
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger._handleKeydown(SPACE_EVENT);
+      fixture.detectChanges();
+
+      expect(input.value).not.toContain('New York', `Expected option not to be selected on SPACE.`);
+    });
+
+    it('should mark the control dirty when selecting an option from the keyboard', fakeAsync(() => {
+      expect(fixture.componentInstance.stateCtrl.dirty)
+          .toBe(false, `Expected control to start out pristine.`);
+
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      flush();
+      fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.stateCtrl.dirty)
+          .toBe(true, `Expected control to become dirty when option was selected by ENTER.`);
+    }));
+
+    it('should open the panel again when typing after making a selection', fakeAsync(() => {
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      flush();
+      fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(false, `Expected panel state to read closed after ENTER key.`);
+      expect(overlayContainerElement.textContent)
+          .toEqual('', `Expected panel to close after ENTER key.`);
+
+      dispatchFakeEvent(input, 'focusin');
+      clearElement(input);
+      typeInElement(input, 'Alabama');
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(true, `Expected panel state to read open when typing in input.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('Alabama', `Expected panel to display when typing in input.`);
+    }));
+
+    it('should not open the panel if the `input` event was dispatched with changing the value',
+      fakeAsync(() => {
+        const trigger = fixture.componentInstance.trigger;
+
+        dispatchFakeEvent(input, 'focusin');
+        typeInElement(input, 'A');
+        fixture.detectChanges();
+        tick();
+
+        expect(trigger.panelOpen).toBe(true, 'Expected panel to be open.');
+
+        trigger.closePanel();
+        fixture.detectChanges();
+
+        expect(trigger.panelOpen).toBe(false, 'Expected panel to be closed.');
+
+        // Dispatch the event without actually changing the value
+        // to simulate what happen in some cases on IE.
+        dispatchFakeEvent(input, 'input');
+        fixture.detectChanges();
+        tick();
+
+        expect(trigger.panelOpen).toBe(false, 'Expected panel to stay closed.');
+      }));
+
+    it('should scroll to active options below the fold', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer =
+          document.querySelector('.cdk-overlay-pane .mat-mdc-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 6th option active, below the fold.
+      [1, 2, 3, 4, 5].forEach(() => trigger._handleKeydown(DOWN_ARROW_EVENT));
+
+      // Expect option bottom minus the panel height plus padding (288 - 256 + 8 = 40)
+      expect(scrollContainer.scrollTop)
+          .toEqual(40, `Expected panel to reveal the sixth option.`);
+    });
+
+    it('should scroll to active options on UP arrow', () => {
+      const scrollContainer =
+          document.querySelector('.cdk-overlay-pane .mat-mdc-autocomplete-panel')!;
+
+      fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+      fixture.detectChanges();
+
+      // Expect option bottom minus the panel height plus padding (528 - 256 + 8 = 272)
+      expect(scrollContainer.scrollTop).toEqual(280, `Expected panel to reveal last option.`);
+    });
+
+    it('should not scroll to active options that are fully in the panel', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer =
+          document.querySelector('.cdk-overlay-pane .mat-mdc-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 6th option active, below the fold.
+      [1, 2, 3, 4, 5].forEach(() => trigger._handleKeydown(DOWN_ARROW_EVENT));
+
+      // Expect option bottom minus the panel height plus the padding (288 - 256 + 8 = 40)
+      expect(scrollContainer.scrollTop)
+          .toEqual(40, `Expected panel to reveal the sixth option.`);
+
+      // These up arrows will set the 2nd option active
+      [4, 3, 2, 1].forEach(() => trigger._handleKeydown(UP_ARROW_EVENT));
+
+      // Expect no scrolling to have occurred. Still showing bottom of 6th option.
+      expect(scrollContainer.scrollTop)
+          .toEqual(40, `Expected panel not to scroll up since sixth option still fully visible.`);
+    });
+
+    it('should scroll to active options that are above the panel', () => {
+      const trigger = fixture.componentInstance.trigger;
+      const scrollContainer =
+          document.querySelector('.cdk-overlay-pane .mat-mdc-autocomplete-panel')!;
+
+      trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      expect(scrollContainer.scrollTop).toEqual(0, `Expected panel not to scroll.`);
+
+      // These down arrows will set the 7th option active, below the fold.
+      [1, 2, 3, 4, 5, 6].forEach(() => trigger._handleKeydown(DOWN_ARROW_EVENT));
+
+      // These up arrows will set the 2nd option active
+      [5, 4, 3, 2, 1].forEach(() => trigger._handleKeydown(UP_ARROW_EVENT));
+
+      // Expect to show the top of the 2nd option at the top of the panel
+      expect(scrollContainer.scrollTop)
+          .toEqual(56, `Expected panel to scroll up when option is above panel.`);
+    });
+
+    it('should close the panel when pressing escape', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+
+      input.focus();
+      flush();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(input, 'Expected input to be focused.');
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to be open.');
+
+      dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(input, 'Expected input to continue to be focused.');
+      expect(trigger.panelOpen).toBe(false, 'Expected panel to be closed.');
+    }));
+
+    it('should prevent the default action when pressing escape', fakeAsync(() => {
+      const escapeEvent = dispatchKeyboardEvent(input, 'keydown', ESCAPE);
+      fixture.detectChanges();
+
+      expect(escapeEvent.defaultPrevented).toBe(true);
+    }));
+
+    it('should close the panel when pressing ALT + UP_ARROW', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+      const upArrowEvent = createKeyboardEvent('keydown', UP_ARROW, undefined, {alt: true});
+      spyOn(upArrowEvent, 'stopPropagation').and.callThrough();
+
+      input.focus();
+      flush();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(input, 'Expected input to be focused.');
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to be open.');
+
+      dispatchEvent(document.body, upArrowEvent);
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(input, 'Expected input to continue to be focused.');
+      expect(trigger.panelOpen).toBe(false, 'Expected panel to be closed.');
+      expect(upArrowEvent.stopPropagation).toHaveBeenCalled();
+    }));
+
+    it('should close the panel when tabbing away from a trigger without results', fakeAsync(() => {
+      fixture.componentInstance.states = [];
+      fixture.componentInstance.filteredStates = [];
+      fixture.detectChanges();
+      input.focus();
+      flush();
+
+      expect(overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel'))
+          .toBeTruthy('Expected panel to be rendered.');
+
+      dispatchKeyboardEvent(input, 'keydown', TAB);
+      fixture.detectChanges();
+
+      expect(overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel'))
+          .toBeFalsy('Expected panel to be removed.');
+    }));
+
+    it('should reset the active option when closing with the escape key', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      tick();
+
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to be open.');
+      expect(!!trigger.activeOption).toBe(false, 'Expected no active option.');
+
+      // Press the down arrow a few times.
+      [1, 2, 3].forEach(() => {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+        tick();
+        fixture.detectChanges();
+      });
+
+      // Note that this casts to a boolean, in order to prevent Jasmine
+      // from crashing when trying to stringify the option if the test fails.
+      expect(!!trigger.activeOption).toBe(true, 'Expected to find an active option.');
+
+      dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+      tick();
+
+      expect(!!trigger.activeOption).toBe(false, 'Expected no active options.');
+    }));
+
+    it('should reset the active option when closing by selecting with enter', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      tick();
+
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to be open.');
+      expect(!!trigger.activeOption).toBe(false, 'Expected no active option.');
+
+      // Press the down arrow a few times.
+      [1, 2, 3].forEach(() => {
+        trigger._handleKeydown(DOWN_ARROW_EVENT);
+        tick();
+        fixture.detectChanges();
+      });
+
+      // Note that this casts to a boolean, in order to prevent Jasmine
+      // from crashing when trying to stringify the option if the test fails.
+      expect(!!trigger.activeOption).toBe(true, 'Expected to find an active option.');
+
+      trigger._handleKeydown(ENTER_EVENT);
+      tick();
+
+      expect(!!trigger.activeOption).toBe(false, 'Expected no active options.');
+    }));
+
+  });
+
+  describe('option groups', () => {
+    let DOWN_ARROW_EVENT: KeyboardEvent;
+    let UP_ARROW_EVENT: KeyboardEvent;
+
+    beforeEach(() => {
+      DOWN_ARROW_EVENT = createKeyboardEvent('keydown', DOWN_ARROW);
+      UP_ARROW_EVENT = createKeyboardEvent('keydown', UP_ARROW);
+    });
+
+    it('should scroll to active options below the fold', fakeAsync(() => {
+      const fixture = createComponent(AutocompleteWithGroups);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+      const container = document.querySelector('.mat-mdc-autocomplete-panel') as HTMLElement;
+
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      tick();
+      fixture.detectChanges();
+      expect(container.scrollTop).toBe(0, 'Expected the panel not to scroll.');
+
+      // Press the down arrow five times.
+      [1, 2, 3, 4, 5].forEach(() => {
+        fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+        tick();
+      });
+
+      // <option bottom> - <panel height> + <2x group labels> + panel padding = 136
+      // 288 - 256 + 96 + 8 = 128
+      expect(container.scrollTop)
+          .toBe(136, 'Expected panel to reveal the sixth option.');
+    }));
+
+    it('should scroll to active options on UP arrow', fakeAsync(() => {
+      const fixture = createComponent(AutocompleteWithGroups);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+      const container = document.querySelector('.mat-mdc-autocomplete-panel') as HTMLElement;
+
+      fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+      tick();
+      fixture.detectChanges();
+
+      // <option bottom> - <panel height> + <3x group label> + panel padding = 472
+      // 576 - 256 + 144 + 8 = 472
+      expect(container.scrollTop).toBe(472, 'Expected panel to reveal last option.');
+    }));
+
+    it('should scroll to active options that are above the panel', fakeAsync(() => {
+      const fixture = createComponent(AutocompleteWithGroups);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      const container = document.querySelector('.mat-mdc-autocomplete-panel') as HTMLElement;
+
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      tick();
+      fixture.detectChanges();
+      expect(container.scrollTop).toBe(0, 'Expected panel not to scroll.');
+
+      // These down arrows will set the 7th option active, below the fold.
+      [1, 2, 3, 4, 5, 6].forEach(() => {
+        fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+        tick();
+      });
+
+      // These up arrows will set the 2nd option active
+      [5, 4, 3, 2, 1].forEach(() => {
+        fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+        tick();
+      });
+
+      // Expect to show the top of the 2nd option at the top of the panel.
+      // It is offset by 56, because there's a group label above it plus the panel padding.
+      expect(container.scrollTop)
+          .toBe(104, 'Expected panel to scroll up when option is above panel.');
+    }));
+
+    it('should scroll back to the top when reaching the first option with preceding group label',
+      fakeAsync(() => {
+        const fixture = createComponent(AutocompleteWithGroups);
+        fixture.detectChanges();
+
+        fixture.componentInstance.trigger.openPanel();
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        const container = document.querySelector('.mat-mdc-autocomplete-panel') as HTMLElement;
+
+        fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+        tick();
+        fixture.detectChanges();
+        expect(container.scrollTop).toBe(0, 'Expected the panel not to scroll.');
+
+        // Press the down arrow five times.
+        [1, 2, 3, 4, 5].forEach(() => {
+          fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+          tick();
+        });
+
+        // Press the up arrow five times.
+        [1, 2, 3, 4, 5].forEach(() => {
+          fixture.componentInstance.trigger._handleKeydown(UP_ARROW_EVENT);
+          tick();
+        });
+
+        expect(container.scrollTop).toBe(0, 'Expected panel to be scrolled to the top.');
+      }));
+
+      it('should scroll to active option when group is indirect descendant', fakeAsync(() => {
+        const fixture = createComponent(AutocompleteWithIndirectGroups);
+        fixture.detectChanges();
+
+        fixture.componentInstance.trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        fixture.detectChanges();
+        const container = document.querySelector('.mat-mdc-autocomplete-panel') as HTMLElement;
+
+        fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+        tick();
+        fixture.detectChanges();
+        expect(container.scrollTop).toBe(0, 'Expected the panel not to scroll.');
+
+        // Press the down arrow five times.
+        [1, 2, 3, 4, 5].forEach(() => {
+          fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+          tick();
+        });
+
+        // <option bottom> - <panel height> + <2x group labels> + panel padding = 128
+        // 288 - 256 + 96 + 8 = 136
+        expect(container.scrollTop)
+            .toBe(136, 'Expected panel to reveal the sixth option.');
+      }));
+  });
+
+  describe('aria', () => {
+    let fixture: ComponentFixture<SimpleAutocomplete>;
+    let input: HTMLInputElement;
+
+    beforeEach(() => {
+      fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    });
+
+    it('should set role of input to combobox', () => {
+      expect(input.getAttribute('role'))
+          .toEqual('combobox', 'Expected role of input to be combobox.');
+    });
+
+    it('should set role of autocomplete panel to listbox', () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      const panel =
+          fixture.debugElement.query(By.css('.mat-mdc-autocomplete-panel'))!.nativeElement;
+
+      expect(panel.getAttribute('role'))
+          .toEqual('listbox', 'Expected role of the panel to be listbox.');
+    });
+
+    it('should set aria-autocomplete to list', () => {
+      expect(input.getAttribute('aria-autocomplete'))
+          .toEqual('list', 'Expected aria-autocomplete attribute to equal list.');
+    });
+
+    it('should set aria-activedescendant based on the active option', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      expect(input.hasAttribute('aria-activedescendant'))
+          .toBe(false, 'Expected aria-activedescendant to be absent if no active item.');
+
+      const DOWN_ARROW_EVENT = createKeyboardEvent('keydown', DOWN_ARROW);
+
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      tick();
+      fixture.detectChanges();
+
+      expect(input.getAttribute('aria-activedescendant'))
+          .toEqual(fixture.componentInstance.options.first.id,
+              'Expected aria-activedescendant to match the active item after 1 down arrow.');
+
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      tick();
+      fixture.detectChanges();
+
+      expect(input.getAttribute('aria-activedescendant'))
+          .toEqual(fixture.componentInstance.options.toArray()[1].id,
+              'Expected aria-activedescendant to match the active item after 2 down arrows.');
+    }));
+
+    it('should set aria-expanded based on whether the panel is open', () => {
+      expect(input.getAttribute('aria-expanded'))
+          .toBe('false', 'Expected aria-expanded to be false while panel is closed.');
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      expect(input.getAttribute('aria-expanded'))
+          .toBe('true', 'Expected aria-expanded to be true while panel is open.');
+
+      fixture.componentInstance.trigger.closePanel();
+      fixture.detectChanges();
+
+      expect(input.getAttribute('aria-expanded'))
+          .toBe('false', 'Expected aria-expanded to be false when panel closes again.');
+    });
+
+    it('should set aria-expanded properly when the panel is hidden', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      expect(input.getAttribute('aria-expanded'))
+          .toBe('true', 'Expected aria-expanded to be true while panel is open.');
+
+      typeInElement(input, 'zz');
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(input.getAttribute('aria-expanded'))
+          .toBe('false', 'Expected aria-expanded to be false when panel hides itself.');
+    }));
+
+    it('should set aria-owns based on the attached autocomplete', () => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      const panel =
+          fixture.debugElement.query(By.css('.mat-mdc-autocomplete-panel'))!.nativeElement;
+
+      expect(input.getAttribute('aria-owns'))
+          .toBe(panel.getAttribute('id'), 'Expected aria-owns to match attached autocomplete.');
+    });
+
+    it('should not set aria-owns while the autocomplete is closed', () => {
+      expect(input.getAttribute('aria-owns')).toBeFalsy();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      expect(input.getAttribute('aria-owns')).toBeTruthy();
+    });
+
+    it('should restore focus to the input when clicking to select a value', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const option = overlayContainerElement.querySelector('mat-option') as HTMLElement;
+
+      // Focus the option manually since the synthetic click may not do it.
+      option.focus();
+      option.click();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(input, 'Expected focus to be restored to the input.');
+    }));
+
+    it('should remove autocomplete-specific aria attributes when autocomplete is disabled', () => {
+      fixture.componentInstance.autocompleteDisabled = true;
+      fixture.detectChanges();
+
+      expect(input.getAttribute('role')).toBeFalsy();
+      expect(input.getAttribute('aria-autocomplete')).toBeFalsy();
+      expect(input.getAttribute('aria-expanded')).toBeFalsy();
+      expect(input.getAttribute('aria-owns')).toBeFalsy();
+    });
+
+  });
+
+  describe('Fallback positions', () => {
+    it('should use below positioning by default', fakeAsync(() => {
+      let fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      const inputBottom = inputReference.getBoundingClientRect().bottom;
+      const panel = overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!;
+      const panelTop = panel.getBoundingClientRect().top;
+
+      expect(Math.floor(inputBottom))
+          .toEqual(Math.floor(panelTop), `Expected panel top to match input bottom by default.`);
+      expect(panel.classList).not.toContain('mat-mdc-autocomplete-panel-above');
+    }));
+
+    it('should reposition the panel on scroll', () => {
+      let scrolledSubject = new Subject();
+      let spacer = document.createElement('div');
+      let fixture = createComponent(SimpleAutocomplete, [{
+        provide: ScrollDispatcher,
+        useValue: {scrolled: () => scrolledSubject.asObservable()}
+      }]);
+
+      fixture.detectChanges();
+
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+      spacer.style.height = '1000px';
+      document.body.appendChild(spacer);
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      window.scroll(0, 100);
+      scrolledSubject.next();
+      fixture.detectChanges();
+
+      const inputBottom = inputReference.getBoundingClientRect().bottom;
+      const panel = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+      const panelTop = panel.getBoundingClientRect().top;
+
+      expect(Math.floor(inputBottom)).toEqual(Math.floor(panelTop),
+          'Expected panel top to match input bottom after scrolling.');
+
+      document.body.removeChild(spacer);
+      window.scroll(0, 0);
+    });
+
+    it('should fall back to above position if panel cannot fit below', fakeAsync(() => {
+      let fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+
+      // Push the autocomplete trigger down so it won't have room to open "below"
+      inputReference.style.bottom = '0';
+      inputReference.style.position = 'fixed';
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      const inputTop = inputReference.getBoundingClientRect().top;
+      const panel = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+      const panelBottom = panel.getBoundingClientRect().bottom;
+
+      expect(Math.floor(inputTop))
+          .toEqual(Math.floor(panelBottom), `Expected panel to fall back to above position.`);
+
+      expect(panel.classList).toContain('mat-mdc-autocomplete-panel-above');
+    }));
+
+    it('should allow the panel to expand when the number of results increases', fakeAsync(() => {
+      let fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+
+      let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+
+      // Push the element down so it has a little bit of space, but not enough to render.
+      inputReference.style.bottom = '10px';
+      inputReference.style.position = 'fixed';
+
+      // Type enough to only show one option.
+      typeInElement(inputEl, 'California');
+      fixture.detectChanges();
+      tick();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      let panel = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+      let initialPanelHeight = panel.getBoundingClientRect().height;
+
+      fixture.componentInstance.trigger.closePanel();
+      fixture.detectChanges();
+
+      // Change the text so we get more than one result.
+      clearElement(inputEl);
+      typeInElement(inputEl, 'C');
+      fixture.detectChanges();
+      tick();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      panel = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+
+      expect(panel.getBoundingClientRect().height).toBeGreaterThan(initialPanelHeight);
+    }));
+
+    it('should align panel properly when filtering in "above" position', fakeAsync(() => {
+      let fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+
+      let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+
+      // Push the autocomplete trigger down so it won't have room to open "below"
+      inputReference.style.bottom = '0';
+      inputReference.style.position = 'fixed';
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      typeInElement(input, 'f');
+      fixture.detectChanges();
+      tick();
+
+      const inputTop = inputReference.getBoundingClientRect().top;
+      const panel = overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!;
+      const panelBottom = panel.getBoundingClientRect().bottom;
+
+      expect(Math.floor(inputTop))
+          .toEqual(Math.floor(panelBottom), `Expected panel to stay aligned after filtering.`);
+    }));
+
+    it('should fall back to above position when requested if options are added while ' +
+        'the panel is open', fakeAsync(() => {
+      let fixture = createComponent(SimpleAutocomplete);
+      fixture.componentInstance.states = fixture.componentInstance.states.slice(0, 1);
+      fixture.componentInstance.filteredStates = fixture.componentInstance.states.slice();
+      fixture.detectChanges();
+
+      let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+
+      // Push the element down so it has a little bit of space, but not enough to render.
+      inputReference.style.bottom = '75px';
+      inputReference.style.position = 'fixed';
+
+      dispatchFakeEvent(inputEl, 'focusin');
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      let panel = overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!;
+      let inputRect = inputReference.getBoundingClientRect();
+      let panelRect = panel.getBoundingClientRect();
+
+      expect(Math.floor(panelRect.top))
+        .toBe(Math.floor(inputRect.bottom),
+          `Expected panel top to be below input before repositioning.`);
+
+      for (let i = 0; i < 20; i++) {
+        fixture.componentInstance.filteredStates.push({code: 'FK', name: 'Fake State'});
+        fixture.detectChanges();
+      }
+
+      // Request a position update now that there are too many suggestions to fit in the viewport.
+      fixture.componentInstance.trigger.updatePosition();
+
+      inputRect = inputReference.getBoundingClientRect();
+      panelRect = panel.getBoundingClientRect();
+
+      expect(Math.floor(panelRect.bottom))
+        .toBe(Math.floor(inputRect.top),
+          `Expected panel to fall back to above position after repositioning.`);
+      tick();
+    }));
+
+    it('should not throw if a panel reposition is requested while the panel is closed', () => {
+        let fixture = createComponent(SimpleAutocomplete);
+        fixture.detectChanges();
+
+        expect(() => fixture.componentInstance.trigger.updatePosition()).not.toThrow();
+    });
+
+    it('should be able to force below position even if there is not enough space', fakeAsync(() => {
+      let fixture = createComponent(SimpleAutocomplete);
+      fixture.componentInstance.position = 'below';
+      fixture.detectChanges();
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+
+      // Push the autocomplete trigger down so it won't have room to open below.
+      inputReference.style.bottom = '0';
+      inputReference.style.position = 'fixed';
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      const inputBottom = inputReference.getBoundingClientRect().bottom;
+      const panel = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+      const panelTop = panel.getBoundingClientRect().top;
+
+      expect(Math.floor(inputBottom))
+          .toEqual(Math.floor(panelTop), 'Expected panel to be below the input.');
+
+      expect(panel.classList).not.toContain('mat-mdc-autocomplete-panel-above');
+    }));
+
+    it('should be able to force above position even if there is not enough space', fakeAsync(() => {
+      let fixture = createComponent(SimpleAutocomplete);
+      fixture.componentInstance.position = 'above';
+      fixture.detectChanges();
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+
+      // Push the autocomplete trigger up so it won't have room to open above.
+      inputReference.style.top = '0';
+      inputReference.style.position = 'fixed';
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      const inputTop = inputReference.getBoundingClientRect().top;
+      const panel = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+      const panelBottom = panel.getBoundingClientRect().bottom;
+
+      expect(Math.floor(inputTop))
+          .toEqual(Math.floor(panelBottom), 'Expected panel to be above the input.');
+
+      expect(panel.classList).toContain('mat-mdc-autocomplete-panel-above');
+    }));
+
+    it('should handle the position being changed after the first open', fakeAsync(() => {
+      let fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+      let inputReference =
+          fixture.debugElement.query(By.css('.mdc-text-field'))!.nativeElement;
+      let openPanel = () => {
+        fixture.componentInstance.trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        fixture.detectChanges();
+      };
+
+      // Push the autocomplete trigger down so it won't have room to open below.
+      inputReference.style.bottom = '0';
+      inputReference.style.position = 'fixed';
+      openPanel();
+
+      let inputRect = inputReference.getBoundingClientRect();
+      let panel = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+      let panelRect = panel.getBoundingClientRect();
+
+      expect(Math.floor(inputRect.top))
+          .toEqual(Math.floor(panelRect.bottom), 'Expected panel to be above the input.');
+      expect(panel.classList).toContain('mat-mdc-autocomplete-panel-above');
+
+      fixture.componentInstance.trigger.closePanel();
+      fixture.detectChanges();
+
+      fixture.componentInstance.position = 'below';
+      fixture.detectChanges();
+      openPanel();
+
+      inputRect = inputReference.getBoundingClientRect();
+      panel = overlayContainerElement.querySelector('.cdk-overlay-pane')!;
+      panelRect = panel.getBoundingClientRect();
+
+      expect(Math.floor(inputRect.bottom))
+          .toEqual(Math.floor(panelRect.top), 'Expected panel to be below the input.');
+      expect(panel.classList).not.toContain('mat-mdc-autocomplete-panel-above');
+    }));
+
+  });
+
+  describe('Option selection', () => {
+    let fixture: ComponentFixture<SimpleAutocomplete>;
+
+    beforeEach(() => {
+      fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+    });
+
+    it('should deselect any other selected option', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      let options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[0].click();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      let componentOptions = fixture.componentInstance.options.toArray();
+      expect(componentOptions[0].selected)
+          .toBe(true, `Clicked option should be selected.`);
+
+      options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(componentOptions[0].selected)
+          .toBe(false, `Previous option should not be selected.`);
+      expect(componentOptions[1].selected)
+          .toBe(true, `New Clicked option should be selected.`);
+    }));
+
+    it('should call deselect only on the previous selected option', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      let options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[0].click();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      let componentOptions = fixture.componentInstance.options.toArray();
+      componentOptions.forEach(option => spyOn(option, 'deselect'));
+
+      expect(componentOptions[0].selected)
+          .toBe(true, `Clicked option should be selected.`);
+
+      options =
+          overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+      options[1].click();
+      fixture.detectChanges();
+
+      expect(componentOptions[0].deselect).toHaveBeenCalled();
+      componentOptions.slice(1).forEach(option => expect(option.deselect).not.toHaveBeenCalled());
+    }));
+
+    it('should be able to preselect the first option', fakeAsync(() => {
+      fixture.componentInstance.trigger.autocomplete.autoActiveFirstOption = true;
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      expect(overlayContainerElement.querySelectorAll('mat-option')[0].classList)
+          .toContain('mat-mdc-option-active', 'Expected first option to be highlighted.');
+    }));
+
+    it('should remove aria-activedescendant when panel is closed with autoActiveFirstOption',
+      fakeAsync(() => {
+        const input: HTMLElement = fixture.nativeElement.querySelector('input');
+
+        expect(input.hasAttribute('aria-activedescendant'))
+            .toBe(false, 'Expected no active descendant on init.');
+
+        fixture.componentInstance.trigger.autocomplete.autoActiveFirstOption = true;
+        fixture.componentInstance.trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        fixture.detectChanges();
+
+        expect(input.getAttribute('aria-activedescendant'))
+            .toBeTruthy('Expected active descendant while open.');
+
+        fixture.componentInstance.trigger.closePanel();
+        fixture.detectChanges();
+
+        expect(input.hasAttribute('aria-activedescendant'))
+            .toBe(false, 'Expected no active descendant when closed.');
+      }));
+
+    it('should be able to configure preselecting the first option globally', fakeAsync(() => {
+      overlayContainer.ngOnDestroy();
+      fixture.destroy();
+      TestBed.resetTestingModule();
+      fixture = createComponent(SimpleAutocomplete, [
+        {provide: MAT_AUTOCOMPLETE_DEFAULT_OPTIONS, useValue: {autoActiveFirstOption: true}}
+      ]);
+
+      fixture.detectChanges();
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      expect(overlayContainerElement.querySelectorAll('mat-option')[0].classList)
+          .toContain('mat-mdc-option-active', 'Expected first option to be highlighted.');
+    }));
+
+    it('should handle `optionSelections` being accessed too early', fakeAsync(() => {
+      overlayContainer.ngOnDestroy();
+      fixture.destroy();
+      fixture = TestBed.createComponent(SimpleAutocomplete);
+
+      let spy = jasmine.createSpy('option selection spy');
+      let subscription: Subscription;
+
+      expect(fixture.componentInstance.trigger.autocomplete).toBeFalsy();
+      expect(() => {
+        subscription = fixture.componentInstance.trigger.optionSelections.subscribe(spy);
+      }).not.toThrow();
+
+      fixture.detectChanges();
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const option = overlayContainerElement.querySelector('mat-option') as HTMLElement;
+
+      option.click();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      expect(spy).toHaveBeenCalledWith(jasmine.any(MatOptionSelectionChange));
+      subscription!.unsubscribe();
+    }));
+
+    it('should reposition the panel when the amount of options changes', fakeAsync(() => {
+      let formField = fixture.debugElement.query(By.css('.mat-mdc-form-field'))!.nativeElement;
+      let inputReference = formField.querySelector('.mdc-text-field');
+      let input = inputReference.querySelector('input');
+
+      formField.style.bottom = '100px';
+      formField.style.position = 'fixed';
+
+      typeInElement(input, 'Cali');
+      fixture.detectChanges();
+      tick();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      const inputBottom = inputReference.getBoundingClientRect().bottom;
+      const panel = overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!;
+      const panelTop = panel.getBoundingClientRect().top;
+
+      expect(Math.floor(inputBottom)).toBe(Math.floor(panelTop),
+          `Expected panel top to match input bottom when there is only one option.`);
+
+      clearElement(input);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const inputTop = inputReference.getBoundingClientRect().top;
+      const panelBottom = panel.getBoundingClientRect().bottom;
+
+      expect(Math.floor(inputTop)).toBe(Math.floor(panelBottom),
+          `Expected panel switch to the above position if the options no longer fit.`);
+    }));
+
+  });
+
+  describe('panel closing', () => {
+    let fixture: ComponentFixture<SimpleAutocomplete>;
+    let input: HTMLInputElement;
+    let trigger: MatAutocompleteTrigger;
+    let closingActionSpy: jasmine.Spy;
+    let closingActionsSub: Subscription;
+
+    beforeEach(fakeAsync(() => {
+      fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+
+      input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      flush();
+
+      trigger = fixture.componentInstance.trigger;
+      closingActionSpy = jasmine.createSpy('closing action listener');
+      closingActionsSub = trigger.panelClosingActions.subscribe(closingActionSpy);
+    }));
+
+    afterEach(() => {
+      closingActionsSub.unsubscribe();
+    });
+
+    it('should emit panel close event when clicking away', () => {
+      expect(closingActionSpy).not.toHaveBeenCalled();
+      dispatchFakeEvent(document, 'click');
+      expect(closingActionSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('should emit panel close event when tabbing out', () => {
+      const tabEvent = createKeyboardEvent('keydown', TAB);
+      input.focus();
+
+      expect(closingActionSpy).not.toHaveBeenCalled();
+      trigger._handleKeydown(tabEvent);
+      expect(closingActionSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('should not emit when tabbing away from a closed panel', () => {
+      const tabEvent = createKeyboardEvent('keydown', TAB);
+
+      input.focus();
+      zone.simulateZoneExit();
+
+      trigger._handleKeydown(tabEvent);
+
+      // Ensure that it emitted once while the panel was open.
+      expect(closingActionSpy).toHaveBeenCalledTimes(1);
+
+      trigger._handleKeydown(tabEvent);
+
+      // Ensure that it didn't emit again when tabbing out again.
+      expect(closingActionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit panel close event when selecting an option', () => {
+      const option = overlayContainerElement.querySelector('mat-option') as HTMLElement;
+
+      expect(closingActionSpy).not.toHaveBeenCalled();
+      option.click();
+      expect(closingActionSpy).toHaveBeenCalledWith(jasmine.any(MatOptionSelectionChange));
+    });
+
+    it('should close the panel when pressing escape', () => {
+      expect(closingActionSpy).not.toHaveBeenCalled();
+      dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+      expect(closingActionSpy).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('without matInput', () => {
+    let fixture: ComponentFixture<AutocompleteWithNativeInput>;
+
+    beforeEach(() => {
+      fixture = createComponent(AutocompleteWithNativeInput);
+      fixture.detectChanges();
+    });
+
+    it('should not throw when clicking outside', fakeAsync(() => {
+      dispatchFakeEvent(fixture.debugElement.query(By.css('input'))!.nativeElement, 'focus');
+      fixture.detectChanges();
+      flush();
+
+      expect(() => dispatchFakeEvent(document, 'click')).not.toThrow();
+    }));
+  });
+
+  describe('misc', () => {
+
+    it('should allow basic use without any forms directives', () => {
+      expect(() => {
+        const fixture = createComponent(AutocompleteWithoutForms);
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+        typeInElement(input, 'd');
+        fixture.detectChanges();
+
+        const options =
+            overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+        expect(options.length).toBe(1);
+      }).not.toThrowError();
+    });
+
+    it('should display an empty input when the value is undefined with ngModel', () => {
+      const fixture = createComponent(AutocompleteWithNgModel);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('input'))!.nativeElement.value).toBe('');
+    });
+
+    it('should display the number when the selected option is the number zero', fakeAsync(() => {
+      const fixture = createComponent(AutocompleteWithNumbers);
+
+      fixture.componentInstance.selectedNumber = 0;
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.debugElement.query(By.css('input'))!.nativeElement.value).toBe('0');
+    }));
+
+    it('should work when input is wrapped in ngIf', () => {
+      const fixture = createComponent(NgIfAutocomplete);
+      fixture.detectChanges();
+
+      dispatchFakeEvent(fixture.debugElement.query(By.css('input'))!.nativeElement, 'focusin');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.trigger.panelOpen)
+          .toBe(true, `Expected panel state to read open when input is focused.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('One', `Expected panel to display when input is focused.`);
+      expect(overlayContainerElement.textContent)
+          .toContain('Two', `Expected panel to display when input is focused.`);
+    });
+
+    it('should filter properly with ngIf after setting the active item', () => {
+      const fixture = createComponent(NgIfAutocomplete);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+
+      const DOWN_ARROW_EVENT = createKeyboardEvent('keydown', DOWN_ARROW);
+      fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      typeInElement(input, 'o');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.matOptions.length).toBe(2);
+    });
+
+    it('should throw if the user attempts to open the panel too early', () => {
+      const fixture = createComponent(AutocompleteWithoutPanel);
+      fixture.detectChanges();
+
+      expect(() => {
+        fixture.componentInstance.trigger.openPanel();
+      }).toThrow(getMatAutocompleteMissingPanelError());
+    });
+
+    it('should not throw on init, even if the panel is not defined', fakeAsync(() => {
+      expect(() => {
+        const fixture = createComponent(AutocompleteWithoutPanel);
+        fixture.componentInstance.control.setValue('Something');
+        fixture.detectChanges();
+        tick();
+      }).not.toThrow();
+    }));
+
+    it('should transfer the mat-autocomplete classes to the panel element', fakeAsync(() => {
+      const fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.openPanel();
+      tick();
+      fixture.detectChanges();
+
+      const autocomplete = fixture.debugElement.nativeElement.querySelector('mat-autocomplete');
+      const panel = overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!;
+
+      expect(autocomplete.classList).not.toContain('class-one');
+      expect(autocomplete.classList).not.toContain('class-two');
+
+      expect(panel.classList).toContain('class-one');
+      expect(panel.classList).toContain('class-two');
+    }));
+
+    it('should remove old classes when the panel class changes', fakeAsync(() => {
+         const fixture = createComponent(SimpleAutocomplete);
+         fixture.detectChanges();
+
+         fixture.componentInstance.trigger.openPanel();
+         tick();
+         fixture.detectChanges();
+
+         const classList =
+             overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel')!.classList;
+
+         expect(classList).toContain('mat-mdc-autocomplete-visible');
+         expect(classList).toContain('class-one');
+         expect(classList).toContain('class-two');
+
+         fixture.componentInstance.panelClass = 'class-three class-four';
+         fixture.detectChanges();
+
+         expect(classList).not.toContain('class-one');
+         expect(classList).not.toContain('class-two');
+         expect(classList).toContain('mat-mdc-autocomplete-visible');
+         expect(classList).toContain('class-three');
+         expect(classList).toContain('class-four');
+       }));
+
+    it('should reset correctly when closed programmatically', fakeAsync(() => {
+      const scrolledSubject = new Subject();
+      const fixture = createComponent(SimpleAutocomplete, [
+        {
+          provide: ScrollDispatcher,
+          useValue: {scrolled: () => scrolledSubject.asObservable()}
+        },
+        {
+          provide: MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
+          useFactory: (overlay: Overlay) => () => overlay.scrollStrategies.close(),
+          deps: [Overlay]
+        }
+      ]);
+
+      fixture.detectChanges();
+      const trigger = fixture.componentInstance.trigger;
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to be open.');
+
+      scrolledSubject.next();
+      fixture.detectChanges();
+
+      expect(trigger.panelOpen).toBe(false, 'Expected panel to be closed.');
+    }));
+
+    it('should handle autocomplete being attached to number inputs', fakeAsync(() => {
+      const fixture = createComponent(AutocompleteWithNumberInputAndNgModel);
+      fixture.detectChanges();
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+
+      typeInElement(input, '1337');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.selectedValue).toBe(1337);
+    }));
+
+  });
+
+  it('should have correct width when opened', () => {
+    const widthFixture = createComponent(SimpleAutocomplete);
+    widthFixture.componentInstance.width = 300;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    // Firefox, edge return a decimal value for width, so we need to parse and round it to verify
+    expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(300);
+
+    widthFixture.componentInstance.trigger.closePanel();
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.width = 500;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    // Firefox, edge return a decimal value for width, so we need to parse and round it to verify
+    expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(500);
+  });
+
+  it('should update the width while the panel is open', () => {
+    const widthFixture = createComponent(SimpleAutocomplete);
+
+    widthFixture.componentInstance.width = 300;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const input = widthFixture.debugElement.query(By.css('input'))!.nativeElement;
+
+    expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(300);
+
+    widthFixture.componentInstance.width = 500;
+    widthFixture.detectChanges();
+
+    input.focus();
+    dispatchFakeEvent(input, 'input');
+    widthFixture.detectChanges();
+
+    expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(500);
+  });
+
+  it('should not reopen a closed autocomplete when returning to a blurred tab', () => {
+    const fixture = createComponent(SimpleAutocomplete);
+    fixture.detectChanges();
+
+    const trigger = fixture.componentInstance.trigger;
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+
+    input.focus();
+    fixture.detectChanges();
+
+    expect(trigger.panelOpen).toBe(true, 'Expected panel to be open.');
+
+    trigger.closePanel();
+    fixture.detectChanges();
+
+    expect(trigger.panelOpen).toBe(false, 'Expected panel to be closed.');
+
+    // Simulate the user going to a different tab.
+    dispatchFakeEvent(window, 'blur');
+    input.blur();
+    fixture.detectChanges();
+
+    // Simulate the user coming back.
+    dispatchFakeEvent(window, 'focus');
+    input.focus();
+    fixture.detectChanges();
+
+    expect(trigger.panelOpen).toBe(false, 'Expected panel to remain closed.');
+  });
+
+  it('should update the panel width if the window is resized', fakeAsync(() => {
+    const widthFixture = createComponent(SimpleAutocomplete);
+
+    widthFixture.componentInstance.width = 300;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+
+    expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(300);
+
+    widthFixture.componentInstance.width = 400;
+    widthFixture.detectChanges();
+
+    dispatchFakeEvent(window, 'resize');
+    tick(20);
+
+    expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(400);
+  }));
+
+  it('should have panel width match host width by default', () => {
+    const widthFixture = createComponent(SimpleAutocomplete);
+
+    widthFixture.componentInstance.width = 300;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+
+    expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(300);
+  });
+
+  it('should have panel width set to string value', () => {
+    const widthFixture = createComponent(SimpleAutocomplete);
+
+    widthFixture.componentInstance.width = 300;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.autocomplete.panelWidth = 'auto';
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+
+    expect(overlayPane.style.width).toBe('auto');
+  });
+
+  it('should have panel width set to number value', () => {
+    const widthFixture = createComponent(SimpleAutocomplete);
+
+    widthFixture.componentInstance.width = 300;
+    widthFixture.detectChanges();
+
+    widthFixture.componentInstance.trigger.autocomplete.panelWidth = 400;
+    widthFixture.componentInstance.trigger.openPanel();
+    widthFixture.detectChanges();
+
+    const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+
+    expect(Math.ceil(parseFloat(overlayPane.style.width as string))).toBe(400);
+  });
+
+  it('should show the panel when the options are initialized later within a component with ' +
+    'OnPush change detection', fakeAsync(() => {
+      let fixture = createComponent(AutocompleteWithOnPushDelay);
+
+      fixture.detectChanges();
+      dispatchFakeEvent(fixture.debugElement.query(By.css('input'))!.nativeElement, 'focusin');
+      tick(1000);
+
+      fixture.detectChanges();
+      tick();
+
+      Promise.resolve().then(() => {
+        let panel =
+            overlayContainerElement.querySelector('.mat-mdc-autocomplete-panel') as HTMLElement;
+        let visibleClass = 'mat-mdc-autocomplete-visible';
+
+        fixture.detectChanges();
+        expect(panel.classList).toContain(visibleClass, `Expected panel to be visible.`);
+      });
+    }));
+
+  it('should emit an event when an option is selected', fakeAsync(() => {
+    let fixture = createComponent(AutocompleteWithSelectEvent);
+
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    zone.simulateZoneExit();
+    fixture.detectChanges();
+
+    let options = overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+    let spy = fixture.componentInstance.optionSelected;
+
+    options[1].click();
+    tick();
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    let event = spy.calls.mostRecent().args[0] as MatAutocompleteSelectedEvent;
+
+    expect(event.source).toBe(fixture.componentInstance.autocomplete);
+    expect(event.option.value).toBe('Washington');
+  }));
+
+  it('should emit an event when a newly-added option is selected', fakeAsync(() => {
+    let fixture = createComponent(AutocompleteWithSelectEvent);
+
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    tick();
+    fixture.detectChanges();
+
+    fixture.componentInstance.states.push('Puerto Rico');
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    let options = overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+    let spy = fixture.componentInstance.optionSelected;
+
+    options[3].click();
+    tick();
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    let event = spy.calls.mostRecent().args[0] as MatAutocompleteSelectedEvent;
+
+    expect(event.source).toBe(fixture.componentInstance.autocomplete);
+    expect(event.option.value).toBe('Puerto Rico');
+  }));
+
+  it('should emit an event when an option is activated', fakeAsync(() => {
+    const fixture = createComponent(AutocompleteWithActivatedEvent);
+
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    zone.simulateZoneExit();
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input');
+    const spy = fixture.componentInstance.optionActivated;
+    const autocomplete = fixture.componentInstance.autocomplete;
+    const options = fixture.componentInstance.options.toArray();
+
+    expect(spy).not.toHaveBeenCalled();
+
+    dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+    fixture.detectChanges();
+    expect(spy.calls.mostRecent().args[0]).toEqual({source: autocomplete, option: options[0]});
+
+    dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+    fixture.detectChanges();
+    expect(spy.calls.mostRecent().args[0]).toEqual({source: autocomplete, option: options[1]});
+
+    dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+    fixture.detectChanges();
+    expect(spy.calls.mostRecent().args[0]).toEqual({source: autocomplete, option: options[2]});
+  }));
+
+  it('should be able to set a custom panel connection element', () => {
+    const fixture = createComponent(AutocompleteWithDifferentOrigin);
+
+    fixture.detectChanges();
+    fixture.componentInstance.connectedTo = fixture.componentInstance.alternateOrigin;
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    zone.simulateZoneExit();
+
+    const overlayRect =
+        overlayContainerElement.querySelector('.cdk-overlay-pane')!.getBoundingClientRect();
+    const originRect = fixture.nativeElement.querySelector('.origin').getBoundingClientRect();
+
+    expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom),
+        'Expected autocomplete panel to align with the bottom of the new origin.');
+  });
+
+  it('should be able to change the origin after the panel has been opened', () => {
+    const fixture = createComponent(AutocompleteWithDifferentOrigin);
+
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    zone.simulateZoneExit();
+
+    fixture.componentInstance.trigger.closePanel();
+    fixture.detectChanges();
+
+    fixture.componentInstance.connectedTo = fixture.componentInstance.alternateOrigin;
+    fixture.detectChanges();
+
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    zone.simulateZoneExit();
+
+    const overlayRect =
+        overlayContainerElement.querySelector('.cdk-overlay-pane')!.getBoundingClientRect();
+    const originRect = fixture.nativeElement.querySelector('.origin').getBoundingClientRect();
+
+    expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom),
+        'Expected autocomplete panel to align with the bottom of the new origin.');
+  });
+
+  it('should be able to re-type the same value when it is reset while open', fakeAsync(() => {
+    const fixture = createComponent(SimpleAutocomplete);
+    fixture.detectChanges();
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    const formControl = fixture.componentInstance.stateCtrl;
+
+    typeInElement(input, 'Cal');
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(formControl.value).toBe('Cal', 'Expected initial value to be propagated to model');
+
+    formControl.setValue('');
+    fixture.detectChanges();
+
+    expect(input.value).toBe('', 'Expected input value to reset when model is reset');
+
+    typeInElement(input, 'Cal');
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(formControl.value).toBe('Cal', 'Expected new value to be propagated to model');
+  }));
+
+  it('should not close when clicking inside alternate origin', () => {
+    const fixture = createComponent(AutocompleteWithDifferentOrigin);
+    fixture.detectChanges();
+    fixture.componentInstance.connectedTo = fixture.componentInstance.alternateOrigin;
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    zone.simulateZoneExit();
+
+    expect(fixture.componentInstance.trigger.panelOpen).toBe(true);
+
+    const origin = fixture.nativeElement.querySelector('.origin');
+    origin.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.trigger.panelOpen).toBe(true);
+  });
+
+});
+
+const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
+  <mat-form-field [floatLabel]="floatLabel" [style.width.px]="width">
+    <input
+      matInput
+      placeholder="State"
+      [matAutocomplete]="auto"
+      [matAutocompletePosition]="position"
+      [matAutocompleteDisabled]="autocompleteDisabled"
+      [formControl]="stateCtrl">
+  </mat-form-field>
+
+  <mat-autocomplete [class]="panelClass" #auto="matAutocomplete" [displayWith]="displayFn"
+    [disableRipple]="disableRipple" (opened)="openedSpy()" (closed)="closedSpy()">
+    <mat-option *ngFor="let state of filteredStates" [value]="state">
+      <span>{{ state.code }}: {{ state.name }}</span>
+    </mat-option>
+  </mat-autocomplete>
+`;
+
+@Component({template: SIMPLE_AUTOCOMPLETE_TEMPLATE})
+class SimpleAutocomplete implements OnDestroy {
+  stateCtrl = new FormControl();
+  filteredStates: any[];
+  valueSub: Subscription;
+  floatLabel = 'auto';
+  position = 'auto';
+  width: number;
+  disableRipple = false;
+  autocompleteDisabled = false;
+  panelClass = 'class-one class-two';
+  openedSpy = jasmine.createSpy('autocomplete opened spy');
+  closedSpy = jasmine.createSpy('autocomplete closed spy');
+
+  @ViewChild(MatAutocompleteTrigger, {static: true}) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocomplete) panel: MatAutocomplete;
+  @ViewChild(MatFormField) formField: MatFormField;
+  @ViewChildren(MatOption) options: QueryList<MatOption>;
+
+  states = [
+    {code: 'AL', name: 'Alabama'},
+    {code: 'CA', name: 'California'},
+    {code: 'FL', name: 'Florida'},
+    {code: 'KS', name: 'Kansas'},
+    {code: 'MA', name: 'Massachusetts'},
+    {code: 'NY', name: 'New York'},
+    {code: 'OR', name: 'Oregon'},
+    {code: 'PA', name: 'Pennsylvania'},
+    {code: 'TN', name: 'Tennessee'},
+    {code: 'VA', name: 'Virginia'},
+    {code: 'WY', name: 'Wyoming'},
+  ];
+
+
+  constructor() {
+    this.filteredStates = this.states;
+    this.valueSub = this.stateCtrl.valueChanges.subscribe(val => {
+      this.filteredStates = val ? this.states.filter((s) => s.name.match(new RegExp(val, 'gi')))
+                                : this.states;
+    });
+  }
+
+  displayFn(value: any): string {
+    return value ? value.name : value;
+  }
+
+  ngOnDestroy() {
+    this.valueSub.unsubscribe();
+  }
+}
+
+@Component({template: SIMPLE_AUTOCOMPLETE_TEMPLATE, encapsulation: ViewEncapsulation.ShadowDom})
+class SimpleAutocompleteShadowDom extends SimpleAutocomplete {
+}
+
+@Component({
+  template: `
+    <mat-form-field *ngIf="isVisible">
+      <input matInput placeholder="Choose" [matAutocomplete]="auto" [formControl]="optionCtrl">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let option of filteredOptions | async" [value]="option">
+         {{option}}
+      </mat-option>
+    </mat-autocomplete>
+  `
+})
+class NgIfAutocomplete {
+  optionCtrl = new FormControl();
+  filteredOptions: Observable<any>;
+  isVisible = true;
+  options = ['One', 'Two', 'Three'];
+
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChildren(MatOption) matOptions: QueryList<MatOption>;
+
+  constructor() {
+    this.filteredOptions = this.optionCtrl.valueChanges.pipe(
+      startWith(null),
+      map((val: string) => {
+        return val ? this.options.filter(option => new RegExp(val, 'gi').test(option))
+                    : this.options.slice();
+      }));
+  }
+}
+
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput placeholder="State" [matAutocomplete]="auto"
+      (input)="onInput($event.target?.value)">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let state of filteredStates" [value]="state">
+        <span> {{ state }}  </span>
+      </mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithoutForms {
+  filteredStates: any[];
+  states = ['Alabama', 'California', 'Florida'];
+
+  constructor() {
+    this.filteredStates = this.states.slice();
+  }
+
+  onInput(value: any) {
+    this.filteredStates = this.states.filter(s => new RegExp(value, 'gi').test(s));
+  }
+}
+
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput placeholder="State" [matAutocomplete]="auto" [(ngModel)]="selectedState"
+      (ngModelChange)="onInput($event)">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let state of filteredStates" [value]="state">
+        <span>{{ state }}</span>
+      </mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithNgModel {
+  filteredStates: any[];
+  selectedState: string;
+  states = ['New York', 'Washington', 'Oregon'];
+
+  constructor() {
+    this.filteredStates = this.states.slice();
+  }
+
+  onInput(value: any) {
+    this.filteredStates = this.states.filter(s => new RegExp(value, 'gi').test(s));
+  }
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput placeholder="Number" [matAutocomplete]="auto" [(ngModel)]="selectedNumber">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let number of numbers" [value]="number">
+        <span>{{ number }}</span>
+      </mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithNumbers {
+  selectedNumber: number;
+  numbers = [0, 1, 2];
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <mat-form-field>
+      <input type="text" matInput [matAutocomplete]="auto">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let option of options" [value]="option">{{ option }}</mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithOnPushDelay implements OnInit {
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  options: string[];
+
+  ngOnInit() {
+    setTimeout(() => {
+      this.options = ['One'];
+    }, 1000);
+  }
+}
+
+@Component({
+  template: `
+    <input placeholder="Choose" [matAutocomplete]="auto" [formControl]="optionCtrl">
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let option of filteredOptions | async" [value]="option">
+         {{option}}
+      </mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithNativeInput {
+  optionCtrl = new FormControl();
+  filteredOptions: Observable<any>;
+  options = ['En', 'To', 'Tre', 'Fire', 'Fem'];
+
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChildren(MatOption) matOptions: QueryList<MatOption>;
+
+  constructor() {
+    this.filteredOptions = this.optionCtrl.valueChanges.pipe(
+      startWith(null),
+      map((val: string) => {
+        return val ? this.options.filter(option => new RegExp(val, 'gi').test(option))
+                    : this.options.slice();
+      }));
+  }
+}
+
+
+@Component({
+  template: `<input placeholder="Choose" [matAutocomplete]="auto" [formControl]="control">`
+})
+class AutocompleteWithoutPanel {
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  control = new FormControl();
+}
+
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput placeholder="State" [matAutocomplete]="auto" [(ngModel)]="selectedState">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-optgroup *ngFor="let group of stateGroups" [label]="group.label">
+        <mat-option *ngFor="let state of group.states" [value]="state">
+          <span>{{ state }}</span>
+        </mat-option>
+      </mat-optgroup>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithGroups {
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  selectedState: string;
+  stateGroups = [
+    {
+      title: 'One',
+      states: ['Alabama', 'California', 'Florida', 'Oregon']
+    },
+    {
+      title: 'Two',
+      states: ['Kansas', 'Massachusetts', 'New York', 'Pennsylvania']
+    },
+    {
+      title: 'Three',
+      states: ['Tennessee', 'Virginia', 'Wyoming', 'Alaska']
+    }
+  ];
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput placeholder="State" [matAutocomplete]="auto" [(ngModel)]="selectedState">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <ng-container [ngSwitch]="true">
+        <mat-optgroup *ngFor="let group of stateGroups" [label]="group.label">
+          <mat-option *ngFor="let state of group.states" [value]="state">
+            <span>{{ state }}</span>
+          </mat-option>
+        </mat-optgroup>
+      </ng-container>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithIndirectGroups extends AutocompleteWithGroups {}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput placeholder="State" [matAutocomplete]="auto" [(ngModel)]="selectedState">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete" (optionSelected)="optionSelected($event)">
+      <mat-option *ngFor="let state of states" [value]="state">
+        <span>{{ state }}</span>
+      </mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithSelectEvent {
+  selectedState: string;
+  states = ['New York', 'Washington', 'Oregon'];
+  optionSelected = jasmine.createSpy('optionSelected callback');
+
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocomplete) autocomplete: MatAutocomplete;
+}
+
+
+@Component({
+  template: `
+    <input [formControl]="formControl" [matAutocomplete]="auto"/>
+    <mat-autocomplete #auto="matAutocomplete"></mat-autocomplete>
+  `
+})
+class PlainAutocompleteInputWithFormControl {
+  formControl = new FormControl();
+}
+
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input type="number" matInput [matAutocomplete]="auto" [(ngModel)]="selectedValue">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let value of values" [value]="value">{{value}}</mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithNumberInputAndNgModel {
+  selectedValue: number;
+  values = [1, 2, 3];
+}
+
+
+@Component({
+  template: `
+    <div>
+      <mat-form-field>
+        <input
+          matInput
+          [matAutocomplete]="auto"
+          [matAutocompleteConnectedTo]="connectedTo"
+          [(ngModel)]="selectedValue">
+      </mat-form-field>
+    </div>
+
+    <div
+      class="origin"
+      matAutocompleteOrigin
+      #origin="matAutocompleteOrigin"
+      style="margin-top: 50px">
+      Connection element
+    </div>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      <mat-option *ngFor="let value of values" [value]="value">{{value}}</mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithDifferentOrigin {
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocompleteOrigin) alternateOrigin: MatAutocompleteOrigin;
+  selectedValue: string;
+  values = ['one', 'two', 'three'];
+  connectedTo?: MatAutocompleteOrigin;
+}
+
+@Component({
+  template: `
+    <input autocomplete="changed" [(ngModel)]="value" [matAutocomplete]="auto"/>
+    <mat-autocomplete #auto="matAutocomplete"></mat-autocomplete>
+  `
+})
+class AutocompleteWithNativeAutocompleteAttribute {
+  value: string;
+}
+
+@Component({
+  template: '<input [matAutocomplete]="null" matAutocompleteDisabled>'
+})
+class InputWithoutAutocompleteAndDisabled {
+}
+
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput [matAutocomplete]="auto">
+    </mat-form-field>
+
+    <mat-autocomplete #auto="matAutocomplete" (optionActivated)="optionActivated($event)">
+      <mat-option *ngFor="let state of states" [value]="state">{{ state }}</mat-option>
+    </mat-autocomplete>
+  `
+})
+class AutocompleteWithActivatedEvent {
+  states = ['California', 'West Virginia', 'Florida'];
+  optionActivated = jasmine.createSpy('optionActivated callback');
+
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+  @ViewChild(MatAutocomplete) autocomplete: MatAutocomplete;
+  @ViewChildren(MatOption) options: QueryList<MatOption>;
+}

--- a/src/material-experimental/mdc-autocomplete/autocomplete.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  Component,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+  ContentChildren,
+  QueryList,
+} from '@angular/core';
+import {MAT_OPTGROUP} from '@angular/material/core';
+import {_MatAutocompleteBase} from '@angular/material/autocomplete';
+import {
+  MAT_OPTION_PARENT_COMPONENT,
+  MatOptgroup,
+  MatOption,
+} from '@angular/material-experimental/mdc-core';
+
+
+@Component({
+  selector: 'mat-autocomplete',
+  templateUrl: 'autocomplete.html',
+  styleUrls: ['autocomplete.css'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  exportAs: 'matAutocomplete',
+  inputs: ['disableRipple'],
+  host: {
+    'class': 'mat-mdc-autocomplete'
+  },
+  providers: [
+    {provide: MAT_OPTION_PARENT_COMPONENT, useExisting: MatAutocomplete}
+  ]
+})
+export class MatAutocomplete extends _MatAutocompleteBase {
+  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
+  @ContentChildren(MAT_OPTGROUP as any, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
+  protected _visibleClass = 'mat-mdc-autocomplete-visible';
+  protected _hiddenClass = 'mat-mdc-autocomplete-hidden';
+}
+

--- a/src/material-experimental/mdc-autocomplete/module.ts
+++ b/src/material-experimental/mdc-autocomplete/module.ts
@@ -8,10 +8,32 @@
 
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material/core';
+import {MatOptionModule} from '@angular/material-experimental/mdc-core';
+import {CommonModule} from '@angular/common';
+import {CdkScrollableModule} from '@angular/cdk/scrolling';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER} from '@angular/material/autocomplete';
+import {MatAutocomplete} from './autocomplete';
+import {MatAutocompleteTrigger} from './autocomplete-trigger';
+import {MatAutocompleteOrigin} from './autocomplete-origin';
+
 
 @NgModule({
-  imports: [MatCommonModule],
-  exports: [MatCommonModule],
+  imports: [
+    OverlayModule,
+    MatOptionModule,
+    MatCommonModule,
+    CommonModule
+  ],
+  exports: [
+    CdkScrollableModule,
+    MatAutocomplete,
+    MatOptionModule,
+    MatCommonModule,
+    MatAutocompleteTrigger,
+    MatAutocompleteOrigin,
+  ],
+  declarations: [MatAutocomplete, MatAutocompleteTrigger, MatAutocompleteOrigin],
+  providers: [MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER],
 })
-export class MatAutocompleteModule {
-}
+export class MatAutocompleteModule {}

--- a/src/material-experimental/mdc-autocomplete/public-api.ts
+++ b/src/material-experimental/mdc-autocomplete/public-api.ts
@@ -7,3 +7,21 @@
  */
 
 export * from './module';
+export * from './autocomplete';
+export * from './autocomplete-origin';
+export * from './autocomplete-trigger';
+
+// Everything from `material/autocomplete`, except for `MatAutcomplete` and `MatAutocompleteModule`.
+export {
+  AUTOCOMPLETE_OPTION_HEIGHT,
+  AUTOCOMPLETE_PANEL_HEIGHT,
+  getMatAutocompleteMissingPanelError,
+  MAT_AUTOCOMPLETE_DEFAULT_OPTIONS,
+  MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY,
+  MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
+  MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY,
+  MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER,
+  MatAutocompleteActivatedEvent,
+  MatAutocompleteDefaultOptions,
+  MatAutocompleteSelectedEvent,
+} from '@angular/material/autocomplete';

--- a/src/material-experimental/mdc-core/option/optgroup.ts
+++ b/src/material-experimental/mdc-core/option/optgroup.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, ViewEncapsulation, ChangeDetectionStrategy} from '@angular/core';
-import {_MatOptgroupBase} from '@angular/material/core';
+import {_MatOptgroupBase, MAT_OPTGROUP} from '@angular/material/core';
 
 
 /**
@@ -26,7 +26,9 @@ import {_MatOptgroupBase} from '@angular/material/core';
     'role': 'group',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[attr.aria-labelledby]': '_labelId',
-  }
+  },
+  providers: [
+    {provide: MAT_OPTGROUP, useExisting: MatOptgroup}
+  ]
 })
-export class MatOptgroup extends _MatOptgroupBase {
-}
+export class MatOptgroup extends _MatOptgroupBase {}

--- a/src/material-experimental/mdc-theming/BUILD.bazel
+++ b/src/material-experimental/mdc-theming/BUILD.bazel
@@ -16,6 +16,7 @@ sass_library(
         "_all-theme.scss",
     ],
     deps = [
+        "//src/material-experimental/mdc-autocomplete:mdc_autocomplete_scss_lib",
         "//src/material-experimental/mdc-button:mdc_button_scss_lib",
         "//src/material-experimental/mdc-card:mdc_card_scss_lib",
         "//src/material-experimental/mdc-checkbox:mdc_checkbox_scss_lib",

--- a/src/material-experimental/mdc-theming/_all-theme.scss
+++ b/src/material-experimental/mdc-theming/_all-theme.scss
@@ -1,4 +1,5 @@
 @import '../mdc-core/core';
+@import '../mdc-autocomplete/autocomplete-theme';
 @import '../mdc-button/button-theme';
 @import '../mdc-card/card-theme';
 @import '../mdc-checkbox/checkbox-theme';
@@ -20,6 +21,7 @@
 @mixin angular-material-mdc-theme($theme-or-color-config) {
   @include _mat-check-duplicate-theme-styles($theme-or-color-config, 'angular-material-mdc-theme') {
     @include mat-mdc-core-theme($theme-or-color-config);
+    @include mat-mdc-autocomplete-theme($theme-or-color-config);
     @include mat-mdc-button-theme($theme-or-color-config);
     @include mat-mdc-dialog-theme($theme-or-color-config);
     @include mat-mdc-fab-theme($theme-or-color-config);

--- a/src/material/autocomplete/autocomplete-module.ts
+++ b/src/material/autocomplete/autocomplete-module.ts
@@ -18,15 +18,21 @@ import {
 } from './autocomplete-trigger';
 import {MatAutocompleteOrigin} from './autocomplete-origin';
 
+
 @NgModule({
-  imports: [MatOptionModule, OverlayModule, MatCommonModule, CommonModule],
-  exports: [
-    CdkScrollableModule,
-    MatAutocomplete,
+  imports: [
+    OverlayModule,
     MatOptionModule,
+    MatCommonModule,
+    CommonModule
+  ],
+  exports: [
+    MatAutocomplete,
     MatAutocompleteTrigger,
     MatAutocompleteOrigin,
-    MatCommonModule
+    CdkScrollableModule,
+    MatOptionModule,
+    MatCommonModule,
   ],
   declarations: [MatAutocomplete, MatAutocompleteTrigger, MatAutocompleteOrigin],
   providers: [MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER],

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -25,15 +25,18 @@ import {
   ViewChild,
   ViewEncapsulation,
   OnDestroy,
+  Directive,
 } from '@angular/core';
 import {
   CanDisableRipple,
   CanDisableRippleCtor,
   MAT_OPTGROUP,
   MAT_OPTION_PARENT_COMPONENT,
-  MatOptgroup,
-  MatOption,
+  _MatOptgroupBase,
+  _MatOptionBase,
   mixinDisableRipple,
+  MatOption,
+  MatOptgroup,
 } from '@angular/material/core';
 import {Subscription} from 'rxjs';
 
@@ -48,18 +51,18 @@ let _uniqueAutocompleteIdCounter = 0;
 export class MatAutocompleteSelectedEvent {
   constructor(
     /** Reference to the autocomplete panel that emitted the event. */
-    public source: MatAutocomplete,
+    public source: _MatAutocompleteBase,
     /** Option that was selected. */
-    public option: MatOption) { }
+    public option: _MatOptionBase) { }
 }
 
 /** Event object that is emitted when an autocomplete option is activated. */
 export interface MatAutocompleteActivatedEvent {
   /** Reference to the autocomplete panel that emitted the event. */
-  source: MatAutocomplete;
+  source: _MatAutocompleteBase;
 
   /** Option that was selected. */
-  option: MatOption|null;
+  option: _MatOptionBase|null;
 }
 
 // Boilerplate for applying mixins to MatAutocomplete.
@@ -86,27 +89,20 @@ export function MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY(): MatAutocompleteDefau
   return {autoActiveFirstOption: false};
 }
 
-@Component({
-  selector: 'mat-autocomplete',
-  templateUrl: 'autocomplete.html',
-  styleUrls: ['autocomplete.css'],
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  exportAs: 'matAutocomplete',
-  inputs: ['disableRipple'],
-  host: {
-    'class': 'mat-autocomplete'
-  },
-  providers: [
-    {provide: MAT_OPTION_PARENT_COMPONENT, useExisting: MatAutocomplete}
-  ]
-})
-export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterContentInit,
-  CanDisableRipple, OnDestroy {
-    private _activeOptionChanges = Subscription.EMPTY;
+/** Base class with all of the `MatAutocomplete` functionality. */
+@Directive()
+export abstract class _MatAutocompleteBase extends _MatAutocompleteMixinBase implements
+  AfterContentInit, CanDisableRipple, OnDestroy {
+  private _activeOptionChanges = Subscription.EMPTY;
+
+  /** Class to apply to the panel when it's visible. */
+  protected abstract _visibleClass: string;
+
+  /** Class to apply to the panel when it's hidden. */
+  protected abstract _hiddenClass: string;
 
   /** Manages active item in option list based on key events. */
-  _keyManager: ActiveDescendantKeyManager<MatOption>;
+  _keyManager: ActiveDescendantKeyManager<_MatOptionBase>;
 
   /** Whether the autocomplete panel should be visible, depending on option length. */
   showPanel: boolean = false;
@@ -126,11 +122,10 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   @ViewChild('panel') panel: ElementRef;
 
   /** @docs-private */
-  @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
+  abstract options: QueryList<_MatOptionBase>;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** @docs-private */
-  @ContentChildren(MAT_OPTGROUP as any, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  abstract optionGroups: QueryList<_MatOptgroupBase>;
 
   /** Function that maps an option's control value to its display value in the trigger. */
   @Input() displayWith: ((value: any) => string) | null = null;
@@ -199,7 +194,7 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   }
 
   ngAfterContentInit() {
-    this._keyManager = new ActiveDescendantKeyManager<MatOption>(this.options).withWrap();
+    this._keyManager = new ActiveDescendantKeyManager<_MatOptionBase>(this.options).withWrap();
     this._activeOptionChanges = this._keyManager.change.subscribe(index => {
       this.optionActivated.emit({source: this, option: this.options.toArray()[index] || null});
     });
@@ -235,18 +230,41 @@ export class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterC
   }
 
   /** Emits the `select` event. */
-  _emitSelectEvent(option: MatOption): void {
+  _emitSelectEvent(option: _MatOptionBase): void {
     const event = new MatAutocompleteSelectedEvent(this, option);
     this.optionSelected.emit(event);
   }
 
   /** Sets the autocomplete visibility classes on a classlist based on the panel is visible. */
   private _setVisibilityClasses(classList: {[key: string]: boolean}) {
-    classList['mat-autocomplete-visible'] = this.showPanel;
-    classList['mat-autocomplete-hidden'] = !this.showPanel;
+    classList[this._visibleClass] = this.showPanel;
+    classList[this._hiddenClass] = !this.showPanel;
   }
 
   static ngAcceptInputType_autoActiveFirstOption: BooleanInput;
   static ngAcceptInputType_disableRipple: BooleanInput;
+}
+
+@Component({
+  selector: 'mat-autocomplete',
+  templateUrl: 'autocomplete.html',
+  styleUrls: ['autocomplete.css'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  exportAs: 'matAutocomplete',
+  inputs: ['disableRipple'],
+  host: {
+    'class': 'mat-autocomplete'
+  },
+  providers: [
+    {provide: MAT_OPTION_PARENT_COMPONENT, useExisting: MatAutocomplete}
+  ]
+})
+export class MatAutocomplete extends _MatAutocompleteBase {
+  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
+  @ContentChildren(MAT_OPTGROUP as any, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
+  protected _visibleClass = 'mat-autocomplete-visible';
+  protected _hiddenClass = 'mat-autocomplete-hidden';
 }
 

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -313,16 +313,14 @@ export function _countGroupLabelsBeforeOption(optionIndex: number, options: Quer
 
 /**
  * Determines the position to which to scroll a panel in order for an option to be into view.
- * @param optionIndex Index of the option to be scrolled into the view.
+ * @param optionOffset Offset of the option from the top of the panel.
  * @param optionHeight Height of the options.
  * @param currentScrollPosition Current scroll position of the panel.
  * @param panelHeight Height of the panel.
  * @docs-private
  */
-export function _getOptionScrollPosition(optionIndex: number, optionHeight: number,
+export function _getOptionScrollPosition(optionOffset: number, optionHeight: number,
     currentScrollPosition: number, panelHeight: number): number {
-  const optionOffset = optionIndex * optionHeight;
-
   if (optionOffset < currentScrollPosition) {
     return optionOffset;
   }

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -1092,10 +1092,11 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
     const activeOptionIndex = this._keyManager.activeItemIndex || 0;
     const labelCount = _countGroupLabelsBeforeOption(activeOptionIndex, this.options,
         this.optionGroups);
+    const itemHeight = this._getItemHeight();
 
     this.panel.nativeElement.scrollTop = _getOptionScrollPosition(
-      activeOptionIndex + labelCount,
-      this._getItemHeight(),
+      (activeOptionIndex + labelCount) * itemHeight,
+      itemHeight,
       this.panel.nativeElement.scrollTop,
       SELECT_PANEL_MAX_HEIGHT
     );

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
@@ -1,3 +1,10 @@
+<h2>Autocomplete</h2>
+<mat-autocomplete>
+  <mat-option>Grace Hopper</mat-option>
+  <mat-option>Anita Borg</mat-option>
+  <mat-option>Ada Lovelace</mat-option>
+</mat-autocomplete>
+
 <h2>Button</h2>
 
 <button mat-button>go</button>

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
@@ -1,4 +1,5 @@
 import {Component, NgModule, ErrorHandler} from '@angular/core';
+import {MatAutocompleteModule} from '@angular/material-experimental/mdc-autocomplete';
 import {MatButtonModule} from '@angular/material-experimental/mdc-button';
 import {MatCardModule} from '@angular/material-experimental/mdc-card';
 import {MatCheckboxModule} from '@angular/material-experimental/mdc-checkbox';
@@ -34,6 +35,7 @@ export class KitchenSinkMdc {
 
 @NgModule({
   imports: [
+    MatAutocompleteModule,
     MatButtonModule,
     MatCardModule,
     MatCheckboxModule,

--- a/tools/public_api_guard/material/autocomplete.d.ts
+++ b/tools/public_api_guard/material/autocomplete.d.ts
@@ -1,3 +1,82 @@
+export declare abstract class _MatAutocompleteBase extends _MatAutocompleteMixinBase implements AfterContentInit, CanDisableRipple, OnDestroy {
+    _classList: {
+        [key: string]: boolean;
+    };
+    protected abstract _hiddenClass: string;
+    _isOpen: boolean;
+    _keyManager: ActiveDescendantKeyManager<_MatOptionBase>;
+    protected abstract _visibleClass: string;
+    get autoActiveFirstOption(): boolean;
+    set autoActiveFirstOption(value: boolean);
+    set classList(value: string);
+    readonly closed: EventEmitter<void>;
+    displayWith: ((value: any) => string) | null;
+    id: string;
+    get isOpen(): boolean;
+    readonly opened: EventEmitter<void>;
+    readonly optionActivated: EventEmitter<MatAutocompleteActivatedEvent>;
+    abstract optionGroups: QueryList<_MatOptgroupBase>;
+    readonly optionSelected: EventEmitter<MatAutocompleteSelectedEvent>;
+    abstract options: QueryList<_MatOptionBase>;
+    panel: ElementRef;
+    panelWidth: string | number;
+    showPanel: boolean;
+    template: TemplateRef<any>;
+    constructor(_changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, defaults: MatAutocompleteDefaultOptions);
+    _emitSelectEvent(option: _MatOptionBase): void;
+    _getScrollTop(): number;
+    _setScrollTop(scrollTop: number): void;
+    _setVisibility(): void;
+    ngAfterContentInit(): void;
+    ngOnDestroy(): void;
+    static ngAcceptInputType_autoActiveFirstOption: BooleanInput;
+    static ngAcceptInputType_disableRipple: BooleanInput;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatAutocompleteBase, never, never, { "displayWith": "displayWith"; "autoActiveFirstOption": "autoActiveFirstOption"; "panelWidth": "panelWidth"; "classList": "class"; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; "optionActivated": "optionActivated"; }, never>;
+    static ɵfac: i0.ɵɵFactoryDef<_MatAutocompleteBase, never>;
+}
+
+export declare abstract class _MatAutocompleteOriginBase {
+    elementRef: ElementRef<HTMLElement>;
+    constructor(
+    elementRef: ElementRef<HTMLElement>);
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatAutocompleteOriginBase, never, never, {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<_MatAutocompleteOriginBase, never>;
+}
+
+export declare abstract class _MatAutocompleteTriggerBase implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
+    protected abstract _aboveClass: string;
+    _onChange: (value: any) => void;
+    _onTouched: () => void;
+    get activeOption(): MatOption | null;
+    autocomplete: _MatAutocompleteBase;
+    autocompleteAttribute: string;
+    get autocompleteDisabled(): boolean;
+    set autocompleteDisabled(value: boolean);
+    connectedTo: _MatAutocompleteOriginBase;
+    readonly optionSelections: Observable<MatOptionSelectionChange>;
+    get panelClosingActions(): Observable<MatOptionSelectionChange | null>;
+    get panelOpen(): boolean;
+    position: 'auto' | 'above' | 'below';
+    constructor(_element: ElementRef<HTMLInputElement>, _overlay: Overlay, _viewContainerRef: ViewContainerRef, _zone: NgZone, _changeDetectorRef: ChangeDetectorRef, scrollStrategy: any, _dir: Directionality, _formField: MatFormField, _document: any, _viewportRuler: ViewportRuler);
+    _handleFocus(): void;
+    _handleInput(event: KeyboardEvent): void;
+    _handleKeydown(event: KeyboardEvent): void;
+    protected abstract _scrollToOption(index: number): void;
+    closePanel(): void;
+    ngAfterViewInit(): void;
+    ngOnChanges(changes: SimpleChanges): void;
+    ngOnDestroy(): void;
+    openPanel(): void;
+    registerOnChange(fn: (value: any) => {}): void;
+    registerOnTouched(fn: () => {}): void;
+    setDisabledState(isDisabled: boolean): void;
+    updatePosition(): void;
+    writeValue(value: any): void;
+    static ngAcceptInputType_autocompleteDisabled: BooleanInput;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatAutocompleteTriggerBase, never, never, { "autocomplete": "matAutocomplete"; "position": "matAutocompletePosition"; "connectedTo": "matAutocompleteConnectedTo"; "autocompleteAttribute": "autocomplete"; "autocompleteDisabled": "matAutocompleteDisabled"; }, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<_MatAutocompleteTriggerBase, [null, null, null, null, null, null, { optional: true; }, { optional: true; host: true; }, { optional: true; }, null]>;
+}
+
 export declare const AUTOCOMPLETE_OPTION_HEIGHT = 48;
 
 export declare const AUTOCOMPLETE_PANEL_HEIGHT = 256;
@@ -20,44 +99,18 @@ export declare const MAT_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER: {
 
 export declare const MAT_AUTOCOMPLETE_VALUE_ACCESSOR: any;
 
-export declare class MatAutocomplete extends _MatAutocompleteMixinBase implements AfterContentInit, CanDisableRipple, OnDestroy {
-    _classList: {
-        [key: string]: boolean;
-    };
-    _isOpen: boolean;
-    _keyManager: ActiveDescendantKeyManager<MatOption>;
-    get autoActiveFirstOption(): boolean;
-    set autoActiveFirstOption(value: boolean);
-    set classList(value: string);
-    readonly closed: EventEmitter<void>;
-    displayWith: ((value: any) => string) | null;
-    id: string;
-    get isOpen(): boolean;
-    readonly opened: EventEmitter<void>;
-    readonly optionActivated: EventEmitter<MatAutocompleteActivatedEvent>;
+export declare class MatAutocomplete extends _MatAutocompleteBase {
+    protected _hiddenClass: string;
+    protected _visibleClass: string;
     optionGroups: QueryList<MatOptgroup>;
-    readonly optionSelected: EventEmitter<MatAutocompleteSelectedEvent>;
     options: QueryList<MatOption>;
-    panel: ElementRef;
-    panelWidth: string | number;
-    showPanel: boolean;
-    template: TemplateRef<any>;
-    constructor(_changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef<HTMLElement>, defaults: MatAutocompleteDefaultOptions);
-    _emitSelectEvent(option: MatOption): void;
-    _getScrollTop(): number;
-    _setScrollTop(scrollTop: number): void;
-    _setVisibility(): void;
-    ngAfterContentInit(): void;
-    ngOnDestroy(): void;
-    static ngAcceptInputType_autoActiveFirstOption: BooleanInput;
-    static ngAcceptInputType_disableRipple: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": "disableRipple"; "displayWith": "displayWith"; "autoActiveFirstOption": "autoActiveFirstOption"; "panelWidth": "panelWidth"; "classList": "class"; }, { "optionSelected": "optionSelected"; "opened": "opened"; "closed": "closed"; "optionActivated": "optionActivated"; }, ["options", "optionGroups"], ["*"]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatAutocomplete, "mat-autocomplete", ["matAutocomplete"], { "disableRipple": "disableRipple"; }, {}, ["optionGroups", "options"], ["*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatAutocomplete, never>;
 }
 
 export interface MatAutocompleteActivatedEvent {
-    option: MatOption | null;
-    source: MatAutocomplete;
+    option: _MatOptionBase | null;
+    source: _MatAutocompleteBase;
 }
 
 export interface MatAutocompleteDefaultOptions {
@@ -66,53 +119,25 @@ export interface MatAutocompleteDefaultOptions {
 
 export declare class MatAutocompleteModule {
     static ɵinj: i0.ɵɵInjectorDef<MatAutocompleteModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatAutocompleteModule, [typeof i1.MatAutocomplete, typeof i2.MatAutocompleteTrigger, typeof i3.MatAutocompleteOrigin], [typeof i4.MatOptionModule, typeof i5.OverlayModule, typeof i4.MatCommonModule, typeof i6.CommonModule], [typeof i7.CdkScrollableModule, typeof i1.MatAutocomplete, typeof i4.MatOptionModule, typeof i2.MatAutocompleteTrigger, typeof i3.MatAutocompleteOrigin, typeof i4.MatCommonModule]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatAutocompleteModule, [typeof i1.MatAutocomplete, typeof i2.MatAutocompleteTrigger, typeof i3.MatAutocompleteOrigin], [typeof i4.OverlayModule, typeof i5.MatOptionModule, typeof i5.MatCommonModule, typeof i6.CommonModule], [typeof i1.MatAutocomplete, typeof i2.MatAutocompleteTrigger, typeof i3.MatAutocompleteOrigin, typeof i7.CdkScrollableModule, typeof i5.MatOptionModule, typeof i5.MatCommonModule]>;
 }
 
-export declare class MatAutocompleteOrigin {
-    elementRef: ElementRef<HTMLElement>;
-    constructor(
-    elementRef: ElementRef<HTMLElement>);
+export declare class MatAutocompleteOrigin extends _MatAutocompleteOriginBase {
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatAutocompleteOrigin, "[matAutocompleteOrigin]", ["matAutocompleteOrigin"], {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatAutocompleteOrigin, never>;
 }
 
 export declare class MatAutocompleteSelectedEvent {
-    option: MatOption;
-    source: MatAutocomplete;
+    option: _MatOptionBase;
+    source: _MatAutocompleteBase;
     constructor(
-    source: MatAutocomplete,
-    option: MatOption);
+    source: _MatAutocompleteBase,
+    option: _MatOptionBase);
 }
 
-export declare class MatAutocompleteTrigger implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
-    _onChange: (value: any) => void;
-    _onTouched: () => void;
-    get activeOption(): MatOption | null;
-    autocomplete: MatAutocomplete;
-    autocompleteAttribute: string;
-    get autocompleteDisabled(): boolean;
-    set autocompleteDisabled(value: boolean);
-    connectedTo: MatAutocompleteOrigin;
-    readonly optionSelections: Observable<MatOptionSelectionChange>;
-    get panelClosingActions(): Observable<MatOptionSelectionChange | null>;
-    get panelOpen(): boolean;
-    position: 'auto' | 'above' | 'below';
-    constructor(_element: ElementRef<HTMLInputElement>, _overlay: Overlay, _viewContainerRef: ViewContainerRef, _zone: NgZone, _changeDetectorRef: ChangeDetectorRef, scrollStrategy: any, _dir: Directionality, _formField: MatFormField, _document: any, _viewportRuler: ViewportRuler);
-    _handleFocus(): void;
-    _handleInput(event: KeyboardEvent): void;
-    _handleKeydown(event: KeyboardEvent): void;
-    closePanel(): void;
-    ngAfterViewInit(): void;
-    ngOnChanges(changes: SimpleChanges): void;
-    ngOnDestroy(): void;
-    openPanel(): void;
-    registerOnChange(fn: (value: any) => {}): void;
-    registerOnTouched(fn: () => {}): void;
-    setDisabledState(isDisabled: boolean): void;
-    updatePosition(): void;
-    writeValue(value: any): void;
-    static ngAcceptInputType_autocompleteDisabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatAutocompleteTrigger, "input[matAutocomplete], textarea[matAutocomplete]", ["matAutocompleteTrigger"], { "autocomplete": "matAutocomplete"; "position": "matAutocompletePosition"; "connectedTo": "matAutocompleteConnectedTo"; "autocompleteAttribute": "autocomplete"; "autocompleteDisabled": "matAutocompleteDisabled"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatAutocompleteTrigger, [null, null, null, null, null, null, { optional: true; }, { optional: true; host: true; }, { optional: true; }, null]>;
+export declare class MatAutocompleteTrigger extends _MatAutocompleteTriggerBase {
+    protected _aboveClass: string;
+    protected _scrollToOption(index: number): void;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatAutocompleteTrigger, "input[matAutocomplete], textarea[matAutocomplete]", ["matAutocompleteTrigger"], {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatAutocompleteTrigger, never>;
 }

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -1,6 +1,6 @@
 export declare function _countGroupLabelsBeforeOption(optionIndex: number, options: QueryList<MatOption>, optionGroups: QueryList<MatOptgroup>): number;
 
-export declare function _getOptionScrollPosition(optionIndex: number, optionHeight: number, currentScrollPosition: number, panelHeight: number): number;
+export declare function _getOptionScrollPosition(optionOffset: number, optionHeight: number, currentScrollPosition: number, panelHeight: number): number;
 
 export declare class _MatOptgroupBase extends _MatOptgroupMixinBase implements CanDisable {
     _labelId: string;


### PR DESCRIPTION
* Moves all of the autocomplete logic into base classes so that it can be reused between the standard and MDC components.
* Re-implements `mat-autocomplete` using the logic from the existing one and the styling from MDC.

The MDC-based autocomplete behaves identically to the existing one, with the only minor difference being that MDC one fixes a long-standing issue where we expect a hardcoded height for each of the options. It was easier to fix the bug and add logic to support arbitrary option heights than to add more logic to account for MDC's styles.

**Note:** I will make a follow-up PR that adds test harnesses for the new module. I didn't add them here, because the PR is fairly large as it is.