### PR TITLE
fix(material-experimental/mdc-progress-spinner): indeterminate animation not working

### DIFF
--- a/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
+++ b/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
@@ -1,18 +1,28 @@
 @import '@material/circular-progress/mixins.import';
 @import '../mdc-helpers/mdc-helpers';
 
-@include mdc-circular-progress-core-styles($query: $mat-base-styles-without-animation-query);
+@include mdc-circular-progress-core-styles($query: $mat-base-styles-query);
 
 .mat-mdc-progress-spinner {
   // Prevents the spinning of the inner element from affecting layout outside of the spinner.
   overflow: hidden;
-}
 
-.mat-mdc-progress-spinner:not(._mat-animation-noopable) {
-  @include mdc-circular-progress-core-styles($query: animation);
-}
+  &._mat-animation-noopable {
+    &, .mdc-circular-progress__determinate-circle {
+      // The spinner itself has a transition on `opacity`.
+      transition: none;
+    }
 
-// Render the indeterminate spinner as a complete circle when animations are off
-._mat-animation-noopable .mdc-circular-progress__indeterminate-container circle {
-  stroke-dasharray: 0 !important;
+    .mdc-circular-progress__indeterminate-circle-graphic,
+    .mdc-circular-progress__spinner-layer,
+    .mdc-circular-progress__indeterminate-container {
+      // Disables the rotation animations.
+      animation: none;
+    }
+
+    .mdc-circular-progress__indeterminate-container circle {
+      // Render the indeterminate spinner as a complete circle when animations are off
+      stroke-dasharray: 0 !important;
+    }
+  }
 }


### PR DESCRIPTION
Seems like a regression from #21359. We can't use `:not` to apply the animation styles, because MDC's mixins target `.mdc-progress-spinner`, rather than `&`.

These changes use the same manual approach as other components to disable the animations.

For reference, the circle looks like this in master:
![Angular_Material_-_Google_Chrome_2020-12-18_15-06-28](https://user-images.githubusercontent.com/4450522/102624291-16bd0500-4144-11eb-8f08-045e45aee2ef.png)
