### PR TITLE
release: bump version to 11.0.0-rc.4 w/ changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 11.0.0-rc.4 "angora-archipelago" (2020-11-10)
+11.0.0-rc.2 and 11.0.0-rc.3 had a regression in the sass bundle size. This has been fixed in 11.0.0-rc.4
+
+# 11.0.0-rc.3 "merino-meadow" (2020-11-10)
+There are no changes between 11.0.0-rc.2 and 11.0.0-rc.3.
+
 # 11.0.0-rc.2 "vicuna-valley" (2020-11-10)
 
 ### cdk

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "integration-tests:size-test": "bazel test //integration/size-test/...",
     "check-mdc-tests": "ts-node --project scripts/tsconfig.json scripts/check-mdc-tests.ts"
   },
-  "version": "11.0.0-rc.2",
+  "version": "11.0.0-rc.4",
   "dependencies": {
     "@angular/animations": "^11.0.0-rc.3",
     "@angular/common": "^11.0.0-rc.3",
@@ -69,7 +69,7 @@
     "zone.js": "~0.10.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-optimizer": "^0.1100.0-rc.2",
+    "@angular-devkit/build-optimizer": "^0.1100.0-rc.3",
     "@angular-devkit/core": "^11.0.0-rc.3",
     "@angular-devkit/schematics": "^11.0.0-rc.3",
     "@angular/bazel": "^11.0.0-rc.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@angular-devkit/build-optimizer@^0.1100.0-rc.2":
-  version "0.1100.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-optimizer/-/build-optimizer-0.1100.0-rc.2.tgz#e90a7bda8e0c443aefb13b12808fe08438a26160"
-  integrity sha512-aysLYkNVk/4UQQmYCu0vOxtegA6D+HSq4VmIxO5n5P2sAHtgRAYFBiC41lIh/Q2NU/rZVEJRvh7yjcuBd+FSUg==
+"@angular-devkit/build-optimizer@^0.1100.0-rc.3":
+  version "0.1100.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-optimizer/-/build-optimizer-0.1100.0-rc.3.tgz#1db27c32b0380e7f8c5f393b387eb1ecc9eb5e50"
+  integrity sha512-vh7ZsSmUg7teh2edMwmT0SuqBH/zwmy/QtzgUY4g1A8QfF2c0EwQAzwBDZxiGgvJS8yfor7igxKz/vb66DXRXw==
   dependencies:
     loader-utils "2.0.0"
     source-map "0.7.3"


### PR DESCRIPTION
Also updates @angular-devkit/build-optimizer to rc3 since that was missed when updating to rc3