### PR TITLE
fix(cdk/scrolling): Prevents NaN being returned as firstVisibleIndex.

### DIFF
--- a/src/cdk/scrolling/fixed-size-virtual-scroll.ts
+++ b/src/cdk/scrolling/fixed-size-virtual-scroll.ts
@@ -125,7 +125,8 @@ export class FixedSizeVirtualScrollStrategy implements VirtualScrollStrategy {
     const viewportSize = this._viewport.getViewportSize();
     const dataLength = this._viewport.getDataLength();
     let scrollOffset = this._viewport.measureScrollOffset();
-    let firstVisibleIndex = scrollOffset / this._itemSize;
+     // Prevent NaN as result when dividing by zero.
+    let firstVisibleIndex = (this._itemSize > 0) ? scrollOffset / this._itemSize : 0;
 
     // If user scrolls to the bottom of the list and data changes to a smaller list
     if (newRange.end > dataLength) {


### PR DESCRIPTION
When firstVisibleIndex divides by zero, which can happen when the page is built and loaded dynamically; the NaN result will be used in other calculations.

This then throws off things like the `newRange.start` value also returning NaN, breaking the plugin.