### PR TITLE
build: add CI check to keep MDC tests in line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,6 +362,7 @@ jobs:
               yarn ng-dev commit-message validate-range --range $CI_COMMIT_RANGE
             fi
       - run: yarn ownerslint
+      - run: yarn check-mdc-tests
       - run: yarn stylelint
       - run: yarn tslint
       - run: yarn -s ts-circular-deps:check

--- a/scripts/check-mdc-tests-config.ts
+++ b/scripts/check-mdc-tests-config.ts
@@ -1,0 +1,195 @@
+export const config = {
+  // The MDC slider is temporarily disabled.
+  skippedPackages: ['mdc-slider'],
+  skippedTests: {
+    'mdc-autocomplete': [
+      // Tests something that isn't supported by the MDC form field.
+      'should hide the label with a preselected form control value and a disabled floating label'
+    ],
+    'mdc-button': [
+      // The MDC button doesn't use `FocusMonitor` so it can't support passing in a focus origin.
+      'should be able to focus button with a specific focus origin',
+      'should not change focus origin if origin not specified'
+    ],
+    'mdc-checkbox': [
+      // These tests are verifying implementation details that are not relevant for MDC.
+      'should transition unchecked -> checked -> unchecked',
+      'should transition unchecked -> indeterminate -> unchecked',
+      'should transition indeterminate -> checked',
+      'should not apply transition classes when there is no state change',
+      'should not initially have any transition classes',
+      'should not have transition classes when animation ends',
+      'should toggle checkbox disabledness correctly',
+      'should remove margin for checkbox without a label',
+      'should not remove margin if initial label is set through binding',
+      'should re-add margin if label is added asynchronously',
+      'should properly update margin if label content is projected',
+
+      // TODO: the focus origin behavior needs to be implemented in the MDC checkbox
+      'should not change focus origin if origin not specified'
+    ],
+    'mdc-chips': [
+      // The chain of events for dispatching the remove event in the MDC
+      // chips is different so we have a different set of tests.
+      'should emit (removed) on click',
+      'should not remove if parent chip is disabled',
+
+      // This test checks something that isn't supported in the MDC form field.
+      'should propagate the dynamic `placeholder` value to the form field'
+    ],
+    'mdc-dialog': [
+      // These tests are verifying implementation details that are not relevant for MDC.
+      'should set the proper animation states'
+    ],
+    'mdc-input': [
+      // These tests are verifying either implementation details that aren't relevant
+      // for MDC, or features that we've decided not to support in the MDC input.
+      'should default to floating label type provided by global default options',
+      'validates there\'s only one placeholder',
+      'supports placeholder attribute',
+      'should not render the native placeholder when its value is mirrored in the label',
+      'supports placeholder element',
+      'supports placeholder required star',
+      'should hide the required star if input is disabled',
+      'should hide the required star from screen readers',
+      'hide placeholder required star when set to hide the required marker',
+      'should always float the label when floatLabel is set to true',
+      'should never float the label when floatLabel is set to false',
+      'should be able to animate the label up and lock it in position',
+      'should not throw when trying to animate and lock too early',
+      'should only show the native placeholder, when there is a label, on focus',
+      'should always show the native placeholder when floatLabel is set to "always"',
+      'should not show the native placeholder when floatLabel is set to "never"',
+      'should not throw when there is a default ngIf on the label element',
+      'should not throw when there is a default ngIf on the input element',
+      'legacy appearance should promote placeholder to label',
+      'non-legacy appearances should not promote placeholder to label',
+      'legacy appearance should respect float never',
+      'non-legacy appearances should not respect float never',
+      'should recalculate gaps when switching to outline appearance after init',
+      'should calculate the gap when starting off in RTL',
+      'should not set an outline gap if the label is empty',
+      'should calculate the gaps if the default appearance is provided through DI',
+      'should update the outline gap when the prefix/suffix is added or removed',
+      'should calculate the outline gaps if the element starts off invisible',
+      'should update the outline gap if the direction changes',
+      'should update the outline gap correctly if the direction changes multiple times',
+      'should calculate the outline gaps inside the shadow DOM',
+      'should be legacy appearance if no default options provided',
+      'should be legacy appearance if empty default options provided',
+      'should not calculate wrong content height due to long placeholders',
+      'should work in a tab',
+      'should work in a step'
+    ],
+    'mdc-list': [
+      // TODO: these tests need to be double-checked for missing functionality.
+      'should not apply any additional class to a list without lines',
+      'should not add the mat-list-single-selected-option class (in multiple mode)',
+      'should not move focus to the first item if focus originated from a mouse interaction',
+      'should allow focus to escape when tabbing away',
+      'should restore focus if active option is destroyed',
+      'should not attempt to focus the next option when the destroyed option was not focused',
+      'should use `compareWith` function when updating option selection state',
+      'should only be in the tab order if it has options',
+
+      // MDC does not support SHIFT + ARROW for item selection. Tracked as a feature request:
+      // https://github.com/material-components/material-components-web/issues/6364.
+      'should focus and toggle the next item when pressing SHIFT + UP_ARROW',
+      'should focus and toggle the next item when pressing SHIFT + DOWN_ARROW',
+
+      // MDC does not respect modifier keys, so these tests would fail.
+      // Tracked with: https://github.com/material-components/material-components-web/issues/6365.
+      'should not be able to toggle an item when pressing a modifier key',
+      'should not change focus when pressing HOME with a modifier key',
+      'should not change focus when pressing END with a modifier key',
+
+
+      // MDC does not support the common CTRL + A keyboard shortcut.
+      // Tracked with: https://github.com/material-components/material-components-web/issues/6366
+      'should select all items using ctrl + a',
+      'should not select disabled items when pressing ctrl + a',
+      'should select all items using ctrl + a if some items are selected',
+      'should deselect all with ctrl + a if all options are selected',
+      'should dispatch the selectionChange event when selecting via ctrl + a'
+
+    ],
+    'mdc-menu': [
+      // Disabled since we don't have equivalents to our elevation classes in the MDC packages.
+      'should not remove mat-elevation class from overlay when panelClass is changed',
+      'should increase the sub-menu elevation based on its depth',
+      'should update the elevation when the same menu is opened at a different depth',
+      'should not increase the elevation if the user specified a custom one'
+    ],
+    'mdc-progress-bar': [
+      // These tests are verifying implementation details that are not relevant for MDC.
+      'should return the transform attribute for bufferValue and mode',
+      'should prefix SVG references with the current path',
+      'should account for location hash when prefixing the SVG references',
+      'should not be able to tab into the underlying SVG element',
+      'should use latest path when prefixing the SVG references'
+    ],
+    'mdc-progress-spinner': [
+      // These tests are verifying implementation details that are not relevant for MDC.
+      'should use different `circle` elements depending on the mode',
+      'should add a style tag with the indeterminate animation to the document ' +
+          'head when using a non-default diameter',
+      'should handle creating animation style tags based on a floating point diameter',
+      'should add the indeterminate animation style tag to the Shadow root',
+      'should not duplicate style tags inside the Shadow root',
+      'should add the indeterminate animation style tag to the Shadow root if the ' +
+          'element is inside an ngIf'
+    ],
+    'mdc-select': [
+      // These tests are excluded, because they're verifying the functionality that positions
+      // the select panel over the trigger which isn't supported in the MDC select.
+      'should set the width of the overlay based on a larger trigger width',
+      'should float the label when the panel is open and unselected',
+      'should be able to disable the floating label',
+      'should align the first option with trigger text if no option is selected',
+      'should align a selected option too high to be centered with the trigger text',
+      'should align a selected option in the middle with the trigger text',
+      'should align a selected option at the scroll max with the trigger text',
+      'should account for preceding label groups when aligning the option',
+      'should account for indirect preceding label groups when aligning the option',
+      'should adjust position of centered option if there is little space above',
+      'should adjust position of centered option if there is little space below',
+      'should fall back to "above" positioning if scroll adjustment will not help',
+      'should fall back to "below" positioning if scroll adjustment won\'t help',
+      'should stay within the viewport when overflowing on the left in ltr',
+      'should stay within the viewport when overflowing on the left in rtl',
+      'should stay within the viewport when overflowing on the right in ltr',
+      'should stay within the viewport when overflowing on the right in rtl',
+      'should keep the position within the viewport on repeat openings',
+      'should align the first option properly when scrolled',
+      'should align a centered option properly when scrolled',
+      'should align a centered option properly when scrolling while the panel is open',
+      'should fall back to "above" positioning properly when scrolled',
+      'should fall back to "below" positioning properly when scrolled',
+      'should align the trigger and the selected option on the x-axis in ltr',
+      'should align the trigger and the selected option on the x-axis in rtl',
+      'should adjust for the checkbox in ltr',
+      'should adjust for the checkbox in rtl',
+      'should adjust for the group padding in ltr',
+      'should adjust for the group padding in rtl',
+      'should not adjust if all options are within a group, except the selected one',
+      'should align the first option to the trigger, if nothing is selected'
+    ],
+    'mdc-slide-toggle': [
+      // These tests are verifying implementation details that are not relevant for MDC.
+      'should remove margin for slide-toggle without a label',
+      'should not remove margin if initial label is set through binding',
+      'should re-add margin if label is added asynchronously',
+      'should properly update margin if label content is projected',
+
+      // TODO: the focus origin functionality has to be implemeted for the MDC slide toggle.
+      'should not change focus origin if origin not specified'
+    ],
+    'mdc-snack-bar': [
+      // These tests are verifying implementation details that are not relevant for MDC.
+      'should set the animation state to visible on entry',
+      'should set the animation state to complete on exit',
+      'should set the old snack bar animation state to complete and the new snack bar ' +
+          'animation state to visible on entry of new snack bar'
+    ],
+  } as {[key: string]: string[]}
+};

--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -18,10 +18,6 @@ import {
 } from './index';
 
 
-// The following tests have been removed, because the use
-// cases are not support by the MDC-based components:
-// - should propagate the dynamic `placeholder` value to the form field
-
 describe('MDC-based MatChipInput', () => {
   let fixture: ComponentFixture<any>;
   let testChipInput: TestChipInput;

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -266,31 +266,6 @@ describe('MDC-based MatSelectionList without forms', () => {
       expect(event.defaultPrevented).toBe(true);
     });
 
-    // MDC does not respect modifier keys, so this test always fails currently.
-    // Tracked with: https://github.com/material-components/material-components-web/issues/6365.
-    // tslint:disable-next-line:ban
-    xit('should not be able to toggle an item when pressing a modifier key', () => {
-      const testListItem = listOptions[1].nativeElement as HTMLElement;
-      const selectList =
-        selectionList.injector.get<MatSelectionList>(MatSelectionList).selectedOptions;
-
-      expect(selectList.selected.length).toBe(0);
-
-      [ENTER, SPACE].forEach(key => {
-        const event = createKeyboardEvent('keydown', key, undefined, {control: true});
-
-        testListItem.focus();
-        expect(getFocusIndex()).toBe(1);
-
-        dispatchKeyboardEvent(testListItem, 'keydown', key, undefined, {control: true});
-        fixture.detectChanges();
-
-        expect(event.defaultPrevented).toBe(false);
-      });
-
-      expect(selectList.selected.length).toBe(0);
-    });
-
     it('should not be able to toggle a disabled option using SPACE', () => {
       const testListItem = listOptions[1].nativeElement as HTMLElement;
       const selectionModel = selectionList.componentInstance.selectedOptions;
@@ -337,56 +312,6 @@ describe('MDC-based MatSelectionList without forms', () => {
       expect(getFocusIndex()).toEqual(1);
     });
 
-    // MDC does not support SHIFT + ARROW for item selection. Tracked as feature request:
-    // https://github.com/material-components/material-components-web/issues/6364.
-    // tslint:disable-next-line:ban
-    xit('should focus and toggle the next item when pressing SHIFT + UP_ARROW', () => {
-      listOptions[3].nativeElement.focus();
-      expect(getFocusIndex()).toBe(3);
-
-      expect(listOptions[1].componentInstance.selected).toBe(false);
-      expect(listOptions[2].componentInstance.selected).toBe(false);
-
-      dispatchKeyboardEvent(listOptions[3].nativeElement, 'keydown', UP_ARROW,
-          undefined, {shift: true});
-      fixture.detectChanges();
-
-      expect(listOptions[1].componentInstance.selected).toBe(false);
-      expect(listOptions[2].componentInstance.selected).toBe(true);
-
-      dispatchKeyboardEvent(listOptions[2].nativeElement, 'keydown', UP_ARROW,
-        undefined, {shift: true});
-      fixture.detectChanges();
-
-      expect(listOptions[1].componentInstance.selected).toBe(true);
-      expect(listOptions[2].componentInstance.selected).toBe(true);
-    });
-
-    // MDC does not support SHIFT + ARROW for item selection. Tracked as feature request:
-    // https://github.com/material-components/material-components-web/issues/6364.
-    // tslint:disable-next-line:ban
-    xit('should focus and toggle the next item when pressing SHIFT + DOWN_ARROW', () => {
-      listOptions[0].nativeElement.focus();
-      expect(getFocusIndex()).toBe(0);
-
-      expect(listOptions[1].componentInstance.selected).toBe(false);
-      expect(listOptions[2].componentInstance.selected).toBe(false);
-
-      dispatchKeyboardEvent(listOptions[0].nativeElement, 'keydown', DOWN_ARROW,
-          undefined, {shift: true});
-      fixture.detectChanges();
-
-      expect(listOptions[1].componentInstance.selected).toBe(true);
-      expect(listOptions[2].componentInstance.selected).toBe(false);
-
-      dispatchKeyboardEvent(listOptions[1].nativeElement, 'keydown', DOWN_ARROW,
-        undefined, {shift: true});
-      fixture.detectChanges();
-
-      expect(listOptions[1].componentInstance.selected).toBe(true);
-      expect(listOptions[2].componentInstance.selected).toBe(true);
-    });
-
     it('should focus next item when press DOWN ARROW', () => {
       listOptions[2].nativeElement.focus();
       expect(getFocusIndex()).toEqual(2);
@@ -408,22 +333,6 @@ describe('MDC-based MatSelectionList without forms', () => {
       expect(event.defaultPrevented).toBe(true);
     });
 
-    // MDC does not respect the modifier keys. Bug tracked with:
-    // https://github.com/material-components/material-components-web/issues/6365.
-    // tslint:disable-next-line:ban
-    xit('should not change focus when pressing HOME with a modifier key', () => {
-      listOptions[2].nativeElement.focus();
-      expect(getFocusIndex()).toBe(2);
-
-      const event = createKeyboardEvent('keydown', HOME, undefined, {shift: true});
-
-      dispatchEvent(listOptions[2].nativeElement, event);
-      fixture.detectChanges();
-
-      expect(getFocusIndex()).toBe(2);
-      expect(event.defaultPrevented).toBe(false);
-    });
-
     it('should focus the last item when pressing END', () => {
       listOptions[2].nativeElement.focus();
       expect(getFocusIndex()).toBe(2);
@@ -433,119 +342,6 @@ describe('MDC-based MatSelectionList without forms', () => {
 
       expect(getFocusIndex()).toBe(4);
       expect(event.defaultPrevented).toBe(true);
-    });
-
-    // MDC does not respect the modifier keys. Bug tracked with:
-    // https://github.com/material-components/material-components-web/issues/6365.
-    // tslint:disable-next-line:ban
-    xit('should not change focus when pressing END with a modifier key', () => {
-      listOptions[2].nativeElement.focus();
-      expect(getFocusIndex()).toBe(2);
-
-      const event = createKeyboardEvent('keydown', END, undefined, {shift: true});
-
-      dispatchEvent(listOptions[2].nativeElement, event);
-      fixture.detectChanges();
-
-      expect(getFocusIndex()).toBe(2);
-      expect(event.defaultPrevented).toBe(false);
-    });
-
-    // MDC does not support the common CTRL + A keyboard shortcut.
-    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
-    // tslint:disable-next-line:ban
-    xit('should select all items using ctrl + a', () => {
-      listOptions[2].nativeElement.focus();
-      expect(getFocusIndex()).toBe(2);
-
-      listOptions.forEach(option => option.componentInstance.disabled = false);
-      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
-
-      expect(listOptions.some(option => option.componentInstance.selected)).toBe(false);
-
-      dispatchEvent(listOptions[2].nativeElement, event);
-      fixture.detectChanges();
-
-      expect(listOptions.every(option => option.componentInstance.selected)).toBe(true);
-    });
-
-    // MDC does not support the common CTRL + A keyboard shortcut.
-    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
-    // tslint:disable-next-line:ban
-    xit('should not select disabled items when pressing ctrl + a', () => {
-      listOptions[2].nativeElement.focus();
-      expect(getFocusIndex()).toBe(2);
-
-      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
-
-      listOptions.slice(0, 2).forEach(option => option.componentInstance.disabled = true);
-      fixture.detectChanges();
-
-      expect(listOptions.map(option => option.componentInstance.selected))
-        .toEqual([false, false, false, false, false]);
-
-      dispatchEvent(listOptions[2].nativeElement, event);
-      fixture.detectChanges();
-
-      expect(listOptions.map(option => option.componentInstance.selected))
-        .toEqual([false, false, true, true, true]);
-    });
-
-    // MDC does not support the common CTRL + A keyboard shortcut.
-    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
-    // tslint:disable-next-line:ban
-    xit('should select all items using ctrl + a if some items are selected', () => {
-      listOptions[2].nativeElement.focus();
-      expect(getFocusIndex()).toBe(2);
-
-      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
-
-      listOptions.slice(0, 2).forEach(option => option.componentInstance.selected = true);
-      fixture.detectChanges();
-
-      expect(listOptions.some(option => option.componentInstance.selected)).toBe(true);
-
-      dispatchEvent(listOptions[2].nativeElement, event);
-      fixture.detectChanges();
-
-      expect(listOptions.every(option => option.componentInstance.selected)).toBe(true);
-    });
-
-    // MDC does not support the common CTRL + A keyboard shortcut.
-    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
-    // tslint:disable-next-line:ban
-    xit('should deselect all with ctrl + a if all options are selected', () => {
-      listOptions[2].nativeElement.focus();
-      expect(getFocusIndex()).toBe(2);
-
-      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
-
-      listOptions.forEach(option => option.componentInstance.selected = true);
-      fixture.detectChanges();
-
-      expect(listOptions.every(option => option.componentInstance.selected)).toBe(true);
-
-      dispatchEvent(listOptions[2].nativeElement, event);
-      fixture.detectChanges();
-
-      expect(listOptions.every(option => option.componentInstance.selected)).toBe(false);
-    });
-
-    // MDC does not support the common CTRL + A keyboard shortcut.
-    // Tracked with: https://github.com/material-components/material-components-web/issues/6366
-    // tslint:disable-next-line:ban
-    xit('should dispatch the selectionChange event when selecting via ctrl + a', () => {
-      const spy = spyOn(fixture.componentInstance, 'onSelectionChange');
-      listOptions.forEach(option => option.componentInstance.disabled = false);
-      const event = createKeyboardEvent('keydown', A, undefined, {control: true});
-
-      dispatchEvent(selectionList.nativeElement, event);
-      fixture.detectChanges();
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({
-        options: listOptions.map(option => option.componentInstance)
-      }));
     });
 
     it('should be able to jump focus down to an item by typing', fakeAsync(() => {

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -523,30 +523,6 @@ describe('MDC-based MatMenu', () => {
     expect(panel.classList).toContain('custom-two');
   });
 
-  // TODO(crisbeto): disabled until we've mapped our elevation to MDC's.
-  // tslint:disable-next-line:ban
-  xit('should not remove mat-elevation class from overlay when panelClass is changed', () => {
-    const fixture = createComponent(SimpleMenu, [], [FakeIcon]);
-
-    fixture.componentInstance.panelClass = 'custom-one';
-    fixture.detectChanges();
-    fixture.componentInstance.trigger.openMenu();
-    fixture.detectChanges();
-
-    const panel = overlayContainerElement.querySelector('.mat-mdc-menu-panel')!;
-
-    expect(panel.classList).toContain('custom-one');
-    expect(panel.classList).toContain('mat-elevation-z4');
-
-    fixture.componentInstance.panelClass = 'custom-two';
-    fixture.detectChanges();
-
-    expect(panel.classList).not.toContain('custom-one');
-    expect(panel.classList).toContain('custom-two');
-    expect(panel.classList)
-        .toContain('mat-elevation-z4', 'Expected mat-elevation-z4 not to be removed');
-  });
-
   it('should set the "menu" role on the overlay panel', () => {
     const fixture = createComponent(SimpleMenu, [], [FakeIcon]);
     fixture.detectChanges();
@@ -1988,67 +1964,6 @@ describe('MDC-based MatMenu', () => {
       expect(menuItems[1].classList).not.toContain('mat-mdc-menu-item-submenu-trigger');
     });
 
-    // TODO(crisbeto): disabled until we've mapped our elevation to MDC's.
-    // tslint:disable-next-line:ban
-    xit('should increase the sub-menu elevation based on its depth', () => {
-      compileTestComponent();
-      instance.rootTrigger.openMenu();
-      fixture.detectChanges();
-
-      instance.levelOneTrigger.openMenu();
-      fixture.detectChanges();
-
-      instance.levelTwoTrigger.openMenu();
-      fixture.detectChanges();
-
-      const menus = overlay.querySelectorAll('.mat-mdc-menu-panel');
-
-      expect(menus[0].classList)
-          .toContain('mat-elevation-z4', 'Expected root menu to have base elevation.');
-      expect(menus[1].classList)
-          .toContain('mat-elevation-z5', 'Expected first sub-menu to have base elevation + 1.');
-      expect(menus[2].classList)
-          .toContain('mat-elevation-z6', 'Expected second sub-menu to have base elevation + 2.');
-    });
-
-    // TODO(crisbeto): disabled until we've mapped our elevation to MDC's.
-    // tslint:disable-next-line:ban
-    xit('should update the elevation when the same menu is opened at a different depth',
-      fakeAsync(() => {
-        compileTestComponent();
-        instance.rootTrigger.openMenu();
-        fixture.detectChanges();
-
-        instance.levelOneTrigger.openMenu();
-        fixture.detectChanges();
-
-        instance.levelTwoTrigger.openMenu();
-        fixture.detectChanges();
-
-        let lastMenu = overlay.querySelectorAll('.mat-mdc-menu-panel')[2];
-
-        expect(lastMenu.classList)
-            .toContain('mat-elevation-z6', 'Expected menu to have the base elevation plus two.');
-
-        (overlay.querySelector('.cdk-overlay-backdrop')! as HTMLElement).click();
-        fixture.detectChanges();
-        tick(500);
-
-        expect(overlay.querySelectorAll('.mat-mdc-menu-panel').length)
-            .toBe(0, 'Expected no open menus');
-
-        instance.alternateTrigger.openMenu();
-        fixture.detectChanges();
-        tick(500);
-
-        lastMenu = overlay.querySelector('.mat-mdc-menu-panel') as HTMLElement;
-
-        expect(lastMenu.classList)
-            .not.toContain('mat-elevation-z6', 'Expected menu not to maintain old elevation.');
-        expect(lastMenu.classList)
-            .toContain('mat-elevation-z4', 'Expected menu to have the proper updated elevation.');
-      }));
-
     it('should not change focus origin if origin not specified for trigger', fakeAsync(() => {
       compileTestComponent();
 
@@ -2065,27 +1980,6 @@ describe('MDC-based MatMenu', () => {
       expect(levelTwoTrigger.classList).toContain('cdk-focused');
       expect(levelTwoTrigger.classList).toContain('cdk-mouse-focused');
     }));
-
-    // TODO(crisbeto): disabled until we've mapped our elevation to MDC's.
-    // tslint:disable-next-line:ban
-    xit('should not increase the elevation if the user specified a custom one', () => {
-      const elevationFixture = createComponent(NestedMenuCustomElevation);
-
-      elevationFixture.detectChanges();
-      elevationFixture.componentInstance.rootTrigger.openMenu();
-      elevationFixture.detectChanges();
-
-      elevationFixture.componentInstance.levelOneTrigger.openMenu();
-      elevationFixture.detectChanges();
-
-      const menuClasses =
-          overlayContainerElement.querySelectorAll('.mat-mdc-menu-panel')[1].classList;
-
-      expect(menuClasses)
-          .toContain('mat-elevation-z24', 'Expected user elevation to be maintained');
-      expect(menuClasses)
-          .not.toContain('mat-elevation-z3', 'Expected no stacked elevation.');
-    });
 
     it('should close all of the menus when the root is closed programmatically', fakeAsync(() => {
       compileTestComponent();
@@ -2505,26 +2399,6 @@ class NestedMenu {
   @ViewChild('lazy') lazyMenu: MatMenu;
   @ViewChild('lazyTrigger') lazyTrigger: MatMenuTrigger;
   showLazy = false;
-}
-
-@Component({
-  template: `
-    <button [matMenuTriggerFor]="root" #rootTrigger="matMenuTrigger">Toggle menu</button>
-
-    <mat-menu #root="matMenu">
-      <button mat-menu-item
-        [matMenuTriggerFor]="levelOne"
-        #levelOneTrigger="matMenuTrigger">One</button>
-    </mat-menu>
-
-    <mat-menu #levelOne="matMenu" class="mat-elevation-z24">
-      <button mat-menu-item>Two</button>
-    </mat-menu>
-  `
-})
-class NestedMenuCustomElevation {
-  @ViewChild('rootTrigger') rootTrigger: MatMenuTrigger;
-  @ViewChild('levelOneTrigger') levelOneTrigger: MatMenuTrigger;
 }
 
 

--- a/src/material-experimental/mdc-radio/radio.spec.ts
+++ b/src/material-experimental/mdc-radio/radio.spec.ts
@@ -604,6 +604,7 @@ describe('MDC-based MatRadio', () => {
     let seasonRadioInstances: MatRadioButton[];
     let weatherRadioInstances: MatRadioButton[];
     let fruitRadioInstances: MatRadioButton[];
+    let fruitRadioNativeElements: HTMLElement[];
     let fruitRadioNativeInputs: HTMLElement[];
     let testComponent: StandaloneRadioButtons;
 
@@ -623,8 +624,7 @@ describe('MDC-based MatRadio', () => {
       fruitRadioInstances = radioDebugElements
           .filter(debugEl => debugEl.componentInstance.name == 'fruit')
           .map(debugEl => debugEl.componentInstance);
-
-      const fruitRadioNativeElements = radioDebugElements
+      fruitRadioNativeElements = radioDebugElements
           .filter(debugEl => debugEl.componentInstance.name == 'fruit')
           .map(debugEl => debugEl.nativeElement);
 
@@ -736,6 +736,14 @@ describe('MDC-based MatRadio', () => {
 
         expect(document.activeElement).toBe(fruitRadioNativeInputs[i]);
       }
+    });
+
+    it('should not change focus origin if origin not specified', () => {
+      fruitRadioInstances[0].focus(undefined, 'mouse');
+      fruitRadioInstances[1].focus();
+
+      expect(fruitRadioNativeElements[1].classList).toContain('cdk-focused');
+      expect(fruitRadioNativeElements[1].classList).toContain('cdk-mouse-focused');
     });
 
     it('should not add the "name" attribute if it is not passed in', () => {

--- a/src/material-experimental/mdc-select/select.spec.ts
+++ b/src/material-experimental/mdc-select/select.spec.ts
@@ -78,40 +78,6 @@ import {
 /** Default debounce interval when typing letters to select an option. */
 const DEFAULT_TYPEAHEAD_DEBOUNCE_INTERVAL = 200;
 
-// The following tests from the existing `MatSelect` haven't
-// been ported over, because they're no longer relevant:
-// - should float the label when the panel is open and unselected
-// - should be able to disable the floating label
-// - should set the width of the overlay based on a larger trigger width
-// - should align the first option with trigger text if no option is selected
-// - should align a selected option too high to be centered with the trigger text
-// - should align a selected option in the middle with the trigger text
-// - should align a selected option at the scroll max with the trigger text
-// - should account for preceding label groups when aligning the option
-// - should account for indirect preceding label groups when aligning the option
-// - should adjust position of centered option if there is little space above
-// - should adjust position of centered option if there is little space below
-// - should fall back to "above" positioning if scroll adjustment will not help
-// - should fall back to "below" positioning if scroll adjustment won't help
-// - should stay within the viewport when overflowing on the left in ltr
-// - should stay within the viewport when overflowing on the left in rtl
-// - should stay within the viewport when overflowing on the right in ltr
-// - should stay within the viewport when overflowing on the right in rtl
-// - should keep the position within the viewport on repeat openings
-// - should align the first option properly when scrolled
-// - should align a centered option properly when scrolled
-// - should align a centered option properly when scrolling while the panel is open
-// - should fall back to "above" positioning properly when scrolled
-// - should fall back to "below" positioning properly when scrolled
-// - should align the trigger and the selected option on the x-axis in ltr
-// - should align the trigger and the selected option on the x-axis in rtl
-// - should adjust for the checkbox in ltr
-// - should adjust for the checkbox in rtl
-// - should adjust for the group padding in ltr
-// - should adjust for the group padding in rtl
-// - should not adjust if all options are within a group, except the selected one
-// - should align the first option to the trigger, if nothing is selected
-
 describe('MDC-based MatSelect', () => {
   let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;

--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -28,6 +28,8 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSlider, MatSliderModule} from './index';
 
 // TODO: disabled until we implement the new MDC slider.
+// TODO: once the tests are re-enabled, we should remove `mdc-slider`
+// from the `skippedPackages` in `check-mdc-tests-config.ts`.
 describe('MDC-based MatSlider dummy' , () => it('', () => {}));
 
 // tslint:disable-next-line:ban


### PR DESCRIPTION
Adds a CI check that will fail if a test from a Material package is missing from its MDC equivalent. There's also a config file that allows for tests to be excluded. I've populated the file and added context about why tests have been disabled.