### PR TITLE
fix(cdk/stepper): error if out-of-bounds index is assigned before initialization

### DIFF
--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -29,6 +29,7 @@ import {
   Provider,
   ViewChildren,
   QueryList,
+  ViewChild,
 } from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, inject, TestBed} from '@angular/core/testing';
 import {
@@ -1270,6 +1271,24 @@ describe('MatStepper', () => {
     expect(steppers[0].steps.length).toBe(3);
     expect(steppers[1].steps.length).toBe(2);
   });
+
+  it('should not throw when trying to change steps after initializing to an out-of-bounds index',
+    () => {
+      const fixture = createComponent(StepperWithStaticOutOfBoundsIndex);
+      fixture.detectChanges();
+      const stepper = fixture.componentInstance.stepper;
+
+      expect(stepper.selectedIndex).toBe(0);
+      expect(stepper.selected).toBeTruthy();
+
+      expect(() => {
+        stepper.selectedIndex = 1;
+        fixture.detectChanges();
+      }).not.toThrow();
+
+      expect(stepper.selectedIndex).toBe(1);
+      expect(stepper.selected).toBeTruthy();
+    });
 });
 
 /** Asserts that keyboard interaction works correctly. */
@@ -1779,4 +1798,18 @@ class StepperWithNgIf {
 })
 class NestedSteppers {
   @ViewChildren(MatStepper) steppers: QueryList<MatStepper>;
+}
+
+
+@Component({
+  template: `
+    <mat-vertical-stepper selectedIndex="1337">
+      <mat-step label="Step 1">Content 1</mat-step>
+      <mat-step label="Step 2">Content 2</mat-step>
+      <mat-step label="Step 3">Content 3</mat-step>
+    </mat-vertical-stepper>
+  `
+})
+class StepperWithStaticOutOfBoundsIndex {
+  @ViewChild(MatStepper) stepper: MatStepper;
 }


### PR DESCRIPTION
Fixes an error if an out-of-bounds index is assigned before the steps are available and the user tries to navigate. Usually we have an assertion that prevents invalid indexes from being assigned, but it doesn't run before initialization, because we don't know how many steps there will be yet.

These changes add a check that will revert the index back to 0 if the index is invalid on initialization.

Fixes #20735.