### PR TITLE
feat(material-experimental): bump peer dependency to MDC v8.0.0 canary

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -2,7 +2,7 @@
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
 ANGULAR_PACKAGE_VERSION = "^10.0.0 || ^11.0.0-0"
-MDC_PACKAGE_VERSION = "^6.0.0-canary.265ecbad5.0"
+MDC_PACKAGE_VERSION = "^8.0.0-canary.911014711.0"
 TSLIB_PACKAGE_VERSION = "^2.0.0"
 
 VERSION_PLACEHOLDER_REPLACEMENTS = {


### PR DESCRIPTION
We've been using the MDC v8.0.0 canary version pipeline for quite
a while now, but our peer dependency was left on v6.0.0. This commit
updates the peer dependency to the current version we use for
development of the experimental MDC components. We cannot guarantee
compatibility with the older canary versions of MDC as there have
been quite a lot of changes and we actively develop with the most
recent canary versions.

Note that the peer dependency can quickly become outdated, but
it's better being on the correct major at least.

**Note**: Marked as `feat` so that it shows up in the changelog as it might
be useful for the experimental package.