### PR TITLE
build: add husky ignored files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ testem.log
 /.bazelrc.user
 *.log
 .ng-dev.user*
+.husky/_


### PR DESCRIPTION
Ahead of upgrading to husky v5, adding the shell file location
to .gitignore to prevent it from randomly showing up when devs
checkout older branches.