### PR TITLE
docs(material/input): add type="email" to input examples

### DIFF
--- a/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.html
+++ b/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.html
@@ -1,7 +1,7 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
     <mat-label>Email</mat-label>
-    <input matInput [formControl]="emailFormControl" [errorStateMatcher]="matcher"
+    <input type="email" matInput [formControl]="emailFormControl" [errorStateMatcher]="matcher"
            placeholder="Ex. pat@example.com">
     <mat-hint>Errors appear instantly!</mat-hint>
     <mat-error *ngIf="emailFormControl.hasError('email') && !emailFormControl.hasError('required')">

--- a/src/components-examples/material/input/input-errors/input-errors-example.html
+++ b/src/components-examples/material/input/input-errors/input-errors-example.html
@@ -1,7 +1,7 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
     <mat-label>Email</mat-label>
-    <input matInput [formControl]="emailFormControl" placeholder="Ex. pat@example.com">
+    <input type="email" matInput [formControl]="emailFormControl" placeholder="Ex. pat@example.com">
     <mat-error *ngIf="emailFormControl.hasError('email') && !emailFormControl.hasError('required')">
       Please enter a valid email address
     </mat-error>


### PR DESCRIPTION
Adds `type="email"` to examples in Overview and Examples page for inputs.

Fixes #20682