### PR TITLE
fix(material/grid-list): remove internal figure element

### DIFF
--- a/src/material/grid-list/grid-list.scss
+++ b/src/material/grid-list/grid-list.scss
@@ -19,18 +19,6 @@ $text-padding: 16px;
   position: absolute;
   overflow: hidden;
 
-  .mat-figure {
-    @include layout-common.fill;
-    display: flex;
-
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-
-    padding: 0;
-    margin: 0;
-  }
-
   // Headers & footers
   .mat-grid-tile-header,
   .mat-grid-tile-footer {
@@ -78,4 +66,16 @@ $text-padding: 16px;
       display: none;
     }
   }
+}
+
+.mat-grid-tile-content {
+  @include layout-common.fill;
+  display: flex;
+
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+
+  padding: 0;
+  margin: 0;
 }

--- a/src/material/grid-list/grid-tile.html
+++ b/src/material/grid-list/grid-tile.html
@@ -1,4 +1,4 @@
-<!-- TODO(kara): Revisit why this is a figure.-->
-<figure class="mat-figure">
+<!-- The `mat-figure` class is only used for backwards compatibility. -->
+<div class="mat-grid-tile-content mat-figure">
   <ng-content></ng-content>
-</figure>
+</div>


### PR DESCRIPTION
Removes the built-in `figure` element inside the grid tile since it isn't always desirable from an accessibility perspective.

Fixes #21775.