### PR TITLE
fix(material/dialog): focus restoration not working inside shadow dom

### DIFF
--- a/src/material-experimental/mdc-dialog/BUILD.bazel
+++ b/src/material-experimental/mdc-dialog/BUILD.bazel
@@ -65,6 +65,7 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/overlay",
+        "//src/cdk/platform",
         "//src/cdk/scrolling",
         "//src/cdk/testing/private",
         "@npm//@angular/common",

--- a/src/material/dialog/BUILD.bazel
+++ b/src/material/dialog/BUILD.bazel
@@ -61,6 +61,7 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/overlay",
+        "//src/cdk/platform",
         "//src/cdk/scrolling",
         "//src/cdk/testing/private",
         "@npm//@angular/common",

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -182,7 +182,7 @@ export abstract class _MatDialogContainerBase extends BasePortalOutlet {
     // We need the extra check, because IE can set the `activeElement` to null in some cases.
     if (this._config.restoreFocus && previousElement &&
         typeof previousElement.focus === 'function') {
-      const activeElement = this._document.activeElement;
+      const activeElement = this._getActiveElement();
       const element = this._elementRef.nativeElement;
 
       // Make sure that focus is still inside the dialog or is on the body (usually because a
@@ -213,7 +213,7 @@ export abstract class _MatDialogContainerBase extends BasePortalOutlet {
   /** Captures the element that was focused before the dialog was opened. */
   private _capturePreviouslyFocusedElement() {
     if (this._document) {
-      this._elementFocusedBeforeDialogWasOpened = this._document.activeElement as HTMLElement;
+      this._elementFocusedBeforeDialogWasOpened = this._getActiveElement() as HTMLElement;
     }
   }
 
@@ -228,8 +228,16 @@ export abstract class _MatDialogContainerBase extends BasePortalOutlet {
   /** Returns whether focus is inside the dialog. */
   private _containsFocus() {
     const element = this._elementRef.nativeElement;
-    const activeElement = this._document.activeElement;
+    const activeElement = this._getActiveElement();
     return element === activeElement || element.contains(activeElement);
+  }
+
+  /** Gets the currently-focused element on the page. */
+  private _getActiveElement(): Element | null {
+    // If the `activeElement` is inside a shadow root, `document.activeElement` will
+    // point to the shadow root so we have to descend into it ourselves.
+    const activeElement = this._document.activeElement;
+    return activeElement?.shadowRoot?.activeElement as HTMLElement || activeElement;
   }
 }
 


### PR DESCRIPTION
Related to #21796. The dialog focus restoration works by grabbing `document.activeElement` before the dialog is opened and restoring focus to the element on destroy.  This won't work if the element is inside the shadow DOM, because the browser will return the shadow root. These changes add a workaround.