### PR TITLE
fix(material-experimental/mdc-form-field): fix prefix/suffix padding

### DIFF
--- a/src/material-experimental/mdc-form-field/_form-field-sizing.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-sizing.scss
@@ -36,3 +36,11 @@ $mat-form-field-with-label-input-padding-bottom: 8px;
 // same reasoning applies to the padding for text fields without label.
 $mat-form-field-no-label-padding-bottom: 16px;
 $mat-form-field-no-label-padding-top: 16px;
+
+// The amount of padding between the icon prefix/suffix and the infix.
+// This assumes that the icon will be a 24px square with 12px padding.
+$mat-form-field-icon-prefix-infix-padding: 4px;
+
+// The amount of padding between the end of the form-field and the infix for a form-field with no
+// icons.
+$mat-form-field-end-padding: 16px;

--- a/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
+++ b/src/material-experimental/mdc-form-field/_mdc-text-field-structure-overrides.scss
@@ -40,6 +40,31 @@
     flex: auto;
   }
 
+  // The icon prefix/suffix is closer to the edge of the form-field than the infix is in a
+  // form-field with no prefix/suffix. Therefore the standard padding has to be removed when showing
+  // an icon prefix or suffix. We can't rely on MDC's styles for this because we use a different
+  // structure for our form-field in order to support arbitrary height input elements.
+  .mat-mdc-form-field-has-icon-prefix .mat-mdc-text-field-wrapper {
+    padding-left: 0;
+  }
+  .mat-mdc-form-field-has-icon-suffix .mat-mdc-text-field-wrapper {
+    padding-right: 0;
+  }
+  [dir='rtl'] {
+    // Undo the above padding removals which only apply in LTR languages.
+    .mat-mdc-text-field-wrapper {
+      padding-left: form-field-sizing.$mat-form-field-end-padding;
+      padding-right: form-field-sizing.$mat-form-field-end-padding;
+    }
+    // ...and apply the correct padding resets for RTL languages.
+    .mat-mdc-form-field-has-icon-suffix .mat-mdc-text-field-wrapper {
+      padding-left: 0;
+    }
+    .mat-mdc-form-field-has-icon-prefix .mat-mdc-text-field-wrapper {
+      padding-right: 0;
+    }
+  }
+
   // The default MDC text-field implementation does not support labels which always float.
   // MDC only renders the placeholder if the input is focused. We extend this to show the
   // placeholder if the form-field label is set to always float.

--- a/src/material-experimental/mdc-form-field/directives/prefix.ts
+++ b/src/material-experimental/mdc-form-field/directives/prefix.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, InjectionToken} from '@angular/core';
+import {Directive, ElementRef, InjectionToken} from '@angular/core';
 
 /**
  * Injection token that can be used to reference instances of `MatPrefix`. It serves as
@@ -20,4 +20,10 @@ export const MAT_PREFIX = new InjectionToken<MatPrefix>('MatPrefix');
   selector: '[matPrefix], [matIconPrefix], [matTextPrefix]',
   providers: [{provide: MAT_PREFIX, useExisting: MatPrefix}],
 })
-export class MatPrefix {}
+export class MatPrefix {
+  _isText = false;
+
+  constructor(elementRef: ElementRef) {
+    this._isText = elementRef.nativeElement.hasAttribute('matTextPrefix');
+  }
+}

--- a/src/material-experimental/mdc-form-field/directives/suffix.ts
+++ b/src/material-experimental/mdc-form-field/directives/suffix.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, InjectionToken} from '@angular/core';
+import {Directive, ElementRef, InjectionToken} from '@angular/core';
 
 /**
  * Injection token that can be used to reference instances of `MatSuffix`. It serves as
@@ -20,4 +20,10 @@ export const MAT_SUFFIX = new InjectionToken<MatSuffix>('MatSuffix');
   selector: '[matSuffix], [matIconSuffix], [matTextSuffix]',
   providers: [{provide: MAT_SUFFIX, useExisting: MatSuffix}],
 })
-export class MatSuffix {}
+export class MatSuffix {
+  _isText = false;
+
+  constructor(elementRef: ElementRef) {
+    this._isText = elementRef.nativeElement.hasAttribute('matTextSuffix');
+  }
+}

--- a/src/material-experimental/mdc-form-field/form-field.html
+++ b/src/material-experimental/mdc-form-field/form-field.html
@@ -44,10 +44,10 @@
       </ng-template>
     </div>
 
-    <div class="mat-mdc-form-field-icon-prefix" *ngIf="_prefixChildren.length" #iconPrefixContainer>
+    <div class="mat-mdc-form-field-icon-prefix" *ngIf="_hasIconPrefix" #iconPrefixContainer>
       <ng-content select="[matPrefix], [matIconPrefix]"></ng-content>
     </div>
-    <div class="mat-mdc-form-field-text-prefix" *ngIf="_prefixChildren.length" #textPrefixContainer>
+    <div class="mat-mdc-form-field-text-prefix" *ngIf="_hasTextPrefix" #textPrefixContainer>
       <ng-content select="[matTextPrefix]"></ng-content>
     </div>
 
@@ -59,10 +59,10 @@
       <ng-content></ng-content>
     </div>
 
-    <div class="mat-mdc-form-field-text-suffix" *ngIf="_suffixChildren.length">
+    <div class="mat-mdc-form-field-text-suffix" *ngIf="_hasTextSuffix">
       <ng-content select="[matTextSuffix]"></ng-content>
     </div>
-    <div class="mat-mdc-form-field-icon-suffix" *ngIf="_suffixChildren.length">
+    <div class="mat-mdc-form-field-icon-suffix" *ngIf="_hasIconSuffix">
       <ng-content select="[matSuffix], [matIconSuffix]"></ng-content>
     </div>
   </div>

--- a/src/material-experimental/mdc-form-field/form-field.scss
+++ b/src/material-experimental/mdc-form-field/form-field.scss
@@ -7,7 +7,6 @@
 @use '../mdc-helpers/mdc-helpers';
 @import '@material/textfield/mixins.import';
 
-
 // Base styles for MDC text-field, notched-outline, floating label and line-ripple.
 @include mdc-text-field-without-ripple(
   $query: mdc-helpers.$mat-base-styles-without-animation-query);
@@ -52,9 +51,32 @@
   width: 100%;
 }
 
+// Vertically center icons.
 .mat-mdc-form-field-icon-prefix,
 .mat-mdc-form-field-icon-suffix {
   align-self: center;
+  // The line-height can cause the prefix/suffix container to be taller than the actual icons,
+  // breaking the vertical centering. To prevent this we set the line-height to 0.
+  line-height: 0;
+}
+
+// The prefix/suffix needs a little extra padding between the icon and the infix. Because we need to
+// support arbitrary height input elements, we use a different DOM structure for prefix and suffix
+// icons, and therefore can't rely on MDC for these styles.
+.mat-mdc-form-field-icon-prefix,
+[dir='rtl'] .mat-mdc-form-field-icon-suffix {
+  padding: 0 form-field-sizing.$mat-form-field-icon-prefix-infix-padding 0 0;
+}
+.mat-mdc-form-field-icon-suffix,
+[dir='rtl'] .mat-mdc-form-field-icon-prefix {
+  padding: 0 0 0 form-field-sizing.$mat-form-field-icon-prefix-infix-padding;
+}
+
+.mat-mdc-form-field-icon-prefix,
+.mat-mdc-form-field-icon-suffix {
+  & > .mat-icon {
+    padding: 12px;
+  }
 }
 
 // Infix that contains the projected content (usually an input or a textarea). We ensure


### PR DESCRIPTION
Demo: https://mmalerba-demo-1.web.app/mdc-input

Open question: when a mat-icon-button is placed in the prefix/suffix area the padding is wrong. This is because the spec expects the icon-button to take up a 24px square in the layout. However, in reality the button takes up a 48px square because of its touch target. Should we add custom CSS to add some negative margin around icon buttons in this case? In that case it would look right, but if people tried to put an icon-button plus something else in the prefix/suffix it would look broken. (cc @jelbourn)