### PR TITLE
fix(cdk/a11y): FocusTrap deprecation docs don't render correctly

### DIFF
--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -30,10 +30,10 @@ import {InteractivityChecker} from '../interactivity-checker/interactivity-check
  *
  * This class currently uses a relatively simple approach to focus trapping.
  * It assumes that the tab order is the same as DOM order, which is not necessarily true.
- * Things like `tabIndex > 0`, flex `order`, and shadow roots can cause the two to misalign.
+ * Things like `tabIndex > 0`, flex `order`, and shadow roots can cause the two to be misaligned.
  *
  * @deprecated Use `ConfigurableFocusTrap` instead.
- * @breaking-change for 11.0.0 Remove this class.
+ * @breaking-change 11.0.0
  */
 export class FocusTrap {
   private _startAnchor: HTMLElement | null;
@@ -96,7 +96,7 @@ export class FocusTrap {
   /**
    * Inserts the anchors into the DOM. This is usually done automatically
    * in the constructor, but can be deferred for cases like directives with `*ngIf`.
-   * @returns Whether the focus trap managed to attach successfuly. This may not be the case
+   * @returns Whether the focus trap managed to attach successfully. This may not be the case
    * if the target element isn't currently in the DOM.
    */
   attachAnchors(): boolean {
@@ -355,7 +355,7 @@ export class FocusTrap {
 /**
  * Factory that allows easy instantiation of focus traps.
  * @deprecated Use `ConfigurableFocusTrapFactory` instead.
- * @breaking-change for 11.0.0 Remove this class.
+ * @breaking-change 11.0.0
  */
 @Injectable({providedIn: 'root'})
 export class FocusTrapFactory {

--- a/tools/dgeni/templates/macros.html
+++ b/tools/dgeni/templates/macros.html
@@ -1,5 +1,5 @@
 {% macro deprecationTitle(doc) %}
   {%- if doc.breakingChange -%}
-    title="Will be deleted in v{$ doc.breakingChange $}"
+    title="Will be removed in v{$ doc.breakingChange $} or later"
   {%- endif -%}
 {% endmacro %}


### PR DESCRIPTION
- fix invalid usage of `@breaking-change`
- update breaking change dgeni template to add 'or later' 
- fix a couple of API doc typos

Relates to #18201. Relates to #22136.

# Before

![Will be deleted in vfor 11.0.0 Remove this class.](https://user-images.githubusercontent.com/3506071/110229003-fb0c0400-7ed3-11eb-8867-376f4b65177b.png)
Tooltip: "Will be deleted in vfor 11.0.0 Remove this class."

# After

Verified via `yarn build-docs-content` that it generates this output now:

```html
<div class="docs-api-class-deprecated-marker" title="Will be removed in v11.0.0 or later">
  Deprecated
</div>
```

# Questions

While this fixes the tooltip to render properly. It still states that the `FocusTrap` class will be removed in `v11.0.0`, but that didn't happen and it may not be removed in `v12.0.0` either. Should we update this (to what release?) or leave it as is?