### PR TITLE
refactor(material/core): add functions for normalizing to 2014 and

### DIFF
--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -74,24 +74,54 @@
   @return map-get($config, headline-1) != null;
 }
 
+// Whether a config is for the Material Design 2014 typography system.
+@function mat-private-typography-is-2014-config($config) {
+  @return map-get($config, headline) != null;
+}
+
 // Given a config for either the 2014 or 2018 Material Design typography system,
 // produces a normalized typography config for the 2014 Material Design typography system.
 // 2014 - https://material.io/archive/guidelines/style/typography.html#typography-styles
 // 2018 - https://material.io/design/typography/the-type-system.html#type-scale
-@function mat-private-typography-normalized-config($config) {
+@function mat-private-typography-to-2014-config($config) {
   @if mat-private-typography-is-2018-config($config) {
     @return mat-typography-config(
-        $display-3: map-get($config, display-1),
-        $display-2: map-get($config, display-2),
-        $display-1: map-get($config, display-3),
-        $headline: map-get($config, headline-4),
-        $title: map-get($config, subtitle-1),
-        $subheading-2: map-get($config, subhead-1),
-        $subheading-1: map-get($config, subhead-2),
+        $display-4: map-get($config, headline-1),
+        $display-3: map-get($config, headline-2),
+        $display-2: map-get($config, headline-3),
+        $display-1: map-get($config, headline-4),
+        $headline: map-get($config, headline-5),
+        $title: map-get($config, headline-6),
+        $subheading-2: map-get($config, subtitle-1),
+        $subheading-1: map-get($config, subtitle-2),
         $body-2: map-get($config, body-1),
         $body-1: map-get($config, body-2),
-        $caption: map-get($config, caption),
         $button: map-get($config, button),
+        $caption: map-get($config, caption),
+    );
+  }
+  @return $config;
+}
+
+// Given a config for either the 2014 or 2018 Material Design typography system,
+// produces a normalized typography config for the 2018 Material Design typography system.
+// 2014 - https://material.io/archive/guidelines/style/typography.html#typography-styles
+// 2018 - https://material.io/design/typography/the-type-system.html#type-scale
+@function mat-private-typography-to-2018-config($config) {
+  @if mat-private-typography-is-2014-config($config) {
+    @return (
+        headline-1: map-get($config, display-4),
+        headline-2: map-get($config, display-3),
+        headline-3: map-get($config, display-2),
+        headline-4: map-get($config, display-1),
+        headline-5: map-get($config, headline),
+        headline-6: map-get($config, title),
+        subtitle-1: map-get($config, subheading-2),
+        subtitle-2: map-get($config, subheading-1),
+        body-1: map-get($config, body-2),
+        body-2: map-get($config, body-1),
+        button: map-get($config, button),
+        caption: map-get($config, caption),
     );
   }
   @return $config;


### PR DESCRIPTION
2018 style typography configs.

This is part of a plan to reconcile how typography is handled in the
different versions of Material Design (both external versions and
Google's internal spec).