### PR TITLE
feat(material-experimental/mdc-menu): support density

### DIFF
--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -189,7 +189,10 @@ export class DevAppLayout {
 
   /** Selects the next possible density scale. */
   selectNextDensity() {
+    // The class has to be toggled on the `body` too so it applies to overlay-based components.
+    document.body.classList.remove(this.getDensityClass());
     this.currentDensityIndex = this.getNextDensityIndex();
+    document.body.classList.add(this.getDensityClass());
   }
 
   /**

--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -4,6 +4,7 @@
 @use '@material/list' as mdc-list;
 @use '@material/typography' as mdc-typography;
 @use '@material/ripple' as mdc-ripple;
+@use '@material/density' as mdc-density;
 @use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/theming/theming';
 
@@ -62,7 +63,19 @@
   }
 }
 
-@mixin density($config-or-theme) {}
+@mixin density($config-or-theme) {
+  $density-scale: theming.get-density-config($config-or-theme);
+
+  .mat-mdc-menu-item {
+    $height: mdc-density.prop-value(
+      $density-config: mdc-list.$deprecated-single-line-density-config,
+      $density-scale: $density-scale,
+      $property-name: height,
+    );
+
+    @include mdc-list.deprecated-single-line-height($height);
+  }
+}
 
 @mixin theme($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);


### PR DESCRIPTION
Adds support for density to the MDC-based `mat-menu`.