### PR TITLE
fix(google-maps): Missing fallback zoom

### DIFF
--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -464,9 +464,9 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
       ...options,
       // It's important that we set **some** kind of `center` and `zoom`, otherwise
       // Google Maps will render a blank rectangle which looks broken.
-      center: this._center || options.center || DEFAULT_OPTIONS.center,
-      zoom: this._zoom ?? options.zoom ?? DEFAULT_OPTIONS.zoom,
-      mapTypeId: this.mapTypeId || options.mapTypeId
+      center: this._center || this.googleMap?.getCenter() || options.center || DEFAULT_OPTIONS.center,
+      zoom: this._zoom ?? this.googleMap?.getZoom() ?? options.zoom ?? DEFAULT_OPTIONS.zoom,
+      mapTypeId: this.mapTypeId || this.googleMap?.getMapTypeId() || options.mapTypeId,
     };
   }
 


### PR DESCRIPTION
When passing new options to `GoogleMap` without zoom specified, the `DEFAULT_OPTIONS.zoom` will take over the current zoom level.

-------

I want to disable map movement when holding `CTRL` key.

My real world example:
```ts
export class AppComponent {
  readonly draggable = new BehaviorSubject(true);
  readonly mapOptions: Observable<google.maps.MapOptions> = combineLatest([
    this.draggable.pipe(
      map((draggable): Pick<google.maps.MapOptions, 'draggable' | 'draggableCursor'> => {
        return {
          draggable,
          draggableCursor: draggable ? undefined : 'default',
        };
      }),
    ),
  ]).pipe(
    map(([draggable], index) => {
      let initialMapOptions: Pick<google.maps.MapOptions, 'center' | 'zoom'> = {};
      if (!index) {
        initialMapOptions = {
          center: { lat: 49.8037633, lng: 15.4749126 },
          zoom: 8,
        };
      }

      return {
        ...initialMapOptions,
        ...draggable,
      };
    }),
  );
}
```