### PR TITLE
build: resolve circular dependencies in e2e code

### DIFF
--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -27,9 +27,5 @@
   [
     "src/cdk/scrolling/virtual-scroll-strategy.ts",
     "src/cdk/scrolling/virtual-scroll-viewport.ts"
-  ],
-  [
-    "src/cdk/testing/private/e2e/actions.ts",
-    "src/cdk/testing/private/e2e/query.ts"
   ]
 ]

--- a/src/cdk/testing/private/e2e/actions.ts
+++ b/src/cdk/testing/private/e2e/actions.ts
@@ -7,7 +7,7 @@
  */
 
 import {browser} from 'protractor';
-import {getElement, FinderResult} from './query';
+import {getElement, FinderResult, Point} from './query';
 
 /**
  * Presses a single key or a sequence of keys.
@@ -25,5 +25,3 @@ export async function clickElementAtPoint(element: FinderResult, coords: Point) 
   const webElement = await getElement(element).getWebElement();
   await browser.actions().mouseMove(webElement, coords).click().perform();
 }
-
-export interface Point { x: number; y: number; }

--- a/src/cdk/testing/private/e2e/asserts.ts
+++ b/src/cdk/testing/private/e2e/asserts.ts
@@ -7,8 +7,7 @@
  */
 
 import {browser} from 'protractor';
-import {getElement, FinderResult, waitForElement} from './query';
-import {Point} from './actions';
+import {getElement, FinderResult, waitForElement, Point} from './query';
 
 /**
  * Asserts that an element exists.

--- a/src/cdk/testing/private/e2e/query.ts
+++ b/src/cdk/testing/private/e2e/query.ts
@@ -7,7 +7,6 @@
  */
 
 import {browser, by, element, ElementFinder} from 'protractor';
-import {Point} from './actions';
 
 /**
  * Normalizes either turning a selector into an
@@ -42,3 +41,5 @@ export async function getScrollPosition(): Promise<Point> {
 }
 
 export type FinderResult = ElementFinder | string;
+
+export interface Point { x: number; y: number; }


### PR DESCRIPTION
Moves an interface in order to resolve a circular dependency.