### PR TITLE
fix(material-experimental/mdc-core): Allow typography mixin to consume 2018 style configs

### DIFF
--- a/src/material-experimental/mdc-core/option/_optgroup-theme.scss
+++ b/src/material-experimental/mdc-core/option/_optgroup-theme.scss
@@ -20,6 +20,7 @@
 }
 
 @mixin mat-mdc-optgroup-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
 }
 

--- a/src/material-experimental/mdc-core/option/_option-theme.scss
+++ b/src/material-experimental/mdc-core/option/_option-theme.scss
@@ -42,6 +42,7 @@
 }
 
 @mixin mat-mdc-option-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
 }
 


### PR DESCRIPTION
See https://github.com/angular/components/pull/21059 for context.