### PR TITLE
feat(material/datepicker): add the ability to customize datepicker content

### DIFF
--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -101,6 +101,13 @@ const _MatDatepickerContentMixinBase: CanColorCtor & typeof MatDatepickerContent
     mixinColor(MatDatepickerContentBase);
 
 /**
+ * Injection token used to customize the MatDatepickerContent class in the datepicker dialog and
+ * popup.
+ */
+export const MAT_DATEPICKER_CONTENT =
+  new InjectionToken<ComponentType<MatDatepickerContent<any>>>('mat-datepicker-content');
+
+/**
  * Component used as the content for the datepicker dialog and popup. We use this instead of using
  * MatCalendar directly as the content so we can control the initial focus. This also gives us a
  * place to put additional features of the popup that are not part of the calendar itself in the
@@ -238,6 +245,12 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
     }
   }
 }
+
+/** @docs-private */
+export const MAT_DATEPICKER_CONTENT_PROVIDER = {
+  provide: MAT_DATEPICKER_CONTENT,
+  useValue: MatDatepickerContent,
+};
 
 /** Form control that can be associated with a datepicker. */
 export interface MatDatepickerControl<D> {
@@ -452,6 +465,8 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
               private _ngZone: NgZone,
               private _viewContainerRef: ViewContainerRef,
               @Inject(MAT_DATEPICKER_SCROLL_STRATEGY) scrollStrategy: any,
+              @Inject(MAT_DATEPICKER_CONTENT)
+                  private _datepickerContent: ComponentType<MatDatepickerContent<S, D>>,
               @Optional() private _dateAdapter: DateAdapter<D>,
               @Optional() private _dir: Directionality,
               @Optional() @Inject(DOCUMENT) private _document: any,
@@ -614,7 +629,7 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
       this._dialogRef.close();
     }
 
-    this._dialogRef = this._dialog.open<MatDatepickerContent<S, D>>(MatDatepickerContent, {
+    this._dialogRef = this._dialog.open<MatDatepickerContent<S, D>>(this._datepickerContent, {
       direction: this._dir ? this._dir.value : 'ltr',
       viewContainerRef: this._viewContainerRef,
       panelClass: 'mat-datepicker-dialog',
@@ -651,7 +666,7 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
 
   /** Open the calendar as a popup. */
   private _openAsPopup(): void {
-    const portal = new ComponentPortal<MatDatepickerContent<S, D>>(MatDatepickerContent,
+    const portal = new ComponentPortal<MatDatepickerContent<S, D>>(this._datepickerContent,
                                                                    this._viewContainerRef);
 
     this._destroyPopup();

--- a/src/material/datepicker/datepicker-module.ts
+++ b/src/material/datepicker/datepicker-module.ts
@@ -20,7 +20,8 @@ import {MatCalendarBody} from './calendar-body';
 import {MatDatepicker} from './datepicker';
 import {
   MatDatepickerContent,
-  MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
+  MAT_DATEPICKER_CONTENT_PROVIDER,
+  MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER
 } from './datepicker-base';
 import {MatDatepickerInput} from './datepicker-input';
 import {MatDatepickerIntl} from './datepicker-intl';
@@ -87,7 +88,8 @@ import {MatDatepickerActions, MatDatepickerApply, MatDatepickerCancel} from './d
   ],
   providers: [
     MatDatepickerIntl,
-    MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER
+    MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
+    MAT_DATEPICKER_CONTENT_PROVIDER
   ],
   entryComponents: [
     MatDatepickerContent,

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -36,7 +36,9 @@ import {MatDatepicker} from './datepicker';
 import {MatDatepickerInput} from './datepicker-input';
 import {MatDatepickerToggle} from './datepicker-toggle';
 import {
+  MAT_DATEPICKER_CONTENT,
   MAT_DATEPICKER_SCROLL_STRATEGY,
+  MatDatepickerContent,
   MatDatepickerIntl,
   MatDatepickerModule,
   MatDateSelectionModel,
@@ -2075,6 +2077,49 @@ describe('MatDatepicker', () => {
     }));
   });
 
+  describe('datepicker with custom content', () => {
+    let fixture: ComponentFixture<DatepickerWithCustomContent>;
+    let testComponent: DatepickerWithCustomContent;
+
+    beforeEach(fakeAsync(() => {
+      fixture = createComponent(
+        DatepickerWithCustomContent,
+        [MatNativeDateModule],
+        [{
+          provide: MAT_DATEPICKER_CONTENT,
+          useValue: CustomDatepickerContent
+        }],
+        [CustomDatepickerContent]
+      );
+      fixture.detectChanges();
+      testComponent = fixture.componentInstance;
+    }));
+
+    it('should instantiate a datepicker with a custom content', fakeAsync(() => {
+      expect(testComponent).toBeTruthy();
+    }));
+
+    it('should find the custom element when open as popup', fakeAsync(() => {
+      testComponent.datepicker.open();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+
+      expect(document.querySelector('.custom-element')).toBeTruthy();
+    }));
+
+    it('should find the custom element when open as dialog', fakeAsync(() => {
+      testComponent.touchUi = true;
+      fixture.detectChanges();
+      testComponent.datepicker.open();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+
+      expect(document.querySelector('.custom-element')).toBeTruthy();
+    }));
+  });
+
   it('should not pick up values from the global dialog config', () => {
     const fixture = createComponent(StandardDatepicker, [MatNativeDateModule], [{
       provide: MAT_DIALOG_DEFAULT_OPTIONS,
@@ -2506,6 +2551,27 @@ class DatepickerWithCustomHeader {
   `,
 })
 class CustomHeaderForDatepicker {}
+
+
+@Component({
+  template: `
+    <input [matDatepicker]="d">
+    <mat-datepicker #d [touchUi]="touchUi"></mat-datepicker>
+  `
+})
+class DatepickerWithCustomContent {
+  @ViewChild('d') datepicker: MatDatepicker<Date>;
+  touchUi = false;
+}
+
+@Component({
+  template: `
+    <div class="custom-element">Custom element</div>
+    <mat-calendar></mat-calendar>
+  `,
+})
+class CustomDatepickerContent extends MatDatepickerContent<any> {}
+
 
 @Component({
   template: `

--- a/src/material/datepicker/public-api.ts
+++ b/src/material/datepicker/public-api.ts
@@ -17,6 +17,7 @@ export {
 } from './date-range-selection-strategy';
 export * from './datepicker-animations';
 export {
+  MAT_DATEPICKER_CONTENT,
   MAT_DATEPICKER_SCROLL_STRATEGY,
   MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY,
   MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -29,6 +29,8 @@ export declare type ExtractDateTypeFromSelection<T> = T extends DateRange<infer 
 
 export declare const MAT_DATE_RANGE_SELECTION_STRATEGY: InjectionToken<MatDateRangeSelectionStrategy<any>>;
 
+export declare const MAT_DATEPICKER_CONTENT: InjectionToken<ComponentType<MatDatepickerContent<any, any>>>;
+
 export declare const MAT_DATEPICKER_SCROLL_STRATEGY: InjectionToken<() => ScrollStrategy>;
 
 export declare function MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy;


### PR DESCRIPTION
Add a feature in the Angular Material `datepicker` component
to customize datepicker content. With this feature, we can
add some preset of buttons or other templates to datepicker.

Closes #20613