### PR TITLE
feat(material-experimental/mdc-paginator): add test harness

### DIFF
--- a/src/material-experimental/config.bzl
+++ b/src/material-experimental/config.bzl
@@ -22,6 +22,7 @@ entryPoints = [
     "mdc-menu",
     "mdc-menu/testing",
     "mdc-paginator",
+    "mdc-paginator/testing",
     "mdc-progress-bar",
     "mdc-progress-bar/testing",
     "mdc-progress-spinner",

--- a/src/material-experimental/mdc-paginator/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-paginator/testing/BUILD.bazel
@@ -1,0 +1,43 @@
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material-experimental/mdc-paginator/testing",
+    deps = [
+        "//src/cdk/coercion",
+        "//src/cdk/testing",
+        "//src/material-experimental/mdc-select/testing",
+        "//src/material/paginator/testing",
+    ],
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":testing",
+        "//src/material-experimental/mdc-paginator",
+        "//src/material/paginator/testing:harness_tests_lib",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    static_files = [
+        "@npm//:node_modules/@material/textfield/dist/mdc.textfield.js",
+        "@npm//:node_modules/@material/line-ripple/dist/mdc.lineRipple.js",
+        "@npm//:node_modules/@material/notched-outline/dist/mdc.notchedOutline.js",
+        "@npm//:node_modules/@material/ripple/dist/mdc.ripple.js",
+        "@npm//:node_modules/@material/dom/dist/mdc.dom.js",
+    ],
+    deps = [
+        ":unit_tests_lib",
+        "//src/material-experimental:mdc_require_config.js",
+    ],
+)

--- a/src/material-experimental/mdc-paginator/testing/index.ts
+++ b/src/material-experimental/mdc-paginator/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-paginator/testing/paginator-harness-filters.ts
+++ b/src/material-experimental/mdc-paginator/testing/paginator-harness-filters.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BaseHarnessFilters} from '@angular/cdk/testing';
+
+/** A set of criteria that can be used to filter a list of `MatPaginatorHarness` instances. */
+export interface PaginatorHarnessFilters extends BaseHarnessFilters {
+}

--- a/src/material-experimental/mdc-paginator/testing/paginator-harness.spec.ts
+++ b/src/material-experimental/mdc-paginator/testing/paginator-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatPaginatorModule} from '@angular/material-experimental/mdc-paginator';
+import {runHarnessTests} from '@angular/material/paginator/testing/shared.spec';
+import {MatPaginatorHarness} from './paginator-harness';
+
+describe('MDC-based MatPaginatorHarness', () => {
+  runHarnessTests(MatPaginatorModule, MatPaginatorHarness as any);
+});

--- a/src/material-experimental/mdc-paginator/testing/paginator-harness.ts
+++ b/src/material-experimental/mdc-paginator/testing/paginator-harness.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {MatSelectHarness} from '@angular/material-experimental/mdc-select/testing';
+import {coerceNumberProperty} from '@angular/cdk/coercion';
+import {PaginatorHarnessFilters} from './paginator-harness-filters';
+
+
+/** Harness for interacting with an MDC-based mat-paginator in tests. */
+export class MatPaginatorHarness extends ComponentHarness {
+  /** Selector used to find paginator instances. */
+  static hostSelector = '.mat-mdc-paginator';
+  private _nextButton = this.locatorFor('.mat-mdc-paginator-navigation-next');
+  private _previousButton = this.locatorFor('.mat-mdc-paginator-navigation-previous');
+  private _firstPageButton = this.locatorForOptional('.mat-mdc-paginator-navigation-first');
+  private _lastPageButton = this.locatorForOptional('.mat-mdc-paginator-navigation-last');
+  private _select = this.locatorForOptional(MatSelectHarness.with({
+    ancestor: '.mat-mdc-paginator-page-size'
+  }));
+  private _pageSizeFallback = this.locatorFor('.mat-mdc-paginator-page-size-value');
+  private _rangeLabel = this.locatorFor('.mat-mdc-paginator-range-label');
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatPaginatorHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which paginator instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: PaginatorHarnessFilters = {}): HarnessPredicate<MatPaginatorHarness> {
+    return new HarnessPredicate(MatPaginatorHarness, options);
+  }
+
+  /** Goes to the next page in the paginator. */
+  async goToNextPage(): Promise<void> {
+    return (await this._nextButton()).click();
+  }
+
+  /** Goes to the previous page in the paginator. */
+  async goToPreviousPage(): Promise<void> {
+    return (await this._previousButton()).click();
+  }
+
+  /** Goes to the first page in the paginator. */
+  async goToFirstPage(): Promise<void> {
+    const button = await this._firstPageButton();
+
+    // The first page button isn't enabled by default so we need to check for it.
+    if (!button) {
+      throw Error('Could not find first page button inside paginator. ' +
+                  'Make sure that `showFirstLastButtons` is enabled.');
+    }
+
+    return button.click();
+  }
+
+  /** Goes to the last page in the paginator. */
+  async goToLastPage(): Promise<void> {
+    const button = await this._lastPageButton();
+
+    // The last page button isn't enabled by default so we need to check for it.
+    if (!button) {
+      throw Error('Could not find last page button inside paginator. ' +
+                  'Make sure that `showFirstLastButtons` is enabled.');
+    }
+
+    return button.click();
+  }
+
+  /**
+   * Sets the page size of the paginator.
+   * @param size Page size that should be select.
+   */
+  async setPageSize(size: number): Promise<void> {
+    const select = await this._select();
+
+    // The select is only available if the `pageSizeOptions` are
+    // set to an array with more than one item.
+    if (!select) {
+      throw Error('Cannot find page size selector in paginator. ' +
+                  'Make sure that the `pageSizeOptions` have been configured.');
+    }
+
+    return select.clickOptions({text: `${size}`});
+  }
+
+  /** Gets the page size of the paginator. */
+  async getPageSize(): Promise<number> {
+    const select = await this._select();
+    const value = select ? select.getValueText() : (await this._pageSizeFallback()).text();
+    return coerceNumberProperty(await value);
+  }
+
+  /** Gets the text of the range labe of the paginator. */
+  async getRangeLabel(): Promise<string> {
+    return (await this._rangeLabel()).text();
+  }
+}

--- a/src/material-experimental/mdc-paginator/testing/public-api.ts
+++ b/src/material-experimental/mdc-paginator/testing/public-api.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './paginator-harness';
+export * from './paginator-harness-filters';


### PR DESCRIPTION
Sets up a test harness for the MDC-based paginator.