### PR TITLE
refactor(material/core): remove unnecessary styles from mat-option

### DIFF
--- a/src/material-experimental/mdc-core/option/option.scss
+++ b/src/material-experimental/mdc-core/option/option.scss
@@ -61,11 +61,6 @@
     // user content and we don't want to disable mouse events on the user content.
     // Pointer events can be safely disabled because the ripple trigger element is the host element.
     pointer-events: none;
-
-    // Prevents the ripple from completely covering the option in high contrast mode.
-    @include cdk-high-contrast(active, off) {
-      opacity: 0.5;
-    }
   }
 }
 

--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -67,11 +67,6 @@
   // user content and we don't want to disable mouse events on the user content.
   // Pointer events can be safely disabled because the ripple trigger element is the host element.
   pointer-events: none;
-
-  // Prevents the ripple from completely covering the option in high contrast mode.
-  @include cdk-high-contrast(active, off) {
-    opacity: 0.5;
-  }
 }
 
 .mat-option-pseudo-checkbox {


### PR DESCRIPTION
We had an override to make the option ripple semi-transparent in high contrast mode. This hasn't been necessary for a while, because we've been setting `display: none` on all ripples for high contrast users.