### PR TITLE
refactor(google-maps): clean up internal setup

### DIFF
--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -40,7 +40,7 @@ export declare class GoogleMap implements OnChanges, OnInit, OnDestroy {
     getStreetView(): google.maps.StreetViewPanorama;
     getTilt(): number;
     getZoom(): number;
-    ngOnChanges(): void;
+    ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
     panBy(x: number, y: number): void;


### PR DESCRIPTION
Reworks the internal setup of the `google-map` component so that we don't have to declare observables for each input.