### PR TITLE
fix(material-experimental/mdc-form-field): always check hideRequiredMarker

### DIFF
--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -314,7 +314,9 @@ export class MatFormField implements AfterViewInit, OnDestroy, AfterContentCheck
               @Inject(DOCUMENT) private _document?: any) {
     if (_defaults && _defaults.appearance) {
       this.appearance = _defaults.appearance;
-    } else if (_defaults && _defaults.hideRequiredMarker) {
+    }
+
+    if (_defaults && _defaults.hideRequiredMarker) {
       this.hideRequiredMarker = true;
     }
   }

--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -1274,13 +1274,17 @@ describe('MatFormField default options', () => {
     expect(fixture.componentInstance.formField.hideRequiredMarker).toBe(false);
   });
 
-  it('should be able to change the default value of hideRequiredMarker', () => {
+  it('should be able to change the default value of hideRequiredMarker and appearance', () => {
     const fixture = createComponent(MatInputWithAppearance, [{
-      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {hideRequiredMarker: true}}
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {
+        hideRequiredMarker: true,
+        appearance: 'outline',
+      }}
     ]);
 
     fixture.detectChanges();
     expect(fixture.componentInstance.formField.hideRequiredMarker).toBe(true);
+    expect(fixture.componentInstance.formField.appearance).toBe('outline');
   });
 
 });

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1703,13 +1703,17 @@ describe('MatFormField default options', () => {
     expect(fixture.componentInstance.formField.hideRequiredMarker).toBe(false);
   });
 
-  it('should be able to change the default value of hideRequiredMarker', () => {
+  it('should be able to change the default value of hideRequiredMarker and appearance', () => {
     const fixture = createComponent(MatInputWithAppearance, [{
-      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {hideRequiredMarker: true}}
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {
+        hideRequiredMarker: true,
+        appearance: 'outline',
+      }}
     ]);
 
     fixture.detectChanges();
     expect(fixture.componentInstance.formField.hideRequiredMarker).toBe(true);
+    expect(fixture.componentInstance.formField.appearance).toBe('outline');
   });
 
 });


### PR DESCRIPTION
Doesn't appear to be any reason why this was an `else if` - the legacy form field does not do this. Reported internally by Googler