### PR TITLE
feat(material-experimental/mdc-list): add test harness

### DIFF
--- a/src/dev-app/list/list-demo.html
+++ b/src/dev-app/list/list-demo.html
@@ -199,4 +199,31 @@
       </mat-list-option>
     </mat-selection-list>
   </div>
+
+  <div>
+    <h2>Icon alignment in selection list</h2>
+
+    <mat-selection-list>
+      <mat-list-option value="bananas" [checkboxPosition]="checkboxPosition">
+        <mat-icon matListIcon>info</mat-icon>
+        Bananas
+      </mat-list-option>
+      <mat-list-option value="oranges" [checkboxPosition]="checkboxPosition">
+        <mat-icon matListIcon>info</mat-icon>
+        Oranges
+      </mat-list-option>
+      <mat-list-option value="cake" [checkboxPosition]="checkboxPosition">
+        <mat-icon matListIcon>info</mat-icon>
+        Cake
+      </mat-list-option>
+      <mat-list-option value="fries" [checkboxPosition]="checkboxPosition">
+        <mat-icon matListIcon>info</mat-icon>
+        Fries
+      </mat-list-option>
+    </mat-selection-list>
+
+    <button mat-raised-button (click)="toggleCheckboxPosition()">
+      Toggle checkbox position
+    </button>
+  </div>
 </div>

--- a/src/dev-app/list/list-demo.ts
+++ b/src/dev-app/list/list-demo.ts
@@ -27,6 +27,8 @@ export class ListDemo {
     {name: 'Bobby', headline: 'UX designer'}
   ];
 
+  checkboxPosition: 'before'|'after' = 'before';
+
   messages: {from: string, subject: string, message: string, image: string}[] = [
     {
       from: 'Nancy',
@@ -68,6 +70,10 @@ export class ListDemo {
   onSelectedOptionsChange(values: string[]) {
     this.selectedOptions = values;
     this.modelChangeEventCount++;
+  }
+
+  toggleCheckboxPosition() {
+    this.checkboxPosition = this.checkboxPosition === 'before' ? 'after' : 'before';
   }
 
   favoriteOptions: string[] = [];

--- a/src/dev-app/list/list-demo.ts
+++ b/src/dev-app/list/list-demo.ts
@@ -7,6 +7,7 @@
  */
 
 import {Component} from '@angular/core';
+import {MatListOptionCheckboxPosition} from '@angular/material/list';
 
 
 @Component({
@@ -27,7 +28,7 @@ export class ListDemo {
     {name: 'Bobby', headline: 'UX designer'}
   ];
 
-  checkboxPosition: 'before'|'after' = 'before';
+  checkboxPosition: MatListOptionCheckboxPosition = 'before';
 
   messages: {from: string, subject: string, message: string, image: string}[] = [
     {

--- a/src/dev-app/mdc-list/mdc-list-demo.html
+++ b/src/dev-app/mdc-list/mdc-list-demo.html
@@ -201,4 +201,31 @@
       </mat-list-option>
     </mat-selection-list>
   </div>
+
+  <div>
+    <h2>Icon alignment in selection list</h2>
+
+    <mat-selection-list>
+      <mat-list-option value="bananas" [checkboxPosition]="checkboxPosition">
+        <mat-icon matListIcon>info</mat-icon>
+        Bananas
+      </mat-list-option>
+      <mat-list-option value="oranges" [checkboxPosition]="checkboxPosition">
+        <mat-icon matListIcon #ok>info</mat-icon>
+        Oranges
+      </mat-list-option>
+      <mat-list-option value="cake" [checkboxPosition]="checkboxPosition">
+        <mat-icon matListIcon>info</mat-icon>
+        Cake
+      </mat-list-option>
+      <mat-list-option value="fries" [checkboxPosition]="checkboxPosition">
+        <mat-icon matListIcon>info</mat-icon>
+        Fries
+      </mat-list-option>
+    </mat-selection-list>
+
+    <button mat-raised-button (click)="toggleCheckboxPosition()">
+      Toggle checkbox position
+    </button>
+  </div>
 </div>

--- a/src/dev-app/mdc-list/mdc-list-demo.ts
+++ b/src/dev-app/mdc-list/mdc-list-demo.ts
@@ -7,6 +7,7 @@
  */
 
 import {Component} from '@angular/core';
+import {MatListOptionCheckboxPosition} from '@angular/material-experimental/mdc-list';
 
 
 @Component({
@@ -20,6 +21,8 @@ export class MdcListDemo {
     'Salt',
     'Paprika'
   ];
+
+  checkboxPosition: MatListOptionCheckboxPosition = 'before';
 
   contacts: {name: string, headline: string}[] = [
     {name: 'Nancy', headline: 'Software engineer'},
@@ -68,6 +71,10 @@ export class MdcListDemo {
   onSelectedOptionsChange(values: string[]) {
     this.selectedOptions = values;
     this.modelChangeEventCount++;
+  }
+
+  toggleCheckboxPosition() {
+    this.checkboxPosition = this.checkboxPosition === 'before' ? 'after' : 'before';
   }
 
   favoriteOptions: string[] = [];

--- a/src/material-experimental/config.bzl
+++ b/src/material-experimental/config.bzl
@@ -19,6 +19,7 @@ entryPoints = [
     "mdc-input",
     "mdc-input/testing",
     "mdc-list",
+    "mdc-list/testing",
     "mdc-menu",
     "mdc-menu/testing",
     "mdc-progress-bar",

--- a/src/material-experimental/mdc-list/list-option-types.ts
+++ b/src/material-experimental/mdc-list/list-option-types.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '@angular/core';
+
+/**
+ * Type describing possible positions of a checkbox in a list option
+ * with respect to the list item's text.
+ */
+export type MatListOptionCheckboxPosition = 'before'|'after';
+
+/**
+ * Interface describing a list option. This is used to avoid circular
+ * dependencies between the list-option and the styler directives.
+ * @docs-private
+ */
+export interface ListOption {
+  _getCheckboxPosition(): MatListOptionCheckboxPosition;
+}
+
+/**
+ * Injection token that can be used to reference instances of an `ListOption`. It serves
+ * as alternative token to an actual implementation which could result in undesired
+ * retention of the class or circular references breaking runtime execution.
+ * @docs-private
+ */
+export const LIST_OPTION = new InjectionToken<ListOption>('ListOption');

--- a/src/material-experimental/mdc-list/list-option.html
+++ b/src/material-experimental/mdc-list/list-option.html
@@ -1,6 +1,7 @@
 <!--
-  Save icons and the pseudo checkbox so that they can be re-used in the
-  template without duplication.
+  Save icons and the pseudo checkbox so that they can be re-used in the template without
+  duplication. Also content can only be injected once so we need to extract icons/avatars
+  into a template since we use it in multiple places.
 -->
 <ng-template #icons>
   <ng-content select="[mat-list-avatar],[matListAvatar],[mat-list-icon],[matListIcon]">
@@ -29,24 +30,29 @@
   </div>
 </ng-template>
 
-<!-- Prefix -->
-<span class="mdc-list-item__graphic"
-      *ngIf="!_isReversed() && (_hasIconOrAvatar() || _hasCheckbox())">
-  <ng-container [ngTemplateOutlet]="_hasCheckbox() ? checkbox : icons">
-  </ng-container>
+<!-- Container for the checkbox at start. -->
+<span class="mdc-list-item__graphic mat-mdc-list-option-checkbox-before"
+      *ngIf="_shouldShowCheckboxAt('before')">
+  <ng-template [ngTemplateOutlet]="checkbox"></ng-template>
 </span>
+<!-- Conditionally renders icons/avatars before the list item text. -->
+<ng-template [ngIf]="_shouldShowIconsAndAvatarsAt('before')">
+  <ng-template [ngTemplateOutlet]="icons"></ng-template>
+</ng-template>
 
 <!-- Text -->
 <span class="mdc-list-item__text" #text [id]="_optionTextId">
   <ng-content></ng-content>
 </span>
 
-<!-- Suffix -->
-<span class="mdc-list-item__meta"
-      *ngIf="_isReversed() && (_hasCheckbox() || _hasIconOrAvatar())">
-  <ng-container [ngTemplateOutlet]="_hasCheckbox() ? checkbox : icons">
-  </ng-container>
+<!-- Container for the checkbox at the end. -->
+<span class="mdc-list-item__meta" *ngIf="_shouldShowCheckboxAt('after')">
+  <ng-template [ngTemplateOutlet]="checkbox"></ng-template>
 </span>
+<!-- Conditionally renders icons/avatars after the list item text. -->
+<ng-template [ngIf]="_shouldShowIconsAndAvatarsAt('after')">
+  <ng-template [ngTemplateOutlet]="icons"></ng-template>
+</ng-template>
 
 <!-- Divider -->
 <ng-content select="mat-divider"></ng-content>

--- a/src/material-experimental/mdc-list/list-styler-elements.ts
+++ b/src/material-experimental/mdc-list/list-styler-elements.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directive, Inject, Optional} from '@angular/core';
+import {LIST_OPTION, ListOption} from './list-option-types';
+
+/**
+ * Directive whose purpose is to add the MDC list-item `graphic` or `meta`
+ * class depending on checkbox position in list options.
+ * @docs-private
+ */
+@Directive({
+  selector: '[mat-list-avatar], [matListAvatar], [mat-list-icon], [matListIcon]',
+  host: {
+    '[class.mdc-list-item__graphic]': '_isAlignedAtStart()',
+    '[class.mdc-list-item__meta]': '!_isAlignedAtStart()',
+  }
+})
+export class MatListGraphicAlignmentStyler {
+  constructor(
+    @Optional() @Inject(LIST_OPTION) public _listOption: ListOption) {}
+
+  _isAlignedAtStart() {
+    // By default, in all list items the graphic is aligned at start. In list options,
+    // the graphic is only aligned at start if the checkbox is at the end.
+    return !this._listOption || this._listOption?._getCheckboxPosition() === 'after';
+  }
+}
+
+/**
+ * Directive whose purpose is to add the mat- CSS styling to this selector.
+ * @docs-private
+ */
+@Directive({
+  selector: '[mat-list-avatar], [matListAvatar]',
+  host: {'class': 'mat-mdc-list-avatar'}
+})
+export class MatListAvatarCssMatStyler {}
+
+/**
+ * Directive whose purpose is to add the mat- CSS styling to this selector.
+ * @docs-private
+ */
+@Directive({
+  selector: '[mat-list-icon], [matListIcon]',
+  host: {'class': 'mat-mdc-list-icon'}
+})
+export class MatListIconCssMatStyler {}
+
+/**
+ * Directive whose purpose is to add the mat- CSS styling to this selector.
+ * @docs-private
+ */
+@Directive({
+  selector: '[mat-subheader], [matSubheader]',
+  // TODO(mmalerba): MDC's subheader font looks identical to the list item font, figure out why and
+  //  make a change in one of the repos to visually distinguish.
+  host: {'class': 'mat-mdc-subheader mdc-list-group__subheader'}
+})
+export class MatListSubheaderCssMatStyler {}

--- a/src/material-experimental/mdc-list/list.scss
+++ b/src/material-experimental/mdc-list/list.scss
@@ -50,16 +50,22 @@
   $size: 40px;
   $margin-value: 72px - $mdc-list-side-padding - $size;
 
-  margin-left: 0;
-  margin-right: $margin-value;
   width: $size;
   height: $size;
   border-radius: 50%;
 
-  // `.mdc-list-item` added for extra specificity to override MDC's built in styles.
-  [dir='rtl'] .mdc-list-item & {
-    margin-left: $margin-value;
-    margin-right: 0;
+  // If the avatar is displayed in the graphic section of a list-item (i.e. at the start),
+  // we override the default "graphic" horizontal spacing that is designed for icons, to
+  // work for actual avatar images. The avatar by default is used within the `graphic` section,
+  // but could be also outside in case of a selection-list option with a checkbox at start.
+  &.mdc-list-item__graphic {
+    margin-left: 0;
+    margin-right: $margin-value;
+
+    [dir='rtl'] & {
+      margin-left: $margin-value;
+      margin-right: 0;
+    }
   }
 }
 

--- a/src/material-experimental/mdc-list/list.ts
+++ b/src/material-experimental/mdc-list/list.ts
@@ -11,46 +11,14 @@ import {
   ChangeDetectionStrategy,
   Component,
   ContentChildren,
-  Directive,
   ElementRef,
   NgZone,
-  QueryList, ViewChild,
+  QueryList,
+  ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 import {MatLine} from '@angular/material/core';
 import {MatListBase, MatListItemBase} from './list-base';
-
-/**
- * Directive whose purpose is to add the mat- CSS styling to this selector.
- * @docs-private
- */
-@Directive({
-  selector: '[mat-list-avatar], [matListAvatar]',
-  host: {'class': 'mat-mdc-list-avatar mdc-list-item__graphic'}
-})
-export class MatListAvatarCssMatStyler {}
-
-/**
- * Directive whose purpose is to add the mat- CSS styling to this selector.
- * @docs-private
- */
-@Directive({
-  selector: '[mat-list-icon], [matListIcon]',
-  host: {'class': 'mat-mdc-list-icon mdc-list-item__graphic'}
-})
-export class MatListIconCssMatStyler {}
-
-/**
- * Directive whose purpose is to add the mat- CSS styling to this selector.
- * @docs-private
- */
-@Directive({
-  selector: '[mat-subheader], [matSubheader]',
-  // TODO(mmalerba): MDC's subheader font looks identical to the list item font, figure out why and
-  //  make a change in one of the repos to visually distinguish.
-  host: {'class': 'mat-mdc-subheader mdc-list-group__subheader'}
-})
-export class MatListSubheaderCssMatStyler {}
 
 @Component({
   selector: 'mat-list',

--- a/src/material-experimental/mdc-list/module.ts
+++ b/src/material-experimental/mdc-list/module.ts
@@ -11,16 +11,16 @@ import {NgModule} from '@angular/core';
 import {MatLineModule, MatPseudoCheckboxModule, MatRippleModule} from '@angular/material/core';
 import {MatDividerModule} from '@angular/material/divider';
 import {MatActionList} from './action-list';
+import {MatList, MatListItem} from './list';
+import {MatListOption} from './list-option';
 import {
-  MatList,
   MatListAvatarCssMatStyler,
+  MatListGraphicAlignmentStyler,
   MatListIconCssMatStyler,
-  MatListItem,
-  MatListSubheaderCssMatStyler,
-} from './list';
+  MatListSubheaderCssMatStyler
+} from './list-styler-elements';
 import {MatNavList} from './nav-list';
 import {MatSelectionList} from './selection-list';
-import {MatListOption} from './list-option';
 
 @NgModule({
   imports: [
@@ -39,6 +39,7 @@ import {MatListOption} from './list-option';
     MatListAvatarCssMatStyler,
     MatListIconCssMatStyler,
     MatListSubheaderCssMatStyler,
+    MatListGraphicAlignmentStyler,
     MatDividerModule,
     MatLineModule,
   ],
@@ -52,6 +53,7 @@ import {MatListOption} from './list-option';
     MatListAvatarCssMatStyler,
     MatListIconCssMatStyler,
     MatListSubheaderCssMatStyler,
+    MatListGraphicAlignmentStyler,
   ]
 })
 export class MatListModule {}

--- a/src/material-experimental/mdc-list/public-api.ts
+++ b/src/material-experimental/mdc-list/public-api.ts
@@ -6,9 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export * from './list';
 export * from './action-list';
+export * from './list';
+export * from './list-styler-elements';
+export * from './module';
 export * from './nav-list';
 export * from './selection-list';
-export * from './module';
-export * from './list-option';
+
+export {MatListOptionCheckboxPosition} from './list-option-types';
+export {MatListOption} from './list-option';

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -25,7 +25,13 @@ import {FormControl, FormsModule, NgModel, ReactiveFormsModule} from '@angular/f
 import {defaultRippleAnimationConfig, ThemePalette} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
 import {numbers} from '@material/list';
-import {MatListModule, MatListOption, MatSelectionList, MatSelectionListChange} from './index';
+import {
+  MatListModule,
+  MatListOption,
+  MatListOptionCheckboxPosition,
+  MatSelectionList,
+  MatSelectionListChange
+} from './index';
 
 describe('MDC-based MatSelectionList without forms', () => {
   describe('with list option', () => {
@@ -912,6 +918,14 @@ describe('MDC-based MatSelectionList without forms', () => {
       }).compileComponents();
     }));
 
+    function expectCheckboxAtPosition(listItemElement: HTMLElement,
+                              position: MatListOptionCheckboxPosition) {
+      const containerSelector = position === 'before' ?
+          '.mdc-list-item__graphic' : 'mdc-list-item__meta';
+      expect(listItemElement.querySelector(`${containerSelector} .mdc-checkbox`))
+          .toBeDefined(`Expected checkbox to be aligned ${position}`);
+    }
+
     it('should add a class to reflect that it has an avatar', () => {
       const fixture = TestBed.createComponent(SelectionListWithIcon);
       fixture.detectChanges();
@@ -926,6 +940,48 @@ describe('MDC-based MatSelectionList without forms', () => {
 
       const listOption = fixture.nativeElement.querySelector('.mat-mdc-list-option');
       expect(listOption.classList).toContain('mat-mdc-list-item-with-avatar');
+    });
+
+    it('should align icons properly together with checkbox', () => {
+      const fixture = TestBed.createComponent(SelectionListWithIcon);
+      fixture.detectChanges();
+      const listOption = fixture.nativeElement
+        .querySelector('.mat-mdc-list-option')! as HTMLElement;
+      const icon = listOption.querySelector('.mat-mdc-list-icon')!;
+
+      expectCheckboxAtPosition(listOption, 'after');
+      expect(icon.classList).toContain('mdc-list-item__graphic');
+
+      fixture.componentInstance.checkboxPosition = 'before';
+      fixture.detectChanges();
+      expectCheckboxAtPosition(listOption, 'before');
+      expect(icon.classList).toContain('mdc-list-item__meta');
+
+      fixture.componentInstance.checkboxPosition = 'after';
+      fixture.detectChanges();
+      expectCheckboxAtPosition(listOption, 'after');
+      expect(icon.classList).toContain('mdc-list-item__graphic');
+    });
+
+    it('should align avatars properly together with checkbox', () => {
+      const fixture = TestBed.createComponent(SelectionListWithAvatar);
+      fixture.detectChanges();
+      const listOption = fixture.nativeElement
+          .querySelector('.mat-mdc-list-option')! as HTMLElement;
+      const avatar = listOption.querySelector('.mat-mdc-list-avatar')!;
+
+      expectCheckboxAtPosition(listOption, 'after');
+      expect(avatar.classList).toContain('mdc-list-item__graphic');
+
+      fixture.componentInstance.checkboxPosition = 'before';
+      fixture.detectChanges();
+      expect(avatar.classList).toContain('mdc-list-item__meta');
+      expectCheckboxAtPosition(listOption, 'before');
+
+      fixture.componentInstance.checkboxPosition = 'after';
+      fixture.detectChanges();
+      expect(avatar.classList).toContain('mdc-list-item__graphic');
+      expectCheckboxAtPosition(listOption, 'after');
     });
   });
 
@@ -1627,7 +1683,7 @@ class SelectionListWithCustomComparator {
 @Component({
   template: `
     <mat-selection-list>
-      <mat-list-option>
+      <mat-list-option [checkboxPosition]="checkboxPosition">
         <div mat-list-avatar>I</div>
         Inbox
       </mat-list-option>
@@ -1635,12 +1691,13 @@ class SelectionListWithCustomComparator {
   `
 })
 class SelectionListWithAvatar {
+  checkboxPosition: MatListOptionCheckboxPosition|undefined;
 }
 
 @Component({
   template: `
     <mat-selection-list>
-      <mat-list-option>
+      <mat-list-option [checkboxPosition]="checkboxPosition">
         <div mat-list-icon>I</div>
         Inbox
       </mat-list-option>
@@ -1648,6 +1705,7 @@ class SelectionListWithAvatar {
   `
 })
 class SelectionListWithIcon {
+  checkboxPosition: MatListOptionCheckboxPosition|undefined;
 }
 
 

--- a/src/material-experimental/mdc-list/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-list/testing/BUILD.bazel
@@ -1,0 +1,48 @@
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material-experimental/mdc-list/testing",
+    deps = [
+        "//src/cdk/coercion",
+        "//src/cdk/testing",
+        "//src/material-experimental/mdc-list",
+        "//src/material/divider/testing",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob(["**/*.ts"]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["shared.spec.ts"],
+    ),
+    deps = [
+        ":testing",
+        "//src/material-experimental/mdc-list",
+        "//src/material/divider/testing",
+        "//src/material/list/testing:harness_tests_lib",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    static_files = [
+        "@npm//:node_modules/@material/list/dist/mdc.list.js",
+    ],
+    deps = [
+        ":unit_tests_lib",
+        "//src/material-experimental:mdc_require_config.js",
+    ],
+)

--- a/src/material-experimental/mdc-list/testing/action-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/action-list-harness.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate} from '@angular/cdk/testing';
+import {MatListHarnessBase} from './list-harness-base';
+import {ActionListHarnessFilters, ActionListItemHarnessFilters} from './list-harness-filters';
+import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
+
+/** Harness for interacting with a MDC-based action-list in tests. */
+export class MatActionListHarness extends MatListHarnessBase<
+    typeof MatActionListItemHarness, MatActionListItemHarness, ActionListItemHarnessFilters> {
+  /** The selector for the host element of a `MatActionList` instance. */
+  static hostSelector = '.mat-mdc-action-list';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatActionListHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which action list instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: ActionListHarnessFilters = {}): HarnessPredicate<MatActionListHarness> {
+    return new HarnessPredicate(MatActionListHarness, options);
+  }
+
+  _itemHarness = MatActionListItemHarness;
+}
+
+/** Harness for interacting with an action list item. */
+export class MatActionListItemHarness extends MatListItemHarnessBase {
+  /** The selector for the host element of a `MatListItem` instance. */
+  static hostSelector = `${MatActionListHarness.hostSelector} .mat-mdc-list-item`;
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatActionListItemHarness` that
+   * meets certain criteria.
+   * @param options Options for filtering which action list item instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: ActionListItemHarnessFilters = {}):
+      HarnessPredicate<MatActionListItemHarness> {
+    return getListItemPredicate(MatActionListItemHarness, options);
+  }
+
+  /** Clicks on the action list item. */
+  async click(): Promise<void> {
+    return (await this.host()).click();
+  }
+
+  /** Focuses the action list item. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the action list item. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the action list item is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+}

--- a/src/material-experimental/mdc-list/testing/index.ts
+++ b/src/material-experimental/mdc-list/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-list/testing/list-harness-base.ts
+++ b/src/material-experimental/mdc-list/testing/list-harness-base.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate
+} from '@angular/cdk/testing';
+import {DividerHarnessFilters, MatDividerHarness} from '@angular/material/divider/testing';
+import {BaseListItemHarnessFilters, SubheaderHarnessFilters} from './list-harness-filters';
+import {MatSubheaderHarness} from './list-item-harness-base';
+
+/** Represents a section of a list falling under a specific header. */
+export interface ListSection<I> {
+  /** The heading for this list section. `undefined` if there is no heading. */
+  heading?: string;
+
+  /** The items in this list section. */
+  items: I[];
+}
+
+/**
+ * Shared behavior among the harnesses for the various `MatList` flavors.
+ * @template T A constructor type for a list item harness type used by this list harness.
+ * @template C The list item harness type that `T` constructs.
+ * @template F The filter type used filter list item harness of type `C`.
+ * @docs-private
+ */
+export abstract class MatListHarnessBase<
+    T extends(ComponentHarnessConstructor<C>& {with: (options?: F) => HarnessPredicate<C>}),
+             C extends ComponentHarness, F extends BaseListItemHarnessFilters> extends
+    ComponentHarness {
+  protected _itemHarness: T;
+
+  /**
+   * Gets a list of harnesses representing the items in this list.
+   * @param filters Optional filters used to narrow which harnesses are included
+   * @return The list of items matching the given filters.
+   */
+  async getItems(filters?: F): Promise<C[]> {
+    return this.locatorForAll(this._itemHarness.with(filters))();
+  }
+
+  /**
+   * Gets a list of `ListSection` representing the list items grouped by subheaders. If the list has
+   * no subheaders it is represented as a single `ListSection` with an undefined `heading` property.
+   * @param filters Optional filters used to narrow which list item harnesses are included
+   * @return The list of items matching the given filters, grouped into sections by subheader.
+   */
+  async getItemsGroupedBySubheader(filters?: F): Promise<ListSection<C>[]> {
+    const listSections = [];
+    let currentSection: {items: C[], heading?: Promise<string>} = {items: []};
+    const itemsAndSubheaders =
+        await this.getItemsWithSubheadersAndDividers({item: filters, divider: false});
+
+    for (const itemOrSubheader of itemsAndSubheaders) {
+      if (itemOrSubheader instanceof MatSubheaderHarness) {
+        if (currentSection.heading !== undefined || currentSection.items.length) {
+          listSections.push(currentSection);
+        }
+        currentSection = {heading: itemOrSubheader.getText(), items: []};
+      } else {
+        currentSection.items.push(itemOrSubheader);
+      }
+    }
+    if (currentSection.heading !== undefined || currentSection.items.length ||
+        !listSections.length) {
+      listSections.push(currentSection);
+    }
+
+    // Concurrently wait for all sections to resolve their heading if present.
+    return Promise.all(listSections.map(async (s) =>
+        ({items: s.items, heading: await s.heading})));
+  }
+
+  /**
+   * Gets a list of sub-lists representing the list items grouped by dividers. If the list has no
+   * dividers it is represented as a list with a single sub-list.
+   * @param filters Optional filters used to narrow which list item harnesses are included
+   * @return The list of items matching the given filters, grouped into sub-lists by divider.
+   */
+  async getItemsGroupedByDividers(filters?: F): Promise<C[][]> {
+    const listSections: C[][] = [[]];
+    const itemsAndDividers =
+        await this.getItemsWithSubheadersAndDividers({item: filters, subheader: false});
+    for (const itemOrDivider of itemsAndDividers) {
+      if (itemOrDivider instanceof MatDividerHarness) {
+        listSections.push([]);
+      } else {
+        listSections[listSections.length - 1].push(itemOrDivider);
+      }
+    }
+    return listSections;
+  }
+
+  /**
+   * Gets a list of harnesses representing all of the items, subheaders, and dividers
+   * (in the order they appear in the list). Use `instanceof` to check which type of harness a given
+   * item is.
+   * @param filters Optional filters used to narrow which list items, subheaders, and dividers are
+   *     included. A value of `false` for the `item`, `subheader`, or `divider` properties indicates
+   *     that the respective harness type should be omitted completely.
+   * @return The list of harnesses representing the items, subheaders, and dividers matching the
+   *     given filters.
+   */
+  getItemsWithSubheadersAndDividers(filters: {item: false, subheader: false, divider: false}):
+      Promise<[]>;
+  getItemsWithSubheadersAndDividers(filters: {item?: F|false, subheader: false, divider: false}):
+      Promise<C[]>;
+  getItemsWithSubheadersAndDividers(filters: {
+    item: false,
+    subheader?: SubheaderHarnessFilters|false, divider: false
+  }): Promise<MatSubheaderHarness[]>;
+  getItemsWithSubheadersAndDividers(
+      filters: {item: false, subheader: false, divider?: DividerHarnessFilters|false}):
+      Promise<MatDividerHarness[]>;
+  getItemsWithSubheadersAndDividers(filters: {
+    item?: F|false,
+    subheader?: SubheaderHarnessFilters|false, divider: false
+  }): Promise<(C | MatSubheaderHarness)[]>;
+  getItemsWithSubheadersAndDividers(filters: {
+    item?: F|false, subheader: false,
+    divider?: false|DividerHarnessFilters
+  }): Promise<(C | MatDividerHarness)[]>;
+  getItemsWithSubheadersAndDividers(filters: {
+    item: false,
+    subheader?: false|SubheaderHarnessFilters,
+    divider?: false|DividerHarnessFilters
+  }): Promise<(MatSubheaderHarness | MatDividerHarness)[]>;
+  getItemsWithSubheadersAndDividers(filters?: {
+    item?: F|false,
+    subheader?: SubheaderHarnessFilters|false,
+    divider?: DividerHarnessFilters|false
+  }): Promise<(C | MatSubheaderHarness | MatDividerHarness)[]>;
+  async getItemsWithSubheadersAndDividers(filters: {
+    item?: F|false,
+    subheader?: SubheaderHarnessFilters|false,
+    divider?: DividerHarnessFilters|false
+  } = {}): Promise<(C | MatSubheaderHarness | MatDividerHarness)[]> {
+    const query = [];
+    if (filters.item !== false) {
+      query.push(this._itemHarness.with(filters.item || {} as F));
+    }
+    if (filters.subheader !== false) {
+      query.push(MatSubheaderHarness.with(filters.subheader));
+    }
+    if (filters.divider !== false) {
+      query.push(MatDividerHarness.with(filters.divider));
+    }
+    return this.locatorForAll(...query)();
+  }
+}

--- a/src/material-experimental/mdc-list/testing/list-harness-filters.ts
+++ b/src/material-experimental/mdc-list/testing/list-harness-filters.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+export interface ListHarnessFilters extends BaseHarnessFilters {}
+
+export interface ActionListHarnessFilters extends BaseHarnessFilters {}
+
+export interface NavListHarnessFilters extends BaseHarnessFilters {}
+
+export interface SelectionListHarnessFilters extends BaseHarnessFilters {}
+
+export interface BaseListItemHarnessFilters extends BaseHarnessFilters {
+  text?: string|RegExp;
+}
+
+export interface ListItemHarnessFilters extends BaseListItemHarnessFilters {}
+
+export interface ActionListItemHarnessFilters extends BaseListItemHarnessFilters {}
+
+export interface NavListItemHarnessFilters extends BaseListItemHarnessFilters {
+  href?: string|RegExp|null;
+}
+
+export interface ListOptionHarnessFilters extends BaseListItemHarnessFilters {
+  selected?: boolean;
+}
+
+export interface SubheaderHarnessFilters extends BaseHarnessFilters {
+  text?: string|RegExp;
+}

--- a/src/material-experimental/mdc-list/testing/list-harness.spec.ts
+++ b/src/material-experimental/mdc-list/testing/list-harness.spec.ts
@@ -1,0 +1,19 @@
+import {MatDividerHarness} from '@angular/material/divider/testing';
+import {runHarnessTests} from '@angular/material/list/testing/shared.spec';
+import {MatListModule} from '../index';
+import {MatActionListHarness} from './action-list-harness';
+import {MatListHarness} from './list-harness';
+import {
+  MatListItemHarnessBase,
+  MatListItemSection,
+  MatSubheaderHarness
+} from './list-item-harness-base';
+import {MatNavListHarness} from './nav-list-harness';
+import {MatSelectionListHarness} from './selection-list-harness';
+
+describe('MDC-based list harnesses', () => {
+  runHarnessTests(
+      MatListModule, MatListHarness as any, MatActionListHarness as any, MatNavListHarness as any,
+      MatSelectionListHarness as any, MatListItemHarnessBase as any, MatSubheaderHarness as any,
+      MatDividerHarness, {content: MatListItemSection.CONTENT});
+});

--- a/src/material-experimental/mdc-list/testing/list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/list-harness.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate} from '@angular/cdk/testing';
+import {MatListHarnessBase} from './list-harness-base';
+import {ListHarnessFilters, ListItemHarnessFilters} from './list-harness-filters';
+import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
+
+/** Harness for interacting with a MDC-based list in tests. */
+export class MatListHarness extends
+    MatListHarnessBase<typeof MatListItemHarness, MatListItemHarness, ListItemHarnessFilters> {
+  /** The selector for the host element of a `MatList` instance. */
+  static hostSelector = '.mat-mdc-list';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatListHarness` that meets certain
+   * criteria.
+   * @param options Options for filtering which list instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: ListHarnessFilters = {}): HarnessPredicate<MatListHarness> {
+    return new HarnessPredicate(MatListHarness, options);
+  }
+
+  _itemHarness = MatListItemHarness;
+}
+
+/** Harness for interacting with a list item. */
+export class MatListItemHarness extends MatListItemHarnessBase {
+  /** The selector for the host element of a `MatListItem` instance. */
+  static hostSelector = `${MatListHarness.hostSelector} .mat-mdc-list-item`;
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatListItemHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which list item instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: ListItemHarnessFilters = {}): HarnessPredicate<MatListItemHarness> {
+    return getListItemPredicate(MatListItemHarness, options);
+  }
+}

--- a/src/material-experimental/mdc-list/testing/list-item-harness-base.ts
+++ b/src/material-experimental/mdc-list/testing/list-item-harness-base.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  ContentContainerComponentHarness,
+  HarnessPredicate
+} from '@angular/cdk/testing';
+import {BaseListItemHarnessFilters, SubheaderHarnessFilters} from './list-harness-filters';
+
+/**
+ * Gets a `HarnessPredicate` that applies the given `BaseListItemHarnessFilters` to the given
+ * list item harness.
+ * @template H The type of list item harness to create a predicate for.
+ * @param harnessType A constructor for a list item harness.
+ * @param options An instance of `BaseListItemHarnessFilters` to apply.
+ * @return A `HarnessPredicate` for the given harness type with the given options applied.
+ */
+export function getListItemPredicate<H extends MatListItemHarnessBase>(
+    harnessType: ComponentHarnessConstructor<H>,
+    options: BaseListItemHarnessFilters): HarnessPredicate<H> {
+  return new HarnessPredicate(harnessType, options)
+      .addOption(
+          'text', options.text,
+          (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text));
+}
+
+/** Harness for interacting with a MDC-based list subheader. */
+export class MatSubheaderHarness extends ComponentHarness {
+  static hostSelector = '.mat-mdc-subheader';
+
+  static with(options: SubheaderHarnessFilters = {}): HarnessPredicate<MatSubheaderHarness> {
+    return new HarnessPredicate(MatSubheaderHarness, options)
+        .addOption(
+            'text', options.text,
+            (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text));
+  }
+
+  /** Gets the full text content of the list item (including text from any font icons). */
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+}
+
+/** Selectors for the various list item sections that may contain user content. */
+export const enum MatListItemSection {
+  CONTENT = '.mdc-list-item__text',
+}
+
+/**
+ * Shared behavior among the harnesses for the various `MatListItem` flavors.
+ * @docs-private
+ */
+export abstract class MatListItemHarnessBase
+    extends ContentContainerComponentHarness<MatListItemSection> {
+
+  private _lines = this.locatorForAll('.mat-line');
+  private _avatar = this.locatorForOptional('.mat-mdc-list-avatar');
+  private _icon = this.locatorForOptional('.mat-mdc-list-icon');
+
+  /** Gets the full text content of the list item (including text from any font icons). */
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Gets the lines of text (`mat-line` elements) in this nav list item. */
+  async getLinesText(): Promise<string[]> {
+    return Promise.all((await this._lines()).map(l => l.text()));
+  }
+
+  /** Whether this list item has an avatar. */
+  async hasAvatar(): Promise<boolean> {
+    return !!await this._avatar();
+  }
+
+  /** Whether this list item has an icon. */
+  async hasIcon(): Promise<boolean> {
+    return !!await this._icon();
+  }
+}

--- a/src/material-experimental/mdc-list/testing/nav-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/nav-list-harness.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate} from '@angular/cdk/testing';
+import {MatListHarnessBase} from './list-harness-base';
+import {NavListHarnessFilters, NavListItemHarnessFilters} from './list-harness-filters';
+import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
+
+/** Harness for interacting with a MDC-based mat-nav-list in tests. */
+export class MatNavListHarness extends MatListHarnessBase<
+    typeof MatNavListItemHarness, MatNavListItemHarness, NavListItemHarnessFilters> {
+  /** The selector for the host element of a `MatNavList` instance. */
+  static hostSelector = '.mat-mdc-nav-list';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatNavListHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which nav list instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: NavListHarnessFilters = {}): HarnessPredicate<MatNavListHarness> {
+    return new HarnessPredicate(MatNavListHarness, options);
+  }
+
+  _itemHarness = MatNavListItemHarness;
+}
+
+/** Harness for interacting with a MDC-based nav-list item. */
+export class MatNavListItemHarness extends MatListItemHarnessBase {
+  /** The selector for the host element of a `MatListItem` instance. */
+  static hostSelector = `${MatNavListHarness.hostSelector} .mat-mdc-list-item`;
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatNavListItemHarness` that
+   * meets certain criteria.
+   * @param options Options for filtering which nav list item instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: NavListItemHarnessFilters = {}): HarnessPredicate<MatNavListItemHarness> {
+    return getListItemPredicate(MatNavListItemHarness, options)
+        .addOption(
+            'href', options.href,
+            async (harness, href) => HarnessPredicate.stringMatches(harness.getHref(), href));
+  }
+
+  /** Gets the href for this nav list item. */
+  async getHref(): Promise<string|null> {
+    return (await this.host()).getAttribute('href');
+  }
+
+  /** Clicks on the nav list item. */
+  async click(): Promise<void> {
+    return (await this.host()).click();
+  }
+
+  /** Focuses the nav list item. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the nav list item. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the nav list item is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+}

--- a/src/material-experimental/mdc-list/testing/public-api.ts
+++ b/src/material-experimental/mdc-list/testing/public-api.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './action-list-harness';
+export * from './list-harness';
+export * from './list-harness-filters';
+export * from './nav-list-harness';
+export * from './selection-list-harness';
+export {MatListItemSection} from './list-item-harness-base';

--- a/src/material-experimental/mdc-list/testing/selection-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/selection-list-harness.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate} from '@angular/cdk/testing';
+import {MatListOptionCheckboxPosition} from '@angular/material-experimental/mdc-list';
+import {MatListHarnessBase} from './list-harness-base';
+import {
+  ListItemHarnessFilters,
+  ListOptionHarnessFilters,
+  SelectionListHarnessFilters
+} from './list-harness-filters';
+import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
+
+/** Harness for interacting with a MDC_based selection-list in tests. */
+export class MatSelectionListHarness extends MatListHarnessBase<
+    typeof MatListOptionHarness, MatListOptionHarness, ListOptionHarnessFilters> {
+  /** The selector for the host element of a `MatSelectionList` instance. */
+  static hostSelector = '.mat-mdc-selection-list';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatSelectionListHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which selection list instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: SelectionListHarnessFilters = {}):
+      HarnessPredicate<MatSelectionListHarness> {
+    return new HarnessPredicate(MatSelectionListHarness, options);
+  }
+
+  _itemHarness = MatListOptionHarness;
+
+  /** Whether the selection list is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-disabled') === 'true';
+  }
+
+  /**
+   * Selects all items matching any of the given filters.
+   * @param filters Filters that specify which items should be selected.
+   */
+  async selectItems(...filters: ListOptionHarnessFilters[]): Promise<void> {
+    const items = await this._getItems(filters);
+    await Promise.all(items.map(item => item.select()));
+  }
+
+  /**
+   * Deselects all items matching any of the given filters.
+   * @param filters Filters that specify which items should be deselected.
+   */
+  async deselectItems(...filters: ListItemHarnessFilters[]): Promise<void> {
+    const items = await this._getItems(filters);
+    await Promise.all(items.map(item => item.deselect()));
+  }
+
+  /** Gets all items matching the given list of filters. */
+  private async _getItems(filters: ListOptionHarnessFilters[]): Promise<MatListOptionHarness[]> {
+    if (!filters.length) {
+      return this.getItems();
+    }
+    const matches = await Promise.all(
+      filters.map(filter => this.locatorForAll(MatListOptionHarness.with(filter))()));
+    return matches.reduce((result, current) => [...result, ...current], []);
+  }
+}
+
+/** Harness for interacting with a MDC-based list option. */
+export class MatListOptionHarness extends MatListItemHarnessBase {
+  /** The selector for the host element of a `MatListOption` instance. */
+  static hostSelector = '.mat-mdc-list-option';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatListOptionHarness` that
+   * meets certain criteria.
+   * @param options Options for filtering which list option instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: ListOptionHarnessFilters = {}): HarnessPredicate<MatListOptionHarness> {
+    return getListItemPredicate(MatListOptionHarness, options)
+        .addOption(
+            'is selected', options.selected,
+            async (harness, selected) => await harness.isSelected() === selected);
+  }
+
+  private _beforeCheckbox = this.locatorForOptional('.mdc-list-item__graphic .mdc-checkbox');
+
+  /** Gets the position of the checkbox relative to the list option content. */
+  async getCheckboxPosition(): Promise<MatListOptionCheckboxPosition> {
+    return (await this._beforeCheckbox()) !== null ? 'before' : 'after';
+  }
+
+  /** Whether the list option is selected. */
+  async isSelected(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-selected') === 'true';
+  }
+
+  /** Whether the list option is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-disabled') === 'true';
+  }
+
+  /** Focuses the list option. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the list option. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the list option is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
+  /** Toggles the checked state of the checkbox. */
+  async toggle() {
+    return (await this.host()).click();
+  }
+
+  /**
+   * Puts the list option in a checked state by toggling it if it is currently
+   * unchecked, or doing nothing if it is already checked.
+   */
+  async select() {
+    if (!await this.isSelected()) {
+      return this.toggle();
+    }
+  }
+
+  /**
+   * Puts the list option in an unchecked state by toggling it if it is currently
+   * checked, or doing nothing if it is already unchecked.
+   */
+  async deselect() {
+    if (await this.isSelected()) {
+      return this.toggle();
+    }
+  }
+}

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -77,6 +77,12 @@ export class MatSelectionListChange {
 }
 
 /**
+ * Type describing possible positions of a checkbox in a list option
+ * with respect to the list item's text.
+ */
+export type MatListOptionCheckboxPosition = 'before'|'after';
+
+/**
  * Component for list-options of selection-list. Each list-option can automatically
  * generate a checkbox and can put current item into the selectionModel of selection-list
  * if the current item is selected.
@@ -125,7 +131,7 @@ export class MatListOption extends _MatListOptionMixinBase implements AfterConte
   @ViewChild('text') _text: ElementRef;
 
   /** Whether the label should appear before or after the checkbox. Defaults to 'after' */
-  @Input() checkboxPosition: 'before' | 'after' = 'after';
+  @Input() checkboxPosition: MatListOptionCheckboxPosition = 'after';
 
   /** Theme color of the list option. This sets the color of the checkbox. */
   @Input()

--- a/src/material/list/testing/BUILD.bazel
+++ b/src/material/list/testing/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//src/cdk/coercion",
         "//src/cdk/testing",
         "//src/material/divider/testing",
+        "//src/material/list",
     ],
 )
 

--- a/src/material/list/testing/list-harness-base.ts
+++ b/src/material/list/testing/list-harness-base.ts
@@ -31,7 +31,7 @@ export interface ListSection<I> {
  * @template F The filter type used filter list item harness of type `C`.
  * @docs-private
  */
-export class MatListHarnessBase
+export abstract class MatListHarnessBase
     <
       T extends (ComponentHarnessConstructor<C> & {with: (options?: F) => HarnessPredicate<C>}),
       C extends ComponentHarness,

--- a/src/material/list/testing/list-harness.spec.ts
+++ b/src/material/list/testing/list-harness.spec.ts
@@ -4,11 +4,16 @@ import {MatActionListHarness} from './action-list-harness';
 import {MatListHarness} from './list-harness';
 import {MatNavListHarness} from './nav-list-harness';
 import {MatSelectionListHarness} from './selection-list-harness';
-import {MatListItemHarnessBase, MatSubheaderHarness} from './list-item-harness-base';
+import {
+  MatListItemHarnessBase,
+  MatListItemSection,
+  MatSubheaderHarness
+} from './list-item-harness-base';
 import {runHarnessTests} from './shared.spec';
 
 describe('Non-MDC-based list harnesses', () => {
   runHarnessTests(
       MatListModule, MatListHarness, MatActionListHarness, MatNavListHarness,
-      MatSelectionListHarness, MatListItemHarnessBase, MatSubheaderHarness, MatDividerHarness);
+      MatSelectionListHarness, MatListItemHarnessBase, MatSubheaderHarness, MatDividerHarness,
+      {content: MatListItemSection.CONTENT});
 });

--- a/src/material/list/testing/list-item-harness-base.ts
+++ b/src/material/list/testing/list-item-harness-base.ts
@@ -56,7 +56,9 @@ export const enum MatListItemSection {
  * Shared behavior among the harnesses for the various `MatListItem` flavors.
  * @docs-private
  */
-export class MatListItemHarnessBase extends ContentContainerComponentHarness<MatListItemSection> {
+export abstract class MatListItemHarnessBase
+    extends ContentContainerComponentHarness<MatListItemSection> {
+
   private _lines = this.locatorForAll('.mat-line');
   private _avatar = this.locatorForOptional('.mat-list-avatar');
   private _icon = this.locatorForOptional('.mat-list-icon');

--- a/src/material/list/testing/selection-list-harness.ts
+++ b/src/material/list/testing/selection-list-harness.ts
@@ -62,8 +62,9 @@ export class MatSelectionListHarness extends MatListHarnessBase<
     if (!filters.length) {
       return this.getItems();
     }
-    return ([] as MatListOptionHarness[]).concat(...await Promise.all(
-        filters.map(filter => this.locatorForAll(MatListOptionHarness.with(filter))())));
+    const matches = await Promise.all(
+      filters.map(filter => this.locatorForAll(MatListOptionHarness.with(filter))()));
+    return matches.reduce((result, current) => [...result, ...current], []);
   }
 }
 

--- a/src/material/list/testing/selection-list-harness.ts
+++ b/src/material/list/testing/selection-list-harness.ts
@@ -7,6 +7,7 @@
  */
 
 import {HarnessPredicate} from '@angular/cdk/testing';
+import {MatListOptionCheckboxPosition} from '@angular/material/list';
 import {MatListHarnessBase} from './list-harness-base';
 import {
   ListItemHarnessFilters,
@@ -88,7 +89,7 @@ export class MatListOptionHarness extends MatListItemHarnessBase {
   private _itemContent = this.locatorFor('.mat-list-item-content');
 
   /** Gets the position of the checkbox relative to the list option content. */
-  async getCheckboxPosition(): Promise<'before' | 'after'> {
+  async getCheckboxPosition(): Promise<MatListOptionCheckboxPosition> {
     return await (await this._itemContent()).hasClass('mat-list-item-content-reverse') ?
         'after' : 'before';
   }

--- a/src/material/list/testing/shared.spec.ts
+++ b/src/material/list/testing/shared.spec.ts
@@ -13,7 +13,11 @@ import {MatActionListHarness, MatActionListItemHarness} from './action-list-harn
 import {MatListHarness, MatListItemHarness} from './list-harness';
 import {MatListHarnessBase} from './list-harness-base';
 import {BaseListItemHarnessFilters} from './list-harness-filters';
-import {MatListItemHarnessBase, MatSubheaderHarness} from './list-item-harness-base';
+import {
+  MatListItemHarnessBase,
+  MatListItemSection,
+  MatSubheaderHarness
+} from './list-item-harness-base';
 import {MatNavListHarness, MatNavListItemHarness} from './nav-list-harness';
 import {MatListOptionHarness, MatSelectionListHarness} from './selection-list-harness';
 
@@ -33,7 +37,8 @@ function runBaseListFunctionalityTests<
     },
     listItemHarnessBase: typeof MatListItemHarnessBase,
     subheaderHarness: typeof MatSubheaderHarness,
-    dividerHarness: typeof MatDividerHarness) {
+    dividerHarness: typeof MatDividerHarness,
+    selectors: {content: string}) {
   describe('base list functionality', () => {
     let simpleListHarness: L;
     let emptyListHarness: L;
@@ -183,6 +188,13 @@ function runBaseListFunctionalityTests<
       const childHarness = await items[1].getHarness(TestItemContentHarness);
       expect(childHarness).not.toBeNull();
     });
+
+    it('should be able to get content harness loader of list item', async () => {
+      const items = await simpleListHarness.getItems();
+      expect(items.length).toBe(3);
+      const loader = await items[1].getChildLoader(selectors.content as MatListItemSection);
+      await expectAsync(loader.getHarness(TestItemContentHarness)).toBeResolved();
+    });
   });
 }
 
@@ -199,17 +211,18 @@ export function runHarnessTests(
     selectionListHarness: typeof MatSelectionListHarness,
     listItemHarnessBase: typeof MatListItemHarnessBase,
     subheaderHarness: typeof MatSubheaderHarness,
-    dividerHarness: typeof MatDividerHarness) {
+    dividerHarness: typeof MatDividerHarness,
+    selectors: {content: string}) {
   describe('MatListHarness', () => {
     runBaseListFunctionalityTests<MatListHarness, MatListItemHarness>(
         ListHarnessTest, listModule, listHarness, listItemHarnessBase, subheaderHarness,
-        dividerHarness);
+        dividerHarness, selectors);
   });
 
   describe('MatActionListHarness', () => {
     runBaseListFunctionalityTests<MatActionListHarness, MatActionListItemHarness>(
         ActionListHarnessTest, listModule, actionListHarness, listItemHarnessBase, subheaderHarness,
-        dividerHarness);
+        dividerHarness, selectors);
 
     describe('additional functionality', () => {
       let harness: MatActionListHarness;
@@ -244,7 +257,7 @@ export function runHarnessTests(
   describe('MatNavListHarness', () => {
     runBaseListFunctionalityTests<MatNavListHarness, MatNavListItemHarness>(
         NavListHarnessTest, listModule, navListHarness, listItemHarnessBase, subheaderHarness,
-        dividerHarness);
+        dividerHarness, selectors);
 
     describe('additional functionality', () => {
       let harness: MatNavListHarness;
@@ -290,7 +303,7 @@ export function runHarnessTests(
   describe('MatSelectionListHarness', () => {
     runBaseListFunctionalityTests<MatSelectionListHarness, MatListOptionHarness>(
         SelectionListHarnessTest, listModule, selectionListHarness, listItemHarnessBase,
-        subheaderHarness, dividerHarness);
+        subheaderHarness, dividerHarness, selectors);
 
     describe('additional functionality', () => {
       let harness: MatSelectionListHarness;

--- a/tools/public_api_guard/material/list.d.ts
+++ b/tools/public_api_guard/material/list.d.ts
@@ -53,7 +53,7 @@ export declare class MatListOption extends _MatListOptionMixinBase implements Af
     _icon: MatListIconCssMatStyler;
     _lines: QueryList<MatLine>;
     _text: ElementRef;
-    checkboxPosition: 'before' | 'after';
+    checkboxPosition: MatListOptionCheckboxPosition;
     get color(): ThemePalette;
     set color(newValue: ThemePalette);
     get disabled(): any;
@@ -84,6 +84,8 @@ export declare class MatListOption extends _MatListOptionMixinBase implements Af
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatListOption, "mat-list-option", ["matListOption"], { "disableRipple": "disableRipple"; "checkboxPosition": "checkboxPosition"; "color": "color"; "value": "value"; "disabled": "disabled"; "selected": "selected"; }, {}, ["_avatar", "_icon", "_lines"], ["*", "[mat-list-avatar], [mat-list-icon], [matListAvatar], [matListIcon]"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatListOption, never>;
 }
+
+export declare type MatListOptionCheckboxPosition = 'before' | 'after';
 
 export declare class MatListSubheaderCssMatStyler {
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatListSubheaderCssMatStyler, "[mat-subheader], [matSubheader]", never, {}, {}, never>;

--- a/tools/public_api_guard/material/list/testing.d.ts
+++ b/tools/public_api_guard/material/list/testing.d.ts
@@ -52,7 +52,7 @@ export declare class MatListOptionHarness extends MatListItemHarnessBase {
     blur(): Promise<void>;
     deselect(): Promise<void>;
     focus(): Promise<void>;
-    getCheckboxPosition(): Promise<'before' | 'after'>;
+    getCheckboxPosition(): Promise<MatListOptionCheckboxPosition>;
     isDisabled(): Promise<boolean>;
     isFocused(): Promise<boolean>;
     isSelected(): Promise<boolean>;


### PR DESCRIPTION
* Fixes a discovered issue with icon/avatar alignment in the list-option (that would otherwise block the harness).
* Adds a test harness for MDC-based list

**Note for reviewer**: I'd recommend reviewing on a per-commit basis.

Resolves COMP-337