### PR TITLE
refactor(material-experimental/mdc-form-field): de-duplicate test harness logic

### DIFF
--- a/scripts/check-mdc-exports-config.ts
+++ b/scripts/check-mdc-exports-config.ts
@@ -33,6 +33,10 @@ export const config = {
       '_MatDialogContainerBase',
       '_closeDialogVia',
     ],
+    'mdc-form-field/testing': [
+      // Private base class that is only exported for MDC.
+      '_MatFormFieldHarnessBase'
+    ],
     'mdc-menu': [
       // Private base class that is only exported for MDC.
       '_MatMenuBase'

--- a/src/material/form-field/testing/form-field-harness.ts
+++ b/src/material/form-field/testing/form-field-harness.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  AsyncFactoryFn,
   ComponentHarness,
   ComponentHarnessConstructor,
   HarnessPredicate,
@@ -24,44 +25,44 @@ import {FormFieldHarnessFilters} from './form-field-harness-filters';
 /** Possible harnesses of controls which can be bound to a form-field. */
 export type FormFieldControlHarness = MatInputHarness|MatSelectHarness;
 
-/** Harness for interacting with a standard Material form-field's in tests. */
-export class MatFormFieldHarness extends ComponentHarness {
-  static hostSelector = '.mat-form-field';
-
-  /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatFormFieldHarness` that meets
-   * certain criteria.
-   * @param options Options for filtering which form field instances are considered a match.
-   * @return a `HarnessPredicate` configured with the given options.
-   */
-  static with(options: FormFieldHarnessFilters = {}): HarnessPredicate<MatFormFieldHarness> {
-    return new HarnessPredicate(MatFormFieldHarness, options)
-      .addOption('floatingLabelText', options.floatingLabelText, async (harness, text) =>
-          HarnessPredicate.stringMatches(await harness.getLabel(), text))
-      .addOption('hasErrors', options.hasErrors, async (harness, hasErrors) =>
-          await harness.hasErrors() === hasErrors);
-  }
-
-  private _prefixContainer = this.locatorForOptional('.mat-form-field-prefix');
-  private _suffixContainer = this.locatorForOptional('.mat-form-field-suffix');
-  private _label = this.locatorForOptional('.mat-form-field-label');
-  private _errors = this.locatorForAll('.mat-error');
-  private _hints = this.locatorForAll('mat-hint, .mat-hint');
-
-  private _inputControl = this.locatorForOptional(MatInputHarness);
-  private _selectControl = this.locatorForOptional(MatSelectHarness);
+export abstract class _MatFormFieldHarnessBase<ControlHarness extends MatFormFieldControlHarness>
+  extends ComponentHarness {
+  protected abstract _prefixContainer: AsyncFactoryFn<TestElement|null>;
+  protected abstract _suffixContainer: AsyncFactoryFn<TestElement|null>;
+  protected abstract _label: AsyncFactoryFn<TestElement|null>;
+  protected abstract _errors: AsyncFactoryFn<TestElement[]>;
+  protected abstract _hints: AsyncFactoryFn<TestElement[]>;
+  protected abstract _inputControl: AsyncFactoryFn<ControlHarness|null>;
+  protected abstract _selectControl: AsyncFactoryFn<ControlHarness|null>;
 
   /** Gets the appearance of the form-field. */
-  async getAppearance(): Promise<'legacy'|'standard'|'fill'|'outline'> {
-    const hostClasses = await (await this.host()).getAttribute('class');
-    if (hostClasses !== null) {
-      const appearanceMatch =
-          hostClasses.match(/mat-form-field-appearance-(legacy|standard|fill|outline)(?:$| )/);
-      if (appearanceMatch) {
-        return appearanceMatch[1] as 'legacy' | 'standard' | 'fill' | 'outline';
-      }
-    }
-    throw Error('Could not determine appearance of form-field.');
+  abstract getAppearance(): Promise<string>;
+
+  /** Whether the label is currently floating. */
+  abstract isLabelFloating(): Promise<boolean>;
+
+  /** Whether the form-field has a label. */
+  abstract hasLabel(): Promise<boolean>;
+
+  /** Gets the label of the form-field. */
+  async getLabel(): Promise<string|null> {
+    const labelEl = await this._label();
+    return labelEl ? labelEl.text() : null;
+  }
+
+  /** Whether the form-field has errors. */
+  async hasErrors(): Promise<boolean> {
+    return (await this.getTextErrors()).length > 0;
+  }
+
+  /** Whether the form-field is disabled. */
+  async isDisabled(): Promise<boolean> {
+    return (await this.host()).hasClass('mat-form-field-disabled');
+  }
+
+  /** Whether the form-field is currently autofilled. */
+  async isAutofilled(): Promise<boolean> {
+    return (await this.host()).hasClass('mat-form-field-autofilled');
   }
 
   /**
@@ -69,7 +70,7 @@ export class MatFormFieldHarness extends ComponentHarness {
    * default controls such as "MatInputHarness" and "MatSelectHarness" are
    * supported.
    */
-  async getControl(): Promise<FormFieldControlHarness|null>;
+  async getControl(): Promise<ControlHarness|null>;
 
   /**
    * Gets the harness of the control that is bound to the form-field. Searches
@@ -90,55 +91,8 @@ export class MatFormFieldHarness extends ComponentHarness {
     if (type) {
       return this.locatorForOptional(type)();
     }
-    const hostEl = await this.host();
-    const [isInput, isSelect] = await parallel(() => [
-      hostEl.hasClass('mat-form-field-type-mat-input'),
-      hostEl.hasClass('mat-form-field-type-mat-select'),
-    ]);
-    if (isInput) {
-      return this._inputControl();
-    } else if (isSelect) {
-      return this._selectControl();
-    }
-    return null;
-  }
-
-  /** Whether the form-field has a label. */
-  async hasLabel(): Promise<boolean> {
-    return (await this.host()).hasClass('mat-form-field-has-label');
-  }
-
-  /** Gets the label of the form-field. */
-  async getLabel(): Promise<string|null> {
-    const labelEl = await this._label();
-    return labelEl ? labelEl.text() : null;
-  }
-
-  /** Whether the form-field has errors. */
-  async hasErrors(): Promise<boolean> {
-    return (await this.getTextErrors()).length > 0;
-  }
-
-  /** Whether the label is currently floating. */
-  async isLabelFloating(): Promise<boolean> {
-    const host = await this.host();
-    const [hasLabel, shouldFloat] = await parallel(() => [
-      this.hasLabel(),
-      host.hasClass('mat-form-field-should-float'),
-    ]);
-    // If there is no label, the label conceptually can never float. The `should-float` class
-    // is just always set regardless of whether the label is displayed or not.
-    return hasLabel && shouldFloat;
-  }
-
-  /** Whether the form-field is disabled. */
-  async isDisabled(): Promise<boolean> {
-    return (await this.host()).hasClass('mat-form-field-disabled');
-  }
-
-  /** Whether the form-field is currently autofilled. */
-  async isAutofilled(): Promise<boolean> {
-    return (await this.host()).hasClass('mat-form-field-autofilled');
+    const [select, input] = await parallel(() => [this._selectControl(), this._inputControl()]);
+    return select || input;
   }
 
   /** Gets the theme color of the form-field. */
@@ -252,5 +206,62 @@ export class MatFormFieldHarness extends ComponentHarness {
     const [isTouched, isUntouched] =
         await parallel(() => [hostEl.hasClass('ng-touched'), hostEl.hasClass('ng-untouched')]);
     return isTouched || isUntouched;
+  }
+}
+
+/** Harness for interacting with a standard Material form-field's in tests. */
+export class MatFormFieldHarness extends _MatFormFieldHarnessBase<FormFieldControlHarness> {
+  static hostSelector = '.mat-form-field';
+
+  /**
+   * Gets a `HarnessPredicate` that can be used to search for a `MatFormFieldHarness` that meets
+   * certain criteria.
+   * @param options Options for filtering which form field instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  static with(options: FormFieldHarnessFilters = {}): HarnessPredicate<MatFormFieldHarness> {
+    return new HarnessPredicate(MatFormFieldHarness, options)
+      .addOption('floatingLabelText', options.floatingLabelText, async (harness, text) =>
+          HarnessPredicate.stringMatches(await harness.getLabel(), text))
+      .addOption('hasErrors', options.hasErrors, async (harness, hasErrors) =>
+          await harness.hasErrors() === hasErrors);
+  }
+
+  protected _prefixContainer = this.locatorForOptional('.mat-form-field-prefix');
+  protected _suffixContainer = this.locatorForOptional('.mat-form-field-suffix');
+  protected _label = this.locatorForOptional('.mat-form-field-label');
+  protected _errors = this.locatorForAll('.mat-error');
+  protected _hints = this.locatorForAll('mat-hint, .mat-hint');
+  protected _inputControl = this.locatorForOptional(MatInputHarness);
+  protected _selectControl = this.locatorForOptional(MatSelectHarness);
+
+  /** Gets the appearance of the form-field. */
+  async getAppearance(): Promise<'legacy'|'standard'|'fill'|'outline'> {
+    const hostClasses = await (await this.host()).getAttribute('class');
+    if (hostClasses !== null) {
+      const appearanceMatch =
+          hostClasses.match(/mat-form-field-appearance-(legacy|standard|fill|outline)(?:$| )/);
+      if (appearanceMatch) {
+        return appearanceMatch[1] as 'legacy' | 'standard' | 'fill' | 'outline';
+      }
+    }
+    throw Error('Could not determine appearance of form-field.');
+  }
+
+  /** Whether the form-field has a label. */
+  async hasLabel(): Promise<boolean> {
+    return (await this.host()).hasClass('mat-form-field-has-label');
+  }
+
+  /** Whether the label is currently floating. */
+  async isLabelFloating(): Promise<boolean> {
+    const host = await this.host();
+    const [hasLabel, shouldFloat] = await parallel(() => [
+      this.hasLabel(),
+      host.hasClass('mat-form-field-should-float'),
+    ]);
+    // If there is no label, the label conceptually can never float. The `should-float` class
+    // is just always set regardless of whether the label is displayed or not.
+    return hasLabel && shouldFloat;
   }
 }

--- a/tools/public_api_guard/material/form-field/testing.d.ts
+++ b/tools/public_api_guard/material/form-field/testing.d.ts
@@ -1,13 +1,13 @@
-export declare type FormFieldControlHarness = MatInputHarness | MatSelectHarness;
-
-export interface FormFieldHarnessFilters extends BaseHarnessFilters {
-    floatingLabelText?: string | RegExp;
-    hasErrors?: boolean;
-}
-
-export declare class MatFormFieldHarness extends ComponentHarness {
-    getAppearance(): Promise<'legacy' | 'standard' | 'fill' | 'outline'>;
-    getControl(): Promise<FormFieldControlHarness | null>;
+export declare abstract class _MatFormFieldHarnessBase<ControlHarness extends MatFormFieldControlHarness> extends ComponentHarness {
+    protected abstract _errors: AsyncFactoryFn<TestElement[]>;
+    protected abstract _hints: AsyncFactoryFn<TestElement[]>;
+    protected abstract _inputControl: AsyncFactoryFn<ControlHarness | null>;
+    protected abstract _label: AsyncFactoryFn<TestElement | null>;
+    protected abstract _prefixContainer: AsyncFactoryFn<TestElement | null>;
+    protected abstract _selectControl: AsyncFactoryFn<ControlHarness | null>;
+    protected abstract _suffixContainer: AsyncFactoryFn<TestElement | null>;
+    abstract getAppearance(): Promise<string>;
+    getControl(): Promise<ControlHarness | null>;
     getControl<X extends MatFormFieldControlHarness>(type: ComponentHarnessConstructor<X>): Promise<X | null>;
     getControl<X extends MatFormFieldControlHarness>(type: HarnessPredicate<X>): Promise<X | null>;
     getHarnessLoaderForPrefix(): Promise<TestElement | null>;
@@ -19,13 +19,33 @@ export declare class MatFormFieldHarness extends ComponentHarness {
     getTextHints(): Promise<string[]>;
     getThemeColor(): Promise<'primary' | 'accent' | 'warn'>;
     hasErrors(): Promise<boolean>;
-    hasLabel(): Promise<boolean>;
+    abstract hasLabel(): Promise<boolean>;
     isAutofilled(): Promise<boolean>;
     isControlDirty(): Promise<boolean | null>;
     isControlPending(): Promise<boolean | null>;
     isControlTouched(): Promise<boolean | null>;
     isControlValid(): Promise<boolean | null>;
     isDisabled(): Promise<boolean>;
+    abstract isLabelFloating(): Promise<boolean>;
+}
+
+export declare type FormFieldControlHarness = MatInputHarness | MatSelectHarness;
+
+export interface FormFieldHarnessFilters extends BaseHarnessFilters {
+    floatingLabelText?: string | RegExp;
+    hasErrors?: boolean;
+}
+
+export declare class MatFormFieldHarness extends _MatFormFieldHarnessBase<FormFieldControlHarness> {
+    protected _errors: AsyncFactoryFn<TestElement[]>;
+    protected _hints: AsyncFactoryFn<TestElement[]>;
+    protected _inputControl: AsyncFactoryFn<MatInputHarness | null>;
+    protected _label: AsyncFactoryFn<TestElement | null>;
+    protected _prefixContainer: AsyncFactoryFn<TestElement | null>;
+    protected _selectControl: AsyncFactoryFn<MatSelectHarness | null>;
+    protected _suffixContainer: AsyncFactoryFn<TestElement | null>;
+    getAppearance(): Promise<'legacy' | 'standard' | 'fill' | 'outline'>;
+    hasLabel(): Promise<boolean>;
     isLabelFloating(): Promise<boolean>;
     static hostSelector: string;
     static with(options?: FormFieldHarnessFilters): HarnessPredicate<MatFormFieldHarness>;


### PR DESCRIPTION
De-duplicates the test harness logic between the MDC and non-MDC implementations.