### PR TITLE
docs(material/slider): updated slider documentation.

### DIFF
--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -54,7 +54,7 @@ displayed, you can do so using the `displayWith` input.
 ### Tick marks
 By default, sliders do not show tick marks along the thumb track. This can be enabled using the
 `tickInterval` attribute. The value of `tickInterval` should be a number representing the number
-of steps between between ticks. For example a `tickInterval` of `3` with a `step` of `4` will draw
+of steps between ticks. For example a `tickInterval` of `3` with a `step` of `4` will draw
 tick marks at every `3` steps, which is the same as every `12` values.
 
 ```html


### PR DESCRIPTION
In the tick marks section of the slider the word between is repeated.