### PR TITLE
refactor(material/core): remove usages of deprecated Sass functions

### DIFF
--- a/src/material-experimental/mdc-form-field/_form-field-density.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-density.scss
@@ -7,14 +7,14 @@
 // provided by MDC in order to support arbitrary form-field controls.
 @mixin _mat-mdc-form-field-infix-vertical-spacing-filled($with-label-padding, $no-label-padding) {
   .mat-mdc-text-field-wrapper:not(.mdc-text-field--outlined) .mat-mdc-form-field-infix {
-    padding-top: map_get($with-label-padding, top);
-    padding-bottom: map_get($with-label-padding, bottom);
+    padding-top: map-get($with-label-padding, top);
+    padding-bottom: map-get($with-label-padding, bottom);
   }
 
   .mdc-text-field--no-label:not(.mdc-text-field--outlined):not(.mdc-text-field--textarea)
   .mat-mdc-form-field-infix {
-    padding-top: map_get($no-label-padding, top);
-    padding-bottom: map_get($no-label-padding, bottom);
+    padding-top: map-get($no-label-padding, top);
+    padding-bottom: map-get($no-label-padding, bottom);
   }
 }
 
@@ -23,8 +23,8 @@
 // provided by MDC in order to support arbitrary form-field controls.
 @mixin _mat-mdc-form-field-infix-vertical-spacing-outlined($padding) {
   .mat-mdc-text-field-wrapper.mdc-text-field--outlined .mat-mdc-form-field-infix {
-    padding-top: map_get($padding, top);
-    padding-bottom: map_get($padding, bottom);
+    padding-top: map-get($padding, top);
+    padding-bottom: map-get($padding, bottom);
   }
 }
 

--- a/src/material-experimental/mdc-helpers/_focus-indicators.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators.scss
@@ -96,7 +96,7 @@
 
 @mixin mat-mdc-strong-focus-indicators-color($config-or-theme) {
   $config: mat-get-color-config($config-or-theme);
-  @include _mat-mdc-strong-focus-indicators-border-color(mat-color(map_get($config, primary)));
+  @include _mat-mdc-strong-focus-indicators-border-color(mat-color(map-get($config, primary)));
 }
 
 /// Mixin that sets the color of the focus indicators.

--- a/src/material-experimental/mdc-list/_interactive-list-theme.scss
+++ b/src/material-experimental/mdc-list/_interactive-list-theme.scss
@@ -14,7 +14,7 @@
     }
 
     &.mdc-list-item--selected::before {
-      background: mat-color(map_get($config, primary));
+      background: mat-color(map-get($config, primary));
       opacity: map-get($state-opacities, selected);
     }
 

--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -113,7 +113,7 @@ $_mat-button-ripple-opacity: 0.1;
   }
 
   .mat-button-focus-overlay {
-    background: map_get($foreground, base);
+    background: map-get($foreground, base);
   }
 
   // Note: this needs a bit extra specificity, because we're not guaranteed the inclusion

--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -77,7 +77,7 @@
   // Switch this to a solid color since we're using `opacity`
   // to control how opaque the ripple should be.
   .mat-checkbox .mat-ripple-element {
-    background-color: map_get(map-get($config, foreground), base);
+    background-color: map-get(map-get($config, foreground), base);
   }
 
   .mat-checkbox-checked:not(.mat-checkbox-disabled),

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -68,7 +68,7 @@ $mat-chip-remove-font-size: 18px;
     }
 
     &::after {
-      background: map_get($foreground, base);
+      background: map-get($foreground, base);
     }
   }
 

--- a/src/material/core/density/_index.scss
+++ b/src/material/core/density/_index.scss
@@ -47,17 +47,17 @@ $_mat-density-generate-styles: true;
   }
 
   $value: null;
-  $property-scale-map: map_get($density-config, $property-name);
+  $property-scale-map: map-get($density-config, $property-name);
 
-  @if map_has_key($property-scale-map, $density-scale) {
-    $value: map_get($property-scale-map, $density-scale);
+  @if map-has-key($property-scale-map, $density-scale) {
+    $value: map-get($property-scale-map, $density-scale);
   }
   @else {
-    $value: map_get($property-scale-map, default) + $density-scale * $_mat-density-interval;
+    $value: map-get($property-scale-map, default) + $density-scale * $_mat-density-interval;
   }
 
-  $min-value: map_get($property-scale-map, $_mat-density-minimum-scale);
-  $max-value: map_get($property-scale-map, $_mat-density-maximum-scale);
+  $min-value: map-get($property-scale-map, $_mat-density-minimum-scale);
+  $max-value: map-get($property-scale-map, $_mat-density-maximum-scale);
 
   @if ($value < $min-value or $value > $max-value) {
     @error 'mat-density: #{$property-name} must be between #{$min-value} and ' +

--- a/src/material/core/focus-indicators/_focus-indicators.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.scss
@@ -87,7 +87,7 @@
 
 @mixin mat-strong-focus-indicators-color($config-or-theme) {
   $config: mat-get-color-config($config-or-theme);
-  @include _mat-strong-focus-indicators-border-color(mat-color(map_get($config, primary)));
+  @include _mat-strong-focus-indicators-border-color(mat-color(map-get($config, primary)));
 }
 
 /// Mixin that sets the color of the focus indicators.

--- a/src/material/core/ripple/_ripple.scss
+++ b/src/material/core/ripple/_ripple.scss
@@ -47,8 +47,8 @@ $mat-ripple-color-opacity: 0.1;
 /* Colors for the ripple elements.*/
 @mixin mat-ripple-color($config-or-theme) {
   $config: mat-get-color-config($config-or-theme);
-  $foreground: map_get($config, foreground);
-  $foreground-base: map_get($foreground, base);
+  $foreground: map-get($config, foreground);
+  $foreground-base: map-get($foreground, base);
 
   .mat-ripple-element {
     // If the ripple color is resolves to a color *type*, we can use it directly, otherwise

--- a/src/material/core/theming/_check-duplicate-styles.scss
+++ b/src/material/core/theming/_check-duplicate-styles.scss
@@ -31,9 +31,9 @@ $_mat-theme-emitted-density: () !default;
   $density-config: mat-get-density-config($theme);
   $typography-config: mat-get-typography-config($theme);
   // Lists of previous `color`, `density` and `typography` configurations.
-  $previous-color: map_get($_mat-theme-emitted-color, $id) or ();
-  $previous-typography: map_get($_mat-theme-emitted-typography, $id) or ();
-  $previous-density: map_get($_mat-theme-emitted-density, $id) or ();
+  $previous-color: map-get($_mat-theme-emitted-color, $id) or ();
+  $previous-typography: map-get($_mat-theme-emitted-typography, $id) or ();
+  $previous-density: map-get($_mat-theme-emitted-density, $id) or ();
   // Whether duplicate legacy density styles would be generated.
   $duplicate-legacy-density: false;
 
@@ -74,11 +74,11 @@ $_mat-theme-emitted-density: () !default;
     $previous-density: append($previous-density, $density-config);
   }
 
-  $_mat-theme-emitted-color: map_merge(
+  $_mat-theme-emitted-color: map-merge(
       $_mat-theme-emitted-color, ($id: $previous-color)) !global;
-  $_mat-theme-emitted-density: map_merge(
+  $_mat-theme-emitted-density: map-merge(
       $_mat-theme-emitted-density, ($id: $previous-density)) !global;
-  $_mat-theme-emitted-typography: map_merge(
+  $_mat-theme-emitted-typography: map-merge(
       $_mat-theme-emitted-typography, ($id: $previous-typography)) !global;
 
   // Optionally, consumers of this mixin can wrap contents inside so that nested

--- a/src/material/core/theming/_palette.scss
+++ b/src/material/core/theming/_palette.scss
@@ -672,40 +672,40 @@ $mat-blue-gray: $mat-blue-grey;
 
 // Background palette for light themes.
 $mat-light-theme-background: (
-  status-bar: map_get($mat-grey, 300),
-  app-bar:    map_get($mat-grey, 100),
-  background: map_get($mat-grey, 50),
+  status-bar: map-get($mat-grey, 300),
+  app-bar:    map-get($mat-grey, 100),
+  background: map-get($mat-grey, 50),
   hover:      rgba(black, 0.04), // TODO(kara): check style with Material Design UX
   card:       white,
   dialog:     white,
   disabled-button: rgba(black, 0.12),
   raised-button: white,
   focused-button: $dark-focused,
-  selected-button: map_get($mat-grey, 300),
-  selected-disabled-button: map_get($mat-grey, 400),
-  disabled-button-toggle: map_get($mat-grey, 200),
-  unselected-chip: map_get($mat-grey, 300),
-  disabled-list-option: map_get($mat-grey, 200),
-  tooltip: map_get($mat-grey, 700),
+  selected-button: map-get($mat-grey, 300),
+  selected-disabled-button: map-get($mat-grey, 400),
+  disabled-button-toggle: map-get($mat-grey, 200),
+  unselected-chip: map-get($mat-grey, 300),
+  disabled-list-option: map-get($mat-grey, 200),
+  tooltip: map-get($mat-grey, 700),
 );
 
 // Background palette for dark themes.
 $mat-dark-theme-background: (
   status-bar: black,
-  app-bar:    map_get($mat-grey, 900),
+  app-bar:    map-get($mat-grey, 900),
   background: #303030,
   hover:      rgba(white, 0.04), // TODO(kara): check style with Material Design UX
-  card:       map_get($mat-grey, 800),
-  dialog:     map_get($mat-grey, 800),
+  card:       map-get($mat-grey, 800),
+  dialog:     map-get($mat-grey, 800),
   disabled-button: rgba(white, 0.12),
   raised-button: map-get($mat-grey, 800),
   focused-button: $light-focused,
-  selected-button: map_get($mat-grey, 900),
-  selected-disabled-button: map_get($mat-grey, 800),
+  selected-button: map-get($mat-grey, 900),
+  selected-disabled-button: map-get($mat-grey, 800),
   disabled-button-toggle: black,
-  unselected-chip: map_get($mat-grey, 700),
+  unselected-chip: map-get($mat-grey, 700),
   disabled-list-option: black,
-  tooltip: map_get($mat-grey, 700),
+  tooltip: map-get($mat-grey, 700),
 );
 
 // Foreground palette for light themes.

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -17,7 +17,7 @@ $_mat-theme-generate-default-density: true !default;
 // @param $primary
 // @param $lighter
 @function mat-palette($base-palette, $default: 500, $lighter: 100, $darker: 700, $text: $default) {
-  $result: map_merge($base-palette, (
+  $result: map-merge($base-palette, (
     default: map-get($base-palette, $default),
     lighter: map-get($base-palette, $lighter),
     darker: map-get($base-palette, $darker),
@@ -30,7 +30,7 @@ $_mat-theme-generate-default-density: true !default;
 
   // For each hue in the palette, add a "-contrast" color to the map.
   @each $hue, $color in $base-palette {
-    $result: map_merge($result, (
+    $result: map-merge($result, (
       '#{$hue}-contrast': mat-contrast($base-palette, $hue)
     ));
   }
@@ -69,15 +69,15 @@ $_mat-theme-generate-default-density: true !default;
 // Validates the specified theme by ensuring that the optional color config defines
 // a primary, accent and warn palette. Returns the theme if no failures were found.
 @function _mat-validate-theme($theme) {
-  @if map_get($theme, color) {
-    $color: map_get($theme, color);
-    @if not map_get($color, primary) {
+  @if map-get($theme, color) {
+    $color: map-get($theme, color);
+    @if not map-get($color, primary) {
       @error 'Theme does not define a valid "primary" palette.';
     }
-    @else if not map_get($color, accent) {
+    @else if not map-get($color, accent) {
       @error 'Theme does not define a valid "accent" palette.';
     }
-    @else if not map_get($color, warn) {
+    @else if not map-get($color, warn) {
       @error 'Theme does not define a valid "warn" palette.';
     }
   }
@@ -94,7 +94,7 @@ $_mat-theme-generate-default-density: true !default;
 //
 //    @mixin my-custom-component-theme($theme) {
 //      .my-comp {
-//        background-color: mat-color(map_get($theme, primary));
+//        background-color: mat-color(map-get($theme, primary));
 //      }
 //    }
 //
@@ -102,11 +102,11 @@ $_mat-theme-generate-default-density: true !default;
 // is stored in `$theme.color` which contains a property for `primary`. This method copies
 // the map from `$theme.color` to `$theme` for backwards compatibility.
 @function _mat-create-backwards-compatibility-theme($theme) {
-  @if not map_get($theme, color) {
+  @if not map-get($theme, color) {
     @return $theme;
   }
-  $color: map_get($theme, color);
-  @return map_merge($theme, $color);
+  $color: map-get($theme, color);
+  @return map-merge($theme, $color);
 }
 
 // Creates a light-themed color configuration from the specified
@@ -162,12 +162,12 @@ $_mat-theme-generate-default-density: true !default;
   // parts of the theming system, but update the `color` configuration if set. As explained
   // above, the color shorthand will be expanded to an actual light-themed color configuration.
   $result: $primary;
-  @if map_get($primary, color) {
-    $color-settings: map_get($primary, color);
-    $primary: map_get($color-settings, primary);
-    $accent: map_get($color-settings, accent);
-    $warn: map_get($color-settings, warn);
-    $result: map_merge($result, (color: _mat-create-light-color-config($primary, $accent, $warn)));
+  @if map-get($primary, color) {
+    $color-settings: map-get($primary, color);
+    $primary: map-get($color-settings, primary);
+    $accent: map-get($color-settings, accent);
+    $warn: map-get($color-settings, warn);
+    $result: map-merge($result, (color: _mat-create-light-color-config($primary, $accent, $warn)));
   }
   @return _mat-create-backwards-compatibility-theme(_mat-validate-theme($result));
 }
@@ -199,12 +199,12 @@ $_mat-theme-generate-default-density: true !default;
   // parts of the theming system, but update the `color` configuration if set. As explained
   // above, the color shorthand will be expanded to an actual dark-themed color configuration.
   $result: $primary;
-  @if map_get($primary, color) {
-    $color-settings: map_get($primary, color);
-    $primary: map_get($color-settings, primary);
-    $accent: map_get($color-settings, accent);
-    $warn: map_get($color-settings, warn);
-    $result: map_merge($result, (color: _mat-create-dark-color-config($primary, $accent, $warn)));
+  @if map-get($primary, color) {
+    $color-settings: map-get($primary, color);
+    $primary: map-get($color-settings, primary);
+    $accent: map-get($color-settings, accent);
+    $warn: map-get($color-settings, warn);
+    $result: map-merge($result, (color: _mat-create-dark-color-config($primary, $accent, $warn)));
   }
   @return _mat-create-backwards-compatibility-theme(_mat-validate-theme($result));
 }
@@ -223,8 +223,8 @@ $_mat-theme-generate-default-density: true !default;
   @if _mat-is-legacy-constructed-theme($theme) {
     @return $theme;
   }
-  @if map_has_key($theme, color) {
-    @return map_get($theme, color);
+  @if map-has-key($theme, color) {
+    @return map-get($theme, color);
   }
   @return $default;
 }
@@ -237,8 +237,8 @@ $_mat-theme-generate-default-density: true !default;
   }
   // In case a theme has been passed, extract the configuration if present,
   // or fall back to the default density config.
-  @if map_has_key($theme-or-config, density) {
-    @return map_get($theme-or-config, density);
+  @if map-has-key($theme-or-config, density) {
+    @return map-get($theme-or-config, density);
   }
   @return $default;
 }
@@ -252,8 +252,8 @@ $_mat-theme-generate-default-density: true !default;
   }
   // In case a theme has been passed, extract the configuration if present,
   // or fall back to the default typography config.
-  @if (map_has_key($theme-or-config, typography)) {
-    @return map_get($theme-or-config, typography);
+  @if (map-has-key($theme-or-config, typography)) {
+    @return map-get($theme-or-config, typography);
   }
   @return $default;
 }
@@ -262,16 +262,16 @@ $_mat-theme-generate-default-density: true !default;
 // of type `map` and can optionally only specify `color`, `density` or `typography`.
 @function _mat-is-theme-object($value) {
   @return type-of($value) == 'map' and (
-    map_has_key($value, color) or
-    map_has_key($value, density) or
-    map_has_key($value, typography) or
+    map-has-key($value, color) or
+    map-has-key($value, density) or
+    map-has-key($value, typography) or
     length($value) == 0
   );
 }
 
 // Checks whether a given value corresponds to a legacy constructed theme.
 @function _mat-is-legacy-constructed-theme($value) {
-  @return type-of($value) == 'map' and map_get($value, '_is-legacy-theme');
+  @return type-of($value) == 'map' and map-get($value, '_is-legacy-theme');
 }
 
 // Gets the theme from the given value that is either already a theme, or a color configuration.

--- a/src/material/core/theming/tests/test-theming-api.scss
+++ b/src/material/core/theming/tests/test-theming-api.scss
@@ -26,14 +26,14 @@ $default-warn: mat-palette($mat-red);
 
 // Asserts that the specified color configuration is configured properly.
 @mixin assert-color-config($config, $primary, $accent, $warn, $is-dark) {
-  $color: map_get($config, color);
-  @include assert(map_get($color, primary), $primary,
+  $color: map-get($config, color);
+  @include assert(map-get($color, primary), $primary,
       'Primary palette does not match expected palette.');
-  @include assert(map_get($color, accent), $accent,
+  @include assert(map-get($color, accent), $accent,
       'Accent palette does not match expected palette.');
-  @include assert(map_get($color, warn), $warn,
+  @include assert(map-get($color, warn), $warn,
       'Warn palette does not match expected palette.');
-  @include assert(map_get($color, is-dark), $is-dark,
+  @include assert(map-get($color, is-dark), $is-dark,
       'Expected color config `is-dark` to be: #{$is-dark}');
 }
 
@@ -67,16 +67,16 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
 @mixin test-default-theming-system-configs() {
   $themes: ($legacy-light-theme, $legacy-dark-theme, $new-api-light-theme, $new-api-dark-theme);
   @each $theme in $themes {
-    @include assert(map_has_key($theme, color), true,
+    @include assert(map-has-key($theme, color), true,
       'Expected color to be explicitly configured.');
-    @include assert(map_has_key($theme, typography), false,
+    @include assert(map-has-key($theme, typography), false,
       'Expected typography to be not explicitly configured.');
-    @include assert(map_has_key($theme, density), false,
+    @include assert(map-has-key($theme, density), false,
       'Expected density to be not explicitly configured.');
   }
-  @include assert(map_has_key($light-theme-only-density, color), false,
+  @include assert(map-has-key($light-theme-only-density, color), false,
       'Expected color to be not explicitly configured.');
-  @include assert(map_has_key($dark-theme-only-density, color), false,
+  @include assert(map-has-key($dark-theme-only-density, color), false,
       'Expected color to be not explicitly configured.');
 }
 
@@ -100,20 +100,20 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
 // Test which ensures that constructed themes pass through the specified
 // density and typography configurations.
 @mixin test-density-typography-config-pass-through() {
-  @include assert(map_get($light-theme-only-density, density), -3,
+  @include assert(map-get($light-theme-only-density, density), -3,
     'Expected density config to be included in theme.');
-  @include assert(map_get($dark-theme-only-density, density), -3,
+  @include assert(map-get($dark-theme-only-density, density), -3,
     'Expected density config to be included in theme.');
-  @include assert(map_get($light-theme-only-typography, typography), $typography-config,
+  @include assert(map-get($light-theme-only-typography, typography), $typography-config,
     'Expected typography config to be included in theme.');
-  @include assert(map_get($dark-theme-only-typography, typography), $typography-config,
+  @include assert(map-get($dark-theme-only-typography, typography), $typography-config,
     'Expected typography config to be included in theme.');
 }
 
 // Test which ensures that color configurations can be properly read from
 // theme objects passed to individual component theme mixins.
 @mixin test-get-color-config() {
-  $color-config: map_get($legacy-light-theme, color);
+  $color-config: map-get($legacy-light-theme, color);
   $no-color-light-theme: mat-light-theme((color: null));
   $no-color-dark-theme: mat-dark-theme((color: null));
   @include assert(mat-get-color-config($color-config), $color-config,
@@ -123,7 +123,7 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
   // by updating immediate properties on the `$theme` object.
   @include assert(mat-get-color-config($legacy-light-theme), $legacy-light-theme,
       'Expected that the theme object is used for the color configuration.');
-  @include assert(mat-get-color-config($new-api-dark-theme), map_get($new-api-dark-theme, color),
+  @include assert(mat-get-color-config($new-api-dark-theme), map-get($new-api-dark-theme, color),
     'Expected that a color config can be read from a theme object.');
   @include assert(mat-get-color-config($light-theme-only-density), null,
       'Expected that by default, no color configuration is used.');
@@ -136,7 +136,7 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
 // Test which ensures that density configurations can be properly read from
 // theme objects passed to individual component theme mixins.
 @mixin test-get-density-config() {
-  $density-config: map_get($light-theme-only-density, density);
+  $density-config: map-get($light-theme-only-density, density);
   $no-density-light-theme: mat-light-theme((density: null));
   $no-density-dark-theme: mat-dark-theme((density: null));
   @include assert(mat-get-density-config($light-theme-only-density), -3,
@@ -185,7 +185,7 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
 // This replicates a custom theme that expects legacy theme objects.
 @mixin _my-custom-theme-legacy($theme) {
   .demo-custom-comp {
-    border-color: mat-color(map_get($theme, primary));
+    border-color: mat-color(map-get($theme, primary));
   }
 }
 
@@ -193,7 +193,7 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
   $config: mat-get-color-config($config-or-theme);
 
   .demo-custom-comp {
-    border-color: mat-color(map_get($config, primary));
+    border-color: mat-color(map-get($config, primary));
   }
 }
 
@@ -248,24 +248,24 @@ $dark-theme-only-typography: mat-dark-theme((typography: $typography-config));
     @include _angular-material-density($theme);
   }
 
-  @include angular-material-typography(map_get($light-theme-only-typography, typography));
+  @include angular-material-typography(map-get($light-theme-only-typography, typography));
   @include angular-material-typography($light-theme-only-typography);
 
-  @include _angular-material-density(map_get($light-theme-only-density, density));
+  @include _angular-material-density(map-get($light-theme-only-density, density));
   @include _angular-material-density($light-theme-only-density);
 
-  @include angular-material-color(map_get($new-api-dark-theme, color));
+  @include angular-material-color(map-get($new-api-dark-theme, color));
   @include angular-material-color($new-api-dark-theme);
 }
 
 @mixin test-individual-system-mixins-unwrap() {
   @include _my-custom-theme-new-api-color($new-api-dark-theme);
-  @include _my-custom-theme-new-api-color(map_get($new-api-dark-theme, color));
+  @include _my-custom-theme-new-api-color(map-get($new-api-dark-theme, color));
   @include _my-custom-theme-new-api($new-api-dark-theme);
-  @include _my-custom-theme-new-api(map_get($new-api-dark-theme, color));
+  @include _my-custom-theme-new-api(map-get($new-api-dark-theme, color));
 
   @include angular-material-theme($new-api-dark-theme);
-  @include angular-material-theme(map_get($new-api-dark-theme, color));
+  @include angular-material-theme(map-get($new-api-dark-theme, color));
 }
 
 // Include all tests. Sass will throw if one of the tests fails.

--- a/src/material/core/theming/tests/theming-api.spec.ts
+++ b/src/material/core/theming/tests/theming-api.spec.ts
@@ -219,8 +219,8 @@ describe('theming api', () => {
         $theme: mat-light-theme($mat-red, $mat-blue);
 
         // Updates the "icon" foreground color to "canary".
-        $theme: map_merge($theme,
-          (foreground: map_merge(map_get($theme, foreground), (icon: "canary"))));
+        $theme: map-merge($theme,
+          (foreground: map-merge(map-get($theme, foreground), (icon: "canary"))));
 
         @include angular-material-theme($theme);
       `);

--- a/src/material/radio/_radio-theme.scss
+++ b/src/material/radio/_radio-theme.scss
@@ -63,7 +63,7 @@
     // Switch this to a solid color since we're using `opacity`
     // to control how opaque the ripple should be.
     .mat-ripple-element {
-      background-color: map_get($foreground, base);
+      background-color: map-get($foreground, base);
     }
   }
 }

--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -26,7 +26,7 @@
 
 @mixin mat-slide-toggle-color($config-or-theme) {
   $config: mat-get-color-config($config-or-theme);
-  $is-dark: map_get($config, is-dark);
+  $is-dark: map-get($config, is-dark);
   $primary: map-get($config, primary);
   $accent: map-get($config, accent);
   $warn: map-get($config, warn);


### PR DESCRIPTION
We had a bunch of places using the deprecated variants of functions like `map_get`, `map_has_key` and `map_merge`. These changes migrate to the non-deprecated variants.

These changes are also necessary in order for the `sass-migrator` script to migrate the function calls.