### PR TITLE
fix(material-experimental/mdc-form-field): add padding to subscript t…

### DIFF
--- a/src/material-experimental/mdc-form-field/_form-field-subscript.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-subscript.scss
@@ -43,6 +43,8 @@
   }
 }
 
+// We need to define our own typography for the subscript because we don't include MDC's
+// helper text in our MDC based form field
 @mixin mat-mdc-private-form-field-subscript-typography($config-or-theme) {
   $config: mat-get-typography-config($config-or-theme);
   // The unit-less line-height from the font config.
@@ -59,6 +61,8 @@
   // combination of the subscript's margin and line-height, but we need to multiply by the
   // subscript font scale factor since the subscript has a reduced font size.
   $subscript-min-height: ($subscript-margin-top + $line-height) * $subscript-font-scale;
+  // The horizontal padding between the edge of the text box and the start of the subscript text.
+  $subscript-horizontal-padding: 16px;
 
   // The subscript wrapper has a minimum height to avoid that the form-field
   // jumps when hints or errors are displayed.
@@ -66,5 +70,6 @@
     min-height: $subscript-min-height;
     font-size: $subscript-font-size;
     margin-top: $subscript-margin-top;
+    padding: 0 $subscript-horizontal-padding;
   }
 }


### PR DESCRIPTION
…o align with spec

There should be 16px padding between the the edge of the form field box and start of the hint/error.
https://material.io/components/text-fields#specs


Before:
![54VdYuytKZFrzXT](https://user-images.githubusercontent.com/20130030/101707697-965e1c00-3a40-11eb-8606-105c94ee184f.png)

After:
![4vAJ9fnk4JbURnL](https://user-images.githubusercontent.com/20130030/101707712-9cec9380-3a40-11eb-8f23-e7076b6fafc0.png)
