### PR TITLE
fix(cdk/scrolling): virtual scroll not picking up trackBy function when items come in after init

### DIFF
--- a/src/cdk/scrolling/BUILD.bazel
+++ b/src/cdk/scrolling/BUILD.bazel
@@ -45,6 +45,7 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/collections",
         "//src/cdk/testing/private",
+        "@npm//@angular/common",
         "@npm//rxjs",
     ],
 )

--- a/src/cdk/scrolling/virtual-for-of.ts
+++ b/src/cdk/scrolling/virtual-for-of.ts
@@ -288,7 +288,11 @@ export class CdkVirtualForOf<T> implements
     }
     this._renderedItems = this._data.slice(this._renderedRange.start, this._renderedRange.end);
     if (!this._differ) {
-      this._differ = this._differs.find(this._renderedItems).create(this.cdkVirtualForTrackBy);
+      // Use a wrapper function for the `trackBy` so any new values are
+      // picked up automatically without having to recreate the differ.
+      this._differ = this._differs.find(this._renderedItems).create((index, item) => {
+        return this.cdkVirtualForTrackBy ? this.cdkVirtualForTrackBy(index, item) : item;
+      });
     }
     this._needsUpdate = true;
   }
@@ -310,7 +314,7 @@ export class CdkVirtualForOf<T> implements
     const count = this._data.length;
     let i = this._viewContainerRef.length;
     while (i--) {
-      let view = this._viewContainerRef.get(i) as EmbeddedViewRef<CdkVirtualForOfContext<T>>;
+      const view = this._viewContainerRef.get(i) as EmbeddedViewRef<CdkVirtualForOfContext<T>>;
       view.context.index = this._renderedRange.start + i;
       view.context.count = count;
       this._updateComputedContextProperties(view.context);
@@ -324,7 +328,7 @@ export class CdkVirtualForOf<T> implements
         changes,
         this._viewContainerRef,
         (record: IterableChangeRecord<T>,
-         adjustedPreviousIndex: number | null,
+         _adjustedPreviousIndex: number | null,
          currentIndex: number | null) => this._getEmbeddedViewArgs(record, currentIndex!),
         (record) => record.item);
 


### PR DESCRIPTION
The virtual scroll only creates its `IterableDiffer` once, which means that if the `trackBy` function comes in at a later point (e.g. the input changed or the initialization order is different), it won't be picked up.

These changes make it so the differ always has a `trackBy` which then delegates to the user-provided one or falls back to the default.

Fixes #21281.