### PR TITLE
fix(material/menu): focus indication rendering partially in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-menu/menu.scss
+++ b/src/material-experimental/mdc-menu/menu.scss
@@ -79,10 +79,16 @@
   }
 
   @include cdk-high-contrast(active, off) {
+    $outline-width: 1px;
+
+    // We need to move the item 1px down, because Firefox seems to have
+    // an issue rendering the top part of the outline (see #21524).
+    margin-top: $outline-width;
+
     &.cdk-program-focused,
     &.cdk-keyboard-focused,
     &-highlighted {
-      outline: dotted 1px;
+      outline: dotted $outline-width;
     }
   }
 }

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -54,10 +54,16 @@ $mat-menu-submenu-indicator-size: 10px !default;
   }
 
   @include cdk-high-contrast(active, off) {
+    $outline-width: 1px;
+
+    // We need to move the item 1px down, because Firefox seems to have
+    // an issue rendering the top part of the outline (see #21524).
+    margin-top: $outline-width;
+
     &.cdk-program-focused,
     &.cdk-keyboard-focused,
     &-highlighted {
-      outline: dotted 1px;
+      outline: dotted $outline-width;
     }
   }
 }


### PR DESCRIPTION
Firefox seems to have an issue where the items cut off each other's outline in high contrast mode. These changes work around the issue by introducing a slight margin.

Note that this isn't ideal, because the whole point of using an outline is so that the layout isn't different on high contrast mode. The alternate approach is to use a `border`, but it will cause the element to move around as the user is navigating.

Fixes #21524.