### PR TITLE
fix(material-experimental/mdc-slide-toggle): align focus behavior with standard version

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/BUILD.bazel
+++ b/src/material-experimental/mdc-slide-toggle/BUILD.bazel
@@ -64,6 +64,7 @@ ng_test_library(
     ),
     deps = [
         ":mdc-slide-toggle",
+        "//src/cdk/a11y",
         "//src/cdk/bidi",
         "//src/cdk/testing/private",
         "//src/material/slide-toggle",

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -21,14 +21,12 @@
             [attr.aria-label]="ariaLabel"
             [attr.aria-labelledby]="ariaLabelledby"
             (change)="_onChangeEvent($event)"
-            (click)="_onInputClick($event)"
-            (blur)="_onBlur()"
-            (focus)="_focused = true">
+            (click)="_onInputClick($event)">
       </div>
     </div>
   </div>
 
-  <label [for]="inputId" (click)="$event.stopPropagation()">
+  <label [for]="inputId">
     <ng-content></ng-content>
   </label>
 </div>

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -333,7 +333,7 @@ describe('MatSlideToggle without forms', () => {
       expect(slideToggleElement.classList).toContain('mat-slide-toggle-label-before');
     });
 
-    it('should show ripples on label mousedown', () => {
+    it('should show ripples', () => {
       const rippleSelector = '.mat-ripple-element:not(.mat-slide-toggle-persistent-ripple)';
 
       expect(slideToggleElement.querySelectorAll(rippleSelector).length).toBe(0);
@@ -408,7 +408,8 @@ describe('MatSlideToggle without forms', () => {
   });
 
   describe('custom action configuration', () => {
-    it('should not change value on click when click action is noop', () => {
+    it('should not change value on click when click action is noop when using custom a ' +
+      'action configuration', () => {
       TestBed
         .resetTestingModule()
         .configureTestingModule({


### PR DESCRIPTION
The focus behavior of the existing `mat-slide-toggle` was changed slightly after the MDC version was implemented. These changes align the behavior and add some missing tests.