### PR TITLE
feat(material/expansion): allow focus origin to be optional input in focus method

### DIFF
--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -190,8 +190,12 @@ export class MatExpansionPanelHeader implements AfterViewInit, OnDestroy, Focusa
    * @param origin Origin of the action that triggered the focus.
    * @docs-private
    */
-  focus(origin: FocusOrigin = 'program', options?: FocusOptions) {
-    this._focusMonitor.focusVia(this._element, origin, options);
+  focus(origin?: FocusOrigin, options?: FocusOptions) {
+    if (origin) {
+      this._focusMonitor.focusVia(this._element, origin, options);
+    } else {
+      this._element.nativeElement.focus(options);
+    }
   }
 
   ngAfterViewInit() {

--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -223,6 +223,24 @@ describe('MatExpansionPanel', () => {
     expect(document.activeElement).toBe(header, 'Expected header to be focused.');
   }));
 
+  it('should not change focus origin if origin not specified', fakeAsync(() => {
+    const fixture = TestBed.createComponent(PanelWithContent);
+    fixture.componentInstance.expanded = true;
+    fixture.detectChanges();
+    tick(250);
+
+    const header = fixture.debugElement.query(By.css('mat-expansion-panel-header'))!;
+    const headerInstance = header.componentInstance;
+
+    headerInstance.focus('mouse');
+    headerInstance.focus();
+    fixture.detectChanges();
+    tick(250);
+
+    expect(header.nativeElement.classList).toContain('cdk-focused');
+    expect(header.nativeElement.classList).toContain('cdk-mouse-focused');
+  }));
+
   it('should not override the panel margin if it is not inside an accordion', fakeAsync(() => {
     const fixture = TestBed.createComponent(PanelWithCustomMargin);
     fixture.detectChanges();


### PR DESCRIPTION
WHAT: For Angular Material components that have a focus() method, allow for the origin param to be optional and remove the default origin value.

WHY: For cases where the focus() method is called and the origin is already defined, we don’t want to override the origin using focusVia to always be some default value. In many cases, we want to leave the origin unchanged, but if there are cases that need the origin to be updated, allow for this with an optional origin param.