### PR TITLE
build: update mdc_snapshot_test_cronjob to yarn install before bazel setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,6 +636,7 @@ jobs:
     steps:
       - checkout_and_rebase
       - *restore_cache
+      - *yarn_install_loose_lockfile
       - *setup_bazel_binary
       - *setup_bazel_ci_config
       - *setup_bazel_remote_execution


### PR DESCRIPTION
The mdc_snapshot_test_cronjob needs to yarn install to ensure
that the bazel binary is available before attempting to reference it.