### PR TITLE
fix(material/tabs): projected tabs not being picked up

### DIFF
--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -269,7 +269,9 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
     this._allTabs.changes
       .pipe(startWith(this._allTabs))
       .subscribe((tabs: QueryList<MatTab>) => {
-        this._tabs.reset(tabs.filter(tab => tab._closestTabGroup === this));
+        this._tabs.reset(tabs.filter(tab => {
+          return tab._closestTabGroup === this || !tab._closestTabGroup;
+        }));
         this._tabs.notifyOnChanges();
       });
   }

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -23,6 +23,7 @@ import {
   ViewEncapsulation,
   InjectionToken,
   Inject,
+  Optional,
 } from '@angular/core';
 import {CanDisable, CanDisableCtor, mixinDisabled} from '@angular/material/core';
 import {Subject} from 'rxjs';
@@ -109,7 +110,7 @@ export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnCh
 
   constructor(
     private _viewContainerRef: ViewContainerRef,
-    @Inject(MAT_TAB_GROUP) public _closestTabGroup: any) {
+    @Inject(MAT_TAB_GROUP) @Optional() public _closestTabGroup: any) {
     super();
   }
 

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -152,7 +152,7 @@ export declare class MatTab extends _MatTabMixinBase implements OnInit, CanDisab
     ngOnInit(): void;
     static ngAcceptInputType_disabled: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDeclaration<MatTab, "mat-tab", ["matTab"], { "disabled": "disabled"; "textLabel": "label"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; }, {}, ["templateLabel", "_explicitContent"], ["*"]>;
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatTab, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatTab, [null, { optional: true; }]>;
 }
 
 export declare class MatTabBody extends _MatTabBodyBase {


### PR DESCRIPTION
Fixes an error that is thrown when tabs are projected in from another component into a `mat-tab-group`.

Fixes #21770.