### PR TITLE
fix(material-experimental/mdc-progress-spinner): prevent animation from affecting surrounding layout

### DIFF
--- a/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
+++ b/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
@@ -1,9 +1,13 @@
 @import '@material/circular-progress/mixins.import';
 @import '../mdc-helpers/mdc-helpers';
 
-
 @include mdc-circular-progress-core-styles($query: $mat-base-styles-without-animation-query);
 
+.mat-mdc-progress-spinner {
+  // Prevents the spinning of the inner element from affecting layout outside of the spinner.
+  overflow: hidden;
+}
+
 :not(._mat-animation-noopable) {
-    @include mdc-circular-progress-core-styles($query: animation);
+  @include mdc-circular-progress-core-styles($query: animation);
 }


### PR DESCRIPTION
Similar to #16930. Prevents the indeterminate animation from overflowing the host node and affecting the page layout.

The issue can be seen on Windows where the scroll bar is always visible.

![demo](https://user-images.githubusercontent.com/4450522/98035418-c0f0ff80-1e18-11eb-8646-33ba5c702ced.gif)
