### PR TITLE
docs: use valid SCSS variables for example

### DIFF
--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -22,8 +22,8 @@ For example, if building a custom carousel component:
   // Define any styles affected by the theme.
   .candy-carousel {
     // Use mat-color to extract individual colors from a palette.
-    background-color: mat-color($config);
-    border-color: mat-color($config, A400);
+    background-color: mat-color($primary);
+    border-color: mat-color($accent, A400);
   }
 }
 ```


### PR DESCRIPTION
The current example on "How to theme your own components" includes an invalid SCSS example. This PR fixed that.