### PR TITLE
fix(material/core): remove label element from option group

### DIFF
--- a/src/material-experimental/mdc-core/option/optgroup.html
+++ b/src/material-experimental/mdc-core/option/optgroup.html
@@ -1,8 +1,8 @@
-<label
+<div
   class="mat-mdc-optgroup-label"
   [class.mdc-list-item--disabled]="disabled"
   [id]="_labelId">
   <span class="mdc-list-item__text">{{ label }} <ng-content></ng-content></span>
-</label>
+</div>
 
 <ng-content select="mat-option, ng-container"></ng-content>

--- a/src/material-experimental/mdc-select/select.spec.ts
+++ b/src/material-experimental/mdc-select/select.spec.ts
@@ -1133,7 +1133,7 @@ describe('MDC-based MatSelect', () => {
 
         it('should set the `aria-labelledby` attribute', fakeAsync(() => {
           let group = groups[0];
-          let label = group.querySelector('label')!;
+          let label = group.querySelector('.mat-mdc-optgroup-label')!;
 
           expect(label.getAttribute('id')).toBeTruthy('Expected label to have an id.');
           expect(group.getAttribute('aria-labelledby'))

--- a/src/material/core/option/optgroup.html
+++ b/src/material/core/option/optgroup.html
@@ -1,2 +1,2 @@
-<label class="mat-optgroup-label" [id]="_labelId">{{ label }} <ng-content></ng-content></label>
+<div class="mat-optgroup-label" [id]="_labelId">{{ label }} <ng-content></ng-content></div>
 <ng-content select="mat-option, ng-container"></ng-content>

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -1129,7 +1129,7 @@ describe('MatSelect', () => {
 
         it('should set the `aria-labelledby` attribute', fakeAsync(() => {
           let group = groups[0];
-          let label = group.querySelector('label')!;
+          let label = group.querySelector('.mat-optgroup-label')!;
 
           expect(label.getAttribute('id')).toBeTruthy('Expected label to have an id.');
           expect(group.getAttribute('aria-labelledby'))


### PR DESCRIPTION
Replaces the `label` element in `mat-optgroup` with a regular `div`, because `label` is primarily meant for labelling interactive elements.