### PR TITLE
fix: checkbox high contrast improvements

### DIFF
--- a/src/material-experimental/mdc-checkbox/checkbox.scss
+++ b/src/material-experimental/mdc-checkbox/checkbox.scss
@@ -4,6 +4,7 @@
 @use 'sass:map';
 @use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/style/_layout-common.scss';
+@use '../../cdk/a11y/a11y';
 @import '@material/checkbox/functions.import';
 @import '@material/checkbox/mixins.import';
 @import '@material/form-field/mixins.import';
@@ -27,8 +28,7 @@
   // The MDC checkbox styles related to the hover state are intertwined with the MDC ripple styles.
   // We currently don't use the MDC ripple due to size concerns, therefore we need to add some
   // additional styles to restore the hover state.
-  .mdc-checkbox:hover
-  .mdc-checkbox__native-control:not([disabled]) ~ .mdc-checkbox__ripple {
+  .mdc-checkbox:hover .mdc-checkbox__native-control:not([disabled]) ~ .mdc-checkbox__ripple {
     opacity: map.get($mdc-ripple-dark-ink-opacities, hover);
     transform: scale(1);
     transition: mdc-checkbox-transition-enter(opacity, 0, 80ms),
@@ -37,10 +37,14 @@
 
   // Note that the :not([disabled]) here isn't necessary, but we need it for the
   // extra specificity so that the hover styles don't override the focus styles.
-  .mdc-checkbox
-  .mdc-checkbox__native-control:not([disabled]):focus ~ .mdc-checkbox__ripple {
+  .mdc-checkbox .mdc-checkbox__native-control:not([disabled]):focus ~ .mdc-checkbox__ripple {
     opacity: map.get($mdc-ripple-dark-ink-opacities, hover) +
       map.get($mdc-ripple-dark-ink-opacities, focus);
+
+    @include a11y.high-contrast(active, off) {
+      outline: solid 3px;
+      opacity: 1;
+    }
   }
 
   // Angular Material supports disabling all animations when NoopAnimationsModule is imported.

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -193,6 +193,24 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * checkbox-common.$size !default;
   .mat-ripple-element:not(.mat-checkbox-persistent-ripple) {
     opacity: 0.16;
   }
+
+  // Increase specificity because ripple styles are part of the `mat-core` mixin and can
+  // potentially overwrite the absolute position of the container.
+  .mat-checkbox-ripple {
+    position: absolute;
+    left: calc(50% - #{$_mat-checkbox-ripple-radius});
+    top: calc(50% - #{$_mat-checkbox-ripple-radius});
+    height: $_mat-checkbox-ripple-radius * 2;
+    width: $_mat-checkbox-ripple-radius * 2;
+    z-index: 1;
+    pointer-events: none;
+  }
+
+  &.cdk-keyboard-focused .mat-checkbox-ripple {
+    @include a11y.high-contrast(active, off) {
+      outline: solid 3px;
+    }
+  }
 }
 
 .mat-checkbox-layout {
@@ -257,14 +275,6 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * checkbox-common.$size !default;
 
   ._mat-animation-noopable & {
     transition: none;
-  }
-
-  .mat-checkbox.cdk-keyboard-focused & {
-    @include a11y.high-contrast(active, off) {
-      // Note that we change the border style of the checkbox frame to dotted because this
-      // is how IE/Edge similarly treats native checkboxes in high contrast mode.
-      border-style: dotted;
-    }
   }
 }
 
@@ -505,16 +515,4 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * checkbox-common.$size !default;
   // Visual improvement to properly show browser popups when being required.
   bottom: 0;
   left: 50%;
-}
-
-// Increase specificity because ripple styles are part of the `mat-core` mixin and can
-// potentially overwrite the absolute position of the container.
-.mat-checkbox .mat-checkbox-ripple {
-  position: absolute;
-  left: calc(50% - #{$_mat-checkbox-ripple-radius});
-  top: calc(50% - #{$_mat-checkbox-ripple-radius});
-  height: $_mat-checkbox-ripple-radius * 2;
-  width: $_mat-checkbox-ripple-radius * 2;
-  z-index: 1;
-  pointer-events: none;
 }


### PR DESCRIPTION
Split up into the following commits:
1. Makes the high contrast focus indication on the current checkbox more prominent.
2. Adds high contrast focus indication to the MDC checkbox.