### PR TITLE
docs(material/select): fix select within dialog example not selecting option

### DIFF
--- a/src/dev-app/select/select-demo.html
+++ b/src/dev-app/select/select-demo.html
@@ -261,9 +261,9 @@ Space above cards: <input type="number" [formControl]="topHeightCtrl">
         <mat-form-field>
           <mat-label>Select a topping</mat-label>
           <mat-select>
-            <mat-option>Cheese</mat-option>
-            <mat-option>Onion</mat-option>
-            <mat-option>Pepper</mat-option>
+            <mat-option value="cheese">Cheese</mat-option>
+            <mat-option value="onion">Onion</mat-option>
+            <mat-option value="pepper">Pepper</mat-option>
           </mat-select>
         </mat-form-field>
 


### PR DESCRIPTION
`<mat-option>` within the select was missing `[value]`

Fixes: https://github.com/angular/components/issues/20840