### PR TITLE
build: update to latest ts-api-guardian and fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "shelljs": "^0.8.3",
     "stylelint": "^13.8.0",
     "terser": "^4.8.0",
-    "ts-api-guardian": "^0.5.0",
+    "ts-api-guardian": "^0.6.0",
     "ts-node": "^9.0.0",
     "tsickle": "0.39.1",
     "tslint": "^6.1.3",

--- a/src/material/grid-list/public-api.ts
+++ b/src/material/grid-list/public-api.ts
@@ -5,10 +5,11 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {TileCoordinator} from './tile-coordinator';
 
 export * from './grid-list-module';
 export * from './grid-list';
 export * from './grid-tile';
 
 // Privately exported for the grid-list harness.
-export {TileCoordinator as ɵTileCoordinator} from './tile-coordinator';
+export const ɵTileCoordinator = TileCoordinator;

--- a/tools/public_api_guard/generate-guard-tests.bzl
+++ b/tools/public_api_guard/generate-guard-tests.bzl
@@ -1,4 +1,4 @@
-load("@npm_ts_api_guardian//:index.bzl", "ts_api_guardian_test")
+load("@npm//ts-api-guardian:index.bzl", "ts_api_guardian_test")
 
 """
   Macro for generating ts-api-guardian Bazel test targets. Since there are multiple golden files

--- a/tools/public_api_guard/material/grid-list.d.ts
+++ b/tools/public_api_guard/material/grid-list.d.ts
@@ -58,3 +58,5 @@ export declare class MatGridTileText implements AfterContentInit {
     static ɵcmp: i0.ɵɵComponentDefWithMeta<MatGridTileText, "mat-grid-tile-header, mat-grid-tile-footer", never, {}, {}, ["_lines"], ["[mat-grid-avatar], [matGridAvatar]", "[mat-line], [matLine]", "*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MatGridTileText, never>;
 }
+
+export declare const ɵTileCoordinator: typeof TileCoordinator;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12822,10 +12822,10 @@ trough@^1.0.0:
   dependencies:
     glob "^7.1.2"
 
-ts-api-guardian@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/ts-api-guardian/-/ts-api-guardian-0.5.0.tgz#1b63546dfd61581054802bdc8d5915ceebcc2c35"
-  integrity sha512-BjVlb23FUqWU+wmdHkLdaHcllU+v/Cca26sY40bCkM15BCF2yc17daOm+UXyvxQ9NndPM/40m+X+GLyDkrE9tA==
+ts-api-guardian@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ts-api-guardian/-/ts-api-guardian-0.6.0.tgz#9f44cf9bad1db5de358ccca7b4e6fb1d2c7fe462"
+  integrity sha512-DVA+UgPI1TVRI7GNDG1XBxwGs+cKqJq1os00txr52TUxBPwsUWWT7f83VHWvPQvh7G2wj93U/dTUBeDq3FIDTg==
   dependencies:
     chalk "^2.3.1"
     diff "^3.5.0"


### PR DESCRIPTION
Updates to `ts-api-guardian` 0.6.0 and fixes a newly-introduced build error.