### PR TITLE
fix(material-experimental/mdc-form-field): fix fill appearance contra…

### DIFF
--- a/src/material-experimental/mdc-form-field/_mdc-text-field-theme-variable-refresh.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-theme-variable-refresh.scss
@@ -21,7 +21,7 @@
   $_mdc-text-field-focused-label-color: $mdc-text-field-focused-label-color;
   $mdc-text-field-focused-label-color: rgba(theme-variables.prop-value(primary), 0.87) !global;
   $_mdc-text-field-placeholder-ink-color: $mdc-text-field-placeholder-ink-color;
-  $mdc-text-field-placeholder-ink-color: rgba(theme-variables.prop-value(on-surface), 0.54) !global;
+  $mdc-text-field-placeholder-ink-color: rgba(theme-variables.prop-value(on-surface), 0.6) !global;
   $_mdc-text-field-disabled-label-color: $mdc-text-field-disabled-label-color;
   $mdc-text-field-disabled-label-color: rgba(theme-variables.prop-value(on-surface), 0.38) !global;
   $_mdc-text-field-disabled-ink-color: $mdc-text-field-disabled-ink-color;


### PR DESCRIPTION
…st ratio

Previous contrast ratio for fill appearance form field when focused with placeholder text was 4.25 which fails 4.5:1 text contrast ratio.

This is because we use an overlay instead of a ripple (like mdc) for focus and hover indication. 
Decreasing the overlay opacity for the focus state did not work because the ratio did not go over 4.5:1 until it was the same opacity as the hover state.
Now the placeholder text is the same color as label text which is on spec and passes contrast ratio in focus state.

In the long run the mat ripple component should be reconciled with the mdc ripple and replace this overlay div.