### PR TITLE
fix(material/button): anchor mat-icon-button as matSuffix focus misaligned

### DIFF
--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -143,7 +143,7 @@
   .mat-form-field-prefix,
   .mat-form-field-suffix {
     .mat-icon-button {
-      display: flex;
+      display: inline-flex;
       justify-content: center;
       align-items: center;
       font-size: inherit;

--- a/src/material/button/button.scss
+++ b/src/material/button/button.scss
@@ -143,7 +143,9 @@
   .mat-form-field-prefix,
   .mat-form-field-suffix {
     .mat-icon-button {
-      display: block;
+      display: flex;
+      justify-content: center;
+      align-items: center;
       font-size: inherit;
       width: 2.5em;
       height: 2.5em;


### PR DESCRIPTION
Fixes misaligning anchor element with mat-icon-button applied. This also fixes misaligning on other elements like div.

Fixes #20949