### PR TITLE
fix(material/datepicker): lifecycle hooks not being called

### DIFF
--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -197,7 +197,8 @@ const _MatDateRangeInputBase:
     {provide: NG_VALIDATORS, useExisting: MatStartDate, multi: true}
   ]
 })
-export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
+    CanUpdateErrorState, DoCheck, OnInit {
   /** Validator that checks that the start date isn't after the end date. */
   private _startValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
     const start = this._dateAdapter.getValidDateOrNull(
@@ -223,6 +224,26 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpd
     // constructor once ViewEngine is removed.
     super(rangeInput, elementRef, defaultErrorStateMatcher, injector, parentForm, parentFormGroup,
         dateAdapter, dateFormats);
+  }
+
+  ngOnInit() {
+    // Normally this happens automatically, but it seems to break if not added explicitly when all
+    // of the criteria below are met:
+    // 1) The class extends a TS mixin.
+    // 2) The application is running in ViewEngine.
+    // 3) The application is being transpiled through tsickle.
+    // This can be removed once google3 is completely migrated to Ivy.
+    super.ngOnInit();
+  }
+
+  ngDoCheck() {
+    // Normally this happens automatically, but it seems to break if not added explicitly when all
+    // of the criteria below are met:
+    // 1) The class extends a TS mixin.
+    // 2) The application is running in ViewEngine.
+    // 3) The application is being transpiled through tsickle.
+    // This can be removed once google3 is completely migrated to Ivy.
+    super.ngDoCheck();
   }
 
   protected _validator = Validators.compose([...super._getValidators(), this._startValidator]);
@@ -282,7 +303,8 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpd
     {provide: NG_VALIDATORS, useExisting: MatEndDate, multi: true}
   ]
 })
-export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements
+    CanUpdateErrorState, DoCheck, OnInit {
   /** Validator that checks that the end date isn't before the start date. */
   private _endValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
     const end = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(control.value));
@@ -307,6 +329,26 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdat
     // constructor once ViewEngine is removed.
     super(rangeInput, elementRef, defaultErrorStateMatcher, injector, parentForm, parentFormGroup,
         dateAdapter, dateFormats);
+  }
+
+  ngOnInit() {
+    // Normally this happens automatically, but it seems to break if not added explicitly when all
+    // of the criteria below are met:
+    // 1) The class extends a TS mixin.
+    // 2) The application is running in ViewEngine.
+    // 3) The application is being transpiled through tsickle.
+    // This can be removed once google3 is completely migrated to Ivy.
+    super.ngOnInit();
+  }
+
+  ngDoCheck() {
+    // Normally this happens automatically, but it seems to break if not added explicitly when all
+    // of the criteria below are met:
+    // 1) The class extends a TS mixin.
+    // 2) The application is running in ViewEngine.
+    // 3) The application is being transpiled through tsickle.
+    // This can be removed once google3 is completely migrated to Ivy.
+    super.ngDoCheck();
   }
 
   protected _validator = Validators.compose([...super._getValidators(), this._endValidator]);

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -366,13 +366,15 @@ export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSe
     static ɵfac: i0.ɵɵFactoryDef<MatDateSelectionModel<any, any>, never>;
 }
 
-export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState, DoCheck, OnInit {
     protected _canEmitChangeEvent: (event: DateSelectionModelChange<DateRange<D>>) => boolean;
     protected _validator: ValidatorFn | null;
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
     protected _assignValueToModel(value: D | null): void;
     protected _getValueFromModel(modelValue: DateRange<D>): D | null;
     _onKeydown(event: KeyboardEvent): void;
+    ngDoCheck(): void;
+    ngOnInit(): void;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
@@ -473,7 +475,7 @@ export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionMode
     static ɵprov: i0.ɵɵInjectableDef<MatSingleDateSelectionModel<any>>;
 }
 
-export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState {
+export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState, DoCheck, OnInit {
     protected _canEmitChangeEvent: (event: DateSelectionModelChange<DateRange<D>>) => boolean;
     protected _validator: ValidatorFn | null;
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
@@ -481,6 +483,8 @@ export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implement
     protected _formatValue(value: D | null): void;
     protected _getValueFromModel(modelValue: DateRange<D>): D | null;
     getMirrorValue(): string;
+    ngDoCheck(): void;
+    ngOnInit(): void;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatStartDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;


### PR DESCRIPTION
Lifecycle hooks are not being called in some cases due to a weird
interaction between extending TS mixins, running in view engine, and
transpiling the code with tsickle.