### PR TITLE
tests: remove unsupported TS integration tests

### DIFF
--- a/integration/ts-compat/BUILD.bazel
+++ b/integration/ts-compat/BUILD.bazel
@@ -13,9 +13,6 @@ write_file(
 # List of TypeScript packages that we want to run the compatibility test against.
 # The list contains NPM module names that resolve to the desired TypeScript version.
 typescript_version_packages = [
-    "typescript-3.6",
-    "typescript-3.7",
-    "typescript-3.8",
     "typescript",
 ]
 

--- a/package.json
+++ b/package.json
@@ -168,9 +168,6 @@
     "tslint": "^6.1.0",
     "tsutils": "^3.17.1",
     "typescript": "3.9.5",
-    "typescript-3.6": "npm:typescript@~3.6.4",
-    "typescript-3.7": "npm:typescript@~3.7.0",
-    "typescript-3.8": "npm:typescript@~3.8.0",
     "vrsource-tslint-rules": "5.1.1",
     "yaml": "^1.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -167,12 +167,12 @@
     "tsickle": "0.38.1",
     "tslint": "^6.1.0",
     "tsutils": "^3.17.1",
-    "typescript": "3.9.5",
+    "typescript": "3.9.7",
     "vrsource-tslint-rules": "5.1.1",
     "yaml": "^1.10.0"
   },
   "resolutions": {
-    "dgeni-packages/typescript": "3.9.5",
+    "dgeni-packages/typescript": "3.9.7",
     "**/graceful-fs": "4.2.2"
   }
 }

--- a/src/cdk-experimental/tsconfig-tests.json
+++ b/src/cdk-experimental/tsconfig-tests.json
@@ -9,7 +9,7 @@
       "../../dist/packages/cdk-experimental"
     ],
     "importHelpers": false,
-    "module": "commonjs",
+    "module": "umd",
     "target": "es5",
     "types": ["jasmine"],
     "experimentalDecorators": true,

--- a/src/cdk/tsconfig-tests.json
+++ b/src/cdk/tsconfig-tests.json
@@ -9,7 +9,7 @@
       "../../dist/packages/cdk"
     ],
     "importHelpers": false,
-    "module": "commonjs",
+    "module": "umd",
     "target": "es5",
     "types": ["jasmine"],
     "experimentalDecorators": true,

--- a/src/google-maps/tsconfig-tests.json
+++ b/src/google-maps/tsconfig-tests.json
@@ -9,7 +9,7 @@
       "../../dist/packages/google-maps"
     ],
     "importHelpers": false,
-    "module": "commonjs",
+    "module": "umd",
     "target": "es5",
     "types": ["jasmine"],
     "experimentalDecorators": true,

--- a/src/material-experimental/tsconfig-tests.json
+++ b/src/material-experimental/tsconfig-tests.json
@@ -9,7 +9,7 @@
       "../../dist/packages/material-experimental"
     ],
     "importHelpers": false,
-    "module": "commonjs",
+    "module": "umd",
     "target": "es5",
     "types": ["jasmine"],
     "experimentalDecorators": true,

--- a/src/material-moment-adapter/tsconfig-tests.json
+++ b/src/material-moment-adapter/tsconfig-tests.json
@@ -11,7 +11,7 @@
       "../../dist/packages/material-moment-adapter"
     ],
     "importHelpers": false,
-    "module": "commonjs",
+    "module": "umd",
     "target": "es5",
     "types": ["jasmine"],
     "experimentalDecorators": true,

--- a/src/material/tsconfig-tests.json
+++ b/src/material/tsconfig-tests.json
@@ -9,7 +9,7 @@
       "../../dist/packages/material"
     ],
     "importHelpers": false,
-    "module": "commonjs",
+    "module": "umd",
     "target": "es5",
     "types": ["jasmine"],
     "experimentalDecorators": true,

--- a/tools/package-tools/ts-compile.ts
+++ b/tools/package-tools/ts-compile.ts
@@ -10,7 +10,7 @@ import chalk from 'chalk';
  */
 export function tsCompile(binary: 'tsc' | 'ngc', flags: string[]) {
   return new Promise((resolve, reject) => {
-    const binaryPath = resolvePath(`./node_modules/.bin/${binary}`);
+    const binaryPath = resolvePath(`./node_modules/typescript/bin/${binary}`);
     const childProcess = spawn(binaryPath, flags, {shell: true});
 
     // Pipe stdout and stderr from the child process.

--- a/yarn.lock
+++ b/yarn.lock
@@ -12093,21 +12093,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-"typescript-3.6@npm:typescript@~3.6.4":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
-  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
-
-"typescript-3.7@npm:typescript@~3.7.0", typescript@~3.7.2:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
-
-"typescript-3.8@npm:typescript@~3.8.0":
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
 typescript@3.9.5, typescript@^3.2.2:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
@@ -12117,6 +12102,11 @@ typescript@^3.0.3, typescript@^3.4.5:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
+typescript@~3.7.2:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 ua-parser-js@0.7.17:
   version "0.7.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12093,10 +12093,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.9.5, typescript@^3.2.2:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+typescript@3.9.7, typescript@^3.2.2:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.0.3, typescript@^3.4.5:
   version "3.5.3"


### PR DESCRIPTION
**build: point to typescript node_modules folder instead of `.bin`**

Since we are installing multiple TS versions https://github.com/angular/components/blob/1f6b90c0a515397526d7c6b35f047827bfaa8652/package.json#L170-L173 yarn will link the last tsc binary which may not be the TSC version we want to use to build/test this reproduction.

Currently with the following package.json packages
```
"typescript": "3.9.5",
"typescript-3.6": "npm:typescript@~3.6.4",
"typescript-3.7": "npm:typescript@~3.7.0",
"typescript-3.8": "npm:typescript@~3.8.0",
```

If we run `npx tsc --v` the output will be `Version 3.8.3` as opposed to `3.9.5`


**build: update tests to use UMD module format**

The current version of system.js used doesn't seem to handle the `exports` correctly for TypeScript 3.9 output and causes `Cannot find variable: exports` during runtime.

With this change we change the tests module to use UMD.


**build: update to TypeScript 3.9.7**


**test: remove unsupported TS integration tests**

With this change we remove TS integration tests for unsupported TS versions.
Angular version 10 doesn't TS versions older than TS 3.9.