### PR TITLE
build: add support for shorthand names in API golden approval script

### DIFF
--- a/scripts/approve-api-golden.js
+++ b/scripts/approve-api-golden.js
@@ -4,13 +4,23 @@ const shelljs = require('shelljs');
 const chalk = require('chalk');
 const path = require('path');
 const packageName = process.argv[2];
+const {guessPackageName} = require('./util');
 
 if (!packageName) {
   console.error(chalk.red('No package name has been passed in for API golden approval.'));
   process.exit(1);
 }
 
+const projectDir = path.join(__dirname, '../');
+const packageNameGuess = guessPackageName(packageName, path.join(projectDir, 'src'));
+
+if (!packageNameGuess.result) {
+  console.error(chalk.red(`Could not find package for API golden approval called ` +
+    `${chalk.yellow(packageName)}. Looked in packages: \n${packageNameGuess.attempts.join('\n')}`));
+  process.exit(1);
+}
+
 // ShellJS should exit if any command fails.
 shelljs.set('-e');
-shelljs.cd(path.join(__dirname, '../'));
-shelljs.exec(`yarn bazel run //tools/public_api_guard:${packageName}.d.ts_api.accept`);
+shelljs.cd(projectDir);
+shelljs.exec(`yarn bazel run //tools/public_api_guard:${packageNameGuess.result}.d.ts_api.accept`);

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const shelljs = require('shelljs');
+
+/** Map of common typos in target names. The key is the typo, the value is the correct form. */
+const commonTypos = new Map([
+  ['snackbar', 'snack-bar'],
+]);
+
+// List of packages where the specified component could be defined in. The script uses the
+// first package that contains the component (if no package is specified explicitly).
+// e.g. "button" will become "material/button", and "overlay" becomes "cdk/overlay".
+const orderedGuessPackages = ['material', 'cdk', 'material-experimental', 'cdk-experimental'];
+
+/**
+ * Tries to guess the full name of a package, based on a shorthand name.
+ * Returns an object with the result of the guess and the names that were attempted.
+ */
+function guessPackageName(name, packagesDir) {
+  name = correctTypos(name);
+
+  // Build up a list of packages that we're going to try.
+  const attempts = [name, ...orderedGuessPackages.map(package => path.join(package, name))];
+  const result = attempts.find(guessName => shelljs.test('-d', path.join(packagesDir, guessName)));
+
+  return {
+    result: result ? convertPathToPosix(result) : null,
+    attempts
+  };
+}
+
+/** Converts an arbitrary path to a Posix path. */
+function convertPathToPosix(pathName) {
+  return pathName.replace(/\\/g, '/');
+}
+
+/** Correct common typos in a target name */
+function correctTypos(target) {
+  let correctedTarget = target;
+  for (const [typo, correction] of commonTypos) {
+    correctedTarget = correctedTarget.replace(typo, correction);
+  }
+
+  return correctedTarget;
+}
+
+module.exports = {
+  guessPackageName,
+  convertPathToPosix
+};


### PR DESCRIPTION
Currently we have to write the full path for the API golden approval script, whereas the `test` script supports shorthands. These changes move the logic that guesses the name of a package out into a separate file so that it can be reused in the `approve-api` script.