### PR TITLE
build: configure the ng-dev caretaker check command

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -30,8 +30,7 @@ merge:
     disabled: true
 
   # comment that will be added to a PR when there is a conflict, leave empty or set to false to disable
-  mergeConflictComment: "Hi @{{PRAuthor}}! This PR has merge conflicts due to recent upstream merges.
-\nPlease help to unblock it by resolving these conflicts. Thanks!"
+  mergeConflictComment: "Hi @{{PRAuthor}}! This PR has merge conflicts due to recent upstream merges.\nPlease help to unblock it by resolving these conflicts. Thanks!"
 
   # label to monitor
   mergeLabel: "pr: merge ready"
@@ -67,12 +66,7 @@ merge:
   # the comment that will be added when the merge label is added despite failing checks, leave empty or set to false to disable
   # {{MERGE_LABEL}} will be replaced by the value of the mergeLabel option
   # {{PLACEHOLDER}} will be replaced by the list of failing checks
-  mergeRemovedComment: "I see that you just added the `{{MERGE_LABEL}}` label, but the following checks are still failing:
-\n{{PLACEHOLDER}}
-\n
-\n**If you want your PR to be merged, it has to pass all the CI checks.**
-\n
-\nIf you can't get the PR to a green state due to flakes or broken master, please try rebasing to master and/or restarting the CI job. If that fails and you believe that the issue is not due to your change, please contact the caretaker and ask for help."
+  mergeRemovedComment: "I see that you just added the `{{MERGE_LABEL}}` label, but the following checks are still failing:\n{{PLACEHOLDER}}\n\n**If you want your PR to be merged, it has to pass all the CI checks.**\n\nIf you can't get the PR to a green state due to flakes or broken master, please try rebasing to master and/or restarting the CI job. If that fails and you believe that the issue is not due to your change, please contact the caretaker and ask for help."
 
 # options for the triage plugin
 triage:

--- a/.ng-dev/caretaker.ts
+++ b/.ng-dev/caretaker.ts
@@ -1,0 +1,15 @@
+import {CaretakerConfig} from '@angular/dev-infra-private/caretaker/config';
+
+/** The configuration for `ng-dev caretaker` commands. */
+export const caretaker: CaretakerConfig = {
+  githubQueries: [
+    {
+      name: 'Merge Queue',
+      query: `is:pr is:open status:success label:"pr: merge ready"`,
+    },
+    {
+      name: 'Triage Queue',
+      query: `is:open label:"needs triage"`,
+    }
+  ]
+};

--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -2,10 +2,12 @@ import {format} from './format';
 import {github} from './github';
 import {merge} from './merge';
 import {commitMessage} from './commit-message';
+import {caretaker} from './caretaker';
 
 module.exports = {
   commitMessage,
   format,
   github,
   merge,
+  caretaker,
 };


### PR DESCRIPTION
Create the configuration for the caretaker check command in the repo.


Makes available a check of the state of repository for caretakers via `yarn ng-dev caretaker check`

```
$ yarn ng-dev caretaker check
fatal: couldn't find remote ref g3
Github Tasks
  Merge Queue   0
  Triage Queue  3
  https://github.com/angular/components/issues?q=is:open%20label:%22needs%20triage%22
    - https://github.com/angular/components/issues/21593
    - https://github.com/angular/components/issues/21592
    - https://github.com/angular/components/issues/21583

Service Statuses
  Saucelabs ✅
  Npm       ✅
  CircleCi  ✅
  Github    ✅

CI
  releaseCandidate (11.1.x) ✅
  latest (11.0.x)           ✅
  next (master)             ✅
```