### PR TITLE
fix(google-maps): avoid using dotted property access

### DIFF
--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -279,23 +279,23 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
     const {marker, _title, _position, _label, _clickable} = this;
 
     if (marker) {
-      if (changes.options) {
+      if (changes['options']) {
         marker.setOptions(this._combineOptions());
       }
 
-      if (changes.title && _title !== undefined) {
+      if (changes['title'] && _title !== undefined) {
         marker.setTitle(_title);
       }
 
-      if (changes.position && _position) {
+      if (changes['position'] && _position) {
         marker.setPosition(_position);
       }
 
-      if (changes.label && _label !== undefined) {
+      if (changes['label'] && _label !== undefined) {
         marker.setLabel(_label);
       }
 
-      if (changes.clickable && _clickable !== undefined) {
+      if (changes['clickable'] && _clickable !== undefined) {
         marker.setClickable(_clickable);
       }
     }


### PR DESCRIPTION
* This was causing internal errors because these properties
  are not declared on SimpleChanges. According to the error:
  'The type has a string index signature, but it is being
  accessed using a dotted property access'.