### PR TITLE
test(material/select): remove form-field dependency in deselection test

### DIFF
--- a/src/material-experimental/mdc-select/select.spec.ts
+++ b/src/material-experimental/mdc-select/select.spec.ts
@@ -89,6 +89,7 @@ describe('MDC-based MatSelect', () => {
    * that we're only compiling the necessary test components for each test in order to speed up
    * overall test time.
    * @param declarations Components to declare for this block
+   * @param providers Additional providers for this block
    */
   function configureMatSelectTestingModule(declarations: any[], providers: Provider[] = []) {
     TestBed.configureTestingModule({
@@ -1088,7 +1089,7 @@ describe('MDC-based MatSelect', () => {
 
             options[1].click();
             fixture.detectChanges();
-            trigger.click();
+            fixture.componentInstance.select.open();
             fixture.detectChanges();
             flush();
 
@@ -1100,9 +1101,12 @@ describe('MDC-based MatSelect', () => {
 
             fixture.componentInstance.control.setValue(fixture.componentInstance.foods[7].value);
             fixture.detectChanges();
-            trigger.click();
+            fixture.componentInstance.select.close();
             fixture.detectChanges();
             flush();
+
+            fixture.componentInstance.select.open();
+            fixture.detectChanges();
 
             activeOptions = options.filter(option => {
               return option.classList.contains('mat-mdc-option-active');

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -91,6 +91,7 @@ describe('MatSelect', () => {
    * that we're only compiling the necessary test components for each test in order to speed up
    * overall test time.
    * @param declarations Components to declare for this block
+   * @param providers Additional providers for this block
    */
   function configureMatSelectTestingModule(declarations: any[], providers: Provider[] = []) {
     TestBed.configureTestingModule({
@@ -1088,7 +1089,7 @@ describe('MatSelect', () => {
 
             options[1].click();
             fixture.detectChanges();
-            trigger.click();
+            fixture.componentInstance.select.open();
             fixture.detectChanges();
             flush();
 
@@ -1098,9 +1099,12 @@ describe('MatSelect', () => {
 
             fixture.componentInstance.control.setValue(fixture.componentInstance.foods[7].value);
             fixture.detectChanges();
-            trigger.click();
+            fixture.componentInstance.select.close();
             fixture.detectChanges();
             flush();
+
+            fixture.componentInstance.select.open();
+            fixture.detectChanges();
 
             activeOptions = options.filter(option => option.classList.contains('mat-active'));
             expect(activeOptions).toEqual([options[7]],


### PR DESCRIPTION
The existing test would not work without using mat-form-field wrapper because the trigger.click() propagates to onContainerClick of FormField which calls select.open() a second time.
With this change, the logic does not base on propagating/onContainerClick but on specific open and close commands of the panel.