### PR TITLE
fix(datepicker): don't revalidate if new date object for same date is passed through input

### DIFF
--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -20,6 +20,7 @@ import {
   ElementRef,
   Inject,
   OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import {MatFormFieldControl, MatFormField, MAT_FORM_FIELD} from '@angular/material/form-field';
 import {ThemePalette, DateAdapter} from '@angular/material/core';
@@ -34,7 +35,7 @@ import {
 } from './date-range-input-parts';
 import {MatDatepickerControl} from './datepicker-base';
 import {createMissingDateImplError} from './datepicker-errors';
-import {DateFilterFn} from './datepicker-input-base';
+import {DateFilterFn, dateInputsHaveChanged} from './datepicker-input-base';
 import {MatDateRangePicker, MatDateRangePickerInput} from './date-range-picker';
 import {DateRange, MatDateSelectionModel} from './date-selection-model';
 
@@ -71,9 +72,6 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   get value() {
     return this._model ? this._model.selection : null;
   }
-
-  /** Emits when the input's state has changed. */
-  stateChanges = new Subject<void>();
 
   /** Unique ID for the input. */
   id = `mat-date-range-input-${nextUniqueId++}`;
@@ -133,8 +131,12 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   @Input()
   get min(): D | null { return this._min; }
   set min(value: D | null) {
-    this._min = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
-    this._revalidate();
+    const validValue = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+
+    if (!this._dateAdapter.sameDate(validValue, this._min)) {
+      this._min = validValue;
+      this._revalidate();
+    }
   }
   private _min: D | null;
 
@@ -142,8 +144,12 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   @Input()
   get max(): D | null { return this._max; }
   set max(value: D | null) {
-    this._max = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
-    this._revalidate();
+    const validValue = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+
+    if (!this._dateAdapter.sameDate(validValue, this._max)) {
+      this._max = validValue;
+      this._revalidate();
+    }
   }
   private _max: D | null;
 
@@ -159,7 +165,7 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
 
     if (newValue !== this._groupDisabled) {
       this._groupDisabled = newValue;
-      this._stateChanges.next(undefined);
+      this.stateChanges.next(undefined);
     }
   }
   _groupDisabled = false;
@@ -205,8 +211,8 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
    */
   ngControl: NgControl | null;
 
-  /** Emits when the input's state changes. */
-  _stateChanges = new Subject<void>();
+  /** Emits when the input's state has changed. */
+  stateChanges = new Subject<void>();
 
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
@@ -261,17 +267,18 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
     // We don't need to unsubscribe from this, because we
     // know that the input streams will be completed on destroy.
     merge(this._startInput.stateChanges, this._endInput.stateChanges).subscribe(() => {
-      this._stateChanges.next(undefined);
+      this.stateChanges.next(undefined);
     });
   }
 
-  ngOnChanges() {
-    this._stateChanges.next(undefined);
+  ngOnChanges(changes: SimpleChanges) {
+    if (dateInputsHaveChanged(changes, this._dateAdapter)) {
+      this.stateChanges.next(undefined);
+    }
   }
 
   ngOnDestroy() {
     this.stateChanges.complete();
-    this._stateChanges.unsubscribe();
   }
 
   /** Gets the date at which the calendar should start. */

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -232,7 +232,7 @@ export interface MatDatepickerControl<D> {
   disabled: boolean;
   dateFilter: DateFilterFn<D>;
   getConnectedOverlayOrigin(): ElementRef;
-  _stateChanges: Observable<void>;
+  stateChanges: Observable<void>;
 }
 
 /** Base class for a datepicker. */
@@ -440,7 +440,7 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
     this._inputStateChanges.unsubscribe();
     this._datepickerInput = input;
     this._inputStateChanges =
-        input._stateChanges.subscribe(() => this._stateChanges.next(undefined));
+        input.stateChanges.subscribe(() => this._stateChanges.next(undefined));
     return this._model;
   }
 

--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -19,6 +19,7 @@ import {
   Output,
   AfterViewInit,
   OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -97,7 +98,7 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
 
     if (this._disabled !== newValue) {
       this._disabled = newValue;
-      this._stateChanges.next(undefined);
+      this.stateChanges.next(undefined);
     }
 
     // We need to null check the `blur` method, because it's undefined during SSR.
@@ -125,7 +126,7 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
   _valueChange = new EventEmitter<D | null>();
 
   /** Emits when the internal state has changed */
-  _stateChanges = new Subject<void>();
+  stateChanges = new Subject<void>();
 
   _onTouched = () => {};
   _validatorOnChange = () => {};
@@ -267,15 +268,17 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
     this._isInitialized = true;
   }
 
-  ngOnChanges() {
-    this._stateChanges.next(undefined);
+  ngOnChanges(changes: SimpleChanges) {
+    if (dateInputsHaveChanged(changes, this._dateAdapter)) {
+      this.stateChanges.next(undefined);
+    }
   }
 
   ngOnDestroy() {
     this._valueChangesSubscription.unsubscribe();
     this._localeSubscription.unsubscribe();
     this._valueChange.complete();
-    this._stateChanges.complete();
+    this.stateChanges.complete();
   }
 
   /** @docs-private */
@@ -390,4 +393,28 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
   // may accept different types.
   static ngAcceptInputType_value: any;
   static ngAcceptInputType_disabled: BooleanInput;
+}
+
+/**
+ * Checks whether the `SimpleChanges` object from an `ngOnChanges`
+ * callback has any changes, accounting for date objects.
+ */
+export function dateInputsHaveChanged(
+  changes: SimpleChanges,
+  adapter: DateAdapter<unknown>): boolean {
+  const keys = Object.keys(changes);
+
+  for (let key of keys) {
+    const {previousValue, currentValue} = changes[key];
+
+    if (adapter.isDateInstance(previousValue) && adapter.isDateInstance(currentValue)) {
+      if (!adapter.sameDate(previousValue, currentValue)) {
+        return true;
+      }
+    } else {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -87,8 +87,12 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
   @Input()
   get min(): D | null { return this._min; }
   set min(value: D | null) {
-    this._min = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
-    this._validatorOnChange();
+    const validValue = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+
+    if (!this._dateAdapter.sameDate(validValue, this._min)) {
+      this._min = validValue;
+      this._validatorOnChange();
+    }
   }
   private _min: D | null;
 
@@ -96,8 +100,12 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
   @Input()
   get max(): D | null { return this._max; }
   set max(value: D | null) {
-    this._max = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
-    this._validatorOnChange();
+    const validValue = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+
+    if (!this._dateAdapter.sameDate(validValue, this._max)) {
+      this._max = validValue;
+      this._validatorOnChange();
+    }
   }
   private _max: D | null;
 

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -120,7 +120,7 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   private _watchStateChanges() {
     const datepickerStateChanged = this.datepicker ? this.datepicker._stateChanges : observableOf();
     const inputStateChanged = this.datepicker && this.datepicker._datepickerInput ?
-        this.datepicker._datepickerInput._stateChanges : observableOf();
+        this.datepicker._datepickerInput.stateChanges : observableOf();
     const datepickerToggled = this.datepicker ?
         merge(this.datepicker.openedStream, this.datepicker.closedStream) :
         observableOf();

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -292,7 +292,6 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     _endInput: MatEndDate<D>;
     _groupDisabled: boolean;
     _startInput: MatStartDate<D>;
-    _stateChanges: Subject<void>;
     comparisonEnd: D | null;
     comparisonStart: D | null;
     controlType: string;
@@ -329,7 +328,7 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     getStartValue(): D | null;
     getThemePalette(): ThemePalette;
     ngAfterContentInit(): void;
-    ngOnChanges(): void;
+    ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     onContainerClick(): void;
     setDescribedByIds(ids: string[]): void;


### PR DESCRIPTION
If a function is used to provide a new date object for the `min` or `max` of a datepicker input, we currently trigger a revalidation on each change detection, because the input value is technically different. Historically this is something that we haven't fixed on our end, because it masks an anti-pattern on the user's end, however in this case it breaks in a non-obvious way and detecting it would be more code than just handling it.

These changes add checks in several places so that we don't trigger validators or extra change detections if a new date object for the same date is provided.

These changes also clean up the date range input which had both a `stateChanges` and `_stateChanges` streams which are required by two separate interfaces. Now there's a single `stateChanges`.

Fixes #19907.