### PR TITLE
feat(material/tree): add getTreeStructure for tree harness

### DIFF
--- a/src/material/tree/testing/shared.spec.ts
+++ b/src/material/tree/testing/shared.spec.ts
@@ -100,7 +100,7 @@ export function runHarnessTests(
   it ('should correctly get tree structure', async () => {
     const trees = await loader.getAllHarnesses(treeHarness);
     const flatTree = trees[0];
-    expect(await flatTree.getTreeStructure()).toEqual(
+    expect(await flatTree.getStructureText()).toEqual(
       `Flat Group 1
 Flat Group 2`);
   });
@@ -108,7 +108,7 @@ Flat Group 2`);
   it('should correctly get tree structure', async () => {
     const trees = await loader.getAllHarnesses(treeHarness);
     const nestedTree = trees[1];
-    expect(await nestedTree.getTreeStructure()).toEqual(
+    expect(await nestedTree.getStructureText()).toEqual(
       `Nested Group 1
 \tNested Leaf 1.1
 \tNested Leaf 1.2

--- a/src/material/tree/testing/shared.spec.ts
+++ b/src/material/tree/testing/shared.spec.ts
@@ -100,32 +100,111 @@ export function runHarnessTests(
   it ('should correctly get tree structure', async () => {
     const trees = await loader.getAllHarnesses(treeHarness);
     const flatTree = trees[0];
-    expect(await flatTree.getStructureText()).toEqual(
-      `Flat Group 1
-Flat Group 2`);
+
+    expect(await flatTree.getTreeStructure()).toEqual({
+      children: [
+        {text: 'Flat Group 1'},
+        {text: 'Flat Group 2'}
+      ]
+    });
+
+    const firstGroup = (await flatTree.getNodes({text: /Flat Group 1/}))[0];
+    await firstGroup.expand();
+
+    expect(await flatTree.getTreeStructure()).toEqual({
+      children: [
+        {
+          text: 'Flat Group 1',
+          children: [
+            {text: 'Flat Leaf 1.1'},
+            {text: 'Flat Leaf 1.2'},
+            {text: 'Flat Leaf 1.3'}
+          ]
+        },
+        {text: 'Flat Group 2'}
+      ]
+    });
+
+    const secondGroup = (await flatTree.getNodes({text: /Flat Group 2/}))[0];
+    await secondGroup.expand();
+
+    expect(await flatTree.getTreeStructure()).toEqual({
+      children: [
+        {
+          text: 'Flat Group 1',
+          children: [
+            {text: 'Flat Leaf 1.1'},
+            {text: 'Flat Leaf 1.2'},
+            {text: 'Flat Leaf 1.3'}
+          ]
+        },
+        {
+          text: 'Flat Group 2',
+          children: [
+            {text: 'Flat Group 2.1'},
+          ]
+        }
+      ]
+    });
   });
 
   it('should correctly get tree structure', async () => {
     const trees = await loader.getAllHarnesses(treeHarness);
     const nestedTree = trees[1];
-    expect(await nestedTree.getStructureText()).toEqual(
-      `Nested Group 1
-\tNested Leaf 1.1
-\tNested Leaf 1.2
-\tNested Leaf 1.3
-Nested Group 2
-\tNested Group 2.1
-\t\tNested Leaf 2.1.1
-\t\tNested Leaf 2.1.2`);
+    expect(await nestedTree.getTreeStructure()).toEqual({
+      children: [
+        {text: 'Nested Group 1'},
+        {text: 'Nested Group 2'}
+      ]
+    });
+
+    const firstGroup = (await nestedTree.getNodes({text: /Nested Group 1/}))[0];
+    await firstGroup.expand();
+    expect(await nestedTree.getTreeStructure()).toEqual(
+      {
+        children: [
+          {
+            text: 'Nested Group 1',
+            children: [
+              {text: 'Nested Leaf 1.1'},
+              {text: 'Nested Leaf 1.2'},
+              {text: 'Nested Leaf 1.3'}
+            ]
+          },
+          {text: 'Nested Group 2'}
+        ]
+      });
+
+    const secondGroup = (await nestedTree.getNodes({text: /Nested Group 2/}))[0];
+    await secondGroup.expand();
+    expect(await nestedTree.getTreeStructure()).toEqual(
+      {
+        children: [
+          {
+            text: 'Nested Group 1',
+            children: [
+              {text: 'Nested Leaf 1.1'},
+              {text: 'Nested Leaf 1.2'},
+              {text: 'Nested Leaf 1.3'}
+            ]
+          },
+          {
+            text: 'Nested Group 2',
+            children: [
+              {text: 'Nested Group 2.1'},
+            ]
+          }
+        ]
+      });
   });
 }
 
-interface FoodNode {
+interface Node {
   name: string;
-  children?: FoodNode[];
+  children?: Node[];
 }
 
-const FLAT_TREE_DATA: FoodNode[] = [
+const FLAT_TREE_DATA: Node[] = [
   {
     name: 'Flat Group 1',
     children: [
@@ -148,7 +227,7 @@ const FLAT_TREE_DATA: FoodNode[] = [
   },
 ];
 
-const NESTED_TREE_DATA: FoodNode[] = [
+const NESTED_TREE_DATA: Node[] = [
   {
     name: 'Nested Group 1',
     children: [
@@ -210,7 +289,7 @@ interface ExampleFlatNode {
   `
 })
 class TreeHarnessTest {
-  private _transformer = (node: FoodNode, level: number) => {
+  private _transformer = (node: Node, level: number) => {
     return {
       expandable: !!node.children && node.children.length > 0,
       name: node.name,
@@ -223,8 +302,8 @@ class TreeHarnessTest {
   flatTreeControl = new FlatTreeControl<ExampleFlatNode>(
     node => node.level, node => node.expandable);
   flatTreeDataSource = new MatTreeFlatDataSource(this.flatTreeControl, this.treeFlattener);
-  nestedTreeControl = new NestedTreeControl<FoodNode>(node => node.children);
-  nestedTreeDataSource = new MatTreeNestedDataSource<FoodNode>();
+  nestedTreeControl = new NestedTreeControl<Node>(node => node.children);
+  nestedTreeDataSource = new MatTreeNestedDataSource<Node>();
 
   constructor() {
     this.flatTreeDataSource.data = FLAT_TREE_DATA;
@@ -233,5 +312,5 @@ class TreeHarnessTest {
 
   flatTreeHasChild = (_: number, node: ExampleFlatNode) => node.expandable;
 
-  nestedTreeHasChild = (_: number, node: FoodNode) => !!node.children && node.children.length > 0;
+  nestedTreeHasChild = (_: number, node: Node) => !!node.children && node.children.length > 0;
 }

--- a/src/material/tree/testing/shared.spec.ts
+++ b/src/material/tree/testing/shared.spec.ts
@@ -96,6 +96,28 @@ export function runHarnessTests(
     // no-op if already collapsed
     expect(await firstGroup.isExpanded()).toBe(false);
   });
+
+  it ('should correctly get tree structure', async () => {
+    const trees = await loader.getAllHarnesses(treeHarness);
+    const flatTree = trees[0];
+    expect(await flatTree.getTreeStructure()).toEqual(
+      `Flat Group 1
+Flat Group 2`);
+  });
+
+  it('should correctly get tree structure', async () => {
+    const trees = await loader.getAllHarnesses(treeHarness);
+    const nestedTree = trees[1];
+    expect(await nestedTree.getTreeStructure()).toEqual(
+      `Nested Group 1
+\tNested Leaf 1.1
+\tNested Leaf 1.2
+\tNested Leaf 1.3
+Nested Group 2
+\tNested Group 2.1
+\t\tNested Leaf 2.1.1
+\t\tNested Leaf 2.1.2`);
+  });
 }
 
 interface FoodNode {

--- a/src/material/tree/testing/tree-harness.ts
+++ b/src/material/tree/testing/tree-harness.ts
@@ -28,4 +28,17 @@ export class MatTreeHarness extends ComponentHarness {
   async getNodes(filter: TreeNodeHarnessFilters = {}): Promise<MatTreeNodeHarness[]> {
     return this.locatorForAll(MatTreeNodeHarness.with(filter))();
   }
+
+  async getTreeStructure(): Promise<string> {
+    let treeString = '';
+    const nodes = await this.getNodes();
+    for (let i = 0; i < nodes.length; i++) {
+      treeString += i === 0 ? '' : '\n';
+      const node = nodes[i];
+      const level = await node.getLevel();
+      treeString += '\t'.repeat(level - 1);
+      treeString += await node.getText();
+    }
+    return treeString;
+  }
 }

--- a/src/material/tree/testing/tree-harness.ts
+++ b/src/material/tree/testing/tree-harness.ts
@@ -29,15 +29,45 @@ export class MatTreeHarness extends ComponentHarness {
     return this.locatorForAll(MatTreeNodeHarness.with(filter))();
   }
 
-  async getTreeStructure(): Promise<string> {
+  /**
+   * String representation of the tree structure.
+   * Eg.
+   * Tree:
+   * `
+   * <mat-tree>
+   *   <mat-tree-node>Node 1<mat-tree-node>
+   *   <mat-nested-tree-node>
+   *     Node 2
+   *     <mat-nested-tree-node>
+   *       Node 2.1
+   *       <mat-tree-node>
+   *         Node 2.1.1
+   *       <mat-tree-node>
+   *     <mat-nested-tree-node>
+   *     <mat-tree-node>
+   *       Node 2.2
+   *     <mat-tree-node>
+   *   <mat-nested-tree-node>
+   * </mat-tree>`
+   *
+   * Structured text:
+   * Node 1
+   * Node 2
+   *   Node 2.1
+   *     Node 2.1.1
+   *   Node 2.2
+   */
+  async getStructureText(): Promise<string> {
     let treeString = '';
     const nodes = await this.getNodes();
+    const levelsAndText = await Promise.all(nodes.map(node => {
+      return Promise.all([node.getLevel(), node.getText()]);
+    }));
     for (let i = 0; i < nodes.length; i++) {
+      const [level, text] = levelsAndText[i];
       treeString += i === 0 ? '' : '\n';
-      const node = nodes[i];
-      const level = await node.getLevel();
       treeString += '\t'.repeat(level - 1);
-      treeString += await node.getText();
+      treeString += text;
     }
     return treeString;
   }

--- a/tools/public_api_guard/material/tree/testing.d.ts
+++ b/tools/public_api_guard/material/tree/testing.d.ts
@@ -1,5 +1,6 @@
 export declare class MatTreeHarness extends ComponentHarness {
     getNodes(filter?: TreeNodeHarnessFilters): Promise<MatTreeNodeHarness[]>;
+    getTreeStructure(): Promise<string>;
     static hostSelector: string;
     static with(options?: TreeHarnessFilters): HarnessPredicate<MatTreeHarness>;
 }

--- a/tools/public_api_guard/material/tree/testing.d.ts
+++ b/tools/public_api_guard/material/tree/testing.d.ts
@@ -1,6 +1,6 @@
 export declare class MatTreeHarness extends ComponentHarness {
     getNodes(filter?: TreeNodeHarnessFilters): Promise<MatTreeNodeHarness[]>;
-    getTreeStructure(): Promise<string>;
+    getTreeStructure(): Promise<TextTree>;
     static hostSelector: string;
     static with(options?: TreeHarnessFilters): HarnessPredicate<MatTreeHarness>;
 }
@@ -17,6 +17,11 @@ export declare class MatTreeNodeHarness extends ComponentHarness {
     static hostSelector: string;
     static with(options?: TreeNodeHarnessFilters): HarnessPredicate<MatTreeNodeHarness>;
 }
+
+export declare type TextTree = {
+    text?: string;
+    children?: TextTree[];
+};
 
 export interface TreeHarnessFilters extends BaseHarnessFilters {
 }


### PR DESCRIPTION
Add a "pretty print" method for the tree harness.
The method is only available at the tree/root level because it is not possible to get children of flat nodes as they are siblings in the DOM.