### PR TITLE
Allow buttons with text+icon or icon+text

### DIFF
--- a/src/material/icon/icon.scss
+++ b/src/material/icon/icon.scss
@@ -27,11 +27,8 @@ $mat-icon-size: 24px !default;
 .mat-form-field:not(.mat-form-field-appearance-legacy) {
   .mat-form-field-prefix,
   .mat-form-field-suffix {
-    .mat-icon {
-      display: block;
-    }
-
     .mat-icon-button .mat-icon {
+      display: block;
       margin: auto;
     }
   }


### PR DESCRIPTION
Only using block on mat-icon-button means you can have buttons that are not icon only (icon+text or text+icon)