### PR TITLE
fix(cdk/clipboard): typo in injection token name

### DIFF
--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -27,8 +27,14 @@ export interface CdkCopyToClipboardConfig {
 }
 
 /** Injection token that can be used to provide the default options to `CdkCopyToClipboard`. */
-export const CKD_COPY_TO_CLIPBOARD_CONFIG =
-    new InjectionToken<CdkCopyToClipboardConfig>('CKD_COPY_TO_CLIPBOARD_CONFIG');
+export const CDK_COPY_TO_CLIPBOARD_CONFIG =
+    new InjectionToken<CdkCopyToClipboardConfig>('CDK_COPY_TO_CLIPBOARD_CONFIG');
+
+/**
+ * @deprecated Use `CDK_COPY_TO_CLIPBOARD_CONFIG` instead.
+ * @breaking-change 13.0.0
+ */
+export const CKD_COPY_TO_CLIPBOARD_CONFIG = CDK_COPY_TO_CLIPBOARD_CONFIG;
 
 /**
  * Provides behavior for a button that when clicked copies content into user's

--- a/tools/public_api_guard/cdk/clipboard.d.ts
+++ b/tools/public_api_guard/cdk/clipboard.d.ts
@@ -1,3 +1,5 @@
+export declare const CDK_COPY_TO_CLIPBOARD_CONFIG: InjectionToken<CdkCopyToClipboardConfig>;
+
 export declare class CdkCopyToClipboard implements OnDestroy {
     attempts: number;
     copied: EventEmitter<boolean>;


### PR DESCRIPTION
There was a typo in the name of the `CDK_COPY_TO_CLIPBOARD_CONFIG` token.

Fixes #21976.