### PR TITLE
build: run example harness unit tests and fix errors

### DIFF
--- a/src/components-examples/material/autocomplete/BUILD.bazel
+++ b/src/components-examples/material/autocomplete/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "autocomplete",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -33,4 +36,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":autocomplete",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/autocomplete",
+        "//src/material/autocomplete/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
@@ -1,43 +1,30 @@
-import {TestBed, ComponentFixture, waitForAsync, inject} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatAutocompleteHarness} from '@angular/material/autocomplete/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {AutocompleteHarnessExample} from './autocomplete-harness-example';
-import {OverlayContainer} from '@angular/cdk/overlay';
 
 describe('AutocompleteHarnessExample', () => {
   let fixture: ComponentFixture<AutocompleteHarnessExample>;
   let loader: HarnessLoader;
-  let overlayContainer: OverlayContainer;
 
   beforeAll(() => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatAutocompleteModule],
-        declarations: [AutocompleteHarnessExample]
-      }).compileComponents();
-    }));
-
-  beforeEach( () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatAutocompleteModule],
+      declarations: [AutocompleteHarnessExample]
+    }).compileComponents();
     fixture = TestBed.createComponent(AutocompleteHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);
-    inject([OverlayContainer], (oc: OverlayContainer) => {
-      overlayContainer = oc;
-    })();
-  });
-
-  afterEach(() => {
-    // Angular won't call this for us so we need to do it ourselves to avoid leaks.
-    overlayContainer.ngOnDestroy();
-    overlayContainer = null!;
   });
 
   it('should load all autocomplete harnesses', async () => {

--- a/src/components-examples/material/badge/BUILD.bazel
+++ b/src/components-examples/material/badge/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "badge",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -30,4 +33,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":badge",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/badge",
+        "//src/material/badge/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/badge/badge-harness/badge-harness-example.spec.ts
+++ b/src/components-examples/material/badge/badge-harness/badge-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatBadgeHarness} from '@angular/material/badge/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatBadgeModule} from '@angular/material/badge';
 import {BadgeHarnessExample} from './badge-harness-example';
 
@@ -15,17 +17,15 @@ describe('BadgeHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatBadgeModule],
-        declarations: [BadgeHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(BadgeHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatBadgeModule],
+      declarations: [BadgeHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(BadgeHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all badge harnesses', async () => {
     const badges = await loader.getAllHarnesses(MatBadgeHarness);

--- a/src/components-examples/material/bottom-sheet/BUILD.bazel
+++ b/src/components-examples/material/bottom-sheet/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "bottom-sheet",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -31,4 +34,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":bottom-sheet",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/bottom-sheet",
+        "//src/material/bottom-sheet/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
+++ b/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
@@ -1,12 +1,13 @@
-import {TestBed, ComponentFixture, waitForAsync, inject} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatBottomSheetHarness} from '@angular/material/bottom-sheet/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatBottomSheetModule} from '@angular/material/bottom-sheet';
 import {BottomSheetHarnessExample} from './bottom-sheet-harness-example';
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('BottomSheetHarnessExample', () => {
@@ -17,19 +18,14 @@ describe('BottomSheetHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatBottomSheetModule, NoopAnimationsModule],
-        declarations: [BottomSheetHarnessExample]
-      }).compileComponents();
-    }));
-
-  beforeEach(() => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatBottomSheetModule, NoopAnimationsModule],
+      declarations: [BottomSheetHarnessExample]
+    }).compileComponents();
     fixture = TestBed.createComponent(BottomSheetHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
-    inject([OverlayContainer], () => {})();
   });
 
   it('should load harness for a bottom sheet', async () => {

--- a/src/components-examples/material/button-toggle/BUILD.bazel
+++ b/src/components-examples/material/button-toggle/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "button-toggle",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -29,4 +32,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":button-toggle",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/button-toggle",
+        "//src/material/button-toggle/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/button-toggle/button-toggle-harness/button-toggle-harness-example.spec.ts
+++ b/src/components-examples/material/button-toggle/button-toggle-harness/button-toggle-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatButtonToggleGroupHarness} from '@angular/material/button-toggle/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {ButtonToggleHarnessExample} from './button-toggle-harness-example';
 
@@ -15,15 +17,11 @@ describe('ButtonToggleHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatButtonToggleModule],
-        declarations: [ButtonToggleHarnessExample]
-      }).compileComponents();
-    }));
-
-  beforeEach(() => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatButtonToggleModule],
+      declarations: [ButtonToggleHarnessExample]
+    }).compileComponents();
     fixture = TestBed.createComponent(ButtonToggleHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/button/BUILD.bazel
+++ b/src/components-examples/material/button/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "button",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -30,4 +33,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":button",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/button",
+        "//src/material/button/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
+++ b/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatButtonHarness} from '@angular/material/button/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {ButtonHarnessExample} from './button-harness-example';
 
@@ -16,17 +18,15 @@ describe('ButtonHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatButtonModule],
-        declarations: [ButtonHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(ButtonHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatButtonModule],
+      declarations: [ButtonHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ButtonHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all button harnesses', async () => {
       const buttons = await loader.getAllHarnesses(MatButtonHarness);

--- a/src/components-examples/material/card/BUILD.bazel
+++ b/src/components-examples/material/card/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "card",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -30,4 +33,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":card",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/button/testing",
+        "//src/material/card",
+        "//src/material/card/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
+++ b/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatButtonHarness} from '@angular/material/button/testing';
 import {MatCardHarness} from '@angular/material/card/testing';
@@ -16,15 +16,11 @@ describe('CardHarnessExample', () => {
   beforeAll(() => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatCardModule],
-        declarations: [CardHarnessExample]
-      }).compileComponents();
-    }));
-
-  beforeEach(() => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatCardModule],
+      declarations: [CardHarnessExample]
+    }).compileComponents();
     fixture = TestBed.createComponent(CardHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/checkbox/BUILD.bazel
+++ b/src/components-examples/material/checkbox/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "checkbox",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -31,4 +34,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":checkbox",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/checkbox",
+        "//src/material/checkbox/testing",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
+++ b/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
@@ -1,10 +1,12 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatCheckboxHarness} from '@angular/material/checkbox/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {ReactiveFormsModule} from '@angular/forms';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {CheckboxHarnessExample} from './checkbox-harness-example';
 
@@ -16,15 +18,11 @@ describe('CheckboxHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatCheckboxModule, ReactiveFormsModule],
-        declarations: [CheckboxHarnessExample]
-      }).compileComponents();
-    }));
-
-  beforeEach(() => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatCheckboxModule, ReactiveFormsModule],
+      declarations: [CheckboxHarnessExample]
+    }).compileComponents();
     fixture = TestBed.createComponent(CheckboxHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/src/components-examples/material/chips/BUILD.bazel
+++ b/src/components-examples/material/chips/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "chips",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -33,4 +36,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":chips",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/chips",
+        "//src/material/chips/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
+++ b/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatChipHarness, MatChipListboxHarness} from '@angular/material/chips/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
@@ -13,20 +13,20 @@ import {MatChipsModule} from '@angular/material/chips';
 describe('ChipsHarnessExample', () => {
   let fixture: ComponentFixture<ChipsHarnessExample>;
   let loader: HarnessLoader;
+
   beforeAll(() => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatChipsModule, NoopAnimationsModule],
-        declarations: [ChipsHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(ChipsHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatChipsModule, NoopAnimationsModule],
+      declarations: [ChipsHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ChipsHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should get whether a chip list is disabled', async () => {
     const chipList = await loader.getHarness(MatChipListboxHarness);

--- a/src/components-examples/material/datepicker/BUILD.bazel
+++ b/src/components-examples/material/datepicker/BUILD.bazel
@@ -1,11 +1,14 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_config")
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "datepicker",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -43,4 +46,26 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":datepicker",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/core",
+        "//src/material/datepicker",
+        "//src/material/datepicker/testing",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
+++ b/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatDatepickerInputHarness} from '@angular/material/datepicker/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 import {DatepickerHarnessExample} from './datepicker-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -18,17 +20,15 @@ describe('DatepickerHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatDatepickerModule, NoopAnimationsModule, MatNativeDateModule, FormsModule],
-        declarations: [DatepickerHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(DatepickerHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatDatepickerModule, NoopAnimationsModule, MatNativeDateModule, FormsModule],
+      declarations: [DatepickerHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DatepickerHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all datepicker input harnesses', async () => {
     const inputs = await loader.getAllHarnesses(MatDatepickerInputHarness);

--- a/src/components-examples/material/dialog/BUILD.bazel
+++ b/src/components-examples/material/dialog/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "dialog",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -32,4 +35,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":dialog",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/dialog",
+        "//src/material/dialog/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
+++ b/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
@@ -2,8 +2,10 @@ import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatDialogModule} from '@angular/material/dialog';
 import {DialogHarnessExample} from './dialog-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -16,19 +18,15 @@ describe('DialogHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatDialogModule, NoopAnimationsModule],
-        declarations: [DialogHarnessExample]
-      }).compileComponents();
-    }));
-
-  beforeEach(() => {
+  beforeEach(waitForAsync(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatDialogModule, NoopAnimationsModule],
+      declarations: [DialogHarnessExample]
+    }).compileComponents();
     fixture = TestBed.createComponent(DialogHarnessExample);
     fixture.detectChanges();
-    loader = TestbedHarnessEnvironment.loader(fixture);
-  });
+    loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+  }));
 
   it('should load harness for dialog', async () => {
     fixture.componentInstance.open();

--- a/src/components-examples/material/divider/BUILD.bazel
+++ b/src/components-examples/material/divider/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "divider",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -29,4 +32,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":divider",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/divider",
+        "//src/material/divider/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/divider/divider-harness/divider-harness-example.spec.ts
+++ b/src/components-examples/material/divider/divider-harness/divider-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatDividerHarness} from '@angular/material/divider/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatDividerModule} from '@angular/material/divider';
 import {DividerHarnessExample} from './divider-harness-example';
 
@@ -15,17 +17,15 @@ describe('DividerHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatDividerModule],
-        declarations: [DividerHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(DividerHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatDividerModule],
+      declarations: [DividerHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(DividerHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all divider harnesses', async () => {
     const dividers = await loader.getAllHarnesses(MatDividerHarness);

--- a/src/components-examples/material/expansion/BUILD.bazel
+++ b/src/components-examples/material/expansion/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "expansion",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -32,4 +35,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":expansion",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/expansion",
+        "//src/material/expansion/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
+++ b/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
@@ -1,10 +1,13 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatExpansionPanelHarness, MatAccordionHarness} from '@angular/material/expansion/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatExpansionModule} from '@angular/material/expansion';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ExpansionHarnessExample} from './expansion-harness-example';
 
 describe('ExpansionHarnessExample', () => {
@@ -15,17 +18,15 @@ describe('ExpansionHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatExpansionModule],
-        declarations: [ExpansionHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(ExpansionHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatExpansionModule, NoopAnimationsModule],
+      declarations: [ExpansionHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ExpansionHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should be able to load accordion', async () => {
     const accordions = await loader.getAllHarnesses(MatAccordionHarness);

--- a/src/components-examples/material/form-field/BUILD.bazel
+++ b/src/components-examples/material/form-field/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "form-field",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -36,4 +39,27 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":form-field",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/form-field",
+        "//src/material/form-field/testing",
+        "//src/material/input",
+        "//src/material/input/testing",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
+++ b/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatFormFieldHarness} from '@angular/material/form-field/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {FormFieldHarnessExample} from './form-field-harness-example';
 import {MatInputModule} from '@angular/material/input';
@@ -19,17 +21,15 @@ describe('FormFieldHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatFormFieldModule, MatInputModule, ReactiveFormsModule, NoopAnimationsModule],
-        declarations: [FormFieldHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(FormFieldHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatFormFieldModule, MatInputModule, ReactiveFormsModule, NoopAnimationsModule],
+      declarations: [FormFieldHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(FormFieldHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should be able to load harnesses', async () => {
     const formFields = await loader.getAllHarnesses(MatFormFieldHarness);
@@ -47,8 +47,8 @@ describe('FormFieldHarnessExample', () => {
     expect(await formField.getTextHints()).toEqual(['Hint']);
 
     fixture.componentInstance.requiredControl.setValue('');
-    (await formField.getControl())?.blur();
-    expect(await formField.getTextErrors()).toEqual(['Error 1']);
+    await (await formField.getControl())?.blur();
+    expect(await formField.getTextErrors()).toEqual(['Error']);
     expect(await formField.getTextHints()).toEqual([]);
   });
 

--- a/src/components-examples/material/grid-list/BUILD.bazel
+++ b/src/components-examples/material/grid-list/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "grid-list",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -28,4 +31,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":grid-list",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/grid-list",
+        "//src/material/grid-list/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
+++ b/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatGridListHarness, MatGridTileHarness} from '@angular/material/grid-list/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatGridListModule} from '@angular/material/grid-list';
 import {GridListHarnessExample} from './grid-list-harness-example';
 
@@ -15,17 +17,15 @@ describe('GridListHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatGridListModule],
-        declarations: [GridListHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(GridListHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatGridListModule],
+      declarations: [GridListHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(GridListHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should be able to load grid-list harnesses', async () => {
     const harnesses = await loader.getAllHarnesses(MatGridListHarness);

--- a/src/components-examples/material/icon/BUILD.bazel
+++ b/src/components-examples/material/icon/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "icon",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -28,4 +31,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":icon",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/icon",
+        "//src/material/icon/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
+++ b/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
@@ -1,8 +1,10 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {IconHarnessExample} from './icon-harness-example';
 import {MatIconModule, MatIconRegistry} from '@angular/material/icon';
 import {MatIconHarness} from '@angular/material/icon/testing';
@@ -17,16 +19,11 @@ describe('IconHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatIconModule],
-        declarations: [IconHarnessExample]
-      }).compileComponents();
-    })
-  );
-
-  beforeEach(() => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatIconModule],
+      declarations: [IconHarnessExample]
+    }).compileComponents();
     const registry = TestBed.inject(MatIconRegistry);
     const sanitizer = TestBed.inject(DomSanitizer);
 

--- a/src/components-examples/material/input/BUILD.bazel
+++ b/src/components-examples/material/input/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "input",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -31,4 +34,25 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":input",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/input",
+        "//src/material/input/testing",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
+++ b/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatInputHarness} from '@angular/material/input/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatInputModule} from '@angular/material/input';
 import {InputHarnessExample} from './input-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -17,17 +19,16 @@ describe('InputHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatInputModule, NoopAnimationsModule, ReactiveFormsModule],
-        declarations: [InputHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(InputHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatInputModule, NoopAnimationsModule, ReactiveFormsModule],
+      declarations: [InputHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(InputHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
   it('should load all input harnesses', async () => {
     const inputs = await loader.getAllHarnesses(MatInputHarness);
     expect(inputs.length).toBe(3);

--- a/src/components-examples/material/list/BUILD.bazel
+++ b/src/components-examples/material/list/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "list",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -29,4 +32,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":list",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/list",
+        "//src/material/list/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/list/list-harness/list-harness-example.spec.ts
+++ b/src/components-examples/material/list/list-harness/list-harness-example.spec.ts
@@ -1,9 +1,11 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatListHarness} from '@angular/material/list/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatListModule} from '@angular/material/list';
 import {ListHarnessExample} from './list-harness-example';
 
@@ -15,17 +17,15 @@ describe('ListHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatListModule],
-        declarations: [ListHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(ListHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatListModule],
+      declarations: [ListHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ListHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should get all items', async () => {
     const list = await loader.getHarness(MatListHarness);

--- a/src/components-examples/material/menu/BUILD.bazel
+++ b/src/components-examples/material/menu/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "menu",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -31,4 +34,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":menu",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/menu",
+        "//src/material/menu/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
+++ b/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
@@ -1,12 +1,13 @@
-import {TestBed, ComponentFixture, waitForAsync, inject} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatMenuHarness} from '@angular/material/menu/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatMenuModule} from '@angular/material/menu';
 import {MenuHarnessExample} from './menu-harness-example';
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('MenuHarnessExample', () => {
@@ -17,19 +18,14 @@ describe('MenuHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatMenuModule, NoopAnimationsModule],
-        declarations: [MenuHarnessExample]
-      }).compileComponents();
-    }));
-
-  beforeEach(() => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatMenuModule, NoopAnimationsModule],
+      declarations: [MenuHarnessExample]
+    }).compileComponents();
     fixture = TestBed.createComponent(MenuHarnessExample);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);
-    inject([OverlayContainer], () => {})();
   });
 
   it('should load all menu harnesses', async () => {

--- a/src/components-examples/material/paginator/BUILD.bazel
+++ b/src/components-examples/material/paginator/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "paginator",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -30,4 +33,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":paginator",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/paginator",
+        "//src/material/paginator/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
+++ b/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatPaginatorHarness} from '@angular/material/paginator/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatPaginatorModule} from '@angular/material/paginator';
 import {PaginatorHarnessExample} from './paginator-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -17,18 +19,16 @@ describe('PaginatorHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatPaginatorModule, NoopAnimationsModule],
-        declarations: [PaginatorHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(PaginatorHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-      instance = fixture.componentInstance;
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatPaginatorModule, NoopAnimationsModule],
+      declarations: [PaginatorHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(PaginatorHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    instance = fixture.componentInstance;
+  });
 
   it('should load all paginator harnesses', async () => {
     const paginators = await loader.getAllHarnesses(MatPaginatorHarness);

--- a/src/components-examples/material/progress-bar/BUILD.bazel
+++ b/src/components-examples/material/progress-bar/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "progress-bar",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -32,4 +35,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":progress-bar",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/progress-bar",
+        "//src/material/progress-bar/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/progress-bar/progress-bar-harness/progress-bar-harness-example.spec.ts
+++ b/src/components-examples/material/progress-bar/progress-bar-harness/progress-bar-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatProgressBarHarness} from '@angular/material/progress-bar/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {ProgressBarHarnessExample} from './progress-bar-harness-example';
 
@@ -15,17 +17,15 @@ describe('ProgressBarHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatProgressBarModule],
-        declarations: [ProgressBarHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(ProgressBarHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatProgressBarModule],
+      declarations: [ProgressBarHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ProgressBarHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all progress bar harnesses', async () => {
     const progressBars = await loader.getAllHarnesses(MatProgressBarHarness);

--- a/src/components-examples/material/progress-spinner/BUILD.bazel
+++ b/src/components-examples/material/progress-spinner/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "progress-spinner",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -32,4 +35,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":progress-spinner",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/progress-spinner",
+        "//src/material/progress-spinner/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/progress-spinner/progress-spinner-harness/progress-spinner-harness-example.spec.ts
+++ b/src/components-examples/material/progress-spinner/progress-spinner-harness/progress-spinner-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatProgressSpinnerHarness} from '@angular/material/progress-spinner/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {ProgressSpinnerHarnessExample} from './progress-spinner-harness-example';
 
@@ -15,17 +17,15 @@ describe('ProgressSpinnerHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatProgressSpinnerModule],
-        declarations: [ProgressSpinnerHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(ProgressSpinnerHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatProgressSpinnerModule],
+      declarations: [ProgressSpinnerHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ProgressSpinnerHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all progress spinner harnesses', async () => {
     const progressSpinners = await loader.getAllHarnesses(MatProgressSpinnerHarness);

--- a/src/components-examples/material/radio/BUILD.bazel
+++ b/src/components-examples/material/radio/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "radio",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -29,4 +32,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":radio",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/radio",
+        "//src/material/radio/testing",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/radio/radio-harness/radio-harness-example.spec.ts
+++ b/src/components-examples/material/radio/radio-harness/radio-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatRadioButtonHarness, MatRadioGroupHarness} from '@angular/material/radio/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatRadioModule} from '@angular/material/radio';
 import {RadioHarnessExample} from './radio-harness-example';
 import {ReactiveFormsModule} from '@angular/forms';
@@ -16,17 +18,15 @@ describe('RadioHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatRadioModule, ReactiveFormsModule],
-        declarations: [RadioHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(RadioHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatRadioModule, ReactiveFormsModule],
+      declarations: [RadioHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(RadioHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all radio-group harnesses', async () => {
     const groups = await loader.getAllHarnesses(MatRadioGroupHarness);

--- a/src/components-examples/material/select/BUILD.bazel
+++ b/src/components-examples/material/select/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "select",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -32,4 +35,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":select",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/select",
+        "//src/material/select/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
+++ b/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSelectHarness} from '@angular/material/select/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatSelectModule} from '@angular/material/select';
 import {SelectHarnessExample} from './select-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -16,17 +18,15 @@ describe('SelectHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatSelectModule, NoopAnimationsModule],
-        declarations: [SelectHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(SelectHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatSelectModule, NoopAnimationsModule],
+      declarations: [SelectHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SelectHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all select harnesses', async () => {
     const selects = await loader.getAllHarnesses(MatSelectHarness);

--- a/src/components-examples/material/slide-toggle/BUILD.bazel
+++ b/src/components-examples/material/slide-toggle/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "slide-toggle",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -33,4 +36,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":slide-toggle",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/slide-toggle",
+        "//src/material/slide-toggle/testing",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/slide-toggle/slide-toggle-harness/slide-toggle-harness-example.spec.ts
+++ b/src/components-examples/material/slide-toggle/slide-toggle-harness/slide-toggle-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSlideToggleHarness} from '@angular/material/slide-toggle/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {SlideToggleHarnessExample} from './slide-toggle-harness-example';
 import {ReactiveFormsModule} from '@angular/forms';
@@ -16,17 +18,15 @@ describe('SlideToggleHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatSlideToggleModule, ReactiveFormsModule],
-        declarations: [SlideToggleHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(SlideToggleHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatSlideToggleModule, ReactiveFormsModule],
+      declarations: [SlideToggleHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SlideToggleHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all slide-toggle harnesses', async () => {
     const slideToggles = await loader.getAllHarnesses(MatSlideToggleHarness);

--- a/src/components-examples/material/slider/BUILD.bazel
+++ b/src/components-examples/material/slider/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "slider",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -32,4 +35,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":slider",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/slider",
+        "//src/material/slider/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
+++ b/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSliderHarness} from '@angular/material/slider/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatSliderModule} from '@angular/material/slider';
 import {SliderHarnessExample} from './slider-harness-example';
 
@@ -15,17 +17,15 @@ describe('SliderHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatSliderModule],
-        declarations: [SliderHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(SliderHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatSliderModule],
+      declarations: [SliderHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SliderHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all slider harnesses', async () => {
     const sliders = await loader.getAllHarnesses(MatSliderHarness);

--- a/src/components-examples/material/sort/BUILD.bazel
+++ b/src/components-examples/material/sort/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "sort",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -28,4 +31,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":sort",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/sort",
+        "//src/material/sort/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
+++ b/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSortHarness} from '@angular/material/sort/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatSortModule} from '@angular/material/sort';
 import {SortHarnessExample} from './sort-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -16,17 +18,15 @@ describe('SortHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatSortModule, NoopAnimationsModule],
-        declarations: [SortHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(SortHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatSortModule, NoopAnimationsModule],
+      declarations: [SortHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(SortHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load harness for mat-sort', async () => {
     const sorts = await loader.getAllHarnesses(MatSortHarness);

--- a/src/components-examples/material/stepper/BUILD.bazel
+++ b/src/components-examples/material/stepper/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "stepper",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -33,4 +36,25 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":stepper",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/stepper",
+        "//src/material/stepper/testing",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
+++ b/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatStepperHarness, MatStepperNextHarness} from '@angular/material/stepper/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatStepperModule} from '@angular/material/stepper';
 import {StepperHarnessExample} from './stepper-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -17,17 +19,15 @@ describe('StepperHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatStepperModule, NoopAnimationsModule, ReactiveFormsModule],
-        declarations: [StepperHarnessExample],
-      }).compileComponents();
-      fixture = TestBed.createComponent(StepperHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatStepperModule, NoopAnimationsModule, ReactiveFormsModule],
+      declarations: [StepperHarnessExample],
+    }).compileComponents();
+    fixture = TestBed.createComponent(StepperHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all stepper harnesses', async () => {
     const steppers = await loader.getAllHarnesses(MatStepperHarness);

--- a/src/components-examples/material/table/BUILD.bazel
+++ b/src/components-examples/material/table/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "table",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -38,4 +41,23 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":table",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/table",
+        "//src/material/table/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/table/table-harness/table-harness-example.spec.ts
+++ b/src/components-examples/material/table/table-harness/table-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTableHarness} from '@angular/material/table/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatTableModule} from '@angular/material/table';
 import {TableHarnessExample} from './table-harness-example';
 
@@ -15,17 +17,15 @@ describe('TableHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatTableModule],
-        declarations: [TableHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(TableHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatTableModule],
+      declarations: [TableHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(TableHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load harness for a table', async () => {
     const tables = await loader.getAllHarnesses(MatTableHarness);

--- a/src/components-examples/material/tabs/BUILD.bazel
+++ b/src/components-examples/material/tabs/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tabs",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -34,4 +37,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":tabs",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/tabs",
+        "//src/material/tabs/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
+++ b/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTabGroupHarness} from '@angular/material/tabs/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatTabsModule} from '@angular/material/tabs';
 import {TabGroupHarnessExample} from './tab-group-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -16,17 +18,15 @@ describe('TabGroupHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatTabsModule, NoopAnimationsModule],
-        declarations: [TabGroupHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(TabGroupHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatTabsModule, NoopAnimationsModule],
+      declarations: [TabGroupHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(TabGroupHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load harness for tab-group', async () => {
     const tabGroups = await loader.getAllHarnesses(MatTabGroupHarness);

--- a/src/components-examples/material/toolbar/BUILD.bazel
+++ b/src/components-examples/material/toolbar/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "toolbar",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -30,4 +33,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":toolbar",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/icon",
+        "//src/material/toolbar",
+        "//src/material/toolbar/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.spec.ts
+++ b/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatToolbarHarness} from '@angular/material/toolbar/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {ToolbarHarnessExample} from './toolbar-harness-example';
 import {MatIconModule} from '@angular/material/icon';
@@ -16,17 +18,15 @@ describe('ToolbarHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatToolbarModule, MatIconModule],
-        declarations: [ToolbarHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(ToolbarHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatToolbarModule, MatIconModule],
+      declarations: [ToolbarHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(ToolbarHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should find all toolbars', async () => {
     const toolbars = await loader.getAllHarnesses(MatToolbarHarness);

--- a/src/components-examples/material/tooltip/BUILD.bazel
+++ b/src/components-examples/material/tooltip/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tooltip",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -34,4 +37,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":tooltip",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/tooltip",
+        "//src/material/tooltip/testing",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
+++ b/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTooltipHarness} from '@angular/material/tooltip/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {TooltipHarnessExample} from './tooltip-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -16,17 +18,15 @@ describe('TooltipHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatTooltipModule, NoopAnimationsModule],
-        declarations: [TooltipHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(TooltipHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatTooltipModule, NoopAnimationsModule],
+      declarations: [TooltipHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(TooltipHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should load all tooltip harnesses', async () => {
     const tooltips = await loader.getAllHarnesses(MatTooltipHarness);

--- a/src/components-examples/material/tree/BUILD.bazel
+++ b/src/components-examples/material/tree/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ng_module")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "tree",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
     assets = glob([
         "**/*.html",
         "**/*.css",
@@ -33,4 +36,24 @@ filegroup(
         "**/*.css",
         "**/*.ts",
     ]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":tree",
+        "//src/cdk/testing",
+        "//src/cdk/testing/testbed",
+        "//src/material/icon",
+        "//src/material/tree",
+        "//src/material/tree/testing",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    exclude_init_script = True,
+    deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/tree/tree-harness/tree-harness-example.spec.ts
+++ b/src/components-examples/material/tree/tree-harness/tree-harness-example.spec.ts
@@ -1,9 +1,11 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTreeHarness} from '@angular/material/tree/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {BrowserDynamicTestingModule, platformBrowserDynamicTesting}
-  from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 import {MatTreeModule} from '@angular/material/tree';
 import {TreeHarnessExample} from './tree-harness-example';
 import {MatIconModule} from '@angular/material/icon';
@@ -16,17 +18,15 @@ describe('TreeHarnessExample', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
   });
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [MatTreeModule, MatIconModule],
-        declarations: [TreeHarnessExample]
-      }).compileComponents();
-      fixture = TestBed.createComponent(TreeHarnessExample);
-      fixture.detectChanges();
-      loader = TestbedHarnessEnvironment.loader(fixture);
-    })
-  );
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatTreeModule, MatIconModule],
+      declarations: [TreeHarnessExample]
+    }).compileComponents();
+    fixture = TestBed.createComponent(TreeHarnessExample);
+    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
 
   it('should get correct number of children and descendants', async () => {
     const tree = await loader.getHarness(MatTreeHarness);

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -204,7 +204,7 @@ def protractor_web_test_suite(**kwargs):
         **kwargs
     )
 
-def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], **kwargs):
+def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], exclude_init_script = False, **kwargs):
     # Always include a prebuilt theme in the test suite because otherwise tests, which depend on CSS
     # that is needed for measuring, will unexpectedly fail. Also always adding a prebuilt theme
     # reduces the amount of setup that is needed to create a test suite Bazel target. Note that the
@@ -245,9 +245,7 @@ def ng_web_test_suite(deps = [], static_css = [], bootstrap = [], **kwargs):
 
     karma_web_test_suite(
         # Depend on our custom test initialization script. This needs to be the first dependency.
-        deps = [
-            "//test:angular_test_init",
-        ] + deps,
+        deps = deps if exclude_init_script else ["//test:angular_test_init"] + deps,
         bootstrap = [
             # This matches the ZoneJS bundles used in default CLI projects. See:
             # https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/application/files/src/polyfills.ts.template#L58


### PR DESCRIPTION
* Makes it so we're able to run the test harness example tests to make sure they actually work.
* Fixes several example unit tests that didn't pass.
* Reduces the boilerplate in the example tests.

Fixes #21758.