### PR TITLE
fix(cdk/drag-drop): destroyed items not being cleaned up correctly

### DIFF
--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -327,7 +327,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
     const index = CdkDrag._dragInstances.indexOf(this);
     if (index > -1) {
-      CdkDrag._dragInstances.splice(index, -1);
+      CdkDrag._dragInstances.splice(index, 1);
     }
     this._destroyed.next();
     this._destroyed.complete();


### PR DESCRIPTION
Fixes a memory leak in `CdkDrag` which prevented it from being cleaned up. The problem is that we keep track of all the instances in an array, but there was a typo in the cleanup logic which meant that the items would never be removed from the array.

Fixes #21818.