### PR TITLE
fix(material/list): emit selectionChange event when selecting with ctrl + a

### DIFF
--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -71,25 +71,25 @@ describe('MDC-based MatSelectionList without forms', () => {
     });
 
     it('should not emit a selectionChange event if an option changed programmatically', () => {
-      spyOn(fixture.componentInstance, 'onValueChange');
+      spyOn(fixture.componentInstance, 'onSelectionChange');
 
-      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(0);
 
       listOptions[2].componentInstance.toggle();
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(0);
     });
 
     it('should emit a selectionChange event if an option got clicked', () => {
-      spyOn(fixture.componentInstance, 'onValueChange');
+      spyOn(fixture.componentInstance, 'onSelectionChange');
 
-      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(0);
 
       dispatchMouseEvent(listOptions[2].nativeElement, 'click');
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(1);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(1);
     });
 
     it('should be able to dispatch one selected item', () => {
@@ -523,6 +523,23 @@ describe('MDC-based MatSelectionList without forms', () => {
       fixture.detectChanges();
 
       expect(listOptions.every(option => option.componentInstance.selected)).toBe(false);
+    });
+
+    // MDC does not support the common CTRL + A keyboard shortcut.
+    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
+    // tslint:disable-next-line:ban
+    xit('should dispatch the selectionChange event when selecting via ctrl + a', () => {
+      const spy = spyOn(fixture.componentInstance, 'onSelectionChange');
+      listOptions.forEach(option => option.componentInstance.disabled = false);
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
+
+      dispatchEvent(selectionList.nativeElement, event);
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({
+        options: listOptions.map(option => option.componentInstance)
+      }));
     });
 
     it('should be able to jump focus down to an item by typing', fakeAsync(() => {
@@ -1433,7 +1450,7 @@ describe('MDC-based MatSelectionList with forms', () => {
 @Component({template: `
   <mat-selection-list
     id="selection-list-1"
-    (selectionChange)="onValueChange($event)"
+    (selectionChange)="onSelectionChange($event)"
     [disableRipple]="listRippleDisabled"
     [color]="selectionListColor"
     [multiple]="multiple">
@@ -1462,7 +1479,7 @@ class SelectionListWithListOptions {
   selectionListColor: ThemePalette;
   firstOptionColor: ThemePalette;
 
-  onValueChange(_change: MatSelectionListChange) {}
+  onSelectionChange(_change: MatSelectionListChange) {}
 }
 
 @Component({template: `

--- a/src/material-experimental/mdc-list/selection-list.ts
+++ b/src/material-experimental/mdc-list/selection-list.ts
@@ -44,10 +44,16 @@ const MAT_SELECTION_LIST_VALUE_ACCESSOR: any = {
 /** Change event that is being fired whenever the selected state of an option changes. */
 export class MatSelectionListChange {
   constructor(
-      /** Reference to the selection list that emitted the event. */
-      public source: MatSelectionList,
-      /** Reference to the option that has been changed. */
-      public option: MatListOption) {}
+    /** Reference to the selection list that emitted the event. */
+    public source: MatSelectionList,
+    /**
+     * Reference to the option that has been changed.
+     * @deprecated Use `options` instead, because some events may change more than one option.
+     * @breaking-change 12.0.0
+     */
+    public option: MatListOption,
+    /** Reference to the options that have been changed. */
+    public options: MatListOption[]) {}
 }
 
 @Component({
@@ -209,8 +215,8 @@ export class MatSelectionList extends MatInteractiveListBase<MatListOption>
   }
 
   /** Emits a change event if the selected state of an option changed. */
-  _emitChangeEvent(option: MatListOption) {
-    this.selectionChange.emit(new MatSelectionListChange(this, option));
+  _emitChangeEvent(options: MatListOption[]) {
+    this.selectionChange.emit(new MatSelectionListChange(this, options[0], options));
   }
 
   /** Implemented as part of ControlValueAccessor. */
@@ -366,7 +372,7 @@ function getSelectionListAdapter(list: MatSelectionList): MDCListAdapter {
       baseAdapter.setAttributeForElementIndex(index, attribute, value);
     },
     notifyAction(index: number): void {
-      list._emitChangeEvent(list._itemsArr[index]);
+      list._emitChangeEvent([list._itemsArr[index]]);
     },
   };
 }

--- a/src/material/list/selection-list.spec.ts
+++ b/src/material/list/selection-list.spec.ts
@@ -74,25 +74,25 @@ describe('MatSelectionList without forms', () => {
     });
 
     it('should not emit a selectionChange event if an option changed programmatically', () => {
-      spyOn(fixture.componentInstance, 'onValueChange');
+      spyOn(fixture.componentInstance, 'onSelectionChange');
 
-      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(0);
 
       listOptions[2].componentInstance.toggle();
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(0);
     });
 
     it('should emit a selectionChange event if an option got clicked', () => {
-      spyOn(fixture.componentInstance, 'onValueChange');
+      spyOn(fixture.componentInstance, 'onSelectionChange');
 
-      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(0);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(0);
 
       dispatchFakeEvent(listOptions[2].nativeElement, 'click');
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.onValueChange).toHaveBeenCalledTimes(1);
+      expect(fixture.componentInstance.onSelectionChange).toHaveBeenCalledTimes(1);
     });
 
     it('should be able to dispatch one selected item', () => {
@@ -564,6 +564,20 @@ describe('MatSelectionList without forms', () => {
       fixture.detectChanges();
 
       expect(listOptions.every(option => option.componentInstance.selected)).toBe(false);
+    });
+
+    it('should dispatch the selectionChange event when selecting via ctrl + a', () => {
+      const spy = spyOn(fixture.componentInstance, 'onSelectionChange');
+      listOptions.forEach(option => option.componentInstance.disabled = false);
+      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
+
+      dispatchEvent(selectionList.nativeElement, event);
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({
+        options: listOptions.map(option => option.componentInstance)
+      }));
     });
 
     it('should be able to jump focus down to an item by typing', fakeAsync(() => {
@@ -1520,7 +1534,7 @@ describe('MatSelectionList with forms', () => {
 @Component({template: `
   <mat-selection-list
     id="selection-list-1"
-    (selectionChange)="onValueChange($event)"
+    (selectionChange)="onSelectionChange($event)"
     [disableRipple]="listRippleDisabled"
     [color]="selectionListColor"
     [multiple]="multiple">
@@ -1549,7 +1563,7 @@ class SelectionListWithListOptions {
   selectionListColor: ThemePalette;
   firstOptionColor: ThemePalette;
 
-  onValueChange(_change: MatSelectionListChange) {}
+  onSelectionChange(_change: MatSelectionListChange) {}
 }
 
 @Component({template: `

--- a/tools/public_api_guard/material/list.d.ts
+++ b/tools/public_api_guard/material/list.d.ts
@@ -116,7 +116,7 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
     readonly selectionChange: EventEmitter<MatSelectionListChange>;
     tabIndex: number;
     constructor(_element: ElementRef<HTMLElement>, tabIndex: string, _changeDetector: ChangeDetectorRef, _focusMonitor?: FocusMonitor | undefined);
-    _emitChangeEvent(option: MatListOption): void;
+    _emitChangeEvent(options: MatListOption[]): void;
     _keydown(event: KeyboardEvent): void;
     _removeOptionFromList(option: MatListOption): MatListOption | null;
     _reportValueChange(): void;
@@ -140,8 +140,10 @@ export declare class MatSelectionList extends _MatSelectionListMixinBase impleme
 
 export declare class MatSelectionListChange {
     option: MatListOption;
+    options: MatListOption[];
     source: MatSelectionList;
     constructor(
     source: MatSelectionList,
-    option: MatListOption);
+    option: MatListOption,
+    options: MatListOption[]);
 }


### PR DESCRIPTION
Fixes that we weren't emitting the `selectionChange` event when the user toggles all options with the ctrl + a shortcut. Also replaces `MatSelectionListChange.option` with `options` which is an array of all options that were changed by the current event.

Fixes #15696.