### PR TITLE
fix(material/card): Allow typography mixin to consume 2018 style configs

### DIFF
--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -1,6 +1,7 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/style/private';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 
 
@@ -26,6 +27,7 @@
 }
 
 @mixin mat-card-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   .mat-card {
     font-family: mat-font-family($config);


### PR DESCRIPTION
See https://github.com/angular/components/pull/21059 for context.