### PR TITLE
fix(material-experimental/mdc-tabs): support backgroundColor on nav bar

### DIFF
--- a/src/material-experimental/mdc-tabs/_tabs-theme.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-theme.scss
@@ -36,7 +36,7 @@
       }
     }
 
-    .mat-mdc-tab-group {
+    .mat-mdc-tab-group, .mat-mdc-tab-nav-bar {
       &.mat-background-primary {
         @include _mat-mdc-tabs-background(primary, on-primary);
       }


### PR DESCRIPTION
Fixes that the MDC-based `mat-tab-nav-bar` doesn't support a `backgroundColor`. This is something we support on the non-MDC version, but it didn't make it into the MDC one for some reason.