### PR TITLE
refactor(material-experimental/mdc-select): de-duplicate test harness logic

### DIFF
--- a/src/material-experimental/mdc-select/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-select/testing/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//src/cdk/testing",
         "//src/material-experimental/mdc-core/testing",
         "//src/material/form-field/testing/control",
+        "//src/material/select/testing",
     ],
 )
 

--- a/tools/public_api_guard/material/select/testing.d.ts
+++ b/tools/public_api_guard/material/select/testing.d.ts
@@ -1,10 +1,19 @@
-export declare class MatSelectHarness extends MatFormFieldControlHarness {
+export declare abstract class _MatSelectHarnessBase<OptionType extends (ComponentHarnessConstructor<Option> & {
+    with: (options?: OptionFilters) => HarnessPredicate<Option>;
+}), Option extends ComponentHarness & {
+    click(): Promise<void>;
+}, OptionFilters extends BaseHarnessFilters, OptionGroupType extends (ComponentHarnessConstructor<OptionGroup> & {
+    with: (options?: OptionGroupFilters) => HarnessPredicate<OptionGroup>;
+}), OptionGroup extends ComponentHarness, OptionGroupFilters extends BaseHarnessFilters> extends MatFormFieldControlHarness {
+    protected abstract _optionClass: OptionType;
+    protected abstract _optionGroupClass: OptionGroupType;
+    protected abstract _prefix: string;
     blur(): Promise<void>;
-    clickOptions(filter?: OptionHarnessFilters): Promise<void>;
+    clickOptions(filter?: OptionFilters): Promise<void>;
     close(): Promise<void>;
     focus(): Promise<void>;
-    getOptionGroups(filter?: Omit<OptgroupHarnessFilters, 'ancestor'>): Promise<MatOptgroupHarness[]>;
-    getOptions(filter?: Omit<OptionHarnessFilters, 'ancestor'>): Promise<MatOptionHarness[]>;
+    getOptionGroups(filter?: Omit<OptionGroupFilters, 'ancestor'>): Promise<OptionGroup[]>;
+    getOptions(filter?: Omit<OptionFilters, 'ancestor'>): Promise<Option[]>;
     getValueText(): Promise<string>;
     isDisabled(): Promise<boolean>;
     isEmpty(): Promise<boolean>;
@@ -14,6 +23,12 @@ export declare class MatSelectHarness extends MatFormFieldControlHarness {
     isRequired(): Promise<boolean>;
     isValid(): Promise<boolean>;
     open(): Promise<void>;
+}
+
+export declare class MatSelectHarness extends _MatSelectHarnessBase<typeof MatOptionHarness, MatOptionHarness, OptionHarnessFilters, typeof MatOptgroupHarness, MatOptgroupHarness, OptgroupHarnessFilters> {
+    protected _optionClass: typeof MatOptionHarness;
+    protected _optionGroupClass: typeof MatOptgroupHarness;
+    protected _prefix: string;
     static hostSelector: string;
     static with(options?: SelectHarnessFilters): HarnessPredicate<MatSelectHarness>;
 }


### PR DESCRIPTION
Reworks the `MatSelectHarness` in order to de-duplicate the logic between the base and MDC implementations.