### PR TITLE
fix(material-experimental/mdc-select): correct some differences between

### DIFF
--- a/src/material-experimental/mdc-form-field/_form-field-native-select.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-native-select.scss
@@ -1,7 +1,9 @@
 @use 'sass:map';
+@use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/theming/theming';
 @use '../../cdk/a11y/a11y';
 @use '../../material/core/theming/palette';
+@use '@material/theme/theme-color' as mdc-theme-color;
 
 // Width of the Material Design form-field select arrow.
 $mat-form-field-select-arrow-width: 10px;
@@ -68,7 +70,6 @@ $mat-form-field-select-horizontal-end-padding: $mat-form-field-select-arrow-widt
       border-right: ($mat-form-field-select-arrow-width / 2) solid transparent;
       border-top: $mat-form-field-select-arrow-height solid;
       position: absolute;
-      top: 50%;
       right: 0;
 
       // Make the arrow non-clickable so the user can click on the form control under it.
@@ -92,20 +93,62 @@ $mat-form-field-select-horizontal-end-padding: $mat-form-field-select-arrow-widt
   }
 }
 
+// Gets the color to use for some text that is highlighted while a select has focus.
+@function _get-focused-arrow-color($palette) {
+  @return rgba(mdc-theme-color.prop-value($palette), 0.87);
+}
+
 @mixin private-form-field-native-select-color($config) {
-  select.mat-mdc-input-element {
-    // On dark themes we set the native `select` color to some shade of white,
-    // however the color propagates to all of the `option` elements, which are
-    // always on a white background inside the dropdown, causing them to blend in.
-    // Since we can't change background of the dropdown, we need to explicitly
-    // reset the color of the options to something dark.
-    @if (map.get($config, is-dark)) {
-      option {
-        color: palette.$dark-primary-text;
+  @include mdc-helpers.mat-using-mdc-theme($config) {
+    $_arrow-color: rgba(mdc-theme-color.prop-value(on-surface), 0.54);
+    $_disabled-arrow-color: rgba(mdc-theme-color.prop-value(on-surface), 0.38);
+
+    select.mat-mdc-input-element {
+      // On dark themes we set the native `select` color to some shade of white,
+      // however the color propagates to all of the `option` elements, which are
+      // always on a white background inside the dropdown, causing them to blend in.
+      // Since we can't change background of the dropdown, we need to explicitly
+      // reset the color of the options to something dark.
+      @if (map.get($config, is-dark)) {
+        option {
+          color: palette.$dark-primary-text;
+        }
+
+        option:disabled {
+          color: palette.$dark-disabled-text;
+        }
+      }
+    }
+
+    .mat-mdc-form-field-type-mat-native-select {
+      .mat-mdc-form-field-infix::after {
+        color: $_arrow-color;
       }
 
-      option:disabled {
-        color: palette.$dark-disabled-text;
+      &.mat-focused {
+        &.mat-primary {
+          .mat-mdc-form-field-infix::after {
+            color: _get-focused-arrow-color(primary);
+          }
+        }
+
+        &.mat-accent {
+          .mat-mdc-form-field-infix::after {
+            color: _get-focused-arrow-color(secondary);
+          }
+        }
+
+        &.mat-warn {
+          .mat-mdc-form-field-infix::after {
+            color: _get-focused-arrow-color(error);
+          }
+        }
+      }
+
+      &.mat-form-field-disabled {
+        .mat-mdc-form-field-infix::after {
+          color: $_disabled-arrow-color;
+        }
       }
     }
   }

--- a/src/material-experimental/mdc-form-field/_form-field-native-select.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-native-select.scss
@@ -100,8 +100,10 @@ $mat-form-field-select-horizontal-end-padding: $mat-form-field-select-arrow-widt
 
 @mixin private-form-field-native-select-color($config) {
   @include mdc-helpers.mat-using-mdc-theme($config) {
-    $_arrow-color: rgba(mdc-theme-color.prop-value(on-surface), 0.54);
-    $_disabled-arrow-color: rgba(mdc-theme-color.prop-value(on-surface), 0.38);
+    // These values are taken from the MDC select implementation:
+    // https://github.com/material-components/material-components-web/blob/master/packages/mdc-select/_select-theme.scss
+    $dropdown-icon-color: rgba(mdc-theme-color.prop-value(on-surface), 0.54);
+    $disabled-dropdown-icon-color: rgba(mdc-theme-color.prop-value(on-surface), 0.38);
 
     select.mat-mdc-input-element {
       // On dark themes we set the native `select` color to some shade of white,
@@ -122,7 +124,7 @@ $mat-form-field-select-horizontal-end-padding: $mat-form-field-select-arrow-widt
 
     .mat-mdc-form-field-type-mat-native-select {
       .mat-mdc-form-field-infix::after {
-        color: $_arrow-color;
+        color: $dropdown-icon-color;
       }
 
       &.mat-focused {
@@ -147,7 +149,7 @@ $mat-form-field-select-horizontal-end-padding: $mat-form-field-select-arrow-widt
 
       &.mat-form-field-disabled {
         .mat-mdc-form-field-infix::after {
-          color: $_disabled-arrow-color;
+          color: $disabled-dropdown-icon-color;
         }
       }
     }

--- a/src/material-experimental/mdc-select/select.scss
+++ b/src/material-experimental/mdc-select/select.scss
@@ -61,7 +61,6 @@ $scale: 0.75 !default;
 }
 
 .mat-mdc-select-arrow {
-  margin: 0 $mat-select-arrow-margin;
   width: $mat-select-arrow-size * 2;
   height: $mat-select-arrow-size;
   position: relative;


### PR DESCRIPTION
mat-select and native select

fixes the native select arrow color and vertical alignment and removes extra padding from the mat-select arrow