### PR TITLE
fix(material/datepicker): fix handling of short years

### DIFF
--- a/src/material/core/datetime/native-date-adapter.spec.ts
+++ b/src/material/core/datetime/native-date-adapter.spec.ts
@@ -152,7 +152,7 @@ describe('NativeDateAdapter', () => {
     expect(adapter.getYearName(new Date(2017, JAN, 1))).toBe('2017');
   });
 
-  it('should year name for low year numbers', () => {
+  it('should get year name for low year numbers', () => {
     const createAndFormat = (year: number) => {
       return adapter.getYearName(adapter.createDate(year, JAN, 1));
     };


### PR DESCRIPTION
This should hopefully fix test flakiness introduced by https://github.com/angular/components/commit/dd49fa69ddaa8106d5d2b9cacc67f45120fdccbc. The previous fix seems to sometimes report an incorrect date based on the time zone the test runs in