### PR TITLE
fix(cdk/drag-drop): error when cloning file input with value

### DIFF
--- a/src/cdk/drag-drop/clone-node.ts
+++ b/src/cdk/drag-drop/clone-node.ts
@@ -50,7 +50,11 @@ let cloneUniqueId = 0;
 /** Transfers the data of one input element to another. */
 function transferInputData(source: Element & {value: string},
                            clone: Element & {value: string; name: string; type: string}) {
-  clone.value = source.value;
+  // Browsers throw an error when assigning the value of a file input programmatically.
+  if (clone.type !== 'file') {
+    clone.value = source.value;
+  }
+
   // Radio button `name` attributes must be unique for radio button groups
   // otherwise original radio buttons can lose their checked state
   // once the clone is inserted in the DOM.


### PR DESCRIPTION
When we clone the dragged element to generate its preview, we transfer the values of inputs so that they look identical. The problem is that assigning the value of a `file` input will throw an error so we have to skip it.

**Note:** does not include a unit test, because we can't set the of a test element programmatically.

Fixes #20783.