### PR TITLE
docs(material-experimental): fix scss examples

### DIFF
--- a/src/material-experimental/mdc-autocomplete/README.md
+++ b/src/material-experimental/mdc-autocomplete/README.md
@@ -70,7 +70,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-autocomplete-theme($my-theme);
-   @include mat-mdc-autocomplete-typography();
+   @include mat-mdc-autocomplete-typography($my-theme);
    ```
 
 ## API differences

--- a/src/material-experimental/mdc-checkbox/README.md
+++ b/src/material-experimental/mdc-checkbox/README.md
@@ -66,7 +66,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-checkbox-theme($my-theme);
-   @include mat-mdc-checkbox-typography();
+   @include mat-mdc-checkbox-typography($my-theme);
    ```
 
 ## API differences

--- a/src/material-experimental/mdc-menu/README.md
+++ b/src/material-experimental/mdc-menu/README.md
@@ -70,7 +70,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-menu-theme($my-theme);
-   @include mat-mdc-menu-typography();
+   @include mat-mdc-menu-typography($my-theme);
    ```
 
 ## API differences

--- a/src/material-experimental/mdc-paginator/README.md
+++ b/src/material-experimental/mdc-paginator/README.md
@@ -66,7 +66,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-paginator-theme($my-theme);
-   @include mat-mdc-paginator-typography();
+   @include mat-mdc-paginator-typography($my-theme);
    ```
 
 ## API differences

--- a/src/material-experimental/mdc-progress-bar/README.md
+++ b/src/material-experimental/mdc-progress-bar/README.md
@@ -67,7 +67,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-progress-bar-theme($my-theme);
-   @include mat-mdc-progress-bar-typography();
+   @include mat-mdc-progress-bar-typography($my-theme);
    ```
 
 ## Replacing the standard progress bar in an existing app

--- a/src/material-experimental/mdc-progress-spinner/README.md
+++ b/src/material-experimental/mdc-progress-spinner/README.md
@@ -67,7 +67,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-progress-spinner-theme($my-theme);
-   @include mat-mdc-progress-spinner-typography();
+   @include mat-mdc-progress-spinner-typography($my-theme);
    ```
 
 ## Replacing the standard progress spinner in an existing app

--- a/src/material-experimental/mdc-select/README.md
+++ b/src/material-experimental/mdc-select/README.md
@@ -74,7 +74,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-select-theme($my-theme);
-   @include mat-mdc-select-typography();
+   @include mat-mdc-select-typography($my-theme);
    ```
 
 ## API differences

--- a/src/material-experimental/mdc-slide-toggle/README.md
+++ b/src/material-experimental/mdc-slide-toggle/README.md
@@ -66,7 +66,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-slide-toggle-theme($my-theme);
-   @include mat-mdc-slide-toggle-typography();
+   @include mat-mdc-slide-toggle-typography($my-theme);
    ```
 
 ## Replacing the standard slide toggle in an existing app

--- a/src/material-experimental/mdc-tabs/README.md
+++ b/src/material-experimental/mdc-tabs/README.md
@@ -70,7 +70,7 @@ component by following these steps:
    ));
 
    @include mat-mdc-tabs-theme($my-theme);
-   @include mat-mdc-tabs-typography();
+   @include mat-mdc-tabs-typography($my-theme);
    ```
 
 ## API differences


### PR DESCRIPTION
Fixes the error
```
Error: ./src/styles.scss
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Missing argument $config-or-theme.
   ┌──> src\styles.scss
14 │ @include mat-mdc-select-typography();
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invocation
   ╵
   ┌──> node_modules\@angular\material-experimental\mdc-select\_select-theme.scss
82 │ @mixin mat-mdc-select-typography($config-or-theme) {
   │        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ declaration
   ╵
  src\styles.scss 14:1  mat-mdc-select-typography()
```

Note: the same problem also occurs in 
```
src\material-experimental\mdc-autocomplete  (1 usage found)
            README.md  (1 usage found)
                73 @include mat-mdc-autocomplete-typography();
        src\material-experimental\mdc-checkbox  (1 usage found)
            README.md  (1 usage found)
                69 @include mat-mdc-checkbox-typography();
        src\material-experimental\mdc-menu  (1 usage found)
            README.md  (1 usage found)
                73 @include mat-mdc-menu-typography();
        src\material-experimental\mdc-paginator  (1 usage found)
            README.md  (1 usage found)
                69 @include mat-mdc-paginator-typography();
        src\material-experimental\mdc-progress-bar  (1 usage found)
            README.md  (1 usage found)
                70 @include mat-mdc-progress-bar-typography();
        src\material-experimental\mdc-progress-spinner  (1 usage found)
            README.md  (1 usage found)
                70 @include mat-mdc-progress-spinner-typography();
        src\material-experimental\mdc-select  (1 usage found)
            README.md  (1 usage found)
                77 @include mat-mdc-select-typography();
        src\material-experimental\mdc-slide-toggle  (1 usage found)
            README.md  (1 usage found)
                69 @include mat-mdc-slide-toggle-typography();
        src\material-experimental\mdc-tabs  (1 usage found)
            README.md  (1 usage found)
                73 @include mat-mdc-tabs-typography();
```