### PR TITLE
fix(material-experimental/mdc-dialog): blending in with background in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-dialog/dialog.scss
+++ b/src/material-experimental/mdc-dialog/dialog.scss
@@ -2,6 +2,7 @@
 @import '@material/dialog/variables.import';
 @import '../mdc-helpers/mdc-helpers';
 @import './mdc-dialog-structure-overrides';
+@import '../../cdk/a11y/a11y';
 
 // Dialog content max height. This has been copied from the standard dialog
 // and is needed to make the dialog content scrollable.
@@ -16,6 +17,10 @@ $mat-dialog-button-horizontal-margin: 8px !default;
 // The dialog container is focusable. We remove the default outline shown in browsers.
 .mat-mdc-dialog-container {
   outline: 0;
+
+  @include cdk-high-contrast(active, off) {
+    outline: solid 1px;
+  }
 }
 
 // MDC sets the display behavior for title and actions, but not for content. Since we support


### PR DESCRIPTION
The MDC dialog was blending in with the page background, because it doesn't have a border or an outline.