### PR TITLE
fix(google-maps): info window not opening if no anchor is passed in

### DIFF
--- a/src/google-maps/map-info-window/map-info-window.spec.ts
+++ b/src/google-maps/map-info-window/map-info-window.spec.ts
@@ -205,6 +205,20 @@ describe('MapInfoWindow', () => {
     expect(addSpy).toHaveBeenCalledWith('zindex_changed', jasmine.any(Function));
     subscription.unsubscribe();
   });
+
+  it('should be able to open an info window without passing in an anchor', () => {
+    const infoWindowSpy = createInfoWindowSpy({});
+    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    const infoWindowComponent = fixture.debugElement.query(By.directive(
+        MapInfoWindow))!.injector.get<MapInfoWindow>(MapInfoWindow);
+    fixture.detectChanges();
+
+    infoWindowComponent.open();
+    expect(infoWindowSpy.open).toHaveBeenCalledTimes(1);
+  });
+
 });
 
 @Component({

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -175,8 +175,11 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     this._assertInitialized();
     const anchorObject = anchor ? anchor.getAnchor() : undefined;
 
-    // Prevent the info window from initializing if trying to reopen on the same anchor.
-    if (this.infoWindow.get('anchor') !== anchorObject) {
+    // Prevent the info window from initializing when trying to reopen on the same anchor.
+    // Note that when the window is opened for the first time, the anchor will always be
+    // undefined. If that's the case, we have to allow it to open in order to handle the
+    // case where the window doesn't have an anchor, but is placed at a particular position.
+    if (this.infoWindow.get('anchor') !== anchorObject || !anchorObject) {
       this._elementRef.nativeElement.style.display = '';
       this.infoWindow.open(this._googleMap.googleMap, anchorObject);
     }


### PR DESCRIPTION
Some time ago we added logic to prevent the info window from reopening if the same anchor is passed in. This ended up breaking the use case where a window is opened without an anchor, because the window always starts off without one.

Fixes #21013.