### PR TITLE
test: switch all async usages to waitForAsync

### DIFF
--- a/src/cdk-experimental/combobox/combobox.spec.ts
+++ b/src/cdk-experimental/combobox/combobox.spec.ts
@@ -9,7 +9,7 @@ import {
   Optional,
   ViewChild
 } from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkComboboxModule} from './combobox-module';
 import {CdkCombobox} from './combobox';
@@ -35,7 +35,7 @@ describe('Combobox', () => {
     let applyButton: DebugElement;
     let applyButtonElement: HTMLElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkComboboxModule],
         declarations: [ComboboxToggle, FakeDialogContent],
@@ -200,7 +200,7 @@ describe('Combobox', () => {
     let combobox: DebugElement;
     let comboboxInstance: CdkCombobox<unknown>;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkComboboxModule],
         declarations: [ComboboxToggle, FakeDialogContent],
@@ -271,7 +271,7 @@ describe('Combobox', () => {
     let comboboxInstance: CdkCombobox<unknown>;
     let comboboxElement: HTMLElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkComboboxModule],
         declarations: [ComboboxToggle, FakeDialogContent],

--- a/src/cdk-experimental/listbox/listbox.spec.ts
+++ b/src/cdk-experimental/listbox/listbox.spec.ts
@@ -1,6 +1,6 @@
 import {
   ComponentFixture,
-  async,
+  waitForAsync,
   TestBed, tick, fakeAsync,
 } from '@angular/core/testing';
 import {Component, DebugElement, ViewChild} from '@angular/core';
@@ -34,14 +34,14 @@ describe('CdkOption and CdkListbox', () => {
     let optionInstances: CdkOption[];
     let optionElements: HTMLElement[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkListboxModule],
         declarations: [ListboxWithOptions],
       }).compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(ListboxWithOptions);
       fixture.detectChanges();
 
@@ -369,14 +369,14 @@ describe('CdkOption and CdkListbox', () => {
     let optionInstances: CdkOption[];
     let optionElements: HTMLElement[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkListboxModule],
         declarations: [ListboxMultiselect],
       }).compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(ListboxMultiselect);
       fixture.detectChanges();
 
@@ -512,14 +512,14 @@ describe('CdkOption and CdkListbox', () => {
     let optionInstances: CdkOption[];
     let optionElements: HTMLElement[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkListboxModule],
         declarations: [ListboxActiveDescendant],
       }).compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(ListboxActiveDescendant);
       fixture.detectChanges();
 
@@ -597,7 +597,7 @@ describe('CdkOption and CdkListbox', () => {
     let optionInstances: CdkOption[];
     let optionElements: HTMLElement[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkListboxModule, FormsModule, ReactiveFormsModule],
         declarations: [ListboxControlValueAccessor],
@@ -786,7 +786,7 @@ describe('CdkOption and CdkListbox', () => {
     let optionInstances: CdkOption[];
     let optionElements: HTMLElement[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkListboxModule, CdkComboboxModule],
         declarations: [ListboxInsideCombobox],

--- a/src/cdk-experimental/menu/context-menu.spec.ts
+++ b/src/cdk-experimental/menu/context-menu.spec.ts
@@ -1,6 +1,6 @@
 import {Component, ViewChild, ElementRef, Type, ViewChildren, QueryList} from '@angular/core';
 import {CdkMenuModule} from './menu-module';
-import {TestBed, async, ComponentFixture} from '@angular/core/testing';
+import {TestBed, waitForAsync, ComponentFixture} from '@angular/core/testing';
 import {CdkMenu} from './menu';
 import {CdkContextMenuTrigger} from './context-menu';
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
@@ -13,7 +13,7 @@ describe('CdkContextMenuTrigger', () => {
   describe('with simple context menu trigger', () => {
     let fixture: ComponentFixture<SimpleContextMenu>;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [SimpleContextMenu],
@@ -108,7 +108,7 @@ describe('CdkContextMenuTrigger', () => {
   describe('nested context menu triggers', () => {
     let fixture: ComponentFixture<NestedContextMenu>;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [NestedContextMenu],
@@ -222,7 +222,7 @@ describe('CdkContextMenuTrigger', () => {
     let fixture: ComponentFixture<ContextMenuWithSubmenu>;
     let instance: ContextMenuWithSubmenu;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [ContextMenuWithSubmenu],
@@ -253,7 +253,7 @@ describe('CdkContextMenuTrigger', () => {
     let nativeMenuBar: HTMLElement;
     let nativeMenuBarTrigger: HTMLElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [ContextMenuWithMenuBarAndInlineMenu],

--- a/src/cdk-experimental/menu/item-pointer-entries.spec.ts
+++ b/src/cdk-experimental/menu/item-pointer-entries.spec.ts
@@ -1,5 +1,5 @@
 import {Component, QueryList, ElementRef, ViewChildren, AfterViewInit} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {createMouseEvent, dispatchEvent} from '@angular/cdk/testing/private';
 import {Observable} from 'rxjs';
 import {FocusableElement, getItemPointerEntries} from './item-pointer-entries';
@@ -15,7 +15,7 @@ describe('FocusMouseManger', () => {
     mockElements = fixture.componentInstance._allItems.toArray();
   }
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [MultiElementWithConditionalComponent, MockWrapper],
     }).compileComponents();

--- a/src/cdk-experimental/menu/menu-bar.spec.ts
+++ b/src/cdk-experimental/menu/menu-bar.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, TestBed, async, fakeAsync, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync, fakeAsync, tick} from '@angular/core/testing';
 import {
   Component,
   ViewChild,
@@ -43,7 +43,7 @@ describe('MenuBar', () => {
     let fixture: ComponentFixture<MenuBarRadioGroup>;
     let menuItems: CdkMenuItemRadio[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuBarRadioGroup],
@@ -72,7 +72,7 @@ describe('MenuBar', () => {
     let fixture: ComponentFixture<MenuBarRadioGroup>;
     let menuItems: CdkMenuItemRadio[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuBarRadioGroup],
@@ -137,7 +137,7 @@ describe('MenuBar', () => {
         detectChanges();
       }
 
-      beforeEach(async(() => {
+      beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule],
           declarations: [MultiMenuWithSubmenu],
@@ -562,7 +562,7 @@ describe('MenuBar', () => {
         detectChanges();
       }
 
-      beforeEach(async(() => {
+      beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule],
           declarations: [MultiMenuWithSubmenu],
@@ -690,7 +690,7 @@ describe('MenuBar', () => {
         detectChanges();
       }
 
-      beforeEach(async(() => {
+      beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule],
           declarations: [MenuWithCheckboxes],
@@ -757,7 +757,7 @@ describe('MenuBar', () => {
         detectChanges();
       }
 
-      beforeEach(async(() => {
+      beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule],
           declarations: [MenuWithRadioButtons],
@@ -813,7 +813,7 @@ describe('MenuBar', () => {
       grabElementsForTesting();
     }
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuBarWithMenusAndInlineMenu],
@@ -933,7 +933,7 @@ describe('MenuBar', () => {
       detectChanges();
     }
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MultiMenuWithSubmenu],

--- a/src/cdk-experimental/menu/menu-group.spec.ts
+++ b/src/cdk-experimental/menu/menu-group.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkMenuModule} from './menu-module';
 import {CdkMenuGroup} from './menu-group';
@@ -14,7 +14,7 @@ describe('MenuGroup', () => {
     let fixture: ComponentFixture<CheckboxMenu>;
     let menuItems: CdkMenuItemCheckbox[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [CheckboxMenu],
@@ -43,7 +43,7 @@ describe('MenuGroup', () => {
     let fixture: ComponentFixture<MenuWithMultipleRadioGroups>;
     let menuItems: CdkMenuItemRadio[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuWithMultipleRadioGroups],
@@ -89,7 +89,7 @@ describe('MenuGroup', () => {
     let fixture: ComponentFixture<MenuWithMenuItemsAndRadioGroups>;
     let menuItems: CdkMenuItemRadio[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuWithMenuItemsAndRadioGroups],

--- a/src/cdk-experimental/menu/menu-item-checkbox.spec.ts
+++ b/src/cdk-experimental/menu/menu-item-checkbox.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkMenuModule} from './menu-module';
 import {CdkMenuItemCheckbox} from './menu-item-checkbox';
@@ -11,7 +11,7 @@ describe('MenuItemCheckbox', () => {
   let checkbox: CdkMenuItemCheckbox;
   let checkboxElement: HTMLButtonElement;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CdkMenuModule],
       declarations: [SingleCheckboxButton],

--- a/src/cdk-experimental/menu/menu-item-radio.spec.ts
+++ b/src/cdk-experimental/menu/menu-item-radio.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {UniqueSelectionDispatcher} from '@angular/cdk/collections';
 import {CdkMenuModule} from './menu-module';
@@ -13,7 +13,7 @@ describe('MenuItemRadio', () => {
   let radioElement: HTMLButtonElement;
   let selectionDispatcher: UniqueSelectionDispatcher;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     selectionDispatcher = new UniqueSelectionDispatcher();
     TestBed.configureTestingModule({
       imports: [CdkMenuModule],

--- a/src/cdk-experimental/menu/menu-item-trigger.spec.ts
+++ b/src/cdk-experimental/menu/menu-item-trigger.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChildren, QueryList, ElementRef, ViewChild, Type} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {TAB, SPACE} from '@angular/cdk/keycodes';
@@ -15,7 +15,7 @@ describe('MenuItemTrigger', () => {
     let menuItem: CdkMenuItem;
     let menuItemElement: HTMLButtonElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [TriggerForEmptyMenu],
@@ -82,7 +82,7 @@ describe('MenuItemTrigger', () => {
 
     const setDocumentDirection = (dir: 'ltr' | 'rtl') => (document.dir = dir);
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuBarWithNestedSubMenus],
@@ -351,7 +351,7 @@ describe('MenuItemTrigger', () => {
       grabElementsForTesting();
     };
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [StandaloneTriggerWithInlineMenu],

--- a/src/cdk-experimental/menu/menu-item.spec.ts
+++ b/src/cdk-experimental/menu/menu-item.spec.ts
@@ -1,5 +1,5 @@
 import {Component, Type} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CdkMenuModule} from './menu-module';
 import {CdkMenuItem} from './menu-item';
@@ -12,7 +12,7 @@ describe('MenuItem', () => {
     let menuItem: CdkMenuItem;
     let nativeButton: HTMLButtonElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [SingleMenuItem],

--- a/src/cdk-experimental/menu/menu-stack.spec.ts
+++ b/src/cdk-experimental/menu/menu-stack.spec.ts
@@ -1,7 +1,7 @@
 import {QueryList, ViewChild, ViewChildren, Component} from '@angular/core';
 import {CdkMenu} from './menu';
 import {CdkMenuBar} from './menu-bar';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {CdkMenuItemTrigger} from './menu-item-trigger';
 import {MenuStack} from './menu-stack';
 import {CdkMenuModule} from './menu-module';
@@ -20,7 +20,7 @@ describe('MenuStack', () => {
     menuStack = fixture.componentInstance.menuBar._menuStack;
   }
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [CdkMenuModule],
       declarations: [MultiMenuWithSubmenu],

--- a/src/cdk-experimental/menu/menu.spec.ts
+++ b/src/cdk-experimental/menu/menu.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {TAB} from '@angular/cdk/keycodes';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
@@ -15,7 +15,7 @@ describe('Menu', () => {
     let fixture: ComponentFixture<MenuCheckboxGroup>;
     let menuItems: CdkMenuItemCheckbox[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuCheckboxGroup],
@@ -51,7 +51,7 @@ describe('Menu', () => {
     let fixture: ComponentFixture<MenuCheckboxGroup>;
     let menuItems: CdkMenuItemCheckbox[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuCheckboxGroup],
@@ -85,7 +85,7 @@ describe('Menu', () => {
     let menuItems: CdkMenuItemCheckbox[];
     let menu: CdkMenu;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuWithNestedGroup],
@@ -128,7 +128,7 @@ describe('Menu', () => {
         .map(element => element.injector.get(CdkMenuItemCheckbox));
     };
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [MenuWithConditionalGroup],
@@ -166,7 +166,7 @@ describe('Menu', () => {
     let nativeMenu: HTMLElement;
     let nativeMenuItems: HTMLElement[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [CdkMenuModule],
         declarations: [InlineMenu],

--- a/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk-experimental/scrolling/virtual-scroll-viewport.spec.ts
@@ -1,6 +1,6 @@
 import {CdkVirtualScrollViewport, ScrollingModule} from '@angular/cdk/scrolling';
 import {Component, Input, ViewChild, ViewEncapsulation} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {ScrollingModule as ExperimentalScrollingModule} from './scrolling-module';
 
 
@@ -10,7 +10,7 @@ describe('CdkVirtualScrollViewport', () => {
     let testComponent: AutoSizeVirtualScroll;
     let viewport: CdkVirtualScrollViewport;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule, ExperimentalScrollingModule],
         declarations: [AutoSizeVirtualScroll],

--- a/src/cdk-experimental/selection/selection.spec.ts
+++ b/src/cdk-experimental/selection/selection.spec.ts
@@ -6,7 +6,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   flush,
@@ -21,7 +21,7 @@ describe('CdkSelection', () => {
   let fixture: ComponentFixture<ListWithMultiSelection>;
   let component: ListWithMultiSelection;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed
         .configureTestingModule({
           imports: [CdkSelectionModule],
@@ -258,7 +258,7 @@ describe('CdkSelection with multiple = false', () => {
   let fixture: ComponentFixture<ListWithSingleSelection>;
   let component: ListWithSingleSelection;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed
         .configureTestingModule({
           imports: [CdkSelectionModule],
@@ -336,7 +336,7 @@ describe('cdkSelectionColumn', () => {
   let fixture: ComponentFixture<MultiSelectTableWithSelectionColumn>;
   let component: MultiSelectTableWithSelectionColumn;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed
         .configureTestingModule({
           imports: [
@@ -438,7 +438,7 @@ describe('cdkSelectionColumn with multiple = false', () => {
   let fixture: ComponentFixture<SingleSelectTableWithSelectionColumn>;
   let component: SingleSelectTableWithSelectionColumn;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed
         .configureTestingModule({
           imports: [

--- a/src/cdk/a11y/focus-trap/focus-trap.spec.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.spec.ts
@@ -1,13 +1,13 @@
 import {Platform} from '@angular/cdk/platform';
 import {Component, ViewChild, TemplateRef, ViewContainerRef} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {PortalModule, CdkPortalOutlet, TemplatePortal} from '@angular/cdk/portal';
 import {A11yModule, FocusTrap, CdkTrapFocus} from '../index';
 
 
 describe('FocusTrap', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [A11yModule, PortalModule],
       declarations: [
@@ -170,7 +170,7 @@ describe('FocusTrap', () => {
   });
 
   describe('with autoCapture', () => {
-    it('should automatically capture and return focus on init / destroy', async(() => {
+    it('should automatically capture and return focus on init / destroy', waitForAsync(() => {
       const fixture = TestBed.createComponent(FocusTrapWithAutoCapture);
       fixture.detectChanges();
 
@@ -189,7 +189,7 @@ describe('FocusTrap', () => {
       });
     }));
 
-    it('should capture focus if auto capture is enabled later on', async(() => {
+    it('should capture focus if auto capture is enabled later on', waitForAsync(() => {
       const fixture = TestBed.createComponent(FocusTrapWithAutoCapture);
       fixture.componentInstance.autoCaptureEnabled = false;
       fixture.componentInstance.showTrappedRegion = true;

--- a/src/cdk/accordion/accordion-item.spec.ts
+++ b/src/cdk/accordion/accordion-item.spec.ts
@@ -1,11 +1,11 @@
-import {async, TestBed, ComponentFixture} from '@angular/core/testing';
+import {waitForAsync, TestBed, ComponentFixture} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {CdkAccordionModule, CdkAccordionItem} from './public-api';
 
 describe('CdkAccordionItem', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,

--- a/src/cdk/accordion/accordion.spec.ts
+++ b/src/cdk/accordion/accordion.spec.ts
@@ -1,11 +1,11 @@
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {CdkAccordionModule, CdkAccordionItem} from './public-api';
 
 describe('CdkAccordion', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,

--- a/src/cdk/bidi/directionality.spec.ts
+++ b/src/cdk/bidi/directionality.spec.ts
@@ -1,4 +1,4 @@
-import {async, fakeAsync, TestBed} from '@angular/core/testing';
+import {waitForAsync, fakeAsync, TestBed} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {BidiModule, Directionality, Dir, Direction, DIR_DOCUMENT} from './index';
@@ -6,7 +6,7 @@ import {BidiModule, Directionality, Dir, Direction, DIR_DOCUMENT} from './index'
 describe('Directionality', () => {
   let fakeDocument: FakeDocument;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fakeDocument = {body: {}, documentElement: {}};
 
     TestBed.configureTestingModule({

--- a/src/cdk/observers/observe-content.spec.ts
+++ b/src/cdk/observers/observe-content.spec.ts
@@ -1,10 +1,17 @@
 import {Component, ElementRef, ViewChild} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {
+  waitForAsync,
+  ComponentFixture,
+  fakeAsync,
+  inject,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import {ContentObserver, MutationObserverFactory, ObserversModule} from './observe-content';
 
 describe('Observe content directive', () => {
   describe('basic usage', () => {
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ObserversModule],
         declarations: [ComponentWithTextContent, ComponentWithChildTextContent]
@@ -79,7 +86,7 @@ describe('Observe content directive', () => {
     let callbacks: Function[];
     let invokeCallbacks = (args?: any) => callbacks.forEach(callback => callback(args));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       callbacks = [];
 
       TestBed.configureTestingModule({

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -1,5 +1,5 @@
 import {DOCUMENT} from '@angular/common';
-import {async, inject, TestBed} from '@angular/core/testing';
+import {waitForAsync, inject, TestBed} from '@angular/core/testing';
 import {Component, NgModule, ViewChild, ViewContainerRef} from '@angular/core';
 import {PortalModule, CdkPortal} from '@angular/cdk/portal';
 import {Overlay, OverlayContainer, OverlayModule, FullscreenOverlayContainer} from './index';
@@ -10,7 +10,7 @@ describe('FullscreenOverlayContainer', () => {
   let fullscreenListeners: Set<Function>;
   let fakeDocument: any;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fullscreenListeners = new Set();
 
     TestBed.configureTestingModule({

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -1,4 +1,4 @@
-import {async, inject, TestBed} from '@angular/core/testing';
+import {waitForAsync, inject, TestBed} from '@angular/core/testing';
 import {Component, NgModule, ViewChild, ViewContainerRef} from '@angular/core';
 import {PortalModule, CdkPortal} from '@angular/cdk/portal';
 import {Overlay, OverlayContainer, OverlayModule} from './index';
@@ -7,7 +7,7 @@ describe('OverlayContainer', () => {
   let overlay: Overlay;
   let overlayContainer: OverlayContainer;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [OverlayTestModule]
     }).compileComponents();

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -1,6 +1,13 @@
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {ComponentFixture, TestBed, async, inject, fakeAsync, tick} from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+  inject,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import {Directionality} from '@angular/cdk/bidi';
 import {
   dispatchKeyboardEvent,
@@ -169,7 +176,7 @@ describe('Overlay directives', () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
-  it('should not depend on the order in which the `origin` and `open` are set', async(() => {
+  it('should not depend on the order in which the `origin` and `open` are set', waitForAsync(() => {
     fixture.destroy();
 
     const propOrderFixture = TestBed.createComponent(ConnectedOverlayPropertyInitOrder);

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -1,4 +1,11 @@
-import {async, fakeAsync, tick, ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {
+  waitForAsync,
+  fakeAsync,
+  tick,
+  ComponentFixture,
+  inject,
+  TestBed,
+} from '@angular/core/testing';
 import {
   Component,
   NgModule,
@@ -42,7 +49,7 @@ describe('Overlay', () => {
   let zone: MockNgZone;
   let mockLocation: SpyLocation;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [OverlayModule, PortalModule, OverlayTestModule],

--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -1,5 +1,5 @@
 import {Component, NgModule} from '@angular/core';
-import {async, inject, TestBed} from '@angular/core/testing';
+import {waitForAsync, inject, TestBed} from '@angular/core/testing';
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
 import {Platform} from '@angular/cdk/platform';
 import {ViewportRuler} from '@angular/cdk/scrolling';
@@ -14,7 +14,7 @@ describe('BlockScrollStrategy', () => {
   let componentPortal: ComponentPortal<FocacciaMsg>;
   let forceScrollElement: HTMLElement;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     documentElement = document.documentElement!;
 
     // Ensure a clean state for every test.

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -1,4 +1,4 @@
-import {async, inject, TestBed} from '@angular/core/testing';
+import {waitForAsync, inject, TestBed} from '@angular/core/testing';
 import {Component, NgModule} from '@angular/core';
 import {Subject} from 'rxjs';
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
@@ -18,7 +18,7 @@ describe('RepositionScrollStrategy', () => {
   let componentPortal: ComponentPortal<PastaMsg>;
   let scrolledSubject = new Subject();
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [OverlayModule, PortalModule, OverlayTestModule],
       providers: [

--- a/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/cdk/schematics/ng-generate/drag-drop/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,5 +1,5 @@
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 
@@ -7,7 +7,7 @@ describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
   let fixture: ComponentFixture<<%= classify(name) %>Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %>Component ],
       imports: [

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -1,11 +1,18 @@
-import {inject, TestBed, async, fakeAsync, ComponentFixture, tick} from '@angular/core/testing';
+import {
+  inject,
+  TestBed,
+  waitForAsync,
+  fakeAsync,
+  ComponentFixture,
+  tick,
+} from '@angular/core/testing';
 import {NgModule, Component, ViewChild, ElementRef} from '@angular/core';
 import {CdkScrollable, ScrollDispatcher, ScrollingModule} from './public-api';
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
 
 describe('ScrollDispatcher', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ScrollTestModule],
     });

--- a/src/cdk/scrolling/scrollable.spec.ts
+++ b/src/cdk/scrolling/scrollable.spec.ts
@@ -1,7 +1,7 @@
 import {Direction} from '@angular/cdk/bidi';
 import {CdkScrollable, ScrollingModule} from '@angular/cdk/scrolling';
 import {Component, ElementRef, Input, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 
 function expectOverlapping(el1: ElementRef<Element>, el2: ElementRef<Element>, expected = true) {
   const r1 = el1.nativeElement.getBoundingClientRect();
@@ -22,7 +22,7 @@ describe('CdkScrollable', () => {
   let testComponent: ScrollableViewport;
   let maxOffset = 0;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ScrollingModule],
       declarations: [ScrollableViewport],

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -17,7 +17,7 @@ import {
   ViewContainerRef
 } from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   flush,
@@ -34,7 +34,7 @@ describe('CdkVirtualScrollViewport', () => {
     let testComponent: FixedSizeVirtualScroll;
     let viewport: CdkVirtualScrollViewport;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule],
         declarations: [FixedSizeVirtualScroll],
@@ -866,7 +866,7 @@ describe('CdkVirtualScrollViewport', () => {
     let testComponent: VirtualScrollWithItemInjectingViewContainer;
     let viewport: CdkVirtualScrollViewport;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [ScrollingModule],
         declarations: [VirtualScrollWithItemInjectingViewContainer, InjectsViewContainer],

--- a/src/cdk/table/text-column.spec.ts
+++ b/src/cdk/table/text-column.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {
   getTableTextColumnMissingParentTableError,
@@ -15,7 +15,7 @@ describe('CdkTextColumn', () => {
   let component: BasicTextColumnApp;
   let tableElement: HTMLElement;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed
         .configureTestingModule({
           imports: [CdkTableModule],

--- a/src/cdk/testing/tests/testbed.spec.ts
+++ b/src/cdk/testing/tests/testbed.spec.ts
@@ -3,7 +3,7 @@ import {
   HarnessLoader,
 } from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {async, ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import {querySelectorAll as piercingQuerySelectorAll} from 'kagekiri';
 import {crossEnvironmentSpecs} from './cross-environment.spec';
 import {FakeOverlayHarness} from './harnesses/fake-overlay-harness';
@@ -70,7 +70,7 @@ describe('TestbedHarnessEnvironment', () => {
       });
 
       it('should be able to wait for tasks outside of Angular within async test zone',
-          async (() => {
+          waitForAsync(() => {
         harness.getTaskStateResult().then(res => expect(res).toBe('result'));
       }));
 

--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -1,6 +1,13 @@
 import {dispatchFakeEvent} from '@angular/cdk/testing/private';
 import {Component, ViewChild} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {
+  waitForAsync,
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,7 +20,7 @@ describe('CdkTextareaAutosize', () => {
   let textarea: HTMLTextAreaElement;
   let autosize: CdkTextareaAutosize;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         FormsModule,

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {GoogleMapsModule} from '../google-maps-module';
@@ -24,7 +24,7 @@ describe('GoogleMap', () => {
   let mapConstructorSpy: jasmine.Spy;
   let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         GoogleMapsModule,

--- a/src/google-maps/map-bicycling-layer/map-bicycling-layer.spec.ts
+++ b/src/google-maps/map-bicycling-layer/map-bicycling-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {GoogleMapsModule} from '../google-maps-module';
@@ -13,7 +13,7 @@ import {
 describe('MapBicyclingLayer', () => {
   let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [GoogleMapsModule],
       declarations: [TestApp],

--- a/src/google-maps/map-circle/map-circle.spec.ts
+++ b/src/google-maps/map-circle/map-circle.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
@@ -19,7 +19,7 @@ describe('MapCircle', () => {
   let circleRadius: number;
   let circleOptions: google.maps.CircleOptions;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     circleCenter = {lat: 30, lng: 15};
     circleRadius = 15;
     circleOptions = {

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
@@ -21,7 +21,7 @@ describe('MapGroundOverlay', () => {
   const opacity = 0.5;
   const groundOverlayOptions: google.maps.GroundOverlayOptions = {clickable, opacity};
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [GoogleMapsModule],
       declarations: [TestApp],

--- a/src/google-maps/map-info-window/map-info-window.spec.ts
+++ b/src/google-maps/map-info-window/map-info-window.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
@@ -17,7 +17,7 @@ import {MapInfoWindow} from './map-info-window';
 describe('MapInfoWindow', () => {
   let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [GoogleMapsModule],
       declarations: [TestApp],

--- a/src/google-maps/map-kml-layer/map-kml-layer.spec.ts
+++ b/src/google-maps/map-kml-layer/map-kml-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
@@ -23,7 +23,7 @@ const DEFAULT_KML_OPTIONS: google.maps.KmlLayerOptions = {
 describe('MapKmlLayer', () => {
   let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [GoogleMapsModule],
       declarations: [TestApp],

--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
 
@@ -15,7 +15,7 @@ import {DEFAULT_MARKER_OPTIONS, MapMarker} from './map-marker';
 describe('MapMarker', () => {
   let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [GoogleMapsModule],
       declarations: [TestApp],

--- a/src/google-maps/map-polygon/map-polygon.spec.ts
+++ b/src/google-maps/map-polygon/map-polygon.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
@@ -18,7 +18,7 @@ describe('MapPolygon', () => {
   let polygonPath: google.maps.LatLngLiteral[];
   let polygonOptions: google.maps.PolygonOptions;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     polygonPath = [{lat: 25, lng: 26}, {lat: 26, lng: 27}, {lat: 30, lng: 34}];
     polygonOptions = {paths: polygonPath, strokeColor: 'grey', strokeOpacity: 0.8};
     TestBed.configureTestingModule({

--- a/src/google-maps/map-polyline/map-polyline.spec.ts
+++ b/src/google-maps/map-polyline/map-polyline.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
@@ -18,7 +18,7 @@ describe('MapPolyline', () => {
   let polylinePath: google.maps.LatLngLiteral[];
   let polylineOptions: google.maps.PolylineOptions;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     polylinePath = [{ lat: 25, lng: 26 }, { lat: 26, lng: 27 }, { lat: 30, lng: 34 }];
     polylineOptions = {
       path: polylinePath,

--- a/src/google-maps/map-rectangle/map-rectangle.spec.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
@@ -18,7 +18,7 @@ describe('MapRectangle', () => {
   let rectangleBounds: google.maps.LatLngBoundsLiteral;
   let rectangleOptions: google.maps.RectangleOptions;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     rectangleBounds = {east: 30, north: 15, west: 10, south: -5};
     rectangleOptions = {bounds: rectangleBounds, strokeColor: 'grey', strokeOpacity: 0.8};
     TestBed.configureTestingModule({

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.spec.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {GoogleMapsModule} from '../google-maps-module';
@@ -14,7 +14,7 @@ describe('MapTrafficLayer', () => {
   let mapSpy: jasmine.SpyObj<google.maps.Map>;
   const trafficLayerOptions: google.maps.TrafficLayerOptions = {autoRefresh: false};
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [GoogleMapsModule],
       declarations: [TestApp],

--- a/src/google-maps/map-transit-layer/map-transit-layer.spec.ts
+++ b/src/google-maps/map-transit-layer/map-transit-layer.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 
 import {DEFAULT_OPTIONS} from '../google-map/google-map';
 import {GoogleMapsModule} from '../google-maps-module';
@@ -13,7 +13,7 @@ import {
 describe('MapTransitLayer', () => {
   let mapSpy: jasmine.SpyObj<google.maps.Map>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [GoogleMapsModule],
       declarations: [TestApp],

--- a/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
@@ -26,7 +26,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   flush,
@@ -161,7 +161,7 @@ describe('MDC-based MatAutocomplete', () => {
     });
 
     it('should show the panel when the first open is after the initial zone stabilization',
-      async(() => {
+      waitForAsync(() => {
         // Note that we're running outside the Angular zone, in order to be able
         // to test properly without the subscription from `_subscribeToClosingActions`
         // giving us a false positive.

--- a/src/material-experimental/mdc-button/button.spec.ts
+++ b/src/material-experimental/mdc-button/button.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MatButtonModule, MatButton} from './index';
@@ -7,7 +7,7 @@ import {MatRipple, ThemePalette} from '@angular/material/core';
 
 describe('MDC-based MatButton', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatButtonModule],
       declarations: [TestApp],

--- a/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
@@ -1,5 +1,5 @@
 import {Component, DebugElement} from '@angular/core';
-import {async, TestBed, ComponentFixture} from '@angular/core/testing';
+import {waitForAsync, TestBed, ComponentFixture} from '@angular/core/testing';
 import {MatChipEditInput, MatChipsModule} from './index';
 import {By} from '@angular/platform-browser';
 
@@ -11,7 +11,7 @@ describe('MDC-based MatChipEditInput', () => {
   let inputDebugElement: DebugElement;
   let inputInstance: MatChipEditInput;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [

--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -3,7 +3,7 @@ import {COMMA, ENTER, TAB} from '@angular/cdk/keycodes';
 import {PlatformModule} from '@angular/cdk/platform';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -26,7 +26,7 @@ describe('MDC-based MatChipInput', () => {
   let chipInputDirective: MatChipInput;
   let dir = 'ltr';
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [PlatformModule, MatChipsModule, MatFormFieldModule, NoopAnimationsModule],
       declarations: [TestChipInput],
@@ -43,7 +43,7 @@ describe('MDC-based MatChipInput', () => {
     TestBed.compileComponents();
   }));
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(TestChipInput);
     testChipInput = fixture.debugElement.componentInstance;
     fixture.detectChanges();

--- a/src/material-experimental/mdc-chips/chip-option.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-option.spec.ts
@@ -2,7 +2,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {SPACE} from '@angular/cdk/keycodes';
 import {createKeyboardEvent, dispatchFakeEvent} from '@angular/cdk/testing/private';
 import {Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {chipCssClasses} from '@material/chips';
 import {Subject} from 'rxjs';
@@ -23,7 +23,7 @@ describe('MDC-based Option Chips', () => {
 
   let dir = 'ltr';
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [SingleChip],

--- a/src/material-experimental/mdc-chips/chip-remove.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-remove.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/cdk/testing/private';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {SPACE, ENTER, TAB} from '@angular/cdk/keycodes';
 import {MatChip, MatChipsModule} from './index';
 
@@ -16,7 +16,7 @@ describe('MDC-based Chip Remove', () => {
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [
@@ -27,7 +27,7 @@ describe('MDC-based Chip Remove', () => {
     TestBed.compileComponents();
   }));
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(TestChip);
     testChip = fixture.debugElement.componentInstance;
     fixture.detectChanges();

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -7,7 +7,7 @@ import {
   dispatchFakeEvent,
 } from '@angular/cdk/testing/private';
 import {Component, DebugElement, ElementRef, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed, flush, fakeAsync} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed, flush, fakeAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
 import {
@@ -30,7 +30,7 @@ describe('MDC-based Row Chips', () => {
 
   let dir = 'ltr';
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [SingleChip],

--- a/src/material-experimental/mdc-chips/chip-set.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-set.spec.ts
@@ -1,12 +1,12 @@
 import {Component, DebugElement, QueryList} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {CommonModule} from '@angular/common';
 import {By} from '@angular/platform-browser';
 import {MatChip, MatChipSet, MatChipsModule} from './index';
 
 
 describe('MDC-based MatChipSet', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule, CommonModule],
       declarations: [BasicChipSet, IndirectDescendantsChipSet],

--- a/src/material-experimental/mdc-chips/chip.spec.ts
+++ b/src/material-experimental/mdc-chips/chip.spec.ts
@@ -1,7 +1,7 @@
 import {Directionality} from '@angular/cdk/bidi';
 import {createFakeEvent} from '@angular/cdk/testing/private';
 import {Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatRipple} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
@@ -18,7 +18,7 @@ describe('MDC-based MatChip', () => {
 
   let dir = 'ltr';
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [

--- a/src/material-experimental/mdc-core/option/option.spec.ts
+++ b/src/material-experimental/mdc-core/option/option.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
@@ -12,7 +12,7 @@ import {MatOption, MatOptionModule} from './index';
 
 describe('MatOption component', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatOptionModule],
       declarations: [BasicOption]

--- a/src/material-experimental/mdc-list/list.spec.ts
+++ b/src/material-experimental/mdc-list/list.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {waitForAsync, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {Component, QueryList, ViewChildren} from '@angular/core';
 import {defaultRippleAnimationConfig} from '@angular/material/core';
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
@@ -9,7 +9,7 @@ describe('MDC-based MatList', () => {
   // Default ripple durations used for testing.
   const {enterDuration, exitDuration} = defaultRippleAnimationConfig;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatListModule],
       declarations: [

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -13,7 +13,14 @@ import {
   QueryList,
   ViewChildren,
 } from '@angular/core';
-import {async, ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {
+  waitForAsync,
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {defaultRippleAnimationConfig, ThemePalette} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
@@ -26,7 +33,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     let listOptions: DebugElement[];
     let selectionList: DebugElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -43,7 +50,7 @@ describe('MDC-based MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithListOptions);
       fixture.detectChanges();
 
@@ -741,7 +748,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     let listItemEl: DebugElement;
     let selectionList: DebugElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [SelectionListWithSelectedOption],
@@ -750,7 +757,7 @@ describe('MDC-based MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithSelectedOption);
       listItemEl = fixture.debugElement.query(By.directive(MatListOption))!;
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
@@ -769,7 +776,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     let listOptionEl: HTMLElement;
     let listOption: MatListOption;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [SelectionListWithDisabledOption]
@@ -778,7 +785,7 @@ describe('MDC-based MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithDisabledOption);
 
       const listOptionDebug = fixture.debugElement.query(By.directive(MatListOption))!;
@@ -815,7 +822,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     let listOption: DebugElement[];
     let selectionList: DebugElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -829,7 +836,7 @@ describe('MDC-based MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithListDisabled);
       listOption = fixture.debugElement.queryAll(By.directive(MatListOption));
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
@@ -866,7 +873,7 @@ describe('MDC-based MatSelectionList without forms', () => {
   describe('with checkbox position after', () => {
     let fixture: ComponentFixture<SelectionListWithCheckboxPositionAfter>;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -880,7 +887,7 @@ describe('MDC-based MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithCheckboxPositionAfter);
       fixture.detectChanges();
     }));
@@ -894,7 +901,7 @@ describe('MDC-based MatSelectionList without forms', () => {
   });
 
   describe('with list item elements', () => {
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -926,7 +933,7 @@ describe('MDC-based MatSelectionList without forms', () => {
     let listOptions: DebugElement[];
     let selectionList: DebugElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -1046,7 +1053,7 @@ describe('MDC-based MatSelectionList without forms', () => {
 
 describe('MDC-based MatSelectionList with forms', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatListModule, FormsModule, ReactiveFormsModule],
       declarations: [

--- a/src/material-experimental/mdc-progress-spinner/progress-spinner.spec.ts
+++ b/src/material-experimental/mdc-progress-spinner/progress-spinner.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed} from '@angular/core/testing';
+import {waitForAsync, TestBed} from '@angular/core/testing';
 import {
   MatProgressSpinner,
   MatProgressSpinnerModule
@@ -9,7 +9,7 @@ import {MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS} from '@angular/material/progress-s
 import {Component, ElementRef, ViewChild, ViewEncapsulation} from '@angular/core';
 
 describe('MDC-based MatProgressSpinner', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatProgressSpinnerModule, CommonModule],
       declarations: [

--- a/src/material-experimental/mdc-radio/radio.spec.ts
+++ b/src/material-experimental/mdc-radio/radio.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {Component, DebugElement, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
@@ -12,7 +12,7 @@ import {
 } from './index';
 
 describe('MDC-based MatRadio', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
       declarations: [
@@ -44,7 +44,7 @@ describe('MDC-based MatRadio', () => {
     let radioInstances: MatRadioButton[];
     let testComponent: RadiosInsideRadioGroup;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(RadiosInsideRadioGroup);
       fixture.detectChanges();
 
@@ -824,7 +824,7 @@ describe('MDC-based MatRadio', () => {
     let radioDebugElements: DebugElement[];
     let radioInstances: MatRadioButton[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(InterleavedRadioGroup);
       fixture.detectChanges();
 
@@ -842,7 +842,7 @@ describe('MDC-based MatRadio', () => {
 
 describe('MatRadioDefaultOverrides', () => {
   describe('when MAT_RADIO_DEFAULT_OPTIONS overridden', () => {
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatRadioModule, FormsModule],
         declarations: [DefaultRadioButton, RadioButtonWithColorBinding],

--- a/src/material-experimental/mdc-table/table.spec.ts
+++ b/src/material-experimental/mdc-table/table.spec.ts
@@ -1,6 +1,6 @@
 import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   flushMicrotasks,
@@ -16,7 +16,7 @@ import {MatTableDataSource} from '@angular/material/table';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('MDC-based MatTable', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatTableModule, MatPaginatorModule, MatSortModule, NoopAnimationsModule],
       declarations: [

--- a/src/material-experimental/mdc-tabs/tab-body.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-body.spec.ts
@@ -2,7 +2,7 @@ import {Direction, Directionality} from '@angular/cdk/bidi';
 import {PortalModule, TemplatePortal} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {AfterContentInit, Component, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatRippleModule} from '@angular/material/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTabBody, MatTabBodyPortal} from './tab-body';
@@ -13,7 +13,7 @@ describe('MDC-based MatTabBody', () => {
   let dir: Direction = 'ltr';
   let dirChange: Subject<Direction> = new Subject<Direction>();
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [CommonModule, PortalModule, MatRippleModule, NoopAnimationsModule],

--- a/src/material-experimental/mdc-tabs/tab-group.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.spec.ts
@@ -1,7 +1,7 @@
 import {LEFT_ARROW} from '@angular/cdk/keycodes';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {Component, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {CommonModule} from '@angular/common';
@@ -81,7 +81,7 @@ describe('MDC-based MatTabGroup', () => {
     }));
 
     // Note: needs to be `async` in order to fail when we expect it to.
-    it('should set to correct tab on fast change', async(() => {
+    it('should set to correct tab on fast change', waitForAsync(() => {
       let component = fixture.componentInstance;
       component.selectedIndex = 0;
       fixture.detectChanges();

--- a/src/material-experimental/mdc-tabs/tab-header.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.spec.ts
@@ -12,7 +12,7 @@ import {
 import {CommonModule} from '@angular/common';
 import {Component, ViewChild} from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   discardPeriodicTasks,
   fakeAsync,
@@ -33,7 +33,7 @@ describe('MDC-based MatTabHeader', () => {
   let fixture: ComponentFixture<SimpleTabHeaderApp>;
   let appComponent: SimpleTabHeaderApp;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [CommonModule, PortalModule, MatRippleModule, ScrollingModule, ObserversModule],

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
@@ -16,7 +16,7 @@ describe('MDC-based MatTabNavBar', () => {
   let dirChange = new Subject();
   let globalRippleOptions: RippleGlobalOptions;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     globalRippleOptions = {};
 
     TestBed.configureTestingModule({

--- a/src/material-experimental/menubar/menubar-item.spec.ts
+++ b/src/material-experimental/menubar/menubar-item.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ElementRef, ViewChild} from '@angular/core';
-import {ComponentFixture, async, TestBed} from '@angular/core/testing';
+import {ComponentFixture, waitForAsync, TestBed} from '@angular/core/testing';
 import {CdkMenuItem, CdkMenuModule, CdkMenu} from '@angular/cdk-experimental/menu';
 import {MatMenuBarItem} from './menubar-item';
 import {MatMenuBarModule} from './menubar-module';
@@ -9,7 +9,7 @@ describe('MatMenuBarItem', () => {
   let menubarItem: MatMenuBarItem;
   let nativeMenubarItem: HTMLElement;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatMenuBarModule, CdkMenuModule],
       declarations: [SimpleMenuBarItem],

--- a/src/material-experimental/menubar/menubar.spec.ts
+++ b/src/material-experimental/menubar/menubar.spec.ts
@@ -1,7 +1,7 @@
 import {Component, ViewChild, ElementRef} from '@angular/core';
 import {RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {CdkMenuBar} from '@angular/cdk-experimental/menu';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {MatMenuBarModule} from './menubar-module';
 import {MatMenuBar} from './menubar';
@@ -11,7 +11,7 @@ describe('MatMenuBar', () => {
   let matMenubar: MatMenuBar;
   let nativeMatMenubar: HTMLElement;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatMenuBarModule],
       declarations: [SimpleMatMenuBar],

--- a/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {LOCALE_ID} from '@angular/core';
-import {async, inject, TestBed} from '@angular/core/testing';
+import {waitForAsync, inject, TestBed} from '@angular/core/testing';
 import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
 import {DEC, FEB, JAN, MAR} from '@angular/material/testing';
 import {MomentDateModule} from './index';
@@ -19,7 +19,7 @@ describe('MomentDateAdapter', () => {
   let adapter: MomentDateAdapter;
   let assertValidDate: (d: moment.Moment | null, valid: boolean) => void;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MomentDateModule]
     }).compileComponents();
@@ -399,7 +399,7 @@ describe('MomentDateAdapter', () => {
 describe('MomentDateAdapter with MAT_DATE_LOCALE override', () => {
   let adapter: MomentDateAdapter;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MomentDateModule],
       providers: [{provide: MAT_DATE_LOCALE, useValue: 'ja-JP'}]
@@ -418,7 +418,7 @@ describe('MomentDateAdapter with MAT_DATE_LOCALE override', () => {
 describe('MomentDateAdapter with LOCALE_ID override', () => {
   let adapter: MomentDateAdapter;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MomentDateModule],
       providers: [{provide: LOCALE_ID, useValue: 'fr'}]
@@ -437,7 +437,7 @@ describe('MomentDateAdapter with LOCALE_ID override', () => {
 describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () => {
   let adapter: MomentDateAdapter;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MomentDateModule],
       providers: [{
@@ -471,7 +471,7 @@ describe('MomentDateAdapter with MAT_MOMENT_DATE_ADAPTER_OPTIONS override', () =
 
   describe('strict mode', () => {
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         imports: [MomentDateModule],

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -26,7 +26,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   flush,
@@ -162,7 +162,7 @@ describe('MatAutocomplete', () => {
     });
 
     it('should show the panel when the first open is after the initial zone stabilization',
-      async(() => {
+      waitForAsync(() => {
         // Note that we're running outside the Angular zone, in order to be able
         // to test properly without the subscription from `_subscribeToClosingActions`
         // giving us a false positive.

--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MatButtonModule, MatButton} from './index';
@@ -7,7 +7,7 @@ import {MatRipple, ThemePalette} from '@angular/material/core';
 
 describe('MatButton', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatButtonModule],
       declarations: [TestApp],

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -3,7 +3,7 @@ import {COMMA, ENTER, TAB} from '@angular/cdk/keycodes';
 import {PlatformModule} from '@angular/cdk/platform';
 import {dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -22,7 +22,7 @@ describe('MatChipInput', () => {
   let chipInputDirective: MatChipInput;
   let dir = 'ltr';
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [PlatformModule, MatChipsModule, MatFormFieldModule, NoopAnimationsModule],
       declarations: [TestChipInput],
@@ -39,7 +39,7 @@ describe('MatChipInput', () => {
     TestBed.compileComponents();
   }));
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(TestChipInput);
     testChipInput = fixture.debugElement.componentInstance;
     fixture.detectChanges();

--- a/src/material/chips/chip-remove.spec.ts
+++ b/src/material/chips/chip-remove.spec.ts
@@ -1,6 +1,6 @@
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChip, MatChipsModule} from './index';
 
 describe('Chip Remove', () => {
@@ -9,7 +9,7 @@ describe('Chip Remove', () => {
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatChipsModule],
       declarations: [
@@ -20,7 +20,7 @@ describe('Chip Remove', () => {
     TestBed.compileComponents();
   }));
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(TestChip);
     testChip = fixture.debugElement.componentInstance;
     fixture.detectChanges();

--- a/src/material/chips/chip.spec.ts
+++ b/src/material/chips/chip.spec.ts
@@ -2,7 +2,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {BACKSPACE, DELETE, SPACE} from '@angular/cdk/keycodes';
 import {createKeyboardEvent, dispatchFakeEvent} from '@angular/cdk/testing/private';
 import {Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
@@ -17,7 +17,7 @@ describe('MatChip', () => {
   let globalRippleOptions: RippleGlobalOptions;
   let dir = 'ltr';
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     globalRippleOptions = {};
     TestBed.configureTestingModule({
       imports: [MatChipsModule],

--- a/src/material/core/datetime/native-date-adapter.spec.ts
+++ b/src/material/core/datetime/native-date-adapter.spec.ts
@@ -1,6 +1,6 @@
 import {Platform} from '@angular/cdk/platform';
 import {LOCALE_ID} from '@angular/core';
-import {async, inject, TestBed} from '@angular/core/testing';
+import {waitForAsync, inject, TestBed} from '@angular/core/testing';
 import {DEC, FEB, JAN, MAR} from '@angular/material/testing';
 import {DateAdapter, MAT_DATE_LOCALE, NativeDateAdapter, NativeDateModule} from './index';
 
@@ -12,7 +12,7 @@ describe('NativeDateAdapter', () => {
   let adapter: NativeDateAdapter;
   let assertValidDate: (d: Date | null, valid: boolean) => void;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [NativeDateModule]
     }).compileComponents();
@@ -393,7 +393,7 @@ describe('NativeDateAdapter', () => {
 describe('NativeDateAdapter with MAT_DATE_LOCALE override', () => {
   let adapter: NativeDateAdapter;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [NativeDateModule],
       providers: [{provide: MAT_DATE_LOCALE, useValue: 'da-DK'}]
@@ -417,7 +417,7 @@ describe('NativeDateAdapter with MAT_DATE_LOCALE override', () => {
 describe('NativeDateAdapter with LOCALE_ID override', () => {
   let adapter: NativeDateAdapter;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [NativeDateModule],
       providers: [{provide: LOCALE_ID, useValue: 'da-DK'}]

--- a/src/material/core/option/option.spec.ts
+++ b/src/material/core/option/option.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {
@@ -12,7 +12,7 @@ import {MatOption, MatOptionModule} from './index';
 
 describe('MatOption component', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatOptionModule],
       declarations: [BasicOption]

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {MatCalendarBody, MatCalendarCell, MatCalendarUserEvent} from './calendar-body';
 import {By} from '@angular/platform-browser';
@@ -6,7 +6,7 @@ import {dispatchMouseEvent, dispatchFakeEvent} from '@angular/cdk/testing/privat
 
 
 describe('MatCalendarBody', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [
         MatCalendarBody,

--- a/src/material/datepicker/calendar-header.spec.ts
+++ b/src/material/datepicker/calendar-header.spec.ts
@@ -1,6 +1,6 @@
 import {Directionality} from '@angular/cdk/bidi';
 import {Component} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatNativeDateModule, DateAdapter} from '@angular/material/core';
 import {DEC, FEB, JAN} from '@angular/material/testing';
 import {By} from '@angular/platform-browser';
@@ -10,7 +10,7 @@ import {MatDatepickerModule} from './datepicker-module';
 import {yearsPerPage} from './multi-year-view';
 
 describe('MatCalendarHeader', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatNativeDateModule,

--- a/src/material/datepicker/calendar.spec.ts
+++ b/src/material/datepicker/calendar.spec.ts
@@ -7,7 +7,7 @@ import {
   MockNgZone,
 } from '@angular/cdk/testing/private';
 import {Component, NgZone} from '@angular/core';
-import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {DateAdapter, MatNativeDateModule} from '@angular/material/core';
 import {DEC, FEB, JAN, JUL, NOV} from '@angular/material/testing';
 import {By} from '@angular/platform-browser';
@@ -18,7 +18,7 @@ import {MatDatepickerModule} from './datepicker-module';
 describe('MatCalendar', () => {
   let zone: MockNgZone;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatNativeDateModule,

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -20,7 +20,7 @@ import {
   dispatchEvent,
 } from '@angular/cdk/testing/private';
 import {Component} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatNativeDateModule} from '@angular/material/core';
 import {DEC, FEB, JAN, MAR, NOV} from '@angular/material/testing';
 import {By} from '@angular/platform-browser';
@@ -35,7 +35,7 @@ import {
 describe('MatMonthView', () => {
   let dir: {value: Direction};
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatNativeDateModule,

--- a/src/material/datepicker/multi-year-view.spec.ts
+++ b/src/material/datepicker/multi-year-view.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/cdk/keycodes';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {Component, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatNativeDateModule} from '@angular/material/core';
 import {JAN} from '@angular/material/testing';
 import {By} from '@angular/platform-browser';
@@ -21,7 +21,7 @@ import {MatMultiYearView, yearsPerPage, yearsPerRow} from './multi-year-view';
 describe('MatMultiYearView', () => {
   let dir: {value: Direction};
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatNativeDateModule,

--- a/src/material/datepicker/year-view.spec.ts
+++ b/src/material/datepicker/year-view.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/cdk/keycodes';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {Component, ViewChild} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatNativeDateModule} from '@angular/material/core';
 import {AUG, DEC, FEB, JAN, JUL, JUN, MAR, MAY, NOV, OCT, SEP} from '@angular/material/testing';
 import {By} from '@angular/platform-browser';
@@ -21,7 +21,7 @@ import {MatYearView} from './year-view';
 describe('MatYearView', () => {
   let dir: {value: Direction};
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatNativeDateModule,

--- a/src/material/expansion/accordion.spec.ts
+++ b/src/material/expansion/accordion.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed, inject} from '@angular/core/testing';
+import {waitForAsync, TestBed, inject} from '@angular/core/testing';
 import {Component, ViewChild, QueryList, ViewChildren} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
@@ -20,7 +20,7 @@ import {FocusMonitor} from '@angular/cdk/a11y';
 describe('MatAccordion', () => {
   let focusMonitor: FocusMonitor;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         BrowserAnimationsModule,

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -1,4 +1,11 @@
-import {async, TestBed, fakeAsync, tick, ComponentFixture, flush} from '@angular/core/testing';
+import {
+  waitForAsync,
+  TestBed,
+  fakeAsync,
+  tick,
+  ComponentFixture,
+  flush,
+} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -17,7 +24,7 @@ import {
 
 
 describe('MatExpansionPanel', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatExpansionModule,

--- a/src/material/icon/icon.spec.ts
+++ b/src/material/icon/icon.spec.ts
@@ -1,4 +1,4 @@
-import {inject, async, fakeAsync, tick, TestBed} from '@angular/core/testing';
+import {inject, waitForAsync, fakeAsync, tick, TestBed} from '@angular/core/testing';
 import {SafeResourceUrl, DomSanitizer, SafeHtml} from '@angular/platform-browser';
 import {
   HttpClientTestingModule,
@@ -46,7 +46,7 @@ describe('MatIcon', () => {
   let fakePath: string;
   let errorHandler: jasmine.SpyObj<ErrorHandler>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     // The $ prefix tells Karma not to try to process the
     // request so that we don't get warnings in our logs.
     fakePath = '/$fake-path';
@@ -1015,7 +1015,7 @@ describe('MatIcon without HttpClientModule', () => {
   let iconRegistry: MatIconRegistry;
   let sanitizer: DomSanitizer;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatIconModule],
       declarations: [IconFromSvgName],

--- a/src/material/list/list.spec.ts
+++ b/src/material/list/list.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {waitForAsync, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {Component, QueryList, ViewChildren} from '@angular/core';
 import {defaultRippleAnimationConfig} from '@angular/material/core';
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
@@ -9,7 +9,7 @@ describe('MatList', () => {
   // Default ripple durations used for testing.
   const {enterDuration, exitDuration} = defaultRippleAnimationConfig;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatListModule],
       declarations: [

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -14,7 +14,7 @@ import {
   ViewChildren,
 } from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   TestBed,
@@ -39,7 +39,7 @@ describe('MatSelectionList without forms', () => {
     let listOptions: DebugElement[];
     let selectionList: DebugElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -57,7 +57,7 @@ describe('MatSelectionList without forms', () => {
     }));
 
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithListOptions);
       fixture.detectChanges();
 
@@ -791,7 +791,7 @@ describe('MatSelectionList without forms', () => {
     let listItemEl: DebugElement;
     let selectionList: DebugElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [SelectionListWithSelectedOption],
@@ -800,7 +800,7 @@ describe('MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithSelectedOption);
       listItemEl = fixture.debugElement.query(By.directive(MatListOption))!;
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
@@ -819,7 +819,7 @@ describe('MatSelectionList without forms', () => {
     let selectionList: MatSelectionList;
     let listOption: MatListOption;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [SelectionListWithChangingOptionValue],
@@ -852,7 +852,7 @@ describe('MatSelectionList without forms', () => {
     let listOptionEl: HTMLElement;
     let listOption: MatListOption;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [SelectionListWithDisabledOption]
@@ -861,7 +861,7 @@ describe('MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithDisabledOption);
 
       const listOptionDebug = fixture.debugElement.query(By.directive(MatListOption))!;
@@ -898,7 +898,7 @@ describe('MatSelectionList without forms', () => {
     let listOption: DebugElement[];
     let selectionList: DebugElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -912,7 +912,7 @@ describe('MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithListDisabled);
       listOption = fixture.debugElement.queryAll(By.directive(MatListOption));
       selectionList = fixture.debugElement.query(By.directive(MatSelectionList))!;
@@ -954,7 +954,7 @@ describe('MatSelectionList without forms', () => {
   describe('with checkbox position after', () => {
     let fixture: ComponentFixture<SelectionListWithCheckboxPositionAfter>;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -968,7 +968,7 @@ describe('MatSelectionList without forms', () => {
       TestBed.compileComponents();
     }));
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(SelectionListWithCheckboxPositionAfter);
       fixture.detectChanges();
     }));
@@ -980,7 +980,7 @@ describe('MatSelectionList without forms', () => {
   });
 
   describe('with list item elements', () => {
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -1012,7 +1012,7 @@ describe('MatSelectionList without forms', () => {
     let listOptions: DebugElement[];
     let selectionList: DebugElement;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatListModule],
         declarations: [
@@ -1132,7 +1132,7 @@ describe('MatSelectionList without forms', () => {
 
 describe('MatSelectionList with forms', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatListModule, FormsModule, ReactiveFormsModule],
       declarations: [

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, async, inject} from '@angular/core/testing';
+import {TestBed, waitForAsync, inject} from '@angular/core/testing';
 import {Component, ViewEncapsulation, ViewChild, ElementRef} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {Platform, _getShadowRoot, _supportsShadowDom} from '@angular/cdk/platform';
@@ -10,7 +10,7 @@ import {
 } from './index';
 
 describe('MatProgressSpinner', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatProgressSpinnerModule, CommonModule],
       declarations: [

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/forms';
 import {Component, DebugElement, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
@@ -9,7 +9,7 @@ import {MatRadioButton, MatRadioChange, MatRadioGroup, MatRadioModule} from './i
 
 describe('MatRadio', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatRadioModule, FormsModule, ReactiveFormsModule],
       declarations: [
@@ -40,7 +40,7 @@ describe('MatRadio', () => {
     let radioInstances: MatRadioButton[];
     let testComponent: RadiosInsideRadioGroup;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(RadiosInsideRadioGroup);
       fixture.detectChanges();
 
@@ -808,7 +808,7 @@ describe('MatRadio', () => {
     let radioDebugElements: DebugElement[];
     let radioInstances: MatRadioButton[];
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       fixture = TestBed.createComponent(InterleavedRadioGroup);
       fixture.detectChanges();
 
@@ -826,7 +826,7 @@ describe('MatRadio', () => {
 
 describe('MatRadioDefaultOverrides', () => {
   describe('when MAT_RADIO_DEFAULT_OPTIONS overridden', () => {
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [MatRadioModule, FormsModule],
         declarations: [DefaultRadioButton, RadioButtonWithColorBinding],

--- a/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/address-form/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonModule } from '@angular/material/button';
@@ -13,7 +13,7 @@ describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
   let fixture: ComponentFixture<<%= classify(name) %>Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %>Component ],
       imports: [

--- a/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/dashboard/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,6 +1,6 @@
 import { LayoutModule } from '@angular/cdk/layout';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatGridListModule } from '@angular/material/grid-list';
@@ -13,7 +13,7 @@ describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
   let fixture: ComponentFixture<<%= classify(name) %>Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [<%= classify(name) %>Component],
       imports: [

--- a/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/navigation/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,5 +1,5 @@
 import { LayoutModule } from '@angular/cdk/layout';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -13,7 +13,7 @@ describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
   let fixture: ComponentFixture<<%= classify(name) %>Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [<%= classify(name) %>Component],
       imports: [

--- a/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/table/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
@@ -10,7 +10,7 @@ describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
   let fixture: ComponentFixture<<%= classify(name) %>Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %>Component ],
       imports: [

--- a/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
+++ b/src/material/schematics/ng-generate/tree/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts.template
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTreeModule } from '@angular/material/tree';
@@ -9,7 +9,7 @@ describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
   let fixture: ComponentFixture<<%= classify(name) %>Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %>Component ],
       imports: [

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -33,7 +33,7 @@ import {
   Provider,
 } from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   flush,
@@ -123,7 +123,7 @@ describe('MatSelect', () => {
   });
 
   describe('core', () => {
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       configureMatSelectTestingModule([
         BasicSelect,
         MultiSelect,
@@ -2110,7 +2110,7 @@ describe('MatSelect', () => {
   });
 
   describe('when initialized without options', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([SelectInitWithoutOptions])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectInitWithoutOptions])));
 
     it('should select the proper option when option list is initialized later', fakeAsync(() => {
       const fixture = TestBed.createComponent(SelectInitWithoutOptions);
@@ -2132,7 +2132,7 @@ describe('MatSelect', () => {
   });
 
   describe('with a selectionChange event handler', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([SelectWithChangeEvent])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectWithChangeEvent])));
 
     let fixture: ComponentFixture<SelectWithChangeEvent>;
     let trigger: HTMLElement;
@@ -2176,7 +2176,7 @@ describe('MatSelect', () => {
   });
 
   describe('with ngModel', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([NgModelSelect])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([NgModelSelect])));
 
     it('should disable itself when control is disabled using the property', fakeAsync(() => {
       const fixture = TestBed.createComponent(NgModelSelect);
@@ -2219,7 +2219,7 @@ describe('MatSelect', () => {
   });
 
   describe('with ngIf', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([NgIfSelect])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([NgIfSelect])));
 
     it('should handle nesting in an ngIf', fakeAsync(() => {
       const fixture = TestBed.createComponent(NgIfSelect);
@@ -2250,7 +2250,7 @@ describe('MatSelect', () => {
   });
 
   describe('with multiple mat-select elements in one view', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([ManySelects])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([ManySelects])));
 
       let fixture: ComponentFixture<ManySelects>;
       let triggers: DebugElement[];
@@ -2295,7 +2295,7 @@ describe('MatSelect', () => {
   });
 
   describe('with floatLabel', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([FloatLabelSelect])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([FloatLabelSelect])));
 
     let fixture: ComponentFixture<FloatLabelSelect>;
     let formField: HTMLElement;
@@ -2363,7 +2363,7 @@ describe('MatSelect', () => {
   });
 
   describe('with a sibling component that throws an error', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([
       SelectWithErrorSibling,
       ThrowsErrorOnInit,
     ])));
@@ -2378,7 +2378,7 @@ describe('MatSelect', () => {
   });
 
   describe('with tabindex', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([SelectWithPlainTabindex])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectWithPlainTabindex])));
 
     it('should be able to set the tabindex via the native attribute', fakeAsync(() => {
       const fixture = TestBed.createComponent(SelectWithPlainTabindex);
@@ -2390,7 +2390,7 @@ describe('MatSelect', () => {
   });
 
   describe('change events', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([SelectWithPlainTabindex])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectWithPlainTabindex])));
 
     it('should complete the stateChanges stream on destroy', () => {
       const fixture = TestBed.createComponent(SelectWithPlainTabindex);
@@ -2409,7 +2409,7 @@ describe('MatSelect', () => {
   });
 
   describe('when initially hidden', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([BasicSelectInitiallyHidden])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([BasicSelectInitiallyHidden])));
 
     it('should set the width of the overlay if the element was hidden initially', fakeAsync(() => {
       const fixture = TestBed.createComponent(BasicSelectInitiallyHidden);
@@ -2430,7 +2430,7 @@ describe('MatSelect', () => {
   });
 
   describe('with no placeholder', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([BasicSelectNoPlaceholder])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([BasicSelectNoPlaceholder])));
 
     it('should set the width of the overlay if there is no placeholder', fakeAsync(() => {
       const fixture = TestBed.createComponent(BasicSelectNoPlaceholder);
@@ -2448,7 +2448,7 @@ describe('MatSelect', () => {
   });
 
   describe('with theming', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([BasicSelectWithTheming])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([BasicSelectWithTheming])));
 
     let fixture: ComponentFixture<BasicSelectWithTheming>;
 
@@ -2470,7 +2470,7 @@ describe('MatSelect', () => {
   });
 
   describe('when invalid inside a form', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([InvalidSelectInForm])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([InvalidSelectInForm])));
 
     it('should not throw SelectionModel errors in addition to ngModel errors', fakeAsync(() => {
       const fixture = TestBed.createComponent(InvalidSelectInForm);
@@ -2484,7 +2484,7 @@ describe('MatSelect', () => {
   });
 
   describe('with ngModel using compareWith', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([NgModelCompareWithSelect])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([NgModelCompareWithSelect])));
 
     let fixture: ComponentFixture<NgModelCompareWithSelect>;
     let instance: NgModelCompareWithSelect;
@@ -2549,7 +2549,7 @@ describe('MatSelect', () => {
   });
 
   describe(`when the select's value is accessed on initialization`, () => {
-    beforeEach(async(() => configureMatSelectTestingModule([SelectEarlyAccessSibling])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectEarlyAccessSibling])));
 
     it('should not throw when trying to access the selected value on init', fakeAsync(() => {
       expect(() => {
@@ -2559,7 +2559,7 @@ describe('MatSelect', () => {
   });
 
   describe('with ngIf and mat-label', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([SelectWithNgIfAndLabel])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectWithNgIfAndLabel])));
 
     it('should not throw when using ngIf on a select with an associated label', fakeAsync(() => {
       expect(() => {
@@ -2570,7 +2570,7 @@ describe('MatSelect', () => {
   });
 
   describe('inside of a form group', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([SelectInsideFormGroup])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectInsideFormGroup])));
 
     let fixture: ComponentFixture<SelectInsideFormGroup>;
     let testComponent: SelectInsideFormGroup;
@@ -2691,7 +2691,7 @@ describe('MatSelect', () => {
   });
 
   describe('with custom error behavior', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([CustomErrorBehaviorSelect])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([CustomErrorBehaviorSelect])));
 
     it('should be able to override the error matching behavior via an @Input', fakeAsync(() => {
       const fixture = TestBed.createComponent(CustomErrorBehaviorSelect);
@@ -2712,7 +2712,7 @@ describe('MatSelect', () => {
   });
 
   describe('with preselected array values', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([
       SingleSelectWithPreselectedArrayValues,
     ])));
 
@@ -2730,7 +2730,7 @@ describe('MatSelect', () => {
   });
 
   describe('with custom value accessor', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([
       CompWithCustomSelect,
       CustomSelectAccessor,
     ])));
@@ -2747,7 +2747,7 @@ describe('MatSelect', () => {
   });
 
   describe('with a falsy value', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([FalsyValueSelect])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([FalsyValueSelect])));
 
     it('should be able to programmatically select a falsy option', fakeAsync(() => {
       const fixture = TestBed.createComponent(FalsyValueSelect);
@@ -2766,7 +2766,7 @@ describe('MatSelect', () => {
   });
 
   describe('with OnPush', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([
       BasicSelectOnPush,
       BasicSelectOnPushPreselected,
     ])));
@@ -2802,7 +2802,7 @@ describe('MatSelect', () => {
   });
 
   describe('with custom trigger', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([SelectWithCustomTrigger])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([SelectWithCustomTrigger])));
 
     it('should allow the user to customize the label', fakeAsync(() => {
       const fixture = TestBed.createComponent(SelectWithCustomTrigger);
@@ -2819,7 +2819,7 @@ describe('MatSelect', () => {
   });
 
   describe('when reseting the value by setting null or undefined', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([ResetValuesSelect])));
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([ResetValuesSelect])));
 
     let fixture: ComponentFixture<ResetValuesSelect>;
     let trigger: HTMLElement;
@@ -2952,7 +2952,7 @@ describe('MatSelect', () => {
   });
 
   describe('without Angular forms', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([
       BasicSelectWithoutForms,
       BasicSelectWithoutFormsPreselected,
       BasicSelectWithoutFormsMultiple,
@@ -3289,7 +3289,7 @@ describe('MatSelect', () => {
   });
 
   describe('with option centering disabled', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([
       SelectWithoutOptionCentering,
     ])));
 
@@ -3320,7 +3320,7 @@ describe('MatSelect', () => {
   });
 
   describe('positioning', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([
       BasicSelect,
       MultiSelect,
       SelectWithGroups,
@@ -4184,7 +4184,7 @@ describe('MatSelect', () => {
   });
 
   describe('with multiple selection', () => {
-    beforeEach(async(() => configureMatSelectTestingModule([
+    beforeEach(waitForAsync(() => configureMatSelectTestingModule([
       MultiSelect,
       MultiSelectWithLotsOfOptions
     ])));

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -1,6 +1,6 @@
 import {
   fakeAsync,
-  async,
+  waitForAsync,
   tick,
   ComponentFixture,
   TestBed,
@@ -26,7 +26,7 @@ import {CommonModule} from '@angular/common';
 
 
 describe('MatDrawer', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSidenavModule, A11yModule, PlatformModule, NoopAnimationsModule, CommonModule],
       declarations: [
@@ -645,7 +645,7 @@ describe('MatDrawer', () => {
 });
 
 describe('MatDrawerContainer', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSidenavModule, A11yModule, PlatformModule, NoopAnimationsModule],
       declarations: [

--- a/src/material/sidenav/sidenav.spec.ts
+++ b/src/material/sidenav/sidenav.spec.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {async, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {waitForAsync, TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {MatSidenav, MatSidenavModule, MatSidenavContainer} from './index';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {By} from '@angular/platform-browser';
@@ -7,7 +7,7 @@ import {CommonModule} from '@angular/common';
 
 
 describe('MatSidenav', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSidenavModule, NoopAnimationsModule, CommonModule],
       declarations: [SidenavWithFixedPosition, IndirectDescendantSidenav, NestedSidenavContainers],

--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -7,7 +7,7 @@ import {
   wrappedErrorMessage,
 } from '@angular/cdk/testing/private';
 import {Component, ElementRef, ViewChild} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {By} from '@angular/platform-browser';
 import {Observable} from 'rxjs';
@@ -32,7 +32,7 @@ describe('MatSort', () => {
   let fixture: ComponentFixture<SimpleMatSortApp>;
   let component: SimpleMatSortApp;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSortModule, MatTableModule, CdkTableModule, NoopAnimationsModule],
       declarations: [

--- a/src/material/table/table-data-source.spec.ts
+++ b/src/material/table/table-data-source.spec.ts
@@ -1,5 +1,5 @@
 import {MatTableDataSource} from './table-data-source';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatSort, MatSortModule} from '@angular/material/sort';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Component, ViewChild} from '@angular/core';
@@ -7,7 +7,7 @@ import {Component, ViewChild} from '@angular/core';
 describe('MatTableDataSource', () => {
   const dataSource = new MatTableDataSource();
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSortModule, NoopAnimationsModule],
       declarations: [MatSortApp],

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -1,7 +1,7 @@
 import {DataSource} from '@angular/cdk/collections';
 import {Component, OnInit, ViewChild, AfterViewInit} from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   flushMicrotasks,
@@ -18,7 +18,7 @@ import {MatTableDataSource} from './table-data-source';
 
 
 describe('MatTable', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatTableModule, MatPaginatorModule, MatSortModule, NoopAnimationsModule],
       declarations: [

--- a/src/material/table/text-column.spec.ts
+++ b/src/material/table/text-column.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatTableModule} from './table-module';
 import {expectTableToMatchContent} from './table.spec';
 
@@ -7,7 +7,7 @@ describe('MatTextColumn', () => {
   let fixture: ComponentFixture<BasicTextColumnApp>;
   let tableElement: HTMLElement;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatTableModule],
       declarations: [

--- a/src/material/tabs/tab-body.spec.ts
+++ b/src/material/tabs/tab-body.spec.ts
@@ -2,7 +2,7 @@ import {Direction, Directionality} from '@angular/cdk/bidi';
 import {PortalModule, TemplatePortal} from '@angular/cdk/portal';
 import {CommonModule} from '@angular/common';
 import {AfterContentInit, Component, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatRippleModule} from '@angular/material/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTabBody, MatTabBodyPortal} from './tab-body';
@@ -13,7 +13,7 @@ describe('MatTabBody', () => {
   let dir: Direction = 'ltr';
   let dirChange: Subject<Direction> = new Subject<Direction>();
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [CommonModule, PortalModule, MatRippleModule, NoopAnimationsModule],

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -1,7 +1,7 @@
 import {LEFT_ARROW} from '@angular/cdk/keycodes';
 import {dispatchFakeEvent, dispatchKeyboardEvent} from '@angular/cdk/testing/private';
 import {Component, OnInit, QueryList, ViewChild, ViewChildren} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {CommonModule} from '@angular/common';
@@ -80,7 +80,7 @@ describe('MatTabGroup', () => {
     }));
 
     // Note: needs to be `async` in order to fail when we expect it to.
-    it('should set to correct tab on fast change', async(() => {
+    it('should set to correct tab on fast change', waitForAsync(() => {
       let component = fixture.componentInstance;
       component.selectedIndex = 0;
       fixture.detectChanges();

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -12,7 +12,7 @@ import {
 import {CommonModule} from '@angular/common';
 import {Component, ViewChild} from '@angular/core';
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   discardPeriodicTasks,
   fakeAsync,
@@ -34,7 +34,7 @@ describe('MatTabHeader', () => {
   let fixture: ComponentFixture<SimpleTabHeaderApp>;
   let appComponent: SimpleTabHeaderApp;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [CommonModule, PortalModule, MatRippleModule, ScrollingModule, ObserversModule],

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component, ViewChild, ViewChildren, QueryList} from '@angular/core';
 import {MAT_RIPPLE_GLOBAL_OPTIONS, RippleGlobalOptions} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
@@ -13,7 +13,7 @@ describe('MatTabNavBar', () => {
   let dirChange = new Subject();
   let globalRippleOptions: RippleGlobalOptions;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     globalRippleOptions = {};
 
     TestBed.configureTestingModule({

--- a/src/material/toolbar/toolbar.spec.ts
+++ b/src/material/toolbar/toolbar.spec.ts
@@ -1,12 +1,12 @@
 import {Component} from '@angular/core';
-import {TestBed, async, ComponentFixture, fakeAsync, flush} from '@angular/core/testing';
+import {TestBed, waitForAsync, ComponentFixture, fakeAsync, flush} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CommonModule} from '@angular/common';
 import {MatToolbarModule} from './index';
 
 describe('MatToolbar', () => {
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatToolbarModule, CommonModule],
       declarations: [

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -1,5 +1,5 @@
 import {
-  async,
+  waitForAsync,
   ComponentFixture,
   fakeAsync,
   flush,
@@ -51,7 +51,7 @@ describe('MatTooltip', () => {
   let platform: {IOS: boolean, isBrowser: boolean, ANDROID: boolean};
   let focusMonitor: FocusMonitor;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     // Set the default Platform override that can be updated before component creation.
     platform = {IOS: false, isBrowser: true, ANDROID: false};
 
@@ -290,7 +290,7 @@ describe('MatTooltip', () => {
       expect(tooltipDirective._isTooltipVisible()).toBe(false);
     }));
 
-    it('should not show if hide is called before delay finishes', async(() => {
+    it('should not show if hide is called before delay finishes', waitForAsync(() => {
       assertTooltipInstance(tooltipDirective, false);
 
       const tooltipDelay = 1000;

--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {waitForAsync, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {YouTubePlayerModule} from './youtube-module';
 import {YouTubePlayer, DEFAULT_PLAYER_WIDTH, DEFAULT_PLAYER_HEIGHT} from './youtube-player';
@@ -14,7 +14,7 @@ describe('YoutubePlayer', () => {
   let testComponent: TestApp;
   let events: Required<YT.Events>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     const fake = createFakeYtNamespace();
     playerCtorSpy = fake.playerCtorSpy;
     playerSpy = fake.playerSpy;


### PR DESCRIPTION
In the latest version of Angular the `async` testing function was renamed to `waitForAsync`. These changes fix up all the places where we were using it.