### PR TITLE
fix(material-experimental/mdc-table): remove bottom border for flex table

### DIFF
--- a/src/material-experimental/mdc-table/table.scss
+++ b/src/material-experimental/mdc-table/table.scss
@@ -20,3 +20,10 @@
 .mdc-data-table__table {
   table-layout: auto;
 }
+
+// MDC table rows are styled with a top border, whereas our legacy flex table styles rows with
+// a bottom border. Remove the bottom border style from the rows and let MDC display its top
+// border.
+mat-row.mat-mdc-row, mat-header-row.mat-mdc-header-row, mat-footer-row.mat-mdc-footer-row {
+  border-bottom: none;
+}


### PR DESCRIPTION
MDC flex table rows have a bottom border from legacy styles, and a top border for MDC styles. This means each row has two borders between them. This removes the bottom border and leaves the top

![image](https://user-images.githubusercontent.com/22898577/104379256-765dc480-54e6-11eb-93a3-80e0c32cbf3a.png)

One option could have been to pass a flag to the mixin `mat-private-table-flex-styles` that says not to put in the border. However, this won't help in the case for apps that want to load both old and new table styles.