### PR TITLE
refactor(google-maps): remove deprecated APIs for v11

### DIFF
--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -19,7 +19,6 @@ import {
   OnInit,
   Output,
   ViewEncapsulation,
-  Optional,
   Inject,
   PLATFORM_ID,
   NgZone,
@@ -231,15 +230,9 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
   constructor(
     private readonly _elementRef: ElementRef,
     private _ngZone: NgZone,
-    /**
-     * @deprecated `platformId` parameter to become required.
-     * @breaking-change 10.0.0
-     */
-    @Optional() @Inject(PLATFORM_ID) platformId?: Object) {
+    @Inject(PLATFORM_ID) platformId: Object) {
 
-    // @breaking-change 10.0.0 Remove null check for `platformId`.
-    this._isBrowser =
-        platformId ? isPlatformBrowser(platformId) : typeof window === 'object' && !!window;
+    this._isBrowser = isPlatformBrowser(platformId);
 
     if (this._isBrowser) {
       const googleMapsWindow: GoogleMapsWindow = window;

--- a/src/google-maps/map-polyline/map-polyline.ts
+++ b/src/google-maps/map-polyline/map-polyline.ts
@@ -188,7 +188,6 @@ export class MapPolyline implements OnInit, OnDestroy {
    */
   getPath(): google.maps.MVCArray<google.maps.LatLng> {
     this._assertInitialized();
-    // @breaking-change 11.0.0 Make the return value nullable.
     return this.polyline.getPath();
   }
 

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -29,8 +29,7 @@ export declare class GoogleMap implements OnChanges, OnInit, OnDestroy {
     width: string | number | null;
     set zoom(zoom: number);
     zoomChanged: Observable<void>;
-    constructor(_elementRef: ElementRef, _ngZone: NgZone,
-    platformId?: Object);
+    constructor(_elementRef: ElementRef, _ngZone: NgZone, platformId: Object);
     fitBounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral, padding?: number | google.maps.Padding): void;
     getBounds(): google.maps.LatLngBounds | null;
     getCenter(): google.maps.LatLng;
@@ -48,7 +47,7 @@ export declare class GoogleMap implements OnChanges, OnInit, OnDestroy {
     panTo(latLng: google.maps.LatLng | google.maps.LatLngLiteral): void;
     panToBounds(latLngBounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral, padding?: number | google.maps.Padding): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<GoogleMap, "google-map", ["googleMap"], { "height": "height"; "width": "width"; "mapTypeId": "mapTypeId"; "center": "center"; "zoom": "zoom"; "options": "options"; }, { "boundsChanged": "boundsChanged"; "centerChanged": "centerChanged"; "mapClick": "mapClick"; "mapDblclick": "mapDblclick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "mapDragstart": "mapDragstart"; "headingChanged": "headingChanged"; "idle": "idle"; "maptypeidChanged": "maptypeidChanged"; "mapMousemove": "mapMousemove"; "mapMouseout": "mapMouseout"; "mapMouseover": "mapMouseover"; "projectionChanged": "projectionChanged"; "mapRightclick": "mapRightclick"; "tilesloaded": "tilesloaded"; "tiltChanged": "tiltChanged"; "zoomChanged": "zoomChanged"; }, never, ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDef<GoogleMap, [null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<GoogleMap, never>;
 }
 
 export declare class GoogleMapsModule {


### PR DESCRIPTION
Removes the APIs that have been marked as deprecated for v11 from the `google-maps` package.

BREAKING CHANGES:
* `platformId` parameter of the `GoogleMap` constructor is now required.