### PR TITLE
feat(material/checkbox): allow focus origin to be optional input in focus method

### DIFF
--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -909,6 +909,21 @@ describe('MatCheckbox', () => {
       expect(secondId).toMatch(/mat-checkbox-\d+-input/);
       expect(firstId).not.toEqual(secondId);
     });
+
+    it('should not change focus origin if origin not specified', () => {
+      let [firstCheckboxDebugEl, secondCheckboxDebugEl] =
+             fixture.debugElement.queryAll(By.directive(MatCheckbox));
+      fixture.detectChanges();
+
+      const firstCheckboxInstance = firstCheckboxDebugEl.componentInstance as MatCheckbox;
+      const secondCheckboxInstance = secondCheckboxDebugEl.componentInstance as MatCheckbox;
+
+      firstCheckboxInstance.focus('mouse');
+      secondCheckboxInstance.focus();
+
+      expect(secondCheckboxDebugEl.nativeElement.classList).toContain('cdk-focused');
+      expect(secondCheckboxDebugEl.nativeElement.classList).toContain('cdk-mouse-focused');
+    });
   });
 
   describe('with ngModel', () => {

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -425,8 +425,12 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
   }
 
   /** Focuses the checkbox. */
-  focus(origin: FocusOrigin = 'keyboard', options?: FocusOptions): void {
-    this._focusMonitor.focusVia(this._inputElement, origin, options);
+  focus(origin?: FocusOrigin, options?: FocusOptions): void {
+    if (origin) {
+      this._focusMonitor.focusVia(this._inputElement, origin, options);
+    } else {
+      this._inputElement.nativeElement.focus(options);
+    }
   }
 
   _onInteractionEvent(event: Event) {


### PR DESCRIPTION
WHAT: For Angular Material components that have a focus() method, allow for the origin param to be optional and remove the default origin value.

WHY: For cases where the focus() method is called and the origin is already defined, we don’t want to override the origin using focusVia to always be some default value. In many cases, we want to leave the origin unchanged, but if there are cases that need the origin to be updated, allow for this with an optional origin param.