### PR TITLE
ci: fix indentation of CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -342,7 +342,7 @@
 
 # Misc
 /.github/**                                        @angular/dev-infra-components
-/.husky/**                                        @angular/dev-infra-components
+/.husky/**                                         @angular/dev-infra-components
 /.github/CODEOWNERS                                @angular/dev-infra-components @jelbourn
 /.github/ISSUE_TEMPLATE/**                         @andrewseguin @jelbourn
 /.vscode/**                                        @angular/dev-infra-components @mmalerba


### PR DESCRIPTION
Correct the misindented entry for husky files in CODEOWNERS.