### PR TITLE
fix(material/core): Allow typography mixin to consume 2018 style configs

### DIFF
--- a/src/material/core/option/_optgroup-theme.scss
+++ b/src/material/core/option/_optgroup-theme.scss
@@ -1,5 +1,6 @@
 @import '../theming/palette';
 @import '../theming/theming';
+@import '../typography/typography';
 @import '../typography/typography-utils';
 
 @mixin mat-optgroup-color($config-or-theme) {
@@ -16,6 +17,7 @@
 }
 
 @mixin mat-optgroup-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   .mat-optgroup-label {
     @include mat-typography-level-to-styles($config, body-2);

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -1,5 +1,6 @@
 @import '../theming/palette';
 @import '../theming/theming';
+@import '../typography/typography';
 @import '../typography/typography-utils';
 
 @mixin mat-option-color($config-or-theme) {
@@ -47,6 +48,7 @@
 }
 
 @mixin mat-option-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   .mat-option {
     font: {


### PR DESCRIPTION
See https://github.com/angular/components/pull/21059 for context.