### PR TITLE
fix(material/datepicker): mark date input as touched when calendar is closed

### DIFF
--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -636,6 +636,36 @@ describe('MatDateRangeInput', () => {
     expect(endModel.dirty).toBe(true);
   }));
 
+  it('should mark both inputs as touched when the range picker is closed', fakeAsync(() => {
+    const fixture = createComponent(RangePickerNgModel);
+    fixture.detectChanges();
+    flush();
+    const {startModel, endModel, rangePicker} = fixture.componentInstance;
+
+    expect(startModel.dirty).toBe(false);
+    expect(startModel.touched).toBe(false);
+    expect(endModel.dirty).toBe(false);
+    expect(endModel.touched).toBe(false);
+
+    rangePicker.open();
+    fixture.detectChanges();
+    flush();
+
+    expect(startModel.dirty).toBe(false);
+    expect(startModel.touched).toBe(false);
+    expect(endModel.dirty).toBe(false);
+    expect(endModel.touched).toBe(false);
+
+    rangePicker.close();
+    fixture.detectChanges();
+    flush();
+
+    expect(startModel.dirty).toBe(false);
+    expect(startModel.touched).toBe(true);
+    expect(endModel.dirty).toBe(false);
+    expect(endModel.touched).toBe(true);
+  }));
+
   it('should move focus to the start input when pressing backspace on an empty end input', () => {
     const fixture = createComponent(StandardRangePicker);
     fixture.detectChanges();
@@ -928,6 +958,7 @@ class RangePickerNgModel {
   @ViewChild(MatEndDate, {read: NgModel}) endModel: NgModel;
   @ViewChild(MatStartDate, {read: ElementRef}) startInput: ElementRef<HTMLInputElement>;
   @ViewChild(MatEndDate, {read: ElementRef}) endInput: ElementRef<HTMLInputElement>;
+  @ViewChild(MatDateRangePicker) rangePicker: MatDateRangePicker<Date>;
   start: Date | null = null;
   end: Date | null = null;
 }

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -12,6 +12,7 @@ import {
   forwardRef,
   Inject,
   Input,
+  OnDestroy,
   Optional,
 } from '@angular/core';
 import {
@@ -28,6 +29,7 @@ import {
 } from '@angular/material/core';
 import {MatFormField, MAT_FORM_FIELD} from '@angular/material/form-field';
 import {MAT_INPUT_VALUE_ACCESSOR} from '@angular/material/input';
+import {Subscription} from 'rxjs';
 import {MatDatepickerInputBase, DateFilterFn} from './datepicker-input-base';
 import {MatDatepickerControl, MatDatepickerPanel} from './datepicker-base';
 import {DateSelectionModelChange} from './date-selection-model';
@@ -72,12 +74,15 @@ export const MAT_DATEPICKER_VALIDATORS: any = {
   exportAs: 'matDatepickerInput',
 })
 export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
-  implements MatDatepickerControl<D | null> {
+  implements MatDatepickerControl<D | null>, OnDestroy {
+  private _closedSubscription = Subscription.EMPTY;
+
   /** The datepicker that this input is associated with. */
   @Input()
   set matDatepicker(datepicker: MatDatepickerPanel<MatDatepickerControl<D>, D | null, D>) {
     if (datepicker) {
       this._datepicker = datepicker;
+      this._closedSubscription = datepicker.closedStream.subscribe(() => this._onTouched());
       this._registerModel(datepicker.registerInput(this));
     }
   }
@@ -150,6 +155,11 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
   /** Gets the value at which the calendar should start. */
   getStartValue(): D | null {
     return this.value;
+  }
+
+  ngOnDestroy() {
+    super.ngOnDestroy();
+    this._closedSubscription.unsubscribe();
   }
 
   /** Opens the associated datepicker. */

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -857,6 +857,26 @@ describe('MatDatepicker', () => {
         expect(inputEl.classList).toContain('ng-touched');
       });
 
+      it('should mark input as touched when the datepicker is closed', fakeAsync(() => {
+        let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+
+        expect(inputEl.classList).toContain('ng-untouched');
+
+        fixture.componentInstance.datepicker.open();
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
+
+        expect(inputEl.classList).toContain('ng-untouched');
+
+        fixture.componentInstance.datepicker.close();
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
+
+        expect(inputEl.classList).toContain('ng-touched');
+      }));
+
       it('should reformat the input value on blur', () => {
         if (SUPPORTS_INTL) {
           // Skip this test if the internationalization API is not supported in the current

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -236,7 +236,7 @@ export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerContent<any, any>, [null, null, null, null, { optional: true; }, null]>;
 }
 
-export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> implements MatDatepickerControl<D | null> {
+export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D> implements MatDatepickerControl<D | null>, OnDestroy {
     _datepicker: MatDatepickerPanel<MatDatepickerControl<D>, D | null, D>;
     protected _validator: ValidatorFn | null;
     get dateFilter(): DateFilterFn<D | null>;
@@ -257,6 +257,7 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | nu
     getConnectedOverlayOrigin(): ElementRef;
     getStartValue(): D | null;
     getThemePalette(): ThemePalette;
+    ngOnDestroy(): void;
     static ngAcceptInputType_value: any;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatDatepickerInput<any>, "input[matDatepicker]", ["matDatepickerInput"], { "matDatepicker": "matDatepicker"; "min": "min"; "max": "max"; "dateFilter": "matDatepickerFilter"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatDatepickerInput<any>, [null, { optional: true; }, { optional: true; }, { optional: true; }]>;


### PR DESCRIPTION
Currently we mark the date input model as touched when it is blurred or the user types something in, however opening and closing the calendar is also an indicator that the user has interacted with it.

These changes add some logic to mark the inputs as touched when the calendar is closed as well.

Fixes #21643.