### PR TITLE
refactor: clean up MDC menu inheritance

### DIFF
--- a/src/material-experimental/mdc-menu/menu.ts
+++ b/src/material-experimental/mdc-menu/menu.ts
@@ -20,7 +20,7 @@ import {
   MAT_MENU_DEFAULT_OPTIONS,
   MAT_MENU_PANEL,
   MAT_MENU_SCROLL_STRATEGY,
-  MatMenu as BaseMatMenu,
+  _MatMenuBase,
   matMenuAnimations,
   MatMenuDefaultOptions,
 } from '@angular/material/menu';
@@ -50,11 +50,9 @@ export const MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER: Provider = {
   ],
   providers: [
     {provide: MAT_MENU_PANEL, useExisting: MatMenu},
-    {provide: BaseMatMenu, useExisting: MatMenu},
   ]
 })
-export class MatMenu extends BaseMatMenu {
-
+export class MatMenu extends _MatMenuBase {
   constructor(_elementRef: ElementRef<HTMLElement>,
               _ngZone: NgZone,
               @Inject(MAT_MENU_DEFAULT_OPTIONS) _defaultOptions: MatMenuDefaultOptions) {

--- a/src/material/menu/menu-module.ts
+++ b/src/material/menu/menu-module.ts
@@ -11,7 +11,7 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {CdkScrollableModule} from '@angular/cdk/scrolling';
-import {_MatMenu} from './menu';
+import {MatMenu} from './menu';
 import {MatMenuContent} from './menu-content';
 import {MatMenuItem} from './menu-item';
 import {MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER, MatMenuTrigger} from './menu-trigger';
@@ -38,8 +38,8 @@ export class _MatMenuDirectivesModule {}
     OverlayModule,
     _MatMenuDirectivesModule,
   ],
-  exports: [CdkScrollableModule, MatCommonModule, _MatMenu, MatMenuItem, _MatMenuDirectivesModule],
-  declarations: [_MatMenu, MatMenuItem],
+  exports: [CdkScrollableModule, MatCommonModule, MatMenu, MatMenuItem, _MatMenuDirectivesModule],
+  declarations: [MatMenu, MatMenuItem],
   providers: [MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER]
 })
 export class MatMenuModule {}

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -481,21 +481,6 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
   static ngAcceptInputType_hasBackdrop: BooleanInput;
 }
 
-/** @docs-private We show the "_MatMenu" class as "MatMenu" in the docs. */
-@Directive()
-export class MatMenu extends _MatMenuBase {}
-
-// Note on the weird inheritance setup: we need three classes, because the MDC-based menu has to
-// extend `MatMenu`, however keeping a reference to it will cause the inlined template and styles
-// to be retained as well. The MDC menu also has to provide itself as a `MatMenu` in order for
-// queries and DI to work correctly, while still not referencing the actual menu class.
-// Class responsibility is split up as follows:
-// * _MatMenuBase - provides all the functionality without any of the Angular metadata.
-// * MatMenu - keeps the same name symbol name as the current menu and
-// is used as a provider for DI and query purposes.
-// * _MatMenu - the actual menu component implementation with the Angular metadata that should
-// be tree shaken away for MDC.
-
 /** @docs-public MatMenu */
 @Component({
   selector: 'mat-menu',
@@ -510,10 +495,9 @@ export class MatMenu extends _MatMenuBase {}
   ],
   providers: [
     {provide: MAT_MENU_PANEL, useExisting: MatMenu},
-    {provide: MatMenu, useExisting: _MatMenu}
   ]
 })
-export class _MatMenu extends MatMenu {
+export class MatMenu extends _MatMenuBase {
   constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone,
       @Inject(MAT_MENU_DEFAULT_OPTIONS) defaultOptions: MatMenuDefaultOptions) {
     super(elementRef, ngZone, defaultOptions);

--- a/src/material/menu/public-api.ts
+++ b/src/material/menu/public-api.ts
@@ -7,10 +7,9 @@
  */
 
 export {
-  MatMenu,
   MatMenuDefaultOptions,
   MAT_MENU_DEFAULT_OPTIONS,
-  _MatMenu,
+  MatMenu,
   _MatMenuBase,
 } from './menu';
 export {MatMenuItem} from './menu-item';

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -1,9 +1,3 @@
-export declare class _MatMenu extends MatMenu {
-    constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone, defaultOptions: MatMenuDefaultOptions);
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<_MatMenu, "mat-menu", ["matMenu"], {}, {}, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<_MatMenu, never>;
-}
-
 export declare class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit, OnDestroy {
     _allItems: QueryList<MatMenuItem>;
     _animationDone: Subject<AnimationEvent>;
@@ -74,7 +68,8 @@ export declare const MAT_MENU_PANEL: InjectionToken<MatMenuPanel<any>>;
 export declare const MAT_MENU_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 export declare class MatMenu extends _MatMenuBase {
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatMenu, never, never, {}, {}, never>;
+    constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone, defaultOptions: MatMenuDefaultOptions);
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatMenu, "mat-menu", ["matMenu"], {}, {}, never, ["*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatMenu, never>;
 }
 
@@ -126,7 +121,7 @@ export declare class MatMenuItem extends _MatMenuItemMixinBase implements Focusa
 
 export declare class MatMenuModule {
     static ɵinj: i0.ɵɵInjectorDef<MatMenuModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatMenuModule, [typeof i4._MatMenu, typeof i5.MatMenuItem], [typeof i6.CommonModule, typeof i3.MatCommonModule, typeof i3.MatRippleModule, typeof i7.OverlayModule, typeof _MatMenuDirectivesModule], [typeof i8.CdkScrollableModule, typeof i3.MatCommonModule, typeof i4._MatMenu, typeof i5.MatMenuItem, typeof _MatMenuDirectivesModule]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatMenuModule, [typeof i4.MatMenu, typeof i5.MatMenuItem], [typeof i6.CommonModule, typeof i3.MatCommonModule, typeof i3.MatRippleModule, typeof i7.OverlayModule, typeof _MatMenuDirectivesModule], [typeof i8.CdkScrollableModule, typeof i3.MatCommonModule, typeof i4.MatMenu, typeof i5.MatMenuItem, typeof _MatMenuDirectivesModule]>;
 }
 
 export interface MatMenuPanel<T = any> {
@@ -164,7 +159,7 @@ export declare class MatMenuTrigger implements AfterContentInit, OnDestroy {
     readonly onMenuClose: EventEmitter<void>;
     readonly onMenuOpen: EventEmitter<void>;
     restoreFocus: boolean;
-    constructor(_overlay: Overlay, _element: ElementRef<HTMLElement>, _viewContainerRef: ViewContainerRef, scrollStrategy: any, _parentMenu: MatMenu, _menuItemInstance: MatMenuItem, _dir: Directionality, _focusMonitor?: FocusMonitor | undefined);
+    constructor(_overlay: Overlay, _element: ElementRef<HTMLElement>, _viewContainerRef: ViewContainerRef, scrollStrategy: any, parentMenu: MatMenuPanel, _menuItemInstance: MatMenuItem, _dir: Directionality, _focusMonitor?: FocusMonitor | undefined);
     _handleClick(event: MouseEvent): void;
     _handleKeydown(event: KeyboardEvent): void;
     _handleMousedown(event: MouseEvent): void;


### PR DESCRIPTION
Now that we're using lightweight tokens everywhere, we don't have to jump through hoops to prevent the base menu styles from being imported into MDC.