### PR TITLE
refactor(drag-drop): change deprecated APIs for v11

### DIFF
--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -168,15 +168,11 @@ export class CdkDropList<T = any> implements OnDestroy {
   constructor(
       /** Element that the drop list is attached to. */
       public element: ElementRef<HTMLElement>, dragDrop: DragDrop,
-      private _changeDetectorRef: ChangeDetectorRef, @Optional() private _dir?: Directionality,
+      private _changeDetectorRef: ChangeDetectorRef,
+      private _scrollDispatcher: ScrollDispatcher,
+      @Optional() private _dir?: Directionality,
       @Optional() @Inject(CDK_DROP_LIST_GROUP) @SkipSelf()
       private _group?: CdkDropListGroup<CdkDropList>,
-
-      /**
-       * @deprecated _scrollDispatcher parameter to become required.
-       * @breaking-change 11.0.0
-       */
-      private _scrollDispatcher?: ScrollDispatcher,
       @Optional() @Inject(CDK_DRAG_CONFIG) config?: DragDropConfig) {
     this._dropListRef = dragDrop.createDropList(element);
     this._dropListRef.data = this;
@@ -284,8 +280,7 @@ export class CdkDropList<T = any> implements OnDestroy {
 
       // Note that we resolve the scrollable parents here so that we delay the resolution
       // as long as possible, ensuring that the element is in its final place in the DOM.
-      // @breaking-change 11.0.0 Remove null check for _scrollDispatcher once it's required.
-      if (!this._scrollableParentsResolved && this._scrollDispatcher) {
+      if (!this._scrollableParentsResolved) {
         const scrollableParents = this._scrollDispatcher
           .getAncestorScrollContainers(this.element)
           .map(scrollable => scrollable.getElementRef().nativeElement);

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -851,8 +851,8 @@ export class DragRef<T = any> {
         isPointerOverContainer,
         distance
       });
-      container.drop(this, currentIndex, this._initialContainer, isPointerOverContainer, distance,
-          this._initialIndex);
+      container.drop(this, currentIndex, this._initialIndex, this._initialContainer,
+        isPointerOverContainer, distance);
       this._dropContainer = this._initialContainer;
     });
   }

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -339,24 +339,17 @@ export class DropListRef<T = any> {
    * Drops an item into this container.
    * @param item Item being dropped into the container.
    * @param currentIndex Index at which the item should be inserted.
+   * @param previousIndex Index of the item when dragging started.
    * @param previousContainer Container from which the item got dragged in.
    * @param isPointerOverContainer Whether the user's pointer was over the
    *    container when the item was dropped.
    * @param distance Distance the user has dragged since the start of the dragging sequence.
-   * @param previousIndex Index of the item when dragging started.
-   *
-   * @breaking-change 11.0.0 `previousIndex` parameter to become required.
    */
-  drop(item: DragRef, currentIndex: number, previousContainer: DropListRef,
-    isPointerOverContainer: boolean, distance: Point, previousIndex?: number): void {
+  drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef,
+    isPointerOverContainer: boolean, distance: Point): void {
     this._reset();
-
-    // @breaking-change 11.0.0 Remove this fallback logic once `previousIndex` is a required param.
-    if (previousIndex == null) {
-      previousIndex = previousContainer.getItemIndex(item);
-    }
-
-    this.dropped.next({item,
+    this.dropped.next({
+      item,
       currentIndex,
       previousIndex,
       container: this,

--- a/src/cdk/schematics/ng-update/data/constructor-checks.ts
+++ b/src/cdk/schematics/ng-update/data/constructor-checks.ts
@@ -21,6 +21,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/20454',
       changes: ['ScrollDispatcher', 'ViewportRuler', 'CdkVirtualScrollViewport']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/20500',
+      changes: ['CdkDropList']
     }
   ],
   [TargetVersion.V10]: [

--- a/src/cdk/schematics/ng-update/data/method-call-checks.ts
+++ b/src/cdk/schematics/ng-update/data/method-call-checks.ts
@@ -16,6 +16,17 @@ export interface MethodCallUpgradeData {
 }
 
 export const methodCallChecks: VersionChanges<MethodCallUpgradeData> = {
+  [TargetVersion.V11]: [{
+    pr: 'https://github.com/angular/components/pull/20500',
+    changes: [{
+      className: 'DropListRef',
+      method: 'drop',
+      invalidArgCounts: [{
+        count: 5,
+        message: 'The "previousIndex" parameter is required and the parameter order has changed.'
+      }]
+    }]
+  }],
   [TargetVersion.V9]: [{
     pr: 'https://github.com/angular/components/pull/17084',
     changes: [{

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -172,8 +172,7 @@ export declare class CdkDropList<T = any> implements OnDestroy {
     sorted: EventEmitter<CdkDragSortEvent<T>>;
     sortingDisabled: boolean;
     constructor(
-    element: ElementRef<HTMLElement>, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined,
-    _scrollDispatcher?: ScrollDispatcher | undefined, config?: DragDropConfig);
+    element: ElementRef<HTMLElement>, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _scrollDispatcher: ScrollDispatcher, _dir?: Directionality | undefined, _group?: CdkDropListGroup<CdkDropList<any>> | undefined, config?: DragDropConfig);
     addItem(item: CdkDrag): void;
     getSortedItems(): CdkDrag[];
     ngOnDestroy(): void;
@@ -182,7 +181,7 @@ export declare class CdkDropList<T = any> implements OnDestroy {
     static ngAcceptInputType_disabled: BooleanInput;
     static ngAcceptInputType_sortingDisabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDropList<any>, "[cdkDropList], cdk-drop-list", ["cdkDropList"], { "connectedTo": "cdkDropListConnectedTo"; "data": "cdkDropListData"; "orientation": "cdkDropListOrientation"; "id": "id"; "lockAxis": "cdkDropListLockAxis"; "disabled": "cdkDropListDisabled"; "sortingDisabled": "cdkDropListSortingDisabled"; "enterPredicate": "cdkDropListEnterPredicate"; "sortPredicate": "cdkDropListSortPredicate"; "autoScrollDisabled": "cdkDropListAutoScrollDisabled"; }, { "dropped": "cdkDropListDropped"; "entered": "cdkDropListEntered"; "exited": "cdkDropListExited"; "sorted": "cdkDropListSorted"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<CdkDropList<any>, [null, null, null, { optional: true; }, { optional: true; skipSelf: true; }, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<CdkDropList<any>, [null, null, null, null, { optional: true; }, { optional: true; skipSelf: true; }, { optional: true; }]>;
 }
 
 export declare class CdkDropListGroup<T> implements OnDestroy {
@@ -380,7 +379,7 @@ export declare class DropListRef<T = any> {
     _stopScrolling(): void;
     connectedTo(connectedTo: DropListRef[]): this;
     dispose(): void;
-    drop(item: DragRef, currentIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, previousIndex?: number): void;
+    drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point): void;
     enter(item: DragRef, pointerX: number, pointerY: number, index?: number): void;
     exit(item: DragRef): void;
     getItemIndex(item: DragRef): number;


### PR DESCRIPTION
Changes the APIs that were marked as deprecated for v11.

BREAKING CHANGES:
* `_scrollDispatcher` parameter of the `CdkDropList` constructor is now required. Also the order of the parameters has changed to accommodate the parameter becoming required.
* `previousIndex` parameter of `DropListRef.drop` is now required. Also the parameter order has changed.