### PR TITLE
test(material/datepicker): fix test failure

### DIFF
--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -2121,7 +2121,8 @@ describe('MatDatepicker', () => {
       fixture.detectChanges();
 
       const datepickerContent = testComponent.datepicker['_dialogRef']!!.componentInstance;
-      const actualClasses = datepickerContent._elementRef.nativeElement.children[1].classList;
+      const actualClasses =
+          datepickerContent._elementRef.nativeElement.querySelector('.mat-calendar').classList;
       expect(actualClasses.contains('foo')).toBe(true);
       expect(actualClasses.contains('bar')).toBe(true);
     });


### PR DESCRIPTION
A PR that changes the DOM structure of the datepicker went in at the same time as a PR that was depending on the old one, causing a test failure.