### PR TITLE
feat(material/sort): Add default configuration options

### DIFF
--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -14,6 +14,7 @@ import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {MatTableModule} from '../table/index';
 import {
+  MAT_SORT_DEFAULT_OPTIONS,
   MatSort,
   MatSortHeader,
   MatSortModule,
@@ -29,375 +30,415 @@ import {
 
 
 describe('MatSort', () => {
-  let fixture: ComponentFixture<SimpleMatSortApp>;
-  let component: SimpleMatSortApp;
+ describe('without default options', () => {
+   let fixture: ComponentFixture<SimpleMatSortApp>;
+   let component: SimpleMatSortApp;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatSortModule, MatTableModule, CdkTableModule, NoopAnimationsModule],
-      declarations: [
-        SimpleMatSortApp,
-        CdkTableMatSortApp,
-        MatTableMatSortApp,
-        MatSortHeaderMissingMatSortApp,
-        MatSortDuplicateMatSortableIdsApp,
-        MatSortableMissingIdApp,
-        MatSortableInvalidDirection
-      ],
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SimpleMatSortApp);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should have the sort headers register and deregister themselves', () => {
-    const sortables = component.matSort.sortables;
-    expect(sortables.size).toBe(4);
-    expect(sortables.get('defaultA')).toBe(component.defaultA);
-    expect(sortables.get('defaultB')).toBe(component.defaultB);
-
-    fixture.destroy();
-    expect(sortables.size).toBe(0);
-  });
-
-  it('should mark itself as initialized', fakeAsync(() => {
-    let isMarkedInitialized = false;
-    component.matSort.initialized.subscribe(() => isMarkedInitialized = true);
-
-    tick();
-    expect(isMarkedInitialized).toBeTruthy();
-  }));
-
-  it('should use the column definition if used within a cdk table', () => {
-    let cdkTableMatSortAppFixture = TestBed.createComponent(CdkTableMatSortApp);
-    let cdkTableMatSortAppComponent = cdkTableMatSortAppFixture.componentInstance;
-
-    cdkTableMatSortAppFixture.detectChanges();
-    cdkTableMatSortAppFixture.detectChanges();
-
-    const sortables = cdkTableMatSortAppComponent.matSort.sortables;
-    expect(sortables.size).toBe(3);
-    expect(sortables.has('column_a')).toBe(true);
-    expect(sortables.has('column_b')).toBe(true);
-    expect(sortables.has('column_c')).toBe(true);
-  });
-
-  it('should use the column definition if used within an mat table', () => {
-    let matTableMatSortAppFixture = TestBed.createComponent(MatTableMatSortApp);
-    let matTableMatSortAppComponent = matTableMatSortAppFixture.componentInstance;
-
-    matTableMatSortAppFixture.detectChanges();
-    matTableMatSortAppFixture.detectChanges();
-
-    const sortables = matTableMatSortAppComponent.matSort.sortables;
-    expect(sortables.size).toBe(3);
-    expect(sortables.has('column_a')).toBe(true);
-    expect(sortables.has('column_b')).toBe(true);
-    expect(sortables.has('column_c')).toBe(true);
-  });
-
-  describe('checking correct arrow direction and view state for its various states', () => {
-    let expectedStates: Map<string, {viewState: string, arrowDirection: string}>;
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [MatSortModule, MatTableModule, CdkTableModule, NoopAnimationsModule],
+        declarations: [
+          SimpleMatSortApp,
+          CdkTableMatSortApp,
+          MatTableMatSortApp,
+          MatSortHeaderMissingMatSortApp,
+          MatSortDuplicateMatSortableIdsApp,
+          MatSortableMissingIdApp,
+          MatSortableInvalidDirection
+        ],
+      }).compileComponents();
+    }));
 
     beforeEach(() => {
-      // Starting state for the view and directions - note that overrideStart is reversed to be desc
-      expectedStates = new Map<string, {viewState: string, arrowDirection: string}>([
-        ['defaultA', {viewState: 'asc', arrowDirection: 'asc'}],
-        ['defaultB', {viewState: 'asc', arrowDirection: 'asc'}],
-        ['overrideStart', {viewState: 'desc', arrowDirection: 'desc'}],
-        ['overrideDisableClear', {viewState: 'asc', arrowDirection: 'asc'}],
-      ]);
-      component.expectViewAndDirectionStates(expectedStates);
+      fixture = TestBed.createComponent(SimpleMatSortApp);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
     });
 
-    it('should be correct when mousing over headers and leaving on mouseleave', () => {
-      // Mousing over the first sort should set the view state to hint (asc)
-      component.dispatchMouseEvent('defaultA', 'mouseenter');
-      expectedStates.set('defaultA', {viewState: 'asc-to-hint', arrowDirection: 'asc'});
-      component.expectViewAndDirectionStates(expectedStates);
+    it('should have the sort headers register and deregister themselves', () => {
+      const sortables = component.matSort.sortables;
+      expect(sortables.size).toBe(4);
+      expect(sortables.get('defaultA')).toBe(component.defaultA);
+      expect(sortables.get('defaultB')).toBe(component.defaultB);
 
-      // Mousing away from the first sort should hide the arrow
-      component.dispatchMouseEvent('defaultA', 'mouseleave');
-      expectedStates.set('defaultA', {viewState: 'hint-to-asc', arrowDirection: 'asc'});
-      component.expectViewAndDirectionStates(expectedStates);
-
-      // Mousing over another sort should set the view state to hint (desc)
-      component.dispatchMouseEvent('overrideStart', 'mouseenter');
-      expectedStates.set('overrideStart', {viewState: 'desc-to-hint', arrowDirection: 'desc'});
-      component.expectViewAndDirectionStates(expectedStates);
+      fixture.destroy();
+      expect(sortables.size).toBe(0);
     });
 
-    it('should be correct when mousing over header and then sorting', () => {
-      // Mousing over the first sort should set the view state to hint
-      component.dispatchMouseEvent('defaultA', 'mouseenter');
-      expectedStates.set('defaultA', {viewState: 'asc-to-hint', arrowDirection: 'asc'});
-      component.expectViewAndDirectionStates(expectedStates);
+    it('should mark itself as initialized', fakeAsync(() => {
+      let isMarkedInitialized = false;
+      component.matSort.initialized.subscribe(() => isMarkedInitialized = true);
 
-      // Clicking sort on the header should set it to be active immediately
-      // (since it was already hinted)
-      component.dispatchMouseEvent('defaultA', 'click');
-      expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-asc'});
-      component.expectViewAndDirectionStates(expectedStates);
+      tick();
+      expect(isMarkedInitialized).toBeTruthy();
+    }));
+
+    it('should use the column definition if used within a cdk table', () => {
+      let cdkTableMatSortAppFixture = TestBed.createComponent(CdkTableMatSortApp);
+      let cdkTableMatSortAppComponent = cdkTableMatSortAppFixture.componentInstance;
+
+      cdkTableMatSortAppFixture.detectChanges();
+      cdkTableMatSortAppFixture.detectChanges();
+
+      const sortables = cdkTableMatSortAppComponent.matSort.sortables;
+      expect(sortables.size).toBe(3);
+      expect(sortables.has('column_a')).toBe(true);
+      expect(sortables.has('column_b')).toBe(true);
+      expect(sortables.has('column_c')).toBe(true);
     });
 
-    it('should be correct when cycling through a default sort header', () => {
-      // Sort the header to set it to the active start state
+    it('should use the column definition if used within an mat table', () => {
+      let matTableMatSortAppFixture = TestBed.createComponent(MatTableMatSortApp);
+      let matTableMatSortAppComponent = matTableMatSortAppFixture.componentInstance;
+
+      matTableMatSortAppFixture.detectChanges();
+      matTableMatSortAppFixture.detectChanges();
+
+      const sortables = matTableMatSortAppComponent.matSort.sortables;
+      expect(sortables.size).toBe(3);
+      expect(sortables.has('column_a')).toBe(true);
+      expect(sortables.has('column_b')).toBe(true);
+      expect(sortables.has('column_c')).toBe(true);
+    });
+
+    describe('checking correct arrow direction and view state for its various states', () => {
+      let expectedStates: Map<string, {viewState: string, arrowDirection: string}>;
+
+      beforeEach(() => {
+        // Starting state for the view and directions - note that overrideStart is reversed to be
+        // desc
+        expectedStates = new Map<string, {viewState: string, arrowDirection: string}>([
+          ['defaultA', {viewState: 'asc', arrowDirection: 'asc'}],
+          ['defaultB', {viewState: 'asc', arrowDirection: 'asc'}],
+          ['overrideStart', {viewState: 'desc', arrowDirection: 'desc'}],
+          ['overrideDisableClear', {viewState: 'asc', arrowDirection: 'asc'}],
+        ]);
+        component.expectViewAndDirectionStates(expectedStates);
+      });
+
+      it('should be correct when mousing over headers and leaving on mouseleave', () => {
+        // Mousing over the first sort should set the view state to hint (asc)
+        component.dispatchMouseEvent('defaultA', 'mouseenter');
+        expectedStates.set('defaultA', {viewState: 'asc-to-hint', arrowDirection: 'asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+
+        // Mousing away from the first sort should hide the arrow
+        component.dispatchMouseEvent('defaultA', 'mouseleave');
+        expectedStates.set('defaultA', {viewState: 'hint-to-asc', arrowDirection: 'asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+
+        // Mousing over another sort should set the view state to hint (desc)
+        component.dispatchMouseEvent('overrideStart', 'mouseenter');
+        expectedStates.set('overrideStart', {viewState: 'desc-to-hint', arrowDirection: 'desc'});
+        component.expectViewAndDirectionStates(expectedStates);
+      });
+
+      it('should be correct when mousing over header and then sorting', () => {
+        // Mousing over the first sort should set the view state to hint
+        component.dispatchMouseEvent('defaultA', 'mouseenter');
+        expectedStates.set('defaultA', {viewState: 'asc-to-hint', arrowDirection: 'asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+
+        // Clicking sort on the header should set it to be active immediately
+        // (since it was already hinted)
+        component.dispatchMouseEvent('defaultA', 'click');
+        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+      });
+
+      it('should be correct when cycling through a default sort header', () => {
+        // Sort the header to set it to the active start state
+        component.sort('defaultA');
+        expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+
+        // Sorting again will reverse its direction
+        component.dispatchMouseEvent('defaultA', 'click');
+        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-desc'});
+        component.expectViewAndDirectionStates(expectedStates);
+
+        // Sorting again will remove the sort and animate away the view
+        component.dispatchMouseEvent('defaultA', 'click');
+        expectedStates.set('defaultA', {viewState: 'active-to-desc', arrowDirection: 'desc'});
+        component.expectViewAndDirectionStates(expectedStates);
+      });
+
+      it('should not enter sort with animations if an animations is disabled', () => {
+        // Sort the header to set it to the active start state
+        component.defaultA._disableViewStateAnimation = true;
+        component.sort('defaultA');
+        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+
+        // Sorting again will reverse its direction
+        component.defaultA._disableViewStateAnimation = true;
+        component.dispatchMouseEvent('defaultA', 'click');
+        expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-desc'});
+        component.expectViewAndDirectionStates(expectedStates);
+      });
+
+      it('should be correct when sort has changed while a header is active', () => {
+        // Sort the first header to set up
+        component.sort('defaultA');
+        expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+
+        // Sort the second header and verify that the first header animated away
+        component.dispatchMouseEvent('defaultB', 'click');
+        expectedStates.set('defaultA', {viewState: 'active-to-asc', arrowDirection: 'asc'});
+        expectedStates.set('defaultB', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
+        component.expectViewAndDirectionStates(expectedStates);
+      });
+
+      it('should be correct when sort has been disabled', () => {
+        // Mousing over the first sort should set the view state to hint
+        component.disabledColumnSort = true;
+        fixture.detectChanges();
+
+        component.dispatchMouseEvent('defaultA', 'mouseenter');
+        component.expectViewAndDirectionStates(expectedStates);
+      });
+    });
+
+    it('should be able to cycle from asc -> desc from either start point', () => {
+      component.disableClear = true;
+
+      component.start = 'asc';
+      testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc']);
+
+      // Reverse directions
+      component.start = 'desc';
+      testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc']);
+    });
+
+    it('should be able to cycle asc -> desc -> [none]', () => {
+      component.start = 'asc';
+      testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc', '']);
+    });
+
+    it('should be able to cycle desc -> asc -> [none]', () => {
+      component.start = 'desc';
+      testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc', '']);
+    });
+
+    it('should allow for the cycling the sort direction to be disabled per column', () => {
+      const container = fixture.nativeElement.querySelector('#defaultA .mat-sort-header-container');
+
       component.sort('defaultA');
-      expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
-      component.expectViewAndDirectionStates(expectedStates);
+      expect(component.matSort.direction).toBe('asc');
+      expect(container.getAttribute('tabindex')).toBe('0');
 
-      // Sorting again will reverse its direction
-      component.dispatchMouseEvent('defaultA', 'click');
-      expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-desc'});
-      component.expectViewAndDirectionStates(expectedStates);
-
-      // Sorting again will remove the sort and animate away the view
-      component.dispatchMouseEvent('defaultA', 'click');
-      expectedStates.set('defaultA', {viewState: 'active-to-desc', arrowDirection: 'desc'});
-      component.expectViewAndDirectionStates(expectedStates);
-    });
-
-    it('should not enter sort with animations if an animations is disabled', () => {
-      // Sort the header to set it to the active start state
-      component.defaultA._disableViewStateAnimation = true;
-      component.sort('defaultA');
-      expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-asc'});
-      component.expectViewAndDirectionStates(expectedStates);
-
-      // Sorting again will reverse its direction
-      component.defaultA._disableViewStateAnimation = true;
-      component.dispatchMouseEvent('defaultA', 'click');
-      expectedStates.set('defaultA', {viewState: 'active', arrowDirection: 'active-desc'});
-      component.expectViewAndDirectionStates(expectedStates);
-    });
-
-    it('should be correct when sort has changed while a header is active', () => {
-      // Sort the first header to set up
-      component.sort('defaultA');
-      expectedStates.set('defaultA', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
-      component.expectViewAndDirectionStates(expectedStates);
-
-      // Sort the second header and verify that the first header animated away
-      component.dispatchMouseEvent('defaultB', 'click');
-      expectedStates.set('defaultA', {viewState: 'active-to-asc', arrowDirection: 'asc'});
-      expectedStates.set('defaultB', {viewState: 'asc-to-active', arrowDirection: 'active-asc'});
-      component.expectViewAndDirectionStates(expectedStates);
-    });
-
-    it('should be correct when sort has been disabled', () => {
-      // Mousing over the first sort should set the view state to hint
       component.disabledColumnSort = true;
       fixture.detectChanges();
 
-      component.dispatchMouseEvent('defaultA', 'mouseenter');
-      component.expectViewAndDirectionStates(expectedStates);
+      component.sort('defaultA');
+      expect(component.matSort.direction).toBe('asc');
+      expect(container.getAttribute('tabindex')).toBeFalsy();
+    });
+
+    it('should allow for the cycling the sort direction to be disabled for all columns', () => {
+      const container = fixture.nativeElement.querySelector('#defaultA .mat-sort-header-container');
+
+      component.sort('defaultA');
+      expect(component.matSort.active).toBe('defaultA');
+      expect(component.matSort.direction).toBe('asc');
+      expect(container.getAttribute('tabindex')).toBe('0');
+
+      component.disableAllSort = true;
+      fixture.detectChanges();
+
+      component.sort('defaultA');
+      expect(component.matSort.active).toBe('defaultA');
+      expect(component.matSort.direction).toBe('asc');
+      expect(container.getAttribute('tabindex')).toBeFalsy();
+
+      component.sort('defaultB');
+      expect(component.matSort.active).toBe('defaultA');
+      expect(component.matSort.direction).toBe('asc');
+      expect(container.getAttribute('tabindex')).toBeFalsy();
+    });
+
+    it('should reset sort direction when a different column is sorted', () => {
+      component.sort('defaultA');
+      expect(component.matSort.active).toBe('defaultA');
+      expect(component.matSort.direction).toBe('asc');
+
+      component.sort('defaultA');
+      expect(component.matSort.active).toBe('defaultA');
+      expect(component.matSort.direction).toBe('desc');
+
+      component.sort('defaultB');
+      expect(component.matSort.active).toBe('defaultB');
+      expect(component.matSort.direction).toBe('asc');
+    });
+
+    it('should throw an error if an MatSortable is not contained within an MatSort ' +
+        'directive', () => {
+      expect(() => TestBed.createComponent(MatSortHeaderMissingMatSortApp).detectChanges())
+      .toThrowError(wrappedErrorMessage(getSortHeaderNotContainedWithinSortError()));
+    });
+
+    it('should throw an error if two MatSortables have the same id', () => {
+      expect(() => TestBed.createComponent(MatSortDuplicateMatSortableIdsApp).detectChanges())
+      .toThrowError(wrappedErrorMessage(getSortDuplicateSortableIdError('duplicateId')));
+    });
+
+    it('should throw an error if an MatSortable is missing an id', () => {
+      expect(() => TestBed.createComponent(MatSortableMissingIdApp).detectChanges())
+      .toThrowError(wrappedErrorMessage(getSortHeaderMissingIdError()));
+    });
+
+    it('should throw an error if the provided direction is invalid', () => {
+      expect(() => TestBed.createComponent(MatSortableInvalidDirection).detectChanges())
+      .toThrowError(wrappedErrorMessage(getSortInvalidDirectionError('ascending')));
+    });
+
+    it('should allow let MatSortable override the default sort parameters', () => {
+      testSingleColumnSortDirectionSequence(
+          fixture, ['asc', 'desc', '']);
+
+      testSingleColumnSortDirectionSequence(
+          fixture, ['desc', 'asc', ''], 'overrideStart');
+
+      testSingleColumnSortDirectionSequence(
+          fixture, ['asc', 'desc'], 'overrideDisableClear');
+    });
+
+    it('should toggle indicator hint on button focus/blur and hide on click', () => {
+      const header = fixture.componentInstance.defaultA;
+      const container = fixture.nativeElement.querySelector('#defaultA .mat-sort-header-container');
+      const focusEvent = createFakeEvent('focus');
+      const blurEvent = createFakeEvent('blur');
+
+      // Should start without a displayed hint
+      expect(header._showIndicatorHint).toBeFalsy();
+
+      // Focusing the button should show the hint, blurring should hide it
+      container.dispatchEvent(focusEvent);
+      expect(header._showIndicatorHint).toBeTruthy();
+
+      container.dispatchEvent(blurEvent);
+      expect(header._showIndicatorHint).toBeFalsy();
+
+      // Show the indicator hint. On click the hint should be hidden
+      container.dispatchEvent(focusEvent);
+      expect(header._showIndicatorHint).toBeTruthy();
+
+      header._handleClick();
+      expect(header._showIndicatorHint).toBeFalsy();
+    });
+
+    it('should toggle indicator hint on mouseenter/mouseleave and hide on click', () => {
+      const header = fixture.componentInstance.defaultA;
+      const headerElement = fixture.nativeElement.querySelector('#defaultA');
+      const mouseenterEvent = createMouseEvent('mouseenter');
+      const mouseleaveEvent = createMouseEvent('mouseleave');
+
+      // Should start without a displayed hint
+      expect(header._showIndicatorHint).toBeFalsy();
+
+      // Mouse enter should show the hint, blurring should hide it
+      headerElement.dispatchEvent(mouseenterEvent);
+      expect(header._showIndicatorHint).toBeTruthy();
+
+      headerElement.dispatchEvent(mouseleaveEvent);
+      expect(header._showIndicatorHint).toBeFalsy();
+
+      // Show the indicator hint. On click the hint should be hidden
+      headerElement.dispatchEvent(mouseenterEvent);
+      expect(header._showIndicatorHint).toBeTruthy();
+
+      header._handleClick();
+      expect(header._showIndicatorHint).toBeFalsy();
+    });
+
+    it('should apply the aria-sort label to the header when sorted', () => {
+      const sortHeaderElement = fixture.nativeElement.querySelector('#defaultA');
+      expect(sortHeaderElement.getAttribute('aria-sort')).toBe('none');
+
+      component.sort('defaultA');
+      fixture.detectChanges();
+      expect(sortHeaderElement.getAttribute('aria-sort')).toBe('ascending');
+
+      component.sort('defaultA');
+      fixture.detectChanges();
+      expect(sortHeaderElement.getAttribute('aria-sort')).toBe('descending');
+
+      component.sort('defaultA');
+      fixture.detectChanges();
+      expect(sortHeaderElement.getAttribute('aria-sort')).toBe('none');
+    });
+
+    it('should not render the arrow if sorting is disabled for that column', fakeAsync(() => {
+      const sortHeaderElement = fixture.nativeElement.querySelector('#defaultA');
+
+      // Switch sorting to a different column before asserting.
+      component.sort('defaultB');
+      fixture.componentInstance.disabledColumnSort = true;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(sortHeaderElement.querySelector('.mat-sort-header-arrow')).toBeFalsy();
+    }));
+
+    it('should render the arrow if a disabled column is being sorted by', fakeAsync(() => {
+      const sortHeaderElement = fixture.nativeElement.querySelector('#defaultA');
+
+      component.sort('defaultA');
+      fixture.componentInstance.disabledColumnSort = true;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(sortHeaderElement.querySelector('.mat-sort-header-arrow')).toBeTruthy();
+    }));
+
+    it('should have a focus indicator', () => {
+      const headerNativeElement =
+          fixture.debugElement.query(By.directive(MatSortHeader))!.nativeElement;
+      const container = headerNativeElement.querySelector('.mat-sort-header-container');
+
+      expect(container.classList.contains('mat-focus-indicator')).toBe(true);
     });
   });
 
-  it('should be able to cycle from asc -> desc from either start point', () => {
-    component.disableClear = true;
+  describe('with default options', () => {
+    let fixture: ComponentFixture<MatSortWithoutExplicitInputs>;
+    let component: MatSortWithoutExplicitInputs;
 
-    component.start = 'asc';
-    testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc']);
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [MatSortModule, MatTableModule, CdkTableModule, NoopAnimationsModule],
+        declarations: [
+          MatSortWithoutExplicitInputs
+        ],
+        providers: [
+          {
+            provide: MAT_SORT_DEFAULT_OPTIONS,
+            useValue: {
+              disableClear: true,
+            },
+          }
+        ],
+      }).compileComponents();
+    }));
 
-    // Reverse directions
-    component.start = 'desc';
-    testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc']);
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MatSortWithoutExplicitInputs);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should be able to cycle from asc -> desc from either start point', () => {
+      component.start = 'asc';
+      testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc']);
+
+      // Reverse directions
+      component.start = 'desc';
+      testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc']);
+    });
   });
-
-  it('should be able to cycle asc -> desc -> [none]', () => {
-    component.start = 'asc';
-    testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc', '']);
-  });
-
-  it('should be able to cycle desc -> asc -> [none]', () => {
-    component.start = 'desc';
-    testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc', '']);
-  });
-
-  it('should allow for the cycling the sort direction to be disabled per column', () => {
-    const container = fixture.nativeElement.querySelector('#defaultA .mat-sort-header-container');
-
-    component.sort('defaultA');
-    expect(component.matSort.direction).toBe('asc');
-    expect(container.getAttribute('tabindex')).toBe('0');
-
-    component.disabledColumnSort = true;
-    fixture.detectChanges();
-
-    component.sort('defaultA');
-    expect(component.matSort.direction).toBe('asc');
-    expect(container.getAttribute('tabindex')).toBeFalsy();
-  });
-
-  it('should allow for the cycling the sort direction to be disabled for all columns', () => {
-    const container = fixture.nativeElement.querySelector('#defaultA .mat-sort-header-container');
-
-    component.sort('defaultA');
-    expect(component.matSort.active).toBe('defaultA');
-    expect(component.matSort.direction).toBe('asc');
-    expect(container.getAttribute('tabindex')).toBe('0');
-
-    component.disableAllSort = true;
-    fixture.detectChanges();
-
-    component.sort('defaultA');
-    expect(component.matSort.active).toBe('defaultA');
-    expect(component.matSort.direction).toBe('asc');
-    expect(container.getAttribute('tabindex')).toBeFalsy();
-
-    component.sort('defaultB');
-    expect(component.matSort.active).toBe('defaultA');
-    expect(component.matSort.direction).toBe('asc');
-    expect(container.getAttribute('tabindex')).toBeFalsy();
-  });
-
-  it('should reset sort direction when a different column is sorted', () => {
-    component.sort('defaultA');
-    expect(component.matSort.active).toBe('defaultA');
-    expect(component.matSort.direction).toBe('asc');
-
-    component.sort('defaultA');
-    expect(component.matSort.active).toBe('defaultA');
-    expect(component.matSort.direction).toBe('desc');
-
-    component.sort('defaultB');
-    expect(component.matSort.active).toBe('defaultB');
-    expect(component.matSort.direction).toBe('asc');
-  });
-
-  it('should throw an error if an MatSortable is not contained within an MatSort directive', () => {
-    expect(() => TestBed.createComponent(MatSortHeaderMissingMatSortApp).detectChanges())
-        .toThrowError(wrappedErrorMessage(getSortHeaderNotContainedWithinSortError()));
-  });
-
-  it('should throw an error if two MatSortables have the same id', () => {
-    expect(() => TestBed.createComponent(MatSortDuplicateMatSortableIdsApp).detectChanges())
-        .toThrowError(wrappedErrorMessage(getSortDuplicateSortableIdError('duplicateId')));
-  });
-
-  it('should throw an error if an MatSortable is missing an id', () => {
-    expect(() => TestBed.createComponent(MatSortableMissingIdApp).detectChanges())
-        .toThrowError(wrappedErrorMessage(getSortHeaderMissingIdError()));
-  });
-
-  it('should throw an error if the provided direction is invalid', () => {
-    expect(() => TestBed.createComponent(MatSortableInvalidDirection).detectChanges())
-        .toThrowError(wrappedErrorMessage(getSortInvalidDirectionError('ascending')));
-  });
-
-  it('should allow let MatSortable override the default sort parameters', () => {
-    testSingleColumnSortDirectionSequence(
-        fixture, ['asc', 'desc', '']);
-
-    testSingleColumnSortDirectionSequence(
-        fixture, ['desc', 'asc', ''], 'overrideStart');
-
-    testSingleColumnSortDirectionSequence(
-        fixture, ['asc', 'desc'], 'overrideDisableClear');
-  });
-
-  it('should toggle indicator hint on button focus/blur and hide on click', () => {
-    const header = fixture.componentInstance.defaultA;
-    const container = fixture.nativeElement.querySelector('#defaultA .mat-sort-header-container');
-    const focusEvent = createFakeEvent('focus');
-    const blurEvent = createFakeEvent('blur');
-
-    // Should start without a displayed hint
-    expect(header._showIndicatorHint).toBeFalsy();
-
-    // Focusing the button should show the hint, blurring should hide it
-    container.dispatchEvent(focusEvent);
-    expect(header._showIndicatorHint).toBeTruthy();
-
-    container.dispatchEvent(blurEvent);
-    expect(header._showIndicatorHint).toBeFalsy();
-
-    // Show the indicator hint. On click the hint should be hidden
-    container.dispatchEvent(focusEvent);
-    expect(header._showIndicatorHint).toBeTruthy();
-
-    header._handleClick();
-    expect(header._showIndicatorHint).toBeFalsy();
-  });
-
-  it('should toggle indicator hint on mouseenter/mouseleave and hide on click', () => {
-    const header = fixture.componentInstance.defaultA;
-    const headerElement = fixture.nativeElement.querySelector('#defaultA');
-    const mouseenterEvent = createMouseEvent('mouseenter');
-    const mouseleaveEvent = createMouseEvent('mouseleave');
-
-    // Should start without a displayed hint
-    expect(header._showIndicatorHint).toBeFalsy();
-
-    // Mouse enter should show the hint, blurring should hide it
-    headerElement.dispatchEvent(mouseenterEvent);
-    expect(header._showIndicatorHint).toBeTruthy();
-
-    headerElement.dispatchEvent(mouseleaveEvent);
-    expect(header._showIndicatorHint).toBeFalsy();
-
-    // Show the indicator hint. On click the hint should be hidden
-    headerElement.dispatchEvent(mouseenterEvent);
-    expect(header._showIndicatorHint).toBeTruthy();
-
-    header._handleClick();
-    expect(header._showIndicatorHint).toBeFalsy();
-  });
-
-  it('should apply the aria-sort label to the header when sorted', () => {
-    const sortHeaderElement = fixture.nativeElement.querySelector('#defaultA');
-    expect(sortHeaderElement.getAttribute('aria-sort')).toBe('none');
-
-    component.sort('defaultA');
-    fixture.detectChanges();
-    expect(sortHeaderElement.getAttribute('aria-sort')).toBe('ascending');
-
-    component.sort('defaultA');
-    fixture.detectChanges();
-    expect(sortHeaderElement.getAttribute('aria-sort')).toBe('descending');
-
-    component.sort('defaultA');
-    fixture.detectChanges();
-    expect(sortHeaderElement.getAttribute('aria-sort')).toBe('none');
-  });
-
-  it('should not render the arrow if sorting is disabled for that column', fakeAsync(() => {
-    const sortHeaderElement = fixture.nativeElement.querySelector('#defaultA');
-
-    // Switch sorting to a different column before asserting.
-    component.sort('defaultB');
-    fixture.componentInstance.disabledColumnSort = true;
-    fixture.detectChanges();
-    tick();
-    fixture.detectChanges();
-
-    expect(sortHeaderElement.querySelector('.mat-sort-header-arrow')).toBeFalsy();
-  }));
-
-  it('should render the arrow if a disabled column is being sorted by', fakeAsync(() => {
-    const sortHeaderElement = fixture.nativeElement.querySelector('#defaultA');
-
-    component.sort('defaultA');
-    fixture.componentInstance.disabledColumnSort = true;
-    fixture.detectChanges();
-    tick();
-    fixture.detectChanges();
-
-    expect(sortHeaderElement.querySelector('.mat-sort-header-arrow')).toBeTruthy();
-  }));
-
-  it('should have a focus indicator', () => {
-    const headerNativeElement =
-        fixture.debugElement.query(By.directive(MatSortHeader))!.nativeElement;
-    const container = headerNativeElement.querySelector('.mat-sort-header-container');
-
-    expect(container.classList.contains('mat-focus-indicator')).toBe(true);
-  });
-
 });
 
 /**
@@ -405,9 +446,10 @@ describe('MatSort', () => {
  * consistent with expectations. Detects any changes in the fixture to reflect any changes in
  * the inputs and resets the MatSort to remove any side effects from previous tests.
  */
-function testSingleColumnSortDirectionSequence(fixture: ComponentFixture<SimpleMatSortApp>,
-                                               expectedSequence: SortDirection[],
-                                               id: SimpleMatSortAppColumnIds = 'defaultA') {
+function testSingleColumnSortDirectionSequence(
+    fixture: ComponentFixture<SimpleMatSortApp|MatSortWithoutExplicitInputs>,
+    expectedSequence: SortDirection[],
+    id: SimpleMatSortAppColumnIds = 'defaultA') {
   // Detect any changes that were made in preparation for this sort sequence
   fixture.detectChanges();
 
@@ -624,3 +666,36 @@ class MatSortableMissingIdApp { }
   `
 })
 class MatSortableInvalidDirection { }
+
+@Component({
+  template: `
+    <div matSort
+         [matSortActive]="active"
+         [matSortStart]="start"
+         (matSortChange)="latestSortEvent = $event">
+      <div id="defaultA" #defaultA mat-sort-header="defaultA">
+        A
+      </div>
+    </div>
+  `
+})
+class MatSortWithoutExplicitInputs {
+  latestSortEvent: Sort;
+
+  active: string;
+  start: SortDirection = 'asc';
+
+  @ViewChild(MatSort) matSort: MatSort;
+  @ViewChild('defaultA') defaultA: MatSortHeader;
+
+  constructor (public elementRef: ElementRef<HTMLElement>) { }
+
+  sort(id: SimpleMatSortAppColumnIds) {
+    this.dispatchMouseEvent(id, 'click');
+  }
+
+  dispatchMouseEvent(id: SimpleMatSortAppColumnIds, event: string) {
+    const sortElement = this.elementRef.nativeElement.querySelector(`#${id}`)!;
+    dispatchMouseEvent(sortElement, event);
+  }
+}

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -10,10 +10,13 @@ import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   Directive,
   EventEmitter,
+  Inject,
+  InjectionToken,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
+  Optional,
   Output,
 } from '@angular/core';
 import {
@@ -52,6 +55,17 @@ export interface Sort {
   /** The sort direction. */
   direction: SortDirection;
 }
+
+/** Default options for `mat-sort`.  */
+export interface MatSortDefaultOptions {
+  /** Whether to disable clearing the sorting state. */
+  disableClear?: boolean;
+}
+
+/** Injection token to be used to override the default options for `mat-sort`. */
+export const MAT_SORT_DEFAULT_OPTIONS =
+    new InjectionToken<MatSortDefaultOptions>('MAT_SORT_DEFAULT_OPTIONS');
+
 
 // Boilerplate for applying mixins to MatSort.
 /** @docs-private */
@@ -107,6 +121,11 @@ export class MatSort extends _MatSortMixinBase
   /** Event emitted when the user changes either the active sort or sort direction. */
   @Output('matSortChange') readonly sortChange: EventEmitter<Sort> = new EventEmitter<Sort>();
 
+  constructor(@Optional() @Inject(MAT_SORT_DEFAULT_OPTIONS)
+              private _defaultOptions?: MatSortDefaultOptions) {
+    super();
+  }
+
   /**
    * Register function to be used by the contained MatSortables. Adds the MatSortable to the
    * collection of MatSortables.
@@ -150,7 +169,8 @@ export class MatSort extends _MatSortMixinBase
     if (!sortable) { return ''; }
 
     // Get the sort direction cycle with the potential sortable overrides.
-    const disableClear = sortable.disableClear != null ? sortable.disableClear : this.disableClear;
+    const disableClear = sortable?.disableClear ??
+        this.disableClear ?? !!this._defaultOptions?.disableClear;
     let sortDirectionCycle = getSortDirectionCycle(sortable.start || this.start, disableClear);
 
     // Get and return the next direction in the cycle

--- a/tools/public_api_guard/material/sort.d.ts
+++ b/tools/public_api_guard/material/sort.d.ts
@@ -5,6 +5,8 @@ export interface ArrowViewStateTransition {
     toState: ArrowViewState;
 }
 
+export declare const MAT_SORT_DEFAULT_OPTIONS: InjectionToken<MatSortDefaultOptions>;
+
 export declare const MAT_SORT_HEADER_INTL_PROVIDER: {
     provide: typeof MatSortHeaderIntl;
     deps: Optional[][];
@@ -23,6 +25,7 @@ export declare class MatSort extends _MatSortMixinBase implements CanDisable, Ha
     readonly sortChange: EventEmitter<Sort>;
     sortables: Map<string, MatSortable>;
     start: 'asc' | 'desc';
+    constructor(_defaultOptions?: MatSortDefaultOptions | undefined);
     deregister(sortable: MatSortable): void;
     getNextSortDirection(sortable: MatSortable): SortDirection;
     ngOnChanges(): void;
@@ -33,7 +36,7 @@ export declare class MatSort extends _MatSortMixinBase implements CanDisable, Ha
     static ngAcceptInputType_disableClear: BooleanInput;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatSort, "[matSort]", ["matSort"], { "disabled": "matSortDisabled"; "active": "matSortActive"; "start": "matSortStart"; "direction": "matSortDirection"; "disableClear": "matSortDisableClear"; }, { "sortChange": "matSortChange"; }, never>;
-    static ɵfac: i0.ɵɵFactoryDef<MatSort, never>;
+    static ɵfac: i0.ɵɵFactoryDef<MatSort, [{ optional: true; }]>;
 }
 
 export interface MatSortable {
@@ -50,6 +53,10 @@ export declare const matSortAnimations: {
     readonly arrowPosition: AnimationTriggerMetadata;
     readonly allowChildren: AnimationTriggerMetadata;
 };
+
+export interface MatSortDefaultOptions {
+    disableClear?: boolean;
+}
 
 export declare class MatSortHeader extends _MatSortHeaderMixinBase implements CanDisable, MatSortable, OnDestroy, OnInit, AfterViewInit {
     _arrowDirection: SortDirection;


### PR DESCRIPTION
- Adds `MAT_SORT_DEFAULT_OPTIONS` injection token so apps can configure default behavior of `mat-sort` for the entire app.
- Adds tests to verify default options. Existing tests were grouped into a separate `describe()` block. This messed with github's diff view, but existing tests were not changed.