### PR TITLE
fix(material/tabs): Allow typography mixin to consume 2018 style configs

### DIFF
--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -1,5 +1,6 @@
 @import '../core/theming/palette';
 @import '../core/theming/theming';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 
 @mixin mat-tabs-color($config-or-theme) {
@@ -127,6 +128,7 @@
 }
 
 @mixin mat-tabs-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   .mat-tab-group {
     font-family: mat-font-family($config);


### PR DESCRIPTION
See https://github.com/angular/components/pull/21059 for context.