### PR TITLE
refactor(material/core): make typography normalization function private

### DIFF
--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -78,7 +78,7 @@
 // produces a normalized typography config for the 2014 Material Design typography system.
 // 2014 - https://material.io/archive/guidelines/style/typography.html#typography-styles
 // 2018 - https://material.io/design/typography/the-type-system.html#type-scale
-@function mat-typography-normalized-config($config) {
+@function mat-private-typography-normalized-config($config) {
   @if mat-private-typography-is-2018-config($config) {
     @return mat-typography-config(
         $display-3: map-get($config, display-1),


### PR DESCRIPTION
This was mistakenly made public in https://github.com/angular/components/pull/21059