### PR TITLE
feat(material/paginator): add labels for page size options

### DIFF
--- a/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.html
+++ b/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.html
@@ -9,8 +9,9 @@
 </mat-form-field>
 <mat-form-field>
   <mat-label>Page size options</mat-label>
-  <input matInput [ngModel]="pageSizeOptions" (ngModelChange)="setPageSizeOptions($event)"
-         [ngModelOptions]="{updateOn: 'blur'}" placeholder="Ex. 10,25,50">
+  <input matInput [ngModel]="pageSizeOptionsString" (ngModelChange)="setPageSizeOptions($event)"
+         [ngModelOptions]="{updateOn: 'blur'}"
+         placeholder="Ex. 10: '10', 25: '25', 50: '50'">
 </mat-form-field>
 
 <mat-paginator [length]="length"

--- a/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.ts
+++ b/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {PageEvent} from '@angular/material/paginator';
 
 /**
@@ -9,18 +9,30 @@ import {PageEvent} from '@angular/material/paginator';
   templateUrl: 'paginator-configurable-example.html',
   styleUrls: ['paginator-configurable-example.css'],
 })
-export class PaginatorConfigurableExample {
+export class PaginatorConfigurableExample implements OnInit {
   // MatPaginator Inputs
   length = 100;
   pageSize = 10;
-  pageSizeOptions: number[] = [5, 10, 25, 100];
+  pageSizeOptionsString = `5: '5', 10: '10', 25: '25', 100: 'All'`;
+  pageSizeOptions: {[key: string]: string};
 
   // MatPaginator Output
   pageEvent: PageEvent;
 
+  ngOnInit(): void {
+    this.setPageSizeOptions(this.pageSizeOptionsString);
+  }
+
   setPageSizeOptions(setPageSizeOptionsInput: string) {
     if (setPageSizeOptionsInput) {
-      this.pageSizeOptions = setPageSizeOptionsInput.split(',').map(str => +str);
+      let options: {[key: string]: string} = {};
+
+      setPageSizeOptionsInput.split(',').forEach(p => {
+        const kv = p.split(':');
+        options[kv[0].replace(/['"]+/g, '').trim()] = kv[1].replace(/['"]+/g, '').trim();
+      });
+
+      this.pageSizeOptions = options;
     }
   }
 }

--- a/src/components-examples/material/paginator/paginator-overview/paginator-overview-example.html
+++ b/src/components-examples/material/paginator/paginator-overview/paginator-overview-example.html
@@ -1,4 +1,4 @@
 <mat-paginator [length]="100"
               [pageSize]="10"
-              [pageSizeOptions]="[5, 10, 25, 100]">
+              [pageSizeOptions]="{'5': '5', '10': '10', '25': '25', '100': '100'}">
 </mat-paginator>

--- a/src/components-examples/material/table/table-overview/table-overview-example.html
+++ b/src/components-examples/material/table/table-overview/table-overview-example.html
@@ -39,5 +39,5 @@
     </tr>
   </table>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="{'5': '5', '10': '10', '25': '25', '100': '100'}"></mat-paginator>
 </div>

--- a/src/components-examples/material/table/table-pagination/table-pagination-example.html
+++ b/src/components-examples/material/table/table-pagination/table-pagination-example.html
@@ -29,5 +29,5 @@
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
   </table>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+  <mat-paginator [pageSizeOptions]="{'5': '5', '10': '10', '20': '20'}" showFirstLastButtons></mat-paginator>
 </div>

--- a/src/dev-app/paginator/paginator-demo.html
+++ b/src/dev-app/paginator/paginator-demo.html
@@ -29,11 +29,12 @@
                  [pageSize]="pageSize"
                  [disabled]="disabled"
                  [showFirstLastButtons]="showFirstLastButtons"
-                 [pageSizeOptions]="showPageSizeOptions ? pageSizeOptions : []"
+                 [pageSizeOptions]="showPageSizeOptions ? pageSizeOptions : {}"
                  [hidePageSize]="hidePageSize"
                  [pageIndex]="pageIndex">
   </mat-paginator>
 
+  <div> pageSizeOptions: {{pageSizeOptionsString()}} </div>
   <div> Output event: {{pageEvent | json}} </div>
   <div> getNumberOfPages: {{paginator.getNumberOfPages()}} </div>
 </mat-card>

--- a/src/dev-app/paginator/paginator-demo.ts
+++ b/src/dev-app/paginator/paginator-demo.ts
@@ -19,10 +19,11 @@ export class PaginatorDemo {
   length = 50;
   pageSize = 10;
   pageIndex = 0;
-  pageSizeOptions = [5, 10, 25];
+  pageSizeOptions: {[key: string]: string} = {5: '5', 10: '10', 25: '25', 100: 'All'};
 
   hidePageSize = false;
   showPageSizeOptions = true;
+  showPageSizeOptionLabels = false;
   showFirstLastButtons = true;
   disabled = false;
 
@@ -34,4 +35,9 @@ export class PaginatorDemo {
     this.pageSize = e.pageSize;
     this.pageIndex = e.pageIndex;
   }
+
+  pageSizeOptionsString(): string {
+    return JSON.stringify(this.pageSizeOptions);
+  }
+
 }

--- a/src/material/paginator/paginator.html
+++ b/src/material/paginator/paginator.html
@@ -16,14 +16,14 @@
           [aria-label]="_intl.itemsPerPageLabel"
           (selectionChange)="_changePageSize($event.value)">
           <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
-            {{pageSizeOption}}
+            {{_getPageSizeOptionLabel(pageSizeOption)}}
           </mat-option>
         </mat-select>
       </mat-form-field>
 
       <div
         class="mat-paginator-page-size-value"
-        *ngIf="_displayedPageSizeOptions.length <= 1">{{pageSize}}</div>
+        *ngIf="_displayedPageSizeOptions.length <= 1">{{_getPageSizeOptionLabel(pageSize)}}</div>
     </div>
 
     <div class="mat-paginator-range-actions">

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -279,7 +279,7 @@ describe('MatPaginator', () => {
     // Having one option and the same page size should remove the select menu
     expect(fixture.nativeElement.querySelector('.mat-select')).not.toBeNull();
     paginator.pageSize = 10;
-    paginator.pageSizeOptions = [10];
+    paginator.pageSizeOptions = {10: '10'};
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.mat-select')).toBeNull();
   });
@@ -306,10 +306,10 @@ describe('MatPaginator', () => {
 
     component.pageSize = 30;
     fixture.detectChanges();
-    expect(paginator.pageSizeOptions).toEqual([5, 10, 25, 100]);
+    expect(paginator.pageSizeOptions).toEqual({'5': '5', '10': '10', '25': '25', '100': '100'});
     expect(paginator._displayedPageSizeOptions).toEqual([5, 10, 25, 30, 100]);
 
-    component.pageSizeOptions = [100, 25, 10, 5];
+    expect(paginator.pageSizeOptions).toEqual({'100': '100', '25': '25', '10': '10', '5': '5'});
     fixture.detectChanges();
     expect(paginator._displayedPageSizeOptions).toEqual([5, 10, 25, 30, 100]);
   });
@@ -390,20 +390,22 @@ describe('MatPaginator', () => {
 
     // Remove options so that the paginator only uses the current page size (10) as an option.
     // Should no longer show the select component since there is only one option.
-    component.pageSizeOptions = [];
+    component.pageSizeOptions = {};
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.mat-select')).toBeNull();
   });
 
-  it('should handle the number inputs being passed in as strings', () => {
-    const fixture = createComponent(MatPaginatorWithStringValues);
-    fixture.detectChanges();
+  it('should show label for an option if specified', () => {
+    const fixture = createComponent(MatPaginatorApp);
+    const component = fixture.componentInstance;
+    const paginator = component.paginator;
 
-    const withStringPaginator = fixture.componentInstance.paginator;
-    expect(withStringPaginator.pageIndex).toEqual(0);
-    expect(withStringPaginator.length).toEqual(100);
-    expect(withStringPaginator.pageSize).toEqual(10);
-    expect(withStringPaginator.pageSizeOptions).toEqual([5, 10, 25, 100]);
+    expect(paginator._getPageSizeOptionLabel(5)).toBe('5');
+
+    // Change label for option '5' to the word 'Five'.
+    paginator.pageSizeOptions = {5: 'Five'};
+    fixture.detectChanges();
+    expect(paginator._getPageSizeOptionLabel(5)).toBe('Five');
   });
 
   it('should be able to hide the page size select', () => {
@@ -423,7 +425,7 @@ describe('MatPaginator', () => {
   it('should be able to disable all the controls in the paginator via the binding', () => {
     const fixture = createComponent(MatPaginatorApp);
     const select: MatSelect =
-        fixture.debugElement.query(By.directive(MatSelect))!.componentInstance;
+      fixture.debugElement.query(By.directive(MatSelect))!.componentInstance;
 
     fixture.componentInstance.pageIndex = 1;
     fixture.componentInstance.showFirstLastButtons = true;
@@ -451,7 +453,11 @@ describe('MatPaginator', () => {
       provide: MAT_PAGINATOR_DEFAULT_OPTIONS,
       useValue: {
         pageSize: 7,
-        pageSizeOptions: [7, 14, 21],
+        pageSizeOptions: {
+          7: '7',
+          14: '14',
+          21: '21'
+        },
         hidePageSize: true,
         showFirstLastButtons: true
       } as MatPaginatorDefaultOptions
@@ -459,7 +465,7 @@ describe('MatPaginator', () => {
     const paginator = fixture.componentInstance.paginator;
 
     expect(paginator.pageSize).toBe(7);
-    expect(paginator.pageSizeOptions).toEqual([7, 14, 21]);
+    expect(paginator.pageSizeOptions).toEqual({'7': '7', '14': '14', '21': '21'});
     expect(paginator.hidePageSize).toBe(true);
     expect(paginator.showFirstLastButtons).toBe(true);
   });
@@ -479,7 +485,7 @@ function getFirstButton(fixture: ComponentFixture<any>) {
 }
 
 function getLastButton(fixture: ComponentFixture<any>) {
-    return fixture.nativeElement.querySelector('.mat-paginator-navigation-last');
+  return fixture.nativeElement.querySelector('.mat-paginator-navigation-last');
 }
 
 @Component({
@@ -499,7 +505,7 @@ function getLastButton(fixture: ComponentFixture<any>) {
 class MatPaginatorApp {
   pageIndex = 0;
   pageSize = 10;
-  pageSizeOptions = [5, 10, 25, 100];
+  pageSizeOptions: {[key: string]: string} = {5: '5', 10: '10', 25: '25', 100: '100'};
   hidePageSize = false;
   showFirstLastButtons = false;
   length = 100;
@@ -518,14 +524,14 @@ class MatPaginatorApp {
   template: `
     <mat-paginator></mat-paginator>
   `,
-})
+ })
 class MatPaginatorWithoutInputsApp {
   @ViewChild(MatPaginator) paginator: MatPaginator;
 }
 
 @Component({
   template: `
-    <mat-paginator [pageSizeOptions]="[10, 20, 30]"></mat-paginator>
+    <mat-paginator [pageSizeOptions]="{'10': '10', '20': '20', '30': '30'}"></mat-paginator>
   `,
 })
 class MatPaginatorWithoutPageSizeApp {
@@ -538,18 +544,5 @@ class MatPaginatorWithoutPageSizeApp {
   `,
 })
 class MatPaginatorWithoutOptionsApp {
-  @ViewChild(MatPaginator) paginator: MatPaginator;
-}
-
-@Component({
-  template: `
-    <mat-paginator pageIndex="0"
-                   pageSize="10"
-                   [pageSizeOptions]="['5', '10', '25', '100']"
-                   length="100">
-    </mat-paginator>
-  `
-  })
-class MatPaginatorWithStringValues {
   @ViewChild(MatPaginator) paginator: MatPaginator;
 }

--- a/src/material/paginator/testing/shared.spec.ts
+++ b/src/material/paginator/testing/shared.spec.ts
@@ -107,7 +107,7 @@ export function runHarnessTests(
   it('should throw an error if the page size selector is not available', async () => {
     const paginator = await loader.getHarness(paginatorHarness);
 
-    instance.pageSizeOptions = [];
+    instance.pageSizeOptions = {};
     fixture.detectChanges();
 
     await expectAsync(paginator.setPageSize(10)).toBeRejectedWithError(
@@ -132,7 +132,7 @@ class PaginatorHarnessTest {
   length = 500;
   pageSize = 10;
   pageIndex = 0;
-  pageSizeOptions = [5, 10, 25];
+  pageSizeOptions: {[key: string]: string} = {5: '5', 10: '10', 25: '25'};
   showFirstLastButtons = true;
 
   handlePageEvent(event: PageEvent) {

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -231,7 +231,7 @@
 <h2>Paginator</h2>
 
 <mat-paginator [length]="100"
-              [pageSizeOptions]="[5, 10, 25, 100]">
+              [pageSizeOptions]="{'5': '5', '10': '10', '25': '25', '100': '100'}">
 </mat-paginator>
 
 <h2>Toolbar</h2>

--- a/tools/public_api_guard/material/paginator.d.ts
+++ b/tools/public_api_guard/material/paginator.d.ts
@@ -22,12 +22,17 @@ export declare class MatPaginator extends _MatPaginatorBase implements OnInit, O
     set pageIndex(value: number);
     get pageSize(): number;
     set pageSize(value: number);
-    get pageSizeOptions(): number[];
-    set pageSizeOptions(value: number[]);
+    get pageSizeOptions(): {
+        [key: string]: string;
+    };
+    set pageSizeOptions(p: {
+        [key: string]: string;
+    });
     get showFirstLastButtons(): boolean;
     set showFirstLastButtons(value: boolean);
     constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef, defaults?: MatPaginatorDefaultOptions);
     _changePageSize(pageSize: number): void;
+    _getPageSizeOptionLabel(pageSize: number): string;
     _nextButtonsDisabled(): boolean;
     _previousButtonsDisabled(): boolean;
     firstPage(): void;
@@ -53,7 +58,9 @@ export interface MatPaginatorDefaultOptions {
     formFieldAppearance?: MatFormFieldAppearance;
     hidePageSize?: boolean;
     pageSize?: number;
-    pageSizeOptions?: number[];
+    pageSizeOptions?: {
+        [key: string]: string;
+    };
     showFirstLastButtons?: boolean;
 }
 


### PR DESCRIPTION
Specify a label for each value in `pageSizeOptions`, e.g. `{5, '5', 10,
'10', 25, '25', ...}` . Use case: to display a page size option of 'ALL'
to the user, include the table's length as an option, i.e. `{... length:
'ALL'}` .
BREAKING CHANGE: `pageSizeOptions` type change from `number[]` to
`{[key: string]: string}`
Fixes #8150