### PR TITLE
feat: native select testing APIs

### DIFF
--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -119,17 +119,27 @@ export interface TestElement {
   /** Gets the value of a property of an element. */
   getProperty(name: string): Promise<any>;
 
+  /** Checks whether this element matches the given selector. */
+  matchesSelector(selector: string): Promise<boolean>;
+
+  /** Checks whether the element is focused. */
+  isFocused(): Promise<boolean>;
+
   /**
    * Sets the value of a property of an input.
    * @breaking-change 11.0.0 To become a required method.
    */
   setInputValue?(value: string): Promise<void>;
 
-  /** Checks whether this element matches the given selector. */
-  matchesSelector(selector: string): Promise<boolean>;
-
-  /** Checks whether the element is focused. */
-  isFocused(): Promise<boolean>;
+  // Note that ideally here we'd be selecting options based on their value, rather than their
+  // index, but we're limited by `@angular/forms` which will modify the option value in some cases.
+  // Since the value will be truncated, we can't rely on it to do the lookup in the DOM. See:
+  // https://github.com/angular/angular/blob/master/packages/forms/src/directives/select_control_value_accessor.ts#L19
+  /**
+   * Selects the options at the specified indexes inside of a native `select` element.
+   * @breaking-change 12.0.0 To become a required method.
+   */
+  selectOptions?(...optionIndexes: number[]): Promise<void>;
 }
 
 export interface TextOptions {

--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -406,6 +406,32 @@ export function crossEnvironmentSpecs(
       expect(await input.getProperty('value')).toBe('hello');
     });
 
+    it('should be able to set the value of a select in single selection mode', async () => {
+      const [select, value, changeEventCounter] = await Promise.all([
+        harness.singleSelect(),
+        harness.singleSelectValue(),
+        harness.singleSelectChangeEventCounter()
+      ]);
+
+      // @breaking-change 12.0.0 Remove non-null assertion once `setSelectValue` is required.
+      await select.selectOptions!(2);
+      expect(await value.text()).toBe('Select: three');
+      expect(await changeEventCounter.text()).toBe('Change events: 1');
+    });
+
+    it('should be able to set the value of a select in multi-selection mode', async () => {
+      const [select, value, changeEventCounter] = await Promise.all([
+        harness.multiSelect(),
+        harness.multiSelectValue(),
+        harness.multiSelectChangeEventCounter()
+      ]);
+
+      // @breaking-change 12.0.0 Remove non-null assertion once `setSelectValue` is required.
+      await select.selectOptions!(0, 2);
+      expect(await value.text()).toBe('Multi-select: one,three');
+      expect(await changeEventCounter.text()).toBe('Change events: 2');
+    });
+
     it('should check if selector matches', async () => {
       const button = await harness.button();
       expect(await button.matchesSelector('button:not(.fake-class)')).toBe(true);

--- a/src/cdk/testing/tests/harnesses/main-component-harness.ts
+++ b/src/cdk/testing/tests/harnesses/main-component-harness.ts
@@ -28,6 +28,12 @@ export class MainComponentHarness extends ComponentHarness {
   readonly memo = this.locatorFor('textarea');
   readonly clickTest = this.locatorFor('.click-test');
   readonly clickTestResult = this.locatorFor('.click-test-result');
+  readonly singleSelect = this.locatorFor('#single-select');
+  readonly singleSelectValue = this.locatorFor('#single-select-value');
+  readonly singleSelectChangeEventCounter = this.locatorFor('#single-select-change-counter');
+  readonly multiSelect = this.locatorFor('#multi-select');
+  readonly multiSelectValue = this.locatorFor('#multi-select-value');
+  readonly multiSelectChangeEventCounter = this.locatorFor('#multi-select-change-counter');
   // Allow null for element
   readonly nullItem = this.locatorForOptional('wrong locator');
   // Allow null for component harness

--- a/src/cdk/testing/tests/test-main-component.html
+++ b/src/cdk/testing/tests/test-main-component.html
@@ -17,6 +17,31 @@
   <span class="special-key">{{specialKey}}</span>
   <div id="value">Input: {{input}}</div>
   <textarea id="memo" aria-label="memo">{{memo}}</textarea>
+  <select
+    id="single-select"
+    aria-label="single select"
+    [(ngModel)]="singleSelect"
+    (change)="singleSelectChangeEventCount = singleSelectChangeEventCount + 1">
+    <option value="one">One</option>
+    <option value="two">Two</option>
+    <option value="three">Three</option>
+  </select>
+  <div id="single-select-value">Select: {{singleSelect}}</div>
+  <div id="single-select-change-counter">Change events: {{singleSelectChangeEventCount}}</div>
+
+  <select
+    multiple
+    id="multi-select"
+    aria-label="multi select"
+    [(ngModel)]="multiSelect"
+    (change)="multiSelectChangeEventCount = multiSelectChangeEventCount + 1">
+    <option value="one">One</option>
+    <option value="two">Two</option>
+    <option value="three">Three</option>
+  </select>
+  <div id="multi-select-value">Multi-select: {{multiSelect}}</div>
+  <div id="multi-select-change-counter">Change events: {{multiSelectChangeEventCount}}</div>
+
 </div>
 <div class="subcomponents">
   <test-sub class="test-special" title="test tools" [items]="testTools"></test-sub>

--- a/src/cdk/testing/tests/test-main-component.ts
+++ b/src/cdk/testing/tests/test-main-component.ts
@@ -43,6 +43,10 @@ export class TestMainComponent implements OnDestroy {
   specialKey = '';
   relativeX = 0;
   relativeY = 0;
+  singleSelect: string;
+  singleSelectChangeEventCount = 0;
+  multiSelect: string[] = [];
+  multiSelectChangeEventCount = 0;
   _shadowDomSupported = _supportsShadowDom();
 
   @ViewChild('clickTestElement') clickTestElement: ElementRef<HTMLElement>;

--- a/src/material-experimental/mdc-input/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-input/testing/BUILD.bazel
@@ -22,10 +22,7 @@ filegroup(
 
 ng_test_library(
     name = "unit_tests_lib",
-    srcs = glob(
-        ["**/*.spec.ts"],
-        exclude = ["shared.spec.ts"],
-    ),
+    srcs = glob(["**/*.spec.ts"]),
     deps = [
         ":testing",
         "//src/material-experimental/mdc-input",

--- a/src/material-experimental/mdc-input/testing/input-harness.spec.ts
+++ b/src/material-experimental/mdc-input/testing/input-harness.spec.ts
@@ -1,7 +1,7 @@
 import {MatInputModule} from '@angular/material-experimental/mdc-input';
-import {runHarnessTests} from '@angular/material/input/testing/shared.spec';
+import {runInputHarnessTests} from '@angular/material/input/testing/shared-input.spec';
 import {MatInputHarness} from './index';
 
 describe('MDC-based MatInputHarness', () => {
-  runHarnessTests(MatInputModule, MatInputHarness);
+  runInputHarnessTests(MatInputModule, MatInputHarness);
 });

--- a/src/material-experimental/mdc-input/testing/native-select-harness.spec.ts
+++ b/src/material-experimental/mdc-input/testing/native-select-harness.spec.ts
@@ -1,0 +1,9 @@
+import {MatInputModule} from '@angular/material-experimental/mdc-input';
+import {
+  runNativeSelectHarnessTests
+} from '@angular/material/input/testing/shared-native-select.spec';
+import {MatNativeSelectHarness} from './index';
+
+describe('MDC-based MatNativeSelectHarness', () => {
+  runNativeSelectHarnessTests(MatInputModule, MatNativeSelectHarness);
+});

--- a/src/material-experimental/mdc-input/testing/public-api.ts
+++ b/src/material-experimental/mdc-input/testing/public-api.ts
@@ -6,4 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {InputHarnessFilters, MatInputHarness} from '@angular/material/input/testing';
+export {
+  InputHarnessFilters,
+  MatInputHarness,
+  MatNativeSelectHarness,
+  MatNativeOptionHarness,
+  NativeOptionHarnessFilters,
+  NativeSelectHarnessFilters,
+} from '@angular/material/input/testing';

--- a/src/material/input/testing/BUILD.bazel
+++ b/src/material/input/testing/BUILD.bazel
@@ -23,7 +23,10 @@ filegroup(
 
 ng_test_library(
     name = "harness_tests_lib",
-    srcs = ["shared.spec.ts"],
+    srcs = [
+        "shared-input.spec.ts",
+        "shared-native-select.spec.ts",
+    ],
     deps = [
         ":testing",
         "//src/cdk/platform",
@@ -39,7 +42,10 @@ ng_test_library(
     name = "unit_tests_lib",
     srcs = glob(
         ["**/*.spec.ts"],
-        exclude = ["shared.spec.ts"],
+        exclude = [
+            "shared-input.spec.ts",
+            "shared-native-select.spec.ts",
+        ],
     ),
     deps = [
         ":harness_tests_lib",

--- a/src/material/input/testing/input-harness.spec.ts
+++ b/src/material/input/testing/input-harness.spec.ts
@@ -1,7 +1,7 @@
 import {MatInputModule} from '@angular/material/input';
 import {MatInputHarness} from './input-harness';
-import {runHarnessTests} from './shared.spec';
+import {runInputHarnessTests} from './shared-input.spec';
 
 describe('Non-MDC-based MatInputHarness', () => {
-  runHarnessTests(MatInputModule, MatInputHarness);
+  runInputHarnessTests(MatInputModule, MatInputHarness);
 });

--- a/src/material/input/testing/native-option-harness.ts
+++ b/src/material/input/testing/native-option-harness.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {NativeOptionHarnessFilters} from './native-select-harness-filters';
+
+/** Harness for interacting with a native `option` in tests. */
+export class MatNativeOptionHarness extends ComponentHarness {
+  /** Selector used to locate option instances. */
+  static hostSelector = 'select[matNativeControl] option';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatNativeOptionHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which option instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: NativeOptionHarnessFilters = {}) {
+    return new HarnessPredicate(MatNativeOptionHarness, options)
+        .addOption('text', options.text,
+            async (harness, title) =>
+                HarnessPredicate.stringMatches(await harness.getText(), title))
+        .addOption('index', options.index,
+            async (harness, index) => await harness.getIndex() === index)
+        .addOption('isSelected', options.isSelected,
+            async (harness, isSelected) => await harness.isSelected() === isSelected);
+
+  }
+
+  /** Gets the option's label text. */
+  async getText(): Promise<string> {
+    return (await this.host()).getProperty('label');
+  }
+
+  /** Index of the option within the native `select` element. */
+  async getIndex(): Promise<number> {
+    return (await this.host()).getProperty('index');
+  }
+
+  /** Gets whether the option is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return (await this.host()).getProperty('disabled');
+  }
+
+  /** Gets whether the option is selected. */
+  async isSelected(): Promise<boolean> {
+    return (await this.host()).getProperty('selected');
+  }
+}

--- a/src/material/input/testing/native-select-harness-filters.ts
+++ b/src/material/input/testing/native-select-harness-filters.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+/** A set of criteria that can be used to filter a list of `MatNativeSelectHarness` instances. */
+export interface NativeSelectHarnessFilters extends BaseHarnessFilters {}
+
+/** A set of criteria that can be used to filter a list of `MatNativeOptionHarness` instances. */
+export interface NativeOptionHarnessFilters extends BaseHarnessFilters {
+  text?: string | RegExp;
+  index?: number;
+  isSelected?: boolean;
+}

--- a/src/material/input/testing/native-select-harness.spec.ts
+++ b/src/material/input/testing/native-select-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatInputModule} from '@angular/material/input';
+import {MatNativeSelectHarness} from './native-select-harness';
+import {runNativeSelectHarnessTests} from './shared-native-select.spec';
+
+describe('Non-MDC-based MatNativeSelectHarness', () => {
+  runNativeSelectHarnessTests(MatInputModule, MatNativeSelectHarness);
+});

--- a/src/material/input/testing/native-select-harness.ts
+++ b/src/material/input/testing/native-select-harness.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate} from '@angular/cdk/testing';
+import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
+import {MatNativeOptionHarness} from './native-option-harness';
+import {
+  NativeOptionHarnessFilters,
+  NativeSelectHarnessFilters,
+} from './native-select-harness-filters';
+
+
+/** Harness for interacting with a native `select` in tests. */
+export class MatNativeSelectHarness extends MatFormFieldControlHarness {
+  static hostSelector = 'select[matNativeControl]';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatNativeSelectHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which select instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: NativeSelectHarnessFilters = {}): HarnessPredicate<MatNativeSelectHarness> {
+    return new HarnessPredicate(MatNativeSelectHarness, options);
+  }
+
+  /** Gets a boolean promise indicating if the select is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return (await this.host()).getProperty('disabled');
+  }
+
+  /** Gets a boolean promise indicating if the select is required. */
+  async isRequired(): Promise<boolean> {
+    return (await this.host()).getProperty('required');
+  }
+
+  /** Gets a boolean promise indicating if the select is in multi-selection mode. */
+  async isMultiple(): Promise<boolean> {
+    return (await this.host()).getProperty('multiple');
+  }
+
+  /** Gets the name of the select. */
+  async getName(): Promise<string> {
+    // The "name" property of the native select is never undefined.
+    return (await (await this.host()).getProperty('name'))!;
+  }
+
+  /** Gets the id of the select. */
+  async getId(): Promise<string> {
+    // We're guaranteed to have an id, because the `matNativeControl` always assigns one.
+    return (await (await this.host()).getProperty('id'))!;
+  }
+
+  /** Focuses the select and returns a void promise that indicates when the action is complete. */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /** Blurs the select and returns a void promise that indicates when the action is complete. */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the select is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
+  /** Gets the options inside the select panel. */
+  async getOptions(filter: NativeOptionHarnessFilters = {}):
+    Promise<MatNativeOptionHarness[]> {
+    return this.locatorForAll(MatNativeOptionHarness.with(filter))();
+  }
+
+  /**
+   * Selects the options that match the passed-in filter. If the select is in multi-selection
+   * mode all options will be clicked, otherwise the harness will pick the first matching option.
+   */
+  async selectOptions(filter: NativeOptionHarnessFilters = {}): Promise<void> {
+    const [isMultiple, options] = await Promise.all([this.isMultiple(), this.getOptions(filter)]);
+
+    if (options.length === 0) {
+      throw Error('Select does not have options matching the specified filter');
+    }
+
+    const [host, optionIndexes] = await Promise.all([
+      this.host(),
+      Promise.all(options.slice(0, isMultiple ? undefined : 1).map(option => option.getIndex()))
+    ]);
+
+    // @breaking-change 12.0.0 Error can be removed once `selectOptions` is a required method.
+    if (!host.selectOptions) {
+      throw Error('TestElement implementation does not support the selectOptions ' +
+                  'method which is required for this function.');
+    }
+
+    await host.selectOptions(...optionIndexes);
+  }
+}

--- a/src/material/input/testing/public-api.ts
+++ b/src/material/input/testing/public-api.ts
@@ -8,3 +8,6 @@
 
 export * from './input-harness';
 export * from './input-harness-filters';
+export * from './native-select-harness';
+export * from './native-select-harness-filters';
+export * from './native-option-harness';

--- a/src/material/input/testing/shared-input.spec.ts
+++ b/src/material/input/testing/shared-input.spec.ts
@@ -9,7 +9,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatInputHarness} from './input-harness';
 
 /** Shared tests to run on both the original and MDC-based input's. */
-export function runHarnessTests(
+export function runInputHarnessTests(
     inputModule: typeof MatInputModule, inputHarness: typeof MatInputHarness) {
   let fixture: ComponentFixture<InputHarnessTest>;
   let loader: HarnessLoader;

--- a/src/material/input/testing/shared-native-select.spec.ts
+++ b/src/material/input/testing/shared-native-select.spec.ts
@@ -1,0 +1,226 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {MatInputModule} from '@angular/material/input';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatNativeSelectHarness} from './native-select-harness';
+
+/** Shared tests to run on both the original and MDC-based native selects. */
+export function runNativeSelectHarnessTests(
+    inputModule: typeof MatInputModule,
+    selectHarness: typeof MatNativeSelectHarness) {
+  let fixture: ComponentFixture<SelectHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, inputModule, FormsModule],
+      declarations: [SelectHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load all select harnesses', async () => {
+    const selects = await loader.getAllHarnesses(selectHarness);
+    expect(selects.length).toBe(2);
+  });
+
+  it('should get the id of a select', async () => {
+    const selects = await loader.getAllHarnesses(selectHarness);
+    expect(await Promise.all(selects.map(select => select.getId()))).toEqual(['food', 'drink']);
+  });
+
+  it('should get the name of a select', async () => {
+    const selects = await loader.getAllHarnesses(selectHarness);
+
+    expect(await Promise.all(selects.map(select => select.getName()))).toEqual([
+      'favorite-food',
+      'favorite-drink'
+    ]);
+  });
+
+  it('should get whether a select is disabled', async () => {
+    const selects = await loader.getAllHarnesses(selectHarness);
+    expect(await Promise.all(selects.map(select => select.isDisabled()))).toEqual([false, false]);
+
+    fixture.componentInstance.favoriteDrinkDisabled = true;
+    expect(await Promise.all(selects.map(select => select.isDisabled()))).toEqual([false, true]);
+  });
+
+  it('should get whether the select is in multi-selection mode', async () => {
+    const selects = await loader.getAllHarnesses(selectHarness);
+    expect(await Promise.all(selects.map(select => select.isMultiple()))).toEqual([false, true]);
+  });
+
+  it('should get whether a select is required', async () => {
+    const selects = await loader.getAllHarnesses(selectHarness);
+    expect(await Promise.all(selects.map(select => select.isRequired()))).toEqual([false, false]);
+
+    fixture.componentInstance.favoriteFoodRequired = true;
+    expect(await Promise.all(selects.map(select => select.isRequired()))).toEqual([true, false]);
+  });
+
+  it('should be able to focus a select', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
+    expect(await select.isFocused()).toBe(false);
+    await select.focus();
+    expect(await select.isFocused()).toBe(true);
+  });
+
+  it('should be able to blur a select', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
+    expect(await select.isFocused()).toBe(false);
+    await select.focus();
+    expect(await select.isFocused()).toBe(true);
+    await select.blur();
+    expect(await select.isFocused()).toBe(false);
+  });
+
+  it('should get the options of a select', async () => {
+    const selects = await loader.getAllHarnesses(selectHarness);
+    const options = await Promise.all(selects.map(select => select.getOptions()));
+
+    expect(options.length).toBe(2);
+    expect(options[0].length).toBe(3);
+    expect(options[1].length).toBe(4);
+  });
+
+  it('should select an option inside of a single-selection select', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
+    expect(fixture.componentInstance.favoriteFood).toBeFalsy();
+
+    await select.selectOptions({text: 'Ramen'});
+    expect(fixture.componentInstance.favoriteFood).toBe('ramen');
+  });
+
+  it('should select an option inside of a multi-selection select', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#drink'}));
+    expect(fixture.componentInstance.favoriteDrink).toEqual([]);
+
+    await select.selectOptions({text: /Water|Juice/});
+    expect(fixture.componentInstance.favoriteDrink).toEqual(['water', 'juice']);
+  });
+
+  it('should get the text of select options', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#drink'}));
+    const options = await select.getOptions();
+
+    expect(await Promise.all(options.map(option => option.getText()))).toEqual([
+      'Water',
+      'Soda',
+      'Coffee',
+      'Juice'
+    ]);
+  });
+
+  it('should get the index of select options', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
+    const options = await select.getOptions();
+
+    expect(await Promise.all(options.map(option => option.getIndex()))).toEqual([0, 1, 2]);
+  });
+
+  it('should get the disabled state of select options', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
+    const options = await select.getOptions();
+
+    expect(await Promise.all(options.map(option => option.isDisabled()))).toEqual([
+      false,
+      false,
+      false
+    ]);
+
+    fixture.componentInstance.pastaDisabled = true;
+
+    expect(await Promise.all(options.map(option => option.isDisabled()))).toEqual([
+      false,
+      true,
+      false
+    ]);
+  });
+
+  it('should get the selected state of an option in a single-selection list', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
+    const options = await select.getOptions();
+
+    expect(await Promise.all(options.map(option => option.isSelected()))).toEqual([
+      false,
+      false,
+      false
+    ]);
+
+    await select.selectOptions({index: 2});
+
+    expect(await Promise.all(options.map(option => option.isSelected()))).toEqual([
+      false,
+      false,
+      true
+    ]);
+  });
+
+  it('should get the selected state of an option in a multi-selection list', async () => {
+    const select = await loader.getHarness(selectHarness.with({selector: '#drink'}));
+    const options = await select.getOptions();
+
+    expect(await Promise.all(options.map(option => option.isSelected()))).toEqual([
+      false,
+      false,
+      false,
+      false
+    ]);
+
+    await select.selectOptions({text: /Water|Coffee/});
+
+    expect(await Promise.all(options.map(option => option.isSelected()))).toEqual([
+      true,
+      false,
+      true,
+      false
+    ]);
+  });
+
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <select
+        id="food"
+        matNativeControl
+        name="favorite-food"
+        [(ngModel)]="favoriteFood"
+        [required]="favoriteFoodRequired">
+        <option value="pizza">Pizza</option>
+        <option value="pasta" [disabled]="pastaDisabled">Pasta</option>
+        <option value="ramen">Ramen</option>
+      </select>
+    </mat-form-field>
+
+    <mat-form-field>
+      <select
+        id="drink"
+        matNativeControl
+        name="favorite-drink"
+        [(ngModel)]="favoriteDrink"
+        [disabled]="favoriteDrinkDisabled"
+        multiple>
+        <option value="water">Water</option>
+        <option value="soda">Soda</option>
+        <option value="coffee">Coffee</option>
+        <option value="juice">Juice</option>
+      </select>
+    </mat-form-field>
+  `
+})
+class SelectHarnessTest {
+  favoriteFood: string;
+  favoriteDrink: string[] = [];
+  favoriteFoodRequired = false;
+  favoriteDrinkDisabled = false;
+  pastaDisabled = false;
+}

--- a/tools/public_api_guard/cdk/testing.d.ts
+++ b/tools/public_api_guard/cdk/testing.d.ts
@@ -130,6 +130,7 @@ export interface TestElement {
     isFocused(): Promise<boolean>;
     matchesSelector(selector: string): Promise<boolean>;
     mouseAway(): Promise<void>;
+    selectOptions?(...optionIndexes: number[]): Promise<void>;
     sendKeys(...keys: (string | TestKey)[]): Promise<void>;
     sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
     setInputValue?(value: string): Promise<void>;

--- a/tools/public_api_guard/cdk/testing/protractor.d.ts
+++ b/tools/public_api_guard/cdk/testing/protractor.d.ts
@@ -14,6 +14,7 @@ export declare class ProtractorElement implements TestElement {
     isFocused(): Promise<boolean>;
     matchesSelector(selector: string): Promise<boolean>;
     mouseAway(): Promise<void>;
+    selectOptions(...optionIndexes: number[]): Promise<void>;
     sendKeys(...keys: (string | TestKey)[]): Promise<void>;
     sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
     setInputValue(value: string): Promise<void>;

--- a/tools/public_api_guard/cdk/testing/testbed.d.ts
+++ b/tools/public_api_guard/cdk/testing/testbed.d.ts
@@ -31,6 +31,7 @@ export declare class UnitTestElement implements TestElement {
     isFocused(): Promise<boolean>;
     matchesSelector(selector: string): Promise<boolean>;
     mouseAway(): Promise<void>;
+    selectOptions(...optionIndexes: number[]): Promise<void>;
     sendKeys(...keys: (string | TestKey)[]): Promise<void>;
     sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
     setInputValue(value: string): Promise<void>;

--- a/tools/public_api_guard/material/input/testing.d.ts
+++ b/tools/public_api_guard/material/input/testing.d.ts
@@ -19,3 +19,36 @@ export declare class MatInputHarness extends MatFormFieldControlHarness {
     static hostSelector: string;
     static with(options?: InputHarnessFilters): HarnessPredicate<MatInputHarness>;
 }
+
+export declare class MatNativeOptionHarness extends ComponentHarness {
+    getIndex(): Promise<number>;
+    getText(): Promise<string>;
+    isDisabled(): Promise<boolean>;
+    isSelected(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: NativeOptionHarnessFilters): HarnessPredicate<MatNativeOptionHarness>;
+}
+
+export declare class MatNativeSelectHarness extends MatFormFieldControlHarness {
+    blur(): Promise<void>;
+    focus(): Promise<void>;
+    getId(): Promise<string>;
+    getName(): Promise<string>;
+    getOptions(filter?: NativeOptionHarnessFilters): Promise<MatNativeOptionHarness[]>;
+    isDisabled(): Promise<boolean>;
+    isFocused(): Promise<boolean>;
+    isMultiple(): Promise<boolean>;
+    isRequired(): Promise<boolean>;
+    selectOptions(filter?: NativeOptionHarnessFilters): Promise<void>;
+    static hostSelector: string;
+    static with(options?: NativeSelectHarnessFilters): HarnessPredicate<MatNativeSelectHarness>;
+}
+
+export interface NativeOptionHarnessFilters extends BaseHarnessFilters {
+    index?: number;
+    isSelected?: boolean;
+    text?: string | RegExp;
+}
+
+export interface NativeSelectHarnessFilters extends BaseHarnessFilters {
+}


### PR DESCRIPTION
For more info, look at the individual commits. Here's an overview:

* Adds a `selectOptions` method to `TestElement` that allows us to select options within a native `select`. The method is limited to working with indexes, because of some issues with `@angular/forms` that prevent us from using values for the DOM lookup.
* Adds the `MatNativeSelectHarness` and `MatNativeOptionHarness` that are used to work with a `select`, marked with `matNativeControl` inside a `mat-form-field`.

Fixes #20005.