### PR TITLE
docs: remove deprecated harness usage and use parallel promise utility

### DIFF
--- a/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
+++ b/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
@@ -2,9 +2,11 @@ import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatButtonHarness} from '@angular/material/button/testing';
 import {MatCardHarness} from '@angular/material/card/testing';
-import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
 import {MatCardModule} from '@angular/material/card';
 import {CardHarnessExample} from './card-harness-example';
 
@@ -36,7 +38,7 @@ describe('CardHarnessExample', () => {
 
   it('should get subtitle text', async () => {
     const cards = await loader.getAllHarnesses(MatCardHarness);
-    expect(await Promise.all(cards.map(c => c.getSubtitleText()))).toEqual([
+    expect(await parallel(() => cards.map(card => card.getSubtitleText()))).toEqual([
       '',
       'Dog Breed'
     ]);

--- a/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
+++ b/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
@@ -1,9 +1,11 @@
 import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {MatChipHarness, MatChipListHarness} from '@angular/material/chips/testing';
-import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {MatChipHarness, MatChipListboxHarness} from '@angular/material/chips/testing';
+import {HarnessLoader, parallel} from '@angular/cdk/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {ChipsHarnessExample} from './chips-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatChipsModule} from '@angular/material/chips';
@@ -27,7 +29,7 @@ describe('ChipsHarnessExample', () => {
   );
 
   it('should get whether a chip list is disabled', async () => {
-    const chipList = await loader.getHarness(MatChipListHarness);
+    const chipList = await loader.getHarness(MatChipListboxHarness);
 
     expect(await chipList.isDisabled()).toBeFalse();
 
@@ -38,20 +40,20 @@ describe('ChipsHarnessExample', () => {
   });
 
   it('should get the orientation of a chip list', async () => {
-    const chipList = await loader.getHarness(MatChipListHarness);
+    const chipList = await loader.getHarness(MatChipListboxHarness);
 
     expect(await chipList.getOrientation()).toEqual('horizontal');
   });
 
   it('should be able to get the selected chips in a list', async () => {
-    const chipList = await loader.getHarness(MatChipListHarness);
+    const chipList = await loader.getHarness(MatChipListboxHarness);
     const chips = await chipList.getChips();
 
     expect((await chipList.getChips({selected: true})).length).toBe(0);
     await chips[1].select();
 
     const selectedChips = await chipList.getChips({selected: true});
-    expect(await Promise.all(selectedChips.map(chip => chip.getText()))).toEqual(['Chip 2']);
+    expect(await parallel(() => selectedChips.map(chip => chip.getText()))).toEqual(['Chip 2']);
   });
 
   it('should be able to trigger chip removal', async () => {


### PR DESCRIPTION
* Uses `MatChipListboxHarness` for the chip harness example since `MatChipList` harness has some deprecated methods.
* Uses `parallel` instead of `Promise.all` like we do in the test harness code.