### PR TITLE
fix(material/sort): If there is no direction, setting active as empty

### DIFF
--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -593,12 +593,18 @@ function testSingleColumnSortDirectionSequence(
   component.matSort.direction = '';
 
   // Run through the sequence to confirm the order
-  const actualSequence = expectedSequence.map(() => {
+  const actualSequence = expectedSequence.map(currentSequence => {
     component.sort(id);
 
     // Check that the sort event's active sort is consistent with the MatSort
-    expect(component.matSort.active).toBe(id);
-    expect(component.latestSortEvent.active).toBe(id);
+    if (currentSequence) {
+      expect(component.matSort.active).toBe(id);
+      expect(component.latestSortEvent.active).toBe(id);
+    } else {
+      // For empty sequence the mat sort active should be empty
+      expect(component.matSort.active).toBe('');
+      expect(component.latestSortEvent.active).toBe('');
+    }
 
     // Check that the sort event's direction is consistent with the MatSort
     expect(component.matSort.direction).toBe(component.latestSortEvent.direction);

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -87,7 +87,7 @@ export class MatSort
   readonly _stateChanges = new Subject<void>();
 
   /** The id of the most recently sorted MatSortable. */
-  @Input('matSortActive') active: string;
+  @Input('matSortActive') active: string = '';
 
   /**
    * The direction to set when an MatSortable is initially sorted.
@@ -171,7 +171,9 @@ export class MatSort
     } else {
       this.direction = this.getNextSortDirection(sortable);
     }
-
+    if (!this.direction) {
+      this.active = '';
+    }
     this.sortChange.emit({active: this.active, direction: this.direction});
   }
 


### PR DESCRIPTION
Fixes #15169