### PR TITLE
feat(cdk/drag-drop): custom drag clone target

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -4255,6 +4255,44 @@ describe('CdkDrag', () => {
       expect(spy).not.toHaveBeenCalled();
     }));
 
+    it('should clone the CDK Drag to preview container (via template ref)', () => {
+      const fixture = createComponent(DraggableInDropZoneWithCustomDragPreviewContainerTemplateRef);
+      fixture.detectChanges();
+      const item = fixture.componentInstance.dragItems.toArray()[1].element.nativeElement;
+
+      startDraggingViaMouse(fixture, item);
+
+      const preview = document.querySelector('.cdk-drag-preview')! as HTMLElement;
+      const previewContainer = document.querySelector('#preview-container')! as HTMLElement;
+
+      expect(preview.parentNode).toBe(previewContainer);
+    });
+
+    it('should clone the CDK Drag to preview container (via element ref)', () => {
+      const fixture = createComponent(DraggableInDropZoneWithCustomDragPreviewContainerElementRef);
+      fixture.detectChanges();
+      const item = fixture.componentInstance.dragItems.toArray()[1].element.nativeElement;
+
+      startDraggingViaMouse(fixture, item);
+
+      const preview = document.querySelector('.cdk-drag-preview')! as HTMLElement;
+      expect(preview.parentNode)
+        .toBe(fixture.componentInstance.previewContainerElementRef.nativeElement);
+    });
+
+    it('should clone the CDK Drag to <body> (global)', () => {
+      const fixture = createComponent(DraggableInDropZoneWithCustomDragPreviewContainerString);
+      fixture.componentInstance.previewContainer = 'global';
+      fixture.detectChanges();
+      const item = fixture.componentInstance.dragItems.toArray()[1].element.nativeElement;
+
+      startDraggingViaMouse(fixture, item);
+      const previewContainer = document.querySelector('body')! as HTMLElement;
+
+      const preview = document.querySelector('.cdk-drag-preview')! as HTMLElement;
+      expect(preview.parentNode).toBe(previewContainer);
+    });
+
     it('should throw if drop list is attached to an ng-container', fakeAsync(() => {
       expect(() => {
         createComponent(DropListOnNgContainer).detectChanges();
@@ -5934,6 +5972,59 @@ class DraggableInDropZoneWithCustomPreview {
   constrainPosition: (point: Point) => Point;
 }
 
+@Component({
+  template: `
+    <div cdkDropList style="width: 100px; background: pink;">
+      <div *ngFor="let item of items" cdkDrag [cdkDragPreviewContainer]="previewContainer"
+        style="width: 100%; height: ${ITEM_HEIGHT}px; background: red;">
+          {{item}}
+          <ng-template cdkDragPlaceholder>Hello {{item}}</ng-template>
+      </div>
+    </div>
+    <div id="preview-container" #previewContainer></div>
+  `,
+})
+class DraggableInDropZoneWithCustomDragPreviewContainerTemplateRef {
+  @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
+  items = ['Zero', 'One', 'Two', 'Three'];
+}
+
+@Component({
+  template: `
+    <div cdkDropList style="width: 100px; background: pink;">
+      <div *ngFor="let item of items" cdkDrag [cdkDragPreviewContainer]="previewContainer"
+        style="width: 100%; height: ${ITEM_HEIGHT}px; background: red;">
+          {{item}}
+          <ng-template cdkDragPlaceholder>Hello {{item}}</ng-template>
+      </div>
+    </div>
+    <div id="preview-container" #previewContainer></div>
+  `,
+})
+class DraggableInDropZoneWithCustomDragPreviewContainerElementRef {
+  @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
+  @ViewChild('previewContainer') previewContainerElementRef: ElementRef<HTMLDivElement>;
+  items = ['Zero', 'One', 'Two', 'Three'];
+}
+
+@Component({
+  template: `
+    <div id="preview-container">
+      <div cdkDropList style="width: 100px; background: pink;">
+        <div *ngFor="let item of items" cdkDrag [cdkDragPreviewContainer]="previewContainer"
+          style="width: 100%; height: ${ITEM_HEIGHT}px; background: red;">
+          {{item}}
+            <ng-template cdkDragPlaceholder>Hello {{item}}</ng-template>
+        </div>
+      </div>
+    </div>
+  `,
+})
+class DraggableInDropZoneWithCustomDragPreviewContainerString {
+  @ViewChildren(CdkDrag) dragItems: QueryList<CdkDrag>;
+  previewContainer = 'global';
+  items = ['Zero', 'One', 'Two', 'Three'];
+}
 
 @Component({
   template: `

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -137,6 +137,22 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   /** Class to be added to the preview element. */
   @Input('cdkDragPreviewClass') previewClass: string | string[];
 
+  /**
+   *  Target for Drag Preview clone to append into.
+   *  `global` will place the clone at the end of `<body>`.
+   *  An `ElementRef` or `HTMLElement` will place the clone inside the element.
+   *
+   *  When `global` (default), the Drag Preview is appended to `<body>` to avoid
+   *  potential issues with `z-index` and `overflow: hidden`. By changing the
+   *  location you run risk of ancestors styled with `overflow: hidden` hiding part
+   *  or all of the Drag Preview, as well as other items styled with a higher
+   *  `z-index` overlapping the preview container.
+   *
+   *  Specifying the cdkDropList can lead to rendering performance issues.
+   */
+  @Input('cdkDragPreviewContainer') previewContainer:
+    'global' | ElementRef<HTMLElement> | HTMLElement;
+
   /** Emits when the user starts dragging the item. */
   @Output('cdkDragStarted') started: EventEmitter<CdkDragStart> = new EventEmitter<CdkDragStart>();
 
@@ -356,6 +372,20 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     return element;
   }
 
+  /**
+   *  Gets the element for the preview clone to be created in,
+   *  based on the `previewContainer` value.
+   */
+  private _getPreviewContainer(): HTMLElement | ElementRef<HTMLElement> | null {
+    const cloneTarget = this.previewContainer;
+
+    if (!cloneTarget || cloneTarget === 'global') {
+      return null;
+    }
+
+    return cloneTarget;
+  }
+
   /** Syncs the inputs of the CdkDrag with the options of the underlying DragRef. */
   private _syncInputs(ref: DragRef<CdkDrag<T>>) {
     ref.beforeStarted.subscribe(() => {
@@ -383,7 +413,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
         ref
           .withBoundaryElement(this._getBoundaryElement())
           .withPlaceholderTemplate(placeholder)
-          .withPreviewTemplate(preview);
+          .withPreviewTemplate(preview)
+          .withPreviewContainer(this._getPreviewContainer());
 
         if (dir) {
           ref.withDirection(dir.value);

--- a/src/cdk/drag-drop/drag-drop.md
+++ b/src/cdk/drag-drop/drag-drop.md
@@ -136,6 +136,16 @@ directive:
 
 <!-- example(cdk-drag-drop-custom-placeholder) -->
 
+### Customizing the drag preview container
+When a `cdkDrag` element is picked up, it will create a preview element which is appended to
+the end of `<body>`. There may be times when you need to have the preview created elsewhere.
+
+This can be configured using the `cdkDragPreviewContainer` input.
+Passing `global` will respect the default behavior and the preview will be appended to `<body>`.
+You can also pass in `ElementRef` for finer control.
+
+<!-- example(cdk-drag-drop-custom-preview-container) -->
+
 ### List orientation
 The `cdkDropList` directive assumes that lists are vertical by default. This can be
 changed by setting the `orientation` property to `"horizontal".

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -227,6 +227,9 @@ export class DragRef<T = any> {
   /** Layout direction of the item. */
   private _direction: Direction = 'ltr';
 
+  /** Location for preview clone to append into */
+  private _previewContainer: HTMLElement | null;
+
   /** Axis along which dragging is locked. */
   lockAxis: 'x' | 'y';
 
@@ -375,6 +378,15 @@ export class DragRef<T = any> {
    */
   withPlaceholderTemplate(template: DragHelperTemplate | null): this {
     this._placeholderTemplate = template;
+    return this;
+  }
+
+  /**
+   * Registers the element which the drag template is to be cloned into.
+   * @param previewContainer Element which the drag template is to be cloned into
+   */
+  withPreviewContainer(previewContainer: HTMLElement | ElementRef<HTMLElement> | null): this {
+    this._previewContainer = previewContainer ? coerceElement<HTMLElement>(previewContainer) : null;
     return this;
   }
 
@@ -740,9 +752,9 @@ export class DragRef<T = any> {
       const element = this._rootElement;
       const parent = element.parentNode!;
       const preview = this._preview = this._createPreviewElement();
+      const previewContainer = this._previewContainer || getPreviewInsertionPoint(this._document);
       const placeholder = this._placeholder = this._createPlaceholderElement();
       const anchor = this._anchor = this._anchor || this._document.createComment('');
-
       // Insert an anchor node so that we can restore the element's position in the DOM.
       parent.insertBefore(anchor, element);
 
@@ -751,7 +763,7 @@ export class DragRef<T = any> {
       // from the DOM completely, because iOS will stop firing all subsequent events in the chain.
       toggleVisibility(element, false);
       this._document.body.appendChild(parent.replaceChild(placeholder, element));
-      getPreviewInsertionPoint(this._document).appendChild(preview);
+      previewContainer.appendChild(preview);
       this.started.next({source: this}); // Emit before notifying the container.
       dropContainer.start();
       this._initialContainer = dropContainer;

--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview-container/cdk-drag-drop-custom-preview-container-example.css
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview-container/cdk-drag-drop-custom-preview-container-example.css
@@ -1,0 +1,64 @@
+.example-list {
+  width: 500px;
+  max-width: 100%;
+  border: solid 1px #ccc;
+  min-height: 60px;
+  display: block;
+  background: white;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.example-box {
+  padding: 20px 10px;
+  border-bottom: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  cursor: move;
+  background: white;
+  font-size: 14px;
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+              0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.example-box:last-child {
+  border: none;
+}
+
+.example-list.cdk-drop-list-dragging .example-box:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.example-container {
+    width: 300px;
+    max-width: 100%;
+    margin: 0 25px 25px 0;
+    display: inline-block;
+    vertical-align: top;
+}
+
+.example-list-two .cdk-drag-dragging {
+    border: 1px solid #ccc;
+}
+
+.example-preview-container .cdk-drag-dragging {
+    border: 2px solid #ccc;
+}

--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview-container/cdk-drag-drop-custom-preview-container-example.html
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview-container/cdk-drag-drop-custom-preview-container-example.html
@@ -1,0 +1,17 @@
+<div class="example-container">
+  <div cdkDropList class="example-list example-list-one" (cdkDropListDropped)="drop(moviesOne, $event)">
+    <div class="example-box" *ngFor="let movie of moviesOne," cdkDrag cdkDragPreviewContainer="global">
+      {{movie.title}}
+    </div>
+  </div>
+</div>
+
+<div class="example-container">
+  <div cdkDropList class="example-list example-list-two" (cdkDropListDropped)="drop(moviesTwo, $event)">
+    <div class="example-box" *ngFor="let movie of moviesTwo," cdkDrag [cdkDragPreviewContainer]="previewContainer">
+      {{movie.title}}
+    </div>
+  </div>
+</div>
+
+<div class="example-preview-container" #previewContainer></div>

--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview-container/cdk-drag-drop-custom-preview-container-example.ts
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-preview-container/cdk-drag-drop-custom-preview-container-example.ts
@@ -1,0 +1,46 @@
+import {Component} from '@angular/core';
+import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
+
+/**
+ * @title Drag&Drop custom preview container example
+ */
+@Component({
+  selector: 'cdk-drag-drop-custom-preview-container-example',
+  templateUrl: 'cdk-drag-drop-custom-preview-container-example.html',
+  styleUrls: ['cdk-drag-drop-custom-preview-container-example.css'],
+})
+export class CdkDragDropCustomPreviewContainerExample {
+  moviesOne = [
+    {
+      title: 'Episode I - The Phantom Menace'
+    },
+    {
+      title: 'Episode II - Attack of the Clones'
+    },
+    {
+      title: 'Episode III - Revenge of the Sith'
+    },
+    {
+      title: 'Episode IV - A New Hope'
+    },
+  ];
+
+  moviesTwo = [
+    {
+      title: 'Episode V - The Empire Strikes Back'
+    },
+    {
+      title: 'Episode VI - Return of the Jedi'
+    },
+    {
+      title: 'Episode VII - The Force Awakens'
+    },
+    {
+      title: 'Episode VIII - The Last Jedi'
+    },
+  ];
+
+  drop(which: any[], event: CdkDragDrop<{title: string, poster: string}[]>) {
+    moveItemInArray(which, event.previousIndex, event.currentIndex);
+  }
+}

--- a/src/components-examples/cdk/drag-drop/index.ts
+++ b/src/components-examples/cdk/drag-drop/index.ts
@@ -18,6 +18,9 @@ import {
 import {
   CdkDragDropCustomPreviewExample
 } from './cdk-drag-drop-custom-preview/cdk-drag-drop-custom-preview-example';
+import {
+  CdkDragDropCustomPreviewContainerExample,
+} from './cdk-drag-drop-custom-preview-container/cdk-drag-drop-custom-preview-container-example';
 import {CdkDragDropDelayExample} from './cdk-drag-drop-delay/cdk-drag-drop-delay-example';
 import {
   CdkDragDropDisabledSortingExample
@@ -49,6 +52,7 @@ export {
   CdkDragDropConnectedSortingGroupExample,
   CdkDragDropCustomPlaceholderExample,
   CdkDragDropCustomPreviewExample,
+  CdkDragDropCustomPreviewContainerExample,
   CdkDragDropDelayExample,
   CdkDragDropDisabledExample,
   CdkDragDropDisabledSortingExample,
@@ -69,6 +73,7 @@ const EXAMPLES = [
   CdkDragDropConnectedSortingGroupExample,
   CdkDragDropCustomPlaceholderExample,
   CdkDragDropCustomPreviewExample,
+  CdkDragDropCustomPreviewContainerExample,
   CdkDragDropDelayExample,
   CdkDragDropDisabledExample,
   CdkDragDropDisabledSortingExample,

--- a/src/dev-app/drag-drop/drag-drop-demo.html
+++ b/src/dev-app/drag-drop/drag-drop-demo.html
@@ -7,7 +7,7 @@
       (cdkDropListDropped)="drop($event)"
       [cdkDropListLockAxis]="axisLock"
       [cdkDropListData]="todo">
-      <div *ngFor="let item of todo" cdkDrag>
+      <div *ngFor="let item of todo" cdkDrag [cdkDragPreviewContainer]="dragPreviewContainer">
         {{item}}
         <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
       </div>
@@ -21,7 +21,7 @@
       (cdkDropListDropped)="drop($event)"
       [cdkDropListLockAxis]="axisLock"
       [cdkDropListData]="done">
-      <div *ngFor="let item of done" cdkDrag>
+      <div *ngFor="let item of done" cdkDrag [cdkDragPreviewContainer]="dragPreviewContainer">
         {{item}}
         <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
       </div>
@@ -38,7 +38,7 @@
       (cdkDropListDropped)="drop($event)"
       [cdkDropListLockAxis]="axisLock"
       [cdkDropListData]="ages">
-      <div *ngFor="let item of ages" cdkDrag>
+      <div *ngFor="let item of ages" cdkDrag [cdkDragPreviewContainer]="dragPreviewContainer">
         {{item}}
         <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
       </div>
@@ -53,7 +53,7 @@
       (cdkDropListDropped)="drop($event)"
       [cdkDropListLockAxis]="axisLock"
       [cdkDropListData]="preferredAges">
-      <div *ngFor="let item of preferredAges" cdkDrag>
+      <div *ngFor="let item of preferredAges" cdkDrag [cdkDragPreviewContainer]="dragPreviewContainer">
         {{item}}
         <mat-icon cdkDragHandle svgIcon="dnd-move"></mat-icon>
       </div>
@@ -65,6 +65,8 @@
   <h2>Free dragging</h2>
   <div cdkDrag class="demo-free-draggable" [cdkDragLockAxis]="axisLock" [cdkDragStartDelay]="dragStartDelay">Drag me around</div>
 </div>
+
+<div class="demo-preview-container" #previewContainer></div>
 
 <div>
   <h2>Data</h2>
@@ -82,6 +84,18 @@
       <mat-option>None</mat-option>
       <mat-option value="x">X axis</mat-option>
       <mat-option value="y">Y axis</mat-option>
+    </mat-select>
+  </mat-form-field>
+</div>
+
+<div>
+  <h2>Drag Preview Container</h2>
+  <mat-form-field>
+    <mat-label>Drag preview should clone into</mat-label>
+    <mat-select [(ngModel)]="dragPreviewContainer">
+      <mat-option value="global">Global</mat-option>
+      <mat-option [value]="previewContainer">Preview Container (HTMLElement)</mat-option>
+      <mat-option [value]="previewContainerElementRef">Preview Container (ElementRef)</mat-option>
     </mat-select>
   </mat-form-field>
 </div>

--- a/src/dev-app/drag-drop/drag-drop-demo.scss
+++ b/src/dev-app/drag-drop/drag-drop-demo.scss
@@ -99,3 +99,11 @@ pre {
   justify-content: center;
   align-items: center;
 }
+
+.demo-preview-container .cdk-drag-preview {
+  border: 2px solid #3f51b5;
+}
+
+.demo-list .cdk-drag-preview {
+  border: 2px solid #607d8b;
+}

--- a/src/dev-app/drag-drop/drag-drop-demo.ts
+++ b/src/dev-app/drag-drop/drag-drop-demo.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ViewEncapsulation, ChangeDetectionStrategy} from '@angular/core';
+import {
+  Component,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+  ViewChild,
+  ElementRef
+} from '@angular/core';
 import {MatIconRegistry} from '@angular/material/icon';
 import {DomSanitizer} from '@angular/platform-browser';
 import {CdkDragDrop, moveItemInArray, transferArrayItem} from '@angular/cdk/drag-drop';
@@ -19,8 +25,10 @@ import {CdkDragDrop, moveItemInArray, transferArrayItem} from '@angular/cdk/drag
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DragAndDropDemo {
+  @ViewChild('previewContainer') previewContainerElementRef: ElementRef<HTMLDivElement>;
   axisLock: 'x' | 'y';
   dragStartDelay = 0;
+  dragPreviewContainer: 'global' | ElementRef<HTMLElement> | HTMLElement = 'global';
   todo = [
     'Go out for Lunch',
     'Make a cool app',

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -36,6 +36,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     lockAxis: DragAxis;
     moved: Observable<CdkDragMove<T>>;
     previewClass: string | string[];
+    previewContainer: 'global' | ElementRef<HTMLElement> | HTMLElement;
     released: EventEmitter<CdkDragRelease>;
     rootElementSelector: string;
     started: EventEmitter<CdkDragStart>;
@@ -54,7 +55,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     ngOnDestroy(): void;
     reset(): void;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { "data": "cdkDragData"; "lockAxis": "cdkDragLockAxis"; "rootElementSelector": "cdkDragRootElement"; "boundaryElement": "cdkDragBoundary"; "dragStartDelay": "cdkDragStartDelay"; "freeDragPosition": "cdkDragFreeDragPosition"; "disabled": "cdkDragDisabled"; "constrainPosition": "cdkDragConstrainPosition"; "previewClass": "cdkDragPreviewClass"; }, { "started": "cdkDragStarted"; "released": "cdkDragReleased"; "ended": "cdkDragEnded"; "entered": "cdkDragEntered"; "exited": "cdkDragExited"; "dropped": "cdkDragDropped"; "moved": "cdkDragMoved"; }, ["_previewTemplate", "_placeholderTemplate", "_handles"]>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { "data": "cdkDragData"; "lockAxis": "cdkDragLockAxis"; "rootElementSelector": "cdkDragRootElement"; "boundaryElement": "cdkDragBoundary"; "dragStartDelay": "cdkDragStartDelay"; "freeDragPosition": "cdkDragFreeDragPosition"; "disabled": "cdkDragDisabled"; "constrainPosition": "cdkDragConstrainPosition"; "previewClass": "cdkDragPreviewClass"; "previewContainer": "cdkDragPreviewContainer"; }, { "started": "cdkDragStarted"; "released": "cdkDragReleased"; "ended": "cdkDragEnded"; "entered": "cdkDragEntered"; "exited": "cdkDragExited"; "dropped": "cdkDragDropped"; "moved": "cdkDragMoved"; }, ["_previewTemplate", "_placeholderTemplate", "_handles"]>;
     static ɵfac: i0.ɵɵFactoryDef<CdkDrag<any>, [null, { optional: true; skipSelf: true; }, null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; self: true; }]>;
 }
 
@@ -315,6 +316,7 @@ export declare class DragRef<T = any> {
     withDirection(direction: Direction): this;
     withHandles(handles: (HTMLElement | ElementRef<HTMLElement>)[]): this;
     withPlaceholderTemplate(template: DragHelperTemplate | null): this;
+    withPreviewContainer(previewContainer: HTMLElement | ElementRef<HTMLElement> | null): this;
     withPreviewTemplate(template: DragPreviewTemplate | null): this;
     withRootElement(rootElement: ElementRef<HTMLElement> | HTMLElement): this;
 }


### PR DESCRIPTION
By default the drag directive clones the element it's applied to and appends to
the end of body. This change allows for a selector, HTML element, or an ElementRef
to be provided for the clone to be appended to instead.

Closes #20536 #13288 