### PR TITLE
build: migrate to new dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "javascript"
-    commit_message:
-      prefix: "build"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -342,7 +342,6 @@
 /.github/**                                        @angular/dev-infra-components
 /.github/CODEOWNERS                                @angular/dev-infra-components @jelbourn
 /.github/ISSUE_TEMPLATE/**                         @andrewseguin @jelbourn
-/.dependabot/**                                    @angular/dev-infra-components
 /.vscode/**                                        @angular/dev-infra-components @mmalerba
 /.ng-dev/**                                        @angular/dev-infra-components
 /goldens/size-test.yml                             @jelbourn @mmalerba @crisbeto

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    commit-message:
+      prefix: "build"
+    labels:
+      - "area: build"
+      - "merge ready"
+      - "merge safe"
+      - "target: patch"


### PR DESCRIPTION
Migrates to the new dependabot config rolled out since dependabot was
moved into Github.