### PR TITLE
feat(cdk/table): fixed table layouts

### DIFF
--- a/src/cdk/table/BUILD.bazel
+++ b/src/cdk/table/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "ng_module",
     "ng_test_library",
     "ng_web_test_suite",
+    "sass_binary",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -14,6 +15,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
+    assets = [":table.css"],
     module_name = "@angular/cdk/table",
     deps = [
         "//src/cdk/bidi",
@@ -24,6 +26,11 @@ ng_module(
         "@npm//@angular/core",
         "@npm//rxjs",
     ],
+)
+
+sass_binary(
+    name = "table_scss",
+    src = "table.scss",
 )
 
 ng_test_library(

--- a/src/cdk/table/sticky-styler.ts
+++ b/src/cdk/table/sticky-styler.ts
@@ -27,6 +27,8 @@ export const STICKY_DIRECTIONS: StickyDirection[] = ['top', 'bottom', 'left', 'r
  * @docs-private
  */
 export class StickyStyler {
+  private _cachedCellWidths: number[] = [];
+
   /**
    * @param _isNativeHtmlTable Whether the sticky logic should be based on a table
    *     that uses the native `<table>` element.
@@ -83,9 +85,12 @@ export class StickyStyler {
    *     in this index position should be stuck to the start of the row.
    * @param stickyEndStates A list of boolean states where each state represents whether the cell
    *     in this index position should be stuck to the end of the row.
+   * @param recalculateCellWidths Whether the sticky styler should recalculate the width of each
+   *     column cell. If `false` cached widths will be used instead.
    */
   updateStickyColumns(
-      rows: HTMLElement[], stickyStartStates: boolean[], stickyEndStates: boolean[]) {
+      rows: HTMLElement[], stickyStartStates: boolean[], stickyEndStates: boolean[],
+      recalculateCellWidths = true) {
     if (!rows.length || !this._isBrowser || !(stickyStartStates.some(state => state) ||
         stickyEndStates.some(state => state))) {
       return;
@@ -93,7 +98,7 @@ export class StickyStyler {
 
     const firstRow = rows[0];
     const numCells = firstRow.children.length;
-    const cellWidths: number[] = this._getCellWidths(firstRow);
+    const cellWidths: number[] = this._getCellWidths(firstRow, recalculateCellWidths);
 
     const startPositions = this._getStickyStartColumnPositions(cellWidths, stickyStartStates);
     const endPositions = this._getStickyEndColumnPositions(cellWidths, stickyEndStates);
@@ -275,7 +280,11 @@ export class StickyStyler {
   }
 
   /** Gets the widths for each cell in the provided row. */
-  _getCellWidths(row: HTMLElement): number[] {
+  _getCellWidths(row: HTMLElement, recalculateCellWidths = true): number[] {
+    if (!recalculateCellWidths && this._cachedCellWidths.length) {
+      return this._cachedCellWidths;
+    }
+
     const cellWidths: number[] = [];
     const firstRowCells = row.children;
     for (let i = 0; i < firstRowCells.length; i++) {
@@ -283,6 +292,7 @@ export class StickyStyler {
       cellWidths.push(cell.getBoundingClientRect().width);
     }
 
+    this._cachedCellWidths = cellWidths;
     return cellWidths;
   }
 

--- a/src/cdk/table/table.scss
+++ b/src/cdk/table/table.scss
@@ -1,0 +1,3 @@
+.cdk-table-fixed-layout {
+  table-layout: fixed;
+}

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -20,6 +20,7 @@ import {
   _ViewRepeaterOperation,
 } from '@angular/cdk/collections';
 import {Platform} from '@angular/cdk/platform';
+import {ViewportRuler} from '@angular/cdk/scrolling';
 import {DOCUMENT} from '@angular/common';
 import {
   AfterContentChecked,
@@ -188,8 +189,10 @@ export interface RenderRow<T> {
   selector: 'cdk-table, table[cdk-table]',
   exportAs: 'cdkTable',
   template: CDK_TABLE_TEMPLATE,
+  styleUrls: ['table.css'],
   host: {
     'class': 'cdk-table',
+    '[class.cdk-table-fixed-layout]': 'fixedLayout',
   },
   encapsulation: ViewEncapsulation.None,
   // The "OnPush" status for the `MatTable` component is effectively a noop, so we are removing it.
@@ -290,6 +293,19 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
    * content is checked. Initialized as true so that the table renders the initial set of rows.
    */
   private _footerRowDefChanged = true;
+
+  /**
+   * Whether the sticky column styles need to be updated. Set to `true` when the visible columns
+   * change.
+   */
+  private _stickyColumnStylesNeedReset = true;
+
+  /**
+   * Whether the sticky styler should recalculate cell widths when applying sticky styles. If
+   * `false`, cached values will be used instead. This is only applicable to tables with
+   * {@link fixedLayout} enabled. For other tables, cell widths will always be recalculated.
+   */
+  private _forceRecalculateCellWidths = true;
 
   /**
    * Cache of the latest rendered `RenderRow` objects as a map for easy retrieval when constructing
@@ -403,6 +419,23 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   }
   _multiTemplateDataRows: boolean = false;
 
+  /**
+   * Whether to use a fixed table layout. Enabling this option will enforce consistent column widths
+   * and optimize rendering sticky styles for native tables. No-op for flex tables.
+   */
+  @Input()
+  get fixedLayout(): boolean {
+    return this._fixedLayout;
+  }
+  set fixedLayout(v: boolean) {
+    this._fixedLayout = coerceBooleanProperty(v);
+
+    // Toggling `fixedLayout` may change column widths. Sticky column styles should be recalculated.
+    this._forceRecalculateCellWidths = true;
+    this._stickyColumnStylesNeedReset = true;
+  }
+  private _fixedLayout: boolean = false;
+
   // TODO(andrewseguin): Remove max value as the end index
   //   and instead calculate the view on init and scroll.
   /**
@@ -452,7 +485,11 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
       // Optional for backwards compatibility, but a view repeater strategy will always
       // be provided.
       @Optional() @Inject(_VIEW_REPEATER_STRATEGY)
-      protected readonly _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>) {
+      protected readonly _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>,
+      // Optional for backwards compatibility. The viewport ruler is provided in root. Therefore,
+      // this property will never be null.
+      // tslint:disable-next-line: lightweight-tokens
+      @Optional() private readonly _viewportRuler: ViewportRuler) {
     if (!role) {
       this._elementRef.nativeElement.setAttribute('role', 'grid');
     }
@@ -474,6 +511,12 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     this._dataDiffer = this._differs.find([]).create((_i: number, dataRow: RenderRow<T>) => {
       return this.trackBy ? this.trackBy(dataRow.dataIndex, dataRow.data) : dataRow;
     });
+
+    // Table cell dimensions may change after resizing the window. Signal the sticky styler to
+    // refresh its cache of cell widths the next time sticky styles are updated.
+    this._viewportRuler.change().pipe(takeUntil(this._onDestroy)).subscribe(() => {
+      this._forceRecalculateCellWidths = true;
+    });
   }
 
   ngAfterContentChecked() {
@@ -488,8 +531,10 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
 
     // Render updates if the list of columns have been changed for the header, row, or footer defs.
     const columnsChanged = this._renderUpdatedColumns();
-    const stickyColumnStyleUpdateNeeded =
-            columnsChanged || this._headerRowDefChanged || this._footerRowDefChanged;
+    const rowDefsChanged = columnsChanged || this._headerRowDefChanged || this._footerRowDefChanged;
+    // Ensure sticky column styles are reset if set to `true` elsewhere.
+    this._stickyColumnStylesNeedReset = this._stickyColumnStylesNeedReset || rowDefsChanged;
+    this._forceRecalculateCellWidths = rowDefsChanged;
 
     // If the header row definition has been changed, trigger a render to the header row.
     if (this._headerRowDefChanged) {
@@ -507,7 +552,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     // connection has already been made.
     if (this.dataSource && this._rowDefs.length > 0 && !this._renderChangeSubscription) {
       this._observeRenderChanges();
-    } else if (stickyColumnStyleUpdateNeeded) {
+    } else if (this._stickyColumnStylesNeedReset) {
       // In the above case, _observeRenderChanges will result in updateStickyColumnStyles being
       // called when it row data arrives. Otherwise, we need to call it proactively.
       this.updateStickyColumnStyles();
@@ -689,10 +734,18 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     const dataRows = this._getRenderedRows(this._rowOutlet);
     const footerRows = this._getRenderedRows(this._footerRowOutlet);
 
-    // Clear the left and right positioning from all columns in the table across all rows since
-    // sticky columns span across all table sections (header, data, footer)
-    this._stickyStyler.clearStickyPositioning(
-        [...headerRows, ...dataRows, ...footerRows], ['left', 'right']);
+    // For tables not using a fixed layout, the column widths may change when new rows are rendered.
+    // In a table using a fixed layout, row content won't affect column width, so sticky styles
+    // don't need to be cleared unless either the sticky column config changes or one of the row
+    // defs change.
+    if ((this._isNativeHtmlTable && !this._fixedLayout)
+        || this._stickyColumnStylesNeedReset) {
+      // Clear the left and right positioning from all columns in the table across all rows since
+      // sticky columns span across all table sections (header, data, footer)
+      this._stickyStyler.clearStickyPositioning(
+          [...headerRows, ...dataRows, ...footerRows], ['left', 'right']);
+      this._stickyColumnStylesNeedReset = false;
+    }
 
     // Update the sticky styles for each header row depending on the def's sticky state
     headerRows.forEach((headerRow, i) => {
@@ -934,7 +987,9 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     });
     const stickyStartStates = columnDefs.map(columnDef => columnDef.sticky);
     const stickyEndStates = columnDefs.map(columnDef => columnDef.stickyEnd);
-    this._stickyStyler.updateStickyColumns(rows, stickyStartStates, stickyEndStates);
+    this._stickyStyler.updateStickyColumns(
+        rows, stickyStartStates, stickyEndStates,
+        !this._fixedLayout || this._forceRecalculateCellWidths);
   }
 
   /** Gets the list of rows that have been rendered in the row outlet. */
@@ -1113,6 +1168,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     }
 
     if (Array.from(this._columnDefsByName.values()).reduce(stickyCheckReducer, false)) {
+      this._stickyColumnStylesNeedReset = true;
       this.updateStickyColumnStyles();
     }
   }
@@ -1154,6 +1210,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
   }
 
   static ngAcceptInputType_multiTemplateDataRows: BooleanInput;
+  static ngAcceptInputType_fixedLayout: BooleanInput;
 }
 
 /** Utility function that gets a merged list of the entries in an array and values of a Set. */

--- a/src/components-examples/cdk/table/cdk-table-fixed-layout/cdk-table-fixed-layout-example.css
+++ b/src/components-examples/cdk/table/cdk-table-fixed-layout/cdk-table-fixed-layout-example.css
@@ -1,0 +1,7 @@
+table {
+  width: 100%;
+}
+
+th {
+  text-align: left;
+}

--- a/src/components-examples/cdk/table/cdk-table-fixed-layout/cdk-table-fixed-layout-example.html
+++ b/src/components-examples/cdk/table/cdk-table-fixed-layout/cdk-table-fixed-layout-example.html
@@ -1,0 +1,28 @@
+<table cdk-table [dataSource]="dataSource" fixedLayout>
+  <!-- Position Column -->
+  <ng-container cdkColumnDef="position">
+    <th cdk-header-cell *cdkHeaderCellDef> No. </th>
+    <td cdk-cell *cdkCellDef="let element"> {{element.position}} </td>
+  </ng-container>
+
+  <!-- Name Column -->
+  <ng-container cdkColumnDef="name">
+    <th cdk-header-cell *cdkHeaderCellDef> Name </th>
+    <td cdk-cell *cdkCellDef="let element"> {{element.name}} </td>
+  </ng-container>
+
+  <!-- Weight Column -->
+  <ng-container cdkColumnDef="weight">
+    <th cdk-header-cell *cdkHeaderCellDef> Weight </th>
+    <td cdk-cell *cdkCellDef="let element"> {{element.weight}} </td>
+  </ng-container>
+
+  <!-- Symbol Column -->
+  <ng-container cdkColumnDef="symbol">
+    <th cdk-header-cell *cdkHeaderCellDef> Symbol </th>
+    <td cdk-cell *cdkCellDef="let element"> {{element.symbol}} </td>
+  </ng-container>
+
+  <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
+  <tr cdk-row *cdkRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/src/components-examples/cdk/table/cdk-table-fixed-layout/cdk-table-fixed-layout-example.ts
+++ b/src/components-examples/cdk/table/cdk-table-fixed-layout/cdk-table-fixed-layout-example.ts
@@ -1,0 +1,55 @@
+import {DataSource} from '@angular/cdk/collections';
+import {Component} from '@angular/core';
+import {BehaviorSubject, Observable} from 'rxjs';
+
+export interface PeriodicElement {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: PeriodicElement[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+];
+
+/**
+ * @title CDK table with a fixed layout.
+ */
+@Component({
+  selector: 'cdk-table-fixed-layout-example',
+  styleUrls: ['cdk-table-fixed-layout-example.css'],
+  templateUrl: 'cdk-table-fixed-layout-example.html',
+})
+export class CdkTableFixedLayoutExample {
+  displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
+  dataSource = new ExampleDataSource();
+}
+
+/**
+ * Data source to provide what data should be rendered in the table. Note that the data source
+ * can retrieve its data in any way. In this case, the data source is provided a reference
+ * to a common data base, ExampleDatabase. It is not the data source's responsibility to manage
+ * the underlying data. Instead, it only needs to take the data and send the table exactly what
+ * should be rendered.
+ */
+export class ExampleDataSource extends DataSource<PeriodicElement> {
+  /** Stream of data that is provided to the table. */
+  data = new BehaviorSubject<PeriodicElement[]>(ELEMENT_DATA);
+
+  /** Connect function called by the table to retrieve one stream containing the data to render. */
+  connect(): Observable<PeriodicElement[]> {
+    return this.data;
+  }
+
+  disconnect() {}
+}

--- a/src/components-examples/cdk/table/index.ts
+++ b/src/components-examples/cdk/table/index.ts
@@ -2,15 +2,20 @@ import {CdkTableModule} from '@angular/cdk/table';
 import {NgModule} from '@angular/core';
 import {CdkTableFlexBasicExample} from './cdk-table-flex-basic/cdk-table-flex-basic-example';
 import {CdkTableBasicExample} from './cdk-table-basic/cdk-table-basic-example';
+import {
+  CdkTableFixedLayoutExample,
+} from './cdk-table-fixed-layout/cdk-table-fixed-layout-example';
 
 export {
   CdkTableBasicExample,
   CdkTableFlexBasicExample,
+  CdkTableFixedLayoutExample,
 };
 
 const EXAMPLES = [
   CdkTableBasicExample,
   CdkTableFlexBasicExample,
+  CdkTableFixedLayoutExample,
 ];
 
 @NgModule({

--- a/src/dev-app/table/table-demo.html
+++ b/src/dev-app/table/table-demo.html
@@ -1,6 +1,9 @@
 <h3>Cdk table basic</h3>
 <cdk-table-basic-example></cdk-table-basic-example>
 
+<h3>Cdk table basic with fixed column widths</h3>
+<cdk-table-fixed-layout-example></cdk-table-fixed-layout-example>
+
 <h3>Cdk table basic flex</h3>
 <cdk-table-flex-basic-example></cdk-table-flex-basic-example>
 

--- a/src/material-experimental/mdc-table/table.ts
+++ b/src/material-experimental/mdc-table/table.ts
@@ -17,6 +17,7 @@ import {_DisposeViewRepeaterStrategy, _VIEW_REPEATER_STRATEGY} from '@angular/cd
   styleUrls: ['table.css'],
   host: {
     'class': 'mat-mdc-table mdc-data-table__table',
+    '[class.mdc-table-fixed-layout]': 'fixedLayout',
   },
   providers: [
     {provide: CdkTable, useExisting: MatTable},

--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -120,3 +120,7 @@ th.mat-header-cell:last-of-type, td.mat-cell:last-of-type, td.mat-footer-cell:la
 .mat-table-sticky {
   @include vendor-prefixes.position-sticky;
 }
+
+.mat-table-fixed-layout {
+  table-layout: fixed;
+}

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -25,6 +25,7 @@ import {_DisposeViewRepeaterStrategy, _VIEW_REPEATER_STRATEGY} from '@angular/cd
   styleUrls: ['table.css'],
   host: {
     'class': 'mat-table',
+    '[class.mat-table-fixed-layout]': 'fixedLayout',
   },
   providers: [
     // TODO(michaeljamesparsons) Abstract the view repeater strategy to a directive API so this code

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -203,6 +203,8 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
     protected readonly _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>;
     get dataSource(): CdkTableDataSourceInput<T>;
     set dataSource(dataSource: CdkTableDataSourceInput<T>);
+    get fixedLayout(): boolean;
+    set fixedLayout(v: boolean);
     get multiTemplateDataRows(): boolean;
     set multiTemplateDataRows(v: boolean);
     protected needsPositionStickyOnElement: boolean;
@@ -213,7 +215,7 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
         start: number;
         end: number;
     }>;
-    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _coalescedStyleScheduler: _CoalescedStyleScheduler, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform, _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>);
+    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _coalescedStyleScheduler: _CoalescedStyleScheduler, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform, _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>, _viewportRuler: ViewportRuler);
     _getRenderedRows(rowOutlet: RowOutlet): HTMLElement[];
     _getRowDefs(data: T, dataIndex: number): CdkRowDef<T>[];
     addColumnDef(columnDef: CdkColumnDef): void;
@@ -231,9 +233,10 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
     updateStickyColumnStyles(): void;
     updateStickyFooterRowStyles(): void;
     updateStickyHeaderRowStyles(): void;
+    static ngAcceptInputType_fixedLayout: BooleanInput;
     static ngAcceptInputType_multiTemplateDataRows: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<CdkTable<any>, "cdk-table, table[cdk-table]", ["cdkTable"], { "trackBy": "trackBy"; "dataSource": "dataSource"; "multiTemplateDataRows": "multiTemplateDataRows"; }, {}, ["_noDataRow", "_contentColumnDefs", "_contentRowDefs", "_contentHeaderRowDefs", "_contentFooterRowDefs"], ["caption", "colgroup, col"]>;
-    static ɵfac: i0.ɵɵFactoryDef<CdkTable<any>, [null, null, null, null, { attribute: "role"; }, { optional: true; }, null, null, { optional: true; }]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<CdkTable<any>, "cdk-table, table[cdk-table]", ["cdkTable"], { "trackBy": "trackBy"; "dataSource": "dataSource"; "multiTemplateDataRows": "multiTemplateDataRows"; "fixedLayout": "fixedLayout"; }, {}, ["_noDataRow", "_contentColumnDefs", "_contentRowDefs", "_contentHeaderRowDefs", "_contentFooterRowDefs"], ["caption", "colgroup, col"]>;
+    static ɵfac: i0.ɵɵFactoryDef<CdkTable<any>, [null, null, null, null, { attribute: "role"; }, { optional: true; }, null, null, { optional: true; }, { optional: true; }]>;
 }
 
 export declare class CdkTableModule {
@@ -321,13 +324,13 @@ export declare class StickyStyler {
     constructor(_isNativeHtmlTable: boolean, _stickCellCss: string, direction: Direction, _coalescedStyleScheduler: _CoalescedStyleScheduler, _isBrowser?: boolean, _needsPositionStickyOnElement?: boolean);
     _addStickyStyle(element: HTMLElement, dir: StickyDirection, dirValue: number): void;
     _getCalculatedZIndex(element: HTMLElement): string;
-    _getCellWidths(row: HTMLElement): number[];
+    _getCellWidths(row: HTMLElement, recalculateCellWidths?: boolean): number[];
     _getStickyEndColumnPositions(widths: number[], stickyStates: boolean[]): number[];
     _getStickyStartColumnPositions(widths: number[], stickyStates: boolean[]): number[];
     _removeStickyStyle(element: HTMLElement, stickyDirections: StickyDirection[]): void;
     clearStickyPositioning(rows: HTMLElement[], stickyDirections: StickyDirection[]): void;
     stickRows(rowsToStick: HTMLElement[], stickyStates: boolean[], position: 'top' | 'bottom'): void;
-    updateStickyColumns(rows: HTMLElement[], stickyStartStates: boolean[], stickyEndStates: boolean[]): void;
+    updateStickyColumns(rows: HTMLElement[], stickyStartStates: boolean[], stickyEndStates: boolean[], recalculateCellWidths?: boolean): void;
     updateStickyFooterContainer(tableElement: Element, stickyStates: boolean[]): void;
 }
 


### PR DESCRIPTION
### Summary

- Adds `fixedColumnWidths` input to the CDK table. When `true`, native tables will display with `table-layout: fixed`. No-op for flex tables.
- Reduces the number of times sticky styles are recalculated for native fixed layout tables and flex tables.


### Open question
- `fixedLayout` might make a better name for the input. Preferences?