### PR TITLE
docs(expansion-panel): fix duplicate selectors and add missing docume…

### DIFF
--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -6,43 +6,41 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FocusMonitor, FocusableOption, FocusOrigin} from '@angular/cdk/a11y';
-import {ENTER, SPACE, hasModifierKey} from '@angular/cdk/keycodes';
+import {FocusableOption, FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
+import {ENTER, hasModifierKey, SPACE} from '@angular/cdk/keycodes';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Directive,
   ElementRef,
   Host,
+  Inject,
   Input,
   OnDestroy,
-  ViewEncapsulation,
   Optional,
-  Inject,
-  AfterViewInit,
+  ViewEncapsulation,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {merge, Subscription, EMPTY} from 'rxjs';
+import {EMPTY, merge, Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
+import {MatAccordionTogglePosition} from './accordion-base';
 import {matExpansionAnimations} from './expansion-animations';
 import {
   MatExpansionPanel,
   MatExpansionPanelDefaultOptions,
   MAT_EXPANSION_PANEL_DEFAULT_OPTIONS,
 } from './expansion-panel';
-import {MatAccordionTogglePosition} from './accordion-base';
 
 
 /**
- * `<mat-expansion-panel-header>`
- *
- * This component corresponds to the header element of an `<mat-expansion-panel>`.
+ * Header element of a `<mat-expansion-panel>`.
  */
 @Component({
   selector: 'mat-expansion-panel-header',
-  styleUrls: ['./expansion-panel-header.css'],
-  templateUrl: './expansion-panel-header.html',
+  styleUrls: ['expansion-panel-header.css'],
+  templateUrl: 'expansion-panel-header.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
@@ -211,9 +209,7 @@ export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, Focusa
 }
 
 /**
- * `<mat-panel-description>`
- *
- * This directive is to be used inside of the MatExpansionPanelHeader component.
+ * Description element of a `<mat-expansion-panel-header>`.
  */
 @Directive({
   selector: 'mat-panel-description',
@@ -224,9 +220,7 @@ export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, Focusa
 export class MatExpansionPanelDescription {}
 
 /**
- * `<mat-panel-title>`
- *
- * This directive is to be used inside of the MatExpansionPanelHeader component.
+ * Title element of a `<mat-expansion-panel-header>`.
  */
 @Directive({
   selector: 'mat-panel-title',

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -11,6 +11,7 @@ import {CdkAccordionItem} from '@angular/cdk/accordion';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {TemplatePortal} from '@angular/cdk/portal';
+import {DOCUMENT} from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -18,28 +19,27 @@ import {
   Component,
   ContentChild,
   Directive,
-  EventEmitter,
   ElementRef,
-  Input,
+  EventEmitter,
   Inject,
+  InjectionToken,
+  Input,
   OnChanges,
   OnDestroy,
   Optional,
   Output,
   SimpleChanges,
   SkipSelf,
+  ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
-  ViewChild,
-  InjectionToken,
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
-import {filter, startWith, take, distinctUntilChanged} from 'rxjs/operators';
+import {distinctUntilChanged, filter, startWith, take} from 'rxjs/operators';
+import {MatAccordionBase, MatAccordionTogglePosition, MAT_ACCORDION} from './accordion-base';
 import {matExpansionAnimations} from './expansion-animations';
 import {MatExpansionPanelContent} from './expansion-panel-content';
-import {MAT_ACCORDION, MatAccordionBase, MatAccordionTogglePosition} from './accordion-base';
 
 /** MatExpansionPanel's states. */
 export type MatExpansionPanelState = 'expanded' | 'collapsed';
@@ -70,16 +70,14 @@ export const MAT_EXPANSION_PANEL_DEFAULT_OPTIONS =
     new InjectionToken<MatExpansionPanelDefaultOptions>('MAT_EXPANSION_PANEL_DEFAULT_OPTIONS');
 
 /**
- * `<mat-expansion-panel>`
- *
  * This component can be used as a single element to show expandable content, or as one of
  * multiple children of an element with the MatAccordion directive attached.
  */
 @Component({
-  styleUrls: ['./expansion-panel.css'],
+  styleUrls: ['expansion-panel.css'],
   selector: 'mat-expansion-panel',
   exportAs: 'matExpansionPanel',
-  templateUrl: './expansion-panel.html',
+  templateUrl: 'expansion-panel.html',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   inputs: ['disabled', 'expanded'],
@@ -246,6 +244,9 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
   static ngAcceptInputType_disabled: BooleanInput;
 }
 
+/**
+ * Actions of a `<mat-expansion-panel>`.
+ */
 @Directive({
   selector: 'mat-action-row',
   host: {


### PR DESCRIPTION
…ntation

**Current behavior**:
- Selectors are written inside JSDoc unnecessarily as the generated docs pick it through the `selector` attribute, e.g.:
![Captura de Tela 2020-08-12 às 19 58 50](https://user-images.githubusercontent.com/11965907/90076509-4790b780-dcd6-11ea-9a28-56d0d65e9ea6.png)
Note that it results in duplicate selectors in documentation.
- MatExpansionPanelActionRow has no docs;

<hr>

PS: About the changed docs feel free to suggest a more readable description.
