### PR TITLE
fix(cdk/drag-drop): support for nested drop containers (#16671)

### DIFF
--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -820,7 +820,99 @@ export class DropListRef<T = any> {
    * @param y Position of the item along the Y axis.
    */
   _getSiblingContainerFromPosition(item: DragRef, x: number, y: number): DropListRef | undefined {
-    return this._siblings.find(sibling => sibling._canReceive(item, x, y));
+    // Possible targets include siblings and 'this'
+    let targets = [this, ...this._siblings];
+    
+    // Only consider targets where the drag postition is within the client rect
+    // (this avoids calling enterPredicate on each possible target)
+    let matchingTargets = targets.filter(ref => {
+      return ref._clientRect && isInsideClientRect(ref._clientRect, x, y)
+    })
+  
+    // Stop if no targets match the coordinates
+    if (matchingTargets.length == 0)
+        return undefined;
+  
+    // Order candidates by DOM hierarchy and z-index
+    let orderedMatchingTargets = this._orderByHierarchy(matchingTargets);
+  
+    // The drop target is the last matching target in the list
+    let matchingTarget = orderedMatchingTargets[orderedMatchingTargets.length-1];
+  
+    // Only return matching target if it is a sibling
+    if (matchingTarget === this)
+      return undefined;
+
+    // Can the matching target receive the item?
+    if (!matchingTarget._canReceive(item, x, y))
+      return undefined;
+
+    // Return matching target
+    return matchingTarget;
+  }
+
+  /**
+   * Sort a list of DropListRef in such that forevery nested pair drop containers, the
+   * outer drop container appear before the inner drop container.
+   * @param refs List of DropListRefs.
+   */
+  _orderByHierarchy(refs: DropListRef[]): DropListRef[] {
+    // Build a map from HTMLElement to DropListRef
+    let refsByElement: Map<HTMLElement, DropListRef> = new Map();
+    refs.forEach(ref => {
+      refsByElement.set(coerceElement(ref.element), ref)
+    });
+
+    // Function to identify the closest ancestor among th DropListRefs
+    let findAncestor = (ref: DropListRef) => {
+      let ancestor = coerceElement(ref.element).parentElement;
+
+      while (ancestor) {
+          if (refsByElement.has(ancestor))
+              return refsByElement.get(ancestor)
+
+          ancestor = ancestor.parentElement;
+      }
+
+      return undefined;
+    }
+
+    // Node type for tree structure
+    type NodeType = {ref: DropListRef, parent?: NodeType, children: NodeType[]}
+
+    // Add all refs as nodes to the tree
+    let tree: Map<DropListRef, NodeType> = new Map();
+    refs.forEach(ref => {
+      tree.set(ref, {ref: ref, children: []})
+    });
+
+    // Build parent-child links in tree
+    refs.forEach(ref => {
+    let parent = findAncestor(ref);
+
+    if (parent) {
+        let node = tree.get(ref);
+        let parentNode = tree.get(parent);
+
+        node!.parent = parentNode;
+        parentNode!.children.push(node!);
+    }
+    });
+
+    // Find tree roots
+    let roots = [...tree.values()].filter(node => !node.parent);
+
+    // Function to recursively build ordered list from roots and down
+    let buildOrderedList = (nodes: NodeType[], list: DropListRef[]) => {
+    list.push(... nodes.map(node => node.ref));
+
+    nodes.forEach(node => {buildOrderedList(node.children, list)});
+    }
+
+    // Build and return the ordered list
+    let ordered: DropListRef[] = [];
+    buildOrderedList(roots, ordered);
+    return ordered;
   }
 
   /**

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -822,30 +822,33 @@ export class DropListRef<T = any> {
   _getSiblingContainerFromPosition(item: DragRef, x: number, y: number): DropListRef | undefined {
     // Possible targets include siblings and 'this'
     let targets = [this, ...this._siblings];
-    
+
     // Only consider targets where the drag postition is within the client rect
     // (this avoids calling enterPredicate on each possible target)
     let matchingTargets = targets.filter(ref => {
-      return ref._clientRect && isInsideClientRect(ref._clientRect, x, y)
-    })
-  
+      return ref._clientRect && isInsideClientRect(ref._clientRect, x, y);
+    });
+
     // Stop if no targets match the coordinates
-    if (matchingTargets.length == 0)
+    if (matchingTargets.length == 0) {
         return undefined;
-  
+    }
+
     // Order candidates by DOM hierarchy and z-index
     let orderedMatchingTargets = this._orderByHierarchy(matchingTargets);
-  
+
     // The drop target is the last matching target in the list
-    let matchingTarget = orderedMatchingTargets[orderedMatchingTargets.length-1];
-  
+    let matchingTarget = orderedMatchingTargets[orderedMatchingTargets.length - 1];
+
     // Only return matching target if it is a sibling
-    if (matchingTarget === this)
+    if (matchingTarget === this) {
       return undefined;
+    }
 
     // Can the matching target receive the item?
-    if (!matchingTarget._canReceive(item, x, y))
+    if (!matchingTarget._canReceive(item, x, y)) {
       return undefined;
+    }
 
     // Return matching target
     return matchingTarget;
@@ -860,7 +863,7 @@ export class DropListRef<T = any> {
     // Build a map from HTMLElement to DropListRef
     let refsByElement: Map<HTMLElement, DropListRef> = new Map();
     refs.forEach(ref => {
-      refsByElement.set(coerceElement(ref.element), ref)
+      refsByElement.set(coerceElement(ref.element), ref);
     });
 
     // Function to identify the closest ancestor among th DropListRefs
@@ -868,46 +871,45 @@ export class DropListRef<T = any> {
       let ancestor = coerceElement(ref.element).parentElement;
 
       while (ancestor) {
-          if (refsByElement.has(ancestor))
-              return refsByElement.get(ancestor)
-
+          if (refsByElement.has(ancestor)) {
+              return refsByElement.get(ancestor);
+          }
           ancestor = ancestor.parentElement;
       }
 
       return undefined;
-    }
+    };
 
     // Node type for tree structure
-    type NodeType = {ref: DropListRef, parent?: NodeType, children: NodeType[]}
+    type NodeType = {ref: DropListRef, parent?: NodeType, children: NodeType[]};
 
     // Add all refs as nodes to the tree
     let tree: Map<DropListRef, NodeType> = new Map();
     refs.forEach(ref => {
-      tree.set(ref, {ref: ref, children: []})
+      tree.set(ref, {ref: ref, children: []});
     });
 
     // Build parent-child links in tree
     refs.forEach(ref => {
-    let parent = findAncestor(ref);
+      let parent = findAncestor(ref);
 
-    if (parent) {
-        let node = tree.get(ref);
-        let parentNode = tree.get(parent);
+      if (parent) {
+          let node = tree.get(ref);
+          let parentNode = tree.get(parent);
 
-        node!.parent = parentNode;
-        parentNode!.children.push(node!);
-    }
+          node!.parent = parentNode;
+          parentNode!.children.push(node!);
+      }
     });
 
     // Find tree roots
-    let roots = [...tree.values()].filter(node => !node.parent);
+    let roots = Array.from(tree.values()).filter(node => !node.parent);
 
     // Function to recursively build ordered list from roots and down
     let buildOrderedList = (nodes: NodeType[], list: DropListRef[]) => {
-    list.push(... nodes.map(node => node.ref));
-
-    nodes.forEach(node => {buildOrderedList(node.children, list)});
-    }
+      list.push(... nodes.map(node => node.ref));
+      nodes.forEach(node => {buildOrderedList(node.children, list); });
+    };
 
     // Build and return the ordered list
     let ordered: DropListRef[] = [];

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -859,7 +859,7 @@ export class DropListRef<T = any> {
    * outer drop container appear before the inner drop container.
    * @param refs List of DropListRefs.
    */
-  _orderByHierarchy(refs: DropListRef[]): DropListRef[] {
+  private _orderByHierarchy(refs: DropListRef[]): DropListRef[] {
     // Build a map from HTMLElement to DropListRef
     let refsByElement: Map<HTMLElement, DropListRef> = new Map();
     refs.forEach(ref => {


### PR DESCRIPTION
Fixes a two issues with nested drop containers. The first fixed issue is that the elements of
cdkDropListConnectedTo previously had to be ordered correctly to support moving items into an
inner drop container. Sepcifically, inner drop containers had to be listed before their outer
ancestors. The second fixed issue is that items of an inner container could not be re-ordered
without moving the item out of the container and then back in.

Fixes #16671