### PR TITLE
feat(cdk-experimental/table-scroll-container): Create directive and demo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,6 +133,7 @@
 /src/cdk-experimental/menu/**                      @jelbourn @andy9775
 /src/cdk-experimental/popover-edit/**              @kseamon @andrewseguin
 /src/cdk-experimental/scrolling/**                 @mmalerba
+/src/cdk-experimental/table-scroll-container/**    @kseamon @andrewseguin
 /src/cdk-experimental/listbox/**                   @nielsr98 @jelbourn
 /src/cdk-experimental/selection/**                 @yifange @jelbourn
 
@@ -215,6 +216,7 @@
 /src/dev-app/snack-bar/**                          @jelbourn @crisbeto
 /src/dev-app/stepper/**                            @mmalerba
 /src/dev-app/table/**                              @andrewseguin
+/src/dev-app/table-scroll-container/**             @kseamon @andrewseguin
 /src/dev-app/tabs/**                               @andrewseguin
 /src/dev-app/toolbar/**                            @devversion
 /src/dev-app/tooltip/**                            @andrewseguin

--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -16,6 +16,7 @@ export const commitMessage: CommitMessageConfig = {
     'cdk-experimental/popover-edit',
     'cdk-experimental/scrolling',
     'cdk-experimental/selection',
+    'cdk-experimental/table-scroll-container',
     'cdk/a11y',
     'cdk/accordion',
     'cdk/bidi',

--- a/src/cdk-experimental/config.bzl
+++ b/src/cdk-experimental/config.bzl
@@ -8,6 +8,7 @@ CDK_EXPERIMENTAL_ENTRYPOINTS = [
     "popover-edit",
     "scrolling",
     "selection",
+    "table-scroll-container",
 ]
 
 # List of all entry-point targets of the Angular cdk-experimental package.

--- a/src/cdk-experimental/table-scroll-container/BUILD.bazel
+++ b/src/cdk-experimental/table-scroll-container/BUILD.bazel
@@ -1,0 +1,45 @@
+load(
+    "//tools:defaults.bzl",
+    "ng_module",
+    "ng_test_library",
+    "ng_web_test_suite",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "table-scroll-container",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/cdk-experimental/table-scroll-container",
+    deps = [
+        "//src/cdk/bidi",
+        "//src/cdk/platform",
+        "//src/cdk/table",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//rxjs",
+    ],
+)
+
+ng_test_library(
+    name = "unit_test_sources",
+    srcs = glob(
+        ["**/*.spec.ts"],
+        exclude = ["**/*.e2e.spec.ts"],
+    ),
+    deps = [
+        ":table-scroll-container",
+        "//src/cdk/collections",
+        "//src/cdk/platform",
+        "//src/cdk/table",
+        "@npm//rxjs",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [":unit_test_sources"],
+)

--- a/src/cdk-experimental/table-scroll-container/index.ts
+++ b/src/cdk-experimental/table-scroll-container/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/cdk-experimental/table-scroll-container/public-api.ts
+++ b/src/cdk-experimental/table-scroll-container/public-api.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './table-scroll-container';
+export * from './table-scroll-container-module';

--- a/src/cdk-experimental/table-scroll-container/table-scroll-container-module.ts
+++ b/src/cdk-experimental/table-scroll-container/table-scroll-container-module.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+
+import {CdkTableScrollContainer} from './table-scroll-container';
+
+@NgModule({
+  declarations: [CdkTableScrollContainer],
+  exports: [CdkTableScrollContainer],
+})
+export class CdkTableScrollContainerModule {}

--- a/src/cdk-experimental/table-scroll-container/table-scroll-container.spec.ts
+++ b/src/cdk-experimental/table-scroll-container/table-scroll-container.spec.ts
@@ -1,0 +1,333 @@
+import {CollectionViewer, DataSource} from '@angular/cdk/collections';
+import {
+  Component,
+  Type,
+  ViewChild,
+} from '@angular/core';
+import {ComponentFixture, fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
+import {BehaviorSubject, combineLatest} from 'rxjs';
+import {map} from 'rxjs/operators';
+import {CdkTable, CdkTableModule} from '@angular/cdk/table';
+import {Platform} from '@angular/cdk/platform';
+
+import {CdkTableScrollContainerModule} from './index';
+
+describe('CdkTableScrollContainer', () => {
+  let fixture: ComponentFixture<any>;
+  let component: any;
+  let platform: Platform;
+  let tableElement: HTMLElement;
+  let scrollerElement: HTMLElement;
+  let dataRows: HTMLElement[];
+  let headerRows: HTMLElement[];
+  let footerRows: HTMLElement[];
+
+  function createComponent<T>(
+      componentType: Type<T>, declarations: any[] = []): ComponentFixture<T> {
+    TestBed.configureTestingModule({
+      imports: [CdkTableModule, CdkTableScrollContainerModule],
+      declarations: [componentType, ...declarations],
+    }).compileComponents();
+
+    return TestBed.createComponent<T>(componentType);
+  }
+
+  function setupTableTestApp(componentType: Type<any>, declarations: any[] = []) {
+    fixture = createComponent(componentType, declarations);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    tableElement = fixture.nativeElement.querySelector('.cdk-table');
+    scrollerElement = fixture.nativeElement.querySelector('.cdk-table-scroll-container');
+  }
+
+  beforeEach(() => {
+    setupTableTestApp(StickyNativeLayoutCdkTableApp);
+
+    platform = TestBed.inject(Platform);
+
+    headerRows = getHeaderRows(tableElement);
+    footerRows = getFooterRows(tableElement);
+    dataRows = getRows(tableElement);
+  });
+
+  it('sets scrollbar track margin for sticky headers', fakeAsync(() => {
+    component.stickyHeaders = ['header-1', 'header-3'];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    if (platform.FIREFOX) {
+      // ::-webkit-scrollbar-track is not recognized by Firefox.
+      return;
+    }
+
+    const scrollerStyle =
+        window.getComputedStyle(scrollerElement, '::-webkit-scrollbar-track');
+    expect(scrollerStyle.getPropertyValue('margin-top'))
+        .toBe(`${headerRows[0].offsetHeight}px`);
+    expect(scrollerStyle.getPropertyValue('margin-right')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-bottom')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-left')).toBe('0px');
+
+    component.stickyHeaders = [];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    expect(scrollerStyle.getPropertyValue('margin-top')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-right')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-bottom')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-left')).toBe('0px');
+  }));
+
+  it('sets scrollbar track margin for sticky footers', fakeAsync(() => {
+    component.stickyFooters = ['footer-1', 'footer-3'];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    if (platform.FIREFOX) {
+      // ::-webkit-scrollbar-track is not recognized by Firefox.
+      return;
+    }
+
+    const scrollerStyle =
+        window.getComputedStyle(scrollerElement, '::-webkit-scrollbar-track');
+    expect(scrollerStyle.getPropertyValue('margin-top')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-right')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-bottom'))
+        .toBe(`${footerRows[2].offsetHeight}px`);
+    expect(scrollerStyle.getPropertyValue('margin-left')).toBe('0px');
+
+    component.stickyFooters = [];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    expect(scrollerStyle.getPropertyValue('margin-top')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-right')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-bottom')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-left')).toBe('0px');
+  }));
+
+  it('sets scrollbar track margin for sticky start columns', fakeAsync(() => {
+    component.stickyStartColumns = ['column-1', 'column-3'];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    if (platform.FIREFOX) {
+      // ::-webkit-scrollbar-track is not recognized by Firefox.
+      return;
+    }
+
+    const scrollerStyle =
+        window.getComputedStyle(scrollerElement, '::-webkit-scrollbar-track');
+    expect(scrollerStyle.getPropertyValue('margin-top')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-right')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-bottom')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-left'))
+        .toBe(`${getCells(dataRows[0])[0].offsetWidth}px`);
+
+    component.stickyStartColumns = [];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    expect(scrollerStyle.getPropertyValue('margin-top')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-right')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-bottom')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-left')).toBe('0px');
+  }));
+
+  it('sets scrollbar track margin for sticky end columns', fakeAsync(() => {
+    component.stickyEndColumns = ['column-4', 'column-6'];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    if (platform.FIREFOX) {
+      // ::-webkit-scrollbar-track is not recognized by Firefox.
+      return;
+    }
+
+    const scrollerStyle =
+        window.getComputedStyle(scrollerElement, '::-webkit-scrollbar-track');
+    expect(scrollerStyle.getPropertyValue('margin-top')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-right'))
+        .toBe(`${getCells(dataRows[0])[5].offsetWidth}px`);
+    expect(scrollerStyle.getPropertyValue('margin-bottom')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-left')).toBe('0px');
+
+    component.stickyEndColumns = [];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    expect(scrollerStyle.getPropertyValue('margin-top')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-right')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-bottom')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-left')).toBe('0px');
+  }));
+
+  it('sets scrollbar track margin for a combination of sticky rows and columns', fakeAsync(() => {
+    component.stickyHeaders = ['header-1'];
+    component.stickyFooters = ['footer-3'];
+    component.stickyStartColumns = ['column-1'];
+    component.stickyEndColumns = ['column-6'];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    if (platform.FIREFOX) {
+      // ::-webkit-scrollbar-track is not recognized by Firefox.
+      return;
+    }
+
+    const scrollerStyle =
+        window.getComputedStyle(scrollerElement, '::-webkit-scrollbar-track');
+    expect(scrollerStyle.getPropertyValue('margin-top'))
+        .toBe(`${headerRows[0].offsetHeight}px`);
+    expect(scrollerStyle.getPropertyValue('margin-right'))
+        .toBe(`${getCells(dataRows[0])[5].offsetWidth}px`);
+    expect(scrollerStyle.getPropertyValue('margin-bottom'))
+        .toBe(`${footerRows[2].offsetHeight}px`);
+    expect(scrollerStyle.getPropertyValue('margin-left'))
+        .toBe(`${getCells(dataRows[0])[0].offsetWidth}px`);
+
+    component.stickyHeaders = [];
+    component.stickyFooters = [];
+    component.stickyStartColumns = [];
+    component.stickyEndColumns = [];
+    fixture.detectChanges();
+    flushMicrotasks();
+
+    expect(scrollerStyle.getPropertyValue('margin-top')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-right')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-bottom')).toBe('0px');
+    expect(scrollerStyle.getPropertyValue('margin-left')).toBe('0px');
+  }));
+});
+
+interface TestData {
+  a: string;
+  b: string;
+  c: string;
+}
+
+class FakeDataSource extends DataSource<TestData> {
+  isConnected = false;
+
+  get data() {
+    return this._dataChange.getValue();
+  }
+  set data(data: TestData[]) {
+    this._dataChange.next(data);
+  }
+  _dataChange = new BehaviorSubject<TestData[]>([]);
+
+  constructor() {
+    super();
+    for (let i = 0; i < 3; i++) {
+      this.addData();
+    }
+  }
+
+  connect(collectionViewer: CollectionViewer) {
+    this.isConnected = true;
+    return combineLatest([this._dataChange, collectionViewer.viewChange])
+      .pipe(map(data => data[0]));
+  }
+
+  disconnect() {
+    this.isConnected = false;
+  }
+
+  addData() {
+    const nextIndex = this.data.length + 1;
+
+    let copiedData = this.data.slice();
+    copiedData.push({
+      a: `a_${nextIndex}`,
+      b: `b_${nextIndex}`,
+      c: `c_${nextIndex}`
+    });
+
+    this.data = copiedData;
+  }
+}
+
+@Component({
+  template: `
+    <div cdkTableScrollContainer>
+    <table cdk-table [dataSource]="dataSource">
+      <ng-container [cdkColumnDef]="column" *ngFor="let column of columns"
+                    [sticky]="isStuck(stickyStartColumns, column)"
+                    [stickyEnd]="isStuck(stickyEndColumns, column)">
+        <th cdk-header-cell *cdkHeaderCellDef> Header {{column}} </th>
+        <td cdk-cell *cdkCellDef="let row"> {{column}} </td>
+        <td cdk-footer-cell *cdkFooterCellDef> Footer {{column}} </td>
+      </ng-container>
+
+      <tr cdk-header-row *cdkHeaderRowDef="columns; sticky: isStuck(stickyHeaders, 'header-1')">
+      </tr>
+      <tr cdk-header-row *cdkHeaderRowDef="columns; sticky: isStuck(stickyHeaders, 'header-2')">
+      </tr>
+      <tr cdk-header-row *cdkHeaderRowDef="columns; sticky: isStuck(stickyHeaders, 'header-3')">
+      </tr>
+
+      <tr cdk-row *cdkRowDef="let row; columns: columns"></tr>
+
+      <tr cdk-footer-row *cdkFooterRowDef="columns; sticky: isStuck(stickyFooters, 'footer-1')">
+      </tr>
+      <tr cdk-footer-row *cdkFooterRowDef="columns; sticky: isStuck(stickyFooters, 'footer-2')">
+      </tr>
+      <tr cdk-footer-row *cdkFooterRowDef="columns; sticky: isStuck(stickyFooters, 'footer-3')">
+      </tr>
+    </table>
+    </div>
+  `,
+  styles: [`
+    .cdk-header-cell, .cdk-cell, .cdk-footer-cell {
+      display: block;
+      width: 20px;
+      box-sizing: border-box;
+    }
+  `]
+})
+class StickyNativeLayoutCdkTableApp {
+  dataSource: FakeDataSource = new FakeDataSource();
+  columns = ['column-1', 'column-2', 'column-3', 'column-4', 'column-5', 'column-6'];
+
+  @ViewChild(CdkTable) table: CdkTable<TestData>;
+
+  stickyHeaders: string[] = [];
+  stickyFooters: string[] = [];
+  stickyStartColumns: string[] = [];
+  stickyEndColumns: string[] = [];
+
+  isStuck(list: string[], id: string) {
+    return list.indexOf(id) != -1;
+  }
+}
+
+function getElements(element: Element, query: string): HTMLElement[] {
+  return [].slice.call(element.querySelectorAll(query));
+}
+
+function getHeaderRows(tableElement: Element): HTMLElement[] {
+  return [].slice.call(tableElement.querySelectorAll('.cdk-header-row'));
+}
+
+function getFooterRows(tableElement: Element): HTMLElement[] {
+  return [].slice.call(tableElement.querySelectorAll('.cdk-footer-row'));
+}
+
+function getRows(tableElement: Element): HTMLElement[] {
+  return getElements(tableElement, '.cdk-row');
+}
+
+function getCells(row: Element): HTMLElement[] {
+  if (!row) {
+    return [];
+  }
+
+  let cells = getElements(row, 'cdk-cell');
+  if (!cells.length) {
+    cells = getElements(row, 'td.cdk-cell');
+  }
+
+  return cells;
+}

--- a/src/cdk-experimental/table-scroll-container/table-scroll-container.ts
+++ b/src/cdk-experimental/table-scroll-container/table-scroll-container.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directive, ElementRef, Inject, OnDestroy, OnInit, Optional} from '@angular/core';
+import {DOCUMENT} from '@angular/common';
+import {Directionality} from '@angular/cdk/bidi';
+import {_getShadowRoot} from '@angular/cdk/platform';
+import {
+  STICKY_POSITIONING_LISTENER,
+  StickyPositioningListener,
+  StickySize,
+  StickyUpdate,
+} from '@angular/cdk/table';
+
+let nextId = 0;
+
+/**
+ * Applies styles to the host element that make its scrollbars match up with
+ * the non-sticky scrollable portions of the CdkTable contained within.
+ *
+ * This visual effect only works in Webkit and Blink based browsers (eg Chrome,
+ * Safari, Edge). Other browsers such as Firefox will gracefully degrade to
+ * normal scrollbar appearance.
+ * Further note: These styles have no effect when the browser is using OS-default
+ * scrollbars. The easiest way to force them into custom mode is to specify width
+ * and height for the scrollbar and thumb.
+ */
+@Directive({
+  selector: '[cdkTableScrollContainer]',
+  host: {
+    'class': 'cdk-table-scroll-container',
+  },
+  providers: [
+    {provide: STICKY_POSITIONING_LISTENER, useExisting: CdkTableScrollContainer},
+  ],
+})
+export class CdkTableScrollContainer implements StickyPositioningListener,
+    OnDestroy, OnInit {
+  private readonly _uniqueClassName: string;
+  private _styleRoot!: Node;
+  private _styleElement?: HTMLStyleElement;
+
+  /** The most recent sticky column size values from the CdkTable. */
+  private _startSizes: StickySize[] = [];
+  private _endSizes: StickySize[] = [];
+  private _headerSizes: StickySize[] = [];
+  private _footerSizes: StickySize[] = [];
+
+  constructor(
+      private readonly _elementRef: ElementRef<HTMLElement>,
+      @Inject(DOCUMENT) private readonly _document: Document,
+      @Optional() private readonly _directionality?: Directionality) {
+    this._uniqueClassName = `cdk-table-scroll-container-${++nextId}`;
+    _elementRef.nativeElement.classList.add(this._uniqueClassName);
+  }
+
+  ngOnInit() {
+    // Note that we need to look up the root node in ngOnInit, rather than the constructor, because
+    // Angular seems to create the element outside the shadow root and then moves it inside, if the
+    // node is inside an `ngIf` and a ShadowDom-encapsulated component.
+    this._styleRoot = _getShadowRoot(this._elementRef.nativeElement) ?? this._document.head;
+  }
+
+  ngOnDestroy(): void {
+    // TODO: Use remove() once we're off IE11.
+    if (this._styleElement?.parentNode) {
+      this._styleElement.parentNode.removeChild(this._styleElement);
+      this._styleElement = undefined;
+    }
+  }
+
+  stickyColumnsUpdated({sizes}: StickyUpdate): void {
+    this._startSizes = sizes;
+    this._updateScrollbar();
+  }
+
+  stickyEndColumnsUpdated({sizes}: StickyUpdate): void {
+    this._endSizes = sizes;
+    this._updateScrollbar();
+  }
+
+  stickyHeaderRowsUpdated({sizes}: StickyUpdate): void {
+    this._headerSizes = sizes;
+    this._updateScrollbar();
+  }
+
+  stickyFooterRowsUpdated({sizes}: StickyUpdate): void {
+    this._footerSizes = sizes;
+    this._updateScrollbar();
+  }
+
+  /**
+   * Set padding on the scrollbar track based on the sticky states from CdkTable.
+   */
+  private _updateScrollbar(): void {
+    const topMargin = computeMargin(this._headerSizes);
+    const bottomMargin = computeMargin(this._footerSizes);
+    const startMargin = computeMargin(this._startSizes);
+    const endMargin = computeMargin(this._endSizes);
+
+    if (topMargin === 0 && bottomMargin === 0 && startMargin === 0 && endMargin === 0) {
+      this._clearCss();
+      return;
+    }
+
+    const direction = this._directionality ? this._directionality.value : 'ltr';
+    const leftMargin = direction === 'rtl' ? endMargin : startMargin;
+    const rightMargin = direction === 'rtl' ? startMargin : endMargin;
+
+    this._applyCss(`${topMargin}px ${rightMargin}px ${bottomMargin}px ${leftMargin}px`);
+  }
+
+  /** Gets the stylesheet for the scrollbar styles and creates it if need be. */
+  private _getStyleSheet(): CSSStyleSheet {
+    if (!this._styleElement) {
+      this._styleElement = this._document.createElement('style');
+      this._styleRoot.appendChild(this._styleElement);
+    }
+
+    return this._styleElement.sheet as CSSStyleSheet;
+  }
+
+  /** Updates the stylesheet with the specified scrollbar style. */
+  private _applyCss(value: string) {
+    this._clearCss();
+
+    const selector = `.${this._uniqueClassName}::-webkit-scrollbar-track`;
+    this._getStyleSheet().insertRule(`${selector} {margin: ${value}}`, 0);
+  }
+
+  private _clearCss() {
+    const styleSheet = this._getStyleSheet();
+    if (styleSheet.cssRules.length > 0) {
+      styleSheet.deleteRule(0);
+    }
+  }
+}
+
+function computeMargin(sizes: (number|null|undefined)[]): number {
+  let margin = 0;
+  for (const size of sizes) {
+    if (size == null) {
+      break;
+    }
+    margin += size;
+  }
+  return margin;
+}

--- a/src/cdk/table/public-api.ts
+++ b/src/cdk/table/public-api.ts
@@ -12,6 +12,7 @@ export * from './coalesced-style-scheduler';
 export * from './row';
 export * from './table-module';
 export * from './sticky-styler';
+export * from './sticky-position-listener';
 export * from './can-stick';
 export * from './text-column';
 export * from './tokens';

--- a/src/cdk/table/sticky-position-listener.ts
+++ b/src/cdk/table/sticky-position-listener.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '@angular/core';
+
+/** The injection token used to specify the StickyPositioningListener. */
+export const STICKY_POSITIONING_LISTENER =
+    new InjectionToken<StickyPositioningListener>('CDK_SPL');
+
+export type StickySize = number|null|undefined;
+
+export interface StickyUpdate {
+  sizes: StickySize[];
+}
+
+/**
+ * If provided, CdkTable will call the methods below when it updates the size/
+ * postion/etc of its sticky rows and columns.
+ */
+export interface StickyPositioningListener {
+  /** Called when CdkTable updates its sticky start columns. */
+  stickyColumnsUpdated(update: StickyUpdate): void;
+
+  /** Called when CdkTable updates its sticky end columns. */
+  stickyEndColumnsUpdated(update: StickyUpdate): void;
+
+  /** Called when CdkTable updates its sticky header rows. */
+  stickyHeaderRowsUpdated(update: StickyUpdate): void;
+
+  /** Called when CdkTable updates its sticky footer rows. */
+  stickyFooterRowsUpdated(update: StickyUpdate): void;
+}

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -86,6 +86,7 @@ ng_module(
         "//src/dev-app/snack-bar",
         "//src/dev-app/stepper",
         "//src/dev-app/table",
+        "//src/dev-app/table-scroll-container",
         "//src/dev-app/tabs",
         "//src/dev-app/toolbar",
         "//src/dev-app/tooltip",

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -74,6 +74,7 @@ export class DevAppLayout {
     {name: 'Snack Bar', route: '/snack-bar'},
     {name: 'Stepper', route: '/stepper'},
     {name: 'Table', route: '/table'},
+    {name: 'Table Scroll Container', route: '/table-scroll-container'},
     {name: 'Tabs', route: '/tabs'},
     {name: 'Toolbar', route: '/toolbar'},
     {name: 'Tooltip', route: '/tooltip'},

--- a/src/dev-app/dev-app/routes.ts
+++ b/src/dev-app/dev-app/routes.ts
@@ -140,6 +140,11 @@ export const DEV_APP_ROUTES: Routes = [
   {path: 'snack-bar', loadChildren: 'snack-bar/snack-bar-demo-module#SnackBarDemoModule'},
   {path: 'stepper', loadChildren: 'stepper/stepper-demo-module#StepperDemoModule'},
   {path: 'table', loadChildren: 'table/table-demo-module#TableDemoModule'},
+  {
+    path: 'table-scroll-container',
+    loadChildren:
+        'table-scroll-container/table-scroll-container-demo-module#TableScrollContainerDemoModule',
+  },
   {path: 'tabs', loadChildren: 'tabs/tabs-demo-module#TabsDemoModule'},
   {path: 'toolbar', loadChildren: 'toolbar/toolbar-demo-module#ToolbarDemoModule'},
   {path: 'tooltip', loadChildren: 'tooltip/tooltip-demo-module#TooltipDemoModule'},

--- a/src/dev-app/table-scroll-container/BUILD.bazel
+++ b/src/dev-app/table-scroll-container/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "table-scroll-container",
+    srcs = glob(["**/*.ts"]),
+    assets = [
+        "table-scroll-container-demo.html",
+        ":table_scroll_container_demo_scss",
+    ],
+    deps = [
+        "//src/cdk-experimental/table-scroll-container",
+        "//src/material-experimental/mdc-button",
+        "//src/material-experimental/mdc-table",
+        "//src/material/button-toggle",
+        "//src/material/table",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/router",
+    ],
+)
+
+sass_binary(
+    name = "table_scroll_container_demo_scss",
+    src = "table-scroll-container-demo.scss",
+)

--- a/src/dev-app/table-scroll-container/table-scroll-container-demo-module.ts
+++ b/src/dev-app/table-scroll-container/table-scroll-container-demo-module.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {CdkTableScrollContainerModule} from '@angular/cdk-experimental/table-scroll-container';
+import {MatButtonModule} from '@angular/material-experimental/mdc-button';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+/*import {MatTableModule} from '@angular/material-experimental/mdc-table';*/
+import {MatTableModule} from '@angular/material/table';
+import {RouterModule} from '@angular/router';
+import {TableScrollContainerDemo} from './table-scroll-container-demo';
+
+@NgModule({
+  imports: [
+    CdkTableScrollContainerModule,
+    CommonModule,
+    MatButtonModule,
+    MatButtonToggleModule,
+    MatTableModule,
+    RouterModule.forChild([{path: '', component: TableScrollContainerDemo}]),
+  ],
+  declarations: [TableScrollContainerDemo],
+})
+export class TableScrollContainerDemoModule {
+}

--- a/src/dev-app/table-scroll-container/table-scroll-container-demo.html
+++ b/src/dev-app/table-scroll-container/table-scroll-container-demo.html
@@ -1,0 +1,80 @@
+<div>
+  <button mat-raised-button (click)="tables.push(tables.length)">Add table</button>
+  <button mat-raised-button (click)="tables.pop()">Remove table</button>
+</div>
+
+<div>
+  Sticky Headers:
+  <mat-button-toggle-group multiple [value]="['header-1']"
+                           #stickyHeaders="matButtonToggleGroup"
+                           class="example-sticky-toggle-group">
+    <mat-button-toggle value="header-1"> Row 1 </mat-button-toggle>
+    <mat-button-toggle value="header-2"> Row 2 </mat-button-toggle>
+  </mat-button-toggle-group>
+</div>
+
+<div>
+  Sticky Footers:
+  <mat-button-toggle-group multiple [value]="['footer-1']"
+                           #stickyFooters="matButtonToggleGroup"
+                           class="example-sticky-toggle-group">
+    <mat-button-toggle value="footer-1"> Row 1 </mat-button-toggle>
+    <mat-button-toggle value="footer-2"> Row 2 </mat-button-toggle>
+  </mat-button-toggle-group>
+</div>
+
+<div>
+  Sticky Columns:
+  <mat-button-toggle-group multiple [value]="['position', 'symbol']"
+                           #stickyColumns="matButtonToggleGroup"
+                           class="example-sticky-toggle-group">
+    <mat-button-toggle value="position"> Position </mat-button-toggle>
+    <mat-button-toggle value="name"> Name </mat-button-toggle>
+    <mat-button-toggle value="weight"> Weight </mat-button-toggle>
+    <mat-button-toggle value="symbol"> Symbol </mat-button-toggle>
+  </mat-button-toggle-group>
+</div>
+
+<div class="example-container mat-elevation-z8"
+    cdkTableScrollContainer
+    *ngFor="let table of tables">
+  <table mat-table [dataSource]="dataSource">
+    <ng-container matColumnDef="position" [sticky]="isSticky(stickyColumns, 'position')">
+      <th mat-header-cell *matHeaderCellDef> Position </th>
+      <td mat-cell *matCellDef="let element"> {{element.position}} </td>
+      <td mat-footer-cell *matFooterCellDef> Position Footer </td>
+    </ng-container>
+
+    <ng-container matColumnDef="name" [sticky]="isSticky(stickyColumns, 'name')">
+      <th mat-header-cell *matHeaderCellDef> Name </th>
+      <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+      <td mat-footer-cell *matFooterCellDef> Name Footer </td>
+    </ng-container>
+
+    <ng-container matColumnDef="weight" [stickyEnd]="isSticky(stickyColumns, 'weight')">
+      <th mat-header-cell *matHeaderCellDef> Weight </th>
+      <td mat-cell *matCellDef="let element"> {{element.weight}} </td>
+      <td mat-footer-cell *matFooterCellDef> Weight Footer </td>
+    </ng-container>
+
+    <ng-container matColumnDef="symbol" [stickyEnd]="isSticky(stickyColumns, 'symbol')">
+      <th mat-header-cell *matHeaderCellDef> Symbol </th>
+      <td mat-cell *matCellDef="let element"> {{element.symbol}} </td>
+      <td mat-footer-cell *matFooterCellDef> Symbol Footer </td>
+    </ng-container>
+
+    <ng-container matColumnDef="filler">
+      <th mat-header-cell *matHeaderCellDef> Filler header cell </th>
+      <td mat-cell *matCellDef="let element"> Filler data cell </td>
+      <td mat-footer-cell *matFooterCellDef> Filler footer cell </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: isSticky(stickyHeaders, 'header-1')"></tr>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: isSticky(stickyHeaders, 'header-2')"></tr>
+
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+
+    <tr mat-footer-row *matFooterRowDef="displayedColumns; sticky: isSticky(stickyFooters, 'footer-1')"></tr>
+    <tr mat-footer-row *matFooterRowDef="displayedColumns; sticky: isSticky(stickyFooters, 'footer-2')"></tr>
+  </table>
+</div>

--- a/src/dev-app/table-scroll-container/table-scroll-container-demo.scss
+++ b/src/dev-app/table-scroll-container/table-scroll-container-demo.scss
@@ -1,0 +1,40 @@
+.example-container {
+  height: 400px;
+  overflow: auto;
+}
+
+.mat-table-sticky {
+  background: #59abfd;
+  opacity: 1;
+}
+
+.example-sticky-toggle-group {
+  margin: 8px;
+}
+
+.mat-column-filler {
+  padding: 0 8px;
+  font-size: 10px;
+  text-align: center;
+}
+
+.mat-header-cell, .mat-footer-cell, .mat-cell {
+  min-width: 80px;
+  box-sizing: border-box;
+}
+
+// A width and/or height must be specified to get the browser to show any customizations to
+// the scrollbar.
+.cdk-table-scroll-container::-webkit-scrollbar {
+  background: #59abfd;
+  height: 10px;
+  width: 10px;
+}
+
+.cdk-table-scroll-container::-webkit-scrollbar-track {
+  background: white;
+}
+
+.cdk-table-scroll-container::-webkit-scrollbar-thumb {
+  background: gray;
+}

--- a/src/dev-app/table-scroll-container/table-scroll-container-demo.ts
+++ b/src/dev-app/table-scroll-container/table-scroll-container-demo.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+import {MatButtonToggleGroup} from '@angular/material/button-toggle';
+
+/**
+ * @title Tables with toggle-able sticky headers, footers, and columns
+ */
+@Component({
+  selector: 'table-scroll-container-demo',
+  styleUrls: ['table-scroll-container-demo.css'],
+  templateUrl: 'table-scroll-container-demo.html',
+})
+export class TableScrollContainerDemo {
+  displayedColumns: string[] = [];
+  dataSource = ELEMENT_DATA;
+
+  tables = [0];
+
+  constructor() {
+    this.displayedColumns.length = 24;
+    this.displayedColumns.fill('filler');
+
+    // The first two columns should be position and name; the last two columns: weight, symbol
+    this.displayedColumns[0] = 'position';
+    this.displayedColumns[1] = 'name';
+    this.displayedColumns[22] = 'weight';
+    this.displayedColumns[23] = 'symbol';
+  }
+
+  /** Whether the button toggle group contains the id as an active value. */
+  isSticky(buttonToggleGroup: MatButtonToggleGroup, id: string) {
+    return (buttonToggleGroup.value || []).indexOf(id) !== -1;
+  }
+}
+
+export interface PeriodicElement {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: PeriodicElement[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+];

--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -11,6 +11,7 @@
 @import '../material-experimental/mdc-density/all-density';
 @import '../material-experimental/mdc-slider/slider-theme';
 @import '../material-experimental/popover-edit/popover-edit';
+@import '../material-experimental/mdc-table/table-theme';
 
 // Plus imports for other components in your app.
 

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -203,6 +203,7 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
     _noDataRow: CdkNoDataRow;
     _noDataRowOutlet: NoDataRowOutlet;
     _rowOutlet: DataRowOutlet;
+    protected readonly _stickyPositioningListener?: StickyPositioningListener | undefined;
     protected readonly _viewRepeater?: _ViewRepeater<T, RenderRow<T>, RowContext<T>> | undefined;
     get dataSource(): CdkTableDataSourceInput<T>;
     set dataSource(dataSource: CdkTableDataSourceInput<T>);
@@ -219,7 +220,7 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
         end: number;
     }>;
     constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform,
-    _viewRepeater?: _ViewRepeater<T, RenderRow<T>, RowContext<T>> | undefined, _coalescedStyleScheduler?: _CoalescedStyleScheduler | undefined, _viewportRuler?: ViewportRuler | undefined);
+    _viewRepeater?: _ViewRepeater<T, RenderRow<T>, RowContext<T>> | undefined, _coalescedStyleScheduler?: _CoalescedStyleScheduler | undefined, _stickyPositioningListener?: StickyPositioningListener | undefined, _viewportRuler?: ViewportRuler | undefined);
     _getRenderedRows(rowOutlet: RowOutlet): HTMLElement[];
     _getRowDefs(data: T, dataIndex: number): CdkRowDef<T>[];
     addColumnDef(columnDef: CdkColumnDef): void;
@@ -241,7 +242,7 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
     static ngAcceptInputType_fixedLayout: BooleanInput;
     static ngAcceptInputType_multiTemplateDataRows: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<CdkTable<any>, "cdk-table, table[cdk-table]", ["cdkTable"], { "trackBy": "trackBy"; "dataSource": "dataSource"; "multiTemplateDataRows": "multiTemplateDataRows"; "fixedLayout": "fixedLayout"; }, {}, ["_noDataRow", "_contentColumnDefs", "_contentRowDefs", "_contentHeaderRowDefs", "_contentFooterRowDefs"], ["caption", "colgroup, col"]>;
-    static ɵfac: i0.ɵɵFactoryDef<CdkTable<any>, [null, null, null, { attribute: "role"; }, { optional: true; }, null, null, { optional: true; }, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDef<CdkTable<any>, [null, null, null, { attribute: "role"; }, { optional: true; }, null, null, { optional: true; }, { optional: true; }, { optional: true; skipSelf: true; }, { optional: true; }]>;
 }
 
 export declare class CdkTableModule {
@@ -322,12 +323,23 @@ export interface RowOutlet {
 
 export declare const STICKY_DIRECTIONS: StickyDirection[];
 
+export declare const STICKY_POSITIONING_LISTENER: InjectionToken<StickyPositioningListener>;
+
 export declare type StickyDirection = 'top' | 'bottom' | 'left' | 'right';
+
+export interface StickyPositioningListener {
+    stickyColumnsUpdated(update: StickyUpdate): void;
+    stickyEndColumnsUpdated(update: StickyUpdate): void;
+    stickyFooterRowsUpdated(update: StickyUpdate): void;
+    stickyHeaderRowsUpdated(update: StickyUpdate): void;
+}
+
+export declare type StickySize = number | null | undefined;
 
 export declare class StickyStyler {
     direction: Direction;
     constructor(_isNativeHtmlTable: boolean, _stickCellCss: string, direction: Direction,
-    _coalescedStyleScheduler?: _CoalescedStyleScheduler | undefined, _isBrowser?: boolean, _needsPositionStickyOnElement?: boolean);
+    _coalescedStyleScheduler?: _CoalescedStyleScheduler | undefined, _isBrowser?: boolean, _needsPositionStickyOnElement?: boolean, _positionListener?: StickyPositioningListener | undefined);
     _addStickyStyle(element: HTMLElement, dir: StickyDirection, dirValue: number, isBorderElement: boolean): void;
     _getCalculatedZIndex(element: HTMLElement): string;
     _getCellWidths(row: HTMLElement, recalculateCellWidths?: boolean): number[];
@@ -338,6 +350,10 @@ export declare class StickyStyler {
     stickRows(rowsToStick: HTMLElement[], stickyStates: boolean[], position: 'top' | 'bottom'): void;
     updateStickyColumns(rows: HTMLElement[], stickyStartStates: boolean[], stickyEndStates: boolean[], recalculateCellWidths?: boolean): void;
     updateStickyFooterContainer(tableElement: Element, stickyStates: boolean[]): void;
+}
+
+export interface StickyUpdate {
+    sizes: StickySize[];
 }
 
 export declare const TEXT_COLUMN_OPTIONS: InjectionToken<TextColumnOptions<any>>;


### PR DESCRIPTION
Adds the CdkTableScrollContainer and some hooks in CdkTable for it.

For Webkit/Blink browsers, this sizes the scroll bars in coordinating with
sticky rows/columns in the table to create the user experience that a lot of
commenters in #5885 seemed to want but without the accessibility problems of
other approaches.

![image](https://user-images.githubusercontent.com/923677/100938465-b3d03a80-34c2-11eb-81a3-eaf0a5c7020b.png)
