### PR TITLE
fix(cdk/platform): adjust return type for _getShadowRoot

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -69,7 +69,7 @@ export const FOCUS_MONITOR_DEFAULT_OPTIONS =
 type MonitoredElementInfo = {
   checkChildren: boolean,
   subject: Subject<FocusOrigin>,
-  rootNode: HTMLElement|Document
+  rootNode: HTMLElement|ShadowRoot|Document
 };
 
 /**
@@ -118,7 +118,7 @@ export class FocusMonitor implements OnDestroy {
    * handlers differently from the rest of the events, because the browser won't emit events
    * to the document when focus moves inside of a shadow root.
    */
-  private _rootNodeFocusListenerCount = new Map<HTMLElement|Document, number>();
+  private _rootNodeFocusListenerCount = new Map<HTMLElement|Document|ShadowRoot, number>();
 
   /**
    * The specified detection mode, used for attributing the origin of a focus
@@ -235,7 +235,7 @@ export class FocusMonitor implements OnDestroy {
     // If the element is inside the shadow DOM, we need to bind our focus/blur listeners to
     // the shadow root, rather than the `document`, because the browser won't emit focus events
     // to the `document`, if focus is moving within the same shadow root.
-    const rootNode = (_getShadowRoot(nativeElement) as HTMLElement|null) || this._getDocument();
+    const rootNode = _getShadowRoot(nativeElement) || this._getDocument();
     const cachedInfo = this._elementInfo.get(nativeElement);
 
     // Check if we're already monitoring this element.

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -1353,7 +1353,7 @@ export class DragRef<T = any> {
    */
   private _getShadowRoot(): ShadowRoot | null {
     if (this._cachedShadowRoot === undefined) {
-      this._cachedShadowRoot = _getShadowRoot(this._rootElement) as ShadowRoot | null;
+      this._cachedShadowRoot = _getShadowRoot(this._rootElement);
     }
 
     return this._cachedShadowRoot;

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -923,7 +923,7 @@ export class DropListRef<T = any> {
    */
   private _getShadowRoot(): DocumentOrShadowRoot {
     if (!this._cachedShadowRoot) {
-      const shadowRoot = _getShadowRoot(coerceElement(this.element)) as ShadowRoot | null;
+      const shadowRoot = _getShadowRoot(coerceElement(this.element));
       this._cachedShadowRoot = shadowRoot || this._document;
     }
 

--- a/src/cdk/platform/features/shadow-dom.ts
+++ b/src/cdk/platform/features/shadow-dom.ts
@@ -19,7 +19,7 @@ export function _supportsShadowDom(): boolean {
 }
 
 /** Gets the shadow root of an element, if supported and the element is inside the Shadow DOM. */
-export function _getShadowRoot(element: HTMLElement): Node | null {
+export function _getShadowRoot(element: HTMLElement): ShadowRoot | null {
   if (_supportsShadowDom()) {
     const rootNode = element.getRootNode ? element.getRootNode() : null;
 

--- a/src/material/progress-spinner/progress-spinner.spec.ts
+++ b/src/material/progress-spinner/progress-spinner.spec.ts
@@ -421,7 +421,7 @@ describe('MatProgressSpinner', () => {
     fixture.detectChanges();
 
     const spinner = fixture.debugElement.query(By.css('mat-progress-spinner'))!.nativeElement;
-    const shadowRoot = _getShadowRoot(spinner) as HTMLElement;
+    const shadowRoot = _getShadowRoot(spinner)!;
 
     expect(shadowRoot.querySelector('style[mat-spinner-animation="27"]')).toBeTruthy();
 
@@ -442,7 +442,7 @@ describe('MatProgressSpinner', () => {
     fixture.detectChanges();
 
     const spinner = fixture.debugElement.query(By.css('mat-progress-spinner'))!.nativeElement;
-    const shadowRoot = _getShadowRoot(spinner) as HTMLElement;
+    const shadowRoot = _getShadowRoot(spinner)!;
 
     expect(shadowRoot.querySelectorAll('style[mat-spinner-animation="39"]').length).toBe(1);
 
@@ -473,7 +473,7 @@ describe('MatProgressSpinner', () => {
       fixture.detectChanges();
 
       const spinner = fixture.componentInstance.spinner.nativeElement;
-      const shadowRoot = _getShadowRoot(spinner) as HTMLElement;
+      const shadowRoot = _getShadowRoot(spinner)!;
 
       expect(shadowRoot.querySelector('style[mat-spinner-animation="27"]')).toBeTruthy();
 

--- a/tools/public_api_guard/cdk/platform.d.ts
+++ b/tools/public_api_guard/cdk/platform.d.ts
@@ -1,4 +1,4 @@
-export declare function _getShadowRoot(element: HTMLElement): Node | null;
+export declare function _getShadowRoot(element: HTMLElement): ShadowRoot | null;
 
 export declare function _supportsShadowDom(): boolean;
 


### PR DESCRIPTION
The return type for `_getShadowRoot` is actually a `ShadowRoot`, not a `Node`.