### PR TITLE
feat(material-experimental/mdc-tooltip): add test harness

### DIFF
--- a/scripts/check-mdc-exports-config.ts
+++ b/scripts/check-mdc-exports-config.ts
@@ -98,6 +98,10 @@ export const config = {
       '_MatTooltipBase',
       '_TooltipComponentBase'
     ],
+    'mdc-tooltip/testing': [
+      // Private symbols that are only exported for MDC.
+      '_MatTooltipHarnessBase'
+    ],
     'mdc-checkbox/testing': [
       // Private symbols that are only exported for MDC.
       '_MatCheckboxHarnessBase'

--- a/src/material-experimental/config.bzl
+++ b/src/material-experimental/config.bzl
@@ -44,6 +44,7 @@ entryPoints = [
     "mdc-tabs",
     "mdc-tabs/testing",
     "mdc-tooltip",
+    "mdc-tooltip/testing",
     "menubar",
     "popover-edit",
     "selection",

--- a/src/material-experimental/mdc-tooltip/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-tooltip/testing/BUILD.bazel
@@ -1,0 +1,40 @@
+load("//tools:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "testing",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    module_name = "@angular/material-experimental/mdc-tooltip/testing",
+    deps = [
+        "//src/cdk/testing",
+        "//src/material/tooltip/testing",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob(["**/*.ts"]),
+)
+
+ng_test_library(
+    name = "unit_tests_lib",
+    srcs = glob(["**/*.spec.ts"]),
+    deps = [
+        ":testing",
+        "//src/material-experimental/mdc-tooltip",
+        "//src/material/tooltip/testing:harness_tests_lib",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    static_files = ["@npm//:node_modules/@material/tooltip/dist/mdc.tooltip.js"],
+    deps = [
+        ":unit_tests_lib",
+        "//src/material-experimental:mdc_require_config.js",
+    ],
+)

--- a/src/material-experimental/mdc-tooltip/testing/index.ts
+++ b/src/material-experimental/mdc-tooltip/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './public-api';

--- a/src/material-experimental/mdc-tooltip/testing/public-api.ts
+++ b/src/material-experimental/mdc-tooltip/testing/public-api.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './tooltip-harness';
+export {TooltipHarnessFilters} from '@angular/material/tooltip/testing';

--- a/src/material-experimental/mdc-tooltip/testing/tooltip-harness.spec.ts
+++ b/src/material-experimental/mdc-tooltip/testing/tooltip-harness.spec.ts
@@ -1,0 +1,7 @@
+import {MatTooltipModule} from '@angular/material-experimental/mdc-tooltip';
+import {runHarnessTests} from '@angular/material/tooltip/testing/shared.spec';
+import {MatTooltipHarness} from './index';
+
+describe('MDC-based MatTooltipHarness', () => {
+  runHarnessTests(MatTooltipModule, MatTooltipHarness as any);
+});

--- a/src/material-experimental/mdc-tooltip/testing/tooltip-harness.ts
+++ b/src/material-experimental/mdc-tooltip/testing/tooltip-harness.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HarnessPredicate} from '@angular/cdk/testing';
+import {_MatTooltipHarnessBase, TooltipHarnessFilters} from '@angular/material/tooltip/testing';
+
+/** Harness for interacting with a standard mat-tooltip in tests. */
+export class MatTooltipHarness extends _MatTooltipHarnessBase {
+  protected _optionalPanel =
+      this.documentRootLocatorFactory().locatorForOptional('.mat-mdc-tooltip');
+  static hostSelector = '.mat-mdc-tooltip-trigger';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search
+   * for a tooltip trigger with specific attributes.
+   * @param options Options for narrowing the search.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: TooltipHarnessFilters = {}): HarnessPredicate<MatTooltipHarness> {
+    return new HarnessPredicate(MatTooltipHarness, options);
+  }
+}

--- a/src/material/tooltip/testing/tooltip-harness.ts
+++ b/src/material/tooltip/testing/tooltip-harness.ts
@@ -6,23 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  AsyncFactoryFn,
+  ComponentHarness,
+  HarnessPredicate,
+  TestElement,
+} from '@angular/cdk/testing';
 import {TooltipHarnessFilters} from './tooltip-harness-filters';
 
-/** Harness for interacting with a standard mat-tooltip in tests. */
-export class MatTooltipHarness extends ComponentHarness {
-  private _optionalPanel = this.documentRootLocatorFactory().locatorForOptional('.mat-tooltip');
-  static hostSelector = '.mat-tooltip-trigger';
-
-  /**
-   * Gets a `HarnessPredicate` that can be used to search
-   * for a tooltip trigger with specific attributes.
-   * @param options Options for narrowing the search.
-   * @return a `HarnessPredicate` configured with the given options.
-   */
-  static with(options: TooltipHarnessFilters = {}): HarnessPredicate<MatTooltipHarness> {
-    return new HarnessPredicate(MatTooltipHarness, options);
-  }
+export abstract class _MatTooltipHarnessBase extends ComponentHarness {
+  protected abstract _optionalPanel: AsyncFactoryFn<TestElement | null>;
 
   /** Shows the tooltip. */
   async show(): Promise<void> {
@@ -57,5 +50,21 @@ export class MatTooltipHarness extends ComponentHarness {
   async getTooltipText(): Promise<string> {
     const panel = await this._optionalPanel();
     return panel ? panel.text() : '';
+  }
+}
+
+/** Harness for interacting with a standard mat-tooltip in tests. */
+export class MatTooltipHarness extends _MatTooltipHarnessBase {
+  protected _optionalPanel = this.documentRootLocatorFactory().locatorForOptional('.mat-tooltip');
+  static hostSelector = '.mat-tooltip-trigger';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search
+   * for a tooltip trigger with specific attributes.
+   * @param options Options for narrowing the search.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: TooltipHarnessFilters = {}): HarnessPredicate<MatTooltipHarness> {
+    return new HarnessPredicate(MatTooltipHarness, options);
   }
 }

--- a/tools/public_api_guard/material/tooltip/testing.d.ts
+++ b/tools/public_api_guard/material/tooltip/testing.d.ts
@@ -1,8 +1,13 @@
-export declare class MatTooltipHarness extends ComponentHarness {
+export declare abstract class _MatTooltipHarnessBase extends ComponentHarness {
+    protected abstract _optionalPanel: AsyncFactoryFn<TestElement | null>;
     getTooltipText(): Promise<string>;
     hide(): Promise<void>;
     isOpen(): Promise<boolean>;
     show(): Promise<void>;
+}
+
+export declare class MatTooltipHarness extends _MatTooltipHarnessBase {
+    protected _optionalPanel: AsyncFactoryFn<TestElement | null>;
     static hostSelector: string;
     static with(options?: TooltipHarnessFilters): HarnessPredicate<MatTooltipHarness>;
 }


### PR DESCRIPTION
Sets up a test harness for the MDC-based tooltip.