### PR TITLE
fix(material-experimental/mdc-input): add autosize directive

### DIFF
--- a/scripts/check-mdc-exports-config.ts
+++ b/scripts/check-mdc-exports-config.ts
@@ -24,10 +24,6 @@ export const config = {
       '_MatDialogContainerBase',
       '_closeDialogVia',
     ],
-    'mdc-input': [
-      // TODO: an MDC version of this directive has to be implemented.
-      'MatTextareaAutosize'
-    ],
     'mdc-menu': [
       // Private base class that is only exported for MDC.
       '_MatMenuBase'

--- a/src/material-experimental/mdc-input/autosize.ts
+++ b/src/material-experimental/mdc-input/autosize.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MatTextareaAutosize as BaseTextareaAutosize} from '@angular/material/input';
+import {Directive} from '@angular/core';
+
+/**
+ * Directive to automatically resize a textarea to fit its content.
+ * @deprecated Use `cdkTextareaAutosize` from `@angular/cdk/text-field` instead.
+ * @breaking-change 8.0.0
+ */
+@Directive({
+  selector: 'textarea[mat-autosize], textarea[matTextareaAutosize]',
+  exportAs: 'matTextareaAutosize',
+  inputs: ['cdkAutosizeMinRows', 'cdkAutosizeMaxRows'],
+  host: {
+    'class': 'cdk-textarea-autosize mat-mdc-autosize',
+    // Textarea elements that have the directive applied should have a single row by default.
+    // Browsers normally show two rows by default and therefore this limits the minRows binding.
+    'rows': '1',
+  },
+})
+export class MatTextareaAutosize extends BaseTextareaAutosize {
+}

--- a/src/material-experimental/mdc-input/module.ts
+++ b/src/material-experimental/mdc-input/module.ts
@@ -10,11 +10,12 @@ import {TextFieldModule} from '@angular/cdk/text-field';
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material-experimental/mdc-core';
 import {MatFormFieldModule} from '@angular/material-experimental/mdc-form-field';
+import {MatTextareaAutosize} from './autosize';
 import {MatInput} from './input';
 
 @NgModule({
   imports: [MatCommonModule, MatFormFieldModule],
-  exports: [MatInput, MatFormFieldModule, TextFieldModule, MatCommonModule],
-  declarations: [MatInput],
+  exports: [MatInput, MatTextareaAutosize, MatFormFieldModule, TextFieldModule, MatCommonModule],
+  declarations: [MatInput, MatTextareaAutosize],
 })
 export class MatInputModule {}

--- a/src/material-experimental/mdc-input/public-api.ts
+++ b/src/material-experimental/mdc-input/public-api.ts
@@ -8,7 +8,7 @@
 
 export {MatInput} from './input';
 export {MatInputModule} from './module';
-
+export {MatTextareaAutosize} from './autosize';
 export {
   getMatInputUnsupportedTypeError,
   MAT_INPUT_VALUE_ACCESSOR,


### PR DESCRIPTION
Adds an equivalent to `MatTextareaAutosize` in the `mdc-input` package for backwards compatibility.