### PR TITLE
fix(material-experimental/mdc-snack-bar): not aligned correctly on IE11

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.scss
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.scss
@@ -16,6 +16,10 @@
 }
 
 // These elements need to have full width using flex layout.
-.mat-mdc-snack-bar-handset, .mat-mdc-snack-bar-container, .mat-mdc-snack-bar-label {
-  flex: 1;
+.mat-mdc-snack-bar-handset,
+.mat-mdc-snack-bar-container,
+.mat-mdc-snack-bar-label {
+  // Note that we need to include the full `flex` shorthand
+  // declaration so the container doesn't collapse on IE11.
+  flex: 1 0 auto;
 }


### PR DESCRIPTION
We were hitting a flexbox bug that was causing the snack bar container to collapse on IE11, shifting it off-center when using the `center` alignment and pushing it completely off-screen in the `end` alignment.