### PR TITLE
fix(material/autocomplete): activate first enabled option with autoActiveFirstOption

### DIFF
--- a/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
@@ -1994,6 +1994,21 @@ describe('MDC-based MatAutocomplete', () => {
           .toContain('mat-mdc-option-active', 'Expected first option to be highlighted.');
     }));
 
+    it('should skip to the next enabled option if the first one is disabled ' +
+      'when using `autoActiveFirstOption`', fakeAsync(() => {
+        const testComponent = fixture.componentInstance;
+        testComponent.trigger.autocomplete.autoActiveFirstOption = true;
+        testComponent.states[0].disabled = true;
+        testComponent.states[1].disabled = true;
+        testComponent.trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        fixture.detectChanges();
+
+        expect(overlayContainerElement.querySelectorAll('mat-option')[2].classList)
+            .toContain('mat-mdc-option-active', 'Expected third option to be highlighted.');
+      }));
+
     it('should remove aria-activedescendant when panel is closed with autoActiveFirstOption',
       fakeAsync(() => {
         const input: HTMLElement = fixture.nativeElement.querySelector('input');
@@ -2744,7 +2759,8 @@ const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
     <mat-option
       *ngFor="let state of filteredStates"
       [value]="state"
-      [style.height.px]="state.height">
+      [style.height.px]="state.height"
+      [disabled]="state.disabled">
       <span>{{ state.code }}: {{ state.name }}</span>
     </mat-option>
   </mat-autocomplete>
@@ -2771,7 +2787,7 @@ class SimpleAutocomplete implements OnDestroy {
   @ViewChild(MatFormField) formField: MatFormField;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 
-  states: {code: string, name: string, height?: number}[] = [
+  states: {code: string, name: string, height?: number, disabled?: boolean}[] = [
     {code: 'AL', name: 'Alabama'},
     {code: 'CA', name: 'California'},
     {code: 'FL', name: 'Florida'},

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -716,7 +716,15 @@ export abstract class _MatAutocompleteTriggerBase implements ControlValueAccesso
    * correct options, or to 0 if the consumer opted into it.
    */
   private _resetActiveItem(): void {
-    this.autocomplete._keyManager.setActiveItem(this.autocomplete.autoActiveFirstOption ? 0 : -1);
+    const autocomplete = this.autocomplete;
+
+    if (autocomplete.autoActiveFirstOption) {
+      // Note that we go through `setFirstItemActive`, rather than `setActiveItem(0)`, because
+      // the former will find the next enabled option, if the first one is disabled.
+      autocomplete._keyManager.setFirstItemActive();
+    } else {
+      autocomplete._keyManager.setActiveItem(-1);
+    }
   }
 
   /** Determines whether the panel can be opened. */

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1985,6 +1985,21 @@ describe('MatAutocomplete', () => {
           .toContain('mat-active', 'Expected first option to be highlighted.');
     }));
 
+    it('should skip to the next enabled option if the first one is disabled ' +
+      'when using `autoActiveFirstOption`', fakeAsync(() => {
+        const testComponent = fixture.componentInstance;
+        testComponent.trigger.autocomplete.autoActiveFirstOption = true;
+        testComponent.states[0].disabled = true;
+        testComponent.states[1].disabled = true;
+        testComponent.trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        fixture.detectChanges();
+
+        expect(overlayContainerElement.querySelectorAll('mat-option')[2].classList)
+            .toContain('mat-active', 'Expected third option to be highlighted.');
+      }));
+
     it('should remove aria-activedescendant when panel is closed with autoActiveFirstOption',
       fakeAsync(() => {
         const input: HTMLElement = fixture.nativeElement.querySelector('input');
@@ -2748,7 +2763,8 @@ const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
     <mat-option
       *ngFor="let state of filteredStates"
       [value]="state"
-      [style.height.px]="state.height">
+      [style.height.px]="state.height"
+      [disabled]="state.disabled">
       <span>{{ state.code }}: {{ state.name }}</span>
     </mat-option>
   </mat-autocomplete>
@@ -2775,7 +2791,7 @@ class SimpleAutocomplete implements OnDestroy {
   @ViewChild(MatFormField) formField: MatFormField;
   @ViewChildren(MatOption) options: QueryList<MatOption>;
 
-  states: {code: string, name: string, height?: number}[] = [
+  states: {code: string, name: string, height?: number, disabled?: boolean}[] = [
     {code: 'AL', name: 'Alabama'},
     {code: 'CA', name: 'California'},
     {code: 'FL', name: 'Florida'},


### PR DESCRIPTION
Currently the autocomplete trigger will activate the first option when `autoActiveFirstOption`, no matter whether it is disabled. These changes use a different API which will allow us to pick the first enabled option.

Fixes #21498.