### PR TITLE
test(material-experimental/mdc-slide-toggle): resolve test flakes

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
@@ -441,6 +441,7 @@ describe('MDC-based MatSlideToggle without forms', () => {
 
       labelElement.click();
       fixture.detectChanges();
+      tick();
 
       expect(slideToggle.checked).toBe(false, 'Expect slide toggle value not changed');
       expect(testComponent.toggleTriggered).toBe(1, 'Expect toggle once');
@@ -448,6 +449,7 @@ describe('MDC-based MatSlideToggle without forms', () => {
 
       inputElement.click();
       fixture.detectChanges();
+      tick();
 
       expect(slideToggle.checked).toBe(false, 'Expect slide toggle value not changed');
       expect(testComponent.toggleTriggered).toBe(2, 'Expect toggle twice');
@@ -557,6 +559,7 @@ describe('MDC-based MatSlideToggle with forms', () => {
         // Focus the input element because after disabling, the `blur` event should automatically
         // fire and not result in a changed after checked exception. Related: #12323
         inputElement.focus();
+        tick();
 
         fixture.componentInstance.isDisabled = true;
         fixture.detectChanges();


### PR DESCRIPTION
The changes from #20772 appear to have introduce a flaky test. These changes try to resolve it.