### PR TITLE
refactor(material-experimental/mdc-menu): de-duplicate test harness logic

### DIFF
--- a/src/material-experimental/mdc-menu/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/testing/BUILD.bazel
@@ -10,7 +10,6 @@ ts_library(
     ),
     module_name = "@angular/material-experimental/mdc-menu/testing",
     deps = [
-        "//src/cdk/coercion",
         "//src/cdk/testing",
         "//src/material/menu/testing",
     ],

--- a/src/material-experimental/mdc-menu/testing/menu-harness.ts
+++ b/src/material-experimental/mdc-menu/testing/menu-harness.ts
@@ -6,25 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {HarnessPredicate} from '@angular/cdk/testing';
 import {
-  ComponentHarness,
-  ContentContainerComponentHarness,
-  HarnessLoader,
-  HarnessPredicate,
-  TestElement,
-  TestKey,
-} from '@angular/cdk/testing';
-import {coerceBooleanProperty} from '@angular/cdk/coercion';
-import {MenuHarnessFilters, MenuItemHarnessFilters} from '@angular/material/menu/testing';
+  MenuHarnessFilters,
+  MenuItemHarnessFilters,
+  _MatMenuItemHarnessBase,
+  _MatMenuHarnessBase
+} from '@angular/material/menu/testing';
 
 /** Harness for interacting with an MDC-based mat-menu in tests. */
-export class MatMenuHarness extends ContentContainerComponentHarness<string> {
+export class MatMenuHarness extends _MatMenuHarnessBase<
+  typeof MatMenuItemHarness, MatMenuItemHarness, MenuItemHarnessFilters> {
   /** The selector for the host element of a `MatMenu` instance. */
   static hostSelector = '.mat-menu-trigger';
-
-  private _documentRootLocator = this.documentRootLocatorFactory();
-
-  // TODO: potentially extend MatButtonHarness
+  protected _itemClass = MatMenuItemHarness;
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatMenuHarness` that meets certain
@@ -37,118 +32,14 @@ export class MatMenuHarness extends ContentContainerComponentHarness<string> {
         .addOption('triggerText', options.triggerText,
             (harness, text) => HarnessPredicate.stringMatches(harness.getTriggerText(), text));
   }
-
-  /** Whether the menu is disabled. */
-  async isDisabled(): Promise<boolean> {
-    const disabled = (await this.host()).getAttribute('disabled');
-    return coerceBooleanProperty(await disabled);
-  }
-
-  /** Whether the menu is open. */
-  async isOpen(): Promise<boolean> {
-    return !!(await this._getMenuPanel());
-  }
-
-  /** Gets the text of the menu's trigger element. */
-  async getTriggerText(): Promise<string> {
-    return (await this.host()).text();
-  }
-
-  /** Focuses the menu. */
-  async focus(): Promise<void> {
-    return (await this.host()).focus();
-  }
-
-  /** Blurs the menu. */
-  async blur(): Promise<void> {
-    return (await this.host()).blur();
-  }
-
-  /** Whether the menu is focused. */
-  async isFocused(): Promise<boolean> {
-    return (await this.host()).isFocused();
-  }
-
-  /** Opens the menu. */
-  async open(): Promise<void> {
-    if (!await this.isOpen()) {
-      return (await this.host()).click();
-    }
-  }
-
-  /** Closes the menu. */
-  async close(): Promise<void> {
-    const panel = await this._getMenuPanel();
-    if (panel) {
-      return panel.sendKeys(TestKey.ESCAPE);
-    }
-  }
-
-  /**
-   * Gets a list of `MatMenuItemHarness` representing the items in the menu.
-   * @param filters Optionally filters which menu items are included.
-   */
-  async getItems(filters: Omit<MenuItemHarnessFilters, 'ancestor'> = {}):
-      Promise<MatMenuItemHarness[]> {
-    const panelId = await this._getPanelId();
-    if (panelId) {
-      return this._documentRootLocator.locatorForAll(
-          MatMenuItemHarness.with({...filters, ancestor: `#${panelId}`}))();
-    }
-    return [];
-  }
-
-  /**
-   * Clicks an item in the menu, and optionally continues clicking items in subsequent sub-menus.
-   * @param itemFilter A filter used to represent which item in the menu should be clicked. The
-   *     first matching menu item will be clicked.
-   * @param subItemFilters A list of filters representing the items to click in any subsequent
-   *     sub-menus. The first item in the sub-menu matching the corresponding filter in
-   *     `subItemFilters` will be clicked.
-   */
-  async clickItem(
-      itemFilter: Omit<MenuItemHarnessFilters, 'ancestor'>,
-      ...subItemFilters: Omit<MenuItemHarnessFilters, 'ancestor'>[]): Promise<void> {
-    await this.open();
-    const items = await this.getItems(itemFilter);
-    if (!items.length) {
-      throw Error(`Could not find item matching ${JSON.stringify(itemFilter)}`);
-    }
-
-    if (!subItemFilters.length) {
-      return await items[0].click();
-    }
-
-    const menu = await items[0].getSubmenu();
-    if (!menu) {
-      throw Error(`Item matching ${JSON.stringify(itemFilter)} does not have a submenu`);
-    }
-    return menu.clickItem(...subItemFilters as [Omit<MenuItemHarnessFilters, 'ancestor'>]);
-  }
-
-  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
-    const panelId = await this._getPanelId();
-    return this.documentRootLocatorFactory().harnessLoaderFor(`#${panelId}`);
-  }
-
-  /** Gets the menu panel associated with this menu. */
-  private async _getMenuPanel(): Promise<TestElement | null> {
-    const panelId = await this._getPanelId();
-    return panelId ? this._documentRootLocator.locatorForOptional(`#${panelId}`)() : null;
-  }
-
-  /** Gets the id of the menu panel associated with this menu. */
-  private async _getPanelId(): Promise<string | null> {
-    const panelId = await (await this.host()).getAttribute('aria-controls');
-    return panelId || null;
-  }
 }
 
-
 /** Harness for interacting with an MDC-based mat-menu-item in tests. */
-export class MatMenuItemHarness extends ComponentHarness {
+export class MatMenuItemHarness extends
+  _MatMenuItemHarnessBase<typeof MatMenuHarness, MatMenuHarness> {
   /** The selector for the host element of a `MatMenuItem` instance. */
   static hostSelector = '.mat-mdc-menu-item';
+  protected _menuClass = MatMenuHarness;
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatMenuItemHarness` that meets
@@ -162,49 +53,5 @@ export class MatMenuItemHarness extends ComponentHarness {
             (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text))
         .addOption('hasSubmenu', options.hasSubmenu,
             async (harness, hasSubmenu) => (await harness.hasSubmenu()) === hasSubmenu);
-  }
-
-  /** Whether the menu is disabled. */
-  async isDisabled(): Promise<boolean> {
-    const disabled = (await this.host()).getAttribute('disabled');
-    return coerceBooleanProperty(await disabled);
-  }
-
-  /** Gets the text of the menu item. */
-  async getText(): Promise<string> {
-    return (await this.host()).text();
-  }
-
-  /** Focuses the menu item. */
-  async focus(): Promise<void> {
-    return (await this.host()).focus();
-  }
-
-  /** Blurs the menu item. */
-  async blur(): Promise<void> {
-    return (await this.host()).blur();
-  }
-
-  /** Whether the menu item is focused. */
-  async isFocused(): Promise<boolean> {
-    return (await this.host()).isFocused();
-  }
-
-  /** Clicks the menu item. */
-  async click(): Promise<void> {
-    return (await this.host()).click();
-  }
-
-  /** Whether this item has a submenu. */
-  async hasSubmenu(): Promise<boolean> {
-    return (await this.host()).matchesSelector(MatMenuHarness.hostSelector);
-  }
-
-  /** Gets the submenu associated with this menu item, or null if none. */
-  async getSubmenu(): Promise<MatMenuHarness | null> {
-    if (await this.hasSubmenu()) {
-      return new MatMenuHarness(this.locatorFactory);
-    }
-    return null;
   }
 }

--- a/tools/public_api_guard/material/menu/testing.d.ts
+++ b/tools/public_api_guard/material/menu/testing.d.ts
@@ -1,28 +1,43 @@
-export declare class MatMenuHarness extends ContentContainerComponentHarness<string> {
+export declare abstract class _MatMenuHarnessBase<ItemType extends (ComponentHarnessConstructor<Item> & {
+    with: (options?: ItemFilters) => HarnessPredicate<Item>;
+}), Item extends ComponentHarness & {
+    click(): Promise<void>;
+    getSubmenu(): Promise<_MatMenuHarnessBase<ItemType, Item, ItemFilters> | null>;
+}, ItemFilters extends BaseHarnessFilters> extends ContentContainerComponentHarness<string> {
+    protected abstract _itemClass: ItemType;
     blur(): Promise<void>;
-    clickItem(itemFilter: Omit<MenuItemHarnessFilters, 'ancestor'>, ...subItemFilters: Omit<MenuItemHarnessFilters, 'ancestor'>[]): Promise<void>;
+    clickItem(itemFilter: Omit<ItemFilters, 'ancestor'>, ...subItemFilters: Omit<ItemFilters, 'ancestor'>[]): Promise<void>;
     close(): Promise<void>;
     focus(): Promise<void>;
-    getItems(filters?: Omit<MenuItemHarnessFilters, 'ancestor'>): Promise<MatMenuItemHarness[]>;
+    getItems(filters?: Omit<ItemFilters, 'ancestor'>): Promise<Item[]>;
     protected getRootHarnessLoader(): Promise<HarnessLoader>;
     getTriggerText(): Promise<string>;
     isDisabled(): Promise<boolean>;
     isFocused(): Promise<boolean>;
     isOpen(): Promise<boolean>;
     open(): Promise<void>;
-    static hostSelector: string;
-    static with(options?: MenuHarnessFilters): HarnessPredicate<MatMenuHarness>;
 }
 
-export declare class MatMenuItemHarness extends ContentContainerComponentHarness<string> {
+export declare abstract class _MatMenuItemHarnessBase<MenuType extends ComponentHarnessConstructor<Menu>, Menu extends ComponentHarness> extends ContentContainerComponentHarness<string> {
+    protected abstract _menuClass: MenuType;
     blur(): Promise<void>;
     click(): Promise<void>;
     focus(): Promise<void>;
-    getSubmenu(): Promise<MatMenuHarness | null>;
+    getSubmenu(): Promise<Menu | null>;
     getText(): Promise<string>;
     hasSubmenu(): Promise<boolean>;
     isDisabled(): Promise<boolean>;
     isFocused(): Promise<boolean>;
+}
+
+export declare class MatMenuHarness extends _MatMenuHarnessBase<typeof MatMenuItemHarness, MatMenuItemHarness, MenuItemHarnessFilters> {
+    protected _itemClass: typeof MatMenuItemHarness;
+    static hostSelector: string;
+    static with(options?: MenuHarnessFilters): HarnessPredicate<MatMenuHarness>;
+}
+
+export declare class MatMenuItemHarness extends _MatMenuItemHarnessBase<typeof MatMenuHarness, MatMenuHarness> {
+    protected _menuClass: typeof MatMenuHarness;
     static hostSelector: string;
     static with(options?: MenuItemHarnessFilters): HarnessPredicate<MatMenuItemHarness>;
 }


### PR DESCRIPTION
De-duplicates the test harness logic between the base and MDC menu test harnesses.