### PR TITLE
test(material/menu): resolve test failures

### DIFF
--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -617,6 +617,27 @@ describe('MDC-based MatMenu', () => {
     expect(items.every(item => item.getAttribute('role') === 'menuitemcheckbox')).toBe(true);
   });
 
+  it('should not change focus origin if origin not specified for menu items', () => {
+    const fixture = createComponent(MenuWithCheckboxItems);
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openMenu();
+    fixture.detectChanges();
+
+    let [firstMenuItemDebugEl, secondMenuItemDebugEl] =
+           fixture.debugElement.queryAll(By.css('.mat-mdc-menu-item'))!;
+
+    const firstMenuItemInstance = firstMenuItemDebugEl.componentInstance as MatMenuItem;
+    const secondMenuItemInstance = secondMenuItemDebugEl.componentInstance as MatMenuItem;
+
+    firstMenuItemDebugEl.nativeElement.blur();
+    firstMenuItemInstance.focus('mouse');
+    secondMenuItemDebugEl.nativeElement.blur();
+    secondMenuItemInstance.focus();
+
+    expect(secondMenuItemDebugEl.nativeElement.classList).toContain('cdk-focused');
+    expect(secondMenuItemDebugEl.nativeElement.classList).toContain('cdk-mouse-focused');
+  });
+
   it('should not throw an error on destroy', () => {
     const fixture = createComponent(SimpleMenu, [], [FakeIcon]);
     expect(fixture.destroy.bind(fixture)).not.toThrow();
@@ -2027,6 +2048,23 @@ describe('MDC-based MatMenu', () => {
         expect(lastMenu.classList)
             .toContain('mat-elevation-z4', 'Expected menu to have the proper updated elevation.');
       }));
+
+    it('should not change focus origin if origin not specified for trigger', fakeAsync(() => {
+      compileTestComponent();
+
+      instance.levelOneTrigger.openMenu();
+      instance.levelOneTrigger.focus('mouse');
+      fixture.detectChanges();
+
+      instance.levelTwoTrigger.focus();
+      fixture.detectChanges();
+      tick(500);
+
+      const levelTwoTrigger = overlay.querySelector('#level-two-trigger')! as HTMLElement;
+
+      expect(levelTwoTrigger.classList).toContain('cdk-focused');
+      expect(levelTwoTrigger.classList).toContain('cdk-mouse-focused');
+    }));
 
     // TODO(crisbeto): disabled until we've mapped our elevation to MDC's.
     // tslint:disable-next-line:ban

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -627,7 +627,9 @@ describe('MatMenu', () => {
     const firstMenuItemInstance = firstMenuItemDebugEl.componentInstance as MatMenuItem;
     const secondMenuItemInstance = secondMenuItemDebugEl.componentInstance as MatMenuItem;
 
+    firstMenuItemDebugEl.nativeElement.blur();
     firstMenuItemInstance.focus('mouse');
+    secondMenuItemDebugEl.nativeElement.blur();
     secondMenuItemInstance.focus();
 
     expect(secondMenuItemDebugEl.nativeElement.classList).toContain('cdk-focused');
@@ -2028,8 +2030,7 @@ describe('MatMenu', () => {
             .toContain('mat-elevation-z4', 'Expected menu to have the proper updated elevation.');
       }));
 
-        it('should not change focus origin if origin not specified for menu trigger',
-      fakeAsync(() => {
+      it('should not change focus origin if origin not specified for trigger', fakeAsync(() => {
         compileTestComponent();
 
         instance.levelOneTrigger.openMenu();


### PR DESCRIPTION
Fixes some test failures that were in master. Also adds some missing tests to the MDC menu.