### PR TITLE
test: reduce reliance on static queries

### DIFF
--- a/src/cdk/accordion/accordion.spec.ts
+++ b/src/cdk/accordion/accordion.spec.ts
@@ -53,6 +53,7 @@ describe('CdkAccordion', () => {
 
   it('should not register nested items to the same accordion', () => {
     const fixture = TestBed.createComponent(NestedItems);
+    fixture.detectChanges();
     const innerItem = fixture.componentInstance.innerItem;
     const outerItem = fixture.componentInstance.outerItem;
 
@@ -77,6 +78,6 @@ class SetOfItems {
     </cdk-accordion-item>
   </cdk-accordion>`})
 class NestedItems {
-  @ViewChild('outerItem', {static: true}) outerItem: CdkAccordionItem;
-  @ViewChild('innerItem', {static: true}) innerItem: CdkAccordionItem;
+  @ViewChild('outerItem') outerItem: CdkAccordionItem;
+  @ViewChild('innerItem') innerItem: CdkAccordionItem;
 }

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -70,6 +70,7 @@ describe('FullscreenOverlayContainer', () => {
 
   it('should open an overlay inside a fullscreen element and move it to the body', () => {
     const fixture = TestBed.createComponent(TestComponentWithTemplatePortals);
+    fixture.detectChanges();
     const overlayRef = overlay.create();
     const fullscreenElement = fakeDocument.fullscreenElement;
 
@@ -91,6 +92,7 @@ describe('FullscreenOverlayContainer', () => {
     fakeDocument.fullscreenElement = null;
 
     const fixture = TestBed.createComponent(TestComponentWithTemplatePortals);
+    fixture.detectChanges();
     const overlayRef = overlay.create();
 
     overlayRef.attach(fixture.componentInstance.templatePortal);
@@ -114,7 +116,7 @@ describe('FullscreenOverlayContainer', () => {
   providers: [Overlay],
 })
 class TestComponentWithTemplatePortals {
-  @ViewChild(CdkPortal, {static: true}) templatePortal: CdkPortal;
+  @ViewChild(CdkPortal) templatePortal: CdkPortal;
 
   constructor(public viewContainerRef: ViewContainerRef) { }
 }

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -24,7 +24,7 @@ describe('OverlayContainer', () => {
 
   it('should remove the overlay container element from the DOM on destruction', () => {
     const fixture = TestBed.createComponent(TestComponentWithTemplatePortals);
-
+    fixture.detectChanges();
     const overlayRef = overlay.create();
     overlayRef.attach(fixture.componentInstance.templatePortal);
     fixture.detectChanges();
@@ -101,7 +101,7 @@ describe('OverlayContainer', () => {
   providers: [Overlay],
 })
 class TestComponentWithTemplatePortals {
-  @ViewChild(CdkPortal, {static: true}) templatePortal: CdkPortal;
+  @ViewChild(CdkPortal) templatePortal: CdkPortal;
 
   constructor(public viewContainerRef: ViewContainerRef) { }
 }

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -37,6 +37,7 @@ describe('Portals', () => {
 
     beforeEach(() => {
       fixture = TestBed.createComponent(PortalTestApp);
+      fixture.detectChanges();
 
       inject([ComponentFactoryResolver], (cfr: ComponentFactoryResolver) => {
         componentFactoryResolver = cfr;
@@ -348,6 +349,7 @@ describe('Portals', () => {
       fixture.destroy();
 
       const unboundFixture = TestBed.createComponent(UnboundPortalTestApp);
+      unboundFixture.detectChanges();
 
       // Note: calling `detectChanges` here will cause a false positive.
       // What we're testing is attaching before the first CD cycle.
@@ -717,10 +719,10 @@ class ArbitraryViewContainerRefComponent {
 })
 class PortalTestApp {
   @ViewChildren(CdkPortal) portals: QueryList<CdkPortal>;
-  @ViewChild(CdkPortalOutlet, {static: true}) portalOutlet: CdkPortalOutlet;
-  @ViewChild('templateRef', {read: TemplateRef, static: true}) templateRef: TemplateRef<any>;
-  @ViewChild('domPortalContent', {static: true}) domPortalContent: ElementRef<HTMLElement>;
-  @ViewChild('alternateContainer', {read: ViewContainerRef, static: true})
+  @ViewChild(CdkPortalOutlet) portalOutlet: CdkPortalOutlet;
+  @ViewChild('templateRef', {read: TemplateRef}) templateRef: TemplateRef<any>;
+  @ViewChild('domPortalContent') domPortalContent: ElementRef<HTMLElement>;
+  @ViewChild('alternateContainer', {read: ViewContainerRef})
   alternateContainer: ViewContainerRef;
 
   selectedPortal: Portal<any>|undefined;
@@ -757,7 +759,7 @@ class PortalTestApp {
   `,
 })
 class UnboundPortalTestApp {
-  @ViewChild(CdkPortalOutlet, {static: true}) portalOutlet: CdkPortalOutlet;
+  @ViewChild(CdkPortalOutlet) portalOutlet: CdkPortalOutlet;
 }
 
 // Create a real (non-test) NgModule as a workaround for

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -33,13 +33,12 @@ describe('AutofillMonitor', () => {
     autofillMonitor = afm;
     fixture = TestBed.createComponent(Inputs);
     testComponent = fixture.componentInstance;
+    fixture.detectChanges();
 
     for (const input of [testComponent.input1, testComponent.input2, testComponent.input3]) {
       spyOn(input.nativeElement, 'addEventListener');
       spyOn(input.nativeElement, 'removeEventListener');
     }
-
-    fixture.detectChanges();
   }));
 
   afterEach(() => {
@@ -217,9 +216,9 @@ describe('cdkAutofill', () => {
 })
 class Inputs {
   // Cast to `any` so we can stub out some methods in the tests.
-  @ViewChild('input1', {static: true}) input1: ElementRef<any>;
-  @ViewChild('input2', {static: true}) input2: ElementRef<any>;
-  @ViewChild('input3', {static: true}) input3: ElementRef<any>;
+  @ViewChild('input1') input1: ElementRef<any>;
+  @ViewChild('input2') input2: ElementRef<any>;
+  @ViewChild('input3') input3: ElementRef<any>;
 }
 
 @Component({

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -254,7 +254,7 @@ abstract class BaseTestComponentRtl extends BaseTestComponent {
 
 @Component({template: getTableTemplate(false)})
 class MatResizeTest extends BaseTestComponent {
-  @ViewChild(MatColumnResize, {static: true}) columnResize: AbstractMatColumnResize;
+  @ViewChild(MatColumnResize) columnResize: AbstractMatColumnResize;
 }
 
 @Component({template: getTableTemplate(false), changeDetection: ChangeDetectionStrategy.OnPush})
@@ -262,28 +262,28 @@ class MatResizeOnPushTest extends MatResizeTest {}
 
 @Component({template: getTableTemplate(true)})
 class MatResizeDefaultTest extends BaseTestComponent {
-  @ViewChild(MatDefaultEnabledColumnResize, {static: true}) columnResize: AbstractMatColumnResize;
+  @ViewChild(MatDefaultEnabledColumnResize) columnResize: AbstractMatColumnResize;
 }
 
 @Component({template: getTableTemplate(true)})
 class MatResizeDefaultRtlTest extends BaseTestComponentRtl {
-  @ViewChild(MatDefaultEnabledColumnResize, {static: true}) columnResize: AbstractMatColumnResize;
+  @ViewChild(MatDefaultEnabledColumnResize) columnResize: AbstractMatColumnResize;
 }
 
 @Component({template: getFlexTemplate(false)})
 class MatResizeFlexTest extends BaseTestComponent {
-  @ViewChild(MatColumnResizeFlex, {static: true}) columnResize: AbstractMatColumnResize;
+  @ViewChild(MatColumnResizeFlex) columnResize: AbstractMatColumnResize;
 }
 
 @Component({template: getFlexTemplate(true)})
 class MatResizeDefaultFlexTest extends BaseTestComponent {
-  @ViewChild(MatDefaultEnabledColumnResizeFlex, {static: true})
+  @ViewChild(MatDefaultEnabledColumnResizeFlex)
   columnResize: AbstractMatColumnResize;
 }
 
 @Component({template: getFlexTemplate(true)})
 class MatResizeDefaultFlexRtlTest extends BaseTestComponentRtl {
-  @ViewChild(MatDefaultEnabledColumnResizeFlex, {static: true})
+  @ViewChild(MatDefaultEnabledColumnResizeFlex)
   columnResize: AbstractMatColumnResize;
 }
 

--- a/src/material-experimental/mdc-table/table.spec.ts
+++ b/src/material-experimental/mdc-table/table.spec.ts
@@ -598,7 +598,7 @@ class MatTableApp {
   columnsToRender = ['column_a', 'column_b', 'column_c'];
   isFourthRow = (i: number, _rowData: TestData) => i == 3;
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
+  @ViewChild(MatTable) table: MatTable<TestData>;
 }
 
 @Component({
@@ -669,7 +669,7 @@ class StickyTableApp {
   dataSource = new FakeDataSource();
   columnsToRender = ['column_a'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
+  @ViewChild(MatTable) table: MatTable<TestData>;
 }
 
 
@@ -736,9 +736,9 @@ class ArrayDataSourceMatTableApp implements AfterViewInit {
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
-  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
-  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatTable) table: MatTable<TestData>;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
   @ViewChild(MatSortHeader) sortHeader: MatSortHeader;
 
   constructor() {
@@ -789,8 +789,8 @@ class MatTableWithSortApp implements OnInit {
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
-  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatTable) table: MatTable<TestData>;
+  @ViewChild(MatSort) sort: MatSort;
 
   constructor() {
     this.underlyingDataSource.data = [];
@@ -840,8 +840,8 @@ class MatTableWithPaginatorApp implements OnInit {
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
-  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+  @ViewChild(MatTable) table: MatTable<TestData>;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
 
   constructor() {
     this.underlyingDataSource.data = [];

--- a/src/material-experimental/mdc-tabs/tab-body.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-body.spec.ts
@@ -193,7 +193,7 @@ class SimpleTabBodyApp implements AfterContentInit {
   origin: number | null;
 
   @ViewChild(MatTabBody) tabBody: MatTabBody;
-  @ViewChild(TemplateRef, {static: true}) template: TemplateRef<any>;
+  @ViewChild(TemplateRef) template: TemplateRef<any>;
 
   constructor(private _viewContainerRef: ViewContainerRef) { }
 

--- a/src/material/table/table-data-source.spec.ts
+++ b/src/material/table/table-data-source.spec.ts
@@ -20,8 +20,8 @@ describe('MatTableDataSource', () => {
 
     beforeEach(() => {
       fixture = TestBed.createComponent(MatSortApp);
-      sort = fixture.componentInstance.sort;
       fixture.detectChanges();
+      sort = fixture.componentInstance.sort;
     });
 
     /** Test the data source's `sortData` function. */
@@ -58,5 +58,5 @@ describe('MatTableDataSource', () => {
   template: `<div matSort matSortDirection="asc"></div>`
 })
 class MatSortApp {
-  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatSort) sort: MatSort;
 }

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -635,7 +635,7 @@ class MatTableApp {
   columnsToRender = ['column_a', 'column_b', 'column_c'];
   isFourthRow = (i: number, _rowData: TestData) => i == 3;
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
+  @ViewChild(MatTable) table: MatTable<TestData>;
 }
 
 @Component({
@@ -668,7 +668,7 @@ class NativeHtmlTableApp {
   dataSource: FakeDataSource | null = new FakeDataSource();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
+  @ViewChild(MatTable) table: MatTable<TestData>;
 }
 
 @Component({
@@ -736,7 +736,7 @@ class StickyTableApp {
   dataSource = new FakeDataSource();
   columnsToRender = ['column_a'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
+  @ViewChild(MatTable) table: MatTable<TestData>;
 }
 
 
@@ -803,9 +803,9 @@ class ArrayDataSourceMatTableApp implements AfterViewInit {
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
-  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
-  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatTable) table: MatTable<TestData>;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
   @ViewChild(MatSortHeader) sortHeader: MatSortHeader;
 
   constructor() {
@@ -856,8 +856,8 @@ class MatTableWithSortApp implements OnInit {
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
-  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatTable) table: MatTable<TestData>;
+  @ViewChild(MatSort) sort: MatSort;
 
   constructor() {
     this.underlyingDataSource.data = [];
@@ -907,8 +907,8 @@ class MatTableWithPaginatorApp implements OnInit {
   dataSource = new MatTableDataSource<TestData>();
   columnsToRender = ['column_a', 'column_b', 'column_c'];
 
-  @ViewChild(MatTable, {static: true}) table: MatTable<TestData>;
-  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+  @ViewChild(MatTable) table: MatTable<TestData>;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
 
   constructor() {
     this.underlyingDataSource.data = [];

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -193,7 +193,7 @@ class SimpleTabBodyApp implements AfterContentInit {
   origin: number | null;
 
   @ViewChild(MatTabBody) tabBody: MatTabBody;
-  @ViewChild(TemplateRef, {static: true}) template: TemplateRef<any>;
+  @ViewChild(TemplateRef) template: TemplateRef<any>;
 
   constructor(private _viewContainerRef: ViewContainerRef) { }
 


### PR DESCRIPTION
When Ivy issues were first being resolved in the repo, we accumulated a lot of static queries in tests which we generally shouldn't be depending on. These changes clean up most of the ones that don't require much refactoring to clean up. I'll make some follow-up changes for the trickier ones once these changes land.