### PR TITLE
fix(material/snack-bar): Allow typography mixin to consume 2018 style…

### DIFF
--- a/src/material/snack-bar/_snack-bar-theme.scss
+++ b/src/material/snack-bar/_snack-bar-theme.scss
@@ -1,3 +1,4 @@
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 @import '../core/theming/theming';
 @import '../core/theming/palette';
@@ -23,6 +24,7 @@
 }
 
 @mixin mat-snack-bar-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   .mat-simple-snackbar {
     font: {


### PR DESCRIPTION
… configs

See https://github.com/angular/components/pull/21059 for context.