### PR TITLE
fix(material-experimental/mdc-paginator): use MDC-based tooltip

### DIFF
--- a/src/material-experimental/mdc-paginator/BUILD.bazel
+++ b/src/material-experimental/mdc-paginator/BUILD.bazel
@@ -20,8 +20,8 @@ ng_module(
     deps = [
         "//src/material-experimental/mdc-button",
         "//src/material-experimental/mdc-select",
+        "//src/material-experimental/mdc-tooltip",
         "//src/material/paginator",
-        "//src/material/tooltip",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/forms",  # TODO(jelbourn): transitive dep via generated code
@@ -69,6 +69,7 @@ ng_web_test_suite(
         "@npm//:node_modules/@material/textfield/dist/mdc.textfield.js",
         "@npm//:node_modules/@material/line-ripple/dist/mdc.lineRipple.js",
         "@npm//:node_modules/@material/notched-outline/dist/mdc.notchedOutline.js",
+        "@npm//:node_modules/@material/tooltip/dist/mdc.tooltip.js",
         "@npm//:node_modules/@material/ripple/dist/mdc.ripple.js",
         "@npm//:node_modules/@material/dom/dist/mdc.dom.js",
     ],

--- a/src/material-experimental/mdc-paginator/paginator-module.ts
+++ b/src/material-experimental/mdc-paginator/paginator-module.ts
@@ -11,7 +11,7 @@ import {NgModule} from '@angular/core';
 import {MAT_PAGINATOR_INTL_PROVIDER} from '@angular/material/paginator';
 import {MatButtonModule} from '@angular/material-experimental/mdc-button';
 import {MatSelectModule} from '@angular/material-experimental/mdc-select';
-import {MatTooltipModule} from '@angular/material/tooltip';
+import {MatTooltipModule} from '@angular/material-experimental/mdc-tooltip';
 import {MatPaginator} from './paginator';
 
 

--- a/src/material-experimental/mdc-paginator/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-paginator/testing/BUILD.bazel
@@ -32,6 +32,7 @@ ng_web_test_suite(
         "@npm//:node_modules/@material/textfield/dist/mdc.textfield.js",
         "@npm//:node_modules/@material/line-ripple/dist/mdc.lineRipple.js",
         "@npm//:node_modules/@material/notched-outline/dist/mdc.notchedOutline.js",
+        "@npm//:node_modules/@material/tooltip/dist/mdc.tooltip.js",
         "@npm//:node_modules/@material/ripple/dist/mdc.ripple.js",
         "@npm//:node_modules/@material/dom/dist/mdc.dom.js",
     ],

--- a/src/material-experimental/mdc-table/BUILD.bazel
+++ b/src/material-experimental/mdc-table/BUILD.bazel
@@ -78,6 +78,7 @@ ng_web_test_suite(
         "@npm//:node_modules/@material/textfield/dist/mdc.textfield.js",
         "@npm//:node_modules/@material/line-ripple/dist/mdc.lineRipple.js",
         "@npm//:node_modules/@material/notched-outline/dist/mdc.notchedOutline.js",
+        "@npm//:node_modules/@material/tooltip/dist/mdc.tooltip.js",
         "@npm//:node_modules/@material/ripple/dist/mdc.ripple.js",
         "@npm//:node_modules/@material/dom/dist/mdc.dom.js",
         "@npm//:node_modules/@material/data-table/dist/mdc.dataTable.js",


### PR DESCRIPTION
Switches the MDC-based paginator to use the MDC tooltip.