### PR TITLE
fix(cdk/observers): incorrect coercion member type

### DIFF
--- a/src/cdk/observers/observe-content.ts
+++ b/src/cdk/observers/observe-content.ts
@@ -10,7 +10,8 @@ import {
   coerceBooleanProperty,
   coerceNumberProperty,
   coerceElement,
-  BooleanInput
+  BooleanInput,
+  NumberInput
 } from '@angular/cdk/coercion';
 import {
   AfterContentInit,
@@ -194,13 +195,11 @@ export class CdkObserveContent implements AfterContentInit, OnDestroy {
   }
 
   private _unsubscribe() {
-    if (this._currentSubscription) {
-      this._currentSubscription.unsubscribe();
-    }
+    this._currentSubscription?.unsubscribe();
   }
 
   static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_debounce: BooleanInput;
+  static ngAcceptInputType_debounce: NumberInput;
 }
 
 

--- a/tools/public_api_guard/cdk/observers.d.ts
+++ b/tools/public_api_guard/cdk/observers.d.ts
@@ -7,7 +7,7 @@ export declare class CdkObserveContent implements AfterContentInit, OnDestroy {
     constructor(_contentObserver: ContentObserver, _elementRef: ElementRef<HTMLElement>, _ngZone: NgZone);
     ngAfterContentInit(): void;
     ngOnDestroy(): void;
-    static ngAcceptInputType_debounce: BooleanInput;
+    static ngAcceptInputType_debounce: NumberInput;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkObserveContent, "[cdkObserveContent]", ["cdkObserveContent"], { "disabled": "cdkObserveContentDisabled"; "debounce": "debounce"; }, { "event": "cdkObserveContent"; }, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkObserveContent, never>;


### PR DESCRIPTION
Fixes that the `ngAcceptInputType_debounce` was typed as a boolean input, even though it's a number.

Fixes #21101.