### PR TITLE
fix(tabs): some bugs with docs and coercion

### DIFF
--- a/src/material/tabs/tab-content.ts
+++ b/src/material/tabs/tab-content.ts
@@ -21,5 +21,6 @@ export const MAT_TAB_CONTENT = new InjectionToken<MatTabContent>('MatTabContent'
   providers: [{provide: MAT_TAB_CONTENT, useExisting: MatTabContent}],
 })
 export class MatTabContent {
-  constructor(public template: TemplateRef<any>) { }
+  constructor(
+    /** Content for the tab. */ public template: TemplateRef<any>) {}
 }

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -5,12 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FocusableOption, FocusMonitor} from '@angular/cdk/a11y';
 import {Directionality} from '@angular/cdk/bidi';
+import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coercion';
 import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {
   AfterContentChecked,
   AfterContentInit,
+  AfterViewInit,
   Attribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -27,7 +30,6 @@ import {
   QueryList,
   ViewChild,
   ViewEncapsulation,
-  AfterViewInit,
 } from '@angular/core';
 import {
   CanDisable, CanDisableCtor,
@@ -42,12 +44,10 @@ import {
   RippleTarget,
   ThemePalette,
 } from '@angular/material/core';
-import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coercion';
-import {FocusMonitor, FocusableOption} from '@angular/cdk/a11y';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
+import {startWith, takeUntil} from 'rxjs/operators';
 import {MatInkBar} from '../ink-bar';
 import {MatPaginatedTabHeader, MatPaginatedTabHeaderItem} from '../paginated-tab-header';
-import {startWith, takeUntil} from 'rxjs/operators';
 
 /**
  * Base class with all of the `MatTabNav` functionality.
@@ -227,7 +227,8 @@ export class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewIn
   }
 
   constructor(
-      private _tabNavBar: _MatTabNavBase, public elementRef: ElementRef,
+      private _tabNavBar: _MatTabNavBase,
+      /** @docs-private */ public elementRef: ElementRef,
       @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS) globalRippleOptions: RippleGlobalOptions|null,
       @Attribute('tabindex') tabIndex: string, private _focusMonitor: FocusMonitor,
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
@@ -241,6 +242,7 @@ export class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewIn
     }
   }
 
+  /** Focuses the tab link. */
   focus() {
     this.elementRef.nativeElement.focus();
   }

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -201,7 +201,9 @@ export class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewIn
   @Input()
   get active(): boolean { return this._isActive; }
   set active(value: boolean) {
-    if (value !== this._isActive) {
+    const newValue = coerceBooleanProperty(value);
+
+    if (newValue !== this._isActive) {
       this._isActive = value;
       this._tabNavBar.updateActiveLink(this.elementRef);
     }
@@ -251,6 +253,7 @@ export class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewIn
     this._focusMonitor.stopMonitoring(this.elementRef);
   }
 
+  static ngAcceptInputType_active: BooleanInput;
   static ngAcceptInputType_disabled: BooleanInput;
   static ngAcceptInputType_disableRipple: BooleanInput;
   static ngAcceptInputType_tabIndex: NumberInput;

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -178,9 +178,8 @@ export declare class MatTabChangeEvent {
     tab: MatTab;
 }
 
-export declare class MatTabContent {
-    template: TemplateRef<any>;
-    constructor(template: TemplateRef<any>);
+export declare class MatTabContent { template: TemplateRef<any>;
+    constructor( template: TemplateRef<any>);
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTabContent, "[matTabContent]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabContent, never>;
 }

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -82,14 +82,14 @@ export declare abstract class _MatTabHeaderBase extends MatPaginatedTabHeader im
 export declare class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewInit, OnDestroy, CanDisable, CanDisableRipple, HasTabIndex, RippleTarget, FocusableOption {
     protected _isActive: boolean;
     get active(): boolean;
-    set active(value: boolean);
-    elementRef: ElementRef;
+    set active(value: boolean); elementRef: ElementRef;
     rippleConfig: RippleConfig & RippleGlobalOptions;
     get rippleDisabled(): boolean;
     constructor(_tabNavBar: _MatTabNavBase, elementRef: ElementRef, globalRippleOptions: RippleGlobalOptions | null, tabIndex: string, _focusMonitor: FocusMonitor, animationMode?: string);
     focus(): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
+    static ngAcceptInputType_active: BooleanInput;
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_tabIndex: NumberInput;


### PR DESCRIPTION
Currently there are some missing docs for tabs like this:

<details>

![Captura de Tela 2020-08-19 às 00 45 58](https://user-images.githubusercontent.com/11965907/90589823-65b65600-e1b5-11ea-926f-33602ab033ed.png)
</details>

I'm send this PR to fix **some** of them (some of them can't be fixed there because there's a problem with the docs generator).

Here's the summary:

~**_MatPaginatedTabHeader_/MatTabHeader/MatTabNav**: adds missing `@Input` for `selectedIndex` and `@Output` for `selectFocusedIndex` and `indexFocused`.~

**_MatTabContent_**: document `template`.

**__MatTabLinkBase/MatTabLink_**:
- adds coercion for `active` `@Input`;
- adjust docs.