### PR TITLE
fix(material/chips): screen readers announcing placeholder twice in some cases

### DIFF
--- a/scripts/check-mdc-tests-config.ts
+++ b/scripts/check-mdc-tests-config.ts
@@ -35,7 +35,9 @@ export const config = {
       'should not remove if parent chip is disabled',
 
       // This test checks something that isn't supported in the MDC form field.
-      'should propagate the dynamic `placeholder` value to the form field'
+      'should propagate the dynamic `placeholder` value to the form field',
+      'should propagate the dynamic `placeholder` value to the form field and clear the ' +
+        'native placeholder',
     ],
     'mdc-dialog': [
       // These tests are verifying implementation details that are not relevant for MDC.

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -70,20 +70,24 @@ describe('MatChipInput', () => {
       expect(inputNativeElement.getAttribute('placeholder')).toBe('bound placeholder');
     });
 
-    it('should propagate the dynamic `placeholder` value to the form field', () => {
-      fixture.componentInstance.placeholder = 'add a chip';
-      fixture.detectChanges();
+    it('should propagate the dynamic `placeholder` value to the form field and clear the ' +
+      'native placeholder', () => {
+        fixture.componentInstance.appearance = 'legacy';
+        fixture.componentInstance.placeholder = 'add a chip';
+        fixture.detectChanges();
 
-      const label: HTMLElement = fixture.nativeElement.querySelector('.mat-form-field-label');
+        const label: HTMLElement = fixture.nativeElement.querySelector('.mat-form-field-label');
 
-      expect(label).toBeTruthy();
-      expect(label.textContent).toContain('add a chip');
+        expect(label).toBeTruthy();
+        expect(label.textContent).toContain('add a chip');
+        expect(inputNativeElement.hasAttribute('placeholder')).toBe(false);
 
-      fixture.componentInstance.placeholder = 'or don\'t';
-      fixture.detectChanges();
+        fixture.componentInstance.placeholder = 'or don\'t';
+        fixture.detectChanges();
 
-      expect(label.textContent).toContain('or don\'t');
-    });
+        expect(label.textContent).toContain('or don\'t');
+        expect(inputNativeElement.hasAttribute('placeholder')).toBe(false);
+      });
 
     it('should become disabled if the list is disabled', () => {
       expect(inputNativeElement.hasAttribute('disabled')).toBe(false);
@@ -244,7 +248,7 @@ describe('MatChipInput', () => {
 
 @Component({
   template: `
-    <mat-form-field>
+    <mat-form-field [appearance]="appearance">
       <mat-chip-list #chipList [required]="required">
         <mat-chip>Hello</mat-chip>
         <input matInput [matChipInputFor]="chipList"
@@ -260,6 +264,7 @@ class TestChipInput {
   addOnBlur = false;
   required = false;
   placeholder = '';
+  appearance = 'standard';
 
   add(_: MatChipInputEvent) {
   }

--- a/src/material/chips/testing/shared.spec.ts
+++ b/src/material/chips/testing/shared.spec.ts
@@ -323,6 +323,7 @@ export function runHarnessTests(
     <mat-chip-list></mat-chip-list>
 
     <mat-form-field>
+      <mat-label>Hobbits</mat-label>
       <mat-chip-list #chipList required>
         <mat-chip (removed)="remove()">
           Frodo

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -70,7 +70,7 @@ export interface MatChipEvent {
     chip: MatChip;
 }
 
-export declare class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy, AfterContentInit {
+export declare class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy, AfterContentInit, DoCheck {
     _addOnBlur: boolean;
     _chipList: MatChipList;
     protected _elementRef: ElementRef<HTMLInputElement>;
@@ -86,7 +86,7 @@ export declare class MatChipInput implements MatChipTextControl, OnChanges, OnDe
     readonly inputElement: HTMLInputElement;
     placeholder: string;
     separatorKeyCodes: readonly number[] | ReadonlySet<number>;
-    constructor(_elementRef: ElementRef<HTMLInputElement>, _defaultOptions: MatChipsDefaultOptions);
+    constructor(_elementRef: ElementRef<HTMLInputElement>, _defaultOptions: MatChipsDefaultOptions, _formField?: MatFormField | undefined);
     _blur(): void;
     _emitChipEnd(event?: KeyboardEvent): void;
     _focus(): void;
@@ -96,12 +96,13 @@ export declare class MatChipInput implements MatChipTextControl, OnChanges, OnDe
     clear(): void;
     focus(options?: FocusOptions): void;
     ngAfterContentInit(): void;
+    ngDoCheck(): void;
     ngOnChanges(): void;
     ngOnDestroy(): void;
     static ngAcceptInputType_addOnBlur: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatChipInput, "input[matChipInputFor]", ["matChipInput", "matChipInputFor"], { "chipList": "matChipInputFor"; "addOnBlur": "matChipInputAddOnBlur"; "separatorKeyCodes": "matChipInputSeparatorKeyCodes"; "placeholder": "placeholder"; "id": "id"; "disabled": "disabled"; }, { "chipEnd": "matChipInputTokenEnd"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatChipInput, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatChipInput, [null, null, { optional: true; }]>;
 }
 
 export interface MatChipInputEvent {


### PR DESCRIPTION
When a form field is in legacy mode and it doesn't have a label, it'll promote the input placeholder to the label which will cause screen readers to read out the same text twice. These changes clear the chip input placeholder if it's placed in such a form field, similarly to how we do it for `MatInput`.

Fixes #20761.