### PR TITLE
refactor(material/autocomplete): remove deprecated APIs for v12

### DIFF
--- a/src/material-experimental/mdc-autocomplete/public-api.ts
+++ b/src/material-experimental/mdc-autocomplete/public-api.ts
@@ -13,8 +13,6 @@ export * from './autocomplete-trigger';
 
 // Everything from `material/autocomplete`, except for `MatAutcomplete` and `MatAutocompleteModule`.
 export {
-  AUTOCOMPLETE_OPTION_HEIGHT,
-  AUTOCOMPLETE_PANEL_HEIGHT,
   getMatAutocompleteMissingPanelError,
   MAT_AUTOCOMPLETE_DEFAULT_OPTIONS,
   MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY,

--- a/src/material/autocomplete/autocomplete-trigger.ts
+++ b/src/material/autocomplete/autocomplete-trigger.ts
@@ -57,26 +57,6 @@ import {
 import {_MatAutocompleteOriginBase} from './autocomplete-origin';
 
 
-/**
- * The following style constants are necessary to save here in order
- * to properly calculate the scrollTop of the panel. Because we are not
- * actually focusing the active item, scroll must be handled manually.
- */
-
-/**
- * The height of each autocomplete option.
- * @deprecated No longer being used. To be removed.
- * @breaking-change 12.0.0
- */
-export const AUTOCOMPLETE_OPTION_HEIGHT = 48;
-
-/**
- * The total height of the autocomplete panel.
- * @deprecated No longer being used. To be removed.
- * @breaking-change 12.0.0
- */
-export const AUTOCOMPLETE_PANEL_HEIGHT = 256;
-
 /** Injection token that determines the scroll handling while the autocomplete panel is open. */
 export const MAT_AUTOCOMPLETE_SCROLL_STRATEGY =
     new InjectionToken<() => ScrollStrategy>('mat-autocomplete-scroll-strategy');

--- a/tools/public_api_guard/material/autocomplete.d.ts
+++ b/tools/public_api_guard/material/autocomplete.d.ts
@@ -80,10 +80,6 @@ export declare abstract class _MatAutocompleteTriggerBase implements ControlValu
     static ɵfac: i0.ɵɵFactoryDef<_MatAutocompleteTriggerBase, [null, null, null, null, null, null, { optional: true; }, { optional: true; host: true; }, { optional: true; }, null, { optional: true; }]>;
 }
 
-export declare const AUTOCOMPLETE_OPTION_HEIGHT = 48;
-
-export declare const AUTOCOMPLETE_PANEL_HEIGHT = 256;
-
 export declare function getMatAutocompleteMissingPanelError(): Error;
 
 export declare const MAT_AUTOCOMPLETE_DEFAULT_OPTIONS: InjectionToken<MatAutocompleteDefaultOptions>;


### PR DESCRIPTION
Removes the APIs that were marked for removal in v12.

BREAKING CHANGES:
* `AUTOCOMPLETE_OPTION_HEIGHT` has been removed.
* `AUTOCOMPLETE_PANEL_HEIGHT` has been removed.