### PR TITLE
fix(material/menu): allow menu height to grow after open

### DIFF
--- a/src/material/menu/menu-trigger.ts
+++ b/src/material/menu/menu-trigger.ts
@@ -416,6 +416,7 @@ export class MatMenuTrigger implements AfterContentInit, OnDestroy {
       positionStrategy: this._overlay.position()
           .flexibleConnectedTo(this._element)
           .withLockedPosition()
+          .withGrowAfterOpen()
           .withTransformOriginOn('.mat-menu-panel, .mat-mdc-menu-panel'),
       backdropClass: this.menu.backdropClass || 'cdk-overlay-transparent-backdrop',
       panelClass: this.menu.overlayPanelClass,


### PR DESCRIPTION
Currently the menu only shrinks if the users scrolls after it has been opened, but
if they scroll back to a place where there's enough place to fit the content, the menu
will stay collapsed.

These changes adjust the config so the menu can grow after it was opened.

Fixes #18168.
Fixes #13988.