### PR TITLE
feat(button): Update css to allow text wrapping on reflow of window size.

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -42,7 +42,7 @@ $mat-mini-fab-padding: 8px !default;
 
   // Make anchors render like buttons.
   display: inline-block;
-  white-space: nowrap;
+  white-space: normal;
   text-decoration: none;
   vertical-align: baseline;
   text-align: center;


### PR DESCRIPTION
What: Use `white-space: normal`.

Why: To conform to WCAG 2.1, when the window is resized to a smaller width, content should not be hidden. If a button has long text, the text should wrap instead of overflow off the screen. 