### PR TITLE
test(material/select): remove form-field dependency in focus test

### DIFF
--- a/src/material-experimental/mdc-select/select.spec.ts
+++ b/src/material-experimental/mdc-select/select.spec.ts
@@ -3093,6 +3093,7 @@ describe('MDC-based MatSelect', () => {
       const select = fixture.debugElement.nativeElement.querySelector('mat-select');
 
       fixture.detectChanges();
+      select.focus(); // Focus manually since the programmatic click might not do it.
       fixture.debugElement.query(By.css('.mat-mdc-select-trigger'))!.nativeElement.click();
       fixture.detectChanges();
       flush();

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -3159,6 +3159,7 @@ describe('MatSelect', () => {
       const select = fixture.debugElement.nativeElement.querySelector('mat-select');
 
       fixture.detectChanges();
+      select.focus(); // Focus manually since the programmatic click might not do it.
       fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement.click();
       fixture.detectChanges();
       flush();


### PR DESCRIPTION
The existing test would not work without using mat-form-field wrapper
because when the click() method in the trigger is called, the event
propagates to onContainerClick of FormField which calls focus() of select.
With this addition, the logic does not base on propagating/onContainerClick
but on a specific focus instruction.