### PR TITLE
docs(material/table): additional details on table data sources

### DIFF
--- a/src/material/table/table.md
+++ b/src/material/table/table.md
@@ -107,13 +107,22 @@ automatically trigger an update to the rows each time a new data array is emitte
 #### DataSource
 
 For most real-world applications, providing the table a DataSource instance will be the best way to
-manage data. The DataSource is meant to serve a place to encapsulate any sorting, filtering,
+manage data. The DataSource is meant to serve as a place to encapsulate any sorting, filtering,
 pagination, and data retrieval logic specific to the application.
 
-A DataSource is simply a base class that has two functions: `connect` and `disconnect`. The
-`connect` function will be called by the table to receive a stream that emits the data array that
-should be rendered. The table will call `disconnect` when the table is destroyed, which may be the
-right time to clean up any subscriptions that may have been registered during the connect process.
+A DataSource is simply a class that has at a minimum the following methods: `connect` and 
+`disconnect`. The `connect` method will be called by the table to provide an Observable that emits 
+the data array that should be rendered. The table will call `disconnect` when the table is destroyed,
+which may be the right time to clean up any subscriptions that may have been registered in the 
+`connect` method. 
+
+Although Angular Material provides a ready-made table DataSource class, `MatTableDataSource`, you may
+want to create your own custom DataSource class for more complex use cases. This can be done by 
+`extending` the abstract DataSource class with a custom DataSource class that then implements the 
+`connect` and `disconnect` methods. For use cases where the custom DataSource must also inherit 
+functionality by extending a different base class, the DataSource base class can be 
+implemented instead (`MyCustomDataSource extends SomeOtherBaseClass implements DataSource`) to
+respect Typescript's restriction to only implement one base class.
 
 ### Features
 

--- a/src/material/table/table.md
+++ b/src/material/table/table.md
@@ -118,7 +118,7 @@ which may be the right time to clean up any subscriptions that may have been reg
 
 Although Angular Material provides a ready-made table DataSource class, `MatTableDataSource`, you may
 want to create your own custom DataSource class for more complex use cases. This can be done by 
-`extending` the abstract DataSource class with a custom DataSource class that then implements the 
+extending the abstract DataSource class with a custom DataSource class that then implements the 
 `connect` and `disconnect` methods. For use cases where the custom DataSource must also inherit 
 functionality by extending a different base class, the DataSource base class can be 
 implemented instead (`MyCustomDataSource extends SomeOtherBaseClass implements DataSource`) to


### PR DESCRIPTION
docs(table): additional details on table data sources

Provides additional documentation and clarification on extending the base DataSource class with custom data sources either by extending or implementing.

Fixes #21887