### PR TITLE
build: drop typescript 3.9 checks

### DIFF
--- a/integration/ts-compat/BUILD.bazel
+++ b/integration/ts-compat/BUILD.bazel
@@ -13,7 +13,6 @@ write_file(
 # List of TypeScript packages that we want to run the compatibility test against.
 # The list contains NPM module names that resolve to the desired TypeScript version.
 typescript_version_packages = [
-    "typescript-3.9",
     "typescript",
 ]
 

--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     "tslint": "^6.1.3",
     "tsutils": "^3.17.1",
     "typescript": "4.0.5",
-    "typescript-3.9": "npm:typescript@~3.9.7",
     "vrsource-tslint-rules": "5.1.1",
     "yaml": "^1.10.0"
   },

--- a/scripts/caretaking/firebase-functions/package.json
+++ b/scripts/caretaking/firebase-functions/package.json
@@ -11,10 +11,10 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^9.0.0",
-    "firebase-functions": "^3.8.0"
+    "firebase-functions": "^3.11.0"
   },
   "devDependencies": {
-    "typescript": "^3.9.7",
+    "typescript": "^4.0.2",
     "firebase-tools": "^8.6.0"
   },
   "private": true

--- a/scripts/caretaking/firebase-functions/yarn.lock
+++ b/scripts/caretaking/firebase-functions/yarn.lock
@@ -1539,10 +1539,10 @@ firebase-admin@^9.0.0:
     "@google-cloud/firestore" "^4.0.0"
     "@google-cloud/storage" "^5.0.0"
 
-firebase-functions@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-3.8.0.tgz#ac53c615ef365cd9a19604f84ec9835a340c7b76"
-  integrity sha512-RFvoS7ZcXrk2sQ918czsjv94p4hnSoD0/e4cZ86XFpa1HbNZBI7ZuSgBCzRvlv6dJ1ArytAL13NpB1Bp2tJ6Yg==
+firebase-functions@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-3.11.0.tgz#92f5a6af6a10641da6dc9b41b29974658b621a7b"
+  integrity sha512-i1uMhZ/M6i5SCI3ulKo7EWX0/LD+I5o6N+sk0HbOWfzyWfOl0iJTvQkR3BVDcjrlhPVC4xG1bDTLxd+DTkLqaw==
   dependencies:
     "@types/express" "4.17.3"
     cors "^2.8.5"
@@ -3794,10 +3794,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 unique-string@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12968,11 +12968,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-"typescript-3.9@npm:typescript@~3.9.7":
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
-
 typescript@4.0.2, typescript@^3.2.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"


### PR DESCRIPTION
Removes the TypeScript 3.9 checks since the framework is in the process of removing support (see https://github.com/angular/angular/pull/39313).

Also updates the Firebase functions to TS 4.0.

**Note:** this is merge-safe since it only changes build-related code.