### PR TITLE
chore: modified table predicate filter

### DIFF
--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -188,21 +188,10 @@ export class _MatTableDataSource<T, P extends Paginator> extends DataSource<T> {
    * @returns Whether the filter matches against the data
    */
   filterPredicate: ((data: T, filter: string) => boolean) = (data: T, filter: string): boolean => {
-    // Transform the data into a lowercase string of all property values.
-    const dataStr = Object.keys(data).reduce((currentTerm: string, key: string) => {
-      // Use an obscure Unicode character to delimit the words in the concatenated string.
-      // This avoids matches where the values of two columns combined will match the user's query
-      // (e.g. `Flute` and `Stop` will match `Test`). The character is intended to be something
-      // that has a very low chance of being typed in by somebody in a text field. This one in
-      // particular is "White up-pointing triangle with dot" from
-      // https://en.wikipedia.org/wiki/List_of_Unicode_characters
-      return currentTerm + (data as {[key: string]: any})[key] + '◬';
-    }, '').toLowerCase();
-
     // Transform the filter by converting it to lowercase and removing whitespace.
     const transformedFilter = filter.trim().toLowerCase();
-
-    return dataStr.indexOf(transformedFilter) != -1;
+    // Loops over the values in the array and returns true if any of them match the filter string
+    return Object.values(data).some(term=>term.toLowerCase().includes(transformedFilter));
   }
 
   constructor(initialData: T[] = []) {

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -191,7 +191,9 @@ export class _MatTableDataSource<T, P extends Paginator> extends DataSource<T> {
     // Transform the filter by converting it to lowercase and removing whitespace.
     const transformedFilter = filter.trim().toLowerCase();
     // Loops over the values in the array and returns true if any of them match the filter string
-    return Object.values(data).some(term=>term.toLowerCase().includes(transformedFilter));
+    return Object.keys(data).some(
+      (key)=>(data as {[key: string]: any})[key].toLowerCase().includes(transformedFilter)
+    );
   }
 
   constructor(initialData: T[] = []) {


### PR DESCRIPTION
Replaces the string concatenation and index search with the .some check and a contains check. This should not be less efficient since the data is only getting checked once per row instead of twice, and the row will stop being looped over if a match is found earlier. Also removes unlikely edge case of a user inputing an obscure unicode character.