### PR TITLE
docs: implement ControlValueAccessor in the code snippet

### DIFF
--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -202,7 +202,7 @@ To resolve this, remove the `NG_VALUE_ACCESSOR` provider and instead set the val
     // },
   ],
 })
-export class MyTelInput implements MatFormFieldControl<MyTel> {
+export class MyTelInput implements MatFormFieldControl<MyTel>, ControlValueAccessor {
   constructor(
     ...,
     @Optional() @Self() public ngControl: NgControl,


### PR DESCRIPTION
`this` should implement `ControlValueAccessor` because
`valueAccessor` has type `ControlValueAccessor | null`
in the `this.ngControl.valueAccessor = this;` (line 216)

Affected URL: https://material.angular.io/guide/creating-a-custom-form-field-control#ngcontrol