### PR TITLE
build: check tooling scripts for compilation errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,6 +395,9 @@ jobs:
             pkg_json_version=$(node -pe "require('./package.json').version")
             expected_version="${pkg_json_version}-sha-$(git rev-parse --short HEAD)"
             yarn check-release-output ${expected_version}
+      - run:
+          name: Checking tooling scripts
+          command: yarn check-tools
 
       # TODO(devversion): replace this with bazel tests that run Madge. This is
       # cumbersome and doesn't guarantee no circular deps for other entry-points.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "integration-tests:view-engine": "bazel test --test_tag_filters=view-engine-only --build_tests_only -- //integration/... -//integration/size-test/...",
     "integration-tests:size-test": "bazel test //integration/size-test/...",
     "check-mdc-tests": "ts-node --project scripts/tsconfig.json scripts/check-mdc-tests.ts",
-    "check-mdc-exports": "ts-node --project scripts/tsconfig.json scripts/check-mdc-exports.ts"
+    "check-mdc-exports": "ts-node --project scripts/tsconfig.json scripts/check-mdc-exports.ts",
+    "check-tools": "yarn tsc --project tools/tsconfig-ci.json"
   },
   "version": "11.2.0-next.0",
   "dependencies": {

--- a/tools/tsconfig-ci.json
+++ b/tools/tsconfig-ci.json
@@ -1,0 +1,15 @@
+// A lot of the scripts under `tools` are run manually, rather than on the CI. As such, it's easy
+// to miss compilation errors in them. This config is used to verify the files on the CI. Note that
+// the compiler options are somewhat loose, which is intentional in order to mimic the default
+// options used by `ts-node` when running the scripts.
+{
+  "include": ["./**/*.ts"],
+  "exclude": ["./public_api_guard/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "../dist/tools",
+    "lib": ["es2015"],
+    "skipLibCheck": true,
+    // Don't emit to the file system, because we only want to check for compilation errors.
+    "noEmit": true
+  }
+}

--- a/tools/tslint-rules/noUnescapedHtmlTagRule.ts
+++ b/tools/tslint-rules/noUnescapedHtmlTagRule.ts
@@ -51,10 +51,10 @@ class NoUnescapedHtmlTagWalker extends Lint.RuleWalker {
     // Whether an opening backtick has been found without a closing pair
     let openBacktick = false;
 
-    for (const char of fullText) {
-      if (char === '`') {
+    for (let i = 0; i < fullText.length; i++) {
+      if (fullText[i] === '`') {
         openBacktick = !openBacktick;
-      } else if (matches.test(char) && !openBacktick) {
+      } else if (matches.test(fullText[i]) && !openBacktick) {
         return false;
       }
     }


### PR DESCRIPTION
A lot of the scripts under `tools` are only run manually which means that it's easy for compilation errors to slip by when dependencies are updated.

These changes add another CI check to ensure that the scripts compile.