### PR TITLE
fix(drag-drop): remove redundant style changes from handle directive

### DIFF
--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -19,7 +19,6 @@ import {
 } from '@angular/core';
 import {Subject} from 'rxjs';
 import {CDK_DRAG_PARENT} from '../drag-parent';
-import {toggleNativeDragInteractions} from '../drag-styling';
 
 /**
  * Injection token that can be used to reference instances of `CdkDragHandle`. It serves as
@@ -55,9 +54,7 @@ export class CdkDragHandle implements OnDestroy {
   constructor(
     public element: ElementRef<HTMLElement>,
     @Inject(CDK_DRAG_PARENT) @Optional() @SkipSelf() parentDrag?: any) {
-
     this._parentDrag = parentDrag;
-    toggleNativeDragInteractions(element.nativeElement, false);
   }
 
   ngOnDestroy() {

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -713,11 +713,18 @@ describe('CdkDrag', () => {
       }).not.toThrow();
     }));
 
-    it('should enable native drag interactions when there is a drag handle', () => {
+    it('should enable native drag interactions on the drag item when there is a handle', () => {
       const fixture = createComponent(StandaloneDraggableWithHandle);
       fixture.detectChanges();
       const dragElement = fixture.componentInstance.dragElement.nativeElement;
       expect(dragElement.style.touchAction).not.toBe('none');
+    });
+
+    it('should disable native drag interactions on the drag handle', () => {
+      const fixture = createComponent(StandaloneDraggableWithHandle);
+      fixture.detectChanges();
+      const styles = fixture.componentInstance.handleElement.nativeElement.style;
+      expect(styles.touchAction || (styles as any).webkitUserDrag).toBe('none');
     });
 
     it('should be able to reset a freely-dragged item to its initial position', fakeAsync(() => {


### PR DESCRIPTION
This came up from #19919, although it's not the root cause. We were disabling the native drag interactions on the handle element in two places which is redundant. These changes remove one of them and add a unit test since we were missing coverage.