### PR TITLE
docs(material/chips): add mat-labels to examples

### DIFF
--- a/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
+++ b/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
@@ -1,4 +1,5 @@
 <mat-form-field class="example-chip-list">
+  <mat-label>Favorite Fruits</mat-label>
   <mat-chip-list #chipList aria-label="Fruit selection">
     <mat-chip
       *ngFor="let fruit of fruits"

--- a/src/components-examples/material/chips/chips-input/chips-input-example.html
+++ b/src/components-examples/material/chips/chips-input/chips-input-example.html
@@ -1,4 +1,5 @@
 <mat-form-field class="example-chip-list">
+  <mat-label>Favorite Fruits</mat-label>
   <mat-chip-list #chipList aria-label="Fruit selection">
     <mat-chip *ngFor="let fruit of fruits" [selectable]="selectable"
              [removable]="removable" (removed)="remove(fruit)">

--- a/src/dev-app/chips/chips-demo.html
+++ b/src/dev-app/chips/chips-demo.html
@@ -99,6 +99,7 @@
         Set tabIndex to {{tabIndex === 0 ? -1 : 0}}
       </button>
       <mat-form-field class="demo-has-chip-list">
+        <mat-label>Contributors</mat-label>
         <mat-chip-list [tabIndex]="tabIndex" #chipList1 [(ngModel)]="selectedPeople" required>
           <mat-chip  *ngFor="let person of people" [color]="color" [selectable]="selectable"
                    [removable]="removable" (removed)="remove(person)">
@@ -120,7 +121,8 @@
         With <code>matChipInput</code> the input work with chip-list
       </p>
 
-      <mat-form-field>
+      <mat-form-field class="demo-has-chip-list">
+        <mat-label>Contributors</mat-label>
         <mat-chip-list [tabIndex]="tabIndex"  #chipList2 [(ngModel)]="selectedPeople" required>
           <mat-chip *ngFor="let person of people" [color]="color" [selectable]="selectable"
                    [removable]="removable" (removed)="remove(person)">
@@ -141,6 +143,7 @@
 
 
       <mat-form-field class="demo-has-chip-list">
+        <mat-label>Contributors</mat-label>
         <mat-chip-list #chipList3>
           <mat-chip *ngFor="let person of people" [color]="color" [selectable]="selectable"
                    [removable]="removable" (removed)="remove(person)">


### PR DESCRIPTION
- add `mat-label`s to dev-app demos as well
- fix demo that doesn't have 100% width

As we discussed in a team meeting a few weeks ago, the docs don't have any examples of using chips in a form field with `mat-label`, which is our recommended approach now that the new appearances are the default.