### PR TITLE
fix(material-experimental/mdc-core): set up strong focus indication for MDC-based option

### DIFF
--- a/src/material-experimental/mdc-helpers/_focus-indicators.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators.scss
@@ -73,8 +73,11 @@
   .mat-mdc-slide-toggle-focused .mat-mdc-focus-indicator::before,
   .mat-mdc-radio-button.cdk-focused .mat-mdc-focus-indicator::before,
 
-    // For buttons, render the focus indicator when the parent button is focused.
+  // For buttons, render the focus indicator when the parent button is focused.
   .mat-mdc-button-base:focus .mat-mdc-focus-indicator::before,
+
+  // For options, render the focus indicator when the class .mat-mdc-option-active is present.
+  .mat-mdc-focus-indicator.mat-mdc-option-active::before,
 
     // For all other components, render the focus indicator on focus.
   .mat-mdc-focus-indicator:focus::before {


### PR DESCRIPTION
The MDC-based `mat-option` had the proper strong focus indicator class, but the styles weren't implemented.