### PR TITLE
feat(material/tabs): add test harnesses for tab nav bar

### DIFF
--- a/src/material-experimental/mdc-tabs/testing/public-api.ts
+++ b/src/material-experimental/mdc-tabs/testing/public-api.ts
@@ -9,3 +9,5 @@
 export * from './tab-group-harness';
 export * from './tab-harness';
 export * from './tab-harness-filters';
+export * from './tab-nav-bar-harness';
+export * from './tab-link-harness';

--- a/src/material-experimental/mdc-tabs/testing/tab-group-harness.spec.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-group-harness.spec.ts
@@ -1,7 +1,7 @@
 import {MatTabsModule} from '@angular/material-experimental/mdc-tabs';
-import {runHarnessTests} from '@angular/material/tabs/testing/shared.spec';
+import {runTabGroupHarnessTests} from '@angular/material/tabs/testing/tab-group-shared.spec';
 import {MatTabGroupHarness} from './tab-group-harness';
 
 describe('MDC-based MatTabGroupHarness', () => {
-  runHarnessTests(MatTabsModule, MatTabGroupHarness as any);
+  runTabGroupHarnessTests(MatTabsModule, MatTabGroupHarness as any);
 });

--- a/src/material-experimental/mdc-tabs/testing/tab-harness-filters.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-harness-filters.ts
@@ -18,3 +18,12 @@ export interface TabGroupHarnessFilters extends BaseHarnessFilters {
   /** Only find instances whose selected tab label matches the given value. */
   selectedTabLabel?: string | RegExp;
 }
+
+/** A set of criteria that can be used to filter a list of `MatTabLinkHarness` instances. */
+export interface TabLinkHarnessFilters extends BaseHarnessFilters {
+  /** Only find instances whose label matches the given value. */
+  label?: string | RegExp;
+}
+
+/** A set of criteria that can be used to filter a list of `MatTabNavBarHarness` instances. */
+export interface TabNavBarHarnessFilters extends BaseHarnessFilters {}

--- a/src/material-experimental/mdc-tabs/testing/tab-link-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-link-harness.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {TabLinkHarnessFilters} from './tab-harness-filters';
+
+/** Harness for interacting with an MDC-based Angular Material tab link in tests. */
+export class MatTabLinkHarness extends ComponentHarness {
+  /** The selector for the host element of a `MatTabLink` instance. */
+  static hostSelector = '.mat-mdc-tab-link';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatTabLinkHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which tab link instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: TabLinkHarnessFilters = {}): HarnessPredicate<MatTabLinkHarness> {
+    return new HarnessPredicate(MatTabLinkHarness, options)
+        .addOption('label', options.label,
+            (harness, label) => HarnessPredicate.stringMatches(harness.getLabel(), label));
+  }
+
+  /** Gets the label of the link. */
+  async getLabel(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Whether the link is active. */
+  async isActive(): Promise<boolean> {
+    const host = await this.host();
+    return host.hasClass('mdc-tab--active');
+  }
+
+  /** Whether the link is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const host = await this.host();
+    return host.hasClass('mat-mdc-tab-disabled');
+  }
+
+  /** Clicks on the link. */
+  async click(): Promise<void> {
+    await (await this.host()).click();
+  }
+}

--- a/src/material-experimental/mdc-tabs/testing/tab-nav-bar-harness.spec.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-nav-bar-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatTabsModule} from '@angular/material-experimental/mdc-tabs';
+import {runTabNavBarHarnessTests} from '@angular/material/tabs/testing/tab-nav-bar-shared.spec';
+import {MatTabNavBarHarness} from './tab-nav-bar-harness';
+
+describe('MDC-based MatTabNavBarHarness', () => {
+  runTabNavBarHarnessTests(MatTabsModule, MatTabNavBarHarness as any);
+});

--- a/src/material-experimental/mdc-tabs/testing/tab-nav-bar-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-nav-bar-harness.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {TabNavBarHarnessFilters, TabLinkHarnessFilters} from './tab-harness-filters';
+import {MatTabLinkHarness} from './tab-link-harness';
+
+/** Harness for interacting with an MDC-based mat-tab-nav-bar in tests. */
+export class MatTabNavBarHarness extends ComponentHarness {
+  /** The selector for the host element of a `MatTabNavBar` instance. */
+  static hostSelector = '.mat-mdc-tab-nav-bar';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatTabNavBar` that meets
+   * certain criteria.
+   * @param options Options for filtering which tab nav bar instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: TabNavBarHarnessFilters = {}): HarnessPredicate<MatTabNavBarHarness> {
+    return new HarnessPredicate(MatTabNavBarHarness, options);
+  }
+
+  /**
+   * Gets the list of links in the nav bar.
+   * @param filter Optionally filters which links are included.
+   */
+  async getLinks(filter: TabLinkHarnessFilters = {}): Promise<MatTabLinkHarness[]> {
+    return this.locatorForAll(MatTabLinkHarness.with(filter))();
+  }
+
+  /** Gets the active link in the nav bar. */
+  async getActiveLink(): Promise<MatTabLinkHarness> {
+    const links = await this.getLinks();
+    const isActive = await Promise.all(links.map(t => t.isActive()));
+    for (let i = 0; i < links.length; i++) {
+      if (isActive[i]) {
+        return links[i];
+      }
+    }
+    throw new Error('No active link could be found.');
+  }
+
+  /**
+   * Clicks a link inside the nav bar.
+   * @param filter An optional filter to apply to the child link. The first link matching the filter
+   *     will be clicked.
+   */
+  async clickLink(filter: TabLinkHarnessFilters = {}): Promise<void> {
+    const tabs = await this.getLinks(filter);
+    if (!tabs.length) {
+      throw Error(`Cannot find mat-tab-link matching filter ${JSON.stringify(filter)}`);
+    }
+    await tabs[0].click();
+  }
+}

--- a/src/material/tabs/testing/BUILD.bazel
+++ b/src/material/tabs/testing/BUILD.bazel
@@ -22,7 +22,10 @@ filegroup(
 
 ng_test_library(
     name = "harness_tests_lib",
-    srcs = ["shared.spec.ts"],
+    srcs = [
+        "tab-group-shared.spec.ts",
+        "tab-nav-bar-shared.spec.ts",
+    ],
     deps = [
         ":testing",
         "//src/cdk/testing",
@@ -38,7 +41,10 @@ ng_test_library(
     name = "unit_tests_lib",
     srcs = glob(
         ["**/*.spec.ts"],
-        exclude = ["shared.spec.ts"],
+        exclude = [
+            "tab-group-shared.spec.ts",
+            "tab-nav-bar-shared.spec.ts",
+        ],
     ),
     deps = [
         ":harness_tests_lib",

--- a/src/material/tabs/testing/public-api.ts
+++ b/src/material/tabs/testing/public-api.ts
@@ -9,3 +9,5 @@
 export * from './tab-group-harness';
 export * from './tab-harness';
 export * from './tab-harness-filters';
+export * from './tab-nav-bar-harness';
+export * from './tab-link-harness';

--- a/src/material/tabs/testing/tab-group-harness.spec.ts
+++ b/src/material/tabs/testing/tab-group-harness.spec.ts
@@ -1,7 +1,7 @@
 import {MatTabsModule} from '@angular/material/tabs';
-import {runHarnessTests} from '@angular/material/tabs/testing/shared.spec';
+import {runTabGroupHarnessTests} from '@angular/material/tabs/testing/tab-group-shared.spec';
 import {MatTabGroupHarness} from './tab-group-harness';
 
 describe('Non-MDC-based MatTabGroupHarness', () => {
-  runHarnessTests(MatTabsModule, MatTabGroupHarness);
+  runTabGroupHarnessTests(MatTabsModule, MatTabGroupHarness);
 });

--- a/src/material/tabs/testing/tab-group-shared.spec.ts
+++ b/src/material/tabs/testing/tab-group-shared.spec.ts
@@ -7,7 +7,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatTabGroupHarness} from './tab-group-harness';
 
 /** Shared tests to run on both the original and MDC-based tab-group's. */
-export function runHarnessTests(
+export function runTabGroupHarnessTests(
     tabsModule: typeof MatTabsModule,
     tabGroupHarness: typeof MatTabGroupHarness) {
   let fixture: ComponentFixture<TabGroupHarnessTest>;

--- a/src/material/tabs/testing/tab-harness-filters.ts
+++ b/src/material/tabs/testing/tab-harness-filters.ts
@@ -7,14 +7,23 @@
  */
 import {BaseHarnessFilters} from '@angular/cdk/testing';
 
-/** A set of criteria that can be used to filter a list of `MatRadioButtonHarness` instances. */
+/** A set of criteria that can be used to filter a list of `MatTabHarness` instances. */
 export interface TabHarnessFilters extends BaseHarnessFilters {
   /** Only find instances whose label matches the given value. */
   label?: string | RegExp;
 }
 
-/** A set of criteria that can be used to filter a list of `MatRadioButtonHarness` instances. */
+/** A set of criteria that can be used to filter a list of `MatTabGroupHarness` instances. */
 export interface TabGroupHarnessFilters extends BaseHarnessFilters {
   /** Only find instances whose selected tab label matches the given value. */
   selectedTabLabel?: string | RegExp;
 }
+
+/** A set of criteria that can be used to filter a list of `MatTabLinkHarness` instances. */
+export interface TabLinkHarnessFilters extends BaseHarnessFilters {
+  /** Only find instances whose label matches the given value. */
+  label?: string | RegExp;
+}
+
+/** A set of criteria that can be used to filter a list of `MatTabNavBarHarness` instances. */
+export interface TabNavBarHarnessFilters extends BaseHarnessFilters {}

--- a/src/material/tabs/testing/tab-link-harness.ts
+++ b/src/material/tabs/testing/tab-link-harness.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {TabLinkHarnessFilters} from './tab-harness-filters';
+
+/** Harness for interacting with a standard Angular Material tab link in tests. */
+export class MatTabLinkHarness extends ComponentHarness {
+  /** The selector for the host element of a `MatTabLink` instance. */
+  static hostSelector = '.mat-tab-link';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatTabLinkHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which tab link instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: TabLinkHarnessFilters = {}): HarnessPredicate<MatTabLinkHarness> {
+    return new HarnessPredicate(MatTabLinkHarness, options)
+        .addOption('label', options.label,
+            (harness, label) => HarnessPredicate.stringMatches(harness.getLabel(), label));
+  }
+
+  /** Gets the label of the link. */
+  async getLabel(): Promise<string> {
+    return (await this.host()).text();
+  }
+
+  /** Whether the link is active. */
+  async isActive(): Promise<boolean> {
+    const host = await this.host();
+    return host.hasClass('mat-tab-label-active');
+  }
+
+  /** Whether the link is disabled. */
+  async isDisabled(): Promise<boolean> {
+    const host = await this.host();
+    return host.hasClass('mat-tab-disabled');
+  }
+
+  /** Clicks on the link. */
+  async click(): Promise<void> {
+    await (await this.host()).click();
+  }
+}

--- a/src/material/tabs/testing/tab-nav-bar-harness.spec.ts
+++ b/src/material/tabs/testing/tab-nav-bar-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatTabsModule} from '@angular/material/tabs';
+import {runTabNavBarHarnessTests} from '@angular/material/tabs/testing/tab-nav-bar-shared.spec';
+import {MatTabNavBarHarness} from './tab-nav-bar-harness';
+
+describe('Non-MDC-based MatTabNavBarHarness', () => {
+  runTabNavBarHarnessTests(MatTabsModule, MatTabNavBarHarness);
+});

--- a/src/material/tabs/testing/tab-nav-bar-harness.ts
+++ b/src/material/tabs/testing/tab-nav-bar-harness.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {TabNavBarHarnessFilters, TabLinkHarnessFilters} from './tab-harness-filters';
+import {MatTabLinkHarness} from './tab-link-harness';
+
+/** Harness for interacting with a standard mat-tab-nav-bar in tests. */
+export class MatTabNavBarHarness extends ComponentHarness {
+  /** The selector for the host element of a `MatTabNavBar` instance. */
+  static hostSelector = '.mat-tab-nav-bar';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatTabNavBar` that meets
+   * certain criteria.
+   * @param options Options for filtering which tab nav bar instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: TabNavBarHarnessFilters = {}): HarnessPredicate<MatTabNavBarHarness> {
+    return new HarnessPredicate(MatTabNavBarHarness, options);
+  }
+
+  /**
+   * Gets the list of links in the nav bar.
+   * @param filter Optionally filters which links are included.
+   */
+  async getLinks(filter: TabLinkHarnessFilters = {}): Promise<MatTabLinkHarness[]> {
+    return this.locatorForAll(MatTabLinkHarness.with(filter))();
+  }
+
+  /** Gets the active link in the nav bar. */
+  async getActiveLink(): Promise<MatTabLinkHarness> {
+    const links = await this.getLinks();
+    const isActive = await Promise.all(links.map(t => t.isActive()));
+    for (let i = 0; i < links.length; i++) {
+      if (isActive[i]) {
+        return links[i];
+      }
+    }
+    throw new Error('No active link could be found.');
+  }
+
+  /**
+   * Clicks a link inside the nav bar.
+   * @param filter An optional filter to apply to the child link. The first link matching the filter
+   *     will be clicked.
+   */
+  async clickLink(filter: TabLinkHarnessFilters = {}): Promise<void> {
+    const tabs = await this.getLinks(filter);
+    if (!tabs.length) {
+      throw Error(`Cannot find mat-tab-link matching filter ${JSON.stringify(filter)}`);
+    }
+    await tabs[0].click();
+  }
+}

--- a/src/material/tabs/testing/tab-nav-bar-shared.spec.ts
+++ b/src/material/tabs/testing/tab-nav-bar-shared.spec.ts
@@ -1,0 +1,117 @@
+import {HarnessLoader} from '@angular/cdk/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatTabsModule} from '@angular/material/tabs';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatTabNavBarHarness} from './tab-nav-bar-harness';
+
+/** Shared tests to run on both the original and MDC-based tab nav bars. */
+export function runTabNavBarHarnessTests(
+    tabsModule: typeof MatTabsModule,
+    tabNavBarHarness: typeof MatTabNavBarHarness) {
+  let fixture: ComponentFixture<TabNavBarHarnessTest>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [tabsModule, NoopAnimationsModule],
+      declarations: [TabNavBarHarnessTest],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TabNavBarHarnessTest);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should load harness for tab nav bar', async () => {
+    const navBars = await loader.getAllHarnesses(tabNavBarHarness);
+    expect(navBars.length).toBe(1);
+  });
+
+  it('should be able to get links of nav bar', async () => {
+    const navBar = await loader.getHarness(tabNavBarHarness);
+    const links = await navBar.getLinks();
+    expect(links.length).toBe(3);
+  });
+
+  it('should be able to get filtered links', async () => {
+    const navBar = await loader.getHarness(tabNavBarHarness);
+    const links = await navBar.getLinks({label: 'Third'});
+    expect(links.length).toBe(1);
+    expect(await links[0].getLabel()).toBe('Third');
+  });
+
+  it('should be able to click tab from nav bar', async () => {
+    const navBar = await loader.getHarness(tabNavBarHarness);
+    expect(await (await navBar.getActiveLink()).getLabel()).toBe('First');
+    await navBar.clickLink({label: 'Second'});
+    expect(await (await navBar.getActiveLink()).getLabel()).toBe('Second');
+  });
+
+  it('should throw error when attempting to click invalid link', async () => {
+    const navBar = await loader.getHarness(tabNavBarHarness);
+    await expectAsync(navBar.clickLink({label: 'Fake'})).toBeRejectedWithError(
+        /Cannot find mat-tab-link matching filter {"label":"Fake"}/);
+  });
+
+  it('should be able to get label of links', async () => {
+    const navBar = await loader.getHarness(tabNavBarHarness);
+    const links = await navBar.getLinks();
+    expect(await links[0].getLabel()).toBe('First');
+    expect(await links[1].getLabel()).toBe('Second');
+    expect(await links[2].getLabel()).toBe('Third');
+  });
+
+  it('should be able to get disabled state of link', async () => {
+    const navBar = await loader.getHarness(tabNavBarHarness);
+    const links = await navBar.getLinks();
+    expect(await links[0].isDisabled()).toBe(false);
+    expect(await links[1].isDisabled()).toBe(false);
+    expect(await links[2].isDisabled()).toBe(false);
+
+    fixture.componentInstance.isDisabled = true;
+    fixture.detectChanges();
+
+    expect(await links[0].isDisabled()).toBe(false);
+    expect(await links[1].isDisabled()).toBe(false);
+    expect(await links[2].isDisabled()).toBe(true);
+  });
+
+  it('should be able to click specific link', async () => {
+    const navBar = await loader.getHarness(tabNavBarHarness);
+    const links = await navBar.getLinks();
+    expect(await links[0].isActive()).toBe(true);
+    expect(await links[1].isActive()).toBe(false);
+    expect(await links[2].isActive()).toBe(false);
+
+    await links[1].click();
+    expect(await links[0].isActive()).toBe(false);
+    expect(await links[1].isActive()).toBe(true);
+    expect(await links[2].isActive()).toBe(false);
+  });
+}
+
+@Component({
+  template: `
+    <nav mat-tab-nav-bar>
+      <a href="#" (click)="select(0, $event)" [active]="activeLink === 0" matTabLink>First</a>
+      <a href="#" (click)="select(1, $event)" [active]="activeLink === 1" matTabLink>Second</a>
+      <a
+        href="#"
+        (click)="select(2, $event)"
+        [active]="activeLink === 2"
+        [disabled]="isDisabled"
+        matTabLink>Third</a>
+    </nav>
+  `
+})
+class TabNavBarHarnessTest {
+  activeLink = 0;
+  isDisabled = false;
+
+  select(index: number, event: MouseEvent) {
+    this.activeLink = index;
+    event.preventDefault();
+  }
+}

--- a/tools/public_api_guard/material/tabs/testing.d.ts
+++ b/tools/public_api_guard/material/tabs/testing.d.ts
@@ -20,10 +20,34 @@ export declare class MatTabHarness extends ContentContainerComponentHarness<stri
     static with(options?: TabHarnessFilters): HarnessPredicate<MatTabHarness>;
 }
 
+export declare class MatTabLinkHarness extends ComponentHarness {
+    click(): Promise<void>;
+    getLabel(): Promise<string>;
+    isActive(): Promise<boolean>;
+    isDisabled(): Promise<boolean>;
+    static hostSelector: string;
+    static with(options?: TabLinkHarnessFilters): HarnessPredicate<MatTabLinkHarness>;
+}
+
+export declare class MatTabNavBarHarness extends ComponentHarness {
+    clickLink(filter?: TabLinkHarnessFilters): Promise<void>;
+    getActiveLink(): Promise<MatTabLinkHarness>;
+    getLinks(filter?: TabLinkHarnessFilters): Promise<MatTabLinkHarness[]>;
+    static hostSelector: string;
+    static with(options?: TabNavBarHarnessFilters): HarnessPredicate<MatTabNavBarHarness>;
+}
+
 export interface TabGroupHarnessFilters extends BaseHarnessFilters {
     selectedTabLabel?: string | RegExp;
 }
 
 export interface TabHarnessFilters extends BaseHarnessFilters {
     label?: string | RegExp;
+}
+
+export interface TabLinkHarnessFilters extends BaseHarnessFilters {
+    label?: string | RegExp;
+}
+
+export interface TabNavBarHarnessFilters extends BaseHarnessFilters {
 }


### PR DESCRIPTION
Adds test harnesses for the MDC and non-MDC `mat-tab-nav-bar` and `matTabLink`. It seems like they were missing, because they were overlooked during the initial implementation.