### PR TITLE
fix(material/slider): unable to assign min/max values if they are more precise than then step

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -391,6 +391,29 @@ describe('MatSlider', () => {
       expect(ticksElement.style.transform).toContain('translateX(25%)');
       expect(ticksContainerElement.style.transform).toBe('translateX(-25%)');
     });
+
+    it('should be able to set the min and max values when they are more precise ' +
+      'than the step', () => {
+      // Note that we assign min/max with more decimals than the
+      // step to ensure that the value doesn't get rounded up.
+      testComponent.step = 0.5;
+      testComponent.min = 10.15;
+      testComponent.max = 50.15;
+      fixture.detectChanges();
+
+      dispatchSlideEventSequence(sliderNativeElement, 0.5, 0);
+      fixture.detectChanges();
+
+      expect(sliderInstance.value).toBe(10.15);
+      expect(sliderInstance.percent).toBe(0);
+
+      dispatchSlideEventSequence(sliderNativeElement, 0.5, 1);
+      fixture.detectChanges();
+
+      expect(sliderInstance.value).toBe(50.15);
+      expect(sliderInstance.percent).toBe(1);
+    });
+
   });
 
   describe('slider with set value', () => {
@@ -1510,12 +1533,13 @@ class StandardSlider { }
 class DisabledSlider { }
 
 @Component({
-  template: `<mat-slider [min]="min" [max]="max" tickInterval="6"></mat-slider>`,
+  template: `<mat-slider [min]="min" [max]="max" [step]="step" tickInterval="6"></mat-slider>`,
   styles: [styles],
 })
 class SliderWithMinAndMax {
   min = 4;
   max = 6;
+  step = 1;
 }
 
 @Component({

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -255,7 +255,7 @@ export class MatSlider extends _MatSliderMixinBase
 
       // While incrementing by a decimal we can end up with values like 33.300000000000004.
       // Truncate it to ensure that it matches the label and to make it easier to work with.
-      if (this._roundToDecimal) {
+      if (this._roundToDecimal && value !== this.min && value !== this.max) {
         value = parseFloat(value.toFixed(this._roundToDecimal));
       }
 


### PR DESCRIPTION
We have some logic that trims the value to the same number of decimals as the `step`, in order to avoid assigning long decimal values. The problem is that if the `min` or `max` are more precise than the `step`, we round up just above the `min` or below the `max`, preventing the user from reaching the end values.

These changes add an exception to the rounding for the `min` and `max` values.

Fixes #21147.