### PR TITLE
build: set up generic way of passing in environment variables to dev app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,6 @@ testem.log
 *.log
 .ng-dev.user*
 .husky/_
-/src/dev-app/google-maps-api-key.txt
+
+# Variables that are inlined into the dev app index.html
+/src/dev-app/variables.json

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -121,11 +121,11 @@ create_system_config(
     output_name = "system-config.js",
 )
 
-# File group for static files that are listed in the gitignore file that contain
-# secrets like API keys.
+# Variables that are going to be inlined into the dev app index.html.
+# Uses a glob, because the file is optional.
 filegroup(
-    name = "environment-secret-assets",
-    srcs = glob(["*-api-key.txt"]),
+    name = "variables",
+    srcs = glob(["variables.json"]),
 )
 
 # File group for all static files which are needed to serve the dev-app. These files are
@@ -136,9 +136,9 @@ filegroup(
     srcs = [
         "favicon.ico",
         "index.html",
-        ":environment-secret-assets",
         ":system-config",
         ":theme",
+        ":variables",
         "//src/dev-app/icon:icon_demo_assets",
         "//tools:system-rxjs-operators.js",
         "@npm//:node_modules/@material/animation/dist/mdc.animation.js",

--- a/src/dev-app/index.html
+++ b/src/dev-app/index.html
@@ -25,12 +25,6 @@
 <body>
   <dev-app>Loading...</dev-app>
 
-  <!-- This iframe loads the hidden Google Maps API Key. -->
-  <iframe id="google-maps-api-key"
-          src="google-maps-api-key.txt"
-          style="display:none;"
-          onload="loadGoogleMapsScript()"></iframe>
-
   <script src="core-js-bundle/index.js"></script>
   <script src="zone.js/dist/zone.js"></script>
   <script src="systemjs/dist/system.js"></script>
@@ -38,17 +32,11 @@
   <script src="https://www.youtube.com/iframe_api"></script>
   <script src="https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js"></script>
   <script>
-    function loadGoogleMapsScript() {
-      var iframe = document.getElementById('google-maps-api-key');
-      var googleMapsScript = document.createElement('script');
-      var googleMapsApiKey = iframe.contentDocument.body.textContent;
-      var googleMapsUrl = 'https://maps.googleapis.com/maps/api/js';
-      if (googleMapsApiKey !== 'Page not found') {
-        googleMapsUrl = googleMapsUrl + '?key=' + googleMapsApiKey;
-      }
-      googleMapsScript.src = googleMapsUrl;
-      document.body.appendChild(googleMapsScript);
-    }
+    (function loadGoogleMaps(key) {
+      var script = document.createElement('script');
+      script.src = 'https://maps.googleapis.com/maps/api/js' + (key ? '?key=' + key : '');
+      document.body.appendChild(script);
+    })(window.DEV_APP_VARIABLES.GOOGLE_MAPS_KEY);
   </script>
   <script>
     System.config({

--- a/tools/dev-server/dev-server.ts
+++ b/tools/dev-server/dev-server.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {readFileSync, existsSync} from 'fs';
 import * as browserSync from 'browser-sync';
 import * as http from 'http';
 import * as path from 'path';
@@ -17,6 +18,9 @@ import * as send from 'send';
  * environment and on Windows (with a runfile manifest file).
  */
 export class DevServer {
+  /** Cached content of the index.html. */
+  private _index: string|null = null;
+
   /** Instance of the browser-sync server. */
   server = browserSync.create();
 
@@ -38,7 +42,7 @@ export class DevServer {
       private _historyApiFallback: boolean = false) {}
 
   /** Starts the server on the given port. */
-  async start() {
+  start() {
     return new Promise<void>((resolve, reject) => {
       this.server.init(this.options, (err) => {
         if (err) {
@@ -82,18 +86,18 @@ export class DevServer {
     // to the index: https://github.com/bripkens/connect-history-api-fallback#introduction
     if (this._historyApiFallback && req.method === 'GET' && !req.url.includes('.') &&
         req.headers.accept && req.headers.accept.includes('text/html')) {
-      req.url = '/index.html';
+      res.end(this._getIndex());
+    } else {
+      const resolvedPath = this._resolveUrlFromRunfiles(req.url);
+
+      if (resolvedPath === null) {
+        res.statusCode = 404;
+        res.end('Page not found');
+        return;
+      }
+
+      send(req, resolvedPath).pipe(res);
     }
-
-    const resolvedPath = this._resolveUrlFromRunfiles(req.url);
-
-    if (resolvedPath === null) {
-      res.statusCode = 404;
-      res.end('Page not found');
-      return;
-    }
-
-    send(req, resolvedPath).pipe(res);
   }
 
   /** Resolves a given URL from the runfiles using the corresponding manifest path. */
@@ -101,10 +105,31 @@ export class DevServer {
     for (let rootPath of this._rootPaths) {
       try {
         return require.resolve(path.posix.join(rootPath, getManifestPath(url)));
-      } catch {
-      }
+      } catch {}
     }
     return null;
+  }
+
+  /** Gets the content of the index.html. */
+  private _getIndex(): string {
+    if (!this._index) {
+      const indexPath = this._resolveUrlFromRunfiles('/index.html');
+
+      if (!indexPath) {
+        throw Error('Could not resolve dev server index.html');
+      }
+
+      // We support specifying a variables.json file next to the index.html which will be inlined
+      // into the dev app as a `script` tag. It is used to pass in environment-specific variables.
+      const varsPath = path.join(path.dirname(indexPath), 'variables.json');
+      const scriptTag = '<script>window.DEV_APP_VARIABLES = ' +
+        (existsSync(varsPath) ? readFileSync(varsPath, 'utf8') : '{}') + ';</script>';
+      const content = readFileSync(indexPath, 'utf8');
+      const headIndex = content.indexOf('</head>');
+      this._index = content.slice(0, headIndex) + scriptTag + content.slice(headIndex);
+    }
+
+    return this._index;
   }
 }
 


### PR DESCRIPTION
Currently we have a one-off way of passing the Google Maps API key to the dev app. These changes rework the approach so that we have a single `variables.json` file which can be used for the Google Maps key, as well as any other variables in the future.