### PR TITLE
fix(datepicker): remove red shadow from invalid range inputs in Firefox

### DIFF
--- a/src/material/datepicker/date-range-input.scss
+++ b/src/material/datepicker/date-range-input.scss
@@ -58,6 +58,12 @@ $mat-date-range-input-part-max-width: calc(50% - #{$mat-date-range-input-separat
     display: none;
   }
 
+  // Undo the red box-shadow glow added by Firefox on invalid inputs.
+  // See https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-ui-invalid
+  &:-moz-ui-invalid {
+    box-shadow: none;
+  }
+
   @include input-placeholder {
     @include _mat-date-range-input-placeholder-transition(color);
   }


### PR DESCRIPTION
Firefox automatically adds a red `box-shadow` to invalid inputs. These changes remove it from the inner range inputs since their invalid state is shown through the `mat-form-field`.

Fixes #20483.