### PR TITLE
fix(material-experimental/mdc-autocomplete): Allow typography mixin t…

### DIFF
--- a/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
+++ b/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
@@ -11,6 +11,7 @@
 }
 
 @mixin mat-mdc-autocomplete-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   @include mat-using-mdc-typography($config) {
     @include mdc-menu-surface-core-styles($mat-typography-styles-query);


### PR DESCRIPTION
…o consume 2018 style configs

See https://github.com/angular/components/pull/21059 for context.