### PR TITLE
build: update to the latest version of @angular/dev-infra-private

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@angular/bazel": "^11.1.0",
     "@angular/benchpress": "^0.2.1",
     "@angular/compiler-cli": "^11.1.0",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#62d6227d822b26b60919950dbbbd399f287956e5",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#71d57c29a10c03d07f889581608e3a2315a1dc7e",
     "@angular/platform-browser-dynamic": "^11.1.0",
     "@angular/platform-server": "^11.1.0",
     "@angular/router": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,9 +116,9 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#62d6227d822b26b60919950dbbbd399f287956e5":
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#71d57c29a10c03d07f889581608e3a2315a1dc7e":
   version "0.0.0"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#62d6227d822b26b60919950dbbbd399f287956e5"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#71d57c29a10c03d07f889581608e3a2315a1dc7e"
   dependencies:
     "@angular/benchpress" "0.2.1"
     "@bazel/buildifier" "^0.29.0"


### PR DESCRIPTION
Update to the latest version of the ng-dev toolset, bringing in support for the
`--[no-]branch-prompt` flag.