### PR TITLE
feat(table): expand cell harness api

### DIFF
--- a/src/material-experimental/mdc-table/testing/cell-harness.ts
+++ b/src/material-experimental/mdc-table/testing/cell-harness.ts
@@ -7,14 +7,14 @@
  */
 
 import {
-  ComponentHarness,
   HarnessPredicate,
   ComponentHarnessConstructor,
+  ContentContainerComponentHarness,
 } from '@angular/cdk/testing';
 import {CellHarnessFilters} from './table-harness-filters';
 
 /** Harness for interacting with an MDC-based Angular Material table cell. */
-export class MatCellHarness extends ComponentHarness {
+export class MatCellHarness extends ContentContainerComponentHarness {
   /** The selector for the host element of a `MatCellHarness` instance. */
   static hostSelector = '.mat-mdc-cell';
 

--- a/src/material/table/testing/cell-harness.ts
+++ b/src/material/table/testing/cell-harness.ts
@@ -7,14 +7,14 @@
  */
 
 import {
-  ComponentHarness,
   HarnessPredicate,
   ComponentHarnessConstructor,
+  ContentContainerComponentHarness
 } from '@angular/cdk/testing';
 import {CellHarnessFilters} from './table-harness-filters';
 
 /** Harness for interacting with a standard Angular Material table cell. */
-export class MatCellHarness extends ComponentHarness {
+export class MatCellHarness extends ContentContainerComponentHarness {
   /** The selector for the host element of a `MatCellHarness` instance. */
   static hostSelector = '.mat-cell';
 

--- a/tools/public_api_guard/material/table/testing.d.ts
+++ b/tools/public_api_guard/material/table/testing.d.ts
@@ -3,7 +3,7 @@ export interface CellHarnessFilters extends BaseHarnessFilters {
     text?: string | RegExp;
 }
 
-export declare class MatCellHarness extends ComponentHarness {
+export declare class MatCellHarness extends ContentContainerComponentHarness {
     getColumnName(): Promise<string>;
     getText(): Promise<string>;
     static hostSelector: string;


### PR DESCRIPTION
Besides text, table cells can contain other components.
Extending from ContentContainerComponentHarness
exposes more apis to query for children in the table cell.

Closes #21157