### PR TITLE
fix(material-experimental/mdc-snack-bar): button pushed outside container

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.scss
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.scss
@@ -21,5 +21,5 @@
 .mat-mdc-snack-bar-label {
   // Note that we need to include the full `flex` shorthand
   // declaration so the container doesn't collapse on IE11.
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }


### PR DESCRIPTION
Fixes a regression from #20690 that caused the snack bar button to be pushed outside of the container.