### PR TITLE
refactor(cdk/schematics): change usages of whitelist in selector interfaces to fileTypeFilter

### DIFF
--- a/src/cdk/schematics/ng-update/data/css-selectors.ts
+++ b/src/cdk/schematics/ng-update/data/css-selectors.ts
@@ -14,14 +14,17 @@ export interface CssSelectorUpgradeData {
   replace: string;
   /** The new CSS selector. */
   replaceWith: string;
-  /** Whitelist where this replacement is made. If omitted it is made in all files. */
-  whitelist?: {
+  /**
+   * Controls which file types in which this replacement is made. If omitted, it is made in all
+   * files.
+   */
+  replaceIn?: {
     /** Replace this name in stylesheet files. */
     stylesheet?: boolean,
     /** Replace this name in HTML files. */
     html?: boolean,
     /** Replace this name in TypeScript strings. */
-    strings?: boolean
+    tsStringLiterals?: boolean
   };
 }
 

--- a/src/cdk/schematics/ng-update/data/input-names.ts
+++ b/src/cdk/schematics/ng-update/data/input-names.ts
@@ -14,8 +14,8 @@ export interface InputNameUpgradeData {
   replace: string;
   /** The new name for the @Input(). */
   replaceWith: string;
-  /** Whitelist where this replacement is made. If omitted it is made in all HTML & CSS */
-  whitelist: {
+  /** Controls which elements and attributes in which this replacement is made. */
+  limitedTo: {
     /** Limit to elements with any of these element tags. */
     elements?: string[],
     /** Limit to elements with any of these attributes. */
@@ -31,73 +31,73 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
         {
           replace: 'origin',
           replaceWith: 'cdkConnectedOverlayOrigin',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'positions',
           replaceWith: 'cdkConnectedOverlayPositions',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'offsetX',
           replaceWith: 'cdkConnectedOverlayOffsetX',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'offsetY',
           replaceWith: 'cdkConnectedOverlayOffsetY',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'width',
           replaceWith: 'cdkConnectedOverlayWidth',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'height',
           replaceWith: 'cdkConnectedOverlayHeight',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'minWidth',
           replaceWith: 'cdkConnectedOverlayMinWidth',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'minHeight',
           replaceWith: 'cdkConnectedOverlayMinHeight',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'backdropClass',
           replaceWith: 'cdkConnectedOverlayBackdropClass',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'scrollStrategy',
           replaceWith: 'cdkConnectedOverlayScrollStrategy',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'open',
           replaceWith: 'cdkConnectedOverlayOpen',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         },
         {
           replace: 'hasBackdrop',
           replaceWith: 'cdkConnectedOverlayHasBackdrop',
-          whitelist:
+          limitedTo:
               {attributes: ['cdk-connected-overlay', 'connected-overlay', 'cdkConnectedOverlay']}
         }
       ]

--- a/src/cdk/schematics/ng-update/data/output-names.ts
+++ b/src/cdk/schematics/ng-update/data/output-names.ts
@@ -14,8 +14,8 @@ export interface OutputNameUpgradeData {
   replace: string;
   /** The new name for the @Output(). */
   replaceWith: string;
-  /** Whitelist where this replacement is made. If omitted it is made in all HTML & CSS */
-  whitelist: {
+  /** Controls which elements and attributes in which this replacement is made. */
+  limitedTo: {
     /** Limit to elements with any of these element tags. */
     elements?: string[],
     /** Limit to elements with any of these attributes. */
@@ -30,7 +30,7 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
       changes: [{
         replace: 'copied',
         replaceWith: 'cdkCopyToClipboardCopied',
-        whitelist: {
+        limitedTo: {
           attributes: ['cdkCopyToClipboard']
         }
       }]

--- a/src/cdk/schematics/ng-update/data/property-names.ts
+++ b/src/cdk/schematics/ng-update/data/property-names.ts
@@ -14,8 +14,8 @@ export interface PropertyNameUpgradeData {
   replace: string;
   /** The new name for the property. */
   replaceWith: string;
-  /** Whitelist where this replacement is made. If omitted it is made for all Classes. */
-  whitelist: {
+  /** Controls which classes in which this replacement is made. */
+  limitedTo: {
     /** Replace the property only when its type is one of the given Classes. */
     classes: string[];
   };
@@ -28,7 +28,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
       changes: [{
         replace: 'boundaryElementSelector',
         replaceWith: 'boundaryElement',
-        whitelist: {classes: ['CdkDrag']}
+        limitedTo: {classes: ['CdkDrag']}
       }]
     },
     {
@@ -36,7 +36,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
       changes: [{
         replace: 'onChange',
         replaceWith: 'changed',
-        whitelist: {classes: ['SelectionModel']}
+        limitedTo: {classes: ['SelectionModel']}
       }]
     }
   ],
@@ -45,7 +45,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/8286',
       changes:
-          [{replace: 'onChange', replaceWith: 'changed', whitelist: {classes: ['SelectionModel']}}]
+          [{replace: 'onChange', replaceWith: 'changed', limitedTo: {classes: ['SelectionModel']}}]
     },
 
     {
@@ -53,7 +53,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
       changes: [{
         replace: 'flexibleDiemsions',
         replaceWith: 'flexibleDimensions',
-        whitelist: {classes: ['CdkConnectedOverlay']}
+        limitedTo: {classes: ['CdkConnectedOverlay']}
       }]
     }
   ],
@@ -65,62 +65,62 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
         {
           replace: '_deprecatedOrigin',
           replaceWith: 'origin',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedPositions',
           replaceWith: 'positions',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedOffsetX',
           replaceWith: 'offsetX',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedOffsetY',
           replaceWith: 'offsetY',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedWidth',
           replaceWith: 'width',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedHeight',
           replaceWith: 'height',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedMinWidth',
           replaceWith: 'minWidth',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedMinHeight',
           replaceWith: 'minHeight',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedBackdropClass',
           replaceWith: 'backdropClass',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedScrollStrategy',
           replaceWith: 'scrollStrategy',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedOpen',
           replaceWith: 'open',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         },
         {
           replace: '_deprecatedHasBackdrop',
           replaceWith: 'hasBackdrop',
-          whitelist: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
+          limitedTo: {classes: ['CdkConnectedOverlay', 'ConnectedOverlayDirective']}
         }
       ]
     },
@@ -131,12 +131,12 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
         {
           replace: '_deprecatedPortal',
           replaceWith: 'portal',
-          whitelist: {classes: ['CdkPortalOutlet']}
+          limitedTo: {classes: ['CdkPortalOutlet']}
         },
         {
           replace: '_deprecatedPortalHost',
           replaceWith: 'portal',
-          whitelist: {classes: ['CdkPortalOutlet']}
+          limitedTo: {classes: ['CdkPortalOutlet']}
         }
       ]
     },

--- a/src/cdk/schematics/ng-update/migrations/class-inheritance.ts
+++ b/src/cdk/schematics/ng-update/migrations/class-inheritance.ts
@@ -28,9 +28,9 @@ export class ClassInheritanceMigration extends Migration<UpgradeData> {
 
   init(): void {
     getVersionUpgradeData(this, 'propertyNames')
-        .filter(data => data.whitelist && data.whitelist.classes)
+        .filter(data => data.limitedTo && data.limitedTo.classes)
         .forEach(
-            data => data.whitelist.classes.forEach(name => this.propertyNames.set(name, data)));
+            data => data.limitedTo.classes.forEach(name => this.propertyNames.set(name, data)));
   }
 
   visitNode(node: ts.Node): void {

--- a/src/cdk/schematics/ng-update/migrations/css-selectors.ts
+++ b/src/cdk/schematics/ng-update/migrations/css-selectors.ts
@@ -20,7 +20,7 @@ import {getVersionUpgradeData, UpgradeData} from '../upgrade-data';
  */
 export class CssSelectorsMigration extends Migration<UpgradeData> {
   /** Change data that upgrades to the specified target version. */
-  data = getVersionUpgradeData(this, 'cssSelectors');
+  data: CssSelectorUpgradeData[] = getVersionUpgradeData(this, 'cssSelectors');
 
   // Only enable the migration rule if there is upgrade data.
   enabled = this.data.length !== 0;
@@ -33,7 +33,7 @@ export class CssSelectorsMigration extends Migration<UpgradeData> {
 
   visitTemplate(template: ResolvedResource): void {
     this.data.forEach(data => {
-      if (data.whitelist && !data.whitelist.html) {
+      if (data.replaceIn && !data.replaceIn.html) {
         return;
       }
 
@@ -45,7 +45,7 @@ export class CssSelectorsMigration extends Migration<UpgradeData> {
 
   visitStylesheet(stylesheet: ResolvedResource): void {
     this.data.forEach(data => {
-      if (data.whitelist && !data.whitelist.stylesheet) {
+      if (data.replaceIn && !data.replaceIn.stylesheet) {
         return;
       }
 
@@ -64,7 +64,7 @@ export class CssSelectorsMigration extends Migration<UpgradeData> {
     const filePath = this.fileSystem.resolve(node.getSourceFile().fileName);
 
     this.data.forEach(data => {
-      if (data.whitelist && !data.whitelist.strings) {
+      if (data.replaceIn && !data.replaceIn.tsStringLiterals) {
         return;
       }
 

--- a/src/cdk/schematics/ng-update/migrations/input-names.ts
+++ b/src/cdk/schematics/ng-update/migrations/input-names.ts
@@ -44,17 +44,17 @@ export class InputNamesMigration extends Migration<UpgradeData> {
 
   visitTemplate(template: ResolvedResource): void {
     this.data.forEach(name => {
-      const whitelist = name.whitelist;
+      const limitedTo = name.limitedTo;
       const relativeOffsets: number[] = [];
 
-      if (whitelist.attributes) {
+      if (limitedTo.attributes) {
         relativeOffsets.push(
-            ...findInputsOnElementWithAttr(template.content, name.replace, whitelist.attributes));
+            ...findInputsOnElementWithAttr(template.content, name.replace, limitedTo.attributes));
       }
 
-      if (whitelist.elements) {
+      if (limitedTo.elements) {
         relativeOffsets.push(
-            ...findInputsOnElementWithTag(template.content, name.replace, whitelist.elements));
+            ...findInputsOnElementWithTag(template.content, name.replace, limitedTo.elements));
       }
 
       relativeOffsets.map(offset => template.start + offset)

--- a/src/cdk/schematics/ng-update/migrations/output-names.ts
+++ b/src/cdk/schematics/ng-update/migrations/output-names.ts
@@ -30,17 +30,17 @@ export class OutputNamesMigration extends Migration<UpgradeData> {
 
   visitTemplate(template: ResolvedResource): void {
     this.data.forEach(name => {
-      const whitelist = name.whitelist;
+      const limitedTo = name.limitedTo;
       const relativeOffsets: number[] = [];
 
-      if (whitelist.attributes) {
+      if (limitedTo.attributes) {
         relativeOffsets.push(
-            ...findOutputsOnElementWithAttr(template.content, name.replace, whitelist.attributes));
+            ...findOutputsOnElementWithAttr(template.content, name.replace, limitedTo.attributes));
       }
 
-      if (whitelist.elements) {
+      if (limitedTo.elements) {
         relativeOffsets.push(
-            ...findOutputsOnElementWithTag(template.content, name.replace, whitelist.elements));
+            ...findOutputsOnElementWithTag(template.content, name.replace, limitedTo.elements));
       }
 
       relativeOffsets.map(offset => template.start + offset)

--- a/src/cdk/schematics/ng-update/migrations/property-names.ts
+++ b/src/cdk/schematics/ng-update/migrations/property-names.ts
@@ -38,7 +38,7 @@ export class PropertyNamesMigration extends Migration<UpgradeData> {
         return;
       }
 
-      if (!data.whitelist || data.whitelist.classes.includes(typeName)) {
+      if (!data.limitedTo || data.limitedTo.classes.includes(typeName)) {
         this.fileSystem.edit(this.fileSystem.resolve(node.getSourceFile().fileName))
           .remove(node.name.getStart(), node.name.getWidth())
           .insertRight(node.name.getStart(), data.replaceWith);

--- a/src/material/schematics/ng-update/data/css-selectors.ts
+++ b/src/material/schematics/ng-update/data/css-selectors.ts
@@ -13,14 +13,17 @@ export interface MaterialCssSelectorData {
   replace: string;
   /** The new CSS selector. */
   replaceWith: string;
-  /** Whitelist where this replacement is made. If omitted it is made in all files. */
-  whitelist?: {
+  /**
+   * Controls which file types in which this replacement is made. If omitted, it is made in all
+   * files.
+   */
+  replaceIn?: {
     /** Replace this name in stylesheet files. */
     stylesheet?: boolean,
     /** Replace this name in HTML files. */
     html?: boolean,
     /** Replace this name in TypeScript strings. */
-    strings?: boolean
+    tsStringLiterals?: boolean
   };
 }
 
@@ -54,7 +57,7 @@ export const cssSelectors: VersionChanges<MaterialCssSelectorData> = {
       changes: [{
         replace: '$mat-font-family',
         replaceWith: 'Roboto, \'Helvetica Neue\', sans-serif',
-        whitelist: {stylesheet: true}
+        replaceIn: {stylesheet: true}
       }]
     }
   ]

--- a/src/material/schematics/ng-update/data/input-names.ts
+++ b/src/material/schematics/ng-update/data/input-names.ts
@@ -15,7 +15,7 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
       changes: [{
         replace: 'align',
         replaceWith: 'labelPosition',
-        whitelist: {elements: ['mat-radio-group', 'mat-radio-button']}
+        limitedTo: {elements: ['mat-radio-group', 'mat-radio-button']}
       }]
     },
 
@@ -24,18 +24,18 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
       changes: [{
         replace: 'align',
         replaceWith: 'position',
-        whitelist: {elements: ['mat-drawer', 'mat-sidenav']}
+        limitedTo: {elements: ['mat-drawer', 'mat-sidenav']}
       }]
     },
 
     {
       pr: 'https://github.com/angular/components/pull/10294',
       changes: [
-        {replace: 'dividerColor', replaceWith: 'color', whitelist: {elements: ['mat-form-field']}},
+        {replace: 'dividerColor', replaceWith: 'color', limitedTo: {elements: ['mat-form-field']}},
         {
           replace: 'floatPlaceholder',
           replaceWith: 'floatLabel',
-          whitelist: {elements: ['mat-form-field']}
+          limitedTo: {elements: ['mat-form-field']}
         }
       ]
     },
@@ -45,14 +45,14 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
       changes: [{
         replace: 'mat-dynamic-height',
         replaceWith: 'dynamicHeight',
-        whitelist: {elements: ['mat-tab-group']}
+        limitedTo: {elements: ['mat-tab-group']}
       }]
     },
 
     {
       pr: 'https://github.com/angular/components/pull/10342',
       changes: [
-        {replace: 'align', replaceWith: 'labelPosition', whitelist: {elements: ['mat-checkbox']}}
+        {replace: 'align', replaceWith: 'labelPosition', limitedTo: {elements: ['mat-checkbox']}}
       ]
     },
 
@@ -61,18 +61,18 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
       changes: [{
         replace: 'tooltip-position',
         replaceWith: 'matTooltipPosition',
-        whitelist: {attributes: ['matTooltip']}
+        limitedTo: {attributes: ['matTooltip']}
       }]
     },
 
     {
       pr: 'https://github.com/angular/components/pull/10373',
       changes: [
-        {replace: 'thumb-label', replaceWith: 'thumbLabel', whitelist: {elements: ['mat-slider']}},
+        {replace: 'thumb-label', replaceWith: 'thumbLabel', limitedTo: {elements: ['mat-slider']}},
         {
           replace: 'tick-interval',
           replaceWith: 'tickInterval',
-          whitelist: {elements: ['mat-slider']}
+          limitedTo: {elements: ['mat-slider']}
         }
       ]
     }

--- a/src/material/schematics/ng-update/data/output-names.ts
+++ b/src/material/schematics/ng-update/data/output-names.ts
@@ -16,21 +16,21 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
         {
           replace: 'change',
           replaceWith: 'selectionChange',
-          whitelist: {
+          limitedTo: {
             elements: ['mat-select'],
           },
         },
         {
           replace: 'onClose',
           replaceWith: 'closed',
-          whitelist: {
+          limitedTo: {
             elements: ['mat-select'],
           },
         },
         {
           replace: 'onOpen',
           replaceWith: 'opened',
-          whitelist: {
+          limitedTo: {
             elements: ['mat-select'],
           },
         },
@@ -43,21 +43,21 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
         {
           replace: 'align-changed',
           replaceWith: 'positionChanged',
-          whitelist: {
+          limitedTo: {
             elements: ['mat-drawer', 'mat-sidenav'],
           },
         },
         {
           replace: 'close',
           replaceWith: 'closed',
-          whitelist: {
+          limitedTo: {
             elements: ['mat-drawer', 'mat-sidenav'],
           },
         },
         {
           replace: 'open',
           replaceWith: 'opened',
-          whitelist: {
+          limitedTo: {
             elements: ['mat-drawer', 'mat-sidenav'],
           },
         },
@@ -70,7 +70,7 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
         {
           replace: 'selectChange',
           replaceWith: 'selectedTabChange',
-          whitelist: {
+          limitedTo: {
             elements: ['mat-tab-group'],
           },
         },
@@ -83,7 +83,7 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
         {
           replace: 'remove',
           replaceWith: 'removed',
-          whitelist: {
+          limitedTo: {
             attributes: ['mat-chip', 'mat-basic-chip'],
             elements: ['mat-chip', 'mat-basic-chip'],
           },
@@ -91,7 +91,7 @@ export const outputNames: VersionChanges<OutputNameUpgradeData> = {
         {
           replace: 'destroy',
           replaceWith: 'destroyed',
-          whitelist: {
+          limitedTo: {
             attributes: ['mat-chip', 'mat-basic-chip'],
             elements: ['mat-chip', 'mat-basic-chip'],
           },

--- a/src/material/schematics/ng-update/data/property-names.ts
+++ b/src/material/schematics/ng-update/data/property-names.ts
@@ -16,17 +16,17 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
         {
           replace: 'afterOpen',
           replaceWith: 'afterOpened',
-          whitelist: {classes: ['MatDialogRef']}
+          limitedTo: {classes: ['MatDialogRef']}
         },
         {
           replace: 'beforeClose',
           replaceWith: 'beforeClosed',
-          whitelist: {classes: ['MatDialogRef']}
+          limitedTo: {classes: ['MatDialogRef']}
         },
         {
           replace: 'afterOpen',
           replaceWith: 'afterOpened',
-          whitelist: {classes: ['MatDialog']}
+          limitedTo: {classes: ['MatDialog']}
         }
       ]
     }
@@ -35,15 +35,15 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/10163',
       changes: [
-        {replace: 'change', replaceWith: 'selectionChange', whitelist: {classes: ['MatSelect']}}, {
+        {replace: 'change', replaceWith: 'selectionChange', limitedTo: {classes: ['MatSelect']}}, {
           replace: 'onOpen',
           replaceWith: 'openedChange.pipe(filter(isOpen => isOpen))',
-          whitelist: {classes: ['MatSelect']}
+          limitedTo: {classes: ['MatSelect']}
         },
         {
           replace: 'onClose',
           replaceWith: 'openedChange.pipe(filter(isOpen => !isOpen))',
-          whitelist: {classes: ['MatSelect']}
+          limitedTo: {classes: ['MatSelect']}
         }
       ]
     },
@@ -53,7 +53,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
       changes: [{
         replace: 'align',
         replaceWith: 'labelPosition',
-        whitelist: {classes: ['MatRadioGroup', 'MatRadioButton']}
+        limitedTo: {classes: ['MatRadioGroup', 'MatRadioButton']}
       }]
     },
 
@@ -62,7 +62,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
       changes: [{
         replace: 'extraClasses',
         replaceWith: 'panelClass',
-        whitelist: {classes: ['MatSnackBarConfig']}
+        limitedTo: {classes: ['MatSnackBarConfig']}
       }]
     },
 
@@ -72,22 +72,22 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
         {
           replace: 'align',
           replaceWith: 'position',
-          whitelist: {classes: ['MatDrawer', 'MatSidenav']}
+          limitedTo: {classes: ['MatDrawer', 'MatSidenav']}
         },
         {
           replace: 'onAlignChanged',
           replaceWith: 'onPositionChanged',
-          whitelist: {classes: ['MatDrawer', 'MatSidenav']}
+          limitedTo: {classes: ['MatDrawer', 'MatSidenav']}
         },
         {
           replace: 'onOpen',
           replaceWith: 'openedChange.pipe(filter(isOpen => isOpen))',
-          whitelist: {classes: ['MatDrawer', 'MatSidenav']}
+          limitedTo: {classes: ['MatDrawer', 'MatSidenav']}
         },
         {
           replace: 'onClose',
           replaceWith: 'openedChange.pipe(filter(isOpen => !isOpen))',
-          whitelist: {classes: ['MatDrawer', 'MatSidenav']}
+          limitedTo: {classes: ['MatDrawer', 'MatSidenav']}
         }
       ]
     },
@@ -97,17 +97,17 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
       changes: [{
         replace: 'shouldPlaceholderFloat',
         replaceWith: 'shouldLabelFloat',
-        whitelist: {classes: ['MatFormFieldControl', 'MatSelect']}
+        limitedTo: {classes: ['MatFormFieldControl', 'MatSelect']}
       }]
     },
 
     {
       pr: 'https://github.com/angular/components/pull/10294',
       changes: [
-        {replace: 'dividerColor', replaceWith: 'color', whitelist: {classes: ['MatFormField']}}, {
+        {replace: 'dividerColor', replaceWith: 'color', limitedTo: {classes: ['MatFormField']}}, {
           replace: 'floatPlaceholder',
           replaceWith: 'floatLabel',
-          whitelist: {classes: ['MatFormField']}
+          limitedTo: {classes: ['MatFormField']}
         }
       ]
     },
@@ -118,12 +118,12 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
         {
           replace: 'selectChange',
           replaceWith: 'selectedTabChange',
-          whitelist: {classes: ['MatTabGroup']}
+          limitedTo: {classes: ['MatTabGroup']}
         },
         {
           replace: '_dynamicHeightDeprecated',
           replaceWith: 'dynamicHeight',
-          whitelist: {classes: ['MatTabGroup']}
+          limitedTo: {classes: ['MatTabGroup']}
         }
       ]
     },
@@ -131,15 +131,15 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/10311',
       changes: [
-        {replace: 'destroy', replaceWith: 'destroyed', whitelist: {classes: ['MatChip']}},
-        {replace: 'onRemove', replaceWith: 'removed', whitelist: {classes: ['MatChip']}}
+        {replace: 'destroy', replaceWith: 'destroyed', limitedTo: {classes: ['MatChip']}},
+        {replace: 'onRemove', replaceWith: 'removed', limitedTo: {classes: ['MatChip']}}
       ]
     },
 
     {
       pr: 'https://github.com/angular/components/pull/10342',
       changes:
-          [{replace: 'align', replaceWith: 'labelPosition', whitelist: {classes: ['MatCheckbox']}}]
+          [{replace: 'align', replaceWith: 'labelPosition', limitedTo: {classes: ['MatCheckbox']}}]
     },
 
     {
@@ -147,7 +147,7 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
       changes: [{
         replace: '_positionDeprecated',
         replaceWith: 'position',
-        whitelist: {classes: ['MatTooltip']}
+        limitedTo: {classes: ['MatTooltip']}
       }]
     },
 
@@ -157,12 +157,12 @@ export const propertyNames: VersionChanges<PropertyNameUpgradeData> = {
         {
           replace: '_thumbLabelDeprecated',
           replaceWith: 'thumbLabel',
-          whitelist: {classes: ['MatSlider']}
+          limitedTo: {classes: ['MatSlider']}
         },
         {
           replace: '_tickIntervalDeprecated',
           replaceWith: 'tickInterval',
-          whitelist: {classes: ['MatSlider']}
+          limitedTo: {classes: ['MatSlider']}
         }
       ]
     },


### PR DESCRIPTION
Same changes as #20619, but for the patch branch