### PR TITLE
fix(chips/testing): exclude icons from getText result

### DIFF
--- a/src/material-experimental/mdc-chips/testing/chip-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-harness.spec.ts
@@ -22,22 +22,24 @@ describe('MatChipHarness', () => {
 
   it('should get correct number of chip harnesses', async () => {
     const harnesses = await loader.getAllHarnesses(MatChipHarness);
-    expect(harnesses.length).toBe(3);
+    expect(harnesses.length).toBe(4);
   });
 
   it('should get the chip text content', async () => {
     const harnesses = await loader.getAllHarnesses(MatChipHarness);
     expect(await harnesses[0].getText()).toBe('Basic Chip');
     expect(await harnesses[1].getText()).toBe('Chip');
-    expect(await harnesses[2].getText()).toBe('Disabled Chip');
+    expect(await harnesses[2].getText()).toBe('Chip with avatar');
+    expect(await harnesses[3].getText()).toBe('Disabled Chip');
   });
 });
 
 @Component({
   template: `
-    <mat-basic-chip> Basic Chip </mat-basic-chip>
-    <mat-chip> Chip </mat-chip>
-    <mat-chip disabled> Disabled Chip </mat-chip>
+    <mat-basic-chip>Basic Chip</mat-basic-chip>
+    <mat-chip>Chip <span matChipTrailingIcon>trailing_icon</span></mat-chip>
+    <mat-chip><mat-chip-avatar>B</mat-chip-avatar>Chip with avatar</mat-chip>
+    <mat-chip disabled>Disabled Chip <span matChipRemove>remove_icon</span></mat-chip>
   `
 })
 class ChipHarnessTest {}

--- a/src/material-experimental/mdc-chips/testing/chip-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-harness.ts
@@ -26,6 +26,8 @@ export class MatChipHarness extends ComponentHarness {
 
   /** Gets a promise for the text content the option. */
   async getText(): Promise<string> {
-    return (await this.host()).text();
+    return (await this.host()).text({
+      exclude: '.mat-mdc-chip-avatar, .mat-mdc-chip-trailing-icon, .mat-icon'
+    });
   }
 }

--- a/src/material-experimental/mdc-chips/testing/chip-option-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-option-harness.spec.ts
@@ -37,15 +37,29 @@ describe('MatChipOptionHarness', () => {
     expect(await harnesses[0].isDisabled()).toBe(false);
     expect(await harnesses[3].isDisabled()).toBe(true);
   });
+
+  it('should get the chip text content', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipOptionHarness);
+    expect(await harnesses[0].getText()).toBe('Basic Chip Option');
+    expect(await harnesses[1].getText()).toBe('Chip Option');
+    expect(await harnesses[2].getText()).toBe('Selected Chip Option');
+    expect(await harnesses[3].getText()).toBe('Chip Option');
+  });
 });
 
 @Component({
   template: `
     <mat-chip-listbox>
       <mat-basic-chip-option> Basic Chip Option </mat-basic-chip-option>
-      <mat-chip-option> Chip Option </mat-chip-option>
-      <mat-chip-option selected> Selected Chip Option </mat-chip-option>
-      <mat-chip-option disabled> Chip Option </mat-chip-option>
+      <mat-chip-option> <mat-chip-avatar>C</mat-chip-avatar>Chip Option </mat-chip-option>
+      <mat-chip-option selected>
+        Selected Chip Option
+        <span matChipTrailingIcon>trailing_icon</span>
+      </mat-chip-option>
+      <mat-chip-option disabled>
+        Chip Option
+        <span matChipRemove>remove_icon</span>
+      </mat-chip-option>
     </mat-chip-listbox>
   `
 })

--- a/src/material/chips/testing/chip-harness.ts
+++ b/src/material/chips/testing/chip-harness.ts
@@ -31,7 +31,9 @@ export class MatChipHarness extends ComponentHarness {
 
   /** Gets the text of the chip. */
   async getText(): Promise<string> {
-    return (await this.host()).text();
+    return (await this.host()).text({
+      exclude: '.mat-chip-avatar, .mat-chip-trailing-icon, .mat-icon'
+    });
   }
 
   /** Whether the chip is selected. */

--- a/src/material/chips/testing/shared.spec.ts
+++ b/src/material/chips/testing/shared.spec.ts
@@ -306,9 +306,14 @@ export function runHarnessTests(
       [multiple]="isMultiple"
       [aria-orientation]="orientation">
       <mat-chip (removed)="remove()">Chip 1</mat-chip>
-      <mat-chip (removed)="remove()">Chip 2</mat-chip>
-      <mat-chip disabled (removed)="remove()">Chip 3</mat-chip>
-      <mat-chip (removed)="remove()">Chip 4</mat-chip>
+      <mat-chip (removed)="remove()">Chip 2 <span matChipRemove>remove_icon</span></mat-chip>
+      <mat-chip
+        disabled
+        (removed)="remove()">
+        Chip 3
+        <span matChipTrailingIcon>trailing_icon</span>
+      </mat-chip>
+      <mat-chip (removed)="remove()"><mat-chip-avatar>C</mat-chip-avatar>Chip 4</mat-chip>
     </mat-chip-list>
 
     <mat-chip-list></mat-chip-list>


### PR DESCRIPTION
Excludes the text of icons from the result of the `getText` method.

Fixes #20503.