### PR TITLE
fix(material/list): Allow typography mixin to consume 2018 style configs

### DIFF
--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -1,5 +1,6 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 @import '../core/style/list-common';
 
@@ -43,6 +44,7 @@
 }
 
 @mixin mat-list-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   $font-family: mat-font-family($config);
 


### PR DESCRIPTION
See https://github.com/angular/components/pull/21059 for context.