### PR TITLE
fix(material/form-field): focus indication not working for standard appearance in high contrast mode

### DIFF
--- a/src/material/form-field/form-field-standard.scss
+++ b/src/material/form-field/form-field-standard.scss
@@ -35,7 +35,7 @@ $mat-form-field-standard-padding-top: 0.75em !default;
 
     @include cdk-high-contrast(active, off) {
       height: 0;
-      border-top: $height;
+      border-top: solid $height;
     }
   }
 


### PR DESCRIPTION
There was a syntax error which prevented the focus indication from rendering in high contrast mode.

Fixes #21780.