### PR TITLE
refactor(cdk/testing): change deprecated APIs for v12

### DIFF
--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -94,9 +94,8 @@ export interface TestElement {
    * @param relativeX Coordinate within the element, along the X-axis at which to click.
    * @param relativeY Coordinate within the element, along the Y-axis at which to click.
    * @param modifiers Modifier keys held while clicking
-   * @breaking-change 11.0.0 To become a required method.
    */
-  rightClick?(relativeX: number, relativeY: number, modifiers?: ModifierKeys): Promise<void>;
+  rightClick(relativeX: number, relativeY: number, modifiers?: ModifierKeys): Promise<void>;
 
   /** Focus the element. */
   focus(): Promise<void>;
@@ -148,9 +147,8 @@ export interface TestElement {
 
   /**
    * Sets the value of a property of an input.
-   * @breaking-change 11.0.0 To become a required method.
    */
-  setInputValue?(value: string): Promise<void>;
+  setInputValue(value: string): Promise<void>;
 
   // Note that ideally here we'd be selecting options based on their value, rather than their
   // index, but we're limited by `@angular/forms` which will modify the option value in some cases.
@@ -158,16 +156,14 @@ export interface TestElement {
   // https://github.com/angular/angular/blob/master/packages/forms/src/directives/select_control_value_accessor.ts#L19
   /**
    * Selects the options at the specified indexes inside of a native `select` element.
-   * @breaking-change 12.0.0 To become a required method.
    */
-  selectOptions?(...optionIndexes: number[]): Promise<void>;
+  selectOptions(...optionIndexes: number[]): Promise<void>;
 
   /**
    * Dispatches an event with a particular name.
    * @param name Name of the event to be dispatched.
-   * @breaking-change 12.0.0 To be a required method.
    */
-  dispatchEvent?(name: string, data?: Record<string, EventData>): Promise<void>;
+  dispatchEvent(name: string, data?: Record<string, EventData>): Promise<void>;
 }
 
 export interface TextOptions {

--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -369,14 +369,14 @@ export function crossEnvironmentSpecs(
     it('should be able to right click at a specific position within an element', async () => {
       const clickTest = await harness.clickTest();
       const contextmenuTestResult = await harness.contextmenuTestResult();
-      await clickTest.rightClick!(50, 50);
+      await clickTest.rightClick(50, 50);
       expect(await contextmenuTestResult.text()).toBe('50-50-2');
     });
 
     it('should be able to right click with modifiers', async () => {
       const clickTest = await harness.clickTest();
       const modifiersResult = await harness.clickModifiersResult();
-      await clickTest.rightClick!(50, 50, {alt: true, control: true});
+      await clickTest.rightClick(50, 50, {alt: true, control: true});
       expect(await modifiersResult.text()).toBe('-alt-control-');
     });
 
@@ -455,8 +455,7 @@ export function crossEnvironmentSpecs(
     it('should be able to set the value of an input', async () => {
       const input = await harness.input();
 
-      // @breaking-change 11.0.0 Remove non-null assertion once `setInputValue` is required.
-      await input.setInputValue!('hello');
+      await input.setInputValue('hello');
       expect(await input.getProperty('value')).toBe('hello');
     });
 
@@ -467,8 +466,7 @@ export function crossEnvironmentSpecs(
         harness.singleSelectChangeEventCounter()
       ]);
 
-      // @breaking-change 12.0.0 Remove non-null assertion once `setSelectValue` is required.
-      await select.selectOptions!(2);
+      await select.selectOptions(2);
       expect(await value.text()).toBe('Select: three');
       expect(await changeEventCounter.text()).toBe('Change events: 1');
     });
@@ -480,8 +478,7 @@ export function crossEnvironmentSpecs(
         harness.multiSelectChangeEventCounter()
       ]);
 
-      // @breaking-change 12.0.0 Remove non-null assertion once `setSelectValue` is required.
-      await select.selectOptions!(0, 2);
+      await select.selectOptions(0, 2);
       expect(await value.text()).toBe('Multi-select: one,three');
       expect(await changeEventCounter.text()).toBe('Change events: 2');
     });
@@ -503,16 +500,14 @@ export function crossEnvironmentSpecs(
     it('should dispatch a basic custom event', async () => {
       const target = await harness.customEventBasic();
 
-      // @breaking-change 12.0.0 Remove non-null assertion once `dispatchEvent` is required.
-      await target.dispatchEvent!('myCustomEvent');
+      await target.dispatchEvent('myCustomEvent');
       expect(await target.text()).toBe('Basic event: 1');
     });
 
     it('should dispatch a custom event with attached data', async () => {
       const target = await harness.customEventObject();
 
-      // @breaking-change 12.0.0 Remove non-null assertion once `dispatchEvent` is required.
-      await target.dispatchEvent!('myCustomEvent', {message: 'Hello', value: 1337});
+      await target.dispatchEvent('myCustomEvent', {message: 'Hello', value: 1337});
       expect(await target.text()).toBe('Event with object: {"message":"Hello","value":1337}');
     });
 

--- a/src/material/datepicker/testing/datepicker-input-harness-base.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness-base.ts
@@ -60,10 +60,7 @@ export abstract class MatDatepickerInputHarnessBase extends ComponentHarness {
       await inputEl.sendKeys(newValue);
     }
 
-    // @breaking-change 12.0.0 Remove null check once `dispatchEvent` is a required method.
-    if (inputEl.dispatchEvent) {
-      await inputEl.dispatchEvent('change');
-    }
+    await inputEl.dispatchEvent('change');
   }
 
   /** Gets the placeholder of the input. */

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -124,9 +124,6 @@ export class MatInputHarness extends MatFormFieldControlHarness {
     // Some input types won't respond to key presses (e.g. `color`) so to be sure that the
     // value is set, we also set the property after the keyboard sequence. Note that we don't
     // want to do it before, because it can cause the value to be entered twice.
-    // @breaking-change 11.0.0 Remove non-null assertion once `setInputValue` is required.
-    if (inputEl.setInputValue) {
-      await inputEl.setInputValue(newValue);
-    }
+    await inputEl.setInputValue(newValue);
   }
 }

--- a/src/material/input/testing/native-select-harness.ts
+++ b/src/material/input/testing/native-select-harness.ts
@@ -95,12 +95,6 @@ export class MatNativeSelectHarness extends MatFormFieldControlHarness {
       parallel(() => options.slice(0, isMultiple ? undefined : 1).map(option => option.getIndex()))
     ]);
 
-    // @breaking-change 12.0.0 Error can be removed once `selectOptions` is a required method.
-    if (!host.selectOptions) {
-      throw Error('TestElement implementation does not support the selectOptions ' +
-                  'method which is required for this function.');
-    }
-
     await host.selectOptions(...optionIndexes);
   }
 }

--- a/tools/public_api_guard/cdk/testing.d.ts
+++ b/tools/public_api_guard/cdk/testing.d.ts
@@ -154,7 +154,7 @@ export interface TestElement {
     click(modifiers?: ModifierKeys): Promise<void>;
     click(location: 'center', modifiers?: ModifierKeys): Promise<void>;
     click(relativeX: number, relativeY: number, modifiers?: ModifierKeys): Promise<void>;
-    dispatchEvent?(name: string, data?: Record<string, EventData>): Promise<void>;
+    dispatchEvent(name: string, data?: Record<string, EventData>): Promise<void>;
     focus(): Promise<void>;
     getAttribute(name: string): Promise<string | null>;
     getCssValue(property: string): Promise<string>;
@@ -165,11 +165,11 @@ export interface TestElement {
     isFocused(): Promise<boolean>;
     matchesSelector(selector: string): Promise<boolean>;
     mouseAway(): Promise<void>;
-    rightClick?(relativeX: number, relativeY: number, modifiers?: ModifierKeys): Promise<void>;
-    selectOptions?(...optionIndexes: number[]): Promise<void>;
+    rightClick(relativeX: number, relativeY: number, modifiers?: ModifierKeys): Promise<void>;
+    selectOptions(...optionIndexes: number[]): Promise<void>;
     sendKeys(...keys: (string | TestKey)[]): Promise<void>;
     sendKeys(modifiers: ModifierKeys, ...keys: (string | TestKey)[]): Promise<void>;
-    setInputValue?(value: string): Promise<void>;
+    setInputValue(value: string): Promise<void>;
     text(options?: TextOptions): Promise<string>;
 }
 


### PR DESCRIPTION
Changes the APIs that were marked as deprecated for v12.0.0.

BREAKING CHANGES:
* `TestElement.rightClick` is now a required method.
* `TestElement.setInputValue` is now a required method.
* `TestElement.selectOptions` is now a required method.
* `TestElement.dispatchEvent` is now a required method.