### PR TITLE
fix(material/menu): Allow typography mixin to consume 2018 style configs

### DIFF
--- a/src/material/menu/_menu-theme.scss
+++ b/src/material/menu/_menu-theme.scss
@@ -1,6 +1,7 @@
 @import '../core/style/private';
 @import '../core/theming/palette';
 @import '../core/theming/theming';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 
 
@@ -43,6 +44,7 @@
 }
 
 @mixin mat-menu-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   .mat-menu-item {
     font: {


### PR DESCRIPTION
See https://github.com/angular/components/pull/21059 for context.