### PR TITLE
refactor(material/core): resolve circular dependency and remove underscores from more imported mixins

### DIFF
--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -1,5 +1,5 @@
 @import '../material/core/color/all-color';
-@import '../material/core/density/private';
+@import '../material/core/density/private/all-density';
 @import '../material/core/focus-indicators/focus-indicators';
 @import '../material/core/theming/all-theme';
 @import '../material-experimental/column-resize/column-resize';

--- a/src/material/button-toggle/_button-toggle-theme.scss
+++ b/src/material/button-toggle/_button-toggle-theme.scss
@@ -4,7 +4,7 @@
 @import '../core/theming/theming';
 @import '../core/theming/private';
 @import '../core/typography/typography-utils';
-@import '../core/density/private';
+@import '../core/density/private/all-density';
 @import './button-toggle-variables';
 
 @mixin mat-button-toggle-color($config-or-theme) {

--- a/src/material/core/BUILD.bazel
+++ b/src/material/core/BUILD.bazel
@@ -47,7 +47,7 @@ ALL_THEMING_FILES = [
     # on the `_all-typography` file.
     "_core.scss",
     "color/_all-color.scss",
-    "density/_private.scss",
+    "density/private/_all-density.scss",
     "theming/_all-theme.scss",
     "typography/_all-typography.scss",
 ]

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -19,7 +19,7 @@
   @include cdk-overlay();
   @include cdk-text-field();
 
-  @include _mat-strong-focus-indicators-positioning();
+  @include mat-private-strong-focus-indicators-positioning();
   @include _mat-mdc-core();
 }
 

--- a/src/material/core/density/private/_all-density.scss
+++ b/src/material/core/density/private/_all-density.scss
@@ -1,0 +1,19 @@
+@import '../../theming/private';
+
+// Includes all of the density styles.
+@mixin angular-material-density($config-or-theme) {
+  // In case a theme object has been passed instead of a configuration for
+  // the density system, extract the density config from the theme object.
+  $config: if(mat-private-is-theme-object($config-or-theme),
+      mat-get-density-config($config-or-theme), $config-or-theme);
+
+  @if $config == null {
+    @error 'No density configuration specified.';
+  }
+
+  @include angular-material-theme((
+    color: null,
+    typography: null,
+    density: $config,
+  ));
+}

--- a/src/material/core/density/private/_compatibility.scss
+++ b/src/material/core/density/private/_compatibility.scss
@@ -1,5 +1,3 @@
-@import '../theming/private';
-
 // Note that this file is called `private`, because the APIs in it aren't public yet.
 // Once they're made available, the code should be moved out into an `index.scss`.
 
@@ -70,23 +68,4 @@ $mat-private-density-generate-styles: true;
   }
 
   @return $value;
-}
-
-
-// Includes all of the density styles.
-@mixin angular-material-density($config-or-theme) {
-  // In case a theme object has been passed instead of a configuration for
-  // the density system, extract the density config from the theme object.
-  $config: if(mat-private-is-theme-object($config-or-theme),
-      mat-get-density-config($config-or-theme), $config-or-theme);
-
-  @if $config == null {
-    @error 'No density configuration specified.';
-  }
-
-  @include angular-material-theme((
-    color: null,
-    typography: null,
-    density: $config,
-  ));
 }

--- a/src/material/core/focus-indicators/_focus-indicators.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.scss
@@ -124,7 +124,7 @@
 // Mixin that ensures focus indicator host elements are positioned so that the focus indicator
 // pseudo element within is positioned relative to the host. Private mixin included within
 // `mat-core`.
-@mixin _mat-strong-focus-indicators-positioning() {
+@mixin mat-private-strong-focus-indicators-positioning() {
   .mat-focus-indicator {
     position: relative;
   }

--- a/src/material/core/theming/tests/test-theming-api.scss
+++ b/src/material/core/theming/tests/test-theming-api.scss
@@ -1,4 +1,4 @@
-@import '../../density/private';
+@import '../../density/private/all-density';
 @import '../../color/all-color';
 @import '../../typography/all-typography';
 @import '../all-theme';

--- a/src/material/core/theming/tests/theming-api.spec.ts
+++ b/src/material/core/theming/tests/theming-api.spec.ts
@@ -295,7 +295,7 @@ describe('theming api', () => {
              data: `
         @import '../_all-theme.scss';
         @import '../../color/_all-color.scss';
-        @import '../../density/_private.scss';
+        @import '../../density/private/_all-density.scss';
         @import '../../typography/_all-typography.scss';
         ${content}
       `,

--- a/src/material/expansion/_expansion-theme.scss
+++ b/src/material/expansion/_expansion-theme.scss
@@ -1,4 +1,4 @@
-@import '../core/density/private';
+@import '../core/density/private/compatibility';
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/theming/private';

--- a/src/material/form-field/_form-field-fill-theme.scss
+++ b/src/material/form-field/_form-field-fill-theme.scss
@@ -102,7 +102,7 @@ $mat-form-field-fill-dedupe: 0;
   }
 }
 
-@mixin _mat-form-field-fill-density($config-or-theme) {}
+@mixin mat-private-form-field-fill-density($config-or-theme) {}
 
 @mixin mat-form-field-fill-theme($theme-or-color-config) {
   $theme: mat-private-legacy-get-theme($theme-or-color-config);
@@ -115,7 +115,7 @@ $mat-form-field-fill-dedupe: 0;
       @include mat-form-field-fill-color($color);
     }
     @if $density != null {
-      @include _mat-form-field-fill-density($density);
+      @include mat-private-form-field-fill-density($density);
     }
     @if $typography != null {
       @include mat-form-field-fill-typography($typography);

--- a/src/material/form-field/_form-field-legacy-theme.scss
+++ b/src/material/form-field/_form-field-legacy-theme.scss
@@ -175,7 +175,7 @@ $mat-form-field-legacy-dedupe: 0;
   }
 }
 
-@mixin _mat-form-field-legacy-density($config-or-theme) {}
+@mixin mat-private-form-field-legacy-density($config-or-theme) {}
 
 @mixin mat-form-field-legacy-theme($theme-or-color-config) {
   $theme: mat-private-legacy-get-theme($theme-or-color-config);
@@ -188,7 +188,7 @@ $mat-form-field-legacy-dedupe: 0;
       @include mat-form-field-legacy-color($color);
     }
     @if $density != null {
-      @include _mat-form-field-legacy-density($density);
+      @include mat-private-form-field-legacy-density($density);
     }
     @if $typography != null {
       @include mat-form-field-legacy-typography($typography);

--- a/src/material/form-field/_form-field-outline-theme.scss
+++ b/src/material/form-field/_form-field-outline-theme.scss
@@ -132,7 +132,7 @@ $mat-form-field-outline-dedupe: 0;
   }
 }
 
-@mixin _mat-form-field-outline-density($config-or-theme) {}
+@mixin mat-private-form-field-outline-density($config-or-theme) {}
 
 @mixin mat-form-field-outline-theme($theme-or-color-config) {
   $theme: mat-private-legacy-get-theme($theme-or-color-config);
@@ -145,7 +145,7 @@ $mat-form-field-outline-dedupe: 0;
       @include mat-form-field-outline-color($color);
     }
     @if $density != null {
-      @include _mat-form-field-outline-density($density);
+      @include mat-private-form-field-outline-density($density);
     }
     @if $typography != null {
       @include mat-form-field-outline-typography($typography);

--- a/src/material/form-field/_form-field-standard-theme.scss
+++ b/src/material/form-field/_form-field-standard-theme.scss
@@ -27,7 +27,7 @@
 
 @mixin mat-form-field-standard-typography($config-or-theme) {}
 
-@mixin _mat-form-field-standard-density($config-or-theme) {}
+@mixin mat-private-form-field-standard-density($config-or-theme) {}
 
 @mixin mat-form-field-standard-theme($theme-or-color-config) {
   $theme: mat-private-legacy-get-theme($theme-or-color-config);
@@ -40,7 +40,7 @@
       @include mat-form-field-standard-color($color);
     }
     @if $density != null {
-      @include _mat-form-field-standard-density($density);
+      @include mat-private-form-field-standard-density($density);
     }
     @if $typography != null {
       @include mat-form-field-standard-typography($typography);

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -240,10 +240,10 @@ $mat-form-field-dedupe: 0;
 
 @mixin _mat-form-field-density($config-or-theme) {
   $density-scale: mat-get-density-config($config-or-theme);
-  @include _mat-form-field-legacy-density($density-scale);
-  @include _mat-form-field-standard-density($density-scale);
-  @include _mat-form-field-fill-density($density-scale);
-  @include _mat-form-field-outline-density($density-scale);
+  @include mat-private-form-field-legacy-density($density-scale);
+  @include mat-private-form-field-standard-density($density-scale);
+  @include mat-private-form-field-fill-density($density-scale);
+  @include mat-private-form-field-outline-density($density-scale);
 }
 
 @mixin mat-form-field-theme($theme-or-color-config) {

--- a/src/material/paginator/_paginator-theme.scss
+++ b/src/material/paginator/_paginator-theme.scss
@@ -2,7 +2,7 @@
 @import '../core/theming/theming';
 @import '../core/theming/private';
 @import '../core/typography/typography-utils';
-@import '../core/density/private';
+@import '../core/density/private/compatibility';
 @import './paginator-variables';
 
 @mixin mat-paginator-color($config-or-theme) {

--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -2,7 +2,7 @@
 @import '../core/theming/theming';
 @import '../core/theming/private';
 @import '../core/typography/typography-utils';
-@import '../core/density/private';
+@import '../core/density/private/compatibility';
 @import './stepper-variables';
 
 @mixin mat-stepper-color($config-or-theme) {

--- a/src/material/theming-bundle.scss
+++ b/src/material/theming-bundle.scss
@@ -2,6 +2,6 @@
 // the `@angular/material` theming Sass bundle. See `//src/material:theming_bundle`.
 
 @import './core/color/all-color';
-@import './core/density/private';
+@import './core/density/private/all-density';
 @import './core/theming/all-theme';
 @import './core/typography/all-typography';

--- a/src/material/toolbar/_toolbar-theme.scss
+++ b/src/material/toolbar/_toolbar-theme.scss
@@ -1,4 +1,4 @@
-@import '../core/density/private';
+@import '../core/density/private/compatibility';
 @import '../core/style/variables';
 @import '../core/theming/palette';
 @import '../core/theming/theming';

--- a/src/material/tree/_tree-theme.scss
+++ b/src/material/tree/_tree-theme.scss
@@ -1,4 +1,4 @@
-@import '../core/density/private';
+@import '../core/density/private/compatibility';
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/theming/private';


### PR DESCRIPTION
Resolves the following issues with our Sass that are errors under the Sass module system:
* There were a handful of mixins with underscores in their name which were imported into other files.
* There was a circular dependency between `density/private` and `theming/all-theme`.