### PR TITLE
refactor(material/datepicker): expose month view change detector ref

### DIFF
--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -180,7 +180,7 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
   /** The names of the weekdays. */
   _weekdays: {long: string, narrow: string}[];
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef,
+  constructor(readonly _changeDetectorRef: ChangeDetectorRef,
               @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
               @Optional() public _dateAdapter: DateAdapter<D>,
               @Optional() private _dir?: Directionality,

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -385,6 +385,7 @@ export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements 
 }
 
 export declare class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
+    readonly _changeDetectorRef: ChangeDetectorRef;
     _comparisonRangeEnd: number | null;
     _comparisonRangeStart: number | null;
     _dateAdapter: DateAdapter<D>;


### PR DESCRIPTION
Expose the datepicker month view's `ChangeDetectorRef` as part of its public (internal) API so it can be accessed by other components.