### PR TITLE
fix(material/datepicker): remove scroll bar while animating in touch UI mode

### DIFF
--- a/src/material/datepicker/datepicker-content.scss
+++ b/src/material/datepicker/datepicker-content.scss
@@ -37,6 +37,12 @@ $mat-datepicker-touch-max-height: 788px;
     top: 100%;
     left: 0;
     margin-top: 8px;
+
+    // Hide the button while the overlay is animating, because it's rendered
+    // outside of it and it seems to cause scrollbars in some cases (see #21493).
+    .ng-animating & {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
The screen reader close button is rendered outside the dialog which seems to cause a scrollbar to be shown while the animation is running. These changes fix the issue by hiding the button while the dialog is animating.

Slowed down video for reference:
![demo](https://user-images.githubusercontent.com/4450522/103630226-0e3d3a80-4f4a-11eb-9ed5-aa7f53c9b69f.gif)
