### PR TITLE
feat(cdk/a11y): extend LiveAnnouncer with aria attributes

### DIFF
--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -54,6 +54,27 @@ describe('LiveAnnouncer', () => {
       expect(ariaLiveElement.getAttribute('aria-live')).toBe('assertive');
     }));
 
+    it('should correctly update labelledby and describedby attributes', fakeAsync(() => {
+      announcer.announce('Hey Google', 'assertive', 0, 'ID123', 'ID456');
+
+      tick(100);
+
+      expect(ariaLiveElement.getAttribute('aria-labelledby')).toBe('ID123');
+      expect(ariaLiveElement.getAttribute('aria-describedby')).toBe('ID456');
+    }));
+
+    it('should correctly update aria attributes with array arguments', fakeAsync(() => {
+      const labelledBy = ['a', 'b', 'c'];
+      const describeBy = ['d', 'e', 'f'];
+
+      announcer.announce('Hey Google', 'assertive', 0, labelledBy, describeBy);
+
+      tick(100);
+
+      expect(ariaLiveElement.getAttribute('aria-labelledby')).toBe('a b c');
+      expect(ariaLiveElement.getAttribute('aria-describedby')).toBe('d e f');
+    }));
+
     it('should apply the aria-live value polite by default', fakeAsync(() => {
       announcer.announce('Hey Google');
 

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -56,11 +56,10 @@ describe('LiveAnnouncer', () => {
 
     it('should correctly update labelledby and describedby attributes', fakeAsync(() => {
       announcer.announce('Hey Google', 'assertive', 0, 'ID123', 'ID456');
-
-      tick(100);
-
       expect(ariaLiveElement.getAttribute('aria-labelledby')).toBe('ID123');
       expect(ariaLiveElement.getAttribute('aria-describedby')).toBe('ID456');
+
+      tick(100);
     }));
 
     it('should correctly update aria attributes with array arguments', fakeAsync(() => {
@@ -68,11 +67,10 @@ describe('LiveAnnouncer', () => {
       const describeBy = ['d', 'e', 'f'];
 
       announcer.announce('Hey Google', 'assertive', 0, labelledBy, describeBy);
-
-      tick(100);
-
       expect(ariaLiveElement.getAttribute('aria-labelledby')).toBe('a b c');
       expect(ariaLiveElement.getAttribute('aria-describedby')).toBe('d e f');
+
+      tick(100);
     }));
 
     it('should apply the aria-live value polite by default', fakeAsync(() => {

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -151,6 +151,8 @@ export class LiveAnnouncer implements OnDestroy {
   clear() {
     if (this._liveElement) {
       this._liveElement.textContent = '';
+      this._liveElement.removeAttribute('aria-labelledby');
+      this._liveElement.removeAttribute('aria-describedby');
     }
   }
 

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -72,6 +72,7 @@ export class LiveAnnouncer implements OnDestroy {
    */
   announce(message: string, duration?: number): Promise<void>;
 
+
   /**
    * Announces a message to screenreaders.
    * @param message Message to be announced to the screenreader.
@@ -79,19 +80,29 @@ export class LiveAnnouncer implements OnDestroy {
    * @param duration Time in milliseconds after which to clear out the announcer element. Note
    *   that this takes effect after the message has been added to the DOM, which can be up to
    *   100ms after `announce` has been called.
+   * @param labelledBy List of label identifiers associated with announcer element.
+   * @param describedBy List of description identifiers associated with announcer element.
    * @returns Promise that will be resolved when the message is added to the DOM.
    */
-  announce(message: string, politeness?: AriaLivePoliteness, duration?: number): Promise<void>;
+  announce(
+    message: string,
+    politeness?: AriaLivePoliteness,
+    duration?: number,
+    labelledBy?: string[] | string,
+    describedBy?: string[] | string
+  ): Promise<void>;
 
   announce(message: string, ...args: any[]): Promise<void> {
     const defaultOptions = this._defaultOptions;
     let politeness: AriaLivePoliteness | undefined;
     let duration: number | undefined;
+    let labelledBy: string[] | string | undefined;
+    let describedBy: string[] | string | undefined;
 
     if (args.length === 1 && typeof args[0] === 'number') {
       duration = args[0];
     } else {
-      [politeness, duration] = args;
+      [politeness, duration, labelledBy, describedBy] = args;
     }
 
     this.clear();
@@ -108,6 +119,9 @@ export class LiveAnnouncer implements OnDestroy {
 
     // TODO: ensure changing the politeness works on all environments we support.
     this._liveElement.setAttribute('aria-live', politeness);
+
+    this._setIdentifiersAttribute('aria-labelledby', labelledBy);
+    this._setIdentifiersAttribute('aria-describedby', describedBy);
 
     // This 100ms timeout is necessary for some browser + screen-reader combinations:
     // - Both JAWS and NVDA over IE11 will not announce anything without a non-zero timeout.
@@ -168,6 +182,16 @@ export class LiveAnnouncer implements OnDestroy {
     this._document.body.appendChild(liveEl);
 
     return liveEl;
+  }
+
+  private _setIdentifiersAttribute(attribute: string, identifiers?: string | string[]): void {
+    if (identifiers && this._liveElement) {
+      if (Array.isArray(identifiers)) {
+        this._liveElement.setAttribute(attribute, identifiers.join(' '));
+      } else {
+        this._liveElement.setAttribute(attribute, identifiers);
+      }
+    }
   }
 
 }

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -239,7 +239,7 @@ export declare class LiveAnnouncer implements OnDestroy {
     announce(message: string): Promise<void>;
     announce(message: string, politeness?: AriaLivePoliteness): Promise<void>;
     announce(message: string, duration?: number): Promise<void>;
-    announce(message: string, politeness?: AriaLivePoliteness, duration?: number): Promise<void>;
+    announce(message: string, politeness?: AriaLivePoliteness, duration?: number, labelledBy?: string[] | string, describedBy?: string[] | string): Promise<void>;
     clear(): void;
     ngOnDestroy(): void;
     static ɵfac: i0.ɵɵFactoryDef<LiveAnnouncer, [{ optional: true; }, null, null, { optional: true; }]>;


### PR DESCRIPTION
Extend LiveAnnouncer with aria-labelledby and aria-describedby