### PR TITLE
fix(ListKeyManager): Unset activeItem if it is removed from items

### DIFF
--- a/src/cdk/a11y/key-manager/list-key-manager.spec.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.spec.ts
@@ -114,6 +114,18 @@ describe('Key managers', () => {
       expect(keyManager.activeItem).toBeNull();
     });
 
+    it('should reset the activeItem to null if it is removed from the QueryList', () => {
+      expect(keyManager.activeItemIndex).toBe(0);
+      expect(keyManager.activeItem!.getLabel()).toBe('one');
+
+      itemList.items.splice(0);
+      itemList.notifyOnChanges();
+
+      expect(keyManager.activeItemIndex).toBe(-1);
+      expect(keyManager.activeItem).toBeNull();
+
+    });
+
     describe('Key events', () => {
 
       it('should emit tabOut when the tab key is pressed', () => {

--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -72,6 +72,9 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
 
           if (newIndex > -1 && newIndex !== this._activeItemIndex) {
             this._activeItemIndex = newIndex;
+          } else {
+            this._activeItemIndex = -1;
+            this._activeItem = null;
           }
         }
       });


### PR DESCRIPTION
If the items QueryList changes such the previous activeItem is no
longer in it, reset activeItem and activeItemIndex to null and -1.
This will allow code like:
if (keyManager.activeItem) {
  // Do something with the active item
}
to work properly by not operating on an item that has been removed.