### PR TITLE
refactor(chips): remove deprecated APIs for v11

### DIFF
--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -100,7 +100,6 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
     changeDetectorRef: ChangeDetectorRef,
     elementRef: ElementRef, ngZone: NgZone,
     @Optional() dir: Directionality,
-    // @breaking-change 8.0.0 `animationMode` parameter to become required.
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(changeDetectorRef, elementRef, ngZone, dir, animationMode);
   }

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -355,7 +355,6 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
       public _changeDetectorRef: ChangeDetectorRef,
       readonly _elementRef: ElementRef, protected _ngZone: NgZone,
       @Optional() private _dir: Directionality,
-      // @breaking-change 8.0.0 `animationMode` parameter to become required.
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(_elementRef);
     this._chipFoundation = new MDCChipFoundation(this._chipAdapter);

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -283,14 +283,11 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
               private _ngZone: NgZone,
               platform: Platform,
               @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
-              globalRippleOptions: RippleGlobalOptions | null,
-              // @breaking-change 8.0.0 `animationMode` parameter to become required.
+                  globalRippleOptions: RippleGlobalOptions | null,
+              private _changeDetectorRef: ChangeDetectorRef,
+              @Inject(DOCUMENT) _document: any,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
-              // @breaking-change 9.0.0 `_changeDetectorRef` parameter to become required.
-              private _changeDetectorRef?: ChangeDetectorRef,
-              @Attribute('tabindex') tabIndex?: string,
-              // @breaking-change 11.0.0 `_document` parameter to become required.
-              @Optional() @Inject(DOCUMENT) _document?: any) {
+              @Attribute('tabindex') tabIndex?: string) {
     super(_elementRef);
 
     this._addHostClassName();
@@ -298,7 +295,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     // Dynamically create the ripple target, append it within the chip, and use it as the
     // chip's ripple target. Adding the class '.mat-chip-ripple' ensures that it will have
     // the proper styles.
-    this._chipRippleTarget = (_document || document).createElement('div');
+    this._chipRippleTarget = _document.createElement('div');
     this._chipRippleTarget.classList.add('mat-chip-ripple');
     this._elementRef.nativeElement.appendChild(this._chipRippleTarget);
     this._chipRipple = new RippleRenderer(this, _ngZone, this._chipRippleTarget, platform);
@@ -332,7 +329,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     if (!this._selected) {
       this._selected = true;
       this._dispatchSelectionChange();
-      this._markForCheck();
+      this._changeDetectorRef.markForCheck();
     }
   }
 
@@ -341,7 +338,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     if (this._selected) {
       this._selected = false;
       this._dispatchSelectionChange();
-      this._markForCheck();
+      this._changeDetectorRef.markForCheck();
     }
   }
 
@@ -350,7 +347,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     if (!this._selected) {
       this._selected = true;
       this._dispatchSelectionChange(true);
-      this._markForCheck();
+      this._changeDetectorRef.markForCheck();
     }
   }
 
@@ -358,7 +355,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
   toggleSelected(isUserInput: boolean = false): boolean {
     this._selected = !this.selected;
     this._dispatchSelectionChange(isUserInput);
-    this._markForCheck();
+    this._changeDetectorRef.markForCheck();
     return this.selected;
   }
 
@@ -441,13 +438,6 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     });
   }
 
-  private _markForCheck() {
-    // @breaking-change 9.0.0 Remove this method once the _changeDetectorRef is a required param.
-    if (this._changeDetectorRef) {
-      this._changeDetectorRef.markForCheck();
-    }
-  }
-
   static ngAcceptInputType_selected: BooleanInput;
   static ngAcceptInputType_selectable: BooleanInput;
   static ngAcceptInputType_removable: BooleanInput;
@@ -480,11 +470,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
 export class MatChipRemove {
   constructor(
     protected _parentChip: MatChip,
-    // @breaking-change 11.0.0 `elementRef` parameter to be made required.
-    elementRef?: ElementRef<HTMLElement>) {
-
-      // @breaking-change 11.0.0 Remove null check for `elementRef`.
-    if (elementRef && elementRef.nativeElement.nodeName === 'BUTTON') {
+    elementRef: ElementRef<HTMLElement>) {
+    if (elementRef.nativeElement.nodeName === 'BUTTON') {
       elementRef.nativeElement.setAttribute('type', 'button');
     }
    }

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -14,6 +14,12 @@ import {ConstructorChecksUpgradeData, TargetVersion, VersionChanges} from '@angu
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V11]: [
+    {
+      pr: 'https://github.com/angular/components/issues/20463',
+      changes: ['MatChip', 'MatChipRemove']
+    }
+  ],
   [TargetVersion.V10]: [
     {
       pr: 'https://github.com/angular/components/pull/19307',

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -39,7 +39,7 @@ export declare class MatChip extends _MatChipMixinBase implements FocusableOptio
     trailingIcon: MatChipTrailingIcon;
     get value(): any;
     set value(value: any);
-    constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, animationMode?: string, _changeDetectorRef?: ChangeDetectorRef | undefined, tabIndex?: string, _document?: any);
+    constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, _changeDetectorRef: ChangeDetectorRef, _document: any, animationMode?: string, tabIndex?: string);
     _addHostClassName(): void;
     _blur(): void;
     _handleClick(event: Event): void;
@@ -58,7 +58,7 @@ export declare class MatChip extends _MatChipMixinBase implements FocusableOptio
     static ngAcceptInputType_selected: BooleanInput;
     static ngAcceptInputType_tabIndex: NumberInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatChip, "mat-basic-chip, [mat-basic-chip], mat-chip, [mat-chip]", ["matChip"], { "color": "color"; "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "selected": "selected"; "value": "value"; "selectable": "selectable"; "disabled": "disabled"; "removable": "removable"; }, { "selectionChange": "selectionChange"; "destroyed": "destroyed"; "removed": "removed"; }, ["avatar", "trailingIcon", "removeIcon"]>;
-    static ɵfac: i0.ɵɵFactoryDef<MatChip, [null, null, null, { optional: true; }, { optional: true; }, null, { attribute: "tabindex"; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatChip, [null, null, null, { optional: true; }, null, null, { optional: true; }, { attribute: "tabindex"; }]>;
 }
 
 export declare class MatChipAvatar {
@@ -193,7 +193,7 @@ export declare class MatChipListChange {
 
 export declare class MatChipRemove {
     protected _parentChip: MatChip;
-    constructor(_parentChip: MatChip, elementRef?: ElementRef<HTMLElement>);
+    constructor(_parentChip: MatChip, elementRef: ElementRef<HTMLElement>);
     _handleClick(event: Event): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatChipRemove, "[matChipRemove]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatChipRemove, never>;


### PR DESCRIPTION
Removes the APIs that were marked for deprecation in v11. I also decided to un-deprecate making the `animationMode` parameters required, because there's no good reason for them to be mandatory.

BREAKING CHANGES:
* `_changeDetectorRef` and `_document` parameters of the `MatChip` constructor are now required. Also the order of some constructor parameters has changed.
* `elementRef` parameter of the `MatChipRemove` constructor is now required.