### PR TITLE
fix(material/menu): icons in menu not inheriting disabled color

### DIFF
--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -14,7 +14,9 @@
     // MDC doesn't appear to have disabled styling for menu
     // items so we have to grey them out ourselves.
     .mat-mdc-menu-item[disabled] {
-      &, &::after {
+      &,
+      &::after,
+      .mat-icon-no-color {
         @include mdc-theme-prop(color, text-disabled-on-background);
       }
     }

--- a/src/material/menu/_menu-theme.scss
+++ b/src/material/menu/_menu-theme.scss
@@ -20,7 +20,9 @@
     color: mat-color($foreground, 'text');
 
     &[disabled] {
-      &, &::after {
+      &,
+      &::after,
+      .mat-icon-no-color {
         color: mat-color($foreground, 'disabled');
       }
     }


### PR DESCRIPTION
Fixes that the icons inside a disabled menu item still have their non-disabled color.

Fixes #20947.