### PR TITLE
fix(material/snack-bar): remove the query for aria-live/hidden by usi…

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.html
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.html
@@ -5,11 +5,11 @@
   -->
   <div class="mat-mdc-snack-bar-label" #label>
     <!-- Initialy holds the snack bar content, will be empty after announcing to screen readers. -->
-    <div aria-hidden="true">
+    <div aria-hidden="true" #inertElement>
       <ng-template cdkPortalOutlet></ng-template>
     </div>
 
     <!-- Will receive the snack bar content from the non-live div, move will happen a short delay after opening -->
-    <div [attr.aria-live]="_live"></div>
+    <div [attr.aria-live]="_live" #liveElement></div>
   </div>
 </div>

--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
@@ -80,10 +80,10 @@ export class MatSnackBarContainer extends BasePortalOutlet
   _live: AriaLivePoliteness;
 
   /** The aria-hidden container which holds the snack bar content. */
-  @ViewChild('inertElement') inertElement: ElementRef<HTMLElement>;
+  @ViewChild('_inertElement') private _inertElement: ElementRef<HTMLElement>;
 
   /** The aria-live container used to announce contents to screen readers. */
-  @ViewChild('liveElement') liveElement: ElementRef<HTMLElement>;
+  @ViewChild('_liveElement') private _liveElement: ElementRef<HTMLElement>;
 
   /** Whether the snack bar is currently exiting. */
   _exiting = false;
@@ -220,20 +220,20 @@ export class MatSnackBarContainer extends BasePortalOutlet
     if (!this._announceTimeoutId) {
       this._ngZone.runOutsideAngular(() => {
         this._announceTimeoutId = setTimeout(() => {
-          const inertElement = this.inertElement?.nativeElement;
-          const liveElement = this.liveElement?.nativeElement;
+          const _inertElement = this._inertElement?.nativeElement;
+          const _liveElement = this._liveElement?.nativeElement;
 
-          if (inertElement && liveElement) {
+          if (_inertElement && _liveElement) {
             // If an element in the snack bar content is focused before being moved
             // track it and restore focus after moving to the live region.
             let focusedElement: HTMLElement | null = null;
             if (document.activeElement instanceof HTMLElement &&
-                inertElement.contains(document.activeElement)) {
+                _inertElement.contains(document.activeElement)) {
               focusedElement = document.activeElement;
             }
 
-            inertElement.removeAttribute('aria-hidden');
-            liveElement.appendChild(inertElement);
+            _inertElement.removeAttribute('aria-hidden');
+            _liveElement.appendChild(_inertElement);
             focusedElement?.focus();
 
             this._onAnnounce.next();

--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
@@ -79,6 +79,12 @@ export class MatSnackBarContainer extends BasePortalOutlet
   /** aria-live value for the live region. */
   _live: AriaLivePoliteness;
 
+  /** The aria-hidden container which holds the snack bar content. */
+  @ViewChild('inertElement') inertElement: ElementRef<HTMLElement>;
+
+  /** The aria-live container used to announce contents to screen readers. */
+  @ViewChild('liveElement') liveElement: ElementRef<HTMLElement>;
+
   /** Whether the snack bar is currently exiting. */
   _exiting = false;
 
@@ -214,8 +220,8 @@ export class MatSnackBarContainer extends BasePortalOutlet
     if (!this._announceTimeoutId) {
       this._ngZone.runOutsideAngular(() => {
         this._announceTimeoutId = setTimeout(() => {
-          const inertElement = this._elementRef.nativeElement.querySelector('[aria-hidden]');
-          const liveElement = this._elementRef.nativeElement.querySelector('[aria-live]');
+          const inertElement = this.inertElement.nativeElement;
+          const liveElement = this.liveElement.nativeElement;
 
           if (inertElement && liveElement) {
             // If an element in the snack bar content is focused before being moved

--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
@@ -220,8 +220,8 @@ export class MatSnackBarContainer extends BasePortalOutlet
     if (!this._announceTimeoutId) {
       this._ngZone.runOutsideAngular(() => {
         this._announceTimeoutId = setTimeout(() => {
-          const inertElement = this.inertElement.nativeElement;
-          const liveElement = this.liveElement.nativeElement;
+          const inertElement = this.inertElement?.nativeElement;
+          const liveElement = this.liveElement?.nativeElement;
 
           if (inertElement && liveElement) {
             // If an element in the snack bar content is focused before being moved

--- a/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
@@ -81,7 +81,7 @@ describe('MatSnackBar', () => {
   });
 
   it('should not error when opening a component with an aria-live attribute', fakeAsync(() => {
-    snackBar.openFromComponent(KenobiNotification);
+    snackBar.openFromComponent(ComponentWithAriaLive);
     viewContainerFixture.detectChanges();
     tick(announceDelay);
     flush();
@@ -950,9 +950,9 @@ class BurritosNotification {
 
 /** Component with an aria-live element for testing ComponentPortal. */
 @Component({template: '<span aria-live="polite">Hello there.</span>'})
-class KenobiNotification {
+class ComponentWithAriaLive {
   constructor(
-    public snackBarRef: MatSnackBarRef<KenobiNotification>,
+    public snackBarRef: MatSnackBarRef<ComponentWithAriaLive>,
     @Inject(MAT_SNACK_BAR_DATA) public data: any) { }
 }
 
@@ -971,7 +971,7 @@ class ComponentThatProvidesMatSnackBar {
  */
 const TEST_DIRECTIVES = [ComponentWithChildViewContainer,
   BurritosNotification,
-  KenobiNotification,
+  ComponentWithAriaLive,
   DirectiveWithViewContainer,
   ComponentWithTemplateRef];
 @NgModule({
@@ -981,7 +981,7 @@ const TEST_DIRECTIVES = [ComponentWithChildViewContainer,
   entryComponents: [
     ComponentWithChildViewContainer,
     BurritosNotification,
-    KenobiNotification,
+    ComponentWithAriaLive,
   ],
 })
 class SnackBarTestModule { }

--- a/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
@@ -80,6 +80,13 @@ describe('MatSnackBar', () => {
         .toBe(0, 'Expected live region to not contain any content');
   });
 
+  it('should not error when opening a component with an aria-live attribute', fakeAsync(() => {
+    snackBar.openFromComponent(KenobiNotification);
+    viewContainerFixture.detectChanges();
+    tick(announceDelay);
+    flush();
+  }));
+
   it('should move content to the live region after 150ms', fakeAsync(() => {
     snackBar.open('Snack time!', 'Chew');
     viewContainerFixture.detectChanges();
@@ -941,6 +948,14 @@ class BurritosNotification {
       @Inject(MAT_SNACK_BAR_DATA) public data: any) { }
 }
 
+/** Component with an aria-live element for testing ComponentPortal. */
+@Component({template: '<span aria-live="polite">Hello there.</span>'})
+class KenobiNotification {
+  constructor(
+    public snackBarRef: MatSnackBarRef<KenobiNotification>,
+    @Inject(MAT_SNACK_BAR_DATA) public data: any) { }
+}
+
 @Component({
   template: '',
   providers: [MatSnackBar]
@@ -956,12 +971,17 @@ class ComponentThatProvidesMatSnackBar {
  */
 const TEST_DIRECTIVES = [ComponentWithChildViewContainer,
   BurritosNotification,
+  KenobiNotification,
   DirectiveWithViewContainer,
   ComponentWithTemplateRef];
 @NgModule({
   imports: [CommonModule, MatSnackBarModule],
   exports: TEST_DIRECTIVES,
   declarations: TEST_DIRECTIVES,
-  entryComponents: [ComponentWithChildViewContainer, BurritosNotification],
+  entryComponents: [
+    ComponentWithChildViewContainer,
+    BurritosNotification,
+    KenobiNotification,
+  ],
 })
 class SnackBarTestModule { }

--- a/src/material/snack-bar/snack-bar-container.html
+++ b/src/material/snack-bar/snack-bar-container.html
@@ -1,7 +1,7 @@
 <!-- Initialy holds the snack bar content, will be empty after announcing to screen readers. -->
-<div aria-hidden="true">
+<div aria-hidden="true" #inertElement>
   <ng-template cdkPortalOutlet></ng-template>
 </div>
 
 <!-- Will receive the snack bar content from the non-live div, move will happen a short delay after opening -->
-<div [attr.aria-live]="_live"></div>
+<div [attr.aria-live]="_live" #liveElement></div>

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -99,10 +99,10 @@ export class MatSnackBarContainer extends BasePortalOutlet
   _live: AriaLivePoliteness;
 
   /** The aria-hidden container which holds the snack bar content. */
-  @ViewChild('inertElement') inertElement: ElementRef<HTMLElement>;
+  @ViewChild('_inertElement') private _inertElement: ElementRef<HTMLElement>;
 
   /** The aria-live container used to announce contents to screen readers. */
-  @ViewChild('liveElement') liveElement: ElementRef<HTMLElement>;
+  @ViewChild('_liveElement') private _liveElement: ElementRef<HTMLElement>;
 
   constructor(
     private _ngZone: NgZone,
@@ -253,21 +253,21 @@ export class MatSnackBarContainer extends BasePortalOutlet
     if (!this._announceTimeoutId) {
       this._ngZone.runOutsideAngular(() => {
         this._announceTimeoutId = setTimeout(() => {
-          const inertElement = this.inertElement?.nativeElement;
-          const liveElement = this.liveElement?.nativeElement;
+          const _inertElement = this._inertElement?.nativeElement;
+          const _liveElement = this._liveElement?.nativeElement;
 
-          if (inertElement && liveElement) {
+          if (_inertElement && _liveElement) {
             // If an element in the snack bar content is focused before being moved
             // track it and restore focus after moving to the live region.
             let focusedElement: HTMLElement | null = null;
             if (this._platform.isBrowser &&
                 document.activeElement instanceof HTMLElement &&
-                inertElement.contains(document.activeElement)) {
+                _inertElement.contains(document.activeElement)) {
               focusedElement = document.activeElement;
             }
 
-            inertElement.removeAttribute('aria-hidden');
-            liveElement.appendChild(inertElement);
+            _inertElement.removeAttribute('aria-hidden');
+            _liveElement.appendChild(_inertElement);
             focusedElement?.focus();
 
             this._onAnnounce.next();

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -253,8 +253,8 @@ export class MatSnackBarContainer extends BasePortalOutlet
     if (!this._announceTimeoutId) {
       this._ngZone.runOutsideAngular(() => {
         this._announceTimeoutId = setTimeout(() => {
-          const inertElement = this.inertElement.nativeElement;
-          const liveElement = this.liveElement.nativeElement;
+          const inertElement = this.inertElement?.nativeElement;
+          const liveElement = this.liveElement?.nativeElement;
 
           if (inertElement && liveElement) {
             // If an element in the snack bar content is focused before being moved

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -98,6 +98,12 @@ export class MatSnackBarContainer extends BasePortalOutlet
   /** aria-live value for the live region. */
   _live: AriaLivePoliteness;
 
+  /** The aria-hidden container which holds the snack bar content. */
+  @ViewChild('inertElement') inertElement: ElementRef<HTMLElement>;
+
+  /** The aria-live container used to announce contents to screen readers. */
+  @ViewChild('liveElement') liveElement: ElementRef<HTMLElement>;
+
   constructor(
     private _ngZone: NgZone,
     private _elementRef: ElementRef<HTMLElement>,
@@ -247,8 +253,8 @@ export class MatSnackBarContainer extends BasePortalOutlet
     if (!this._announceTimeoutId) {
       this._ngZone.runOutsideAngular(() => {
         this._announceTimeoutId = setTimeout(() => {
-          const inertElement = this._elementRef.nativeElement.querySelector('[aria-hidden]');
-          const liveElement = this._elementRef.nativeElement.querySelector('[aria-live]');
+          const inertElement = this.inertElement.nativeElement;
+          const liveElement = this.liveElement.nativeElement;
 
           if (inertElement && liveElement) {
             // If an element in the snack bar content is focused before being moved

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -81,7 +81,7 @@ describe('MatSnackBar', () => {
   });
 
   it('should not error when opening a component with an aria-live attribute', fakeAsync(() => {
-    snackBar.openFromComponent(KenobiNotification);
+    snackBar.openFromComponent(ComponentWithAriaLive);
     viewContainerFixture.detectChanges();
     tick(announceDelay);
     flush();
@@ -1045,9 +1045,9 @@ class BurritosNotification {
 
 /** Component with an aria-live element for testing ComponentPortal. */
 @Component({template: '<span aria-live="polite">Hello there.</span>'})
-class KenobiNotification {
+class ComponentWithAriaLive {
   constructor(
-    public snackBarRef: MatSnackBarRef<KenobiNotification>,
+    public snackBarRef: MatSnackBarRef<ComponentWithAriaLive>,
     @Inject(MAT_SNACK_BAR_DATA) public data: any) { }
 }
 
@@ -1068,7 +1068,7 @@ class ComponentThatProvidesMatSnackBar {
  */
 const TEST_DIRECTIVES = [ComponentWithChildViewContainer,
                          BurritosNotification,
-                         KenobiNotification,
+                         ComponentWithAriaLive,
                          DirectiveWithViewContainer,
                          ComponentWithTemplateRef];
 @NgModule({
@@ -1078,7 +1078,7 @@ const TEST_DIRECTIVES = [ComponentWithChildViewContainer,
   entryComponents: [
     ComponentWithChildViewContainer,
     BurritosNotification,
-    KenobiNotification,
+    ComponentWithAriaLive,
   ],
 })
 class SnackBarTestModule { }

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -80,6 +80,13 @@ describe('MatSnackBar', () => {
         .toBe(0, 'Expected live region to not contain any content');
   });
 
+  it('should not error when opening a component with an aria-live attribute', fakeAsync(() => {
+    snackBar.openFromComponent(KenobiNotification);
+    viewContainerFixture.detectChanges();
+    tick(announceDelay);
+    flush();
+  }));
+
   it('should move content to the live region after 150ms', fakeAsync(() => {
     snackBar.open('Snack time!', 'Chew');
     viewContainerFixture.detectChanges();
@@ -1036,6 +1043,14 @@ class BurritosNotification {
     @Inject(MAT_SNACK_BAR_DATA) public data: any) { }
 }
 
+/** Component with an aria-live element for testing ComponentPortal. */
+@Component({template: '<span aria-live="polite">Hello there.</span>'})
+class KenobiNotification {
+  constructor(
+    public snackBarRef: MatSnackBarRef<KenobiNotification>,
+    @Inject(MAT_SNACK_BAR_DATA) public data: any) { }
+}
+
 
 @Component({
   template: '',
@@ -1053,12 +1068,17 @@ class ComponentThatProvidesMatSnackBar {
  */
 const TEST_DIRECTIVES = [ComponentWithChildViewContainer,
                          BurritosNotification,
+                         KenobiNotification,
                          DirectiveWithViewContainer,
                          ComponentWithTemplateRef];
 @NgModule({
   imports: [CommonModule, MatSnackBarModule],
   exports: TEST_DIRECTIVES,
   declarations: TEST_DIRECTIVES,
-  entryComponents: [ComponentWithChildViewContainer, BurritosNotification],
+  entryComponents: [
+    ComponentWithChildViewContainer,
+    BurritosNotification,
+    KenobiNotification,
+  ],
 })
 class SnackBarTestModule { }


### PR DESCRIPTION
…ng a template ref

* In the case where a user provides snack-bar content containing
  an element with the aria-live attribute specified, the previous
  query would find that element instead. By using a template
  reference, we avoid the need to use querySelector entirely.