### PR TITLE
refactor(cdk/tree): remove deprecated APIs for v11

### DIFF
--- a/src/cdk/schematics/ng-update/data/constructor-checks.ts
+++ b/src/cdk/schematics/ng-update/data/constructor-checks.ts
@@ -25,6 +25,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/20500',
       changes: ['CdkDropList']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/20572',
+      changes: ['CdkTreeNodePadding']
     }
   ],
   [TargetVersion.V10]: [

--- a/src/cdk/tree/padding.ts
+++ b/src/cdk/tree/padding.ts
@@ -8,7 +8,7 @@
 
 import {Directionality} from '@angular/cdk/bidi';
 import {coerceNumberProperty, NumberInput} from '@angular/cdk/coercion';
-import {Directive, ElementRef, Input, OnDestroy, Optional, Renderer2} from '@angular/core';
+import {Directive, ElementRef, Input, OnDestroy, Optional} from '@angular/core';
 import {takeUntil} from 'rxjs/operators';
 import {Subject} from 'rxjs';
 import {CdkTree, CdkTreeNode} from './tree';
@@ -50,11 +50,6 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
 
   constructor(private _treeNode: CdkTreeNode<T>,
               private _tree: CdkTree<T>,
-              /**
-               * @deprecated _renderer parameter no longer being used. To be removed.
-               * @breaking-change 11.0.0
-               */
-              _renderer: Renderer2,
               private _element: ElementRef<HTMLElement>,
               @Optional() private _dir: Directionality) {
     this._setPadding();

--- a/tools/public_api_guard/cdk/tree.d.ts
+++ b/tools/public_api_guard/cdk/tree.d.ts
@@ -120,8 +120,7 @@ export declare class CdkTreeNodePadding<T> implements OnDestroy {
     indentUnits: string;
     get level(): number;
     set level(value: number);
-    constructor(_treeNode: CdkTreeNode<T>, _tree: CdkTree<T>,
-    _renderer: Renderer2, _element: ElementRef<HTMLElement>, _dir: Directionality);
+    constructor(_treeNode: CdkTreeNode<T>, _tree: CdkTree<T>, _element: ElementRef<HTMLElement>, _dir: Directionality);
     _paddingIndent(): string | null;
     protected _setIndentInput(indent: number | string): void;
     protected _setLevelInput(value: number): void;
@@ -129,7 +128,7 @@ export declare class CdkTreeNodePadding<T> implements OnDestroy {
     ngOnDestroy(): void;
     static ngAcceptInputType_level: NumberInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkTreeNodePadding<any>, "[cdkTreeNodePadding]", never, { "level": "cdkTreeNodePadding"; "indent": "cdkTreeNodePaddingIndent"; }, {}, never>;
-    static ɵfac: i0.ɵɵFactoryDef<CdkTreeNodePadding<any>, [null, null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<CdkTreeNodePadding<any>, [null, null, null, { optional: true; }]>;
 }
 
 export declare class CdkTreeNodeToggle<T> {


### PR DESCRIPTION
Removes the APIs that were marked as deprecated for v11 in the tree module.

BREAKING CHANGES:
* `_renderer` parameter of the `CdkTreeNodePadding` constructor has been removed.