### PR TITLE
fix(cdk/tree): remove CdkTreeNodeDef from CdkTreeModules providers

### DIFF
--- a/src/cdk/tree/tree-module.ts
+++ b/src/cdk/tree/tree-module.ts
@@ -28,6 +28,6 @@ const EXPORTED_DECLARATIONS = [
 @NgModule({
   exports: EXPORTED_DECLARATIONS,
   declarations: EXPORTED_DECLARATIONS,
-  providers: [FocusMonitor, CdkTreeNodeDef]
+  providers: [FocusMonitor]
 })
 export class CdkTreeModule {}


### PR DESCRIPTION
`CdkTreeNodeDef` is a directive and should not be included in the providers