### PR TITLE
build: set up schematics for v12

### DIFF
--- a/src/cdk/schematics/migration.json
+++ b/src/cdk/schematics/migration.json
@@ -31,6 +31,11 @@
       "description": "Updates the Angular CDK to v11",
       "factory": "./ng-update/index#updateToV11"
     },
+    "migration-v12": {
+      "version": "12.0.0-0",
+      "description": "Updates the Angular CDK to v12",
+      "factory": "./ng-update/index#updateToV12"
+    },
     "ng-post-update": {
       "description": "Prints out results after ng-update.",
       "factory": "./ng-update/index#postUpdate",

--- a/src/cdk/schematics/ng-update/index.ts
+++ b/src/cdk/schematics/ng-update/index.ts
@@ -41,6 +41,11 @@ export function updateToV11(): Rule {
   return createMigrationSchematicRule(TargetVersion.V11, [], cdkUpgradeData, onMigrationComplete);
 }
 
+/** Entry point for the migration schematics with target of Angular CDK 12.0.0 */
+export function updateToV12(): Rule {
+  return createMigrationSchematicRule(TargetVersion.V12, [], cdkUpgradeData, onMigrationComplete);
+}
+
 /** Function that will be called when the migration completed. */
 function onMigrationComplete(context: SchematicContext, targetVersion: TargetVersion,
                              hasFailures: boolean) {

--- a/src/cdk/schematics/update-tool/target-version.ts
+++ b/src/cdk/schematics/update-tool/target-version.ts
@@ -16,6 +16,7 @@ export enum TargetVersion {
   V9 = 'version 9',
   V10 = 'version 10',
   V11 = 'version 11',
+  V12 = 'version 12',
 }
 
 /**

--- a/src/material/schematics/migration.json
+++ b/src/material/schematics/migration.json
@@ -31,6 +31,11 @@
       "description": "Updates Angular Material to v11",
       "factory": "./ng-update/index#updateToV11"
     },
+    "migration-v12": {
+      "version": "12.0.0-0",
+      "description": "Updates Angular Material to v12",
+      "factory": "./ng-update/index#updateToV12"
+    },
     "ng-post-update": {
       "description": "Prints out results after ng-update.",
       "factory": "./ng-update/index#postUpdate",

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -74,6 +74,12 @@ export function updateToV11(): Rule {
       TargetVersion.V11, materialMigrations, materialUpgradeData, onMigrationComplete);
 }
 
+/** Entry point for the migration schematics with target of Angular Material v12 */
+export function updateToV12(): Rule {
+  return createMigrationSchematicRule(
+      TargetVersion.V12, materialMigrations, materialUpgradeData, onMigrationComplete);
+}
+
 /** Function that will be called when the migration completed. */
 function onMigrationComplete(context: SchematicContext, targetVersion: TargetVersion,
                              hasFailures: boolean) {


### PR DESCRIPTION
Sets up the schematics for the next major version so everything is in place once we need to add migrations.