### PR TITLE
build: fix theming api lint rule

### DIFF
--- a/src/material/expansion/_expansion-theme.scss
+++ b/src/material/expansion/_expansion-theme.scss
@@ -91,7 +91,7 @@
 
 @mixin theme($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);
-  @include theming.private-check-duplicate-theme-styles($theme, 'mat-expansion-panel') {
+  @include theming.private-check-duplicate-theme-styles($theme, 'mat-expansion') {
     $color: theming.get-color-config($theme);
     $density: theming.get-density-config($theme);
     $typography: theming.get-typography-config($theme);


### PR DESCRIPTION
Reworks the `theme-mixin-api` lint rule to account for the Sass module changes.