### PR TITLE
docs(material/paginator): add explicit type for better formatting in docs

### DIFF
--- a/src/material/paginator/paginator-intl.ts
+++ b/src/material/paginator/paginator-intl.ts
@@ -38,20 +38,21 @@ export class MatPaginatorIntl {
   lastPageLabel: string = 'Last page';
 
   /** A label for the range of items within the current page and the length of the whole list. */
-  getRangeLabel = (page: number, pageSize: number, length: number) => {
-    if (length == 0 || pageSize == 0) { return `0 of ${length}`; }
+  getRangeLabel: (page: number, pageSize: number, length: number) => string =
+    (page: number, pageSize: number, length: number) => {
+      if (length == 0 || pageSize == 0) { return `0 of ${length}`; }
 
-    length = Math.max(length, 0);
+      length = Math.max(length, 0);
 
-    const startIndex = page * pageSize;
+      const startIndex = page * pageSize;
 
-    // If the start index exceeds the list length, do not try and fix the end index to the end.
-    const endIndex = startIndex < length ?
-        Math.min(startIndex + pageSize, length) :
-        startIndex + pageSize;
+      // If the start index exceeds the list length, do not try and fix the end index to the end.
+      const endIndex = startIndex < length ?
+          Math.min(startIndex + pageSize, length) :
+          startIndex + pageSize;
 
-    return `${startIndex + 1} – ${endIndex} of ${length}`;
-  }
+      return `${startIndex + 1} – ${endIndex} of ${length}`;
+    }
 }
 
 /** @docs-private */


### PR DESCRIPTION
`MatPaginatorIntl.getRangeLabel` didn't have an explicit type which was causing dgeni to output the entire initializer.

For reference:
![Paginator__Angular_Material_-_Google_Chrome_2020-09-20_16-26-20](https://user-images.githubusercontent.com/4450522/93712422-77956b00-fb5e-11ea-9e97-d0ffe482555f.png)
