### PR TITLE
build: clean up some internal deprecated API usages

### DIFF
--- a/src/cdk-experimental/menu/menu.spec.ts
+++ b/src/cdk-experimental/menu/menu.spec.ts
@@ -1,7 +1,6 @@
 import {
   ComponentFixture,
   TestBed,
-  async,
   fakeAsync,
   tick,
   flush,
@@ -260,7 +259,7 @@ describe('Menu', () => {
 
       let nativeMenus: HTMLElement[];
 
-      beforeEach(async(() => {
+      beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule],
           declarations: [WithComplexNestedMenus],
@@ -456,7 +455,7 @@ describe('Menu', () => {
 
       let nativeMenus: HTMLElement[];
 
-      beforeEach(async(() => {
+      beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkMenuModule],
           declarations: [WithComplexNestedMenusOnBottom],

--- a/test/benchmarks/cdk/testing/component-harness/protractor-benchmark-utilities.ts
+++ b/test/benchmarks/cdk/testing/component-harness/protractor-benchmark-utilities.ts
@@ -31,7 +31,6 @@ async function benchmarkWithBenchpress(id: string, callback: () => Promise<unkno
     id,
     url: '',
     ignoreBrowserSynchronization: true,
-    params: [],
     work: async () => await callback(),
   });
 }

--- a/test/benchmarks/material/button/button.perf-spec.ts
+++ b/test/benchmarks/material/button/button.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('button performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a basic raised button', async() => {
@@ -19,7 +19,6 @@ describe('button performance benchmarks', () => {
       id: 'button-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide').click(),
       work: async () => await $('#show').click(),
     });
@@ -30,7 +29,6 @@ describe('button performance benchmarks', () => {
       id: 'button-click',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => await $('#show').click(),
       work: async () => await $('.mat-raised-button').click(),
     });

--- a/test/benchmarks/material/card/card.perf-spec.ts
+++ b/test/benchmarks/material/card/card.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('card performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a simple card', async() => {
@@ -19,7 +19,6 @@ describe('card performance benchmarks', () => {
       id: 'card-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide').click(),
       work: async () => await $('#show').click()
     });

--- a/test/benchmarks/material/checkbox/checkbox.perf-spec.ts
+++ b/test/benchmarks/material/checkbox/checkbox.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('checkbox performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a checked checkbox', async() => {
@@ -19,7 +19,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-render-checked',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         await $('#show').click();
         await $('mat-checkbox').click();
@@ -38,7 +37,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-render-unchecked',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => await $('#show').click(),
       prepare: async () => {
         expect(await $('mat-checkbox input').isSelected())
@@ -54,7 +52,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-render-indeterminate',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => {
         await $('#show').click();
         await $('#indeterminate').click();
@@ -73,7 +70,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-click-unchecked-to-checked',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         await $('#show').click();
         await $('mat-checkbox').click();
@@ -92,7 +88,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-click-checked-to-unchecked',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => await $('#show').click(),
       prepare: async () => {
         await $('mat-checkbox').click();

--- a/test/benchmarks/material/chips/chips.perf-spec.ts
+++ b/test/benchmarks/material/chips/chips.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('chip performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a single chip', async() => {
@@ -19,7 +19,6 @@ describe('chip performance benchmarks', () => {
       id: 'single-chip-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide-single').click(),
       work: async () => await $('#show-single').click(),
     });
@@ -30,7 +29,6 @@ describe('chip performance benchmarks', () => {
       id: 'multiple-chip-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide-multiple').click(),
       work: async () => await $('#show-multiple').click(),
     });
@@ -41,7 +39,6 @@ describe('chip performance benchmarks', () => {
       id: 'chip-click',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => await $('#show-single').click(),
       work: async () => await $('.mat-chip').click(),
     });

--- a/test/benchmarks/material/form-field/form-field.perf-spec.ts
+++ b/test/benchmarks/material/form-field/form-field.perf-spec.ts
@@ -14,7 +14,6 @@ function runFormFieldRenderBenchmark(testId: string, showBtnId: string) {
     id: testId,
     url: '',
     ignoreBrowserSynchronization: true,
-    params: [],
     prepare: async () => await $('#hide').click(),
     work: async () => await $(showBtnId).click()
   });
@@ -22,7 +21,7 @@ function runFormFieldRenderBenchmark(testId: string, showBtnId: string) {
 
 describe('form field performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders an input in a form field', async() => {

--- a/test/benchmarks/material/menu/menu.perf-spec.ts
+++ b/test/benchmarks/material/menu/menu.perf-spec.ts
@@ -26,7 +26,6 @@ describe('menu performance benchmarks', () => {
       id: 'open-and-close-basic-menu',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         trigger = element(by.buttonText('Basic Menu'));
       },
@@ -43,7 +42,6 @@ describe('menu performance benchmarks', () => {
       id: 'shallow-open-and-close-nested-menu',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         trigger = element(by.buttonText('Nested Menu'));
       },
@@ -60,7 +58,6 @@ describe('menu performance benchmarks', () => {
       id: 'deep-open-and-close-nested-menus',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: () => {
         trigger = element(by.buttonText('Nested Menu'));
       },

--- a/test/benchmarks/material/radio/radio.perf-spec.ts
+++ b/test/benchmarks/material/radio/radio.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('radio button performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders two radio buttons', async() => {
@@ -19,7 +19,6 @@ describe('radio button performance benchmarks', () => {
       id: 'render-two-radio-buttons',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide-two').click(),
       work: async () => await $('#show-two').click(),
     });
@@ -30,7 +29,6 @@ describe('radio button performance benchmarks', () => {
       id: 'render-ten-radio-buttons',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide-ten').click(),
       work: async () => await $('#show-ten').click(),
     });
@@ -41,7 +39,6 @@ describe('radio button performance benchmarks', () => {
       id: 'click-radio-button',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => await $('#show-two').click(),
       prepare: async() => await $('#btn-1').click(),
       work: async () => await $('#btn-2').click(),

--- a/test/benchmarks/material/slide-toggle/slide-toggle.perf-spec.ts
+++ b/test/benchmarks/material/slide-toggle/slide-toggle.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('slide toggle performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a slide toggle', async() => {
@@ -19,7 +19,6 @@ describe('slide toggle performance benchmarks', () => {
       id: 'slide-toggle-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide').click(),
       work: async () => await $('#show').click(),
     });
@@ -30,7 +29,6 @@ describe('slide toggle performance benchmarks', () => {
       id: 'slide-toggle-click',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => await $('#show').click(),
       work: async () => await $('.mat-slide-toggle-bar').click(),
     });

--- a/test/benchmarks/material/table/table.perf-spec.ts
+++ b/test/benchmarks/material/table/table.perf-spec.ts
@@ -14,15 +14,14 @@ function runTableRenderBenchmark(testId: string, buttonId: string) {
     id: testId,
     url: '',
     ignoreBrowserSynchronization: true,
-    params: [],
-    prepare: async () => await $('#hide').click(),
+        prepare: async () => await $('#hide').click(),
     work: async () => await $(buttonId).click(),
   });
 }
 
 describe('table performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders 10 rows with 5 cols', async() => {

--- a/test/benchmarks/material/tabs/tabs.perf-spec.ts
+++ b/test/benchmarks/material/tabs/tabs.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('tabs performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders three tabs', async() => {
@@ -19,7 +19,6 @@ describe('tabs performance benchmarks', () => {
       id: 'three-tab-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async() => await $('#hide').click(),
       work: async() => await $('#show-three-tabs').click(),
     });
@@ -30,7 +29,6 @@ describe('tabs performance benchmarks', () => {
       id: 'ten-tab-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async() => await $('#hide').click(),
       work: async() => await $('#show-ten-tabs').click(),
     });
@@ -41,7 +39,6 @@ describe('tabs performance benchmarks', () => {
       id: 'twenty-tab-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async() => await $('#hide').click(),
       work: async() => await $('#show-twenty-tabs').click(),
     });
@@ -52,7 +49,6 @@ describe('tabs performance benchmarks', () => {
       id: 'tab-switching',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => await $('#show-three-tabs').click(),
       prepare: async() => await $('#mat-tab-label-0-0').click(),
       work: async() => await $('#mat-tab-label-0-1').click(),
@@ -67,7 +63,6 @@ describe('tabs performance benchmarks', () => {
       id: 'tab-pagination',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async() => {
         await $('#hide').click();
         await $('#show-twenty-tabs').click();

--- a/test/benchmarks/mdc/button/button.perf-spec.ts
+++ b/test/benchmarks/mdc/button/button.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('button performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a basic raised button', async() => {
@@ -19,7 +19,6 @@ describe('button performance benchmarks', () => {
       id: 'button-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide').click(),
       work: async () => await $('#show').click(),
     });
@@ -30,7 +29,6 @@ describe('button performance benchmarks', () => {
       id: 'button-click',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => await $('#show').click(),
       work: async () => await $('.mat-mdc-raised-button').click(),
     });

--- a/test/benchmarks/mdc/card/card.perf-spec.ts
+++ b/test/benchmarks/mdc/card/card.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('card performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a simple card', async() => {
@@ -19,7 +19,6 @@ describe('card performance benchmarks', () => {
       id: 'card-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide').click(),
       work: async () => await $('#show').click()
     });

--- a/test/benchmarks/mdc/checkbox/checkbox.perf-spec.ts
+++ b/test/benchmarks/mdc/checkbox/checkbox.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('checkbox performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a checked checkbox', async() => {
@@ -19,7 +19,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-render-checked',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         await $('#show').click();
         await $('mat-checkbox').click();
@@ -38,7 +37,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-render-unchecked',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => await $('#show').click(),
       prepare: async () => {
         expect(await $('mat-checkbox input').isSelected())
@@ -54,7 +52,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-render-indeterminate',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => {
         await $('#show').click();
         await $('#indeterminate').click();
@@ -73,7 +70,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-click-unchecked-to-checked',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         await $('#show').click();
         await $('mat-checkbox').click();
@@ -92,7 +88,6 @@ describe('checkbox performance benchmarks', () => {
       id: 'checkbox-click-checked-to-unchecked',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => await $('#show').click(),
       prepare: async () => {
         await $('mat-checkbox').click();

--- a/test/benchmarks/mdc/chips/chips.perf-spec.ts
+++ b/test/benchmarks/mdc/chips/chips.perf-spec.ts
@@ -14,7 +14,6 @@ async function runRenderBenchmark(testId: string, showBtnId: string) {
     id: testId,
     url: '',
     ignoreBrowserSynchronization: true,
-    params: [],
     prepare: async () => await $('#hide').click(),
     work: async () => await $(showBtnId).click(),
   });
@@ -22,7 +21,7 @@ async function runRenderBenchmark(testId: string, showBtnId: string) {
 
 describe('chip performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a single chip', async() => {
@@ -46,7 +45,6 @@ describe('chip performance benchmarks', () => {
       id: 'chip-click',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => await $('#show-single-chip').click(),
       work: async () => await $('#single-chip').click(),
     });

--- a/test/benchmarks/mdc/form-field/form-field.perf-spec.ts
+++ b/test/benchmarks/mdc/form-field/form-field.perf-spec.ts
@@ -14,7 +14,6 @@ function runFormFieldRenderBenchmark(testId: string, showBtnId: string) {
     id: testId,
     url: '',
     ignoreBrowserSynchronization: true,
-    params: [],
     prepare: async () => await $('#hide').click(),
     work: async () => await $(showBtnId).click()
   });
@@ -22,7 +21,7 @@ function runFormFieldRenderBenchmark(testId: string, showBtnId: string) {
 
 describe('form field performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders an input in a form field', async() => {

--- a/test/benchmarks/mdc/menu/menu.perf-spec.ts
+++ b/test/benchmarks/mdc/menu/menu.perf-spec.ts
@@ -26,7 +26,6 @@ describe('menu performance benchmarks', () => {
       id: 'open-and-close-basic-menu',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         trigger = element(by.buttonText('Basic Menu'));
       },
@@ -43,7 +42,6 @@ describe('menu performance benchmarks', () => {
       id: 'shallow-open-and-close-nested-menu',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         trigger = element(by.buttonText('Nested Menu'));
       },
@@ -60,7 +58,6 @@ describe('menu performance benchmarks', () => {
       id: 'deep-open-and-close-nested-menus',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => {
         trigger = element(by.buttonText('Nested Menu'));
       },

--- a/test/benchmarks/mdc/radio/radio.perf-spec.ts
+++ b/test/benchmarks/mdc/radio/radio.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('radio button performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders two radio buttons', async() => {
@@ -19,7 +19,6 @@ describe('radio button performance benchmarks', () => {
       id: 'render-two-radio-buttons',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide-two').click(),
       work: async () => await $('#show-two').click(),
     });
@@ -30,7 +29,6 @@ describe('radio button performance benchmarks', () => {
       id: 'render-ten-radio-buttons',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide-ten').click(),
       work: async () => await $('#show-ten').click(),
     });
@@ -41,7 +39,6 @@ describe('radio button performance benchmarks', () => {
       id: 'click-radio-button',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => await $('#show-two').click(),
       prepare: async() => await $('#btn-1').click(),
       work: async () => await $('#btn-2').click(),

--- a/test/benchmarks/mdc/slide-toggle/slide-toggle.perf-spec.ts
+++ b/test/benchmarks/mdc/slide-toggle/slide-toggle.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('slide toggle performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders a slide toggle', async() => {
@@ -19,7 +19,6 @@ describe('slide toggle performance benchmarks', () => {
       id: 'slide-toggle-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async () => await $('#hide').click(),
       work: async () => await $('#show').click(),
     });
@@ -30,7 +29,6 @@ describe('slide toggle performance benchmarks', () => {
       id: 'slide-toggle-click',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async () => await $('#show').click(),
       work: async () => await $('.mat-mdc-slide-toggle label').click(),
     });

--- a/test/benchmarks/mdc/table/table.perf-spec.ts
+++ b/test/benchmarks/mdc/table/table.perf-spec.ts
@@ -14,7 +14,6 @@ function runTableRenderBenchmark(testId: string, buttonId: string) {
     id: testId,
     url: '',
     ignoreBrowserSynchronization: true,
-    params: [],
     prepare: async () => await $('#hide').click(),
     work: async () => await $(buttonId).click(),
   });
@@ -22,7 +21,7 @@ function runTableRenderBenchmark(testId: string, buttonId: string) {
 
 describe('table performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders 10 rows with 5 cols', async() => {

--- a/test/benchmarks/mdc/tabs/tabs.perf-spec.ts
+++ b/test/benchmarks/mdc/tabs/tabs.perf-spec.ts
@@ -11,7 +11,7 @@ import {runBenchmark} from '@angular/dev-infra-private/benchmark/driver-utilitie
 
 describe('tabs performance benchmarks', () => {
   beforeAll(() => {
-    browser.rootEl = '#root';
+    browser.angularAppRoot('#root');
   });
 
   it('renders three tabs', async() => {
@@ -19,7 +19,6 @@ describe('tabs performance benchmarks', () => {
       id: 'three-tab-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async() => await $('#hide').click(),
       work: async() => await $('#show-three-tabs').click(),
     });
@@ -30,7 +29,6 @@ describe('tabs performance benchmarks', () => {
       id: 'ten-tab-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async() => await $('#hide').click(),
       work: async() => await $('#show-ten-tabs').click(),
     });
@@ -41,7 +39,6 @@ describe('tabs performance benchmarks', () => {
       id: 'twenty-tab-render',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async() => await $('#hide').click(),
       work: async() => await $('#show-twenty-tabs').click(),
     });
@@ -52,7 +49,6 @@ describe('tabs performance benchmarks', () => {
       id: 'tab-switching',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       setup: async() => await $('#show-three-tabs').click(),
       prepare: async() => await $('#mat-tab-label-0-0').click(),
       work: async() => await $('#mat-tab-label-0-1').click(),
@@ -67,7 +63,6 @@ describe('tabs performance benchmarks', () => {
       id: 'tab-pagination',
       url: '',
       ignoreBrowserSynchronization: true,
-      params: [],
       prepare: async() => {
         await $('#hide').click();
         await $('#show-twenty-tabs').click();


### PR DESCRIPTION
* Replaces usages of the deprecated `browser.rootEl` with `browser.angularAppRoot`.
* Fixes a couple of places that were using `async` instead of `waitForAsync`.