### PR TITLE
docs(material/autocomplete): add mat-label to examples

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.html
@@ -1,5 +1,6 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
+    <mat-label>Number</mat-label>
     <input type="text"
            placeholder="Pick one"
            aria-label="Number"

--- a/src/components-examples/material/autocomplete/autocomplete-filter/autocomplete-filter-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-filter/autocomplete-filter-example.html
@@ -1,5 +1,6 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
+    <mat-label>Number</mat-label>
     <input type="text"
            placeholder="Pick one"
            aria-label="Number"

--- a/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.html
@@ -1,8 +1,8 @@
 <form [formGroup]="stateForm">
   <mat-form-field>
+    <mat-label>States Group</mat-label>
     <input type="text"
            matInput
-           placeholder="States Group"
            formControlName="stateGroup"
            required
            [matAutocomplete]="autoGroup">

--- a/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.html
@@ -1,7 +1,7 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
+    <mat-label>State</mat-label>
     <input matInput
-           placeholder="State"
            aria-label="State"
            [matAutocomplete]="auto"
            [formControl]="stateCtrl">

--- a/src/components-examples/material/autocomplete/autocomplete-simple/autocomplete-simple-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-simple/autocomplete-simple-example.html
@@ -1,5 +1,6 @@
 <form class="example-form">
   <mat-form-field class="example-full-width">
+    <mat-label>Number</mat-label>
 <!-- #docregion input -->
     <input type="text"
            placeholder="Pick one"


### PR DESCRIPTION
Update form field related examples to use `<mat-label>` where appropriate