### PR TITLE
refactor: change templateUrl and styleUrls to use absolute paths

### DIFF
--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -46,7 +46,7 @@ export function throwDialogContentAlreadyAttachedError() {
  */
 @Component({
   selector: 'cdk-dialog-container',
-  templateUrl: './dialog-container.html',
+  templateUrl: 'dialog-container.html',
   styleUrls: ['dialog-container.css'],
   encapsulation: ViewEncapsulation.None,
   // Using OnPush for dialogs caused some G3 sync issues. Disabled until we can track them down.

--- a/src/components-examples/cdk/overlay/cdk-overlay-basic/cdk-overlay-basic-example.ts
+++ b/src/components-examples/cdk/overlay/cdk-overlay-basic/cdk-overlay-basic-example.ts
@@ -5,8 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
   selector: 'cdk-overlay-basic-example',
-  templateUrl: './cdk-overlay-basic-example.html',
-  styleUrls: ['./cdk-overlay-basic-example.css'],
+  templateUrl: 'cdk-overlay-basic-example.html',
+  styleUrls: ['cdk-overlay-basic-example.css'],
 })
 export class CdkOverlayBasicExample {
   isOpen = false;

--- a/src/components-examples/cdk/stepper/cdk-custom-stepper-without-form/cdk-custom-stepper-without-form-example.ts
+++ b/src/components-examples/cdk/stepper/cdk-custom-stepper-without-form/cdk-custom-stepper-without-form-example.ts
@@ -1,19 +1,18 @@
-import {Component} from '@angular/core';
 import {CdkStepper} from '@angular/cdk/stepper';
+import {Component} from '@angular/core';
 
 /** @title A custom CDK stepper without a form */
 @Component({
   selector: 'cdk-custom-stepper-without-form-example',
-  templateUrl: './cdk-custom-stepper-without-form-example.html',
-  styleUrls: ['./cdk-custom-stepper-without-form-example.css']
+  templateUrl: 'cdk-custom-stepper-without-form-example.html',
 })
 export class CdkCustomStepperWithoutFormExample {}
 
 /** Custom CDK stepper component */
 @Component({
   selector: 'example-custom-stepper',
-  templateUrl: './example-custom-stepper.html',
-  styleUrls: ['./example-custom-stepper.css'],
+  templateUrl: 'example-custom-stepper.html',
+  styleUrls: ['example-custom-stepper.css'],
   providers: [{ provide: CdkStepper, useExisting: CustomStepper }]
 })
 export class CustomStepper extends CdkStepper {

--- a/src/components-examples/cdk/stepper/cdk-linear-stepper-with-form/cdk-linear-stepper-with-form-example.ts
+++ b/src/components-examples/cdk/stepper/cdk-linear-stepper-with-form/cdk-linear-stepper-with-form-example.ts
@@ -1,12 +1,12 @@
-import {Component} from '@angular/core';
 import {CdkStepper} from '@angular/cdk/stepper';
+import {Component} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
 /** @title A custom CDK linear stepper with forms */
 @Component({
   selector: 'cdk-linear-stepper-with-form-example',
-  templateUrl: './cdk-linear-stepper-with-form-example.html',
-  styleUrls: ['./cdk-linear-stepper-with-form-example.css']
+  templateUrl: 'cdk-linear-stepper-with-form-example.html',
+  styleUrls: ['cdk-linear-stepper-with-form-example.css']
 })
 export class CdkLinearStepperWithFormExample {
   isLinear = true;
@@ -30,8 +30,8 @@ export class CdkLinearStepperWithFormExample {
 /** Custom CDK linear stepper component */
 @Component({
   selector: 'example-custom-linear-stepper',
-  templateUrl: './example-custom-linear-stepper.html',
-  styleUrls: ['./example-custom-linear-stepper.css'],
+  templateUrl: 'example-custom-linear-stepper.html',
+  styleUrls: ['example-custom-linear-stepper.css'],
   providers: [{provide: CdkStepper, useExisting: CustomLinearStepper}]
 })
 export class CustomLinearStepper extends CdkStepper {

--- a/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.ts
+++ b/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.ts
@@ -3,8 +3,8 @@ import {Component} from '@angular/core';
 /** @title Monitoring autofill state with cdkAutofill */
 @Component({
   selector: 'text-field-autofill-directive-example',
-  templateUrl: './text-field-autofill-directive-example.html',
-  styleUrls: ['./text-field-autofill-directive-example.css'],
+  templateUrl: 'text-field-autofill-directive-example.html',
+  styleUrls: ['text-field-autofill-directive-example.css'],
 })
 export class TextFieldAutofillDirectiveExample {
   firstNameAutofilled: boolean;

--- a/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.ts
+++ b/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.ts
@@ -4,8 +4,8 @@ import {AfterViewInit, Component, ElementRef, OnDestroy, ViewChild} from '@angul
 /** @title Monitoring autofill state with AutofillMonitor */
 @Component({
   selector: 'text-field-autofill-monitor-example',
-  templateUrl: './text-field-autofill-monitor-example.html',
-  styleUrls: ['./text-field-autofill-monitor-example.css'],
+  templateUrl: 'text-field-autofill-monitor-example.html',
+  styleUrls: ['text-field-autofill-monitor-example.css'],
 })
 export class TextFieldAutofillMonitorExample implements AfterViewInit, OnDestroy {
   @ViewChild('first', {read: ElementRef}) firstName: ElementRef<HTMLElement>;

--- a/src/components-examples/cdk/text-field/text-field-autosize-textarea/text-field-autosize-textarea-example.ts
+++ b/src/components-examples/cdk/text-field/text-field-autosize-textarea/text-field-autosize-textarea-example.ts
@@ -5,8 +5,8 @@ import {take} from 'rxjs/operators';
 /** @title Auto-resizing textarea */
 @Component({
   selector: 'text-field-autosize-textarea-example',
-  templateUrl: './text-field-autosize-textarea-example.html',
-  styleUrls: ['./text-field-autosize-textarea-example.css'],
+  templateUrl: 'text-field-autosize-textarea-example.html',
+  styleUrls: ['text-field-autosize-textarea-example.css'],
 })
 export class TextFieldAutosizeTextareaExample {
   constructor(private _ngZone: NgZone) {}

--- a/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup} from '@angular/forms';
 import {Observable} from 'rxjs';
-import {startWith, map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
 
 export interface StateGroup {
   letter: string;
@@ -19,7 +19,7 @@ export const _filter = (opt: string[], value: string): string[] => {
  */
 @Component({
   selector: 'autocomplete-optgroup-example',
-  templateUrl: './autocomplete-optgroup-example.html',
+  templateUrl: 'autocomplete-optgroup-example.html',
 })
 
 export class AutocompleteOptgroupExample implements OnInit {

--- a/src/components-examples/material/input/input-clearable/input-clearable-example.ts
+++ b/src/components-examples/material/input/input-clearable/input-clearable-example.ts
@@ -5,8 +5,8 @@ import {Component} from '@angular/core';
  */
 @Component({
   selector: 'input-clearable-example',
-  templateUrl: './input-clearable-example.html',
-  styleUrls: ['./input-clearable-example.css'],
+  templateUrl: 'input-clearable-example.html',
+  styleUrls: ['input-clearable-example.css'],
 })
 export class InputClearableExample {
   value = 'Clear me';

--- a/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.ts
+++ b/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.ts
@@ -13,8 +13,8 @@ export class MyErrorStateMatcher implements ErrorStateMatcher {
 /** @title Input with a custom ErrorStateMatcher */
 @Component({
   selector: 'input-error-state-matcher-example',
-  templateUrl: './input-error-state-matcher-example.html',
-  styleUrls: ['./input-error-state-matcher-example.css'],
+  templateUrl: 'input-error-state-matcher-example.html',
+  styleUrls: ['input-error-state-matcher-example.css'],
 })
 export class InputErrorStateMatcherExample {
   emailFormControl = new FormControl('', [

--- a/src/components-examples/material/slide-toggle/slide-toggle-forms/slide-toggle-forms-example.ts
+++ b/src/components-examples/material/slide-toggle/slide-toggle-forms/slide-toggle-forms-example.ts
@@ -6,8 +6,8 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
  */
 @Component({
   selector: 'slide-toggle-forms-example',
-  templateUrl: './slide-toggle-forms-example.html',
-  styleUrls: ['./slide-toggle-forms-example.css'],
+  templateUrl: 'slide-toggle-forms-example.html',
+  styleUrls: ['slide-toggle-forms-example.css'],
 })
 export class SlideToggleFormsExample {
   isChecked = true;

--- a/src/components-examples/material/table/table-reorderable/table-reorderable-example.ts
+++ b/src/components-examples/material/table/table-reorderable/table-reorderable-example.ts
@@ -1,13 +1,13 @@
-import {Component} from '@angular/core';
 import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
+import {Component} from '@angular/core';
 
 /**
  * @title Table with re-orderable columns
  */
 @Component({
   selector: 'table-reorderable-example',
-  templateUrl: './table-reorderable-example.html',
-  styleUrls: ['./table-reorderable-example.css']
+  templateUrl: 'table-reorderable-example.html',
+  styleUrls: ['table-reorderable-example.css']
 })
 export class TableReorderableExample {
   columns: string[] = ['position', 'name', 'weight', 'symbol'];

--- a/src/dev-app/checkbox/checkbox-demo.ts
+++ b/src/dev-app/checkbox/checkbox-demo.ts
@@ -8,8 +8,8 @@
 
 import {Component, Directive} from '@angular/core';
 import {MAT_CHECKBOX_CLICK_ACTION} from '@angular/material/checkbox';
-import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {ThemePalette} from '@angular/material/core';
+import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 
 export interface Task {
@@ -46,7 +46,7 @@ export class AnimationsNoop {
       margin-bottom: 4px;
     }
   `],
-  templateUrl: './nested-checklist.html',
+  templateUrl: 'nested-checklist.html',
 })
 export class MatCheckboxDemoNestedChecklist {
   tasks: Task[] = [

--- a/src/dev-app/table/table-demo.ts
+++ b/src/dev-app/table/table-demo.ts
@@ -9,6 +9,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  templateUrl: './table-demo.html',
+  templateUrl: 'table-demo.html',
 })
 export class TableDemo {}

--- a/src/material-experimental/mdc-form-field/directives/notched-outline.ts
+++ b/src/material-experimental/mdc-form-field/directives/notched-outline.ts
@@ -30,7 +30,7 @@ import {MDCNotchedOutline} from '@material/notched-outline';
  */
 @Component({
   selector: 'div[matFormFieldNotchedOutline]',
-  templateUrl: './notched-outline.html',
+  templateUrl: 'notched-outline.html',
   host: {
     'class': 'mdc-notched-outline',
     // Besides updating the notch state through the MDC component, we toggle this class through

--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -33,9 +33,9 @@ import {LabelOptions, MAT_LABEL_GLOBAL_OPTIONS, ThemePalette} from '@angular/mat
 import {
   getMatFormFieldDuplicatedHintError,
   getMatFormFieldMissingControlError,
-  MAT_FORM_FIELD,
   matFormFieldAnimations,
   MatFormFieldControl,
+  MAT_FORM_FIELD,
 } from '@angular/material/form-field';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {
@@ -45,14 +45,14 @@ import {
 } from '@material/textfield';
 import {merge, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
-import {MAT_ERROR, MatError} from './directives/error';
+import {MatError, MAT_ERROR} from './directives/error';
 import {MatFormFieldFloatingLabel} from './directives/floating-label';
 import {MatHint} from './directives/hint';
 import {MatLabel} from './directives/label';
 import {MatFormFieldLineRipple} from './directives/line-ripple';
 import {MatFormFieldNotchedOutline} from './directives/notched-outline';
-import {MAT_PREFIX, MatPrefix} from './directives/prefix';
-import {MAT_SUFFIX, MatSuffix} from './directives/suffix';
+import {MatPrefix, MAT_PREFIX} from './directives/prefix';
+import {MatSuffix, MAT_SUFFIX} from './directives/suffix';
 
 /** Type for the available floatLabel values. */
 export type FloatLabelType = 'always' | 'auto';
@@ -95,8 +95,8 @@ const FLOATING_LABEL_DEFAULT_DOCKED_TRANSFORM = `translateY(-50%)`;
 @Component({
   selector: 'mat-form-field',
   exportAs: 'matFormField',
-  templateUrl: './form-field.html',
-  styleUrls: ['./form-field.css'],
+  templateUrl: 'form-field.html',
+  styleUrls: ['form-field.css'],
   animations: [matFormFieldAnimations.transitionMessages],
   host: {
     'class': 'mat-mdc-form-field',

--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -6,32 +6,32 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FocusMonitor, FocusableOption, FocusOrigin} from '@angular/cdk/a11y';
-import {ENTER, SPACE, hasModifierKey} from '@angular/cdk/keycodes';
+import {FocusableOption, FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
+import {ENTER, hasModifierKey, SPACE} from '@angular/cdk/keycodes';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Directive,
   ElementRef,
   Host,
+  Inject,
   Input,
   OnDestroy,
-  ViewEncapsulation,
   Optional,
-  Inject,
-  AfterViewInit,
+  ViewEncapsulation,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {merge, Subscription, EMPTY} from 'rxjs';
+import {EMPTY, merge, Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
+import {MatAccordionTogglePosition} from './accordion-base';
 import {matExpansionAnimations} from './expansion-animations';
 import {
   MatExpansionPanel,
   MatExpansionPanelDefaultOptions,
   MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
 } from './expansion-panel';
-import {MatAccordionTogglePosition} from './accordion-base';
 
 
 /**
@@ -41,8 +41,8 @@ import {MatAccordionTogglePosition} from './accordion-base';
  */
 @Component({
   selector: 'mat-expansion-panel-header',
-  styleUrls: ['./expansion-panel-header.css'],
-  templateUrl: './expansion-panel-header.html',
+  styleUrls: ['expansion-panel-header.css'],
+  templateUrl: 'expansion-panel-header.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -11,6 +11,7 @@ import {CdkAccordionItem} from '@angular/cdk/accordion';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {TemplatePortal} from '@angular/cdk/portal';
+import {DOCUMENT} from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -18,28 +19,27 @@ import {
   Component,
   ContentChild,
   Directive,
-  EventEmitter,
   ElementRef,
-  Input,
+  EventEmitter,
   Inject,
+  InjectionToken,
+  Input,
   OnChanges,
   OnDestroy,
   Optional,
   Output,
   SimpleChanges,
   SkipSelf,
+  ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
-  ViewChild,
-  InjectionToken,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
-import {filter, startWith, take, distinctUntilChanged} from 'rxjs/operators';
+import {distinctUntilChanged, filter, startWith, take} from 'rxjs/operators';
+import {MatAccordionBase, MatAccordionTogglePosition, MAT_ACCORDION} from './accordion-base';
 import {matExpansionAnimations} from './expansion-animations';
 import {MatExpansionPanelContent} from './expansion-panel-content';
-import {MAT_ACCORDION, MatAccordionBase, MatAccordionTogglePosition} from './accordion-base';
 
 /** MatExpansionPanel's states. */
 export type MatExpansionPanelState = 'expanded' | 'collapsed';
@@ -76,10 +76,10 @@ export const MAT_EXPANSION_PANEL_DEFAULT_OPTIONS =
  * multiple children of an element with the MatAccordion directive attached.
  */
 @Component({
-  styleUrls: ['./expansion-panel.css'],
+  styleUrls: ['expansion-panel.css'],
   selector: 'mat-expansion-panel',
   exportAs: 'matExpansionPanel',
-  templateUrl: './expansion-panel.html',
+  templateUrl: 'expansion-panel.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   inputs: ['disabled', 'expanded'],

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
@@ -1,21 +1,21 @@
-import {Component, NgModule, ErrorHandler} from '@angular/core';
+import {Component, ErrorHandler, NgModule} from '@angular/core';
 import {MatButtonModule} from '@angular/material-experimental/mdc-button';
 import {MatCardModule} from '@angular/material-experimental/mdc-card';
 import {MatCheckboxModule} from '@angular/material-experimental/mdc-checkbox';
+import {MatChipsModule} from '@angular/material-experimental/mdc-chips';
+import {MatDialog, MatDialogModule} from '@angular/material-experimental/mdc-dialog';
 import {MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
 import {MatInputModule} from '@angular/material-experimental/mdc-input';
-import {MatProgressBarModule} from '@angular/material-experimental/mdc-progress-bar';
-import {MatChipsModule} from '@angular/material-experimental/mdc-chips';
 import {MatMenuModule} from '@angular/material-experimental/mdc-menu';
+import {MatProgressBarModule} from '@angular/material-experimental/mdc-progress-bar';
+import {MatProgressSpinnerModule} from '@angular/material-experimental/mdc-progress-spinner';
 import {MatRadioModule} from '@angular/material-experimental/mdc-radio';
 import {MatSlideToggleModule} from '@angular/material-experimental/mdc-slide-toggle';
 import {MatSliderModule} from '@angular/material-experimental/mdc-slider';
-import {MatTabsModule} from '@angular/material-experimental/mdc-tabs';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material-experimental/mdc-snack-bar';
 import {MatTableModule} from '@angular/material-experimental/mdc-table';
-import {MatDialog, MatDialogModule} from '@angular/material-experimental/mdc-dialog';
+import {MatTabsModule} from '@angular/material-experimental/mdc-tabs';
 import {MatIconModule} from '@angular/material/icon';
-import {MatSnackBarModule, MatSnackBar} from '@angular/material-experimental/mdc-snack-bar';
-import {MatProgressSpinnerModule} from '@angular/material-experimental/mdc-progress-spinner';
 
 @Component({
   template: `<button>Do the thing</button>`
@@ -24,7 +24,7 @@ export class TestEntryComponent {}
 
 @Component({
   selector: 'kitchen-sink-mdc',
-  templateUrl: './kitchen-sink-mdc.html',
+  templateUrl: 'kitchen-sink-mdc.html',
 })
 export class KitchenSinkMdc {
   constructor(dialog: MatDialog) {

--- a/src/universal-app/kitchen-sink/kitchen-sink.ts
+++ b/src/universal-app/kitchen-sink/kitchen-sink.ts
@@ -2,18 +2,22 @@ import {FocusMonitor} from '@angular/cdk/a11y';
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import {ScrollingModule, ViewportRuler} from '@angular/cdk/scrolling';
 import {CdkTableModule, DataSource} from '@angular/cdk/table';
-import {Component, ElementRef, NgModule, ErrorHandler} from '@angular/core';
-import {MatNativeDateModule, MatRippleModule} from '@angular/material/core';
+import {Component, ElementRef, ErrorHandler, NgModule} from '@angular/core';
+import {GoogleMapsModule} from '@angular/google-maps';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
+import {MatBadgeModule} from '@angular/material/badge';
+import {MatBottomSheet, MatBottomSheetModule} from '@angular/material/bottom-sheet';
 import {MatButtonModule} from '@angular/material/button';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {MatCardModule} from '@angular/material/card';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatChipsModule} from '@angular/material/chips';
-import {MatTableModule} from '@angular/material/table';
+import {MatNativeDateModule, MatRippleModule} from '@angular/material/core';
 import {MatDatepickerModule} from '@angular/material/datepicker';
-import {MatDialogModule, MatDialog} from '@angular/material/dialog';
+import {MatDialog, MatDialogModule} from '@angular/material/dialog';
+import {MatDividerModule} from '@angular/material/divider';
 import {MatExpansionModule} from '@angular/material/expansion';
+import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatGridListModule} from '@angular/material/grid-list';
 import {MatIconModule} from '@angular/material/icon';
 import {MatInputModule} from '@angular/material/input';
@@ -25,20 +29,16 @@ import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatRadioModule} from '@angular/material/radio';
 import {MatSelectModule} from '@angular/material/select';
 import {MatSidenavModule} from '@angular/material/sidenav';
-import {MatSliderModule} from '@angular/material/slider';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
-import {MatSnackBarModule, MatSnackBar} from '@angular/material/snack-bar';
+import {MatSliderModule} from '@angular/material/slider';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatSortModule} from '@angular/material/sort';
+import {MatStepperModule} from '@angular/material/stepper';
+import {MatTableModule} from '@angular/material/table';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatTooltipModule} from '@angular/material/tooltip';
-import {MatBottomSheetModule, MatBottomSheet} from '@angular/material/bottom-sheet';
-import {MatBadgeModule} from '@angular/material/badge';
-import {MatDividerModule} from '@angular/material/divider';
-import {MatFormFieldModule} from '@angular/material/form-field';
-import {MatSortModule} from '@angular/material/sort';
-import {MatStepperModule} from '@angular/material/stepper';
 import {YouTubePlayerModule} from '@angular/youtube-player';
-import {GoogleMapsModule} from '@angular/google-maps';
 import {Observable, of as observableOf} from 'rxjs';
 
 export class TableDataSource extends DataSource<any> {
@@ -58,7 +58,7 @@ export class TestEntryComponent {}
 
 @Component({
   selector: 'kitchen-sink',
-  templateUrl: './kitchen-sink.html',
+  templateUrl: 'kitchen-sink.html',
   styles: [`
     .universal-viewport {
       height: 100px;


### PR DESCRIPTION
**Current behavior**:

![Captura de Tela 2020-08-12 às 19 22 04](https://user-images.githubusercontent.com/11965907/90074309-4b6e0b00-dcd1-11ea-871f-5c19c515e7d7.png)
![Captura de Tela 2020-08-12 às 19 22 31](https://user-images.githubusercontent.com/11965907/90074313-4c06a180-dcd1-11ea-940b-9c99670ff28d.png)

With this change, the tab labels become CSS and HTML as usual, instead of the file paths and also the stackblitz folder structure will be correct.