### PR TITLE
fix(material-experimental/mdc-chips): set correct ripple opacity for …

### DIFF
--- a/src/material-experimental/mdc-chips/_chips-theme.scss
+++ b/src/material-experimental/mdc-chips/_chips-theme.scss
@@ -29,21 +29,36 @@
       @include mdc-chip-fill-color-accessible($unselected-background,
         $query: $mat-theme-styles-query);
 
+      // mdc-chip-fill-color-accessible includes mdc-chip-selected-ink-color which overrides the opacity
+      // so selected chips always show a ripple.
+      // Include the same mixins but use mdc-chip-selected-ink-color-without-ripple
       &.mat-primary {
         &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-          @include mdc-chip-fill-color-accessible($primary, $query: $mat-theme-styles-query);
+          @include mdc-chip-fill-color($primary, $query: $mat-theme-styles-query);
+          @include mdc-chip-ink-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-selected-ink-color-without-ripple_(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-leading-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-trailing-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
         }
       }
 
       &.mat-accent {
         &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-          @include mdc-chip-fill-color-accessible($accent, $query: $mat-theme-styles-query);
+          @include mdc-chip-fill-color($accent, $query: $mat-theme-styles-query);
+          @include mdc-chip-ink-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-selected-ink-color-without-ripple_(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-leading-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-trailing-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
         }
       }
 
       &.mat-warn {
         &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-          @include mdc-chip-fill-color-accessible($warn, $query: $mat-theme-styles-query);
+          @include mdc-chip-fill-color($warn, $query: $mat-theme-styles-query);
+          @include mdc-chip-ink-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-selected-ink-color-without-ripple_(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-leading-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include mdc-chip-trailing-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
         }
       }
     }

--- a/src/material-experimental/mdc-chips/_chips-theme.scss
+++ b/src/material-experimental/mdc-chips/_chips-theme.scss
@@ -2,6 +2,17 @@
 @import '../mdc-helpers/mdc-helpers';
 @import '@material/theme/functions.import';
 
+@mixin _selected-color($color) {
+  @include mdc-chip-fill-color($color, $query: $mat-theme-styles-query);
+  @include mdc-chip-ink-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+  @include mdc-chip-selected-ink-color-without-ripple_(
+                  text-primary-on-dark,
+                  $query: $mat-theme-styles-query
+  );
+  @include mdc-chip-leading-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+  @include mdc-chip-trailing-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+}
+
 @mixin mat-mdc-chips-color($config-or-theme) {
   $config: mat-get-color-config($config-or-theme);
   $primary: mat-color(map-get($config, primary));
@@ -29,36 +40,24 @@
       @include mdc-chip-fill-color-accessible($unselected-background,
         $query: $mat-theme-styles-query);
 
-      // mdc-chip-fill-color-accessible includes mdc-chip-selected-ink-color which overrides the opacity
-      // so selected chips always show a ripple.
+      // mdc-chip-fill-color-accessible includes mdc-chip-selected-ink-color which overrides the
+      // opacity so selected chips always show a ripple.
       // Include the same mixins but use mdc-chip-selected-ink-color-without-ripple
       &.mat-primary {
         &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-          @include mdc-chip-fill-color($primary, $query: $mat-theme-styles-query);
-          @include mdc-chip-ink-color(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-selected-ink-color-without-ripple_(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-leading-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-trailing-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include _selected-color($primary);
         }
       }
 
       &.mat-accent {
         &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-          @include mdc-chip-fill-color($accent, $query: $mat-theme-styles-query);
-          @include mdc-chip-ink-color(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-selected-ink-color-without-ripple_(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-leading-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-trailing-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include _selected-color($accent);
         }
       }
 
       &.mat-warn {
         &.mdc-chip--selected, &.mat-mdc-chip-highlighted {
-          @include mdc-chip-fill-color($warn, $query: $mat-theme-styles-query);
-          @include mdc-chip-ink-color(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-selected-ink-color-without-ripple_(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-leading-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
-          @include mdc-chip-trailing-icon-color(text-primary-on-dark, $query: $mat-theme-styles-query);
+          @include _selected-color($warn);
         }
       }
     }


### PR DESCRIPTION
…focus states

Previously the ripple was always set to the focus opacity for selected chips even when not focused. 
This is because `mdc-chip-fill-color-accessible` includes `mdc-chip-selected-ink-color` which overrides the default ripple opacity so the focus ripple is always visible for selected chips.


The first chip is focused for both images. 
Before
![Screen Shot 2021-01-19 at 9 29 35 PM](https://user-images.githubusercontent.com/20130030/105041363-daabf580-5a9d-11eb-90dc-858ac75d2928.png)

After
![Screen Shot 2021-01-19 at 9 28 58 PM](https://user-images.githubusercontent.com/20130030/105041317-cbc54300-5a9d-11eb-85e5-0929bcf2e41e.png)

