### PR TITLE
fix(material/select): VoiceOver reading out blank space

### DIFF
--- a/src/material-experimental/mdc-select/select.html
+++ b/src/material-experimental/mdc-select/select.html
@@ -14,9 +14,9 @@
      #fallbackOverlayOrigin="cdkOverlayOrigin"
      #trigger>
   <div class="mat-mdc-select-value" [ngSwitch]="empty" [attr.id]="_valueId">
-    <span class="mat-mdc-select-placeholder" *ngSwitchCase="true">{{placeholder || '\u00A0'}}</span>
+    <span class="mat-mdc-select-placeholder mat-mdc-select-min-line" *ngSwitchCase="true">{{placeholder}}</span>
     <span class="mat-mdc-select-value-text" *ngSwitchCase="false" [ngSwitch]="!!customTrigger">
-      <span *ngSwitchDefault>{{triggerValue || '\u00A0'}}</span>
+      <span class="mat-mdc-select-min-line" *ngSwitchDefault>{{triggerValue}}</span>
       <ng-content select="mat-select-trigger" *ngSwitchCase="true"></ng-content>
     </span>
   </div>

--- a/src/material-experimental/mdc-select/select.scss
+++ b/src/material-experimental/mdc-select/select.scss
@@ -144,3 +144,12 @@ $scale: 0.75 !default;
     }
   }
 }
+
+// Used to prevent inline elements from collapsing if their text bindings
+// become empty. This is preferrable to inserting a blank space, because the
+// space can be read out by screen readers (see #21725).
+.mat-mdc-select-min-line:empty::before {
+  content: ' ';
+  white-space: pre;
+  width: 1px;
+}

--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -14,9 +14,9 @@
      #origin="cdkOverlayOrigin"
      #trigger>
   <div class="mat-select-value" [ngSwitch]="empty" [attr.id]="_valueId">
-    <span class="mat-select-placeholder" *ngSwitchCase="true">{{placeholder || '\u00A0'}}</span>
+    <span class="mat-select-placeholder mat-select-min-line" *ngSwitchCase="true">{{placeholder}}</span>
     <span class="mat-select-value-text" *ngSwitchCase="false" [ngSwitch]="!!customTrigger">
-      <span *ngSwitchDefault>{{triggerValue || '\u00A0'}}</span>
+      <span class="mat-select-min-line" *ngSwitchDefault>{{triggerValue}}</span>
       <ng-content select="mat-select-trigger" *ngSwitchCase="true"></ng-content>
     </span>
   </div>

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -147,3 +147,12 @@ $mat-select-placeholder-arrow-space: 2 * ($mat-select-arrow-size + $mat-select-a
     display: block;
   }
 }
+
+// Used to prevent inline elements from collapsing if their text bindings
+// become empty. This is preferrable to inserting a blank space, because the
+// space can be read out by screen readers (see #21725).
+.mat-select-min-line:empty::before {
+  content: ' ';
+  white-space: pre;
+  width: 1px;
+}


### PR DESCRIPTION
We have some inline elements inside `mat-select` which may collapse if their text bindings are empty. To work around it we replace the content with a blank space. The problem is that VoiceOver seems to read out this text.

These changes fix the issue by keeping the height of the elements using CSS instead.

Fixes #21725.