### PR TITLE
build: assert correct placement in breaking change rule

### DIFF
--- a/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
+++ b/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
@@ -40,7 +40,8 @@ export class MatSnackBarHarness extends ComponentHarness {
   /**
    * Gets the role of the snack-bar. The role of a snack-bar is determined based
    * on the ARIA politeness specified in the snack-bar config.
-   * @deprecated @breaking-change 13.0.0 Use `getAriaLive` instead.
+   * @deprecated Use `getAriaLive` instead.
+   * @breaking-change 13.0.0
    */
   async getRole(): Promise<'alert'|'status'|null> {
     return (await this.host()).getAttribute('role') as Promise<'alert'|'status'|null>;

--- a/src/material/snack-bar/testing/snack-bar-harness.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.ts
@@ -36,7 +36,8 @@ export class MatSnackBarHarness extends ContentContainerComponentHarness<string>
   /**
    * Gets the role of the snack-bar. The role of a snack-bar is determined based
    * on the ARIA politeness specified in the snack-bar config.
-   * @deprecated @breaking-change 13.0.0 Use `getAriaLive` instead.
+   * @deprecated Use `getAriaLive` instead.
+   * @breaking-change 13.0.0
    */
   async getRole(): Promise<'alert'|'status'|null> {
     return (await this.host()).getAttribute('role') as Promise<'alert'|'status'|null>;


### PR DESCRIPTION
Dgeni was logging a warning, because we had `@deprecated` and `@breaking-change` on the same line in a couple of places, but we didn't notice it since it's not a hard error.

These changes update our lint rule to assert that the tags can only be set at the start of a line.