### PR TITLE
fix(material/select): remove focus outline on panel

### DIFF
--- a/src/material-experimental/mdc-select/select.scss
+++ b/src/material-experimental/mdc-select/select.scss
@@ -70,6 +70,7 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
   width: 100%; // Ensures that the panel matches the overlay width.
   max-height: $mat-select-panel-max-height;
   position: static; // MDC uses `absolute` by default which will throw off our positioning.
+  outline: 0;
 
   // Note that we include this private mixin, because the public
   // one adds a bunch of styles that we aren't using for the menu.

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -96,6 +96,7 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
   max-height: $mat-select-panel-max-height;
   min-width: 100%; // prevents some animation twitching and test inconsistencies in IE11
   border-radius: 4px;
+  outline: 0;
 
   @include cdk-high-contrast(active, off) {
     outline: solid 1px;


### PR DESCRIPTION
The panel has a focus outline since it has `tabindex="-1"`. We generally don't keep focus on it so the outline isn't shown, but it can happen if the user clicks on the scroll bar. These changes remove the outline.