### PR TITLE
fix(material/core): restore private- mixin prefix

### DIFF
--- a/scripts/migrate-sass-modules.js
+++ b/scripts/migrate-sass-modules.js
@@ -27,7 +27,7 @@ const materialPrefixes = [
   'mat-pseudo-checkbox-',
   'mat-elevation-',
   'mat-optgroup-',
-  'mat-private-'
+  'mat-expansion-panel-'
 ];
 const mdcPrefixes = [
   ...getPrefixes('material-experimental', 'mat'),

--- a/src/material-experimental/column-resize/_column-resize.scss
+++ b/src/material-experimental/column-resize/_column-resize.scss
@@ -105,8 +105,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-column-resize') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-column-resize') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
+++ b/src/material-experimental/mdc-autocomplete/_autocomplete-theme.scss
@@ -27,8 +27,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-autocomplete') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-autocomplete') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-button/_button-theme.scss
+++ b/src/material-experimental/mdc-button/_button-theme.scss
@@ -190,8 +190,8 @@ $mat-button-state-target: '.mdc-button__ripple';
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-button') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-button') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
@@ -269,8 +269,8 @@ $mat-button-state-target: '.mdc-button__ripple';
 @mixin fab-density($config-or-theme) {}
 
 @mixin fab-theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-fab') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-fab') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
@@ -347,8 +347,8 @@ $mat-button-state-target: '.mdc-button__ripple';
 }
 
 @mixin icon-button-theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-icon-button') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-icon-button') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-card/_card-theme.scss
+++ b/src/material-experimental/mdc-card/_card-theme.scss
@@ -54,8 +54,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-card') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-card') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
+++ b/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
@@ -144,8 +144,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-checkbox') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-checkbox') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-chips/_chips-theme.scss
+++ b/src/material-experimental/mdc-chips/_chips-theme.scss
@@ -91,8 +91,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-chips') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-chips') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-color/_all-color.scss
+++ b/src/material-experimental/mdc-color/_all-color.scss
@@ -4,7 +4,7 @@
 @mixin angular-material-mdc-color($config-or-theme) {
   // In case a theme object has been passed instead of a configuration for
   // the color system, extract the color config from the theme object.
-  $config: if(theming.is-theme-object($config-or-theme),
+  $config: if(theming.private-is-theme-object($config-or-theme),
       theming.get-color-config($config-or-theme), $config-or-theme);
 
   @if $config == null {

--- a/src/material-experimental/mdc-core/_core-theme.scss
+++ b/src/material-experimental/mdc-core/_core-theme.scss
@@ -4,11 +4,11 @@
 
 // Mixin that renders all of the core styles that depend on the theme.
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
   // Wrap the sub-theme includes in the duplicate theme styles mixin. This ensures that
   // there won't be multiple warnings. e.g. if `mat-mdc-core-theme` reports a warning, then
   // the imported themes (such as `mat-ripple-theme`) should not report again.
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-core') {
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-core') {
     @include option-theme.option-theme($theme);
     @include optgroup-theme.theme($theme);
   }

--- a/src/material-experimental/mdc-core/option/_optgroup-theme.scss
+++ b/src/material-experimental/mdc-core/option/_optgroup-theme.scss
@@ -28,8 +28,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-optgroup') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-optgroup') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-core/option/_option-theme.scss
+++ b/src/material-experimental/mdc-core/option/_option-theme.scss
@@ -62,8 +62,8 @@
 }
 
 @mixin option-theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-option') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-option') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-density/_all-density.scss
+++ b/src/material-experimental/mdc-density/_all-density.scss
@@ -4,7 +4,7 @@
 @mixin angular-material-mdc-density($config-or-theme) {
   // In case a theme object has been passed instead of a configuration for
   // the density system, extract the density config from the theme object.
-  $config: if(theming.is-theme-object($config-or-theme),
+  $config: if(theming.private-is-theme-object($config-or-theme),
       theming.get-density-config($config-or-theme), $config-or-theme);
 
   @if $config == null {

--- a/src/material-experimental/mdc-dialog/_dialog-theme.scss
+++ b/src/material-experimental/mdc-dialog/_dialog-theme.scss
@@ -22,8 +22,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-dialog') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-dialog') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-form-field/_form-field-theme.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-theme.scss
@@ -88,8 +88,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-form-field') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-form-field') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-helpers/_focus-indicators.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators.scss
@@ -122,8 +122,9 @@
     @include _mat-mdc-strong-focus-indicators-border-color($theme-or-color);
   }
   @else {
-    $theme: theming.legacy-get-theme($theme-or-color);
-    @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-strong-focus-indicators') {
+    $theme: theming.private-legacy-get-theme($theme-or-color);
+    @include theming.private-check-duplicate-theme-styles($theme,
+      'mat-mdc-strong-focus-indicators') {
       $color: theming.get-color-config($theme);
       @if $color != null {
         @include strong-focus-indicators-color($color);

--- a/src/material-experimental/mdc-helpers/_mdc-helpers.scss
+++ b/src/material-experimental/mdc-helpers/_mdc-helpers.scss
@@ -94,7 +94,7 @@ $mat-typography-2018-level-mappings: (
 
 // Converts an Angular Material typography level config to an MDC one.
 @function mat-typography-level-config-to-mdc($mat-config, $mat-level) {
-  $mappings: if(typography.typography-is-2018-config($mat-config),
+  $mappings: if(typography.private-typography-is-2018-config($mat-config),
       $mat-typography-2018-level-mappings, $mat-typography-2014-level-mappings);
   $mdc-level: map.get(map.get($mappings, mat-to-mdc), $mat-level);
 
@@ -133,7 +133,7 @@ $mat-typography-2018-level-mappings: (
 @function mat-typography-config-to-mdc($mat-config: typography.config()) {
   $mdc-config: ();
 
-  $mappings: if(typography.typography-is-2018-config($mat-config),
+  $mappings: if(typography.private-typography-is-2018-config($mat-config),
       $mat-typography-2018-level-mappings, $mat-typography-2014-level-mappings);
 
   @each $mdc-level, $mat-level in map.get($mappings, mdc-to-mat) {

--- a/src/material-experimental/mdc-input/_input-theme.scss
+++ b/src/material-experimental/mdc-input/_input-theme.scss
@@ -14,8 +14,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-input') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-input') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-list/_list-theme.scss
+++ b/src/material-experimental/mdc-list/_list-theme.scss
@@ -61,8 +61,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-list') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-list') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -66,8 +66,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-menu') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-menu') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-paginator/_paginator-theme.scss
+++ b/src/material-experimental/mdc-paginator/_paginator-theme.scss
@@ -64,10 +64,10 @@
 
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
-  $height: compatibility.density-prop-value(
+  $height: compatibility.private-density-prop-value(
       paginator-variables.$density-config, $density-scale, height);
 
-  @include compatibility.density-legacy-compatibility() {
+  @include compatibility.private-density-legacy-compatibility() {
     .mat-mdc-paginator-container {
       min-height: $height;
     }
@@ -75,8 +75,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-paginator') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-paginator') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
+++ b/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
@@ -37,8 +37,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-progress-bar') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-progress-bar') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-progress-spinner/_progress-spinner-theme.scss
+++ b/src/material-experimental/mdc-progress-spinner/_progress-spinner-theme.scss
@@ -28,8 +28,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-progress-spinner') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-progress-spinner') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-radio/_radio-theme.scss
+++ b/src/material-experimental/mdc-radio/_radio-theme.scss
@@ -58,8 +58,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-radio') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-radio') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-select/_select-theme.scss
+++ b/src/material-experimental/mdc-select/_select-theme.scss
@@ -101,8 +101,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-select') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-select') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-sidenav/_sidenav-theme.scss
+++ b/src/material-experimental/mdc-sidenav/_sidenav-theme.scss
@@ -10,8 +10,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-sidenav') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-sidenav') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
+++ b/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
@@ -96,8 +96,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-slide-toggle') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-slide-toggle') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-slider/_slider-theme.scss
+++ b/src/material-experimental/mdc-slider/_slider-theme.scss
@@ -34,8 +34,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-slider') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-slider') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
+++ b/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
@@ -53,8 +53,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-snack-bar') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-snack-bar') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-table/_table-theme.scss
+++ b/src/material-experimental/mdc-table/_table-theme.scss
@@ -59,8 +59,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-table') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-table') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-table/table.scss
+++ b/src/material-experimental/mdc-table/table.scss
@@ -4,7 +4,7 @@
 @import '@material/data-table/mixins.import';
 
 @include mdc-data-table-core-styles($query: mdc-helpers.$mat-base-styles-without-animation-query);
-@include table-flex-styles.table-flex-styles();
+@include table-flex-styles.private-table-flex-styles();
 
 .mat-mdc-table-sticky {
   // Note that the table can either set this class or an inline style to make something sticky.

--- a/src/material-experimental/mdc-tabs/_tabs-theme.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-theme.scss
@@ -118,8 +118,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-tabs') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-tabs') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-tabs/tab-group.scss
+++ b/src/material-experimental/mdc-tabs/tab-group.scss
@@ -39,7 +39,7 @@
 
 // The bottom section of the view; contains the tab bodies
 .mat-mdc-tab-body-wrapper {
-  @include private.animation-noop();
+  @include private.private-animation-noop();
   position: relative;
   overflow: hidden;
   display: flex;

--- a/src/material-experimental/mdc-theming/_all-theme.scss
+++ b/src/material-experimental/mdc-theming/_all-theme.scss
@@ -24,7 +24,7 @@
 
 @mixin angular-material-mdc-theme($theme-or-color-config) {
   $dedupe-key: 'angular-material-mdc-theme';
-  @include theming.check-duplicate-theme-styles($theme-or-color-config, $dedupe-key) {
+  @include theming.private-check-duplicate-theme-styles($theme-or-color-config, $dedupe-key) {
     @include core-theme.theme($theme-or-color-config);
     @include autocomplete-theme.theme($theme-or-color-config);
     @include button-theme.theme($theme-or-color-config);

--- a/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
+++ b/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
@@ -21,8 +21,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-mdc-tooltip') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-mdc-tooltip') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/mdc-typography/_all-typography.scss
+++ b/src/material-experimental/mdc-typography/_all-typography.scss
@@ -73,7 +73,7 @@
 }
 
 @mixin angular-material-mdc-typography($config-or-theme: null) {
-  $config: if(theming.is-theme-object($config-or-theme),
+  $config: if(theming.private-is-theme-object($config-or-theme),
       theming.get-typography-config($config-or-theme), $config-or-theme);
 
   // If no actual color configuration has been specified, create a default one.

--- a/src/material-experimental/popover-edit/_popover-edit.scss
+++ b/src/material-experimental/popover-edit/_popover-edit.scss
@@ -79,7 +79,7 @@
   }
 
   .mat-edit-pane {
-    @include private.theme-elevation(2, $config);
+    @include private.private-theme-elevation(2, $config);
     background: $background-color;
     color: theming.color($foreground, text);
     display: block;
@@ -146,7 +146,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   [mat-edit-title] {
     @include typography-utils.level-to-styles($config, title);
   }
@@ -156,8 +157,8 @@
 @mixin density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-popover-edit') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-popover-edit') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material-experimental/selection/_selection.scss
+++ b/src/material-experimental/selection/_selection.scss
@@ -1,8 +1,8 @@
 @use '../../material/core/theming/theming';
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-selection');
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-selection');
 }
 
 @mixin typography($config-or-theme) {}

--- a/src/material/autocomplete/_autocomplete-theme.scss
+++ b/src/material/autocomplete/_autocomplete-theme.scss
@@ -8,7 +8,7 @@
   $background: map.get($config, background);
 
   .mat-autocomplete-panel {
-    @include private.theme-overridable-elevation(4, $config);
+    @include private.private-theme-overridable-elevation(4, $config);
     background: theming.color($background, card);
     color: theming.color($foreground, text);
 
@@ -32,8 +32,8 @@
 @mixin _mat-autocomplete-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-autocomplete') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-autocomplete') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/badge/_badge-theme.scss
+++ b/src/material/badge/_badge-theme.scss
@@ -192,7 +192,8 @@ $large-size: $default-size + 6;
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-badge-content {
     font-weight: $font-weight;
     font-size: $font-size;
@@ -212,8 +213,8 @@ $large-size: $default-size + 6;
 @mixin _mat-badge-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-badge') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-badge') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/bottom-sheet/_bottom-sheet-theme.scss
+++ b/src/material/bottom-sheet/_bottom-sheet-theme.scss
@@ -11,14 +11,15 @@
   $foreground: map.get($config, foreground);
 
   .mat-bottom-sheet-container {
-    @include private.theme-elevation(16, $config);
+    @include private.private-theme-elevation(16, $config);
     background: theming.color($background, dialog);
     color: theming.color($foreground, text);
   }
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-bottom-sheet-container {
     @include typography-utils.level-to-styles($config, body-1);
   }
@@ -27,8 +28,8 @@
 @mixin _mat-bottom-sheet-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-bottom-sheet') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-bottom-sheet') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/button-toggle/_button-toggle-theme.scss
+++ b/src/material/button-toggle/_button-toggle-theme.scss
@@ -16,7 +16,7 @@
 
   .mat-button-toggle-standalone,
   .mat-button-toggle-group {
-    @include private.theme-elevation(2, $config);
+    @include private.private-theme-elevation(2, $config);
   }
 
   .mat-button-toggle-standalone.mat-button-toggle-appearance-standard,
@@ -87,7 +87,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-button-toggle {
     font-family: typography-utils.font-family($config);
   }
@@ -95,10 +96,10 @@
 
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
-  $standard-height: compatibility.density-prop-value(
+  $standard-height: compatibility.private-density-prop-value(
       button-toggle-variables.$standard-density-config, $density-scale, height);
 
-  @include compatibility.density-legacy-compatibility() {
+  @include compatibility.private-density-legacy-compatibility() {
     .mat-button-toggle-appearance-standard .mat-button-toggle-label-content {
       line-height: $standard-height;
     }
@@ -106,8 +107,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-button-toggle') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-button-toggle') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -76,7 +76,7 @@ $mini-fab-padding: 8px !default;
 // Applies styles to buttons with backgrounds: raised, fab, and mini-fab
 @mixin raised-button {
   @include base;
-  @include private.animation-noop();
+  @include private.private-animation-noop();
 
   // Force hardware acceleration.
   transform: translate3d(0, 0, 0);

--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -135,36 +135,37 @@ $_mat-button-ripple-opacity: 0.1;
   }
 
   .mat-stroked-button, .mat-flat-button {
-    @include private.theme-overridable-elevation(0, $config);
+    @include private.private-theme-overridable-elevation(0, $config);
   }
 
   .mat-raised-button {
-    @include private.theme-overridable-elevation(2, $config);
+    @include private.private-theme-overridable-elevation(2, $config);
 
     &:not(.mat-button-disabled):active {
-      @include private.theme-overridable-elevation(8, $config);
+      @include private.private-theme-overridable-elevation(8, $config);
     }
 
     &.mat-button-disabled {
-      @include private.theme-overridable-elevation(0, $config);
+      @include private.private-theme-overridable-elevation(0, $config);
     }
   }
 
   .mat-fab, .mat-mini-fab {
-    @include private.theme-overridable-elevation(6, $config);
+    @include private.private-theme-overridable-elevation(6, $config);
 
     &:not(.mat-button-disabled):active {
-      @include private.theme-overridable-elevation(12, $config);
+      @include private.private-theme-overridable-elevation(12, $config);
     }
 
     &.mat-button-disabled {
-      @include private.theme-overridable-elevation(0, $config);
+      @include private.private-theme-overridable-elevation(0, $config);
     }
   }
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-button, .mat-raised-button, .mat-icon-button, .mat-stroked-button,
   .mat-flat-button, .mat-fab, .mat-mini-fab {
     font: {
@@ -178,8 +179,8 @@ $_mat-button-ripple-opacity: 0.1;
 @mixin _mat-button-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-button') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-button') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/card/_card-theme.scss
+++ b/src/material/card/_card-theme.scss
@@ -12,13 +12,13 @@
   $foreground: map.get($config, foreground);
 
   .mat-card {
-    @include private.theme-overridable-elevation(1, $config);
+    @include private.private-theme-overridable-elevation(1, $config);
     background: theming.color($background, card);
     color: theming.color($foreground, text);
 
     // Needs extra specificity to be able to override the elevation selectors.
     &.mat-card-flat {
-      @include private.theme-overridable-elevation(0, $config);
+      @include private.private-theme-overridable-elevation(0, $config);
     }
   }
 
@@ -28,7 +28,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-card {
     font-family: typography-utils.font-family($config);
   }
@@ -53,8 +54,8 @@
 @mixin _mat-card-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-card') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-card') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -10,7 +10,7 @@ $header-size: 40px !default;
 
 .mat-card {
   @include elevation.transition;
-  @include private.animation-noop();
+  @include private.private-animation-noop();
   display: block;
   position: relative;
   padding: $padding;

--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -98,7 +98,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-checkbox {
     font-family: typography-utils.font-family($config);
   }
@@ -112,8 +113,8 @@
 @mixin _mat-checkbox-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-checkbox') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-checkbox') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -177,7 +177,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * checkbox-common.$size !default;
 }
 
 .mat-checkbox {
-  @include private.animation-noop();
+  @include private.private-animation-noop();
 
   // The host node defaults to `diplay: inline` so
   // we have to change it in order for margins to work.

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -58,7 +58,7 @@ $chip-remove-font-size: 18px;
 
     &:not(.mat-chip-disabled) {
       &:active {
-        @include private.theme-elevation(3, $config);
+        @include private.private-theme-elevation(3, $config);
       }
 
       .mat-chip-remove:hover {
@@ -91,7 +91,8 @@ $chip-remove-font-size: 18px;
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-chip {
     font-size: typography-utils.font-size($config, body-2);
     font-weight: typography-utils.font-weight($config, body-2);
@@ -106,8 +107,8 @@ $chip-remove-font-size: 18px;
 @mixin _mat-chips-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-chips') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-chips') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/chips/chips.scss
+++ b/src/material/chips/chips.scss
@@ -41,7 +41,7 @@ $chip-remove-size: 18px;
 
 .mat-standard-chip {
   @include elevation.transition;
-  @include private.animation-noop;
+  @include private.private-animation-noop;
   display: inline-flex;
   padding: $chip-vertical-padding $chip-horizontal-padding;
   border-radius: 16px;

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -22,7 +22,7 @@
   @include overlay.overlay();
   @include text-field.text-field();
 
-  @include focus-indicators.strong-focus-indicators-positioning();
+  @include focus-indicators.private-strong-focus-indicators-positioning();
   @include _mat-mdc-core();
 }
 
@@ -44,7 +44,7 @@
   // elevated.
   @for $zValue from 0 through 24 {
     .#{elevation.$prefix}#{$zValue} {
-      @include private.theme-elevation($zValue, $config);
+      @include private.private-theme-elevation($zValue, $config);
     }
   }
 
@@ -58,11 +58,11 @@
 
 // Mixin that renders all of the core styles that depend on the theme.
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
   // Wrap the sub-theme includes in the duplicate theme styles mixin. This ensures that
   // there won't be multiple warnings. e.g. if `mat-core-theme` reports a warning, then
   // the imported themes (such as `mat-ripple-theme`) should not report again.
-  @include theming.check-duplicate-theme-styles($theme, 'mat-core') {
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-core') {
     @include ripple.theme($theme);
     @include option-theme.theme($theme);
     @include optgroup-theme.theme($theme);

--- a/src/material/core/color/_all-color.scss
+++ b/src/material/core/color/_all-color.scss
@@ -5,7 +5,7 @@
 @mixin angular-material-color($config-or-theme) {
   // In case a theme object has been passed instead of a configuration for
   // the color system, extract the color config from the theme object.
-  $config: if(theming.is-theme-object($config-or-theme),
+  $config: if(theming.private-is-theme-object($config-or-theme),
       theming.get-color-config($config-or-theme), $config-or-theme);
 
   @if $config == null {

--- a/src/material/core/density/private/_all-density.scss
+++ b/src/material/core/density/private/_all-density.scss
@@ -11,7 +11,7 @@
 @mixin angular-material-density($config-or-theme) {
   // In case a theme object has been passed instead of a configuration for
   // the density system, extract the density config from the theme object.
-  $config: if(theming.is-theme-object($config-or-theme),
+  $config: if(theming.private-is-theme-object($config-or-theme),
       theming.get-density-config($config-or-theme), $config-or-theme);
 
   @if $config == null {
@@ -24,7 +24,7 @@
   // mixin that is transitively loaded by the `all-theme` file, imports `all-density` which
   // would then load `all-theme` again. This ultimately results a circular dependency.
 
-  @include expansion-theme.panel-density($config);
+  @include expansion-theme.density($config);
   @include stepper-theme.density($config);
   @include toolbar-theme.density($config);
   @include tree-theme.density($config);

--- a/src/material/core/density/private/_compatibility.import.scss
+++ b/src/material/core/density/private/_compatibility.import.scss
@@ -1,4 +1,4 @@
-@forward 'compatibility' hide $density-generate-at-root, $density-generate-styles,
-density-legacy-compatibility, density-prop-value;
-@forward 'compatibility' as mat-private-* hide $mat-private-default-scale, $mat-private-interval,
-$mat-private-maximum-scale, $mat-private-minimum-scale, $mat-private-supported-scales;
+@forward 'compatibility' hide $private-density-generate-at-root, $private-density-generate-styles,
+private-density-legacy-compatibility, private-density-prop-value;
+@forward 'compatibility' as mat-* hide $mat-default-scale, $mat-interval, $mat-maximum-scale,
+$mat-minimum-scale, $mat-supported-scales;

--- a/src/material/core/density/private/_compatibility.scss
+++ b/src/material/core/density/private/_compatibility.scss
@@ -16,11 +16,11 @@ $_mat-density-default-scale: 0 !default;
 
 // Whether density should be generated at root. This will be temporarily set to `true`
 // whenever density styles for legacy themes are generated.
-$density-generate-at-root: false;
+$private-density-generate-at-root: false;
 // Whether density styles should be generated. This will be temporarily set to `false` if
 // duplicate density styles for a legacy theme would be generated. For legacy themes,
 // we always generate the default density **only once** at root.
-$density-generate-styles: true;
+$private-density-generate-styles: true;
 
 // Mixin that can be used to wrap density styles of given components. The mixin will
 // move the density styles to root if the `$mat-private-density-generate-at-root` global variable
@@ -34,18 +34,18 @@ $density-generate-styles: true;
 // density styles. This is breaking as it increases specificity of density styles. This mixin
 // provides an API to control generation of density styles so that we can ensure they are only
 // created *once* and at root.
-@mixin density-legacy-compatibility() {
-  @if $density-generate-styles and $density-generate-at-root {
+@mixin private-density-legacy-compatibility() {
+  @if $private-density-generate-styles and $private-density-generate-at-root {
     @at-root {
       @content;
     }
   }
-  @else if $density-generate-styles {
+  @else if $private-density-generate-styles {
     @content;
   }
 }
 
-@function density-prop-value($density-config, $density-scale, $property-name) {
+@function private-density-prop-value($density-config, $density-scale, $property-name) {
   @if (meta.type-of($density-scale) == 'string' and
       list.index($list: $_mat-density-supported-scales, $value: $density-scale) == null) {
     @error 'mat-density: Supported density scales #{$_mat-density-supported-scales}, '  +

--- a/src/material/core/focus-indicators/_focus-indicators.import.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.import.scss
@@ -7,22 +7,12 @@ $mat-black-87-opacity, $mat-dark-disabled-text, $mat-dark-dividers, $mat-dark-fo
 $mat-dark-primary-text, $mat-dark-secondary-text, $mat-light-disabled-text, $mat-light-dividers,
 $mat-light-focused, $mat-light-primary-text, $mat-light-secondary-text, $mat-white-12-opacity,
 $mat-white-6-opacity, $mat-white-87-opacity;
-@forward '../density/private/compatibility' as mat-private-*;
-@forward '../theming/theming' as mat-* hide mat-check-duplicate-theme-styles,
-mat-create-backwards-compatibility-theme, mat-is-legacy-constructed-theme, mat-is-theme-object,
-mat-legacy-get-theme;
-@forward '../theming/theming' as mat-private-* hide $mat-private-theme-ignore-duplication-warnings,
-mat-private-color, mat-private-contrast, mat-private-dark-theme, mat-private-get-color-config,
-mat-private-get-density-config, mat-private-get-typography-config, mat-private-light-theme,
-mat-private-palette;
+@forward '../density/private/compatibility' as mat-*;
+@forward '../theming/theming' as mat-*;
 @forward '../style/layout-common' as mat-*;
-@forward 'focus-indicators' hide strong-focus-indicators, strong-focus-indicators-color,
-strong-focus-indicators-positioning, strong-focus-indicators-theme;
-@forward 'focus-indicators' as mat-* hide mat-strong-focus-indicators-border-color,
-mat-strong-focus-indicators-positioning;
-@forward 'focus-indicators' as mat-private-* hide mat-private-strong-focus-indicators,
-mat-private-strong-focus-indicators-border-color, mat-private-strong-focus-indicators-color,
-mat-private-strong-focus-indicators-theme;
+@forward 'focus-indicators' hide private-strong-focus-indicators-positioning,
+strong-focus-indicators, strong-focus-indicators-color, strong-focus-indicators-theme;
+@forward 'focus-indicators' as mat-* hide mat-strong-focus-indicators-border-color;
 
 @import '../theming/theming';
 @import '../style/layout-common';

--- a/src/material/core/focus-indicators/_focus-indicators.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.scss
@@ -112,8 +112,8 @@
     @include _mat-strong-focus-indicators-border-color($theme-or-color);
   }
   @else {
-    $theme: theming.legacy-get-theme($theme-or-color);
-    @include theming.check-duplicate-theme-styles($theme, 'mat-strong-focus-indicators') {
+    $theme: theming.private-legacy-get-theme($theme-or-color);
+    @include theming.private-check-duplicate-theme-styles($theme, 'mat-strong-focus-indicators') {
       $color: theming.get-color-config($theme);
       @if $color != null {
         @include strong-focus-indicators-color($color);
@@ -125,7 +125,7 @@
 // Mixin that ensures focus indicator host elements are positioned so that the focus indicator
 // pseudo element within is positioned relative to the host. Private mixin included within
 // `mat-core`.
-@mixin strong-focus-indicators-positioning() {
+@mixin private-strong-focus-indicators-positioning() {
   .mat-focus-indicator {
     position: relative;
   }

--- a/src/material/core/option/_optgroup-theme.import.scss
+++ b/src/material/core/option/_optgroup-theme.import.scss
@@ -7,14 +7,8 @@ $mat-black-87-opacity, $mat-dark-disabled-text, $mat-dark-dividers, $mat-dark-fo
 $mat-dark-primary-text, $mat-dark-secondary-text, $mat-light-disabled-text, $mat-light-dividers,
 $mat-light-focused, $mat-light-primary-text, $mat-light-secondary-text, $mat-white-12-opacity,
 $mat-white-6-opacity, $mat-white-87-opacity;
-@forward '../density/private/compatibility' as mat-private-*;
-@forward '../theming/theming' as mat-* hide mat-check-duplicate-theme-styles,
-mat-create-backwards-compatibility-theme, mat-is-legacy-constructed-theme, mat-is-theme-object,
-mat-legacy-get-theme;
-@forward '../theming/theming' as mat-private-* hide $mat-private-theme-ignore-duplication-warnings,
-mat-private-color, mat-private-contrast, mat-private-dark-theme, mat-private-get-color-config,
-mat-private-get-density-config, mat-private-get-typography-config, mat-private-light-theme,
-mat-private-palette;
+@forward '../density/private/compatibility' as mat-*;
+@forward '../theming/theming' as mat-*;
 @forward '../typography/typography-utils' as mat-* hide mat-font-shorthand, mat-height,
 mat-level-to-styles;
 @forward '../typography/typography-utils' as mat-line-* hide mat-line-font-family,

--- a/src/material/core/option/_optgroup-theme.scss
+++ b/src/material/core/option/_optgroup-theme.scss
@@ -18,7 +18,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-optgroup-label {
     @include typography-utils.level-to-styles($config, body-2);
   }
@@ -27,8 +28,8 @@
 @mixin _mat-optgroup-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-optgroup') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-optgroup') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/core/option/_option-theme.import.scss
+++ b/src/material/core/option/_option-theme.import.scss
@@ -7,14 +7,8 @@ $mat-black-87-opacity, $mat-dark-disabled-text, $mat-dark-dividers, $mat-dark-fo
 $mat-dark-primary-text, $mat-dark-secondary-text, $mat-light-disabled-text, $mat-light-dividers,
 $mat-light-focused, $mat-light-primary-text, $mat-light-secondary-text, $mat-white-12-opacity,
 $mat-white-6-opacity, $mat-white-87-opacity;
-@forward '../density/private/compatibility' as mat-private-*;
-@forward '../theming/theming' as mat-* hide mat-check-duplicate-theme-styles,
-mat-create-backwards-compatibility-theme, mat-is-legacy-constructed-theme, mat-is-theme-object,
-mat-legacy-get-theme;
-@forward '../theming/theming' as mat-private-* hide $mat-private-theme-ignore-duplication-warnings,
-mat-private-color, mat-private-contrast, mat-private-dark-theme, mat-private-get-color-config,
-mat-private-get-density-config, mat-private-get-typography-config, mat-private-light-theme,
-mat-private-palette;
+@forward '../density/private/compatibility' as mat-*;
+@forward '../theming/theming' as mat-*;
 @forward '../typography/typography-utils' as mat-* hide mat-font-shorthand, mat-height,
 mat-level-to-styles;
 @forward '../typography/typography-utils' as mat-line-* hide mat-line-font-family,

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -49,7 +49,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-option {
     font: {
       family: typography-utils.font-family($config);
@@ -61,8 +62,8 @@
 @mixin _mat-option-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-option') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-option') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/core/ripple/_ripple.import.scss
+++ b/src/material/core/ripple/_ripple.import.scss
@@ -7,14 +7,8 @@ $mat-black-87-opacity, $mat-dark-disabled-text, $mat-dark-dividers, $mat-dark-fo
 $mat-dark-primary-text, $mat-dark-secondary-text, $mat-light-disabled-text, $mat-light-dividers,
 $mat-light-focused, $mat-light-primary-text, $mat-light-secondary-text, $mat-white-12-opacity,
 $mat-white-6-opacity, $mat-white-87-opacity;
-@forward '../density/private/compatibility' as mat-private-*;
-@forward '../theming/theming' as mat-* hide mat-check-duplicate-theme-styles,
-mat-create-backwards-compatibility-theme, mat-is-legacy-constructed-theme, mat-is-theme-object,
-mat-legacy-get-theme;
-@forward '../theming/theming' as mat-private-* hide $mat-private-theme-ignore-duplication-warnings,
-mat-private-color, mat-private-contrast, mat-private-dark-theme, mat-private-get-color-config,
-mat-private-get-density-config, mat-private-get-typography-config, mat-private-light-theme,
-mat-private-palette;
+@forward '../density/private/compatibility' as mat-*;
+@forward '../theming/theming' as mat-*;
 @forward '../../../cdk/a11y/a11y.import';
 @forward 'ripple' as mat-* hide $mat-color-opacity, mat-color, mat-theme;
 @forward 'ripple' as mat-ripple-* hide mat-ripple-ripple;

--- a/src/material/core/ripple/_ripple.scss
+++ b/src/material/core/ripple/_ripple.scss
@@ -65,8 +65,8 @@ $color-opacity: 0.1;
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-ripple') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-ripple') {
     $color: theming.get-color-config($theme);
     @if $color != null {
       @include color($color);

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.import.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.import.scss
@@ -7,14 +7,8 @@ $mat-black-87-opacity, $mat-dark-disabled-text, $mat-dark-dividers, $mat-dark-fo
 $mat-dark-primary-text, $mat-dark-secondary-text, $mat-light-disabled-text, $mat-light-dividers,
 $mat-light-focused, $mat-light-primary-text, $mat-light-secondary-text, $mat-white-12-opacity,
 $mat-white-6-opacity, $mat-white-87-opacity;
-@forward '../../density/private/compatibility' as mat-private-*;
-@forward '../../theming/theming' as mat-* hide mat-check-duplicate-theme-styles,
-mat-create-backwards-compatibility-theme, mat-is-legacy-constructed-theme, mat-is-theme-object,
-mat-legacy-get-theme;
-@forward '../../theming/theming' as mat-private-* hide
-$mat-private-theme-ignore-duplication-warnings, mat-private-color, mat-private-contrast,
-mat-private-dark-theme, mat-private-get-color-config, mat-private-get-density-config,
-mat-private-get-typography-config, mat-private-light-theme, mat-private-palette;
+@forward '../../density/private/compatibility' as mat-*;
+@forward '../../theming/theming' as mat-*;
 @forward 'pseudo-checkbox-theme' hide color, theme, typography;
 @forward 'pseudo-checkbox-theme' as mat-pseudo-checkbox-* hide mat-pseudo-checkbox-density;
 

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -64,8 +64,8 @@
 @mixin _mat-pseudo-checkbox-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-pseudo-checkbox') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-pseudo-checkbox') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.scss
+++ b/src/material/core/selection/pseudo-checkbox/pseudo-checkbox.scss
@@ -38,7 +38,7 @@ $_mat-pseudo-checkmark-size: checkbox-common.$size - (2 * $_mat-pseudo-checkbox-
     border-color: transparent;
   }
 
-  @include private.animation-noop {
+  @include private.private-animation-noop {
     &::after {
       transition: none;
     }

--- a/src/material/core/style/_form-common.import.scss
+++ b/src/material/core/style/_form-common.import.scss
@@ -7,14 +7,8 @@ $mat-black-87-opacity, $mat-dark-disabled-text, $mat-dark-dividers, $mat-dark-fo
 $mat-dark-primary-text, $mat-dark-secondary-text, $mat-light-disabled-text, $mat-light-dividers,
 $mat-light-focused, $mat-light-primary-text, $mat-light-secondary-text, $mat-white-12-opacity,
 $mat-white-6-opacity, $mat-white-87-opacity;
-@forward '../density/private/compatibility' as mat-private-*;
-@forward '../theming/theming' as mat-* hide mat-check-duplicate-theme-styles,
-mat-create-backwards-compatibility-theme, mat-is-legacy-constructed-theme, mat-is-theme-object,
-mat-legacy-get-theme;
-@forward '../theming/theming' as mat-private-* hide $mat-private-theme-ignore-duplication-warnings,
-mat-private-color, mat-private-contrast, mat-private-dark-theme, mat-private-get-color-config,
-mat-private-get-density-config, mat-private-get-typography-config, mat-private-light-theme,
-mat-private-palette;
-@forward 'form-common' as mat-private-*;
+@forward '../density/private/compatibility' as mat-*;
+@forward '../theming/theming' as mat-*;
+@forward 'form-common' as mat-*;
 
 @import '../theming/theming';

--- a/src/material/core/style/_form-common.scss
+++ b/src/material/core/style/_form-common.scss
@@ -4,7 +4,7 @@
 // Renders a gradient for showing the dashed line when the input is disabled.
 // Unlike using a border, a gradient allows us to adjust the spacing of the dotted line
 // to match the Material Design spec.
-@mixin control-disabled-underline($color) {
+@mixin private-control-disabled-underline($color) {
   background-image: linear-gradient(to right, $color 0%, $color 33%, transparent 0%);
   background-size: 4px 100%;
   background-repeat: repeat-x;
@@ -13,7 +13,7 @@
 // Figures out the color of the placeholder for a form control.
 // Used primarily to prevent the various form controls from
 // becoming out of sync since these colors aren't in a palette.
-@function control-placeholder-color($config) {
+@function private-control-placeholder-color($config) {
   $foreground: map.get($config, foreground);
   $is-dark-theme: map.get($config, is-dark);
   @return theming.color($foreground, secondary-text, if($is-dark-theme, 0.5, 0.42));

--- a/src/material/core/style/_private.import.scss
+++ b/src/material/core/style/_private.import.scss
@@ -10,6 +10,6 @@ $mat-z-index-fab;
 $mat-transition-timing-function, mat-transition, mat-transition-property-value;
 @forward 'elevation' as mat-elevation-* hide mat-elevation-elevation,
 mat-elevation-overridable-elevation;
-@forward 'private' as mat-private-*;
+@forward 'private' as mat-*;
 
 @import './elevation';

--- a/src/material/core/style/_private.scss
+++ b/src/material/core/style/_private.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use './elevation';
 
-@mixin theme-elevation($zValue, $config, $opacity: elevation.$opacity) {
+@mixin private-theme-elevation($zValue, $config, $opacity: elevation.$opacity) {
   $foreground: map.get($config, foreground);
   $elevation-color: map.get($foreground, elevation);
   $elevation-color-or-default: if($elevation-color == null, elevation.$color, $elevation-color);
@@ -9,7 +9,7 @@
   @include elevation.elevation($zValue, $elevation-color-or-default, $opacity);
 }
 
-@mixin theme-overridable-elevation($zValue, $config, $opacity: elevation.$opacity) {
+@mixin private-theme-overridable-elevation($zValue, $config, $opacity: elevation.$opacity) {
   $foreground: map.get($config, foreground);
   $elevation-color: map.get($foreground, elevation);
   $elevation-color-or-default: if($elevation-color == null, elevation.$color, $elevation-color);
@@ -21,7 +21,7 @@
 // prevent non css animations from running.
 // NOTE: Currently this mixin should only be used with components that do not
 // have any projected content.
-@mixin animation-noop() {
+@mixin private-animation-noop() {
   // @at-root is used to steps outside of the hierarchy of the scss rules. This is
   // done to allow a class to be added to be added to base of the scss nesting
   // context.

--- a/src/material/core/theming/_all-theme.scss
+++ b/src/material/core/theming/_all-theme.scss
@@ -39,7 +39,7 @@
 // Create a theme.
 @mixin angular-material-theme($theme-or-color-config) {
   $dedupe-key: 'angular-material-theme';
-  @include theming.check-duplicate-theme-styles($theme-or-color-config, $dedupe-key) {
+  @include theming.private-check-duplicate-theme-styles($theme-or-color-config, $dedupe-key) {
     @include core.theme($theme-or-color-config);
     @include autocomplete-theme.theme($theme-or-color-config);
     @include badge-theme.theme($theme-or-color-config);
@@ -53,7 +53,7 @@
     @include datepicker-theme.theme($theme-or-color-config);
     @include dialog-theme.theme($theme-or-color-config);
     @include divider-theme.theme($theme-or-color-config);
-    @include expansion-theme.panel-theme($theme-or-color-config);
+    @include expansion-theme.theme($theme-or-color-config);
     @include form-field-theme.theme($theme-or-color-config);
     @include grid-list-theme.theme($theme-or-color-config);
     @include icon-theme.theme($theme-or-color-config);

--- a/src/material/core/theming/_theming.import.scss
+++ b/src/material/core/theming/_theming.import.scss
@@ -7,23 +7,14 @@ $mat-dark-disabled-text, $mat-dark-dividers, $mat-dark-focused, $mat-dark-primar
 $mat-dark-secondary-text, $mat-light-disabled-text, $mat-light-dividers, $mat-light-focused,
 $mat-light-primary-text, $mat-light-secondary-text, $mat-white-12-opacity, $mat-white-6-opacity,
 $mat-white-87-opacity;
-@forward '../density/private/compatibility' as mat-private-*;
-@forward 'theming' hide $theme-ignore-duplication-warnings, check-duplicate-theme-styles, color,
-contrast, create-backwards-compatibility-theme, dark-theme, get-color-config, get-density-config,
-get-typography-config, is-legacy-constructed-theme, is-theme-object, legacy-get-theme, light-theme,
-palette;
+@forward '../density/private/compatibility' as mat-*;
+@forward 'theming' hide $theme-ignore-duplication-warnings, color, contrast, dark-theme,
+get-color-config, get-density-config, get-typography-config, light-theme, palette,
+private-check-duplicate-theme-styles, private-create-backwards-compatibility-theme,
+private-is-legacy-constructed-theme, private-is-theme-object, private-legacy-get-theme;
 @forward 'theming' as mat-* hide $mat-theme-duplicate-warning, $mat-theme-emitted-color,
 $mat-theme-emitted-density, $mat-theme-emitted-typography, $mat-theme-generate-default-density,
-mat-check-duplicate-theme-styles, mat-create-backwards-compatibility-theme,
-mat-create-dark-color-config, mat-create-light-color-config, mat-is-legacy-constructed-theme,
-mat-is-theme-object, mat-legacy-get-theme, mat-validate-theme;
-@forward 'theming' as mat-private-* hide $mat-private-theme-duplicate-warning,
-$mat-private-theme-emitted-color, $mat-private-theme-emitted-density,
-$mat-private-theme-emitted-typography, $mat-private-theme-generate-default-density,
-$mat-private-theme-ignore-duplication-warnings, mat-private-color, mat-private-contrast,
-mat-private-create-dark-color-config, mat-private-create-light-color-config, mat-private-dark-theme,
-mat-private-get-color-config, mat-private-get-density-config, mat-private-get-typography-config,
-mat-private-light-theme, mat-private-palette, mat-private-validate-theme;
+mat-create-dark-color-config, mat-create-light-color-config, mat-validate-theme;
 
 @import 'palette';
 @import '../density/private/compatibility';

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -147,7 +147,7 @@ $_mat-theme-emitted-density: () !default;
   // If the legacy pattern is used, we generate a container object only with a light-themed
   // configuration for the `color` theming part.
   @if $accent != null {
-    @return create-backwards-compatibility-theme(_mat-validate-theme((
+    @return private-create-backwards-compatibility-theme(_mat-validate-theme((
       _is-legacy-theme: true,
       color: _mat-create-light-color-config($primary, $accent, $warn),
     )));
@@ -163,7 +163,7 @@ $_mat-theme-emitted-density: () !default;
     $warn: map.get($color-settings, warn);
     $result: map.merge($result, (color: _mat-create-light-color-config($primary, $accent, $warn)));
   }
-  @return create-backwards-compatibility-theme(_mat-validate-theme($result));
+  @return private-create-backwards-compatibility-theme(_mat-validate-theme($result));
 }
 
 // Creates a container object for a dark theme to be given to individual component theme mixins.
@@ -184,7 +184,7 @@ $_mat-theme-emitted-density: () !default;
   // If the legacy pattern is used, we generate a container object only with a dark-themed
   // configuration for the `color` theming part.
   @if $accent != null {
-    @return create-backwards-compatibility-theme(_mat-validate-theme((
+    @return private-create-backwards-compatibility-theme(_mat-validate-theme((
       _is-legacy-theme: true,
       color: _mat-create-dark-color-config($primary, $accent, $warn),
     )));
@@ -200,13 +200,13 @@ $_mat-theme-emitted-density: () !default;
     $warn: map.get($color-settings, warn);
     $result: map.merge($result, (color: _mat-create-dark-color-config($primary, $accent, $warn)));
   }
-  @return create-backwards-compatibility-theme(_mat-validate-theme($result));
+  @return private-create-backwards-compatibility-theme(_mat-validate-theme($result));
 }
 
 /// Gets the color configuration from the given theme or configuration.
 @function get-color-config($theme, $default: null) {
   // If a configuration has been passed, return the config directly.
-  @if not is-theme-object($theme) {
+  @if not private-is-theme-object($theme) {
     @return $theme;
   }
   // If the theme has been constructed through the legacy theming API, we use the theme object
@@ -214,7 +214,7 @@ $_mat-theme-emitted-density: () !default;
   // backwards compatibility, we copied the color configuration from `$theme.color` to `$theme`.
   // Hence developers could customize the colors at top-level and want to respect these changes
   // TODO: Remove when legacy theming API is removed.
-  @if is-legacy-constructed-theme($theme) {
+  @if private-is-legacy-constructed-theme($theme) {
     @return $theme;
   }
   @if map.has-key($theme, color) {
@@ -226,7 +226,7 @@ $_mat-theme-emitted-density: () !default;
 /// Gets the density configuration from the given theme or configuration.
 @function get-density-config($theme-or-config, $default: 0) {
   // If a configuration has been passed, return the config directly.
-  @if not is-theme-object($theme-or-config) {
+  @if not private-is-theme-object($theme-or-config) {
     @return $theme-or-config;
   }
   // In case a theme has been passed, extract the configuration if present,
@@ -241,7 +241,7 @@ $_mat-theme-emitted-density: () !default;
 /// For backwards compatibility, typography is not included by default.
 @function get-typography-config($theme-or-config, $default: null) {
   // If a configuration has been passed, return the config directly.
-  @if not is-theme-object($theme-or-config) {
+  @if not private-is-theme-object($theme-or-config) {
     @return $theme-or-config;
   }
   // In case a theme has been passed, extract the configuration if present,
@@ -269,8 +269,8 @@ $_mat-theme-emitted-density: () !default;
 // id. This is necessary because a given theme can be passed to multiple disjoint theme mixins
 // (e.g. `angular-material-theme` and `angular-material-mdc-theme`) without causing any
 // style duplication.
-@mixin check-duplicate-theme-styles($theme-or-color-config, $id) {
-  $theme: legacy-get-theme($theme-or-color-config);
+@mixin private-check-duplicate-theme-styles($theme-or-color-config, $id) {
+  $theme: private-legacy-get-theme($theme-or-color-config);
   $color-config: get-color-config($theme);
   $density-config: get-density-config($theme);
   $typography-config: get-typography-config($theme);
@@ -307,7 +307,7 @@ $_mat-theme-emitted-density: () !default;
       // Only report a warning if density styles would be duplicated for non-legacy theme
       // definitions. For legacy themes, we have compatibility logic that avoids duplication
       // of default density styles. We don't want to report a warning in those cases.
-      @if is-legacy-constructed-theme($theme) {
+      @if private-is-legacy-constructed-theme($theme) {
         $duplicate-legacy-density: true;
       }
       @else if not $theme-ignore-duplication-warnings {
@@ -339,19 +339,19 @@ $_mat-theme-emitted-density: () !default;
   // styles **once** and at root. This matches the old behavior where density styles were
   // part of the base component styles (that did not use view encapsulation).
   // TODO: Remove this compatibility logic when the legacy theming API is removed.
-  compatibility.$density-generate-at-root: is-legacy-constructed-theme($theme);
-  compatibility.$density-generate-styles: not $duplicate-legacy-density;
+  compatibility.$private-density-generate-at-root: private-is-legacy-constructed-theme($theme);
+  compatibility.$private-density-generate-styles: not $duplicate-legacy-density;
 
   @content;
   $theme-ignore-duplication-warnings: $orig-mat-theme-ignore-duplication-warnings !global;
 
-  compatibility.$density-generate-at-root: false;
-  compatibility.$density-generate-styles: true;
+  compatibility.$private-density-generate-at-root: false;
+  compatibility.$private-density-generate-styles: true;
 }
 
 // Checks whether the given value resolves to a theme object. Theme objects are always
 // of type `map` and can optionally only specify `color`, `density` or `typography`.
-@function is-theme-object($value) {
+@function private-is-theme-object($value) {
   @return meta.type-of($value) == 'map' and (
     map.has-key($value, color) or
     map.has-key($value, density) or
@@ -361,7 +361,7 @@ $_mat-theme-emitted-density: () !default;
 }
 
 // Checks whether a given value corresponds to a legacy constructed theme.
-@function is-legacy-constructed-theme($value) {
+@function private-is-legacy-constructed-theme($value) {
   @return meta.type-of($value) == 'map' and map.get($value, '_is-legacy-theme');
 }
 
@@ -382,7 +382,7 @@ $_mat-theme-emitted-density: () !default;
 // Note that the `$theme.primary` key does usually not exist since the color configuration
 // is stored in `$theme.color` which contains a property for `primary`. This method copies
 // the map from `$theme.color` to `$theme` for backwards compatibility.
-@function create-backwards-compatibility-theme($theme) {
+@function private-create-backwards-compatibility-theme($theme) {
   @if not map.get($theme, color) {
     @return $theme;
   }
@@ -397,11 +397,11 @@ $_mat-theme-emitted-density: () !default;
 // construct a theme manually and pass it to a theme. We support this for backwards compatibility.
 // TODO(devversion): remove this in the future. Constructing themes manually is rare,
 // and the code can be easily updated to the new API.
-@function legacy-get-theme($theme-or-color-config) {
-  @if is-theme-object($theme-or-color-config) {
+@function private-legacy-get-theme($theme-or-color-config) {
+  @if private-is-theme-object($theme-or-color-config) {
     @return $theme-or-color-config;
   }
-  @return create-backwards-compatibility-theme((
+  @return private-create-backwards-compatibility-theme((
     _is-legacy-theme: true,
     color: $theme-or-color-config
   ));

--- a/src/material/core/theming/tests/test-theming-api.scss
+++ b/src/material/core/theming/tests/test-theming-api.scss
@@ -214,7 +214,7 @@ $dark-theme-only-typography: theming.dark-theme((typography: $typography-config)
 
 // Custom theme mixin used by the custom theme backwards compatibility test.
 @mixin _my-custom-theme-new-api($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
   $color: theming.get-color-config($theme);
   $density: theming.get-density-config($theme);
 

--- a/src/material/core/typography/_all-typography.scss
+++ b/src/material/core/typography/_all-typography.scss
@@ -40,7 +40,7 @@
 
 // Includes all of the typographic styles.
 @mixin angular-material-typography($config-or-theme: null) {
-  $config: if(theming.is-theme-object($config-or-theme),
+  $config: if(theming.private-is-theme-object($config-or-theme),
       theming.get-typography-config($config-or-theme), $config-or-theme);
 
   // If no actual color configuration has been specified, create a default one.
@@ -67,7 +67,7 @@
   @include table-theme.typography($config);
   @include datepicker-theme.typography($config);
   @include dialog-theme.typography($config);
-  @include expansion-theme.panel-typography($config);
+  @include expansion-theme.typography($config);
   @include form-field-theme.typography($config);
   @include grid-list-theme.typography($config);
   @include icon-theme.typography($config);

--- a/src/material/core/typography/_typography.import.scss
+++ b/src/material/core/typography/_typography.import.scss
@@ -4,12 +4,9 @@ mat-line-font-size, mat-line-font-weight, mat-line-letter-spacing, mat-line-leve
 @forward 'typography-utils' as mat-typography-* hide mat-typography-font-family,
 mat-typography-font-size, mat-typography-font-weight, mat-typography-height,
 mat-typography-letter-spacing;
-@forward 'typography' as mat-* hide mat-config, mat-level, mat-typography-is-2014-config,
-mat-typography-is-2018-config, mat-typography-to-2014-config, mat-typography-to-2018-config;
-@forward 'typography' as mat-private-* hide mat-private-base-typography, mat-private-config,
-mat-private-level;
+@forward 'typography' as mat-* hide mat-config, mat-level;
 @forward 'typography' as mat-typography-* hide mat-typography-base-typography,
-mat-typography-typography-is-2014-config, mat-typography-typography-is-2018-config,
-mat-typography-typography-to-2014-config, mat-typography-typography-to-2018-config;
+mat-typography-private-typography-is-2014-config, mat-typography-private-typography-is-2018-config,
+mat-typography-private-typography-to-2014-config, mat-typography-private-typography-to-2018-config;
 
 @import 'typography-utils';

--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -72,12 +72,12 @@
 }
 
 // Whether a config is for the Material Design 2018 typography system.
-@function typography-is-2018-config($config) {
+@function private-typography-is-2018-config($config) {
   @return map.get($config, headline-1) != null;
 }
 
 // Whether a config is for the Material Design 2014 typography system.
-@function typography-is-2014-config($config) {
+@function private-typography-is-2014-config($config) {
   @return map.get($config, headline) != null;
 }
 
@@ -88,11 +88,11 @@
 //
 // Components using this function should be migrated to normalize to the 2018 style config instead.
 // New components should not use this function.
-@function typography-to-2014-config($config) {
+@function private-typography-to-2014-config($config) {
   @if $config == null {
     @return null;
   }
-  @if not typography-is-2014-config($config) {
+  @if not private-typography-is-2014-config($config) {
     $args: (
         display-4: map.get($config, headline-1),
         display-3: map.get($config, headline-2),
@@ -122,11 +122,11 @@
 // produces a normalized typography config for the 2018 Material Design typography system.
 // 2014 - https://material.io/archive/guidelines/style/typography.html#typography-styles
 // 2018 - https://material.io/design/typography/the-type-system.html#type-scale
-@function typography-to-2018-config($config) {
+@function private-typography-to-2018-config($config) {
   @if $config == null {
     @return null;
   }
-  @if typography-is-2014-config($config) {
+  @if private-typography-is-2014-config($config) {
     @return (
         headline-1: map.get($config, display-4),
         headline-2: map.get($config, display-3),
@@ -151,7 +151,7 @@
 // Adds the base typography styles, based on a config.
 /* stylelint-disable-next-line material/theme-mixin-api */
 @mixin base-typography($config-or-theme, $selector: '.mat-typography') {
-  $config: typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: private-typography-to-2014-config(theming.get-typography-config($config-or-theme));
 
   .mat-h1, .mat-headline, #{$selector} h1 {
     @include typography-utils.level-to-styles($config, headline);

--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -149,7 +149,7 @@ $calendar-weekday-table-font-size: 11px !default;
   @include _mat-datepicker-color(map.get($config, primary));
 
   .mat-datepicker-content {
-    @include private.theme-elevation(4, $config);
+    @include private.private-theme-elevation(4, $config);
     background-color: theming.color($background, card);
     color: theming.color($foreground, text);
 
@@ -163,7 +163,7 @@ $calendar-weekday-table-font-size: 11px !default;
   }
 
   .mat-datepicker-content-touch {
-    @include private.theme-elevation(0, $config);
+    @include private.private-theme-elevation(0, $config);
   }
 
   .mat-datepicker-toggle-active {
@@ -184,7 +184,8 @@ $calendar-weekday-table-font-size: 11px !default;
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-calendar {
     font-family: typography-utils.font-family($config);
   }
@@ -248,8 +249,8 @@ $calendar-weekday-table-font-size: 11px !default;
 @mixin _mat-datepicker-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-datepicker') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-datepicker') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -12,14 +12,15 @@
   $foreground: map.get($config, foreground);
 
   .mat-dialog-container {
-    @include private.theme-elevation(24, $config);
+    @include private.private-theme-elevation(24, $config);
     background: theming.color($background, dialog);
     color: theming.color($foreground, text);
   }
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-dialog-title {
     @include typography-utils.level-to-styles($config, title);
   }
@@ -28,8 +29,8 @@
 @mixin _mat-dialog-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-dialog') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-dialog') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/divider/_divider-theme.scss
+++ b/src/material/divider/_divider-theme.scss
@@ -20,8 +20,8 @@
 @mixin _mat-divider-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-divider') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-divider') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/expansion/_expansion-mixins.import.scss
+++ b/src/material/expansion/_expansion-mixins.import.scss
@@ -1,1 +1,1 @@
-@forward 'expansion-mixins' as mat-private-*;
+@forward 'expansion-mixins' as mat-*;

--- a/src/material/expansion/_expansion-mixins.scss
+++ b/src/material/expansion/_expansion-mixins.scss
@@ -1,4 +1,4 @@
-@mixin expansion-focus {
+@mixin private-expansion-focus {
   .mat-expansion-panel {
     & .mat-expansion-panel-header.cdk-keyboard-focused,
     & .mat-expansion-panel-header.cdk-program-focused,

--- a/src/material/expansion/_expansion-theme.import.scss
+++ b/src/material/expansion/_expansion-theme.import.scss
@@ -1,9 +1,9 @@
 @forward '../core/theming/theming.import';
 @forward '../core/style/private.import';
-@forward 'expansion-variables' as mat-expansion-*;
+@forward 'expansion-variables' as mat-expansion-panel-*;
 @forward '../core/typography/typography-utils.import';
-@forward 'expansion-mixins' as mat-private-*;
-@forward 'expansion-theme' as mat-expansion-*;
+@forward 'expansion-mixins' as mat-*;
+@forward 'expansion-theme' as mat-expansion-panel-*;
 
 @import '../core/density/private/compatibility';
 @import '../core/theming/palette';

--- a/src/material/expansion/_expansion-theme.scss
+++ b/src/material/expansion/_expansion-theme.scss
@@ -8,13 +8,13 @@
 @use './expansion-variables';
 @use './expansion-mixins';
 
-@mixin panel-color($config-or-theme) {
+@mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 
   .mat-expansion-panel {
-    @include private.theme-overridable-elevation(2, $config);
+    @include private.private-theme-overridable-elevation(2, $config);
     background: theming.color($background, card);
     color: theming.color($foreground, text);
   }
@@ -23,7 +23,7 @@
     border-top-color: theming.color($foreground, divider);
   }
 
-  @include expansion-mixins.expansion-focus {
+  @include expansion-mixins.private-expansion-focus {
     background: theming.color($background, hover);
   }
 
@@ -55,8 +55,9 @@
   }
 }
 
-@mixin panel-typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+@mixin typography($config-or-theme) {
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-expansion-panel-header {
     font: {
       family: typography-utils.font-family($config, subheading-1);
@@ -70,14 +71,14 @@
   }
 }
 
-@mixin panel-density($config-or-theme) {
+@mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
-  $expanded-height: compatibility.density-prop-value(
-        expansion-variables.$panel-header-density-config, $density-scale, expanded-height);
-  $collapsed-height: compatibility.density-prop-value(
-      expansion-variables.$panel-header-density-config, $density-scale, collapsed-height);
+  $expanded-height: compatibility.private-density-prop-value(
+        expansion-variables.$header-density-config, $density-scale, expanded-height);
+  $collapsed-height: compatibility.private-density-prop-value(
+      expansion-variables.$header-density-config, $density-scale, collapsed-height);
 
-  @include compatibility.density-legacy-compatibility() {
+  @include compatibility.private-density-legacy-compatibility() {
     .mat-expansion-panel-header {
       height: $collapsed-height;
 
@@ -88,21 +89,21 @@
   }
 }
 
-@mixin panel-theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-expansion-panel') {
+@mixin theme($theme-or-color-config) {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-expansion-panel') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
 
     @if $color != null {
-      @include panel-color($color);
+      @include color($color);
     }
     @if $density != null {
-      @include panel-density($density);
+      @include density($density);
     }
     @if $typography != null {
-      @include panel-typography($typography);
+      @include typography($typography);
     }
   }
 }

--- a/src/material/expansion/_expansion-variables.import.scss
+++ b/src/material/expansion/_expansion-variables.import.scss
@@ -1,1 +1,1 @@
-@forward 'expansion-variables' as mat-expansion-*;
+@forward 'expansion-variables' as mat-expansion-panel-*;

--- a/src/material/expansion/_expansion-variables.scss
+++ b/src/material/expansion/_expansion-variables.scss
@@ -1,30 +1,30 @@
 // Default minimum and maximum height for collapsed panel headers.
-$panel-header-collapsed-height: 48px !default;
-$panel-header-collapsed-minimum-height: 36px !default;
-$panel-header-collapsed-maximum-height:
-    $panel-header-collapsed-height !default;
+$header-collapsed-height: 48px !default;
+$header-collapsed-minimum-height: 36px !default;
+$header-collapsed-maximum-height:
+    $header-collapsed-height !default;
 
 // Default minimum and maximum height for expanded panel headers.
-$panel-header-expanded-height: 64px !default;
-$panel-header-expanded-minimum-height: 48px !default;
-$panel-header-expanded-maximum-height:
-    $panel-header-expanded-height !default;
+$header-expanded-height: 64px !default;
+$header-expanded-minimum-height: 48px !default;
+$header-expanded-maximum-height:
+    $header-expanded-height !default;
 
 // Density configuration for the expansion panel. Captures the
 // height for both expanded and collapsed panel headers.
-$panel-header-density-config: (
+$header-density-config: (
   collapsed-height: (
-    default: $panel-header-collapsed-height,
-    maximum: $panel-header-collapsed-maximum-height,
-    minimum: $panel-header-collapsed-minimum-height,
+    default: $header-collapsed-height,
+    maximum: $header-collapsed-maximum-height,
+    minimum: $header-collapsed-minimum-height,
   ),
   expanded-height: (
-    default: $panel-header-expanded-height,
-    maximum: $panel-header-expanded-maximum-height,
-    minimum: $panel-header-expanded-minimum-height,
+    default: $header-expanded-height,
+    maximum: $header-expanded-maximum-height,
+    minimum: $header-expanded-minimum-height,
   )
 ) !default;
 
 // Note: Keep this in sync with the animation timing for the toggle indicator
 // and body expansion. These are animated using Angular animations.
-$panel-header-transition: 225ms cubic-bezier(0.4, 0, 0.2, 1);
+$header-transition: 225ms cubic-bezier(0.4, 0, 0.2, 1);

--- a/src/material/expansion/expansion-panel-header.scss
+++ b/src/material/expansion/expansion-panel-header.scss
@@ -9,7 +9,7 @@
   align-items: center;
   padding: 0 24px;
   border-radius: inherit;
-  transition: height expansion-variables.$panel-header-transition;
+  transition: height expansion-variables.$header-transition;
 
   // If the `NoopAnimationsModule` is used, disable the height transition.
   &._mat-animation-noopable {
@@ -81,7 +81,7 @@
 }
 
 @include a11y.high-contrast(active, off) {
-  @include expansion-mixins.expansion-focus {
+  @include expansion-mixins.private-expansion-focus {
     &::before {
       // These styles are identical to the ones generated for all
       // `.mat-focus-indicator` when strong focus indication is enabled.

--- a/src/material/form-field/_form-field-fill-theme.import.scss
+++ b/src/material/form-field/_form-field-fill-theme.import.scss
@@ -1,12 +1,11 @@
 @forward '../core/style/form-common.import';
 @forward '../core/typography/typography-utils.import';
 @forward 'form-field-fill-theme' hide $fill-dedupe, fill-color, fill-theme, fill-typography,
-form-field-fill-density;
+private-form-field-fill-density;
+@forward 'form-field-fill-theme' as mat-* hide $mat-fill-dedupe, mat-fill-color,
+mat-fill-label-floating, mat-fill-theme, mat-fill-typography;
 @forward 'form-field-fill-theme' as mat-form-field-* hide mat-form-field-fill-label-floating,
-mat-form-field-form-field-fill-density;
-@forward 'form-field-fill-theme' as mat-private-* hide $mat-private-fill-dedupe,
-mat-private-fill-color, mat-private-fill-label-floating, mat-private-fill-theme,
-mat-private-fill-typography;
+mat-form-field-private-form-field-fill-density;
 
 @import '../core/theming/palette';
 @import '../core/theming/theming';

--- a/src/material/form-field/_form-field-fill-theme.scss
+++ b/src/material/form-field/_form-field-fill-theme.scss
@@ -59,7 +59,8 @@ $fill-dedupe: 0;
 }
 
 @mixin fill-typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   // The unit-less line-height from the font config.
   $line-height: typography-utils.height($config, input);
   // The amount to scale the font for the floating label and subscript.
@@ -103,11 +104,11 @@ $fill-dedupe: 0;
   }
 }
 
-@mixin form-field-fill-density($config-or-theme) {}
+@mixin private-form-field-fill-density($config-or-theme) {}
 
 @mixin fill-theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-form-field-fill') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-form-field-fill') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
@@ -116,7 +117,7 @@ $fill-dedupe: 0;
       @include fill-color($color);
     }
     @if $density != null {
-      @include form-field-fill-density($density);
+      @include private-form-field-fill-density($density);
     }
     @if $typography != null {
       @include fill-typography($typography);

--- a/src/material/form-field/_form-field-legacy-theme.import.scss
+++ b/src/material/form-field/_form-field-legacy-theme.import.scss
@@ -1,13 +1,11 @@
 @forward '../core/style/form-common.import';
 @forward '../core/typography/typography-utils.import';
-@forward 'form-field-legacy-theme' hide $legacy-dedupe, form-field-legacy-density, legacy-color,
-legacy-theme, legacy-typography;
-@forward 'form-field-legacy-theme' as mat-form-field-* hide
-mat-form-field-form-field-legacy-density, mat-form-field-legacy-label-floating,
-mat-form-field-legacy-label-floating-print;
-@forward 'form-field-legacy-theme' as mat-private-* hide $mat-private-legacy-dedupe,
-mat-private-legacy-color, mat-private-legacy-label-floating,
-mat-private-legacy-label-floating-print, mat-private-legacy-theme, mat-private-legacy-typography;
+@forward 'form-field-legacy-theme' hide $legacy-dedupe, legacy-color, legacy-theme,
+legacy-typography, private-form-field-legacy-density;
+@forward 'form-field-legacy-theme' as mat-* hide $mat-legacy-dedupe, mat-legacy-color,
+mat-legacy-label-floating, mat-legacy-label-floating-print, mat-legacy-theme, mat-legacy-typography;
+@forward 'form-field-legacy-theme' as mat-form-field-* hide mat-form-field-legacy-label-floating,
+mat-form-field-legacy-label-floating-print, mat-form-field-private-form-field-legacy-density;
 
 @import '../core/theming/palette';
 @import '../core/theming/theming';

--- a/src/material/form-field/_form-field-legacy-theme.scss
+++ b/src/material/form-field/_form-field-legacy-theme.scss
@@ -30,7 +30,7 @@
     }
 
     &.mat-form-field-disabled .mat-form-field-underline {
-      @include form-common.control-disabled-underline($underline-color);
+      @include form-common.private-control-disabled-underline($underline-color);
     }
   }
 }
@@ -71,7 +71,8 @@ $legacy-dedupe: 0;
 }
 
 @mixin legacy-typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   // The unit-less line-height from the font config.
   $line-height: typography-utils.height($config, input);
   // The amount to scale the font for the floating label and subscript.
@@ -176,11 +177,11 @@ $legacy-dedupe: 0;
   }
 }
 
-@mixin form-field-legacy-density($config-or-theme) {}
+@mixin private-form-field-legacy-density($config-or-theme) {}
 
 @mixin legacy-theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-form-field-legacy') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-form-field-legacy') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
@@ -189,7 +190,7 @@ $legacy-dedupe: 0;
       @include legacy-color($color);
     }
     @if $density != null {
-      @include form-field-legacy-density($density);
+      @include private-form-field-legacy-density($density);
     }
     @if $typography != null {
       @include legacy-typography($typography);

--- a/src/material/form-field/_form-field-outline-theme.import.scss
+++ b/src/material/form-field/_form-field-outline-theme.import.scss
@@ -1,12 +1,11 @@
 @forward '../core/style/form-common.import';
 @forward '../core/typography/typography-utils.import';
-@forward 'form-field-outline-theme' hide $outline-dedupe, form-field-outline-density, outline-color,
-outline-theme, outline-typography;
-@forward 'form-field-outline-theme' as mat-form-field-* hide
-mat-form-field-form-field-outline-density, mat-form-field-outline-label-floating;
-@forward 'form-field-outline-theme' as mat-private-* hide $mat-private-outline-dedupe,
-mat-private-outline-color, mat-private-outline-label-floating, mat-private-outline-theme,
-mat-private-outline-typography;
+@forward 'form-field-outline-theme' hide $outline-dedupe, outline-color, outline-theme,
+outline-typography, private-form-field-outline-density;
+@forward 'form-field-outline-theme' as mat-* hide $mat-outline-dedupe, mat-outline-color,
+mat-outline-label-floating, mat-outline-theme, mat-outline-typography;
+@forward 'form-field-outline-theme' as mat-form-field-* hide mat-form-field-outline-label-floating,
+mat-form-field-private-form-field-outline-density;
 
 @import '../core/theming/palette';
 @import '../core/theming/theming';

--- a/src/material/form-field/_form-field-outline-theme.scss
+++ b/src/material/form-field/_form-field-outline-theme.scss
@@ -82,7 +82,8 @@ $outline-dedupe: 0;
 }
 
 @mixin outline-typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   // The unit-less line-height from the font config.
   $line-height: typography-utils.height($config, input);
   // The amount to scale the font for the floating label and subscript.
@@ -133,11 +134,11 @@ $outline-dedupe: 0;
   }
 }
 
-@mixin form-field-outline-density($config-or-theme) {}
+@mixin private-form-field-outline-density($config-or-theme) {}
 
 @mixin outline-theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-form-field-outline') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-form-field-outline') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
@@ -146,7 +147,7 @@ $outline-dedupe: 0;
       @include outline-color($color);
     }
     @if $density != null {
-      @include form-field-outline-density($density);
+      @include private-form-field-outline-density($density);
     }
     @if $typography != null {
       @include outline-typography($typography);

--- a/src/material/form-field/_form-field-standard-theme.import.scss
+++ b/src/material/form-field/_form-field-standard-theme.import.scss
@@ -1,9 +1,9 @@
 @forward '../core/style/form-common.import';
 @forward '../core/typography/typography-utils.import';
+@forward 'form-field-standard-theme' as mat-* hide mat-standard-color, mat-standard-theme,
+mat-standard-typography;
 @forward 'form-field-standard-theme' as mat-form-field-* hide
-mat-form-field-form-field-standard-density;
-@forward 'form-field-standard-theme' as mat-private-* hide mat-private-standard-color,
-mat-private-standard-theme, mat-private-standard-typography;
+mat-form-field-private-form-field-standard-density;
 
 @import '../core/theming/palette';
 @import '../core/theming/theming';

--- a/src/material/form-field/_form-field-standard-theme.scss
+++ b/src/material/form-field/_form-field-standard-theme.scss
@@ -20,18 +20,18 @@
     }
 
     &.mat-form-field-disabled .mat-form-field-underline {
-      @include form-common.control-disabled-underline($underline-color);
+      @include form-common.private-control-disabled-underline($underline-color);
     }
   }
 }
 
 @mixin standard-typography($config-or-theme) {}
 
-@mixin form-field-standard-density($config-or-theme) {}
+@mixin private-form-field-standard-density($config-or-theme) {}
 
 @mixin standard-theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-form-field-standard') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-form-field-standard') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);
@@ -40,7 +40,7 @@
       @include standard-color($color);
     }
     @if $density != null {
-      @include form-field-standard-density($density);
+      @include private-form-field-standard-density($density);
     }
     @if $typography != null {
       @include standard-typography($typography);

--- a/src/material/form-field/_form-field-theme.import.scss
+++ b/src/material/form-field/_form-field-theme.import.scss
@@ -1,20 +1,21 @@
 @forward '../core/style/form-common.import';
-@forward 'form-field-fill-theme' as mat-form-field-* hide mat-form-field-form-field-fill-density;
-@forward 'form-field-fill-theme' as mat-private-* hide $mat-private-fill-dedupe,
-mat-private-fill-color, mat-private-fill-theme, mat-private-fill-typography;
+@forward 'form-field-fill-theme' as mat-* hide $mat-fill-dedupe, mat-fill-color, mat-fill-theme,
+mat-fill-typography;
+@forward 'form-field-fill-theme' as mat-form-field-* hide
+mat-form-field-private-form-field-fill-density;
+@forward 'form-field-legacy-theme' as mat-* hide $mat-legacy-dedupe, mat-legacy-color,
+mat-legacy-theme, mat-legacy-typography;
 @forward 'form-field-legacy-theme' as mat-form-field-* hide
-mat-form-field-form-field-legacy-density;
-@forward 'form-field-legacy-theme' as mat-private-* hide $mat-private-legacy-dedupe,
-mat-private-legacy-color, mat-private-legacy-theme, mat-private-legacy-typography;
+mat-form-field-private-form-field-legacy-density;
+@forward 'form-field-outline-theme' as mat-* hide $mat-outline-dedupe, mat-outline-color,
+mat-outline-theme, mat-outline-typography;
 @forward 'form-field-outline-theme' as mat-form-field-* hide
-mat-form-field-form-field-outline-density;
-@forward 'form-field-outline-theme' as mat-private-* hide $mat-private-outline-dedupe,
-mat-private-outline-color, mat-private-outline-theme, mat-private-outline-typography;
+mat-form-field-private-form-field-outline-density;
 @forward '../core/typography/typography-utils.import';
+@forward 'form-field-standard-theme' as mat-* hide mat-standard-color, mat-standard-theme,
+mat-standard-typography;
 @forward 'form-field-standard-theme' as mat-form-field-* hide
-mat-form-field-form-field-standard-density;
-@forward 'form-field-standard-theme' as mat-private-* hide mat-private-standard-color,
-mat-private-standard-theme, mat-private-standard-typography;
+mat-form-field-private-form-field-standard-density;
 @forward 'form-field-theme' hide $dedupe, color, density, theme, typography;
 @forward 'form-field-theme' as mat-form-field-* hide mat-form-field-label-floating;
 

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -132,7 +132,8 @@ $dedupe: 0;
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   // The unit-less line-height from the font config.
   $line-height: typography-utils.height($config, input);
 
@@ -241,15 +242,15 @@ $dedupe: 0;
 
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
-  @include form-field-legacy-theme.form-field-legacy-density($density-scale);
-  @include form-field-standard-theme.form-field-standard-density($density-scale);
-  @include form-field-fill-theme.form-field-fill-density($density-scale);
-  @include form-field-outline-theme.form-field-outline-density($density-scale);
+  @include form-field-legacy-theme.private-form-field-legacy-density($density-scale);
+  @include form-field-standard-theme.private-form-field-standard-density($density-scale);
+  @include form-field-fill-theme.private-form-field-fill-density($density-scale);
+  @include form-field-outline-theme.private-form-field-outline-density($density-scale);
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-form-field') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-form-field') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/grid-list/_grid-list-theme.scss
+++ b/src/material/grid-list/_grid-list-theme.scss
@@ -9,7 +9,8 @@
 @mixin color($config-or-theme) {}
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-grid-tile-header,
   .mat-grid-tile-footer {
     @include list-common.base(typography-utils.font-size($config, caption));
@@ -20,8 +21,8 @@
 @mixin _mat-grid-list-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-grid-list') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-grid-list') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/icon/_icon-theme.scss
+++ b/src/material/icon/_icon-theme.scss
@@ -29,8 +29,8 @@
 @mixin _mat-icon-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-icon') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-icon') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/input/_input-theme.scss
+++ b/src/material/input/_input-theme.scss
@@ -27,7 +27,7 @@
     caret-color: theming.color($primary, text);
 
     @include vendor-prefixes.input-placeholder {
-      color: form-common.control-placeholder-color($config);
+      color: form-common.private-control-placeholder-color($config);
     }
 
     // On dark themes we set the native `select` color to some shade of white,
@@ -61,7 +61,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   // The unit-less line-height from the font config.
   $line-height: typography-utils.height($config, input);
 
@@ -79,8 +80,8 @@
 @mixin _mat-input-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-input') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-input') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/list/_list-theme.scss
+++ b/src/material/list/_list-theme.scss
@@ -45,7 +45,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   $font-family: typography-utils.font-family($config);
 
   .mat-list-item {
@@ -98,8 +99,8 @@
 @mixin _mat-list-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-list') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-list') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/menu/_menu-theme.scss
+++ b/src/material/menu/_menu-theme.scss
@@ -12,7 +12,7 @@
   $foreground: map.get($config, foreground);
 
   .mat-menu-panel {
-    @include private.theme-overridable-elevation(4, $config);
+    @include private.private-theme-overridable-elevation(4, $config);
     background: theming.color($background, 'card');
   }
 
@@ -45,7 +45,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-menu-item {
     font: {
       family: typography-utils.font-family($config, body-1);
@@ -58,8 +59,8 @@
 @mixin _mat-menu-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-menu') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-menu') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/paginator/_paginator-theme.scss
+++ b/src/material/paginator/_paginator-theme.scss
@@ -42,7 +42,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-paginator,
   .mat-paginator-page-size .mat-select-trigger {
     font: {
@@ -54,10 +55,10 @@
 
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
-  $height: compatibility.density-prop-value(paginator-variables.$density-config, $density-scale,
-    height);
+  $height: compatibility.private-density-prop-value(paginator-variables.$density-config,
+    $density-scale, height);
 
-  @include compatibility.density-legacy-compatibility() {
+  @include compatibility.private-density-legacy-compatibility() {
     .mat-paginator-container {
       min-height: $height;
     }
@@ -65,8 +66,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-paginator') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-paginator') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -54,8 +54,8 @@
 @mixin _mat-progress-bar-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-progress-bar') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-progress-bar') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/progress-bar/progress-bar.scss
+++ b/src/material/progress-bar/progress-bar.scss
@@ -9,7 +9,7 @@ $piece-animation-duration: 250ms !default;
 
 
 .mat-progress-bar {
-  @include private.animation-noop();
+  @include private.private-animation-noop();
   display: block;
   // Height is provided for mat-progress-bar to act as a default.
   height: $height;

--- a/src/material/progress-spinner/_progress-spinner-theme.scss
+++ b/src/material/progress-spinner/_progress-spinner-theme.scss
@@ -28,8 +28,8 @@
 @mixin _mat-progress-spinner-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-progress-spinner') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-progress-spinner') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/progress-spinner/progress-spinner.scss
+++ b/src/material/progress-spinner/progress-spinner.scss
@@ -29,7 +29,7 @@ $_mat-progress-spinner-default-circumference:
   }
 
   circle {
-    @include private.animation-noop();
+    @include private.private-animation-noop();
     fill: transparent;
     transform-origin: center;
     transition: stroke-dashoffset 225ms linear;
@@ -43,13 +43,13 @@ $_mat-progress-spinner-default-circumference:
 
   &.mat-progress-spinner-indeterminate-animation[mode='indeterminate'] {
     svg {
-      @include private.animation-noop();
+      @include private.private-animation-noop();
       animation: mat-progress-spinner-linear-rotate variables.$swift-ease-in-out-duration * 4
           linear infinite;
     }
 
     circle {
-      @include private.animation-noop();
+      @include private.private-animation-noop();
       transition-property: stroke;
       // Note: we multiply the duration by 8, because the animation is spread out in 8 stages.
       animation-duration: variables.$swift-ease-in-out-duration * 8;
@@ -60,7 +60,7 @@ $_mat-progress-spinner-default-circumference:
 
   &.mat-progress-spinner-indeterminate-fallback-animation[mode='indeterminate'] {
     svg {
-      @include private.animation-noop();
+      @include private.private-animation-noop();
       animation: mat-progress-spinner-stroke-rotate-fallback
                  $stroke-rotate-fallback-duration
                  $stroke-rotate-fallback-ease
@@ -68,7 +68,7 @@ $_mat-progress-spinner-default-circumference:
     }
 
     circle {
-      @include private.animation-noop();
+      @include private.private-animation-noop();
       transition-property: stroke;
     }
   }

--- a/src/material/radio/_radio-theme.scss
+++ b/src/material/radio/_radio-theme.scss
@@ -70,7 +70,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-radio-button {
     font-family: typography-utils.font-family($config);
   }
@@ -79,8 +80,8 @@
 @mixin _mat-radio-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-radio') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-radio') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/select/_select-theme.scss
+++ b/src/material/select/_select-theme.scss
@@ -20,7 +20,7 @@
   }
 
   .mat-select-placeholder {
-    color: form-common.control-placeholder-color($config);
+    color: form-common.private-control-placeholder-color($config);
   }
 
   .mat-select-disabled .mat-select-value {
@@ -33,7 +33,7 @@
 
   .mat-select-panel {
     background: theming.color($background, card);
-    @include private.theme-overridable-elevation(4, $config);
+    @include private.private-theme-overridable-elevation(4, $config);
 
     .mat-option.mat-selected:not(.mat-option-multiple) {
       background: theming.color($background, hover, 0.12);
@@ -66,7 +66,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   // The unit-less line-height from the font config.
   $line-height: typography-utils.height($config, input);
 
@@ -82,8 +83,8 @@
 @mixin _mat-select-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-select') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-select') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/sidenav/_sidenav-theme.scss
+++ b/src/material/sidenav/_sidenav-theme.scss
@@ -34,7 +34,7 @@
     &:not(.mat-drawer-side) {
       // The elevation of z-16 is noted in the design specifications.
       // See https://material.io/design/components/navigation-drawer.html
-      @include private.theme-elevation(16, $config);
+      @include private.private-theme-elevation(16, $config);
     }
   }
 
@@ -81,8 +81,8 @@
 @mixin _mat-sidenav-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-sidenav') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-sidenav') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -65,7 +65,7 @@
   }
 
   .mat-slide-toggle-thumb {
-    @include private.theme-elevation(1, $config);
+    @include private.private-theme-elevation(1, $config);
     background-color: theming.color(palette.$grey, $thumb-unchecked-hue);
   }
 
@@ -75,7 +75,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-slide-toggle-content {
     font-family: typography-utils.font-family($config);
   }
@@ -84,8 +85,8 @@
 @mixin _mat-slide-toggle-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-slide-toggle') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-slide-toggle') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/slider/_slider-theme.scss
+++ b/src/material/slider/_slider-theme.scss
@@ -167,7 +167,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-slider-thumb-label-text {
     font: {
       family: typography-utils.font-family($config);
@@ -180,8 +181,8 @@
 @mixin _mat-slider-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-slider') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-slider') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/snack-bar/_snack-bar-theme.scss
+++ b/src/material/snack-bar/_snack-bar-theme.scss
@@ -16,7 +16,7 @@
     color: if($is-dark-theme, palette.$dark-primary-text, palette.$light-secondary-text);
     background: if($is-dark-theme, map.get(palette.$grey, 50), #323232);
 
-    @include private.theme-elevation(6, $config);
+    @include private.private-theme-elevation(6, $config);
   }
 
   .mat-simple-snackbar-action {
@@ -25,7 +25,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-simple-snackbar {
     font: {
       family: typography-utils.font-family($config, body-1);
@@ -46,8 +47,8 @@
 @mixin _mat-snack-bar-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-snack-bar') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-snack-bar') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/sort/_sort-theme.scss
+++ b/src/material/sort/_sort-theme.scss
@@ -33,8 +33,8 @@
 @mixin _mat-sort-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-sort') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-sort') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -107,7 +107,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-stepper-vertical, .mat-stepper-horizontal {
     font-family: typography-utils.font-family($config);
   }
@@ -137,11 +138,11 @@
 
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
-  $height: compatibility.density-prop-value(stepper-variables.$density-config, $density-scale,
-    height);
+  $height: compatibility.private-density-prop-value(stepper-variables.$density-config,
+    $density-scale, height);
   $vertical-padding: ($height - stepper-variables.$label-header-height) / 2;
 
-  @include compatibility.density-legacy-compatibility() {
+  @include compatibility.private-density-legacy-compatibility() {
     .mat-horizontal-stepper-header {
       height: $height;
     }
@@ -173,8 +174,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-stepper') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-stepper') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/table/_table-flex-styles.import.scss
+++ b/src/material/table/_table-flex-styles.import.scss
@@ -1,3 +1,1 @@
-@forward 'table-flex-styles' as mat-* hide mat-table-flex-styles;
-@forward 'table-flex-styles' as mat-private-* hide $mat-private-header-row-height,
-$mat-private-row-height, $mat-private-row-horizontal-padding;
+@forward 'table-flex-styles' as mat-*;

--- a/src/material/table/_table-flex-styles.scss
+++ b/src/material/table/_table-flex-styles.scss
@@ -6,7 +6,7 @@ $row-height: 48px;
 $row-horizontal-padding: 24px;
 
 // Only use tag name selectors here since the styles are shared between MDC and non-MDC
-@mixin table-flex-styles {
+@mixin private-table-flex-styles {
   mat-table {
     display: block;
   }

--- a/src/material/table/_table-theme.scss
+++ b/src/material/table/_table-theme.scss
@@ -35,7 +35,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-table {
     font-family: typography-utils.font-family($config);
   }
@@ -53,8 +54,8 @@
 @mixin _mat-table-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-table') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-table') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -1,7 +1,7 @@
 @use '../core/style/vendor-prefixes';
 @use './table-flex-styles';
 
-@include table-flex-styles.table-flex-styles();
+@include table-flex-styles.private-table-flex-styles();
 
 /**
  * Native HTML table structure

--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -58,7 +58,7 @@ $tab-animation-duration: 500ms !default;
 @mixin ink-bar {
   $height: 2px;
 
-  @include private.animation-noop();
+  @include private.private-animation-noop();
   position: absolute;
   bottom: 0;
   height: $height;

--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -137,7 +137,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-tab-group {
     font-family: typography-utils.font-family($config);
   }
@@ -154,8 +155,8 @@
 @mixin _mat-tabs-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-tabs') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-tabs') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/tabs/tab-group.scss
+++ b/src/material/tabs/tab-group.scss
@@ -38,7 +38,7 @@
 
 // The bottom section of the view; contains the tab bodies
 .mat-tab-body-wrapper {
-  @include private.animation-noop();
+  @include private.private-animation-noop();
   position: relative;
   overflow: hidden;
   display: flex;

--- a/src/material/tabs/tab-header.scss
+++ b/src/material/tabs/tab-header.scss
@@ -17,7 +17,7 @@
 }
 
 .mat-tab-list {
-  @include private.animation-noop();
+  @include private.private-animation-noop();
 }
 
 // Wraps each tab label

--- a/src/material/toolbar/_toolbar-theme.scss
+++ b/src/material/toolbar/_toolbar-theme.scss
@@ -70,7 +70,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-toolbar,
   .mat-toolbar h1,
   .mat-toolbar h2,
@@ -85,12 +86,12 @@
 
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
-  $height-desktop: compatibility.density-prop-value(
+  $height-desktop: compatibility.private-density-prop-value(
       toolbar-variables.$desktop-density-config, $density-scale, height);
-  $height-mobile: compatibility.density-prop-value(
+  $height-mobile: compatibility.private-density-prop-value(
       toolbar-variables.$mobile-density-config, $density-scale, height);
 
-  @include compatibility.density-legacy-compatibility() {
+  @include compatibility.private-density-legacy-compatibility() {
     // Set the default height for the toolbar.
     @include _mat-toolbar-height($height-desktop);
 
@@ -104,8 +105,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-toolbar') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-toolbar') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/tooltip/_tooltip-theme.scss
+++ b/src/material/tooltip/_tooltip-theme.scss
@@ -23,7 +23,8 @@ $handset-vertical-padding:
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-tooltip {
     font-family: typography-utils.font-family($config);
     font-size: $font-size;
@@ -41,8 +42,8 @@ $handset-vertical-padding:
 @mixin _mat-tooltip-density($config-or-theme) {}
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-tooltip') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-tooltip') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);

--- a/src/material/tree/_tree-theme.scss
+++ b/src/material/tree/_tree-theme.scss
@@ -22,7 +22,8 @@
 }
 
 @mixin typography($config-or-theme) {
-  $config: typography.typography-to-2014-config(theming.get-typography-config($config-or-theme));
+  $config: typography.private-typography-to-2014-config(
+      theming.get-typography-config($config-or-theme));
   .mat-tree {
     font-family: typography-utils.font-family($config);
   }
@@ -36,9 +37,10 @@
 
 @mixin density($config-or-theme) {
   $density-scale: theming.get-density-config($config-or-theme);
-  $height: compatibility.density-prop-value(tree-variables.$density-config, $density-scale, height);
+  $height: compatibility.private-density-prop-value(tree-variables.$density-config,
+    $density-scale, height);
 
-  @include compatibility.density-legacy-compatibility() {
+  @include compatibility.private-density-legacy-compatibility() {
     .mat-tree-node {
       min-height: $height;
     }
@@ -46,8 +48,8 @@
 }
 
 @mixin theme($theme-or-color-config) {
-  $theme: theming.legacy-get-theme($theme-or-color-config);
-  @include theming.check-duplicate-theme-styles($theme, 'mat-tree') {
+  $theme: theming.private-legacy-get-theme($theme-or-color-config);
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-tree') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);


### PR DESCRIPTION
* In #21204 the `private-` prefix was unintentionally removed from all of the symbols. These changes restore the prefix.
* Fixes the prefixes on the expansion panel theming mixins.