### PR TITLE
refactor(overlay): remove deprecated APIs for v11

### DIFF
--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.ts
@@ -7,13 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {
-  Inject,
-  Injectable,
-  InjectionToken,
-  Optional,
-  SkipSelf,
-} from '@angular/core';
+import {Inject, Injectable} from '@angular/core';
 import {OverlayReference} from '../overlay-reference';
 import {BaseOverlayDispatcher} from './base-overlay-dispatcher';
 
@@ -67,25 +61,3 @@ export class OverlayKeyboardDispatcher extends BaseOverlayDispatcher {
     }
   }
 }
-
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export function OVERLAY_KEYBOARD_DISPATCHER_PROVIDER_FACTORY(
-    dispatcher: OverlayKeyboardDispatcher, _document: any) {
-  return dispatcher || new OverlayKeyboardDispatcher(_document);
-}
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export const OVERLAY_KEYBOARD_DISPATCHER_PROVIDER = {
-  // If there is already an OverlayKeyboardDispatcher available, use that.
-  // Otherwise, provide a new one.
-  provide: OverlayKeyboardDispatcher,
-  deps: [
-    [new Optional(), new SkipSelf(), OverlayKeyboardDispatcher],
-
-    // Coerce to `InjectionToken` so that the `deps` match the "shape"
-    // of the type expected by Angular
-    DOCUMENT as InjectionToken<any>
-  ],
-  useFactory: OVERLAY_KEYBOARD_DISPATCHER_PROVIDER_FACTORY
-};

--- a/src/cdk/overlay/fullscreen-overlay-container.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.ts
@@ -24,13 +24,7 @@ export class FullscreenOverlayContainer extends OverlayContainer implements OnDe
   private _fullScreenEventName: string | undefined;
   private _fullScreenListener: () => void;
 
-  constructor(
-    @Inject(DOCUMENT) _document: any,
-    /**
-     * @deprecated `platform` parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    platform?: Platform) {
+  constructor(@Inject(DOCUMENT) _document: any, platform: Platform) {
     super(_document, platform);
   }
 

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -7,14 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {
-  Inject,
-  Injectable,
-  InjectionToken,
-  OnDestroy,
-  Optional,
-  SkipSelf,
-} from '@angular/core';
+import {Inject, Injectable, OnDestroy} from '@angular/core';
 import {Platform} from '@angular/cdk/platform';
 
 /**
@@ -30,13 +23,7 @@ export class OverlayContainer implements OnDestroy {
   protected _containerElement: HTMLElement;
   protected _document: Document;
 
-  constructor(
-    @Inject(DOCUMENT) document: any,
-    /**
-     * @deprecated `platform` parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    protected _platform?: Platform) {
+  constructor(@Inject(DOCUMENT) document: any, protected _platform: Platform) {
     this._document = document;
   }
 
@@ -67,11 +54,9 @@ export class OverlayContainer implements OnDestroy {
    * with the 'cdk-overlay-container' class on the document body.
    */
   protected _createContainer(): void {
-    // @breaking-change 10.0.0 Remove null check for `_platform`.
-    const isBrowser = this._platform ? this._platform.isBrowser : typeof window !== 'undefined';
     const containerClass = 'cdk-overlay-container';
 
-    if (isBrowser || isTestEnvironment) {
+    if (this._platform.isBrowser || isTestEnvironment) {
       const oppositePlatformContainers =
           this._document.querySelectorAll(`.${containerClass}[platform="server"], ` +
                                           `.${containerClass}[platform="test"]`);
@@ -97,7 +82,7 @@ export class OverlayContainer implements OnDestroy {
     // TODO(crisbeto): remove the test environment check once we have an overlay testing module.
     if (isTestEnvironment) {
       container.setAttribute('platform', 'test');
-    } else if (!isBrowser) {
+    } else if (!this._platform.isBrowser) {
       container.setAttribute('platform', 'server');
     }
 
@@ -105,21 +90,3 @@ export class OverlayContainer implements OnDestroy {
     this._containerElement = container;
   }
 }
-
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export function OVERLAY_CONTAINER_PROVIDER_FACTORY(parentContainer: OverlayContainer,
-  _document: any) {
-  return parentContainer || new OverlayContainer(_document);
-}
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export const OVERLAY_CONTAINER_PROVIDER = {
-  // If there is already an OverlayContainer available, use that. Otherwise, provide a new one.
-  provide: OverlayContainer,
-  deps: [
-    [new Optional(), new SkipSelf(), OverlayContainer],
-    DOCUMENT as InjectionToken<any> // We need to use the InjectionToken somewhere to keep TS happy
-  ],
-  useFactory: OVERLAY_CONTAINER_PROVIDER_FACTORY
-};

--- a/src/cdk/overlay/overlay-directives.ts
+++ b/src/cdk/overlay/overlay-directives.ts
@@ -37,7 +37,6 @@ import {
 } from './position/flexible-connected-position-strategy';
 import {
   RepositionScrollStrategy,
-  RepositionScrollStrategyConfig,
   ScrollStrategy,
 } from './scroll/index';
 
@@ -73,12 +72,6 @@ const defaultPositionList: ConnectedPosition[] = [
 /** Injection token that determines the scroll handling while the connected overlay is open. */
 export const CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY =
     new InjectionToken<() => ScrollStrategy>('cdk-connected-overlay-scroll-strategy');
-
-/** @docs-private @deprecated @breaking-change 8.0.0 */
-export function CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_FACTORY(overlay: Overlay):
-  () => ScrollStrategy {
-  return (config?: RepositionScrollStrategyConfig) => overlay.scrollStrategies.reposition(config);
-}
 
 /**
  * Directive applied to an element to make it usable as an origin for an Overlay using a

--- a/src/cdk/overlay/overlay-module.ts
+++ b/src/cdk/overlay/overlay-module.ts
@@ -9,16 +9,13 @@
 import {BidiModule} from '@angular/cdk/bidi';
 import {PortalModule} from '@angular/cdk/portal';
 import {ScrollingModule} from '@angular/cdk/scrolling';
-import {NgModule, Provider} from '@angular/core';
-import {OVERLAY_KEYBOARD_DISPATCHER_PROVIDER} from './dispatchers/overlay-keyboard-dispatcher';
+import {NgModule} from '@angular/core';
 import {Overlay} from './overlay';
-import {OVERLAY_CONTAINER_PROVIDER} from './overlay-container';
 import {
   CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER,
   CdkConnectedOverlay,
   CdkOverlayOrigin,
 } from './overlay-directives';
-import {OverlayPositionBuilder} from './position/overlay-position-builder';
 
 
 @NgModule({
@@ -31,17 +28,3 @@ import {OverlayPositionBuilder} from './position/overlay-position-builder';
   ],
 })
 export class OverlayModule {}
-
-
-/**
- * @deprecated Use `OverlayModule` instead.
- * @breaking-change 8.0.0
- * @docs-private
- */
-export const OVERLAY_PROVIDERS: Provider[] = [
-  Overlay,
-  OverlayPositionBuilder,
-  OVERLAY_KEYBOARD_DISPATCHER_PROVIDER,
-  OVERLAY_CONTAINER_PROVIDER,
-  CDK_CONNECTED_OVERLAY_SCROLL_STRATEGY_PROVIDER,
-];

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -60,10 +60,8 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
       private _ngZone: NgZone,
       private _keyboardDispatcher: OverlayKeyboardDispatcher,
       private _document: Document,
-      // @breaking-change 8.0.0 `_location` parameter to be made required.
-      private _location?: Location,
-      // @breaking-change 9.0.0 `_mouseClickDispatcher` parameter to be made required.
-      private _outsideClickDispatcher?: OverlayOutsideClickDispatcher) {
+      private _location: Location,
+      private _outsideClickDispatcher: OverlayOutsideClickDispatcher) {
 
     if (_config.scrollStrategy) {
       this._scrollStrategy = _config.scrollStrategy;
@@ -152,17 +150,11 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     // Track this overlay by the keyboard dispatcher
     this._keyboardDispatcher.add(this);
 
-    // @breaking-change 8.0.0 remove the null check for `_location`
-    // once the constructor parameter is made required.
-    if (this._config.disposeOnNavigation && this._location) {
+    if (this._config.disposeOnNavigation) {
       this._locationChanges = this._location.subscribe(() => this.dispose());
     }
 
-    // @breaking-change 9.0.0 remove the null check for `_mouseClickDispatcher`
-    if (this._outsideClickDispatcher) {
-      this._outsideClickDispatcher.add(this);
-    }
-
+    this._outsideClickDispatcher.add(this);
     return attachResult;
   }
 
@@ -201,15 +193,8 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     // Keeping the host element in the DOM can cause scroll jank, because it still gets
     // rendered, even though it's transparent and unclickable which is why we remove it.
     this._detachContentWhenStable();
-
-    // Stop listening for location changes.
     this._locationChanges.unsubscribe();
-
-    // @breaking-change 9.0.0 remove the null check for `_outsideClickDispatcher`
-    if (this._outsideClickDispatcher) {
-      this._outsideClickDispatcher.remove(this);
-    }
-
+    this._outsideClickDispatcher.remove(this);
     return detachmentResult;
   }
 
@@ -230,11 +215,7 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     this._backdropClick.complete();
     this._keydownEvents.complete();
     this._outsidePointerEvents.complete();
-
-    // @breaking-change 9.0.0 remove the null check for `_outsideClickDispatcher`
-    if (this._outsideClickDispatcher) {
-      this._outsideClickDispatcher.remove(this);
-    }
+    this._outsideClickDispatcher.remove(this);
 
     if (this._host && this._host.parentNode) {
       this._host.parentNode.removeChild(this._host);

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -55,10 +55,8 @@ export class Overlay {
               private _ngZone: NgZone,
               @Inject(DOCUMENT) private _document: any,
               private _directionality: Directionality,
-              // @breaking-change 8.0.0 `_location` parameter to be made required.
-              private _location?: Location,
-              // @breaking-change 9.0.0 `_outsideClickDispatcher` parameter to be made required.
-              private _outsideClickDispatcher?: OverlayOutsideClickDispatcher) { }
+              private _location: Location,
+              private _outsideClickDispatcher: OverlayOutsideClickDispatcher) { }
 
   /**
    * Creates an overlay.

--- a/src/cdk/schematics/ng-update/data/constructor-checks.ts
+++ b/src/cdk/schematics/ng-update/data/constructor-checks.ts
@@ -29,6 +29,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/20572',
       changes: ['CdkTreeNodePadding']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/20511',
+      changes: ['OverlayContainer', 'FullscreenOverlayContainer', 'OverlayRef', 'Overlay']
     }
   ],
   [TargetVersion.V10]: [

--- a/tools/public_api_guard/cdk/overlay.d.ts
+++ b/tools/public_api_guard/cdk/overlay.d.ts
@@ -152,8 +152,7 @@ export declare type FlexibleConnectedPositionStrategyOrigin = ElementRef | Eleme
 };
 
 export declare class FullscreenOverlayContainer extends OverlayContainer implements OnDestroy {
-    constructor(_document: any,
-    platform?: Platform);
+    constructor(_document: any, platform: Platform);
     protected _createContainer(): void;
     getFullscreenElement(): Element;
     ngOnDestroy(): void;
@@ -191,14 +190,12 @@ export interface OriginConnectionPosition {
 export declare class Overlay {
     scrollStrategies: ScrollStrategyOptions;
     constructor(
-    scrollStrategies: ScrollStrategyOptions, _overlayContainer: OverlayContainer, _componentFactoryResolver: ComponentFactoryResolver, _positionBuilder: OverlayPositionBuilder, _keyboardDispatcher: OverlayKeyboardDispatcher, _injector: Injector, _ngZone: NgZone, _document: any, _directionality: Directionality, _location?: Location | undefined, _outsideClickDispatcher?: OverlayOutsideClickDispatcher | undefined);
+    scrollStrategies: ScrollStrategyOptions, _overlayContainer: OverlayContainer, _componentFactoryResolver: ComponentFactoryResolver, _positionBuilder: OverlayPositionBuilder, _keyboardDispatcher: OverlayKeyboardDispatcher, _injector: Injector, _ngZone: NgZone, _document: any, _directionality: Directionality, _location: Location, _outsideClickDispatcher: OverlayOutsideClickDispatcher);
     create(config?: OverlayConfig): OverlayRef;
     position(): OverlayPositionBuilder;
     static ɵfac: i0.ɵɵFactoryDef<Overlay, never>;
     static ɵprov: i0.ɵɵInjectableDef<Overlay>;
 }
-
-export declare const OVERLAY_PROVIDERS: Provider[];
 
 export declare class OverlayConfig {
     backdropClass?: string | string[];
@@ -225,9 +222,8 @@ export interface OverlayConnectionPosition {
 export declare class OverlayContainer implements OnDestroy {
     protected _containerElement: HTMLElement;
     protected _document: Document;
-    protected _platform?: Platform | undefined;
-    constructor(document: any,
-    _platform?: Platform | undefined);
+    protected _platform: Platform;
+    constructor(document: any, _platform: Platform);
     protected _createContainer(): void;
     getContainerElement(): HTMLElement;
     ngOnDestroy(): void;
@@ -271,7 +267,7 @@ export declare class OverlayRef implements PortalOutlet, OverlayReference {
     get backdropElement(): HTMLElement | null;
     get hostElement(): HTMLElement;
     get overlayElement(): HTMLElement;
-    constructor(_portalOutlet: PortalOutlet, _host: HTMLElement, _pane: HTMLElement, _config: ImmutableObject<OverlayConfig>, _ngZone: NgZone, _keyboardDispatcher: OverlayKeyboardDispatcher, _document: Document, _location?: Location | undefined, _outsideClickDispatcher?: OverlayOutsideClickDispatcher | undefined);
+    constructor(_portalOutlet: PortalOutlet, _host: HTMLElement, _pane: HTMLElement, _config: ImmutableObject<OverlayConfig>, _ngZone: NgZone, _keyboardDispatcher: OverlayKeyboardDispatcher, _document: Document, _location: Location, _outsideClickDispatcher: OverlayOutsideClickDispatcher);
     addPanelClass(classes: string | string[]): void;
     attach<T>(portal: ComponentPortal<T>): ComponentRef<T>;
     attach<T>(portal: TemplatePortal<T>): EmbeddedViewRef<T>;


### PR DESCRIPTION
Removes most of the deprecated APIs for v11 under `cdk/overlay`. Note that these changes target primarily the breaking changes that should be easier to land. I've left out removing `ConnectedPositionStrategy` which has a separate PR (#17519), and `GlobalPositionStrategy.width` and `GlobalPositionStrategy.height`, because they'll be trickier to land.

BREAKING CHANGES:
* The `OVERLAY_PROVIDERS` constant has been removed. Import `OverlayModule` and use the providers directly instead.
* `_platform` parameter of the `OverlayContainer` constructor is now required.
* `_platform` parameter of the `FullscreenOverlayContainer` constructor is now required.
* `_location` and `_outsideClickDispatcher` parameters of the `OverlayRef` constructor are now required.
* `_location` and `_outsideClickDispatcher` parameters of the `Overlay` constructor are now required.