### PR TITLE
fix(material/datepicker): range input emitters not picked up by language service

### DIFF
--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -195,7 +195,10 @@ const _MatDateRangeInputBase:
   providers: [
     {provide: NG_VALUE_ACCESSOR, useExisting: MatStartDate, multi: true},
     {provide: NG_VALIDATORS, useExisting: MatStartDate, multi: true}
-  ]
+  ],
+  // These need to be specified explicitly, because some tooling doesn't
+  // seem to pick them up from the base class. See #20932.
+  outputs: ['dateChange', 'dateInput']
 })
 export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
     CanUpdateErrorState, DoCheck, OnInit {
@@ -301,7 +304,10 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
   providers: [
     {provide: NG_VALUE_ACCESSOR, useExisting: MatEndDate, multi: true},
     {provide: NG_VALIDATORS, useExisting: MatEndDate, multi: true}
-  ]
+  ],
+  // These need to be specified explicitly, because some tooling doesn't
+  // seem to pick them up from the base class. See #20932.
+  outputs: ['dateChange', 'dateInput']
 })
 export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements
     CanUpdateErrorState, DoCheck, OnInit {

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -380,7 +380,7 @@ export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements 
     ngDoCheck(): void;
     ngOnInit(): void;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatEndDate<any>, "input[matEndDate]", never, {}, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatEndDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
 
@@ -490,7 +490,7 @@ export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implement
     ngDoCheck(): void;
     ngOnInit(): void;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatStartDate<any>, "input[matStartDate]", never, {}, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatStartDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
 


### PR DESCRIPTION
The `dateChange` and `dateInput` outputs are inherited through a mixin which seems to prevent the language service from picking them up. These changes add extra hints to the component metadata.

Fixes #20932.