### PR TITLE
fix(material/autocomplete): prevent inert host node from affecting surrounding layout

### DIFF
--- a/src/material-experimental/mdc-autocomplete/autocomplete.scss
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.scss
@@ -47,3 +47,7 @@
   }
 }
 
+// Prevent the overlay host node from affecting its surrounding layout.
+mat-autocomplete {
+  display: none;
+}

--- a/src/material/autocomplete/autocomplete.scss
+++ b/src/material/autocomplete/autocomplete.scss
@@ -43,3 +43,7 @@ $mat-autocomplete-panel-border-radius: 4px !default;
   }
 }
 
+// Prevent the overlay host node from affecting its surrounding layout.
+mat-autocomplete {
+  display: none;
+}


### PR DESCRIPTION
Similar to #21246. Prevents the inert host node for `mat-autocomplete` from affecting the layout around it.