### PR TITLE
perf(cdk/testing): reduce change detections when running parallel actions

### DIFF
--- a/src/cdk/testing/change-detection.ts
+++ b/src/cdk/testing/change-detection.ts
@@ -110,6 +110,8 @@ export async function manualChangeDetection<T>(fn: () => Promise<T>) {
   return batchChangeDetection(fn, false);
 }
 
+
+
 /**
  * Resolves the given list of async values in parallel (i.e. via Promise.all) while batching change
  * detection over the entire operation such that change detection occurs exactly once before
@@ -117,6 +119,54 @@ export async function manualChangeDetection<T>(fn: () => Promise<T>) {
  * @param values A getter for the async values to resolve in parallel with batched change detection.
  * @return The resolved values.
  */
-export async function parallel<T>(values: () => Iterable<T | PromiseLike<T>>) {
+export function parallel<T1, T2, T3, T4, T5>(
+  values: () =>
+      [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>,
+       T5 | PromiseLike<T5>
+      ]): Promise<[T1, T2, T3, T4, T5]>;
+
+/**
+ * Resolves the given list of async values in parallel (i.e. via Promise.all) while batching change
+ * detection over the entire operation such that change detection occurs exactly once before
+ * resolving the values and once after.
+ * @param values A getter for the async values to resolve in parallel with batched change detection.
+ * @return The resolved values.
+ */
+export function parallel<T1, T2, T3, T4>(
+  values: () =>
+      [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>]):
+  Promise<[T1, T2, T3, T4]>;
+
+/**
+ * Resolves the given list of async values in parallel (i.e. via Promise.all) while batching change
+ * detection over the entire operation such that change detection occurs exactly once before
+ * resolving the values and once after.
+ * @param values A getter for the async values to resolve in parallel with batched change detection.
+ * @return The resolved values.
+ */
+export function parallel<T1, T2, T3>(
+  values: () => [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]):
+  Promise<[T1, T2, T3]>;
+
+/**
+ * Resolves the given list of async values in parallel (i.e. via Promise.all) while batching change
+ * detection over the entire operation such that change detection occurs exactly once before
+ * resolving the values and once after.
+ * @param values A getter for the async values to resolve in parallel with batched change detection.
+ * @return The resolved values.
+ */
+export function parallel<T1, T2>(values: () => [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]):
+  Promise<[T1, T2]>;
+
+/**
+ * Resolves the given list of async values in parallel (i.e. via Promise.all) while batching change
+ * detection over the entire operation such that change detection occurs exactly once before
+ * resolving the values and once after.
+ * @param values A getter for the async values to resolve in parallel with batched change detection.
+ * @return The resolved values.
+ */
+export function parallel<T>(values: () => (T | PromiseLike<T>)[]): Promise<T[]>;
+
+export async function parallel<T>(values: () => Iterable<T | PromiseLike<T>>): Promise<T[]> {
   return batchChangeDetection(() => Promise.all(values()), true);
 }

--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -168,12 +168,12 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
 
     const perElementMatches = await parallel(() => rawElements.map(async rawElement => {
       const testElement = this.createTestElement(rawElement);
-      const allResultsForElement = await Promise.all(
+      const allResultsForElement = await parallel(
           // For each query, get `null` if it doesn't match, or a `TestElement` or
           // `ComponentHarness` as appropriate if it does match. This gives us everything that
           // matches the current raw element, but it may contain duplicate entries (e.g.
           // multiple `TestElement` or multiple `ComponentHarness` of the same type).
-          allQueries.map(query => this._getQueryResultForElement(
+          () => allQueries.map(query => this._getQueryResultForElement(
               query, rawElement, testElement, skipSelectorCheck)));
       return _removeDuplicateQueryResults(allResultsForElement);
     }));

--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -10,6 +10,7 @@ import {
   ComponentHarness,
   ComponentHarnessConstructor,
   HarnessLoader,
+  parallel,
   TestElement,
 } from '@angular/cdk/testing';
 import {MainComponentHarness} from './harnesses/main-component-harness';
@@ -214,7 +215,7 @@ export function crossEnvironmentSpecs(
         });
 
     it('should load optional harness with ancestor selector restriction', async () => {
-      const [subcomp1, subcomp2] = await Promise.all([
+      const [subcomp1, subcomp2] = await parallel(() => [
         harness.optionalAncestorRestrictedSubcomponent(),
         harness.optionalAncestorRestrictedMissingSubcomponent()
       ]);
@@ -224,14 +225,14 @@ export function crossEnvironmentSpecs(
     });
 
     it('should load all harnesses with ancestor selector restriction', async () => {
-      const [subcomps1, subcomps2] = await Promise.all([
+      const [subcomps1, subcomps2] = await parallel(() => [
         harness.allAncestorRestrictedSubcomponent(),
         harness.allAncestorRestrictedMissingSubcomponent()
       ]);
       expect(subcomps1.length).toBe(2);
       expect(subcomps2.length).toBe(0);
       const [title1, title2] =
-          await Promise.all(subcomps1.map(async comp => (await comp.title()).text()));
+          await parallel(() => subcomps1.map(async comp => (await comp.title()).text()));
       expect(title1).toBe('List of other 1');
       expect(title2).toBe('List of other 2');
     });
@@ -421,7 +422,7 @@ export function crossEnvironmentSpecs(
     });
 
     it('should be able to set the value of a select in single selection mode', async () => {
-      const [select, value, changeEventCounter] = await Promise.all([
+      const [select, value, changeEventCounter] = await parallel(() => [
         harness.singleSelect(),
         harness.singleSelectValue(),
         harness.singleSelectChangeEventCounter()
@@ -434,7 +435,7 @@ export function crossEnvironmentSpecs(
     });
 
     it('should be able to set the value of a select in multi-selection mode', async () => {
-      const [select, value, changeEventCounter] = await Promise.all([
+      const [select, value, changeEventCounter] = await parallel(() => [
         harness.multiSelect(),
         harness.multiSelectValue(),
         harness.multiSelectChangeEventCounter()

--- a/src/cdk/testing/tests/protractor.e2e.spec.ts
+++ b/src/cdk/testing/tests/protractor.e2e.spec.ts
@@ -1,6 +1,7 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {ProtractorHarnessEnvironment} from '@angular/cdk/testing/protractor';
 import {browser, by, element as protractorElement, ElementFinder} from 'protractor';
+import {parallel} from '../change-detection';
 import {crossEnvironmentSpecs} from './cross-environment.spec';
 import {MainComponentHarness} from './harnesses/main-component-harness';
 
@@ -70,7 +71,9 @@ describe('ProtractorHarnessEnvironment', () => {
         const harness = await ProtractorHarnessEnvironment.loader({queryFn: piercingQueryFn})
             .getHarness(MainComponentHarness);
         const shadows = await harness.shadows();
-        expect(await Promise.all(shadows.map(el => el.text()))).toEqual(['Shadow 1', 'Shadow 2']);
+        expect(await parallel(() => {
+          return shadows.map(el => el.text());
+        })).toEqual(['Shadow 1', 'Shadow 2']);
       });
 
       it('should allow querying across shadow boundary', async () => {

--- a/src/cdk/testing/tests/testbed.spec.ts
+++ b/src/cdk/testing/tests/testbed.spec.ts
@@ -115,7 +115,7 @@ describe('TestbedHarnessEnvironment', () => {
         // promises.
         detectChangesSpy.calls.reset();
         expect(detectChangesSpy).toHaveBeenCalledTimes(0);
-        await parallel<unknown>(() => {
+        await parallel(() => {
           // Chain together our promises to ensure the before clause runs first and the after clause
           // runs last.
           const before =
@@ -153,7 +153,9 @@ describe('TestbedHarnessEnvironment', () => {
             fixture, MainComponentHarness, {queryFn: piercingQuerySelectorAll},
           );
           const shadows = await harness.shadows();
-          expect(await Promise.all(shadows.map(el => el.text()))).toEqual(['Shadow 1', 'Shadow 2']);
+          expect(await parallel(() => {
+            return shadows.map(el => el.text());
+          })).toEqual(['Shadow 1', 'Shadow 2']);
         });
 
         it('should allow querying across shadow boundary', async () => {

--- a/src/material-experimental/mdc-form-field/testing/form-field-harness.ts
+++ b/src/material-experimental/mdc-form-field/testing/form-field-harness.ts
@@ -11,6 +11,7 @@ import {
   ComponentHarnessConstructor,
   HarnessPredicate,
   HarnessQuery,
+  parallel,
   TestElement
 } from '@angular/cdk/testing';
 import {FormFieldHarnessFilters} from '@angular/material/form-field/testing';
@@ -90,7 +91,7 @@ export class MatFormFieldHarness extends ComponentHarness {
       return this.locatorForOptional(type)();
     }
     const hostEl = await this.host();
-    const [isInput, isSelect] = await Promise.all([
+    const [isInput, isSelect] = await parallel(() => [
       hostEl.hasClass('mat-mdc-form-field-type-mat-input'),
       hostEl.hasClass('mat-mdc-form-field-type-mat-select'),
     ]);
@@ -138,7 +139,7 @@ export class MatFormFieldHarness extends ComponentHarness {
   async getThemeColor(): Promise<'primary'|'accent'|'warn'> {
     const hostEl = await this.host();
     const [isAccent, isWarn] =
-        await Promise.all([hostEl.hasClass('mat-accent'), hostEl.hasClass('mat-warn')]);
+        await parallel(() => [hostEl.hasClass('mat-accent'), hostEl.hasClass('mat-warn')]);
     if (isAccent) {
       return 'accent';
     } else if (isWarn) {
@@ -149,12 +150,14 @@ export class MatFormFieldHarness extends ComponentHarness {
 
   /** Gets error messages which are currently displayed in the form-field. */
   async getTextErrors(): Promise<string[]> {
-    return Promise.all((await this._errors()).map(e => e.text()));
+    const errors = await this._errors();
+    return parallel(() => errors.map(e => e.text()));
   }
 
   /** Gets hint messages which are currently displayed in the form-field. */
   async getTextHints(): Promise<string[]> {
-    return Promise.all((await this._hints()).map(e => e.text()));
+    const hints = await this._hints();
+    return parallel(() => hints.map(e => e.text()));
   }
 
   /**
@@ -240,7 +243,7 @@ export class MatFormFieldHarness extends ComponentHarness {
     // is not able to forward any control status classes. Therefore if either the
     // "ng-touched" or "ng-untouched" class is set, we know that it has a form control
     const [isTouched, isUntouched] =
-        await Promise.all([hostEl.hasClass('ng-touched'), hostEl.hasClass('ng-untouched')]);
+        await parallel(() => [hostEl.hasClass('ng-touched'), hostEl.hasClass('ng-untouched')]);
     return isTouched || isUntouched;
   }
 }

--- a/src/material-experimental/mdc-list/testing/list-harness-base.ts
+++ b/src/material-experimental/mdc-list/testing/list-harness-base.ts
@@ -9,7 +9,8 @@
 import {
   ComponentHarness,
   ComponentHarnessConstructor,
-  HarnessPredicate
+  HarnessPredicate,
+  parallel
 } from '@angular/cdk/testing';
 import {DividerHarnessFilters, MatDividerHarness} from '@angular/material/divider/testing';
 import {BaseListItemHarnessFilters, SubheaderHarnessFilters} from './list-harness-filters';
@@ -53,8 +54,9 @@ export abstract class MatListHarnessBase<
    * @return The list of items matching the given filters, grouped into sections by subheader.
    */
   async getItemsGroupedBySubheader(filters?: F): Promise<ListSection<C>[]> {
-    const listSections = [];
-    let currentSection: {items: C[], heading?: Promise<string>} = {items: []};
+    type Section = {items: C[], heading?: Promise<string>};
+    const listSections: Section[] = [];
+    let currentSection: Section = {items: []};
     const itemsAndSubheaders =
         await this.getItemsWithSubheadersAndDividers({item: filters, divider: false});
 
@@ -74,7 +76,7 @@ export abstract class MatListHarnessBase<
     }
 
     // Concurrently wait for all sections to resolve their heading if present.
-    return Promise.all(listSections.map(async (s) =>
+    return parallel(() => listSections.map(async (s) =>
         ({items: s.items, heading: await s.heading})));
   }
 

--- a/src/material-experimental/mdc-list/testing/list-item-harness-base.ts
+++ b/src/material-experimental/mdc-list/testing/list-item-harness-base.ts
@@ -10,7 +10,8 @@ import {
   ComponentHarness,
   ComponentHarnessConstructor,
   ContentContainerComponentHarness,
-  HarnessPredicate
+  HarnessPredicate,
+  parallel
 } from '@angular/cdk/testing';
 import {BaseListItemHarnessFilters, SubheaderHarnessFilters} from './list-harness-filters';
 
@@ -74,7 +75,8 @@ export abstract class MatListItemHarnessBase
 
   /** Gets the lines of text (`mat-line` elements) in this nav list item. */
   async getLinesText(): Promise<string[]> {
-    return Promise.all((await this._lines()).map(l => l.text()));
+    const lines = await this._lines();
+    return parallel(() => lines.map(l => l.text()));
   }
 
   /** Whether this list item has an avatar. */

--- a/src/material-experimental/mdc-list/testing/selection-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/selection-list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatListOptionCheckboxPosition} from '@angular/material-experimental/mdc-list';
 import {MatListHarnessBase} from './list-harness-base';
 import {
@@ -46,7 +46,7 @@ export class MatSelectionListHarness extends MatListHarnessBase<
    */
   async selectItems(...filters: ListOptionHarnessFilters[]): Promise<void> {
     const items = await this._getItems(filters);
-    await Promise.all(items.map(item => item.select()));
+    await parallel(() => items.map(item => item.select()));
   }
 
   /**
@@ -55,7 +55,7 @@ export class MatSelectionListHarness extends MatListHarnessBase<
    */
   async deselectItems(...filters: ListItemHarnessFilters[]): Promise<void> {
     const items = await this._getItems(filters);
-    await Promise.all(items.map(item => item.deselect()));
+    await parallel(() => items.map(item => item.deselect()));
   }
 
   /** Gets all items matching the given list of filters. */
@@ -63,7 +63,7 @@ export class MatSelectionListHarness extends MatListHarnessBase<
     if (!filters.length) {
       return this.getItems();
     }
-    const matches = await Promise.all(
+    const matches = await parallel(() =>
       filters.map(filter => this.locatorForAll(MatListOptionHarness.with(filter))()));
     return matches.reduce((result, current) => [...result, ...current], []);
   }

--- a/src/material-experimental/mdc-select/testing/select-harness.ts
+++ b/src/material-experimental/mdc-select/testing/select-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
 import {
   MatOptionHarness,
@@ -118,14 +118,15 @@ export class MatSelectHarness extends MatFormFieldControlHarness {
   async clickOptions(filter: OptionHarnessFilters = {}): Promise<void> {
     await this.open();
 
-    const [isMultiple, options] = await Promise.all([this.isMultiple(), this.getOptions(filter)]);
+    const [isMultiple, options] =
+        await parallel(() => [this.isMultiple(), this.getOptions(filter)]);
 
     if (options.length === 0) {
       throw Error('Select does not have options matching the specified filter');
     }
 
     if (isMultiple) {
-      await Promise.all(options.map(option => option.click()));
+      await parallel(() => options.map(option => option.click()));
     } else {
       await options[0].click();
     }

--- a/src/material-experimental/mdc-slider/testing/slider-harness.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-harness.ts
@@ -7,7 +7,7 @@
  */
 
 import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {SliderHarnessFilters} from '@angular/material/slider/testing';
 
 /** Harness for interacting with a MDC mat-slider in tests. */
@@ -95,7 +95,7 @@ export class MatSliderHarness extends ComponentHarness {
     await this.waitForTasksOutsideAngular();
 
     const [sliderEl, trackContainer] =
-        await Promise.all([this.host(), this._trackContainer()]);
+        await parallel(() => [this.host(), this._trackContainer()]);
     let percentage = await this._calculatePercentage(value);
     const {width} = await trackContainer.getDimensions();
 
@@ -133,7 +133,7 @@ export class MatSliderHarness extends ComponentHarness {
 
   /** Calculates the percentage of the given value. */
   private async _calculatePercentage(value: number) {
-    const [min, max] = await Promise.all([this.getMinValue(), this.getMaxValue()]);
+    const [min, max] = await parallel(() => [this.getMinValue(), this.getMaxValue()]);
     return (value - min) / (max - min);
   }
 }

--- a/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
+++ b/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
@@ -7,7 +7,7 @@
  */
 
 import {AriaLivePoliteness} from '@angular/cdk/a11y';
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {SnackBarHarnessFilters} from './snack-bar-harness-filters';
 
 /** Harness for interacting with an MDC-based mat-snack-bar in tests. */
@@ -97,7 +97,7 @@ export class MatSnackBarHarness extends ComponentHarness {
     // element isn't in the DOM by seeing that its width and height are zero.
 
     const host = await this.host();
-    const [exit, dimensions] = await Promise.all([
+    const [exit, dimensions] = await parallel(() => [
       // The snackbar container is marked with the "exit" attribute after it has been dismissed
       // but before the animation has finished (after which it's removed from the DOM).
       host.getAttribute('mat-exit'),

--- a/src/material-experimental/mdc-table/testing/row-harness.ts
+++ b/src/material-experimental/mdc-table/testing/row-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {RowHarnessFilters, CellHarnessFilters} from './table-harness-filters';
 import {MatCellHarness, MatHeaderCellHarness, MatFooterCellHarness} from './cell-harness';
 
@@ -113,7 +113,7 @@ async function getCellTextByIndex(harness: {
   getCells: (filter?: CellHarnessFilters) => Promise<MatCellHarness[]>
 }, filter: CellHarnessFilters): Promise<string[]> {
   const cells = await harness.getCells(filter);
-  return Promise.all(cells.map(cell => cell.getText()));
+  return parallel(() => cells.map(cell => cell.getText()));
 }
 
 async function getCellTextByColumnName(harness: {
@@ -121,8 +121,8 @@ async function getCellTextByColumnName(harness: {
 }): Promise<MatRowHarnessColumnsText> {
   const output: MatRowHarnessColumnsText = {};
   const cells = await harness.getCells();
-  const cellsData = await Promise.all(cells.map(cell => {
-    return Promise.all([cell.getColumnName(), cell.getText()]);
+  const cellsData = await parallel(() => cells.map(cell => {
+    return parallel(() => [cell.getColumnName(), cell.getText()]);
   }));
   cellsData.forEach(([columnName, text]) => output[columnName] = text);
   return output;

--- a/src/material-experimental/mdc-table/testing/table-harness.ts
+++ b/src/material-experimental/mdc-table/testing/table-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ContentContainerComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ContentContainerComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {TableHarnessFilters, RowHarnessFilters} from './table-harness-filters';
 import {
   MatRowHarness,
@@ -56,22 +56,22 @@ export class MatTableHarness extends ContentContainerComponentHarness<string> {
   /** Gets the text inside the entire table organized by rows. */
   async getCellTextByIndex(): Promise<string[][]> {
     const rows = await this.getRows();
-    return Promise.all(rows.map(row => row.getCellTextByIndex()));
+    return parallel(() => rows.map(row => row.getCellTextByIndex()));
   }
 
   /** Gets the text inside the entire table organized by columns. */
   async getCellTextByColumnName(): Promise<MatTableHarnessColumnsText> {
-    const [headerRows, footerRows, dataRows] = await Promise.all([
+    const [headerRows, footerRows, dataRows] = await parallel(() => [
       this.getHeaderRows(),
       this.getFooterRows(),
       this.getRows()
     ]);
 
     const text: MatTableHarnessColumnsText = {};
-    const [headerData, footerData, rowsData] = await Promise.all([
-      Promise.all(headerRows.map(row => row.getCellTextByColumnName())),
-      Promise.all(footerRows.map(row => row.getCellTextByColumnName())),
-      Promise.all(dataRows.map(row => row.getCellTextByColumnName())),
+    const [headerData, footerData, rowsData] = await parallel(() => [
+      parallel(() => headerRows.map(row => row.getCellTextByColumnName())),
+      parallel(() => footerRows.map(row => row.getCellTextByColumnName())),
+      parallel(() => dataRows.map(row => row.getCellTextByColumnName())),
     ]);
 
     rowsData.forEach(data => {

--- a/src/material-experimental/mdc-tabs/testing/tab-group-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-group-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {TabGroupHarnessFilters, TabHarnessFilters} from './tab-harness-filters';
 import {MatTabHarness} from './tab-harness';
 
@@ -40,7 +40,7 @@ export class MatTabGroupHarness extends ComponentHarness {
   /** Gets the selected tab of the tab group. */
   async getSelectedTab(): Promise<MatTabHarness> {
     const tabs = await this.getTabs();
-    const isSelected = await Promise.all(tabs.map(t => t.isSelected()));
+    const isSelected = await parallel(() => tabs.map(t => t.isSelected()));
     for (let i = 0; i < tabs.length; i++) {
       if (isSelected[i]) {
         return tabs[i];

--- a/src/material-experimental/mdc-tabs/testing/tab-nav-bar-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-nav-bar-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {TabNavBarHarnessFilters, TabLinkHarnessFilters} from './tab-harness-filters';
 import {MatTabLinkHarness} from './tab-link-harness';
 
@@ -36,7 +36,7 @@ export class MatTabNavBarHarness extends ComponentHarness {
   /** Gets the active link in the nav bar. */
   async getActiveLink(): Promise<MatTabLinkHarness> {
     const links = await this.getLinks();
-    const isActive = await Promise.all(links.map(t => t.isActive()));
+    const isActive = await parallel(() => links.map(t => t.isActive()));
     for (let i = 0; i < links.length; i++) {
       if (isActive[i]) {
         return links[i];

--- a/src/material/card/testing/shared.spec.ts
+++ b/src/material/card/testing/shared.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentHarness, HarnessLoader} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -49,7 +49,7 @@ export function runHarnessTests(
 
   it('should get card text', async () => {
     const cards = await loader.getAllHarnesses(cardHarness);
-    expect(await Promise.all(cards.map(c => c.getText()))).toEqual([
+    expect(await parallel(() => cards.map(c => c.getText()))).toEqual([
        '',
        'Shiba InuDog Breed The Shiba Inu is the smallest of the six original and distinct spitz' +
        ' breeds of dog from Japan. A small, agile dog that copes very well with mountainous' +
@@ -59,7 +59,7 @@ export function runHarnessTests(
 
   it('should get title text', async () => {
     const cards = await loader.getAllHarnesses(cardHarness);
-    expect(await Promise.all(cards.map(c => c.getTitleText()))).toEqual([
+    expect(await parallel(() => cards.map(c => c.getTitleText()))).toEqual([
       '',
       'Shiba Inu'
     ]);
@@ -67,7 +67,7 @@ export function runHarnessTests(
 
   it('should get subtitle text', async () => {
     const cards = await loader.getAllHarnesses(cardHarness);
-    expect(await Promise.all(cards.map(c => c.getSubtitleText()))).toEqual([
+    expect(await parallel(() => cards.map(c => c.getSubtitleText()))).toEqual([
       '',
       'Dog Breed'
     ]);

--- a/src/material/chips/testing/chip-list-harness.ts
+++ b/src/material/chips/testing/chip-list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatChipHarness} from './chip-harness';
 import {MatChipInputHarness} from './chip-input-harness';
 import {
@@ -79,7 +79,7 @@ export class MatChipListHarness extends _MatChipListHarnessBase {
     if (!chips.length) {
       throw Error(`Cannot find chip matching filter ${JSON.stringify(filter)}`);
     }
-    await Promise.all(chips.map(chip => chip.select()));
+    await parallel(() => chips.map(chip => chip.select()));
   }
 
   /**

--- a/src/material/chips/testing/chip-listbox-harness.ts
+++ b/src/material/chips/testing/chip-listbox-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatChipOptionHarness} from './chip-option-harness';
 import {
   ChipListboxHarnessFilters,
@@ -48,6 +48,6 @@ export class MatChipListboxHarness extends _MatChipListHarnessBase {
     if (!chips.length) {
       throw Error(`Cannot find chip matching filter ${JSON.stringify(filter)}`);
     }
-    await Promise.all(chips.map(chip => chip.select()));
+    await parallel(() => chips.map(chip => chip.select()));
   }
 }

--- a/src/material/chips/testing/shared.spec.ts
+++ b/src/material/chips/testing/shared.spec.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {HarnessLoader, TestKey} from '@angular/cdk/testing';
+import {HarnessLoader, parallel, TestKey} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -43,7 +43,7 @@ export function runHarnessTests(
   it('should get whether a chip list is disabled', async () => {
     const chipLists = await loader.getAllHarnesses(chipListHarness);
 
-    expect(await Promise.all(chipLists.map(list => list.isDisabled()))).toEqual([
+    expect(await parallel(() => chipLists.map(list => list.isDisabled()))).toEqual([
       false,
       false,
       false
@@ -52,7 +52,7 @@ export function runHarnessTests(
     fixture.componentInstance.isDisabled = true;
     fixture.detectChanges();
 
-    expect(await Promise.all(chipLists.map(list => list.isDisabled()))).toEqual([
+    expect(await parallel(() => chipLists.map(list => list.isDisabled()))).toEqual([
       true,
       false,
       false
@@ -62,7 +62,7 @@ export function runHarnessTests(
   it('should get whether a chip list is required', async () => {
     const chipLists = await loader.getAllHarnesses(chipListHarness);
 
-    expect(await Promise.all(chipLists.map(list => list.isRequired()))).toEqual([
+    expect(await parallel(() => chipLists.map(list => list.isRequired()))).toEqual([
       false,
       false,
       true
@@ -71,7 +71,7 @@ export function runHarnessTests(
     fixture.componentInstance.isRequired = true;
     fixture.detectChanges();
 
-    expect(await Promise.all(chipLists.map(list => list.isRequired()))).toEqual([
+    expect(await parallel(() => chipLists.map(list => list.isRequired()))).toEqual([
       true,
       false,
       true
@@ -81,7 +81,7 @@ export function runHarnessTests(
   it('should get whether a chip list is in multi selection mode', async () => {
     const chipLists = await loader.getAllHarnesses(chipListHarness);
 
-    expect(await Promise.all(chipLists.map(list => list.isMultiple()))).toEqual([
+    expect(await parallel(() => chipLists.map(list => list.isMultiple()))).toEqual([
       false,
       false,
       false
@@ -90,7 +90,7 @@ export function runHarnessTests(
     fixture.componentInstance.isMultiple = true;
     fixture.detectChanges();
 
-    expect(await Promise.all(chipLists.map(list => list.isMultiple()))).toEqual([
+    expect(await parallel(() => chipLists.map(list => list.isMultiple()))).toEqual([
       true,
       false,
       false
@@ -100,7 +100,7 @@ export function runHarnessTests(
   it('should get the orientation of a chip list', async () => {
     const chipLists = await loader.getAllHarnesses(chipListHarness);
 
-    expect(await Promise.all(chipLists.map(list => list.getOrientation()))).toEqual([
+    expect(await parallel(() => chipLists.map(list => list.getOrientation()))).toEqual([
       'horizontal',
       'horizontal',
       'horizontal'
@@ -109,7 +109,7 @@ export function runHarnessTests(
     fixture.componentInstance.orientation = 'vertical';
     fixture.detectChanges();
 
-    expect(await Promise.all(chipLists.map(list => list.getOrientation()))).toEqual([
+    expect(await parallel(() => chipLists.map(list => list.getOrientation()))).toEqual([
       'vertical',
       'horizontal',
       'horizontal'
@@ -118,7 +118,7 @@ export function runHarnessTests(
 
   it('should get the chips in a chip list', async () => {
     const chipLists = await loader.getAllHarnesses(chipListHarness);
-    const chips = await Promise.all(chipLists.map(list => list.getChips()));
+    const chips = await parallel(() => chipLists.map(list => list.getChips()));
     expect(chips.map(list => list.length)).toEqual([4, 0, 2]);
   });
 
@@ -135,7 +135,7 @@ export function runHarnessTests(
     await chips[1].select();
 
     const selectedChips = await chipList.getChips({selected: true});
-    expect(await Promise.all(selectedChips.map(chip => chip.getText()))).toEqual(['Chip 2']);
+    expect(await parallel(() => selectedChips.map(chip => chip.getText()))).toEqual(['Chip 2']);
   });
 
   it('should be able to select chips based on a filter', async () => {
@@ -146,7 +146,7 @@ export function runHarnessTests(
     await chipList.selectChips({text: /^Chip (2|4)$/});
 
     const selectedChips = await chipList.getChips({selected: true});
-    expect(await Promise.all(selectedChips.map(chip => chip.getText()))).toEqual([
+    expect(await parallel(() => selectedChips.map(chip => chip.getText()))).toEqual([
       'Chip 2',
       'Chip 4'
     ]);
@@ -159,7 +159,7 @@ export function runHarnessTests(
 
   it('should get the text of a chip', async () => {
     const chips = await loader.getAllHarnesses(chipHarness);
-    expect(await Promise.all(chips.map(chip => chip.getText()))).toEqual([
+    expect(await parallel(() => chips.map(chip => chip.getText()))).toEqual([
       'Chip 1',
       'Chip 2',
       'Chip 3',
@@ -195,7 +195,7 @@ export function runHarnessTests(
 
   it('should get the disabled text of a chip', async () => {
     const chips = await loader.getAllHarnesses(chipHarness);
-    expect(await Promise.all(chips.map(chip => chip.isDisabled()))).toEqual([
+    expect(await parallel(() => chips.map(chip => chip.isDisabled()))).toEqual([
       false,
       false,
       true,
@@ -207,7 +207,7 @@ export function runHarnessTests(
 
   it('should get the selected text of a chip', async () => {
     const chips = await loader.getAllHarnesses(chipOptionHarness);
-    expect(await Promise.all(chips.map(chip => chip.isSelected()))).toEqual([
+    expect(await parallel(() => chips.map(chip => chip.isSelected()))).toEqual([
       false,
       false,
       false,
@@ -218,7 +218,7 @@ export function runHarnessTests(
 
     await chips[1].select();
 
-    expect(await Promise.all(chips.map(chip => chip.isSelected()))).toEqual([
+    expect(await parallel(() => chips.map(chip => chip.isSelected()))).toEqual([
       false,
       true,
       false,

--- a/src/material/core/testing/optgroup-shared.spec.ts
+++ b/src/material/core/testing/optgroup-shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -42,20 +42,20 @@ export function runHarnessTests(
 
   it('should get the group label text', async () => {
     const groups = await loader.getAllHarnesses(optionGroupHarness);
-    const texts = await Promise.all(groups.map(group => group.getLabelText()));
+    const texts = await parallel(() => groups.map(group => group.getLabelText()));
     expect(texts).toEqual(['Plain group', 'Disabled group']);
   });
 
   it('should get the group disabled state', async () => {
     const groups = await loader.getAllHarnesses(optionGroupHarness);
-    const disabledStates = await Promise.all(groups.map(group => group.isDisabled()));
+    const disabledStates = await parallel(() => groups.map(group => group.isDisabled()));
     expect(disabledStates).toEqual([false, true]);
   });
 
   it('should get the options inside the groups', async () => {
     const group = await loader.getHarness(optionGroupHarness);
     const optionTexts = await group.getOptions().then(async options => {
-      return await Promise.all(options.map(option => option.getText()));
+      return await parallel(() => options.map(option => option.getText()));
     });
 
     expect(optionTexts).toEqual(['Option 1', 'Option 2']);

--- a/src/material/core/testing/option-shared.spec.ts
+++ b/src/material/core/testing/option-shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component, ViewChildren, QueryList} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -60,13 +60,13 @@ export function runHarnessTests(
 
   it('should get the text of options', async () => {
     const options = await loader.getAllHarnesses(optionHarness);
-    const texts = await Promise.all(options.map(option => option.getText()));
+    const texts = await parallel(() => options.map(option => option.getText()));
     expect(texts).toEqual(['Plain option', 'Disabled option']);
   });
 
   it('should get whether an option is disabled', async () => {
     const options = await loader.getAllHarnesses(optionHarness);
-    const disabledStates = await Promise.all(options.map(option => option.isDisabled()));
+    const disabledStates = await parallel(() => options.map(option => option.isDisabled()));
     expect(disabledStates).toEqual([false, true]);
   });
 

--- a/src/material/datepicker/testing/calendar-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/calendar-harness-shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -139,10 +139,10 @@ export function runCalendarHarnessTests(
   it('should get the state of the cell within the main range', async () => {
     const calendar = await loader.getHarness(calendarHarness.with({selector: '#range'}));
     const allCells = await calendar.getCells();
-    const [initialStartStates, initialInRangeStates, initialEndStates] = await Promise.all([
-      Promise.all(allCells.map(cell => cell.isRangeStart())),
-      Promise.all(allCells.map(cell => cell.isInRange())),
-      Promise.all(allCells.map(cell => cell.isRangeEnd()))
+    const [initialStartStates, initialInRangeStates, initialEndStates] = await parallel(() => [
+      parallel(() => allCells.map(cell => cell.isRangeStart())),
+      parallel(() => allCells.map(cell => cell.isInRange())),
+      parallel(() => allCells.map(cell => cell.isRangeEnd()))
     ]);
 
     expect(initialStartStates.every(state => state === false)).toBe(true);
@@ -172,10 +172,10 @@ export function runCalendarHarnessTests(
   it('should get the state of the cell within the comparison range', async () => {
     const calendar = await loader.getHarness(calendarHarness.with({selector: '#range'}));
     const allCells = await calendar.getCells();
-    const [initialStartStates, initialInRangeStates, initialEndStates] = await Promise.all([
-      Promise.all(allCells.map(cell => cell.isComparisonRangeStart())),
-      Promise.all(allCells.map(cell => cell.isInComparisonRange())),
-      Promise.all(allCells.map(cell => cell.isComparisonRangeEnd()))
+    const [initialStartStates, initialInRangeStates, initialEndStates] = await parallel(() => [
+      parallel(() => allCells.map(cell => cell.isComparisonRangeStart())),
+      parallel(() => allCells.map(cell => cell.isInComparisonRange())),
+      parallel(() => allCells.map(cell => cell.isComparisonRangeEnd()))
     ]);
 
     expect(initialStartStates.every(state => state === false)).toBe(true);
@@ -207,10 +207,10 @@ export function runCalendarHarnessTests(
   it('should get the state of the cell within the preview range', async () => {
     const calendar = await loader.getHarness(calendarHarness.with({selector: '#range'}));
     const allCells = await calendar.getCells();
-    const [initialStartStates, initialInRangeStates, initialEndStates] = await Promise.all([
-      Promise.all(allCells.map(cell => cell.isPreviewRangeStart())),
-      Promise.all(allCells.map(cell => cell.isInPreviewRange())),
-      Promise.all(allCells.map(cell => cell.isPreviewRangeEnd()))
+    const [initialStartStates, initialInRangeStates, initialEndStates] = await parallel(() => [
+      parallel(() => allCells.map(cell => cell.isPreviewRangeStart())),
+      parallel(() => allCells.map(cell => cell.isInPreviewRange())),
+      parallel(() => allCells.map(cell => cell.isPreviewRangeEnd()))
     ]);
 
     expect(initialStartStates.every(state => state === false)).toBe(true);
@@ -240,7 +240,7 @@ export function runCalendarHarnessTests(
   it('should filter cells by their text', async () => {
     const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
     const cells = await calendar.getCells({text: /^3/});
-    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['3', '30', '31']);
+    expect(await parallel(() => cells.map(cell => cell.getText()))).toEqual(['3', '30', '31']);
   });
 
   it('should filter cells by their selected state', async () => {
@@ -250,13 +250,13 @@ export function runCalendarHarnessTests(
     await allCells[0].select();
 
     const selectedCells = await calendar.getCells({selected: true});
-    expect(await Promise.all(selectedCells.map(cell => cell.getText()))).toEqual(['1']);
+    expect(await parallel(() => selectedCells.map(cell => cell.getText()))).toEqual(['1']);
   });
 
   it('should filter cells by their active state', async () => {
     const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
     const cells = await calendar.getCells({active: true});
-    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['1']);
+    expect(await parallel(() => cells.map(cell => cell.getText()))).toEqual(['1']);
   });
 
   it('should filter cells by their disabled state', async () => {
@@ -265,7 +265,7 @@ export function runCalendarHarnessTests(
 
     const calendar = await loader.getHarness(calendarHarness.with({selector: '#single'}));
     const cells = await calendar.getCells({disabled: true});
-    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['1', '2']);
+    expect(await parallel(() => cells.map(cell => cell.getText()))).toEqual(['1', '2']);
   });
 
   it('should filter cells based on whether they are inside the comparison range', async () => {
@@ -277,7 +277,7 @@ export function runCalendarHarnessTests(
         new Date(calendarDate.getFullYear(), calendarDate.getMonth(), 8);
 
     const cells = await calendar.getCells({inComparisonRange: true});
-    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['5', '6', '7', '8']);
+    expect(await parallel(() => cells.map(cell => cell.getText()))).toEqual(['5', '6', '7', '8']);
   });
 
   it('should filter cells based on whether they are inside the preview range', async () => {
@@ -287,7 +287,7 @@ export function runCalendarHarnessTests(
     await (await calendar.getCells({text: '8'}))[0].hover();
 
     const cells = await calendar.getCells({inPreviewRange: true});
-    expect(await Promise.all(cells.map(cell => cell.getText()))).toEqual(['5', '6', '7', '8']);
+    expect(await parallel(() => cells.map(cell => cell.getText()))).toEqual(['5', '6', '7', '8']);
   });
 
 }

--- a/src/material/datepicker/testing/date-range-input-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/date-range-input-harness-shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {MatNativeDateModule} from '@angular/material/core';
@@ -71,7 +71,7 @@ export function runDateRangeInputHarnessTests(
 
   it('should get harnesses for the inner inputs', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
     expect(start).toBeInstanceOf(startInputHarness);
     expect(end).toBeInstanceOf(endInputHarness);
   });
@@ -105,54 +105,56 @@ export function runDateRangeInputHarnessTests(
     expect(await input.getCalendar()).toBeInstanceOf(calendarHarness);
   });
 
-  /////
-
   it('should get whether the inner inputs are disabled', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
-    expect(await Promise.all([start.isDisabled(), end.isDisabled()])).toEqual([false, false]);
+    expect(await parallel(() => [start.isDisabled(), end.isDisabled()])).toEqual([false, false]);
 
     fixture.componentInstance.subInputsDisabled = true;
-    expect(await Promise.all([start.isDisabled(), end.isDisabled()])).toEqual([true, true]);
+    expect(await parallel(() => [start.isDisabled(), end.isDisabled()])).toEqual([true, true]);
   });
 
   it('should get whether the inner inputs are required', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
-    expect(await Promise.all([start.isRequired(), end.isRequired()])).toEqual([false, false]);
+    expect(await parallel(() => [start.isRequired(), end.isRequired()])).toEqual([false, false]);
 
     fixture.componentInstance.subInputsRequired = true;
-    expect(await Promise.all([start.isRequired(), end.isRequired()])).toEqual([true, true]);
+    expect(await parallel(() => [start.isRequired(), end.isRequired()])).toEqual([true, true]);
   });
 
   it('should get the values of the inner inputs', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
     fixture.componentInstance.startDate = new Date(2020, 0, 1, 12, 0, 0);
     fixture.componentInstance.endDate = new Date(2020, 1, 2, 12, 0, 0);
 
-    expect(await Promise.all([start.getValue(), end.getValue()])).toEqual(['1/1/2020', '2/2/2020']);
+    expect(await parallel(() => {
+      return [start.getValue(), end.getValue()];
+    })).toEqual(['1/1/2020', '2/2/2020']);
   });
 
   it('should set the values of the inner inputs', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
-    expect(await Promise.all([start.getValue(), end.getValue()])).toEqual(['', '']);
+    expect(await parallel(() => [start.getValue(), end.getValue()])).toEqual(['', '']);
 
-    await Promise.all([start.setValue('1/1/2020'), end.setValue('2/2/2020')]);
+    await parallel(() => [start.setValue('1/1/2020'), end.setValue('2/2/2020')]);
 
-    expect(await Promise.all([start.getValue(), end.getValue()])).toEqual(['1/1/2020', '2/2/2020']);
+    expect(await parallel(() => {
+      return [start.getValue(), end.getValue()];
+    })).toEqual(['1/1/2020', '2/2/2020']);
   });
 
   it('should get the placeholders of the inner inputs', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
-    expect(await Promise.all([start.getPlaceholder(), end.getPlaceholder()])).toEqual([
+    expect(await parallel(() => [start.getPlaceholder(), end.getPlaceholder()])).toEqual([
       'Start date',
       'End date'
     ]);
@@ -160,7 +162,7 @@ export function runDateRangeInputHarnessTests(
 
   it('should be able to change the inner input focused state', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
     expect(await start.isFocused()).toBe(false);
     await start.focus();
@@ -177,33 +179,37 @@ export function runDateRangeInputHarnessTests(
 
   it('should get the minimum date of the inner inputs', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
-    expect(await Promise.all([start.getMin(), end.getMin()])).toEqual([null, null]);
+    expect(await parallel(() => [start.getMin(), end.getMin()])).toEqual([null, null]);
 
     fixture.componentInstance.minDate = new Date(2020, 0, 1, 12, 0, 0);
-    expect(await Promise.all([start.getMin(), end.getMin()])).toEqual(['2020-01-01', '2020-01-01']);
+    expect(await parallel(() => {
+      return [start.getMin(), end.getMin()];
+    })).toEqual(['2020-01-01', '2020-01-01']);
   });
 
   it('should get the maximum date of the inner inputs', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
-    expect(await Promise.all([start.getMax(), end.getMax()])).toEqual([null, null]);
+    expect(await parallel(() => [start.getMax(), end.getMax()])).toEqual([null, null]);
 
     fixture.componentInstance.maxDate = new Date(2020, 0, 1, 12, 0, 0);
 
-    expect(await Promise.all([start.getMax(), end.getMax()])).toEqual(['2020-01-01', '2020-01-01']);
+    expect(await parallel(() => {
+      return [start.getMax(), end.getMax()];
+    })).toEqual(['2020-01-01', '2020-01-01']);
   });
 
   it('should dispatch the dateChange event when the inner input values have changed', async () => {
     const input = await loader.getHarness(dateRangeInputHarness.with({selector: '[basic]'}));
-    const [start, end] = await Promise.all([input.getStartInput(), input.getEndInput()]);
+    const [start, end] = await parallel(() => [input.getStartInput(), input.getEndInput()]);
 
     expect(fixture.componentInstance.startDateChangeCount).toBe(0);
     expect(fixture.componentInstance.endDateChangeCount).toBe(0);
 
-    await Promise.all([start.setValue('1/1/2020'), end.setValue('2/2/2020')]);
+    await parallel(() => [start.setValue('1/1/2020'), end.setValue('2/2/2020')]);
 
     expect(fixture.componentInstance.startDateChangeCount).toBe(1);
     expect(fixture.componentInstance.endDateChangeCount).toBe(1);

--- a/src/material/datepicker/testing/date-range-input-harness.ts
+++ b/src/material/datepicker/testing/date-range-input-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate, TestKey} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel, TestKey} from '@angular/cdk/testing';
 import {MatDatepickerInputHarnessBase, getInputPredicate} from './datepicker-input-harness-base';
 import {DatepickerTriggerHarnessBase} from './datepicker-trigger-harness-base';
 import {
@@ -66,7 +66,7 @@ export class MatDateRangeInputHarness extends DatepickerTriggerHarnessBase {
 
   /** Gets the combined value of the start and end inputs, including the separator. */
   async getValue(): Promise<string> {
-    const [start, end, separator] = await Promise.all([
+    const [start, end, separator] = await parallel(() => [
       this.getStartInput().then(input => input.getValue()),
       this.getEndInput().then(input => input.getValue()),
       this.getSeparator()
@@ -95,7 +95,7 @@ export class MatDateRangeInputHarness extends DatepickerTriggerHarnessBase {
   /** Gets whether the range input is disabled. */
   async isDisabled(): Promise<boolean> {
     // We consider the input as disabled if both of the sub-inputs are disabled.
-    const [startDisabled, endDisabled] = await Promise.all([
+    const [startDisabled, endDisabled] = await parallel(() => [
       this.getStartInput().then(input => input.isDisabled()),
       this.getEndInput().then(input => input.isDisabled())
     ]);

--- a/src/material/datepicker/testing/datepicker-input-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness-shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {MatNativeDateModule} from '@angular/material/core';
@@ -49,7 +49,7 @@ export function runDatepickerInputHarnessTests(
 
   it('should get whether the input has an associated calendar', async () => {
     const inputs = await loader.getAllHarnesses(datepickerInputHarness);
-    expect(await Promise.all(inputs.map(input => input.hasCalendar()))).toEqual([true, false]);
+    expect(await parallel(() => inputs.map(input => input.hasCalendar()))).toEqual([true, false]);
   });
 
   it('should get whether the input is disabled', async () => {
@@ -85,7 +85,7 @@ export function runDatepickerInputHarnessTests(
 
   it('should get the input placeholder', async () => {
     const inputs = await loader.getAllHarnesses(datepickerInputHarness);
-    expect(await Promise.all(inputs.map(input => {
+    expect(await parallel(() => inputs.map(input => {
       return input.getPlaceholder();
     }))).toEqual(['Type a date', '']);
   });
@@ -104,13 +104,13 @@ export function runDatepickerInputHarnessTests(
   it('should get the minimum date of the input', async () => {
     const inputs = await loader.getAllHarnesses(datepickerInputHarness);
     fixture.componentInstance.minDate = new Date(2020, 0, 1, 12, 0, 0);
-    expect(await Promise.all(inputs.map(input => input.getMin()))).toEqual(['2020-01-01', null]);
+    expect(await parallel(() => inputs.map(input => input.getMin()))).toEqual(['2020-01-01', null]);
   });
 
   it('should get the maximum date of the input', async () => {
     const inputs = await loader.getAllHarnesses(datepickerInputHarness);
     fixture.componentInstance.maxDate = new Date(2020, 0, 1, 12, 0, 0);
-    expect(await Promise.all(inputs.map(input => input.getMax()))).toEqual(['2020-01-01', null]);
+    expect(await parallel(() => inputs.map(input => input.getMax()))).toEqual(['2020-01-01', null]);
   });
 
   it('should be able to open and close a calendar in popup mode', async () => {

--- a/src/material/datepicker/testing/datepicker-input-harness.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate, TestKey} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel, TestKey} from '@angular/cdk/testing';
 import {DatepickerInputHarnessFilters, CalendarHarnessFilters} from './datepicker-harness-filters';
 import {MatDatepickerInputHarnessBase, getInputPredicate} from './datepicker-input-harness-base';
 import {MatCalendarHarness} from './calendar-harness';
@@ -42,7 +42,7 @@ export class MatDatepickerInputHarness extends MatDatepickerInputHarnessBase imp
 
   /** Opens the calendar associated with the input. */
   async openCalendar(): Promise<void> {
-    const [isDisabled, hasCalendar] = await Promise.all([this.isDisabled(), this.hasCalendar()]);
+    const [isDisabled, hasCalendar] = await parallel(() => [this.isDisabled(), this.hasCalendar()]);
 
     if (!isDisabled && hasCalendar) {
       // Alt + down arrow is the combination for opening the calendar with the keyboard.

--- a/src/material/datepicker/testing/datepicker-toggle-harness-shared.spec.ts
+++ b/src/material/datepicker/testing/datepicker-toggle-harness-shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {MatNativeDateModule} from '@angular/material/core';
@@ -42,7 +42,9 @@ export function runDatepickerToggleHarnessTests(
 
   it('should get whether the toggle has a calendar associated with it', async () => {
     const toggles = await loader.getAllHarnesses(datepickerToggleHarness);
-    expect(await Promise.all(toggles.map(toggle => toggle.hasCalendar()))).toEqual([true, false]);
+    expect(await parallel(() => {
+      return toggles.map(toggle => toggle.hasCalendar());
+    })).toEqual([true, false]);
   });
 
   it('should be able to open and close a calendar in popup mode', async () => {

--- a/src/material/datepicker/testing/datepicker-trigger-harness-base.ts
+++ b/src/material/datepicker/testing/datepicker-trigger-harness-base.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, LocatorFactory, TestElement} from '@angular/cdk/testing';
+import {ComponentHarness, LocatorFactory, parallel, TestElement} from '@angular/cdk/testing';
 import {CalendarHarnessFilters} from './datepicker-harness-filters';
 import {MatCalendarHarness} from './calendar-harness';
 
@@ -33,7 +33,7 @@ export abstract class DatepickerTriggerHarnessBase extends ComponentHarness impl
 
   /** Opens the calendar if the trigger is enabled and it has a calendar. */
   async openCalendar(): Promise<void> {
-    const [isDisabled, hasCalendar] = await Promise.all([this.isDisabled(), this.hasCalendar()]);
+    const [isDisabled, hasCalendar] = await parallel(() => [this.isDisabled(), this.hasCalendar()]);
 
     if (!isDisabled && hasCalendar) {
       return this._openCalendar();

--- a/src/material/expansion/testing/shared.spec.ts
+++ b/src/material/expansion/testing/shared.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentHarness, HarnessLoader} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -212,10 +212,12 @@ export function runHarnessTests(
     const standalonePanel =
         await loader.getHarness(expansionPanelHarness.with({selector: '#standalonePanel'}));
     const expansionPanels = [standalonePanel, ...await accordion.getExpansionPanels()];
-    let toggleIndicatorChecks = await Promise.all(expansionPanels.map(p => p.hasToggleIndicator()));
+    let toggleIndicatorChecks = await parallel(() => {
+      return expansionPanels.map(p => p.hasToggleIndicator());
+    });
     expect(toggleIndicatorChecks.every(s => s)).toBe(true);
     fixture.componentInstance.hideToggleIndicators = true;
-    toggleIndicatorChecks = await Promise.all(expansionPanels.map(p => p.hasToggleIndicator()));
+    toggleIndicatorChecks = await parallel(() => expansionPanels.map(p => p.hasToggleIndicator()));
     expect(toggleIndicatorChecks.every(s => !s)).toBe(true);
   });
 
@@ -225,10 +227,12 @@ export function runHarnessTests(
         await loader.getHarness(expansionPanelHarness.with({selector: '#standalonePanel'}));
     const expansionPanels = [standalonePanel, ...await accordion.getExpansionPanels()];
     let togglePositions =
-        await Promise.all(expansionPanels.map(p => p.getToggleIndicatorPosition()));
+        await parallel(() => expansionPanels.map(p => p.getToggleIndicatorPosition()));
     expect(togglePositions.every(p => p === 'after')).toBe(true);
     fixture.componentInstance.toggleIndicatorsPosition = 'before';
-    togglePositions = await Promise.all(expansionPanels.map(p => p.getToggleIndicatorPosition()));
+    togglePositions = await parallel(() => {
+      return expansionPanels.map(p => p.getToggleIndicatorPosition());
+    });
     expect(togglePositions.every(p => p === 'before')).toBe(true);
   });
 

--- a/src/material/form-field/testing/shared.spec.ts
+++ b/src/material/form-field/testing/shared.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentHarness, HarnessLoader, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessLoader, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {
   createFakeEvent,
   dispatchFakeEvent,
@@ -190,13 +190,13 @@ export function runHarnessTests(
 
   it('should be able to get the prefix text of a form-field', async () => {
     const formFields = await loader.getAllHarnesses(formFieldHarness);
-    const prefixTexts = await Promise.all(formFields.map(f => f.getPrefixText()));
+    const prefixTexts = await parallel(() => formFields.map(f => f.getPrefixText()));
     expect(prefixTexts).toEqual(['prefix_textprefix_text_2', '', '', '', '']);
   });
 
   it('should be able to get the suffix text of a form-field', async () => {
     const formFields = await loader.getAllHarnesses(formFieldHarness);
-    const suffixTexts = await Promise.all(formFields.map(f => f.getSuffixText()));
+    const suffixTexts = await parallel(() => formFields.map(f => f.getSuffixText()));
     expect(suffixTexts).toEqual(['suffix_text', '', '', '', '']);
   });
 

--- a/src/material/grid-list/testing/grid-list-harness.ts
+++ b/src/material/grid-list/testing/grid-list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {ɵTileCoordinator as TileCoordinator} from '@angular/material/grid-list';
 import {GridListHarnessFilters, GridTileHarnessFilters} from './grid-list-harness-filters';
 import {MatGridTileHarness} from './grid-tile-harness';
@@ -50,9 +50,10 @@ export class MatGridListHarness extends ComponentHarness {
    */
   async getTileAtPosition({row, column}: {row: number, column: number}):
       Promise<MatGridTileHarness> {
-    const [tileHarnesses, columns] = await Promise.all([this.getTiles(), this.getColumns()]);
-    const tileSpans = tileHarnesses.map(t => Promise.all([t.getColspan(), t.getRowspan()]));
-    const tiles = (await Promise.all(tileSpans)).map(([colspan, rowspan]) => ({colspan, rowspan}));
+    const [tileHarnesses, columns] = await parallel(() => [this.getTiles(), this.getColumns()]);
+    const tileSpans = tileHarnesses.map(t => parallel(() => [t.getColspan(), t.getRowspan()]));
+    const tiles = (await parallel(() => tileSpans))
+        .map(([colspan, rowspan]) => ({colspan, rowspan}));
     // Update the tile coordinator to reflect the current column amount and
     // rendered tiles. We update upon every call of this method since we do not
     // know if tiles have been added, removed or updated (in terms of rowspan/colspan).

--- a/src/material/grid-list/testing/shared.spec.ts
+++ b/src/material/grid-list/testing/shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -72,7 +72,7 @@ export function runHarnessTests(
 
   it('should be able to get tile by position', async () => {
     const gridList = await loader.getHarness(gridListHarness);
-    const tiles = await Promise.all([
+    const tiles = await parallel(() => [
       gridList.getTileAtPosition({row: 0, column: 0}),
       gridList.getTileAtPosition({row: 0, column: 1}),
       gridList.getTileAtPosition({row: 1, column: 0}),
@@ -84,7 +84,7 @@ export function runHarnessTests(
 
   it('should be able to get tile by position with respect to tile span', async () => {
     const gridList = await loader.getHarness(gridListHarness);
-    const tiles = await Promise.all([
+    const tiles = await parallel(() => [
       gridList.getTileAtPosition({row: 0, column: 2}),
       gridList.getTileAtPosition({row: 0, column: 3}),
     ]);

--- a/src/material/icon/testing/shared.spec.ts
+++ b/src/material/icon/testing/shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -37,7 +37,7 @@ export function runHarnessTests(
   });
 
   it('should filter icon harnesses based on their type', async () => {
-    const [svgIcons, fontIcons] = await Promise.all([
+    const [svgIcons, fontIcons] = await parallel(() => [
       loader.getAllHarnesses(iconHarness.with({type: IconType.SVG})),
       loader.getAllHarnesses(iconHarness.with({type: IconType.FONT}))
     ]);
@@ -47,7 +47,7 @@ export function runHarnessTests(
   });
 
   it('should filter icon harnesses based on their name', async () => {
-    const [regexFilterResults, stringFilterResults] = await Promise.all([
+    const [regexFilterResults, stringFilterResults] = await parallel(() => [
       loader.getAllHarnesses(iconHarness.with({name: /^font/})),
       loader.getAllHarnesses(iconHarness.with({name: 'fontIcon'}))
     ]);
@@ -57,7 +57,7 @@ export function runHarnessTests(
   });
 
   it('should filter icon harnesses based on their namespace', async () => {
-    const [regexFilterResults, stringFilterResults, nullFilterResults] = await Promise.all([
+    const [regexFilterResults, stringFilterResults, nullFilterResults] = await parallel(() => [
       loader.getAllHarnesses(iconHarness.with({namespace: /^font/})),
       loader.getAllHarnesses(iconHarness.with({namespace: 'svgIcons'})),
       loader.getAllHarnesses(iconHarness.with({namespace: null}))
@@ -70,25 +70,25 @@ export function runHarnessTests(
 
   it('should get the type of each icon', async () => {
     const icons = await loader.getAllHarnesses(iconHarness);
-    const types = await Promise.all(icons.map(icon => icon.getType()));
+    const types = await parallel(() => icons.map(icon => icon.getType()));
     expect(types).toEqual([IconType.FONT, IconType.SVG, IconType.FONT]);
   });
 
   it('should get the name of an icon', async () => {
     const icons = await loader.getAllHarnesses(iconHarness);
-    const names = await Promise.all(icons.map(icon => icon.getName()));
+    const names = await parallel(() => icons.map(icon => icon.getName()));
     expect(names).toEqual(['fontIcon', 'svgIcon', 'ligature_icon']);
   });
 
   it('should get the namespace of an icon', async () => {
     const icons = await loader.getAllHarnesses(iconHarness);
-    const namespaces = await Promise.all(icons.map(icon => icon.getNamespace()));
+    const namespaces = await parallel(() => icons.map(icon => icon.getNamespace()));
     expect(namespaces).toEqual(['fontIcons', 'svgIcons', null]);
   });
 
   it('should get whether an icon is inline', async () => {
     const icons = await loader.getAllHarnesses(iconHarness);
-    const inlineStates = await Promise.all(icons.map(icon => icon.isInline()));
+    const inlineStates = await parallel(() => icons.map(icon => icon.isInline()));
     expect(inlineStates).toEqual([false, false, true]);
   });
 

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
 import {InputHarnessFilters} from './input-harness-filters';
 
@@ -72,7 +72,7 @@ export class MatInputHarness extends MatFormFieldControlHarness {
   /** Gets the placeholder of the input. */
   async getPlaceholder(): Promise<string> {
     const host = await this.host();
-    const [nativePlaceholder, fallback] = await Promise.all([
+    const [nativePlaceholder, fallback] = await parallel(() => [
       host.getProperty('placeholder'),
       host.getAttribute('data-placeholder')
     ]);

--- a/src/material/input/testing/native-select-harness.ts
+++ b/src/material/input/testing/native-select-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
 import {MatNativeOptionHarness} from './native-option-harness';
 import {
@@ -82,15 +82,17 @@ export class MatNativeSelectHarness extends MatFormFieldControlHarness {
    * mode all options will be clicked, otherwise the harness will pick the first matching option.
    */
   async selectOptions(filter: NativeOptionHarnessFilters = {}): Promise<void> {
-    const [isMultiple, options] = await Promise.all([this.isMultiple(), this.getOptions(filter)]);
+    const [isMultiple, options] = await parallel(() => {
+      return [this.isMultiple(), this.getOptions(filter)];
+    });
 
     if (options.length === 0) {
       throw Error('Select does not have options matching the specified filter');
     }
 
-    const [host, optionIndexes] = await Promise.all([
+    const [host, optionIndexes] = await parallel(() => [
       this.host(),
-      Promise.all(options.slice(0, isMultiple ? undefined : 1).map(option => option.getIndex()))
+      parallel(() => options.slice(0, isMultiple ? undefined : 1).map(option => option.getIndex()))
     ]);
 
     // @breaking-change 12.0.0 Error can be removed once `selectOptions` is a required method.

--- a/src/material/input/testing/shared-native-select.spec.ts
+++ b/src/material/input/testing/shared-native-select.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -32,13 +32,13 @@ export function runNativeSelectHarnessTests(
 
   it('should get the id of a select', async () => {
     const selects = await loader.getAllHarnesses(selectHarness);
-    expect(await Promise.all(selects.map(select => select.getId()))).toEqual(['food', 'drink']);
+    expect(await parallel(() => selects.map(select => select.getId()))).toEqual(['food', 'drink']);
   });
 
   it('should get the name of a select', async () => {
     const selects = await loader.getAllHarnesses(selectHarness);
 
-    expect(await Promise.all(selects.map(select => select.getName()))).toEqual([
+    expect(await parallel(() => selects.map(select => select.getName()))).toEqual([
       'favorite-food',
       'favorite-drink'
     ]);
@@ -46,23 +46,27 @@ export function runNativeSelectHarnessTests(
 
   it('should get whether a select is disabled', async () => {
     const selects = await loader.getAllHarnesses(selectHarness);
-    expect(await Promise.all(selects.map(select => select.isDisabled()))).toEqual([false, false]);
+    expect(await parallel(() => {
+      return selects.map(select => select.isDisabled());
+    })).toEqual([false, false]);
 
     fixture.componentInstance.favoriteDrinkDisabled = true;
-    expect(await Promise.all(selects.map(select => select.isDisabled()))).toEqual([false, true]);
+    expect(await parallel(() => selects.map(select => select.isDisabled()))).toEqual([false, true]);
   });
 
   it('should get whether the select is in multi-selection mode', async () => {
     const selects = await loader.getAllHarnesses(selectHarness);
-    expect(await Promise.all(selects.map(select => select.isMultiple()))).toEqual([false, true]);
+    expect(await parallel(() => selects.map(select => select.isMultiple()))).toEqual([false, true]);
   });
 
   it('should get whether a select is required', async () => {
     const selects = await loader.getAllHarnesses(selectHarness);
-    expect(await Promise.all(selects.map(select => select.isRequired()))).toEqual([false, false]);
+    expect(await parallel(() => {
+      return selects.map(select => select.isRequired());
+    })).toEqual([false, false]);
 
     fixture.componentInstance.favoriteFoodRequired = true;
-    expect(await Promise.all(selects.map(select => select.isRequired()))).toEqual([true, false]);
+    expect(await parallel(() => selects.map(select => select.isRequired()))).toEqual([true, false]);
   });
 
   it('should be able to focus a select', async () => {
@@ -83,7 +87,7 @@ export function runNativeSelectHarnessTests(
 
   it('should get the options of a select', async () => {
     const selects = await loader.getAllHarnesses(selectHarness);
-    const options = await Promise.all(selects.map(select => select.getOptions()));
+    const options = await parallel(() => selects.map(select => select.getOptions()));
 
     expect(options.length).toBe(2);
     expect(options[0].length).toBe(3);
@@ -110,7 +114,7 @@ export function runNativeSelectHarnessTests(
     const select = await loader.getHarness(selectHarness.with({selector: '#drink'}));
     const options = await select.getOptions();
 
-    expect(await Promise.all(options.map(option => option.getText()))).toEqual([
+    expect(await parallel(() => options.map(option => option.getText()))).toEqual([
       'Water',
       'Soda',
       'Coffee',
@@ -122,14 +126,14 @@ export function runNativeSelectHarnessTests(
     const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
     const options = await select.getOptions();
 
-    expect(await Promise.all(options.map(option => option.getIndex()))).toEqual([0, 1, 2]);
+    expect(await parallel(() => options.map(option => option.getIndex()))).toEqual([0, 1, 2]);
   });
 
   it('should get the disabled state of select options', async () => {
     const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
     const options = await select.getOptions();
 
-    expect(await Promise.all(options.map(option => option.isDisabled()))).toEqual([
+    expect(await parallel(() => options.map(option => option.isDisabled()))).toEqual([
       false,
       false,
       false
@@ -137,7 +141,7 @@ export function runNativeSelectHarnessTests(
 
     fixture.componentInstance.pastaDisabled = true;
 
-    expect(await Promise.all(options.map(option => option.isDisabled()))).toEqual([
+    expect(await parallel(() => options.map(option => option.isDisabled()))).toEqual([
       false,
       true,
       false
@@ -148,7 +152,7 @@ export function runNativeSelectHarnessTests(
     const select = await loader.getHarness(selectHarness.with({selector: '#food'}));
     const options = await select.getOptions();
 
-    expect(await Promise.all(options.map(option => option.isSelected()))).toEqual([
+    expect(await parallel(() => options.map(option => option.isSelected()))).toEqual([
       false,
       false,
       false
@@ -156,7 +160,7 @@ export function runNativeSelectHarnessTests(
 
     await select.selectOptions({index: 2});
 
-    expect(await Promise.all(options.map(option => option.isSelected()))).toEqual([
+    expect(await parallel(() => options.map(option => option.isSelected()))).toEqual([
       false,
       false,
       true
@@ -167,7 +171,7 @@ export function runNativeSelectHarnessTests(
     const select = await loader.getHarness(selectHarness.with({selector: '#drink'}));
     const options = await select.getOptions();
 
-    expect(await Promise.all(options.map(option => option.isSelected()))).toEqual([
+    expect(await parallel(() => options.map(option => option.isSelected()))).toEqual([
       false,
       false,
       false,
@@ -176,7 +180,7 @@ export function runNativeSelectHarnessTests(
 
     await select.selectOptions({text: /Water|Coffee/});
 
-    expect(await Promise.all(options.map(option => option.isSelected()))).toEqual([
+    expect(await parallel(() => options.map(option => option.isSelected()))).toEqual([
       true,
       false,
       true,

--- a/src/material/list/testing/list-harness-base.ts
+++ b/src/material/list/testing/list-harness-base.ts
@@ -9,7 +9,8 @@
 import {
   ComponentHarness,
   ComponentHarnessConstructor,
-  HarnessPredicate
+  HarnessPredicate,
+  parallel
 } from '@angular/cdk/testing';
 import {DividerHarnessFilters, MatDividerHarness} from '@angular/material/divider/testing';
 import {BaseListItemHarnessFilters, SubheaderHarnessFilters} from './list-harness-filters';
@@ -55,8 +56,9 @@ export abstract class MatListHarnessBase
    * @return The list of items matching the given filters, grouped into sections by subheader.
    */
   async getItemsGroupedBySubheader(filters?: F): Promise<ListSection<C>[]> {
-    const listSections = [];
-    let currentSection: {items: C[], heading?: Promise<string>} = {items: []};
+    type Section = {items: C[], heading?: Promise<string>};
+    const listSections: Section[] = [];
+    let currentSection: Section = {items: []};
     const itemsAndSubheaders =
         await this.getItemsWithSubheadersAndDividers({item: filters, divider: false});
     for (const itemOrSubheader of itemsAndSubheaders) {
@@ -75,7 +77,7 @@ export abstract class MatListHarnessBase
     }
 
     // Concurrently wait for all sections to resolve their heading if present.
-    return Promise.all(listSections.map(async (s) =>
+    return parallel(() => listSections.map(async (s) =>
       ({items: s.items, heading: await s.heading})));
   }
 

--- a/src/material/list/testing/list-item-harness-base.ts
+++ b/src/material/list/testing/list-item-harness-base.ts
@@ -12,6 +12,7 @@ import {
   HarnessLoader,
   HarnessPredicate,
   ContentContainerComponentHarness,
+  parallel,
 } from '@angular/cdk/testing';
 import {BaseListItemHarnessFilters, SubheaderHarnessFilters} from './list-harness-filters';
 
@@ -74,7 +75,8 @@ export abstract class MatListItemHarnessBase
 
   /** Gets the lines of text (`mat-line` elements) in this nav list item. */
   async getLinesText(): Promise<string[]> {
-    return Promise.all((await this._lines()).map(l => l.text()));
+    const lines = await this._lines();
+    return parallel(() => lines.map(l => l.text()));
   }
 
   /** Whether this list item has an avatar. */

--- a/src/material/list/testing/selection-list-harness.ts
+++ b/src/material/list/testing/selection-list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatListOptionCheckboxPosition} from '@angular/material/list';
 import {MatListHarnessBase} from './list-harness-base';
 import {
@@ -46,7 +46,7 @@ export class MatSelectionListHarness extends MatListHarnessBase<
    */
   async selectItems(...filters: ListOptionHarnessFilters[]): Promise<void> {
     const items = await this._getItems(filters);
-    await Promise.all(items.map(item => item.select()));
+    await parallel(() => items.map(item => item.select()));
   }
 
   /**
@@ -55,7 +55,7 @@ export class MatSelectionListHarness extends MatListHarnessBase<
    */
   async deselectItems(...filters: ListItemHarnessFilters[]): Promise<void> {
     const items = await this._getItems(filters);
-    await Promise.all(items.map(item => item.deselect()));
+    await parallel(() => items.map(item => item.deselect()));
   }
 
   /** Gets all items matching the given list of filters. */
@@ -63,8 +63,9 @@ export class MatSelectionListHarness extends MatListHarnessBase<
     if (!filters.length) {
       return this.getItems();
     }
-    const matches = await Promise.all(
-      filters.map(filter => this.locatorForAll(MatListOptionHarness.with(filter))()));
+    const matches = await parallel(() => {
+      return filters.map(filter => this.locatorForAll(MatListOptionHarness.with(filter))());
+    });
     return matches.reduce((result, current) => [...result, ...current], []);
   }
 }

--- a/src/material/list/testing/shared.spec.ts
+++ b/src/material/list/testing/shared.spec.ts
@@ -2,7 +2,8 @@ import {
   BaseHarnessFilters,
   ComponentHarness,
   ComponentHarnessConstructor,
-  HarnessPredicate
+  HarnessPredicate,
+  parallel
 } from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component, Type} from '@angular/core';
@@ -60,13 +61,13 @@ function runBaseListFunctionalityTests<
 
     it('should get all items', async () => {
       const items = await simpleListHarness.getItems();
-      expect(await Promise.all(items.map(i => i.getText())))
+      expect(await parallel(() => items.map(i => i.getText())))
           .toEqual(['Item 1', 'Item 2', 'Item 3']);
     });
 
     it('should get all items matching text', async () => {
       const items = await simpleListHarness.getItems({text: /[13]/});
-      expect(await Promise.all(items.map(i => i.getText()))).toEqual(['Item 1', 'Item 3']);
+      expect(await parallel(() => items.map(i => i.getText()))).toEqual(['Item 1', 'Item 3']);
     });
 
     it('should get all items of empty list', async () => {
@@ -77,9 +78,9 @@ function runBaseListFunctionalityTests<
       const sections = await simpleListHarness.getItemsGroupedBySubheader();
       expect(sections.length).toBe(3);
       expect(sections[0].heading).toBeUndefined();
-      expect(await Promise.all(sections[0].items.map(i => i.getText()))).toEqual(['Item 1']);
+      expect(await parallel(() => sections[0].items.map(i => i.getText()))).toEqual(['Item 1']);
       expect(sections[1].heading).toBe('Section 1');
-      expect(await Promise.all(sections[1].items.map(i => i.getText())))
+      expect(await parallel(() => sections[1].items.map(i => i.getText())))
           .toEqual(['Item 2', 'Item 3']);
       expect(sections[2].heading).toBe('Section 2');
       expect(sections[2].items.length).toEqual(0);
@@ -95,8 +96,8 @@ function runBaseListFunctionalityTests<
     it('should get items grouped by divider', async () => {
       const sections = await simpleListHarness.getItemsGroupedByDividers();
       expect(sections.length).toBe(3);
-      expect(await Promise.all(sections[0].map(i => i.getText()))).toEqual(['Item 1']);
-      expect(await Promise.all(sections[1].map(i => i.getText()))).toEqual(['Item 2', 'Item 3']);
+      expect(await parallel(() => sections[0].map(i => i.getText()))).toEqual(['Item 1']);
+      expect(await parallel(() => sections[1].map(i => i.getText()))).toEqual(['Item 2', 'Item 3']);
       expect(sections[2].length).toBe(0);
     });
 
@@ -136,11 +137,11 @@ function runBaseListFunctionalityTests<
           {item: false, divider: false});
       const dividers = await simpleListHarness.getItemsWithSubheadersAndDividers(
           {item: false, subheader: false});
-      expect(await Promise.all(items.map(i => i.getText())))
+      expect(await parallel(() => items.map(i => i.getText())))
           .toEqual(['Item 1', 'Item 2', 'Item 3']);
-      expect(await Promise.all(subheaders.map(s => s.getText())))
+      expect(await parallel(() => subheaders.map(s => s.getText())))
           .toEqual(['Section 1', 'Section 2']);
-      expect(await Promise.all(dividers.map(d => d.getOrientation())))
+      expect(await parallel(() => dividers.map(d => d.getOrientation())))
           .toEqual(['horizontal', 'horizontal']);
     });
 
@@ -289,7 +290,7 @@ export function runHarnessTests(
 
       it('should get href', async () => {
         const items = await harness.getItems();
-        expect(await Promise.all(items.map(i => i.getHref()))).toEqual([null, '', '/somestuff']);
+        expect(await parallel(() => items.map(i => i.getHref()))).toEqual([null, '', '/somestuff']);
       });
 
       it('should get item harness by href', async () => {
@@ -333,7 +334,7 @@ export function runHarnessTests(
       it('should get all selected options', async () => {
         expect((await harness.getItems({selected: true})).length).toBe(0);
         const items = await harness.getItems();
-        await Promise.all(items.map(item => item.select()));
+        await parallel(() => items.map(item => item.select()));
         expect((await harness.getItems({selected: true})).length).toBe(3);
       });
 
@@ -341,7 +342,7 @@ export function runHarnessTests(
         expect((await harness.getItems({selected: true})).length).toBe(0);
         await harness.selectItems({text: /1/}, {text: /3/});
         const selected = await harness.getItems({selected: true});
-        expect(await Promise.all(selected.map(item => item.getText())))
+        expect(await parallel(() => selected.map(item => item.getText())))
             .toEqual(['Item 1', 'Item 3']);
       });
 
@@ -350,7 +351,7 @@ export function runHarnessTests(
         expect((await harness.getItems({selected: true})).length).toBe(3);
         await harness.deselectItems({text: /1/}, {text: /3/});
         const selected = await harness.getItems({selected: true});
-        expect(await Promise.all(selected.map(item => item.getText()))).toEqual(['Item 2']);
+        expect(await parallel(() => selected.map(item => item.getText()))).toEqual(['Item 2']);
       });
 
       it('should get option checkbox position', async () => {

--- a/src/material/select/testing/select-harness.ts
+++ b/src/material/select/testing/select-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatFormFieldControlHarness} from '@angular/material/form-field/testing/control';
 import {
   MatOptionHarness,
@@ -118,14 +118,16 @@ export class MatSelectHarness extends MatFormFieldControlHarness {
   async clickOptions(filter: OptionHarnessFilters = {}): Promise<void> {
     await this.open();
 
-    const [isMultiple, options] = await Promise.all([this.isMultiple(), this.getOptions(filter)]);
+    const [isMultiple, options] = await parallel(() => {
+      return [this.isMultiple(), this.getOptions(filter)];
+    });
 
     if (options.length === 0) {
       throw Error('Select does not have options matching the specified filter');
     }
 
     if (isMultiple) {
-      await Promise.all(options.map(option => option.click()));
+      await parallel(() => options.map(option => option.click()));
     } else {
       await options[0].click();
     }

--- a/src/material/select/testing/shared.spec.ts
+++ b/src/material/select/testing/shared.spec.ts
@@ -1,5 +1,5 @@
 import {OverlayContainer} from '@angular/cdk/overlay';
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
@@ -166,7 +166,7 @@ export function runHarnessTests(
     const groupedSelect = await loader.getHarness(selectHarness.with({selector: '#grouped'}));
     await groupedSelect.open();
 
-    const [singleOptions, groupedOptions] = await Promise.all([
+    const [singleOptions, groupedOptions] = await parallel(() => [
       singleSelect.getOptions(),
       groupedSelect.getOptions()
     ]);

--- a/src/material/slider/testing/slider-harness.ts
+++ b/src/material/slider/testing/slider-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {coerceBooleanProperty, coerceNumberProperty} from '@angular/cdk/coercion';
 import {SliderHarnessFilters} from './slider-harness-filters';
 
@@ -41,7 +41,7 @@ export class MatSliderHarness extends ComponentHarness {
    * disabled.
    */
   async getDisplayValue(): Promise<string|null> {
-    const [host, textLabel] = await Promise.all([this.host(), this._textLabel()]);
+    const [host, textLabel] = await parallel(() => [this.host(), this._textLabel()]);
     if (await host.hasClass('mat-slider-thumb-label-showing')) {
       return textLabel.text();
     }
@@ -90,7 +90,7 @@ export class MatSliderHarness extends ComponentHarness {
    */
   async setValue(value: number): Promise<void> {
     const [sliderEl, wrapperEl, orientation] =
-        await Promise.all([this.host(), this._wrapper(), this.getOrientation()]);
+        await parallel(() => [this.host(), this._wrapper(), this.getOrientation()]);
     let percentage = await this._calculatePercentage(value);
     const {height, width} = await wrapperEl.getDimensions();
     const isVertical = orientation === 'vertical';
@@ -126,7 +126,7 @@ export class MatSliderHarness extends ComponentHarness {
 
   /** Calculates the percentage of the given value. */
   private async _calculatePercentage(value: number) {
-    const [min, max] = await Promise.all([this.getMinValue(), this.getMaxValue()]);
+    const [min, max] = await parallel(() => [this.getMinValue(), this.getMaxValue()]);
     return (value - min) / (max - min);
   }
 }

--- a/src/material/snack-bar/testing/snack-bar-harness.ts
+++ b/src/material/snack-bar/testing/snack-bar-harness.ts
@@ -7,7 +7,7 @@
  */
 
 import {AriaLivePoliteness} from '@angular/cdk/a11y';
-import {ContentContainerComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ContentContainerComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {SnackBarHarnessFilters} from './snack-bar-harness-filters';
 
 /** Harness for interacting with a standard mat-snack-bar in tests. */
@@ -93,7 +93,7 @@ export class MatSnackBarHarness extends ContentContainerComponentHarness<string>
     // element isn't in the DOM by seeing that its width and height are zero.
 
     const host = await this.host();
-    const [exit, dimensions] = await Promise.all([
+    const [exit, dimensions] = await parallel(() => [
       // The snackbar container is marked with the "exit" attribute after it has been dismissed
       // but before the animation has finished (after which it's removed from the DOM).
       host.getAttribute('mat-exit'),

--- a/src/material/sort/testing/shared.spec.ts
+++ b/src/material/sort/testing/shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -45,7 +45,7 @@ export function runHarnessTests(
   it('should be able to filter headers by their labels via a regex', async () => {
     const sort = await loader.getHarness(sortHarness);
     const headers = await sort.getSortHeaders({label: /^C/});
-    const labels = await Promise.all(headers.map(header => header.getLabel()));
+    const labels = await parallel(() => headers.map(header => header.getLabel()));
     expect(headers.length).toBe(2);
     expect(labels).toEqual(['Calories', 'Carbs']);
   });
@@ -65,7 +65,7 @@ export function runHarnessTests(
   it('should be able to get the label of a header', async () => {
     const sort = await loader.getHarness(sortHarness);
     const headers = await sort.getSortHeaders();
-    const labels = await Promise.all(headers.map(header => header.getLabel()));
+    const labels = await parallel(() => headers.map(header => header.getLabel()));
     expect(labels).toEqual(['Dessert', 'Calories', 'Fat', 'Carbs', 'Protein']);
   });
 

--- a/src/material/stepper/testing/shared.spec.ts
+++ b/src/material/stepper/testing/shared.spec.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {ReactiveFormsModule, FormGroup, FormControl, Validators} from '@angular/forms';
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatStepperModule} from '@angular/material/stepper';
@@ -40,7 +40,7 @@ export function runHarnessTests(
   });
 
   it('should filter steppers by their orientation', async () => {
-    const [verticalSteppers, horizontalSteppers] = await Promise.all([
+    const [verticalSteppers, horizontalSteppers] = await parallel(() => [
       loader.getAllHarnesses(stepperHarness.with({orientation: StepperOrientation.VERTICAL})),
       loader.getAllHarnesses(stepperHarness.with({orientation: StepperOrientation.HORIZONTAL}))
     ]);
@@ -52,7 +52,7 @@ export function runHarnessTests(
   it('should get the orientation of a stepper', async () => {
     const steppers = await loader.getAllHarnesses(stepperHarness);
 
-    expect(await Promise.all(steppers.map(stepper => stepper.getOrientation()))).toEqual([
+    expect(await parallel(() => steppers.map(stepper => stepper.getOrientation()))).toEqual([
       StepperOrientation.VERTICAL,
       StepperOrientation.HORIZONTAL,
       StepperOrientation.VERTICAL
@@ -61,21 +61,21 @@ export function runHarnessTests(
 
   it('should get the steps of a stepper', async () => {
     const steppers = await loader.getAllHarnesses(stepperHarness);
-    const steps = await Promise.all(steppers.map(stepper => stepper.getSteps()));
+    const steps = await parallel(() => steppers.map(stepper => stepper.getSteps()));
     expect(steps.map(current => current.length)).toEqual([4, 3, 2]);
   });
 
   it('should filter the steps of a stepper', async () => {
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#one-stepper'}));
     const steps = await stepper.getSteps({label: /Two|Four/});
-    expect(await Promise.all(steps.map(step => step.getLabel()))).toEqual(['Two', 'Four']);
+    expect(await parallel(() => steps.map(step => step.getLabel()))).toEqual(['Two', 'Four']);
   });
 
   it('should be able to select a particular step that matches a filter', async () => {
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#one-stepper'}));
     const steps = await stepper.getSteps();
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       true,
       false,
       false,
@@ -84,7 +84,7 @@ export function runHarnessTests(
 
     await stepper.selectStep({label: 'Three'});
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       false,
       false,
       true,
@@ -96,7 +96,7 @@ export function runHarnessTests(
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#one-stepper'}));
     const steps = await stepper.getSteps();
 
-    expect(await Promise.all(steps.map(step => step.getLabel()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.getLabel()))).toEqual([
       'One',
       'Two',
       'Three',
@@ -107,13 +107,15 @@ export function runHarnessTests(
   it('should be able to get the template-based label of a step', async () => {
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#two-stepper'}));
     const steps = await stepper.getSteps();
-    expect(await Promise.all(steps.map(step => step.getLabel()))).toEqual(['One', 'Two', 'Three']);
+    expect(await parallel(() => {
+      return steps.map(step => step.getLabel());
+    })).toEqual(['One', 'Two', 'Three']);
   });
 
   it('should be able to get the aria-label of a step', async () => {
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#one-stepper'}));
     const steps = await stepper.getSteps();
-    expect(await Promise.all(steps.map(step => step.getAriaLabel()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.getAriaLabel()))).toEqual([
       null,
       null,
       null,
@@ -124,7 +126,7 @@ export function runHarnessTests(
   it('should be able to get the aria-labelledby of a step', async () => {
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#one-stepper'}));
     const steps = await stepper.getSteps();
-    expect(await Promise.all(steps.map(step => step.getAriaLabelledby()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.getAriaLabelledby()))).toEqual([
       null,
       null,
       'some-label',
@@ -136,7 +138,7 @@ export function runHarnessTests(
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#one-stepper'}));
     const steps = await stepper.getSteps();
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       true,
       false,
       false,
@@ -148,7 +150,7 @@ export function runHarnessTests(
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#one-stepper'}));
     const steps = await stepper.getSteps();
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       true,
       false,
       false,
@@ -157,7 +159,7 @@ export function runHarnessTests(
 
     await steps[2].select();
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       false,
       false,
       true,
@@ -168,13 +170,13 @@ export function runHarnessTests(
   it('should get whether a step is optional', async () => {
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#two-stepper'}));
     const steps = await stepper.getSteps();
-    expect(await Promise.all(steps.map(step => step.isOptional()))).toEqual([false, true, true]);
+    expect(await parallel(() => steps.map(step => step.isOptional()))).toEqual([false, true, true]);
   });
 
   it('should be able to get harness loader for an element inside a tab', async () => {
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#one-stepper'}));
     const [step] = await stepper.getSteps({label: 'Two'});
-    const [nextButton, previousButton] = await Promise.all([
+    const [nextButton, previousButton] = await parallel(() => [
       step.getHarness(stepperNextHarness),
       step.getHarness(stepperPreviousHarness)
     ]);
@@ -191,7 +193,7 @@ export function runHarnessTests(
 
     await secondStep.select();
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       false,
       true,
       false,
@@ -200,7 +202,7 @@ export function runHarnessTests(
 
     await nextButton.click();
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       false,
       false,
       true,
@@ -216,7 +218,7 @@ export function runHarnessTests(
 
     await secondStep.select();
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       false,
       true,
       false,
@@ -225,7 +227,7 @@ export function runHarnessTests(
 
     await previousButton.click();
 
-    expect(await Promise.all(steps.map(step => step.isSelected()))).toEqual([
+    expect(await parallel(() => steps.map(step => step.isSelected()))).toEqual([
       true,
       false,
       false,
@@ -237,23 +239,23 @@ export function runHarnessTests(
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#three-stepper'}));
     const steps = await stepper.getSteps();
 
-    expect(await Promise.all(steps.map(step => step.hasErrors()))).toEqual([false, false]);
+    expect(await parallel(() => steps.map(step => step.hasErrors()))).toEqual([false, false]);
 
     await steps[1].select();
 
-    expect(await Promise.all(steps.map(step => step.hasErrors()))).toEqual([true, false]);
+    expect(await parallel(() => steps.map(step => step.hasErrors()))).toEqual([true, false]);
   });
 
   it('should get whether a step has been completed', async () => {
     const stepper = await loader.getHarness(stepperHarness.with({selector: '#three-stepper'}));
     const steps = await stepper.getSteps();
 
-    expect(await Promise.all(steps.map(step => step.isCompleted()))).toEqual([false, false]);
+    expect(await parallel(() => steps.map(step => step.isCompleted()))).toEqual([false, false]);
 
     fixture.componentInstance.oneGroup.setValue({oneCtrl: 'done'});
     await steps[1].select();
 
-    expect(await Promise.all(steps.map(step => step.isCompleted()))).toEqual([true, false]);
+    expect(await parallel(() => steps.map(step => step.isCompleted()))).toEqual([true, false]);
   });
 
 }

--- a/src/material/table/testing/row-harness.ts
+++ b/src/material/table/testing/row-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {RowHarnessFilters, CellHarnessFilters} from './table-harness-filters';
 import {MatCellHarness, MatHeaderCellHarness, MatFooterCellHarness} from './cell-harness';
 
@@ -113,7 +113,7 @@ async function getCellTextByIndex(harness: {
   getCells: (filter?: CellHarnessFilters) => Promise<MatCellHarness[]>
 }, filter: CellHarnessFilters): Promise<string[]> {
   const cells = await harness.getCells(filter);
-  return Promise.all(cells.map(cell => cell.getText()));
+  return parallel(() => cells.map(cell => cell.getText()));
 }
 
 async function getCellTextByColumnName(harness: {
@@ -121,8 +121,8 @@ async function getCellTextByColumnName(harness: {
 }): Promise<MatRowHarnessColumnsText> {
   const output: MatRowHarnessColumnsText = {};
   const cells = await harness.getCells();
-  const cellsData = await Promise.all(cells.map(cell => {
-    return Promise.all([cell.getColumnName(), cell.getText()]);
+  const cellsData = await parallel(() => cells.map(cell => {
+    return parallel(() => [cell.getColumnName(), cell.getText()]);
   }));
   cellsData.forEach(([columnName, text]) => output[columnName] = text);
   return output;

--- a/src/material/table/testing/shared.spec.ts
+++ b/src/material/table/testing/shared.spec.ts
@@ -1,4 +1,4 @@
-import {HarnessLoader} from '@angular/cdk/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -43,11 +43,11 @@ export function runHarnessTests(
     const headerRows = await table.getHeaderRows();
     const footerRows = await table.getFooterRows();
     const rows = await table.getRows();
-    const headerCells = (await Promise.all(headerRows.map(row => row.getCells())))
+    const headerCells = (await parallel(() => headerRows.map(row => row.getCells())))
       .map(row => row.length);
-    const footerCells = (await Promise.all(footerRows.map(row => row.getCells())))
+    const footerCells = (await parallel(() => footerRows.map(row => row.getCells())))
       .map(row => row.length);
-    const cells = (await Promise.all(rows.map(row => row.getCells())))
+    const cells = (await parallel(() => rows.map(row => row.getCells())))
       .map(row => row.length);
 
     expect(headerCells).toEqual([4]);
@@ -59,7 +59,7 @@ export function runHarnessTests(
     const table = await loader.getHarness(tableHarness);
     const secondRow = (await table.getRows())[1];
     const cells = await secondRow.getCells();
-    const cellTexts = await Promise.all(cells.map(cell => cell.getText()));
+    const cellTexts = await parallel(() => cells.map(cell => cell.getText()));
     expect(cellTexts).toEqual(['2', 'Helium', '4.0026', 'He']);
   });
 
@@ -67,7 +67,7 @@ export function runHarnessTests(
     const table = await loader.getHarness(tableHarness);
     const fifthRow = (await table.getRows())[1];
     const cells = await fifthRow.getCells();
-    const cellColumnNames = await Promise.all(cells.map(cell => cell.getColumnName()));
+    const cellColumnNames = await parallel(() => cells.map(cell => cell.getColumnName()));
     expect(cellColumnNames).toEqual(['position', 'name', 'weight', 'symbol']);
   });
 
@@ -75,7 +75,7 @@ export function runHarnessTests(
     const table = await loader.getHarness(tableHarness);
     const firstRow = (await table.getRows())[0];
     const cells = await firstRow.getCells({text: '1.0079'});
-    const cellTexts = await Promise.all(cells.map(cell => cell.getText()));
+    const cellTexts = await parallel(() => cells.map(cell => cell.getText()));
     expect(cellTexts).toEqual(['1.0079']);
   });
 
@@ -83,7 +83,7 @@ export function runHarnessTests(
     const table = await loader.getHarness(tableHarness);
     const firstRow = (await table.getRows())[0];
     const cells = await firstRow.getCells({columnName: 'symbol'});
-    const cellTexts = await Promise.all(cells.map(cell => cell.getText()));
+    const cellTexts = await parallel(() => cells.map(cell => cell.getText()));
     expect(cellTexts).toEqual(['H']);
   });
 
@@ -91,7 +91,7 @@ export function runHarnessTests(
     const table = await loader.getHarness(tableHarness);
     const firstRow = (await table.getRows())[0];
     const cells = await firstRow.getCells({text: /^H/});
-    const cellTexts = await Promise.all(cells.map(cell => cell.getText()));
+    const cellTexts = await parallel(() => cells.map(cell => cell.getText()));
     expect(cellTexts).toEqual(['Hydrogen', 'H']);
   });
 

--- a/src/material/table/testing/table-harness.ts
+++ b/src/material/table/testing/table-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ContentContainerComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ContentContainerComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {TableHarnessFilters, RowHarnessFilters} from './table-harness-filters';
 import {
   MatRowHarness,
@@ -56,22 +56,22 @@ export class MatTableHarness extends ContentContainerComponentHarness<string> {
   /** Gets the text inside the entire table organized by rows. */
   async getCellTextByIndex(): Promise<string[][]> {
     const rows = await this.getRows();
-    return Promise.all(rows.map(row => row.getCellTextByIndex()));
+    return parallel(() => rows.map(row => row.getCellTextByIndex()));
   }
 
   /** Gets the text inside the entire table organized by columns. */
   async getCellTextByColumnName(): Promise<MatTableHarnessColumnsText> {
-    const [headerRows, footerRows, dataRows] = await Promise.all([
+    const [headerRows, footerRows, dataRows] = await parallel(() => [
       this.getHeaderRows(),
       this.getFooterRows(),
       this.getRows()
     ]);
 
     const text: MatTableHarnessColumnsText = {};
-    const [headerData, footerData, rowsData] = await Promise.all([
-      Promise.all(headerRows.map(row => row.getCellTextByColumnName())),
-      Promise.all(footerRows.map(row => row.getCellTextByColumnName())),
-      Promise.all(dataRows.map(row => row.getCellTextByColumnName())),
+    const [headerData, footerData, rowsData] = await parallel(() => [
+      parallel(() => headerRows.map(row => row.getCellTextByColumnName())),
+      parallel(() => footerRows.map(row => row.getCellTextByColumnName())),
+      parallel(() => dataRows.map(row => row.getCellTextByColumnName())),
     ]);
 
     rowsData.forEach(data => {

--- a/src/material/tabs/testing/tab-group-harness.ts
+++ b/src/material/tabs/testing/tab-group-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {TabGroupHarnessFilters, TabHarnessFilters} from './tab-harness-filters';
 import {MatTabHarness} from './tab-harness';
 
@@ -40,7 +40,7 @@ export class MatTabGroupHarness extends ComponentHarness {
   /** Gets the selected tab of the tab group. */
   async getSelectedTab(): Promise<MatTabHarness> {
     const tabs = await this.getTabs();
-    const isSelected = await Promise.all(tabs.map(t => t.isSelected()));
+    const isSelected = await parallel(() => tabs.map(t => t.isSelected()));
     for (let i = 0; i < tabs.length; i++) {
       if (isSelected[i]) {
         return tabs[i];

--- a/src/material/tabs/testing/tab-nav-bar-harness.ts
+++ b/src/material/tabs/testing/tab-nav-bar-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {TabNavBarHarnessFilters, TabLinkHarnessFilters} from './tab-harness-filters';
 import {MatTabLinkHarness} from './tab-link-harness';
 
@@ -36,7 +36,7 @@ export class MatTabNavBarHarness extends ComponentHarness {
   /** Gets the active link in the nav bar. */
   async getActiveLink(): Promise<MatTabLinkHarness> {
     const links = await this.getLinks();
-    const isActive = await Promise.all(links.map(t => t.isActive()));
+    const isActive = await parallel(() => links.map(t => t.isActive()));
     for (let i = 0; i < links.length; i++) {
       if (isActive[i]) {
         return links[i];

--- a/src/material/toolbar/testing/toolbar-harness.ts
+++ b/src/material/toolbar/testing/toolbar-harness.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {ContentContainerComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {ContentContainerComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {ToolbarHarnessFilters} from './toolbar-harness-filters';
 
 /** Selectors for different sections of the mat-toolbar that contain user content. */
@@ -46,6 +46,6 @@ export class MatToolbarHarness extends ContentContainerComponentHarness<MatToolb
   /** Gets the text of each row in the toolbar. */
   async getRowsAsText(): Promise<string[]> {
     const rows = await this._getRows();
-    return Promise.all(rows.length ? rows.map(r => r.text()) : [this._getText()]);
+    return parallel(() => rows.length ? rows.map(r => r.text()) : [this._getText()]);
   }
 }

--- a/src/material/tree/testing/tree-harness.ts
+++ b/src/material/tree/testing/tree-harness.ts
@@ -80,7 +80,7 @@ export class MatTreeHarness extends ComponentHarness {
   async getTreeStructure(): Promise<TextTree> {
     const nodes = await this.getNodes();
     const nodeInformation = await parallel(() => nodes.map(node => {
-      return Promise.all([node.getLevel(), node.getText(), node.isExpanded()]);
+      return parallel(() => [node.getLevel(), node.getText(), node.isExpanded()]);
     }));
     return this._getTreeStructure(nodeInformation, 1, true);
   }

--- a/tools/public_api_guard/cdk/testing.d.ts
+++ b/tools/public_api_guard/cdk/testing.d.ts
@@ -129,7 +129,22 @@ export interface ModifierKeys {
     shift?: boolean;
 }
 
-export declare function parallel<T>(values: () => Iterable<T | PromiseLike<T>>): Promise<T[]>;
+export declare function parallel<T1, T2, T3, T4, T5>(values: () => [
+    T1 | PromiseLike<T1>,
+    T2 | PromiseLike<T2>,
+    T3 | PromiseLike<T3>,
+    T4 | PromiseLike<T4>,
+    T5 | PromiseLike<T5>
+]): Promise<[T1, T2, T3, T4, T5]>;
+export declare function parallel<T1, T2, T3, T4>(values: () => [
+    T1 | PromiseLike<T1>,
+    T2 | PromiseLike<T2>,
+    T3 | PromiseLike<T3>,
+    T4 | PromiseLike<T4>
+]): Promise<[T1, T2, T3, T4]>;
+export declare function parallel<T1, T2, T3>(values: () => [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<[T1, T2, T3]>;
+export declare function parallel<T1, T2>(values: () => [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<[T1, T2]>;
+export declare function parallel<T>(values: () => (T | PromiseLike<T>)[]): Promise<T[]>;
 
 export declare function stopHandlingAutoChangeDetectionStatus(): void;
 


### PR DESCRIPTION
Switches all of our `testing` code to use `parallel` instead of `Promise.all` which reduces the number of change detections that we'll trigger during tests.

Also adds more type overloads to `parallel`, because the previous types didn't allow the `values` function to return mixed value arrays which we had in ~15 instances. I've tried to reduce the amount of code by only implementing up to 5 overloads, but we may want to expand it to 9 like `Promise.all`.