### PR TITLE
fix(cdk/drag-drop): don't block scrolling if it happens before delay has elapsed

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -318,6 +318,7 @@ describe('CdkDrag', () => {
           dispatchTouchEvent(fixture.componentInstance.dragElement.nativeElement, 'touchstart');
           fixture.detectChanges();
 
+          dispatchTouchEvent(document, 'touchmove');
           expect(dispatchTouchEvent(document, 'touchmove').defaultPrevented).toBe(true);
 
           dispatchTouchEvent(document, 'touchend');
@@ -1059,6 +1060,24 @@ describe('CdkDrag', () => {
           'Expected element to be dragged after all the time has passed.');
     }));
 
+    it('should not prevent the default touch action before the delay has elapsed', fakeAsync(() => {
+      spyOn(Date, 'now').and.callFake(() => currentTime);
+      let currentTime = 0;
+
+      const fixture = createComponent(StandaloneDraggable);
+      fixture.componentInstance.dragStartDelay = 500;
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+
+      expect(dragElement.style.transform).toBeFalsy('Expected element not to be moved by default.');
+
+      dispatchTouchEvent(dragElement, 'touchstart');
+      fixture.detectChanges();
+      currentTime += 250;
+
+      expect(dispatchTouchEvent(document, 'touchmove', 50, 100).defaultPrevented).toBe(false);
+    }));
+
     it('should handle the drag delay as a string', fakeAsync(() => {
       // We can't use Jasmine's `clock` because Zone.js interferes with it.
       spyOn(Date, 'now').and.callFake(() => currentTime);
@@ -1205,34 +1224,6 @@ describe('CdkDrag', () => {
 
       subscription.unsubscribe();
     }));
-
-    it('should prevent the default `mousemove` action even before the drag threshold has ' +
-      'been reached', fakeAsync(() => {
-        const fixture = createComponent(StandaloneDraggable, [], 5);
-        fixture.detectChanges();
-        const dragElement = fixture.componentInstance.dragElement.nativeElement;
-
-        dispatchMouseEvent(dragElement, 'mousedown', 2, 2);
-        fixture.detectChanges();
-        const mousemoveEvent = dispatchMouseEvent(document, 'mousemove', 2, 2);
-        fixture.detectChanges();
-
-        expect(mousemoveEvent.defaultPrevented).toBe(true);
-      }));
-
-    it('should prevent the default `touchmove` action even before the drag threshold has ' +
-      'been reached', fakeAsync(() => {
-        const fixture = createComponent(StandaloneDraggable, [], 5);
-        fixture.detectChanges();
-        const dragElement = fixture.componentInstance.dragElement.nativeElement;
-
-        dispatchTouchEvent(dragElement, 'touchstart', 2, 2);
-        fixture.detectChanges();
-        const touchmoveEvent = dispatchTouchEvent(document, 'touchmove', 2, 2);
-        fixture.detectChanges();
-
-        expect(touchmoveEvent.defaultPrevented).toBe(true);
-      }));
 
     it('should be able to configure the drag input defaults through a provider', fakeAsync(() => {
       const config: DragDropConfig = {

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -593,9 +593,6 @@ export class DragRef<T = any> {
 
   /** Handler that is invoked when the user moves their pointer after they've initiated a drag. */
   private _pointerMove = (event: MouseEvent | TouchEvent) => {
-    // Prevent the default action as early as possible in order to block
-    // native actions like dragging the selected text or images with the mouse.
-    event.preventDefault();
     const pointerPosition = this._getPointerPositionOnPage(event);
 
     if (!this._hasStartedDragging) {
@@ -636,6 +633,11 @@ export class DragRef<T = any> {
         this._previewRect = (this._preview || this._rootElement).getBoundingClientRect();
       }
     }
+
+    // We prevent the default action down here so that we know that dragging has started. This is
+    // important for touch devices where doing this too early can unnecessarily block scrolling,
+    // if there's a dragging delay.
+    event.preventDefault();
 
     const constrainedPointerPosition = this._getConstrainedPointerPosition(pointerPosition);
     this._hasMoved = true;

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -228,7 +228,9 @@ export declare class DragDropModule {
     static ɵmod: i0.ɵɵNgModuleDefWithMeta<DragDropModule, [typeof i1.CdkDropList, typeof i2.CdkDropListGroup, typeof i3.CdkDrag, typeof i4.CdkDragHandle, typeof i5.CdkDragPreview, typeof i6.CdkDragPlaceholder], never, [typeof i7.CdkScrollableModule, typeof i1.CdkDropList, typeof i2.CdkDropListGroup, typeof i3.CdkDrag, typeof i4.CdkDragHandle, typeof i5.CdkDragPreview, typeof i6.CdkDragPlaceholder]>;
 }
 
-export declare class DragDropRegistry<I, C> implements OnDestroy {
+export declare class DragDropRegistry<I extends {
+    isDragging(): boolean;
+}, C> implements OnDestroy {
     readonly pointerMove: Subject<TouchEvent | MouseEvent>;
     readonly pointerUp: Subject<TouchEvent | MouseEvent>;
     readonly scroll: Subject<Event>;


### PR DESCRIPTION
The `DragRef` has the ability to add a delay to the dragging so that scrolling isn't blocked on touch devices. Currently this doesn't really work, because we always block the native event as a result of a949db30c7554c32df77b81d163fe7d8cbb83c97.
These changes move some code around so that we only block the events if the item considers itself as being in a "dragged" state (the delay has elapsed and the user is past the drag threshold).

Fixes #17923.