### PR TITLE
build: check MDC testing exports and add missing symbols

### DIFF
--- a/scripts/check-mdc-exports-config.ts
+++ b/scripts/check-mdc-exports-config.ts
@@ -7,6 +7,11 @@ export const config = {
       'MatChipListChange',
       'MatChipList'
     ],
+    'mdc-chips/testing': [
+      // Test harness code for a component that hasn't been implemented for MDC.
+      'MatChipListHarness',
+      'ChipListHarnessFilters'
+    ],
     'mdc-autocomplete': [
       // Private base classes that are only exported for MDC.
       '_MatAutocompleteBase',

--- a/scripts/check-mdc-exports.ts
+++ b/scripts/check-mdc-exports.ts
@@ -16,12 +16,11 @@ readdirSync(join(__dirname, '../src/material'), {withFileTypes: true})
   .filter(name => !config.skippedPackages.includes(`mdc-${name}`))
   .filter(hasCorrespondingMdcPackage)
   .forEach(name => {
-    const missingSymbols = getMissingSymbols(name, config.skippedExports[`mdc-${name}`] || []);
+    checkPackage(name);
 
-    if (missingSymbols.length) {
-      console.log(chalk.redBright(`\nMissing symbols from mdc-${name}:`));
-      console.log(missingSymbols.join('\n'));
-      hasFailed = true;
+    const testingName = name + '/testing';
+    if (hasTestingPackage(name) && hasCorrespondingMdcPackage(testingName)) {
+      checkPackage(testingName);
     }
   });
 
@@ -37,6 +36,17 @@ if (hasFailed) {
   console.log(chalk.green(
     'All MDC packages export the same public API symbols as their non-MDC counterparts.'));
   process.exit(0);
+}
+
+/** Checks whether the public API of a package matches up with its MDC counterpart. */
+function checkPackage(name: string) {
+  const missingSymbols = getMissingSymbols(name, config.skippedExports[`mdc-${name}`] || []);
+
+  if (missingSymbols.length) {
+    console.log(chalk.redBright(`\nMissing symbols from mdc-${name}:`));
+    console.log(missingSymbols.join('\n'));
+    hasFailed = true;
+  }
 }
 
 /**
@@ -89,4 +99,9 @@ function getExports(name: string): string[] {
 /** Checks whether a particular Material package has an MDC-based equivalent. */
 function hasCorrespondingMdcPackage(name: string): boolean {
   return existsSync(join(__dirname, '../src/material-experimental', 'mdc-' + name));
+}
+
+/** Checks whether a particular Material package has a testing sub-package. */
+function hasTestingPackage(name: string): boolean {
+  return existsSync(join(__dirname, '../src/material', name, 'testing'));
 }

--- a/src/material-experimental/mdc-button/testing/public-api.ts
+++ b/src/material-experimental/mdc-button/testing/public-api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './button-harness';
+export {ButtonHarnessFilters} from '@angular/material/button/testing';

--- a/src/material-experimental/mdc-checkbox/testing/public-api.ts
+++ b/src/material-experimental/mdc-checkbox/testing/public-api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './checkbox-harness';
+export {CheckboxHarnessFilters} from '@angular/material/checkbox/testing';

--- a/src/material-experimental/mdc-menu/testing/public-api.ts
+++ b/src/material-experimental/mdc-menu/testing/public-api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './menu-harness';
+export {MenuHarnessFilters, MenuItemHarnessFilters} from '@angular/material/menu/testing';

--- a/src/material-experimental/mdc-progress-bar/testing/public-api.ts
+++ b/src/material-experimental/mdc-progress-bar/testing/public-api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './progress-bar-harness';
+export {ProgressBarHarnessFilters} from '@angular/material/progress-bar/testing';

--- a/src/material-experimental/mdc-progress-spinner/testing/public-api.ts
+++ b/src/material-experimental/mdc-progress-spinner/testing/public-api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './progress-spinner-harness';
+export {ProgressSpinnerHarnessFilters} from '@angular/material/progress-spinner/testing';

--- a/src/material-experimental/mdc-slide-toggle/testing/public-api.ts
+++ b/src/material-experimental/mdc-slide-toggle/testing/public-api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './slide-toggle-harness';
+export {SlideToggleHarnessFilters} from '@angular/material/slide-toggle/testing';

--- a/src/material-experimental/mdc-slider/testing/public-api.ts
+++ b/src/material-experimental/mdc-slider/testing/public-api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './slider-harness';
+export {SliderHarnessFilters} from '@angular/material/slider/testing';


### PR DESCRIPTION
Expands the `check-mdc-exports` script to also check the `/testing` packages for consistency. Also exports the missing symbols that were caught by the script.