### PR TITLE
refactor(cdk/drag-drop): Correctly type drag handle parent drag witho…

### DIFF
--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -18,6 +18,7 @@ import {
   SkipSelf,
 } from '@angular/core';
 import {Subject} from 'rxjs';
+import type {CdkDrag} from './drag';
 import {CDK_DRAG_PARENT} from '../drag-parent';
 import {assertElementNode} from './assertions';
 
@@ -38,7 +39,7 @@ export const CDK_DRAG_HANDLE = new InjectionToken<CdkDragHandle>('CdkDragHandle'
 })
 export class CdkDragHandle implements OnDestroy {
   /** Closest parent draggable instance. */
-  _parentDrag: {} | undefined;
+  _parentDrag: CdkDrag | null;
 
   /** Emits when the state of the handle has changed. */
   _stateChanges = new Subject<CdkDragHandle>();
@@ -54,7 +55,7 @@ export class CdkDragHandle implements OnDestroy {
 
   constructor(
     public element: ElementRef<HTMLElement>,
-    @Inject(CDK_DRAG_PARENT) @Optional() @SkipSelf() parentDrag?: any) {
+    @Inject(CDK_DRAG_PARENT) @Optional() @SkipSelf() parentDrag?: CdkDrag) {
 
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       assertElementNode(element.nativeElement, 'cdkDragHandle');

--- a/src/cdk/drag-drop/directives/drag-handle.ts
+++ b/src/cdk/drag-drop/directives/drag-handle.ts
@@ -39,7 +39,7 @@ export const CDK_DRAG_HANDLE = new InjectionToken<CdkDragHandle>('CdkDragHandle'
 })
 export class CdkDragHandle implements OnDestroy {
   /** Closest parent draggable instance. */
-  _parentDrag: CdkDrag | null;
+  _parentDrag: CdkDrag | undefined;
 
   /** Emits when the state of the handle has changed. */
   _stateChanges = new Subject<CdkDragHandle>();


### PR DESCRIPTION
…ut circular dependencies warning

Import the `CdkDrag` directive reference as a type-only import to avoid the circular dependency warning.