### PR TITLE
refactor(material/datepicker): remove deprecated APIs for v12

### DIFF
--- a/src/material/datepicker/date-selection-model.ts
+++ b/src/material/datepicker/date-selection-model.ts
@@ -84,18 +84,8 @@ export abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSelection<
   /** Checks whether the current selection is complete. */
   abstract isComplete(): boolean;
 
-  /**
-   * Clones the selection model.
-   * @deprecated To be turned into an abstract method.
-   * @breaking-change 12.0.0
-   */
-  clone(): MatDateSelectionModel<S, D> {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      throw Error('Not implemented');
-    }
-
-    return null!;
-  }
+  /** Clones the selection model. */
+  abstract clone(): MatDateSelectionModel<S, D>;
 }
 
 /**  A selection model that contains a single date. */

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -168,14 +168,9 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
     private _dateAdapter: DateAdapter<D>,
     @Optional() @Inject(MAT_DATE_RANGE_SELECTION_STRATEGY)
         private _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>,
-    /**
-     * @deprecated `intl` argument to become required.
-     * @breaking-change 12.0.0
-     */
-    intl?: MatDatepickerIntl) {
+    intl: MatDatepickerIntl) {
     super(elementRef);
-    // @breaking-change 12.0.0 Remove fallback for `intl`.
-    this._closeButtonText = intl?.closeCalendarLabel || 'Close calendar';
+    this._closeButtonText = intl.closeCalendarLabel;
   }
 
   ngOnInit() {

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -18,6 +18,10 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
     {
       pr: 'https://github.com/angular/components/pull/21897',
       changes: ['MatTooltip']
+    },
+    {
+      pr: 'https://github.com/angular/components/pull/21952',
+      changes: ['MatDatepickerContent']
     }
   ],
   [TargetVersion.V11]: [

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -223,8 +223,7 @@ export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>
     comparisonEnd: D | null;
     comparisonStart: D | null;
     datepicker: MatDatepickerBase<any, S, D>;
-    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _globalModel: MatDateSelectionModel<S, D>, _dateAdapter: DateAdapter<D>, _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>,
-    intl?: MatDatepickerIntl);
+    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _globalModel: MatDateSelectionModel<S, D>, _dateAdapter: DateAdapter<D>, _rangeSelectionStrategy: MatDateRangeSelectionStrategy<D>, intl: MatDatepickerIntl);
     _applyPendingSelection(): void;
     _getSelected(): D | DateRange<D> | null;
     _handleUserSelection(event: MatCalendarUserEvent<D | null>): void;
@@ -390,7 +389,7 @@ export declare abstract class MatDateSelectionModel<S, D = ExtractDateTypeFromSe
     selection: S, _adapter: DateAdapter<D>);
     protected _isValidDateInstance(date: D): boolean;
     abstract add(date: D | null): void;
-    clone(): MatDateSelectionModel<S, D>;
+    abstract clone(): MatDateSelectionModel<S, D>;
     abstract isComplete(): boolean;
     abstract isValid(): boolean;
     ngOnDestroy(): void;


### PR DESCRIPTION
Changes the APIs that were marked as deprecated for v12.

BREAKING CHANGES:
* `MatDateSelectionModel.clone` is now a required abstract method.
* The `intl` parameter of the `MatDatepickerContent` constructor is now required.