### PR TITLE
feat(material/button): allow focus origin to be optional input in focus method

### DIFF
--- a/src/material/button/button.spec.ts
+++ b/src/material/button/button.spec.ts
@@ -84,6 +84,23 @@ describe('MatButton', () => {
     expect(buttonDebugEl.nativeElement.classList).toContain('cdk-touch-focused');
   });
 
+  it('should not change focus origin if origin not specified', () => {
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+
+    const fabButtonDebugEl = fixture.debugElement.query(By.css('button[mat-fab]'))!;
+    const fabButtonInstance = fabButtonDebugEl.componentInstance as MatButton;
+    fabButtonInstance.focus('mouse');
+
+    const miniFabButtonDebugEl = fixture.debugElement.query(By.css('button[mat-mini-fab]'))!;
+    const miniFabButtonInstance = miniFabButtonDebugEl.componentInstance as MatButton;
+
+    miniFabButtonInstance.focus();
+
+    expect(miniFabButtonDebugEl.nativeElement.classList).toContain('cdk-focused');
+    expect(miniFabButtonDebugEl.nativeElement.classList).toContain('cdk-mouse-focused');
+  });
+
   describe('button[mat-fab]', () => {
     it('should have accent palette by default', () => {
       const fixture = TestBed.createComponent(TestApp);

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -127,8 +127,12 @@ export class MatButton extends _MatButtonMixinBase
   }
 
   /** Focuses the button. */
-  focus(origin: FocusOrigin = 'program', options?: FocusOptions): void {
-    this._focusMonitor.focusVia(this._getHostElement(), origin, options);
+  focus(origin?: FocusOrigin, options?: FocusOptions): void {
+    if (origin) {
+      this._focusMonitor.focusVia(this._getHostElement(), origin, options);
+    } else {
+      this._getHostElement().focus(options);
+    }
   }
 
   _getHostElement() {


### PR DESCRIPTION
WHAT: For Angular Material components that have a focus() method, allow for the origin param to be optional and remove the default origin value.

WHY: For cases where the focus() method is called and the origin is already defined, we don’t want to override the origin using focusVia to always be some default value. In many cases, we want to leave the origin unchanged, but if there are cases that need the origin to be updated, allow for this with an optional origin param.