### PR TITLE
build(dev-infra): update dev-infra version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@angular-devkit/core": "^10.0.5",
     "@angular-devkit/schematics": "^10.0.5",
     "@angular/bazel": "^10.1.0",
-    "@angular/benchpress": "^0.2.1",
+    "@angular/benchpress": "0.2.1",
     "@angular/compiler-cli": "^10.1.0",
     "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#0364a68f33191747a0bb7580e44a9ad6d50add10",
     "@angular/platform-browser-dynamic": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,7 +48,7 @@
     shelljs "0.8.2"
     tsickle "^0.38.0"
 
-"@angular/benchpress@0.2.1", "@angular/benchpress@^0.2.1":
+"@angular/benchpress@0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@angular/benchpress/-/benchpress-0.2.1.tgz#f8b58d9acfda0d29959b87dcb8082b1c33735db5"
   integrity sha512-ojHCP96ZunHBZpt08USSEdLJsuXnEEdJtfzl+9oTdMXbooKkzSVO7N6bVdjefbGRNAleAuSAo3gVrdPqumLznA==


### PR DESCRIPTION
* Update to the latest version to allow us to use the new
  default params set up for runBenchmark.