### PR TITLE
fix(material-experimental/mdc-slide-toggle): prevent form field mixin…

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
+++ b/src/material-experimental/mdc-slide-toggle/_slide-toggle-theme.scss
@@ -28,11 +28,11 @@
     $mdc-switch-disabled-thumb-color: mdc-theme-prop-value(surface) !global;
     $mdc-switch-disabled-track-color: mdc-theme-prop-value(on-surface) !global;
 
-    @include mdc-form-field-core-styles($query: mdc-helpers.$mat-theme-styles-query);
-
     // MDC's switch doesn't support a `color` property. We add support
     // for it by adding a CSS class for accent and warn style.
     .mat-mdc-slide-toggle {
+      @include mdc-form-field-core-styles($query: mdc-helpers.$mat-theme-styles-query);
+
       .mdc-switch__thumb-underlay::after, .mat-ripple-element {
         background: $mdc-switch-toggled-off-ripple-color;
       }


### PR DESCRIPTION
… style from leaking out

Nest the `mdc-form-field-core-styles` mixin under `.mat-mdc-slide-toggle` to prevent them from affecting other components