### PR TITLE
fix(material-experimental/mdc-button): double outline for FAB in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -12,14 +12,12 @@
   @include _mat-button-disabled();
 }
 
-// Add an outline to make buttons more visible in high contrast mode. Stroked buttons
+// Add an outline to make buttons more visible in high contrast mode. Stroked buttons and FABs
 // don't need a special look in high-contrast mode, because those already have an outline.
 .mat-mdc-button:not(.mdc-button--outlined),
 .mat-mdc-unelevated-button:not(.mdc-button--outlined),
 .mat-mdc-raised-button:not(.mdc-button--outlined),
 .mat-mdc-outlined-button:not(.mdc-button--outlined),
-.mat-mdc-fab,
-.mat-mdc-mini-fab,
 .mat-mdc-icon-button {
   @include cdk-high-contrast(active, off) {
     outline: solid 1px;


### PR DESCRIPTION
The MDC-based FAB don't need an extra outline high contrast mode, because they have one already.