### PR TITLE
fix(cdk/overlay): remove doubled overlay margin on right and bottom

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -1280,6 +1280,26 @@ describe('FlexibleConnectedPositionStrategy', () => {
       expect(Math.floor(overlayRect.left)).toBe(200);
     });
 
+    it('should not mess with the right offset when pushing from the right', () => {
+      const MARGIN = 20;
+      originElement.style.top = '30px';
+      originElement.style.left = `${viewport.getViewportSize().width - MARGIN - DEFAULT_WIDTH}px`;
+
+      positionStrategy
+        .withViewportMargin(MARGIN)
+        .withPositions([{
+          originX: 'end',
+          originY: 'bottom',
+          overlayX: 'end',
+          overlayY: 'top'
+        }]);
+
+      attachOverlay({positionStrategy});
+
+      const overlayRect = overlayRef.overlayElement.getBoundingClientRect();
+      expect(Math.floor(overlayRect.left)).toBe(viewport.getViewportSize().width - MARGIN - DEFAULT_WIDTH);
+    });
+
     it('should align to the trigger if the overlay is wider than the viewport, but the trigger ' +
       'is still within the viewport', () => {
         originElement.style.top = '200px';

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.ts
@@ -617,8 +617,8 @@ export class FlexibleConnectedPositionStrategy implements PositionStrategy {
 
     // Determine how much the overlay goes outside the viewport on each
     // side, which we'll use to decide which direction to push it.
-    const overflowRight = Math.max(start.x + overlay.width - viewport.width, 0);
-    const overflowBottom = Math.max(start.y + overlay.height - viewport.height, 0);
+    const overflowRight = Math.max(start.x + overlay.width - (viewport.width + this._viewportMargin), 0);
+    const overflowBottom = Math.max(start.y + overlay.height - (viewport.height + this._viewportMargin), 0);
     const overflowTop = Math.max(viewport.top - scrollPosition.top - start.y, 0);
     const overflowLeft = Math.max(viewport.left - scrollPosition.left - start.x, 0);
 


### PR DESCRIPTION
When overlay element with FlexibleConnectedPositionStrategy should be pushed from the right,
it was pushed with the double of the margin value.
On left and top the scroll position was not taken into count.

Fixes #20890 Partially