### PR TITLE
docs(material/table): add multiTemplateDataRows specification

### DIFF
--- a/src/material/table/table.md
+++ b/src/material/table/table.md
@@ -346,6 +346,11 @@ container has a complex box shadow and has sibling elements, the stuck cells wil
 There is currently an [open issue with Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17514118/)
 to resolve this.
 
+
+#### Multiple row templates
+
+When using the `multiTemplateDataRows` directive to support multiple rows for each data object, the context of `*matRowDef` is the same except that the `index` value is replaced by `dataIndex` and `renderIndex`.
+
 ### Accessibility
 Tables without text or labels should be given a meaningful label via `aria-label` or
 `aria-labelledby`. The `aria-readonly` defaults to `true` if it's not set.


### PR DESCRIPTION
## Purpose

Add a section to material/table documentation about how to retrieve the index of a row when using the `multiTemplateDataRows` directive. This information is only accessible as a comment into the [row.ts file](https://github.com/angular/components/blob/34a7e382144bb63965589002d0ed6bb046ac6054/src/cdk/table/row.ts) of the cdk.

```

        Context provided to the row cells when multiTemplateDataRows is true. This context is the same
        as CdkCellOutletRowContext except that the single index value is replaced by dataIndex and
        renderIndex.


```

## Motivation
Having notifications over time about a related issue i gave an answer 2 years ago.

Issue #12793