### PR TITLE
feat(material/datepicker): add support for cancel/apply buttons

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.css
+++ b/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.css
@@ -1,0 +1,3 @@
+.example-form-field {
+  margin-right: 20px;
+}

--- a/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.html
+++ b/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.html
@@ -1,0 +1,30 @@
+<mat-form-field appearance="fill" class="example-form-field">
+  <mat-label>Choose a date</mat-label>
+  <input matInput [matDatepicker]="datepicker">
+  <mat-datepicker-toggle matSuffix [for]="datepicker"></mat-datepicker-toggle>
+<!-- #docregion datepicker-actions -->
+  <mat-datepicker #datepicker>
+    <mat-datepicker-actions>
+      <button mat-button matDatepickerCancel>Cancel</button>
+      <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+    </mat-datepicker-actions>
+  </mat-datepicker>
+<!-- #enddocregion datepicker-actions -->
+</mat-form-field>
+
+<mat-form-field appearance="fill" class="example-form-field">
+  <mat-label>Enter a date range</mat-label>
+  <mat-date-range-input [rangePicker]="rangePicker">
+    <input matStartDate placeholder="Start date">
+    <input matEndDate placeholder="End date">
+  </mat-date-range-input>
+  <mat-datepicker-toggle matSuffix [for]="rangePicker"></mat-datepicker-toggle>
+<!-- #docregion date-range-picker-actions -->
+  <mat-date-range-picker #rangePicker>
+    <mat-date-range-picker-actions>
+      <button mat-button matDateRangePickerCancel>Cancel</button>
+      <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+    </mat-date-range-picker-actions>
+  </mat-date-range-picker>
+<!-- #enddocregion date-range-picker-actions -->
+</mat-form-field>

--- a/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.ts
+++ b/src/components-examples/material/datepicker/datepicker-actions/datepicker-actions-example.ts
@@ -1,0 +1,9 @@
+import {Component} from '@angular/core';
+
+/** @title Datepicker action buttons */
+@Component({
+  selector: 'datepicker-actions-example',
+  templateUrl: 'datepicker-actions-example.html',
+  styleUrls: ['datepicker-actions-example.css']
+})
+export class DatepickerActionsExample {}

--- a/src/components-examples/material/datepicker/index.ts
+++ b/src/components-examples/material/datepicker/index.ts
@@ -42,6 +42,7 @@ import {
   DateRangePickerSelectionStrategyExample
 } from './date-range-picker-selection-strategy/date-range-picker-selection-strategy-example';
 import {DatepickerHarnessExample} from './datepicker-harness/datepicker-harness-example';
+import {DatepickerActionsExample} from './datepicker-actions/datepicker-actions-example';
 
 export {
   DatepickerApiExample,
@@ -66,6 +67,7 @@ export {
   DateRangePickerFormsExample,
   DateRangePickerComparisonExample,
   DateRangePickerSelectionStrategyExample,
+  DatepickerActionsExample,
   ExampleHeader,
 };
 
@@ -92,6 +94,7 @@ const EXAMPLES = [
   DateRangePickerFormsExample,
   DateRangePickerComparisonExample,
   DateRangePickerSelectionStrategyExample,
+  DatepickerActionsExample,
   ExampleHeader,
 ];
 

--- a/src/dev-app/datepicker/datepicker-demo.html
+++ b/src/dev-app/datepicker/datepicker-demo.html
@@ -5,6 +5,7 @@
   <mat-checkbox [(ngModel)]="yearView">Start in year view</mat-checkbox>
   <mat-checkbox [(ngModel)]="datepickerDisabled">Disable datepicker</mat-checkbox>
   <mat-checkbox [(ngModel)]="inputDisabled">Disable input</mat-checkbox>
+  <mat-checkbox [(ngModel)]="showActions">Show action buttons</mat-checkbox>
   <mat-form-field>
     <mat-select [(ngModel)]="color" placeholder="Color">
       <mat-option value="primary">Primary</mat-option>
@@ -19,14 +20,24 @@
     <input matInput [matDatepicker]="minDatePicker" [(ngModel)]="minDate"
         [disabled]="inputDisabled" [max]="maxDate">
     <mat-datepicker-toggle matSuffix [for]="minDatePicker"></mat-datepicker-toggle>
-    <mat-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></mat-datepicker>
+    <mat-datepicker #minDatePicker [touchUi]="touch" [disabled]="datepickerDisabled">
+      <mat-datepicker-actions *ngIf="showActions">
+        <button mat-button matDatepickerCancel>Cancel</button>
+        <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+      </mat-datepicker-actions>
+    </mat-datepicker>
   </mat-form-field>
   <mat-form-field color="accent">
     <mat-label>Max date</mat-label>
     <input matInput [matDatepicker]="maxDatePicker" [(ngModel)]="maxDate"
         [disabled]="inputDisabled" [min]="minDate">
     <mat-datepicker-toggle matSuffix [for]="maxDatePicker"></mat-datepicker-toggle>
-    <mat-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled"></mat-datepicker>
+    <mat-datepicker #maxDatePicker [touchUi]="touch" [disabled]="datepickerDisabled">
+      <mat-datepicker-actions *ngIf="showActions">
+        <button mat-button matDatepickerCancel>Cancel</button>
+        <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+      </mat-datepicker-actions>
+    </mat-datepicker>
   </mat-form-field>
 </p>
 <p>
@@ -35,7 +46,12 @@
     <input matInput [matDatepicker]="startAtPicker" [(ngModel)]="startAt"
         [disabled]="inputDisabled">
     <mat-datepicker-toggle matSuffix [for]="startAtPicker"></mat-datepicker-toggle>
-    <mat-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled"></mat-datepicker>
+    <mat-datepicker #startAtPicker [touchUi]="touch" [disabled]="datepickerDisabled">
+      <mat-datepicker-actions *ngIf="showActions">
+        <button mat-button matDatepickerCancel>Cancel</button>
+        <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+      </mat-datepicker-actions>
+    </mat-datepicker>
   </mat-form-field>
 </p>
 
@@ -62,6 +78,10 @@
         [startAt]="startAt"
         [startView]="yearView ? 'year' : 'month'"
         [color]="color">
+      <mat-datepicker-actions *ngIf="showActions">
+        <button mat-button matDatepickerCancel>Cancel</button>
+        <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+      </mat-datepicker-actions>
     </mat-datepicker>
     <mat-error *ngIf="resultPickerModel.hasError('matDatepickerParse')">
       "{{resultPickerModel.getError('matDatepickerParse').text}}" is not a valid date!
@@ -90,6 +110,10 @@
       [disabled]="datepickerDisabled"
       [startAt]="startAt"
       [startView]="yearView ? 'year' : 'month'">
+    <mat-datepicker-actions *ngIf="showActions">
+      <button mat-button matDatepickerCancel>Cancel</button>
+      <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
+    </mat-datepicker-actions>
   </mat-datepicker>
 </p>
 
@@ -191,7 +215,12 @@
     <mat-date-range-picker
       [touchUi]="touch"
       [disabled]="datepickerDisabled"
-      #range1Picker></mat-date-range-picker>
+      #range1Picker>
+      <mat-date-range-picker-actions *ngIf="showActions">
+        <button mat-button matDateRangePickerCancel>Cancel</button>
+        <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+      </mat-date-range-picker-actions>
+    </mat-date-range-picker>
   </mat-form-field>
   <div>{{range1.value | json}}</div>
 </div>
@@ -216,7 +245,12 @@
       [touchUi]="touch"
       [disabled]="datepickerDisabled"
       panelClass="demo-custom-range"
-      #range2Picker></mat-date-range-picker>
+      #range2Picker>
+      <mat-date-range-picker-actions *ngIf="showActions">
+        <button mat-button matDateRangePickerCancel>Cancel</button>
+        <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+      </mat-date-range-picker-actions>
+    </mat-date-range-picker>
   </mat-form-field>
   <div>{{range2.value | json}}</div>
 </div>
@@ -240,7 +274,12 @@
     <mat-date-range-picker
       [touchUi]="touch"
       [disabled]="datepickerDisabled"
-      #range3Picker></mat-date-range-picker>
+      #range3Picker>
+      <mat-date-range-picker-actions *ngIf="showActions">
+        <button mat-button matDateRangePickerCancel>Cancel</button>
+        <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+      </mat-date-range-picker-actions>
+    </mat-date-range-picker>
   </mat-form-field>
   <div>{{range3.value | json}}</div>
 </div>
@@ -255,6 +294,11 @@
       <input matEndDate placeholder="End date"/>
     </mat-date-range-input>
     <mat-datepicker-toggle [for]="range4Picker" matSuffix></mat-datepicker-toggle>
-    <mat-date-range-picker customRangeStrategy #range4Picker></mat-date-range-picker>
+    <mat-date-range-picker customRangeStrategy #range4Picker>
+      <mat-date-range-picker-actions *ngIf="showActions">
+        <button mat-button matDateRangePickerCancel>Cancel</button>
+        <button mat-raised-button color="primary" matDateRangePickerApply>Apply</button>
+      </mat-date-range-picker-actions>
+    </mat-date-range-picker>
   </mat-form-field>
 </div>

--- a/src/dev-app/datepicker/datepicker-demo.ts
+++ b/src/dev-app/datepicker/datepicker-demo.ts
@@ -52,6 +52,7 @@ export class DatepickerDemo {
   lastDateInput: Date | null;
   lastDateChange: Date | null;
   color: ThemePalette;
+  showActions = false;
 
   dateCtrl = new FormControl();
   range1 = new FormGroup({start: new FormControl(), end: new FormControl()});

--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -18,6 +18,7 @@ ng_module(
     ),
     assets = [
         ":datepicker-content.css",
+        ":datepicker-actions.css",
         ":datepicker-toggle.css",
         ":date-range-input.css",
         ":calendar-body.css",
@@ -79,6 +80,11 @@ sass_binary(
     deps = ["//src/material/core:core_scss_lib"],
 )
 
+sass_binary(
+    name = "datepicker_actions_scss",
+    src = "datepicker-actions.scss",
+)
+
 ng_test_library(
     name = "unit_test_sources",
     srcs = glob(
@@ -98,6 +104,7 @@ ng_test_library(
         "//src/material/form-field",
         "//src/material/input",
         "//src/material/testing",
+        "@npm//@angular/common",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
         "@npm//@angular/platform-browser-dynamic",

--- a/src/material/datepicker/date-range-picker.ts
+++ b/src/material/datepicker/date-range-picker.ts
@@ -33,6 +33,7 @@ export interface MatDateRangePickerInput<D> extends MatDatepickerControl<D> {
   providers: [
     MAT_RANGE_DATE_SELECTION_MODEL_PROVIDER,
     MAT_CALENDAR_RANGE_STRATEGY_PROVIDER,
+    {provide: MatDatepickerBase, useExisting: MatDateRangePicker},
   ]
 })
 export class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRangePickerInput<D>,

--- a/src/material/datepicker/date-selection-model.ts
+++ b/src/material/datepicker/date-selection-model.ts
@@ -83,6 +83,19 @@ export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<
 
   /** Checks whether the current selection is complete. */
   abstract isComplete(): boolean;
+
+  /**
+   * Clones the selection model.
+   * @deprecated To be turned into an abstract method.
+   * @breaking-change 12.0.0
+   */
+  clone(): MatDateSelectionModel<S, D> {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      throw Error('Not implemented');
+    }
+
+    return null!;
+  }
 }
 
 /**  A selection model that contains a single date. */
@@ -111,6 +124,13 @@ export class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | nu
    */
   isComplete() {
     return this.selection != null;
+  }
+
+  /** Clones the selection model. */
+  clone() {
+    const clone = new MatSingleDateSelectionModel<D>(this._adapter);
+    clone.updateSelection(this.selection, this);
+    return clone;
   }
 }
 
@@ -167,6 +187,13 @@ export class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRan
    */
   isComplete(): boolean {
     return this.selection.start != null && this.selection.end != null;
+  }
+
+  /** Clones the selection model. */
+  clone() {
+    const clone = new MatRangeDateSelectionModel<D>(this._adapter);
+    clone.updateSelection(this.selection, this);
+    return clone;
   }
 }
 

--- a/src/material/datepicker/datepicker-actions.scss
+++ b/src/material/datepicker/datepicker-actions.scss
@@ -1,0 +1,16 @@
+.mat-datepicker-actions {
+  $spacing: 8px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 0 $spacing $spacing $spacing;
+
+  .mat-button-base + .mat-button-base {
+    margin-left: $spacing;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: $spacing;
+    }
+  }
+}

--- a/src/material/datepicker/datepicker-actions.spec.ts
+++ b/src/material/datepicker/datepicker-actions.spec.ts
@@ -1,0 +1,279 @@
+import {Component, ElementRef, Type, ViewChild} from '@angular/core';
+import {OverlayContainer} from '@angular/cdk/overlay';
+import {ComponentFixture, TestBed, inject, flush, fakeAsync} from '@angular/core/testing';
+import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatNativeDateModule} from '@angular/material/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {CommonModule} from '@angular/common';
+import {MatDatepickerModule} from './datepicker-module';
+import {MatDatepicker} from './datepicker';
+
+describe('MatDatepickerActions', () => {
+  function createComponent<T>(component: Type<T>): ComponentFixture<T> {
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        FormsModule,
+        MatDatepickerModule,
+        MatFormFieldModule,
+        MatInputModule,
+        NoopAnimationsModule,
+        ReactiveFormsModule,
+        MatNativeDateModule,
+      ],
+      declarations: [component],
+    });
+
+    return TestBed.createComponent(component);
+  }
+
+  afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
+    container.ngOnDestroy();
+  }));
+
+  it('should render the actions inside calendar panel in popup mode', () => {
+    const fixture = createComponent(DatepickerWithActions);
+    fixture.detectChanges();
+    fixture.componentInstance.datepicker.open();
+    fixture.detectChanges();
+
+    const actions = document.querySelector('.mat-datepicker-content .mat-datepicker-actions');
+    expect(actions).toBeTruthy();
+    expect(actions?.querySelector('.cancel')).toBeTruthy();
+    expect(actions?.querySelector('.apply')).toBeTruthy();
+  });
+
+  it('should render the actions inside calendar panel in touch UI mode', () => {
+    const fixture = createComponent(DatepickerWithActions);
+    fixture.componentInstance.touchUi = true;
+    fixture.detectChanges();
+    fixture.componentInstance.datepicker.open();
+    fixture.detectChanges();
+
+    const actions = document.querySelector('.mat-datepicker-content .mat-datepicker-actions');
+    expect(actions).toBeTruthy();
+    expect(actions?.querySelector('.cancel')).toBeTruthy();
+    expect(actions?.querySelector('.apply')).toBeTruthy();
+  });
+
+  it('should not assign the value or close the datepicker when a value is selected',
+    fakeAsync(() => {
+      const fixture = createComponent(DatepickerWithActions);
+      fixture.detectChanges();
+      const {control, datepicker, onDateChange, input} = fixture.componentInstance;
+      datepicker.open();
+      fixture.detectChanges();
+
+      const content = document.querySelector('.mat-datepicker-content')!;
+      const cells = content.querySelectorAll<HTMLElement>('.mat-calendar-body-cell');
+
+      expect(datepicker.opened).toBe(true);
+      expect(input.nativeElement.value).toBeFalsy();
+      expect(control.value).toBeFalsy();
+      expect(onDateChange).not.toHaveBeenCalled();
+      expect(content.querySelector('.mat-calendar-body-selected')).toBeFalsy();
+
+      cells[10].click();
+      fixture.detectChanges();
+      flush();
+
+      expect(datepicker.opened).toBe(true);
+      expect(input.nativeElement.value).toBeFalsy();
+      expect(control.value).toBeFalsy();
+      expect(onDateChange).not.toHaveBeenCalled();
+      expect(content.querySelector('.mat-calendar-body-selected')).toBeTruthy();
+    }));
+
+  it('should close without changing the value when clicking on the cancel button', fakeAsync(() => {
+    const fixture = createComponent(DatepickerWithActions);
+    fixture.detectChanges();
+    const {control, datepicker, onDateChange, input} = fixture.componentInstance;
+    datepicker.open();
+    fixture.detectChanges();
+
+    const content = document.querySelector('.mat-datepicker-content')!;
+    const cells = content.querySelectorAll<HTMLElement>('.mat-calendar-body-cell');
+
+    expect(datepicker.opened).toBe(true);
+    expect(input.nativeElement.value).toBeFalsy();
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+    expect(content.querySelector('.mat-calendar-body-selected')).toBeFalsy();
+
+    cells[10].click();
+    fixture.detectChanges();
+    flush();
+
+    expect(datepicker.opened).toBe(true);
+    expect(input.nativeElement.value).toBeFalsy();
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+    expect(content.querySelector('.mat-calendar-body-selected')).toBeTruthy();
+
+    (content.querySelector('.cancel') as HTMLElement).click();
+    fixture.detectChanges();
+    flush();
+
+    expect(datepicker.opened).toBe(false);
+    expect(input.nativeElement.value).toBeFalsy();
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+  }));
+
+  it('should close while keeping the previous control value when clicking on cancel',
+    fakeAsync(() => {
+      const fixture = createComponent(DatepickerWithActions);
+      fixture.detectChanges();
+      const {control, datepicker, onDateChange} = fixture.componentInstance;
+      const value = new Date(2021, 0, 20);
+      control.setValue(value);
+      fixture.detectChanges();
+      datepicker.open();
+      fixture.detectChanges();
+
+      const content = document.querySelector('.mat-datepicker-content')!;
+      const cells = content.querySelectorAll<HTMLElement>('.mat-calendar-body-cell');
+
+      expect(datepicker.opened).toBe(true);
+      expect(control.value).toBe(value);
+      expect(onDateChange).not.toHaveBeenCalled();
+
+      cells[10].click();
+      fixture.detectChanges();
+      flush();
+
+      expect(datepicker.opened).toBe(true);
+      expect(control.value).toBe(value);
+      expect(onDateChange).not.toHaveBeenCalled();
+
+      (content.querySelector('.cancel') as HTMLElement).click();
+      fixture.detectChanges();
+      flush();
+
+      expect(datepicker.opened).toBe(false);
+      expect(control.value).toBe(value);
+      expect(onDateChange).not.toHaveBeenCalled();
+    }));
+
+  it('should close and accept the value when clicking on the apply button', fakeAsync(() => {
+    const fixture = createComponent(DatepickerWithActions);
+    fixture.detectChanges();
+    const {control, datepicker, onDateChange, input} = fixture.componentInstance;
+    datepicker.open();
+    fixture.detectChanges();
+
+    const content = document.querySelector('.mat-datepicker-content')!;
+    const cells = content.querySelectorAll<HTMLElement>('.mat-calendar-body-cell');
+
+    expect(datepicker.opened).toBe(true);
+    expect(input.nativeElement.value).toBeFalsy();
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+    expect(content.querySelector('.mat-calendar-body-selected')).toBeFalsy();
+
+    cells[10].click();
+    fixture.detectChanges();
+    flush();
+
+    expect(datepicker.opened).toBe(true);
+    expect(input.nativeElement.value).toBeFalsy();
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+    expect(content.querySelector('.mat-calendar-body-selected')).toBeTruthy();
+
+    (content.querySelector('.apply') as HTMLElement).click();
+    fixture.detectChanges();
+    flush();
+
+    expect(datepicker.opened).toBe(false);
+    expect(input.nativeElement.value).toBeTruthy();
+    expect(control.value).toBeTruthy();
+    expect(onDateChange).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should revert to the default behavior if the actions are removed', fakeAsync(() => {
+    const fixture = createComponent(DatepickerWithActions);
+    fixture.detectChanges();
+    const {control, datepicker, onDateChange} = fixture.componentInstance;
+    datepicker.open();
+    fixture.detectChanges();
+
+    let content = document.querySelector('.mat-datepicker-content')!;
+    let actions = content.querySelector('.mat-datepicker-actions')!;
+    let cells = content.querySelectorAll<HTMLElement>('.mat-calendar-body-cell');
+
+    expect(actions).toBeTruthy();
+    expect(datepicker.opened).toBe(true);
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+
+    cells[10].click();
+    fixture.detectChanges();
+    flush();
+
+    expect(datepicker.opened).toBe(true);
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+
+    (actions.querySelector('.cancel') as HTMLElement).click();
+    fixture.detectChanges();
+    flush();
+
+    expect(datepicker.opened).toBe(false);
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+
+    fixture.componentInstance.renderActions = false;
+    fixture.detectChanges();
+    datepicker.open();
+    fixture.detectChanges();
+    content = document.querySelector('.mat-datepicker-content')!;
+    actions = content.querySelector('.mat-datepicker-actions')!;
+    cells = content.querySelectorAll<HTMLElement>('.mat-calendar-body-cell');
+
+    expect(actions).toBeFalsy();
+    expect(datepicker.opened).toBe(true);
+    expect(control.value).toBeFalsy();
+    expect(onDateChange).not.toHaveBeenCalled();
+
+    cells[10].click();
+    fixture.detectChanges();
+    flush();
+
+    expect(datepicker.opened).toBe(false);
+    expect(control.value).toBeTruthy();
+    expect(onDateChange).toHaveBeenCalledTimes(1);
+  }));
+
+});
+
+@Component({
+  template: `
+    <mat-form-field>
+      <mat-label>Pick a date</mat-label>
+      <input
+          #input
+          matInput
+          [matDatepicker]="picker"
+          [formControl]="control"
+          (dateChange)="onDateChange()">
+      <mat-datepicker #picker [touchUi]="touchUi" [startAt]="startAt">
+        <mat-datepicker-actions *ngIf="renderActions">
+          <button mat-button class="cancel" matDatepickerCancel>Cancel</button>
+          <button mat-raised-button class="apply" matDatepickerApply>Apply</button>
+        </mat-datepicker-actions>
+      </mat-datepicker>
+    </mat-form-field>
+  `
+})
+class DatepickerWithActions {
+  @ViewChild(MatDatepicker) datepicker: MatDatepicker<Date>;
+  @ViewChild('input', {read: ElementRef}) input: ElementRef<HTMLInputElement>;
+  control = new FormControl();
+  onDateChange = jasmine.createSpy('dateChange spy');
+  touchUi = false;
+  startAt = new Date(2021, 0, 15);
+  renderActions = true;
+}

--- a/src/material/datepicker/datepicker-actions.ts
+++ b/src/material/datepicker/datepicker-actions.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  OnDestroy,
+  TemplateRef,
+  ViewChild,
+  ViewContainerRef,
+  ViewEncapsulation
+} from '@angular/core';
+import {TemplatePortal} from '@angular/cdk/portal';
+import {MatDatepickerBase, MatDatepickerControl} from './datepicker-base';
+
+
+/** Button that will close the datepicker and assign the current selection to the data model. */
+@Directive({
+  selector: '[matDatepickerApply], [matDateRangePickerApply]',
+  host: {'(click)': '_applySelection()'}
+})
+export class MatDatepickerApply {
+  constructor(private _datepicker: MatDatepickerBase<MatDatepickerControl<unknown>, unknown>) {}
+
+  _applySelection() {
+    this._datepicker._applyPendingSelection();
+    this._datepicker.close();
+  }
+}
+
+
+/** Button that will close the datepicker and discard the current selection. */
+@Directive({
+  selector: '[matDatepickerCancel], [matDateRangePickerCancel]',
+  host: {'(click)': '_datepicker.close()'}
+})
+export class MatDatepickerCancel {
+  constructor(public _datepicker: MatDatepickerBase<MatDatepickerControl<unknown>, unknown>) {}
+}
+
+
+/**
+ * Container that can be used to project a row of action buttons
+ * to the bottom of a datepicker or date range picker.
+ */
+@Component({
+  selector: 'mat-datepicker-actions, mat-date-range-picker-actions',
+  styleUrls: ['datepicker-actions.css'],
+  template: `
+    <ng-template>
+      <div class="mat-datepicker-actions">
+        <ng-content></ng-content>
+      </div>
+    </ng-template>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None
+})
+export class MatDatepickerActions implements AfterViewInit, OnDestroy {
+  @ViewChild(TemplateRef) _template: TemplateRef<unknown>;
+  private _portal: TemplatePortal;
+
+  constructor(
+    private _datepicker: MatDatepickerBase<MatDatepickerControl<unknown>, unknown>,
+    private _viewContainerRef: ViewContainerRef) {}
+
+  ngAfterViewInit() {
+    this._portal = new TemplatePortal(this._template, this._viewContainerRef);
+    this._datepicker.registerActions(this._portal);
+  }
+
+  ngOnDestroy() {
+    this._datepicker.removeActions(this._portal);
+
+    // Needs to be null checked since we initialize it in `ngAfterViewInit`.
+    if (this._portal && this._portal.isAttached) {
+      this._portal?.detach();
+    }
+  }
+}

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -1,4 +1,7 @@
-<div cdkTrapFocus>
+<div
+  cdkTrapFocus
+  class="mat-datepicker-content-container"
+  [class.mat-datepicker-content-container-with-actions]="_actionsPortal">
   <mat-calendar
     [id]="datepicker.id"
     [ngClass]="datepicker.panelClass"
@@ -17,6 +20,8 @@
     (monthSelected)="datepicker._selectMonth($event)"
     (viewChanged)="datepicker._viewChanged($event)"
     (_userSelection)="_handleUserSelection($event)"></mat-calendar>
+
+  <ng-template [cdkPortalOutlet]="_actionsPortal"></ng-template>
 
   <!-- Invisible close button for screen reader users. -->
   <button

--- a/src/material/datepicker/datepicker-content.scss
+++ b/src/material/datepicker/datepicker-content.scss
@@ -15,6 +15,7 @@ $mat-datepicker-touch-landscape-width: 64vh;
 $mat-datepicker-touch-landscape-height: 80vh;
 $mat-datepicker-touch-portrait-width: 80vw;
 $mat-datepicker-touch-portrait-height: 100vw;
+$mat-datepicker-touch-portrait-height-with-actions: 115vw;
 $mat-datepicker-touch-min-width: 250px;
 $mat-datepicker-touch-min-height: 312px;
 $mat-datepicker-touch-max-width: 750px;
@@ -40,6 +41,14 @@ $mat-datepicker-touch-max-height: 788px;
   }
 }
 
+.mat-datepicker-content-container {
+  display: flex;
+  flex-direction: column;
+
+  // Ensures that `mat-datepicker-actions` is pushed to the bottom of the popup.
+  justify-content: space-between;
+}
+
 .mat-datepicker-content-touch {
   display: block;
   // Make sure the dialog scrolls rather than being cropped on ludicrously small screens
@@ -50,24 +59,35 @@ $mat-datepicker-touch-max-height: 788px;
   // TODO(mmalerba): Remove when we switch away from using dialog.
   margin: -24px;
 
-  .mat-calendar {
-    min-width: $mat-datepicker-touch-min-width;
+  .mat-datepicker-content-container {
     min-height: $mat-datepicker-touch-min-height;
-    max-width: $mat-datepicker-touch-max-width;
     max-height: $mat-datepicker-touch-max-height;
+    min-width: $mat-datepicker-touch-min-width;
+    max-width: $mat-datepicker-touch-max-width;
+  }
+
+  .mat-calendar {
+    width: 100%;
+    height: auto;
   }
 }
 
 @media all and (orientation: landscape) {
-  .mat-datepicker-content-touch .mat-calendar {
+  .mat-datepicker-content-touch .mat-datepicker-content-container {
     width: $mat-datepicker-touch-landscape-width;
     height: $mat-datepicker-touch-landscape-height;
   }
 }
 
 @media all and (orientation: portrait) {
-  .mat-datepicker-content-touch .mat-calendar {
+  .mat-datepicker-content-touch .mat-datepicker-content-container {
     width: $mat-datepicker-touch-portrait-width;
     height: $mat-datepicker-touch-portrait-height;
+  }
+
+  // The content needs to be a bit taller when actions have
+  // been projected so that it doesn't have to scroll.
+  .mat-datepicker-content-touch .mat-datepicker-content-container-with-actions {
+    height: $mat-datepicker-touch-portrait-height-with-actions;
   }
 }

--- a/src/material/datepicker/datepicker-module.ts
+++ b/src/material/datepicker/datepicker-module.ts
@@ -31,6 +31,7 @@ import {MatYearView} from './year-view';
 import {MatDateRangeInput} from './date-range-input';
 import {MatStartDate, MatEndDate} from './date-range-input-parts';
 import {MatDateRangePicker} from './date-range-picker';
+import {MatDatepickerActions, MatDatepickerApply, MatDatepickerCancel} from './datepicker-actions';
 
 
 @NgModule({
@@ -60,6 +61,9 @@ import {MatDateRangePicker} from './date-range-picker';
     MatStartDate,
     MatEndDate,
     MatDateRangePicker,
+    MatDatepickerActions,
+    MatDatepickerCancel,
+    MatDatepickerApply
   ],
   declarations: [
     MatCalendar,
@@ -77,6 +81,9 @@ import {MatDateRangePicker} from './date-range-picker';
     MatStartDate,
     MatEndDate,
     MatDateRangePicker,
+    MatDatepickerActions,
+    MatDatepickerCancel,
+    MatDatepickerApply
   ],
   providers: [
     MatDatepickerIntl,

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -193,6 +193,31 @@ but allow selection via the calendar or vice-versa.
 
 <!-- example(datepicker-disabled) -->
 
+### Confirmation action buttons
+
+By default, clicking on a date in the calendar will select it and close the calendar popup. In some
+cases this may not be desirable, because the user doesn't have a quick way of going back if they've
+changed their mind. If you want your users to be able to cancel their selection and to have to
+explicitly accept the value that they've selected, you can add a `<mat-datepicker-actions>` element
+inside `<mat-datepicker>` with a "Cancel" and an "Apply" button marked with the
+`matDatepickerCancel` and `matDatepickerApply` attributes respectively. Doing so will cause the
+datepicker to only assign the value to the data model if the user presses "Apply", whereas pressing
+"Cancel" will close popup without changing the value.
+
+<!-- example({"example":"datepicker-actions",
+              "file":"datepicker-actions-example.html",
+              "region":"datepicker-actions"}) -->
+
+The actions element is also supported for `<mat-date-range-picker>` where that it is called
+`<mat-date-range-picker-actions>` and the buttons are called `matDateRangePickerCancel` and
+`matDateRangePickerApply` respectively.
+
+<!-- example({"example":"datepicker-actions",
+              "file":"datepicker-actions-example.html",
+              "region":"date-range-picker-actions"}) -->
+
+<!-- example(datepicker-actions) -->
+
 ### Comparison ranges
 
 If your users need to compare the date range that they're currently selecting with another range,

--- a/src/material/datepicker/datepicker.ts
+++ b/src/material/datepicker/datepicker.ts
@@ -20,7 +20,10 @@ import {MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER} from './date-selection-model';
   exportAs: 'matDatepicker',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  providers: [MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER]
+  providers: [
+    MAT_SINGLE_DATE_SELECTION_MODEL_PROVIDER,
+    {provide: MatDatepickerBase, useExisting: MatDatepicker},
+  ]
 })
 export class MatDatepicker<D> extends MatDatepickerBase<MatDatepickerControl<D>, D | null, D> {
 }

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -39,3 +39,4 @@ export {MatDateRangePicker} from './date-range-picker';
 export * from './date-selection-model';
 export {MatStartDate, MatEndDate} from './date-range-input-parts';
 export {MatMultiYearView, yearsPerPage, yearsPerRow} from './multi-year-view';
+export * from './datepicker-actions';

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -184,12 +184,36 @@ export declare class MatDatepicker<D> extends MatDatepickerBase<MatDatepickerCon
     static ɵfac: i0.ɵɵFactoryDef<MatDatepicker<any>, never>;
 }
 
+export declare class MatDatepickerActions implements AfterViewInit, OnDestroy {
+    _template: TemplateRef<unknown>;
+    constructor(_datepicker: MatDatepickerBase<MatDatepickerControl<unknown>, unknown>, _viewContainerRef: ViewContainerRef);
+    ngAfterViewInit(): void;
+    ngOnDestroy(): void;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDatepickerActions, "mat-datepicker-actions, mat-date-range-picker-actions", never, {}, {}, never, ["*"]>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDatepickerActions, never>;
+}
+
 export declare const matDatepickerAnimations: {
     readonly transformPanel: AnimationTriggerMetadata;
     readonly fadeInCalendar: AnimationTriggerMetadata;
 };
 
-export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> extends _MatDatepickerContentMixinBase implements AfterViewInit, OnDestroy, CanColor {
+export declare class MatDatepickerApply {
+    constructor(_datepicker: MatDatepickerBase<MatDatepickerControl<unknown>, unknown>);
+    _applySelection(): void;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerApply, "[matDatepickerApply], [matDateRangePickerApply]", never, {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDatepickerApply, never>;
+}
+
+export declare class MatDatepickerCancel {
+    _datepicker: MatDatepickerBase<MatDatepickerControl<unknown>, unknown>;
+    constructor(_datepicker: MatDatepickerBase<MatDatepickerControl<unknown>, unknown>);
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerCancel, "[matDatepickerCancel], [matDateRangePickerCancel]", never, {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatDatepickerCancel, never>;
+}
+
+export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> extends _MatDatepickerContentMixinBase implements OnInit, AfterViewInit, OnDestroy, CanColor {
+    _actionsPortal: TemplatePortal | null;
     _animationDone: Subject<void>;
     _animationState: 'enter' | 'void';
     _calendar: MatCalendar<D>;
@@ -199,13 +223,15 @@ export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>
     comparisonEnd: D | null;
     comparisonStart: D | null;
     datepicker: MatDatepickerBase<any, S, D>;
-    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _model: MatDateSelectionModel<S, D>, _dateAdapter: DateAdapter<D>, _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>,
+    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _globalModel: MatDateSelectionModel<S, D>, _dateAdapter: DateAdapter<D>, _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>,
     intl?: MatDatepickerIntl);
+    _applyPendingSelection(): void;
     _getSelected(): D | DateRange<D> | null;
     _handleUserSelection(event: MatCalendarUserEvent<D | null>): void;
     _startExitAnimation(): void;
     ngAfterViewInit(): void;
     ngOnDestroy(): void;
+    ngOnInit(): void;
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatDatepickerContent<any, any>, "mat-datepicker-content", ["matDatepickerContent"], { "color": "color"; }, {}, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any, any>, [null, null, null, null, { optional: true; }, null]>;
 }
@@ -266,7 +292,7 @@ export declare class MatDatepickerIntl {
 
 export declare class MatDatepickerModule {
     static ɵinj: i0.ɵɵInjectorDef<MatDatepickerModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatDatepickerModule, [typeof i1.MatCalendar, typeof i2.MatCalendarBody, typeof i3.MatDatepicker, typeof i4.MatDatepickerContent, typeof i5.MatDatepickerInput, typeof i6.MatDatepickerToggle, typeof i6.MatDatepickerToggleIcon, typeof i7.MatMonthView, typeof i8.MatYearView, typeof i9.MatMultiYearView, typeof i1.MatCalendarHeader, typeof i10.MatDateRangeInput, typeof i11.MatStartDate, typeof i11.MatEndDate, typeof i12.MatDateRangePicker], [typeof i13.CommonModule, typeof i14.MatButtonModule, typeof i15.MatDialogModule, typeof i16.OverlayModule, typeof i17.A11yModule, typeof i18.PortalModule, typeof i19.MatCommonModule], [typeof i20.CdkScrollableModule, typeof i1.MatCalendar, typeof i2.MatCalendarBody, typeof i3.MatDatepicker, typeof i4.MatDatepickerContent, typeof i5.MatDatepickerInput, typeof i6.MatDatepickerToggle, typeof i6.MatDatepickerToggleIcon, typeof i7.MatMonthView, typeof i8.MatYearView, typeof i9.MatMultiYearView, typeof i1.MatCalendarHeader, typeof i10.MatDateRangeInput, typeof i11.MatStartDate, typeof i11.MatEndDate, typeof i12.MatDateRangePicker]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatDatepickerModule, [typeof i1.MatCalendar, typeof i2.MatCalendarBody, typeof i3.MatDatepicker, typeof i4.MatDatepickerContent, typeof i5.MatDatepickerInput, typeof i6.MatDatepickerToggle, typeof i6.MatDatepickerToggleIcon, typeof i7.MatMonthView, typeof i8.MatYearView, typeof i9.MatMultiYearView, typeof i1.MatCalendarHeader, typeof i10.MatDateRangeInput, typeof i11.MatStartDate, typeof i11.MatEndDate, typeof i12.MatDateRangePicker, typeof i13.MatDatepickerActions, typeof i13.MatDatepickerCancel, typeof i13.MatDatepickerApply], [typeof i14.CommonModule, typeof i15.MatButtonModule, typeof i16.MatDialogModule, typeof i17.OverlayModule, typeof i18.A11yModule, typeof i19.PortalModule, typeof i20.MatCommonModule], [typeof i21.CdkScrollableModule, typeof i1.MatCalendar, typeof i2.MatCalendarBody, typeof i3.MatDatepicker, typeof i4.MatDatepickerContent, typeof i5.MatDatepickerInput, typeof i6.MatDatepickerToggle, typeof i6.MatDatepickerToggleIcon, typeof i7.MatMonthView, typeof i8.MatYearView, typeof i9.MatMultiYearView, typeof i1.MatCalendarHeader, typeof i10.MatDateRangeInput, typeof i11.MatStartDate, typeof i11.MatEndDate, typeof i12.MatDateRangePicker, typeof i13.MatDatepickerActions, typeof i13.MatDatepickerCancel, typeof i13.MatDatepickerApply]>;
 }
 
 export declare class MatDatepickerToggle<D> implements AfterContentInit, OnChanges, OnDestroy {
@@ -364,6 +390,7 @@ export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSe
     selection: S, _adapter: DateAdapter<D>);
     protected _isValidDateInstance(date: D): boolean;
     abstract add(date: D | null): void;
+    clone(): MatDateSelectionModel<S, D>;
     abstract isComplete(): boolean;
     abstract isValid(): boolean;
     ngOnDestroy(): void;
@@ -467,6 +494,7 @@ export declare class MatMultiYearView<D> implements AfterContentInit, OnDestroy 
 export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel<DateRange<D>, D> {
     constructor(adapter: DateAdapter<D>);
     add(date: D | null): void;
+    clone(): MatRangeDateSelectionModel<D>;
     isComplete(): boolean;
     isValid(): boolean;
     static ɵfac: i0.ɵɵFactoryDef<MatRangeDateSelectionModel<any>, never>;
@@ -476,6 +504,7 @@ export declare class MatRangeDateSelectionModel<D> extends MatDateSelectionModel
 export declare class MatSingleDateSelectionModel<D> extends MatDateSelectionModel<D | null, D> {
     constructor(adapter: DateAdapter<D>);
     add(date: D | null): void;
+    clone(): MatSingleDateSelectionModel<D>;
     isComplete(): boolean;
     isValid(): boolean;
     static ɵfac: i0.ɵɵFactoryDef<MatSingleDateSelectionModel<any>, never>;


### PR DESCRIPTION
Adds support for projecting in "Cancel" and "Apply" buttons in `mat-datepicker` and `mat-date-range-picker`. Doing so will change the behavior of the datepicker so that the user has to explicitly accept a value after they've clicked on it. The consumption is as follows:

```
<mat-datepicker>
  <mat-datepicker-actions>
    <button mat-button matDatepickerCancel>Cancel</button>
    <button mat-raised-button color="primary" matDatepickerApply>Apply</button>
  </mat-datepicker-actions>
</mat-datepicker>
```

The result looks like this:
![Example](https://user-images.githubusercontent.com/4450522/103455069-5b26d400-4cf2-11eb-8919-5f389c2506cb.png)
