### PR TITLE
feat(material-experimental): add test harnesses for mdc-core and mdc-autocomplete

### DIFF
--- a/src/material-experimental/config.bzl
+++ b/src/material-experimental/config.bzl
@@ -10,6 +10,7 @@ entryPoints = [
     "mdc-chips",
     "mdc-chips/testing",
     "mdc-core",
+    "mdc-core/testing",
     "mdc-dialog",
     "mdc-dialog/testing",
     "mdc-form-field",

--- a/src/material-experimental/config.bzl
+++ b/src/material-experimental/config.bzl
@@ -1,6 +1,7 @@
 entryPoints = [
     "column-resize",
     "mdc-autocomplete",
+    "mdc-autocomplete/testing",
     "mdc-button",
     "mdc-button/testing",
     "mdc-card",

--- a/src/material-experimental/mdc-autocomplete/autocomplete-trigger.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete-trigger.ts
@@ -24,7 +24,7 @@ export const MAT_AUTOCOMPLETE_VALUE_ACCESSOR: any = {
 @Directive({
   selector: `input[matAutocomplete], textarea[matAutocomplete]`,
   host: {
-    'class': 'mat-autocomplete-trigger',
+    'class': 'mat-mdc-autocomplete-trigger',
     '[attr.autocomplete]': 'autocompleteAttribute',
     '[attr.role]': 'autocompleteDisabled ? null : "combobox"',
     '[attr.aria-autocomplete]': 'autocompleteDisabled ? null : "list"',

--- a/src/material-experimental/mdc-autocomplete/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-autocomplete/testing/BUILD.bazel
@@ -1,0 +1,37 @@
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material-experimental/mdc-autocomplete/testing",
+    deps = [
+        "//src/cdk/coercion",
+        "//src/cdk/testing",
+        "//src/material-experimental/mdc-core/testing",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob(["**/*.ts"]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":testing",
+        "//src/material-experimental/mdc-autocomplete",
+        "//src/material/autocomplete/testing:harness_tests_lib",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [":unit_tests_lib"],
+)

--- a/src/material-experimental/mdc-autocomplete/testing/autocomplete-harness-filters.ts
+++ b/src/material-experimental/mdc-autocomplete/testing/autocomplete-harness-filters.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+/** A set of criteria that can be used to filter a list of `MatAutocompleteHarness` instances. */
+export interface AutocompleteHarnessFilters extends BaseHarnessFilters {
+  /** Only find instances whose associated input element matches the given value. */
+  value?: string | RegExp;
+}

--- a/src/material-experimental/mdc-autocomplete/testing/autocomplete-harness.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/testing/autocomplete-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatAutocompleteModule} from '@angular/material-experimental/mdc-autocomplete';
+import {runHarnessTests} from '@angular/material/autocomplete/testing/shared.spec';
+import {MatAutocompleteHarness} from './autocomplete-harness';
+
+describe('MDC-based MatAutocompleteHarness', () => {
+  runHarnessTests(MatAutocompleteModule, MatAutocompleteHarness as any);
+});

--- a/src/material-experimental/mdc-autocomplete/testing/autocomplete-harness.ts
+++ b/src/material-experimental/mdc-autocomplete/testing/autocomplete-harness.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  MatOptgroupHarness,
+  MatOptionHarness,
+  OptgroupHarnessFilters,
+  OptionHarnessFilters
+} from '@angular/material-experimental/mdc-core/testing';
+import {AutocompleteHarnessFilters} from './autocomplete-harness-filters';
+
+/** Harness for interacting with an MDC-based mat-autocomplete in tests. */
+export class MatAutocompleteHarness extends ComponentHarness {
+  private _documentRootLocator = this.documentRootLocatorFactory();
+
+  /** The selector for the host element of a `MatAutocomplete` instance. */
+  static hostSelector = '.mat-mdc-autocomplete-trigger';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatAutocompleteHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which autocomplete instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: AutocompleteHarnessFilters = {}): HarnessPredicate<MatAutocompleteHarness> {
+    return new HarnessPredicate(MatAutocompleteHarness, options)
+        .addOption('value', options.value,
+            (harness, value) => HarnessPredicate.stringMatches(harness.getValue(), value));
+  }
+
+  /** Gets the value of the autocomplete input. */
+  async getValue(): Promise<string> {
+    return (await this.host()).getProperty('value');
+  }
+
+  /** Whether the autocomplete input is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const disabled = (await this.host()).getAttribute('disabled');
+    return coerceBooleanProperty(await disabled);
+  }
+
+  /** Focuses the autocomplete input. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the autocomplete input. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the autocomplete input is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
+  /** Enters text into the autocomplete. */
+  async enterText(value: string): Promise<void> {
+    return (await this.host()).sendKeys(value);
+  }
+
+  /** Gets the options inside the autocomplete panel. */
+  async getOptions(filters: Omit<OptionHarnessFilters, 'ancestor'> = {}):
+    Promise<MatOptionHarness[]> {
+    return this._documentRootLocator.locatorForAll(MatOptionHarness.with({
+      ...filters,
+      ancestor: await this._getPanelSelector()
+    }))();
+  }
+
+  /** Gets the option groups inside the autocomplete panel. */
+  async getOptionGroups(filters: Omit<OptgroupHarnessFilters, 'ancestor'> = {}):
+    Promise<MatOptgroupHarness[]> {
+    return this._documentRootLocator.locatorForAll(MatOptgroupHarness.with({
+      ...filters,
+      ancestor: await this._getPanelSelector()
+    }))();
+  }
+
+  /** Selects the first option matching the given filters. */
+  async selectOption(filters: OptionHarnessFilters): Promise<void> {
+    await this.focus(); // Focus the input to make sure the autocomplete panel is shown.
+    const options = await this.getOptions(filters);
+    if (!options.length) {
+      throw Error(`Could not find a mat-option matching ${JSON.stringify(filters)}`);
+    }
+    await options[0].click();
+  }
+
+  /** Whether the autocomplete is open. */
+  async isOpen(): Promise<boolean> {
+    const panel = await this._getPanel();
+    return !!panel && await panel.hasClass('mat-mdc-autocomplete-visible');
+  }
+
+  /** Gets the panel associated with this autocomplete trigger. */
+  private async _getPanel() {
+    // Technically this is static, but it needs to be in a
+    // function, because the autocomplete's panel ID can changed.
+    return this._documentRootLocator.locatorForOptional(await this._getPanelSelector())();
+  }
+
+  /** Gets the selector that can be used to find the autocomplete trigger's panel. */
+  private async _getPanelSelector(): Promise<string> {
+    return `#${(await (await this.host()).getAttribute('aria-owns'))}`;
+  }
+}

--- a/src/material-experimental/mdc-autocomplete/testing/index.ts
+++ b/src/material-experimental/mdc-autocomplete/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-autocomplete/testing/public-api.ts
+++ b/src/material-experimental/mdc-autocomplete/testing/public-api.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './autocomplete-harness';
+export * from './autocomplete-harness-filters';

--- a/src/material-experimental/mdc-core/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-core/testing/BUILD.bazel
@@ -1,0 +1,35 @@
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material-experimental/mdc-core/testing",
+    deps = [
+        "//src/cdk/testing",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob(["**/*.ts"]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":testing",
+        "//src/material-experimental/mdc-core",
+        "//src/material/core/testing:harness_tests_lib",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [":unit_tests_lib"],
+)

--- a/src/material-experimental/mdc-core/testing/index.ts
+++ b/src/material-experimental/mdc-core/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-core/testing/optgroup-harness-filters.ts
+++ b/src/material-experimental/mdc-core/testing/optgroup-harness-filters.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+export interface OptgroupHarnessFilters extends BaseHarnessFilters {
+  labelText?: string | RegExp;
+}

--- a/src/material-experimental/mdc-core/testing/optgroup-harness.spec.ts
+++ b/src/material-experimental/mdc-core/testing/optgroup-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatOptionModule} from '@angular/material-experimental/mdc-core';
+import {runHarnessTests} from '@angular/material/core/testing/optgroup-shared.spec';
+import {MatOptgroupHarness} from './optgroup-harness';
+
+describe('MDC-based MatOptgroupHarness', () => {
+  runHarnessTests(MatOptionModule, MatOptgroupHarness as any);
+});

--- a/src/material-experimental/mdc-core/testing/optgroup-harness.ts
+++ b/src/material-experimental/mdc-core/testing/optgroup-harness.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {OptgroupHarnessFilters} from './optgroup-harness-filters';
+import {MatOptionHarness} from './option-harness';
+import {OptionHarnessFilters} from './option-harness-filters';
+
+/** Harness for interacting with an MDC-based `mat-optgroup` in tests. */
+export class MatOptgroupHarness extends ComponentHarness {
+  /** Selector used to locate option group instances. */
+  static hostSelector = '.mat-mdc-optgroup';
+  private _label = this.locatorFor('.mat-mdc-optgroup-label');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatOptgroupHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which option instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: OptgroupHarnessFilters = {}) {
+    return new HarnessPredicate(MatOptgroupHarness, options)
+        .addOption('labelText', options.labelText,
+            async (harness, title) =>
+                HarnessPredicate.stringMatches(await harness.getLabelText(), title));
+  }
+
+  /** Gets the option group's label text. */
+  async getLabelText(): Promise<string> {
+    return (await this._label()).text();
+  }
+
+  /** Gets whether the option group is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return (await (await this.host()).getAttribute('aria-disabled')) === 'true';
+  }
+
+  /**
+   * Gets the options that are inside the group.
+   * @param filter Optionally filters which options are included.
+   */
+  async getOptions(filter: OptionHarnessFilters = {}): Promise<MatOptionHarness[]> {
+    return this.locatorForAll(MatOptionHarness.with(filter))();
+  }
+}
+

--- a/src/material-experimental/mdc-core/testing/option-harness-filters.ts
+++ b/src/material-experimental/mdc-core/testing/option-harness-filters.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+export interface OptionHarnessFilters extends BaseHarnessFilters {
+  text?: string | RegExp;
+  isSelected?: boolean;
+}

--- a/src/material-experimental/mdc-core/testing/option-harness.spec.ts
+++ b/src/material-experimental/mdc-core/testing/option-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatOptionModule, MatOption} from '@angular/material-experimental/mdc-core';
+import {runHarnessTests} from '@angular/material/core/testing/option-shared.spec';
+import {MatOptionHarness} from './option-harness';
+
+describe('MDC-based MatOptionHarness', () => {
+  runHarnessTests(MatOptionModule, MatOptionHarness as any, MatOption);
+});

--- a/src/material-experimental/mdc-core/testing/option-harness.ts
+++ b/src/material-experimental/mdc-core/testing/option-harness.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {OptionHarnessFilters} from './option-harness-filters';
+
+/** Harness for interacting with an MDC-based `mat-option` in tests. */
+export class MatOptionHarness extends ComponentHarness {
+  /** Selector used to locate option instances. */
+  static hostSelector = '.mat-mdc-option';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatOptionsHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which option instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: OptionHarnessFilters = {}) {
+    return new HarnessPredicate(MatOptionHarness, options)
+        .addOption('text', options.text,
+            async (harness, title) =>
+                HarnessPredicate.stringMatches(await harness.getText(), title))
+        .addOption('isSelected', options.isSelected,
+            async (harness, isSelected) => await harness.isSelected() === isSelected);
+
+  }
+
+  /** Clicks the option. */
+  async click(): Promise<void> {
+    return (await this.host()).click();
+  }
+
+  /** Gets the option's label text. */
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Gets whether the option is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return (await this.host()).hasClass('mdc-list-item--disabled');
+  }
+
+  /** Gets whether the option is selected. */
+  async isSelected(): Promise<boolean> {
+    return (await this.host()).hasClass('mdc-list-item--selected');
+  }
+
+  /** Gets whether the option is active. */
+  async isActive(): Promise<boolean> {
+    return (await this.host()).hasClass('mat-mdc-option-active');
+  }
+
+  /** Gets whether the option is in multiple selection mode. */
+  async isMultiple(): Promise<boolean> {
+    return (await this.host()).hasClass('mat-mdc-option-multiple');
+  }
+}

--- a/src/material-experimental/mdc-core/testing/public-api.ts
+++ b/src/material-experimental/mdc-core/testing/public-api.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './option-harness';
+export * from './option-harness-filters';
+export * from './optgroup-harness';
+export * from './optgroup-harness-filters';

--- a/src/material/core/testing/option-harness.spec.ts
+++ b/src/material/core/testing/option-harness.spec.ts
@@ -1,7 +1,7 @@
-import {MatOptionModule} from '@angular/material/core';
+import {MatOptionModule, MatOption} from '@angular/material/core';
 import {runHarnessTests} from './option-shared.spec';
 import {MatOptionHarness} from './option-harness';
 
 describe('Non-MDC-based MatOptionHarness', () => {
-  runHarnessTests(MatOptionModule, MatOptionHarness);
+  runHarnessTests(MatOptionModule, MatOptionHarness, MatOption);
 });

--- a/src/material/core/testing/option-shared.spec.ts
+++ b/src/material/core/testing/option-shared.spec.ts
@@ -12,7 +12,9 @@ import {MatOptionHarness} from './option-harness';
 
 /** Shared tests to run on both the original and MDC-based options. */
 export function runHarnessTests(
-    optionModule: typeof MatOptionModule, optionHarness: typeof MatOptionHarness) {
+    optionModule: typeof MatOptionModule,
+    optionHarness: typeof MatOptionHarness,
+    optionComponent: typeof MatOption) {
   let fixture: ComponentFixture<OptionHarnessTest>;
   let loader: HarnessLoader;
 
@@ -102,21 +104,19 @@ export function runHarnessTests(
 
     expect(await option.isMultiple()).toBe(true);
   });
+
+  @Component({
+    providers: [{
+      provide: MAT_OPTION_PARENT_COMPONENT,
+      useExisting: OptionHarnessTest
+    }],
+    template: `
+      <mat-option>Plain option</mat-option>
+      <mat-option disabled>Disabled option</mat-option>
+    `
+  })
+  class OptionHarnessTest implements MatOptionParentComponent {
+    @ViewChildren(optionComponent) options: QueryList<{setActiveStyles(): void}>;
+    multiple = false;
+  }
 }
-
-
-@Component({
-  providers: [{
-    provide: MAT_OPTION_PARENT_COMPONENT,
-    useExisting: OptionHarnessTest
-  }],
-  template: `
-    <mat-option>Plain option</mat-option>
-    <mat-option disabled>Disabled option</mat-option>
-  `
-})
-class OptionHarnessTest implements MatOptionParentComponent {
-  @ViewChildren(MatOption) options: QueryList<MatOption>;
-  multiple = false;
-}
-

--- a/tools/create-system-config.bzl
+++ b/tools/create-system-config.bzl
@@ -2,7 +2,7 @@ load("//:packages.bzl", "ANGULAR_PACKAGE_BUNDLES")
 load("//src/cdk:config.bzl", "CDK_ENTRYPOINTS")
 load("//src/cdk-experimental:config.bzl", "CDK_EXPERIMENTAL_ENTRYPOINTS")
 load("//src/material:config.bzl", "MATERIAL_ENTRYPOINTS", "MATERIAL_TESTING_ENTRYPOINTS")
-load("//src/material-experimental:config.bzl", "MATERIAL_EXPERIMENTAL_ENTRYPOINTS")
+load("//src/material-experimental:config.bzl", "MATERIAL_EXPERIMENTAL_ENTRYPOINTS", "MATERIAL_EXPERIMENTAL_TESTING_ENTRYPOINTS")
 load("//tools:expand_template.bzl", "expand_template")
 
 """
@@ -34,7 +34,7 @@ def create_system_config(
             "$CDK_ENTRYPOINTS_TMPL": str(CDK_ENTRYPOINTS),
             "$CDK_EXPERIMENTAL_ENTRYPOINTS_TMPL": str(CDK_EXPERIMENTAL_ENTRYPOINTS),
             "$MATERIAL_ENTRYPOINTS_TMPL": str(MATERIAL_ENTRYPOINTS + MATERIAL_TESTING_ENTRYPOINTS),
-            "$MATERIAL_EXPERIMENTAL_ENTRYPOINTS_TMPL": str(MATERIAL_EXPERIMENTAL_ENTRYPOINTS),
+            "$MATERIAL_EXPERIMENTAL_ENTRYPOINTS_TMPL": str(MATERIAL_EXPERIMENTAL_ENTRYPOINTS + MATERIAL_EXPERIMENTAL_TESTING_ENTRYPOINTS),
             "$NODE_MODULES_BASE_PATH": node_modules_base_path,
             "$PACKAGES_DIR": packages_dir,
         },


### PR DESCRIPTION
* Adds test harnesses for the `mdc-core` and `mdc-autocomplete` modules.
* Updates one of the classes on the MDC autocomplete trigger since it was the same as the one on the non-MDC version.
* Fixes a build issue where one `material-experimental` testing package couldn't depend on another one.