### PR TITLE
docs(changelog): clarify end of support for node-sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@
 
 ### material
 
+Note: Support for the node-sass npm package, based on libsass, was deprecated in version 10. This
+support officially ends with version 11. Ending support for node-sass allows us to switch to the
+new Sass module system (the `@use` syntax), simplifying our Sass and keeping up with ecosystem
+best practices. The `sass` npm package is an API compatible replacement maintained by the official
+Sass team at Google. 
+
 _Breaking changes:_
 
 * **snack-bar:** matSnackBarHarness.getRole() replaced with .getAriaLive() due to using aria-live


### PR DESCRIPTION
We deprecated support for node-sass in v10 with the intent of removing it
in v11, but we did not make this clear in the v11 changelog. This PR
clarifies that node-sass support is ended.