### PR TITLE
fix(material-experimental/mdc-slide-toggle): add class to mdc-switch element

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -1,6 +1,6 @@
 <div class="mdc-form-field"
      [class.mdc-form-field--align-end]="labelPosition == 'before'">
-  <div class="mdc-switch" #switch>
+  <div class="mdc-switch mat-mdc-switch" #switch>
     <div class="mdc-switch__track"></div>
     <div class="mdc-switch__thumb-underlay mat-mdc-focus-indicator">
       <div class="mat-mdc-slide-toggle-ripple" mat-ripple


### PR DESCRIPTION
Required for internal styling so that we can target the `mdc-switch` element without using the `.mdc-switch` target