### PR TITLE
feat(cdk/drag-drop): allow for preview container to be customized

### DIFF
--- a/src/cdk/drag-drop/directives/config.ts
+++ b/src/cdk/drag-drop/directives/config.ts
@@ -43,4 +43,5 @@ export interface DragDropConfig extends Partial<DragRefConfig> {
   listAutoScrollDisabled?: boolean;
   listOrientation?: DropListOrientation;
   zIndex?: number;
+  previewContainer?: 'global' | 'parent';
 }

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -50,7 +50,7 @@ import {CDK_DRAG_HANDLE, CdkDragHandle} from './drag-handle';
 import {CDK_DRAG_PLACEHOLDER, CdkDragPlaceholder} from './drag-placeholder';
 import {CDK_DRAG_PREVIEW, CdkDragPreview} from './drag-preview';
 import {CDK_DRAG_PARENT} from '../drag-parent';
-import {DragRef, Point} from '../drag-ref';
+import {DragRef, Point, PreviewContainer} from '../drag-ref';
 import {CDK_DROP_LIST, CdkDropListInternal as CdkDropList} from './drop-list';
 import {DragDrop} from '../drag-drop';
 import {CDK_DRAG_CONFIG, DragDropConfig, DragStartDelay, DragAxis} from './config';
@@ -139,6 +139,21 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
   /** Class to be added to the preview element. */
   @Input('cdkDragPreviewClass') previewClass: string | string[];
+
+  /**
+   * Configures the place into which the preview of the item will be inserted. Can be configured
+   * globally through `CDK_DROP_LIST`. Possible values:
+   * - `global` - Preview will be inserted at the bottom of the `<body>`. The advantage is that
+   * you don't have to worry about `overflow: hidden` or `z-index`, but the item won't retain
+   * its inherited styles.
+   * - `parent` - Preview will be inserted into the parent of the drag item. The advantage is that
+   * inherited styles will be preserved, but it may be clipped by `overflow: hidden` or not be
+   * visible due to `z-index`. Furthermore, the preview is going to have an effect over selectors
+   * like `:nth-child` and some flexbox configurations.
+   * - `ElementRef<HTMLElement> | HTMLElement` - Preview will be inserted into a specific element.
+   * Same advantages and disadvantages as `parent`.
+   */
+  @Input('cdkDragPreviewContainer') previewContainer: PreviewContainer;
 
   /** Emits when the user starts dragging the item. */
   @Output('cdkDragStarted') started: EventEmitter<CdkDragStart> = new EventEmitter<CdkDragStart>();
@@ -396,7 +411,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
         ref
           .withBoundaryElement(this._getBoundaryElement())
           .withPlaceholderTemplate(placeholder)
-          .withPreviewTemplate(preview);
+          .withPreviewTemplate(preview)
+          .withPreviewContainer(this.previewContainer || 'global');
 
         if (dir) {
           ref.withDirection(dir.value);
@@ -481,8 +497,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   /** Assigns the default input values based on a provided config object. */
   private _assignDefaults(config: DragDropConfig) {
     const {
-      lockAxis, dragStartDelay, constrainPosition, previewClass,
-      boundaryElement, draggingDisabled, rootElementSelector
+      lockAxis, dragStartDelay, constrainPosition, previewClass, boundaryElement, draggingDisabled,
+      rootElementSelector, previewContainer
     } = config;
 
     this.disabled = draggingDisabled == null ? false : draggingDisabled;
@@ -506,6 +522,10 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
     if (rootElementSelector) {
       this.rootElementSelector = rootElementSelector;
+    }
+
+    if (previewContainer) {
+      this.previewContainer = previewContainer;
     }
   }
 

--- a/src/cdk/drag-drop/drag-drop.md
+++ b/src/cdk/drag-drop/drag-drop.md
@@ -128,6 +128,19 @@ to be applied.
 
 <!-- example(cdk-drag-drop-custom-preview) -->
 
+### Drag preview insertion point
+By default, the preview of a `cdkDrag` will be inserted into the `<body>` of the page in order to
+avoid issues with `z-index` and `overflow: hidden`. This may not be desireable in some cases,
+because the preview won't retain its inherited styles. You can control where the preview is inserted
+using the `cdkDrawPreviewContainer` input. The possible values are:
+
+| Value             | Description             | Advantages             | Disadvantages             |
+|-------------------|-------------------------|------------------------|---------------------------|
+| `global` | Default value. Preview is inserted into the `<body>` or the closest shadow root. | Preview won't be affected by `z-index` or `overflow: hidden`. It also won't affect `:nth-child` selectors and flex layouts. | Doesn't retain inherited styles.
+| `parent` | Preview is inserted inside the parent of the item that is being dragged. | Preview inherits the same styles as the dragged item. | Preview may be clipped by `overflow: hidden` or be placed under other elements due to `z-index`. Furthermore, it can affect `:nth-child` selectors and some flex layouts.
+| `ElementRef` or `HTMLElement` | Preview will be inserted into the specified element. | Preview inherits styles from the specified container element. | Preview may be clipped by `overflow: hidden` or be placed under other elements due to `z-index`. Furthermore, it can affect `:nth-child` selectors and some flex layouts.
+
+
 ### Customizing the drag placeholder
 While a `cdkDrag` element is being dragged, the CDK will create a placeholder element that will
 show where it will be placed when it's dropped. By default the placeholder is a clone of the element

--- a/src/cdk/drag-drop/public-api.ts
+++ b/src/cdk/drag-drop/public-api.ts
@@ -7,7 +7,7 @@
  */
 
 export {DragDrop} from './drag-drop';
-export {DragRef, DragRefConfig, Point} from './drag-ref';
+export {DragRef, DragRefConfig, Point, PreviewContainer} from './drag-ref';
 export {DropListRef} from './drop-list-ref';
 export {CDK_DRAG_PARENT} from './drag-parent';
 

--- a/src/dev-app/drag-drop/drag-drop-demo.scss
+++ b/src/dev-app/drag-drop/drag-drop-demo.scss
@@ -43,7 +43,7 @@
   justify-content: space-between;
   box-sizing: border-box;
 
-  .cdk-drop-list-dragging &:not(.cdk-drag-placeholder) {
+  .cdk-drop-list-dragging &:not(.cdk-drag-placeholder):not(.cdk-drag-preview) {
     transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
   }
 

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -36,6 +36,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     lockAxis: DragAxis;
     moved: Observable<CdkDragMove<T>>;
     previewClass: string | string[];
+    previewContainer: PreviewContainer;
     released: EventEmitter<CdkDragRelease>;
     rootElementSelector: string;
     started: EventEmitter<CdkDragStart>;
@@ -54,7 +55,7 @@ export declare class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDes
     ngOnDestroy(): void;
     reset(): void;
     static ngAcceptInputType_disabled: BooleanInput;
-    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { "data": "cdkDragData"; "lockAxis": "cdkDragLockAxis"; "rootElementSelector": "cdkDragRootElement"; "boundaryElement": "cdkDragBoundary"; "dragStartDelay": "cdkDragStartDelay"; "freeDragPosition": "cdkDragFreeDragPosition"; "disabled": "cdkDragDisabled"; "constrainPosition": "cdkDragConstrainPosition"; "previewClass": "cdkDragPreviewClass"; }, { "started": "cdkDragStarted"; "released": "cdkDragReleased"; "ended": "cdkDragEnded"; "entered": "cdkDragEntered"; "exited": "cdkDragExited"; "dropped": "cdkDragDropped"; "moved": "cdkDragMoved"; }, ["_previewTemplate", "_placeholderTemplate", "_handles"]>;
+    static ɵdir: i0.ɵɵDirectiveDefWithMeta<CdkDrag<any>, "[cdkDrag]", ["cdkDrag"], { "data": "cdkDragData"; "lockAxis": "cdkDragLockAxis"; "rootElementSelector": "cdkDragRootElement"; "boundaryElement": "cdkDragBoundary"; "dragStartDelay": "cdkDragStartDelay"; "freeDragPosition": "cdkDragFreeDragPosition"; "disabled": "cdkDragDisabled"; "constrainPosition": "cdkDragConstrainPosition"; "previewClass": "cdkDragPreviewClass"; "previewContainer": "cdkDragPreviewContainer"; }, { "started": "cdkDragStarted"; "released": "cdkDragReleased"; "ended": "cdkDragEnded"; "entered": "cdkDragEntered"; "exited": "cdkDragExited"; "dropped": "cdkDragDropped"; "moved": "cdkDragMoved"; }, ["_previewTemplate", "_placeholderTemplate", "_handles"]>;
     static ɵfac: i0.ɵɵFactoryDef<CdkDrag<any>, [null, { optional: true; skipSelf: true; }, null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; self: true; }, { optional: true; skipSelf: true; }]>;
 }
 
@@ -220,6 +221,7 @@ export interface DragDropConfig extends Partial<DragRefConfig> {
     listOrientation?: DropListOrientation;
     lockAxis?: DragAxis;
     previewClass?: string | string[];
+    previewContainer?: 'global' | 'parent';
     rootElementSelector?: string;
     sortingDisabled?: boolean;
     zIndex?: number;
@@ -320,6 +322,7 @@ export declare class DragRef<T = any> {
     withHandles(handles: (HTMLElement | ElementRef<HTMLElement>)[]): this;
     withParent(parent: DragRef<unknown> | null): this;
     withPlaceholderTemplate(template: DragHelperTemplate | null): this;
+    withPreviewContainer(value: PreviewContainer): this;
     withPreviewTemplate(template: DragPreviewTemplate | null): this;
     withRootElement(rootElement: ElementRef<HTMLElement> | HTMLElement): this;
 }
@@ -407,5 +410,7 @@ export interface Point {
     x: number;
     y: number;
 }
+
+export declare type PreviewContainer = 'global' | 'parent' | ElementRef<HTMLElement> | HTMLElement;
 
 export declare function transferArrayItem<T = any>(currentArray: T[], targetArray: T[], currentIndex: number, targetIndex: number): void;


### PR DESCRIPTION
Currently we always insert the drag preview at the `body`, because it allows us to avoid dealing with `overflow` and `z-index`. The problem is that it doesn't allow the preview to retain its inherited styles.

These changes add a new input which allows the consumer to configure the place into which the preview will be inserted.

Fixes #13288.