### PR TITLE
feat(material/icon): add support for registry resolver function

### DIFF
--- a/src/material/icon/testing/fake-icon-registry.ts
+++ b/src/material/icon/testing/fake-icon-registry.ts
@@ -10,11 +10,9 @@ import {Injectable, NgModule, OnDestroy} from '@angular/core';
 import {MatIconRegistry} from '@angular/material/icon';
 import {Observable, of as observableOf} from 'rxjs';
 
-// tslint:disable:no-any Impossible to tell param types.
 type PublicApi<T> = {
   [K in keyof T]: T[K] extends (...x: any[]) => T ? (...x: any[]) => PublicApi<T> : T[K]
 };
-// tslint:enable:no-any
 
 /**
  * A null icon registry that must be imported to allow disabling of custom
@@ -75,6 +73,10 @@ export class FakeMatIconRegistry implements PublicApi<MatIconRegistry>, OnDestro
   }
 
   setDefaultFontSetClass(): this {
+    return this;
+  }
+
+  addSvgIconResolver(): this {
     return this;
   }
 

--- a/tools/public_api_guard/material/icon.d.ts
+++ b/tools/public_api_guard/material/icon.d.ts
@@ -19,6 +19,8 @@ export interface IconOptions {
     withCredentials?: boolean;
 }
 
+export declare type IconResolver = (name: string, namespace: string) => (SafeResourceUrl | SafeResourceUrlWithIconOptions | null);
+
 export declare const MAT_ICON_LOCATION: InjectionToken<MatIconLocation>;
 
 export declare function MAT_ICON_LOCATION_FACTORY(): MatIconLocation;
@@ -59,6 +61,7 @@ export declare class MatIconRegistry implements OnDestroy {
     addSvgIconInNamespace(namespace: string, iconName: string, url: SafeResourceUrl, options?: IconOptions): this;
     addSvgIconLiteral(iconName: string, literal: SafeHtml, options?: IconOptions): this;
     addSvgIconLiteralInNamespace(namespace: string, iconName: string, literal: SafeHtml, options?: IconOptions): this;
+    addSvgIconResolver(resolver: IconResolver): this;
     addSvgIconSet(url: SafeResourceUrl, options?: IconOptions): this;
     addSvgIconSetInNamespace(namespace: string, url: SafeResourceUrl, options?: IconOptions): this;
     addSvgIconSetLiteral(literal: SafeHtml, options?: IconOptions): this;
@@ -72,4 +75,9 @@ export declare class MatIconRegistry implements OnDestroy {
     setDefaultFontSetClass(className: string): this;
     static ɵfac: i0.ɵɵFactoryDef<MatIconRegistry, [{ optional: true; }, null, { optional: true; }, null]>;
     static ɵprov: i0.ɵɵInjectableDef<MatIconRegistry>;
+}
+
+export interface SafeResourceUrlWithIconOptions {
+    options: IconOptions;
+    url: SafeResourceUrl;
 }

--- a/tools/public_api_guard/material/icon/testing.d.ts
+++ b/tools/public_api_guard/material/icon/testing.d.ts
@@ -3,6 +3,7 @@ export declare class FakeMatIconRegistry implements PublicApi<MatIconRegistry>, 
     addSvgIconInNamespace(): this;
     addSvgIconLiteral(): this;
     addSvgIconLiteralInNamespace(): this;
+    addSvgIconResolver(): this;
     addSvgIconSet(): this;
     addSvgIconSetInNamespace(): this;
     addSvgIconSetLiteral(): this;


### PR DESCRIPTION
Currently all of the ways to register icons (e.g. via URL or literal) require the developer to know the list of icons ahead of time or to fetch more icons than the user needs. These changes aim to address this issue by adding the ability to register an icon resolver function which will construct the URL at runtime, depending on the requested icon.

Fixes #18607.