### PR TITLE
refactor(cdk/testing): simplify harnesses extending ContentContainerComponentHarness with a different root element

### DIFF
--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -384,20 +384,28 @@ export abstract class ComponentHarness {
 export abstract class ContentContainerComponentHarness<S extends string = string>
   extends ComponentHarness implements HarnessLoader {
 
-  getChildLoader(selector: S): Promise<HarnessLoader> {
-    return this.locatorFactory.harnessLoaderFor(selector);
+  async getChildLoader(selector: S): Promise<HarnessLoader> {
+    return (await this.getRootHarnessLoader()).getChildLoader(selector);
   }
 
-  getAllChildLoaders(selector: S): Promise<HarnessLoader[]> {
-    return this.locatorFactory.harnessLoaderForAll(selector);
+  async getAllChildLoaders(selector: S): Promise<HarnessLoader[]> {
+    return (await this.getRootHarnessLoader()).getAllChildLoaders(selector);
   }
 
-  getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
-    return this.locatorFor(query)();
+  async getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
+    return (await this.getRootHarnessLoader()).getHarness(query);
   }
 
-  getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
-    return this.locatorForAll(query)();
+  async getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
+    return (await this.getRootHarnessLoader()).getAllHarnesses(query);
+  }
+
+  /**
+   * Gets the root harness loader from which to start
+   * searching for content contained by this harness.
+   */
+  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
+    return this.locatorFactory.rootHarnessLoader();
   }
 }
 

--- a/src/material-experimental/mdc-menu/testing/menu-harness.ts
+++ b/src/material-experimental/mdc-menu/testing/menu-harness.ts
@@ -11,7 +11,6 @@ import {
   ContentContainerComponentHarness,
   HarnessLoader,
   HarnessPredicate,
-  HarnessQuery,
   TestElement,
   TestKey,
 } from '@angular/cdk/testing';
@@ -127,24 +126,7 @@ export class MatMenuHarness extends ContentContainerComponentHarness<string> {
     return menu.clickItem(...subItemFilters as [Omit<MenuItemHarnessFilters, 'ancestor'>]);
   }
 
-  async getChildLoader(selector: string): Promise<HarnessLoader> {
-    return (await this._getPanelLoader()).getChildLoader(selector);
-  }
-
-  async getAllChildLoaders(selector: string): Promise<HarnessLoader[]> {
-    return (await this._getPanelLoader()).getAllChildLoaders(selector);
-  }
-
-  async getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
-    return (await this._getPanelLoader()).getHarness(query);
-  }
-
-  async getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
-    return (await this._getPanelLoader()).getAllHarnesses(query);
-  }
-
-  /** Gets the element id for the content of the current step. */
-  private async _getPanelLoader(): Promise<HarnessLoader> {
+  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
     const panelId = await this._getPanelId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${panelId}`);
   }

--- a/src/material-experimental/mdc-tabs/testing/tab-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-harness.ts
@@ -7,11 +7,9 @@
  */
 
 import {
-  ComponentHarness,
   ContentContainerComponentHarness,
   HarnessLoader,
   HarnessPredicate,
-  HarnessQuery,
 } from '@angular/cdk/testing';
 import {TabHarnessFilters} from './tab-harness-filters';
 
@@ -78,24 +76,12 @@ export class MatTabHarness extends ContentContainerComponentHarness<string> {
    * @breaking-change 12.0.0
    */
   async getHarnessLoaderForContent(): Promise<HarnessLoader> {
+    return this.getRootHarnessLoader();
+  }
+
+  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
     const contentId = await this._getContentId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${contentId}`);
-  }
-
-  async getChildLoader(selector: string): Promise<HarnessLoader> {
-    return (await this.getHarnessLoaderForContent()).getChildLoader(selector);
-  }
-
-  async getAllChildLoaders(selector: string): Promise<HarnessLoader[]> {
-    return (await this.getHarnessLoaderForContent()).getAllChildLoaders(selector);
-  }
-
-  async getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
-    return (await this.getHarnessLoaderForContent()).getHarness(query);
-  }
-
-  async getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
-    return (await this.getHarnessLoaderForContent()).getAllHarnesses(query);
   }
 
   /** Gets the element id for the content of the current tab. */

--- a/src/material/menu/testing/menu-harness.ts
+++ b/src/material/menu/testing/menu-harness.ts
@@ -7,11 +7,9 @@
  */
 
 import {
-  ComponentHarness,
   ContentContainerComponentHarness,
   HarnessLoader,
   HarnessPredicate,
-  HarnessQuery,
   TestElement,
   TestKey,
 } from '@angular/cdk/testing';
@@ -127,24 +125,7 @@ export class MatMenuHarness extends ContentContainerComponentHarness<string> {
     return menu.clickItem(...subItemFilters as [Omit<MenuItemHarnessFilters, 'ancestor'>]);
   }
 
-  async getChildLoader(selector: string): Promise<HarnessLoader> {
-    return (await this._getPanelLoader()).getChildLoader(selector);
-  }
-
-  async getAllChildLoaders(selector: string): Promise<HarnessLoader[]> {
-    return (await this._getPanelLoader()).getAllChildLoaders(selector);
-  }
-
-  async getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
-    return (await this._getPanelLoader()).getHarness(query);
-  }
-
-  async getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
-    return (await this._getPanelLoader()).getAllHarnesses(query);
-  }
-
-  /** Gets the element id for the content of the current step. */
-  private async _getPanelLoader(): Promise<HarnessLoader> {
+  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
     const panelId = await this._getPanelId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${panelId}`);
   }

--- a/src/material/stepper/testing/step-harness.ts
+++ b/src/material/stepper/testing/step-harness.ts
@@ -10,8 +10,6 @@ import {
   ContentContainerComponentHarness,
   HarnessPredicate,
   HarnessLoader,
-  ComponentHarness,
-  HarnessQuery,
 } from '@angular/cdk/testing';
 import {StepHarnessFilters} from './step-harness-filters';
 
@@ -91,24 +89,7 @@ export class MatStepHarness extends ContentContainerComponentHarness<string> {
     await (await this.host()).click();
   }
 
-  async getChildLoader(selector: string): Promise<HarnessLoader> {
-    return (await this._getContentLoader()).getChildLoader(selector);
-  }
-
-  async getAllChildLoaders(selector: string): Promise<HarnessLoader[]> {
-    return (await this._getContentLoader()).getAllChildLoaders(selector);
-  }
-
-  async getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
-    return (await this._getContentLoader()).getHarness(query);
-  }
-
-  async getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
-    return (await this._getContentLoader()).getAllHarnesses(query);
-  }
-
-  /** Gets the harness loader for the content of the current step. */
-  private async _getContentLoader(): Promise<HarnessLoader> {
+  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
     const contentId = await (await this.host()).getAttribute('aria-controls');
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${contentId}`);
   }

--- a/src/material/tabs/testing/tab-harness.ts
+++ b/src/material/tabs/testing/tab-harness.ts
@@ -7,11 +7,9 @@
  */
 
 import {
-  ComponentHarness,
   ContentContainerComponentHarness,
   HarnessLoader,
   HarnessPredicate,
-  HarnessQuery,
 } from '@angular/cdk/testing';
 import {TabHarnessFilters} from './tab-harness-filters';
 
@@ -78,24 +76,12 @@ export class MatTabHarness extends ContentContainerComponentHarness<string> {
    * @breaking-change 12.0.0
    */
   async getHarnessLoaderForContent(): Promise<HarnessLoader> {
+    return this.getRootHarnessLoader();
+  }
+
+  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
     const contentId = await this._getContentId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${contentId}`);
-  }
-
-  async getChildLoader(selector: string): Promise<HarnessLoader> {
-    return (await this.getHarnessLoaderForContent()).getChildLoader(selector);
-  }
-
-  async getAllChildLoaders(selector: string): Promise<HarnessLoader[]> {
-    return (await this.getHarnessLoaderForContent()).getAllChildLoaders(selector);
-  }
-
-  async getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T> {
-    return (await this.getHarnessLoaderForContent()).getHarness(query);
-  }
-
-  async getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]> {
-    return (await this.getHarnessLoaderForContent()).getAllHarnesses(query);
   }
 
   /** Gets the element id for the content of the current tab. */

--- a/tools/public_api_guard/cdk/testing.d.ts
+++ b/tools/public_api_guard/cdk/testing.d.ts
@@ -38,6 +38,7 @@ export declare abstract class ContentContainerComponentHarness<S extends string 
     getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
     getChildLoader(selector: S): Promise<HarnessLoader>;
     getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
+    protected getRootHarnessLoader(): Promise<HarnessLoader>;
 }
 
 export interface ElementDimensions {

--- a/tools/public_api_guard/material/menu/testing.d.ts
+++ b/tools/public_api_guard/material/menu/testing.d.ts
@@ -3,11 +3,8 @@ export declare class MatMenuHarness extends ContentContainerComponentHarness<str
     clickItem(itemFilter: Omit<MenuItemHarnessFilters, 'ancestor'>, ...subItemFilters: Omit<MenuItemHarnessFilters, 'ancestor'>[]): Promise<void>;
     close(): Promise<void>;
     focus(): Promise<void>;
-    getAllChildLoaders(selector: string): Promise<HarnessLoader[]>;
-    getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
-    getChildLoader(selector: string): Promise<HarnessLoader>;
-    getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
     getItems(filters?: Omit<MenuItemHarnessFilters, 'ancestor'>): Promise<MatMenuItemHarness[]>;
+    protected getRootHarnessLoader(): Promise<HarnessLoader>;
     getTriggerText(): Promise<string>;
     isDisabled(): Promise<boolean>;
     isFocused(): Promise<boolean>;

--- a/tools/public_api_guard/material/stepper/testing.d.ts
+++ b/tools/public_api_guard/material/stepper/testing.d.ts
@@ -1,11 +1,8 @@
 export declare class MatStepHarness extends ContentContainerComponentHarness<string> {
-    getAllChildLoaders(selector: string): Promise<HarnessLoader[]>;
-    getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
     getAriaLabel(): Promise<string | null>;
     getAriaLabelledby(): Promise<string | null>;
-    getChildLoader(selector: string): Promise<HarnessLoader>;
-    getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
     getLabel(): Promise<string>;
+    protected getRootHarnessLoader(): Promise<HarnessLoader>;
     hasErrors(): Promise<boolean>;
     isCompleted(): Promise<boolean>;
     isOptional(): Promise<boolean>;

--- a/tools/public_api_guard/material/tabs/testing.d.ts
+++ b/tools/public_api_guard/material/tabs/testing.d.ts
@@ -7,14 +7,11 @@ export declare class MatTabGroupHarness extends ComponentHarness {
 }
 
 export declare class MatTabHarness extends ContentContainerComponentHarness<string> {
-    getAllChildLoaders(selector: string): Promise<HarnessLoader[]>;
-    getAllHarnesses<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T[]>;
     getAriaLabel(): Promise<string | null>;
     getAriaLabelledby(): Promise<string | null>;
-    getChildLoader(selector: string): Promise<HarnessLoader>;
-    getHarness<T extends ComponentHarness>(query: HarnessQuery<T>): Promise<T>;
     getHarnessLoaderForContent(): Promise<HarnessLoader>;
     getLabel(): Promise<string>;
+    protected getRootHarnessLoader(): Promise<HarnessLoader>;
     getTextContent(): Promise<string>;
     isDisabled(): Promise<boolean>;
     isSelected(): Promise<boolean>;


### PR DESCRIPTION
We have some test harnesses that extend `ContentContainerComponentHarness`, but have to override all methods, because their content is in a different element.

These changes clean up such usages by having a protected method for retrieving the harness root element that can be overwritten when necessary.