### PR TITLE
fix(material/datepicker): range input controls dirty on init

### DIFF
--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -159,14 +159,19 @@ abstract class MatDateRangeInputPartBase<D>
     return this._rangeInput.dateFilter;
   }
 
-  protected _outsideValueChanged = () => {
-    // Whenever the value changes outside the input we need to revalidate, because
-    // the validation state of each of the inputs depends on the other one.
-    this._validatorOnChange();
-  }
-
   protected _parentDisabled() {
     return this._rangeInput._groupDisabled;
+  }
+
+  protected _shouldHandleChangeEvent({source}: DateSelectionModelChange<DateRange<D>>): boolean {
+    return source !== this._rangeInput._startInput && source !== this._rangeInput._endInput;
+  }
+
+  protected _assignValueProgrammatically(value: D | null) {
+    super._assignValueProgrammatically(value);
+    const opposite = (this === this._rangeInput._startInput ? this._rangeInput._endInput :
+        this._rangeInput._startInput) as MatDateRangeInputPartBase<D> | undefined;
+    opposite?._validatorOnChange();
   }
 }
 
@@ -259,12 +264,7 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
     if (this._model) {
       const range = new DateRange(value, this._model.selection.end);
       this._model.updateSelection(range, this);
-      this._cvaOnChange(value);
     }
-  }
-
-  protected _canEmitChangeEvent = (event: DateSelectionModelChange<DateRange<D>>): boolean => {
-    return event.source !== this._rangeInput._endInput;
   }
 
   protected _formatValue(value: D | null) {
@@ -367,12 +367,7 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements
     if (this._model) {
       const range = new DateRange(this._model.selection.start, value);
       this._model.updateSelection(range, this);
-      this._cvaOnChange(value);
     }
-  }
-
-  protected _canEmitChangeEvent = (event: DateSelectionModelChange<DateRange<D>>): boolean => {
-    return event.source !== this._rangeInput._startInput;
   }
 
   _onKeydown(event: KeyboardEvent) {

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -30,6 +30,7 @@ import {MatFormField, MAT_FORM_FIELD} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
 import {MatDatepickerInputBase, DateFilterFn} from './datepicker-input-base';
 import {MatDatepickerControl, MatDatepickerPanel} from './datepicker-base';
+import {DateSelectionModelChange} from './date-selection-model';
 
 /** @docs-private */
 export const MAT_DATEPICKER_VALUE_ACCESSOR: any = {
@@ -183,12 +184,9 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
     return this._dateFilter;
   }
 
-  protected _canEmitChangeEvent() {
-    return true;
+  protected _shouldHandleChangeEvent(event: DateSelectionModelChange<D>) {
+    return event.source !== this;
   }
-
-  // Unnecessary when selecting a single date.
-  protected _outsideValueChanged: undefined;
 
   // Accept `any` to avoid conflicts with other directives on `<input>` that
   // may accept different types.

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -211,7 +211,6 @@ export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>
 
 export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> implements MatDatepickerControl<D | null> {
     _datepicker: MatDatepickerPanel<MatDatepickerControl<D>, D | null, D>;
-    protected _outsideValueChanged: undefined;
     protected _validator: ValidatorFn | null;
     get dateFilter(): DateFilterFn<D | null>;
     set dateFilter(value: DateFilterFn<D | null>);
@@ -222,12 +221,12 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | nu
     set min(value: D | null);
     constructor(elementRef: ElementRef<HTMLInputElement>, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats, _formField: MatFormField);
     protected _assignValueToModel(value: D | null): void;
-    protected _canEmitChangeEvent(): boolean;
     protected _getDateFilter(): DateFilterFn<D | null>;
     _getMaxDate(): D | null;
     _getMinDate(): D | null;
     protected _getValueFromModel(modelValue: D | null): D | null;
     protected _openPopup(): void;
+    protected _shouldHandleChangeEvent(event: DateSelectionModelChange<D>): boolean;
     getConnectedOverlayOrigin(): ElementRef;
     getStartValue(): D | null;
     getThemePalette(): ThemePalette;
@@ -372,7 +371,6 @@ export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSe
 }
 
 export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState, DoCheck, OnInit {
-    protected _canEmitChangeEvent: (event: DateSelectionModelChange<DateRange<D>>) => boolean;
     protected _validator: ValidatorFn | null;
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
     protected _assignValueToModel(value: D | null): void;
@@ -482,7 +480,6 @@ export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionMode
 }
 
 export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implements CanUpdateErrorState, DoCheck, OnInit {
-    protected _canEmitChangeEvent: (event: DateSelectionModelChange<DateRange<D>>) => boolean;
     protected _validator: ValidatorFn | null;
     constructor(rangeInput: MatDateRangeInputParent<D>, elementRef: ElementRef<HTMLInputElement>, defaultErrorStateMatcher: ErrorStateMatcher, injector: Injector, parentForm: NgForm, parentFormGroup: FormGroupDirective, dateAdapter: DateAdapter<D>, dateFormats: MatDateFormats);
     protected _assignValueToModel(value: D | null): void;


### PR DESCRIPTION
Fixes that the date range input controls were marking each other as dirty on initialization. This seems like an easy fix on the surface, but it's somewhat tricky, because while we usually don't want the inputs to respond each other's events, we still want it to happen if an end date before the start date is assigned.

These changes resolve the issue by not having the inputs respond to any events from inside the input, but notify each other when a value is assigned programmatically.

I've also cleaned up some unnecessary code and added more test cases for things that tripped me up while fixing the issue.

Fixes #20213.