### PR TITLE
fix(material/tree): Allow typography mixin to consume 2018 style configs

### DIFF
--- a/src/material/tree/_tree-theme.scss
+++ b/src/material/tree/_tree-theme.scss
@@ -1,6 +1,7 @@
 @import '../core/density/private/compatibility';
 @import '../core/theming/palette';
 @import '../core/theming/theming';
+@import '../core/typography/typography';
 @import '../core/typography/typography-utils';
 @import  './tree-variables';
 
@@ -20,6 +21,7 @@
 }
 
 @mixin mat-tree-typography($config-or-theme) {
+  $config: mat-private-typography-normalized-config(mat-get-typography-config($config-or-theme));
   $config: mat-get-typography-config($config-or-theme);
   .mat-tree {
     font-family: mat-font-family($config);


### PR DESCRIPTION
See https://github.com/angular/components/pull/21059 for context.