### PR TITLE
refactor(material/tooltip): change deprecated APIs for v12

### DIFF
--- a/src/material-experimental/mdc-tooltip/tooltip.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.ts
@@ -62,8 +62,6 @@ export class MatTooltip extends _MatTooltipBase<TooltipComponent> {
     @Inject(MAT_TOOLTIP_SCROLL_STRATEGY) scrollStrategy: any,
     @Optional() dir: Directionality,
     @Optional() @Inject(MAT_TOOLTIP_DEFAULT_OPTIONS) defaultOptions: MatTooltipDefaultOptions,
-
-    /** @breaking-change 11.0.0 _document argument to become required. */
     @Inject(DOCUMENT) _document: any) {
 
     super(overlay, elementRef, scrollDispatcher, viewContainerRef, ngZone, platform, ariaDescriber,

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -14,6 +14,12 @@ import {ConstructorChecksUpgradeData, TargetVersion, VersionChanges} from '@angu
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V12]: [
+    {
+      pr: 'https://github.com/angular/components/pull/21897',
+      changes: ['MatTooltip']
+    }
+  ],
   [TargetVersion.V11]: [
     {
       pr: 'https://github.com/angular/components/issues/20463',

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -242,11 +242,8 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase> implement
   private readonly _passiveListeners:
       (readonly [string, EventListenerOrEventListenerObject])[] = [];
 
-  /**
-   * Reference to the current document.
-   * @breaking-change 11.0.0 Remove `| null` typing for `document`.
-   */
-  private _document: Document | null;
+  /** Reference to the current document. */
+  private _document: Document;
 
   /** Timer started at the last `touchstart` event. */
   private _touchstartTimeout: number;
@@ -266,11 +263,10 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase> implement
     scrollStrategy: any,
     protected _dir: Directionality,
     private _defaultOptions: MatTooltipDefaultOptions,
-
-    /** @breaking-change 11.0.0 _document argument to become required. */
     @Inject(DOCUMENT) _document: any) {
 
     this._scrollStrategy = scrollStrategy;
+    this._document = _document;
 
     if (_defaultOptions) {
       if (_defaultOptions.position) {
@@ -671,9 +667,7 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase> implement
   /** Listener for the `wheel` event on the element. */
   private _wheelListener(event: WheelEvent) {
     if (this._isTooltipVisible()) {
-      // @breaking-change 11.0.0 Remove `|| document` once the document is a required param.
-      const doc = this._document || document;
-      const elementUnderPointer = doc.elementFromPoint(event.clientX, event.clientY);
+      const elementUnderPointer = this._document.elementFromPoint(event.clientX, event.clientY);
       const element = this._elementRef.nativeElement;
 
       // On non-touch devices we depend on the `mouseleave` event to close the tooltip, but it
@@ -746,8 +740,6 @@ export class MatTooltip extends _MatTooltipBase<TooltipComponent> {
     @Inject(MAT_TOOLTIP_SCROLL_STRATEGY) scrollStrategy: any,
     @Optional() dir: Directionality,
     @Optional() @Inject(MAT_TOOLTIP_DEFAULT_OPTIONS) defaultOptions: MatTooltipDefaultOptions,
-
-    /** @breaking-change 11.0.0 _document argument to become required. */
     @Inject(DOCUMENT) _document: any) {
 
     super(overlay, elementRef, scrollDispatcher, viewContainerRef, ngZone, platform, ariaDescriber,

--- a/tools/public_api_guard/material/tooltip.d.ts
+++ b/tools/public_api_guard/material/tooltip.d.ts
@@ -20,8 +20,7 @@ export declare abstract class _MatTooltipBase<T extends _TooltipComponentBase> i
         [key: string]: any;
     });
     touchGestures: TooltipTouchGestures;
-    constructor(_overlay: Overlay, _elementRef: ElementRef<HTMLElement>, _scrollDispatcher: ScrollDispatcher, _viewContainerRef: ViewContainerRef, _ngZone: NgZone, _platform: Platform, _ariaDescriber: AriaDescriber, _focusMonitor: FocusMonitor, scrollStrategy: any, _dir: Directionality, _defaultOptions: MatTooltipDefaultOptions,
-    _document: any);
+    constructor(_overlay: Overlay, _elementRef: ElementRef<HTMLElement>, _scrollDispatcher: ScrollDispatcher, _viewContainerRef: ViewContainerRef, _ngZone: NgZone, _platform: Platform, _ariaDescriber: AriaDescriber, _focusMonitor: FocusMonitor, scrollStrategy: any, _dir: Directionality, _defaultOptions: MatTooltipDefaultOptions, _document: any);
     protected _addOffset(position: ConnectedPosition): ConnectedPosition;
     _getOrigin(): {
         main: OriginConnectionPosition;
@@ -85,8 +84,7 @@ export declare const MAT_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER: {
 export declare class MatTooltip extends _MatTooltipBase<TooltipComponent> {
     protected readonly _tooltipComponent: typeof TooltipComponent;
     protected readonly _transformOriginSelector = ".mat-tooltip";
-    constructor(overlay: Overlay, elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, viewContainerRef: ViewContainerRef, ngZone: NgZone, platform: Platform, ariaDescriber: AriaDescriber, focusMonitor: FocusMonitor, scrollStrategy: any, dir: Directionality, defaultOptions: MatTooltipDefaultOptions,
-    _document: any);
+    constructor(overlay: Overlay, elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, viewContainerRef: ViewContainerRef, ngZone: NgZone, platform: Platform, ariaDescriber: AriaDescriber, focusMonitor: FocusMonitor, scrollStrategy: any, dir: Directionality, defaultOptions: MatTooltipDefaultOptions, _document: any);
     static ɵdir: i0.ɵɵDirectiveDefWithMeta<MatTooltip, "[matTooltip]", ["matTooltip"], {}, {}, never>;
     static ɵfac: i0.ɵɵFactoryDef<MatTooltip, [null, null, null, null, null, null, null, null, null, { optional: true; }, { optional: true; }, null]>;
 }


### PR DESCRIPTION
Changes the APIs that were marked as deprecated for v12.

BREAKING CHANGES:
* The `_document` parameter of the `MatTooltip` constructor is now required.