### PR TITLE
refactor: remove light-weight token content-child query cast

### DIFF
--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -72,17 +72,14 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   /** Reference to the underlying drag instance. */
   _dragRef: DragRef<CdkDrag<T>>;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** Elements that can be used to drag the draggable item. */
-  @ContentChildren(CDK_DRAG_HANDLE as any, {descendants: true}) _handles: QueryList<CdkDragHandle>;
+  @ContentChildren(CDK_DRAG_HANDLE, {descendants: true}) _handles: QueryList<CdkDragHandle>;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** Element that will be used as a template to create the draggable item's preview. */
-  @ContentChild(CDK_DRAG_PREVIEW as any) _previewTemplate: CdkDragPreview;
+  @ContentChild(CDK_DRAG_PREVIEW) _previewTemplate: CdkDragPreview;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** Template for placeholder element rendered to show where a draggable would be dropped. */
-  @ContentChild(CDK_DRAG_PLACEHOLDER as any) _placeholderTemplate: CdkDragPlaceholder;
+  @ContentChild(CDK_DRAG_PLACEHOLDER) _placeholderTemplate: CdkDragPlaceholder;
 
   /** Arbitrary data to attach to this drag instance. */
   @Input('cdkDragData') data: T;

--- a/src/material-experimental/mdc-autocomplete/autocomplete.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.ts
@@ -38,8 +38,7 @@ import {
   ]
 })
 export class MatAutocomplete extends _MatAutocompleteBase {
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_OPTGROUP as any, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  @ContentChildren(MAT_OPTGROUP, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
   @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
   protected _visibleClass = 'mat-mdc-autocomplete-visible';
   protected _hiddenClass = 'mat-mdc-autocomplete-hidden';

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -232,17 +232,14 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
   /** Subject that emits when the component has been destroyed. */
   protected _destroyed = new Subject<void>();
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** The chip's leading icon. */
-  @ContentChild(MAT_CHIP_AVATAR as any) leadingIcon: MatChipAvatar;
+  @ContentChild(MAT_CHIP_AVATAR) leadingIcon: MatChipAvatar;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** The chip's trailing icon. */
-  @ContentChild(MAT_CHIP_TRAILING_ICON as any) trailingIcon: MatChipTrailingIcon;
+  @ContentChild(MAT_CHIP_TRAILING_ICON) trailingIcon: MatChipTrailingIcon;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** The chip's trailing remove icon. */
-  @ContentChild(MAT_CHIP_REMOVE as any) removeIcon: MatChipRemove;
+  @ContentChild(MAT_CHIP_REMOVE) removeIcon: MatChipRemove;
 
   /** Reference to the MatRipple instance of the chip. */
   @ViewChild(MatRipple) ripple: MatRipple;

--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -132,12 +132,9 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
   @ContentChild(MatLabel) _labelChildNonStatic: MatLabel|undefined;
   @ContentChild(MatLabel, {static: true}) _labelChildStatic: MatLabel|undefined;
   @ContentChild(MatFormFieldControl) _formFieldControl: MatFormFieldControl<any>;
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_PREFIX as any, {descendants: true}) _prefixChildren: QueryList<MatPrefix>;
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_SUFFIX as any, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_ERROR as any, {descendants: true}) _errorChildren: QueryList<MatError>;
+  @ContentChildren(MAT_PREFIX, {descendants: true}) _prefixChildren: QueryList<MatPrefix>;
+  @ContentChildren(MAT_SUFFIX, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
+  @ContentChildren(MAT_ERROR, {descendants: true}) _errorChildren: QueryList<MatError>;
   @ContentChildren(MatHint, {descendants: true}) _hintChildren: QueryList<MatHint>;
 
   /** Whether the required marker should be hidden. */

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -261,8 +261,7 @@ export abstract class _MatAutocompleteBase extends _MatAutocompleteMixinBase imp
   ]
 })
 export class MatAutocomplete extends _MatAutocompleteBase {
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_OPTGROUP as any, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  @ContentChildren(MAT_OPTGROUP, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
   @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
   protected _visibleClass = 'mat-autocomplete-visible';
   protected _hiddenClass = 'mat-autocomplete-hidden';

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -189,17 +189,14 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   /** Whether the chip list as a whole is disabled. */
   _chipListDisabled: boolean = false;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** The chip avatar */
-  @ContentChild(MAT_CHIP_AVATAR as any) avatar: MatChipAvatar;
+  @ContentChild(MAT_CHIP_AVATAR) avatar: MatChipAvatar;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** The chip's trailing icon. */
-  @ContentChild(MAT_CHIP_TRAILING_ICON as any) trailingIcon: MatChipTrailingIcon;
+  @ContentChild(MAT_CHIP_TRAILING_ICON) trailingIcon: MatChipTrailingIcon;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** The chip's remove toggler. */
-  @ContentChild(MAT_CHIP_REMOVE as any) removeIcon: MatChipRemove;
+  @ContentChild(MAT_CHIP_REMOVE) removeIcon: MatChipRemove;
 
   /** Whether the chip is selected. */
   @Input()

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -273,14 +273,10 @@ export class MatFormField extends _MatFormFieldMixinBase
   @ContentChild(MatLabel, {static: true}) _labelChildStatic: MatLabel;
   @ContentChild(MatPlaceholder) _placeholderChild: MatPlaceholder;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_ERROR as any, {descendants: true}) _errorChildren: QueryList<MatError>;
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(_MAT_HINT as any, {descendants: true}) _hintChildren: QueryList<MatHint>;
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_PREFIX as any, {descendants: true}) _prefixChildren: QueryList<MatPrefix>;
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
-  @ContentChildren(MAT_SUFFIX as any, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
+  @ContentChildren(MAT_ERROR, {descendants: true}) _errorChildren: QueryList<MatError>;
+  @ContentChildren(_MAT_HINT, {descendants: true}) _hintChildren: QueryList<MatHint>;
+  @ContentChildren(MAT_PREFIX, {descendants: true}) _prefixChildren: QueryList<MatPrefix>;
+  @ContentChildren(MAT_SUFFIX, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
 
   constructor(
       public _elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef,

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -177,12 +177,11 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
    */
   @ContentChildren(MatMenuItem, {descendants: false}) items: QueryList<MatMenuItem>;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /**
    * Menu content that will be rendered lazily.
    * @docs-private
    */
-  @ContentChild(MAT_MENU_CONTENT as any) lazyContent: MatMenuContent;
+  @ContentChild(MAT_MENU_CONTENT) lazyContent: MatMenuContent;
 
   /** Whether the menu should overlap its trigger. */
   @Input()

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -378,16 +378,14 @@ export class MatSelect extends _MatSelectMixinBase implements AfterContentInit, 
   /** All of the defined select options. */
   @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** All of the defined groups of options. */
-  @ContentChildren(MAT_OPTGROUP as any, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  @ContentChildren(MAT_OPTGROUP, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
 
   /** Classes to be passed to the select panel. Supports the same syntax as `ngClass`. */
   @Input() panelClass: string|string[]|Set<string>|{[key: string]: any};
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** User-supplied override of the trigger element. */
-  @ContentChild(MAT_SELECT_TRIGGER as any) customTrigger: MatSelectTrigger;
+  @ContentChild(MAT_SELECT_TRIGGER) customTrigger: MatSelectTrigger;
 
   /** Placeholder to be shown if no value has been selected. */
   @Input()

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -53,18 +53,16 @@ export const MAT_TAB_GROUP = new InjectionToken<any>('MAT_TAB_GROUP');
   exportAs: 'matTab',
 })
 export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnChanges, OnDestroy {
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
-  @ContentChild(MAT_TAB_LABEL as any)
+  @ContentChild(MAT_TAB_LABEL)
   get templateLabel(): MatTabLabel { return this._templateLabel; }
   set templateLabel(value: MatTabLabel) { this._setTemplateLabelInput(value); }
   protected _templateLabel: MatTabLabel;
 
-  // TODO: Remove cast once https://github.com/angular/angular/pull/37506 is available.
   /**
    * Template provided in the tab content that will be used if present, used to enable lazy-loading
    */
-  @ContentChild(MAT_TAB_CONTENT as any, {read: TemplateRef, static: true})
+  @ContentChild(MAT_TAB_CONTENT, {read: TemplateRef, static: true})
   _explicitContent: TemplateRef<any>;
 
   /** Template inside the MatTab view that contains an `<ng-content>`. */


### PR DESCRIPTION
Initially when we added light-weight tokens to our components,
the Angular framework was not properly typed to support
injection tokens in the view and content queries.

We fixed this upstream with https://github.com/angular/angular/pull/37506
and can now remove the workaround/cast since this change is available
due to our recent Angular update to a `next` version.