### PR TITLE
feat(material-experimental/mdc-paginator): implement MDC-based paginator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,7 @@
 /src/material-experimental/mdc-list/**             @mmalerba @devversion
 /src/material-experimental/mdc-menu/**             @crisbeto
 /src/material-experimental/mdc-select/**           @crisbeto
+/src/material-experimental/mdc-paginator/**        @crisbeto
 /src/material-experimental/mdc-progress-spinner/** @andrewseguin
 /src/material-experimental/mdc-progress-bar/**     @andrewseguin
 /src/material-experimental/mdc-radio/**            @mmalerba
@@ -183,6 +184,7 @@
 /src/dev-app/mdc-input/**                          @devversion @mmalerba
 /src/dev-app/mdc-list/**                           @mmalerba
 /src/dev-app/mdc-menu/**                           @crisbeto
+/src/dev-app/mdc-paginator/**                      @crisbeto
 /src/dev-app/mdc-progress-bar/**                   @crisbeto
 /src/dev-app/mdc-progress-spinner/**               @annieyw @mmalerba
 /src/dev-app/mdc-radio/**                          @mmalerba

--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -52,6 +52,7 @@ export const commitMessage: CommitMessageConfig = {
     'material-experimental/mdc-input',
     'material-experimental/mdc-list',
     'material-experimental/mdc-menu',
+    'material-experimental/mdc-paginator',
     'material-experimental/mdc-progress-bar',
     'material-experimental/mdc-progress-spinner',
     'material-experimental/mdc-radio',

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -56,6 +56,7 @@ ng_module(
         "//src/dev-app/mdc-input",
         "//src/dev-app/mdc-list",
         "//src/dev-app/mdc-menu",
+        "//src/dev-app/mdc-paginator",
         "//src/dev-app/mdc-progress-bar",
         "//src/dev-app/mdc-progress-spinner",
         "//src/dev-app/mdc-radio",

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -91,6 +91,7 @@ export class DevAppLayout {
     {name: 'MDC List', route: '/mdc-list'},
     {name: 'MDC Menu', route: '/mdc-menu'},
     {name: 'MDC Radio', route: '/mdc-radio'},
+    {name: 'MDC Paginator', route: '/mdc-paginator'},
     {name: 'MDC Progress Bar', route: '/mdc-progress-bar'},
     {name: 'MDC Progress Spinner', route: '/mdc-progress-spinner'},
     {name: 'MDC Tabs', route: '/mdc-tabs'},

--- a/src/dev-app/dev-app/routes.ts
+++ b/src/dev-app/dev-app/routes.ts
@@ -90,6 +90,10 @@ export const DEV_APP_ROUTES: Routes = [
   {path: 'mdc-list', loadChildren: 'mdc-list/mdc-list-demo-module#MdcListDemoModule'},
   {path: 'mdc-menu', loadChildren: 'mdc-menu/mdc-menu-demo-module#MdcMenuDemoModule'},
   {
+    path: 'mdc-paginator',
+    loadChildren: 'mdc-paginator/mdc-paginator-demo-module#MdcPaginatorDemoModule'
+  },
+  {
     path: 'mdc-progress-spinner',
     loadChildren:
       'mdc-progress-spinner/mdc-progress-spinner-demo-module#MdcProgressSpinnerDemoModule'

--- a/src/dev-app/mdc-paginator/BUILD.bazel
+++ b/src/dev-app/mdc-paginator/BUILD.bazel
@@ -1,0 +1,26 @@
+load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "mdc-paginator",
+    srcs = glob(["**/*.ts"]),
+    assets = [
+        "mdc-paginator-demo.html",
+        ":mdc_paginator_demo_scss",
+    ],
+    deps = [
+        "//src/material-experimental/mdc-card",
+        "//src/material-experimental/mdc-form-field",
+        "//src/material-experimental/mdc-input",
+        "//src/material-experimental/mdc-paginator",
+        "//src/material-experimental/mdc-slide-toggle",
+        "@npm//@angular/forms",
+        "@npm//@angular/router",
+    ],
+)
+
+sass_binary(
+    name = "mdc_paginator_demo_scss",
+    src = "mdc-paginator-demo.scss",
+)

--- a/src/dev-app/mdc-paginator/mdc-paginator-demo-module.ts
+++ b/src/dev-app/mdc-paginator/mdc-paginator-demo-module.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatCardModule} from '@angular/material-experimental/mdc-card';
+import {MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
+import {MatInputModule} from '@angular/material-experimental/mdc-input';
+import {MatPaginatorModule} from '@angular/material-experimental/mdc-paginator';
+import {MatSlideToggleModule} from '@angular/material-experimental/mdc-slide-toggle';
+import {RouterModule} from '@angular/router';
+import {MdcPaginatorDemo} from './mdc-paginator-demo';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatPaginatorModule,
+    MatSlideToggleModule,
+    RouterModule.forChild([{path: '', component: MdcPaginatorDemo}]),
+  ],
+  declarations: [MdcPaginatorDemo],
+})
+export class MdcPaginatorDemoModule {
+}

--- a/src/dev-app/mdc-paginator/mdc-paginator-demo.html
+++ b/src/dev-app/mdc-paginator/mdc-paginator-demo.html
@@ -1,0 +1,42 @@
+<mat-card class="demo-section">
+  <h2>No inputs</h2>
+  <mat-paginator></mat-paginator>
+</mat-card>
+
+<mat-card class="demo-section">
+  <div class="demo-options">
+    <mat-form-field>
+      <mat-label>Length</mat-label>
+      <input matInput type="number" [(ngModel)]="length">
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>Page Size</mat-label>
+      <input matInput type="number" [(ngModel)]="pageSize">
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>Page Index</mat-label>
+      <input matInput type="number" [(ngModel)]="pageIndex">
+    </mat-form-field>
+
+    <mat-slide-toggle [(ngModel)]="hidePageSize">Hide page size</mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="showPageSizeOptions">Show multiple page size options</mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="showFirstLastButtons">Show first/last buttons</mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="disabled">Disabled</mat-slide-toggle>
+  </div>
+
+  <mat-paginator #paginator
+                 (page)="handlePageEvent($event)"
+                 [length]="length"
+                 [pageSize]="pageSize"
+                 [disabled]="disabled"
+                 [showFirstLastButtons]="showFirstLastButtons"
+                 [pageSizeOptions]="showPageSizeOptions ? pageSizeOptions : []"
+                 [hidePageSize]="hidePageSize"
+                 [pageIndex]="pageIndex">
+  </mat-paginator>
+
+  <div> Output event: {{pageEvent | json}} </div>
+  <div> getNumberOfPages: {{paginator.getNumberOfPages()}} </div>
+</mat-card>

--- a/src/dev-app/mdc-paginator/mdc-paginator-demo.scss
+++ b/src/dev-app/mdc-paginator/mdc-paginator-demo.scss
@@ -1,6 +1,7 @@
 .demo-section {
-  max-width: 500px;
+  max-width: 600px;
   margin-bottom: 24px;
+  padding: 16px;
   background: #efefef !important;
 
   & > * {
@@ -12,4 +13,8 @@
   display: flex;
   flex-direction: column;
   max-width: 300px;
+
+  .mat-mdc-slide-toggle {
+    margin-bottom: 8px;
+  }
 }

--- a/src/dev-app/mdc-paginator/mdc-paginator-demo.ts
+++ b/src/dev-app/mdc-paginator/mdc-paginator-demo.ts
@@ -7,14 +7,14 @@
  */
 
 import {Component} from '@angular/core';
-import {PageEvent} from '@angular/material/paginator';
+import {PageEvent} from '@angular/material-experimental/mdc-paginator';
 
 @Component({
-  selector: 'paginator-demo',
-  templateUrl: 'paginator-demo.html',
-  styleUrls: ['paginator-demo.css'],
+  selector: 'mdc-paginator-demo',
+  templateUrl: 'mdc-paginator-demo.html',
+  styleUrls: ['mdc-paginator-demo.css'],
 })
-export class PaginatorDemo {
+export class MdcPaginatorDemo {
   length = 50;
   pageSize = 10;
   pageIndex = 0;

--- a/src/material-experimental/config.bzl
+++ b/src/material-experimental/config.bzl
@@ -21,6 +21,7 @@ entryPoints = [
     "mdc-list",
     "mdc-menu",
     "mdc-menu/testing",
+    "mdc-paginator",
     "mdc-progress-bar",
     "mdc-progress-bar/testing",
     "mdc-progress-spinner",

--- a/src/material-experimental/mdc-paginator/BUILD.bazel
+++ b/src/material-experimental/mdc-paginator/BUILD.bazel
@@ -1,0 +1,79 @@
+load(
+    "//tools:defaults.bzl",
+    "ng_module",
+    "ng_test_library",
+    "ng_web_test_suite",
+    "sass_binary",
+    "sass_library",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "mdc-paginator",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    assets = [":paginator.css"] + glob(["**/*.html"]),
+    module_name = "@angular/material-experimental/mdc-paginator",
+    deps = [
+        "//src/material-experimental/mdc-button",
+        "//src/material-experimental/mdc-select",
+        "//src/material/paginator",
+        "//src/material/tooltip",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/forms",  # TODO(jelbourn): transitive dep via generated code
+        "@npm//rxjs",
+    ],
+)
+
+sass_library(
+    name = "mdc_paginator_scss_lib",
+    srcs = glob(["**/_*.scss"]),
+    deps = [
+        "//src/material/core:core_scss_lib",
+    ],
+)
+
+sass_binary(
+    name = "mdc_paginator_scss",
+    src = "paginator.scss",
+    include_paths = [
+        "external/npm/node_modules",
+    ],
+    deps = [
+        "//src/material-experimental/mdc-form-field:mdc_form_field_scss_lib",
+    ],
+)
+
+ng_test_library(
+    name = "mdc_paginator_tests_lib",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["**/*.e2e.spec.ts"],
+    ),
+    deps = [
+        ":mdc-paginator",
+        "//src/cdk/testing/private",
+        "//src/material-experimental/mdc-select",
+        "//src/material/core",
+        "@npm//@angular/platform-browser",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    static_files = [
+        "@npm//:node_modules/@material/textfield/dist/mdc.textfield.js",
+        "@npm//:node_modules/@material/line-ripple/dist/mdc.lineRipple.js",
+        "@npm//:node_modules/@material/notched-outline/dist/mdc.notchedOutline.js",
+        "@npm//:node_modules/@material/ripple/dist/mdc.ripple.js",
+        "@npm//:node_modules/@material/dom/dist/mdc.dom.js",
+    ],
+    deps = [
+        ":mdc_paginator_tests_lib",
+        "//src/material-experimental:mdc_require_config.js",
+    ],
+)

--- a/src/material-experimental/mdc-paginator/README.md
+++ b/src/material-experimental/mdc-paginator/README.md
@@ -1,0 +1,102 @@
+This is prototype of an alternate version of `<mat-paginator>` built on top of
+[MDC Web](https://github.com/material-components/material-components-web). It demonstrates how
+Angular Material could use MDC Web under the hood while still exposing the same API Angular users as
+the existing `<mat-paginator>`. This component is experimental and should not be used in production.
+
+## How to use
+Assuming your application is already up and running using Angular Material, you can add this
+component by following these steps:
+
+1. Install Angular Material Experimental & MDC WEB:
+
+   ```bash
+   npm i material-components-web @angular/material-experimental
+   ```
+
+2. In your `angular.json`, make sure `node_modules/` is listed as a Sass include path. This is
+   needed for the Sass compiler to be able to find the MDC Web Sass files.
+
+   ```json
+   ...
+   "styles": [
+     "src/styles.scss"
+   ],
+   "stylePreprocessorOptions": {
+     "includePaths": [
+       "node_modules/"
+     ]
+   },
+   ...
+   ```
+
+3. Import the experimental `MatPaginatorModule` and add it to the module that declares your
+   component:
+
+   ```ts
+   import {MatPaginatorModule} from '@angular/material-experimental/mdc-paginator';
+
+   @NgModule({
+     declarations: [MyComponent],
+     imports: [MatPaginatorModule],
+   })
+   export class MyModule {}
+   ```
+
+4. Use `<mat-paginator>` in your component's template, just like you would the normal
+   `<mat-paginator>`:
+
+   ```html
+   <mat-paginator></mat-paginator>
+   ```
+
+5. Add the theme and typography mixins to your Sass. (There is currently no pre-built CSS option for
+   the experimental `<mat-paginator>`):
+
+   ```scss
+   @import '~@angular/material/theming';
+   @import '~@angular/material-experimental/mdc-paginator';
+
+   $my-primary: mat-palette($mat-indigo);
+   $my-accent:  mat-palette($mat-pink, A200, A100, A400);
+   $my-theme:   mat-light-theme((
+     color: (
+       primary: $my-primary,
+       accent: $my-accent
+     )
+   ));
+
+   @include mat-mdc-paginator-theme($my-theme);
+   @include mat-mdc-paginator-typography();
+   ```
+
+## API differences
+The experimental paginator API closely matches the
+[API of the standard paginator](https://material.angular.io/components/paginator/api).
+`@angular/material-experimental/mdc-paginator` exports symbols with the same name and public
+interface as all of the symbols found under `@angular/material/paginator`, except for the following
+differences:
+
+* The experimental paginator module has a `MatPaginatorDefaultOptions` interface that is identical
+to the one from `@angular/material/paginator`, with the exception of the `formFieldAppearance`
+property whose type is narrower. It allows only the `fill` and `outline` appearances, because these
+are the appearances supported by the MDC-based `MatFormField`.
+
+## Replacing the standard paginator in an existing app
+Because the experimental API mirrors the API for the standard paginator, it can easily be swapped in
+by just changing the import paths. There is currently no schematic for this, but you can run the
+following string replace across your TypeScript files:
+
+```bash
+grep -lr --include="*.ts" --exclude-dir="node_modules" \
+  --exclude="*.d.ts" "['\"]@angular/material/paginator['\"]" | xargs sed -i \
+  "s/['\"]@angular\/material\/paginator['\"]/'@angular\/material-experimental\/mdc-paginator'/g"
+```
+
+CSS styles and tests that depend on implementation details of `mat-paginator` (such as getting
+elements from the template by class name) will need to be manually updated.
+
+There are some small visual differences between this paginator and the standard `mat-paginator`.
+This paginator depends on `MatFormField` and `MatButton` which are also based on MDC, putting them
+closer to the Material Design specification while making them slightly wider. You may have to
+account for the wider paginator in your app's layout. Furthermore, the form field inside the
+paginator only supports the `outline` and `fill` appearances.

--- a/src/material-experimental/mdc-paginator/_paginator-theme.scss
+++ b/src/material-experimental/mdc-paginator/_paginator-theme.scss
@@ -1,0 +1,84 @@
+@import '@material/theme/variables.import';
+@import '@material/typography/variables.import';
+@import '../../material/core/theming/check-duplicate-styles';
+@import './paginator-variables';
+
+@mixin mat-mdc-paginator-color($config-or-theme) {
+  $config: mat-get-color-config($config-or-theme);
+  @include mat-using-mdc-theme($config) {
+    $icon-color: rgba(mdc-theme-prop-value(on-surface), 0.54);
+    $disabled-color: rgba(mdc-theme-prop-value(on-surface), 0.12);
+
+    .mat-mdc-paginator {
+      background: mdc-theme-prop-value(surface);
+      color: rgba(mdc-theme-prop-value(on-surface), 0.87);
+    }
+
+    .mat-mdc-paginator-icon {
+      fill: $icon-color;
+    }
+
+    .mat-mdc-paginator-decrement,
+    .mat-mdc-paginator-increment {
+      border-top: 2px solid $icon-color;
+      border-right: 2px solid $icon-color;
+    }
+
+    .mat-mdc-paginator-first,
+    .mat-mdc-paginator-last {
+      border-top: 2px solid $icon-color;
+    }
+
+    .mat-mdc-icon-button[disabled] {
+      .mat-mdc-paginator-decrement,
+      .mat-mdc-paginator-increment,
+      .mat-mdc-paginator-first,
+      .mat-mdc-paginator-last {
+        border-color: $disabled-color;
+      }
+
+      .mat-mdc-paginator-icon {
+        fill: $disabled-color;
+      }
+    }
+  }
+}
+
+@mixin mat-mdc-paginator-typography($config-or-theme) {
+  $config: mat-get-typography-config($config-or-theme);
+  .mat-mdc-paginator {
+    @include mat-using-mdc-typography($config) {
+      @include mdc-typography(caption, $query: $mat-typography-styles-query);
+    }
+  }
+}
+
+@mixin _mat-mdc-paginator-density($config-or-theme) {
+  $density-scale: mat-get-density-config($config-or-theme);
+  $height: _mat-density-prop-value($mat-paginator-density-config, $density-scale, height);
+
+  @include _mat-density-legacy-compatibility() {
+    .mat-mdc-paginator-container {
+      min-height: $height;
+    }
+  }
+}
+
+@mixin mat-mdc-paginator-theme($theme-or-color-config) {
+  $theme: _mat-legacy-get-theme($theme-or-color-config);
+  @include _mat-check-duplicate-theme-styles($theme, 'mat-mdc-paginator') {
+    $color: mat-get-color-config($theme);
+    $density: mat-get-density-config($theme);
+    $typography: mat-get-typography-config($theme);
+
+    @if $color != null {
+      @include mat-mdc-paginator-color($color);
+    }
+    @if $density != null {
+      @include _mat-mdc-paginator-density($density);
+    }
+    @if $typography != null {
+      @include mat-mdc-paginator-typography($typography);
+    }
+  }
+}

--- a/src/material-experimental/mdc-paginator/_paginator-variables.scss
+++ b/src/material-experimental/mdc-paginator/_paginator-variables.scss
@@ -1,0 +1,13 @@
+$mat-paginator-height: 56px !default;
+// Minimum height for paginator's in the highest density is determined based on how
+// much the paginator can shrink until the content exceeds (i.e. navigation buttons).
+$mat-paginator-minimum-height: 40px !default;
+$mat-paginator-maximum-height: $mat-paginator-height !default;
+
+$mat-paginator-density-config: (
+  height: (
+    default: $mat-paginator-height,
+    maximum: $mat-paginator-maximum-height,
+    minimum: $mat-paginator-minimum-height,
+  )
+) !default;

--- a/src/material-experimental/mdc-paginator/index.ts
+++ b/src/material-experimental/mdc-paginator/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-paginator/paginator-module.ts
+++ b/src/material-experimental/mdc-paginator/paginator-module.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MAT_PAGINATOR_INTL_PROVIDER} from '@angular/material/paginator';
+import {MatButtonModule} from '@angular/material-experimental/mdc-button';
+import {MatSelectModule} from '@angular/material-experimental/mdc-select';
+import {MatTooltipModule} from '@angular/material/tooltip';
+import {MatPaginator} from './paginator';
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatSelectModule,
+    MatTooltipModule,
+  ],
+  exports: [MatPaginator],
+  declarations: [MatPaginator],
+  providers: [MAT_PAGINATOR_INTL_PROVIDER],
+})
+export class MatPaginatorModule {}

--- a/src/material-experimental/mdc-paginator/paginator.html
+++ b/src/material-experimental/mdc-paginator/paginator.html
@@ -1,0 +1,86 @@
+<div class="mat-mdc-paginator-outer-container">
+  <div class="mat-mdc-paginator-container">
+    <div class="mat-mdc-paginator-page-size" *ngIf="!hidePageSize">
+      <div class="mat-mdc-paginator-page-size-label">
+        {{_intl.itemsPerPageLabel}}
+      </div>
+
+      <mat-form-field
+        *ngIf="_displayedPageSizeOptions.length > 1"
+        [appearance]="_formFieldAppearance!"
+        [color]="color"
+        class="mat-mdc-paginator-page-size-select">
+        <mat-select
+          [value]="pageSize"
+          [disabled]="disabled"
+          [aria-label]="_intl.itemsPerPageLabel"
+          (selectionChange)="_changePageSize($event.value)">
+          <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
+            {{pageSizeOption}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <div
+        class="mat-mdc-paginator-page-size-value"
+        *ngIf="_displayedPageSizeOptions.length <= 1">{{pageSize}}</div>
+    </div>
+
+    <div class="mat-mdc-paginator-range-actions">
+      <div class="mat-mdc-paginator-range-label">
+        {{_intl.getRangeLabel(pageIndex, pageSize, length)}}
+      </div>
+
+      <button mat-icon-button type="button"
+              class="mat-mdc-paginator-navigation-first"
+              (click)="firstPage()"
+              [attr.aria-label]="_intl.firstPageLabel"
+              [matTooltip]="_intl.firstPageLabel"
+              [matTooltipDisabled]="_previousButtonsDisabled()"
+              [matTooltipPosition]="'above'"
+              [disabled]="_previousButtonsDisabled()"
+              *ngIf="showFirstLastButtons">
+        <svg class="mat-mdc-paginator-icon" viewBox="0 0 24 24" focusable="false">
+          <path d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"/>
+        </svg>
+      </button>
+      <button mat-icon-button type="button"
+              class="mat-mdc-paginator-navigation-previous"
+              (click)="previousPage()"
+              [attr.aria-label]="_intl.previousPageLabel"
+              [matTooltip]="_intl.previousPageLabel"
+              [matTooltipDisabled]="_previousButtonsDisabled()"
+              [matTooltipPosition]="'above'"
+              [disabled]="_previousButtonsDisabled()">
+        <svg class="mat-mdc-paginator-icon" viewBox="0 0 24 24" focusable="false">
+          <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>
+        </svg>
+      </button>
+      <button mat-icon-button type="button"
+              class="mat-mdc-paginator-navigation-next"
+              (click)="nextPage()"
+              [attr.aria-label]="_intl.nextPageLabel"
+              [matTooltip]="_intl.nextPageLabel"
+              [matTooltipDisabled]="_nextButtonsDisabled()"
+              [matTooltipPosition]="'above'"
+              [disabled]="_nextButtonsDisabled()">
+        <svg class="mat-mdc-paginator-icon" viewBox="0 0 24 24" focusable="false">
+          <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
+        </svg>
+      </button>
+      <button mat-icon-button type="button"
+              class="mat-mdc-paginator-navigation-last"
+              (click)="lastPage()"
+              [attr.aria-label]="_intl.lastPageLabel"
+              [matTooltip]="_intl.lastPageLabel"
+              [matTooltipDisabled]="_nextButtonsDisabled()"
+              [matTooltipPosition]="'above'"
+              [disabled]="_nextButtonsDisabled()"
+              *ngIf="showFirstLastButtons">
+        <svg class="mat-mdc-paginator-icon" viewBox="0 0 24 24" focusable="false">
+          <path d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/material-experimental/mdc-paginator/paginator.scss
+++ b/src/material-experimental/mdc-paginator/paginator.scss
@@ -1,0 +1,83 @@
+@import '../mdc-form-field/form-field-theme';
+
+$mat-mdc-paginator-padding: 0 8px;
+$mat-mdc-paginator-page-size-margin-right: 8px;
+
+$mat-mdc-paginator-items-per-page-label-margin: 0 4px;
+$mat-mdc-paginator-selector-margin: 0 4px;
+$mat-mdc-paginator-selector-trigger-width: 84px;
+
+$mat-mdc-paginator-range-label-margin: 0 32px 0 24px;
+$mat-mdc-paginator-button-icon-size: 28px;
+
+.mat-mdc-paginator {
+  display: block;
+
+  // We need the form field to be as narrow as possible in order to fit
+  // into the paginator so we always use the densest layout available.
+  @include mat-mdc-form-field-density(minimum);
+
+  // This element reserves space for hints and error messages.
+  // Hide it since we know that we won't need it.
+  .mat-mdc-form-field-subscript-wrapper {
+    display: none;
+  }
+
+  .mat-mdc-select {
+    // The smaller font size inherited from the paginator throws off the centering of the select
+    // inside the form field. This `line-height` helps to center it relative to the other text.
+    line-height: 1.5;
+  }
+}
+
+// Note: this wrapper element is only used to get the flexbox vertical centering to work
+// with the `min-height` on IE11. It can be removed if we drop support for IE.
+.mat-mdc-paginator-outer-container {
+  display: flex;
+}
+
+.mat-mdc-paginator-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: $mat-mdc-paginator-padding;
+  flex-wrap: wrap-reverse;
+  width: 100%;
+}
+
+.mat-mdc-paginator-page-size {
+  display: flex;
+  align-items: baseline;
+  margin-right: $mat-mdc-paginator-page-size-margin-right;
+
+  [dir='rtl'] & {
+    margin-right: 0;
+    margin-left: $mat-mdc-paginator-page-size-margin-right;
+  }
+}
+
+.mat-mdc-paginator-page-size-label {
+  margin: $mat-mdc-paginator-items-per-page-label-margin;
+}
+
+.mat-mdc-paginator-page-size-select {
+  margin: $mat-mdc-paginator-selector-margin;
+  width: $mat-mdc-paginator-selector-trigger-width;
+}
+
+.mat-mdc-paginator-range-label {
+  margin: $mat-mdc-paginator-range-label-margin;
+}
+
+.mat-mdc-paginator-range-actions {
+  display: flex;
+  align-items: center;
+}
+
+.mat-mdc-paginator-icon {
+  width: $mat-mdc-paginator-button-icon-size;
+
+  [dir='rtl'] & {
+    transform: rotate(180deg);
+  }
+}

--- a/src/material-experimental/mdc-paginator/paginator.spec.ts
+++ b/src/material-experimental/mdc-paginator/paginator.spec.ts
@@ -3,13 +3,13 @@ import {Component, ViewChild, Type, Provider} from '@angular/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {dispatchMouseEvent} from '@angular/cdk/testing/private';
 import {ThemePalette} from '@angular/material/core';
-import {MatSelect} from '@angular/material/select';
+import {MatSelect} from '@angular/material-experimental/mdc-select';
 import {By} from '@angular/platform-browser';
 import {MatPaginatorModule, MatPaginator, MatPaginatorIntl} from './index';
 import {MAT_PAGINATOR_DEFAULT_OPTIONS, MatPaginatorDefaultOptions} from './paginator';
 
 
-describe('MatPaginator', () => {
+describe('MDC-based MatPaginator', () => {
   function createComponent<T>(type: Type<T>, providers: Provider[] = []): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [MatPaginatorModule, NoopAnimationsModule],
@@ -26,7 +26,7 @@ describe('MatPaginator', () => {
     it('should show the right range text', () => {
       const fixture = createComponent(MatPaginatorApp);
       const component = fixture.componentInstance;
-      const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+      const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
 
       // View second page of list of 100, each page contains 10 items.
       component.length = 100;
@@ -73,7 +73,7 @@ describe('MatPaginator', () => {
 
     it('should show right aria-labels for select and buttons', () => {
       const fixture = createComponent(MatPaginatorApp);
-      const select = fixture.nativeElement.querySelector('.mat-select');
+      const select = fixture.nativeElement.querySelector('.mat-mdc-select');
       expect(select.getAttribute('aria-label')).toBe('Items per page:');
 
       expect(getPreviousButton(fixture).getAttribute('aria-label')).toBe('Previous page');
@@ -82,7 +82,7 @@ describe('MatPaginator', () => {
 
     it('should re-render when the i18n labels change', () => {
       const fixture = createComponent(MatPaginatorApp);
-      const label = fixture.nativeElement.querySelector('.mat-paginator-page-size-label');
+      const label = fixture.nativeElement.querySelector('.mat-mdc-paginator-page-size-label');
       const intl = TestBed.get<MatPaginatorIntl>(MatPaginatorIntl);
 
       intl.itemsPerPageLabel = '1337 items per page';
@@ -175,7 +175,7 @@ describe('MatPaginator', () => {
   it('should be able to set the color of the form field', () => {
     const fixture = createComponent(MatPaginatorApp);
     const component = fixture.componentInstance;
-    const formField: HTMLElement = fixture.nativeElement.querySelector('.mat-form-field');
+    const formField: HTMLElement = fixture.nativeElement.querySelector('.mat-mdc-form-field');
 
     component.color = 'accent';
     fixture.detectChanges();
@@ -263,7 +263,7 @@ describe('MatPaginator', () => {
     const fixture = createComponent(MatPaginatorApp);
     const component = fixture.componentInstance;
     const paginator = component.paginator;
-    const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+    const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
 
     expect(rangeElement.innerText.trim()).toBe('1 – 10 of 100');
 
@@ -280,11 +280,11 @@ describe('MatPaginator', () => {
     expect(rangeElement.innerText.trim()).toBe('7 – 12 of 99');
 
     // Having one option and the same page size should remove the select menu
-    expect(fixture.nativeElement.querySelector('.mat-select')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.mat-mdc-select')).not.toBeNull();
     paginator.pageSize = 10;
     paginator.pageSizeOptions = [10];
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('.mat-select')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.mat-mdc-select')).toBeNull();
   });
 
   it('should default the page size options to the page size if no options provided', () => {
@@ -389,13 +389,13 @@ describe('MatPaginator', () => {
     const paginator = component.paginator;
 
     expect(paginator._displayedPageSizeOptions).toEqual([5, 10, 25, 100]);
-    expect(fixture.nativeElement.querySelector('.mat-select')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.mat-mdc-select')).not.toBeNull();
 
     // Remove options so that the paginator only uses the current page size (10) as an option.
     // Should no longer show the select component since there is only one option.
     component.pageSizeOptions = [];
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('.mat-select')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.mat-mdc-select')).toBeNull();
   });
 
   it('should handle the number inputs being passed in as strings', () => {
@@ -413,13 +413,13 @@ describe('MatPaginator', () => {
     const fixture = createComponent(MatPaginatorApp);
     const element = fixture.nativeElement;
 
-    expect(element.querySelector('.mat-paginator-page-size'))
+    expect(element.querySelector('.mat-mdc-paginator-page-size'))
         .toBeTruthy('Expected select to be rendered.');
 
     fixture.componentInstance.hidePageSize = true;
     fixture.detectChanges();
 
-    expect(element.querySelector('.mat-paginator-page-size'))
+    expect(element.querySelector('.mat-mdc-paginator-page-size'))
         .toBeNull('Expected select to be removed.');
   });
 
@@ -470,19 +470,19 @@ describe('MatPaginator', () => {
 });
 
 function getPreviousButton(fixture: ComponentFixture<any>) {
-  return fixture.nativeElement.querySelector('.mat-paginator-navigation-previous');
+  return fixture.nativeElement.querySelector('.mat-mdc-paginator-navigation-previous');
 }
 
 function getNextButton(fixture: ComponentFixture<any>) {
-  return fixture.nativeElement.querySelector('.mat-paginator-navigation-next');
+  return fixture.nativeElement.querySelector('.mat-mdc-paginator-navigation-next');
 }
 
 function getFirstButton(fixture: ComponentFixture<any>) {
-  return fixture.nativeElement.querySelector('.mat-paginator-navigation-first');
+  return fixture.nativeElement.querySelector('.mat-mdc-paginator-navigation-first');
 }
 
 function getLastButton(fixture: ComponentFixture<any>) {
-  return fixture.nativeElement.querySelector('.mat-paginator-navigation-last');
+  return fixture.nativeElement.querySelector('.mat-mdc-paginator-navigation-last');
 }
 
 @Component({

--- a/src/material-experimental/mdc-paginator/paginator.ts
+++ b/src/material-experimental/mdc-paginator/paginator.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Inject,
+  InjectionToken,
+  Optional,
+  ViewEncapsulation,
+} from '@angular/core';
+import {MatPaginatorIntl, _MatPaginatorBase} from '@angular/material/paginator';
+import {MatFormFieldAppearance} from '@angular/material-experimental/mdc-form-field';
+
+// Note that while `MatPaginatorDefaultOptions` and `MAT_PAGINATOR_DEFAULT_OPTIONS` are identical
+// between the MDC and non-MDC versions, we have to duplicate them, because the type of
+// `formFieldAppearance` is narrower in the MDC version.
+
+/** Object that can be used to configure the default options for the paginator module. */
+export interface MatPaginatorDefaultOptions {
+  /** Number of items to display on a page. By default set to 50. */
+  pageSize?: number;
+
+  /** The set of provided page size options to display to the user. */
+  pageSizeOptions?: number[];
+
+  /** Whether to hide the page size selection UI from the user. */
+  hidePageSize?: boolean;
+
+  /** Whether to show the first/last buttons UI to the user. */
+  showFirstLastButtons?: boolean;
+
+  /** The default form-field appearance to apply to the page size options selector. */
+  formFieldAppearance?: MatFormFieldAppearance;
+}
+
+/** Injection token that can be used to provide the default options for the paginator module. */
+export const MAT_PAGINATOR_DEFAULT_OPTIONS =
+    new InjectionToken<MatPaginatorDefaultOptions>('MAT_PAGINATOR_DEFAULT_OPTIONS');
+
+/**
+ * Component to provide navigation between paged information. Displays the size of the current
+ * page, user-selectable options to change that size, what items are being shown, and
+ * navigational button to go to the previous or next page.
+ */
+@Component({
+  selector: 'mat-paginator',
+  exportAs: 'matPaginator',
+  templateUrl: 'paginator.html',
+  styleUrls: ['paginator.css'],
+  inputs: ['disabled'],
+  host: {
+    'class': 'mat-mdc-paginator',
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class MatPaginator extends _MatPaginatorBase<MatPaginatorDefaultOptions> {
+  /** If set, styles the "page size" form field with the designated style. */
+  _formFieldAppearance?: MatFormFieldAppearance;
+
+  constructor(intl: MatPaginatorIntl,
+    changeDetectorRef: ChangeDetectorRef,
+    @Optional() @Inject(MAT_PAGINATOR_DEFAULT_OPTIONS) defaults?: MatPaginatorDefaultOptions) {
+    super(intl, changeDetectorRef, defaults);
+    this._formFieldAppearance = defaults?.formFieldAppearance || 'outline';
+  }
+}

--- a/src/material-experimental/mdc-paginator/public-api.ts
+++ b/src/material-experimental/mdc-paginator/public-api.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './paginator-module';
+export * from './paginator';
+export {
+  MatPaginatorIntl,
+  MAT_PAGINATOR_INTL_PROVIDER_FACTORY,
+  MAT_PAGINATOR_INTL_PROVIDER,
+  PageEvent,
+} from '@angular/material/paginator';
+

--- a/src/material-experimental/mdc-theming/BUILD.bazel
+++ b/src/material-experimental/mdc-theming/BUILD.bazel
@@ -27,6 +27,7 @@ sass_library(
         "//src/material-experimental/mdc-input:mdc_input_scss_lib",
         "//src/material-experimental/mdc-list:mdc_list_scss_lib",
         "//src/material-experimental/mdc-menu:mdc_menu_scss_lib",
+        "//src/material-experimental/mdc-paginator:mdc_paginator_scss_lib",
         "//src/material-experimental/mdc-progress-bar:mdc_progress_bar_scss_lib",
         "//src/material-experimental/mdc-progress-spinner:mdc_progress_spinner_scss_lib",
         "//src/material-experimental/mdc-radio:mdc_radio_scss_lib",

--- a/src/material-experimental/mdc-theming/_all-theme.scss
+++ b/src/material-experimental/mdc-theming/_all-theme.scss
@@ -13,6 +13,7 @@
 @import '../mdc-snack-bar/snack-bar-theme';
 @import '../mdc-tabs/tabs-theme';
 @import '../mdc-table/table-theme';
+@import '../mdc-paginator/paginator-theme';
 @import '../mdc-progress-bar/progress-bar-theme';
 @import '../mdc-progress-spinner/progress-spinner-theme';
 @import '../mdc-input/input-theme';
@@ -33,6 +34,7 @@
     @include mat-mdc-chips-theme($theme-or-color-config);
     @include mat-mdc-list-theme($theme-or-color-config);
     @include mat-mdc-menu-theme($theme-or-color-config);
+    @include mat-mdc-paginator-theme($theme-or-color-config);
     @include mat-mdc-progress-bar-theme($theme-or-color-config);
     @include mat-mdc-progress-spinner-theme($theme-or-color-config);
     @include mat-mdc-radio-theme($theme-or-color-config);

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.html
@@ -132,6 +132,12 @@
  <a mat-tab-link href="https://google.com" [active]="true">Also Google</a>
 </nav>
 
+<h2>MDC Paginator</h2>
+
+<mat-paginator [length]="100"
+               [pageSizeOptions]="[5, 10, 25, 100]">
+</mat-paginator>
+
 <h2>MDC Table</h2>
 <table mat-table [dataSource]="[1, 2, 3]">
   <ng-container matColumnDef="first-column">

--- a/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
+++ b/src/universal-app/kitchen-sink-mdc/kitchen-sink-mdc.ts
@@ -19,6 +19,7 @@ import {MatIconModule} from '@angular/material/icon';
 import {MatSnackBarModule, MatSnackBar} from '@angular/material-experimental/mdc-snack-bar';
 import {MatProgressSpinnerModule} from '@angular/material-experimental/mdc-progress-spinner';
 import {MatSelectModule} from '@angular/material-experimental/mdc-select';
+import {MatPaginatorModule} from '@angular/material-experimental/mdc-paginator';
 
 @Component({
   template: `<button>Do the thing</button>`
@@ -57,6 +58,7 @@ export class KitchenSinkMdc {
     MatSnackBarModule,
     MatProgressSpinnerModule,
     MatSelectModule,
+    MatPaginatorModule,
   ],
   declarations: [KitchenSinkMdc, TestEntryComponent],
   exports: [KitchenSinkMdc, TestEntryComponent],

--- a/tools/public_api_guard/material/paginator.d.ts
+++ b/tools/public_api_guard/material/paginator.d.ts
@@ -1,16 +1,10 @@
-export declare const MAT_PAGINATOR_DEFAULT_OPTIONS: InjectionToken<MatPaginatorDefaultOptions>;
-
-export declare const MAT_PAGINATOR_INTL_PROVIDER: {
-    provide: typeof MatPaginatorIntl;
-    deps: Optional[][];
-    useFactory: typeof MAT_PAGINATOR_INTL_PROVIDER_FACTORY;
-};
-
-export declare function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPaginatorIntl): MatPaginatorIntl;
-
-export declare class MatPaginator extends _MatPaginatorBase implements OnInit, OnDestroy, CanDisable, HasInitialized {
+export declare abstract class _MatPaginatorBase<O extends {
+    pageSize?: number;
+    pageSizeOptions?: number[];
+    hidePageSize?: boolean;
+    showFirstLastButtons?: boolean;
+}> extends _MatPaginatorMixinBase implements OnInit, OnDestroy, CanDisable, HasInitialized {
     _displayedPageSizeOptions: number[];
-    _formFieldAppearance?: MatFormFieldAppearance;
     _intl: MatPaginatorIntl;
     color: ThemePalette;
     get hidePageSize(): boolean;
@@ -26,7 +20,7 @@ export declare class MatPaginator extends _MatPaginatorBase implements OnInit, O
     set pageSizeOptions(value: number[]);
     get showFirstLastButtons(): boolean;
     set showFirstLastButtons(value: boolean);
-    constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef, defaults?: MatPaginatorDefaultOptions);
+    constructor(_intl: MatPaginatorIntl, _changeDetectorRef: ChangeDetectorRef, defaults?: O);
     _changePageSize(pageSize: number): void;
     _nextButtonsDisabled(): boolean;
     _previousButtonsDisabled(): boolean;
@@ -45,7 +39,24 @@ export declare class MatPaginator extends _MatPaginatorBase implements OnInit, O
     static ngAcceptInputType_pageIndex: NumberInput;
     static ngAcceptInputType_pageSize: NumberInput;
     static ngAcceptInputType_showFirstLastButtons: BooleanInput;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatPaginator, "mat-paginator", ["matPaginator"], { "disabled": "disabled"; "color": "color"; "pageIndex": "pageIndex"; "length": "length"; "pageSize": "pageSize"; "pageSizeOptions": "pageSizeOptions"; "hidePageSize": "hidePageSize"; "showFirstLastButtons": "showFirstLastButtons"; }, { "page": "page"; }, never, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<_MatPaginatorBase<any>, never, never, { "color": "color"; "pageIndex": "pageIndex"; "length": "length"; "pageSize": "pageSize"; "pageSizeOptions": "pageSizeOptions"; "hidePageSize": "hidePageSize"; "showFirstLastButtons": "showFirstLastButtons"; }, { "page": "page"; }, never>;
+    static ɵfac: i0.ɵɵFactoryDef<_MatPaginatorBase<any>, never>;
+}
+
+export declare const MAT_PAGINATOR_DEFAULT_OPTIONS: InjectionToken<MatPaginatorDefaultOptions>;
+
+export declare const MAT_PAGINATOR_INTL_PROVIDER: {
+    provide: typeof MatPaginatorIntl;
+    deps: Optional[][];
+    useFactory: typeof MAT_PAGINATOR_INTL_PROVIDER_FACTORY;
+};
+
+export declare function MAT_PAGINATOR_INTL_PROVIDER_FACTORY(parentIntl: MatPaginatorIntl): MatPaginatorIntl;
+
+export declare class MatPaginator extends _MatPaginatorBase<MatPaginatorDefaultOptions> {
+    _formFieldAppearance?: MatFormFieldAppearance;
+    constructor(intl: MatPaginatorIntl, changeDetectorRef: ChangeDetectorRef, defaults?: MatPaginatorDefaultOptions);
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatPaginator, "mat-paginator", ["matPaginator"], { "disabled": "disabled"; }, {}, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatPaginator, [null, null, { optional: true; }]>;
 }
 


### PR DESCRIPTION
Implements `mat-paginator` on top of MDC Web and the logic from the existing paginator. The structural styles are close to what we have in the current paginator, while the theming and typography are implemented on top of MDC's mixins. Furthermore, we're using the MDC versions of `mat-select` and `mat-button` inside the paginator.

There are the following gotchas in this implementation:
1. The `mat-form-field` inside the paginator is set to always use the densest layout possible. This is necessary, because the MDC form field is too tall by default.
2. We hide one internal element from the form field, because it throws off the vertical alignment and is only used for hints and error messages which the paginator doesn't have.
3. I had to duplicate the `MatPaginatorDefaultOptions` interface, because the appearance of the MDC form field doesn't support the `legacy` and `standard` values.

**Note:** doesn't include a test harness, because it depends on #20603. I'll make a follow-up PR to add it.

![Angular_Material_-_Google_Chrome_2020-09-20_15-26-55](https://user-images.githubusercontent.com/4450522/93711813-e3c1a000-fb59-11ea-84b0-0a76901fdb76.png)
