### PR TITLE
build: use new labeling and branching in merge script

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@angular/bazel": "^10.0.8",
     "@angular/benchpress": "^0.2.1",
     "@angular/compiler-cli": "^10.0.8",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#0612a30aaf7a7e7eb2a4a5a9fa0f58622ce59590",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#d0855af987db4e426477da1780bcd02941c31271",
     "@angular/platform-browser-dynamic": "^10.0.8",
     "@angular/platform-server": "^10.0.8",
     "@angular/router": "^10.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,9 +135,9 @@
   dependencies:
     tslib "^1.9.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#0612a30aaf7a7e7eb2a4a5a9fa0f58622ce59590":
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#d0855af987db4e426477da1780bcd02941c31271":
   version "0.0.0"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#0612a30aaf7a7e7eb2a4a5a9fa0f58622ce59590"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#d0855af987db4e426477da1780bcd02941c31271"
   dependencies:
     "@angular/benchpress" "0.2.0"
     "@octokit/graphql" "^4.3.1"
@@ -149,6 +149,7 @@
     inquirer "^7.1.0"
     minimatch "^3.0.4"
     multimatch "^4.0.0"
+    node-fetch "^2.6.0"
     node-uuid "1.4.8"
     semver "^6.3.0"
     shelljs "^0.8.3"


### PR DESCRIPTION
We introduced a new shared configuration for merge script
labels that follow the new proposal:

https://docs.google.com/document/d/197kVillDwx-RZtSVOBtPb4BBIAw0E9RT3q3v6DZkykU

These label semantics and the new branching are set up for the Angular
Components repository with this commit. The goal is that labeling and
merging is consistent between all Angular projects and that clear rules
are defined for branching/labeling. This was previously not the case