### PR TITLE
fix(material-experimental/mdc-form-field): test harness referring to non-MDC harnesses

### DIFF
--- a/src/material-experimental/mdc-form-field/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-form-field/testing/BUILD.bazel
@@ -11,10 +11,10 @@ ts_library(
     module_name = "@angular/material-experimental/mdc-form-field/testing",
     deps = [
         "//src/cdk/testing",
+        "//src/material-experimental/mdc-input/testing",
+        "//src/material-experimental/mdc-select/testing",
         "//src/material/form-field/testing",
         "//src/material/form-field/testing/control",
-        "//src/material/input/testing",
-        "//src/material/select/testing",
     ],
 )
 
@@ -31,16 +31,13 @@ ng_test_library(
     ),
     deps = [
         ":testing",
-        "//src/cdk/overlay",
+        "//src/material-experimental/mdc-autocomplete",
         "//src/material-experimental/mdc-form-field",
         "//src/material-experimental/mdc-input",
-        "//src/material/autocomplete",
-        "//src/material/core",
+        "//src/material-experimental/mdc-input/testing",
+        "//src/material-experimental/mdc-select",
+        "//src/material-experimental/mdc-select/testing",
         "//src/material/form-field/testing:harness_tests_lib",
-        "//src/material/input/testing",
-        "//src/material/select",
-        "//src/material/select/testing",
-        "@npm//@angular/common",
     ],
 )
 

--- a/src/material-experimental/mdc-form-field/testing/form-field-harness.spec.ts
+++ b/src/material-experimental/mdc-form-field/testing/form-field-harness.spec.ts
@@ -1,35 +1,15 @@
-import {OverlayModule} from '@angular/cdk/overlay';
-import {CommonModule} from '@angular/common';
-import {NgModule} from '@angular/core';
 import {MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
 import {MatInputModule} from '@angular/material-experimental/mdc-input';
-import {MatAutocompleteModule} from '@angular/material/autocomplete';
-import {MatCommonModule, MatOptionModule} from '@angular/material/core';
-import {MatInputHarness} from '@angular/material/input/testing';
-import {
-  MAT_SELECT_SCROLL_STRATEGY_PROVIDER,
-  MatSelect,
-  MatSelectTrigger
-} from '@angular/material/select';
-import {MatSelectHarness} from '@angular/material/select/testing';
+import {MatAutocompleteModule} from '@angular/material-experimental/mdc-autocomplete';
+import {MatInputHarness} from '@angular/material-experimental/mdc-input/testing';
+import {MatSelectModule} from '@angular/material-experimental/mdc-select';
+import {MatSelectHarness} from '@angular/material-experimental/mdc-select/testing';
 import {runHarnessTests} from '@angular/material/form-field/testing/shared.spec';
 import {MatFormFieldHarness} from './form-field-harness';
 
-// TODO: remove this once there is a `MatSelect` module which does not come
-// with the form-field module provided. This is a copy of the `MatSelect` module
-// that does not provide any form-field module.
-@NgModule({
-  imports: [CommonModule, OverlayModule, MatOptionModule, MatCommonModule],
-  exports: [MatSelect, MatSelectTrigger, MatOptionModule, MatCommonModule],
-  declarations: [MatSelect, MatSelectTrigger],
-  providers: [MAT_SELECT_SCROLL_STRATEGY_PROVIDER]
-})
-export class SelectWithoutFormFieldModule {
-}
-
 describe('MDC-based MatFormFieldHarness', () => {
   runHarnessTests(
-      [MatFormFieldModule, MatAutocompleteModule, MatInputModule, SelectWithoutFormFieldModule], {
+      [MatFormFieldModule, MatAutocompleteModule, MatInputModule, MatSelectModule], {
         formFieldHarness: MatFormFieldHarness as any,
         inputHarness: MatInputHarness,
         selectHarness: MatSelectHarness,

--- a/src/material-experimental/mdc-form-field/testing/form-field-harness.ts
+++ b/src/material-experimental/mdc-form-field/testing/form-field-harness.ts
@@ -15,8 +15,8 @@ import {
 } from '@angular/cdk/testing';
 import {FormFieldHarnessFilters} from '@angular/material/form-field/testing';
 import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
-import {MatInputHarness} from '@angular/material/input/testing';
-import {MatSelectHarness} from '@angular/material/select/testing';
+import {MatInputHarness} from '@angular/material-experimental/mdc-input/testing';
+import {MatSelectHarness} from '@angular/material-experimental/mdc-select/testing';
 
 // TODO(devversion): support datepicker harness once developed (COMP-203).
 // Also support chip list harness.


### PR DESCRIPTION
The test harness for the MDC form field was referring to the non-MDC versions of `MatInput` and `MatSelect`. Furthermore, we were using the non-MDC input, select and autocomplete in tests.