### PR TITLE
fix(material-experimental/mdc-progress-spinner): fix noop animation

### DIFF
--- a/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
+++ b/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
@@ -8,6 +8,11 @@
   overflow: hidden;
 }
 
-:not(._mat-animation-noopable) {
+.mat-mdc-progress-spinner:not(._mat-animation-noopable) {
   @include mdc-circular-progress-core-styles($query: animation);
+}
+
+// Render the indeterminate spinner as a complete circle when animations are off
+._mat-animation-noopable .mdc-circular-progress__indeterminate-container circle {
+  stroke-dasharray: 0 !important;
 }


### PR DESCRIPTION
Animations were still being shown because the selector `:not(._mat-animation-noopable)` by itself matched plenty of parent elements. This specifies the right parent element that should be checked.

Also, this forces the spinner to be a complete circle when there are no animations, rather than some odd looking broken spinner shape 