### PR TITLE
docs: fix link in DEV_ENVIRONMENT guide

### DIFF
--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -3,7 +3,7 @@
 1. Make sure you have both `node` and `yarn` installed.
    We recommend using `nvm` to manage your node versions.
 2. angular/components uses Bazel which requires certain Bash and UNIX tools.
-   - On Windows: Follow the [instructions](https://docs.bazel.build/versions/master/install-windows.html#5-optional-install-compilers-and-language-runtimes)
+   - On Windows: Follow the [instructions](https://docs.bazel.build/versions/master/install-windows.html#installing-compilers-and-language-runtimes)
    to install [`MSYS2`](https://www.msys2.org/) and the listed "Common MSYS2 packages".
    Afterwards add `C:\msys64\usr\bin` to the `PATH` environment variable.
 3. Fork the `angular/components` repo on GitHub.


### PR DESCRIPTION
Fix link for installing MSYS2 in the Developer guide