### PR TITLE
refactor(material/datepicker): expose year view change detector ref

### DIFF
--- a/src/material/datepicker/year-view.ts
+++ b/src/material/datepicker/year-view.ts
@@ -138,7 +138,7 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
    */
   _selectedMonth: number | null;
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef,
+  constructor(readonly _changeDetectorRef: ChangeDetectorRef,
               @Optional() @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
               @Optional() public _dateAdapter: DateAdapter<D>,
               @Optional() private _dir?: Directionality) {

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -498,6 +498,7 @@ export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implement
 }
 
 export declare class MatYearView<D> implements AfterContentInit, OnDestroy {
+    readonly _changeDetectorRef: ChangeDetectorRef;
     _dateAdapter: DateAdapter<D>;
     _matCalendarBody: MatCalendarBody;
     _months: MatCalendarCell[][];


### PR DESCRIPTION
Open up the mat year view's `ChangeDetectorRef`  so it can be accessed by other components. This is necessary to align with an internal Google datepicker spec.