### PR TITLE
docs: pass ElementRef<HTMLElement> as is into FocusMonitor methods

### DIFF
--- a/guides/creating-a-custom-form-field-control.md
+++ b/guides/creating-a-custom-form-field-control.md
@@ -235,7 +235,7 @@ focused = false;
 
 constructor(fb: FormBuilder, private fm: FocusMonitor, private elRef: ElementRef<HTMLElement>) {
   ...
-  fm.monitor(elRef.nativeElement, true).subscribe(origin => {
+  fm.monitor(elRef, true).subscribe(origin => {
     this.focused = !!origin;
     this.stateChanges.next();
   });
@@ -243,7 +243,7 @@ constructor(fb: FormBuilder, private fm: FocusMonitor, private elRef: ElementRef
 
 ngOnDestroy() {
   ...
-  this.fm.stopMonitoring(this.elRef.nativeElement);
+  this.fm.stopMonitoring(this.elRef);
 }
 ```
 


### PR DESCRIPTION
`FocusMonitor`'s `monitor`/`stopMonitoring` methods accept `ElementRef<HTMLElement>` as parameter.
So there's no need to call `ElementRef.nativeElement`
https://material.angular.io/cdk/a11y/api#FocusMonitor