### PR TITLE
refactor(cdk/scrolling): remove deprecated APIs for v11

### DIFF
--- a/src/cdk/schematics/ng-update/data/constructor-checks.ts
+++ b/src/cdk/schematics/ng-update/data/constructor-checks.ts
@@ -17,6 +17,12 @@ export type ConstructorChecksUpgradeData = string;
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V11]: [
+    {
+      pr: 'https://github.com/angular/components/pull/20454',
+      changes: ['ScrollDispatcher', 'ViewportRuler', 'CdkVirtualScrollViewport']
+    }
+  ],
   [TargetVersion.V10]: [
     {
       pr: 'https://github.com/angular/components/pull/19347',

--- a/src/cdk/scrolling/scroll-dispatcher.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.ts
@@ -23,12 +23,11 @@ export const DEFAULT_SCROLL_TIME = 20;
 @Injectable({providedIn: 'root'})
 export class ScrollDispatcher implements OnDestroy {
   /** Used to reference correct document/window */
-  protected _document?: Document;
+  protected _document: Document;
 
   constructor(private _ngZone: NgZone,
               private _platform: Platform,
-              /** @breaking-change 11.0.0 make document required */
-              @Optional() @Inject(DOCUMENT) document?: any) {
+              @Optional() @Inject(DOCUMENT) document: any) {
     this._document = document;
   }
 
@@ -144,15 +143,9 @@ export class ScrollDispatcher implements OnDestroy {
     return scrollingContainers;
   }
 
-  /** Access injected document if available or fallback to global document reference */
-  private _getDocument(): Document {
-    return this._document || document;
-  }
-
   /** Use defaultView of injected document if available or fallback to global window reference */
   private _getWindow(): Window {
-    const doc = this._getDocument();
-    return doc.defaultView || window;
+    return this._document.defaultView || window;
   }
 
   /** Returns true if the element is contained within the provided Scrollable. */

--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -39,12 +39,11 @@ export class ViewportRuler implements OnDestroy {
   }
 
   /** Used to reference correct document/window */
-  protected _document?: Document;
+  protected _document: Document;
 
   constructor(private _platform: Platform,
               ngZone: NgZone,
-              /** @breaking-change 11.0.0 make document required */
-              @Optional() @Inject(DOCUMENT) document?: any) {
+              @Optional() @Inject(DOCUMENT) document: any) {
     this._document = document;
 
     ngZone.runOutsideAngular(() => {
@@ -127,7 +126,7 @@ export class ViewportRuler implements OnDestroy {
     // `scrollTop` and `scrollLeft` is inconsistent. However, using the bounding rect of
     // `document.documentElement` works consistently, where the `top` and `left` values will
     // equal negative the scroll position.
-    const document = this._getDocument();
+    const document = this._document;
     const window = this._getWindow();
     const documentElement = document.documentElement!;
     const documentRect = documentElement.getBoundingClientRect();
@@ -149,15 +148,9 @@ export class ViewportRuler implements OnDestroy {
     return throttleTime > 0 ? this._change.pipe(auditTime(throttleTime)) : this._change;
   }
 
-  /** Access injected document if available or fallback to global document reference */
-  private _getDocument(): Document {
-    return this._document || document;
-  }
-
   /** Use defaultView of injected document if available or fallback to global window reference */
   private _getWindow(): Window {
-    const doc = this._getDocument();
-    return doc.defaultView || window;
+    return this._document.defaultView || window;
   }
 
   /** Updates the cached viewport size. */

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -159,23 +159,16 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
                   private _scrollStrategy: VirtualScrollStrategy,
               @Optional() dir: Directionality,
               scrollDispatcher: ScrollDispatcher,
-              /**
-               * @deprecated `viewportRuler` parameter to become required.
-               * @breaking-change 11.0.0
-               */
-              viewportRuler?: ViewportRuler) {
+              viewportRuler: ViewportRuler) {
     super(elementRef, scrollDispatcher, ngZone, dir);
 
     if (!_scrollStrategy && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw Error('Error: cdk-virtual-scroll-viewport requires the "itemSize" property to be set.');
     }
 
-    // @breaking-change 11.0.0 Remove null check for `viewportRuler`.
-    if (viewportRuler) {
-      this._viewportChanges = viewportRuler.change().subscribe(() => {
-        this.checkViewportSize();
-      });
-    }
+    this._viewportChanges = viewportRuler.change().subscribe(() => {
+      this.checkViewportSize();
+    });
   }
 
   ngOnInit() {

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -62,14 +62,14 @@ import {_MatAutocompleteOriginBase} from './autocomplete-origin';
 /**
  * The height of each autocomplete option.
  * @deprecated No longer being used. To be removed.
- * @breaking-change 11.0.0
+ * @breaking-change 12.0.0
  */
 export const AUTOCOMPLETE_OPTION_HEIGHT = 48;
 
 /**
  * The total height of the autocomplete panel.
  * @deprecated No longer being used. To be removed.
- * @breaking-change 11.0.0
+ * @breaking-change 12.0.0
  */
 export const AUTOCOMPLETE_PANEL_HEIGHT = 256;
 

--- a/tools/public_api_guard/cdk/scrolling.d.ts
+++ b/tools/public_api_guard/cdk/scrolling.d.ts
@@ -124,8 +124,7 @@ export declare class CdkVirtualScrollViewport extends CdkScrollable implements O
     set orientation(orientation: 'horizontal' | 'vertical');
     renderedRangeStream: Observable<ListRange>;
     scrolledIndexChange: Observable<number>;
-    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher,
-    viewportRuler?: ViewportRuler);
+    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher, viewportRuler: ViewportRuler);
     attach(forOf: CdkVirtualScrollRepeater<any>): void;
     checkViewportSize(): void;
     detach(): void;
@@ -167,11 +166,10 @@ export declare class FixedSizeVirtualScrollStrategy implements VirtualScrollStra
 }
 
 export declare class ScrollDispatcher implements OnDestroy {
-    protected _document?: Document;
+    protected _document: Document;
     _globalSubscription: Subscription | null;
     scrollContainers: Map<CdkScrollable, Subscription>;
-    constructor(_ngZone: NgZone, _platform: Platform,
-    document?: any);
+    constructor(_ngZone: NgZone, _platform: Platform, document: any);
     ancestorScrolled(elementRef: ElementRef, auditTimeInMs?: number): Observable<CdkScrollable | void>;
     deregister(scrollable: CdkScrollable): void;
     getAncestorScrollContainers(elementRef: ElementRef): CdkScrollable[];
@@ -188,9 +186,8 @@ export declare class ScrollingModule {
 }
 
 export declare class ViewportRuler implements OnDestroy {
-    protected _document?: Document;
-    constructor(_platform: Platform, ngZone: NgZone,
-    document?: any);
+    protected _document: Document;
+    constructor(_platform: Platform, ngZone: NgZone, document: any);
     change(throttleTime?: number): Observable<Event>;
     getViewportRect(): ClientRect;
     getViewportScrollPosition(): ViewportScrollPosition;


### PR DESCRIPTION
BREAKING CHANGES:
* The `document` parameter of the `ScrollDispatcher` constructor is now required.
* The `document` parameter of the `ViewportRuler` constructor is now required.
* The `viewportRuler` parameter of the `CdkVirtualScrollViewport` constructor is now required.

Also bumps two autocomplete APIs that were only marked as deprecated 10 days ago to v12 instead of v11.