### PR TITLE
fix(material-experimental/mdc-core): active option not visible in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-core/option/option.scss
+++ b/src/material-experimental/mdc-core/option/option.scss
@@ -56,3 +56,25 @@
     }
   }
 }
+
+.mat-mdc-option-active {
+  @include cdk-high-contrast(active, off) {
+    // A pseudo element is used here, because the active indication gets moved between options
+    // and we don't want the border from below to shift the layout around as it's added and removed.
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      pointer-events: none;
+
+      // We use a border here, rather than an outline, because the outline will be cut off
+      // by the `overflow: hidden` on the panel wrapping the options, whereas a border
+      // will push the element inwards. This could be done using `outline-offset: -1px`,
+      // however the property isn't supported on IE11.
+      border: solid 1px currentColor;
+    }
+  }
+}


### PR DESCRIPTION
The active option indication wasn't visible in high contrast mode, because it's based on the option's background color.