### PR TITLE
fix(material/datepicker): focus restoration not working inside shadow dom

### DIFF
--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -97,6 +97,7 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/overlay",
+        "//src/cdk/platform",
         "//src/cdk/scrolling",
         "//src/cdk/testing/private",
         "//src/material/core",

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -550,10 +550,12 @@ export abstract class MatDatepickerBase<C extends MatDatepickerControl<D>, S,
     if (!this.datepickerInput && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw Error('Attempted to open an MatDatepicker with no associated input.');
     }
-    if (this._document) {
-      this._focusedElementBeforeOpen = this._document.activeElement;
-    }
 
+    // If the `activeElement` is inside a shadow root, `document.activeElement` will
+    // point to the shadow root so we have to descend into it ourselves.
+    const activeElement: HTMLElement|null = this._document?.activeElement;
+    this._focusedElementBeforeOpen =
+      activeElement?.shadowRoot?.activeElement as HTMLElement || activeElement;
     this.touchUi ? this._openAsDialog() : this._openAsPopup();
     this._opened = true;
     this.openedStream.emit();


### PR DESCRIPTION
Our focus restoration works by checking `document.activeElement` before the panel is opened and restoring to that element on close. The problem is that `activeElement` will return the shadow root, if the focused element is inside one.

These changes add some extra logic to account for it.

Fixes #21785.