### PR TITLE
feat(material/option): Update styles to be responsive to small window sizes. 

### DIFF
--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -11,6 +11,7 @@
   display: flex;
   flex-direction: row;
   max-width: 100%;
+  white-space: normal;
   box-sizing: border-box;
   align-items: center;
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
To conform to WCAG 2.1 need all content to appear on windows of width 320px. Currently options do not wrap, so content is cut off. This will make option more responsive. 