### PR TITLE
build: fix relative paths resolutions in tslint rules

### DIFF
--- a/tools/tslint-rules/lightweightTokensRule.ts
+++ b/tools/tslint-rules/lightweightTokensRule.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as minimatch from 'minimatch';
 import * as path from 'path';
 import * as Lint from 'tslint';
@@ -38,9 +39,14 @@ export class Rule extends Lint.Rules.TypedRule {
  * for which lightweight tokens are suitable (for optimized tree shaking).
  */
 function checkSourceFileForLightweightTokens(ctx: Context, typeChecker: ts.TypeChecker): void {
+  // Since tslint resolved file names are lowercase when working on a case insensitive
+  // filesystem, we need to transform the current working directory and the source
+  // file name to the real native paths using fs.realpathSync.native function.
+  const cwd = fs.realpathSync.native(process.cwd());
+  const fileName = fs.realpathSync.native(ctx.sourceFile.fileName);
   // Relative path for the current TypeScript source file. This allows for
   // relative globs being used in the rule options.
-  const relativeFilePath = path.relative(process.cwd(), ctx.sourceFile.fileName);
+  const relativeFilePath = path.relative(cwd, fileName);
   const [enabledFilesGlobs] = ctx.options;
   const visitNode = (node: ts.Node) => {
     if (ts.isClassDeclaration(node)) {

--- a/tools/tslint-rules/noCrossEntryPointRelativeImportsRule.ts
+++ b/tools/tslint-rules/noCrossEntryPointRelativeImportsRule.ts
@@ -1,4 +1,4 @@
-import {existsSync} from 'fs';
+import {existsSync, realpathSync} from 'fs';
 import * as minimatch from 'minimatch';
 import {dirname, join, normalize, relative, resolve} from 'path';
 import * as Lint from 'tslint';
@@ -24,8 +24,12 @@ export class Rule extends Lint.Rules.AbstractRule {
  * with relative cross entry-point references.
  */
 function checkSourceFile(ctx: Lint.WalkContext<string[]>) {
-  const filePath = ctx.sourceFile.fileName;
-  const relativeFilePath = relative(process.cwd(), filePath);
+  // Since tslint resolved file names are lowercase when working on a case insensitive
+  // filesystem, we need to transform the current working directory and the source
+  // file name to the real native paths using fs.realpathSync.native function.
+  const cwd = realpathSync.native(process.cwd());
+  const filePath = realpathSync.native(ctx.sourceFile.fileName);
+  const relativeFilePath = relative(cwd, filePath);
 
   if (!ctx.options.every(o => minimatch(relativeFilePath, o))) {
     return;

--- a/tools/tslint-rules/requireLicenseBannerRule.ts
+++ b/tools/tslint-rules/requireLicenseBannerRule.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
@@ -37,8 +38,14 @@ class RequireLicenseBannerWalker extends Lint.RuleWalker {
     // Globs that are used to determine which files to lint.
     const fileGlobs = options.ruleArguments;
 
+    // Since tslint resolved file names are lowercase when working on a case insensitive
+    // filesystem, we need to transform the current working directory and the source
+    // file name to the real native paths using fs.realpathSync.native function.
+    const cwd = fs.realpathSync.native(process.cwd());
+    const fileName = fs.realpathSync.native(sourceFile.fileName);
+
     // Relative path for the current TypeScript source file.
-    const relativeFilePath = path.relative(process.cwd(), sourceFile.fileName);
+    const relativeFilePath = path.relative(cwd, fileName);
 
     // Whether the file should be checked at all.
     this._enabled = fileGlobs.some(p => minimatch(relativeFilePath, p));

--- a/tools/tslint-rules/validateDecoratorsRule.ts
+++ b/tools/tslint-rules/validateDecoratorsRule.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
@@ -71,8 +72,14 @@ class Walker extends Lint.RuleWalker {
     // Globs that are used to determine which files to lint.
     const fileGlobs = options.ruleArguments.slice(1) || [];
 
+    // Since tslint resolved file names are lowercase when working on a case insensitive
+    // filesystem, we need to transform the current working directory and the source
+    // file name to the real native paths using fs.realpathSync.native function.
+    const cwd = fs.realpathSync.native(process.cwd());
+    const fileName = fs.realpathSync.native(sourceFile.fileName);
+
     // Relative path for the current TypeScript source file.
-    const relativeFilePath = path.relative(process.cwd(), sourceFile.fileName);
+    const relativeFilePath = path.relative(cwd, fileName);
 
     this._rules = this._generateRules(options.ruleArguments[0]);
     this._enabled = Object.keys(this._rules).length > 0 &&


### PR DESCRIPTION
When working on a case-insensitive filesystem, source files paths resolved by tslint are in lowercase format. Relative paths computed from the current working directory are not valid and do not match globs defined in tslint configuration.