### PR TITLE
fix(cdk/overlay): overriding pointer-events style

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -368,7 +368,7 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
 
   /** Toggles the pointer events for the overlay pane element. */
   private _togglePointerEvents(enablePointer: boolean) {
-    this._pane.style.pointerEvents = enablePointer ? 'auto' : 'none';
+    this._pane.style.pointerEvents = enablePointer ? '' : 'none';
   }
 
   /** Attaches a backdrop for this overlay. */

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -123,7 +123,7 @@ describe('Overlay', () => {
 
     expect(paneElement.childNodes.length).not.toBe(0);
     expect(paneElement.style.pointerEvents)
-      .toBe('auto', 'Expected the overlay pane to enable pointerEvents when attached.');
+      .toBe('', 'Expected the overlay pane to enable pointerEvents when attached.');
 
     overlayRef.detach();
 


### PR DESCRIPTION
We set `pointer-events: auto` on the overlay when it is attached and then `none` while it's detaching which ends up overriding any other styles the user might have. These changes reset to `''` instead.

Fixes #21656.