### PR TITLE
fix(material/form-field): Allow typography mixin to consume 2018 style configs

### DIFF
--- a/src/material/form-field/_form-field-fill-theme.scss
+++ b/src/material/form-field/_form-field-fill-theme.scss
@@ -1,6 +1,7 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/style/form-common';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 
 
@@ -57,6 +58,7 @@ $mat-form-field-fill-dedupe: 0;
 }
 
 @mixin mat-form-field-fill-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   // The unit-less line-height from the font config.
   $line-height: mat-line-height($config, input);

--- a/src/material/form-field/_form-field-legacy-theme.scss
+++ b/src/material/form-field/_form-field-legacy-theme.scss
@@ -1,6 +1,7 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/style/form-common';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 
 
@@ -69,6 +70,7 @@ $mat-form-field-legacy-dedupe: 0;
 }
 
 @mixin mat-form-field-legacy-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   // The unit-less line-height from the font config.
   $line-height: mat-line-height($config, input);

--- a/src/material/form-field/_form-field-outline-theme.scss
+++ b/src/material/form-field/_form-field-outline-theme.scss
@@ -1,6 +1,7 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/style/form-common';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 
 
@@ -80,6 +81,7 @@ $mat-form-field-outline-dedupe: 0;
 }
 
 @mixin mat-form-field-outline-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   // The unit-less line-height from the font config.
   $line-height: mat-line-height($config, input);

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -1,6 +1,7 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
 @import '../core/style/form-common';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 
 @import './form-field-fill-theme.scss';
@@ -130,6 +131,7 @@ $mat-form-field-dedupe: 0;
 }
 
 @mixin mat-form-field-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   // The unit-less line-height from the font config.
   $line-height: mat-line-height($config, input);


### PR DESCRIPTION
See https://github.com/angular/components/pull/21059 for context.