### PR TITLE
fix(cdk/a11y): allow for origin of already focused element to be changed

### DIFF
--- a/src/cdk/a11y/BUILD.bazel
+++ b/src/cdk/a11y/BUILD.bazel
@@ -52,6 +52,7 @@ ng_test_library(
         "//src/cdk/platform",
         "//src/cdk/portal",
         "//src/cdk/testing/private",
+        "@npm//@angular/common",
         "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -804,6 +804,9 @@ describe('MDC-based MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
 
+    // Reset the automatic focus when the menu is opened.
+    (document.activeElement as HTMLElement)?.blur();
+
     const panel = overlayContainerElement.querySelector('.mat-mdc-menu-panel')!;
     const items = Array.from(panel.querySelectorAll('.mat-mdc-menu-item')) as HTMLElement[];
     items.forEach(patchElementFocus);

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -802,6 +802,9 @@ describe('MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
 
+    // Reset the automatic focus when the menu is opened.
+    (document.activeElement as HTMLElement)?.blur();
+
     const panel = overlayContainerElement.querySelector('.mat-menu-panel')!;
     const items = Array.from(panel.querySelectorAll('.mat-menu-item')) as HTMLElement[];
     items.forEach(patchElementFocus);


### PR DESCRIPTION
The way `FocusMonitor.focusVia` works is by calling `focus` on the specified element and waiting for a `focus` event to trigger so the origin is applied. The problem is that if `focusVia` is called on an element that already has focus, the event won't be dispatched and the origin won't be updated which can cause the UI to look stuck.

These changes make it so that if we detect that an element is focused already, we update its classes and dispatch the relevant event without trying to focus it.

Related to #20965.