### PR TITLE
refactor(material/chips): deprecate selection methods in test harnesses

### DIFF
--- a/src/material/chips/testing/chip-harness-filters.ts
+++ b/src/material/chips/testing/chip-harness-filters.ts
@@ -11,7 +11,11 @@ import {BaseHarnessFilters} from '@angular/cdk/testing';
 export interface ChipHarnessFilters extends BaseHarnessFilters {
   /** Only find instances whose text matches the given value. */
   text?: string | RegExp;
-  /** Only find chip instances whose selected state matches the given value. */
+  /**
+   * Only find chip instances whose selected state matches the given value.
+   * @deprecated Will be moved into separate selection-specific harness.
+   * @breaking-change 12.0.0
+   */
   selected?: boolean;
 }
 

--- a/src/material/chips/testing/chip-harness.ts
+++ b/src/material/chips/testing/chip-harness.ts
@@ -36,7 +36,11 @@ export class MatChipHarness extends ComponentHarness {
     });
   }
 
-  /** Whether the chip is selected. */
+  /**
+   * Whether the chip is selected.
+   * @deprecated Will be moved into separate selection-specific harness.
+   * @breaking-change 12.0.0
+   */
   async isSelected(): Promise<boolean> {
     return (await this.host()).hasClass('mat-chip-selected');
   }
@@ -46,21 +50,33 @@ export class MatChipHarness extends ComponentHarness {
     return (await this.host()).hasClass('mat-chip-disabled');
   }
 
-  /** Selects the given chip. Only applies if it's selectable. */
+  /**
+   * Selects the given chip. Only applies if it's selectable.
+   * @deprecated Will be moved into separate selection-specific harness.
+   * @breaking-change 12.0.0
+   */
   async select(): Promise<void> {
     if (!(await this.isSelected())) {
       await this.toggle();
     }
   }
 
-  /** Deselects the given chip. Only applies if it's selectable. */
+  /**
+   * Deselects the given chip. Only applies if it's selectable.
+   * @deprecated Will be moved into separate selection-specific harness.
+   * @breaking-change 12.0.0
+   */
   async deselect(): Promise<void> {
     if (await this.isSelected()) {
       await this.toggle();
     }
   }
 
-  /** Toggles the selected state of the given chip. Only applies if it's selectable. */
+  /**
+   * Toggles the selected state of the given chip. Only applies if it's selectable.
+   * @deprecated Will be moved into separate selection-specific harness.
+   * @breaking-change 12.0.0
+   */
   async toggle(): Promise<void> {
     return (await this.host()).sendKeys(' ');
   }

--- a/src/material/chips/testing/chip-list-harness.ts
+++ b/src/material/chips/testing/chip-list-harness.ts
@@ -68,6 +68,8 @@ export class MatChipListHarness extends ComponentHarness {
    * Selects a chip inside the chip list.
    * @param filter An optional filter to apply to the child chips.
    *    All the chips matching the filter will be selected.
+   * @deprecated Will be moved into separate selection-specific harness.
+   * @breaking-change 12.0.0
    */
   async selectChips(filter: ChipHarnessFilters = {}): Promise<void> {
     const chips = await this.getChips(filter);


### PR DESCRIPTION
Deprecates the selection-related methods from the test harnesses. They'll be moved into a separate harness in order to make the migration to MDC easier.