### PR TITLE
fix(material/menu): prevent mat-menu from affecting flex layout

### DIFF
--- a/src/material-experimental/mdc-menu/menu.scss
+++ b/src/material-experimental/mdc-menu/menu.scss
@@ -9,6 +9,11 @@
 
 @include mdc-menu-surface-core-styles($query: structure);
 
+// Prevent rendering mat-menu as it can affect the flex layout.
+mat-menu {
+  display: none;
+}
+
 .mat-mdc-menu-content {
   // Note that we include this private mixin, because the public
   // one adds a bunch of styles that we aren't using for the menu.

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -7,6 +7,11 @@ $mat-menu-vertical-padding: 8px !default;
 $mat-menu-border-radius: 4px !default;
 $mat-menu-submenu-indicator-size: 10px !default;
 
+// Prevent rendering mat-menu as it can affect the flex layout.
+mat-menu {
+  display: none;
+}
+
 .mat-menu-panel {
   @include mat-menu-base();
   max-height: calc(100vh - #{$mat-menu-item-height});


### PR DESCRIPTION
Fixes https://github.com/angular/components/issues/21182
