### PR TITLE
refactor(tabs): remove deprecated APIs for v11

### DIFF
--- a/src/material-experimental/mdc-tabs/tab-body.ts
+++ b/src/material-experimental/mdc-tabs/tab-body.ts
@@ -27,6 +27,7 @@ import {
 } from '@angular/material/tabs';
 import {PortalHostDirective} from '@angular/cdk/portal';
 import {Directionality} from '@angular/cdk/bidi';
+import {DOCUMENT} from '@angular/common';
 
 /**
  * The portal host directive for the contents of the tab.
@@ -39,8 +40,9 @@ export class MatTabBodyPortal extends BaseMatTabBodyPortal {
   constructor(
     componentFactoryResolver: ComponentFactoryResolver,
     viewContainerRef: ViewContainerRef,
-    @Inject(forwardRef(() => MatTabBody)) host: MatTabBody) {
-    super(componentFactoryResolver, viewContainerRef, host);
+    @Inject(forwardRef(() => MatTabBody)) host: MatTabBody,
+    @Inject(DOCUMENT) _document: any) {
+    super(componentFactoryResolver, viewContainerRef, host, _document);
   }
 }
 

--- a/src/material-experimental/mdc-tabs/tab-header.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.ts
@@ -64,7 +64,6 @@ export class MatTabHeader extends _MatTabHeaderBase implements AfterContentInit 
               @Optional() dir: Directionality,
               ngZone: NgZone,
               platform: Platform,
-              // @breaking-change 9.0.0 `_animationMode` parameter to be made required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, changeDetectorRef, viewportRuler, dir, ngZone, platform, animationMode);
   }

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -85,10 +85,7 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
               ngZone: NgZone,
               changeDetectorRef: ChangeDetectorRef,
               viewportRuler: ViewportRuler,
-              /**
-               * @deprecated @breaking-change 9.0.0 `platform` parameter to become required.
-               */
-              platform?: Platform,
+              platform: Platform,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
               @Optional() @Inject(MAT_TABS_CONFIG) defaultConfig?: MatTabsConfig) {
     super(elementRef, dir, ngZone, changeDetectorRef, viewportRuler, platform, animationMode);

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -30,6 +30,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/issues/20535',
       changes: ['MatCheckbox']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/20499',
+      changes: ['MatPaginatedTabHeader', 'MatTabBodyPortal', 'MatTabNav', 'MatTab']
     }
   ],
   [TargetVersion.V10]: [

--- a/src/material/schematics/ng-update/data/method-call-checks.ts
+++ b/src/material/schematics/ng-update/data/method-call-checks.ts
@@ -6,6 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MethodCallUpgradeData, VersionChanges} from '@angular/cdk/schematics';
+import {MethodCallUpgradeData, TargetVersion, VersionChanges} from '@angular/cdk/schematics';
 
-export const methodCallChecks: VersionChanges<MethodCallUpgradeData> = {};
+export const methodCallChecks: VersionChanges<MethodCallUpgradeData> = {
+  [TargetVersion.V11]: [{
+    pr: 'https://github.com/angular/components/pull/20499',
+    changes: [{
+      className: 'MatTabNav',
+      method: 'updateActiveLink',
+      invalidArgCounts: [{count: 1, message: 'The "_element" parameter has been removed'}]
+    }]
+  }],
+};

--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -148,11 +148,7 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
               private _viewportRuler: ViewportRuler,
               @Optional() private _dir: Directionality,
               private _ngZone: NgZone,
-              /**
-               * @deprecated @breaking-change 9.0.0 `_platform` and `_animationMode`
-               * parameters to become required.
-               */
-              private _platform?: Platform,
+              private _platform: Platform,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
 
     // Bind the `mouseleave` event on the outside since it doesn't change anything in the view.
@@ -370,7 +366,6 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
     }
 
     const scrollDistance = this.scrollDistance;
-    const platform = this._platform;
     const translateX = this._getLayoutDirection() === 'ltr' ? -scrollDistance : scrollDistance;
 
     // Don't use `translate3d` here because we don't want to create a new layer. A new layer
@@ -385,8 +380,7 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
     // position to be thrown off in some cases. We have to reset it ourselves to ensure that
     // it doesn't get thrown off. Note that we scope it only to IE and Edge, because messing
     // with the scroll position throws off Chrome 71+ in RTL mode (see #14689).
-    // @breaking-change 9.0.0 Remove null check for `platform` after it can no longer be undefined.
-    if (platform && (platform.TRIDENT || platform.EDGE)) {
+    if (this._platform.TRIDENT || this._platform.EDGE) {
       this._tabListContainer.nativeElement.scrollLeft = 0;
     }
   }

--- a/src/material/tabs/tab-body.ts
+++ b/src/material/tabs/tab-body.ts
@@ -71,11 +71,7 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
     componentFactoryResolver: ComponentFactoryResolver,
     viewContainerRef: ViewContainerRef,
     @Inject(forwardRef(() => MatTabBody)) private _host: MatTabBody,
-    /**
-     * @deprecated `_document` parameter to be made required.
-     * @breaking-change 9.0.0
-     */
-    @Inject(DOCUMENT) _document?: any) {
+    @Inject(DOCUMENT) _document: any) {
     super(componentFactoryResolver, viewContainerRef, _document);
   }
 

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -266,11 +266,7 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
     this._allTabs.changes
       .pipe(startWith(this._allTabs))
       .subscribe((tabs: QueryList<MatTab>) => {
-        this._tabs.reset(tabs.filter(tab => {
-          // @breaking-change 10.0.0 Remove null check for `_closestTabGroup`
-          // once it becomes a required parameter in MatTab.
-          return !tab._closestTabGroup || tab._closestTabGroup === this;
-        }));
+        this._tabs.reset(tabs.filter(tab => tab._closestTabGroup === this));
         this._tabs.notifyOnChanges();
       });
   }

--- a/src/material/tabs/tab-header.ts
+++ b/src/material/tabs/tab-header.ts
@@ -54,7 +54,6 @@ export abstract class _MatTabHeaderBase extends MatPaginatedTabHeader implements
               @Optional() dir: Directionality,
               ngZone: NgZone,
               platform: Platform,
-              // @breaking-change 9.0.0 `_animationMode` parameter to be made required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, changeDetectorRef, viewportRuler, dir, ngZone, platform, animationMode);
   }
@@ -100,7 +99,6 @@ export class MatTabHeader extends _MatTabHeaderBase {
               @Optional() dir: Directionality,
               ngZone: NgZone,
               platform: Platform,
-              // @breaking-change 9.0.0 `_animationMode` parameter to be made required.
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, changeDetectorRef, viewportRuler, dir, ngZone, platform, animationMode);
   }

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -89,10 +89,7 @@ export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements Af
               ngZone: NgZone,
               changeDetectorRef: ChangeDetectorRef,
               viewportRuler: ViewportRuler,
-              /**
-               * @deprecated @breaking-change 9.0.0 `platform` parameter to become required.
-               */
-              platform?: Platform,
+              platform: Platform,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, changeDetectorRef, viewportRuler, dir, ngZone, platform, animationMode);
   }
@@ -111,11 +108,8 @@ export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements Af
     super.ngAfterContentInit();
   }
 
-  /**
-   * Notifies the component that the active link has been changed.
-   * @breaking-change 8.0.0 `element` parameter to be removed.
-   */
-  updateActiveLink(_element?: ElementRef) {
+  /** Notifies the component that the active link has been changed. */
+  updateActiveLink() {
     if (!this._items) {
       return;
     }
@@ -172,10 +166,7 @@ export class MatTabNav extends _MatTabNavBase {
     ngZone: NgZone,
     changeDetectorRef: ChangeDetectorRef,
     viewportRuler: ViewportRuler,
-    /**
-     * @deprecated @breaking-change 9.0.0 `platform` parameter to become required.
-     */
-    platform?: Platform,
+    platform: Platform,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
     super(elementRef, dir, ngZone, changeDetectorRef, viewportRuler, platform, animationMode);
   }
@@ -203,7 +194,7 @@ export class _MatTabLinkBase extends _MatTabLinkMixinBase implements AfterViewIn
   set active(value: boolean) {
     if (value !== this._isActive) {
       this._isActive = value;
-      this._tabNavBar.updateActiveLink(this.elementRef);
+      this._tabNavBar.updateActiveLink();
     }
   }
 

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -23,7 +23,6 @@ import {
   ViewEncapsulation,
   InjectionToken,
   Inject,
-  Optional,
 } from '@angular/core';
 import {CanDisable, CanDisableCtor, mixinDisabled} from '@angular/material/core';
 import {Subject} from 'rxjs';
@@ -110,11 +109,7 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
 
   constructor(
     private _viewContainerRef: ViewContainerRef,
-    /**
-     * @deprecated `_closestTabGroup` parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    @Optional() @Inject(MAT_TAB_GROUP) public _closestTabGroup?: any) {
+    @Inject(MAT_TAB_GROUP) public _closestTabGroup: any) {
     super();
   }
 

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -106,11 +106,10 @@ export declare abstract class _MatTabNavBase extends MatPaginatedTabHeader imple
     color: ThemePalette;
     get disableRipple(): any;
     set disableRipple(value: any);
-    constructor(elementRef: ElementRef, dir: Directionality, ngZone: NgZone, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler,
-    platform?: Platform, animationMode?: string);
+    constructor(elementRef: ElementRef, dir: Directionality, ngZone: NgZone, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler, platform: Platform, animationMode?: string);
     protected _itemSelected(): void;
     ngAfterContentInit(): void;
-    updateActiveLink(_element?: ElementRef): void;
+    updateActiveLink(): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatTabNavBase, never, never, { "backgroundColor": "backgroundColor"; "disableRipple": "disableRipple"; "color": "color"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<_MatTabNavBase, [null, { optional: true; }, null, null, null, null, { optional: true; }]>;
 }
@@ -130,7 +129,7 @@ export declare class MatInkBar {
 }
 
 export declare class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnChanges, OnDestroy {
-    _closestTabGroup?: any;
+    _closestTabGroup: any;
     _explicitContent: TemplateRef<any>;
     _implicitContent: TemplateRef<any>;
     readonly _stateChanges: Subject<void>;
@@ -144,15 +143,14 @@ export declare class MatTab extends _MatTabMixinBase implements OnInit, CanDisab
     get templateLabel(): MatTabLabel;
     set templateLabel(value: MatTabLabel);
     textLabel: string;
-    constructor(_viewContainerRef: ViewContainerRef,
-    _closestTabGroup?: any);
+    constructor(_viewContainerRef: ViewContainerRef, _closestTabGroup: any);
     protected _setTemplateLabelInput(value: MatTabLabel): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTab, "mat-tab", ["matTab"], { "disabled": "disabled"; "textLabel": "label"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; }, {}, ["templateLabel", "_explicitContent"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<MatTab, [null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatTab, never>;
 }
 
 export declare class MatTabBody extends _MatTabBodyBase {
@@ -165,8 +163,7 @@ export declare class MatTabBody extends _MatTabBodyBase {
 export declare type MatTabBodyOriginState = 'left' | 'right';
 
 export declare class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestroy {
-    constructor(componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, _host: MatTabBody,
-    _document?: any);
+    constructor(componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, _host: MatTabBody, _document: any);
     ngOnDestroy(): void;
     ngOnInit(): void;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTabBodyPortal, "[matTabBodyHost]", never, {}, {}, never>;
@@ -241,8 +238,7 @@ export declare class MatTabNav extends _MatTabNavBase {
     _previousPaginator: ElementRef<HTMLElement>;
     _tabList: ElementRef;
     _tabListContainer: ElementRef;
-    constructor(elementRef: ElementRef, dir: Directionality, ngZone: NgZone, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler,
-    platform?: Platform, animationMode?: string);
+    constructor(elementRef: ElementRef, dir: Directionality, ngZone: NgZone, changeDetectorRef: ChangeDetectorRef, viewportRuler: ViewportRuler, platform: Platform, animationMode?: string);
     static ngAcceptInputType_disableRipple: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatTabNav, "[mat-tab-nav-bar]", ["matTabNavBar", "matTabNav"], { "color": "color"; }, {}, ["_items"], ["*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatTabNav, [null, { optional: true; }, null, null, null, null, { optional: true; }]>;


### PR DESCRIPTION
Removes the APIs that were marked for removal in v11. There are also a few cases of the `_animationMode` parameter that I decided to keep optional since there's no good reason for it to be required.

BREAKING CHANGES:
* The `_element` parameter has been removed from `MatTabNav.updateActiveLink`.
* `_platform` parameter of the `MatPaginatedTabHeader` constructor is now required.
* `_document` parameter of the `MatTabBodyPortal` constructor is now required.
* `platform` parameter of the `MatTabNav` constructor is now required.
* `_closestTabGroup` parameter of the `MatTab` constructor is now required.