### PR TITLE
fix(material-experimental/mdc-button): use mdc mixins to style icons within buttons

### DIFF
--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -32,6 +32,7 @@
 .mat-mdc-unelevated-button, .mat-mdc-raised-button, .mat-mdc-outlined-button {
   // Icons inside contained buttons have different styles due to increased button padding
   .mat-icon {
+    @include button.icon();
     @include button.icon-contained();
   }
 

--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -1,3 +1,5 @@
+@use '@material/button/button';
+
 @import '@material/button/mixins.import';
 @import '@material/button/variables.import';
 @import '@material/ripple/mixins.import';
@@ -10,20 +12,31 @@
 .mat-mdc-button, .mat-mdc-unelevated-button, .mat-mdc-raised-button, .mat-mdc-outlined-button {
   @include mat-private-button-interactive();
   @include mat-private-button-disabled();
+}
 
-  // MDC expects button icons to contain this HTML content:
-  // ```html
-  //   <span class="mdc-button__icon material-icons">favorite</span>
-  // ```
-  // However, Angular Material expects a `mat-icon` instead. The following
-  // will extend the `mdc-button__icon` styling to the mat icon. Note that
-  // the extended styles inherently only match icons that nest themselves in
-  // a parent `mdc-button`.
-  //
-  // TODO(mmalerba): Have MDC create a mixin for this so we don't have to rely on extending their
-  //  class.
+// MDC expects button icons to contain this HTML content:
+// ```html
+//   <span class="mdc-button__icon material-icons">favorite</span>
+// ```
+// However, Angular Material expects a `mat-icon` instead. The following
+// mixins will style the icons appropriately.
+.mat-mdc-button {
   .mat-icon {
-    @extend .mdc-button__icon;
+    @include button.icon();
+  }
+ .mdc-button__label + .mat-icon {
+   @include button.icon-trailing();
+ }
+}
+
+.mat-mdc-unelevated-button, .mat-mdc-raised-button, .mat-mdc-outlined-button {
+  // Icons inside contained buttons have different styles due to increased button padding
+  .mat-icon {
+    @include button.icon-contained();
+  }
+
+  .mdc-button__label + .mat-icon {
+    @include button.icon-contained-trailing();
   }
 }
 


### PR DESCRIPTION
Add appropriate class to mat-icon when it is within a MDC button to receive the correct styles.
(This is technically a fix for material-experimental/mdc-button but the change is in material/icon)
Before
![Screen Shot 2021-01-19 at 7 01 45 PM](https://user-images.githubusercontent.com/20130030/105026288-594a6800-5a89-11eb-8108-28e3a82c2cfb.png)
After
![Screen Shot 2021-01-19 at 7 02 10 PM](https://user-images.githubusercontent.com/20130030/105026304-5bacc200-5a89-11eb-8e74-733377f3201f.png)
