### PR TITLE
docs: mention `entryComponents` is no longer necessary

### DIFF
--- a/src/cdk/portal/portal.md
+++ b/src/cdk/portal/portal.md
@@ -51,7 +51,8 @@ A component can use `@ViewChild` or `@ViewChildren` to get a reference to a
 
 ##### `ComponentPortal`
 Used to create a portal from a component type. When a component is dynamically created using
-portals, it must be included in the `entryComponents` of its `NgModule`.
+portals, it must be included in the `entryComponents` of its `NgModule`if your project uses ViewEngine. Projects
+using Angular Ivy don't need `entryComponents`.
 
 Usage:
 ```ts

--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -50,6 +50,8 @@ export class HobbitSheet {
 ```
 
 ### Configuring bottom sheet content via `entryComponents`
+**You only need to specify `entryComponents` if your project uses ViewEngine. Projects
+using Angular Ivy don't need `entryComponents`.**
 
 Similarly to `MatDialog`, `MatBottomSheet` instantiates components at run-time. In order for it to
 work, the Angular compiler needs extra information to create the necessary `ComponentFactory` for

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -40,6 +40,8 @@ export class YourDialog {
 ```
 
 ### Configuring dialog content via `entryComponents`
+**You only need to specify `entryComponents` if your project uses ViewEngine. Projects
+using Angular Ivy don't need `entryComponents`.**
 
 Because `MatDialog` instantiates components at run-time, the Angular compiler needs extra
 information to create the necessary `ComponentFactory` for your dialog content component.


### PR DESCRIPTION
https://angular.io/guide/deprecations#entrycomponents-and-analyze_for_entry_components-no-longer-required