### PR TITLE
fix(material-experimental/mdc-select): align drop down width with MDC spec

### DIFF
--- a/src/material-experimental/mdc-select/select.html
+++ b/src/material-experimental/mdc-select/select.html
@@ -34,7 +34,7 @@
   [cdkConnectedOverlayOrigin]="_preferredOverlayOrigin || fallbackOverlayOrigin"
   [cdkConnectedOverlayOpen]="panelOpen"
   [cdkConnectedOverlayPositions]="_positions"
-  [cdkConnectedOverlayWidth]="_overlayWidth"
+  [cdkConnectedOverlayMinWidth]="_overlayMinWidth"
   (backdropClick)="close()"
   (attach)="_onAttached()"
   (detach)="close()">

--- a/src/material-experimental/mdc-select/select.scss
+++ b/src/material-experimental/mdc-select/select.scss
@@ -7,6 +7,7 @@
 $mat-select-arrow-size: 5px !default;
 $mat-select-arrow-margin: 4px !default;
 $mat-select-panel-max-height: 256px !default;
+$mat-select-panel-max-width: 280px !default;
 $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-arrow-margin);
 $leading-width: 12px !default;
 $scale: 0.75 !default;
@@ -73,6 +74,7 @@ $scale: 0.75 !default;
   max-height: $mat-select-panel-max-height;
   position: static; // MDC uses `absolute` by default which will throw off our positioning.
   outline: 0;
+  max-width: $mat-select-panel-max-width;
 
   // Note that we include this private mixin, because the public
   // one adds a bunch of styles that we aren't using for the menu.

--- a/src/material-experimental/mdc-select/select.ts
+++ b/src/material-experimental/mdc-select/select.ts
@@ -110,8 +110,8 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
   /** Ideal origin for the overlay panel. */
   _preferredOverlayOrigin: CdkOverlayOrigin | undefined;
 
-  /** Width of the overlay panel. */
-  _overlayWidth: number;
+  /** Min. width of the overlay panel. */
+  _overlayMinWidth: number;
 
   get shouldLabelFloat(): boolean {
     // Since the panel doesn't overlap the trigger, we
@@ -123,7 +123,7 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
     super.ngOnInit();
     this._viewportRuler.change().pipe(takeUntil(this._destroy)).subscribe(() => {
       if (this.panelOpen) {
-        this._overlayWidth = this._getOverlayWidth();
+        this._overlayMinWidth = this._getOverlayMinWidth();
         this._changeDetectorRef.detectChanges();
       }
     });
@@ -145,7 +145,7 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
   }
 
   open() {
-    this._overlayWidth = this._getOverlayWidth();
+    this._overlayMinWidth = this._getOverlayMinWidth();
     super.open();
   }
 
@@ -182,8 +182,10 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
   }
 
   /** Gets how wide the overlay panel should be. */
-  private _getOverlayWidth() {
+  private _getOverlayMinWidth() {
     const refToMeasure = (this._preferredOverlayOrigin?.elementRef || this._elementRef);
-    return refToMeasure.nativeElement.getBoundingClientRect().width;
+    // The min width of a drop down menu panel is 112px but the panel should not be smaller than
+    // the containing form field.
+    return Math.max(refToMeasure.nativeElement.getBoundingClientRect().width, 112);
   }
 }


### PR DESCRIPTION
Previously the select drop down panel was always the same width as the containing form field even if some of the options are longer. This change aligns the min/max width specs with MDC https://material.io/components/menus#specs
Note that min width is set to max of `112` and width of form field as the panel should not be smaller than the form field.
![4JSzMpdPt93UGB8](https://user-images.githubusercontent.com/20130030/101085918-f9454400-3564-11eb-9246-207a683af5b1.png)
