### PR TITLE
feat(material/menu): allow focus origin to be optional input in focus method

### DIFF
--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -94,8 +94,8 @@ export class MatMenuItem extends _MatMenuItemMixinBase
   }
 
   /** Focuses the menu item. */
-  focus(origin: FocusOrigin = 'program', options?: FocusOptions): void {
-    if (this._focusMonitor) {
+  focus(origin?: FocusOrigin, options?: FocusOptions): void {
+    if (this._focusMonitor && origin) {
       this._focusMonitor.focusVia(this._getHostElement(), origin, options);
     } else {
       this._getHostElement().focus(options);

--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -275,8 +275,8 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
    * Focuses the menu trigger.
    * @param origin Source of the menu trigger's focus.
    */
-  focus(origin: FocusOrigin = 'program', options?: FocusOptions) {
-    if (this._focusMonitor) {
+  focus(origin?: FocusOrigin, options?: FocusOptions) {
+    if (this._focusMonitor && origin) {
       this._focusMonitor.focusVia(this._element, origin, options);
     } else {
       this._element.nativeElement.focus(options);

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -615,6 +615,25 @@ describe('MatMenu', () => {
     expect(items.every(item => item.getAttribute('role') === 'menuitemcheckbox')).toBe(true);
   });
 
+  it('should not change focus origin if origin not specified for menu items', () => {
+    const fixture = createComponent(MenuWithCheckboxItems);
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openMenu();
+    fixture.detectChanges();
+
+    let [firstMenuItemDebugEl, secondMenuItemDebugEl] =
+           fixture.debugElement.queryAll(By.css('.mat-menu-item'))!;
+
+    const firstMenuItemInstance = firstMenuItemDebugEl.componentInstance as MatMenuItem;
+    const secondMenuItemInstance = secondMenuItemDebugEl.componentInstance as MatMenuItem;
+
+    firstMenuItemInstance.focus('mouse');
+    secondMenuItemInstance.focus();
+
+    expect(secondMenuItemDebugEl.nativeElement.classList).toContain('cdk-focused');
+    expect(secondMenuItemDebugEl.nativeElement.classList).toContain('cdk-mouse-focused');
+  });
+
   it('should not throw an error on destroy', () => {
     const fixture = createComponent(SimpleMenu, [], [FakeIcon]);
     expect(fixture.destroy.bind(fixture)).not.toThrow();
@@ -2004,6 +2023,24 @@ describe('MatMenu', () => {
             .not.toContain('mat-elevation-z6', 'Expected menu not to maintain old elevation.');
         expect(lastMenu.classList)
             .toContain('mat-elevation-z4', 'Expected menu to have the proper updated elevation.');
+      }));
+
+        it('should not change focus origin if origin not specified for menu trigger',
+      fakeAsync(() => {
+        compileTestComponent();
+
+        instance.levelOneTrigger.openMenu();
+        instance.levelOneTrigger.focus('mouse');
+        fixture.detectChanges();
+
+        instance.levelTwoTrigger.focus();
+        fixture.detectChanges();
+        tick(500);
+
+        const levelTwoTrigger = overlay.querySelector('#level-two-trigger')! as HTMLElement;
+
+        expect(levelTwoTrigger.classList).toContain('cdk-focused');
+        expect(levelTwoTrigger.classList).toContain('cdk-mouse-focused');
       }));
 
     it('should not increase the elevation if the user specified a custom one', () => {


### PR DESCRIPTION
WHAT: For Angular Material components that have a focus() method, allow for the origin param to be optional and remove the default origin value.

WHY: For cases where the focus() method is called and the origin is already defined, we don’t want to override the origin using focusVia to always be some default value. In many cases, we want to leave the origin unchanged, but if there are cases that need the origin to be updated, allow for this with an optional origin param.