### PR TITLE
fix(material/radio): remove tabindex from host node

### DIFF
--- a/src/material-experimental/mdc-radio/radio.spec.ts
+++ b/src/material-experimental/mdc-radio/radio.spec.ts
@@ -796,17 +796,7 @@ describe('MDC-based MatRadio', () => {
       const radioButtonEl =
           predefinedFixture.debugElement.query(By.css('.mat-mdc-radio-button'))!.nativeElement;
 
-      expect(radioButtonEl.getAttribute('tabindex')).toBe('-1');
-    });
-
-    it('should set the tabindex to -1 on the host element', () => {
-      const predefinedFixture = TestBed.createComponent(RadioButtonWithPredefinedTabindex);
-      predefinedFixture.detectChanges();
-
-      const radioButtonEl =
-          predefinedFixture.debugElement.query(By.css('.mat-mdc-radio-button'))!.nativeElement;
-
-      expect(radioButtonEl.getAttribute('tabindex')).toBe('-1');
+      expect(radioButtonEl.hasAttribute('tabindex')).toBe(false);
     });
 
     it('should forward a pre-defined tabindex to the underlying input', () => {

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -97,7 +97,8 @@ export class MatRadioGroup extends _MatRadioGroupBase<MatRadioButton> {
     '[class.mat-primary]': 'color === "primary"',
     '[class.mat-accent]': 'color === "accent"',
     '[class.mat-warn]': 'color === "warn"',
-    '[attr.tabindex]': 'disabled ? null : -1',
+    // Needs to be removed since it causes some a11y issues (see #21266).
+    '[attr.tabindex]': 'null',
     '[attr.aria-label]': 'null',
     '[attr.aria-labelledby]': 'null',
     '[attr.aria-describedby]': 'null',

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -790,7 +790,7 @@ describe('MatRadio', () => {
       const radioButtonEl =
           predefinedFixture.debugElement.query(By.css('.mat-radio-button'))!.nativeElement;
 
-      expect(radioButtonEl.getAttribute('tabindex')).toBe('-1');
+      expect(radioButtonEl.hasAttribute('tabindex')).toBe(false);
     });
 
     it('should forward a pre-defined tabindex to the underlying input', () => {

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -640,8 +640,8 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
     '[class.mat-primary]': 'color === "primary"',
     '[class.mat-accent]': 'color === "accent"',
     '[class.mat-warn]': 'color === "warn"',
-    // Needs to be -1 so the `focus` event still fires.
-    '[attr.tabindex]': '-1',
+    // Needs to be removed since it causes some a11y issues (see #21266).
+    '[attr.tabindex]': 'null',
     '[attr.id]': 'id',
     '[attr.aria-label]': 'null',
     '[attr.aria-labelledby]': 'null',


### PR DESCRIPTION
Removes the `tabindex` from the host node, because it causes some a11y issues. We had it there before so that things like `cdkFocusInitial` would work, but after #21046 it isn't necessary anymore.

Fixes #21266.