### PR TITLE
mat-tooltip: ensure message is converted to string

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -209,7 +209,9 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this._message);
 
     // If the message is not a string (e.g. number), convert it to a string and trim it.
-    this._message = value != null ? `${value}`.trim() : '';
+    // Must convert with `String(value)`, not `${value}`, otherwise Closure Compiler optimises
+    // away the string-conversion: https://github.com/angular/components/issues/20684
+    this._message = value != null ? String(value).trim() : '';
 
     if (!this._message && this._isTooltipVisible()) {
       this.hide(0);


### PR DESCRIPTION
This ensures that the Closure Compiler doesn't optimise out the format-string stringification.

I've only changed the setter's argument type, and have left `TooltipComponent.message` to be declared as string, with the reasoning that most users will want a type error if they try to set a non-string type.

I'm trying to maintain the runtime API of this code in the face of type-based optimisations.

Fixes #20684