### PR TITLE
docs(material/dialog): state when notification observables close

### DIFF
--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -14,7 +14,7 @@ let dialogRef = dialog.open(UserProfileComponent, {
 ```
 
 The `MatDialogRef` provides a handle on the opened dialog. It can be used to close the dialog and to
-receive notification when the dialog has been closed. Any notification Observables will close with the dialog.
+receive notifications when the dialog has been closed. Any notification Observables will complete when the dialog closes.
 
 ```ts
 dialogRef.afterClosed().subscribe(result => {

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -14,7 +14,7 @@ let dialogRef = dialog.open(UserProfileComponent, {
 ```
 
 The `MatDialogRef` provides a handle on the opened dialog. It can be used to close the dialog and to
-receive notification when the dialog has been closed.
+receive notification when the dialog has been closed. Any notification Observables will close with the dialog.
 
 ```ts
 dialogRef.afterClosed().subscribe(result => {
@@ -26,7 +26,7 @@ dialogRef.close('Pizza!');
 
 Components created via `MatDialog` can _inject_ `MatDialogRef` and use it to close the dialog
 in which they are contained. When closing, an optional result value can be provided. This result
-value is forwarded as the result of the `afterClosed` promise.
+value is forwarded as the result of the `afterClosed` Observable.
 
 ```ts
 @Component({/* ... */})


### PR DESCRIPTION
It's currently not stated if and when the notification observables from `MatDialogRef` are closed. This causes questions and discussions both online and offline (in my team at work to be precise).

See different answers and comments in:
- https://stackoverflow.com/questions/58198544/angular-dialogref-unsubscribe-do-i-need-to-unsubscribe-from-afterclosed, 
- https://stackoverflow.com/questions/42343072/how-to-subscribe-to-angularmaterial-dialog-afterclosed/53556855

I think this matter should be mentioned in the documentation.