### PR TITLE
fix(material-experimental/mdc-form-field): outline appearance border gap spacing

### DIFF
--- a/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
@@ -74,6 +74,12 @@
   // Note: Increased specificity needed here since MDC overwrites the padding on `:focus`.
   .mat-mdc-form-field .mat-mdc-text-field-wrapper.mdc-text-field .mdc-notched-outline__notch {
     padding-top: 0;
+    // MDC adds a 8px padding on the right/left (depending on LTR or RTL mode) that causes the
+    // label to get cut off.
+    // When there is no label the padding rule causes a gap in the outline in RTL mode since it
+    // overwrites the "padding: 0" style.
+    padding-right: 0;
+    padding-left: 0;
   }
 
   // Unset the baseline adjustment styles that are applied to the `.mdc-text-field` before


### PR DESCRIPTION
MDC form field with outline appearance had incorrect notch gaps
![Screen Shot 2020-10-29 at 3 55 13 PM](https://user-images.githubusercontent.com/20130030/97641009-30bd4f80-19ff-11eb-9dbd-47224a87aac4.png)
![8HVhgYvzXZ33Toe](https://user-images.githubusercontent.com/20130030/97641024-37e45d80-19ff-11eb-99d4-61b02de7f5d7.png)

