### PR TITLE
docs: fix the harness with method's options list format in using component harnesses

### DIFF
--- a/guides/using-component-harnesses.md
+++ b/guides/using-component-harnesses.md
@@ -113,7 +113,7 @@ provided constraints. The particular constraint options vary depending on the ha
 harnesses support at least:
  
 - `selector` - CSS selector that the component must match (in addition to its host selector, such
-               as `[mat-button]`)
+  as `[mat-button]`)
 - `ancestor` - CSS selector for a some ancestor element above the component in the DOM
  
 In addition to these standard options, `MatButtonHarness` also supports
@@ -156,7 +156,7 @@ it('should mark confirmed when ok button clicked', async () => {
 });
 ```
 
-Note that the code above has does not call `fixture.detectChanges()`, something you commonly see in
+Note that the code above does not call `fixture.detectChanges()`, something you commonly see in
 unit tests. The CDK's component harnesses automatically invoke change detection after performing
 actions and before reading state. The harness also automatically waits for the fixture to be stable,
 which will cause the test to wait for `setTimeout`, `Promise`, etc.


### PR DESCRIPTION
- Remove whitespace that causes an item in the options list of the harness with method to be
rendered as a code block from the [component harness guide](https://material.angular.io/guide/using-component-harnesses). Use an alignment consistent with other lists in the file.
- Fix a typo in the note about change detection.

Linted, built, and tested
- Verified that the docs build output does not include an extra code block

https://imgur.com/jsrfW6W