### PR TITLE
Revert "fix(material/slider): some screen readers announcing long dec…

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -507,16 +507,6 @@ describe('MatSlider', () => {
       expect(sliderInstance.value).toBe(0.3);
     });
 
-    it('should set the truncated value to the aria-valuetext', () => {
-      fixture.componentInstance.step = 0.1;
-      fixture.detectChanges();
-
-      dispatchSlideEventSequence(sliderNativeElement, 0, 0.333333);
-      fixture.detectChanges();
-
-      expect(sliderNativeElement.getAttribute('aria-valuetext')).toBe('33');
-    });
-
   });
 
   describe('slider with auto ticks', () => {

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -134,13 +134,6 @@ const _MatSliderMixinBase:
     '[attr.aria-valuemax]': 'max',
     '[attr.aria-valuemin]': 'min',
     '[attr.aria-valuenow]': 'value',
-
-    // NVDA and Jaws appear to announce the `aria-valuenow` by calculating its percentage based
-    // on its value between `aria-valuemin` and `aria-valuemax`. Due to how decimals are handled,
-    // it can cause the slider to read out a very long value like 0.20000068 if the current value
-    // is 0.2 with a min of 0 and max of 1. We work around the issue by setting `aria-valuetext`
-    // to the same value that we set on the slider's thumb which will be truncated.
-    '[attr.aria-valuetext]': 'displayValue',
     '[attr.aria-orientation]': 'vertical ? "vertical" : "horizontal"',
     '[class.mat-slider-disabled]': 'disabled',
     '[class.mat-slider-has-ticks]': 'tickInterval',


### PR DESCRIPTION
…imal values (#20721)"

This reverts commit d93e16f5d7c85ca41a71c1ef0bd7fde32e921dee.

Had to revert this change because a custom `aria-valuetext` on the component should override what the component sets