### PR TITLE
docs: fix input text color to match theme in custom form guide

### DIFF
--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -42,6 +42,7 @@ class MyTel {
       outline: none;
       font: inherit;
       text-align: center;
+      color: currentColor;
     }
   `],
 })


### PR DESCRIPTION
- without this, it's black on dark grey

# Before

![Screen Shot 2021-01-30 at 02 46 49](https://user-images.githubusercontent.com/3506071/106350765-6c3d1380-62a5-11eb-8e3e-9587491a9918.png)

This knocks 2 points off of the LH a11y audit for the guide.

# After

![Screen Shot 2021-01-30 at 02 46 40](https://user-images.githubusercontent.com/3506071/106350767-6fd09a80-62a5-11eb-87c5-97f85483df53.png)
