### PR TITLE
feat(material/datepicker) allow custom pickers with date inputs

### DIFF
--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -33,10 +33,10 @@ import {
   MatDateRangeInputParent,
   MAT_DATE_RANGE_INPUT_PARENT,
 } from './date-range-input-parts';
-import {MatDatepickerControl} from './datepicker-base';
+import {MatDatepickerControl, MatDatepickerPanel} from './datepicker-base';
 import {createMissingDateImplError} from './datepicker-errors';
 import {DateFilterFn, dateInputsHaveChanged} from './datepicker-input-base';
-import {MatDateRangePicker, MatDateRangePickerInput} from './date-range-picker';
+import {MatDateRangePickerInput} from './date-range-picker';
 import {DateRange, MatDateSelectionModel} from './date-selection-model';
 
 let nextUniqueId = 0;
@@ -101,14 +101,14 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
   /** The range picker that this input is associated with. */
   @Input()
   get rangePicker() { return this._rangePicker; }
-  set rangePicker(rangePicker: MatDateRangePicker<D>) {
+  set rangePicker(rangePicker: MatDatepickerPanel<MatDatepickerControl<D>, DateRange<D>, D>) {
     if (rangePicker) {
-      this._model = rangePicker._registerInput(this);
+      this._model = rangePicker.registerInput(this);
       this._rangePicker = rangePicker;
       this._registerModel(this._model!);
     }
   }
-  private _rangePicker: MatDateRangePicker<D>;
+  private _rangePicker: MatDatepickerPanel<MatDatepickerControl<D>, DateRange<D>, D>;
 
   /** Whether the input is required. */
   @Input()

--- a/src/material/datepicker/date-range-picker.ts
+++ b/src/material/datepicker/date-range-picker.ts
@@ -40,7 +40,7 @@ export class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRangePickerI
   protected _forwardContentValues(instance: MatDatepickerContent<DateRange<D>, D>) {
     super._forwardContentValues(instance);
 
-    const input = this._datepickerInput;
+    const input = this.datepickerInput;
 
     if (input) {
       instance.comparisonStart = input.comparisonStart;

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -28,9 +28,8 @@ import {
 } from '@angular/material/core';
 import {MatFormField, MAT_FORM_FIELD} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
-import {MatDatepicker} from './datepicker';
 import {MatDatepickerInputBase, DateFilterFn} from './datepicker-input-base';
-import {MatDatepickerControl} from './datepicker-base';
+import {MatDatepickerControl, MatDatepickerPanel} from './datepicker-base';
 
 /** @docs-private */
 export const MAT_DATEPICKER_VALUE_ACCESSOR: any = {
@@ -75,13 +74,13 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
   implements MatDatepickerControl<D | null> {
   /** The datepicker that this input is associated with. */
   @Input()
-  set matDatepicker(datepicker: MatDatepicker<D>) {
+  set matDatepicker(datepicker: MatDatepickerPanel<MatDatepickerControl<D>, D | null, D>) {
     if (datepicker) {
       this._datepicker = datepicker;
-      this._registerModel(datepicker._registerInput(this));
+      this._registerModel(datepicker.registerInput(this));
     }
   }
-  _datepicker: MatDatepicker<D>;
+  _datepicker: MatDatepickerPanel<MatDatepickerControl<D>, D | null, D>;
 
   /** The minimum valid date. */
   @Input()

--- a/src/material/datepicker/datepicker-toggle.ts
+++ b/src/material/datepicker/datepicker-toggle.ts
@@ -25,7 +25,7 @@ import {
 import {MatButton} from '@angular/material/button';
 import {merge, of as observableOf, Subscription} from 'rxjs';
 import {MatDatepickerIntl} from './datepicker-intl';
-import {MatDatepickerBase, MatDatepickerControl} from './datepicker-base';
+import {MatDatepickerControl, MatDatepickerPanel} from './datepicker-base';
 
 
 /** Can be used to override the icon of a `matDatepickerToggle`. */
@@ -59,7 +59,7 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   private _stateChanges = Subscription.EMPTY;
 
   /** Datepicker instance that the button will toggle. */
-  @Input('for') datepicker: MatDatepickerBase<MatDatepickerControl<any>, D>;
+  @Input('for') datepicker: MatDatepickerPanel<MatDatepickerControl<any>, D>;
 
   /** Tabindex for the toggle. */
   @Input() tabIndex: number | null;
@@ -118,9 +118,9 @@ export class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDe
   }
 
   private _watchStateChanges() {
-    const datepickerStateChanged = this.datepicker ? this.datepicker._stateChanges : observableOf();
-    const inputStateChanged = this.datepicker && this.datepicker._datepickerInput ?
-        this.datepicker._datepickerInput.stateChanges : observableOf();
+    const datepickerStateChanged = this.datepicker ? this.datepicker.stateChanges : observableOf();
+    const inputStateChanged = this.datepicker && this.datepicker.datepickerInput ?
+        this.datepicker.datepickerInput.stateChanges : observableOf();
     const datepickerToggled = this.datepicker ?
         merge(this.datepicker.openedStream, this.datepicker.closedStream) :
         observableOf();

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -210,12 +210,12 @@ export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>
 }
 
 export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> implements MatDatepickerControl<D | null> {
-    _datepicker: MatDatepicker<D>;
+    _datepicker: MatDatepickerPanel<MatDatepickerControl<D>, D | null, D>;
     protected _outsideValueChanged: undefined;
     protected _validator: ValidatorFn | null;
     get dateFilter(): DateFilterFn<D | null>;
     set dateFilter(value: DateFilterFn<D | null>);
-    set matDatepicker(datepicker: MatDatepicker<D>);
+    set matDatepicker(datepicker: MatDatepickerPanel<MatDatepickerControl<D>, D | null, D>);
     get max(): D | null;
     set max(value: D | null);
     get min(): D | null;
@@ -272,7 +272,7 @@ export declare class MatDatepickerToggle<D> implements AfterContentInit, OnChang
     _button: MatButton;
     _customIcon: MatDatepickerToggleIcon;
     _intl: MatDatepickerIntl;
-    datepicker: MatDatepickerBase<MatDatepickerControl<any>, D>;
+    datepicker: MatDatepickerPanel<MatDatepickerControl<any>, D>;
     disableRipple: boolean;
     get disabled(): boolean;
     set disabled(value: boolean);
@@ -314,8 +314,8 @@ export declare class MatDateRangeInput<D> implements MatFormFieldControl<DateRan
     set min(value: D | null);
     ngControl: NgControl | null;
     get placeholder(): string;
-    get rangePicker(): MatDateRangePicker<D>;
-    set rangePicker(rangePicker: MatDateRangePicker<D>);
+    get rangePicker(): MatDatepickerPanel<MatDatepickerControl<D>, DateRange<D>, D>;
+    set rangePicker(rangePicker: MatDatepickerPanel<MatDatepickerControl<D>, DateRange<D>, D>);
     get required(): boolean;
     set required(value: boolean);
     separator: string;


### PR DESCRIPTION
Refactor material datepicker so apps can bind custom picker components to date inputs.

### API changes
- Renamed the following in `MatDatepickerBase`:
  - `_registerInput()` -> `registerInput()`
  - `_stateChanges` -> `stateChanges`
  - `_datepickerInput` -> `datepickerInput`
- Added `MatDatepickerPanel` interface (recommendations for another name?).
- Refactored `MatDatepickerInput`, `MatDateRangeInput`, and `MatDatepickerToggle` to receive a `MatDatepickerPanel` instead of a specific implementation of `MatDatepickerBase`.