### PR TITLE
fix(cdk-experimental/combobox): not cleaning up overlay on destroy

### DIFF
--- a/src/cdk-experimental/combobox/combobox.spec.ts
+++ b/src/cdk-experimental/combobox/combobox.spec.ts
@@ -179,6 +179,18 @@ describe('Combobox', () => {
 
       expect(comboboxInstance.isOpen()).toBeFalse();
     });
+
+    it('should clean up the overlay on destroy', () => {
+      expect(document.querySelectorAll('.cdk-overlay-pane').length).toBe(0);
+
+      dispatchMouseEvent(comboboxElement, 'click');
+      fixture.detectChanges();
+      expect(document.querySelectorAll('.cdk-overlay-pane').length).toBe(1);
+
+      fixture.destroy();
+      expect(document.querySelectorAll('.cdk-overlay-pane').length).toBe(0);
+    });
+
   });
 
   describe('with a coerce open action property function', () => {

--- a/src/cdk-experimental/combobox/combobox.ts
+++ b/src/cdk-experimental/combobox/combobox.ts
@@ -114,6 +114,10 @@ export class CdkCombobox<T = unknown> implements OnDestroy, AfterContentInit {
   }
 
   ngOnDestroy() {
+    if (this._overlayRef) {
+      this._overlayRef.dispose();
+    }
+
     this.opened.complete();
     this.closed.complete();
     this.panelValueChanged.complete();


### PR DESCRIPTION
The combobox was leaving behind its open overlays when it gets destroyed, because it wasn't calling `OverlayRef.dispose`.