### PR TITLE
docs: Add types in injection token examples

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -45,7 +45,7 @@ import {MAT_BOTTOM_SHEET_DATA} from '@angular/material/bottom-sheet';
   template: 'passed in {{ data.names }}',
 })
 export class HobbitSheet {
-  constructor(@Inject(MAT_BOTTOM_SHEET_DATA) public data: any) { }
+  constructor(@Inject(MAT_BOTTOM_SHEET_DATA) public data: {names: string[]}) { }
 }
 ```
 

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -102,7 +102,7 @@ import {MAT_DIALOG_DATA} from '@angular/material/dialog';
   template: 'passed in {{ data.name }}',
 })
 export class YourDialog {
-  constructor(@Inject(MAT_DIALOG_DATA) public data: any) { }
+  constructor(@Inject(MAT_DIALOG_DATA) public data: {name: string}) { }
 }
 ```
 

--- a/src/material/snack-bar/snack-bar.md
+++ b/src/material/snack-bar/snack-bar.md
@@ -69,7 +69,7 @@ import {MAT_SNACK_BAR_DATA} from '@angular/material/snack-bar';
   template: 'passed in {{ data }}',
 })
 export class MessageArchivedComponent {
-  constructor(@Inject(MAT_SNACK_BAR_DATA) public data: any) { }
+  constructor(@Inject(MAT_SNACK_BAR_DATA) public data: string) { }
 }
 ```
 


### PR DESCRIPTION
Use strong typing for the MAT_DIALOG_DATA, MAT_BOTTOM_SHEET_DATA and MAT_SNACK_BAR_DATA injection token examples. Closes #20759