### PR TITLE
fix(material-experimental/mdc-progress-bar): improve buffer color

### DIFF
--- a/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
+++ b/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
@@ -8,8 +8,8 @@
   // TODO(crisbeto): the buffer color should come from somewhere in MDC, however at the time of
   // writing, their buffer color is hardcoded to #e6e6e6 which both doesn't account for theming
   // and doesn't match the Material design spec. For now we approximate the buffer background by
-  // lightening the color of the primary bar.
-  $buffer-color: color.adjust(mdc-theme-color.prop-value($color), $lightness: 30%);
+  // applying an opacity to the color of the bar.
+  $buffer-color: rgba(mdc-theme-color.prop-value($color), 0.25);
   @include mdc-linear-progress.bar-color($color, $query: mdc-helpers.$mat-theme-styles-query);
   @include mdc-linear-progress.buffer-color($buffer-color,
     $query: mdc-helpers.$mat-theme-styles-query);

--- a/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
+++ b/src/material-experimental/mdc-progress-bar/_progress-bar-theme.scss
@@ -9,7 +9,7 @@
   // writing, their buffer color is hardcoded to #e6e6e6 which both doesn't account for theming
   // and doesn't match the Material design spec. For now we approximate the buffer background by
   // applying an opacity to the color of the bar.
-  $buffer-color: rgba(mdc-theme-color.prop-value($color), 0.25);
+  $buffer-color: color.adjust(mdc-theme-color.prop-value($color), $alpha: -0.75);
   @include mdc-linear-progress.bar-color($color, $query: mdc-helpers.$mat-theme-styles-query);
   @include mdc-linear-progress.buffer-color($buffer-color,
     $query: mdc-helpers.$mat-theme-styles-query);


### PR DESCRIPTION
Addresses #22130 on the MDC-side of things. Need to consider solutions for legacy progress bar

BEFORE:

<img width="509" alt="Screen Shot 2021-03-08 at 8 44 38 PM" src="https://user-images.githubusercontent.com/22898577/110415453-2404d400-804f-11eb-8a3c-30af4393da6a.png">
<img width="509" alt="Screen Shot 2021-03-08 at 8 44 31 PM" src="https://user-images.githubusercontent.com/22898577/110415460-27985b00-804f-11eb-9c97-4e9e2fce64e6.png">

AFTER:

<img width="509" alt="Screen Shot 2021-03-08 at 8 43 40 PM" src="https://user-images.githubusercontent.com/22898577/110415470-2bc47880-804f-11eb-9f6e-7faa7c0d6ce5.png">
<img width="509" alt="Screen Shot 2021-03-08 at 8 43 48 PM" src="https://user-images.githubusercontent.com/22898577/110415477-2ebf6900-804f-11eb-8a5e-7b8dc6da83e5.png">
