### PR TITLE
refactor(material/sidenav): undeprecate constructor signature

### DIFF
--- a/src/material/sidenav/drawer.ts
+++ b/src/material/sidenav/drawer.ts
@@ -263,10 +263,6 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
               private _platform: Platform,
               private _ngZone: NgZone,
               @Optional() @Inject(DOCUMENT) private _doc: any,
-              /**
-               * @deprecated `_container` parameter to be made required.
-               * @breaking-change 10.0.0
-               */
               @Optional() @Inject(MAT_DRAWER_CONTAINER) public _container?: MatDrawerContainer) {
 
     this.openedChange.subscribe((opened: boolean) => {
@@ -626,7 +622,6 @@ export class MatDrawerContainer implements AfterContentInit, DoCheck, OnDestroy 
     this._allDrawers.changes
       .pipe(startWith(this._allDrawers), takeUntil(this._destroyed))
       .subscribe((drawer: QueryList<MatDrawer>) => {
-        // @breaking-change 10.0.0 Remove `_container` check once container parameter is required.
         this._drawers.reset(drawer.filter(item => !item._container || item._container === this));
         this._drawers.notifyOnChanges();
       });

--- a/tools/public_api_guard/material/sidenav.d.ts
+++ b/tools/public_api_guard/material/sidenav.d.ts
@@ -24,8 +24,7 @@ export declare class MatDrawer implements AfterContentInit, AfterContentChecked,
     readonly openedStart: Observable<void>;
     get position(): 'start' | 'end';
     set position(value: 'start' | 'end');
-    constructor(_elementRef: ElementRef<HTMLElement>, _focusTrapFactory: FocusTrapFactory, _focusMonitor: FocusMonitor, _platform: Platform, _ngZone: NgZone, _doc: any,
-    _container?: MatDrawerContainer | undefined);
+    constructor(_elementRef: ElementRef<HTMLElement>, _focusTrapFactory: FocusTrapFactory, _focusMonitor: FocusMonitor, _platform: Platform, _ngZone: NgZone, _doc: any, _container?: MatDrawerContainer | undefined);
     _animationDoneListener(event: AnimationEvent): void;
     _animationStartListener(event: AnimationEvent): void;
     _closeViaBackdropClick(): Promise<MatDrawerToggleResult>;


### PR DESCRIPTION
Removes the deprecation labels from a constructor parameter since it's tricky to
sync into g3 and is easy to maintain on our end.