### PR TITLE
fix(material/core): incorrectly formatting dates in the years 0 to 99

### DIFF
--- a/src/material/core/datetime/native-date-adapter.spec.ts
+++ b/src/material/core/datetime/native-date-adapter.spec.ts
@@ -152,6 +152,16 @@ describe('NativeDateAdapter', () => {
     expect(adapter.getYearName(new Date(2017, JAN, 1))).toBe('2017');
   });
 
+  it('should year name for low year numbers', () => {
+    const createAndFormat = (year: number) => {
+      return adapter.getYearName(adapter.createDate(year, JAN, 1));
+    };
+
+    expect(createAndFormat(50)).toBe('50');
+    expect(createAndFormat(99)).toBe('99');
+    expect(createAndFormat(100)).toBe('100');
+  });
+
   it('should get year name in a different locale', () => {
     adapter.setLocale('ja-JP');
     if (SUPPORTS_INTL) {
@@ -185,6 +195,22 @@ describe('NativeDateAdapter', () => {
     expect(adapter.createDate(50, JAN, 1).getFullYear()).toBe(50);
     expect(adapter.createDate(99, JAN, 1).getFullYear()).toBe(99);
     expect(adapter.createDate(100, JAN, 1).getFullYear()).toBe(100);
+  });
+
+  it('should format Date with low year number', () => {
+    const createAndFormat = (year: number) => {
+      return adapter.format(adapter.createDate(year, JAN, 1), {});
+    };
+
+    if (SUPPORTS_INTL) {
+      expect(createAndFormat(50)).toBe('1/1/50');
+      expect(createAndFormat(99)).toBe('1/1/99');
+      expect(createAndFormat(100)).toBe('1/1/100');
+    } else {
+      expect(createAndFormat(50)).toBe('Sat Jan 01 0050');
+      expect(createAndFormat(99)).toBe('Thu Jan 01 0099');
+      expect(createAndFormat(100)).toBe('Fri Jan 01 0100');
+    }
   });
 
   it("should get today's date", () => {

--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -283,14 +283,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
 
   /** Creates a date but allows the month and date to overflow. */
   private _createDateWithOverflow(year: number, month: number, date: number) {
-    const result = new Date(year, month, date);
-
-    // We need to correct for the fact that JS native Date treats years in range [0, 99] as
-    // abbreviations for 19xx.
-    if (year >= 0 && year < 100) {
-      result.setFullYear(this.getYear(result) - 1900);
-    }
-    return result;
+    return this._correctYear(new Date(year, month, date), year);
   }
 
   /**
@@ -325,9 +318,22 @@ export class NativeDateAdapter extends DateAdapter<Date> {
    * @returns A Date object with its UTC representation based on the passed in date info
    */
   private _format(dtf: Intl.DateTimeFormat, date: Date) {
+    const year = date.getFullYear();
     const d = new Date(Date.UTC(
-        date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(),
+        year, date.getMonth(), date.getDate(), date.getHours(),
         date.getMinutes(), date.getSeconds(), date.getMilliseconds()));
-    return dtf.format(d);
+    return dtf.format(this._correctYear(d, year));
+  }
+
+  /**
+   * Corrects the year of a date, accounting for the fact that JS
+   * native Date treats years between 0 and 99 as abbreviations for 19xx.
+   */
+  private _correctYear(date: Date, intendedYear: number): Date {
+    if (intendedYear >= 0 && intendedYear < 100) {
+      date.setFullYear(this.getYear(date) - 1900);
+    }
+
+    return date;
   }
 }


### PR DESCRIPTION
We were formatting dates in the years 0 to 99 incorrectly, because we pass it through the `Date` constructor which infers them as 19xx. We already had logic to handle cases like this when creating dates, but the formatting logic didn't go through the same code path. These changes extend the logic to the formatting utilities.

This fix resolves part of #20418, but we'll also have to make some changes to the datepicker calendar so it doesn't generate out-of-bounds years.