### PR TITLE
fix: set role on tooltip description element

### DIFF
--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -206,7 +206,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
   @Input('matTooltip')
   get message() { return this._message; }
   set message(value: string) {
-    this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this._message);
+    this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this._message, 'tooltip');
 
     // If the message is not a string (e.g. number), convert it to a string and trim it.
     // Must convert with `String(value)`, not `${value}`, otherwise Closure Compiler optimises
@@ -224,7 +224,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
         // has a data-bound `aria-label` or when it'll be set for the first time. We can avoid the
         // issue by deferring the description by a tick so Angular has time to set the `aria-label`.
         Promise.resolve().then(() => {
-          this._ariaDescriber.describe(this._elementRef.nativeElement, this.message);
+          this._ariaDescriber.describe(this._elementRef.nativeElement, this.message, 'tooltip');
         });
       });
     }
@@ -322,7 +322,7 @@ export class MatTooltip implements OnDestroy, AfterViewInit {
     this._destroyed.next();
     this._destroyed.complete();
 
-    this._ariaDescriber.removeDescription(nativeElement, this.message);
+    this._ariaDescriber.removeDescription(nativeElement, this.message, 'tooltip');
     this._focusMonitor.stopMonitoring(nativeElement);
   }
 

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -12,9 +12,11 @@ export declare class ActiveDescendantKeyManager<T> extends ListKeyManager<Highli
 export declare class AriaDescriber implements OnDestroy {
     constructor(_document: any,
     _platform?: Platform | undefined);
-    describe(hostElement: Element, message: string | HTMLElement): void;
+    describe(hostElement: Element, message: string, role?: string): void;
+    describe(hostElement: Element, message: HTMLElement): void;
     ngOnDestroy(): void;
-    removeDescription(hostElement: Element, message: string | HTMLElement): void;
+    removeDescription(hostElement: Element, message: string, role?: string): void;
+    removeDescription(hostElement: Element, message: HTMLElement): void;
     static ɵfac: i0.ɵɵFactoryDef<AriaDescriber, never>;
     static ɵprov: i0.ɵɵInjectableDef<AriaDescriber>;
 }


### PR DESCRIPTION
Includes two separate commits that:
1. Add support for setting a `role` through the `AriaDescriber`.
2. Uses the new option to set a `tooltip` role on the tooltip's description elements.

Fixes #20593.