### PR TITLE
fix(cdk/drag-drop): account for enterPredicate when setting receiving class

### DIFF
--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -374,7 +374,7 @@ export declare class DropListRef<T = any> {
         x: number;
         y: number;
     }): void;
-    _startReceiving(sibling: DropListRef): void;
+    _startReceiving(sibling: DropListRef, items: DragRef[]): void;
     _startScrollingIfNecessary(pointerX: number, pointerY: number): void;
     _stopReceiving(sibling: DropListRef): void;
     _stopScrolling(): void;


### PR DESCRIPTION
Currently we set a class when a container is able to receive the dragged item, however we add this class to all connected containers without accounting for other things that could prevent the item from entering, like `enterPredicate`.

These changes add some logic to account for the predicate when setting the class.

Fixes #21171.