### PR TITLE
Fix dialog bottomsheet docs

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -58,7 +58,7 @@ your bottom sheet content component.
 Any components that are include inside of a bottom sheet have to be added to the `entryComponents`
 inside your `NgModule`
 when using the older compiler and runtime known as View Engine.
-`entryComponents` is redundant when using Ivy which is new compilation and rendering pipeline for Angular.
+`entryComponents` is redundant when using Ivy which is the new compilation and rendering pipeline for Angular. Ivy is used by default.
 
 
 ```ts

--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -49,6 +49,39 @@ export class HobbitSheet {
 }
 ```
 
+### Configuring bottom sheet content via `entryComponents`
+
+Similarly to `MatDialog`, `MatBottomSheet` instantiates components at run-time. In order for it to
+work, the Angular compiler needs extra information to create the necessary `ComponentFactory` for
+your bottom sheet content component.
+
+Any components that are include inside of a bottom sheet have to be added to the `entryComponents`
+inside your `NgModule`
+when using the older compiler and runtime known as View Engine.
+`entryComponents` is redundant when using Ivy which is new compilation and rendering pipeline for Angular.
+
+
+```ts
+@NgModule({
+  imports: [
+    // ...
+    MatBottomSheetModule
+  ],
+
+  declarations: [
+    AppComponent,
+    ExampleBottomSheetComponent
+  ],
+
+  entryComponents: [
+    ExampleBottomSheetComponent
+  ],
+
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
+```
+
 ### Specifying global configuration defaults
 Default bottom sheet options can be specified by providing an instance of `MatBottomSheetConfig`
 for `MAT_BOTTOM_SHEET_DEFAULT_OPTIONS` in your application's root module.

--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -49,37 +49,6 @@ export class HobbitSheet {
 }
 ```
 
-### Configuring bottom sheet content via `entryComponents`
-
-Similarly to `MatDialog`, `MatBottomSheet` instantiates components at run-time. In order for it to
-work, the Angular compiler needs extra information to create the necessary `ComponentFactory` for
-your bottom sheet content component.
-
-Any components that are include inside of a bottom sheet have to be added to the `entryComponents`
-inside your `NgModule`.
-
-
-```ts
-@NgModule({
-  imports: [
-    // ...
-    MatBottomSheetModule
-  ],
-
-  declarations: [
-    AppComponent,
-    ExampleBottomSheetComponent
-  ],
-
-  entryComponents: [
-    ExampleBottomSheetComponent
-  ],
-
-  bootstrap: [AppComponent]
-})
-export class AppModule {}
-```
-
 ### Specifying global configuration defaults
 Default bottom sheet options can be specified by providing an instance of `MatBottomSheetConfig`
 for `MAT_BOTTOM_SHEET_DEFAULT_OPTIONS` in your application's root module.

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -39,36 +39,6 @@ export class YourDialog {
 }
 ```
 
-### Configuring dialog content via `entryComponents`
-
-Because `MatDialog` instantiates components at run-time, the Angular compiler needs extra
-information to create the necessary `ComponentFactory` for your dialog content component.
-
-For any component loaded into a dialog, you must include your component class in the list of
-`entryComponents` in your NgModule definition so that the Angular compiler knows to create
-the `ComponentFactory` for it.
-
-```ts
-@NgModule({
-  imports: [
-    // ...
-    MatDialogModule
-  ],
-
-  declarations: [
-    AppComponent,
-    ExampleDialogComponent
-  ],
-
-  entryComponents: [
-    ExampleDialogComponent
-  ],
-
-  bootstrap: [AppComponent]
-})
-export class AppModule {}
-```
-
 ### Specifying global configuration defaults
 Default dialog options can be specified by providing an instance of `MatDialogConfig` for
 MAT_DIALOG_DEFAULT_OPTIONS in your application's root module.

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -39,6 +39,38 @@ export class YourDialog {
 }
 ```
 
+### Configuring dialog content via `entryComponents`
+
+Because `MatDialog` instantiates components at run-time, the Angular compiler needs extra
+information to create the necessary `ComponentFactory` for your dialog content component.
+
+For any component loaded into a dialog, you must include your component class in the list of
+`entryComponents` in your NgModule definition so that the Angular compiler knows to create
+the `ComponentFactory` for it. 
+This is only necessary when using the older compiler and runtime known as View Engine.
+`entryComponents` is redundant when using Ivy which is new compilation and rendering pipeline for Angular.
+
+```ts
+@NgModule({
+  imports: [
+    // ...
+    MatDialogModule
+  ],
+
+  declarations: [
+    AppComponent,
+    ExampleDialogComponent
+  ],
+
+  entryComponents: [
+    ExampleDialogComponent
+  ],
+
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
+```
+
 ### Specifying global configuration defaults
 Default dialog options can be specified by providing an instance of `MatDialogConfig` for
 MAT_DIALOG_DEFAULT_OPTIONS in your application's root module.

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -48,7 +48,7 @@ For any component loaded into a dialog, you must include your component class in
 `entryComponents` in your NgModule definition so that the Angular compiler knows to create
 the `ComponentFactory` for it. 
 This is only necessary when using the older compiler and runtime known as View Engine.
-`entryComponents` is redundant when using Ivy which is new compilation and rendering pipeline for Angular.
+`entryComponents` is redundant when using Ivy which is the new compilation and rendering pipeline for Angular. Ivy is used by default.
 
 ```ts
 @NgModule({


### PR DESCRIPTION
Docs now reflect that entryComponents is redundant with Ivy, but is still required by ViewEngine. Fixes #20574

