### PR TITLE
fix(google-maps): allow ground overlay bounds to be changed

### DIFF
--- a/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.spec.ts
@@ -55,13 +55,6 @@ describe('MapGroundOverlay', () => {
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
   });
 
-  it('has an error if required bounds are not provided', () => {
-    expect(() => {
-      const fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
-    }).toThrow(new Error('Image bounds are required'));
-  });
-
   it('exposes methods that provide information about the Ground Overlay', () => {
     const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
     createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
@@ -141,6 +134,22 @@ describe('MapGroundOverlay', () => {
     expect(groundOverlaySpy.setMap).toHaveBeenCalledTimes(2);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(null);
     expect(groundOverlaySpy.setMap).toHaveBeenCalledWith(mapSpy);
+  });
+
+  it('should recreate the ground overlay when the bounds change', () => {
+    const groundOverlaySpy = createGroundOverlaySpy(url, bounds, groundOverlayOptions);
+    createGroundOverlayConstructorSpy(groundOverlaySpy).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+
+    const oldOverlay = fixture.componentInstance.groundOverlay.groundOverlay;
+    fixture.componentInstance.bounds = {...bounds};
+    fixture.detectChanges();
+
+    const newOverlay = fixture.componentInstance.groundOverlay.groundOverlay;
+    expect(newOverlay).toBeTruthy();
+    expect(newOverlay).not.toBe(oldOverlay);
   });
 
 });

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -113,7 +113,8 @@ export declare class MapCircle implements OnInit, OnDestroy {
 }
 
 export declare class MapGroundOverlay implements OnInit, OnDestroy {
-    bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
+    get bounds(): google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
+    set bounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral);
     clickable: boolean;
     groundOverlay?: google.maps.GroundOverlay;
     mapClick: Observable<google.maps.MouseEvent>;


### PR DESCRIPTION
Allows for the bounds of the Google Maps ground overlay to be changed after initialization. This case is different from other similar components, because Google Maps doesn't provide an API to change the bounds so we have to recreate the overlay any time they change.

Fixes #20865.