### PR TITLE
fix(cdk/drag-drop): avoid retaining disabled handles after they've been destroyed

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -344,6 +344,18 @@ export class DragRef<T = any> {
     this._handles = handles.map(handle => coerceElement(handle));
     this._handles.forEach(handle => toggleNativeDragInteractions(handle, false));
     this._toggleNativeDragInteractions();
+
+    // Delete any lingering disabled handles that may have been destroyed. Note that we re-create
+    // the set, rather than iterate over it and filter out the destroyed handles, because while
+    // the ES spec allows for sets to be modified while they're being iterated over, some polyfills
+    // use an array internally which may throw an error.
+    const disabledHandles = new Set<HTMLElement>();
+    this._disabledHandles.forEach(handle => {
+      if (this._handles.indexOf(handle) > -1) {
+        disabledHandles.add(handle);
+      }
+    });
+    this._disabledHandles = disabledHandles;
     return this;
   }
 


### PR DESCRIPTION
The `DragRef` keeps track of which of its handles have been disabled, but if one of them is destroyed, we still keep its reference until the object is destroyed.

These changes add some extra logic to filter them out.

Fixes #21009.