### PR TITLE
fix(cdk/a11y): set AriaDescriber messages container to visibility:hidden

### DIFF
--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -2,7 +2,6 @@ import {A11yModule, CDK_DESCRIBEDBY_HOST_ATTRIBUTE} from '../index';
 import {AriaDescriber, MESSAGES_CONTAINER_ID} from './aria-describer';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, ElementRef, ViewChild, Provider} from '@angular/core';
-import {Platform} from '@angular/cdk/platform';
 
 describe('AriaDescriber', () => {
   let ariaDescriber: AriaDescriber;
@@ -48,6 +47,12 @@ describe('AriaDescriber', () => {
     createFixture();
     ariaDescriber.describe(component.element1, 'My Message');
     expect(getMessagesContainer().classList).toContain('cdk-visually-hidden');
+  });
+
+  it('should have visibility hidden', () => {
+    createFixture();
+    ariaDescriber.describe(component.element1, 'My Message');
+    expect((getMessagesContainer() as HTMLElement).style.visibility).toBe('hidden');
   });
 
   it('should not register empty strings', () => {
@@ -267,24 +272,6 @@ describe('AriaDescriber', () => {
 
     ariaDescriber.removeDescription(component.element1, 'Message');
     expect(element.hasAttribute('aria-describedby')).toBe(false);
-  });
-
-  it('should set `aria-hidden` on the container by default', () => {
-    createFixture([{provide: Platform, useValue: {BLINK: true}}]);
-    ariaDescriber.describe(component.element1, 'My Message');
-    expect(getMessagesContainer().getAttribute('aria-hidden')).toBe('true');
-  });
-
-  it('should disable `aria-hidden` on the container in IE', () => {
-    createFixture([{provide: Platform, useValue: {TRIDENT: true}}]);
-    ariaDescriber.describe(component.element1, 'My Message');
-    expect(getMessagesContainer().getAttribute('aria-hidden')).toBe('false');
-  });
-
-  it('should disable `aria-hidden` on the container in Edge', () => {
-    createFixture([{provide: Platform, useValue: {EDGE: true}}]);
-    ariaDescriber.describe(component.element1, 'My Message');
-    expect(getMessagesContainer().getAttribute('aria-hidden')).toBe('false');
   });
 
   it('should be able to register the same message with different roles', () => {

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -10,8 +10,7 @@ export declare class ActiveDescendantKeyManager<T> extends ListKeyManager<Highli
 }
 
 export declare class AriaDescriber implements OnDestroy {
-    constructor(_document: any,
-    _platform?: Platform | undefined);
+    constructor(_document: any);
     describe(hostElement: Element, message: string, role?: string): void;
     describe(hostElement: Element, message: HTMLElement): void;
     ngOnDestroy(): void;


### PR DESCRIPTION
Previously searching for AriaDescriber messages in the browser would result in a ctrl-f stop that was invisible. This is because the `cdk-messages-container` had the `cdk-visually-hidden` class but that is not enough to remove the ctrl-f stops.
This fix maintains functionality while preventing extra ctrl-f stops.

Tested with:
macOS/VoiceOver
Windows/NVDA