### PR TITLE
fix(material/menu): nested menu trigger not restoring focus

### DIFF
--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -1883,6 +1883,24 @@ describe('MDC-based MatMenu', () => {
           .toBe(true, 'Expected focus to be back inside the root menu');
     });
 
+    it('should restore focus to a nested trigger when navgating via the keyboard', fakeAsync(() => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      const levelOneTrigger = overlay.querySelector('#level-one-trigger')! as HTMLElement;
+      dispatchKeyboardEvent(levelOneTrigger, 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+
+      const spy = spyOn(levelOneTrigger, 'focus').and.callThrough();
+      dispatchKeyboardEvent(
+        overlay.querySelectorAll('.mat-mdc-menu-panel')[1], 'keydown', LEFT_ARROW);
+      fixture.detectChanges();
+      tick(500);
+
+      expect(spy).toHaveBeenCalled();
+    }));
+
     it('should position the sub-menu to the right edge of the trigger in ltr', () => {
       compileTestComponent();
       instance.rootTriggerEl.nativeElement.style.position = 'fixed';

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -1894,6 +1894,23 @@ describe('MatMenu', () => {
           .toBe(true, 'Expected focus to be back inside the root menu');
     });
 
+    it('should restore focus to a nested trigger when navgating via the keyboard', fakeAsync(() => {
+      compileTestComponent();
+      instance.rootTriggerEl.nativeElement.click();
+      fixture.detectChanges();
+
+      const levelOneTrigger = overlay.querySelector('#level-one-trigger')! as HTMLElement;
+      dispatchKeyboardEvent(levelOneTrigger, 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+
+      const spy = spyOn(levelOneTrigger, 'focus').and.callThrough();
+      dispatchKeyboardEvent(overlay.querySelectorAll('.mat-menu-panel')[1], 'keydown', LEFT_ARROW);
+      fixture.detectChanges();
+      tick(500);
+
+      expect(spy).toHaveBeenCalled();
+    }));
+
     it('should position the sub-menu to the right edge of the trigger in ltr', () => {
       compileTestComponent();
       instance.rootTriggerEl.nativeElement.style.position = 'fixed';

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -93,6 +93,11 @@ const MAT_MENU_BASE_ELEVATION = 4;
 
 let menuPanelUid = 0;
 
+
+/** Reason why the menu was closed. */
+export type MenuCloseReason = void | 'click' | 'keydown' | 'tab';
+
+
 /** Base class with all of the `MatMenu` functionality. */
 @Directive()
 export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit,
@@ -239,15 +244,14 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
   set classList(classes: string) { this.panelClass = classes; }
 
   /** Event emitted when the menu is closed. */
-  @Output() readonly closed: EventEmitter<void | 'click' | 'keydown' | 'tab'> =
-      new EventEmitter<void | 'click' | 'keydown' | 'tab'>();
+  @Output() readonly closed: EventEmitter<MenuCloseReason> = new EventEmitter<MenuCloseReason>();
 
   /**
    * Event emitted when the menu is closed.
    * @deprecated Switch to `closed` instead
    * @breaking-change 8.0.0
    */
-  @Output() close: EventEmitter<void | 'click' | 'keydown' | 'tab'> = this.closed;
+  @Output() close: EventEmitter<MenuCloseReason> = this.closed;
 
   readonly panelId = `mat-menu-panel-${menuPanelUid++}`;
 

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -12,8 +12,8 @@ export declare class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatM
     backdropClass: string;
     get classList(): string;
     set classList(classes: string);
-    close: EventEmitter<void | 'click' | 'keydown' | 'tab'>;
-    readonly closed: EventEmitter<void | 'click' | 'keydown' | 'tab'>;
+    close: EventEmitter<MenuCloseReason>;
+    readonly closed: EventEmitter<MenuCloseReason>;
     direction: Direction;
     get hasBackdrop(): boolean | undefined;
     set hasBackdrop(value: boolean | undefined);
@@ -149,7 +149,7 @@ export interface MatMenuPanel<T = any> {
 export declare class MatMenuTrigger implements AfterContentInit, OnDestroy {
     get _deprecatedMatMenuTriggerFor(): MatMenuPanel;
     set _deprecatedMatMenuTriggerFor(v: MatMenuPanel);
-    _openedBy: Exclude<FocusOrigin, 'program'>;
+    _openedBy: Exclude<FocusOrigin, 'program' | null> | undefined;
     get dir(): Direction;
     get menu(): MatMenuPanel;
     set menu(menu: MatMenuPanel);


### PR DESCRIPTION
Fixes that navigating back from a nested menu using the keyboard doesn't restore focus to the previous trigger, breaking the interaction since it ends up going back to the `body`. This used to work, but seems to have regressed at some point.

**Note:** marking as a P2, because the current behavior completely breaks the keyboard navigation between nested menus.