### PR TITLE
fix(material/table): unsubscribe from source when disconnecting

### DIFF
--- a/src/material/table/table-data-source.spec.ts
+++ b/src/material/table/table-data-source.spec.ts
@@ -5,8 +5,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Component, ViewChild} from '@angular/core';
 
 describe('MatTableDataSource', () => {
-  const dataSource = new MatTableDataSource();
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSortModule, NoopAnimationsModule],
@@ -15,13 +13,16 @@ describe('MatTableDataSource', () => {
   }));
 
   describe('sort', () => {
+    let dataSource: MatTableDataSource<any>;
     let fixture: ComponentFixture<MatSortApp>;
     let sort: MatSort;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(MatSortApp);
       fixture.detectChanges();
+      dataSource = new MatTableDataSource();
       sort = fixture.componentInstance.sort;
+      dataSource.sort = sort;
     });
 
     /** Test the data source's `sortData` function. */
@@ -50,6 +51,19 @@ describe('MatTableDataSource', () => {
 
     it('should be able to correctly sort an array of strings and numbers', () => {
       testSortWithValues([3, 'apples', 'bananas', 'cherries', 'lemons', 'strawberries']);
+    });
+
+    it('should unsubscribe from the re-render stream when disconnected', () => {
+      const spy = spyOn(dataSource._renderChangesSubscription!, 'unsubscribe');
+      dataSource.disconnect();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-subscribe to the sort stream when re-connecting after being disconnected', () => {
+      dataSource.disconnect();
+      const spy = spyOn(fixture.componentInstance.sort.sortChange, 'subscribe');
+      dataSource.connect();
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tools/public_api_guard/material/table.d.ts
+++ b/tools/public_api_guard/material/table.d.ts
@@ -1,7 +1,7 @@
 export declare const _MAT_TEXT_COLUMN_TEMPLATE = "\n  <ng-container matColumnDef>\n    <th mat-header-cell *matHeaderCellDef [style.text-align]=\"justify\">\n      {{headerText}}\n    </th>\n    <td mat-cell *matCellDef=\"let data\" [style.text-align]=\"justify\">\n      {{dataAccessor(data, name)}}\n    </td>\n  </ng-container>\n";
 
 export declare class _MatTableDataSource<T, P extends Paginator> extends DataSource<T> {
-    _renderChangesSubscription: Subscription;
+    _renderChangesSubscription: Subscription | null;
     get data(): T[];
     set data(data: T[]);
     get filter(): string;


### PR DESCRIPTION
* Fixes that the table data source wasn't unsubscribing from sorting, pagination etc. when it is disconnected.
* Adds a bit of logic to properly support re-connecting the same date source again.
* Fixes up a couple of issues in the unit test setup which could cause state to leak between tests.

Fixes #21270.