### PR TITLE
build: correct version for master branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "integration-tests:size-test": "bazel test //integration/size-test/...",
     "check-mdc-tests": "ts-node --project scripts/tsconfig.json scripts/check-mdc-tests.ts"
   },
-  "version": "11.0.0-rc.4",
+  "version": "11.1.0-next.0",
   "dependencies": {
     "@angular/animations": "^11.0.0",
     "@angular/common": "^11.0.0",


### PR DESCRIPTION
The version on the master branch was accidentally lowered from
`11.0.0-next.0` to `11.0.0-rc.2` in 0cd3671a