### PR TITLE
feat(material-experimental/mdc-list): implement selection list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,7 +106,7 @@
 /src/material-experimental/mdc-form-field/**       @devversion @mmalerba
 /src/material-experimental/mdc-helpers/**          @mmalerba
 /src/material-experimental/mdc-input/**            @devversion @mmalerba
-/src/material-experimental/mdc-list/**             @mmalerba
+/src/material-experimental/mdc-list/**             @mmalerba @devversion
 /src/material-experimental/mdc-menu/**             @crisbeto
 /src/material-experimental/mdc-select/**           @crisbeto
 /src/material-experimental/mdc-progress-spinner/** @andrewseguin

--- a/src/dev-app/list/list-demo.html
+++ b/src/dev-app/list/list-demo.html
@@ -118,7 +118,7 @@
 
     <mat-selection-list #groceries [ngModel]="selectedOptions"
                         (ngModelChange)="onSelectedOptionsChange($event)"
-                        (change)="changeEventCount = changeEventCount + 1"
+                        (selectionChange)="changeEventCount = changeEventCount + 1"
                         [disabled]="selectionListDisabled"
                         [disableRipple]="selectionListRippleDisabled"
                         color="primary">
@@ -179,5 +179,24 @@
     </mat-selection-list>
 
     <p>Selected: {{favoriteOptions | json}}</p>
+  </div>
+
+  <div>
+    <h2>Line alignment</h2>
+
+    <mat-list>
+      <mat-list-item *ngFor="let link of links">
+        <span mat-line>{{ link.name }}</span>
+        <span>Not in an <i>matLine</i></span>
+      </mat-list-item>
+    </mat-list>
+
+    <mat-selection-list>
+      <mat-list-option value="first">First</mat-list-option>
+      <mat-list-option value="second">
+        <span matLine>Second</span>
+        <span>Not in an <i>matLine</i></span>
+      </mat-list-option>
+    </mat-selection-list>
   </div>
 </div>

--- a/src/dev-app/mdc-list/BUILD.bazel
+++ b/src/dev-app/mdc-list/BUILD.bazel
@@ -11,7 +11,6 @@ ng_module(
     ],
     deps = [
         "//src/material-experimental/mdc-button",
-        "//src/material-experimental/mdc-checkbox",
         "//src/material-experimental/mdc-list",
         "//src/material/icon",
         "@npm//@angular/router",

--- a/src/dev-app/mdc-list/mdc-list-demo-module.ts
+++ b/src/dev-app/mdc-list/mdc-list-demo-module.ts
@@ -10,7 +10,6 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material-experimental/mdc-button';
-import {MatCheckboxModule} from '@angular/material-experimental/mdc-checkbox';
 import {MatListModule} from '@angular/material-experimental/mdc-list';
 import {MatIconModule} from '@angular/material/icon';
 import {RouterModule} from '@angular/router';
@@ -21,7 +20,6 @@ import {MdcListDemo} from './mdc-list-demo';
     CommonModule,
     FormsModule,
     MatButtonModule,
-    MatCheckboxModule,
     MatIconModule,
     MatListModule,
     RouterModule.forChild([{path: '', component: MdcListDemo}]),

--- a/src/dev-app/mdc-list/mdc-list-demo.html
+++ b/src/dev-app/mdc-list/mdc-list-demo.html
@@ -118,7 +118,7 @@
 
     <mat-selection-list #groceries [ngModel]="selectedOptions"
                         (ngModelChange)="onSelectedOptionsChange($event)"
-                        (change)="changeEventCount = changeEventCount + 1"
+                        (selectionChange)="changeEventCount = changeEventCount + 1"
                         [disabled]="selectionListDisabled"
                         [disableRipple]="selectionListRippleDisabled"
                         color="primary">
@@ -148,14 +148,16 @@
     <p>Change Event Count {{changeEventCount}}</p>
     <p>Model Change Event Count {{modelChangeEventCount}}</p>
     <p>
-      <mat-checkbox [(ngModel)]="selectionListDisabled">
-        Disable Selection List
-      </mat-checkbox>
+      <label>
+        Disable selection list
+        <input type="checkbox" [(ngModel)]="selectionListDisabled">
+      </label>
     </p>
     <p>
-      <mat-checkbox [(ngModel)]="selectionListRippleDisabled">
+      <label>
         Disable Selection List ripples
-      </mat-checkbox>
+        <input type="checkbox" [(ngModel)]="selectionListRippleDisabled">
+      </label>
     </p>
     <p>
       <button mat-raised-button (click)="groceries.selectAll()">Select all</button>
@@ -179,5 +181,24 @@
     </mat-selection-list>
 
     <p>Selected: {{favoriteOptions | json}}</p>
+  </div>
+
+  <div>
+    <h2>Line alignment</h2>
+
+    <mat-list>
+      <mat-list-item *ngFor="let link of links">
+        <span mat-line>{{ link.name }}</span>
+        <span>Not in an <i>matLine</i></span>
+      </mat-list-item>
+    </mat-list>
+
+    <mat-selection-list>
+      <mat-list-option value="first">First</mat-list-option>
+      <mat-list-option value="second">
+        <span matLine>Second</span>
+        <span>Not in an <i>matLine</i></span>
+      </mat-list-option>
+    </mat-selection-list>
   </div>
 </div>

--- a/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
+++ b/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
@@ -5,6 +5,20 @@
 @import '@material/theme/functions.import';
 @import '../mdc-helpers/mdc-helpers';
 
+// Mixin that includes the checkbox theme styles with a given palette.
+// By default, the MDC checkbox always uses the `secondary` palette.
+@mixin _mdc-checkbox-styles-with-color($color) {
+  $orig-mdc-checkbox-mark-color: $mdc-checkbox-mark-color;
+  $mdc-checkbox-mark-color: mdc-theme-prop-value(on-#{$color}) !global;
+  $orig-mdc-checkbox-baseline-theme-color: $mdc-checkbox-baseline-theme-color;
+  $mdc-checkbox-baseline-theme-color: $color !global;
+
+  @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
+
+  $mdc-checkbox-mark-color: $orig-mdc-checkbox-mark-color !global;
+  $mdc-checkbox-baseline-theme-color: $orig-mdc-checkbox-baseline-theme-color !global;
+}
+
 @mixin mat-mdc-checkbox-color($config-or-theme) {
   $config: mat-get-color-config($config-or-theme);
   $primary: mat-color(map-get($config, primary));
@@ -13,18 +27,14 @@
 
   // Save original values of MDC global variables. We need to save these so we can restore the
   // variables to their original values and prevent unintended side effects from using this mixin.
-  $orig-mdc-checkbox-mark-color: $mdc-checkbox-mark-color;
-  $orig-mdc-checkbox-baseline-theme-color: $mdc-checkbox-baseline-theme-color;
   $orig-mdc-checkbox-border-color: $mdc-checkbox-border-color;
   $orig-mdc-checkbox-disabled-color: $mdc-checkbox-disabled-color;
 
   @include mat-using-mdc-theme($config) {
-    $mdc-checkbox-mark-color: mdc-theme-prop-value(on-primary) !global;
-    $mdc-checkbox-baseline-theme-color: primary !global;
     $mdc-checkbox-border-color: rgba(mdc-theme-prop-value(on-surface), 0.54) !global;
     $mdc-checkbox-disabled-color: rgba(mdc-theme-prop-value(on-surface), 0.26) !global;
 
-    @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
+    @include _mdc-checkbox-styles-with-color(primary);
     @include mdc-form-field-core-styles($query: $mat-theme-styles-query);
 
     // MDC's checkbox doesn't support a `color` property. We add support for it by adding a CSS
@@ -41,10 +51,7 @@
       }
 
       &.mat-accent {
-        $mdc-checkbox-mark-color: mdc-theme-prop-value(on-secondary) !global;
-        $mdc-checkbox-baseline-theme-color: secondary !global;
-
-        @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
+        @include _mdc-checkbox-styles-with-color(secondary);
 
         .mdc-checkbox--selected ~ .mat-mdc-checkbox-ripple .mat-ripple-element {
           background: $accent;
@@ -52,10 +59,7 @@
       }
 
       &.mat-warn {
-        $mdc-checkbox-mark-color: mdc-theme-prop-value(on-error) !global;
-        $mdc-checkbox-baseline-theme-color: error !global;
-
-        @include mdc-checkbox-without-ripple($query: $mat-theme-styles-query);
+        @include _mdc-checkbox-styles-with-color(error);
 
         .mdc-checkbox--selected ~ .mat-mdc-checkbox-ripple .mat-ripple-element {
           background: $warn;
@@ -65,8 +69,6 @@
   }
 
   // Restore original values of MDC global variables.
-  $mdc-checkbox-mark-color: $orig-mdc-checkbox-mark-color !global;
-  $mdc-checkbox-baseline-theme-color: $orig-mdc-checkbox-baseline-theme-color !global;
   $mdc-checkbox-border-color: $orig-mdc-checkbox-border-color !global;
   $mdc-checkbox-disabled-color: $orig-mdc-checkbox-disabled-color !global;
 }

--- a/src/material-experimental/mdc-list/BUILD.bazel
+++ b/src/material-experimental/mdc-list/BUILD.bazel
@@ -19,7 +19,10 @@ ng_module(
             "**/*.spec.ts",
         ],
     ),
-    assets = [":list_scss"] + glob(["**/*.html"]),
+    assets = [
+        ":list_scss",
+        ":list_option_scss",
+    ] + glob(["**/*.html"]),
     module_name = "@angular/material-experimental/mdc-list",
     deps = [
         "//src/cdk/collections",
@@ -34,6 +37,7 @@ sass_library(
     name = "mdc_list_scss_lib",
     srcs = glob(["**/_*.scss"]),
     deps = [
+        "//src/material-experimental/mdc-checkbox:mdc_checkbox_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
     ],
@@ -51,6 +55,18 @@ sass_binary(
     ],
 )
 
+sass_binary(
+    name = "list_option_scss",
+    src = "list-option.scss",
+    include_paths = [
+        "external/npm/node_modules",
+    ],
+    deps = [
+        "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
+        "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
+    ],
+)
+
 ng_test_library(
     name = "list_tests_lib",
     srcs = glob(
@@ -59,9 +75,13 @@ ng_test_library(
     ),
     deps = [
         ":mdc-list",
+        "//src/cdk/keycodes",
         "//src/cdk/testing/private",
         "//src/cdk/testing/testbed",
+        "//src/material/core",
+        "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
+        "@npm//@material/list",
     ],
 )
 

--- a/src/material-experimental/mdc-list/_interactive-list-theme.scss
+++ b/src/material-experimental/mdc-list/_interactive-list-theme.scss
@@ -1,0 +1,33 @@
+@import '@material/ripple/variables.import';
+@import '../mdc-helpers/mdc-helpers';
+
+// Mixin that provides colors for the various states of an interactive list-item. MDC
+// has integrated styles for these states but relies on their complex ripples for it.
+@mixin _mat-mdc-interactive-list-item-state-colors($config) {
+  $is-dark-theme: map-get($config, is-dark);
+  $state-opacities:
+    if($is-dark-theme, $mdc-ripple-light-ink-opacities, $mdc-ripple-dark-ink-opacities);
+
+  .mat-mdc-list-item-interactive {
+    &::before {
+      background: if($is-dark-theme, white, black);
+    }
+
+    &.mdc-list-item--selected::before {
+      background: mat-color(map_get($config, primary));
+      opacity: map-get($state-opacities, selected);
+    }
+
+    &:focus::before {
+      opacity: map-get($state-opacities, focus);
+    }
+  }
+
+  // MDC still shows focus/selected state if the option is disabled. Just the hover
+  // styles should not show up.
+  .mat-mdc-list-item-interactive:not(.mdc-list-item--disabled) {
+    &:hover::before {
+      opacity: map-get($state-opacities, hover);
+    }
+  }
+}

--- a/src/material-experimental/mdc-list/_list-option-theme.scss
+++ b/src/material-experimental/mdc-list/_list-option-theme.scss
@@ -1,0 +1,41 @@
+@import '@material/theme/mixins.import';
+@import '@material/list/mixins.import';
+@import '@material/checkbox/mixins.import';
+
+@import '../mdc-checkbox/checkbox-theme';
+
+// Mixin that overrides the selected item and checkbox colors for list options. By
+// default, the MDC list uses the `primary` color for list items. The MDC checkbox
+// inside list options by default uses the `primary` color too.
+@mixin _mat-mdc-list-option-color-override($color) {
+  & .mdc-list-item__meta, & .mdc-list-item__graphic {
+    @include _mdc-checkbox-styles-with-color($color);
+  }
+
+  &.mdc-list-item--selected {
+    @include mdc-list-item-primary-text-ink-color($color);
+    @include mdc-list-item-graphic-ink-color($color);
+
+    &::before {
+      @include mdc-theme-prop(background, $color);
+    }
+  }
+}
+
+@mixin _mat-mdc-list-option-density-styles($density-scale) {
+  .mat-mdc-list-option {
+    .mdc-list-item__meta, .mdc-list-item__graphic {
+      .mdc-checkbox {
+        @include mdc-checkbox-density($density-scale, $query: $mat-base-styles-query);
+      }
+    }
+  }
+}
+
+@mixin _mat-mdc-list-option-typography-styles() {
+  .mat-mdc-list-option {
+    .mdc-list-item__meta, .mdc-list-item__graphic {
+      @include mdc-checkbox-without-ripple($query: $mat-typography-styles-query);
+    }
+  }
+}

--- a/src/material-experimental/mdc-list/_list-theme.scss
+++ b/src/material-experimental/mdc-list/_list-theme.scss
@@ -1,34 +1,33 @@
 @import '@material/density/functions.import';
 @import '@material/list/variables.import';
 @import '@material/list/mixins.import';
-@import '@material/ripple/variables.import';
+
+@import './interactive-list-theme';
+@import './list-option-theme';
 @import '../mdc-helpers/mdc-helpers';
+
 
 // TODO: implement mat-list[dense] once density system is in master
 
+
 @mixin mat-mdc-list-color($config-or-theme) {
   $config: mat-get-color-config($config-or-theme);
-  $is-dark-theme: map-get($config, is-dark);
-  $state-opacities:
-      if($is-dark-theme, $mdc-ripple-light-ink-opacities, $mdc-ripple-dark-ink-opacities);
+
+  // MDC's state styles are tied in with their ripple. Since we don't use the MDC
+  // ripple, we need to add the hover, focus and selected states manually.
+  @include _mat-mdc-interactive-list-item-state-colors($config);
 
   @include mat-using-mdc-theme($config) {
     @include mdc-list-without-ripple($query: $mat-theme-styles-query);
-  }
 
-  // MDC's state styles are tied in with their ripple. Since we don't use the MDC ripple, we need to
-  // add the hover and focus states manually.
-  .mat-mdc-list-item-interactive {
-    &::before {
-      background: if($is-dark-theme, white, black);
+    .mat-mdc-list-option {
+      @include _mat-mdc-list-option-color-override(primary);
     }
-
-    &:hover::before {
-      opacity: map-get($state-opacities, hover);
+    .mat-mdc-list-option.mat-accent {
+      @include _mat-mdc-list-option-color-override(secondary);
     }
-
-    &:focus::before {
-      opacity: map-get($state-opacities, focus);
+    .mat-mdc-list-option.mat-warn {
+      @include _mat-mdc-list-option-color-override(error);
     }
   }
 }
@@ -42,18 +41,21 @@
   );
 
   // MDC list provides a mixin called `mdc-list-single-line-density`, but we cannot use
-  // that mixin the generated generated density styles are scoped to `.mdc-list-item`, while
+  // that mixin, as the generated generated density styles are scoped to `.mdc-list-item`, while
   // the styles should actually only affect single-line list items. This has been reported as
   // a bug in the MDC repository: https://github.com/material-components/material-components-web/issues/5737.
   .mat-mdc-list-item-single-line {
     @include mdc-list-single-line-height($height);
   }
+
+  @include _mat-mdc-list-option-density-styles($density-scale);
 }
 
 @mixin mat-mdc-list-typography($config-or-theme) {
   $config: mat-get-typography-config($config-or-theme);
   @include mat-using-mdc-typography($config) {
     @include mdc-list-without-ripple($query: $mat-typography-styles-query);
+    @include _mat-mdc-list-option-typography-styles();
   }
 }
 

--- a/src/material-experimental/mdc-list/action-list.ts
+++ b/src/material-experimental/mdc-list/action-list.ts
@@ -7,7 +7,7 @@
  */
 
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-import {MatInteractiveListBase, MatListBase} from './list-base';
+import {MatListBase} from './list-base';
 
 @Component({
   selector: 'mat-action-list',
@@ -23,4 +23,10 @@ import {MatInteractiveListBase, MatListBase} from './list-base';
     {provide: MatListBase, useExisting: MatActionList},
   ]
 })
-export class MatActionList extends MatInteractiveListBase {}
+export class MatActionList extends MatListBase {
+  // An action list is considered interactive, but does not extend the interactive
+  // list base class. We do this because as per MDC, items of interactive lists are
+  // only reachable through keyboard shortcuts. We want all items for the action list
+  // to be reachable through tab key though. This ensures best accessibility.
+  _isNonInteractive = false;
+}

--- a/src/material-experimental/mdc-list/action-list.ts
+++ b/src/material-experimental/mdc-list/action-list.ts
@@ -24,9 +24,10 @@ import {MatListBase} from './list-base';
   ]
 })
 export class MatActionList extends MatListBase {
-  // An action list is considered interactive, but does not extend the interactive
-  // list base class. We do this because as per MDC, items of interactive lists are
-  // only reachable through keyboard shortcuts. We want all items for the action list
-  // to be reachable through tab key though. This ensures best accessibility.
+  // An navigation list is considered interactive, but does not extend the interactive list
+  // base class. We do this because as per MDC, items of interactive lists are only reachable
+  // through keyboard shortcuts. We want all items for the navigation list to be reachable
+  // through tab key as we do not intend to provide any special accessibility treatment. The
+  // accessibility treatment depends on how the end-user will interact with it.
   _isNonInteractive = false;
 }

--- a/src/material-experimental/mdc-list/interactive-list-base.ts
+++ b/src/material-experimental/mdc-list/interactive-list-base.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  HostListener, Inject, isDevMode,
+  OnDestroy,
+  QueryList
+} from '@angular/core';
+import {MDCListAdapter, MDCListFoundation} from '@material/list';
+import {Subscription} from 'rxjs';
+import {startWith} from 'rxjs/operators';
+import {MatListBase, MatListItemBase} from './list-base';
+
+@Directive()
+/** @docs-private */
+export abstract class MatInteractiveListBase<T extends MatListItemBase>
+  extends MatListBase implements AfterViewInit, OnDestroy {
+
+  @HostListener('keydown', ['$event'])
+  _handleKeydown(event: KeyboardEvent) {
+    const index = this._indexForElement(event.target as HTMLElement);
+    this._foundation.handleKeydown(
+      event, this._elementAtIndex(index) === event.target, index);
+  }
+
+  @HostListener('click', ['$event'])
+  _handleClick(event: MouseEvent) {
+    // The `toggleCheckbox` parameter can always be `true` as it only has an effect if the list
+    // is recognized as checkbox selection list. For such lists, we would always want to toggle
+    // the checkbox on list item click. MDC added this parameter so that they can avoid dispatching
+    // a fake `change` event when the checkbox is directly clicked for the list item. We don't
+    // need this as we require such list item checkboxes to stop propagation of the change event.
+    // https://github.com/material-components/material-components-web/blob/08ca4d0ec5f359bc3a20bd2a302fa6b733b5e135/packages/mdc-list/component.ts#L308-L310
+    this._foundation.handleClick(this._indexForElement(event.target as HTMLElement),
+      /* toggleCheckbox */ true);
+  }
+
+  @HostListener('focusin', ['$event'])
+  _handleFocusin(event: FocusEvent) {
+    const itemIndex = this._indexForElement(event.target as HTMLElement);
+    const tabIndex = this._itemsArr[itemIndex]?._getHostElement().tabIndex;
+
+    // If the newly focused item is not the designated item that should have received focus
+    // first through keyboard interaction, the tabindex of the previously designated list item
+    // needs to be cleared, so that only one list item is reachable through tab key at any time.
+    // MDC sets a tabindex for the newly focused item, so we do not need to set a tabindex for it.
+    // Workaround for: https://github.com/material-components/material-components-web/issues/6363.
+    if (tabIndex === undefined || tabIndex === -1) {
+      this._clearTabindexForAllItems();
+    }
+
+    this._foundation.handleFocusIn(event, itemIndex);
+  }
+
+  @HostListener('focusout', ['$event'])
+  _handleFocusout(event: FocusEvent) {
+    this._foundation.handleFocusOut(event, this._indexForElement(event.target as HTMLElement));
+  }
+
+  /** Items in the interactive list. */
+  abstract _items: QueryList<T>;
+  _itemsArr: T[] = [];
+  _document: Document;
+
+  protected _foundation: MDCListFoundation;
+  protected _adapter: MDCListAdapter;
+
+  private _subscriptions = new Subscription();
+
+  protected constructor(public _element: ElementRef<HTMLElement>,
+                        @Inject(DOCUMENT) document: any) {
+    super();
+    this._document = document;
+    this._isNonInteractive = false;
+  }
+
+  protected _initWithAdapter(adapter: MDCListAdapter) {
+    this._adapter = adapter;
+    this._foundation = new MDCListFoundation(adapter);
+  }
+
+  ngAfterViewInit() {
+    // TODO: Replace with `ngDevMode` build time check once #20146 is available.
+    if (isDevMode() && !this._foundation) {
+      throw Error('MDC list foundation not initialized for Angular Material list.');
+    }
+
+    this._foundation.init();
+    this._watchListItems();
+
+    // Enable typeahead and focus wrapping for interactive lists.
+    this._foundation.setHasTypeahead(true);
+    this._foundation.setWrapFocus(true);
+  }
+
+  ngOnDestroy() {
+    this._foundation.destroy();
+    this._subscriptions.unsubscribe();
+  }
+
+  protected _watchListItems() {
+    this._subscriptions.add(this._items.changes.pipe(startWith(null)).subscribe(() => {
+      this._itemsArr = this._items.toArray();
+      // Whenever the items change, the foundation needs to be notified through the `layout`
+      // method. It caches items for the typeahead and detects the list type based on the items.
+      this._foundation.layout();
+
+      // The list items changed, so we reset the tabindex for all items and
+      // designate one list item that will be reachable through tab.
+      this._resetTabindexToFirstSelectedOrFocusedItem();
+    }));
+  }
+
+  /**
+   * Clears the tabindex of all items so that no items are reachable through tab key.
+   * MDC intends to always have only one tabbable item that will receive focus first.
+   * This first item is selected by MDC automatically on blur or by manually invoking
+   * the `setTabindexToFirstSelectedOrFocusedItem` method.
+   */
+  private _clearTabindexForAllItems() {
+    for (let items of this._itemsArr) {
+      items._elementRef.nativeElement.setAttribute('tabindex', '-1');
+    }
+  }
+
+  /**
+   * Resets tabindex for all options and sets tabindex for the first selected option or
+   * previously focused item so that an item can be reached when users tab into the list.
+   */
+  protected _resetTabindexToFirstSelectedOrFocusedItem() {
+    this._clearTabindexForAllItems();
+    (this._foundation as any)['setTabindexToFirstSelectedOrFocusedItem']();
+  }
+
+  _elementAtIndex(index: number): HTMLElement|undefined {
+    return this._itemsArr[index]?._elementRef.nativeElement;
+  }
+
+  _indexForElement(element: Element | null): number {
+    return element ?
+      this._itemsArr.findIndex(i => i._elementRef.nativeElement.contains(element)) : -1;
+  }
+}
+
+// TODO: replace with class once material-components-web/pull/6256 is available.
+/** Gets an instance of `MDcListAdapter` for the given interactive list. */
+export function getInteractiveListAdapter(
+    list: MatInteractiveListBase<MatListItemBase>): MDCListAdapter {
+  return {
+    getListItemCount() {
+      return list._items.length;
+    },
+    listItemAtIndexHasClass(index: number, className: string) {
+      const element = list._elementAtIndex(index);
+      return element ? element.classList.contains(className) : false;
+    },
+    addClassForElementIndex(index: number, className: string) {
+      list._elementAtIndex(index)?.classList.add(className);
+    },
+    removeClassForElementIndex(index: number, className: string) {
+      list._elementAtIndex(index)?.classList.remove(className);
+    },
+    getAttributeForElementIndex(index: number, attr: string) {
+      const element = list._elementAtIndex(index);
+      return element ? element.getAttribute(attr) : null;
+    },
+    setAttributeForElementIndex(index: number, attr: string, value: string) {
+      list._elementAtIndex(index)?.setAttribute(attr, value);
+    },
+    getFocusedElementIndex() {
+      return list._indexForElement(list._document?.activeElement);
+    },
+    isFocusInsideList() {
+      return list._element.nativeElement.contains(list._document?.activeElement);
+    },
+    isRootFocused() {
+      return list._element.nativeElement === list._document?.activeElement;
+    },
+    focusItemAtIndex(index: number) {
+      list._elementAtIndex(index)?.focus();
+    },
+    // Gets the text for a list item for the typeahead
+    getPrimaryTextAtIndex(index: number) {
+      return list._itemsArr[index]._getItemLabel();
+    },
+
+    // MDC uses this method to disable focusable children of list items. However, we believe that
+    // this is not an accessible pattern and should be avoided, therefore we intentionally do not
+    // implement this method. In addition, implementing this would require violating Angular
+    // Material's general principle of not having components modify DOM elements they do not own.
+    // A user who feels they really need this feature can simply listen to the `(focus)` and
+    // `(blur)` events on the list item and enable/disable focus on the children themselves as
+    // appropriate.
+    setTabIndexForListItemChildren() {},
+
+    // The following methods have a dummy implementation in the base class because they are only
+    // applicable to certain types of lists. They should be implemented for the concrete classes
+    // where they are applicable.
+    hasCheckboxAtIndex() { return false; },
+    hasRadioAtIndex(index: number) { return false; },
+    setCheckedCheckboxOrRadioAtIndex(index: number, checked: boolean) {},
+    isCheckboxCheckedAtIndex(index: number) { return false; },
+    notifyAction() {},
+  };
+}

--- a/src/material-experimental/mdc-list/interactive-list-base.ts
+++ b/src/material-experimental/mdc-list/interactive-list-base.ts
@@ -47,7 +47,7 @@ export abstract class MatInteractiveListBase<T extends MatListItemBase>
   @HostListener('focusin', ['$event'])
   _handleFocusin(event: FocusEvent) {
     const itemIndex = this._indexForElement(event.target as HTMLElement);
-    const tabIndex = this._itemsArr[itemIndex]?._getHostElement().tabIndex;
+    const tabIndex = this._itemsArr[itemIndex]?._hostElement.tabIndex;
 
     // If the newly focused item is not the designated item that should have received focus
     // first through keyboard interaction, the tabindex of the previously designated list item
@@ -128,7 +128,7 @@ export abstract class MatInteractiveListBase<T extends MatListItemBase>
    */
   private _clearTabindexForAllItems() {
     for (let items of this._itemsArr) {
-      items._elementRef.nativeElement.setAttribute('tabindex', '-1');
+      items._hostElement.setAttribute('tabindex', '-1');
     }
   }
 
@@ -138,16 +138,20 @@ export abstract class MatInteractiveListBase<T extends MatListItemBase>
    */
   protected _resetTabindexToFirstSelectedOrFocusedItem() {
     this._clearTabindexForAllItems();
-    (this._foundation as any)['setTabindexToFirstSelectedOrFocusedItem']();
+    // MDC does not expose the method for setting the tabindex to the first selected
+    // or previously focused item. We can still access the method as private class
+    // members are accessible in the transpiled JavaScript. Tracked upstream with:
+    // TODO: https://github.com/material-components/material-components-web/issues/6375
+    (this._foundation as any).setTabindexToFirstSelectedOrFocusedItem();
   }
 
   _elementAtIndex(index: number): HTMLElement|undefined {
-    return this._itemsArr[index]?._elementRef.nativeElement;
+    return this._itemsArr[index]?._hostElement;
   }
 
   _indexForElement(element: Element | null): number {
     return element ?
-      this._itemsArr.findIndex(i => i._elementRef.nativeElement.contains(element)) : -1;
+      this._itemsArr.findIndex(i => i._hostElement.contains(element)) : -1;
   }
 }
 

--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -6,23 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
-import {DOCUMENT} from '@angular/common';
 import {
   AfterContentInit,
-  AfterViewInit,
-  ContentChildren,
   Directive,
   ElementRef,
   HostBinding,
-  HostListener,
-  Inject,
+  Input,
   NgZone,
   OnDestroy,
   QueryList
 } from '@angular/core';
 import {RippleConfig, RippleRenderer, RippleTarget, setLines} from '@angular/material/core';
-import {MDCListAdapter, MDCListFoundation} from '@material/list';
 import {Subscription} from 'rxjs';
 import {startWith} from 'rxjs/operators';
 
@@ -37,20 +33,61 @@ function toggleClass(el: Element, className: string, on: boolean) {
 @Directive()
 /** @docs-private */
 export abstract class MatListItemBase implements AfterContentInit, OnDestroy, RippleTarget {
-  lines: QueryList<ElementRef<Element>>;
+  /** Query list matching list-item line elements. */
+  abstract lines: QueryList<ElementRef<Element>>;
 
-  rippleConfig: RippleConfig = {};
+  /** Element reference referring to the primary list item text. */
+  abstract _itemText: ElementRef<HTMLElement>;
 
-  // TODO(mmalerba): Add @Input for disabling ripple.
-  rippleDisabled: boolean;
+  @Input()
+  get disableRipple(): boolean {
+    return this.disabled || this._disableRipple || this._listBase.disableRipple;
+  }
+  set disableRipple(value: boolean) { this._disableRipple = coerceBooleanProperty(value); }
+  private _disableRipple: boolean = false;
+
+  /** Whether the list-item is disabled. */
+  @HostBinding('class.mdc-list-item--disabled')
+  @HostBinding('attr.aria-disabled')
+  @Input()
+  get disabled(): boolean { return this._disabled || (this._listBase && this._listBase.disabled); }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+  private _disabled = false;
 
   private _subscriptions = new Subscription();
+  private _rippleRenderer: RippleRenderer|null = null;
 
-  private _rippleRenderer: RippleRenderer;
+  /**
+   * Implemented as part of `RippleTarget`.
+   * @docs-private
+   */
+  rippleConfig: RippleConfig = {};
 
-  protected constructor(public _elementRef: ElementRef<HTMLElement>, protected _ngZone: NgZone,
-                        private _listBase: MatListBase, private _platform: Platform) {
-    this._initRipple();
+  /**
+   * Implemented as part of `RippleTarget`.
+   * @docs-private
+   */
+  get rippleDisabled(): boolean { return this.disableRipple; }
+
+  constructor(public _elementRef: ElementRef<HTMLElement>, protected _ngZone: NgZone,
+              private _listBase: MatListBase, private _platform: Platform) {
+    if (!this._listBase._isNonInteractive) {
+      this._initInteractiveListItem();
+    }
+
+    // Only interactive list items are commonly focusable, but in some situations,
+    // consumers provide a custom tabindex. We still would want to have strong focus
+    // indicator support in such scenarios.
+    this._elementRef.nativeElement.classList.add('mat-mdc-focus-indicator');
+
+    // If no type attributed is specified for a host `<button>` element, set it to
+    // "button". If a type attribute is already specified, do nothing. We do this
+    // for backwards compatibility with the old list.
+    // TODO: Determine if we intend to continue doing this for the MDC-based list.
+    const element = _elementRef.nativeElement;
+    if (element.nodeName.toLowerCase() === 'button' && !element.hasAttribute('type')) {
+      element.setAttribute('type', 'button');
+    }
   }
 
   ngAfterContentInit() {
@@ -59,29 +96,31 @@ export abstract class MatListItemBase implements AfterContentInit, OnDestroy, Ri
 
   ngOnDestroy() {
     this._subscriptions.unsubscribe();
-    this._rippleRenderer._removeTriggerEvents();
-  }
-
-  _initDefaultTabIndex(tabIndex: number) {
-    const el = this._elementRef.nativeElement;
-    if (!el.hasAttribute('tabIndex')) {
-      el.tabIndex = tabIndex;
+    if (this._rippleRenderer !== null) {
+      this._rippleRenderer._removeTriggerEvents();
     }
   }
 
-  private _initRipple() {
-    this.rippleDisabled = this._listBase._isNonInteractive;
-    if (!this._listBase._isNonInteractive) {
-      this._elementRef.nativeElement.classList.add('mat-mdc-list-item-interactive');
-    }
+  /** Gets the label for the list item. This is used for the typeahead. */
+  _getItemLabel(): string {
+    return this._itemText ? (this._itemText.nativeElement.textContent || '') : '';
+  }
+
+  /** Gets the host element of the list item. */
+  _getHostElement(): HTMLElement {
+    return this._elementRef.nativeElement;
+  }
+
+  private _initInteractiveListItem() {
+    this._elementRef.nativeElement.classList.add('mat-mdc-list-item-interactive');
     this._rippleRenderer =
         new RippleRenderer(this, this._ngZone, this._elementRef.nativeElement, this._platform);
     this._rippleRenderer.setupTriggerEvents(this._elementRef.nativeElement);
   }
 
   /**
-   * Subscribes to changes in `MatLine` content children and annotates them appropriately when they
-   * change.
+   * Subscribes to changes in `MatLine` content children and annotates them
+   * appropriately when they change.
    */
   private _monitorLines() {
     this._ngZone.runOutsideAngular(() => {
@@ -98,6 +137,9 @@ export abstract class MatListItemBase implements AfterContentInit, OnDestroy, Ri
           }));
     });
   }
+
+  static ngAcceptInputType_disabled: BooleanInput;
+  static ngAcceptInputType_disableRipple: BooleanInput;
 }
 
 @Directive()
@@ -105,116 +147,20 @@ export abstract class MatListItemBase implements AfterContentInit, OnDestroy, Ri
 export abstract class MatListBase {
   @HostBinding('class.mdc-list--non-interactive')
   _isNonInteractive: boolean = true;
+
+  /** Whether ripples for all list items is disabled. */
+  @Input()
+  get disableRipple(): boolean { return this._disableRipple; }
+  set disableRipple(value: boolean) { this._disableRipple = coerceBooleanProperty(value); }
+  private _disableRipple: boolean = false;
+
+  /** Whether all list items are disabled. */
+  @HostBinding('attr.aria-disabled')
+  @Input()
+  get disabled(): boolean { return this._disabled; }
+  set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+  private _disabled = false;
+
+  static ngAcceptInputType_disabled: BooleanInput;
+  static ngAcceptInputType_disableRipple: BooleanInput;
 }
-
-@Directive()
-export abstract class MatInteractiveListBase extends MatListBase
-    implements AfterViewInit, OnDestroy {
-  @HostListener('keydown', ['$event'])
-  _handleKeydown(event: KeyboardEvent) {
-    const index = this._indexForElement(event.target as HTMLElement);
-    this._foundation.handleKeydown(
-        event, this._elementAtIndex(index) === event.target, index);
-  }
-
-  @HostListener('click', ['$event'])
-  _handleClick(event: MouseEvent) {
-    this._foundation.handleClick(this._indexForElement(event.target as HTMLElement), false);
-  }
-
-  @HostListener('focusin', ['$event'])
-  _handleFocusin(event: FocusEvent) {
-    this._foundation.handleFocusIn(event, this._indexForElement(event.target as HTMLElement));
-  }
-
-  @HostListener('focusout', ['$event'])
-  _handleFocusout(event: FocusEvent) {
-    this._foundation.handleFocusOut(event, this._indexForElement(event.target as HTMLElement));
-  }
-
-  @ContentChildren(MatListItemBase, {descendants: true}) _items: QueryList<MatListItemBase>;
-
-  protected _adapter: MDCListAdapter = {
-    getListItemCount: () => this._items.length,
-    listItemAtIndexHasClass:
-        (index, className) => this._elementAtIndex(index).classList.contains(className),
-    addClassForElementIndex:
-        (index, className) => this._elementAtIndex(index).classList.add(className),
-    removeClassForElementIndex:
-        (index, className) => this._elementAtIndex(index).classList.remove(className),
-    getAttributeForElementIndex: (index, attr) => this._elementAtIndex(index).getAttribute(attr),
-    setAttributeForElementIndex:
-        (index, attr, value) => this._elementAtIndex(index).setAttribute(attr, value),
-    getFocusedElementIndex: () => this._indexForElement(this._document?.activeElement),
-    isFocusInsideList: () => this._element.nativeElement.contains(this._document?.activeElement),
-    isRootFocused: () => this._element.nativeElement === this._document?.activeElement,
-    focusItemAtIndex: index =>  this._elementAtIndex(index).focus(),
-
-    // MDC uses this method to disable focusable children of list items. However, we believe that
-    // this is not an accessible pattern and should be avoided, therefore we intentionally do not
-    // implement this method. In addition, implementing this would require violating Angular
-    // Material's general principle of not having components modify DOM elements they do not own.
-    // A user who feels they really need this feature can simply listen to the `(focus)` and
-    // `(blur)` events on the list item and enable/disable focus on the children themselves as
-    // appropriate.
-    setTabIndexForListItemChildren: () => {},
-
-    // The following methods have a dummy implementation in the base class because they are only
-    // applicable to certain types of lists. They should be implemented for the concrete classes
-    // where they are applicable.
-    hasCheckboxAtIndex: () => false,
-    hasRadioAtIndex: () => false,
-    setCheckedCheckboxOrRadioAtIndex: () => {},
-    isCheckboxCheckedAtIndex: () => false,
-
-    // TODO(mmalerba): Determine if we need to implement these.
-    getPrimaryTextAtIndex: () => '',
-    notifyAction: () => {},
-  };
-
-  protected _foundation: MDCListFoundation;
-
-  protected _document: Document;
-
-  private _itemsArr: MatListItemBase[] = [];
-
-  private _subscriptions = new Subscription();
-
-  constructor(protected _element: ElementRef<HTMLElement>, @Inject(DOCUMENT) document: any) {
-    super();
-    this._document = document;
-    this._isNonInteractive = false;
-    this._foundation = new MDCListFoundation(this._adapter);
-  }
-
-  ngAfterViewInit() {
-    this._initItems();
-    this._foundation.init();
-    this._foundation.layout();
-  }
-
-  ngOnDestroy() {
-    this._foundation.destroy();
-    this._subscriptions.unsubscribe();
-  }
-
-  private _initItems() {
-    this._subscriptions.add(this._items.changes.pipe(startWith(null)).subscribe(() => {
-      this._itemsArr = this._items.toArray();
-    }));
-
-    for (let i = 0; i < this._itemsArr.length; i++) {
-      this._itemsArr[i]._initDefaultTabIndex(i === 0 ? 0 : -1);
-    }
-  }
-
-  private _elementAtIndex(index: number): HTMLElement {
-    return this._itemsArr[index]._elementRef.nativeElement;
-  }
-
-  private _indexForElement(element: Element | null) {
-    return element ?
-        this._itemsArr.findIndex(i => i._elementRef.nativeElement.contains(element)) : -1;
-  }
-}
-

--- a/src/material-experimental/mdc-list/list-item.html
+++ b/src/material-experimental/mdc-list/list-item.html
@@ -9,7 +9,8 @@
   If lines were not explicitly given, assume the remaining content is the text, otherwise assume it
   is an action that belongs in the "meta" section.
 -->
-<span [class.mdc-list-item__text]="!lines.length" [class.mdc-list-item__meta]="lines.length">
+<span [class.mdc-list-item__text]="!lines.length"
+      [class.mdc-list-item__meta]="lines.length" #text>
   <ng-content></ng-content>
 </span>
 

--- a/src/material-experimental/mdc-list/list-option.html
+++ b/src/material-experimental/mdc-list/list-option.html
@@ -1,25 +1,52 @@
-<!-- Save icons and unclassified content to be placed later. -->
+<!--
+  Save icons and the pseudo checkbox so that they can be re-used in the
+  template without duplication.
+-->
 <ng-template #icons>
-  <ng-content select="[mat-list-avatar],[matListAvatar],[mat-list-icon],[matListIcon]"></ng-content>
+  <ng-content select="[mat-list-avatar],[matListAvatar],[mat-list-icon],[matListIcon]">
+  </ng-content>
 </ng-template>
-<ng-template #unsortedContent>
-  <ng-content></ng-content>
+
+<ng-template #checkbox>
+  <div class="mdc-checkbox" [class.mdc-checkbox--disabled]="disabled">
+    <!--
+      Note: We stop propagation of the change event for the indicator checkbox so that
+      no accidental change event leaks out of the list option or selection list when
+      the checkbox is directly clicked.
+    -->
+    <input type="checkbox" tabindex="-1" class="mdc-checkbox__native-control"
+           [checked]="selected" [disabled]="disabled" [attr.aria-describedby]="_optionTextId"
+           (change)="$event.stopPropagation()" />
+    <div class="mdc-checkbox__background">
+      <svg class="mdc-checkbox__checkmark"
+           viewBox="0 0 24 24">
+        <path class="mdc-checkbox__checkmark-path"
+              fill="none"
+              d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+      </svg>
+      <div class="mdc-checkbox__mixedmark"></div>
+    </div>
+  </div>
 </ng-template>
 
 <!-- Prefix -->
-<span class="mdc-list-item__graphic" *ngIf="checkboxPosition !== 'after' else icons">
-  <mat-pseudo-checkbox></mat-pseudo-checkbox>
+<span class="mdc-list-item__graphic"
+      *ngIf="!_isReversed() && (_hasIconOrAvatar() || _hasCheckbox())">
+  <ng-container [ngTemplateOutlet]="_hasCheckbox() ? checkbox : icons">
+  </ng-container>
 </span>
+
 <!-- Text -->
-<span class="mdc-list-item__text">
-  <ng-content *ngIf="lines.length else unsortedContent" select="[mat-line],[matLine]"></ng-content>
+<span class="mdc-list-item__text" #text [id]="_optionTextId">
+  <ng-content></ng-content>
 </span>
+
 <!-- Suffix -->
-<span class="mdc-list-item__meta">
-  <span class="mdc-list-item__graphic" *ngIf="checkboxPosition === 'after' else icons">
-    <mat-pseudo-checkbox></mat-pseudo-checkbox>
-  </span>
-  <ng-container *ngIf="lines.length" [ngTemplateOutlet]="unsortedContent"></ng-container>
+<span class="mdc-list-item__meta"
+      *ngIf="_isReversed() && (_hasCheckbox() || _hasIconOrAvatar())">
+  <ng-container [ngTemplateOutlet]="_hasCheckbox() ? checkbox : icons">
+  </ng-container>
 </span>
+
 <!-- Divider -->
 <ng-content select="mat-divider"></ng-content>

--- a/src/material-experimental/mdc-list/list-option.scss
+++ b/src/material-experimental/mdc-list/list-option.scss
@@ -1,0 +1,6 @@
+@import '@material/checkbox/mixins.import';
+@import '../mdc-helpers/mdc-helpers';
+
+// The MDC-based list-option uses the MDC checkbox for the selection indicators.
+// We need to ensure that the checkbox styles are included for the list-option.
+@include mdc-checkbox-without-ripple($query: $mat-base-styles-query);

--- a/src/material-experimental/mdc-list/list-option.ts
+++ b/src/material-experimental/mdc-list/list-option.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {Platform} from '@angular/cdk/platform';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  ElementRef,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  QueryList,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
+import {MatLine, ThemePalette} from '@angular/material/core';
+import {MatListAvatarCssMatStyler, MatListIconCssMatStyler} from './list';
+import {MatListItemBase} from './list-base';
+import {MAT_LIST_OPTION, MatSelectionList} from './selection-list';
+
+/** Unique id for created list options. */
+let uniqueId = 0;
+
+@Component({
+  selector: 'mat-list-option',
+  exportAs: 'matListOption',
+  styleUrls: ['list-option.css'],
+  host: {
+    'class': 'mat-mdc-list-item mat-mdc-list-option mdc-list-item',
+    'role': 'option',
+    // As per MDC, only list items in single selection mode should receive the `--selected`
+    // class. For multi selection, the checkbox is used as indicator.
+    '[class.mdc-list-item--selected]': 'selected && !selectionList.multiple',
+    '[class.mat-mdc-list-item-with-avatar]': '_hasIconOrAvatar()',
+    '[class.mat-accent]': 'color !== "primary" && color !== "warn"',
+    '[class.mat-warn]': 'color === "warn"',
+    '(blur)': '_handleBlur()',
+  },
+  templateUrl: 'list-option.html',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {provide: MAT_LIST_OPTION, useExisting: MatListOption},
+    {provide: MatListItemBase, useExisting: MatListOption},
+  ]
+})
+export class MatListOption extends MatListItemBase implements OnInit, OnDestroy {
+  /**
+   * This is set to true after the first OnChanges cycle so we don't
+   * clear the value of `selected` in the first cycle.
+   */
+  private _inputsInitialized = false;
+
+  @ViewChild('text') _itemText: ElementRef<HTMLElement>;
+  @ContentChildren(MatLine, {read: ElementRef, descendants: true}) lines:
+    QueryList<ElementRef<Element>>;
+
+  @ContentChildren(MatListAvatarCssMatStyler, {descendants: false}) _avatars: QueryList<never>;
+  @ContentChildren(MatListIconCssMatStyler, {descendants: false}) _icons: QueryList<never>;
+
+  /** Unique id for the text. Used for describing the underlying checkbox input. */
+  _optionTextId: string = `mat-mdc-list-option-text-${uniqueId++}`;
+
+  /** Whether the label should appear before or after the checkbox. Defaults to 'after' */
+  @Input() checkboxPosition: 'before' | 'after' = 'after';
+
+  /** Theme color of the list option. This sets the color of the checkbox. */
+  @Input()
+  get color(): ThemePalette { return this._color || this.selectionList.color; }
+  set color(newValue: ThemePalette) { this._color = newValue; }
+  private _color: ThemePalette;
+
+  /** Value of the option */
+  @Input()
+  get value(): any { return this._value; }
+  set value(newValue: any) {
+    if (this.selected && newValue !== this.value && this._inputsInitialized) {
+      this.selected = false;
+    }
+
+    this._value = newValue;
+  }
+  private _value: any;
+
+  /** Whether the option is selected. */
+  @Input()
+  get selected(): boolean { return this.selectionList.selectedOptions.isSelected(this); }
+  set selected(value: boolean) {
+    const isSelected = coerceBooleanProperty(value);
+
+    if (isSelected !== this._selected) {
+      this._setSelected(isSelected);
+      this.selectionList._reportValueChange();
+    }
+  }
+  private _selected = false;
+
+  constructor(
+      element: ElementRef,
+      ngZone: NgZone,
+      platform: Platform,
+      public selectionList: MatSelectionList,
+      private _changeDetectorRef: ChangeDetectorRef) {
+    super(element, ngZone, selectionList, platform);
+
+    // By default, we mark all options as unselected. The MDC list foundation will
+    // automatically update the attribute based on selection. Note that we need to
+    // initially set this because MDC does not set the default attributes for list
+    // items but expects items to be set up properly in the static markup.
+    element.nativeElement.setAttribute('aria-selected', 'false');
+  }
+
+  ngOnInit() {
+    const list = this.selectionList;
+
+    if (list._value && list._value.some(value => list.compareWith(value, this._value))) {
+      this._setSelected(true);
+    }
+
+    const wasSelected = this._selected;
+
+    // List options that are selected at initialization can't be reported properly to the form
+    // control. This is because it takes some time until the selection-list knows about all
+    // available options. Also it can happen that the ControlValueAccessor has an initial value
+    // that should be used instead. Deferring the value change report to the next tick ensures
+    // that the form control value is not being overwritten.
+    Promise.resolve().then(() => {
+      if (this._selected || wasSelected) {
+        this.selected = true;
+        this._changeDetectorRef.markForCheck();
+      }
+    });
+    this._inputsInitialized = true;
+  }
+
+  ngOnDestroy(): void {
+    if (this.selected) {
+      // We have to delay this until the next tick in order
+      // to avoid changed after checked errors.
+      Promise.resolve().then(() => {
+        this.selected = false;
+      });
+    }
+  }
+
+  /** Toggles the selection state of the option. */
+  toggle(): void {
+    this.selected = !this.selected;
+  }
+
+  /** Allows for programmatic focusing of the option. */
+  focus(): void {
+    this._elementRef.nativeElement.focus();
+  }
+
+  _isReversed(): boolean {
+    return this.checkboxPosition === 'after';
+  }
+
+  /** Whether the list-option has a checkbox. */
+  _hasCheckbox() {
+    return this.selectionList.multiple;
+  }
+
+  /** Whether the list-option has icons or avatars. */
+  _hasIconOrAvatar() {
+    return this._avatars.length || this._icons.length;
+  }
+
+  _handleBlur() {
+    this.selectionList._onTouched();
+  }
+
+  /**
+   * Sets the selected state of the option.
+   * @returns Whether the value has changed.
+   */
+  _setSelected(selected: boolean): boolean {
+    if (selected === this._selected) {
+      return false;
+    }
+
+    this._selected = selected;
+
+    if (selected) {
+      this.selectionList.selectedOptions.select(this);
+    } else {
+      this.selectionList.selectedOptions.deselect(this);
+    }
+
+    this._changeDetectorRef.markForCheck();
+    return true;
+  }
+
+  /**
+   * Notifies Angular that the option needs to be checked in the next change detection run.
+   * Mainly used to trigger an update of the list option if the disabled state of the selection
+   * list changed.
+   */
+  _markForCheck() {
+    this._changeDetectorRef.markForCheck();
+  }
+
+  static ngAcceptInputType_selected: BooleanInput;
+}

--- a/src/material-experimental/mdc-list/list.scss
+++ b/src/material-experimental/mdc-list/list.scss
@@ -97,8 +97,8 @@
   }
 }
 
-// MDC's state styles are included with their ripple which we don't use. Instead we add the focus
-// and hover styles ourselves using this pseudo-element
+// MDC's state styles are included with their ripple which we don't use. Instead we add
+// the focus and hover styles ourselves using this pseudo-element
 .mat-mdc-list-item-interactive::before {
   content: '';
   position: absolute;
@@ -107,12 +107,4 @@
   bottom: 0;
   right: 0;
   opacity: 0;
-}
-
-// Normally the `.mdc-list-item__meta` class would be applied to the icon or checkbox directly.
-// However, we need to group multiple potential `ng-content` blocks inside the meta section, so we
-// add them as children instead. These styles ensure that they are properly aligned.
-.mat-mdc-list-option .mdc-list-item__meta .mdc-list-item__graphic {
-  margin-right: 0;
-  vertical-align: middle;
 }

--- a/src/material-experimental/mdc-list/list.spec.ts
+++ b/src/material-experimental/mdc-list/list.spec.ts
@@ -1,6 +1,477 @@
-import {MatList} from '@angular/material-experimental/mdc-list';
+import {async, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {Component, QueryList, ViewChildren} from '@angular/core';
+import {defaultRippleAnimationConfig} from '@angular/material/core';
+import {dispatchMouseEvent} from '@angular/cdk/testing/private';
+import {By} from '@angular/platform-browser';
+import {MatListItem, MatListModule} from './index';
 
-it('should have unit tests', () => {
-  // TODO: Implement.
-  expect(MatList).toBe(MatList);
+describe('MDC-based MatList', () => {
+  // Default ripple durations used for testing.
+  const {enterDuration, exitDuration} = defaultRippleAnimationConfig;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [MatListModule],
+      declarations: [
+        ListWithOneAnchorItem, ListWithOneItem, ListWithTwoLineItem, ListWithThreeLineItem,
+        ListWithAvatar, ListWithItemWithCssClass, ListWithDynamicNumberOfLines,
+        ListWithMultipleItems, ListWithManyLines, NavListWithOneAnchorItem, ActionListWithoutType,
+        ActionListWithType, ListWithIndirectDescendantLines, ListWithDisabledItems,
+      ],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  it('should apply an additional class lists without lines', () => {
+    const fixture = TestBed.createComponent(ListWithOneItem);
+    const listItem = fixture.debugElement.query(By.css('mat-list-item'))!;
+    fixture.detectChanges();
+    expect(listItem.nativeElement.classList.length).toBe(4);
+    expect(listItem.nativeElement.classList).toContain('mat-mdc-list-item');
+    expect(listItem.nativeElement.classList).toContain('mdc-list-item');
+    expect(listItem.nativeElement.classList).toContain('mat-mdc-list-item-single-line');
+
+    // This spec also ensures the focus indicator is present.
+    expect(listItem.nativeElement.classList).toContain('mat-mdc-focus-indicator');
+  });
+
+  it('should apply mat-mdc-2-line class to lists with two lines', () => {
+    const fixture = TestBed.createComponent(ListWithTwoLineItem);
+    fixture.detectChanges();
+
+    const listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
+    expect(listItems[0].nativeElement.className).toContain('mat-mdc-2-line');
+    expect(listItems[1].nativeElement.className).toContain('mat-mdc-2-line');
+  });
+
+  it('should apply mat-mdc-3-line class to lists with three lines', () => {
+    const fixture = TestBed.createComponent(ListWithThreeLineItem);
+    fixture.detectChanges();
+
+    const listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
+    expect(listItems[0].nativeElement.className).toContain('mat-mdc-3-line');
+    expect(listItems[1].nativeElement.className).toContain('mat-mdc-3-line');
+  });
+
+  it('should apply mat-mdc-multi-line class to lists with more than 3 lines', () => {
+    const fixture = TestBed.createComponent(ListWithManyLines);
+    fixture.detectChanges();
+
+    const listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
+    expect(listItems[0].nativeElement.className).toContain('mat-mdc-multi-line');
+    expect(listItems[1].nativeElement.className).toContain('mat-mdc-multi-line');
+  });
+
+  it('should not clear custom classes provided by user', () => {
+    const fixture = TestBed.createComponent(ListWithItemWithCssClass);
+    fixture.detectChanges();
+
+    const listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
+    expect(listItems[0].nativeElement.classList.contains('test-class')).toBe(true);
+  });
+
+  it('should update classes if number of lines change', () => {
+    const fixture = TestBed.createComponent(ListWithDynamicNumberOfLines);
+    fixture.debugElement.componentInstance.showThirdLine = false;
+    fixture.detectChanges();
+
+    const listItem = fixture.debugElement.children[0].query(By.css('mat-list-item'))!;
+    expect(listItem.nativeElement.classList.length).toBe(4);
+    expect(listItem.nativeElement.classList).toContain('mat-mdc-2-line');
+    expect(listItem.nativeElement.classList).toContain('mat-mdc-list-item');
+    expect(listItem.nativeElement.classList).toContain('mdc-list-item');
+    expect(listItem.nativeElement.classList).toContain('mat-mdc-focus-indicator');
+
+    fixture.debugElement.componentInstance.showThirdLine = true;
+    fixture.detectChanges();
+    expect(listItem.nativeElement.className).toContain('mat-mdc-3-line');
+  });
+
+  it('should add aria roles properly', () => {
+    const fixture = TestBed.createComponent(ListWithMultipleItems);
+    fixture.detectChanges();
+
+    const list = fixture.debugElement.children[0];
+    const listItem = fixture.debugElement.children[0].query(By.css('mat-list-item'))!;
+    expect(list.nativeElement.getAttribute('role')).toBeNull('Expect mat-list no role');
+    expect(listItem.nativeElement.getAttribute('role'))
+        .toBeNull('Expect mat-list-item no role');
+  });
+
+  it('should not show ripples for non-nav lists', fakeAsync(() => {
+    const fixture = TestBed.createComponent(ListWithOneAnchorItem);
+    fixture.detectChanges();
+
+    const items: QueryList<MatListItem> = fixture.debugElement.componentInstance.listItems;
+    expect(items.length).toBeGreaterThan(0);
+
+    items.forEach(item => {
+      dispatchMouseEvent(item._elementRef.nativeElement, 'mousedown');
+      expect(fixture.nativeElement.querySelector('.mat-ripple-element')).toBe(null);
+    });
+  }));
+
+  it('should allow disabling ripples for specific nav-list items', () => {
+    const fixture = TestBed.createComponent(NavListWithOneAnchorItem);
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.listItems;
+    expect(items.length).toBeGreaterThan(0);
+
+    // Ripples should be enabled by default, and can be disabled with a binding.
+    items.forEach(item => expect(item.rippleDisabled).toBe(false));
+
+    fixture.componentInstance.disableItemRipple = true;
+    fixture.detectChanges();
+
+    items.forEach(item => expect(item.rippleDisabled).toBe(true));
+  });
+
+  it('should create an action list', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.listItems;
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it('should set the proper class on the action list host', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement.querySelector('mat-action-list');
+    expect(host.classList).toContain('mat-mdc-action-list');
+  });
+
+  it('should enable ripples for action lists by default', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.listItems;
+    expect(items.toArray().every(item => !item.rippleDisabled)).toBe(true);
+  });
+
+  it('should allow disabling ripples for specific action list items', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.listItems.toArray();
+    expect(items.length).toBeGreaterThan(0);
+
+    expect(items.every(item => !item.rippleDisabled)).toBe(true);
+
+    fixture.componentInstance.disableItemRipple = true;
+    fixture.detectChanges();
+
+    expect(items.every(item => item.rippleDisabled)).toBe(true);
+  });
+
+  it('should set default type attribute to button for action list', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+
+    const listItemEl = fixture.debugElement.query(By.css('.mat-mdc-list-item'))!;
+    expect(listItemEl.nativeElement.getAttribute('type')).toBe('button');
+  });
+
+  it('should not change type attribute if it is already specified', () => {
+    const fixture = TestBed.createComponent(ActionListWithType);
+    fixture.detectChanges();
+
+    const listItemEl = fixture.debugElement.query(By.css('.mat-mdc-list-item'))!;
+    expect(listItemEl.nativeElement.getAttribute('type')).toBe('submit');
+  });
+
+  it('should allow disabling ripples for the whole nav-list', () => {
+    const fixture = TestBed.createComponent(NavListWithOneAnchorItem);
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.listItems;
+    expect(items.length).toBeGreaterThan(0);
+
+    // Ripples should be enabled by default, and can be disabled with a binding.
+    items.forEach(item => expect(item.rippleDisabled).toBe(false));
+
+    fixture.componentInstance.disableListRipple = true;
+    fixture.detectChanges();
+
+    items.forEach(item => expect(item.rippleDisabled).toBe(true));
+  });
+
+  it('should allow disabling ripples for the entire action list', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.listItems.toArray();
+    expect(items.length).toBeGreaterThan(0);
+
+    expect(items.every(item => !item.rippleDisabled)).toBe(true);
+
+    fixture.componentInstance.disableListRipple = true;
+    fixture.detectChanges();
+
+    expect(items.every(item => item.rippleDisabled)).toBe(true);
+  });
+
+  it('should disable item ripples when list ripples are disabled via the input in nav list',
+    fakeAsync(() => {
+      const fixture = TestBed.createComponent(NavListWithOneAnchorItem);
+      fixture.detectChanges();
+
+      const rippleTarget = fixture.nativeElement.querySelector('.mat-mdc-list-item');
+
+      dispatchMouseEvent(rippleTarget, 'mousedown');
+      dispatchMouseEvent(rippleTarget, 'mouseup');
+
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+        .toBe(1, 'Expected ripples to be enabled by default.');
+
+      // Wait for the ripples to go away.
+      tick(enterDuration + exitDuration);
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+        .toBe(0, 'Expected ripples to go away.');
+
+      fixture.componentInstance.disableListRipple = true;
+      fixture.detectChanges();
+
+      dispatchMouseEvent(rippleTarget, 'mousedown');
+      dispatchMouseEvent(rippleTarget, 'mouseup');
+
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+        .toBe(0, 'Expected no ripples after list ripples are disabled.');
+    }));
+
+  it('should disable item ripples when list ripples are disabled via the input in an action list',
+    fakeAsync(() => {
+      const fixture = TestBed.createComponent(ActionListWithoutType);
+      fixture.detectChanges();
+
+      const rippleTarget = fixture.nativeElement.querySelector('.mat-mdc-list-item');
+
+      dispatchMouseEvent(rippleTarget, 'mousedown');
+      dispatchMouseEvent(rippleTarget, 'mouseup');
+
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+        .toBe(1, 'Expected ripples to be enabled by default.');
+
+      // Wait for the ripples to go away.
+      tick(enterDuration + exitDuration);
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+        .toBe(0, 'Expected ripples to go away.');
+
+      fixture.componentInstance.disableListRipple = true;
+      fixture.detectChanges();
+
+      dispatchMouseEvent(rippleTarget, 'mousedown');
+      dispatchMouseEvent(rippleTarget, 'mouseup');
+
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+        .toBe(0, 'Expected no ripples after list ripples are disabled.');
+    }));
+
+
+  it('should pick up indirect descendant lines', () => {
+    const fixture = TestBed.createComponent(ListWithIndirectDescendantLines);
+    fixture.detectChanges();
+
+    const listItems = fixture.debugElement.children[0].queryAll(By.css('mat-list-item'));
+    expect(listItems[0].nativeElement.className).toContain('mat-mdc-2-line');
+    expect(listItems[1].nativeElement.className).toContain('mat-mdc-2-line');
+  });
+
+  it('should be able to disable a single list item', () => {
+    const fixture = TestBed.createComponent(ListWithDisabledItems);
+    const listItems: HTMLElement[] =
+      Array.from(fixture.nativeElement.querySelectorAll('mat-list-item'));
+    fixture.detectChanges();
+
+    expect(listItems.map(item => {
+      return item.classList.contains('mdc-list-item--disabled');
+    })).toEqual([false, false, false]);
+
+    fixture.componentInstance.firstItemDisabled = true;
+    fixture.detectChanges();
+
+    expect(listItems.map(item => {
+      return item.classList.contains('mdc-list-item--disabled');
+    })).toEqual([true, false, false]);
+  });
+
+  it('should be able to disable the entire list', () => {
+    const fixture = TestBed.createComponent(ListWithDisabledItems);
+    const listItems: HTMLElement[] =
+      Array.from(fixture.nativeElement.querySelectorAll('mat-list-item'));
+    fixture.detectChanges();
+
+    expect(listItems.every(item =>
+        item.classList.contains('mdc-list-item--disabled'))).toBe(false);
+
+    fixture.componentInstance.listDisabled = true;
+    fixture.detectChanges();
+
+    expect(listItems.every(item =>
+        item.classList.contains('mdc-list-item--disabled'))).toBe(true);
+  });
+
 });
+
+class BaseTestList {
+  items: any[] = [
+    {'name': 'Paprika', 'description': 'A seasoning'},
+    {'name': 'Pepper', 'description': 'Another seasoning'}
+  ];
+
+  showThirdLine: boolean = false;
+}
+
+@Component({template: `
+  <mat-list>
+    <a mat-list-item>
+      Paprika
+    </a>
+  </mat-list>`})
+class ListWithOneAnchorItem extends BaseTestList {
+  // This needs to be declared directly on the class; if declared on the BaseTestList superclass,
+  // it doesn't get populated.
+  @ViewChildren(MatListItem) listItems: QueryList<MatListItem>;
+}
+
+@Component({template: `
+  <mat-nav-list [disableRipple]="disableListRipple">
+    <a mat-list-item [disableRipple]="disableItemRipple">
+      Paprika
+    </a>
+  </mat-nav-list>`})
+class NavListWithOneAnchorItem extends BaseTestList {
+  @ViewChildren(MatListItem) listItems: QueryList<MatListItem>;
+  disableItemRipple: boolean = false;
+  disableListRipple: boolean = false;
+}
+
+@Component({template: `
+  <mat-action-list [disableRipple]="disableListRipple">
+    <button mat-list-item [disableRipple]="disableItemRipple">
+      Paprika
+    </button>
+  </mat-action-list>`})
+class ActionListWithoutType extends BaseTestList {
+  @ViewChildren(MatListItem) listItems: QueryList<MatListItem>;
+  disableListRipple = false;
+  disableItemRipple = false;
+}
+
+@Component({template: `
+  <mat-action-list>
+    <button mat-list-item type="submit">
+      Paprika
+    </button>
+  </mat-action-list>`})
+class ActionListWithType extends BaseTestList {
+  @ViewChildren(MatListItem) listItems: QueryList<MatListItem>;
+}
+
+@Component({template: `
+  <mat-list>
+    <mat-list-item>
+      Paprika
+    </mat-list-item>
+  </mat-list>`})
+class ListWithOneItem extends BaseTestList { }
+
+@Component({template: `
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
+      <img src="">
+      <h3 mat-line>{{item.name}}</h3>
+      <p mat-line>{{item.description}}</p>
+    </mat-list-item>
+  </mat-list>`})
+class ListWithTwoLineItem extends BaseTestList { }
+
+@Component({template: `
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
+      <h3 mat-line>{{item.name}}</h3>
+      <p mat-line>{{item.description}}</p>
+      <p mat-line>Some other text</p>
+    </mat-list-item>
+  </mat-list>`})
+class ListWithThreeLineItem extends BaseTestList { }
+
+@Component({template: `
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
+      <h3 mat-line>Line 1</h3>
+      <p mat-line>Line 2</p>
+      <p mat-line>Line 3</p>
+      <p mat-line>Line 4</p>
+    </mat-list-item>
+  </mat-list>`})
+class ListWithManyLines extends BaseTestList { }
+
+@Component({template: `
+  <mat-list>
+    <mat-list-item>
+      <img src="" mat-list-avatar>
+      Paprika
+    </mat-list-item>
+    <mat-list-item>
+      Pepper
+    </mat-list-item>
+  </mat-list>`})
+class ListWithAvatar extends BaseTestList { }
+
+@Component({template: `
+  <mat-list>
+    <mat-list-item class="test-class" *ngFor="let item of items">
+      <h3 mat-line>{{item.name}}</h3>
+      <p mat-line>{{item.description}}</p>
+    </mat-list-item>
+  </mat-list>`})
+class ListWithItemWithCssClass extends BaseTestList { }
+
+@Component({template: `
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
+      <h3 mat-line>{{item.name}}</h3>
+      <p mat-line>{{item.description}}</p>
+      <p mat-line *ngIf="showThirdLine">Some other text</p>
+    </mat-list-item>
+  </mat-list>`})
+class ListWithDynamicNumberOfLines extends BaseTestList { }
+
+@Component({template: `
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
+      {{item.name}}
+    </mat-list-item>
+  </mat-list>`})
+class ListWithMultipleItems extends BaseTestList { }
+
+// Note the blank `ngSwitch` which we need in order to hit the bug that we're testing.
+@Component({
+  template: `
+  <mat-list>
+    <mat-list-item *ngFor="let item of items">
+      <ng-container [ngSwitch]="true">
+        <h3 mat-line>{{item.name}}</h3>
+        <p mat-line>{{item.description}}</p>
+      </ng-container>
+    </mat-list-item>
+  </mat-list>`
+})
+class ListWithIndirectDescendantLines extends BaseTestList {
+}
+
+
+@Component({template: `
+  <mat-list [disabled]="listDisabled">
+    <mat-list-item [disabled]="firstItemDisabled">One</mat-list-item>
+    <mat-list-item>Two</mat-list-item>
+    <mat-list-item>Three</mat-list-item>
+  </mat-list>`})
+class ListWithDisabledItems {
+  firstItemDisabled = false;
+  listDisabled = false;
+}

--- a/src/material-experimental/mdc-list/list.spec.ts
+++ b/src/material-experimental/mdc-list/list.spec.ts
@@ -107,7 +107,7 @@ describe('MDC-based MatList', () => {
     expect(items.length).toBeGreaterThan(0);
 
     items.forEach(item => {
-      dispatchMouseEvent(item._elementRef.nativeElement, 'mousedown');
+      dispatchMouseEvent(item._hostElement, 'mousedown');
       expect(fixture.nativeElement.querySelector('.mat-ripple-element')).toBe(null);
     });
   }));

--- a/src/material-experimental/mdc-list/list.ts
+++ b/src/material-experimental/mdc-list/list.ts
@@ -14,7 +14,7 @@ import {
   Directive,
   ElementRef,
   NgZone,
-  QueryList,
+  QueryList, ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 import {MatLine} from '@angular/material/core';
@@ -77,13 +77,11 @@ export class MatList extends MatListBase {}
   templateUrl: 'list-item.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [
-    {provide: MatListItemBase, useExisting: MatListItem},
-  ]
 })
 export class MatListItem extends MatListItemBase {
   @ContentChildren(MatLine, {read: ElementRef, descendants: true}) lines:
       QueryList<ElementRef<Element>>;
+  @ViewChild('text') _itemText: ElementRef<HTMLElement>;
 
   constructor(element: ElementRef, ngZone: NgZone, listBase: MatListBase, platform: Platform) {
     super(element, ngZone, listBase, platform);

--- a/src/material-experimental/mdc-list/module.ts
+++ b/src/material-experimental/mdc-list/module.ts
@@ -19,7 +19,8 @@ import {
   MatListSubheaderCssMatStyler,
 } from './list';
 import {MatNavList} from './nav-list';
-import {MatListOption, MatSelectionList} from './selection-list';
+import {MatSelectionList} from './selection-list';
+import {MatListOption} from './list-option';
 
 @NgModule({
   imports: [

--- a/src/material-experimental/mdc-list/nav-list.ts
+++ b/src/material-experimental/mdc-list/nav-list.ts
@@ -24,9 +24,10 @@ import {MatListBase} from './list-base';
   ]
 })
 export class MatNavList extends MatListBase {
-  // An navigation list is considered interactive, but does not extend the interactive
-  // list base class. We do this because as per MDC, items of interactive lists are
-  // only reachable through keyboard shortcuts. We want all items for the navigation list
-  // to be reachable through tab key though. This ensures best accessibility.
+  // An navigation list is considered interactive, but does not extend the interactive list
+  // base class. We do this because as per MDC, items of interactive lists are only reachable
+  // through keyboard shortcuts. We want all items for the navigation list to be reachable
+  // through tab key as we do not intend to provide any special accessibility treatment. The
+  // accessibility treatment depends on how the end-user will interact with it.
   _isNonInteractive = false;
 }

--- a/src/material-experimental/mdc-list/nav-list.ts
+++ b/src/material-experimental/mdc-list/nav-list.ts
@@ -7,16 +7,11 @@
  */
 
 import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-import {MatList} from './list';
-import {MatInteractiveListBase, MatListBase} from './list-base';
+import {MatListBase} from './list-base';
 
 @Component({
   selector: 'mat-nav-list',
-  /**
-   * @deprecated `matList` export will be removed, use `matNavList`
-   * @breaking-change 11.0.0
-   */
-  exportAs: 'matNavList, matList',
+  exportAs: 'matNavList',
   template: '<ng-content></ng-content>',
   host: {
     'class': 'mat-mdc-nav-list mat-mdc-list-base mdc-list',
@@ -26,11 +21,12 @@ import {MatInteractiveListBase, MatListBase} from './list-base';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {provide: MatListBase, useExisting: MatNavList},
-    /**
-     * @deprecated Provider for `MatList` will be removed, use `MatNavList` instead.
-     * @breaking-change 11.0.0
-     */
-    {provide: MatList, useExisting: MatNavList},
   ]
 })
-export class MatNavList extends MatInteractiveListBase {}
+export class MatNavList extends MatListBase {
+  // An navigation list is considered interactive, but does not extend the interactive
+  // list base class. We do this because as per MDC, items of interactive lists are
+  // only reachable through keyboard shortcuts. We want all items for the navigation list
+  // to be reachable through tab key though. This ensures best accessibility.
+  _isNonInteractive = false;
+}

--- a/src/material-experimental/mdc-list/public-api.ts
+++ b/src/material-experimental/mdc-list/public-api.ts
@@ -11,3 +11,4 @@ export * from './action-list';
 export * from './nav-list';
 export * from './selection-list';
 export * from './module';
+export * from './list-option';

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -189,7 +189,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     it('should not add the mdc-list-item--selected class (in multiple mode)', () => {
       let testListItem = listOptions[2].injector.get<MatListOption>(MatListOption);
 
-      dispatchMouseEvent(testListItem._elementRef.nativeElement, 'click');
+      dispatchMouseEvent(testListItem._hostElement, 'click');
       fixture.detectChanges();
 
       expect(listOptions[2].nativeElement.classList.contains('mdc-list-item--selected'))
@@ -204,7 +204,7 @@ describe('MDC-based MatSelectionList without forms', () => {
       expect(selectList.selected.length).toBe(0);
       expect(listOptions[0].nativeElement.getAttribute('aria-disabled')).toBe('true');
 
-      dispatchMouseEvent(testListItem._elementRef.nativeElement, 'click');
+      dispatchMouseEvent(testListItem._hostElement, 'click');
       fixture.detectChanges();
 
       expect(selectList.selected.length).toBe(0);
@@ -843,7 +843,7 @@ describe('MDC-based MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(0);
 
-      dispatchMouseEvent(testListItem._elementRef.nativeElement, 'click');
+      dispatchMouseEvent(testListItem._hostElement, 'click');
       fixture.detectChanges();
 
       expect(selectList.selected.length).toBe(0);
@@ -953,14 +953,14 @@ describe('MDC-based MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(0);
 
-      dispatchMouseEvent(testListItem1._elementRef.nativeElement, 'click');
+      dispatchMouseEvent(testListItem1._hostElement, 'click');
       fixture.detectChanges();
 
       expect(selectList.selected).toEqual([testListItem1]);
       expect(listOptions[1].nativeElement.classList.contains('mdc-list-item--selected'))
         .toBe(true);
 
-      dispatchMouseEvent(testListItem2._elementRef.nativeElement, 'click');
+      dispatchMouseEvent(testListItem2._hostElement, 'click');
       fixture.detectChanges();
 
       expect(selectList.selected).toEqual([testListItem2]);
@@ -981,12 +981,12 @@ describe('MDC-based MatSelectionList without forms', () => {
 
       expect(selectList.selected.length).toBe(0);
 
-      dispatchMouseEvent(testListItem1._elementRef.nativeElement, 'click');
+      dispatchMouseEvent(testListItem1._hostElement, 'click');
       fixture.detectChanges();
 
       expect(selectList.selected).toEqual([testListItem1]);
 
-      dispatchMouseEvent(testListItem1._elementRef.nativeElement, 'click');
+      dispatchMouseEvent(testListItem1._hostElement, 'click');
       fixture.detectChanges();
 
       expect(selectList.selected).toEqual([testListItem1]);
@@ -1095,7 +1095,7 @@ describe('MDC-based MatSelectionList with forms', () => {
       expect(fixture.componentInstance.selectedOptions.length)
         .toBe(0, 'Expected no options to be selected by default');
 
-      dispatchMouseEvent(listOptions[0]._elementRef.nativeElement, 'click');
+      dispatchMouseEvent(listOptions[0]._hostElement, 'click');
       fixture.detectChanges();
 
       tick();

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -1,0 +1,1673 @@
+import {A, D, DOWN_ARROW, END, ENTER, HOME, SPACE, UP_ARROW} from '@angular/cdk/keycodes';
+import {
+  createKeyboardEvent,
+  dispatchEvent,
+  dispatchFakeEvent,
+  dispatchKeyboardEvent,
+  dispatchMouseEvent,
+} from '@angular/cdk/testing/private';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  QueryList,
+  ViewChildren,
+} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
+import {defaultRippleAnimationConfig, ThemePalette} from '@angular/material/core';
+import {By} from '@angular/platform-browser';
+import {numbers} from '@material/list';
+import {MatListModule, MatListOption, MatSelectionList, MatSelectionListChange} from './index';
+
+describe('MDC-based MatSelectionList without forms', () => {
+  describe('with list option', () => {
+    let fixture: ComponentFixture<SelectionListWithListOptions>;
+    let listOptions: DebugElement[];
+    let selectionList: DebugElement;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [
+          SelectionListWithListOptions,
+          SelectionListWithCheckboxPositionAfter,
+          SelectionListWithListDisabled,
+          SelectionListWithOnlyOneOption,
+          SelectionListWithIndirectChildOptions,
+          SelectionListWithSelectedOptionAndValue,
+          SelectionListWithIndirectDescendantLines,
+        ],
+      });
+
+      TestBed.compileComponents();
+    }));
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(SelectionListWithListOptions);
+      fixture.detectChanges();
+
+      listOptions = fixture.debugElement.queryAll(By.directive(MatListOption));
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
+    }));
+
+    function getFocusIndex() {
+      return listOptions.findIndex(o => document.activeElement === o.nativeElement);
+    }
+
+    it('should be able to set a value on a list option', () => {
+      const optionValues = ['inbox', 'starred', 'sent-mail', 'archive', 'drafts'];
+
+      optionValues.forEach((optionValue, index) => {
+        expect(listOptions[index].componentInstance.value).toBe(optionValue);
+      });
+    });
+
+    it('should not emit a selectionChange event if an option changed programmatically', () => {
+      spyOn(fixture.componentInstance, 'onValueChange');
+
+      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+
+      listOptions[2].componentInstance.toggle();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+    });
+
+    it('should emit a selectionChange event if an option got clicked', () => {
+      spyOn(fixture.componentInstance, 'onValueChange');
+
+      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+
+      dispatchMouseEvent(listOptions[2].nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be able to dispatch one selected item', () => {
+      let testListItem = listOptions[2].injector.get<MatListOption>(MatListOption);
+      let selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+      expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('false');
+
+      testListItem.toggle();
+      fixture.detectChanges();
+
+      expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(listOptions[2].nativeElement.getAttribute('aria-disabled')).toBe('false');
+      expect(selectList.selected.length).toBe(1);
+    });
+
+    it('should be able to dispatch multiple selected items', () => {
+      let testListItem = listOptions[2].injector.get<MatListOption>(MatListOption);
+      let testListItem2 = listOptions[1].injector.get<MatListOption>(MatListOption);
+      let selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+      expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('false');
+      expect(listOptions[1].nativeElement.getAttribute('aria-selected')).toBe('false');
+
+      testListItem.toggle();
+      fixture.detectChanges();
+
+      testListItem2.toggle();
+      fixture.detectChanges();
+
+      expect(selectList.selected.length).toBe(2);
+      expect(listOptions[2].nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(listOptions[1].nativeElement.getAttribute('aria-selected')).toBe('true');
+      expect(listOptions[1].nativeElement.getAttribute('aria-disabled')).toBe('false');
+      expect(listOptions[2].nativeElement.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('should be able to specify a color for list options', () => {
+      const optionNativeElements = listOptions.map(option => option.nativeElement);
+
+      expect(optionNativeElements.every(option => !option.classList.contains('mat-primary')))
+        .toBe(true);
+      expect(optionNativeElements.every(option => !option.classList.contains('mat-warn')))
+        .toBe(true);
+
+      // All options will be set to the "warn" color.
+      fixture.componentInstance.selectionListColor = 'warn';
+      fixture.detectChanges();
+
+      expect(optionNativeElements.every(option => !option.classList.contains('mat-primary')))
+        .toBe(true);
+      expect(optionNativeElements.every(option => option.classList.contains('mat-warn')))
+        .toBe(true);
+
+      // Color will be set explicitly for an option and should take precedence.
+      fixture.componentInstance.firstOptionColor = 'primary';
+      fixture.detectChanges();
+
+      expect(optionNativeElements[0].classList).not.toContain('mat-accent');
+      expect(optionNativeElements[0].classList).not.toContain('mat-warn');
+      expect(optionNativeElements.slice(1).every(option => option.classList.contains('mat-warn')))
+        .toBe(true);
+    });
+
+    it('should explicitly set the `accent` color', () => {
+      const classList = listOptions[0].nativeElement.classList;
+
+      fixture.componentInstance.firstOptionColor = 'primary';
+      fixture.detectChanges();
+
+      expect(classList).not.toContain('mat-accent');
+      expect(classList).not.toContain('mat-warn');
+
+      fixture.componentInstance.firstOptionColor = 'accent';
+      fixture.detectChanges();
+
+      expect(classList).not.toContain('mat-primary');
+      expect(classList).toContain('mat-accent');
+      expect(classList).not.toContain('mat-warn');
+    });
+
+    it('should be able to deselect an option', () => {
+      let testListItem = listOptions[2].injector.get<MatListOption>(MatListOption);
+      let selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+
+      testListItem.toggle();
+      fixture.detectChanges();
+
+      expect(selectList.selected.length).toBe(1);
+
+      testListItem.toggle();
+      fixture.detectChanges();
+
+      expect(selectList.selected.length).toBe(0);
+    });
+
+    it('should not add the mdc-list-item--selected class (in multiple mode)', () => {
+      let testListItem = listOptions[2].injector.get<MatListOption>(MatListOption);
+
+      dispatchMouseEvent(testListItem._elementRef.nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(listOptions[2].nativeElement.classList.contains('mdc-list-item--selected'))
+        .toBe(false);
+    });
+
+    it('should not allow selection of disabled items', () => {
+      let testListItem = listOptions[0].injector.get<MatListOption>(MatListOption);
+      let selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+      expect(listOptions[0].nativeElement.getAttribute('aria-disabled')).toBe('true');
+
+      dispatchMouseEvent(testListItem._elementRef.nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected.length).toBe(0);
+    });
+
+    it('should be able to un-disable disabled items', () => {
+      let testListItem = listOptions[0].injector.get<MatListOption>(MatListOption);
+
+      expect(listOptions[0].nativeElement.getAttribute('aria-disabled')).toBe('true');
+
+      testListItem.disabled = false;
+      fixture.detectChanges();
+
+      expect(listOptions[0].nativeElement.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('should be able to use keyboard select with SPACE', () => {
+      const testListItem = listOptions[1].nativeElement as HTMLElement;
+      const selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+      expect(selectList.selected.length).toBe(0);
+
+      testListItem.focus();
+      expect(getFocusIndex()).toBe(1);
+
+      const event = dispatchKeyboardEvent(testListItem, 'keydown', SPACE);
+      fixture.detectChanges();
+
+      expect(selectList.selected.length).toBe(1);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('should be able to select an item using ENTER', () => {
+      const testListItem = listOptions[1].nativeElement as HTMLElement;
+      const selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+      expect(selectList.selected.length).toBe(0);
+
+      testListItem.focus();
+      expect(getFocusIndex()).toBe(1);
+
+      const event = dispatchKeyboardEvent(testListItem, 'keydown', ENTER);
+      fixture.detectChanges();
+
+      expect(selectList.selected.length).toBe(1);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    // MDC does not respect modifier keys, so this test always fails currently.
+    // Tracked with: https://github.com/material-components/material-components-web/issues/6365.
+    // tslint:disable-next-line:ban
+    xit('should not be able to toggle an item when pressing a modifier key', () => {
+      const testListItem = listOptions[1].nativeElement as HTMLElement;
+      const selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+
+      [ENTER, SPACE].forEach(key => {
+        const event = createKeyboardEvent('keydown', key, undefined, {control: true});
+
+        testListItem.focus();
+        expect(getFocusIndex()).toBe(1);
+
+        dispatchKeyboardEvent(testListItem, 'keydown', key, undefined, {control: true});
+        fixture.detectChanges();
+
+        expect(event.defaultPrevented).toBe(false);
+      });
+
+      expect(selectList.selected.length).toBe(0);
+    });
+
+    it('should not be able to toggle a disabled option using SPACE', () => {
+      const testListItem = listOptions[1].nativeElement as HTMLElement;
+      const selectionModel = selectionList.componentInstance.selectedOptions;
+
+      expect(selectionModel.selected.length).toBe(0);
+
+      listOptions[1].componentInstance.disabled = true;
+      fixture.detectChanges();
+
+      testListItem.focus();
+      expect(getFocusIndex()).toBe(1);
+
+      dispatchKeyboardEvent(testListItem, 'keydown', SPACE);
+      fixture.detectChanges();
+
+      expect(selectionModel.selected.length).toBe(0);
+    });
+
+    it('should focus the first option when the list takes focus for the first time', () => {
+      expect(listOptions[0].nativeElement.tabIndex).toBe(0);
+      expect(listOptions.slice(1).every(o => o.nativeElement.tabIndex === -1)).toBe(true);
+    });
+
+    it('should focus the previously focused option when the list takes focus a second time',
+        fakeAsync(() => {
+      expect(listOptions[0].nativeElement.tabIndex).toBe(0);
+      expect(listOptions[1].nativeElement.tabIndex).toBe(-1);
+
+      dispatchFakeEvent(listOptions[1].nativeElement, 'focusin', true);
+      dispatchFakeEvent(listOptions[1].nativeElement, 'focusout', true);
+      tick(1);
+
+      expect(listOptions[0].nativeElement.tabIndex).toBe(-1);
+      expect(listOptions[1].nativeElement.tabIndex).toBe(0);
+    }));
+
+    it('should focus previous item when press UP ARROW', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toEqual(2);
+
+      dispatchKeyboardEvent(listOptions[2].nativeElement, 'keydown', UP_ARROW);
+      fixture.detectChanges();
+
+      expect(getFocusIndex()).toEqual(1);
+    });
+
+    // MDC does not support SHIFT + ARROW for item selection. Tracked as feature request:
+    // https://github.com/material-components/material-components-web/issues/6364.
+    // tslint:disable-next-line:ban
+    xit('should focus and toggle the next item when pressing SHIFT + UP_ARROW', () => {
+      listOptions[3].nativeElement.focus();
+      expect(getFocusIndex()).toBe(3);
+
+      expect(listOptions[1].componentInstance.selected).toBe(false);
+      expect(listOptions[2].componentInstance.selected).toBe(false);
+
+      dispatchKeyboardEvent(listOptions[3].nativeElement, 'keydown', UP_ARROW,
+          undefined, {shift: true});
+      fixture.detectChanges();
+
+      expect(listOptions[1].componentInstance.selected).toBe(false);
+      expect(listOptions[2].componentInstance.selected).toBe(true);
+
+      dispatchKeyboardEvent(listOptions[2].nativeElement, 'keydown', UP_ARROW,
+        undefined, {shift: true});
+      fixture.detectChanges();
+
+      expect(listOptions[1].componentInstance.selected).toBe(true);
+      expect(listOptions[2].componentInstance.selected).toBe(true);
+    });
+
+    // MDC does not support SHIFT + ARROW for item selection. Tracked as feature request:
+    // https://github.com/material-components/material-components-web/issues/6364.
+    // tslint:disable-next-line:ban
+    xit('should focus and toggle the next item when pressing SHIFT + DOWN_ARROW', () => {
+      listOptions[0].nativeElement.focus();
+      expect(getFocusIndex()).toBe(0);
+
+      expect(listOptions[1].componentInstance.selected).toBe(false);
+      expect(listOptions[2].componentInstance.selected).toBe(false);
+
+      dispatchKeyboardEvent(listOptions[0].nativeElement, 'keydown', DOWN_ARROW,
+          undefined, {shift: true});
+      fixture.detectChanges();
+
+      expect(listOptions[1].componentInstance.selected).toBe(true);
+      expect(listOptions[2].componentInstance.selected).toBe(false);
+
+      dispatchKeyboardEvent(listOptions[1].nativeElement, 'keydown', DOWN_ARROW,
+        undefined, {shift: true});
+      fixture.detectChanges();
+
+      expect(listOptions[1].componentInstance.selected).toBe(true);
+      expect(listOptions[2].componentInstance.selected).toBe(true);
+    });
+
+    it('should focus next item when press DOWN ARROW', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toEqual(2);
+
+      dispatchKeyboardEvent(listOptions[2].nativeElement, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      expect(getFocusIndex()).toEqual(3);
+    });
+
+    it('should be able to focus the first item when pressing HOME', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toBe(2);
+
+      const event = dispatchKeyboardEvent(listOptions[2].nativeElement, 'keydown', HOME);
+      fixture.detectChanges();
+
+      expect(getFocusIndex()).toBe(0);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    // MDC does not respect the modifier keys. Bug tracked with:
+    // https://github.com/material-components/material-components-web/issues/6365.
+    // tslint:disable-next-line:ban
+    xit('should not change focus when pressing HOME with a modifier key', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toBe(2);
+
+      const event = createKeyboardEvent('keydown', HOME, undefined, {shift: true});
+
+      dispatchEvent(listOptions[2].nativeElement, event);
+      fixture.detectChanges();
+
+      expect(getFocusIndex()).toBe(2);
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('should focus the last item when pressing END', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toBe(2);
+
+      const event = dispatchKeyboardEvent(listOptions[2].nativeElement, 'keydown', END);
+      fixture.detectChanges();
+
+      expect(getFocusIndex()).toBe(4);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    // MDC does not respect the modifier keys. Bug tracked with:
+    // https://github.com/material-components/material-components-web/issues/6365.
+    // tslint:disable-next-line:ban
+    xit('should not change focus when pressing END with a modifier key', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toBe(2);
+
+      const event = createKeyboardEvent('keydown', END, undefined, {shift: true});
+
+      dispatchEvent(listOptions[2].nativeElement, event);
+      fixture.detectChanges();
+
+      expect(getFocusIndex()).toBe(2);
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    // MDC does not support the common CTRL + A keyboard shortcut.
+    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
+    // tslint:disable-next-line:ban
+    xit('should select all items using ctrl + a', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toBe(2);
+
+      listOptions.forEach(option => option.componentInstance.disabled = false);
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
+
+      expect(listOptions.some(option => option.componentInstance.selected)).toBe(false);
+
+      dispatchEvent(listOptions[2].nativeElement, event);
+      fixture.detectChanges();
+
+      expect(listOptions.every(option => option.componentInstance.selected)).toBe(true);
+    });
+
+    // MDC does not support the common CTRL + A keyboard shortcut.
+    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
+    // tslint:disable-next-line:ban
+    xit('should not select disabled items when pressing ctrl + a', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toBe(2);
+
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
+
+      listOptions.slice(0, 2).forEach(option => option.componentInstance.disabled = true);
+      fixture.detectChanges();
+
+      expect(listOptions.map(option => option.componentInstance.selected))
+        .toEqual([false, false, false, false, false]);
+
+      dispatchEvent(listOptions[2].nativeElement, event);
+      fixture.detectChanges();
+
+      expect(listOptions.map(option => option.componentInstance.selected))
+        .toEqual([false, false, true, true, true]);
+    });
+
+    // MDC does not support the common CTRL + A keyboard shortcut.
+    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
+    // tslint:disable-next-line:ban
+    xit('should select all items using ctrl + a if some items are selected', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toBe(2);
+
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
+
+      listOptions.slice(0, 2).forEach(option => option.componentInstance.selected = true);
+      fixture.detectChanges();
+
+      expect(listOptions.some(option => option.componentInstance.selected)).toBe(true);
+
+      dispatchEvent(listOptions[2].nativeElement, event);
+      fixture.detectChanges();
+
+      expect(listOptions.every(option => option.componentInstance.selected)).toBe(true);
+    });
+
+    // MDC does not support the common CTRL + A keyboard shortcut.
+    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
+    // tslint:disable-next-line:ban
+    xit('should deselect all with ctrl + a if all options are selected', () => {
+      listOptions[2].nativeElement.focus();
+      expect(getFocusIndex()).toBe(2);
+
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
+
+      listOptions.forEach(option => option.componentInstance.selected = true);
+      fixture.detectChanges();
+
+      expect(listOptions.every(option => option.componentInstance.selected)).toBe(true);
+
+      dispatchEvent(listOptions[2].nativeElement, event);
+      fixture.detectChanges();
+
+      expect(listOptions.every(option => option.componentInstance.selected)).toBe(false);
+    });
+
+    it('should be able to jump focus down to an item by typing', fakeAsync(() => {
+      const firstOption = listOptions[0].nativeElement;
+
+      firstOption.focus();
+      expect(getFocusIndex()).toBe(0);
+
+      dispatchEvent(firstOption, createKeyboardEvent('keydown', 83, 's'));
+      fixture.detectChanges();
+      tick(numbers.TYPEAHEAD_BUFFER_CLEAR_TIMEOUT_MS);
+
+      expect(getFocusIndex()).toBe(1);
+
+      dispatchEvent(firstOption, createKeyboardEvent('keydown', 68, 'd'));
+      fixture.detectChanges();
+      tick(numbers.TYPEAHEAD_BUFFER_CLEAR_TIMEOUT_MS);
+
+      expect(getFocusIndex()).toBe(4);
+    }));
+
+    it('should be able to skip to an item by typing', fakeAsync(() => {
+      listOptions[0].nativeElement.focus();
+      expect(getFocusIndex()).toBe(0);
+
+      dispatchKeyboardEvent(listOptions[0].nativeElement, 'keydown', D, 'd');
+      fixture.detectChanges();
+      tick(numbers.TYPEAHEAD_BUFFER_CLEAR_TIMEOUT_MS);
+
+      expect(getFocusIndex()).toBe(4);
+    }));
+
+    // Test for "A" specifically, because it's a special case that can be used
+    // to select all values.
+    it('should be able to skip to an item by typing the letter "A"', fakeAsync(() => {
+      listOptions[0].nativeElement.focus();
+      expect(getFocusIndex()).toBe(0);
+
+      dispatchKeyboardEvent(listOptions[0].nativeElement, 'keydown', A, 'a');
+      fixture.detectChanges();
+      tick(numbers.TYPEAHEAD_BUFFER_CLEAR_TIMEOUT_MS);
+
+      expect(getFocusIndex()).toBe(3);
+    }));
+
+    it('should not select items while using the typeahead', fakeAsync(() => {
+      const testListItem = listOptions[1].nativeElement as HTMLElement;
+      const model =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      testListItem.focus();
+      dispatchFakeEvent(testListItem, 'focus');
+      fixture.detectChanges();
+
+      expect(getFocusIndex()).toBe(1);
+      expect(model.isEmpty()).toBe(true);
+
+      dispatchKeyboardEvent(testListItem, 'keydown', D, 'd');
+      fixture.detectChanges();
+      tick(numbers.TYPEAHEAD_BUFFER_CLEAR_TIMEOUT_MS / 2); // Tick only half the typeahead timeout.
+
+      dispatchKeyboardEvent(testListItem, 'keydown', SPACE);
+      fixture.detectChanges();
+      // Tick the buffer timeout again as a new key has been pressed that resets
+      // the buffer timeout.
+      tick(numbers.TYPEAHEAD_BUFFER_CLEAR_TIMEOUT_MS);
+
+      expect(getFocusIndex()).toBe(4);
+      expect(model.isEmpty()).toBe(true);
+    }));
+
+    it('should be able to select all options', () => {
+      const list: MatSelectionList = selectionList.componentInstance;
+
+      expect(list.options.toArray().every(option => option.selected)).toBe(false);
+
+      list.selectAll();
+      fixture.detectChanges();
+
+      expect(list.options.toArray().every(option => option.selected)).toBe(true);
+    });
+
+    it('should be able to select all options, even if they are disabled', () => {
+      const list: MatSelectionList = selectionList.componentInstance;
+
+      list.options.forEach(option => option.disabled = true);
+      fixture.detectChanges();
+
+      expect(list.options.toArray().every(option => option.selected)).toBe(false);
+
+      list.selectAll();
+      fixture.detectChanges();
+
+      expect(list.options.toArray().every(option => option.selected)).toBe(true);
+    });
+
+    it('should be able to deselect all options', () => {
+      const list: MatSelectionList = selectionList.componentInstance;
+
+      list.options.forEach(option => option.toggle());
+      expect(list.options.toArray().every(option => option.selected)).toBe(true);
+
+      list.deselectAll();
+      fixture.detectChanges();
+
+      expect(list.options.toArray().every(option => option.selected)).toBe(false);
+    });
+
+    it('should be able to deselect all options, even if they are disabled', () => {
+      const list: MatSelectionList = selectionList.componentInstance;
+
+      list.options.forEach(option => option.toggle());
+      expect(list.options.toArray().every(option => option.selected)).toBe(true);
+
+      list.options.forEach(option => option.disabled = true);
+      fixture.detectChanges();
+
+      list.deselectAll();
+      fixture.detectChanges();
+
+      expect(list.options.toArray().every(option => option.selected)).toBe(false);
+    });
+
+    it('should update the list value when an item is selected programmatically', () => {
+      const list: MatSelectionList = selectionList.componentInstance;
+
+      expect(list.selectedOptions.isEmpty()).toBe(true);
+
+      listOptions[0].componentInstance.selected = true;
+      listOptions[2].componentInstance.selected = true;
+      fixture.detectChanges();
+
+      expect(list.selectedOptions.isEmpty()).toBe(false);
+      expect(list.selectedOptions.isSelected(listOptions[0].componentInstance)).toBe(true);
+      expect(list.selectedOptions.isSelected(listOptions[2].componentInstance)).toBe(true);
+    });
+
+    it('should update the item selected state when it is selected via the model', () => {
+      const list: MatSelectionList = selectionList.componentInstance;
+      const item: MatListOption = listOptions[0].componentInstance;
+
+      expect(item.selected).toBe(false);
+
+      list.selectedOptions.select(item);
+      fixture.detectChanges();
+
+      expect(item.selected).toBe(true);
+    });
+
+    it('should set aria-multiselectable to true on the selection list element', () => {
+      expect(selectionList.nativeElement.getAttribute('aria-multiselectable')).toBe('true');
+    });
+
+    it('should be able to reach list options that are indirect descendants', () => {
+      const descendatsFixture = TestBed.createComponent(SelectionListWithIndirectChildOptions);
+      descendatsFixture.detectChanges();
+      listOptions = descendatsFixture.debugElement.queryAll(By.directive(MatListOption));
+      selectionList = descendatsFixture.debugElement.query(By.directive(MatSelectionList))!;
+      const list: MatSelectionList = selectionList.componentInstance;
+
+      expect(list.options.toArray().every(option => option.selected)).toBe(false);
+
+      list.selectAll();
+      descendatsFixture.detectChanges();
+
+      expect(list.options.toArray().every(option => option.selected)).toBe(true);
+    });
+
+    it('should disable list item ripples when the ripples on the list have been disabled',
+      fakeAsync(() => {
+        const rippleTarget = fixture.nativeElement
+          .querySelector('.mat-mdc-list-option:not(.mdc-list-item--disabled)');
+        const {enterDuration, exitDuration} = defaultRippleAnimationConfig;
+
+        dispatchMouseEvent(rippleTarget, 'mousedown');
+        dispatchMouseEvent(rippleTarget, 'mouseup');
+
+        expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+          .toBe(1, 'Expected ripples to be enabled by default.');
+
+        // Wait for the ripples to go away.
+        tick(enterDuration + exitDuration);
+        expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+          .toBe(0, 'Expected ripples to go away.');
+
+        fixture.componentInstance.listRippleDisabled = true;
+        fixture.detectChanges();
+
+        dispatchMouseEvent(rippleTarget, 'mousedown');
+        dispatchMouseEvent(rippleTarget, 'mouseup');
+
+        expect(rippleTarget.querySelectorAll('.mat-ripple-element').length)
+          .toBe(0, 'Expected no ripples after list ripples are disabled.');
+      }));
+
+    it('can bind both selected and value at the same time', () => {
+      const componentFixture = TestBed.createComponent(SelectionListWithSelectedOptionAndValue);
+      componentFixture.detectChanges();
+      const listItemEl = componentFixture.debugElement.query(By.directive(MatListOption))!;
+      expect(listItemEl.componentInstance.selected).toBe(true);
+      expect(listItemEl.componentInstance.value).toBe(componentFixture.componentInstance.itemValue);
+    });
+
+    it('should pick up indirect descendant lines', () => {
+      const componentFixture = TestBed.createComponent(SelectionListWithIndirectDescendantLines);
+      componentFixture.detectChanges();
+
+      const option = componentFixture.nativeElement.querySelector('mat-list-option');
+      expect(option.classList).toContain('mat-mdc-2-line');
+    });
+
+    it('should have a focus indicator', () => {
+      const optionNativeElements = listOptions.map(option => option.nativeElement);
+
+      expect(optionNativeElements
+        .every(element => element.classList.contains('mat-mdc-focus-indicator'))).toBe(true);
+    });
+
+  });
+
+  describe('with list option selected', () => {
+    let fixture: ComponentFixture<SelectionListWithSelectedOption>;
+    let listItemEl: DebugElement;
+    let selectionList: DebugElement;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [SelectionListWithSelectedOption],
+      });
+
+      TestBed.compileComponents();
+    }));
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(SelectionListWithSelectedOption);
+      listItemEl = fixture.debugElement.query(By.directive(MatListOption))!;
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
+      fixture.detectChanges();
+    }));
+
+    it('should set its initial selected state in the selectedOptions', () => {
+      let optionEl = listItemEl.injector.get<MatListOption>(MatListOption);
+      let selectedOptions = selectionList.componentInstance.selectedOptions;
+      expect(selectedOptions.isSelected(optionEl)).toBeTruthy();
+    });
+  });
+
+  describe('with option disabled', () => {
+    let fixture: ComponentFixture<SelectionListWithDisabledOption>;
+    let listOptionEl: HTMLElement;
+    let listOption: MatListOption;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [SelectionListWithDisabledOption]
+      });
+
+      TestBed.compileComponents();
+    }));
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(SelectionListWithDisabledOption);
+
+      const listOptionDebug = fixture.debugElement.query(By.directive(MatListOption))!;
+
+      listOption = listOptionDebug.componentInstance;
+      listOptionEl = listOptionDebug.nativeElement;
+
+      fixture.detectChanges();
+    }));
+
+    it('should disable ripples for disabled option', () => {
+      expect(listOption.rippleDisabled)
+        .toBe(false, 'Expected ripples to be enabled by default');
+
+      fixture.componentInstance.disableItem = true;
+      fixture.detectChanges();
+
+      expect(listOption.rippleDisabled)
+        .toBe(true, 'Expected ripples to be disabled if option is disabled');
+    });
+
+    it('should apply the "mat-list-item-disabled" class properly', () => {
+      expect(listOptionEl.classList).not.toContain('mdc-list-item--disabled');
+
+      fixture.componentInstance.disableItem = true;
+      fixture.detectChanges();
+
+      expect(listOptionEl.classList).toContain('mdc-list-item--disabled');
+    });
+  });
+
+  describe('with list disabled', () => {
+    let fixture: ComponentFixture<SelectionListWithListDisabled>;
+    let listOption: DebugElement[];
+    let selectionList: DebugElement;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [
+          SelectionListWithListOptions,
+          SelectionListWithCheckboxPositionAfter,
+          SelectionListWithListDisabled,
+          SelectionListWithOnlyOneOption
+        ],
+      });
+
+      TestBed.compileComponents();
+    }));
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(SelectionListWithListDisabled);
+      listOption = fixture.debugElement.queryAll(By.directive(MatListOption));
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
+      fixture.detectChanges();
+    }));
+
+    it('should not allow selection on disabled selection-list', () => {
+      let testListItem = listOption[2].injector.get<MatListOption>(MatListOption);
+      let selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+
+      dispatchMouseEvent(testListItem._elementRef.nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected.length).toBe(0);
+    });
+
+    it('should update state of options if list state has changed', () => {
+      const testOption = listOption[2].componentInstance as MatListOption;
+
+      expect(testOption.rippleDisabled)
+        .toBe(true, 'Expected ripples of list option to be disabled');
+
+      fixture.componentInstance.disabled = false;
+      fixture.detectChanges();
+
+      expect(testOption.rippleDisabled)
+        .toBe(false, 'Expected ripples of list option to be enabled');
+    });
+  });
+
+  describe('with checkbox position after', () => {
+    let fixture: ComponentFixture<SelectionListWithCheckboxPositionAfter>;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [
+          SelectionListWithListOptions,
+          SelectionListWithCheckboxPositionAfter,
+          SelectionListWithListDisabled,
+          SelectionListWithOnlyOneOption
+        ],
+      });
+
+      TestBed.compileComponents();
+    }));
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(SelectionListWithCheckboxPositionAfter);
+      fixture.detectChanges();
+    }));
+
+    it('should be able to customize checkbox position', () => {
+      expect(fixture.nativeElement.querySelector('.mdc-list-item__meta .mdc-checkbox'))
+        .toBeTruthy('Expected checkbox to show up after content.');
+      expect(fixture.nativeElement.querySelector('.mdc-list-item__graphic .mdc-checkbox'))
+        .toBeFalsy('Expected no checkbox to show up before content.');
+    });
+  });
+
+  describe('with list item elements', () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [
+          SelectionListWithAvatar,
+          SelectionListWithIcon,
+        ],
+      }).compileComponents();
+    }));
+
+    it('should add a class to reflect that it has an avatar', () => {
+      const fixture = TestBed.createComponent(SelectionListWithIcon);
+      fixture.detectChanges();
+
+      const listOption = fixture.nativeElement.querySelector('.mat-mdc-list-option');
+      expect(listOption.classList).toContain('mat-mdc-list-item-with-avatar');
+    });
+
+    it('should add a class to reflect that it has an icon', () => {
+      const fixture = TestBed.createComponent(SelectionListWithIcon);
+      fixture.detectChanges();
+
+      const listOption = fixture.nativeElement.querySelector('.mat-mdc-list-option');
+      expect(listOption.classList).toContain('mat-mdc-list-item-with-avatar');
+    });
+  });
+
+  describe('with single selection', () => {
+    let fixture: ComponentFixture<SelectionListWithListOptions>;
+    let listOptions: DebugElement[];
+    let selectionList: DebugElement;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [MatListModule],
+        declarations: [
+          SelectionListWithListOptions,
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(SelectionListWithListOptions);
+      fixture.componentInstance.multiple = false;
+      listOptions = fixture.debugElement.queryAll(By.directive(MatListOption));
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
+      fixture.detectChanges();
+    }));
+
+    function getFocusIndex() {
+      return listOptions.findIndex(o => document.activeElement === o.nativeElement);
+    }
+
+    it('should select one option at a time', () => {
+      const testListItem1 = listOptions[1].injector.get<MatListOption>(MatListOption);
+      const testListItem2 = listOptions[2].injector.get<MatListOption>(MatListOption);
+      const selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+
+      dispatchMouseEvent(testListItem1._elementRef.nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected).toEqual([testListItem1]);
+      expect(listOptions[1].nativeElement.classList.contains('mdc-list-item--selected'))
+        .toBe(true);
+
+      dispatchMouseEvent(testListItem2._elementRef.nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected).toEqual([testListItem2]);
+      expect(listOptions[1].nativeElement.classList.contains('mdc-list-item--selected'))
+        .toBe(false);
+      expect(listOptions[2].nativeElement.classList.contains('mdc-list-item--selected'))
+        .toBe(true);
+    });
+
+    it('should not show check boxes', () => {
+      expect(fixture.nativeElement.querySelector('mat-pseudo-checkbox')).toBeFalsy();
+    });
+
+    it('should not deselect the target option on click', () => {
+      const testListItem1 = listOptions[1].injector.get<MatListOption>(MatListOption);
+      const selectList =
+        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
+
+      expect(selectList.selected.length).toBe(0);
+
+      dispatchMouseEvent(testListItem1._elementRef.nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected).toEqual([testListItem1]);
+
+      dispatchMouseEvent(testListItem1._elementRef.nativeElement, 'click');
+      fixture.detectChanges();
+
+      expect(selectList.selected).toEqual([testListItem1]);
+    });
+
+    it('throws an exception when toggling single/multiple mode after bootstrap', () => {
+      fixture.componentInstance.multiple = true;
+      expect(() => fixture.detectChanges()).toThrow(new Error(
+        'Cannot change `multiple` mode of mat-selection-list after initialization.'));
+    });
+
+    it('should do nothing when pressing ctrl + a', () => {
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
+
+      expect(listOptions.every(option => !option.componentInstance.selected)).toBe(true);
+
+      dispatchEvent(selectionList.nativeElement, event);
+      fixture.detectChanges();
+
+      expect(listOptions.every(option => !option.componentInstance.selected)).toBe(true);
+    });
+
+    it('should focus, but not toggle, the next item when pressing SHIFT + UP_ARROW in single ' +
+        'selection mode', () => {
+      listOptions[3].nativeElement.focus();
+      expect(getFocusIndex()).toBe(3);
+
+      expect(listOptions[1].componentInstance.selected).toBe(false);
+      expect(listOptions[2].componentInstance.selected).toBe(false);
+
+      dispatchKeyboardEvent(listOptions[3].nativeElement, 'keydown', UP_ARROW,
+          undefined, {shift: true});
+      fixture.detectChanges();
+
+      expect(listOptions[1].componentInstance.selected).toBe(false);
+      expect(listOptions[2].componentInstance.selected).toBe(false);
+    });
+
+    it('should focus, but not toggle, the next item when pressing SHIFT + DOWN_ARROW ' +
+        'in single selection mode', () => {
+      listOptions[3].nativeElement.focus();
+      expect(getFocusIndex()).toBe(3);
+
+      expect(listOptions[1].componentInstance.selected).toBe(false);
+      expect(listOptions[2].componentInstance.selected).toBe(false);
+
+      dispatchKeyboardEvent(listOptions[3].nativeElement, 'keydown', DOWN_ARROW,
+        undefined, {shift: true});
+      fixture.detectChanges();
+
+      expect(listOptions[1].componentInstance.selected).toBe(false);
+      expect(listOptions[2].componentInstance.selected).toBe(false);
+    });
+
+  });
+});
+
+describe('MDC-based MatSelectionList with forms', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [MatListModule, FormsModule, ReactiveFormsModule],
+      declarations: [
+        SelectionListWithModel,
+        SelectionListWithFormControl,
+        SelectionListWithPreselectedOption,
+        SelectionListWithPreselectedOptionAndModel,
+        SelectionListWithPreselectedFormControlOnPush,
+        SelectionListWithCustomComparator,
+      ]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  describe('and ngModel', () => {
+    let fixture: ComponentFixture<SelectionListWithModel>;
+    let selectionListDebug: DebugElement;
+    let listOptions: MatListOption[];
+    let ngModel: NgModel;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SelectionListWithModel);
+      fixture.detectChanges();
+
+      selectionListDebug = fixture.debugElement.query(By.directive(MatSelectionList))!;
+      ngModel = selectionListDebug.injector.get<NgModel>(NgModel);
+      listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.componentInstance);
+    });
+
+    it('should update the model if an option got selected programmatically', fakeAsync(() => {
+      expect(fixture.componentInstance.selectedOptions.length)
+        .toBe(0, 'Expected no options to be selected by default');
+
+      listOptions[0].toggle();
+      fixture.detectChanges();
+
+      tick();
+
+      expect(fixture.componentInstance.selectedOptions.length)
+        .toBe(1, 'Expected first list option to be selected');
+    }));
+
+    it('should update the model if an option got clicked', fakeAsync(() => {
+      expect(fixture.componentInstance.selectedOptions.length)
+        .toBe(0, 'Expected no options to be selected by default');
+
+      dispatchMouseEvent(listOptions[0]._elementRef.nativeElement, 'click');
+      fixture.detectChanges();
+
+      tick();
+
+      expect(fixture.componentInstance.selectedOptions.length)
+        .toBe(1, 'Expected first list option to be selected');
+    }));
+
+    it('should update the options if a model value is set', fakeAsync(() => {
+      expect(fixture.componentInstance.selectedOptions.length)
+        .toBe(0, 'Expected no options to be selected by default');
+
+      fixture.componentInstance.selectedOptions = ['opt3'];
+      fixture.detectChanges();
+
+      tick();
+
+      expect(fixture.componentInstance.selectedOptions.length)
+        .toBe(1, 'Expected first list option to be selected');
+    }));
+
+    it('should not mark the model as touched when the list is blurred', fakeAsync(() => {
+      expect(ngModel.touched)
+        .toBe(false, 'Expected the selection-list to be untouched by default.');
+
+      dispatchFakeEvent(selectionListDebug.nativeElement, 'blur');
+      fixture.detectChanges();
+      tick();
+
+      expect(ngModel.touched).toBe(false, 'Expected the selection-list to remain untouched.');
+    }));
+
+    it('should mark the model as touched when a list item is blurred', fakeAsync(() => {
+      expect(ngModel.touched)
+        .toBe(false, 'Expected the selection-list to be untouched by default.');
+
+      dispatchFakeEvent(fixture.nativeElement.querySelector('.mat-mdc-list-option'), 'blur');
+      fixture.detectChanges();
+      tick();
+
+      expect(ngModel.touched)
+        .toBe(true, 'Expected the selection-list to be touched after an item is blurred.');
+    }));
+
+    it('should be pristine by default', fakeAsync(() => {
+      fixture = TestBed.createComponent(SelectionListWithModel);
+      fixture.componentInstance.selectedOptions = ['opt2'];
+      fixture.detectChanges();
+
+      ngModel =
+        fixture.debugElement.query(By.directive(MatSelectionList))!.injector.get<NgModel>(NgModel);
+      listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.componentInstance);
+
+      // Flush the initial tick to ensure that every action from the ControlValueAccessor
+      // happened before the actual test starts.
+      tick();
+
+      expect(ngModel.pristine)
+        .toBe(true, 'Expected the selection-list to be pristine by default.');
+
+      listOptions[1].toggle();
+      fixture.detectChanges();
+
+      tick();
+
+      expect(ngModel.pristine)
+        .toBe(false, 'Expected the selection-list to be dirty after state change.');
+    }));
+
+    it('should remove a selected option from the value on destroy', fakeAsync(() => {
+      listOptions[1].selected = true;
+      listOptions[2].selected = true;
+
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.selectedOptions).toEqual(['opt2', 'opt3']);
+
+      fixture.componentInstance.options.pop();
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.componentInstance.selectedOptions).toEqual(['opt2']);
+    }));
+
+    it('should update the model if an option got selected via the model', fakeAsync(() => {
+      expect(fixture.componentInstance.selectedOptions).toEqual([]);
+
+      selectionListDebug.componentInstance.selectedOptions.select(listOptions[0]);
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.componentInstance.selectedOptions).toEqual(['opt1']);
+    }));
+
+    it('should not dispatch the model change event if nothing changed using selectAll', () => {
+      expect(fixture.componentInstance.modelChangeSpy).not.toHaveBeenCalled();
+
+      selectionListDebug.componentInstance.selectAll();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.modelChangeSpy).toHaveBeenCalledTimes(1);
+
+      selectionListDebug.componentInstance.selectAll();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.modelChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not dispatch the model change event if nothing changed using selectAll', () => {
+      expect(fixture.componentInstance.modelChangeSpy).not.toHaveBeenCalled();
+
+      selectionListDebug.componentInstance.deselectAll();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.modelChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should be able to programmatically set an array with duplicate values', fakeAsync(() => {
+      fixture.componentInstance.options = ['one', 'two', 'two', 'two', 'three'];
+      fixture.detectChanges();
+      tick();
+
+      listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.componentInstance);
+
+      fixture.componentInstance.selectedOptions = ['one', 'two', 'two'];
+      fixture.detectChanges();
+      tick();
+
+      expect(listOptions.map(option => option.selected)).toEqual([true, true, true, false, false]);
+    }));
+  });
+
+  describe('and formControl', () => {
+    let fixture: ComponentFixture<SelectionListWithFormControl>;
+    let listOptions: MatListOption[];
+    let selectionList: MatSelectionList;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SelectionListWithFormControl);
+      fixture.detectChanges();
+
+      selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!.componentInstance;
+      listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.componentInstance);
+    });
+
+    it('should be able to disable options from the control', () => {
+      expect(selectionList.disabled)
+        .toBe(false, 'Expected the selection list to be enabled.');
+      expect(listOptions.every(option => !option.disabled))
+        .toBe(true, 'Expected every list option to be enabled.');
+
+      fixture.componentInstance.formControl.disable();
+      fixture.detectChanges();
+
+      expect(selectionList.disabled)
+        .toBe(true, 'Expected the selection list to be disabled.');
+      expect(listOptions.every(option => option.disabled))
+        .toBe(true, 'Expected every list option to be disabled.');
+    });
+
+    it('should be able to update the disabled property after form control disabling', () => {
+      expect(listOptions.every(option => !option.disabled))
+        .toBe(true, 'Expected every list option to be enabled.');
+
+      fixture.componentInstance.formControl.disable();
+      fixture.detectChanges();
+
+      expect(listOptions.every(option => option.disabled))
+        .toBe(true, 'Expected every list option to be disabled.');
+
+      // Previously the selection list has been disabled through FormControl#disable. Now we
+      // want to verify that we can still change the disabled state through updating the disabled
+      // property. Calling FormControl#disable should not lock the disabled property.
+      // See: https://github.com/angular/material2/issues/12107
+      selectionList.disabled = false;
+      fixture.detectChanges();
+
+      expect(listOptions.every(option => !option.disabled))
+        .toBe(true, 'Expected every list option to be enabled.');
+    });
+
+    it('should be able to set the value through the form control', () => {
+      expect(listOptions.every(option => !option.selected))
+        .toBe(true, 'Expected every list option to be unselected.');
+
+      fixture.componentInstance.formControl.setValue(['opt2', 'opt3']);
+      fixture.detectChanges();
+
+      expect(listOptions[1].selected).toBe(true, 'Expected second option to be selected.');
+      expect(listOptions[2].selected).toBe(true, 'Expected third option to be selected.');
+
+      fixture.componentInstance.formControl.setValue(null);
+      fixture.detectChanges();
+
+      expect(listOptions.every(option => !option.selected))
+        .toBe(true, 'Expected every list option to be unselected.');
+    });
+
+    it('should deselect option whose value no longer matches', () => {
+      const option = listOptions[1];
+
+      fixture.componentInstance.formControl.setValue(['opt2']);
+      fixture.detectChanges();
+
+      expect(option.selected).toBe(true, 'Expected option to be selected.');
+
+      option.value = 'something-different';
+      fixture.detectChanges();
+
+      expect(option.selected).toBe(false, 'Expected option not to be selected.');
+      expect(fixture.componentInstance.formControl.value).toEqual([]);
+    });
+
+    it('should mark options as selected when the value is set before they are initialized', () => {
+      fixture.destroy();
+      fixture = TestBed.createComponent(SelectionListWithFormControl);
+
+      fixture.componentInstance.formControl.setValue(['opt2', 'opt3']);
+      fixture.detectChanges();
+
+      listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.componentInstance);
+
+      expect(listOptions[1].selected).toBe(true, 'Expected second option to be selected.');
+      expect(listOptions[2].selected).toBe(true, 'Expected third option to be selected.');
+    });
+
+    it('should not clear the form control when the list is destroyed', fakeAsync(() => {
+      const option = listOptions[1];
+
+      option.selected = true;
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.formControl.value).toEqual(['opt2']);
+
+      fixture.componentInstance.renderList = false;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.formControl.value).toEqual(['opt2']);
+    }));
+
+    it('should mark options added at a later point as selected', () => {
+      fixture.componentInstance.formControl.setValue(['opt4']);
+      fixture.detectChanges();
+
+      fixture.componentInstance.renderExtraOption = true;
+      fixture.detectChanges();
+
+      listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.componentInstance);
+
+      expect(listOptions.length).toBe(4);
+      expect(listOptions[3].selected).toBe(true);
+    });
+
+  });
+
+  describe('preselected values', () => {
+    it('should add preselected options to the model value', fakeAsync(() => {
+      const fixture = TestBed.createComponent(SelectionListWithPreselectedOption);
+      const listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.componentInstance);
+
+      fixture.detectChanges();
+      tick();
+
+      expect(listOptions[1].selected).toBe(true);
+      expect(fixture.componentInstance.selectedOptions).toEqual(['opt2']);
+    }));
+
+    it('should handle preselected option both through the model and the view', fakeAsync(() => {
+      const fixture = TestBed.createComponent(SelectionListWithPreselectedOptionAndModel);
+      const listOptions = fixture.debugElement.queryAll(By.directive(MatListOption))
+        .map(optionDebugEl => optionDebugEl.componentInstance);
+
+      fixture.detectChanges();
+      tick();
+
+      expect(listOptions[0].selected).toBe(true);
+      expect(listOptions[1].selected).toBe(true);
+      expect(fixture.componentInstance.selectedOptions).toEqual(['opt1', 'opt2']);
+    }));
+
+    it('should show the item as selected when preselected inside OnPush parent', fakeAsync(() => {
+      const fixture = TestBed.createComponent(SelectionListWithPreselectedFormControlOnPush);
+      fixture.detectChanges();
+
+      const option = fixture.debugElement.queryAll(By.directive(MatListOption))[1];
+      const checkbox = option.nativeElement
+          .querySelector('.mdc-checkbox__native-control') as HTMLInputElement;
+
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+
+      expect(option.componentInstance.selected).toBe(true);
+      expect(checkbox.checked).toBe(true);
+    }));
+
+  });
+
+  describe('with custom compare function', () => {
+    it('should use a custom comparator to determine which options are selected', fakeAsync(() => {
+      const fixture = TestBed.createComponent(SelectionListWithCustomComparator);
+      const testComponent = fixture.componentInstance;
+
+      testComponent.compareWith = jasmine.createSpy('comparator', (o1: any, o2: any) => {
+        return o1 && o2 && o1.id === o2.id;
+      }).and.callThrough();
+
+      testComponent.selectedOptions = [{id: 2, label: 'Two'}];
+      fixture.detectChanges();
+      tick();
+
+      expect(testComponent.compareWith).toHaveBeenCalled();
+      expect(testComponent.optionInstances.toArray()[1].selected).toBe(true);
+    }));
+  });
+});
+
+
+@Component({template: `
+  <mat-selection-list
+    id="selection-list-1"
+    (selectionChange)="onValueChange($event)"
+    [disableRipple]="listRippleDisabled"
+    [color]="selectionListColor"
+    [multiple]="multiple">
+    <mat-list-option checkboxPosition="before" disabled="true" value="inbox"
+                     [color]="firstOptionColor">
+      Inbox (disabled selection-option)
+    </mat-list-option>
+    <mat-list-option id="testSelect" checkboxPosition="before" class="test-native-focus"
+                    value="starred">
+      Starred
+    </mat-list-option>
+    <mat-list-option checkboxPosition="before" value="sent-mail">
+      Sent Mail
+    </mat-list-option>
+    <mat-list-option checkboxPosition="before" value="archive">
+      Archive
+    </mat-list-option>
+    <mat-list-option checkboxPosition="before" value="drafts" *ngIf="showLastOption">
+      Drafts
+    </mat-list-option>
+  </mat-selection-list>`})
+class SelectionListWithListOptions {
+  showLastOption = true;
+  listRippleDisabled = false;
+  multiple = true;
+  selectionListColor: ThemePalette;
+  firstOptionColor: ThemePalette;
+
+  onValueChange(_change: MatSelectionListChange) {}
+}
+
+@Component({template: `
+  <mat-selection-list id="selection-list-2">
+    <mat-list-option checkboxPosition="after">
+      Inbox (disabled selection-option)
+    </mat-list-option>
+    <mat-list-option id="testSelect" checkboxPosition="after">
+      Starred
+    </mat-list-option>
+    <mat-list-option checkboxPosition="after">
+      Sent Mail
+    </mat-list-option>
+    <mat-list-option checkboxPosition="after">
+      Drafts
+    </mat-list-option>
+  </mat-selection-list>`})
+class SelectionListWithCheckboxPositionAfter {
+}
+
+@Component({template: `
+  <mat-selection-list id="selection-list-3" [disabled]="disabled">
+    <mat-list-option checkboxPosition="after">
+      Inbox (disabled selection-option)
+    </mat-list-option>
+    <mat-list-option id="testSelect" checkboxPosition="after">
+      Starred
+    </mat-list-option>
+    <mat-list-option checkboxPosition="after">
+      Sent Mail
+    </mat-list-option>
+    <mat-list-option checkboxPosition="after">
+      Drafts
+    </mat-list-option>
+  </mat-selection-list>`})
+class SelectionListWithListDisabled {
+  disabled: boolean = true;
+}
+
+@Component({template: `
+  <mat-selection-list>
+    <mat-list-option [disabled]="disableItem">Item</mat-list-option>
+  </mat-selection-list>
+  `})
+class SelectionListWithDisabledOption {
+  disableItem: boolean = false;
+}
+
+@Component({template: `
+  <mat-selection-list>
+    <mat-list-option [selected]="true">Item</mat-list-option>
+  </mat-selection-list>`})
+class SelectionListWithSelectedOption {
+}
+
+@Component({
+  template: `
+  <mat-selection-list>
+    <mat-list-option [selected]="true" [value]="itemValue">Item</mat-list-option>
+  </mat-selection-list>`
+})
+class SelectionListWithSelectedOptionAndValue {
+  itemValue = 'item1';
+}
+
+@Component({template: `
+  <mat-selection-list id="selection-list-4">
+    <mat-list-option checkboxPosition="after" class="test-focus" id="123">
+      Inbox
+    </mat-list-option>
+  </mat-selection-list>`})
+class SelectionListWithOnlyOneOption {
+}
+
+@Component({
+  template: `
+    <mat-selection-list [(ngModel)]="selectedOptions" (ngModelChange)="modelChangeSpy()">
+      <mat-list-option *ngFor="let option of options" [value]="option">{{option}}</mat-list-option>
+    </mat-selection-list>`
+})
+class SelectionListWithModel {
+  modelChangeSpy = jasmine.createSpy('model change spy');
+  selectedOptions: string[] = [];
+  options = ['opt1', 'opt2', 'opt3'];
+}
+
+@Component({
+  template: `
+    <mat-selection-list [formControl]="formControl" *ngIf="renderList">
+      <mat-list-option value="opt1">Option 1</mat-list-option>
+      <mat-list-option value="opt2">Option 2</mat-list-option>
+      <mat-list-option value="opt3">Option 3</mat-list-option>
+      <mat-list-option value="opt4" *ngIf="renderExtraOption">Option 4</mat-list-option>
+    </mat-selection-list>
+  `
+})
+class SelectionListWithFormControl {
+  formControl = new FormControl();
+  renderList = true;
+  renderExtraOption = false;
+}
+
+
+@Component({
+  template: `
+    <mat-selection-list [(ngModel)]="selectedOptions">
+      <mat-list-option value="opt1">Option 1</mat-list-option>
+      <mat-list-option value="opt2" selected>Option 2</mat-list-option>
+    </mat-selection-list>`
+})
+class SelectionListWithPreselectedOption {
+  selectedOptions: string[];
+}
+
+
+@Component({
+  template: `
+    <mat-selection-list [(ngModel)]="selectedOptions">
+      <mat-list-option value="opt1">Option 1</mat-list-option>
+      <mat-list-option value="opt2" selected>Option 2</mat-list-option>
+    </mat-selection-list>`
+})
+class SelectionListWithPreselectedOptionAndModel {
+  selectedOptions = ['opt1'];
+}
+
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <mat-selection-list [formControl]="formControl">
+      <mat-list-option *ngFor="let opt of opts" [value]="opt">{{opt}}</mat-list-option>
+    </mat-selection-list>
+  `
+})
+class SelectionListWithPreselectedFormControlOnPush {
+  opts = ['opt1', 'opt2', 'opt3'];
+  formControl = new FormControl(['opt2']);
+}
+
+
+@Component({
+  template: `
+    <mat-selection-list [(ngModel)]="selectedOptions" [compareWith]="compareWith">
+      <mat-list-option *ngFor="let option of options" [value]="option">
+        {{option.label}}
+      </mat-list-option>
+    </mat-selection-list>`
+})
+class SelectionListWithCustomComparator {
+  @ViewChildren(MatListOption) optionInstances: QueryList<MatListOption>;
+  selectedOptions: {id: number, label: string}[] = [];
+  compareWith?: (o1: any, o2: any) => boolean;
+  options = [
+    {id: 1, label: 'One'},
+    {id: 2, label: 'Two'},
+    {id: 3, label: 'Three'}
+  ];
+}
+
+
+@Component({
+  template: `
+    <mat-selection-list>
+      <mat-list-option>
+        <div mat-list-avatar>I</div>
+        Inbox
+      </mat-list-option>
+    </mat-selection-list>
+  `
+})
+class SelectionListWithAvatar {
+}
+
+@Component({
+  template: `
+    <mat-selection-list>
+      <mat-list-option>
+        <div mat-list-icon>I</div>
+        Inbox
+      </mat-list-option>
+    </mat-selection-list>
+  `
+})
+class SelectionListWithIcon {
+}
+
+
+@Component({
+  // Note the blank `ngSwitch` which we need in order to hit the bug that we're testing.
+  template: `
+    <mat-selection-list>
+      <ng-container [ngSwitch]="true">
+        <mat-list-option [value]="1">One</mat-list-option>
+        <mat-list-option [value]="2">Two</mat-list-option>
+      </ng-container>
+    </mat-selection-list>`
+})
+class SelectionListWithIndirectChildOptions {
+  @ViewChildren(MatListOption) optionInstances: QueryList<MatListOption>;
+}
+
+// Note the blank `ngSwitch` which we need in order to hit the bug that we're testing.
+@Component({
+  template: `
+  <mat-selection-list>
+    <mat-list-option>
+      <ng-container [ngSwitch]="true">
+        <h3 mat-line>Item</h3>
+        <p mat-line>Item description</p>
+      </ng-container>
+    </mat-list-option>
+  </mat-selection-list>`
+})
+class SelectionListWithIndirectDescendantLines {
+}

--- a/src/material-experimental/mdc-list/selection-list.ts
+++ b/src/material-experimental/mdc-list/selection-list.ts
@@ -18,7 +18,6 @@ import {
   EventEmitter,
   forwardRef,
   Inject,
-  InjectionToken,
   Input,
   isDevMode,
   OnChanges,
@@ -35,21 +34,13 @@ import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {getInteractiveListAdapter, MatInteractiveListBase} from './interactive-list-base';
 import {MatListBase} from './list-base';
-import {MatListOption} from './list-option';
+import {MatListOption, SELECTION_LIST, SelectionList} from './list-option';
 
 const MAT_SELECTION_LIST_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => MatSelectionList),
   multi: true
 };
-
-/**
- * Injection token that can be used to reference instances of `MatListOption`. It
- * serves as alternative token to the actual `MatListOption` class which would result
- * in circular references.
- * @docs-private
- */
-export const MAT_LIST_OPTION = new InjectionToken<MatSelectionList>('MatSelectionList');
 
 /** Change event that is being fired whenever the selected state of an option changes. */
 export class MatSelectionListChange {
@@ -74,17 +65,17 @@ export class MatSelectionListChange {
   providers: [
     MAT_SELECTION_LIST_VALUE_ACCESSOR,
     {provide: MatListBase, useExisting: MatSelectionList},
+    {provide: SELECTION_LIST, useExisting: MatSelectionList},
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatSelectionList extends MatInteractiveListBase<MatListOption>
-    implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
+    implements SelectionList, ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
 
   private _multiple = true;
   private _initialized = false;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_LIST_OPTION as any, {descendants: true}) _items: QueryList<MatListOption>;
+  @ContentChildren(MatListOption, {descendants: true}) _items: QueryList<MatListOption>;
 
   /** Emits a change event whenever the selected state of an option changes. */
   @Output() readonly selectionChange: EventEmitter<MatSelectionListChange> =

--- a/src/material-experimental/mdc-list/selection-list.ts
+++ b/src/material-experimental/mdc-list/selection-list.ts
@@ -6,31 +6,50 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {SelectionModel} from '@angular/cdk/collections';
-import {Platform} from '@angular/cdk/platform';
+import {DOCUMENT} from '@angular/common';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ContentChildren,
   ElementRef,
   EventEmitter,
   forwardRef,
+  Inject,
+  InjectionToken,
   Input,
-  NgZone,
+  isDevMode,
+  OnChanges,
+  OnDestroy,
   Output,
   QueryList,
+  SimpleChanges,
   ViewEncapsulation
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {MatLine, ThemePalette} from '@angular/material/core';
-import {MatListBase, MatListItemBase} from './list-base';
+import {ThemePalette} from '@angular/material/core';
+import {MDCListAdapter} from '@material/list';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+import {getInteractiveListAdapter, MatInteractiveListBase} from './interactive-list-base';
+import {MatListBase} from './list-base';
+import {MatListOption} from './list-option';
 
 const MAT_SELECTION_LIST_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => MatSelectionList),
   multi: true
 };
+
+/**
+ * Injection token that can be used to reference instances of `MatListOption`. It
+ * serves as alternative token to the actual `MatListOption` class which would result
+ * in circular references.
+ * @docs-private
+ */
+export const MAT_LIST_OPTION = new InjectionToken<MatSelectionList>('MatSelectionList');
 
 /** Change event that is being fired whenever the selected state of an option changes. */
 export class MatSelectionListChange {
@@ -47,81 +66,317 @@ export class MatSelectionListChange {
   host: {
     'class': 'mat-mdc-selection-list mat-mdc-list-base mdc-list',
     'role': 'listbox',
+    '[attr.aria-multiselectable]': 'multiple',
   },
   template: '<ng-content></ng-content>',
   styleUrls: ['list.css'],
   encapsulation: ViewEncapsulation.None,
   providers: [
     MAT_SELECTION_LIST_VALUE_ACCESSOR,
-    {provide: MatListBase, useExisting: MatSelectionList}
+    {provide: MatListBase, useExisting: MatSelectionList},
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatSelectionList extends MatListBase implements ControlValueAccessor {
-  // TODO: Implement these inputs.
-  @Input() disableRipple: boolean;
-  @Input() tabIndex: number;
-  @Input() color: ThemePalette;
-  @Input() compareWith: (o1: any, o2: any) => boolean;
-  @Input() disabled: boolean;
-  @Input() multiple: boolean;
+export class MatSelectionList extends MatInteractiveListBase<MatListOption>
+    implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy {
 
-  // TODO: Implement these inputs.
-  @Output() readonly selectionChange = new EventEmitter<MatSelectionListChange>();
+  private _multiple = true;
+  private _initialized = false;
 
-  @ContentChildren(forwardRef(() => MatListOption), {descendants: true}) options:
-      QueryList<MatListOption>;
+  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
+  @ContentChildren(MAT_LIST_OPTION as any, {descendants: true}) _items: QueryList<MatListOption>;
 
-  // TODO: Implement these properties.
-  selectedOptions: SelectionModel<MatListOption>;
+  /** Emits a change event whenever the selected state of an option changes. */
+  @Output() readonly selectionChange: EventEmitter<MatSelectionListChange> =
+    new EventEmitter<MatSelectionListChange>();
 
-  // TODO: Implement these methods.
-  focus(options?: FocusOptions) {}
-  selectAll() {}
-  deselectAll() {}
-  registerOnChange(fn: any) {}
-  registerOnTouched(fn: any) {}
-  writeValue(obj: any) {}
-}
+  /** Theme color of the selection list. This sets the checkbox color for all list options. */
+  @Input() color: ThemePalette = 'accent';
 
-@Component({
-  selector: 'mat-list-option',
-  exportAs: 'matListOption',
-  host: {
-    'class': 'mat-mdc-list-item mat-mdc-list-option mdc-list-item',
-    'role': 'option',
-    'tabindex': '-1',
-  },
-  templateUrl: 'list-option.html',
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [
-    {provide: MatListItemBase, useExisting: MatListOption},
-  ]
-})
-export class MatListOption extends MatListItemBase {
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_selected: BooleanInput;
-  static ngAcceptInputType_disableRipple: BooleanInput;
+  /**
+   * Function used for comparing an option against the selected value when determining which
+   * options should appear as selected. The first argument is the value of an options. The second
+   * one is a value from the selected value. A boolean must be returned.
+   */
+  @Input() compareWith: (o1: any, o2: any) => boolean = (a1, a2) => a1 === a2;
 
-  @ContentChildren(MatLine, {read: ElementRef, descendants: true}) lines:
-      QueryList<ElementRef<Element>>;
+  /** Whether selection is limited to one or multiple items (default multiple). */
+  @Input()
+  get multiple(): boolean { return this._multiple; }
+  set multiple(value: boolean) {
+    const newValue = coerceBooleanProperty(value);
 
-  // TODO: Implement these inputs.
-  @Input() disableRipple: boolean;
-  @Input() checkboxPosition: 'before' | 'after' = 'before';
-  @Input() color: ThemePalette;
-  @Input() value: any;
-  @Input() disabled: boolean;
-  @Input() selected: boolean;
+    if (newValue !== this._multiple) {
+      if (isDevMode() && this._initialized) {
+        throw new Error(
+          'Cannot change `multiple` mode of mat-selection-list after initialization.');
+      }
 
-  constructor(element: ElementRef, ngZone: NgZone, listBase: MatListBase, platform: Platform,
-              public selectionList: MatSelectionList) {
-    super(element, ngZone, listBase, platform);
+      this._multiple = newValue;
+      this.selectedOptions = new SelectionModel(this._multiple, this.selectedOptions.selected);
+    }
   }
 
-  // TODO: Implement these methods.
-  getLabel() { return ''; }
-  focus() {}
-  toggle() {}
+  /** The currently selected options. */
+  selectedOptions = new SelectionModel<MatListOption>(this._multiple);
+
+  /** View to model callback that should be called whenever the selected options change. */
+  private _onChange: (value: any) => void = (_: any) => {};
+
+  /** Keeps track of the currently-selected value. */
+  _value: string[]|null;
+
+  /** Emits when the list has been destroyed. */
+  private _destroyed = new Subject<void>();
+
+  /** View to model callback that should be called if the list or its options lost focus. */
+  _onTouched: () => void = () => {};
+
+  /** Whether the list has been destroyed. */
+  private _isDestroyed: boolean;
+
+  constructor(element: ElementRef<HTMLElement>, @Inject(DOCUMENT) document: any) {
+    super(element, document);
+    super._initWithAdapter(getSelectionListAdapter(this));
+  }
+
+  ngAfterViewInit() {
+    // Mark the selection list as initialized so that the `multiple`
+    // binding can no longer be changed.
+    this._initialized = true;
+
+    // Update the options if a control value has been set initially.
+    if (this._value) {
+      this._setOptionsFromValues(this._value);
+    }
+
+    // Sync external changes to the model back to the options.
+    this.selectedOptions.changed.pipe(takeUntil(this._destroyed)).subscribe(event => {
+      if (event.added) {
+        for (let item of event.added) {
+          item.selected = true;
+        }
+      }
+
+      if (event.removed) {
+        for (let item of event.removed) {
+          item.selected = false;
+        }
+      }
+
+      // Sync the newly selected options with the foundation. Also reset tabindex for all
+      // items if the list is currently not focused. We do this so that always the first
+      // selected list item is focused when users tab into the selection list.
+      this._syncSelectedOptionsWithFoundation();
+      this._resetTabindexForItemsIfBlurred();
+    });
+
+    // Complete the list foundation initialization.
+    super.ngAfterViewInit();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    const disabledChanges = changes['disabled'];
+    const disableRippleChanges = changes['disableRipple'];
+
+    if ((disableRippleChanges && !disableRippleChanges.firstChange) ||
+      (disabledChanges && !disabledChanges.firstChange)) {
+      this._markOptionsForCheck();
+    }
+  }
+
+  ngOnDestroy() {
+    this._destroyed.next();
+    this._destroyed.complete();
+    this._isDestroyed = true;
+  }
+
+  /** Focuses the selection list. */
+  focus(options?: FocusOptions) {
+    this._element.nativeElement.focus(options);
+  }
+
+  /** Selects all of the options. */
+  selectAll() {
+    this._setAllOptionsSelected(true);
+  }
+
+  /** Deselects all of the options. */
+  deselectAll() {
+    this._setAllOptionsSelected(false);
+  }
+
+  /** Reports a value change to the ControlValueAccessor */
+  _reportValueChange() {
+    // Stop reporting value changes after the list has been destroyed. This avoids
+    // cases where the list might wrongly reset its value once it is removed, but
+    // the form control is still live.
+    if (this.options && !this._isDestroyed) {
+      const value = this._getSelectedOptionValues();
+      this._onChange(value);
+      this._value = value;
+    }
+  }
+
+  /** Emits a change event if the selected state of an option changed. */
+  _emitChangeEvent(option: MatListOption) {
+    this.selectionChange.emit(new MatSelectionListChange(this, option));
+  }
+
+  /** Implemented as part of ControlValueAccessor. */
+  writeValue(values: string[]): void {
+    this._value = values;
+
+    if (this.options) {
+      this._setOptionsFromValues(values || []);
+    }
+  }
+
+  /** Implemented as a part of ControlValueAccessor. */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  /** Implemented as part of ControlValueAccessor. */
+  registerOnChange(fn: (value: any) => void): void {
+    this._onChange = fn;
+  }
+
+  /** Implemented as part of ControlValueAccessor. */
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  /**
+   * Resets tabindex for all options and sets tabindex for the first selected option so that
+   * it will become active when users tab into the selection-list. This will be a noop if the
+   * list is currently focused as otherwise multiple options might become reachable through tab.
+   * e.g. A user currently already focused an option. We set tabindex to a new option but the
+   * focus on the current option does persist. Pressing `TAB` then might go to the other option
+   * that received a tabindex. We can skip the reset here as the MDC foundation resets the
+   * tabindex to the first selected option automatically once the current item is blurred.
+   */
+  private _resetTabindexForItemsIfBlurred() {
+    // If focus is inside the list already, then we do not change the tab index of the list.
+    // Changing it while an item is focused could cause multiple items to be reachable through
+    // the tab key. The MDC list foundation will update the tabindex on blur to the appropriate
+    // selected or focused item.
+    if (!this._adapter.isFocusInsideList()) {
+      this._resetTabindexToFirstSelectedOrFocusedItem();
+    }
+  }
+
+  private _syncSelectedOptionsWithFoundation() {
+    if (this._multiple) {
+      this._foundation.setSelectedIndex(this.selectedOptions.selected
+          .map(o => this._itemsArr.indexOf(o)));
+    } else {
+      const selected = this.selectedOptions.selected[0];
+      const index = selected === undefined ? -1 : this._itemsArr.indexOf(selected);
+      this._foundation.setSelectedIndex(index);
+    }
+  }
+
+  /** Sets the selected options based on the specified values. */
+  private _setOptionsFromValues(values: string[]) {
+    this.options.forEach(option => option._setSelected(false));
+
+    values.forEach(value => {
+      const correspondingOption = this.options.find(option => {
+        // Skip options that are already in the model. This allows us to handle cases
+        // where the same primitive value is selected multiple times.
+        return option.selected ? false : this.compareWith(option.value, value);
+      });
+
+      if (correspondingOption) {
+        correspondingOption._setSelected(true);
+      }
+    });
+  }
+
+  /** Returns the values of the selected options. */
+  private _getSelectedOptionValues(): string[] {
+    return this.options.filter(option => option.selected).map(option => option.value);
+  }
+
+  /** Marks all the options to be checked in the next change detection run. */
+  private _markOptionsForCheck() {
+    if (this.options) {
+      this.options.forEach(option => option._markForCheck());
+    }
+  }
+
+  /**
+   * Sets the selected state on all of the options
+   * and emits an event if anything changed.
+   */
+  private _setAllOptionsSelected(isSelected: boolean, skipDisabled?: boolean) {
+    // Keep track of whether anything changed, because we only want to
+    // emit the changed event when something actually changed.
+    let hasChanged = false;
+
+    this.options.forEach(option => {
+      if ((!skipDisabled || !option.disabled) && option._setSelected(isSelected)) {
+        hasChanged = true;
+      }
+    });
+
+    if (hasChanged) {
+      this._reportValueChange();
+    }
+  }
+
+  // Note: This getter exists for backwards compatibility. The `_items` query list
+  // cannot be named `options` as it will be picked up by the interactive list base.
+  /** The option components contained within this selection-list. */
+  get options(): QueryList<MatListOption> {
+    return this._items;
+  }
+
+  static ngAcceptInputType_multiple: BooleanInput;
+}
+
+// TODO: replace with class using inheritance once material-components-web/pull/6256 is available.
+/** Gets a `MDCListAdapter` instance for the given selection list. */
+function getSelectionListAdapter(list: MatSelectionList): MDCListAdapter {
+  const baseAdapter = getInteractiveListAdapter(list);
+  return {
+    ...baseAdapter,
+    hasRadioAtIndex(): boolean {
+      // If multi selection is not used, we treat the list as a radio list so that
+      // the MDC foundation does not keep track of multiple selected list options.
+      // Note that we cannot use MDC's non-radio single selection mode as that one
+      // will keep track of the selection state internally and we cannot update a
+      // control model, or notify/update list-options on selection change. The radio
+      // mode is similar to what we want but with support for change notification
+      // (i.e. `setCheckedCheckboxOrRadioAtIndex`) while maintaining single selection.
+      return !list.multiple;
+    },
+    hasCheckboxAtIndex() {
+      // If multi selection is used, we treat the list as a checkbox list so that
+      // the MDC foundation can keep track of multiple selected list options.
+      return list.multiple;
+    },
+    isCheckboxCheckedAtIndex(index: number) {
+      return list._itemsArr[index].selected;
+    },
+    setCheckedCheckboxOrRadioAtIndex(index: number, checked: boolean) {
+      list._itemsArr[index].selected = checked;
+    },
+    setAttributeForElementIndex(index: number, attribute: string, value: string): void {
+      // MDC list by default sets `aria-checked` for multi selection lists. We do not want to
+      // use this as that signifies a bad accessibility experience. Instead, we change the
+      // attribute update to `aria-selected` as that works best with list-options. See:
+      // https://github.com/material-components/material-components-web/issues/6367.
+      // TODO: Remove this once material-components-web#6367 is improved/fixed.
+      if (attribute === 'aria-checked') {
+        attribute = 'aria-selected';
+      }
+
+      baseAdapter.setAttributeForElementIndex(index, attribute, value);
+    },
+    notifyAction(index: number): void {
+      list._emitChangeEvent(list._itemsArr[index]);
+    },
+  };
 }

--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -211,7 +211,7 @@ export class MatListItem extends _MatListItemMixinBase implements AfterContentIn
     this._isInteractiveList = !!(navList || (list && list._getListType() === 'action-list'));
     this._list = navList || list;
 
-    // If no type attributed is specified for <button>, set it to "button".
+    // If no type attribute is specified for <button>, set it to "button".
     // If a type attribute is already specified, do nothing.
     const element = this._getHostElement();
 

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
@@ -201,3 +201,29 @@
 <mat-spinner></mat-spinner>
 <mat-progress-spinner mode="indeterminate" [diameter]="37"></mat-progress-spinner>
 <mat-spinner [strokeWidth]="4"></mat-spinner>
+
+<h2>List</h2>
+<mat-list>
+  <mat-list-item>Robot</mat-list-item>
+  <mat-list-item>Android</mat-list-item>
+  <mat-list-item>Cyborg</mat-list-item>
+</mat-list>
+
+<mat-nav-list>
+  <a mat-list-item href="https://google.com">Search</a>
+  <a mat-list-item href="https://google.com">Find</a>
+  <a mat-list-item href="https://google.com">Seek</a>
+</mat-nav-list>
+
+<mat-action-list>
+  <button mat-list-item>First action</button>
+  <button mat-list-item>Second action</button>
+  <button mat-list-item>Third action</button>
+</mat-action-list>
+
+<mat-selection-list>
+  <h3 mat-subheader>Groceries</h3>
+  <mat-list-option value="apples">Apples</mat-list-option>
+  <mat-list-option value="bananas">Bananas</mat-list-option>
+  <mat-list-option value="oranges">Oranges</mat-list-option>
+</mat-selection-list>

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
@@ -4,6 +4,7 @@ import {MatCardModule} from '@angular/material-experimental/mdc-card';
 import {MatCheckboxModule} from '@angular/material-experimental/mdc-checkbox';
 import {MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
 import {MatInputModule} from '@angular/material-experimental/mdc-input';
+import {MatListModule} from '@angular/material-experimental/mdc-list';
 import {MatProgressBarModule} from '@angular/material-experimental/mdc-progress-bar';
 import {MatChipsModule} from '@angular/material-experimental/mdc-chips';
 import {MatMenuModule} from '@angular/material-experimental/mdc-menu';
@@ -42,6 +43,7 @@ export class KitchenSinkMdc {
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    MatListModule,
     MatMenuModule,
     MatRadioModule,
     MatSlideToggleModule,

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -144,6 +144,11 @@
   <a mat-list-item href="https://google.com">Seek</a>
 </mat-nav-list>
 
+<mat-action-list>
+  <button mat-list-item>First action</button>
+  <button mat-list-item>Second action</button>
+  <button mat-list-item>Third action</button>
+</mat-action-list>
 
 <h2>Menu</h2>
 


### PR DESCRIPTION
Implements the MDC-based selection list. Accessibility and various
other concepts/features of the MDC list have been audited. Issues
have been reported upstream and workarounds where possible and
reasonable have been applied w/ proper comments.

https://github.com/material-components/material-components-web/issues?q=is%3Aissue+author%3Adevversion+mdc-list+.

Also various other remaining tasks for the MDC-based list have
been completed/resolved, except for implementing the dense attribute.
It's unclear yet how that can work out.