### PR TITLE
fix(material-experimental/mdc-chips): align test harnesses with the non-MDC version

### DIFF
--- a/src/material-experimental/mdc-chips/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-chips/testing/BUILD.bazel
@@ -23,6 +23,7 @@ ng_test_library(
         "//src/cdk/testing",
         "//src/cdk/testing/testbed",
         "//src/material-experimental/mdc-chips",
+        "@npm//@angular/forms",
     ],
 )
 

--- a/src/material-experimental/mdc-chips/testing/chip-grid-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-grid-harness.spec.ts
@@ -1,17 +1,19 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipGridHarness} from './chip-grid-harness';
 
-let fixture: ComponentFixture<ChipGridHarnessTest>;
-let loader: HarnessLoader;
 
 describe('MatChipGridHarness', () => {
+  let fixture: ComponentFixture<ChipGridHarnessTest>;
+  let loader: HarnessLoader;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatChipsModule],
+      imports: [MatChipsModule, ReactiveFormsModule],
       declarations: [ChipGridHarnessTest],
     }).compileComponents();
 
@@ -26,27 +28,59 @@ describe('MatChipGridHarness', () => {
   });
 
   it('should get correct number of rows', async () => {
-    const harnesses = await loader.getAllHarnesses(MatChipGridHarness);
-    const rows = await harnesses[0].getRows();
+    const harness = await loader.getHarness(MatChipGridHarness);
+    const rows = await harness.getRows();
     expect(rows.length).toBe(3);
   });
 
   it('should get the chip input harness', async () => {
-    const harnesses = await loader.getAllHarnesses(MatChipGridHarness);
-    const input = await harnesses[0].getTextInput();
+    const harness = await loader.getHarness(MatChipGridHarness);
+    const input = await harness.getInput();
     expect(input).not.toBe(null);
   });
+
+  it('should get whether the grid is disabled', async () => {
+    const harness = await loader.getHarness(MatChipGridHarness);
+    expect(await harness.isDisabled()).toBe(false);
+
+    fixture.componentInstance.control.disable();
+    expect(await harness.isDisabled()).toBe(true);
+  });
+
+  it('should get whether the grid is required', async () => {
+    const harness = await loader.getHarness(MatChipGridHarness);
+    expect(await harness.isRequired()).toBe(false);
+
+    fixture.componentInstance.required = true;
+    expect(await harness.isRequired()).toBe(true);
+  });
+
+  it('should get whether the grid is invalid', async () => {
+    const harness = await loader.getHarness(MatChipGridHarness);
+    expect(await harness.isInvalid()).toBe(false);
+
+    // Mark the control as touched since the default error
+    // state matcher only activates after a control is touched.
+    fixture.componentInstance.control.markAsTouched();
+    fixture.componentInstance.control.setValue(undefined);
+
+    expect(await harness.isInvalid()).toBe(true);
+  });
+
 });
 
 @Component({
   template: `
-    <mat-chip-grid #grid>
-      <mat-chip-row> Chip A </mat-chip-row>
-      <mat-chip-row> Chip B </mat-chip-row>
-      <mat-chip-row> Chip C </mat-chip-row>
-      <input [matChipInputFor]="grid" />
+    <mat-chip-grid [formControl]="control" [required]="required" #grid>
+      <mat-chip-row>Chip A</mat-chip-row>
+      <mat-chip-row>Chip B</mat-chip-row>
+      <mat-chip-row>Chip C</mat-chip-row>
+      <input [matChipInputFor]="grid"/>
     </mat-chip-grid>
   `
 })
-class ChipGridHarnessTest {}
+class ChipGridHarnessTest {
+  control = new FormControl('value', [Validators.required]);
+  required = false;
+}
 

--- a/src/material-experimental/mdc-chips/testing/chip-grid-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-grid-harness.ts
@@ -7,7 +7,11 @@
  */
 
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
-import {ChipGridHarnessFilters} from './chip-harness-filters';
+import {
+  ChipGridHarnessFilters,
+  ChipInputHarnessFilters,
+  ChipRowHarnessFilters,
+} from './chip-harness-filters';
 import {MatChipInputHarness} from './chip-input-harness';
 import {MatChipRowHarness} from './chip-row-harness';
 
@@ -22,16 +26,28 @@ export class MatChipGridHarness extends ComponentHarness {
     return new HarnessPredicate(MatChipGridHarness, options);
   }
 
-  private _rows = this.locatorForAll(MatChipRowHarness);
-  private _input = this.locatorFor(MatChipInputHarness);
+  /** Gets whether the chip grid is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-disabled') === 'true';
+  }
+
+  /** Gets whether the chip grid is required. */
+  async isRequired(): Promise<boolean> {
+    return await (await this.host()).hasClass('mat-mdc-chip-list-required');
+  }
+
+  /** Gets whether the chip grid is invalid. */
+  async isInvalid(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-invalid') === 'true';
+  }
 
   /** Gets promise of the harnesses for the chip rows. */
-  async getRows(): Promise<MatChipRowHarness[]> {
-    return await this._rows();
+  getRows(filter: ChipRowHarnessFilters = {}): Promise<MatChipRowHarness[]> {
+    return this.locatorForAll(MatChipRowHarness.with(filter))();
   }
 
   /** Gets promise of the chip text input harness. */
-  async getTextInput(): Promise<MatChipInputHarness|null> {
-    return await this._input();
+  getInput(filter: ChipInputHarnessFilters = {}): Promise<MatChipInputHarness|null> {
+    return this.locatorFor(MatChipInputHarness.with(filter))();
   }
 }

--- a/src/material-experimental/mdc-chips/testing/chip-harness-filters.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-harness-filters.ts
@@ -8,17 +8,26 @@
 
 import {BaseHarnessFilters} from '@angular/cdk/testing';
 
-// TODO(mmalerba): Add additional options that make sense for each harness type.
+export interface ChipHarnessFilters extends BaseHarnessFilters {
+  /** Only find instances whose text matches the given value. */
+  text?: string | RegExp;
+}
 
-export interface ChipGridHarnessFilters extends BaseHarnessFilters {}
-
-export interface ChipHarnessFilters extends BaseHarnessFilters {}
-
-export interface ChipInputHarnessFilters extends BaseHarnessFilters {}
+export interface ChipInputHarnessFilters extends BaseHarnessFilters {
+  /** Filters based on the value of the input. */
+  value?: string | RegExp;
+  /** Filters based on the placeholder text of the input. */
+  placeholder?: string | RegExp;
+}
 
 export interface ChipListboxHarnessFilters extends BaseHarnessFilters {}
 
-export interface ChipOptionHarnessFilters extends ChipHarnessFilters {}
+export interface ChipOptionHarnessFilters extends ChipHarnessFilters {
+  /** Only find chip instances whose selected state matches the given value. */
+  selected?: boolean;
+}
+
+export interface ChipGridHarnessFilters extends BaseHarnessFilters {}
 
 export interface ChipRowHarnessFilters extends ChipHarnessFilters {}
 

--- a/src/material-experimental/mdc-chips/testing/chip-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-harness.spec.ts
@@ -1,14 +1,15 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipHarness} from './chip-harness';
 
-let fixture: ComponentFixture<ChipHarnessTest>;
-let loader: HarnessLoader;
 
 describe('MatChipHarness', () => {
+  let fixture: ComponentFixture<ChipHarnessTest>;
+  let loader: HarnessLoader;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatChipsModule],
@@ -34,7 +35,7 @@ describe('MatChipHarness', () => {
     expect(await harnesses[4].getText()).toBe('Chip Row');
   });
 
-  it('should be able to remove a mat-chip-row', async () => {
+  it('should be able to remove a chip', async () => {
     const removeChipSpy = spyOn(fixture.componentInstance, 'removeChip');
 
     const harnesses = await loader.getAllHarnesses(MatChipHarness);
@@ -42,6 +43,18 @@ describe('MatChipHarness', () => {
 
     expect(removeChipSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('should get the disabled state of a chip', async () => {
+    const harnesses = await loader.getAllHarnesses(MatChipHarness);
+    const disabledStates = await parallel(() => harnesses.map(harness => harness.isDisabled()));
+    expect(disabledStates).toEqual([false, false, false, true, false]);
+  });
+
+  it('should get the remove button of a chip', async () => {
+    const harness = await loader.getHarness(MatChipHarness.with({selector: '.has-remove-button'}));
+    expect(await harness.getRemoveButton()).toBeTruthy();
+  });
+
 });
 
 @Component({
@@ -49,7 +62,10 @@ describe('MatChipHarness', () => {
     <mat-basic-chip>Basic Chip</mat-basic-chip>
     <mat-chip>Chip <span matChipTrailingIcon>trailing_icon</span></mat-chip>
     <mat-chip><mat-chip-avatar>B</mat-chip-avatar>Chip with avatar</mat-chip>
-    <mat-chip disabled>Disabled Chip <span matChipRemove>remove_icon</span></mat-chip>
+    <mat-chip
+      class="has-remove-button"
+      disabled>Disabled Chip <span matChipRemove>remove_icon</span>
+    </mat-chip>
     <mat-chip-row (removed)="removeChip()">Chip Row</mat-chip-row>
   `
 })

--- a/src/material-experimental/mdc-chips/testing/chip-input-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-input-harness.spec.ts
@@ -5,10 +5,11 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipInputHarness} from './chip-input-harness';
 
-let fixture: ComponentFixture<ChipInputHarnessTest>;
-let loader: HarnessLoader;
 
 describe('MatChipInputHarness', () => {
+  let fixture: ComponentFixture<ChipInputHarnessTest>;
+  let loader: HarnessLoader;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatChipsModule],
@@ -30,12 +31,45 @@ describe('MatChipInputHarness', () => {
     expect(await harnesses[0].isDisabled()).toBe(false);
     expect(await harnesses[1].isDisabled()).toBe(true);
   });
+
+  it('should get whether the input is required', async () => {
+    const harness = await loader.getHarness(MatChipInputHarness);
+    expect(await harness.isRequired()).toBe(false);
+
+    fixture.componentInstance.required = true;
+    expect(await harness.isRequired()).toBe(true);
+  });
+
+  it('should get whether the input placeholder', async () => {
+    const harness = await loader.getHarness(MatChipInputHarness);
+    expect(await harness.getPlaceholder()).toBe('Placeholder');
+  });
+
+  it('should get and set the input value', async () => {
+    const harness = await loader.getHarness(MatChipInputHarness);
+    expect(await harness.getValue()).toBe('');
+
+    await harness.setValue('value');
+    expect(await harness.getValue()).toBe('value');
+  });
+
+  it('should control the input focus state', async () => {
+    const harness = await loader.getHarness(MatChipInputHarness);
+    expect(await harness.isFocused()).toBe(false);
+
+    await harness.focus();
+    expect(await harness.isFocused()).toBe(true);
+
+    await harness.blur();
+    expect(await harness.isFocused()).toBe(false);
+  });
+
 });
 
 @Component({
   template: `
     <mat-chip-grid #grid1>
-      <input [matChipInputFor]="grid1" />
+      <input [matChipInputFor]="grid1" [required]="required" placeholder="Placeholder" />
     </mat-chip-grid>
 
     <mat-chip-grid #grid2>
@@ -43,5 +77,7 @@ describe('MatChipInputHarness', () => {
     </mat-chip-grid>
   `
 })
-class ChipInputHarnessTest {}
+class ChipInputHarnessTest {
+  required = false;
+}
 

--- a/src/material-experimental/mdc-chips/testing/chip-input-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-input-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, TestKey} from '@angular/cdk/testing';
 import {ChipInputHarnessFilters} from './chip-harness-filters';
 
 /** Harness for interacting with a grid's chip input in tests. */
@@ -14,19 +14,82 @@ export class MatChipInputHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-chip-input';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a chip input with specific attributes.
+   * Gets a `HarnessPredicate` that can be used to search for a `MatChipInputHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
    */
   static with(options: ChipInputHarnessFilters = {}): HarnessPredicate<MatChipInputHarness> {
-    return new HarnessPredicate(MatChipInputHarness, options);
+    return new HarnessPredicate(MatChipInputHarness, options)
+        .addOption('value', options.value, async (harness, value) => {
+          return (await harness.getValue()) === value;
+        })
+        .addOption('placeholder', options.placeholder, async (harness, placeholder) => {
+          return (await harness.getPlaceholder()) === placeholder;
+        });
   }
 
-  /** Gets a promise for the disabled state. */
+  /** Whether the input is disabled. */
   async isDisabled(): Promise<boolean> {
-    return await ((await this.host()).getAttribute('disabled')) === 'true';
+    return (await this.host()).getProperty('disabled')!;
   }
 
-  /** Gets a promise for the placeholder text. */
-  async getPlaceholder(): Promise<string|null> {
-    return (await this.host()).getAttribute('placeholder');
+  /** Whether the input is required. */
+  async isRequired(): Promise<boolean> {
+    return (await this.host()).getProperty('required')!;
+  }
+
+  /** Gets the value of the input. */
+  async getValue(): Promise<string> {
+    // The "value" property of the native input is never undefined.
+    return (await (await this.host()).getProperty('value'))!;
+  }
+
+  /** Gets the placeholder of the input. */
+  async getPlaceholder(): Promise<string> {
+    return (await (await this.host()).getProperty('placeholder'));
+  }
+
+  /**
+   * Focuses the input and returns a promise that indicates when the
+   * action is complete.
+   */
+  async focus(): Promise<void> {
+    return (await this.host()).focus();
+  }
+
+  /**
+   * Blurs the input and returns a promise that indicates when the
+   * action is complete.
+   */
+  async blur(): Promise<void> {
+    return (await this.host()).blur();
+  }
+
+  /** Whether the input is focused. */
+  async isFocused(): Promise<boolean> {
+    return (await this.host()).isFocused();
+  }
+
+  /**
+   * Sets the value of the input. The value will be set by simulating
+   * keypresses that correspond to the given value.
+   */
+  async setValue(newValue: string): Promise<void> {
+    const inputEl = await this.host();
+    await inputEl.clear();
+
+    // We don't want to send keys for the value if the value is an empty
+    // string in order to clear the value. Sending keys with an empty string
+    // still results in unnecessary focus events.
+    if (newValue) {
+      await inputEl.sendKeys(newValue);
+    }
+  }
+
+  /** Sends a chip separator key to the input element. */
+  async sendSeparatorKey(key: TestKey | string): Promise<void> {
+    const inputEl = await this.host();
+    return inputEl.sendKeys(key);
   }
 }

--- a/src/material-experimental/mdc-chips/testing/chip-listbox-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-listbox-harness.spec.ts
@@ -1,14 +1,15 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipListboxHarness} from './chip-listbox-harness';
 
-let fixture: ComponentFixture<ChipListboxHarnessTest>;
-let loader: HarnessLoader;
 
 describe('MatChipListboxHarness', () => {
+  let fixture: ComponentFixture<ChipListboxHarnessTest>;
+  let loader: HarnessLoader;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatChipsModule],
@@ -26,50 +27,82 @@ describe('MatChipListboxHarness', () => {
   });
 
   it('should get the number of options', async () => {
-    const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
-    expect ((await harnesses[0].getOptions()).length).toBe(4);
+    const harness = await loader.getHarness(MatChipListboxHarness);
+    expect ((await harness.getChips()).length).toBe(4);
   });
 
-  describe('should get selection', () => {
-    it('with no selected options', async () => {
-      const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
-      const selectedOption = await harnesses[0].getSelected();
-      expect(selectedOption.length).toBe(0);
-    });
+  it('should get whether the listbox is in multi-selection mode', async () => {
+    const harness = await loader.getHarness(MatChipListboxHarness);
+    expect(await harness.isMultiple()).toBe(false);
 
-    it('with a single selected option', async () => {
-      fixture.componentInstance.options[0].selected = true;
-      fixture.detectChanges();
-
-      const harnesses = await loader.getAllHarnesses(MatChipListboxHarness);
-      const selectedOption = await harnesses[0].getSelected();
-      expect(selectedOption.length).toBe(1);
-      expect(await selectedOption[0].getText()).toContain('Blue');
-    });
-
-    it('with multiple selected options', async () => {
-      fixture.componentInstance.enableMultipleSelection = true;
-      fixture.componentInstance.options[0].selected = true;
-      fixture.componentInstance.options[1].selected = true;
-      fixture.detectChanges();
-
-      const harnesses = (await loader.getAllHarnesses(MatChipListboxHarness));
-      const selectedOption = await harnesses[0].getSelected();
-      expect(selectedOption.length).toBe(2);
-      expect(await selectedOption[0].getText()).toContain('Blue');
-      expect(await selectedOption[1].getText()).toContain('Green');
-    });
+    fixture.componentInstance.isMultiple = true;
+    expect(await harness.isMultiple()).toBe(true);
   });
+
+  it('should get whether the listbox is disabled', async () => {
+    const harness = await loader.getHarness(MatChipListboxHarness);
+    expect(await harness.isDisabled()).toBe(false);
+
+    fixture.componentInstance.disabled = true;
+    expect(await harness.isDisabled()).toBe(true);
+  });
+
+  it('should get whether the listbox is required', async () => {
+    const harness = await loader.getHarness(MatChipListboxHarness);
+    expect(await harness.isRequired()).toBe(false);
+
+    fixture.componentInstance.required = true;
+    expect(await harness.isRequired()).toBe(true);
+  });
+
+  it('should get selection when no options are selected', async () => {
+    const harness = await loader.getHarness(MatChipListboxHarness);
+    const selectedOptions = await harness.getChips({selected: true});
+    expect(selectedOptions.length).toBe(0);
+  });
+
+  it('should get selection in single-selection mode', async () => {
+    fixture.componentInstance.options[0].selected = true;
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(MatChipListboxHarness);
+    const selectedOptions = await harness.getChips({selected: true});
+    expect(selectedOptions.length).toBe(1);
+    expect(await selectedOptions[0].getText()).toContain('Blue');
+  });
+
+  it('should get selection in multi-selection mode', async () => {
+    fixture.componentInstance.isMultiple = true;
+    fixture.componentInstance.options[0].selected = true;
+    fixture.componentInstance.options[1].selected = true;
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(MatChipListboxHarness);
+    const selectedOptions = await harness.getChips({selected: true});
+    expect(selectedOptions.length).toBe(2);
+    expect(await selectedOptions[0].getText()).toContain('Blue');
+    expect(await selectedOptions[1].getText()).toContain('Green');
+  });
+
+  it('should be able to select specific options', async () => {
+    fixture.componentInstance.isMultiple = true;
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(MatChipListboxHarness);
+    expect(await harness.getChips({selected: true})).toEqual([]);
+
+    await harness.selectChips({text: /Blue|Yellow/});
+    const selectedOptions = await harness.getChips({selected: true});
+    const selectedText = await parallel(() => selectedOptions.map(option => option.getText()));
+
+    expect(selectedText).toEqual(['Blue', 'Yellow']);
+  });
+
 });
-
-interface ExampleOption {
-  selected: boolean;
-  text: string;
-}
 
 @Component({
   template: `
-    <mat-chip-listbox [multiple]="enableMultipleSelection">
+    <mat-chip-listbox [multiple]="isMultiple" [disabled]="disabled" [required]="required">
       <mat-chip-option *ngFor="let option of options" [selected]="option.selected">
         {{option.text}}
       </mat-chip-option>
@@ -77,8 +110,10 @@ interface ExampleOption {
   `
 })
 class ChipListboxHarnessTest {
-  enableMultipleSelection = false;
-  options: ExampleOption[] = [
+  isMultiple = false;
+  disabled = false;
+  required = false;
+  options = [
     {text: 'Blue', selected: false},
     {text: 'Green', selected: false},
     {text: 'Red', selected: false},

--- a/src/material-experimental/mdc-chips/testing/chip-listbox-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-listbox-harness.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
-import {ChipListboxHarnessFilters} from './chip-harness-filters';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
+import {ChipListboxHarnessFilters, ChipOptionHarnessFilters} from './chip-harness-filters';
 import {MatChipOptionHarness} from './chip-option-harness';
 
 /** Harness for interacting with a mat-chip-listbox in tests. */
@@ -22,24 +22,45 @@ export class MatChipListboxHarness extends ComponentHarness {
     return new HarnessPredicate(MatChipListboxHarness, options);
   }
 
-  private _options = this.locatorForAll(MatChipOptionHarness);
-
-  /** Gets promise of the harnesses for the chip options in the listbox. */
-  async getOptions(): Promise<MatChipOptionHarness[]> {
-    return await this._options();
+  /** Gets whether the chip listbox is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-disabled') === 'true';
   }
 
-  /** Gets promise of the selected options. */
-  async getSelected(): Promise<MatChipOptionHarness[]> {
-    const options = await this._options();
-    return Promise.all(options.map(o => o.isSelected())).then(isSelectedStates => {
-      const selectedOptions: MatChipOptionHarness[] = [];
-      isSelectedStates.forEach((isSelectedOption, index) => {
-        if (isSelectedOption) {
-          selectedOptions.push(options[index]);
-        }
-      });
-      return selectedOptions;
-    });
+  /** Gets whether the chip listbox is required. */
+  async isRequired(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-required') === 'true';
+  }
+
+  /** Gets whether the chip listbox is in multi selection mode. */
+  async isMultiple(): Promise<boolean> {
+    return await (await this.host()).getAttribute('aria-multiselectable') === 'true';
+  }
+
+  /** Gets whether the orientation of the chip list. */
+  async getOrientation(): Promise<'horizontal' | 'vertical'> {
+    const orientation = await (await this.host()).getAttribute('aria-orientation');
+    return orientation === 'vertical' ? 'vertical' : 'horizontal';
+  }
+
+  /**
+   * Gets the list of chips inside the chip list.
+   * @param filter Optionally filters which chips are included.
+   */
+  async getChips(filter: ChipOptionHarnessFilters = {}): Promise<MatChipOptionHarness[]> {
+    return this.locatorForAll(MatChipOptionHarness.with(filter))();
+  }
+
+  /**
+   * Selects a chip inside the chip list.
+   * @param filter An optional filter to apply to the child chips.
+   *    All the chips matching the filter will be selected.
+   */
+  async selectChips(filter: ChipOptionHarnessFilters = {}): Promise<void> {
+    const chips = await this.getChips(filter);
+    if (!chips.length) {
+      throw Error(`Cannot find chip matching filter ${JSON.stringify(filter)}`);
+    }
+    await parallel(() => chips.map(chip => chip.select()));
   }
 }

--- a/src/material-experimental/mdc-chips/testing/chip-option-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-option-harness.spec.ts
@@ -5,10 +5,11 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipOptionHarness} from './chip-option-harness';
 
-let fixture: ComponentFixture<ChipOptionHarnessTest>;
-let loader: HarnessLoader;
 
 describe('MatChipOptionHarness', () => {
+  let fixture: ComponentFixture<ChipOptionHarnessTest>;
+  let loader: HarnessLoader;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatChipsModule],
@@ -45,6 +46,34 @@ describe('MatChipOptionHarness', () => {
     expect(await harnesses[2].getText()).toBe('Selected Chip Option');
     expect(await harnesses[3].getText()).toBe('Chip Option');
   });
+
+  it('should be able to select a chip', async () => {
+    const harness = await loader.getHarness(MatChipOptionHarness.with({selected: false}));
+    expect(await harness.isSelected()).toBe(false);
+
+    await harness.select();
+    expect(await harness.isSelected()).toBe(true);
+  });
+
+  it('should be able to deselect a chip', async () => {
+    const harness = await loader.getHarness(MatChipOptionHarness.with({selected: true}));
+    expect(await harness.isSelected()).toBe(true);
+
+    await harness.deselect();
+    expect(await harness.isSelected()).toBe(false);
+  });
+
+  it('should be able to toggle the selected state of a chip', async () => {
+    const harness = await loader.getHarness(MatChipOptionHarness.with({selected: false}));
+    expect(await harness.isSelected()).toBe(false);
+
+    await harness.toggle();
+    expect(await harness.isSelected()).toBe(true);
+
+    await harness.toggle();
+    expect(await harness.isSelected()).toBe(false);
+  });
+
 });
 
 @Component({

--- a/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
@@ -22,17 +22,35 @@ export class MatChipOptionHarness extends MatChipHarness {
   // methods. See https://github.com/microsoft/TypeScript/issues/5863
   static with<T extends typeof MatChipHarness>(
       this: T, options: ChipOptionHarnessFilters = {}): HarnessPredicate<InstanceType<T>> {
-    return new HarnessPredicate(MatChipOptionHarness, options) as
-        unknown as HarnessPredicate<InstanceType<T>>;
+    return new HarnessPredicate(MatChipOptionHarness, options)
+      .addOption('text', options.text,
+          (harness, label) => HarnessPredicate.stringMatches(harness.getText(), label))
+      .addOption('selected', options.selected,
+          async (harness, selected) => (await harness.isSelected()) === selected) as
+          unknown as HarnessPredicate<InstanceType<T>>;
   }
 
-  /** Gets a promise for the selected state. */
+  /** Whether the chip is selected. */
   async isSelected(): Promise<boolean> {
-    return await ((await this.host()).getAttribute('aria-selected')) === 'true';
+    return (await this.host()).hasClass('mat-mdc-chip-selected');
   }
 
-  /** Gets a promise for the disabled state. */
-  async isDisabled(): Promise<boolean> {
-    return await ((await this.host()).getAttribute('aria-disabled')) === 'true';
+  /** Selects the given chip. Only applies if it's selectable. */
+  async select(): Promise<void> {
+    if (!(await this.isSelected())) {
+      await this.toggle();
+    }
+  }
+
+  /** Deselects the given chip. Only applies if it's selectable. */
+  async deselect(): Promise<void> {
+    if (await this.isSelected()) {
+      await this.toggle();
+    }
+  }
+
+  /** Toggles the selected state of the given chip. */
+  async toggle(): Promise<void> {
+    return (await this.host()).sendKeys(' ');
   }
 }

--- a/src/material-experimental/mdc-chips/testing/chip-remove-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-remove-harness.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate, ComponentHarness} from '@angular/cdk/testing';
+import {ChipRemoveHarnessFilters} from './chip-harness-filters';
+
+/** Harness for interacting with a standard Material chip remove button in tests. */
+export class MatChipRemoveHarness extends ComponentHarness {
+  static hostSelector = '.mat-mdc-chip-remove';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatChipRemoveHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: ChipRemoveHarnessFilters = {}): HarnessPredicate<MatChipRemoveHarness> {
+    return new HarnessPredicate(MatChipRemoveHarness, options);
+  }
+
+  /** Clicks the remove button. */
+  async click(): Promise<void> {
+    return (await this.host()).click();
+  }
+}

--- a/src/material-experimental/mdc-chips/testing/chip-row-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-row-harness.spec.ts
@@ -5,10 +5,11 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipRowHarness} from './chip-row-harness';
 
-let fixture: ComponentFixture<ChipRowHarnessTest>;
-let loader: HarnessLoader;
 
 describe('MatChipRowHarness', () => {
+  let fixture: ComponentFixture<ChipRowHarnessTest>;
+  let loader: HarnessLoader;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatChipsModule],

--- a/src/material-experimental/mdc-chips/testing/chip-set-harness.spec.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-set-harness.spec.ts
@@ -5,10 +5,10 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatChipsModule} from '../index';
 import {MatChipSetHarness} from './chip-set-harness';
 
-let fixture: ComponentFixture<ChipSetHarnessTest>;
-let loader: HarnessLoader;
-
 describe('MatChipSetHarness', () => {
+  let fixture: ComponentFixture<ChipSetHarnessTest>;
+  let loader: HarnessLoader;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatChipsModule],

--- a/src/material-experimental/mdc-chips/testing/chip-set-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-set-harness.ts
@@ -8,7 +8,7 @@
 
 import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {MatChipHarness} from './chip-harness';
-import {ChipSetHarnessFilters} from './chip-harness-filters';
+import {ChipHarnessFilters, ChipSetHarnessFilters} from './chip-harness-filters';
 
 /** Harness for interacting with a mat-chip-set in tests. */
 export class MatChipSetHarness extends ComponentHarness {
@@ -21,10 +21,8 @@ export class MatChipSetHarness extends ComponentHarness {
     return new HarnessPredicate(MatChipSetHarness, options);
   }
 
-  private _chips = this.locatorForAll(MatChipHarness);
-
   /** Gets promise of the harnesses for the chips. */
-  async getChips(): Promise<MatChipHarness[]> {
-    return await this._chips();
+  async getChips(filter: ChipHarnessFilters = {}): Promise<MatChipHarness[]> {
+    return await this.locatorForAll(MatChipHarness.with(filter))();
   }
 }

--- a/src/material-experimental/mdc-chips/testing/public-api.ts
+++ b/src/material-experimental/mdc-chips/testing/public-api.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export * from './chip-grid-harness';
 export * from './chip-harness';
 export * from './chip-harness-filters';
 export * from './chip-input-harness';
-export * from './chip-listbox-harness';
+export * from './chip-remove-harness';
 export * from './chip-option-harness';
+export * from './chip-listbox-harness';
+export * from './chip-grid-harness';
 export * from './chip-row-harness';
 export * from './chip-set-harness';


### PR DESCRIPTION
Aligns the test harnesses of the MDC-based chips module with the ones from the non-MDC version. Overview of the changes:
* `MatChipGridHarness` - `getTextInput` was renamed to `getInput` to match the non-MDC list harness. Also adds a few utility methods to check whether the grid is disabled, required etc.
* `MatChipHarness` - adds support for the same set of filters when querying for the harness. Also adds a method to get the removal button and disabled state.
* `MatChipInputHarness` - adds a bunch of utility methods that we have on the other input-related harnesses. Also implemets the same set of harness filters as the non-MDC harness.
* `MatChipListboxHarness` - Renames `getOptions` to `getChips` for consistency and removes the `getSelected` method in favor of filtering selected chips through the harness predicate. Also adds some utility methods for selecting chips, getting the disabled and required states etc.
* `MatChipOptionHarness` - implements harness filters and adds APIs for selecting/deselecting.
* `MatChipRemoveHarness` - new harness which is identical to the non-MDC `MatChipRemoveHarness`.
* `MatChipSetHarness` - supports filtering through the `getChips` method.

These changes also include tests for all the new functionality and minor cleanups around the `mdc-chips/testing` package.