### PR TITLE
build: move Edge tests back to Saucelabs

### DIFF
--- a/test/browser-providers.js
+++ b/test/browser-providers.js
@@ -7,7 +7,7 @@
  *   - `saucelabs`: Launches the browser within Saucelabs
  */
 const browserConfig = {
-  'Edge83':            {unitTest: {target: 'browserstack'}},
+  'Edge83':            {unitTest: {target: 'saucelabs'}},
   'iOS13':             {unitTest: {target: 'saucelabs'}},
   'Safari13':          {unitTest: {target: 'browserstack'}},
 };

--- a/test/karma-browsers.json
+++ b/test/karma-browsers.json
@@ -19,12 +19,11 @@
     "platformName": "iOS",
     "deviceName": "iPhone XS Simulator"
   },
-  "BROWSERSTACK_EDGE83": {
-    "base": "BrowserStack",
-    "browser": "Edge",
-    "browser_version": "83.0",
-    "os": "Windows",
-    "os_version": "10"
+  "SAUCELABS_EDGE83": {
+    "base": "SauceLabs",
+    "browserName": "MicrosoftEdge",
+    "browserVersion": "83.0",
+    "platformName": "Windows 10"
   },
   "BROWSERSTACK_SAFARI13": {
     "base": "BrowserStack",


### PR DESCRIPTION
In #20662 we moved the Edge tests to Browserstack to avoid an issue with Saucelabs. These changes try to revert us back.