### PR TITLE
fix(material/select): NVDA reading out table when opening select on Chrome

### DIFF
--- a/src/material-experimental/mdc-select/select.html
+++ b/src/material-experimental/mdc-select/select.html
@@ -1,14 +1,18 @@
 <!--
- Note that the select trigger element specifies `aria-owns` pointing to the listbox overlay.
+ Note 1: that the select trigger element specifies `aria-owns` pointing to the listbox overlay.
  While aria-owns is not required for the ARIA 1.2 `role="combobox"` interaction pattern,
  it fixes an issue with VoiceOver when the select appears inside of an `aria-model="true"`
  element (e.g. a dialog). Without this `aria-owns`, the `aria-modal` on a dialog prevents
  VoiceOver from "seeing" the select's listbox overlay for aria-activedescendant.
  Using `aria-owns` re-parents the select overlay so that it works again.
  See https://github.com/angular/components/issues/20694
+
+ Note 2: we set `role="presentation"`, because the trigger has some CSS that sets it to
+ `display: inline-table` which causes it to be read out as a table by NVDA on Chrome (see #21480).
 -->
 <div cdk-overlay-origin
      [attr.aria-owns]="panelOpen ? id + '-panel' : null"
+     role="presentation"
      class="mat-mdc-select-trigger"
      (click)="toggle()"
      #fallbackOverlayOrigin="cdkOverlayOrigin"

--- a/src/material-experimental/mdc-select/select.spec.ts
+++ b/src/material-experimental/mdc-select/select.spec.ts
@@ -175,6 +175,11 @@ describe('MDC-based MatSelect', () => {
           expect(ariaOwns).toBe(document.querySelector('.mat-mdc-select-panel')!.id);
         }));
 
+        it('should set the trigger as `role="presentation"`', fakeAsync(() => {
+          const trigger = select.querySelector('.mat-mdc-select-trigger')!;
+          expect(trigger.getAttribute('role')).toBe('presentation');
+        }));
+
         it('should set aria-expanded based on the select open state', fakeAsync(() => {
           expect(select.getAttribute('aria-expanded')).toBe('false');
 

--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -1,14 +1,18 @@
 <!--
- Note that the select trigger element specifies `aria-owns` pointing to the listbox overlay.
+ Note 1: that the select trigger element specifies `aria-owns` pointing to the listbox overlay.
  While aria-owns is not required for the ARIA 1.2 `role="combobox"` interaction pattern,
  it fixes an issue with VoiceOver when the select appears inside of an `aria-model="true"`
  element (e.g. a dialog). Without this `aria-owns`, the `aria-modal` on a dialog prevents
  VoiceOver from "seeing" the select's listbox overlay for aria-activedescendant.
  Using `aria-owns` re-parents the select overlay so that it works again.
  See https://github.com/angular/components/issues/20694
+
+ Note 2: we set `role="presentation"`, because the trigger has some CSS that sets it to
+ `display: inline-table` which causes it to be read out as a table by NVDA on Chrome (see #21480).
 -->
 <div cdk-overlay-origin
      [attr.aria-owns]="panelOpen ? id + '-panel' : null"
+     role="presentation"
      class="mat-select-trigger"
      (click)="toggle()"
      #origin="cdkOverlayOrigin"

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -178,6 +178,11 @@ describe('MatSelect', () => {
           expect(ariaOwns).toBe(document.querySelector('.mat-select-panel')!.id);
         }));
 
+        it('should set the trigger as `role="presentation"`', fakeAsync(() => {
+          const trigger = select.querySelector('.mat-select-trigger')!;
+          expect(trigger.getAttribute('role')).toBe('presentation');
+        }));
+
         it('should set aria-expanded based on the select open state', fakeAsync(() => {
           expect(select.getAttribute('aria-expanded')).toBe('false');
 


### PR DESCRIPTION
The `mat-select` trigger element has an `aria-owns` pointing to the overlay and `display: inline-table` in its CSS. The combination of these two causes Chrome to infer the element as a `table` which results in NVDA reading out "table" any time a select is opened.

These changes resolve the issue by setting the element to `role="presentation"`. I've tested out the change against NVDA and VoiceOver and it doesn't seem to affect the accessibility of the select, apart from the "table" not being read out anymore.

Fixes #21480.

For reference, here's what Chrome's constructed a11y node looks like at the moment (note the `LayoutTable`).

![Example](https://user-images.githubusercontent.com/4450522/103535563-9ca5b380-4e99-11eb-8739-3d631cfd5ad3.png)