### PR TITLE
feat(cdk/table) add directive to enable recycle view repeater

### DIFF
--- a/src/cdk/table/table-module.ts
+++ b/src/cdk/table/table-module.ts
@@ -7,7 +7,14 @@
  */
 
 import {NgModule} from '@angular/core';
-import {HeaderRowOutlet, DataRowOutlet, CdkTable, FooterRowOutlet, NoDataRowOutlet} from './table';
+import {
+  HeaderRowOutlet,
+  DataRowOutlet,
+  CdkTable,
+  CdkRecycleRows,
+  FooterRowOutlet,
+  NoDataRowOutlet,
+} from './table';
 import {
   CdkCellOutlet, CdkFooterRow, CdkFooterRowDef, CdkHeaderRow, CdkHeaderRowDef, CdkRow,
   CdkRowDef,
@@ -41,6 +48,7 @@ const EXPORTED_DECLARATIONS = [
   FooterRowOutlet,
   CdkTextColumn,
   CdkNoDataRow,
+  CdkRecycleRows,
   NoDataRowOutlet,
 ];
 

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -12,6 +12,7 @@ import {
   CollectionViewer,
   DataSource,
   _DisposeViewRepeaterStrategy,
+  _RecycleViewRepeaterStrategy,
   isDataSource,
   _VIEW_REPEATER_STRATEGY,
   _ViewRepeater,
@@ -81,6 +82,19 @@ import {
 } from './table-errors';
 import {STICKY_POSITIONING_LISTENER, StickyPositioningListener} from './sticky-position-listener';
 import {CDK_TABLE} from './tokens';
+
+
+/**
+ * Enables the recycle view repeater strategy, which reduces rendering latency. Not compatible with
+ * tables that animate rows.
+ */
+@Directive({
+  selector: 'cdk-table[recycleRows], table[cdk-table][recycleRows]',
+  providers: [
+    {provide: _VIEW_REPEATER_STRATEGY, useClass: _RecycleViewRepeaterStrategy},
+  ],
+})
+export class CdkRecycleRows {}
 
 /** Interface used to provide an outlet for rows to be inserted into. */
 export interface RowOutlet {

--- a/src/components-examples/cdk/table/cdk-table-recycle-rows/cdk-table-recycle-rows-example.css
+++ b/src/components-examples/cdk/table/cdk-table-recycle-rows/cdk-table-recycle-rows-example.css
@@ -1,0 +1,7 @@
+.example-table {
+  width: 100%;
+}
+
+.example-row {
+  text-align: left;
+}

--- a/src/components-examples/cdk/table/cdk-table-recycle-rows/cdk-table-recycle-rows-example.html
+++ b/src/components-examples/cdk/table/cdk-table-recycle-rows/cdk-table-recycle-rows-example.html
@@ -1,0 +1,28 @@
+<table class="example-table" cdk-table recycleRows [dataSource]="dataSource">
+  <!-- Position Column -->
+  <ng-container cdkColumnDef="position">
+    <th class="example-row" cdk-header-cell *cdkHeaderCellDef> No. </th>
+    <td cdk-cell *cdkCellDef="let element"> {{element.position}} </td>
+  </ng-container>
+
+  <!-- Name Column -->
+  <ng-container cdkColumnDef="name">
+    <th class="example-row" cdk-header-cell *cdkHeaderCellDef> Name </th>
+    <td cdk-cell *cdkCellDef="let element"> {{element.name}} </td>
+  </ng-container>
+
+  <!-- Weight Column -->
+  <ng-container cdkColumnDef="weight">
+    <th class="example-row" cdk-header-cell *cdkHeaderCellDef> Weight </th>
+    <td cdk-cell *cdkCellDef="let element"> {{element.weight}} </td>
+  </ng-container>
+
+  <!-- Symbol Column -->
+  <ng-container cdkColumnDef="symbol">
+    <th class="example-row" cdk-header-cell *cdkHeaderCellDef> Symbol </th>
+    <td cdk-cell *cdkCellDef="let element"> {{element.symbol}} </td>
+  </ng-container>
+
+  <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
+  <tr cdk-row *cdkRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/src/components-examples/cdk/table/cdk-table-recycle-rows/cdk-table-recycle-rows-example.ts
+++ b/src/components-examples/cdk/table/cdk-table-recycle-rows/cdk-table-recycle-rows-example.ts
@@ -1,0 +1,55 @@
+import {DataSource} from '@angular/cdk/collections';
+import {Component} from '@angular/core';
+import {BehaviorSubject, Observable} from 'rxjs';
+
+export interface PeriodicElement {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: PeriodicElement[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+];
+
+/**
+ * @title Table that uses the recycle view repeater strategy.
+ */
+@Component({
+  selector: 'cdk-table-recycle-rows-example',
+  styleUrls: ['cdk-table-recycle-rows-example.css'],
+  templateUrl: 'cdk-table-recycle-rows-example.html',
+})
+export class CdkTableRecycleRowsExample {
+  displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
+  dataSource = new ExampleDataSource();
+}
+
+/**
+ * Data source to provide what data should be rendered in the table. Note that the data source
+ * can retrieve its data in any way. In this case, the data source is provided a reference
+ * to a common data base, ExampleDatabase. It is not the data source's responsibility to manage
+ * the underlying data. Instead, it only needs to take the data and send the table exactly what
+ * should be rendered.
+ */
+export class ExampleDataSource extends DataSource<PeriodicElement> {
+  /** Stream of data that is provided to the table. */
+  data = new BehaviorSubject<PeriodicElement[]>(ELEMENT_DATA);
+
+  /** Connect function called by the table to retrieve one stream containing the data to render. */
+  connect(): Observable<PeriodicElement[]> {
+    return this.data;
+  }
+
+  disconnect() {}
+}

--- a/src/components-examples/cdk/table/index.ts
+++ b/src/components-examples/cdk/table/index.ts
@@ -5,17 +5,19 @@ import {CdkTableBasicExample} from './cdk-table-basic/cdk-table-basic-example';
 import {
   CdkTableFixedLayoutExample,
 } from './cdk-table-fixed-layout/cdk-table-fixed-layout-example';
-
+import {CdkTableRecycleRowsExample} from './cdk-table-recycle-rows/cdk-table-recycle-rows-example';
 export {
   CdkTableBasicExample,
   CdkTableFlexBasicExample,
   CdkTableFixedLayoutExample,
+  CdkTableRecycleRowsExample,
 };
 
 const EXAMPLES = [
   CdkTableBasicExample,
   CdkTableFlexBasicExample,
   CdkTableFixedLayoutExample,
+  CdkTableRecycleRowsExample,
 ];
 
 @NgModule({

--- a/src/components-examples/material/table/index.ts
+++ b/src/components-examples/material/table/index.ts
@@ -40,6 +40,7 @@ import {
 import {TableTextColumnExample} from './table-text-column/table-text-column-example';
 import {TableWrappedExample, WrapperTable} from './table-wrapped/table-wrapped-example';
 import {TableReorderableExample} from './table-reorderable/table-reorderable-example';
+import {TableRecycleRowsExample} from './table-recycle-rows/table-recycle-rows-example';
 import {TableHarnessExample} from './table-harness/table-harness-example';
 
 export {
@@ -54,7 +55,8 @@ export {
   TableStickyFooterExample,   TableStickyHeaderExample,
   TableTextColumnExample,     TableTextColumnAdvancedExample,
   TableWrappedExample,        WrapperTable,
-  TableReorderableExample,    TableHarnessExample,
+  TableReorderableExample,    TableRecycleRowsExample,
+  TableHarnessExample,
 };
 
 const EXAMPLES = [
@@ -69,7 +71,8 @@ const EXAMPLES = [
   TableStickyFooterExample,   TableStickyHeaderExample,
   TableTextColumnExample,     TableTextColumnAdvancedExample,
   TableWrappedExample,        WrapperTable,
-  TableReorderableExample,    TableHarnessExample,
+  TableReorderableExample,    TableRecycleRowsExample,
+  TableHarnessExample,
 ];
 
 @NgModule({

--- a/src/components-examples/material/table/table-recycle-rows/table-recycle-rows-example.css
+++ b/src/components-examples/material/table/table-recycle-rows/table-recycle-rows-example.css
@@ -1,0 +1,3 @@
+.example-table {
+  width: 100%;
+}

--- a/src/components-examples/material/table/table-recycle-rows/table-recycle-rows-example.html
+++ b/src/components-examples/material/table/table-recycle-rows/table-recycle-rows-example.html
@@ -1,0 +1,29 @@
+<table class="example-table mat-elevation-z8" mat-table recycleRows [dataSource]="dataSource">
+  <!-- Position Column -->
+  <ng-container matColumnDef="position">
+    <th mat-header-cell *matHeaderCellDef> No. </th>
+    <td mat-cell *matCellDef="let element"> {{element.position}} </td>
+  </ng-container>
+
+  <!-- Name Column -->
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef> Name </th>
+    <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+  </ng-container>
+
+  <!-- Weight Column -->
+  <ng-container matColumnDef="weight">
+    <th mat-header-cell *matHeaderCellDef> Weight </th>
+    <td mat-cell *matCellDef="let element"> {{element.weight}} </td>
+  </ng-container>
+
+  <!-- Symbol Column -->
+  <ng-container matColumnDef="symbol">
+    <th mat-header-cell *matHeaderCellDef> Symbol </th>
+    <td mat-cell *matCellDef="let element"> {{element.symbol}} </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>
+

--- a/src/components-examples/material/table/table-recycle-rows/table-recycle-rows-example.ts
+++ b/src/components-examples/material/table/table-recycle-rows/table-recycle-rows-example.ts
@@ -1,0 +1,34 @@
+import {Component} from '@angular/core';
+
+export interface PeriodicElement {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: PeriodicElement[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+];
+
+/**
+ * @title Table that uses the recycle view repeater strategy.
+ */
+@Component({
+  selector: 'table-recycle-rows-example',
+  styleUrls: ['table-recycle-rows-example.css'],
+  templateUrl: 'table-recycle-rows-example.html',
+})
+export class TableRecycleRowsExample {
+  displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
+  dataSource = ELEMENT_DATA;
+}

--- a/src/dev-app/table/table-demo.html
+++ b/src/dev-app/table/table-demo.html
@@ -1,6 +1,9 @@
 <h3>Cdk table basic</h3>
 <cdk-table-basic-example></cdk-table-basic-example>
 
+<h3>Cdk table with recycled rows</h3>
+<cdk-table-recycle-rows-example></cdk-table-recycle-rows-example>
+
 <h3>Cdk table basic with fixed column widths</h3>
 <cdk-table-fixed-layout-example></cdk-table-fixed-layout-example>
 
@@ -9,6 +12,9 @@
 
 <h3>Table basic</h3>
 <table-basic-example></table-basic-example>
+
+<h3>Table basic with recycled rows</h3>
+<table-recycle-rows-example></table-recycle-rows-example>
 
 <h3>Table basic flex</h3>
 <table-flex-basic-example></table-flex-basic-example>

--- a/src/material-experimental/mdc-table/module.ts
+++ b/src/material-experimental/mdc-table/module.ts
@@ -8,7 +8,7 @@
 
 import {NgModule} from '@angular/core';
 import {MatCommonModule} from '@angular/material-experimental/mdc-core';
-import {MatTable} from './table';
+import {MatRecycleRows, MatTable} from './table';
 import {CdkTableModule} from '@angular/cdk/table';
 import {
   MatCell,
@@ -33,6 +33,7 @@ import {MatTextColumn} from './text-column';
 const EXPORTED_DECLARATIONS = [
   // Table
   MatTable,
+  MatRecycleRows,
 
   // Template defs
   MatHeaderCellDef,

--- a/src/material-experimental/mdc-table/table.ts
+++ b/src/material-experimental/mdc-table/table.ts
@@ -6,14 +6,36 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Component, OnInit, ViewEncapsulation} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  OnInit,
+  ViewEncapsulation
+} from '@angular/core';
 import {
   CDK_TABLE_TEMPLATE,
   CdkTable,
   _CoalescedStyleScheduler,
   _COALESCED_STYLE_SCHEDULER,
 } from '@angular/cdk/table';
-import {_DisposeViewRepeaterStrategy, _VIEW_REPEATER_STRATEGY} from '@angular/cdk/collections';
+import {
+  _DisposeViewRepeaterStrategy,
+  _RecycleViewRepeaterStrategy,
+  _VIEW_REPEATER_STRATEGY
+} from '@angular/cdk/collections';
+
+/**
+ * Enables the recycle view repeater strategy, which reduces rendering latency. Not compatible with
+ * tables that animate rows.
+ */
+@Directive({
+  selector: 'mat-table[recycleRows], table[mat-table][recycleRows]',
+  providers: [
+    {provide: _VIEW_REPEATER_STRATEGY, useClass: _RecycleViewRepeaterStrategy},
+  ],
+})
+export class MatRecycleRows {}
 
 @Component({
   selector: 'mat-table, table[mat-table]',

--- a/src/material/table/table-module.ts
+++ b/src/material/table/table-module.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgModule} from '@angular/core';
-import {MatTable} from './table';
+import {MatRecycleRows, MatTable} from './table';
 import {CdkTableModule} from '@angular/cdk/table';
 import {
   MatCell,
@@ -16,7 +16,7 @@ import {
   MatFooterCell,
   MatFooterCellDef,
   MatHeaderCell,
-  MatHeaderCellDef
+  MatHeaderCellDef,
 } from './cell';
 import {
   MatFooterRow,
@@ -33,6 +33,7 @@ import {MatCommonModule} from '@angular/material/core';
 const EXPORTED_DECLARATIONS = [
   // Table
   MatTable,
+  MatRecycleRows,
 
   // Template defs
   MatHeaderCellDef,

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -12,8 +12,24 @@ import {
   CDK_TABLE,
   _CoalescedStyleScheduler, _COALESCED_STYLE_SCHEDULER
 } from '@angular/cdk/table';
-import {ChangeDetectionStrategy, Component, ViewEncapsulation} from '@angular/core';
-import {_DisposeViewRepeaterStrategy, _VIEW_REPEATER_STRATEGY} from '@angular/cdk/collections';
+import {ChangeDetectionStrategy, Component, Directive, ViewEncapsulation} from '@angular/core';
+import {
+  _DisposeViewRepeaterStrategy,
+  _RecycleViewRepeaterStrategy,
+  _VIEW_REPEATER_STRATEGY
+} from '@angular/cdk/collections';
+
+/**
+ * Enables the recycle view repeater strategy, which reduces rendering latency. Not compatible with
+ * tables that animate rows.
+ */
+@Directive({
+  selector: 'mat-table[recycleRows], table[mat-table][recycleRows]',
+  providers: [
+    {provide: _VIEW_REPEATER_STRATEGY, useClass: _RecycleViewRepeaterStrategy},
+  ],
+})
+export class MatRecycleRows {}
 
 /**
  * Wrapper for the CdkTable with Material design styles.

--- a/tools/public_api_guard/cdk/table.d.ts
+++ b/tools/public_api_guard/cdk/table.d.ts
@@ -173,6 +173,11 @@ export declare class CdkNoDataRow {
     static ɵfac: i0.ɵɵFactoryDef<CdkNoDataRow, never>;
 }
 
+export declare class CdkRecycleRows {
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkRecycleRows, "cdk-table[recycleRows], table[cdk-table][recycleRows]", never, {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<CdkRecycleRows, never>;
+}
+
 export declare class CdkRow {
     static ɵcmp: i0.ɵɵComponentDefWithMeta<CdkRow, "cdk-row, tr[cdk-row]", never, {}, {}, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<CdkRow, never>;
@@ -248,7 +253,7 @@ export declare class CdkTable<T> implements AfterContentChecked, CollectionViewe
 
 export declare class CdkTableModule {
     static ɵinj: i0.ɵɵInjectorDef<CdkTableModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<CdkTableModule, [typeof i1.CdkTable, typeof i2.CdkRowDef, typeof i3.CdkCellDef, typeof i2.CdkCellOutlet, typeof i3.CdkHeaderCellDef, typeof i3.CdkFooterCellDef, typeof i3.CdkColumnDef, typeof i3.CdkCell, typeof i2.CdkRow, typeof i3.CdkHeaderCell, typeof i3.CdkFooterCell, typeof i2.CdkHeaderRow, typeof i2.CdkHeaderRowDef, typeof i2.CdkFooterRow, typeof i2.CdkFooterRowDef, typeof i1.DataRowOutlet, typeof i1.HeaderRowOutlet, typeof i1.FooterRowOutlet, typeof i4.CdkTextColumn, typeof i2.CdkNoDataRow, typeof i1.NoDataRowOutlet], [typeof i5.ScrollingModule], [typeof i1.CdkTable, typeof i2.CdkRowDef, typeof i3.CdkCellDef, typeof i2.CdkCellOutlet, typeof i3.CdkHeaderCellDef, typeof i3.CdkFooterCellDef, typeof i3.CdkColumnDef, typeof i3.CdkCell, typeof i2.CdkRow, typeof i3.CdkHeaderCell, typeof i3.CdkFooterCell, typeof i2.CdkHeaderRow, typeof i2.CdkHeaderRowDef, typeof i2.CdkFooterRow, typeof i2.CdkFooterRowDef, typeof i1.DataRowOutlet, typeof i1.HeaderRowOutlet, typeof i1.FooterRowOutlet, typeof i4.CdkTextColumn, typeof i2.CdkNoDataRow, typeof i1.NoDataRowOutlet]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<CdkTableModule, [typeof i1.CdkTable, typeof i2.CdkRowDef, typeof i3.CdkCellDef, typeof i2.CdkCellOutlet, typeof i3.CdkHeaderCellDef, typeof i3.CdkFooterCellDef, typeof i3.CdkColumnDef, typeof i3.CdkCell, typeof i2.CdkRow, typeof i3.CdkHeaderCell, typeof i3.CdkFooterCell, typeof i2.CdkHeaderRow, typeof i2.CdkHeaderRowDef, typeof i2.CdkFooterRow, typeof i2.CdkFooterRowDef, typeof i1.DataRowOutlet, typeof i1.HeaderRowOutlet, typeof i1.FooterRowOutlet, typeof i4.CdkTextColumn, typeof i2.CdkNoDataRow, typeof i1.CdkRecycleRows, typeof i1.NoDataRowOutlet], [typeof i5.ScrollingModule], [typeof i1.CdkTable, typeof i2.CdkRowDef, typeof i3.CdkCellDef, typeof i2.CdkCellOutlet, typeof i3.CdkHeaderCellDef, typeof i3.CdkFooterCellDef, typeof i3.CdkColumnDef, typeof i3.CdkCell, typeof i2.CdkRow, typeof i3.CdkHeaderCell, typeof i3.CdkFooterCell, typeof i2.CdkHeaderRow, typeof i2.CdkHeaderRowDef, typeof i2.CdkFooterRow, typeof i2.CdkFooterRowDef, typeof i1.DataRowOutlet, typeof i1.HeaderRowOutlet, typeof i1.FooterRowOutlet, typeof i4.CdkTextColumn, typeof i2.CdkNoDataRow, typeof i1.CdkRecycleRows, typeof i1.NoDataRowOutlet]>;
 }
 
 export declare class CdkTextColumn<T> implements OnDestroy, OnInit {

--- a/tools/public_api_guard/material/table.d.ts
+++ b/tools/public_api_guard/material/table.d.ts
@@ -88,6 +88,11 @@ export declare class MatNoDataRow extends CdkNoDataRow {
     static ɵfac: i0.ɵɵFactoryDef<MatNoDataRow, never>;
 }
 
+export declare class MatRecycleRows {
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatRecycleRows, "mat-table[recycleRows], table[mat-table][recycleRows]", never, {}, {}, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatRecycleRows, never>;
+}
+
 export declare class MatRow extends CdkRow {
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatRow, "mat-row, tr[mat-row]", ["matRow"], {}, {}, never, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatRow, never>;
@@ -110,7 +115,7 @@ export declare class MatTableDataSource<T> extends _MatTableDataSource<T, MatPag
 
 export declare class MatTableModule {
     static ɵinj: i0.ɵɵInjectorDef<MatTableModule>;
-    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatTableModule, [typeof i1.MatTable, typeof i2.MatHeaderCellDef, typeof i3.MatHeaderRowDef, typeof i2.MatColumnDef, typeof i2.MatCellDef, typeof i3.MatRowDef, typeof i2.MatFooterCellDef, typeof i3.MatFooterRowDef, typeof i2.MatHeaderCell, typeof i2.MatCell, typeof i2.MatFooterCell, typeof i3.MatHeaderRow, typeof i3.MatRow, typeof i3.MatFooterRow, typeof i3.MatNoDataRow, typeof i4.MatTextColumn], [typeof i5.CdkTableModule, typeof i6.MatCommonModule], [typeof i6.MatCommonModule, typeof i1.MatTable, typeof i2.MatHeaderCellDef, typeof i3.MatHeaderRowDef, typeof i2.MatColumnDef, typeof i2.MatCellDef, typeof i3.MatRowDef, typeof i2.MatFooterCellDef, typeof i3.MatFooterRowDef, typeof i2.MatHeaderCell, typeof i2.MatCell, typeof i2.MatFooterCell, typeof i3.MatHeaderRow, typeof i3.MatRow, typeof i3.MatFooterRow, typeof i3.MatNoDataRow, typeof i4.MatTextColumn]>;
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MatTableModule, [typeof i1.MatTable, typeof i1.MatRecycleRows, typeof i2.MatHeaderCellDef, typeof i3.MatHeaderRowDef, typeof i2.MatColumnDef, typeof i2.MatCellDef, typeof i3.MatRowDef, typeof i2.MatFooterCellDef, typeof i3.MatFooterRowDef, typeof i2.MatHeaderCell, typeof i2.MatCell, typeof i2.MatFooterCell, typeof i3.MatHeaderRow, typeof i3.MatRow, typeof i3.MatFooterRow, typeof i3.MatNoDataRow, typeof i4.MatTextColumn], [typeof i5.CdkTableModule, typeof i6.MatCommonModule], [typeof i6.MatCommonModule, typeof i1.MatTable, typeof i1.MatRecycleRows, typeof i2.MatHeaderCellDef, typeof i3.MatHeaderRowDef, typeof i2.MatColumnDef, typeof i2.MatCellDef, typeof i3.MatRowDef, typeof i2.MatFooterCellDef, typeof i3.MatFooterRowDef, typeof i2.MatHeaderCell, typeof i2.MatCell, typeof i2.MatFooterCell, typeof i3.MatHeaderRow, typeof i3.MatRow, typeof i3.MatFooterRow, typeof i3.MatNoDataRow, typeof i4.MatTextColumn]>;
 }
 
 export declare class MatTextColumn<T> extends CdkTextColumn<T> {


### PR DESCRIPTION
The CDK and Material tables use the dispose view repeater strategy, which creates new rows from scratch when the dataset changes. This PR adds directives that enable the recycle view repeater, which caches disposed rows and reuses them when the dataset changes. This strategy reduces rendering latency for most tables, but may not be compatible with tables that animate rows.