### PR TITLE
fix(material/core): native-adapter uses first day of the week from locale data

### DIFF
--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -8,6 +8,7 @@
 
 import {Platform} from '@angular/cdk/platform';
 import {Inject, Injectable, Optional} from '@angular/core';
+import {getLocaleFirstDayOfWeek} from '@angular/common';
 import {DateAdapter, MAT_DATE_LOCALE} from './date-adapter';
 
 /**
@@ -85,8 +86,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
   }
 
   getFirstDayOfWeek(): number {
-    // We can't tell using native JS Date what the first day of the week is, we default to Sunday.
-    return 0;
+    return getLocaleFirstDayOfWeek(this.locale);
   }
 
   getNumDaysInMonth(date: Date): number {


### PR DESCRIPTION
Native adapter still uses hardcoded 0 value. I applied a fix mentioned here https://github.com/angular/components/issues/8100