### PR TITLE
feat(cdk/table): virtual scroll directive for tables

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,6 +135,7 @@
 /src/cdk-experimental/combobox/**                  @jelbourn
 /src/cdk-experimental/popover-edit/**              @andrewseguin
 /src/cdk-experimental/scrolling/**                 @mmalerba
+/src/cdk-experimental/table/**                     @michaeljamesparsons @andrewseguin
 /src/cdk-experimental/table-scroll-container/**    @andrewseguin
 /src/cdk-experimental/listbox/**                   @jelbourn
 /src/cdk-experimental/selection/**                 @andrewseguin

--- a/src/cdk-experimental/config.bzl
+++ b/src/cdk-experimental/config.bzl
@@ -6,6 +6,7 @@ CDK_EXPERIMENTAL_ENTRYPOINTS = [
     "popover-edit",
     "scrolling",
     "selection",
+    "table",
     "table-scroll-container",
 ]
 

--- a/src/cdk-experimental/table/BUILD.bazel
+++ b/src/cdk-experimental/table/BUILD.bazel
@@ -1,0 +1,22 @@
+load(
+    "//tools:defaults.bzl",
+    "ng_module",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "table",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    deps = [
+        "//src/cdk/bidi",
+        "//src/cdk/platform",
+        "//src/cdk/table",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//rxjs",
+    ],
+)

--- a/src/cdk-experimental/table/index.ts
+++ b/src/cdk-experimental/table/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/cdk-experimental/table/public-api.ts
+++ b/src/cdk-experimental/table/public-api.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './table-virtual-scroll';
+export * from './table-module';

--- a/src/cdk-experimental/table/table-module.ts
+++ b/src/cdk-experimental/table/table-module.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+import {CdkTableModule as TableModule} from '@angular/cdk/table';
+
+import {CdkTableVirtualScroll} from './table-virtual-scroll';
+
+
+
+@NgModule({
+  declarations: [CdkTableVirtualScroll],
+  exports: [CdkTableVirtualScroll],
+  imports: [
+    TableModule,
+  ],
+})
+export class CdkTableModule {}

--- a/src/cdk-experimental/table/table-virtual-scroll.ts
+++ b/src/cdk-experimental/table/table-virtual-scroll.ts
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {
+  Directive,
+  Inject,
+  Input,
+  OnDestroy,
+  SkipSelf,
+} from '@angular/core';
+import {
+  _RecycleViewRepeaterStrategy,
+  _VIEW_REPEATER_STRATEGY,
+  ListRange
+} from '@angular/cdk/collections';
+import {
+  _TABLE_VIEW_CHANGE_STRATEGY,
+  CdkTable,
+  RenderRow,
+  RowContext,
+  STICKY_POSITIONING_LISTENER,
+  StickyPositioningListener,
+  StickyUpdate
+} from '@angular/cdk/table';
+import {
+  BehaviorSubject,
+  combineLatest,
+  Observable,
+  ReplaySubject,
+  Subject,
+} from 'rxjs';
+import {
+  shareReplay,
+  takeUntil
+} from 'rxjs/operators';
+import {
+  CdkVirtualScrollRepeater,
+  CdkVirtualScrollViewport,
+} from '@angular/cdk/scrolling';
+
+/**
+ * An implementation of {@link StickyPositioningListener} that forwards sticky updates to another
+ * listener.
+ *
+ * The {@link CdkTableVirtualScroll} directive cannot provide itself as a
+ * {@link StickyPositioningListener} because the providers for both entities would point to the same
+ * instance. The {@link CdkTable} depends on the sticky positioning listener and the table virtual
+ * scroll depends on the table. Since the sticky positioning listener and table virtual scroll would
+ * be the same instance, this would create a circular dependency.
+ *
+ * The {@link CdkTableVirtualScroll} instead provides this class and attaches itself as the
+ * receiving listener so {@link StickyPositioningListener} and {@link CdkTableVirtualScroll} are
+ * provided as separate instances.
+ *
+ * @docs-private
+ */
+export class _PositioningListenerProxy implements StickyPositioningListener {
+  private _listener?: StickyPositioningListener;
+
+  setListener(listener: StickyPositioningListener) {
+    this._listener = listener;
+  }
+
+  stickyColumnsUpdated(update: StickyUpdate): void {
+    this._listener?.stickyColumnsUpdated(update);
+  }
+
+  stickyEndColumnsUpdated(update: StickyUpdate): void {
+    this._listener?.stickyEndColumnsUpdated(update);
+  }
+
+  stickyFooterRowsUpdated(update: StickyUpdate): void {
+    this._listener?.stickyFooterRowsUpdated(update);
+  }
+
+  stickyHeaderRowsUpdated(update: StickyUpdate): void {
+    this._listener?.stickyHeaderRowsUpdated(update);
+  }
+}
+
+/** @docs-private */
+export const _TABLE_VIRTUAL_SCROLL_COLLECTION_VIEWER_FACTORY =
+    () => new BehaviorSubject<ListRange>({start: 0, end: 0});
+
+
+/**
+ * A directive that enables virtual scroll for a {@link CdkTable}.
+ */
+@Directive({
+  selector: 'cdk-table[virtualScroll], table[cdk-table][virtualScroll]',
+  exportAs: 'cdkVirtualScroll',
+  providers: [
+    {provide: _VIEW_REPEATER_STRATEGY, useClass: _RecycleViewRepeaterStrategy},
+    // The directive cannot provide itself as the sticky positions listener because it introduces
+    // a circular dependency. Use an intermediate listener as a proxy.
+    {provide: STICKY_POSITIONING_LISTENER, useClass: _PositioningListenerProxy},
+    // Initially emit an empty range. The virtual scroll viewport will update the range after it is
+    // initialized.
+    {
+      provide: _TABLE_VIEW_CHANGE_STRATEGY,
+      useFactory: _TABLE_VIRTUAL_SCROLL_COLLECTION_VIEWER_FACTORY,
+    },
+  ],
+  host: {
+    'class': 'cdk-table-virtual-scroll',
+  },
+})
+export class CdkTableVirtualScroll<T>
+    implements CdkVirtualScrollRepeater<T>, OnDestroy, StickyPositioningListener {
+  /** Emits when the component is destroyed. */
+  private _destroyed = new ReplaySubject<void>(1);
+
+  /** Emits when the header rows sticky state changes. */
+  private readonly _headerRowStickyUpdates = new Subject<StickyUpdate>();
+
+  /** Emits when the footer rows sticky state changes. */
+  private readonly _footerRowStickyUpdates = new Subject<StickyUpdate>();
+
+  /**
+   * Observable that emits the data source's complete data set. This exists to implement
+   * {@link CdkVirtualScrollRepeater}.
+   */
+  get dataStream(): Observable<readonly T[]> {
+    return this._dataStream;
+  }
+  private _dataStream = this._table._dataStream.pipe(shareReplay(1));
+
+  /**
+   * The size of the cache used to store unused views. Setting the cache size to `0` will disable
+   * caching.
+   */
+  @Input()
+  get viewCacheSize(): number {
+    return this._viewRepeater.viewCacheSize;
+  }
+  set viewCacheSize(size: number) {
+    this._viewRepeater.viewCacheSize = size;
+  }
+
+  constructor(
+      private readonly _table: CdkTable<T>,
+      @Inject(_TABLE_VIEW_CHANGE_STRATEGY) private readonly _viewChange: BehaviorSubject<ListRange>,
+      @Inject(STICKY_POSITIONING_LISTENER) positioningListener: _PositioningListenerProxy,
+      @Inject(_VIEW_REPEATER_STRATEGY)
+      private readonly _viewRepeater: _RecycleViewRepeaterStrategy<T, RenderRow<T>, RowContext<T>>,
+      @SkipSelf() private readonly _viewport: CdkVirtualScrollViewport) {
+    positioningListener.setListener(this);
+
+    // Force the table to enable `fixedLayout` to prevent column widths from changing as the user
+    // scrolls. This also enables caching in the table's sticky styler which reduces calls to
+    // expensive DOM APIs, such as `getBoundingClientRect()`, and improves overall performance.
+    if (!this._table.fixedLayout && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+      throw Error('[virtualScroll] requires input `fixedLayout` to be set on the table.');
+    }
+
+    // Update sticky styles for header rows when either the render range or sticky state change.
+    combineLatest([this._viewport._renderedContentOffsetRendered, this._headerRowStickyUpdates])
+      .pipe(takeUntil(this._destroyed))
+      .subscribe(([offset, update]) => {
+        this._stickHeaderRows(offset, update);
+      });
+
+    // Update sticky styles for footer rows when either the render range or sticky state change.
+    combineLatest([this._viewport._renderedContentOffsetRendered, this._footerRowStickyUpdates])
+      .pipe(takeUntil(this._destroyed))
+      .subscribe(([offset, update]) => {
+        this._stickFooterRows(offset, update);
+      });
+
+    // Forward the rendered range computed by the virtual scroll viewport to the table.
+    this._viewport.renderedRangeStream.pipe(takeUntil(this._destroyed)).subscribe(this._viewChange);
+    this._viewport.attach(this);
+  }
+
+  ngOnDestroy() {
+    this._destroyed.next();
+    this._destroyed.complete();
+  }
+
+  /**
+   * Measures the combined size (width for horizontal orientation, height for vertical) of all items
+   * in the specified range.
+   */
+  measureRangeSize(range: ListRange, orientation: 'horizontal' | 'vertical'): number {
+    // TODO(michaeljamesparsons) Implement method so virtual tables can use the `autosize` virtual
+    //  scroll strategy.
+    if ((typeof ngDevMode === 'undefined' || ngDevMode)) {
+      throw new Error('autoSize is not supported for tables with virtual scroll enabled.');
+    }
+    return 0;
+  }
+
+  stickyColumnsUpdated(update: StickyUpdate): void {
+    // no-op
+  }
+
+  stickyEndColumnsUpdated(update: StickyUpdate): void {
+    // no-op
+  }
+
+  stickyHeaderRowsUpdated(update: StickyUpdate): void {
+    this._headerRowStickyUpdates.next(update);
+  }
+
+  stickyFooterRowsUpdated(update: StickyUpdate): void {
+    this._footerRowStickyUpdates.next(update);
+  }
+
+  /**
+   * The {@link StickyStyler} sticks elements by applying a `top` position offset to them. However,
+   * the virtual scroll viewport applies a `translateY` offset to a container div that
+   * encapsulates the table. The translation causes the header rows to also be offset by the
+   * distance from the top of the scroll viewport in addition to their `top` offset. This method
+   * negates the translation to move the header rows to their correct positions.
+   *
+   * @param offsetFromTop The distance scrolled from the top of the container.
+   * @param update Metadata about the sticky headers that changed in the last sticky update.
+   * @private
+   */
+  private _stickHeaderRows(offsetFromTop: number, update: StickyUpdate) {
+    if (!update.sizes || !update.offsets || !update.elements) {
+      return;
+    }
+
+    for (let i = 0; i < update.elements.length; i++) {
+      if (!update.elements[i]) {
+        continue;
+      }
+      let offset = offsetFromTop !== 0
+          ? Math.max(offsetFromTop - update.offsets[i]!, update.offsets[i]!)
+          : -update.offsets[i]!;
+
+      this._stickCells(update.elements[i]!, 'top', -offset);
+    }
+  }
+
+  /**
+   * The {@link StickyStyler} sticks elements by applying a `bottom` position offset to them.
+   * However, the virtual scroll viewport applies a `translateY` offset to a container div that
+   * encapsulates the table. The translation causes the footer rows to also be offset by the
+   * distance from the top of the scroll viewport in addition to their `bottom` offset. This method
+   * negates the translation to move the footer rows to their correct positions.
+   *
+   * @param offsetFromTop The distance scrolled from the top of the container.
+   * @param update Metadata about the sticky footers that changed in the last sticky update.
+   * @private
+   */
+  private _stickFooterRows(offsetFromTop: number, update: StickyUpdate) {
+    if (!update.sizes || !update.offsets || !update.elements) {
+      return;
+    }
+
+    for (let i = 0; i < update.elements.length; i++) {
+      if (!update.elements[i]) {
+        continue;
+      }
+      this._stickCells(update.elements[i]!, 'bottom', offsetFromTop + update.offsets[i]!);
+    }
+  }
+
+  private _stickCells(cells: HTMLElement[], position: 'bottom'|'top', offset: number) {
+    for (const cell of cells) {
+      cell.style[position] = `${offset}px`;
+    }
+  }
+}

--- a/src/cdk/collections/recycle-view-repeater-strategy.ts
+++ b/src/cdk/collections/recycle-view-repeater-strategy.ts
@@ -37,8 +37,8 @@ export class _RecycleViewRepeaterStrategy<T, R, C extends _ViewRepeaterItemConte
   implements _ViewRepeater<T, R, C>
 {
   /**
-   * The size of the cache used to store unused views.
-   * Setting the cache size to `0` will disable caching. Defaults to 20 views.
+   * The size of the cache used to store unused views. Setting the cache size to `0` will disable
+   * caching. Defaults to 20 views.
    */
   viewCacheSize: number = 20;
 

--- a/src/cdk/table/table-module.ts
+++ b/src/cdk/table/table-module.ts
@@ -13,7 +13,7 @@ import {
   CdkTable,
   CdkRecycleRows,
   FooterRowOutlet,
-  NoDataRowOutlet,
+  NoDataRowOutlet
 } from './table';
 import {
   CdkCellOutlet,

--- a/src/components-examples/BUILD.bazel
+++ b/src/components-examples/BUILD.bazel
@@ -5,6 +5,72 @@ load(":config.bzl", "ALL_EXAMPLES")
 
 package(default_visibility = ["//visibility:public"])
 
+<<<<<<< a5fb8f85006eab1472a84771533327c90115aeb0
+=======
+ALL_EXAMPLES = [
+    # TODO(devversion): try to have for each entry-point a bazel package so that
+    # we can automate this using the "package.bzl" variables. Currently generated
+    # with "bazel query 'kind("ng_module", //src/components-examples/...:*)' --output="label"
+    "//src/components-examples/material/tree",
+    "//src/components-examples/material/tooltip",
+    "//src/components-examples/material/toolbar",
+    "//src/components-examples/material/tabs",
+    "//src/components-examples/material/table",
+    "//src/components-examples/material/stepper",
+    "//src/components-examples/material/sort",
+    "//src/components-examples/material/snack-bar",
+    "//src/components-examples/material/slider",
+    "//src/components-examples/material/slide-toggle",
+    "//src/components-examples/material/sidenav",
+    "//src/components-examples/material/select",
+    "//src/components-examples/material/radio",
+    "//src/components-examples/material/progress-spinner",
+    "//src/components-examples/material/progress-bar",
+    "//src/components-examples/material/paginator",
+    "//src/components-examples/material/menu",
+    "//src/components-examples/material/list",
+    "//src/components-examples/material/input",
+    "//src/components-examples/material/icon",
+    "//src/components-examples/material/grid-list",
+    "//src/components-examples/material/form-field",
+    "//src/components-examples/material/expansion",
+    "//src/components-examples/material/divider",
+    "//src/components-examples/material/dialog",
+    "//src/components-examples/material/datepicker",
+    "//src/components-examples/material/core",
+    "//src/components-examples/material/chips",
+    "//src/components-examples/material/checkbox",
+    "//src/components-examples/material/card",
+    "//src/components-examples/material/button-toggle",
+    "//src/components-examples/material/button",
+    "//src/components-examples/material/bottom-sheet",
+    "//src/components-examples/material/badge",
+    "//src/components-examples/material/autocomplete",
+    "//src/components-examples/material-experimental/column-resize",
+    "//src/components-examples/material-experimental/popover-edit",
+    "//src/components-examples/material-experimental/mdc-card",
+    "//src/components-examples/material-experimental/mdc-form-field",
+    "//src/components-examples/material-experimental/selection",
+    "//src/components-examples/cdk/tree",
+    "//src/components-examples/cdk/text-field",
+    "//src/components-examples/cdk/table",
+    "//src/components-examples/cdk/stepper",
+    "//src/components-examples/cdk/scrolling",
+    "//src/components-examples/cdk/portal",
+    "//src/components-examples/cdk/accordion",
+    "//src/components-examples/cdk/platform",
+    "//src/components-examples/cdk/drag-drop",
+    "//src/components-examples/cdk/clipboard",
+    "//src/components-examples/cdk/a11y",
+    "//src/components-examples/cdk/layout",
+    "//src/components-examples/cdk/overlay",
+    "//src/components-examples/cdk-experimental/menu",
+    "//src/components-examples/cdk-experimental/popover-edit",
+    "//src/components-examples/cdk-experimental/selection",
+    "//src/components-examples/cdk-experimental/table",
+]
+
+>>>>>>> feat(cdk/table): Virtual scroll directive for tables
 ng_module(
     name = "components-examples",
     srcs = glob(["*.ts"]) + [":example-module.ts"],

--- a/src/components-examples/cdk-experimental/table/BUILD.bazel
+++ b/src/components-examples/cdk-experimental/table/BUILD.bazel
@@ -1,0 +1,26 @@
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "table",
+    srcs = glob(["**/*.ts"]),
+    assets = glob([
+        "**/*.html",
+        "**/*.css",
+    ]),
+    deps = [
+        "//src/cdk-experimental/table",
+        "//src/cdk/scrolling",
+        "//src/cdk/table",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob([
+        "**/*.html",
+        "**/*.css",
+        "**/*.ts",
+    ]),
+)

--- a/src/components-examples/cdk-experimental/table/cdk-virtual-flex-table/cdk-virtual-flex-table-example.css
+++ b/src/components-examples/cdk-experimental/table/cdk-virtual-flex-table/cdk-virtual-flex-table-example.css
@@ -1,0 +1,40 @@
+.example-container {
+  height: 600px;
+  max-width: 1000px;
+  overflow: auto;
+}
+
+.example-virtual-table {
+  width: 1200px;
+}
+
+.example-virtual-table .cdk-header-cell,
+.example-virtual-table .cdk-footer-cell {
+  align-items: center;
+  background: #3f51b5;
+  color: white;
+  display: flex;
+  font-weight: bold;
+  justify-content: center;
+}
+
+.example-virtual-table .cdk-cell,
+.example-virtual-table .cdk-footer-cell,
+.example-virtual-table .cdk-header-cell {
+  height: 48px;
+}
+
+/**
+ * Add basic flex styling so that the cells evenly space themselves in the row.
+ */
+.example-virtual-table cdk-row,
+.example-virtual-table cdk-header-row,
+.example-virtual-table cdk-footer-row {
+  display: flex;
+}
+
+.example-virtual-table cdk-cell,
+.example-virtual-table cdk-header-cell,
+.example-virtual-table cdk-footer-cell {
+  flex: 1;
+}

--- a/src/components-examples/cdk-experimental/table/cdk-virtual-flex-table/cdk-virtual-flex-table-example.html
+++ b/src/components-examples/cdk-experimental/table/cdk-virtual-flex-table/cdk-virtual-flex-table-example.html
@@ -1,0 +1,37 @@
+<cdk-virtual-scroll-viewport class="example-container" [itemSize]="48" [maxBufferPx]="1200" [minBufferPx]="400">
+  <cdk-table class="example-virtual-table" fixedLayout virtualScroll [dataSource]="dataSource" [trackBy]="trackBy">
+    <!-- Position Column -->
+    <ng-container cdkColumnDef="position">
+      <cdk-header-cell *cdkHeaderCellDef> No. </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let element"> {{element.position}} </cdk-cell>
+      <cdk-footer-cell *cdkFooterCellDef> No. </cdk-footer-cell>
+    </ng-container>
+
+    <!-- Name Column -->
+    <ng-container cdkColumnDef="name">
+      <cdk-header-cell *cdkHeaderCellDef> Name </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let element"> {{element.name}} </cdk-cell>
+      <cdk-footer-cell *cdkFooterCellDef> Name </cdk-footer-cell>
+    </ng-container>
+
+    <!-- Weight Column -->
+    <ng-container cdkColumnDef="weight">
+      <cdk-header-cell *cdkHeaderCellDef> Weight </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let element"> {{element.weight}} </cdk-cell>
+      <cdk-footer-cell *cdkFooterCellDef> Weight </cdk-footer-cell>
+    </ng-container>
+
+    <!-- Symbol Column -->
+    <ng-container cdkColumnDef="symbol">
+      <cdk-header-cell *cdkHeaderCellDef> Symbol </cdk-header-cell>
+      <cdk-cell *cdkCellDef="let element"> {{element.symbol}} </cdk-cell>
+      <cdk-footer-cell *cdkFooterCellDef> Symbol </cdk-footer-cell>
+    </ng-container>
+
+    <cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true;"></cdk-header-row>
+    <cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true;"></cdk-header-row>
+    <cdk-row *cdkRowDef="let row; columns: displayedColumns;"></cdk-row>
+    <cdk-footer-row *cdkFooterRowDef="displayedColumns; sticky: true;"></cdk-footer-row>
+    <cdk-footer-row *cdkFooterRowDef="displayedColumns; sticky: true;"></cdk-footer-row>
+  </cdk-table>
+</cdk-virtual-scroll-viewport>

--- a/src/components-examples/cdk-experimental/table/cdk-virtual-flex-table/cdk-virtual-flex-table-example.ts
+++ b/src/components-examples/cdk-experimental/table/cdk-virtual-flex-table/cdk-virtual-flex-table-example.ts
@@ -1,0 +1,42 @@
+import {Component} from '@angular/core';
+
+export interface PeriodicElement {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: PeriodicElement[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+];
+
+const EXPANDED_ELEMENT_DATA: PeriodicElement[] = [];
+for (let x = 0; x < 100; x++) {
+  for (const entry of ELEMENT_DATA) {
+    EXPANDED_ELEMENT_DATA.push({...entry, position: entry.position + (10 * x)});
+  }
+}
+
+/**
+ * @title Example of a flex table with virtual scroll enabled.
+ */
+@Component({
+  selector: 'cdk-virtual-flex-table-example',
+  styleUrls: ['cdk-virtual-flex-table-example.css'],
+  templateUrl: 'cdk-virtual-flex-table-example.html',
+})
+export class CdkVirtualFlexTableExample {
+  displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
+  dataSource = EXPANDED_ELEMENT_DATA;
+  trackBy = (index: number, el: PeriodicElement) => el.position;
+}

--- a/src/components-examples/cdk-experimental/table/cdk-virtual-table/cdk-virtual-table-example.css
+++ b/src/components-examples/cdk-experimental/table/cdk-virtual-table/cdk-virtual-table-example.css
@@ -1,0 +1,30 @@
+.example-container {
+  height: 600px;
+  max-width: 1000px;
+  overflow: auto;
+}
+
+.example-virtual-table {
+  width: 1200px;
+}
+
+.example-virtual-table td,
+.example-virtual-table th {
+  height: 48px;
+  padding: 0;
+}
+
+.example-virtual-table th.cdk-header-cell,
+.example-virtual-table .cdk-footer-row th {
+  background: #3f51b5;
+  color: white;
+}
+
+.example-virtual-table th.mat-column-position,
+.example-virtual-table td.mat-column-position {
+  padding-left: 8px;
+}
+
+.example-virtual-table .cdk-cell.cdk-table-sticky {
+  background: #f0f0f0;
+}

--- a/src/components-examples/cdk-experimental/table/cdk-virtual-table/cdk-virtual-table-example.html
+++ b/src/components-examples/cdk-experimental/table/cdk-virtual-table/cdk-virtual-table-example.html
@@ -1,0 +1,37 @@
+<cdk-virtual-scroll-viewport class="example-container" [itemSize]="48" [maxBufferPx]="1200" [minBufferPx]="400">
+  <table class="example-virtual-table" cdk-table fixedLayout virtualScroll [dataSource]="dataSource" [trackBy]="trackBy">
+    <!-- Position Column -->
+    <ng-container cdkColumnDef="position">
+      <th cdk-header-cell *cdkHeaderCellDef> No. </th>
+      <td cdk-cell *cdkCellDef="let element"> {{element.position}} </td>
+      <th cdk-footer-cell *cdkFooterCellDef> No. </th>
+    </ng-container>
+
+    <!-- Name Column -->
+    <ng-container cdkColumnDef="name">
+      <th cdk-header-cell *cdkHeaderCellDef> Name </th>
+      <td cdk-cell *cdkCellDef="let element"> {{element.name}} </td>
+      <th cdk-footer-cell *cdkFooterCellDef> Name </th>
+    </ng-container>
+
+    <!-- Weight Column -->
+    <ng-container cdkColumnDef="weight">
+      <th cdk-header-cell *cdkHeaderCellDef> Weight </th>
+      <td cdk-cell *cdkCellDef="let element"> {{element.weight}} </td>
+      <th cdk-footer-cell *cdkFooterCellDef> Weight </th>
+    </ng-container>
+
+    <!-- Symbol Column -->
+    <ng-container cdkColumnDef="symbol">
+      <th cdk-header-cell *cdkHeaderCellDef> Symbol </th>
+      <td cdk-cell *cdkCellDef="let element"> {{element.symbol}} </td>
+      <th cdk-footer-cell *cdkFooterCellDef> Symbol </th>
+    </ng-container>
+
+    <tr cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true;"></tr>
+    <tr cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true;"></tr>
+    <tr cdk-row *cdkRowDef="let row; columns: displayedColumns;"></tr>
+    <tr cdk-footer-row *cdkFooterRowDef="displayedColumns; sticky: true;"></tr>
+    <tr cdk-footer-row *cdkFooterRowDef="displayedColumns; sticky: true;"></tr>
+  </table>
+</cdk-virtual-scroll-viewport>

--- a/src/components-examples/cdk-experimental/table/cdk-virtual-table/cdk-virtual-table-example.ts
+++ b/src/components-examples/cdk-experimental/table/cdk-virtual-table/cdk-virtual-table-example.ts
@@ -1,0 +1,43 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+export interface PeriodicElement {
+  name: string;
+  position: number;
+  weight: number;
+  symbol: string;
+}
+
+const ELEMENT_DATA: PeriodicElement[] = [
+  {position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H'},
+  {position: 2, name: 'Helium', weight: 4.0026, symbol: 'He'},
+  {position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li'},
+  {position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be'},
+  {position: 5, name: 'Boron', weight: 10.811, symbol: 'B'},
+  {position: 6, name: 'Carbon', weight: 12.0107, symbol: 'C'},
+  {position: 7, name: 'Nitrogen', weight: 14.0067, symbol: 'N'},
+  {position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O'},
+  {position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F'},
+  {position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne'},
+];
+
+const EXPANDED_ELEMENT_DATA: PeriodicElement[] = [];
+for (let x = 0; x < 100; x++) {
+  for (const entry of ELEMENT_DATA) {
+    EXPANDED_ELEMENT_DATA.push({...entry, position: entry.position + (10 * x)});
+  }
+}
+
+/**
+ * @title Example of a native table with virtual scroll enabled.
+ */
+@Component({
+  selector: 'cdk-virtual-table-example',
+  styleUrls: ['cdk-virtual-table-example.css'],
+  templateUrl: 'cdk-virtual-table-example.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CdkVirtualTableExample {
+  displayedColumns: string[] = ['position', 'name', 'weight', 'symbol'];
+  dataSource = EXPANDED_ELEMENT_DATA;
+  trackBy = (index: number, el: PeriodicElement) => el.position;
+}

--- a/src/components-examples/cdk-experimental/table/index.ts
+++ b/src/components-examples/cdk-experimental/table/index.ts
@@ -1,0 +1,28 @@
+import {NgModule} from '@angular/core';
+import {CdkTableModule} from '@angular/cdk/table';
+import {CdkTableModule as CdkExperimentalTableModule} from '@angular/cdk-experimental/table';
+import {ScrollingModule} from '@angular/cdk/scrolling';
+
+import {CdkVirtualTableExample} from './cdk-virtual-table/cdk-virtual-table-example';
+import {CdkVirtualFlexTableExample} from './cdk-virtual-flex-table/cdk-virtual-flex-table-example';
+
+export {
+  CdkVirtualTableExample,
+  CdkVirtualFlexTableExample,
+};
+
+const EXAMPLES = [
+  CdkVirtualTableExample,
+  CdkVirtualFlexTableExample,
+];
+
+@NgModule({
+  imports: [
+    CdkTableModule,
+    CdkExperimentalTableModule,
+    ScrollingModule,
+  ],
+  declarations: EXAMPLES,
+  exports: EXAMPLES,
+})
+export class CdkTableExamplesModule {}

--- a/src/dev-app/table/BUILD.bazel
+++ b/src/dev-app/table/BUILD.bazel
@@ -7,6 +7,7 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = ["table-demo.html"],
     deps = [
+        "//src/components-examples/cdk-experimental/table",
         "//src/components-examples/cdk/table",
         "//src/components-examples/material/table",
         "//src/dev-app/example",

--- a/src/dev-app/table/table-demo-module.ts
+++ b/src/dev-app/table/table-demo-module.ts
@@ -8,6 +8,9 @@
 
 import {NgModule} from '@angular/core';
 import {CdkTableExamplesModule} from '@angular/components-examples/cdk/table';
+import {
+  CdkTableExamplesModule as CdkExperimentalTableExamplesModule
+} from '@angular/components-examples/cdk-experimental/table';
 import {TableExamplesModule} from '@angular/components-examples/material/table';
 import {RouterModule} from '@angular/router';
 import {TableDemo} from './table-demo';
@@ -15,6 +18,7 @@ import {TableDemo} from './table-demo';
 @NgModule({
   imports: [
     CdkTableExamplesModule,
+    CdkExperimentalTableExamplesModule,
     TableExamplesModule,
     RouterModule.forChild([{path: '', component: TableDemo}]),
   ],

--- a/src/dev-app/table/table-demo.html
+++ b/src/dev-app/table/table-demo.html
@@ -78,3 +78,9 @@
 
 <h3>Table wrapped re-orderable columns</h3>
 <table-reorderable-example></table-reorderable-example>
+
+<h3>Cdk virtual table</h3>
+<cdk-virtual-table-example></cdk-virtual-table-example>
+
+<h3>Cdk virtual flex table</h3>
+<cdk-virtual-flex-table-example></cdk-virtual-flex-table-example>

--- a/src/material-experimental/mdc-table/table.ts
+++ b/src/material-experimental/mdc-table/table.ts
@@ -37,6 +37,7 @@ import {
 })
 export class MatRecycleRows {}
 
+
 @Component({
   selector: 'mat-table, table[mat-table]',
   exportAs: 'matTable',

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -168,6 +168,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     ngOnInit(): void;
     get orientation(): 'horizontal' | 'vertical';
     set orientation(orientation: 'horizontal' | 'vertical');
+    // (undocumented)
+    readonly _renderedContentOffsetRendered: Observable<number>;
     readonly renderedRangeStream: Observable<ListRange>;
     readonly scrolledIndexChange: Observable<number>;
     scrollToIndex(index: number, behavior?: ScrollBehavior): void;

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -20,6 +20,7 @@ import { InjectionToken } from '@angular/core';
 import { IterableChanges } from '@angular/core';
 import { IterableDiffer } from '@angular/core';
 import { IterableDiffers } from '@angular/core';
+import { ListRange } from '@angular/cdk/collections';
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
@@ -28,6 +29,7 @@ import { OnInit } from '@angular/core';
 import { Platform } from '@angular/cdk/platform';
 import { QueryList } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
+import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { TrackByFunction } from '@angular/core';
 import { ViewContainerRef } from '@angular/core';
@@ -288,9 +290,14 @@ export class CdkRowDef<T> extends BaseRowDef {
 
 // @public
 export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDestroy, OnInit {
+<<<<<<< fb4e395bb37b1a10f3fc8af49ae63200b0619c7f
     constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform, _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>, _coalescedStyleScheduler: _CoalescedStyleScheduler, _viewportRuler: ViewportRuler,
     _stickyPositioningListener: StickyPositioningListener,
     _ngZone?: NgZone | undefined);
+=======
+    constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform, _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>, _coalescedStyleScheduler: _CoalescedStyleScheduler,
+    _parentPositioningListener?: StickyPositioningListener | undefined, _viewportRuler?: ViewportRuler | undefined, _positioningListener?: StickyPositioningListener | undefined, viewChange?: BehaviorSubject<ListRange>);
+>>>>>>> feat(cdk/table): Virtual scroll directive for tables
     addColumnDef(columnDef: CdkColumnDef): void;
     addFooterRowDef(footerRowDef: CdkFooterRowDef): void;
     addHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
@@ -307,6 +314,8 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     protected _data: readonly T[];
     get dataSource(): CdkTableDataSourceInput<T>;
     set dataSource(dataSource: CdkTableDataSourceInput<T>);
+    readonly _dataSourceChanges: Subject<CdkTableDataSourceInput<T>>;
+    readonly _dataStream: Subject<readonly T[]>;
     // (undocumented)
     protected readonly _differs: IterableDiffers;
     // (undocumented)
@@ -338,32 +347,36 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     _noDataRow: CdkNoDataRow;
     // (undocumented)
     _noDataRowOutlet: NoDataRowOutlet;
+    // @deprecated (undocumented)
+    protected readonly _parentPositioningListener?: StickyPositioningListener | undefined;
+    // (undocumented)
+    protected readonly _positioningListener?: StickyPositioningListener | undefined;
     removeColumnDef(columnDef: CdkColumnDef): void;
     removeFooterRowDef(footerRowDef: CdkFooterRowDef): void;
     removeHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
     removeRowDef(rowDef: CdkRowDef<T>): void;
+    protected _renderedRange?: ListRange;
     renderRows(): void;
     // (undocumented)
     _rowOutlet: DataRowOutlet;
     setNoDataRow(noDataRow: CdkNoDataRow | null): void;
     protected stickyCssClass: string;
-    // @deprecated (undocumented)
-    protected readonly _stickyPositioningListener: StickyPositioningListener;
     get trackBy(): TrackByFunction<T>;
     set trackBy(fn: TrackByFunction<T>);
     updateStickyColumnStyles(): void;
     updateStickyFooterRowStyles(): void;
     updateStickyHeaderRowStyles(): void;
-    readonly viewChange: BehaviorSubject<{
-        start: number;
-        end: number;
-    }>;
+    readonly viewChange: BehaviorSubject<ListRange>;
     // (undocumented)
     protected readonly _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkTable<any>, "cdk-table, table[cdk-table]", ["cdkTable"], { "trackBy": "trackBy"; "dataSource": "dataSource"; "multiTemplateDataRows": "multiTemplateDataRows"; "fixedLayout": "fixedLayout"; }, { "contentChanged": "contentChanged"; }, ["_noDataRow", "_contentColumnDefs", "_contentRowDefs", "_contentHeaderRowDefs", "_contentFooterRowDefs"], ["caption", "colgroup, col"], false>;
     // (undocumented)
+<<<<<<< fb4e395bb37b1a10f3fc8af49ae63200b0619c7f
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkTable<any>, [null, null, null, { attribute: "role"; }, { optional: true; }, null, null, null, null, null, { optional: true; skipSelf: true; }, { optional: true; }]>;
+=======
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkTable<any>, [null, null, null, { attribute: "role"; }, { optional: true; }, null, null, null, null, { optional: true; skipSelf: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
+>>>>>>> feat(cdk/table): Virtual scroll directive for tables
 }
 
 // @public
@@ -561,6 +574,9 @@ export interface StickyUpdate {
     // (undocumented)
     sizes: StickySize[];
 }
+
+// @public
+export const _TABLE_VIEW_CHANGE_STRATEGY: InjectionToken<TableViewChangeStrategy>;
 
 // @public
 export const TEXT_COLUMN_OPTIONS: InjectionToken<TextColumnOptions<any>>;


### PR DESCRIPTION
Adds a `virtualRows` directive which enables virtual scrolling for CDK tables.

### Open questions
Blocks of code that are subject to further discussion or contain potentially breaking changes are annotated with `FIXME`.

### Out of scope for now
- Variable size rows (virtual scroll `autosize` directive)
- Material tables support (let's hash out the CDK variant first)
- Checkbox state
- Row animations

### Known issues
- Sticky headers/footers flicker if an animation frame exceeds ~35ms. Karl and I will investigate further.

### Performance considerations
We've already improved row rendering by 50% or better. Without headers/footers, the scrolling experience is comparable to most other [Angular material virtual scroll demos](https://material.angular.io/cdk/scrolling/examples).

However, the entire table shifts position as the user scrolls. The position of sticky headers and footers must be offset by the distance scrolled to keep them in place. On average, the table is able to keep 15-20ms per animation frame. Frames that occasionally exceed ~35ms cause sticky headers/footers to flicker. It looks like longer than usual style calculations are hindering performance the most.

While I believe we can further optimize rendering, we will likely reach a threshold where the table can no longer be optimized and non-trivial tables will still experience flickering (e.g. tables with inline editing, cells with custom components, etc.). A while back, I experimented with rendering tables in multiple pieces so the body content can scroll independently of header/footers (https://github.com/angular/components/pull/20414). There are some a11y challenges to this solution, but it would resolve the flickering.

For example:

```
<table><!-- table header --></table>
<div class="scroll-viewport">
  <table>
    <thead><!-- visually hidden header --></thead>
    <tbody>...</tbody>
    <tfoot><!--visually hidden footer --></tfoot>
</div>
<table><!-- table footer --></table>
```

### Related PRs
- https://github.com/angular/components/pull/21704