### PR TITLE
fix(cdk/tree): collapse child nodes if top level collapses

### DIFF
--- a/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.ts
+++ b/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.ts
@@ -88,7 +88,13 @@ export class CdkTreeFlatExample {
   }
 
   shouldRender(node: ExampleFlatNode) {
-    const parent = this.getParentNode(node);
-    return !parent || parent.isExpanded;
+    let parent = this.getParentNode(node);
+    while (parent) {
+      if (!parent.isExpanded) {
+        return false;
+      }
+      parent = this.getParentNode(parent);
+    }
+    return true;
   }
 }


### PR DESCRIPTION
Fixes a bug in the Angular CDK Tree examples where the children nodes
are still visible when the top level node is collapsed. This is because
the `shouldRender()` method of the [cdk-flat-tree-example.ts](https://github.com/angular/components/blob/master/src/components-examples/cdk/tree/cdk-tree-flat/cdk-tree-flat-example.ts) is checking
only the parent of current node.

Fixes #20665