### PR TITLE
feat(cdk/scrolling): update CdkVirtualForOf to work with sets.

### DIFF
--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -105,9 +105,9 @@ export class CdkVirtualForOf<T> implements
     if (isDataSource(value)) {
       this._dataSourceChanges.next(value);
     } else {
-      // Slice the value if its an NgIterable to ensure we're working with an array.
+      // If value is an an NgIterable, convert it to an array.
       this._dataSourceChanges.next(new ArrayDataSource<T>(
-          isObservable(value) ? value : Array.prototype.slice.call(value || [])));
+          isObservable(value) ? value : Array.from(value || [])));
     }
   }
 

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -444,7 +444,7 @@ describe('CdkVirtualScrollViewport', () => {
           .toBe(0, 'should render from first item');
     }));
 
-    it('should handle dynamic item array keeping position when possibile', fakeAsync(() => {
+    it('should handle dynamic item array keeping position when possible', fakeAsync(() => {
       testComponent.items = Array(100).fill(0);
       finishInit(fixture);
       triggerScroll(viewport, testComponent.itemSize * 50);
@@ -514,6 +514,15 @@ describe('CdkVirtualScrollViewport', () => {
             .toBe((expectedRange.end - expectedRange.start) * testComponent.itemSize,
                 `rendered content size should match expected value at offset ${offset}`);
       }
+    }));
+
+    it('should work with a Set', fakeAsync(() => {
+      const data = new Set(['hello', 'world', 'how', 'are', 'you']);
+      testComponent.items = data as any;
+      finishInit(fixture);
+
+      expect(viewport.getRenderedRange())
+          .toEqual({start: 0, end: 4}, 'newly emitted items should be rendered');
     }));
 
     it('should work with an Observable', fakeAsync(() => {


### PR DESCRIPTION
The previous usage of `Array.prototype.slice.call` does not handle `Set`
objects appropriately (since a `Set` does not have a `length` property).
Updated it to use `Array.from`.

Fixes #20210.