### PR TITLE
docs: create anchors for all header elems & fix a11y in guides

### DIFF
--- a/guides/bidirectionality.md
+++ b/guides/bidirectionality.md
@@ -1,6 +1,7 @@
 # Angular Material bi-directionality
 
-### Setting a text-direction for your application
+## Setting a text-direction for your application
+
 The [`dir` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir)
 is typically applied to `<html>` or `<body>` element of a page. However, it can be used on any
 element, within your Angular app, to apply a text-direction to a smaller subset of the page.
@@ -8,7 +9,8 @@ element, within your Angular app, to apply a text-direction to a smaller subset 
 All Angular Material components automatically reflect the LTR/RTL direction
 of their container.
 
-### Reading the text-direction in your own components
+## Reading the text-direction in your own components
+
 `@angular/cdk/bidi` provides a `Directionality` injectable that can be used by any component
 in your application. To consume it, you must import `BidiModule` from `@angular/cdk/bidi`.
 
@@ -18,7 +20,8 @@ in your application. To consume it, you must import `BidiModule` from `@angular/
 captures changes from `dir` attributes _inside the Angular application context_. It will not
 emit for changes to `dir` on `<html>` and `<body>`, as they are assumed to be static.
 
-#### Example
+### Example
+
 ```ts
 @Component({ /* ... */ })
 export class MyCustomComponent {

--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -71,7 +71,7 @@ export class MyTelInput {
 }
 ```
 
-### Providing our component as a MatFormFieldControl
+## Providing our component as a MatFormFieldControl
 
 The first step is to provide our new component as an implementation of the `MatFormFieldControl`
 interface that the `<mat-form-field>` knows how to work with. To do this, we will have our class
@@ -90,7 +90,7 @@ export class MyTelInput implements MatFormFieldControl<MyTel> {
 }
 ```
 
-This sets up our component so it can work with `<mat-form-field>`, but now we need to implement the
+This sets up our component, so it can work with `<mat-form-field>`, but now we need to implement the
 various methods and properties declared by the interface we just implemented. To learn more about
 the `MatFormFieldControl` interface, see the
 [form field API documentation](https://material.angular.io/components/form-field/api).
@@ -184,7 +184,7 @@ constructor(
 
 Note that if your component implements `ControlValueAccessor`, it may already be set up to provide
 `NG_VALUE_ACCESSOR` (in the `providers` part of the component's decorator, or possibly in a module
-declaration). If so you may get a *cannot instantiate cyclic dependency* error.
+declaration). If so, you may get a *cannot instantiate cyclic dependency* error.
 
 To resolve this, remove the `NG_VALUE_ACCESSOR` provider and instead set the value accessor directly:
 
@@ -223,7 +223,7 @@ For additional information about `ControlValueAccessor` see the [API docs](https
 
 #### `focused`
 
-This property indicates whether or not the form field control should be considered to be in a
+This property indicates whether the form field control should be considered to be in a
 focused state. When it is in a focused state, the form field is displayed with a solid color
 underline. For the purposes of our component, we want to consider it focused if any of the part
 inputs are focused. We can use the `FocusMonitor` from `@angular/cdk` to easily check this. We also
@@ -249,7 +249,7 @@ ngOnDestroy() {
 #### `empty`
 
 This property indicates whether the form field control is empty. For our control, we'll consider it
-empty if all of the parts are empty.
+empty if all the parts are empty.
 
 ```ts
 get empty() {
@@ -262,7 +262,7 @@ get empty() {
 
 This property is used to indicate whether the label should be in the floating position. We'll
 use the same logic as `matInput` and float the placeholder when the input is focused or non-empty.
-Since the placeholder will be overlapping our control when when it's not floating, we should hide
+Since the placeholder will be overlapping our control when it's not floating, we should hide
 the `–` characters when it's not floating.
 
 ```ts
@@ -328,7 +328,7 @@ errorState = false;
 #### `controlType`
 
 This property allows us to specify a unique string for the type of control in form field. The
-`<mat-form-field>` will add an additional class based on this type that can be used to easily apply
+`<mat-form-field>` will add a class based on this type that can be used to easily apply
 special styles to a `<mat-form-field>` that contains a specific type of control. In this example
 we'll use `example-tel-input` as our control type which will result in the form field adding the
 class `mat-form-field-type-example-tel-input`.
@@ -421,7 +421,7 @@ export class MyTelInput implements MatFormFieldControl<MyTel> {
 ### Trying it out
 
 Now that we've fully implemented the interface, we're ready to try our component out! All we need to
-do is place it inside of a `<mat-form-field>`
+do is place it inside a `<mat-form-field>`
 
 ```html
 <mat-form-field>
@@ -429,7 +429,7 @@ do is place it inside of a `<mat-form-field>`
 </mat-form-field>
 ```
 
-We also get all of the features that come with `<mat-form-field>` such as floating placeholder,
+We also get all the features that come with `<mat-form-field>` such as floating placeholder,
 prefix, suffix, hints, and errors (if we've given the form field an `NgControl` and correctly report
 the error state).
 

--- a/guides/creating-a-custom-stepper-using-the-cdk-stepper.md
+++ b/guides/creating-a-custom-stepper-using-the-cdk-stepper.md
@@ -100,7 +100,7 @@ In the `app.component.css` file we can now style the stepper however we want:
 
 ## Using our new custom stepper component
 
-Now we are ready to use our new custom stepper component and fill it with steps. Therefore we can, for example, add it to our `app.component.html` and define some steps:
+Now we are ready to use our new custom stepper component and fill it with steps. Therefore, we can, for example, add it to our `app.component.html` and define some steps:
 
 **app.component.html**
 

--- a/guides/customizing-component-styles.md
+++ b/guides/customizing-component-styles.md
@@ -1,6 +1,6 @@
 # Customizing Angular Material component styles
 
-### Styling concepts
+## Styling concepts
 
 There are 3 questions to keep in mind while customizing the styles of Angular Material
 components:
@@ -9,7 +9,7 @@ components:
 2. Are your styles more specific than the defaults?
 3. Is the component a child of your component, or does it exist elsewhere in the DOM?
 
-##### View encapsulation
+### View encapsulation
 
 By default, Angular component styles are scoped to affect the component's view. This means that
 the styles you write will affect all the elements in your component template. They will *not*
@@ -20,7 +20,7 @@ also wish to take a look at
 [_The State of CSS in Angular_](https://blog.angular.io/the-state-of-css-in-angular-4a52d4bd2700)
 on the Angular blog.
 
-##### Selector specificity
+### Selector specificity
 
 Each CSS declaration has a level of *specificity* based on the type and number of selectors used.
 More specific styles will take precedence over less specific styles. Angular Material uses the
@@ -28,15 +28,15 @@ least specific selectors possible for its components in order to make it easy to
 You can read more about specificity and how it is calculated on the
 [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity).
 
-##### Component location
+### Component location
 
-Some Angular Material components, specifically overlay-based ones like MatDialog, MatSnackbar, etc.,
+Some Angular Material components, specifically overlay-based one's like MatDialog, MatSnackbar, etc.,
 do not exist as children of your component. Often they are injected elsewhere in the DOM. This is
 important to keep in mind, since even using high specificity and shadow-piercing selectors will
 not target elements that are not direct children of your component. Global styles are recommended
 for targeting such components.
 
-### Styling overlay components
+## Styling overlay components
 
 Overlay-based components have a `panelClass` property (or similar) that can be used to target the
 overlay pane. For example, to remove the padding from a dialog:
@@ -52,12 +52,12 @@ overlay pane. For example, to remove the padding from a dialog:
 this.dialog.open(MyDialogComponent, {panelClass: 'myapp-no-padding-dialog'})
 ```
 
-Since you are adding the styles to your global stylesheet, it is good practice to scope
+Since you are adding the styles to your global stylesheet, it is a good practice to scope
 them appropriately. Try prefixing your selector with your app name or "custom". Also note that
 the `mat-dialog-container`'s padding is added by default via a selector with specificity of 1. The
 customizing styles have a specificity of 2, so they will always take precedence.
 
-### Styling other components
+## Styling other components
 
 If your component has view encapsulation turned on (default), your component styles will only
 affect the top level children in your template. HTML elements belonging to child components cannot

--- a/guides/duplicate-theming-styles.md
+++ b/guides/duplicate-theming-styles.md
@@ -63,7 +63,7 @@ extract the configuration for the color system from the theme.
 }
 ```
 
-#### Disabling duplication warnings
+## Disabling duplication warnings
 
 If your application intentionally duplicates styles, a global Sass variable can be
 set to disable duplication warnings from Angular Material. For example:

--- a/guides/elevation.md
+++ b/guides/elevation.md
@@ -1,3 +1,5 @@
+# Setting Element Elevation
+
 Angular Material's elevation classes and mixins allow you to add separation between elements along
 the z-axis. All material design elements have resting elevations. In addition, some elements may
 change their elevation in response to user interaction. The
@@ -7,7 +9,7 @@ explains how to best use elevation.
 Angular Material provides two ways to control the elevation of elements: predefined CSS classes
 and mixins.
 
-### Predefined CSS classes
+## Predefined CSS classes
 
 The easiest way to add elevation to an element is to simply add one of the predefined CSS classes
 `mat-elevation-z#` where `#` is the elevation number you want, 0-24. Dynamic elevation can be
@@ -19,7 +21,7 @@ achieved by switching elevation classes:
 
 <!-- example(elevation-overview) -->
 
-### Mixins
+## Mixins
 
 Elevations can also be added in CSS via the `mat-elevation` mixin, which takes a number 0-24
 indicating the elevation of the element as well as optional arguments for the elevation shadow's

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Angular Material
 
-This guide explains how to setup your Angular project to begin using Angular Material. It includes information on prerequisites, installing Angular Material, and optionally displaying a sample material component in your application to verify your setup.
+This guide explains how to set up your Angular project to begin using Angular Material. It includes information on prerequisites, installing Angular Material, and optionally displaying a sample material component in your application to verify your setup.
 
 *Angular Resources*
 
@@ -8,9 +8,9 @@ If you are new to Angular or getting started with a new Angular application, see
 
 For existing applications, follow the steps below to begin using Angular Material.
 
-### Install Angular Material
+## Install Angular Material
 
-Use the Angular CLI's install [schematic](https://material.angular.io/guide/schematics) to set up your Angular Material project by running the following command:
+Use the Angular CLI's installation [schematic](https://material.angular.io/guide/schematics) to set up your Angular Material project by running the following command:
 
 ```bash
 ng add @angular/material
@@ -71,8 +71,8 @@ Run your local dev server:
 ng serve
 ```
 
-and point your browser to [http://localhost:4200](http://localhost:4200)
+Then point your browser to [http://localhost:4200](http://localhost:4200)
 
 You should see the material slider component on the page.
 
-In addition to the install schematic, Angular Material comes with [several schematics](https://material.angular.io/guide/schematics) (like nav, table, address-form, etc.) that can be used to easily generate pre-built components in your application.
+In addition to the installation schematic, Angular Material comes with [several schematics](https://material.angular.io/guide/schematics) (like nav, table, address-form, etc.) that can be used to easily generate pre-built components in your application.

--- a/guides/schematics.md
+++ b/guides/schematics.md
@@ -1,13 +1,16 @@
+# Installation and Code Generation
+
 Angular Material comes packaged with Angular CLI schematics to make
 creating Material applications easier.
 
-### Install Schematics
+## Install Schematics
+
 Schematics are included with both `@angular/cdk` and `@angular/material`. Once you install the npm
 packages, they will be available through the Angular CLI.
 
 Using the command below will install Angular Material, the [Component Dev Kit](https://material.angular.io/cdk) (CDK),
 and [Angular Animations](https://angular.io/guide/animations) in your project. Then it will run the
-install schematic.
+installation schematic.
 
 ```
 ng add @angular/material
@@ -19,7 +22,7 @@ In case you just want to install the `@angular/cdk`, there are also schematics f
 ng add @angular/cdk
 ```
 
-The Angular Material `ng add` schematic helps you setup an Angular CLI project that uses Material. Running `ng add` will:
+The Angular Material `ng add` schematic helps you set up an Angular CLI project that uses Material. Running `ng add` will:
 
 - Ensure [project dependencies](./getting-started#step-1-install-angular-material-angular-cdk-and-angular-animations) are placed in `package.json`
 - Enable the [BrowserAnimationsModule](./getting-started#step-2-configure-animations) your app module
@@ -33,7 +36,8 @@ The Angular Material `ng add` schematic helps you setup an Angular CLI project t
 
 
 ## Component schematics
-In addition to the install schematic, Angular Material comes with multiple schematics that can be
+
+In addition to the installation schematic, Angular Material comes with multiple schematics that can be
 used to easily generate Material Design components:
 
 
@@ -46,14 +50,14 @@ used to easily generate Material Design components:
 | `tree`         | Component that interactively visualizes a nested folder structure by using the `<mat-tree>` component  |
 
 
-Additionally the Angular CDK also comes with a collection of component schematics:
+Additionally, the Angular CDK also comes with a collection of component schematics:
 
 
 | Name           | Description                                                                                        |
 |----------------|----------------------------------------------------------------------------------------------------|
 | `drag-drop`    | Component that uses the `@angular/cdk/drag-drop` directives for creating an interactive to-do list |
 
-#### Address form schematic
+### Address form schematic
 
 Running the `address-form` schematic generates a new Angular component that can be used to get
 started with a Material Design form group consisting of:
@@ -66,16 +70,18 @@ started with a Material Design form group consisting of:
 ng generate @angular/material:address-form <component-name>
 ```
 
-#### Navigation schematic
+### Navigation schematic
+
 The `navigation` schematic will create a new component that includes
-a toolbar with the app name and a responsive side nav based on Material
+a toolbar with the app name, and a responsive side nav based on Material
 breakpoints.
 
 ```
 ng generate @angular/material:navigation <component-name>
 ```
 
-#### Table schematic
+### Table schematic
+
 The table schematic will create a component that renders an Angular Material `<table>` which has
 been pre-configured with a datasource for sorting and pagination.
 
@@ -83,7 +89,8 @@ been pre-configured with a datasource for sorting and pagination.
 ng generate @angular/material:table <component-name>
 ```
 
-#### Dashboard schematic
+### Dashboard schematic
+
 The `dashboard` schematic will create a new component that contains
 a dynamic grid list of Material Design cards.
 
@@ -91,7 +98,8 @@ a dynamic grid list of Material Design cards.
 ng generate @angular/material:dashboard <component-name>
 ```
 
-#### Tree schematic
+### Tree schematic
+
 The `tree` schematic can be used to quickly generate an Angular component that uses the Angular
 Material `<mat-tree>` component to visualize a nested folder structure.
 
@@ -99,7 +107,8 @@ Material `<mat-tree>` component to visualize a nested folder structure.
 ng generate @angular/material:tree <component-name>
 ```
 
-#### Drag and Drop schematic
+### Drag and Drop schematic
+
 The `drag-drop` schematic is provided by the `@angular/cdk` and can be used to generate a component
 that uses the CDK drag and drop directives.
 

--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -1,8 +1,10 @@
-### Theming your custom component with Angular Material's theming system
+# Theming your custom component with Angular Material's theming system
+
 In order to style your own components with Angular Material's tooling, the component's styles must
 be defined with Sass.
 
-#### 1. Define all color and typography styles in a "theme file" for the component
+## 1. Define all color and typography styles in a "theme file" for the component
+
 First, create a Sass mixin that accepts an Angular Material color configuration and
 outputs the color-specific styles for the component. A color configuration is a Sass map.
 
@@ -70,12 +72,14 @@ individual theming systems (`color` and `typography`).
 See the [typography guide](https://material.angular.io/guide/typography) for more information on
 typographic customization.
 
-#### 2. Define all remaining styles in a normal component stylesheet.
+## 2. Define all remaining styles in a normal component stylesheet
+
 Define all styles unaffected by the theme in a separate file referenced directly in the component's
 `styleUrl`.  This generally includes everything except for color and typography styles.
 
 
-#### 3. Include the theme mixin in your application
+## 3. Include the theme mixin in your application
+
 Use the Sass `@include` keyword to include a component's theme mixin wherever you're already
 including Angular Material's built-in theme mixins. 
 
@@ -104,7 +108,8 @@ $theme: mat-light-theme((
 ```
 
 
-#### Note: using the `mat-color` function to extract colors from a palette
+## Note: using the `mat-color` function to extract colors from a palette
+
 You can consume the theming functions and Material Design color palettes from
 `@angular/material/theming`. The `mat-color` Sass function extracts a specific color from a palette.
 For example:

--- a/guides/theming.md
+++ b/guides/theming.md
@@ -1,7 +1,6 @@
 # Theming your Angular Material app
 
-
-### What is a theme?
+## What is a theme?
 
 Angular Material's theming system enables you to customize components to
 better reflect your product's brand. A theme consists of configurations for the individual
@@ -11,21 +10,22 @@ the guidance from the [Material Design spec][1].
 In Angular Material, you create a color configuration by composing multiple palettes. In
 particular, a color configuration consists of:
 
-* A primary palette: colors most widely used across all screens and components.
-* An accent palette: colors used for the floating action button and interactive elements.
-* A warn palette: colors used to convey error state.
-* A foreground palette: colors for text and icons.
-* A background palette: colors used for element backgrounds.
+* A **primary** palette: colors most widely used across all screens and components.
+* An **accent** palette: colors used for the floating action button and interactive elements.
+* A **warn** palette: colors used to convey error state.
+* A **foreground** palette: colors for text and icons.
+* A **background** palette: colors used for element backgrounds.
 
 Additionally, in Angular Material, a configuration may optionally include `typography` settings.
 More information on how typography works can be [found in a dedicated guide][3].
 
 Angular Material theme styles are generated _statically_ at build-time so that your
-app doesn't have to spend cycles generating theme styles on startup.
+app doesn't have to spend cycles generating theme styles when bootstrapping.
 
-### Using a pre-built theme
+## Using a pre-built theme
+
 Angular Material comes prepackaged with several pre-built theme css files. These theme files also
-include all of the styles for core (styles common to all components), so you only have to include a
+include all the styles for the core (styles common to all components), so you only have to include a
 single css file for Angular Material in your app.
 
 You can include a theme file directly into your application from
@@ -51,11 +51,12 @@ The actual path will depend on your server setup.
 
 You can also concatenate the file with the rest of your application's css.
 
-Finally, if your app's content **is not** placed inside of a `mat-sidenav-container` element, you
+Finally, if your app's content **is not** placed inside a `mat-sidenav-container` element, you
 need to add the `mat-app-background` class to your wrapper element (for example the `body`). This
 ensures that the proper theme background is applied to your page.
 
-### Defining a custom theme
+## Defining a custom theme
+
 When you want more customization than a pre-built theme offers, you can create your own theme file.
 
 A custom theme file does two things:
@@ -65,7 +66,7 @@ multiple times, your application will end up with multiple copies of these commo
 2. Defines a **theme** data structure as the composition of configurations for the individual
 theming systems (`color` and `typography`). This object can be created with either the
 `mat-light-theme` function or the `mat-dark-theme` function. The output of this function is then
-passed to the `angular-material-theme` mixin, which will output all of the corresponding styles
+passed to the `angular-material-theme` mixin, which will output all the corresponding styles
 for the theme.
 
 
@@ -115,7 +116,7 @@ as gulp-sass or grunt-sass). The simplest approach is to use the `node-sass` CLI
 ```
 node-sass src/unicorn-app-theme.scss dist/unicorn-app-theme.css
 ```
-and then include the output file in your index.html.
+Then include the output file in your index.html.
 
 Your custom theme file **should not** be imported into other SCSS files. This will duplicate styles
 in your CSS output. If you want to consume your theme definition object
@@ -128,14 +129,16 @@ The theme file can be concatenated and minified with the rest of the application
 Note that if you include the generated theme file in the `styleUrls` of an Angular component, those
 styles will be subject to that component's [view encapsulation](https://angular.io/docs/ts/latest/guide/component-styles.html#!#view-encapsulation).
 
-#### Multiple themes
+### Multiple themes
+
 You can create multiple themes for your application by including the `angular-material-theme` mixin
 multiple times, where each inclusion is gated by an additional CSS class.
 
 Remember to only ever include the `@mat-core` mixin once; it should not be included for each
 theme.
 
-##### Example of defining multiple themes:
+#### Example of defining multiple themes:
+
 ```scss
 @import '~@angular/material/theming';
 // Plus imports for other components in your app.
@@ -179,7 +182,7 @@ $dark-theme:   mat-dark-theme((
 }
 ```
 
-In the above example, any component inside of a parent with the `unicorn-dark-theme` class will use
+In the above example, any component inside a parent with the `unicorn-dark-theme` class will use
 the dark theme, while other components will fall back to the default `$candy-app-theme`.
 
 You can include as many color schemes as you like in this manner. You can also `@include` the
@@ -194,8 +197,9 @@ as `angular-material-color` that only result in styles being generated for the [
 
 Read more about duplicated theme styles in the [dedicated guide](./duplicate-theming-styles.md).
 
-##### Multiple themes and overlay-based components
-Since certain components (e.g. menu, select, dialog, etc.) are inside of a global overlay container,
+#### Multiple themes and overlay-based components
+
+Since certain components (e.g. menu, select, dialog, etc.) are inside a global overlay container,
 an additional step is required for those components to be affected by the theme's css class selector
 (`.unicorn-dark-theme` in the example above).
 
@@ -214,7 +218,8 @@ export class UnicornCandyAppModule {
 }
 ```
 
-#### Theming only certain components
+### Theming only certain components
+
 The `angular-material-theme` mixin will output styles for [all components in the library](https://github.com/angular/components/blob/master/src/material/core/theming/_all-theme.scss).
 If you are only using a subset of the components (or if you want to change the theme for specific
 components), you can include component-specific theme mixins. You also will need to include
@@ -246,9 +251,10 @@ $candy-app-theme:   mat-light-theme((
 @include mat-checkbox-theme($candy-app-theme);
 ```
 
-#### Changing styles at run-time
+### Changing styles at run-time
 
-##### Toggling classes
+#### Toggling classes
+
 You can use the theming mixins to customize any part of your application with standard
 CSS selectors. For example, let's say you want to toggle alternate colors on a button.
 You would first define a CSS class with the alternate colors.
@@ -273,12 +279,12 @@ Then you can use normal Angular class bindings to toggle the alternate styles.
 </div>
 ```
 
-You can use this approach to style any component inside of the region marked with the custom
+You can use this approach to style any component inside the region marked with the custom
 CSS class.
 
-##### Swapping CSS files
+#### Swapping CSS files
 
-If you want to completely swap a theme without including all of the styles at once, you
+If you want to completely swap a theme without including all the styles at once, you
 can swap the loaded theme file. The details will depend on your application, but the general
 idea looks like this:
 
@@ -291,7 +297,8 @@ function changeTheme(themeName) {
 }
 ```
 
-### Theming your own components
+## Theming your own components
+
 For more details about theming your own components,
 see [theming-your-components.md](./theming-your-components.md).
 

--- a/guides/typography.md
+++ b/guides/typography.md
@@ -1,6 +1,6 @@
 # Angular Material typography
 
-### What is typography?
+## What is typography?
 Typography is a way of arranging type to make text legible, readable, and appealing when displayed.
 Angular Material's typography is based on the guidelines from the [Material Design spec][1] and is
 arranged into typography levels. Each level has a `font-size`, `line-height` and `font-weight`. The
@@ -26,7 +26,8 @@ available levels are:
 
 The typography levels are collected into a typography config which is used to generate the CSS.
 
-### Usage
+## Usage
+
 To get started, you first include the `Roboto` font with the 300, 400 and 500 weights.
 You can host it yourself or include it from [Google Fonts][2]:
 
@@ -56,7 +57,8 @@ descendant native elements.
 </section>
 ```
 
-### Customization
+## Customization
+
 Typography customization is an extension of Angular Material's Sass-based theming. Similar to
 creating a custom theme, you can create a custom **typography configuration**.
 
@@ -105,7 +107,8 @@ For more details about the typography functions and default config, see the
 [source](https://github.com/angular/components/blob/master/src/material/core/typography/_typography.scss).
 
 
-### Material typography in your custom CSS
+## Material typography in your custom CSS
+
 Angular Material includes typography utility mixins and functions that you can use to customize your
 own components:
 

--- a/guides/using-component-harnesses.md
+++ b/guides/using-component-harnesses.md
@@ -141,7 +141,7 @@ real user could perform or to inspect component state that a real user might per
 example, `MatButtonHarness` has methods to click, focus, and blur the `mat-button`, as well as
 methods to get the text of the button and its disabled state. Because `MatButton` is a very simple
 component, these harness methods might not seem very different from working directly with the DOM.
-However more complex harnesses like `MatSelectHarness` have methods like `open` and `isOpen` which
+However, more complex harnesses like `MatSelectHarness` have methods like `open` and `isOpen` which
 capture more knowledge about the component's internals.
 
 A test using the `MatButtonHarness` to interact with a `mat-button` might look like the following:
@@ -233,9 +233,9 @@ Specifically in this example, it makes the "open the mat-select" logic more obvi
 reader may not know what clicking on `.mat-select-trigger` does, but `await select.open()` is
 self-explanatory.
 
-The harnesses also make clear which option should be selected. Without the harness, you need a
-comment explaining what `options[1]` means, but with the `MatSelectHarness` you can use the `text`
-filter rather than the index and the code becomes self-documenting.
+The harnesses also make clear which option should be selected. Without the harness, you need a comment that
+explains what `options[1]` means. With `MatSelectHarness`, however, the filter API makes the code
+self-documenting.
 
 Finally, the repeated calls to `detectChanges` and `whenStable()` can obfuscate the underlying
 intent of the test. By using the harness APIs, you eliminate these calls, making the test more

--- a/guides/v9-hammerjs-migration.md
+++ b/guides/v9-hammerjs-migration.md
@@ -4,10 +4,10 @@ Angular Material, as of version 9, no longer requires HammerJS for any component
 previously depended on HammerJS no longer provide a [`HAMMER_GESTURE_CONFIG`][1] that will
 enable use of HammerJS events in templates.
 
-Additionally the `GestureConfig` export from `@angular/material/core` has been marked as
+Additionally, the `GestureConfig` export from `@angular/material/core` has been marked as
 deprecated and will be removed in version 10.
 
-### Why is a migration needed?
+## Why is a migration needed?
 
 Since HammerJS previously was a requirement for a few Angular Material components, projects might
 have installed `HammerJS` exclusively for Angular Material. Since HammerJS is no longer needed when
@@ -19,7 +19,7 @@ modules to set up the HammerJS event plugin. Since this is no longer the case in
 such projects need to manually configure the HammerJS event plugin in order to continue using
 these HammerJS events.
 
-### What does the migration do?
+## What does the migration do?
 
 The migration automatically removes HammerJS from your project if HammerJS is not used.
 
@@ -38,7 +38,7 @@ deprecated Angular Material `GestureConfig`, the migration will print a warning 
 ambiguous usage. The migration cannot migrate your project automatically and manual changes
 are required. Read more [in the dedicated section](#the-migration-reported-ambiguous-usage-what-should-i-do).
 
-### How does the schematic remove HammerJS?
+## How does the schematic remove HammerJS?
 
 HammerJS can be set up in many ways. The migration handles the most common cases, covering
 approaches recommended by Angular Material in the past. The migration performs the following steps:
@@ -64,7 +64,7 @@ The migration cannot automatically remove HammerJS from tests. Please manually c
 the test setup and resolve any test issues. Read more in a
 [dedicated section for test migration](#how-to-migrate-my-tests).
 
-### How do I migrate references to the deprecated `GestureConfig`?
+## How do I migrate references to the deprecated `GestureConfig`?
 
 The `GestureConfig` can be consumed in multiple ways. The migration covers the most common cases.
 The most common case is that an `NgModule` in your application directly provides `GestureConfig`:
@@ -94,7 +94,7 @@ in combination with a different custom gesture config. These patterns cannot be 
 automatically, but the migration will report such patterns and ask you to perform manual cleanup.
 
 <a name="test-migration"></a>
-### How to migrate my tests?
+## How to migrate my tests?
 
 Components in your project might use Angular Material components which previously depended
 upon HammerJS. There might be unit tests for these components which also test gesture functionality
@@ -116,11 +116,11 @@ import 'hammerjs';
 ```
 
 <a name="what-to-do-ambiguous-usage"></a>
-### The migration reported ambiguous usage. What should I do?
+## The migration reported ambiguous usage. What should I do?
 
 **Case 1**: It detected that a HammerJS event provided by the deprecated `GestureConfig` is
 used in a component template. This is because the migration relies on static analysis to detect
-event bindings and can never guarantee that a event binding is bound to the Hammer gesture
+event bindings and can never guarantee that an event binding is bound to the Hammer gesture
 plugin, or to an actual `@Output`. For example:
 
 ```html

--- a/tools/markdown-to-html/docs-marked-renderer.ts
+++ b/tools/markdown-to-html/docs-marked-renderer.ts
@@ -21,11 +21,11 @@ export class DocsMarkdownRenderer extends Renderer {
 
   /**
    * Transforms a markdown heading into the corresponding HTML output. In our case, we
-   * want to create a header-link for each H3 and H4 heading. This allows users to jump to
+   * want to create a header-link for each H2, H3, and H4 heading. This allows users to jump to
    * specific parts of the docs.
    */
   heading(label: string, level: number, raw: string) {
-    if (level === 3 || level === 4) {
+    if (level === 2 || level === 3 || level === 4 || level === 5 || level === 6) {
       const headingId = this._slugger.slug(raw);
       return `
         <h${level} id="${headingId}" class="docs-header-link">


### PR DESCRIPTION
- Lighthouse's a11y audit wants page headers to progress in order
  - https://web.dev/heading-order/
- Go through all guides and make the headers consistent
  - and ordered to pass the a11y audit
- fix grammar issues and typos

# Before

![Screen Shot 2021-01-30 at 03 36 01](https://user-images.githubusercontent.com/3506071/106351780-4b2bf100-62ac-11eb-87d3-7e258c338e53.png)
