### PR TITLE
fix(material-experimental/mdc-table): reset table layout

### DIFF
--- a/src/material-experimental/mdc-table/table.scss
+++ b/src/material-experimental/mdc-table/table.scss
@@ -7,3 +7,9 @@
 .mat-table-sticky {
   @include vendor-prefixes.position-sticky;
 }
+
+// MDC Table applies `table-layout: fixed`, but this is a backwards incompatible
+// change since the table did not previously apply it.
+.mdc-data-table__table {
+  table-layout: auto;
+}


### PR DESCRIPTION
MDC applies a `table-layout: fixed` style to their table. This is backwards incompatible with our current table, so this style addition overrides it with a reset