### PR TITLE
fix(material-experimental/mdc-select): fix long labels being incorrectly cut off

### DIFF
--- a/src/material-experimental/mdc-select/select.scss
+++ b/src/material-experimental/mdc-select/select.scss
@@ -8,6 +8,8 @@ $mat-select-arrow-size: 5px !default;
 $mat-select-arrow-margin: 4px !default;
 $mat-select-panel-max-height: 256px !default;
 $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-arrow-margin);
+$leading-width: 12px !default;
+$scale: 0.75 !default;
 
 // We base the select panel styling on top of MDC's menu styles and we
 // implement the trigger ourselves since MDC doesn't provide an equivalent.
@@ -114,5 +116,29 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
     transition: none;
     // Prevents the '...' from showing on the parent element.
     display: block;
+  }
+}
+
+// Our MDC form field implementation is based on the MDC text field which doesn't include styles
+// for select. The select specific styles are not present as they don't use their text field as a
+// container. Below are the styles to account for the select arrow icon at the end.
+.mat-mdc-form-field-type-mat-select {
+  &.mat-form-field-appearance-fill {
+    .mdc-floating-label {
+      max-width: calc(100% - #{$mat-select-placeholder-arrow-space});
+    }
+
+    .mdc-floating-label--float-above {
+      max-width: calc(100% / #{$scale} - #{$mat-select-placeholder-arrow-space / $scale});
+    }
+  }
+  &.mat-form-field-appearance-outline {
+    .mdc-notched-outline__notch {
+      max-width: calc(100% - #{2 * ($mat-select-placeholder-arrow-space + $leading-width)});
+    }
+
+    .mdc-text-field--label-floating .mdc-notched-outline__notch {
+      max-width: calc(100% - #{$leading-width * 2});
+    }
   }
 }


### PR DESCRIPTION
The MDC based form field is based on the MDC text field which doesn't actually have styles to handle select as the outline/text field is styled individually by each component. There are plans for MDC to consolidate text field/select styles but for now styles have to be added manually.

Before: 
![3sSf9UpRttpptN6](https://user-images.githubusercontent.com/20130030/100796443-822d7580-33d5-11eb-9842-7d2eb87f31cc.png)
![A5BmQDp4JcqbBsw](https://user-images.githubusercontent.com/20130030/100796445-82c60c00-33d5-11eb-957e-1ca30512e511.png)

After:
![AYLSZYzsmZjSwjs](https://user-images.githubusercontent.com/20130030/100796461-88bbed00-33d5-11eb-9944-c5798f27b412.png)
![8vujdrG6iDXZ6qN](https://user-images.githubusercontent.com/20130030/100796463-89548380-33d5-11eb-9e0e-1ecad2d17e20.png)


Note that floating label for the outline appearance currently has `text-overflow: clip` instead of `text-overflow: ellipsis`. https://github.com/material-components/material-components-web/blob/99cfb6bd53f72240fe76852d0fdaa0b82e7dca39/packages/mdc-notched-outline/_mixins.scss#L96



