### PR TITLE
refactor(datepicker): remove deprecated APIs for v11

### DIFF
--- a/src/material/datepicker/calendar.ts
+++ b/src/material/datepicker/calendar.ts
@@ -253,11 +253,8 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   /** End of the comparison range. */
   @Input() comparisonEnd: D | null;
 
-  /**
-   * Emits when the currently selected date changes.
-   * @breaking-change 11.0.0 Emitted value to change to `D | null`.
-   */
-  @Output() readonly selectedChange: EventEmitter<D> = new EventEmitter<D>();
+  /** Emits when the currently selected date changes. */
+  @Output() readonly selectedChange: EventEmitter<D | null> = new EventEmitter<D | null>();
 
   /**
    * Emits the year chosen in multiyear view.
@@ -395,9 +392,7 @@ export class MatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
 
     if (this.selected instanceof DateRange ||
         (date && !this._dateAdapter.sameDate(date, this.selected))) {
-      // @breaking-change 11.0.0 remove non-null assertion
-      // once the `selectedChange` is allowed to be null.
-      this.selectedChange.emit(date!);
+      this.selectedChange.emit(date);
     }
 
     this._userSelection.emit(event);

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -151,26 +151,18 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
 
   constructor(
     elementRef: ElementRef,
-    /**
-     * @deprecated `_changeDetectorRef`, `_model` and `_rangeSelectionStrategy`
-     * parameters to become required.
-     * @breaking-change 11.0.0
-     */
-    private _changeDetectorRef?: ChangeDetectorRef,
-    private _model?: MatDateSelectionModel<S, D>,
-    private _dateAdapter?: DateAdapter<D>,
+    private _changeDetectorRef: ChangeDetectorRef,
+    private _model: MatDateSelectionModel<S, D>,
+    private _dateAdapter: DateAdapter<D>,
     @Optional() @Inject(MAT_DATE_RANGE_SELECTION_STRATEGY)
-        private _rangeSelectionStrategy?: MatDateRangeSelectionStrategy<D>) {
+        private _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>) {
     super(elementRef);
   }
 
   ngAfterViewInit() {
-    // @breaking-change 11.0.0 Remove null check for `_changeDetectorRef.
-    if (this._changeDetectorRef) {
-      this._subscriptions.add(this.datepicker._stateChanges.subscribe(() => {
-        this._changeDetectorRef!.markForCheck();
-      }));
-    }
+    this._subscriptions.add(this.datepicker._stateChanges.subscribe(() => {
+      this._changeDetectorRef.markForCheck();
+    }));
 
     this._calendar.focusActiveCell();
   }
@@ -181,26 +173,22 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
   }
 
   _handleUserSelection(event: MatCalendarUserEvent<D | null>) {
-    // @breaking-change 11.0.0 Remove null checks for _model,
-    // _rangeSelectionStrategy and _dateAdapter.
-    if (this._model && this._dateAdapter) {
-      const selection = this._model.selection;
-      const value = event.value;
-      const isRange = selection instanceof DateRange;
+    const selection = this._model.selection;
+    const value = event.value;
+    const isRange = selection instanceof DateRange;
 
-      // If we're selecting a range and we have a selection strategy, always pass the value through
-      // there. Otherwise don't assign null values to the model, unless we're selecting a range.
-      // A null value when picking a range means that the user cancelled the selection (e.g. by
-      // pressing escape), whereas when selecting a single value it means that the value didn't
-      // change. This isn't very intuitive, but it's here for backwards-compatibility.
-      if (isRange && this._rangeSelectionStrategy) {
-        const newSelection = this._rangeSelectionStrategy.selectionFinished(value,
-            selection as unknown as DateRange<D>, event.event);
-        this._model.updateSelection(newSelection as unknown as S, this);
-      } else if (value && (isRange ||
-                !this._dateAdapter.sameDate(value, selection as unknown as D))) {
-        this._model.add(value);
-      }
+    // If we're selecting a range and we have a selection strategy, always pass the value through
+    // there. Otherwise don't assign null values to the model, unless we're selecting a range.
+    // A null value when picking a range means that the user cancelled the selection (e.g. by
+    // pressing escape), whereas when selecting a single value it means that the value didn't
+    // change. This isn't very intuitive, but it's here for backwards-compatibility.
+    if (isRange && this._rangeSelectionStrategy) {
+      const newSelection = this._rangeSelectionStrategy.selectionFinished(value,
+          selection as unknown as DateRange<D>, event.event);
+      this._model.updateSelection(newSelection as unknown as S, this);
+    } else if (value && (isRange ||
+              !this._dateAdapter.sameDate(value, selection as unknown as D))) {
+      this._model.add(value);
     }
 
     if (!this._model || this._model.isComplete()) {
@@ -210,16 +198,11 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
 
   _startExitAnimation() {
     this._animationState = 'void';
-
-    // @breaking-change 11.0.0 Remove null check for `_changeDetectorRef`.
-    if (this._changeDetectorRef) {
-      this._changeDetectorRef.markForCheck();
-    }
+    this._changeDetectorRef.markForCheck();
   }
 
   _getSelected() {
-    // @breaking-change 11.0.0 Remove null check for `_model`.
-    return this._model ? this._model.selection as unknown as D | DateRange<D> | null : null;
+    return this._model.selection as unknown as D | DateRange<D> | null;
   }
 }
 

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -140,14 +140,6 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
     return this.value;
   }
 
-  /**
-   * @deprecated
-   * @breaking-change 8.0.0 Use `getConnectedOverlayOrigin` instead
-   */
-  getPopupConnectionElementRef(): ElementRef {
-    return this.getConnectedOverlayOrigin();
-  }
-
   /** Opens the associated datepicker. */
   protected _openPopup(): void {
     if (this._datepicker) {

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -18,6 +18,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/issues/20463',
       changes: ['MatChip', 'MatChipRemove']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/20449',
+      changes: ['MatDatepickerContent']
     }
   ],
   [TargetVersion.V10]: [

--- a/src/material/schematics/ng-update/data/property-names.ts
+++ b/src/material/schematics/ng-update/data/property-names.ts
@@ -9,6 +9,18 @@
 import {PropertyNameUpgradeData, TargetVersion, VersionChanges} from '@angular/cdk/schematics';
 
 export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
+  [TargetVersion.V11]: [
+    {
+      pr: 'https://github.com/angular/components/pull/20449',
+      changes: [
+        {
+          replace: 'getPopupConnectionElementRef',
+          replaceWith: 'getConnectedOverlayOrigin',
+          whitelist: {classes: ['MatDatepickerInput']}
+        }
+      ]
+    }
+  ],
   [TargetVersion.V9]: [
     {
       pr: 'https://github.com/angular/components/pull/17333',

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -72,7 +72,7 @@ export declare class MatCalendar<D> implements AfterContentInit, AfterViewChecke
     multiYearView: MatMultiYearView<D>;
     get selected(): DateRange<D> | D | null;
     set selected(value: DateRange<D> | D | null);
-    readonly selectedChange: EventEmitter<D>;
+    readonly selectedChange: EventEmitter<D | null>;
     get startAt(): D | null;
     set startAt(value: D | null);
     startView: MatCalendarView;
@@ -195,8 +195,7 @@ export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>
     comparisonEnd: D | null;
     comparisonStart: D | null;
     datepicker: MatDatepickerBase<any, S, D>;
-    constructor(elementRef: ElementRef,
-    _changeDetectorRef?: ChangeDetectorRef | undefined, _model?: MatDateSelectionModel<S, D> | undefined, _dateAdapter?: DateAdapter<D> | undefined, _rangeSelectionStrategy?: MatDateRangeSelectionStrategy<D> | undefined);
+    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _model: MatDateSelectionModel<S, D>, _dateAdapter: DateAdapter<D>, _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>);
     _getSelected(): D | DateRange<D> | null;
     _handleUserSelection(event: MatCalendarUserEvent<D | null>): void;
     _startExitAnimation(): void;
@@ -226,7 +225,6 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | nu
     protected _getValueFromModel(modelValue: D | null): D | null;
     protected _openPopup(): void;
     getConnectedOverlayOrigin(): ElementRef;
-    getPopupConnectionElementRef(): ElementRef;
     getStartValue(): D | null;
     getThemePalette(): ThemePalette;
     static ngAcceptInputType_value: any;


### PR DESCRIPTION
Removes the APIs that were marked as deprecated for v11 in the datepicker module.

BREAKING CHANGES:
* The value emitted by `MatCalendar.selectedChange` can now be null.
* `MatDatepickerInput.getPopupConnectionElementRef` has been removed. Use `getConnectedOverlayOrigin` instead.
* The `_changeDetectorRef`, `_model`, `_dateAdapter` and `_rangeSelectionStrategy` parameters of the `MatDatepickerContent` constructor are now required.