### PR TITLE
fix(material-experimental/mdc-snack-bar): not stretching to full width on handset

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.scss
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.scss
@@ -23,3 +23,8 @@
   // declaration so the container doesn't collapse on IE11.
   flex: 1 1 auto;
 }
+
+// Ensures that the snack bar stretches to full width in handset mode.
+.mat-mdc-snack-bar-handset .mdc-snackbar__surface {
+  width: 100%;
+}


### PR DESCRIPTION
Fixes that the MDC-based snack bar gets centered, but it doesn't stretch to the full viewport width on the handset breakpoint.