### PR TITLE
fix(drag-drop): expose some missing injection tokens

### DIFF
--- a/src/cdk/drag-drop/public-api.ts
+++ b/src/cdk/drag-drop/public-api.ts
@@ -9,13 +9,14 @@
 export {DragDrop} from './drag-drop';
 export {DragRef, DragRefConfig, Point} from './drag-ref';
 export {DropListRef} from './drop-list-ref';
+export {CDK_DRAG_PARENT} from './drag-parent';
 
 export * from './drag-events';
 export * from './drag-utils';
 export * from './drag-drop-module';
 export * from './drag-drop-registry';
 
-export {CdkDropList} from './directives/drop-list';
+export {CdkDropList, CDK_DROP_LIST} from './directives/drop-list';
 export * from './directives/config';
 export * from './directives/drop-list-group';
 export * from './directives/drag';

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -2,9 +2,13 @@ export declare const CDK_DRAG_CONFIG: InjectionToken<DragDropConfig>;
 
 export declare const CDK_DRAG_HANDLE: InjectionToken<CdkDragHandle>;
 
+export declare const CDK_DRAG_PARENT: InjectionToken<{}>;
+
 export declare const CDK_DRAG_PLACEHOLDER: InjectionToken<CdkDragPlaceholder<any>>;
 
 export declare const CDK_DRAG_PREVIEW: InjectionToken<CdkDragPreview<any>>;
+
+export declare const CDK_DROP_LIST: InjectionToken<CdkDropList<any>>;
 
 export declare const CDK_DROP_LIST_GROUP: InjectionToken<CdkDropListGroup<unknown>>;
 


### PR DESCRIPTION
A couple of injection tokens weren't exposed from the `drag-drop` module. Normally these sorts of tokens would be internal, but the code from the `drag-drop` module is meant to be extended so we have to expose them to allow people to reach the same level of functionality.

Fixes #20406.