### PR TITLE
fix(material/snack-bar): flaky screen reader announcements for NVDA/JAWS

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.html
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.html
@@ -4,6 +4,12 @@
     the attached template/component does not contain it.
   -->
   <div class="mat-mdc-snack-bar-label" #label>
-    <ng-template cdkPortalOutlet></ng-template>
+    <!-- Initialy holds the snack bar content, will be empty after announcing to screen readers. -->
+    <div aria-hidden="true">
+      <ng-template cdkPortalOutlet></ng-template>
+    </div>
+
+    <!-- Will receive the snack bar content from the non-live div, move will happen a short delay after opening -->
+    <div [attr.aria-live]="_live"></div>
   </div>
 </div>

--- a/src/material-experimental/mdc-snack-bar/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-snack-bar/testing/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     ),
     module_name = "@angular/material-experimental/mdc-snack-bar/testing",
     deps = [
+        "//src/cdk/a11y",
         "//src/cdk/testing",
     ],
 )

--- a/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
+++ b/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {AriaLivePoliteness} from '@angular/cdk/a11y';
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {SnackBarHarnessFilters} from './snack-bar-harness-filters';
 
@@ -20,6 +21,7 @@ export class MatSnackBarHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-snack-bar-container:not([mat-exit])';
 
   private _simpleSnackBar = this.locatorForOptional('.mat-mdc-simple-snack-bar');
+  private _simpleSnackBarLiveRegion = this.locatorFor('[aria-live]');
   private _simpleSnackBarMessage =
       this.locatorFor('.mat-mdc-simple-snack-bar .mat-mdc-snack-bar-label');
   private _simpleSnackBarActionButton =
@@ -38,9 +40,19 @@ export class MatSnackBarHarness extends ComponentHarness {
   /**
    * Gets the role of the snack-bar. The role of a snack-bar is determined based
    * on the ARIA politeness specified in the snack-bar config.
+   * @deprecated @breaking-change 13.0.0 Use `getAriaLive` instead.
    */
   async getRole(): Promise<'alert'|'status'|null> {
     return (await this.host()).getAttribute('role') as Promise<'alert'|'status'|null>;
+  }
+
+  /**
+   * Gets the aria-live of the snack-bar's live region. The aria-live of a snack-bar is
+   * determined based on the ARIA politeness specified in the snack-bar config.
+   */
+  async getAriaLive(): Promise<AriaLivePoliteness> {
+    return (await this._simpleSnackBarLiveRegion())
+        .getAttribute('aria-live') as Promise<AriaLivePoliteness>;
   }
 
   /**

--- a/src/material/snack-bar/snack-bar-container.html
+++ b/src/material/snack-bar/snack-bar-container.html
@@ -1,1 +1,7 @@
-<ng-template cdkPortalOutlet></ng-template>
+<!-- Initialy holds the snack bar content, will be empty after announcing to screen readers. -->
+<div aria-hidden="true">
+  <ng-template cdkPortalOutlet></ng-template>
+</div>
+
+<!-- Will receive the snack bar content from the non-live div, move will happen a short delay after opening -->
+<div [attr.aria-live]="_live"></div>

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -35,6 +35,8 @@ describe('MatSnackBar', () => {
   let simpleMessage = 'Burritos are here!';
   let simpleActionLabel = 'pickup';
 
+  const announceDelay = 150;
+
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
@@ -61,44 +63,100 @@ describe('MatSnackBar', () => {
     testViewContainerRef = viewContainerFixture.componentInstance.childViewContainer;
   });
 
-  it('should have the role of `alert` with an `assertive` politeness if no announcement message ' +
-     'is provided', () => {
+  it('should open with content first in the inert region', () => {
+    snackBar.open('Snack time!', 'Chew');
+    viewContainerFixture.detectChanges();
+
+    const containerElement = overlayContainerElement.querySelector('snack-bar-container')!;
+    const inertElement = containerElement.querySelector('[aria-hidden]')!;
+
+    expect(inertElement.getAttribute('aria-hidden'))
+      .toBe('true', 'Expected the non-live region to be aria-hidden');
+    expect(inertElement.textContent).toContain('Snack time!',
+        'Expected non-live region to contain the snack bar content');
+
+    const liveElement = containerElement.querySelector('[aria-live]')!;
+    expect(liveElement.childNodes.length)
+        .toBe(0, 'Expected live region to not contain any content');
+  });
+
+  it('should move content to the live region after 150ms', fakeAsync(() => {
+    snackBar.open('Snack time!', 'Chew');
+    viewContainerFixture.detectChanges();
+
+    const containerElement = overlayContainerElement.querySelector('snack-bar-container')!;
+    const liveElement = containerElement.querySelector('[aria-live]')!;
+    tick(announceDelay);
+
+    expect(liveElement.textContent).toContain('Snack time!',
+        'Expected live region to contain the snack bar content');
+
+    const inertElement = containerElement.querySelector('[aria-hidden]')!;
+    expect(inertElement).toBeFalsy('Expected non-live region to not contain any content');
+  }));
+
+  it('should preserve focus when moving content to the live region', fakeAsync(() => {
+    snackBar.open('Snack time!', 'Chew');
+    viewContainerFixture.detectChanges();
+
+    const actionButton = overlayContainerElement
+        .querySelector('.mat-simple-snackbar-action > button')! as HTMLElement;
+    actionButton.focus();
+    expect(document.activeElement)
+        .toBe(actionButton, 'Expected the focus to move to the action button');
+
+    flush();
+    expect(document.activeElement)
+        .toBe(actionButton, 'Expected the focus to remain on the action button');
+  }));
+
+  it('should have aria-live of `assertive` with an `assertive` politeness if no announcement ' +
+     'message is provided', () => {
     snackBar.openFromComponent(BurritosNotification,
       {announcementMessage: '', politeness: 'assertive'});
 
     viewContainerFixture.detectChanges();
 
     const containerElement = overlayContainerElement.querySelector('snack-bar-container')!;
-    expect(containerElement.getAttribute('role'))
-        .toBe('alert', 'Expected snack bar container to have role="alert"');
+    const liveElement = containerElement.querySelector('[aria-live]')!;
+
+    expect(liveElement.getAttribute('aria-live')).toBe('assertive',
+        'Expected snack bar container live region to have aria-live="assertive"');
   });
 
-  it('should have the role of `status` with an `assertive` politeness if an announcement message ' +
-     'is provided', () => {
+  it('should have aria-live of `polite` with an `assertive` politeness if an announcement ' +
+     'message is provided', () => {
       snackBar.openFromComponent(BurritosNotification,
         {announcementMessage: 'Yay Burritos', politeness: 'assertive'});
     viewContainerFixture.detectChanges();
 
     const containerElement = overlayContainerElement.querySelector('snack-bar-container')!;
-    expect(containerElement.getAttribute('role'))
-        .toBe('status', 'Expected snack bar container to have role="status"');
+    const liveElement = containerElement.querySelector('[aria-live]')!;
+
+    expect(liveElement.getAttribute('aria-live'))
+        .toBe('polite', 'Expected snack bar container live region to have aria-live="polite"');
   });
 
-  it('should have the role of `status` with a `polite` politeness', () => {
+  it('should have aria-live of `polite` with a `polite` politeness', () => {
     snackBar.openFromComponent(BurritosNotification, {politeness: 'polite'});
     viewContainerFixture.detectChanges();
 
     const containerElement = overlayContainerElement.querySelector('snack-bar-container')!;
-    expect(containerElement.getAttribute('role'))
-        .toBe('status', 'Expected snack bar container to have role="status"');
+    const liveElement = containerElement.querySelector('[aria-live]')!;
+
+    expect(liveElement.getAttribute('aria-live'))
+        .toBe('polite', 'Expected snack bar container live region to have aria-live="polite"');
   });
 
-  it('should remove the role if the politeness is turned off', () => {
+  it('should have aria-live of `off` if the politeness is turned off', () => {
     snackBar.openFromComponent(BurritosNotification, {politeness: 'off'});
     viewContainerFixture.detectChanges();
 
     const containerElement = overlayContainerElement.querySelector('snack-bar-container')!;
-    expect(containerElement.getAttribute('role')).toBeFalsy('Expected role to be removed');
+    const liveElement = containerElement.querySelector('[aria-live]')!;
+
+    expect(liveElement.getAttribute('aria-live'))
+        .toBe('off', 'Expected snack bar container live region to have aria-live="off"');
   });
 
   it('should open and close a snackbar without a ViewContainerRef', fakeAsync(() => {
@@ -189,6 +247,7 @@ describe('MatSnackBar', () => {
 
     snackBar.open(simpleMessage, undefined, {announcementMessage: simpleMessage});
     viewContainerFixture.detectChanges();
+    flush();
 
     expect(overlayContainerElement.childElementCount)
       .toBe(1, 'Expected the overlay with the default announcement message to be added');
@@ -204,6 +263,7 @@ describe('MatSnackBar', () => {
       politeness: 'assertive'
     });
     viewContainerFixture.detectChanges();
+    flush();
 
     expect(overlayContainerElement.childElementCount)
       .toBe(1, 'Expected the overlay with a custom `announcementMessage` to be added');

--- a/src/material/snack-bar/snack-bar.ts
+++ b/src/material/snack-bar/snack-bar.ts
@@ -205,6 +205,13 @@ export class MatSnackBar implements OnDestroy {
       state.matches ? classList.add(this.handsetCssClass) : classList.remove(this.handsetCssClass);
     });
 
+    if (config.announcementMessage) {
+      // Wait until the snack bar contents have been announced then deliver this message.
+      container._onAnnounce.subscribe(() => {
+        this._live.announce(config.announcementMessage!, config.politeness);
+      });
+    }
+
     this._animateSnackBar(snackBarRef, config);
     this._openedSnackBarRef = snackBarRef;
     return this._openedSnackBarRef;
@@ -239,10 +246,6 @@ export class MatSnackBar implements OnDestroy {
     // If a dismiss timeout is provided, set up dismiss based on after the snackbar is opened.
     if (config.duration && config.duration > 0) {
       snackBarRef.afterOpened().subscribe(() => snackBarRef._dismissAfter(config.duration!));
-    }
-
-    if (config.announcementMessage) {
-      this._live.announce(config.announcementMessage, config.politeness);
     }
   }
 

--- a/src/material/snack-bar/testing/BUILD.bazel
+++ b/src/material/snack-bar/testing/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     ),
     module_name = "@angular/material/snack-bar/testing",
     deps = [
+        "//src/cdk/a11y",
         "//src/cdk/testing",
     ],
 )

--- a/src/material/snack-bar/testing/shared.spec.ts
+++ b/src/material/snack-bar/testing/shared.spec.ts
@@ -70,17 +70,32 @@ export function runHarnessTests(
   });
 
   it('should be able to get role of snack-bar', async () => {
+    // Get role is now deprecated, so it should always return null.
     fixture.componentInstance.openCustom();
     let snackBar = await loader.getHarness(snackBarHarness);
-    expect(await snackBar.getRole()).toBe('alert');
+    expect(await snackBar.getRole()).toBe(null);
 
     fixture.componentInstance.openCustom({politeness: 'polite'});
     snackBar = await loader.getHarness(snackBarHarness);
-    expect(await snackBar.getRole()).toBe('status');
+    expect(await snackBar.getRole()).toBe(null);
 
     fixture.componentInstance.openCustom({politeness: 'off'});
     snackBar = await loader.getHarness(snackBarHarness);
     expect(await snackBar.getRole()).toBe(null);
+  });
+
+  it('should be able to get aria-live of snack-bar', async () => {
+    fixture.componentInstance.openCustom();
+    let snackBar = await loader.getHarness(snackBarHarness);
+    expect(await snackBar.getAriaLive()).toBe('assertive');
+
+    fixture.componentInstance.openCustom({politeness: 'polite'});
+    snackBar = await loader.getHarness(snackBarHarness);
+    expect(await snackBar.getAriaLive()).toBe('polite');
+
+    fixture.componentInstance.openCustom({politeness: 'off'});
+    snackBar = await loader.getHarness(snackBarHarness);
+    expect(await snackBar.getAriaLive()).toBe('off');
   });
 
   it('should be able to get message of simple snack-bar', async () => {

--- a/src/material/snack-bar/testing/snack-bar-harness.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {AriaLivePoliteness} from '@angular/cdk/a11y';
 import {ContentContainerComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {SnackBarHarnessFilters} from './snack-bar-harness-filters';
 
@@ -17,6 +18,7 @@ export class MatSnackBarHarness extends ContentContainerComponentHarness<string>
   static hostSelector = '.mat-snack-bar-container';
 
   private _simpleSnackBar = this.locatorForOptional('.mat-simple-snackbar');
+  private _simpleSnackBarLiveRegion = this.locatorFor('[aria-live]');
   private _simpleSnackBarMessage = this.locatorFor('.mat-simple-snackbar > span');
   private _simpleSnackBarActionButton =
       this.locatorForOptional('.mat-simple-snackbar-action > button');
@@ -34,9 +36,19 @@ export class MatSnackBarHarness extends ContentContainerComponentHarness<string>
   /**
    * Gets the role of the snack-bar. The role of a snack-bar is determined based
    * on the ARIA politeness specified in the snack-bar config.
+   * @deprecated @breaking-change 13.0.0 Use `getAriaLive` instead.
    */
   async getRole(): Promise<'alert'|'status'|null> {
     return (await this.host()).getAttribute('role') as Promise<'alert'|'status'|null>;
+  }
+
+  /**
+   * Gets the aria-live of the snack-bar's live region. The aria-live of a snack-bar is
+   * determined based on the ARIA politeness specified in the snack-bar config.
+   */
+  async getAriaLive(): Promise<AriaLivePoliteness> {
+    return (await this._simpleSnackBarLiveRegion())
+        .getAttribute('aria-live') as Promise<AriaLivePoliteness>;
   }
 
   /**

--- a/tools/public_api_guard/material/snack-bar.d.ts
+++ b/tools/public_api_guard/material/snack-bar.d.ts
@@ -1,4 +1,5 @@
 export interface _SnackBarContainer {
+    _onAnnounce: Subject<any>;
     _onEnter: Subject<any>;
     _onExit: Subject<any>;
     attachComponentPortal: <T>(portal: ComponentPortal<T>) => ComponentRef<T>;
@@ -48,13 +49,14 @@ export declare class MatSnackBarConfig<D = any> {
 
 export declare class MatSnackBarContainer extends BasePortalOutlet implements OnDestroy, _SnackBarContainer {
     _animationState: string;
+    _live: AriaLivePoliteness;
+    readonly _onAnnounce: Subject<void>;
     readonly _onEnter: Subject<void>;
     readonly _onExit: Subject<void>;
     _portalOutlet: CdkPortalOutlet;
-    _role: 'alert' | 'status' | null;
     attachDomPortal: (portal: DomPortal) => void;
     snackBarConfig: MatSnackBarConfig;
-    constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef,
+    constructor(_ngZone: NgZone, _elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _platform: Platform,
     snackBarConfig: MatSnackBarConfig);
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C>;

--- a/tools/public_api_guard/material/snack-bar/testing.d.ts
+++ b/tools/public_api_guard/material/snack-bar/testing.d.ts
@@ -1,6 +1,7 @@
 export declare class MatSnackBarHarness extends ContentContainerComponentHarness<string> {
     dismissWithAction(): Promise<void>;
     getActionDescription(): Promise<string>;
+    getAriaLive(): Promise<AriaLivePoliteness>;
     getMessage(): Promise<string>;
     getRole(): Promise<'alert' | 'status' | null>;
     hasAction(): Promise<boolean>;


### PR DESCRIPTION
Fixes a bug where NVDA won't announce polite snack bars and JAWS won't announce any.
This is because the live region (snack-bar-container) was added to the DOM, marked as a live
region, and content was added to it in the same operation. Some screen readers require the live
region to be added to the DOM, some time to pass, then content can be added. Now the snack bar
content is added to an aria-hidden div then, 150ms later, moved to a div with aria-live defined.
This won't cause any visual changes and keeps the snack bar content available immediatly after
opening. Also, no longer using the alert or status roles. Instead just using aria-live as testing
showed that NVDA will double announce with the alert role and JAWS won't announce any button text.

BREAKING CHANGE: matSnackBarHarness.getRole() replaced with .getAriaLive() due to using aria-live
rather than the alert and status roles.