### PR TITLE
Update MapGroundOverlay doc for class reference error

### DIFF
--- a/src/google-maps/map-ground-overlay/README.md
+++ b/src/google-maps/map-ground-overlay/README.md
@@ -1,6 +1,6 @@
 # MapGroundOverlay
 
-The `MapGroundOverlay` component wraps the [`google.maps.BicyclingLayer` class](https://developers.google.com/maps/documentation/javascript/reference/image-overlay#GroundOverlay) from the Google Maps JavaScript API. A url and a bounds are required.
+The `MapGroundOverlay` component wraps the [`google.maps.GroundOverlay` class](https://developers.google.com/maps/documentation/javascript/reference/image-overlay#GroundOverlay) from the Google Maps JavaScript API. A url and a bounds are required.
 
 ## Example
 


### PR DESCRIPTION
I was confused at first. The link is correct, the text about the underlying JS class is wrong.