### PR TITLE
fix(material-experimental/mdc-typography): fix always using mat-level

### DIFF
--- a/src/material-experimental/mdc-helpers/_mdc-helpers.scss
+++ b/src/material-experimental/mdc-helpers/_mdc-helpers.scss
@@ -53,7 +53,7 @@ $mat-typography-level-mappings: (
 
 // Converts an Angular Material typography level config to an MDC one.
 @function mat-typography-level-config-to-mdc($mat-config, $mat-level) {
-  $mdc-level: map-get($mat-typography-level-mappings, $mat-level);
+  $mdc-level: map-get(map-get($mat-typography-level-mappings, mat-to-mdc), $mat-level);
 
   @return map-merge(
       if($mdc-level,


### PR DESCRIPTION
It looks like there was a bug in the logic that converts mat- configs to mdc- configs. It caused the mdc-level to always be null. This fixes it, though we'll have to see what the visual effects will be