### PR TITLE
build: setup default browser for running legacy tests locally

### DIFF
--- a/test/karma-browsers.json
+++ b/test/karma-browsers.json
@@ -6,6 +6,12 @@
       "--no-sandbox"
     ]
   },
+  "ChromeLocalDebug": {
+    "base": "Chrome",
+    "flags": [
+      "--window-size=1024,768"
+    ]
+  },
   "SAUCELABS_IOS13": {
     "base": "SauceLabs",
     "browserName": "Safari",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -106,7 +106,7 @@ module.exports = config => {
     browserDisconnectTolerance: 1,
     browserNoActivityTimeout: 300000,
 
-    browsers: [],
+    browsers: ['ChromeLocalDebug'],
     singleRun: false,
 
     // Try Websocket for a faster transmission first. Fallback to polling if necessary.


### PR DESCRIPTION
Sometimes the legacy Karma tests might fail and one might want
to debug those. Currently the Gulp task can be run for that, but
it's not starting any browser so one needs to launch Chrome manually.

Tests usually fail then because the browser has different dimensions
but our test expectations rely on a specific dimension. i.e. 1024x768