### PR TITLE
feat(material/radio): allow focus origin to be optional input in focus method

### DIFF
--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -598,6 +598,7 @@ describe('MatRadio', () => {
     let seasonRadioInstances: MatRadioButton[];
     let weatherRadioInstances: MatRadioButton[];
     let fruitRadioInstances: MatRadioButton[];
+    let fruitRadioNativeElements: HTMLElement[];
     let fruitRadioNativeInputs: HTMLElement[];
     let testComponent: StandaloneRadioButtons;
 
@@ -618,7 +619,7 @@ describe('MatRadio', () => {
           .filter(debugEl => debugEl.componentInstance.name == 'fruit')
           .map(debugEl => debugEl.componentInstance);
 
-      const fruitRadioNativeElements = radioDebugElements
+      fruitRadioNativeElements = radioDebugElements
           .filter(debugEl => debugEl.componentInstance.name == 'fruit')
           .map(debugEl => debugEl.nativeElement);
 
@@ -730,6 +731,14 @@ describe('MatRadio', () => {
 
         expect(document.activeElement).toBe(fruitRadioNativeInputs[i]);
       }
+    });
+
+    it('should not change focus origin if origin not specified', () => {
+      fruitRadioInstances[0].focus(undefined, 'mouse');
+      fruitRadioInstances[1].focus();
+
+      expect(fruitRadioNativeElements[1].classList).toContain('cdk-focused');
+      expect(fruitRadioNativeElements[1].classList).toContain('cdk-mouse-focused');
     });
 
     it('should not add the "name" attribute if it is not passed in', () => {

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FocusMonitor} from '@angular/cdk/a11y';
+import {FocusMonitor, FocusOrigin} from '@angular/cdk/a11y';
 import {
   BooleanInput,
   coerceBooleanProperty,
@@ -516,8 +516,12 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
   }
 
   /** Focuses the radio button. */
-  focus(options?: FocusOptions): void {
-    this._focusMonitor.focusVia(this._inputElement, 'keyboard', options);
+  focus(options?: FocusOptions, origin?: FocusOrigin): void {
+    if (origin) {
+      this._focusMonitor.focusVia(this._inputElement, origin, options);
+    } else {
+      this._inputElement.nativeElement.focus(options);
+    }
   }
 
   /**

--- a/tools/public_api_guard/material/radio.d.ts
+++ b/tools/public_api_guard/material/radio.d.ts
@@ -28,7 +28,7 @@ export declare abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBa
     _onInputChange(event: Event): void;
     _onInputClick(event: Event): void;
     protected _setDisabled(value: boolean): void;
-    focus(options?: FocusOptions): void;
+    focus(options?: FocusOptions, origin?: FocusOrigin): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;


### PR DESCRIPTION
WHAT: For Angular Material components that have a focus() method, allow for the origin param to be optional and remove the default origin value.

WHY: For cases where the focus() method is called and the origin is already defined, we don’t want to override the origin using focusVia to always be some default value. In many cases, we want to leave the origin unchanged, but if there are cases that need the origin to be updated, allow for this with an optional origin param.