### PR TITLE
feat(youtube-player): add config option to automatically load the YouTube API

### DIFF
--- a/src/dev-app/index.html
+++ b/src/dev-app/index.html
@@ -22,7 +22,6 @@
   <script src="zone.js/dist/zone.js"></script>
   <script src="systemjs/dist/system.js"></script>
   <script src="system-config.js"></script>
-  <script src="https://www.youtube.com/iframe_api"></script>
   <script src="https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js"></script>
   <script>
     (function loadGoogleMaps(key) {

--- a/src/dev-app/youtube-player/youtube-player-demo-module.ts
+++ b/src/dev-app/youtube-player/youtube-player-demo-module.ts
@@ -11,7 +11,11 @@ import {FormsModule} from '@angular/forms';
 import {MatRadioModule} from '@angular/material/radio';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
-import {YouTubePlayerModule} from '@angular/youtube-player';
+import {
+  YouTubePlayerModule,
+  YOUTUBE_PLAYER_CONFIG,
+  YouTubePlayerConfig,
+} from '@angular/youtube-player';
 import {YouTubePlayerDemo} from './youtube-player-demo';
 
 @NgModule({
@@ -23,6 +27,12 @@ import {YouTubePlayerDemo} from './youtube-player-demo';
     RouterModule.forChild([{path: '', component: YouTubePlayerDemo}]),
   ],
   declarations: [YouTubePlayerDemo],
+  providers: [{
+    provide: YOUTUBE_PLAYER_CONFIG,
+    useValue: {
+      loadApi: true
+    } as YouTubePlayerConfig
+  }]
 })
 export class YouTubePlayerDemoModule {
 }

--- a/src/youtube-player/README.md
+++ b/src/youtube-player/README.md
@@ -20,36 +20,34 @@ If your video is found at https://www.youtube.com/watch?v=PRQCAL_RMVo, then your
 
 ```typescript
 // example-module.ts
-import {NgModule, Component, OnInit} from '@angular/core';
-import {YouTubePlayerModule} from '@angular/youtube-player';
+import {NgModule, Component} from '@angular/core';
+import {
+  YouTubePlayerModule,
+  YOUTUBE_PLAYER_CONFIG,
+  YouTubePlayerConfig,
+} from '@angular/youtube-player';
 
 @NgModule({
   imports: [YouTubePlayerModule],
+  // Optionally tells the `youtube-player` component to automatically load
+  // the YouTube iframe API. Omit this if you plan to load the API yourself.
+  providers: [{
+    provide: YOUTUBE_PLAYER_CONFIG,
+    useValue: {
+      loadApi: true
+    } as YouTubePlayerConfig
+  }]
   declarations: [YoutubePlayerExample],
 })
 export class YoutubePlayerExampleModule {
 }
-
-let apiLoaded = false;
 
 // example-component.ts
 @Component({
   template: '<youtube-player videoId="PRQCAL_RMVo"></youtube-player>',
   selector: 'youtube-player-example',
 })
-class YoutubePlayerExample implements OnInit {
-  ngOnInit() {
-    if (!apiLoaded) {
-      // This code loads the IFrame Player API code asynchronously, according to the instructions at
-      // https://developers.google.com/youtube/iframe_api_reference#Getting_Started
-      const tag = document.createElement('script');
-      tag.src = 'https://www.youtube.com/iframe_api';
-      document.body.appendChild(tag);
-      apiLoaded = true;
-    }
-  }
-}
-
+class YoutubePlayerExample {}
 ```
 
 ## API

--- a/src/youtube-player/public-api.ts
+++ b/src/youtube-player/public-api.ts
@@ -7,4 +7,4 @@
  */
 
 export * from './youtube-module';
-export {YouTubePlayer} from './youtube-player';
+export {YouTubePlayer, YouTubePlayerConfig, YOUTUBE_PLAYER_CONFIG} from './youtube-player';

--- a/tools/public_api_guard/youtube-player/youtube-player.md
+++ b/tools/public_api_guard/youtube-player/youtube-player.md
@@ -9,6 +9,7 @@
 import { AfterViewInit } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
+import { InjectionToken } from '@angular/core';
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
@@ -21,8 +22,11 @@ const DEFAULT_PLAYER_HEIGHT = 390;
 const DEFAULT_PLAYER_WIDTH = 640;
 
 // @public
+export const YOUTUBE_PLAYER_CONFIG: InjectionToken<YouTubePlayerConfig>;
+
+// @public
 export class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
-    constructor(_ngZone: NgZone, platformId: Object);
+    constructor(_ngZone: NgZone, platformId: Object, _config?: YouTubePlayerConfig | undefined);
     // (undocumented)
     readonly apiChange: Observable<YT.PlayerEvent>;
     // @deprecated (undocumented)
@@ -78,7 +82,13 @@ export class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<YouTubePlayer, "youtube-player", never, { "videoId": "videoId"; "height": "height"; "width": "width"; "startSeconds": "startSeconds"; "endSeconds": "endSeconds"; "suggestedQuality": "suggestedQuality"; "playerVars": "playerVars"; "showBeforeIframeApiLoads": "showBeforeIframeApiLoads"; }, { "ready": "ready"; "stateChange": "stateChange"; "error": "error"; "apiChange": "apiChange"; "playbackQualityChange": "playbackQualityChange"; "playbackRateChange": "playbackRateChange"; }, never, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<YouTubePlayer, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<YouTubePlayer, [null, null, { optional: true; }]>;
+}
+
+// @public
+export interface YouTubePlayerConfig {
+    apiUrl?: string;
+    loadApi?: boolean;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
Adds a new injection token that allows the `YouTubePlayer` to automatically load the API, instead of depending on it to be loaded by the consumer.

Fixes #17037.