### PR TITLE
fix(material/chips): ripple not disabled when animations are disabled

### DIFF
--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -171,7 +171,8 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
    * @docs-private
    */
   get rippleDisabled(): boolean {
-    return this.disabled || this.disableRipple || !!this.rippleConfig.disabled;
+    return this.disabled || this.disableRipple || this._animationsDisabled ||
+           !!this.rippleConfig.disabled;
   }
 
   /** Whether the chip has focus. */


### PR DESCRIPTION
Fixes that the chip fires ripples even if all animations are disabled.

Fixes #20981.