### PR TITLE
fix(cdk/testing): avoid using dotted property access for dispatchEven…

### DIFF
--- a/src/cdk/testing/protractor/protractor-element.ts
+++ b/src/cdk/testing/protractor/protractor-element.ts
@@ -212,5 +212,6 @@ export class ProtractorElement implements TestElement {
 function _dispatchEvent(name: string, element: ElementFinder) {
   const event = document.createEvent('Event');
   event.initEvent(name);
+  // This type has a string index signature, so we cannot access it using a dotted property access.
   element['dispatchEvent'](event);
 }

--- a/src/cdk/testing/protractor/protractor-element.ts
+++ b/src/cdk/testing/protractor/protractor-element.ts
@@ -212,5 +212,5 @@ export class ProtractorElement implements TestElement {
 function _dispatchEvent(name: string, element: ElementFinder) {
   const event = document.createEvent('Event');
   event.initEvent(name);
-  element.dispatchEvent(event);
+  element['dispatchEvent'](event);
 }


### PR DESCRIPTION
…t on ElementFinder

 * Internally this was causing an error saying that the type has a
  string index signature, but it is being accessed using a dotted property access.