### PR TITLE
fix(material-experimental/mdc-autocomplete): only animate along y axis

### DIFF
--- a/src/material-experimental/mdc-autocomplete/animations.ts
+++ b/src/material-experimental/mdc-autocomplete/animations.ts
@@ -22,12 +22,12 @@ import {
 export const panelAnimation: AnimationTriggerMetadata = trigger('panelAnimation', [
   state('void, hidden', style({
     opacity: 0,
-    transform: 'scale(0.8)',
+    transform: 'scaleY(0.8)',
   })),
   transition(':enter, hidden => visible', [
     group([
-        animate('0.03s linear', style({ opacity: 1 })),
-        animate('0.12s cubic-bezier(0, 0, 0.2, 1)', style({ transform: 'scale(1)' })),
+      animate('0.03s linear', style({ opacity: 1 })),
+      animate('0.12s cubic-bezier(0, 0, 0.2, 1)', style({ transform: 'scaleY(1)' })),
     ]),
   ]),
   transition(':leave, visible => hidden', [


### PR DESCRIPTION
Changes the panel animation to only animate vertically, rather than along both x and y axis.

For reference, this is the before:
![demo-current](https://user-images.githubusercontent.com/4450522/104641559-39422f80-56aa-11eb-833c-bfdc3f9c46bf.gif)

This is after:
![demo](https://user-images.githubusercontent.com/4450522/104641580-4101d400-56aa-11eb-971c-6011b3d24d62.gif)
