### PR TITLE
test(datepicker/testing): fix test failure

### DIFF
--- a/src/material/datepicker/testing/calendar-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/calendar-harness-shared.spec.ts
@@ -2,7 +2,12 @@ import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatDatepickerModule, DateRange} from '@angular/material/datepicker';
+import {
+  MatDatepickerModule,
+  DateRange,
+  MAT_DATE_RANGE_SELECTION_STRATEGY,
+  DefaultMatCalendarRangeStrategy,
+} from '@angular/material/datepicker';
 import {MatNativeDateModule} from '@angular/material/core';
 import {MatCalendarHarness, CalendarView} from './calendar-harness';
 
@@ -20,6 +25,12 @@ export function runCalendarHarnessTests(
     await TestBed.configureTestingModule({
       imports: [MatNativeDateModule, datepickerModule],
       declarations: [CalendarHarnessTest],
+      providers: [{
+        // Usually it's the date range picker that provides the default range selection strategy,
+        // but since we're testing the calendar on its own, we have to provide it manually.
+        provide: MAT_DATE_RANGE_SELECTION_STRATEGY,
+        useClass: DefaultMatCalendarRangeStrategy
+      }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CalendarHarnessTest);


### PR DESCRIPTION
Fixes a test failure that is due to a previous fix getting in around the same time as the datepicker harnesses. The problem is that the fix moved the default range selection strategy from the calendar to the range picker which in turn broke the harness unit tests, because they test a standalone calendar.

These changes fix the issue by providing a strategy manually for the tests.