### PR TITLE
fix(cdk-experimental/menu): do not allow two separate triggers to open the same menu

### DIFF
--- a/src/cdk-experimental/menu/context-menu.spec.ts
+++ b/src/cdk-experimental/menu/context-menu.spec.ts
@@ -1,4 +1,4 @@
-import {Component, ViewChild, ElementRef} from '@angular/core';
+import {Component, ViewChild, ElementRef, Type} from '@angular/core';
 import {CdkMenuModule} from './menu-module';
 import {TestBed, async, ComponentFixture} from '@angular/core/testing';
 import {CdkMenu} from './menu';
@@ -351,6 +351,29 @@ describe('CdkContextMenuTrigger', () => {
       expect(getFileMenu()).not.toBeDefined();
     });
   });
+
+  describe('with shared triggered menu', () => {
+    /**
+     * Return a function which builds the given component and renders it.
+     * @param componentClass the component to create
+     */
+    function createComponent<T>(componentClass: Type<T>) {
+      return function () {
+        TestBed.configureTestingModule({
+          imports: [CdkMenuModule],
+          declarations: [componentClass],
+        }).compileComponents();
+
+        TestBed.createComponent(componentClass).detectChanges();
+      };
+    }
+
+    it('should throw an error if context and menubar trigger share a menu', () => {
+      expect(createComponent(MenuBarAndContextTriggerShareMenu)).toThrowError(
+        /CdkMenuPanel is already referenced by different CdkMenuTrigger/
+      );
+    });
+  });
 });
 
 @Component({
@@ -457,3 +480,20 @@ class ContextMenuWithMenuBarAndInlineMenu {
   @ViewChild('inline_menu') nativeInlineMenu: ElementRef;
   @ViewChild('inline_menu_button') nativeInlineMenuButton: ElementRef;
 }
+
+@Component({
+  template: `
+    <div cdkMenuBar>
+      <button cdkMenuItem [cdkMenuTriggerFor]="menu">First</button>
+    </div>
+
+    <div [cdkContextMenuTriggerFor]="menu"></div>
+
+    <ng-template cdkMenuPanel #menu="cdkMenuPanel">
+      <div cdkMenu [cdkMenuPanel]="menu">
+        <button cdkMenuItem></button>
+      </div>
+    </ng-template>
+  `,
+})
+class MenuBarAndContextTriggerShareMenu {}

--- a/src/cdk-experimental/menu/menu-errors.ts
+++ b/src/cdk-experimental/menu/menu-errors.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Throws an exception when a menu panel already has a menu stack.
+ * @docs-private
+ */
+export function throwExistingMenuStackError() {
+  throw Error(
+    'CdkMenuPanel is already referenced by different CdkMenuTrigger. Ensure that a menu is' +
+      ' opened by a single trigger only.'
+  );
+}

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -125,7 +125,7 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, OnDestroy
     }
 
     // don't set the tabindex if there are no open sibling or parent menus
-    if (!event || (event && !this._getMenuStack().isEmpty())) {
+    if (!event || !this._getMenuStack()?.isEmpty()) {
       this._tabindex = 0;
     }
   }
@@ -142,7 +142,7 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, OnDestroy
   trigger() {
     if (!this.disabled && !this.hasMenu()) {
       this.triggered.next();
-      this._getMenuStack().closeAll();
+      this._getMenuStack()?.closeAll();
     }
   }
 
@@ -202,8 +202,8 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, OnDestroy
         if (this._isParentVertical() && !this.hasMenu()) {
           event.preventDefault();
           this._dir?.value === 'rtl'
-            ? this._getMenuStack().close(this._parentMenu, FocusNext.previousItem)
-            : this._getMenuStack().closeAll(FocusNext.nextItem);
+            ? this._getMenuStack()?.close(this._parentMenu, FocusNext.previousItem)
+            : this._getMenuStack()?.closeAll(FocusNext.nextItem);
         }
         break;
 
@@ -211,8 +211,8 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, OnDestroy
         if (this._isParentVertical() && !this.hasMenu()) {
           event.preventDefault();
           this._dir?.value === 'rtl'
-            ? this._getMenuStack().closeAll(FocusNext.nextItem)
-            : this._getMenuStack().close(this._parentMenu, FocusNext.previousItem);
+            ? this._getMenuStack()?.closeAll(FocusNext.nextItem)
+            : this._getMenuStack()?.close(this._parentMenu, FocusNext.previousItem);
         }
         break;
     }
@@ -226,11 +226,11 @@ export class CdkMenuItem implements FocusableOption, FocusableElement, OnDestroy
     this._ngZone.runOutsideAngular(() =>
       fromEvent(this._elementRef.nativeElement, 'mouseenter')
         .pipe(
-          filter(() => !this._getMenuStack().isEmpty() && !this.hasMenu()),
+          filter(() => !this._getMenuStack()?.isEmpty() && !this.hasMenu()),
           takeUntil(this._destroyed)
         )
         .subscribe(() => {
-          this._ngZone.run(() => this._getMenuStack().closeSubMenuOf(this._parentMenu));
+          this._ngZone.run(() => this._getMenuStack()?.closeSubMenuOf(this._parentMenu));
         })
     );
   }

--- a/src/cdk-experimental/menu/menu-panel.ts
+++ b/src/cdk-experimental/menu/menu-panel.ts
@@ -20,7 +20,7 @@ export class CdkMenuPanel {
   _menu?: Menu;
 
   /** Keep track of open Menus. */
-  _menuStack: MenuStack;
+  _menuStack: MenuStack | null;
 
   constructor(readonly _templateRef: TemplateRef<unknown>) {}
 
@@ -35,6 +35,6 @@ export class CdkMenuPanel {
     // inject the menu stack reference into the child menu and menu items, however this isn't
     // possible at this time.
     this._menu._menuStack = this._menuStack;
-    this._menuStack.push(child);
+    this._menuStack?.push(child);
   }
 }

--- a/src/cdk-experimental/menu/menu-stack.ts
+++ b/src/cdk-experimental/menu/menu-stack.ts
@@ -20,7 +20,7 @@ export const enum FocusNext {
  */
 export interface MenuStackItem {
   /** A reference to the previous Menus MenuStack instance. */
-  _menuStack: MenuStack;
+  _menuStack: MenuStack | null;
 }
 
 /**


### PR DESCRIPTION
Fixes the error where two different menu triggers open the same menu which leads to open menus not
closing out on hover and other inconsistent behaviour. Opt to throw and error and not allow two
triggers to share a menu.