### PR TITLE
feat(material/menu) Added option to close menu when outside click occurs

### DIFF
--- a/src/material/menu/menu-panel.ts
+++ b/src/material/menu/menu-panel.ts
@@ -38,6 +38,7 @@ export interface MatMenuPanel<T = any> {
   backdropClass?: string;
   overlayPanelClass?: string|string[];
   hasBackdrop?: boolean;
+  closeOnOutsideClick?: boolean;
   readonly panelId?: string;
 
   /**

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -88,6 +88,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
   private _closingActionsSubscription = Subscription.EMPTY;
   private _hoverSubscription = Subscription.EMPTY;
   private _menuCloseSubscription = Subscription.EMPTY;
+  private _outsidePointerEventsSubscription = Subscription.EMPTY;
   private _scrollStrategy: () => ScrollStrategy;
 
   /**
@@ -212,6 +213,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
     this._menuCloseSubscription.unsubscribe();
     this._closingActionsSubscription.unsubscribe();
     this._hoverSubscription.unsubscribe();
+    this._outsidePointerEventsSubscription.unsubscribe();
   }
 
   /** Whether the menu is open. */
@@ -244,6 +246,15 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
 
     const overlayRef = this._createOverlay();
     const overlayConfig = overlayRef.getConfig();
+
+    // Listen for outside click and close the menu when it occurs
+    if(this.menu.closeOnOutsideClick) {
+      this._outsidePointerEventsSubscription = overlayRef.outsidePointerEvents().subscribe(() => {
+        if(this.menuOpen) {
+          this.menu.close.emit(); // or this.closeMenu();
+        }
+      });
+    }
 
     this._setPosition(overlayConfig.positionStrategy as FlexibleConnectedPositionStrategy);
     overlayConfig.hasBackdrop = this.menu.hasBackdrop == null ? !this.triggersSubmenu() :

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -70,6 +70,9 @@ export interface MatMenuDefaultOptions {
 
   /** Whether the menu has a backdrop. */
   hasBackdrop?: boolean;
+
+  /** Close menu when an outside click is detected */
+  closeOnOutsideClick?: boolean;
 }
 
 /** Injection token to be used to override the default options for `mat-menu`. */
@@ -201,6 +204,15 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
     this._hasBackdrop = coerceBooleanProperty(value);
   }
   private _hasBackdrop: boolean | undefined = this._defaultOptions.hasBackdrop;
+
+  /** Close menu when an outside click is detected */
+  @Input()
+  get closeOnOutsideClick(): boolean | undefined { return this._closeOnOutsideClick; }
+  set closeOnOutsideClick(value: boolean | undefined) {
+    this._closeOnOutsideClick = coerceBooleanProperty(value);
+  }
+  private _closeOnOutsideClick: boolean | undefined = this._defaultOptions.closeOnOutsideClick;
+
 
   /**
    * This method takes classes set on the host mat-menu element and applies them on the


### PR DESCRIPTION
This is addressing: https://github.com/angular/components/issues/9320 as well as other scenarios.
The reason we use backdrop for menus in our project is to make sure user will never see multiple menus at the same time, since they don't automatically close when another one is opened.

However when using backdrop you need at least two interactions to open another menu or press another button on the page.
I've added an option to Material Menu to close the menu on outside clicks with the new outsidePointerEvents obsever added earlier this summer in this pr: https://github.com/angular/components/pull/16611.

I'm not sure it this is a valid approach, but at least it's a start and I'm open to suggestions.