### PR TITLE
refactor(material/theming): normalize config in all typography mixins for mdc components

### DIFF
--- a/src/dev-app/theme.scss
+++ b/src/dev-app/theme.scss
@@ -15,6 +15,8 @@ $candy-app-theme: mat.define-light-theme((
     accent: $candy-app-accent
   ),
   // Define the default typography for our app.
+  // TODO(mmalerba): Update to `mat-mdc-typography-config()` once non-MDC components can handle
+  //  2018 configs.
   typography: mat.define-typography-config(),
   // Define the default density level for our app.
   density: 0,

--- a/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
+++ b/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
@@ -1,6 +1,7 @@
 @use '@material/menu-surface/mixins' as mdc-menu-surface;
 @use '@material/list/mixins' as mdc-list;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 @mixin color($config-or-theme) {
@@ -12,7 +13,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-menu-surface.core-styles(mdc-helpers.$mat-typography-styles-query);
 

--- a/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
+++ b/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
@@ -13,7 +13,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-menu-surface.core-styles(mdc-helpers.$mat-typography-styles-query);
 

--- a/src/material-experimental/mdc-button/_button-theme.scss
+++ b/src/material-experimental/mdc-button/_button-theme.scss
@@ -8,6 +8,7 @@
 @use '@material/theme/theme' as mdc-theme;
 @use '@material/elevation/elevation-theme' as mdc-elevation-theme;
 @use '../../material/core/ripple/ripple-theme';
+@use '../../material/core/typography/typography';
 @use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/theming/theming';
 
@@ -189,7 +190,7 @@ $mat-fab-state-target: '.mdc-fab__ripple';
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-button.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
   }
@@ -281,7 +282,7 @@ $mat-fab-state-target: '.mdc-fab__ripple';
 }
 
 @mixin fab-typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-fab.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
   }
@@ -350,7 +351,7 @@ $mat-fab-state-target: '.mdc-fab__ripple';
 }
 
 @mixin icon-button-typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-icon-button.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-button/_button-theme.scss
+++ b/src/material-experimental/mdc-button/_button-theme.scss
@@ -190,7 +190,8 @@ $mat-fab-state-target: '.mdc-fab__ripple';
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-button.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
   }
@@ -282,7 +283,8 @@ $mat-fab-state-target: '.mdc-fab__ripple';
 }
 
 @mixin fab-typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-fab.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
   }
@@ -351,7 +353,8 @@ $mat-fab-state-target: '.mdc-fab__ripple';
 }
 
 @mixin icon-button-typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-icon-button.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-card/_card-theme.scss
+++ b/src/material-experimental/mdc-card/_card-theme.scss
@@ -4,6 +4,7 @@
 @use 'sass:color';
 @use 'sass:map';
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 @mixin color($config-or-theme) {
@@ -34,7 +35,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-card.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
 

--- a/src/material-experimental/mdc-card/_card-theme.scss
+++ b/src/material-experimental/mdc-card/_card-theme.scss
@@ -35,7 +35,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-card.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
 

--- a/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
+++ b/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
@@ -6,6 +6,7 @@
 @use '@material/theme/theme';
 @use 'sass:map';
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 @use '../../material/core/ripple/ripple-theme';
 
@@ -108,7 +109,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-checkbox.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-form-field.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
+++ b/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
@@ -109,7 +109,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-checkbox.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-form-field.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-chips/_chips-theme.scss
+++ b/src/material-experimental/mdc-chips/_chips-theme.scss
@@ -76,7 +76,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-chips.set-core-styles($query: mdc-helpers.$mat-typography-styles-query);
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-chips.without-ripple($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-chips/_chips-theme.scss
+++ b/src/material-experimental/mdc-chips/_chips-theme.scss
@@ -3,6 +3,7 @@
 @use 'sass:color';
 @use 'sass:map';
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 @mixin _selected-color($color) {
@@ -75,7 +76,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-chips.set-core-styles($query: mdc-helpers.$mat-typography-styles-query);
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-chips.without-ripple($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-core/option/_optgroup-theme.scss
+++ b/src/material-experimental/mdc-core/option/_optgroup-theme.scss
@@ -19,7 +19,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
 }
 
 @mixin density($config-or-theme) {

--- a/src/material-experimental/mdc-core/option/_optgroup-theme.scss
+++ b/src/material-experimental/mdc-core/option/_optgroup-theme.scss
@@ -2,6 +2,7 @@
 @use '@material/theme/theme' as mdc-theme;
 @use '../../mdc-helpers/mdc-helpers';
 @use '../../../material/core/theming/theming';
+@use '../../../material/core/typography/typography';
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -18,7 +19,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
 }
 
 @mixin density($config-or-theme) {

--- a/src/material-experimental/mdc-core/option/_option-theme.scss
+++ b/src/material-experimental/mdc-core/option/_option-theme.scss
@@ -7,6 +7,7 @@
 @use '@material/ripple' as mdc-ripple;
 @use '../../mdc-helpers/mdc-helpers';
 @use '../../../material/core/theming/theming';
+@use '../../../material/core/typography/typography';
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -54,7 +55,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
 
   @include mdc-helpers.mat-using-mdc-typography($config) {
     // MDC uses the `subtitle1` level for list items, but the spec shows `body1` as the correct

--- a/src/material-experimental/mdc-core/option/_option-theme.scss
+++ b/src/material-experimental/mdc-core/option/_option-theme.scss
@@ -55,7 +55,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
 
   @include mdc-helpers.mat-using-mdc-typography($config) {
     // MDC uses the `subtitle1` level for list items, but the spec shows `body1` as the correct

--- a/src/material-experimental/mdc-dialog/_dialog-theme.scss
+++ b/src/material-experimental/mdc-dialog/_dialog-theme.scss
@@ -11,7 +11,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-dialog.core-styles($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-dialog/_dialog-theme.scss
+++ b/src/material-experimental/mdc-dialog/_dialog-theme.scss
@@ -1,5 +1,6 @@
 @use '@material/dialog' as mdc-dialog;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 @mixin color($config-or-theme) {
@@ -10,7 +11,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-dialog.core-styles($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-form-field/_form-field-theme.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-theme.scss
@@ -6,6 +6,7 @@
 @use '@material/theme/theme-color' as mdc-theme-color;
 @use '@material/typography' as mdc-typography;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use 'form-field-density';
 @use 'form-field-subscript';
 @use 'form-field-focus-overlay';
@@ -63,7 +64,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-textfield.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-floating-label.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-form-field/_form-field-theme.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-theme.scss
@@ -64,7 +64,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-textfield.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-floating-label.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-helpers/_mdc-helpers.scss
+++ b/src/material-experimental/mdc-helpers/_mdc-helpers.scss
@@ -19,84 +19,26 @@ $mat-base-styles-without-animation-query:
 $mat-theme-styles-query: color;
 $mat-typography-styles-query: typography;
 
-// Mappings between Angular Material and MDC's typography levels.
-// TODO: delete once all MDC components have migrated to using the 2018 mappings.
-$mat-typography-2014-level-mappings: (
-  mdc-to-mat: (
-    headline1: display-4,
-    headline2: display-3,
-    headline3: display-2,
-    headline4: display-1,
-    headline5: headline,
-    headline6: title,
-    subtitle1: subheading-2,
-    subtitle2: subheading-1,
-    body1: body-2,
-    body2: body-1,
+// Mappings from Angular Material's typography levels to MDC's typography levels.
+$mat-typography-mdc-level-mappings: (
+    headline-1: headline1,
+    headline-2: headline2,
+    headline-3: headline3,
+    headline-4: headline4,
+    headline-5: headline5,
+    headline-6: headline6,
+    subtitle-1: subtitle1,
+    subtitle-2: subtitle2,
+    body-1: body1,
+    body-2: body2,
     caption: caption,
     button: button,
-    overline: null
-  ),
-  mat-to-mdc: (
-    display-4: headline1,
-    display-3: headline2,
-    display-2: headline3,
-    display-1: headline4,
-    headline: headline5,
-    title: headline6,
-    subheading-2: subtitle1,
-    subheading-1: subtitle2,
-    body-2: body1,
-    body-1: body2,
-    caption: caption,
-    button: button,
-    input: null
-  )
-);
-
-// Mappings between Angular Material and MDC's typography levels.
-$mat-typography-2018-level-mappings: (
-    // Maps from MDC typography levels (e.g. body1) to Angular Material typography levels
-    // (e.g. body-1).
-    mdc-to-mat: (
-        headline1: headline-1,
-        headline2: headline-2,
-        headline3: headline-3,
-        headline4: headline-4,
-        headline5: headline-5,
-        headline6: headline-6,
-        subtitle1: subtitle-1,
-        subtitle2: subtitle-2,
-        body1: body-1,
-        body2: body-2,
-        caption: caption,
-        button: button,
-        overline: overline
-    ),
-    // Maps from Angular Material typography levels (e.g. body-1) to MDC typography levels
-    // (e.g. body1).
-    mat-to-mdc: (
-        headline-1: headline1,
-        headline-2: headline2,
-        headline-3: headline3,
-        headline-4: headline4,
-        headline-5: headline5,
-        headline-6: headline6,
-        subtitle-1: subtitle1,
-        subtitle-2: subtitle2,
-        body-1: body1,
-        body-2: body2,
-        caption: caption,
-        button: button,
-        overline: overline
-    )
+    overline: overline
 );
 
 // Converts an Angular Material typography level config to an MDC one.
 @function mat-typography-level-config-to-mdc($mat-config, $mat-level) {
-  $mappings: if(typography.private-typography-is-2018-config($mat-config),
-      $mat-typography-2018-level-mappings, $mat-typography-2014-level-mappings);
-  $mdc-level: map.get(map.get($mappings, mat-to-mdc), $mat-level);
+  $mdc-level: map.get($mat-typography-mdc-level-mappings, $mat-level);
 
   $result-with-nulls: map.merge(
       if($mdc-level,
@@ -130,13 +72,10 @@ $mat-typography-2018-level-mappings: (
 }
 
 // Converts an Angular Material typography config to an MDC one.
-@function mat-typography-config-to-mdc($mat-config: typography.define-mdc-typography-config()) {
+@function mat-typography-config-to-mdc($mat-config) {
   $mdc-config: ();
 
-  $mappings: if(typography.private-typography-is-2018-config($mat-config),
-      $mat-typography-2018-level-mappings, $mat-typography-2014-level-mappings);
-
-  @each $mdc-level, $mat-level in map.get($mappings, mdc-to-mat) {
+  @each $mat-level, $mdc-level in $mat-typography-mdc-level-mappings {
     $mdc-config: map.merge(
         $mdc-config,
         ($mdc-level: mat-typography-level-config-to-mdc($mat-config, $mat-level)));

--- a/src/material-experimental/mdc-input/_input-theme.scss
+++ b/src/material-experimental/mdc-input/_input-theme.scss
@@ -1,4 +1,5 @@
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 @mixin color($config-or-theme) {
@@ -7,7 +8,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {}
 }
 

--- a/src/material-experimental/mdc-input/_input-theme.scss
+++ b/src/material-experimental/mdc-input/_input-theme.scss
@@ -8,7 +8,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {}
 }
 

--- a/src/material-experimental/mdc-list/_list-theme.scss
+++ b/src/material-experimental/mdc-list/_list-theme.scss
@@ -3,6 +3,7 @@
 @use './interactive-list-theme';
 @use './list-option-theme';
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 
@@ -52,7 +53,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-list.deprecated-without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include list-option-theme.private-list-option-typography-styles();

--- a/src/material-experimental/mdc-list/_list-theme.scss
+++ b/src/material-experimental/mdc-list/_list-theme.scss
@@ -53,7 +53,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-list.deprecated-without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include list-option-theme.private-list-option-typography-styles();

--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -5,6 +5,7 @@
 @use '@material/typography' as mdc-typography;
 @use '@material/ripple' as mdc-ripple;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 @mixin color($config-or-theme) {
@@ -44,7 +45,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-menu-surface.core-styles(mdc-helpers.$mat-typography-styles-query);
 

--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -45,7 +45,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-menu-surface.core-styles(mdc-helpers.$mat-typography-styles-query);
 

--- a/src/material-experimental/mdc-paginator/_paginator-theme.scss
+++ b/src/material-experimental/mdc-paginator/_paginator-theme.scss
@@ -2,6 +2,7 @@
 @use 'sass:map';
 @use '../../material/core/theming/theming';
 @use '../../material/core/density/private/compatibility';
+@use '../../material/core/typography/typography';
 @use '../mdc-helpers/mdc-helpers';
 @use './paginator-variables';
 @use '../../material/core/typography/typography-utils';
@@ -48,7 +49,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
 
   @include mdc-helpers.mat-using-mdc-typography($config) {
     .mat-mdc-paginator {

--- a/src/material-experimental/mdc-paginator/_paginator-theme.scss
+++ b/src/material-experimental/mdc-paginator/_paginator-theme.scss
@@ -49,7 +49,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
 
   @include mdc-helpers.mat-using-mdc-typography($config) {
     .mat-mdc-paginator {

--- a/src/material-experimental/mdc-radio/_radio-theme.scss
+++ b/src/material-experimental/mdc-radio/_radio-theme.scss
@@ -45,7 +45,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-radio.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-form-field.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-radio/_radio-theme.scss
+++ b/src/material-experimental/mdc-radio/_radio-theme.scss
@@ -3,8 +3,8 @@
 @use '@material/radio/radio' as mdc-radio;
 @use '@material/form-field' as mdc-form-field;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
-
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -45,7 +45,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-radio.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-form-field.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-select/_select-theme.scss
+++ b/src/material-experimental/mdc-select/_select-theme.scss
@@ -4,6 +4,7 @@
 @use '@material/select' as mdc-select;
 @use '@material/typography' as mdc-typography;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 // Gets the color to use for some text that is highlighted while a select has focus.
@@ -82,7 +83,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-menu-surface.core-styles(mdc-helpers.$mat-typography-styles-query);
 

--- a/src/material-experimental/mdc-select/_select-theme.scss
+++ b/src/material-experimental/mdc-select/_select-theme.scss
@@ -83,7 +83,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-menu-surface.core-styles(mdc-helpers.$mat-typography-styles-query);
 

--- a/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
+++ b/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
@@ -81,7 +81,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-switch.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-form-field.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
+++ b/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
@@ -3,7 +3,9 @@
 @use '@material/form-field' as mdc-form-field;
 @use 'sass:map';
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
+
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -79,7 +81,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-switch.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-form-field.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-slider/_slider-theme.scss
+++ b/src/material-experimental/mdc-slider/_slider-theme.scss
@@ -25,7 +25,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     // TODO: disabled until we implement the new MDC slider.
     // @include mdc-slider-core-styles($query: $mat-typography-styles-query);

--- a/src/material-experimental/mdc-slider/_slider-theme.scss
+++ b/src/material-experimental/mdc-slider/_slider-theme.scss
@@ -1,6 +1,7 @@
 // TODO: disabled until we implement the new MDC slider.
 // @use '@material/slider' as mdc-slider;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 @mixin color($config-or-theme) {
@@ -24,7 +25,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     // TODO: disabled until we implement the new MDC slider.
     // @include mdc-slider-core-styles($query: $mat-typography-styles-query);

--- a/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
+++ b/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
@@ -3,8 +3,8 @@
 @use 'sass:color';
 @use 'sass:map';
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
-
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -49,7 +49,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-snackbar.core-styles($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
+++ b/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
@@ -49,7 +49,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-snackbar.core-styles($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-table/_table-theme.scss
+++ b/src/material-experimental/mdc-table/_table-theme.scss
@@ -44,7 +44,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-data-table.core-styles($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-table/_table-theme.scss
+++ b/src/material-experimental/mdc-table/_table-theme.scss
@@ -2,8 +2,8 @@
 @use '@material/data-table/data-table' as mdc-data-table;
 @use '@material/data-table/data-table-theme' as mdc-data-table-theme;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
-
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -44,7 +44,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-data-table.core-styles($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-tabs/_tabs-theme.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-theme.scss
@@ -4,6 +4,7 @@
 @use '@material/tab' as mdc-tab;
 @use '@material/tab-bar' as mdc-tab-bar;
 @use '../mdc-helpers/mdc-helpers';
+@use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';
 
 @mixin color($config-or-theme) {
@@ -102,7 +103,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-tab.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-tab-indicator.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-tabs/_tabs-theme.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-theme.scss
@@ -103,7 +103,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include mdc-tab.without-ripple($query: mdc-helpers.$mat-typography-styles-query);
     @include mdc-tab-indicator.core-styles($query: mdc-helpers.$mat-typography-styles-query);

--- a/src/material-experimental/mdc-theming/prebuilt/indigo-pink.scss
+++ b/src/material-experimental/mdc-theming/prebuilt/indigo-pink.scss
@@ -14,7 +14,7 @@ $theme: (
     color: theming.define-light-theme($primary, $accent),
     // TODO(mmalerba): Update to `mat-mdc-typography-config()` once non-MDC components can handle
     //  2018 configs.
-    typography: typography.config()
+    typography: typography.define-typography-config()
 );
 
 // Include non-theme styles for core.

--- a/src/material-experimental/mdc-theming/prebuilt/indigo-pink.scss
+++ b/src/material-experimental/mdc-theming/prebuilt/indigo-pink.scss
@@ -4,17 +4,22 @@
 @use '../../../material/core/core-theme';
 @use '../../../material/core/theming/palette';
 @use '../../../material/core/theming/theming';
-
-// Include non-theme styles for core.
-@include core.core();
+@use '../../../material/core/typography/typography';
 
 // Define a theme.
 $primary: theming.define-palette(palette.$indigo-palette);
 $accent:  theming.define-palette(palette.$pink-palette, A200, A100, A400);
 
-$theme: theming.define-light-theme($primary, $accent);
+$theme: (
+    color: theming.define-light-theme($primary, $accent),
+    // TODO(mmalerba): Update to `mat-mdc-typography-config()` once non-MDC components can handle
+    //  2018 configs.
+    typography: typography.config()
+);
+
+// Include non-theme styles for core.
+@include core.core($theme);
 
 // Include all theme styles for the components.
-@include all-theme.all-mdc-component-themes($theme);
-@include all-typography.all-mdc-component-typographies();
 @include core-theme.theme($theme);
+@include all-theme.all-mdc-component-themes($theme);

--- a/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
+++ b/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
@@ -11,7 +11,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2018-config(
+      theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include tooltip.core-styles($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
+++ b/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
@@ -1,6 +1,7 @@
 @use '@material/tooltip/tooltip';
 @use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/theming/theming';
+@use '../../material/core/typography/typography';
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
@@ -10,7 +11,7 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: theming.get-typography-config($config-or-theme);
+  $config: typography.typography-to-2018-config(theming.get-typography-config($config-or-theme));
   @include mdc-helpers.mat-using-mdc-typography($config) {
     @include tooltip.core-styles($query: mdc-helpers.$mat-typography-styles-query);
   }

--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -126,7 +126,7 @@
   @if $config == null {
     @return null;
   }
-  @if private-typography-is-2014-config($config) {
+  @if not private-typography-is-2018-config($config) {
     @return (
         headline-1: map.get($config, display-4),
         headline-2: map.get($config, display-3),

--- a/tools/stylelint/theme-mixin-api.ts
+++ b/tools/stylelint/theme-mixin-api.ts
@@ -158,8 +158,8 @@ const plugin = (isEnabled: boolean, _options: never, context: {fix: boolean}) =>
         [
           'typography.private-typography-to-2014-config(' +
               'theming.get-typography-config($config-or-theme))',
-          'theming.get-typography-config($config-or-theme)'
-        ] :
+          'typography.private-typography-to-2018-config(' +
+              'theming.get-typography-config($config-or-theme))',        ] :
         [`theming.get-${type}-config($config-or-theme)`];
       let configExtractionNode: Declaration|null = null;
       let nonCommentNodeCount = 0;


### PR DESCRIPTION
This is split off of #21778 which covers non-MDC conmponents as well