### PR TITLE
fix(material/bottom-sheet): some changes not being picked up

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -45,7 +45,11 @@ import {FocusTrap, FocusTrapFactory} from '@angular/cdk/a11y';
   selector: 'mat-bottom-sheet-container',
   templateUrl: 'bottom-sheet-container.html',
   styleUrls: ['bottom-sheet-container.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // In Ivy embedded views will be change detected from their declaration place, rather than where
+  // they were stamped out. This means that we can't have the bottom sheet container be OnPush,
+  // because it might cause the sheets that were opened from a template not to be out of date.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   encapsulation: ViewEncapsulation.None,
   animations: [matBottomSheetAnimations.bottomSheetState],
   host: {


### PR DESCRIPTION
In some components, like the dialog and snack bar, we had to remove `OnPush` change detection some time ago, because the views inside the component were being detected at their declaration place.

These changes apply the same fix to the bottom sheet.

Fixes #21141.