### PR TITLE
refactor(material/sort): remove deprecated APIs for v12

### DIFF
--- a/src/material/sort/sort-header-intl.ts
+++ b/src/material/sort/sort-header-intl.ts
@@ -12,6 +12,8 @@ import {Subject} from 'rxjs';
 /**
  * To modify the labels and text displayed, create a new instance of MatSortHeaderIntl and
  * include it in a custom provider.
+ * @deprecated No longer being used. To be removed.
+ * @breaking-change 13.0.0
  */
 @Injectable({providedIn: 'root'})
 export class MatSortHeaderIntl {
@@ -20,16 +22,8 @@ export class MatSortHeaderIntl {
    * components if the labels have changed after initialization.
    */
   readonly changes: Subject<void> = new Subject<void>();
-
-  /**
-   * ARIA label for the sorting button.
-   * @deprecated Not used anymore. To be removed.
-   * @breaking-change 8.0.0
-   */
-  sortButtonLabel = (id: string) => {
-    return `Change sorting for ${id}`;
-  }
 }
+
 /** @docs-private */
 export function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl) {
   return parentIntl || new MatSortHeaderIntl();

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -140,7 +140,12 @@ export class MatSortHeader extends _MatSortHeaderMixinBase
   set disableClear(v) { this._disableClear = coerceBooleanProperty(v); }
   private _disableClear: boolean;
 
-  constructor(public _intl: MatSortHeaderIntl,
+  constructor(
+              /**
+               * @deprecated `_intl` parameter isn't being used anymore and it'll be removed.
+               * @breaking-change 13.0.0
+               */
+              public _intl: MatSortHeaderIntl,
               private _changeDetectorRef: ChangeDetectorRef,
               // `MatSort` is not optionally injected, but just asserted manually w/ better error.
               // tslint:disable-next-line: lightweight-tokens

--- a/src/material/sort/testing/sort-header-harness.ts
+++ b/src/material/sort/testing/sort-header-harness.ts
@@ -47,15 +47,6 @@ export class MatSortHeaderHarness extends ComponentHarness {
     return '';
   }
 
-  /**
-   * Gets the aria-label of the sort header.
-   * @deprecated The sort header no longer has an `aria-label`. This method will be removed.
-   * @breaking-change 11.0.0
-   */
-  async getAriaLabel(): Promise<string|null> {
-    return (await this._container()).getAttribute('aria-label');
-  }
-
   /** Gets whether the sort header is currently being sorted by. */
   async isActive(): Promise<boolean> {
     return !!(await this.getSortDirection());

--- a/tools/public_api_guard/material/sort.d.ts
+++ b/tools/public_api_guard/material/sort.d.ts
@@ -71,7 +71,8 @@ export declare class MatSortHeader extends _MatSortHeaderMixinBase implements Ca
     set disableClear(v: boolean);
     id: string;
     start: 'asc' | 'desc';
-    constructor(_intl: MatSortHeaderIntl, _changeDetectorRef: ChangeDetectorRef, _sort: MatSort, _columnDef: MatSortHeaderColumnDef, _focusMonitor: FocusMonitor, _elementRef: ElementRef<HTMLElement>);
+    constructor(
+    _intl: MatSortHeaderIntl, _changeDetectorRef: ChangeDetectorRef, _sort: MatSort, _columnDef: MatSortHeaderColumnDef, _focusMonitor: FocusMonitor, _elementRef: ElementRef<HTMLElement>);
     _getAriaSortAttribute(): "none" | "ascending" | "descending";
     _getArrowDirectionState(): string;
     _getArrowViewState(): string;
@@ -95,7 +96,6 @@ export declare class MatSortHeader extends _MatSortHeaderMixinBase implements Ca
 
 export declare class MatSortHeaderIntl {
     readonly changes: Subject<void>;
-    sortButtonLabel: (id: string) => string;
     static ɵfac: i0.ɵɵFactoryDef<MatSortHeaderIntl, never>;
     static ɵprov: i0.ɵɵInjectableDef<MatSortHeaderIntl>;
 }

--- a/tools/public_api_guard/material/sort/testing.d.ts
+++ b/tools/public_api_guard/material/sort/testing.d.ts
@@ -7,7 +7,6 @@ export declare class MatSortHarness extends ComponentHarness {
 
 export declare class MatSortHeaderHarness extends ComponentHarness {
     click(): Promise<void>;
-    getAriaLabel(): Promise<string | null>;
     getLabel(): Promise<string>;
     getSortDirection(): Promise<SortDirection>;
     isActive(): Promise<boolean>;


### PR DESCRIPTION
Cleans up the deprecated APIs that were marked for removal in v12.

BREAKING CHANGES:
* `MatSortHeaderIntl.sortButtonLabel` has been removed.
* `MatSortHeaderHarness.getAriaLabel` has been removed.