### PR TITLE
Fix(cdk/overlay) : adaptation of clientRect according to the zoom level

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -1109,7 +1109,20 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
     const origin = this._origin;
 
     if (origin instanceof ElementRef) {
-      return origin.nativeElement.getBoundingClientRect();
+      const parentZoom = Number(window.getComputedStyle(origin.nativeElement.parentElement).zoom);
+      const rect = origin.nativeElement.getBoundingClientRect();
+      if (parentZoom !== 1) {
+        const {bottom, height: h, left, right, top, width: w} = rect;
+        return {
+          bottom : bottom * parentZoom,
+          height: h,
+          left: left * parentZoom,
+          right,
+          top: top * parentZoom,
+          width: w
+        };
+      }
+      return rect;
     }
 
     // Check for Element so SVG elements are also supported.


### PR DESCRIPTION
Fixed a bug on the cdk/overlay that was incorrectly positioned when the parent element contained a zoom level different from 1. The zoom level is applied on the bottom, left and top properties in order to adapt the positioning.

Fixes #10924