### PR TITLE
refactor(material/tree): change MatNodeHarness to extend ContentContainerComponentHarness

### DIFF
--- a/src/material/tree/testing/node-harness.ts
+++ b/src/material/tree/testing/node-harness.ts
@@ -7,15 +7,15 @@
  */
 
 import {
-  ComponentHarness,
   ComponentHarnessConstructor,
-  HarnessPredicate
+  ContentContainerComponentHarness,
+  HarnessPredicate,
 } from '@angular/cdk/testing';
 import {TreeNodeHarnessFilters} from './tree-harness-filters';
 import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
 
 /** Harness for interacting with a standard Angular Material tree node. */
-export class MatTreeNodeHarness extends ComponentHarness {
+export class MatTreeNodeHarness extends ContentContainerComponentHarness<string> {
   /** The selector of the host element of a `MatTreeNode` instance. */
   static hostSelector = '.mat-tree-node, .mat-nested-tree-node';
 

--- a/tools/public_api_guard/material/tree/testing.d.ts
+++ b/tools/public_api_guard/material/tree/testing.d.ts
@@ -4,7 +4,7 @@ export declare class MatTreeHarness extends ComponentHarness {
     static with(options?: TreeHarnessFilters): HarnessPredicate<MatTreeHarness>;
 }
 
-export declare class MatTreeNodeHarness extends ComponentHarness {
+export declare class MatTreeNodeHarness extends ContentContainerComponentHarness<string> {
     _toggle: import("@angular/cdk/testing").AsyncFactoryFn<import("@angular/cdk/testing").TestElement | null>;
     collapse(): Promise<void>;
     expand(): Promise<void>;


### PR DESCRIPTION
https://github.com/angular/components/pull/20556 switched some component harnesses to extend `ContentContainerComponentHarness` to allow users to query for harnesses inside the components but MatTreeHarness is not merged yet. 