### PR TITLE
fix(material/list): exclude icons from harness getText result

### DIFF
--- a/src/material/list/testing/list-item-harness-base.ts
+++ b/src/material/list/testing/list-item-harness-base.ts
@@ -15,6 +15,9 @@ import {
 } from '@angular/cdk/testing';
 import {BaseListItemHarnessFilters, SubheaderHarnessFilters} from './list-harness-filters';
 
+const iconSelector = '.mat-list-icon';
+const avatarSelector = '.mat-list-avatar';
+
 /**
  * Gets a `HarnessPredicate` that applies the given `BaseListItemHarnessFilters` to the given
  * list item harness.
@@ -58,12 +61,12 @@ export const enum MatListItemSection {
  */
 export class MatListItemHarnessBase extends ContentContainerComponentHarness<MatListItemSection> {
   private _lines = this.locatorForAll('.mat-line');
-  private _avatar = this.locatorForOptional('.mat-list-avatar');
-  private _icon = this.locatorForOptional('.mat-list-icon');
+  private _avatar = this.locatorForOptional(avatarSelector);
+  private _icon = this.locatorForOptional(iconSelector);
 
   /** Gets the full text content of the list item (including text from any font icons). */
   async getText(): Promise<string> {
-    return (await this.host()).text();
+    return (await this.host()).text({exclude: `${iconSelector}, ${avatarSelector}`});
   }
 
   /** Gets the lines of text (`mat-line` elements) in this nav list item. */

--- a/src/material/list/testing/shared.spec.ts
+++ b/src/material/list/testing/shared.spec.ts
@@ -395,8 +395,8 @@ export function runHarnessTests(
         <mat-list-item>
           <div matLine>Item </div>
           <div matLine>1</div>
-          <svg matListIcon></svg>
-          <svg matListAvatar></svg>
+          <div matListIcon>icon</div>
+          <div matListAvatar>Avatar</div>
         </mat-list-item>
         <div matSubheader>Section 1</div>
         <mat-divider></mat-divider>
@@ -419,8 +419,8 @@ class ListHarnessTest {}
         <mat-list-item (click)="lastClicked = 'Item 1'">
           <div matLine>Item </div>
           <div matLine>1</div>
-          <svg matListIcon></svg>
-          <svg matListAvatar></svg>
+          <div matListIcon>icon</div>
+          <div matListAvatar>Avatar</div>
         </mat-list-item>
         <div matSubheader>Section 1</div>
         <mat-divider></mat-divider>
@@ -445,8 +445,8 @@ class ActionListHarnessTest {
         <a mat-list-item (click)="onClick($event, 'Item 1')">
           <div matLine>Item </div>
           <div matLine>1</div>
-          <svg matListIcon></svg>
-          <svg matListAvatar></svg>
+          <div matListIcon>icon</div>
+          <div matListAvatar>Avatar</div>
         </a>
         <div matSubheader>Section 1</div>
         <mat-divider></mat-divider>
@@ -476,8 +476,8 @@ class NavListHarnessTest {
       <mat-list-option checkboxPosition="before">
         <div matLine>Item </div>
         <div matLine>1</div>
-        <svg matListIcon></svg>
-        <svg matListAvatar></svg>
+        <div matListIcon>icon</div>
+        <div matListAvatar>Avatar</div>
       </mat-list-option>
       <div matSubheader>Section 1</div>
       <mat-divider></mat-divider>


### PR DESCRIPTION
Excludes icons and avatars from the `MatListItemHarnessBase.getText` result.

Fixes #20812.