### PR TITLE
refactor(bottom-sheet): remove deprecated APIs for v11

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/material/bottom-sheet/bottom-sheet-ref.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Location} from '@angular/common';
 import {ESCAPE, hasModifierKey} from '@angular/cdk/keycodes';
 import {OverlayRef} from '@angular/cdk/overlay';
 import {merge, Observable, Subject} from 'rxjs';
@@ -44,9 +43,7 @@ export class MatBottomSheetRef<T = any, R = any> {
 
   constructor(
     containerInstance: MatBottomSheetContainer,
-    private _overlayRef: OverlayRef,
-    // @breaking-change 8.0.0 `_location` parameter to be removed.
-    _location?: Location) {
+    private _overlayRef: OverlayRef) {
     this.containerInstance = containerInstance;
     this.disableClose = containerInstance.bottomSheetConfig.disableClose;
 

--- a/src/material/bottom-sheet/bottom-sheet.ts
+++ b/src/material/bottom-sheet/bottom-sheet.ts
@@ -21,7 +21,6 @@ import {
   OnDestroy,
   StaticProvider,
 } from '@angular/core';
-import {Location} from '@angular/common';
 import {of as observableOf} from 'rxjs';
 import {MAT_BOTTOM_SHEET_DATA, MatBottomSheetConfig} from './bottom-sheet-config';
 import {MatBottomSheetContainer} from './bottom-sheet-container';
@@ -58,7 +57,6 @@ export class MatBottomSheet implements OnDestroy {
       private _overlay: Overlay,
       private _injector: Injector,
       @Optional() @SkipSelf() private _parentBottomSheet: MatBottomSheet,
-      @Optional() private _location?: Location,
       @Optional() @Inject(MAT_BOTTOM_SHEET_DEFAULT_OPTIONS)
           private _defaultOptions?: MatBottomSheetConfig) {}
 
@@ -74,7 +72,7 @@ export class MatBottomSheet implements OnDestroy {
         _applyConfigDefaults(this._defaultOptions || new MatBottomSheetConfig(), config);
     const overlayRef = this._createOverlay(_config);
     const container = this._attachContainer(overlayRef, _config);
-    const ref = new MatBottomSheetRef<T, R>(container, overlayRef, this._location);
+    const ref = new MatBottomSheetRef<T, R>(container, overlayRef);
 
     if (componentOrTemplateRef instanceof TemplateRef) {
       container.attachTemplatePortal(new TemplatePortal<T>(componentOrTemplateRef, null!, {

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -22,6 +22,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/20449',
       changes: ['MatDatepickerContent']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/20545',
+      changes: ['MatBottomSheet', 'MatBottomSheetRef']
     }
   ],
   [TargetVersion.V10]: [

--- a/tools/public_api_guard/material/bottom-sheet.d.ts
+++ b/tools/public_api_guard/material/bottom-sheet.d.ts
@@ -5,12 +5,12 @@ export declare const MAT_BOTTOM_SHEET_DEFAULT_OPTIONS: InjectionToken<MatBottomS
 export declare class MatBottomSheet implements OnDestroy {
     get _openedBottomSheetRef(): MatBottomSheetRef<any> | null;
     set _openedBottomSheetRef(value: MatBottomSheetRef<any> | null);
-    constructor(_overlay: Overlay, _injector: Injector, _parentBottomSheet: MatBottomSheet, _location?: Location | undefined, _defaultOptions?: MatBottomSheetConfig<any> | undefined);
+    constructor(_overlay: Overlay, _injector: Injector, _parentBottomSheet: MatBottomSheet, _defaultOptions?: MatBottomSheetConfig<any> | undefined);
     dismiss<R = any>(result?: R): void;
     ngOnDestroy(): void;
     open<T, D = any, R = any>(component: ComponentType<T>, config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
     open<T, D = any, R = any>(template: TemplateRef<T>, config?: MatBottomSheetConfig<D>): MatBottomSheetRef<T, R>;
-    static ɵfac: i0.ɵɵFactoryDef<MatBottomSheet, [null, null, { optional: true; skipSelf: true; }, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatBottomSheet, [null, null, { optional: true; skipSelf: true; }, { optional: true; }]>;
     static ɵprov: i0.ɵɵInjectableDef<MatBottomSheet>;
 }
 
@@ -61,7 +61,7 @@ export declare class MatBottomSheetRef<T = any, R = any> {
     containerInstance: MatBottomSheetContainer;
     disableClose: boolean | undefined;
     instance: T;
-    constructor(containerInstance: MatBottomSheetContainer, _overlayRef: OverlayRef, _location?: Location);
+    constructor(containerInstance: MatBottomSheetContainer, _overlayRef: OverlayRef);
     afterDismissed(): Observable<R | undefined>;
     afterOpened(): Observable<void>;
     backdropClick(): Observable<MouseEvent>;


### PR DESCRIPTION
Removes the APIs that were marked as deprecated for v11.

BREAKING CHANGES:
* `_location` parameter has been removed from the `MatBottomSheet` constructor.
* `_location` parameter has been removed from the `MatBottomSheetRef` constructor.