### PR TITLE
fix(material/expansion): not clearing custom query list

### DIFF
--- a/src/material/expansion/accordion.ts
+++ b/src/material/expansion/accordion.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Input, ContentChildren, QueryList, AfterContentInit} from '@angular/core';
+import {
+  Directive,
+  Input,
+  ContentChildren,
+  QueryList,
+  AfterContentInit,
+  OnDestroy,
+} from '@angular/core';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {CdkAccordion} from '@angular/cdk/accordion';
 import {FocusKeyManager} from '@angular/cdk/a11y';
@@ -37,7 +44,8 @@ import {MatExpansionPanelHeader} from './expansion-panel-header';
     '[class.mat-accordion-multi]': 'this.multi',
   }
 })
-export class MatAccordion extends CdkAccordion implements MatAccordionBase, AfterContentInit {
+export class MatAccordion extends CdkAccordion implements MatAccordionBase,
+  AfterContentInit, OnDestroy {
   private _keyManager: FocusKeyManager<MatExpansionPanelHeader>;
 
   /** Headers belonging to this accordion. */
@@ -84,6 +92,11 @@ export class MatAccordion extends CdkAccordion implements MatAccordionBase, Afte
 
   _handleHeaderFocus(header: MatExpansionPanelHeader) {
     this._keyManager.updateActiveItem(header);
+  }
+
+  ngOnDestroy() {
+    super.ngOnDestroy();
+    this._ownHeaders.destroy();
   }
 
   static ngAcceptInputType_hideToggle: BooleanInput;

--- a/tools/public_api_guard/material/expansion.d.ts
+++ b/tools/public_api_guard/material/expansion.d.ts
@@ -4,7 +4,7 @@ export declare const MAT_ACCORDION: InjectionToken<MatAccordionBase>;
 
 export declare const MAT_EXPANSION_PANEL_DEFAULT_OPTIONS: InjectionToken<MatExpansionPanelDefaultOptions>;
 
-export declare class MatAccordion extends CdkAccordion implements MatAccordionBase, AfterContentInit {
+export declare class MatAccordion extends CdkAccordion implements MatAccordionBase, AfterContentInit, OnDestroy {
     _headers: QueryList<MatExpansionPanelHeader>;
     displayMode: MatAccordionDisplayMode;
     get hideToggle(): boolean;
@@ -13,6 +13,7 @@ export declare class MatAccordion extends CdkAccordion implements MatAccordionBa
     _handleHeaderFocus(header: MatExpansionPanelHeader): void;
     _handleHeaderKeydown(event: KeyboardEvent): void;
     ngAfterContentInit(): void;
+    ngOnDestroy(): void;
     static ngAcceptInputType_hideToggle: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatAccordion, "mat-accordion", ["matAccordion"], { "multi": "multi"; "hideToggle": "hideToggle"; "displayMode": "displayMode"; "togglePosition": "togglePosition"; }, {}, ["_headers"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatAccordion, never>;


### PR DESCRIPTION
`MatAccordion` has a custom `QueryList` for keeping track of its own headers which we weren't destroying. These changes add a call to destroy it since it has the potential of leaking memory.