### PR TITLE
fix(material-experimental/mdc-slide-toggle): hide native focus outline

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.scss
@@ -13,6 +13,9 @@
 .mat-mdc-slide-toggle {
   display: inline-block;
 
+  // Remove the native outline since we use the ripple for focus indication.
+  outline: 0;
+
   // The ripple needs extra specificity so the base ripple styling doesn't override its `position`.
   .mat-mdc-slide-toggle-ripple, .mdc-switch__thumb-underlay::after {
     @include mat-fill;


### PR DESCRIPTION
Hides the native focus outline from the slide toggle since we use the ripple for focus indication.

This is what it currently looks like for reference. This only happens for a split second when clicking on the label.

![nO5nhvD](https://user-images.githubusercontent.com/4450522/98039296-c6e9df00-1e1e-11eb-8f7c-b10ce5f3a84a.png)
