### PR TITLE
feat(paginator): localize preposition in `getRangeLabel`

### DIFF
--- a/src/material/paginator/paginator-intl.ts
+++ b/src/material/paginator/paginator-intl.ts
@@ -37,10 +37,13 @@ export class MatPaginatorIntl {
   /** A label for the button that moves to the last page. */
   lastPageLabel: string = 'Last page';
 
+  /** A preposition used in the range label. E.g., in English '2 of 5'. */
+  ofPreposition = 'of';
+
   /** A label for the range of items within the current page and the length of the whole list. */
   getRangeLabel: (page: number, pageSize: number, length: number) => string =
     (page: number, pageSize: number, length: number) => {
-      if (length == 0 || pageSize == 0) { return `0 of ${length}`; }
+      if (length == 0 || pageSize == 0) { return `0 ${this.ofPreposition} ${length}`; }
 
       length = Math.max(length, 0);
 
@@ -51,7 +54,7 @@ export class MatPaginatorIntl {
           Math.min(startIndex + pageSize, length) :
           startIndex + pageSize;
 
-      return `${startIndex + 1} – ${endIndex} of ${length}`;
+      return `${startIndex + 1} – ${endIndex} ${this.ofPreposition} ${length}`;
     }
 }
 


### PR DESCRIPTION
It's a proposal to localize preposition in `getRangeLabel`

The goal is to simplify localization of paginator.
In many languages it's just enough to replace english words with native equivalents.
Existing `MatPaginatorIntl` implementation has been allowing to do that for all words except the preposition in the range label.
To localize just one word the developer has to copy-paste full `getRangeLabel` method and replace just one word in two places.

After that change a developer would be able just extend `MatPaginatorIntl` and replace english words with native ones _without copy-pasting full `getRangeLabel` implementation_