### PR TITLE
fix(material/progress-bar): adjust buffer colors

### DIFF
--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -1,19 +1,28 @@
 @use 'sass:map';
+@use 'sass:color';
 @use '../core/theming/palette';
 @use '../core/theming/theming';
+
+// Approximates the correct buffer color by using a mix between the theme color
+// and the theme's background color.
+@function _get-buffer-color($theme, $background) {
+  $theme-color: theming.color($theme);
+  @return color.mix($theme-color, $background, $weight: 25%);
+}
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
   $primary: map.get($config, primary);
   $accent: map.get($config, accent);
   $warn: map.get($config, warn);
+  $background: map.get(map.get($config, background), background);
 
   .mat-progress-bar-background {
-    fill: theming.color($primary, lighter);
+    fill: _get-buffer-color($primary, $background);
   }
 
   .mat-progress-bar-buffer {
-    background-color: theming.color($primary, lighter);
+    background-color: _get-buffer-color($primary, $background);
   }
 
   .mat-progress-bar-fill::after {
@@ -22,11 +31,11 @@
 
   .mat-progress-bar.mat-accent {
     .mat-progress-bar-background {
-      fill: theming.color($accent, lighter);
+      fill: _get-buffer-color($accent, $background);
     }
 
     .mat-progress-bar-buffer {
-      background-color: theming.color($accent, lighter);
+      background-color: _get-buffer-color($accent, $background);
     }
 
     .mat-progress-bar-fill::after {
@@ -36,11 +45,11 @@
 
   .mat-progress-bar.mat-warn {
     .mat-progress-bar-background {
-      fill: theming.color($warn, lighter);
+      fill: _get-buffer-color($warn, $background);
     }
 
     .mat-progress-bar-buffer {
-      background-color: theming.color($warn, lighter);
+      background-color: _get-buffer-color($warn, $background);
     }
 
     .mat-progress-bar-fill::after {


### PR DESCRIPTION
Fixes #22130

BEFORE: 

![Screen Shot 2021-03-09 at 10 26 31 AM](https://user-images.githubusercontent.com/22898577/110512031-13da0c80-80c2-11eb-8c8a-56fa33caefb5.png)
![Screen Shot 2021-03-09 at 10 26 42 AM](https://user-images.githubusercontent.com/22898577/110512064-1ccade00-80c2-11eb-94f9-8afceeac635b.png)

AFTER:

![Screen Shot 2021-03-09 at 10 23 10 AM](https://user-images.githubusercontent.com/22898577/110512096-248a8280-80c2-11eb-88f4-f9cad253562c.png)
![Screen Shot 2021-03-09 at 10 23 00 AM](https://user-images.githubusercontent.com/22898577/110512086-20f6fb80-80c2-11eb-81b4-4293a1f946e8.png)
