### PR TITLE
refactor: remove missing asObservable usages

### DIFF
--- a/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
@@ -4,12 +4,12 @@ import {Overlay, OverlayContainer} from '@angular/cdk/overlay';
 import {_supportsShadowDom} from '@angular/cdk/platform';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
-  MockNgZone,
   clearElement,
   createKeyboardEvent,
   dispatchEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
+  MockNgZone,
   typeInElement,
 } from '@angular/cdk/testing/private';
 import {
@@ -37,22 +37,20 @@ import {
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatOption, MatOptionSelectionChange} from '@angular/material-experimental/mdc-core';
 import {MatFormField, MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
-import {By} from '@angular/platform-browser';
 import {MatInputModule} from '@angular/material-experimental/mdc-input';
+import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {EMPTY, Observable, Subject, Subscription} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
-
-
 import {
   getMatAutocompleteMissingPanelError,
-  MAT_AUTOCOMPLETE_DEFAULT_OPTIONS,
-  MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
   MatAutocomplete,
   MatAutocompleteModule,
   MatAutocompleteOrigin,
   MatAutocompleteSelectedEvent,
   MatAutocompleteTrigger,
+  MAT_AUTOCOMPLETE_DEFAULT_OPTIONS,
+  MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
 } from './index';
 
 
@@ -1566,7 +1564,7 @@ describe('MDC-based MatAutocomplete', () => {
       let spacer = document.createElement('div');
       let fixture = createComponent(SimpleAutocomplete, [{
         provide: ScrollDispatcher,
-        useValue: {scrolled: () => scrolledSubject.asObservable()}
+        useValue: {scrolled: () => scrolledSubject}
       }]);
 
       fixture.detectChanges();
@@ -2234,7 +2232,7 @@ describe('MDC-based MatAutocomplete', () => {
       const fixture = createComponent(SimpleAutocomplete, [
         {
           provide: ScrollDispatcher,
-          useValue: {scrolled: () => scrolledSubject.asObservable()}
+          useValue: {scrolled: () => scrolledSubject}
         },
         {
           provide: MAT_AUTOCOMPLETE_SCROLL_STRATEGY,

--- a/src/material-experimental/mdc-dialog/dialog.spec.ts
+++ b/src/material-experimental/mdc-dialog/dialog.spec.ts
@@ -37,12 +37,12 @@ import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-b
 import {numbers} from '@material/dialog';
 import {Subject} from 'rxjs';
 import {
-  MAT_DIALOG_DATA,
-  MAT_DIALOG_DEFAULT_OPTIONS,
   MatDialog,
   MatDialogModule,
   MatDialogRef,
-  MatDialogState
+  MatDialogState,
+  MAT_DIALOG_DATA,
+  MAT_DIALOG_DEFAULT_OPTIONS
 } from './index';
 
 describe('MDC-based MatDialog', () => {
@@ -63,7 +63,7 @@ describe('MDC-based MatDialog', () => {
         {provide: Location, useClass: SpyLocation},
         {
           provide: ScrollDispatcher,
-          useFactory: () => ({scrolled: () => scrolledSubject.asObservable()})
+          useFactory: () => ({scrolled: () => scrolledSubject})
         },
       ],
     });


### PR DESCRIPTION
After #20165 the CI:lint started to fail due to these leftover usages.