### PR TITLE
build: clean up uses of integers as booleans in Bazel files

### DIFF
--- a/src/cdk/coercion/BUILD.bazel
+++ b/src/cdk/coercion/BUILD.bazel
@@ -16,7 +16,7 @@ ts_library(
 
 ts_library(
     name = "unit_test_sources",
-    testonly = 1,
+    testonly = True,
     srcs = glob(
         ["**/*.spec.ts"],
         exclude = ["**/*.e2e.spec.ts"],

--- a/src/cdk/keycodes/BUILD.bazel
+++ b/src/cdk/keycodes/BUILD.bazel
@@ -17,7 +17,7 @@ ng_module(
 
 ts_library(
     name = "unit_test_sources",
-    testonly = 1,
+    testonly = True,
     srcs = glob(
         ["**/*.spec.ts"],
         exclude = ["**/*.e2e.spec.ts"],

--- a/src/circular-deps-test.conf.js
+++ b/src/circular-deps-test.conf.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license

--- a/src/google-maps/testing/BUILD.bazel
+++ b/src/google-maps/testing/BUILD.bazel
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**/*.ts"]),
     deps = [
         "//src/google-maps",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -136,7 +136,7 @@ def ng_test_library(deps = [], tsconfig = None, **kwargs):
     ] + deps
 
     ts_library(
-        testonly = 1,
+        testonly = True,
         deps = local_deps,
         **kwargs
     )
@@ -149,7 +149,7 @@ def ng_e2e_test_library(deps = [], tsconfig = None, **kwargs):
     ] + deps
 
     ts_library(
-        testonly = 1,
+        testonly = True,
         deps = local_deps,
         **kwargs
     )


### PR DESCRIPTION
Fixes a few places that are inconsistent by using `1` instead of `True`.

Also fixes one place where we were using the incorrect wording in a license header.