### PR TITLE
fix(material-experimental/mdc-list): not accounting for global ripple options

### DIFF
--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -14,13 +14,17 @@ import {
   Directive,
   ElementRef,
   HostBinding,
+  Inject,
   Input,
   NgZone,
   OnDestroy,
+  Optional,
   QueryList
 } from '@angular/core';
 import {
+  MAT_RIPPLE_GLOBAL_OPTIONS,
   RippleConfig,
+  RippleGlobalOptions,
   RippleRenderer,
   RippleTarget,
   setLines,
@@ -74,17 +78,20 @@ export abstract class MatListItemBase implements AfterContentInit, OnDestroy, Ri
    * Implemented as part of `RippleTarget`.
    * @docs-private
    */
-  rippleConfig: RippleConfig = {};
+  rippleConfig: RippleConfig & RippleGlobalOptions;
 
   /**
    * Implemented as part of `RippleTarget`.
    * @docs-private
    */
-  get rippleDisabled(): boolean { return this.disableRipple; }
+  get rippleDisabled(): boolean { return this.disableRipple || !!this.rippleConfig.disabled; }
 
   constructor(public _elementRef: ElementRef<HTMLElement>, protected _ngZone: NgZone,
-              private _listBase: MatListBase, private _platform: Platform) {
+              private _listBase: MatListBase, private _platform: Platform,
+              @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
+                  globalRippleOptions?: RippleGlobalOptions) {
     this._hostElement = this._elementRef.nativeElement;
+    this.rippleConfig = globalRippleOptions || {};
 
     if (!this._listBase._isNonInteractive) {
       this._initInteractiveListItem();

--- a/src/material-experimental/mdc-list/list-option.ts
+++ b/src/material-experimental/mdc-list/list-option.ts
@@ -21,11 +21,17 @@ import {
   NgZone,
   OnDestroy,
   OnInit,
+  Optional,
   QueryList,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import {MatLine, ThemePalette} from '@angular/material-experimental/mdc-core';
+import {
+  MatLine,
+  MAT_RIPPLE_GLOBAL_OPTIONS,
+  RippleGlobalOptions,
+  ThemePalette,
+} from '@angular/material-experimental/mdc-core';
 import {MatListBase, MatListItemBase} from './list-base';
 import {LIST_OPTION, ListOption, MatListOptionCheckboxPosition} from './list-option-types';
 
@@ -131,8 +137,9 @@ export class MatListOption extends MatListItemBase implements ListOption, OnInit
       ngZone: NgZone,
       platform: Platform,
       @Inject(SELECTION_LIST) public _selectionList: SelectionList,
-      private _changeDetectorRef: ChangeDetectorRef) {
-    super(element, ngZone, _selectionList, platform);
+      private _changeDetectorRef: ChangeDetectorRef,
+      @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS) globalRippleOptions?: RippleGlobalOptions) {
+    super(element, ngZone, _selectionList, platform, globalRippleOptions);
 
     // By default, we mark all options as unselected. The MDC list foundation will
     // automatically update the attribute based on selection. Note that we need to

--- a/src/material-experimental/mdc-list/list.ts
+++ b/src/material-experimental/mdc-list/list.ts
@@ -12,12 +12,18 @@ import {
   Component,
   ContentChildren,
   ElementRef,
+  Inject,
   NgZone,
+  Optional,
   QueryList,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import {MatLine} from '@angular/material-experimental/mdc-core';
+import {
+  MatLine,
+  MAT_RIPPLE_GLOBAL_OPTIONS,
+  RippleGlobalOptions,
+} from '@angular/material-experimental/mdc-core';
 import {MatListBase, MatListItemBase} from './list-base';
 
 @Component({
@@ -52,7 +58,12 @@ export class MatListItem extends MatListItemBase {
       QueryList<ElementRef<Element>>;
   @ViewChild('text') _itemText: ElementRef<HTMLElement>;
 
-  constructor(element: ElementRef, ngZone: NgZone, listBase: MatListBase, platform: Platform) {
-    super(element, ngZone, listBase, platform);
+  constructor(
+    element: ElementRef,
+    ngZone: NgZone,
+    listBase: MatListBase,
+    platform: Platform,
+    @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS) globalRippleOptions?: RippleGlobalOptions) {
+    super(element, ngZone, listBase, platform, globalRippleOptions);
   }
 }


### PR DESCRIPTION
Fixes that the MDC-based list doesn't disable its ripples when they have been disabled globally.