### PR TITLE
fix(material/dialog): incorrect typing for _closeDialogVia method

### DIFF
--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -243,7 +243,7 @@ export class MatDialogRef<T, R = any> {
  * More details. See: https://github.com/angular/components/pull/9257#issuecomment-651342226.
  */
 // TODO: TODO: Move this back into `MatDialogRef` when we provide an official mock dialog ref.
-export function _closeDialogVia<R>(ref: MatDialogRef<R>, interactionType: FocusOrigin, result?: R) {
+export function _closeDialogVia<T, R>(ref: MatDialogRef<T, R>, interactionType: FocusOrigin, result?: R) {
   // Some mock dialog ref instances in tests do not have the `_containerInstance` property.
   // For those, we keep the behavior as is and do not deal with the interaction type.
   if (ref._containerInstance !== undefined) {

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -243,7 +243,8 @@ export class MatDialogRef<T, R = any> {
  * More details. See: https://github.com/angular/components/pull/9257#issuecomment-651342226.
  */
 // TODO: TODO: Move this back into `MatDialogRef` when we provide an official mock dialog ref.
-export function _closeDialogVia<T, R>(ref: MatDialogRef<T, R>, interactionType: FocusOrigin, result?: R) {
+export function _closeDialogVia<T, R>(
+  ref: MatDialogRef<T, R>, interactionType: FocusOrigin, result?: R) {
   // Some mock dialog ref instances in tests do not have the `_containerInstance` property.
   // For those, we keep the behavior as is and do not deal with the interaction type.
   if (ref._containerInstance !== undefined) {

--- a/tools/public_api_guard/material/dialog.d.ts
+++ b/tools/public_api_guard/material/dialog.d.ts
@@ -1,4 +1,4 @@
-export declare function _closeDialogVia<R>(ref: MatDialogRef<R>, interactionType: FocusOrigin, result?: R): void;
+export declare function _closeDialogVia<T, R>(ref: MatDialogRef<T, R>, interactionType: FocusOrigin, result?: R): void;
 
 export declare abstract class _MatDialogBase<C extends _MatDialogContainerBase> implements OnDestroy {
     readonly afterAllClosed: Observable<void>;


### PR DESCRIPTION
Fixes a bug in typing for the `_closeDialogVia` method and allows to use
`MatDialogRef<T, R>` with the method, providing the result of a different
type from the dialog content component's.

Fixes #21503