### PR TITLE
build: fix exports check failure

### DIFF
--- a/scripts/check-mdc-exports-config.ts
+++ b/scripts/check-mdc-exports-config.ts
@@ -60,6 +60,11 @@ export const config = {
       '_MatTabNavBase',
       '_MatTabLinkBase',
       '_MatTabGroupBase'
+    ],
+    'mdc-table': [
+      // Private symbols that are only exported for MDC.
+      '_MatTableDataSource',
+      '_MAT_TEXT_COLUMN_TEMPLATE'
     ]
   }
 };


### PR DESCRIPTION
Adds a couple of exceptions to the MDC exports CI check in order to resolve a failure in master.