### PR TITLE
Combobox listbox compatible

### DIFF
--- a/src/cdk-experimental/combobox/combobox.spec.ts
+++ b/src/cdk-experimental/combobox/combobox.spec.ts
@@ -379,6 +379,7 @@ describe('Combobox', () => {
     No Value
   </button>
   <div id="other-content"></div>
+
   <ng-template cdkComboboxPanel #panel="cdkComboboxPanel">
     <div dialogContent #dialog="dialogContent" [parentPanel]="panel">
       <input #input>

--- a/src/cdk-experimental/combobox/combobox.spec.ts
+++ b/src/cdk-experimental/combobox/combobox.spec.ts
@@ -373,7 +373,7 @@ describe('Combobox', () => {
 
 @Component({
   template: `
-  <button cdkCombobox #toggleCombobox class="example-combobox"
+  <button cdkCombobox #toggleCombobox class="example-combobox" 
           [cdkComboboxTriggerFor]="panel"
           [openActions]="actions">
     No Value

--- a/src/cdk-experimental/combobox/combobox.spec.ts
+++ b/src/cdk-experimental/combobox/combobox.spec.ts
@@ -373,7 +373,7 @@ describe('Combobox', () => {
 
 @Component({
   template: `
-  <button cdkCombobox #toggleCombobox class="example-combobox" 
+  <button cdkCombobox #toggleCombobox class="example-combobox"
           [cdkComboboxTriggerFor]="panel"
           [openActions]="actions">
     No Value

--- a/src/cdk-experimental/combobox/combobox.ts
+++ b/src/cdk-experimental/combobox/combobox.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 export type OpenAction = 'focus' | 'click' | 'downKey' | 'toggle';
 export type OpenActionInput = OpenAction | OpenAction[] | string | null | undefined;
 

--- a/src/cdk-experimental/listbox/BUILD.bazel
+++ b/src/cdk-experimental/listbox/BUILD.bazel
@@ -10,10 +10,10 @@ ng_module(
     ),
     module_name = "@angular/cdk-experimental/listbox",
     deps = [
+        "//src/cdk-experimental/combobox",
         "//src/cdk/a11y",
         "//src/cdk/collections",
         "//src/cdk/keycodes",
-        "//src/cdk-experimental/combobox",
         "@npm//@angular/forms",
     ],
 )
@@ -26,9 +26,9 @@ ng_test_library(
     ),
     deps = [
         ":listbox",
+        "//src/cdk-experimental/combobox",
         "//src/cdk/keycodes",
         "//src/cdk/testing/private",
-        "//src/cdk-experimental/combobox",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
     ],

--- a/src/cdk-experimental/listbox/BUILD.bazel
+++ b/src/cdk-experimental/listbox/BUILD.bazel
@@ -13,6 +13,7 @@ ng_module(
         "//src/cdk/a11y",
         "//src/cdk/collections",
         "//src/cdk/keycodes",
+        "//src/cdk-experimental/combobox",
         "@npm//@angular/forms",
     ],
 )
@@ -27,6 +28,7 @@ ng_test_library(
         ":listbox",
         "//src/cdk/keycodes",
         "//src/cdk/testing/private",
+        "//src/cdk-experimental/combobox",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
     ],

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -659,6 +659,11 @@ describe('CdkOption and CdkListbox', () => {
       listboxInstance.writeValue(['arc', 'stasis']);
       fixture.detectChanges();
 
+      const selectedValues = listboxInstance.getSelectedValues();
+      expect(selectedValues.length).toBe(2);
+      expect(selectedValues[0]).toBe('arc');
+      expect(selectedValues[1]).toBe('stasis');
+
       expect(optionElements[0].hasAttribute('aria-selected')).toBeFalse();
       expect(optionElements[1].hasAttribute('aria-selected')).toBeFalse();
 

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '@angular/cdk/testing/private';
 import {A, DOWN_ARROW, END, HOME, SPACE} from '@angular/cdk/keycodes';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {CdkCombobox, CdkComboboxModule} from "@angular/cdk-experimental/combobox";
+import {CdkCombobox, CdkComboboxModule} from '@angular/cdk-experimental/combobox';
 
 
 describe('CdkOption and CdkListbox', () => {

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -880,42 +880,6 @@ describe('CdkOption and CdkListbox', () => {
       expect(comboboxInstance.isOpen()).toBeTrue();
       expect(comboboxInstance.value).toBeUndefined();
     });
-
-    it('should not update combobox if the listbox or option is disabled', () => {
-      expect(comboboxInstance.value).toBeUndefined();
-      expect(comboboxInstance.isOpen()).toBeFalse();
-
-      dispatchMouseEvent(comboboxElement, 'click');
-      fixture.detectChanges();
-
-      listbox = fixture.debugElement.query(By.directive(CdkListbox));
-      listboxInstance = listbox.injector.get<CdkListbox<unknown>>(CdkListbox);
-      listboxElement = listbox.nativeElement;
-
-      options = fixture.debugElement.queryAll(By.directive(CdkOption));
-      optionInstances = options.map(o => o.injector.get<CdkOption>(CdkOption));
-      optionElements = options.map(o => o.nativeElement);
-
-      expect(comboboxInstance.isOpen()).toBeTrue();
-      testComponent.isDisabled = true;
-      fixture.detectChanges();
-
-      dispatchMouseEvent(optionElements[0], 'click');
-      fixture.detectChanges();
-
-      expect(comboboxInstance.isOpen()).toBeTrue();
-      expect(comboboxInstance.value).toBeUndefined();
-
-      testComponent.isDisabled = false;
-      optionInstances[0].disabled = true;
-      fixture.detectChanges();
-
-      dispatchMouseEvent(optionElements[0], 'click');
-      fixture.detectChanges();
-
-      expect(comboboxInstance.isOpen()).toBeTrue();
-      expect(comboboxInstance.value).toBeUndefined();
-    });
   });
 });
 
@@ -1022,7 +986,7 @@ class ListboxControlValueAccessor {
   template: `
     <button cdkCombobox #toggleCombobox class="example-combobox"
             [cdkComboboxTriggerFor]="panel"
-            [openActions]="'focus'">
+            [openActions]="'click'">
       No Value
     </button>
 

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -770,7 +770,8 @@ describe('CdkOption and CdkListbox', () => {
     let testComponent: ListboxInsideCombobox;
 
     let listbox: DebugElement;
-    let listboxInstance: CdkListbox<string>;
+    let listboxInstance: CdkListbox<unknown>;
+    let listboxElement: HTMLElement;
 
     let combobox: DebugElement;
     let comboboxInstance: CdkCombobox<string>;
@@ -799,7 +800,7 @@ describe('CdkOption and CdkListbox', () => {
 
     });
 
-    fit('should update combobox value on selection of an option', () => {
+    it('should update combobox value on selection of an option', () => {
       expect(comboboxInstance.value).toBeUndefined();
       expect(comboboxInstance.isOpen()).toBeFalse();
 
@@ -807,7 +808,7 @@ describe('CdkOption and CdkListbox', () => {
       fixture.detectChanges();
 
       listbox = fixture.debugElement.query(By.directive(CdkListbox));
-      listboxInstance = listbox.injector.get<CdkListbox<string>>(CdkListbox);
+      listboxInstance = listbox.injector.get<CdkListbox<unknown>>(CdkListbox);
 
       options = fixture.debugElement.queryAll(By.directive(CdkOption));
       optionInstances = options.map(o => o.injector.get<CdkOption>(CdkOption));
@@ -820,6 +821,95 @@ describe('CdkOption and CdkListbox', () => {
 
       expect(comboboxInstance.isOpen()).toBeFalse();
       expect(comboboxInstance.value).toBe('purple');
+    });
+
+    it('should update combobox value on selection via keyboard', () => {
+      expect(comboboxInstance.value).toBeUndefined();
+      expect(comboboxInstance.isOpen()).toBeFalse();
+
+      dispatchMouseEvent(comboboxElement, 'click');
+      fixture.detectChanges();
+
+      listbox = fixture.debugElement.query(By.directive(CdkListbox));
+      listboxInstance = listbox.injector.get<CdkListbox<unknown>>(CdkListbox);
+      listboxElement = listbox.nativeElement;
+
+      options = fixture.debugElement.queryAll(By.directive(CdkOption));
+      optionInstances = options.map(o => o.injector.get<CdkOption>(CdkOption));
+      optionElements = options.map(o => o.nativeElement);
+
+      expect(comboboxInstance.isOpen()).toBeTrue();
+
+      listboxInstance.setActiveOption(optionInstances[1]);
+      dispatchKeyboardEvent(listboxElement, 'keydown', SPACE);
+      fixture.detectChanges();
+
+      expect(comboboxInstance.isOpen()).toBeFalse();
+      expect(comboboxInstance.value).toBe('solar');
+    });
+
+    it('should not update combobox if listbox is in multiple mode', () => {
+      expect(comboboxInstance.value).toBeUndefined();
+      expect(comboboxInstance.isOpen()).toBeFalse();
+
+      dispatchMouseEvent(comboboxElement, 'click');
+      fixture.detectChanges();
+
+      listbox = fixture.debugElement.query(By.directive(CdkListbox));
+      listboxInstance = listbox.injector.get<CdkListbox<unknown>>(CdkListbox);
+      listboxElement = listbox.nativeElement;
+
+      testComponent.isMultiselectable = true;
+      fixture.detectChanges();
+
+      options = fixture.debugElement.queryAll(By.directive(CdkOption));
+      optionInstances = options.map(o => o.injector.get<CdkOption>(CdkOption));
+      optionElements = options.map(o => o.nativeElement);
+
+      expect(comboboxInstance.isOpen()).toBeTrue();
+
+      listboxInstance.setActiveOption(optionInstances[1]);
+      dispatchKeyboardEvent(listboxElement, 'keydown', SPACE);
+      fixture.detectChanges();
+
+      expect(comboboxInstance.isOpen()).toBeTrue();
+      expect(comboboxInstance.value).toBeUndefined();
+    });
+
+    it('should not update combobox if the listbox or option is disabled', () => {
+      expect(comboboxInstance.value).toBeUndefined();
+      expect(comboboxInstance.isOpen()).toBeFalse();
+
+      dispatchMouseEvent(comboboxElement, 'click');
+      fixture.detectChanges();
+
+      listbox = fixture.debugElement.query(By.directive(CdkListbox));
+      listboxInstance = listbox.injector.get<CdkListbox<unknown>>(CdkListbox);
+      listboxElement = listbox.nativeElement;
+
+      options = fixture.debugElement.queryAll(By.directive(CdkOption));
+      optionInstances = options.map(o => o.injector.get<CdkOption>(CdkOption));
+      optionElements = options.map(o => o.nativeElement);
+
+      expect(comboboxInstance.isOpen()).toBeTrue();
+      testComponent.isDisabled = true;
+      fixture.detectChanges();
+
+      dispatchMouseEvent(optionElements[0], 'click');
+      fixture.detectChanges();
+
+      expect(comboboxInstance.isOpen()).toBeTrue();
+      expect(comboboxInstance.value).toBeUndefined();
+
+      testComponent.isDisabled = false;
+      optionInstances[0].disabled = true;
+      fixture.detectChanges();
+
+      dispatchMouseEvent(optionElements[0], 'click');
+      fixture.detectChanges();
+
+      expect(comboboxInstance.isOpen()).toBeTrue();
+      expect(comboboxInstance.value).toBeUndefined();
     });
   });
 });

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -286,9 +286,9 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
     this.registerWithPanel();
 
     this.optionSelectionChanges.subscribe(event => {
+      this._emitChangeEvent(event.source);
       this._updateSelectionModel(event.source);
       this.setActiveOption(event.source);
-      this._emitChangeEvent(event.source);
       this._updatePanel(event.source);
     });
   }

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -22,7 +22,7 @@ import {SelectionChange, SelectionModel} from '@angular/cdk/collections';
 import {defer, merge, Observable, Subject} from 'rxjs';
 import {startWith, switchMap, takeUntil} from 'rxjs/operators';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {CdkComboboxPanel} from "@angular/cdk-experimental/combobox";
+import {CdkComboboxPanel} from '@angular/cdk-experimental/combobox';
 
 let nextId = 0;
 let listboxId = 0;
@@ -288,7 +288,7 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   ngAfterContentInit() {
     this._initKeyManager();
     this._initSelectionModel();
-    this.registerWithPanel();
+    this._registerWithPanel();
 
     this.optionSelectionChanges.subscribe(event => {
       this._emitChangeEvent(event.source);
@@ -304,7 +304,7 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
     this._destroyed.complete();
   }
 
-  private registerWithPanel(): void {
+  private _registerWithPanel(): void {
     if (this._parentPanel === null || this._parentPanel === undefined) {
       if (this._explicitPanel !== null && this._explicitPanel !== undefined) {
         this._explicitPanel._registerContent(this.id, 'listbox');
@@ -396,7 +396,8 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
           this._explicitPanel.closePanel(data);
         }
       } else {
-        option.selected ? this._parentPanel.closePanel(option.value) : this._parentPanel.closePanel();
+        option.selected ?
+            this._parentPanel.closePanel(option.value) : this._parentPanel.closePanel();
       }
     }
   }

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -11,7 +11,7 @@ import {
   ContentChildren,
   Directive,
   ElementRef, EventEmitter, forwardRef,
-  Inject,
+  Inject, InjectionToken,
   Input, OnDestroy, OnInit, Optional, Output,
   QueryList
 } from '@angular/core';
@@ -32,6 +32,8 @@ export const CDK_LISTBOX_VALUE_ACCESSOR: any = {
   useExisting: forwardRef(() => CdkListbox),
   multi: true
 };
+
+export const PANEL = new InjectionToken<CdkComboboxPanel>('CdkComboboxPanel');
 
 @Directive({
   selector: '[cdkOption]',
@@ -271,7 +273,7 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   @Input('parentPanel') private readonly _explicitPanel: CdkComboboxPanel;
 
   constructor(
-      @Optional() readonly _parentPanel?: CdkComboboxPanel<T>,
+      @Optional() @Inject(PANEL) readonly _parentPanel?: CdkComboboxPanel<T>,
   ) { }
 
   ngOnInit() {

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -305,13 +305,8 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   }
 
   private _registerWithPanel(): void {
-    if (this._parentPanel === null || this._parentPanel === undefined) {
-      if (this._explicitPanel !== null && this._explicitPanel !== undefined) {
-        this._explicitPanel._registerContent(this.id, 'listbox');
-      }
-    } else {
-      this._parentPanel._registerContent(this.id, 'listbox');
-    }
+    const panel = this._parentPanel || this._explicitPanel;
+    panel?._registerContent(this.id, 'listbox');
   }
 
   private _initKeyManager() {
@@ -389,16 +384,9 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   }
 
   _updatePanel(option: CdkOption<T>) {
-    const data = option.selected ? option.value : null;
     if (!this.multiple) {
-      if (this._parentPanel === null || this._parentPanel === undefined) {
-        if (this._explicitPanel !== null && this._explicitPanel !== undefined) {
-          this._explicitPanel.closePanel(data);
-        }
-      } else {
-        option.selected ?
-            this._parentPanel.closePanel(option.value) : this._parentPanel.closePanel();
-      }
+      const panel = this._parentPanel || this._explicitPanel;
+      option.selected ? panel?.closePanel(option.value) : panel?.closePanel();
     }
   }
 
@@ -427,10 +415,6 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
 
     if (!this.useActiveDescendant) {
       this._activeOption.focus();
-    } else {
-      if (document.activeElement === this._activeOption.getElementRef().nativeElement) {
-        this._elementRef.nativeElement.focus();
-      }
     }
   }
 

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -294,7 +294,7 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
       this._emitChangeEvent(event.source);
       this._updateSelectionModel(event.source);
       this.setActiveOption(event.source);
-      this._updatePanel(event.source);
+      this._updatePanelForSelection(event.source);
     });
   }
 
@@ -383,7 +383,7 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
                       this._selectionModel.deselect(option);
   }
 
-  _updatePanel(option: CdkOption<T>) {
+  _updatePanelForSelection(option: CdkOption<T>) {
     if (!this.multiple) {
       const panel = this._parentPanel || this._explicitPanel;
       option.selected ? panel?.closePanel(option.value) : panel?.closePanel();

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -12,7 +12,7 @@ import {
   Directive,
   ElementRef, EventEmitter, forwardRef,
   Inject,
-  Input, OnDestroy, OnInit, Output,
+  Input, OnDestroy, OnInit, Optional, Output,
   QueryList
 } from '@angular/core';
 import {ActiveDescendantKeyManager, Highlightable, ListKeyManagerOption} from '@angular/cdk/a11y';
@@ -22,8 +22,10 @@ import {SelectionChange, SelectionModel} from '@angular/cdk/collections';
 import {defer, merge, Observable, Subject} from 'rxjs';
 import {startWith, switchMap, takeUntil} from 'rxjs/operators';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {CdkComboboxPanel} from "@angular/cdk-experimental/combobox";
 
 let nextId = 0;
+let listboxId = 0;
 
 export const CDK_LISTBOX_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -191,6 +193,7 @@ export class CdkOption<T = unknown> implements ListKeyManagerOption, Highlightab
   exportAs: 'cdkListbox',
   host: {
     'role': 'listbox',
+    '[id]': 'id',
     '(keydown)': '_keydown($event)',
     '[attr.tabindex]': '_tabIndex',
     '[attr.aria-disabled]': 'disabled',
@@ -231,6 +234,8 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   @Output() readonly selectionChange: EventEmitter<ListboxSelectionChangeEvent<T>> =
       new EventEmitter<ListboxSelectionChangeEvent<T>>();
 
+  @Input() id = `cdk-option-${listboxId++}`;
+
   /**
    * Whether the listbox allows multiple options to be selected.
    * If `multiple` switches from `true` to `false`, all options are deselected.
@@ -263,6 +268,12 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
 
   @Input() compareWith: (o1: T, o2: T) => boolean = (a1, a2) => a1 === a2;
 
+  @Input('parentPanel') private readonly _explicitPanel: CdkComboboxPanel;
+
+  constructor(
+      @Optional() readonly _parentPanel?: CdkComboboxPanel<T>,
+  ) { }
+
   ngOnInit() {
     this._selectionModel = new SelectionModel<CdkOption<T>>(this.multiple);
   }
@@ -270,11 +281,13 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   ngAfterContentInit() {
     this._initKeyManager();
     this._initSelectionModel();
+    this.registerWithPanel();
 
     this.optionSelectionChanges.subscribe(event => {
-      this._emitChangeEvent(event.source);
       this._updateSelectionModel(event.source);
       this.setActiveOption(event.source);
+      this._emitChangeEvent(event.source);
+      this._updatePanel(event.source);
     });
   }
 
@@ -282,6 +295,16 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
     this._listKeyManager.change.complete();
     this._destroyed.next();
     this._destroyed.complete();
+  }
+
+  private registerWithPanel(): void {
+    if (this._parentPanel === null || this._parentPanel === undefined) {
+      if (this._explicitPanel !== null && this._explicitPanel !== undefined) {
+        this._explicitPanel._registerContent(this.id, 'listbox');
+      }
+    } else {
+      this._parentPanel._registerContent(this.id, 'listbox');
+    }
   }
 
   private _initKeyManager() {
@@ -356,6 +379,19 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
 
     option.selected ? this._selectionModel.select(option) :
                       this._selectionModel.deselect(option);
+  }
+
+  _updatePanel(option: CdkOption<T>) {
+    const data = option.selected ? option.value : null;
+    if (!this.multiple) {
+      if (this._parentPanel === null || this._parentPanel === undefined) {
+        if (this._explicitPanel !== null && this._explicitPanel !== undefined) {
+          this._explicitPanel.closePanel(data);
+        }
+      } else {
+        option.selected ? this._parentPanel.closePanel(option.value) : this._parentPanel.closePanel();
+      }
+    }
   }
 
   /** Toggles the selected state of the active option if not disabled. */

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -176,6 +176,10 @@ export class CdkOption<T = unknown> implements ListKeyManagerOption, Highlightab
     }
   }
 
+  getElementRef() {
+    return this._elementRef;
+  }
+
   /** Sets the active property to true to enable the active css class. */
   setActiveStyles() {
     this._active = true;
@@ -273,6 +277,7 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   @Input('parentPanel') private readonly _explicitPanel: CdkComboboxPanel;
 
   constructor(
+      private readonly _elementRef: ElementRef,
       @Optional() @Inject(PANEL) readonly _parentPanel?: CdkComboboxPanel<T>,
   ) { }
 
@@ -421,6 +426,10 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
 
     if (!this.useActiveDescendant) {
       this._activeOption.focus();
+    } else {
+      if (document.activeElement === this._activeOption.getElementRef().nativeElement) {
+        this._elementRef.nativeElement.focus();
+      }
     }
   }
 
@@ -458,6 +467,7 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   /** Updates the key manager's active item to the given option. */
   setActiveOption(option: CdkOption<T>) {
     this._listKeyManager.updateActiveItem(option);
+    this._updateActiveOption();
   }
 
   /**
@@ -486,6 +496,11 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
   /** Disables the select. Required to implement ControlValueAccessor. */
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
+  }
+
+  /** Returns the values of the currently selected options. */
+  getSelectedValues(): T[] {
+    return this._options.filter(option => option.selected).map(option => option.value);
   }
 
   /** Selects an option that has the corresponding given value. */

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -276,10 +276,7 @@ export class CdkListbox<T> implements AfterContentInit, OnDestroy, OnInit, Contr
 
   @Input('parentPanel') private readonly _explicitPanel: CdkComboboxPanel;
 
-  constructor(
-      private readonly _elementRef: ElementRef,
-      @Optional() @Inject(PANEL) readonly _parentPanel?: CdkComboboxPanel<T>,
-  ) { }
+  constructor(@Optional() @Inject(PANEL) readonly _parentPanel?: CdkComboboxPanel<T>) { }
 
   ngOnInit() {
     this._selectionModel = new SelectionModel<CdkOption<T>>(this.multiple);

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -26,7 +26,6 @@ ng_module(
         "//src/dev-app/cdk-experimental-combobox",
         "//src/dev-app/cdk-experimental-listbox",
         "//src/dev-app/cdk-experimental-menu",
-        "//src/dev-app/cdk-experimental-listbox",
         "//src/dev-app/checkbox",
         "//src/dev-app/chips",
         "//src/dev-app/clipboard",

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -26,6 +26,7 @@ ng_module(
         "//src/dev-app/cdk-experimental-combobox",
         "//src/dev-app/cdk-experimental-listbox",
         "//src/dev-app/cdk-experimental-menu",
+        "//src/dev-app/cdk-experimental-listbox",
         "//src/dev-app/checkbox",
         "//src/dev-app/chips",
         "//src/dev-app/clipboard",


### PR DESCRIPTION
Added logic necessary for CdkListbox to be used inside CdkComboboxPanel and be ready to communicate with its parent panel without any additional directives. Currently some changes exist that are already in another approved PR. Will rebase after that PR is merged.