### PR TITLE
fix(google-maps): mapTypeId not being set from options

### DIFF
--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -347,6 +347,18 @@ describe('GoogleMap', () => {
 
     expect(mapSpy.setMapTypeId).toHaveBeenCalledWith('roadmap');
   });
+
+  it('sets mapTypeId through the options', () => {
+    const options = {mapTypeId: 'satellite'};
+    mapSpy = createMapSpy(options);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy).and.callThrough();
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.componentInstance.options = options;
+    fixture.detectChanges();
+
+    expect(mapConstructorSpy.calls.mostRecent()?.args[1].mapTypeId).toBe('satellite');
+  });
+
 });
 
 @Component({

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -252,8 +252,8 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
     const googleMap = this.googleMap;
 
     if (googleMap) {
-      if (changes['options'] && this._options) {
-        googleMap.setOptions(this._options);
+      if (changes['options']) {
+        googleMap.setOptions(this._combineOptions());
       }
 
       if (changes['center'] && this._center) {
@@ -459,14 +459,14 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
 
   /** Combines the center and zoom and the other map options into a single object */
   private _combineOptions(): google.maps.MapOptions {
-    const options = this._options;
+    const options = this._options || {};
     return {
       ...options,
       // It's important that we set **some** kind of `center` and `zoom`, otherwise
       // Google Maps will render a blank rectangle which looks broken.
       center: this._center || options.center || DEFAULT_OPTIONS.center,
       zoom: this._zoom ?? options.zoom ?? DEFAULT_OPTIONS.zoom,
-      mapTypeId: this.mapTypeId
+      mapTypeId: this.mapTypeId || options.mapTypeId
     };
   }
 


### PR DESCRIPTION
Fixes a regression where the `mapTypeId` from the `options` object wasn't being preserved when combining the options with the input values.

Fixes #21903.

**Note:** setting as a P2, because it's a regression.