### PR TITLE
docs: update readme for Q1 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you'd like to contribute, please follow our [contributing guidelines][contrib
 our [`help wanted`][help-wanted] label for a list of issues with good opportunities for
 contribution.
 
-## What we're working on now (Q4 2020):
+## What we're working on now (Q1 2021):
 * Continuing to create new, API-compatible versions of the Angular Material components backed by
 [MDC Web][] ([see @jelbourn's ng-conf talk](https://youtu.be/4EXQKP-Sihw?t=891)). Much of our effort
 is dedicated towards rolling out these new versions of the components across Angular apps


### PR DESCRIPTION
We're still working on the same set of projects for Q1 2021 as we were for Q4 2020.
The bulk of our effort is going into rolling out our MDC-based components to our users
inside Google. This is the first phase of our MDC-component rollout; the second phase
will involve moving the components to our stable npm packages.

Fixes #21538