### PR TITLE
fix(testing): defineReadonlyEventProperty only if its not yet on the …

### DIFF
--- a/src/cdk/testing/testbed/fake-events/event-objects.ts
+++ b/src/cdk/testing/testbed/fake-events/event-objects.ts
@@ -46,7 +46,9 @@ export function createMouseEvent(
 
   // IE won't set `defaultPrevented` on synthetic events so we need to do it manually.
   event.preventDefault = function() {
-    defineReadonlyEventProperty(event, 'defaultPrevented', true);
+    if(!event.defaultPrevented) {
+        defineReadonlyEventProperty(event, 'defaultPrevented', true);
+    }
     return originalPreventDefault();
   };
 
@@ -157,7 +159,9 @@ export function createKeyboardEvent(type: string, keyCode: number = 0, key: stri
 
   // IE won't set `defaultPrevented` on synthetic events so we need to do it manually.
   event.preventDefault = function() {
-    defineReadonlyEventProperty(event, 'defaultPrevented', true);
+    if(!event.defaultPrevented) {
+        defineReadonlyEventProperty(event, 'defaultPrevented', true);
+    }
     return originalPreventDefault();
   };
 


### PR DESCRIPTION
We have a project that uses CDK for testing Angular components. Some components are wrappers around a third-party library. We have a case where we need to pass down an event to a third-party component and are out of control how many times `preventDefault` is called. Currently, our test suite fails due to the CDK if `preventDefault` is called multiple times. 

On each `preventDefault` call the CDK tries to redefine the read-only Event Property `defaultPrevented`. In think that we should not fail on multiple `preventDefault` calls. From my point of view, it's not ideal to call `preventDefault` multiple times but also doesn't hurt.

This fix only tries to redefine `defaultPrevented` if it doesn't exist on the event.