### PR TITLE
fix(material/datepicker): unable to distinguish disabled calendar cells in high contrast mode

### DIFF
--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -150,6 +150,13 @@ $mat-calendar-range-end-body-cell-size:
 
 .mat-calendar-body-disabled {
   cursor: default;
+
+  // Fade out the disabled cells so that they can be distinguished from the enabled ones. Note that
+  // ideally we'd use `color: GreyText` here which is what the browser uses for disabled buttons,
+  // but we can't because Firefox doesn't recognize it.
+  @include cdk-high-contrast(active, off) {
+    opacity: 0.5;
+  }
 }
 
 .mat-calendar-body-cell-content {


### PR DESCRIPTION
Fixes that users in high contrast mode aren't able to distinguish between enabled and disabled calendar cells.