### PR TITLE
refactor: remove underscores from non-mdc density mixins

### DIFF
--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -104,6 +104,7 @@ export const commitMessage: CommitMessageConfig = {
     'material/table',
     'material/tabs',
     'material/testing',
+    'material/theming',
     'material/toolbar',
     'material/tooltip',
     'material/tree',

--- a/src/material-experimental/mdc-paginator/_paginator-theme.scss
+++ b/src/material-experimental/mdc-paginator/_paginator-theme.scss
@@ -53,7 +53,7 @@
   }
 }
 
-@mixin _mat-mdc-paginator-density($config-or-theme) {
+@mixin mat-mdc-paginator-density($config-or-theme) {
   $density-scale: mat-get-density-config($config-or-theme);
   $height: _mat-density-prop-value($mat-paginator-density-config, $density-scale, height);
 
@@ -75,7 +75,7 @@
       @include mat-mdc-paginator-color($color);
     }
     @if $density != null {
-      @include _mat-mdc-paginator-density($density);
+      @include mat-mdc-paginator-density($density);
     }
     @if $typography != null {
       @include mat-mdc-paginator-typography($typography);

--- a/src/material/expansion/_expansion-theme.scss
+++ b/src/material/expansion/_expansion-theme.scss
@@ -74,7 +74,7 @@
   }
 }
 
-@mixin _mat-expansion-panel-density($config-or-theme) {
+@mixin mat-expansion-panel-density($config-or-theme) {
   $density-scale: mat-get-density-config($config-or-theme);
   $expanded-height: _mat-density-prop-value(
         $mat-expansion-panel-header-density-config, $density-scale, expanded-height);
@@ -103,7 +103,7 @@
       @include mat-expansion-panel-color($color);
     }
     @if $density != null {
-      @include _mat-expansion-panel-density($density);
+      @include mat-expansion-panel-density($density);
     }
     @if $typography != null {
       @include mat-expansion-panel-typography($typography);

--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -134,7 +134,7 @@
   }
 }
 
-@mixin _mat-stepper-density($config-or-theme) {
+@mixin mat-stepper-density($config-or-theme) {
   $density-scale: mat-get-density-config($config-or-theme);
   $height: _mat-density-prop-value($mat-stepper-density-config, $density-scale, height);
   $vertical-padding: ($height - $mat-stepper-label-header-height) / 2;
@@ -181,7 +181,7 @@
       @include mat-stepper-color($color);
     }
     @if $density != null {
-      @include _mat-stepper-density($density);
+      @include mat-stepper-density($density);
     }
     @if $typography != null {
       @include mat-stepper-typography($typography);

--- a/src/material/toolbar/_toolbar-theme.scss
+++ b/src/material/toolbar/_toolbar-theme.scss
@@ -82,7 +82,7 @@
   }
 }
 
-@mixin _mat-toolbar-density($config-or-theme) {
+@mixin mat-toolbar-density($config-or-theme) {
   $density-scale: mat-get-density-config($config-or-theme);
   $height-desktop: _mat-density-prop-value(
       $mat-toolbar-desktop-density-config, $density-scale, height);
@@ -113,7 +113,7 @@
       @include mat-toolbar-color($color);
     }
     @if $density != null {
-      @include _mat-toolbar-density($density);
+      @include mat-toolbar-density($density);
     }
     @if $typography != null {
       @include mat-toolbar-typography($typography);

--- a/src/material/tree/_tree-theme.scss
+++ b/src/material/tree/_tree-theme.scss
@@ -33,7 +33,7 @@
   }
 }
 
-@mixin _mat-tree-density($config-or-theme) {
+@mixin mat-tree-density($config-or-theme) {
   $density-scale: mat-get-density-config($config-or-theme);
   $height: _mat-density-prop-value($mat-tree-density-config, $density-scale, height);
 
@@ -55,7 +55,7 @@
       @include mat-tree-color($color);
     }
     @if $density != null {
-      @include _mat-tree-density($density);
+      @include mat-tree-density($density);
     }
     @if $typography != null {
       @include mat-tree-typography($typography);


### PR DESCRIPTION
For some components that don't have a corresponding implementation
in MDC Web, we added density mixins. We prefixed this with an
underscore to prevent premature use. Now we remove the underscore
as we're starting rollout in Google.