### PR TITLE
docs(material/checkbox): updated docs for default option value for ch…

### DIFF
--- a/src/material-experimental/mdc-checkbox/testing/checkbox-harness.ts
+++ b/src/material-experimental/mdc-checkbox/testing/checkbox-harness.ts
@@ -112,7 +112,7 @@ export class MatCheckboxHarness extends ComponentHarness {
    * action is complete.
    *
    * Note: This attempts to toggle the checkbox as a user would, by clicking it. Therefore if you
-   * are using `MAT_CHECKBOX_CLICK_ACTION` to change the behavior on click, calling this method
+   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS` to change the behavior on click, calling this method
    * might not have the expected result.
    */
   async toggle(): Promise<void> {
@@ -126,7 +126,7 @@ export class MatCheckboxHarness extends ComponentHarness {
    * complete.
    *
    * Note: This attempts to check the checkbox as a user would, by clicking it. Therefore if you
-   * are using `MAT_CHECKBOX_CLICK_ACTION` to change the behavior on click, calling this method
+   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS` to change the behavior on click, calling this method
    * might not have the expected result.
    */
   async check(): Promise<void> {
@@ -141,7 +141,7 @@ export class MatCheckboxHarness extends ComponentHarness {
    * complete.
    *
    * Note: This attempts to uncheck the checkbox as a user would, by clicking it. Therefore if you
-   * are using `MAT_CHECKBOX_CLICK_ACTION` to change the behavior on click, calling this method
+   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS` to change the behavior on click, calling this method
    * might not have the expected result.
    */
   async uncheck(): Promise<void> {

--- a/src/material/checkbox/checkbox.md
+++ b/src/material/checkbox/checkbox.md
@@ -27,11 +27,11 @@ remove the indeterminate state.
 When user clicks on the `mat-checkbox`, the default behavior is toggle `checked` value and set
 `indeterminate` to `false`. This behavior can be customized by
 [providing a new value](https://angular.io/guide/dependency-injection)
-of `MAT_CHECKBOX_CLICK_ACTION` to the checkbox.
+of `MAT_CHECKBOX_DEFAULT_OPTIONS` to the checkbox.
 
 ```
 providers: [
-  {provide: MAT_CHECKBOX_CLICK_ACTION, useValue: 'check'}
+  {provide: MAT_CHECKBOX_DEFAULT_OPTIONS, useValue: { clickAction: 'noop' } as MatCheckboxDefaultOptions}
 ]
 ```
 

--- a/src/material/checkbox/testing/checkbox-harness.ts
+++ b/src/material/checkbox/testing/checkbox-harness.ts
@@ -136,7 +136,7 @@ export class MatCheckboxHarness extends ComponentHarness {
    * nothing if it is already unchecked.
    *
    * Note: This attempts to uncheck the checkbox as a user would, by clicking it. Therefore if you
-   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS`  to change the behavior on click, calling this method
+   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS` to change the behavior on click, calling this method
    * might not have the expected result.
    */
   async uncheck(): Promise<void> {

--- a/src/material/checkbox/testing/checkbox-harness.ts
+++ b/src/material/checkbox/testing/checkbox-harness.ts
@@ -136,7 +136,7 @@ export class MatCheckboxHarness extends ComponentHarness {
    * nothing if it is already unchecked.
    *
    * Note: This attempts to uncheck the checkbox as a user would, by clicking it. Therefore if you
-   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS` to change the behavior on click, calling this method
+   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS`  to change the behavior on click, calling this method
    * might not have the expected result.
    */
   async uncheck(): Promise<void> {

--- a/src/material/checkbox/testing/checkbox-harness.ts
+++ b/src/material/checkbox/testing/checkbox-harness.ts
@@ -110,7 +110,7 @@ export class MatCheckboxHarness extends ComponentHarness {
    * Toggles the checked state of the checkbox.
    *
    * Note: This attempts to toggle the checkbox as a user would, by clicking it. Therefore if you
-   * are using `MAT_CHECKBOX_CLICK_ACTION` to change the behavior on click, calling this method
+   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS` to change the behavior on click, calling this method
    * might not have the expected result.
    */
   async toggle(): Promise<void> {
@@ -122,7 +122,7 @@ export class MatCheckboxHarness extends ComponentHarness {
    * nothing if it is already checked.
    *
    * Note: This attempts to check the checkbox as a user would, by clicking it. Therefore if you
-   * are using `MAT_CHECKBOX_CLICK_ACTION` to change the behavior on click, calling this method
+   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS` to change the behavior on click, calling this method
    * might not have the expected result.
    */
   async check(): Promise<void> {
@@ -136,7 +136,7 @@ export class MatCheckboxHarness extends ComponentHarness {
    * nothing if it is already unchecked.
    *
    * Note: This attempts to uncheck the checkbox as a user would, by clicking it. Therefore if you
-   * are using `MAT_CHECKBOX_CLICK_ACTION` to change the behavior on click, calling this method
+   * are using `MAT_CHECKBOX_DEFAULT_OPTIONS` to change the behavior on click, calling this method
    * might not have the expected result.
    */
   async uncheck(): Promise<void> {


### PR DESCRIPTION
…eckbox

updates the documentation of customizing the default option of the checkbox.
the default option value to provide for checkbox is MAT_CHECKBOX_DEFAULT_OPTIONS for version>=10

fixes #21025