### PR TITLE
fix(cdk/a11y): cdkAriaLive default to 'polite'

### DIFF
--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -2,7 +2,7 @@ import {MutationObserverFactory} from '@angular/cdk/observers';
 import {Component, Input} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, inject, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {A11yModule} from '../index';
+import {A11yModule, AriaLivePoliteness} from '../index';
 import {LiveAnnouncer} from './live-announcer';
 import {
   LIVE_ANNOUNCER_ELEMENT_TOKEN,
@@ -282,6 +282,15 @@ describe('CdkAriaLive', () => {
     announcer.ngOnDestroy();
   }));
 
+  it('should default politeness to polite', fakeAsync(() => {
+    fixture.componentInstance.content = 'New content';
+    fixture.detectChanges();
+    invokeMutationCallbacks();
+    flush();
+
+    expect(announcer.announce).toHaveBeenCalledWith('New content', 'polite');
+  }));
+
   it('should dynamically update the politeness', fakeAsync(() => {
     fixture.componentInstance.content = 'New content';
     fixture.detectChanges();
@@ -340,8 +349,8 @@ class TestApp {
   }
 }
 
-@Component({template: `<div [cdkAriaLive]="politeness">{{content}}</div>`})
+@Component({template: `<div [cdkAriaLive]="politeness ? politeness : null">{{content}}</div>`})
 class DivWithCdkAriaLive {
-  @Input() politeness = 'polite';
+  @Input() politeness: AriaLivePoliteness;
   @Input() content = 'Initial content';
 }

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -186,7 +186,7 @@ export class CdkAriaLive implements OnDestroy {
   @Input('cdkAriaLive')
   get politeness(): AriaLivePoliteness { return this._politeness; }
   set politeness(value: AriaLivePoliteness) {
-    this._politeness = value === 'polite' || value === 'assertive' ? value : 'off';
+    this._politeness = value === 'off' || value === 'assertive' ? value : 'polite';
     if (this._politeness === 'off') {
       if (this._subscription) {
         this._subscription.unsubscribe();
@@ -210,7 +210,7 @@ export class CdkAriaLive implements OnDestroy {
       });
     }
   }
-  private _politeness: AriaLivePoliteness = 'off';
+  private _politeness: AriaLivePoliteness = 'polite';
 
   private _previousAnnouncedText?: string;
   private _subscription: Subscription | null;


### PR DESCRIPTION
Currently if a cdkAriaLive does not have an `Input` specified defaults
to `off` value. Change default behavior to assign `polite` value to the
directive.

Fixes #11618