### PR TITLE
fix(material/checkbox): set display on host node

### DIFF
--- a/src/material-experimental/mdc-checkbox/checkbox.scss
+++ b/src/material-experimental/mdc-checkbox/checkbox.scss
@@ -9,6 +9,10 @@
 @include mdc-form-field-core-styles($query: $mat-base-styles-query);
 
 .mat-mdc-checkbox {
+  // The host node defaults to `diplay: inline` so
+  // we have to change it in order for margins to work.
+  display: inline-block;
+
   // The MDC checkbox styles related to the hover state are intertwined with the MDC ripple styles.
   // We currently don't use the MDC ripple due to size concerns, therefore we need to add some
   // additional styles to restore the hover state.

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -177,6 +177,10 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * $mat-checkbox-size !default;
 .mat-checkbox {
   @include _noop-animation();
 
+  // The host node defaults to `diplay: inline` so
+  // we have to change it in order for margins to work.
+  display: inline-block;
+
   // Animation
   transition: background $swift-ease-out-duration $swift-ease-out-timing-function,
               mat-elevation-transition-property-value();


### PR DESCRIPTION
Currently the host nodes are `display: inline` by default which doesn't allow for things like `margin` and `width` to be set. These changes switch to `inline-block` which is a bit more flexible.

Fixes #20954.