### PR TITLE
fix(material-experimental/mdc-form-field): fix height for form field …

### DIFF
--- a/src/material-experimental/mdc-form-field/form-field.scss
+++ b/src/material-experimental/mdc-form-field/form-field.scss
@@ -61,6 +61,9 @@
 // that the projected form-field control and content can stretch as needed, but we also
 // apply a default infix width to make the form-field's look natural.
 .mat-mdc-form-field-infix {
+  // Prevent extra height from being added around the textarea, which throws off the overall
+  // height of the form-field
+  line-height: 0;
   flex: auto;
   min-width: 0;
   width: form-field-sizing.$mat-form-field-default-infix-width;


### PR DESCRIPTION
…with textarea

Before:
![Screen Shot 2021-03-02 at 1 57 29 PM](https://user-images.githubusercontent.com/20130030/109720700-5fce1280-7be5-11eb-842f-1bb077f1cd08.png)

After:
![Screen Shot 2021-03-02 at 1 59 36 PM](https://user-images.githubusercontent.com/20130030/109720916-aa4f8f00-7be5-11eb-9c9d-0e91bc14518d.png)


Autosize `<textarea>` inputs and one line `<textarea>` inputs should default to the same height as `<input>` inputs



Line-height can sometimes cause containers to be slightly taller than their content so setting it to 0 prevents that.
