### PR TITLE
fix(material/list/testing): avoid element selectors that could conflict with the MDC version

### DIFF
--- a/src/material/list/testing/action-list-harness.ts
+++ b/src/material/list/testing/action-list-harness.ts
@@ -33,9 +33,7 @@ export class MatActionListHarness extends MatListHarnessBase<
 /** Harness for interacting with an action list item. */
 export class MatActionListItemHarness extends MatListItemHarnessBase {
   /** The selector for the host element of a `MatListItem` instance. */
-  static hostSelector = ['mat-list-item', 'a[mat-list-item]', 'button[mat-list-item]']
-      .map(selector => `${MatActionListHarness.hostSelector} ${selector}`)
-      .join(',');
+  static hostSelector = `${MatActionListHarness.hostSelector} .mat-list-item`;
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatActionListItemHarness` that

--- a/src/material/list/testing/list-harness.ts
+++ b/src/material/list/testing/list-harness.ts
@@ -15,7 +15,7 @@ import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-
 export class MatListHarness extends
     MatListHarnessBase<typeof MatListItemHarness, MatListItemHarness, ListItemHarnessFilters> {
   /** The selector for the host element of a `MatList` instance. */
-  static hostSelector = '.mat-list:not(mat-action-list):not(mat-nav-list):not(mat-selection-list)';
+  static hostSelector = '.mat-list:not(mat-action-list)';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatListHarness` that meets certain
@@ -33,9 +33,7 @@ export class MatListHarness extends
 /** Harness for interacting with a list item. */
 export class MatListItemHarness extends MatListItemHarnessBase {
   /** The selector for the host element of a `MatListItem` instance. */
-  static hostSelector = ['mat-list-item', 'a[mat-list-item]', 'button[mat-list-item]']
-      .map(selector => `${MatListHarness.hostSelector} ${selector}`)
-      .join(',');
+  static hostSelector = `${MatListHarness.hostSelector} .mat-list-item`;
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatListItemHarness` that meets

--- a/src/material/list/testing/list-item-harness-base.ts
+++ b/src/material/list/testing/list-item-harness-base.ts
@@ -51,9 +51,9 @@ export class MatSubheaderHarness extends ComponentHarness {
  * @docs-private
  */
 export class MatListItemHarnessBase extends ComponentHarness {
-  private _lines = this.locatorForAll('[mat-line], [matLine]');
-  private _avatar = this.locatorForOptional('[mat-list-avatar], [matListAvatar]');
-  private _icon = this.locatorForOptional('[mat-list-icon], [matListIcon]');
+  private _lines = this.locatorForAll('.mat-line');
+  private _avatar = this.locatorForOptional('.mat-list-avatar');
+  private _icon = this.locatorForOptional('.mat-list-icon');
 
   /** Gets the full text content of the list item (including text from any font icons). */
   async getText(): Promise<string> {

--- a/src/material/list/testing/nav-list-harness.ts
+++ b/src/material/list/testing/nav-list-harness.ts
@@ -33,9 +33,7 @@ export class MatNavListHarness extends MatListHarnessBase<
 /** Harness for interacting with a nav list item. */
 export class MatNavListItemHarness extends MatListItemHarnessBase {
   /** The selector for the host element of a `MatListItem` instance. */
-  static hostSelector = ['mat-list-item', 'a[mat-list-item]', 'button[mat-list-item]']
-      .map(selector => `${MatNavListHarness.hostSelector} ${selector}`)
-      .join(',');
+  static hostSelector = `${MatNavListHarness.hostSelector} .mat-list-item`;
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatNavListItemHarness` that


### PR DESCRIPTION
Simplifies the harness CSS selectors for list items. They currently are built up based on element
types but could be just using the list-item class that is applied automatically by the component.

Also removes a few of the unnecessary `:not` selectors for the standard `MatList` harness.