### PR TITLE
test(cdk-experimental/menu): fix test failure

### DIFF
--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -894,7 +894,7 @@ describe('MenuBar', () => {
     it('should close the open menu when clicking on an inline menu item', () => {
       openMenu();
 
-      nativeInlineMenuItem.click();
+      dispatchMouseEvent(nativeInlineMenuItem, 'mousedown');
       detectChanges();
 
       expect(popoutMenus.length).toBe(0);


### PR DESCRIPTION
Fixes a test failure that seems to be due to a couple of overlapping PRs landing at the same time.

cc @andy9775 