### PR TITLE
doc(stepper): add missing doc region

### DIFF
--- a/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
+++ b/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
@@ -14,9 +14,10 @@
       </div>
     </form>
   </mat-step>
-  <mat-step [stepControl]="secondFormGroup">
+  <!-- #docregion label -->
+  <mat-step [stepControl]="secondFormGroup" label="Fill out your address">
+  <!-- #enddocregion label -->
     <form [formGroup]="secondFormGroup">
-      <ng-template matStepLabel>Fill out your address</ng-template>
       <mat-form-field>
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"


### PR DESCRIPTION
The stepper overview was referring to a doc region that isn't defined which resulted in an error.

Fixes #20262.