### PR TITLE
fix(material/progress-bar): Support ChromeVox

### DIFF
--- a/src/material-experimental/mdc-progress-bar/progress-bar.html
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.html
@@ -1,3 +1,7 @@
+<!--
+  All children need to be hidden for screen readers in order to support ChromeVox.
+  More context in the issue: https://github.com/angular/components/issues/22165.
+-->
 <div class="mdc-linear-progress" aria-hidden="true">
   <div class="mdc-linear-progress__buffer">
     <div class="mdc-linear-progress__buffer-bar"></div>

--- a/src/material-experimental/mdc-progress-bar/progress-bar.html
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.html
@@ -1,4 +1,4 @@
-<div class="mdc-linear-progress">
+<div class="mdc-linear-progress" aria-hidden="true">
   <div class="mdc-linear-progress__buffer">
     <div class="mdc-linear-progress__buffer-bar"></div>
     <div class="mdc-linear-progress__buffer-dots"></div>

--- a/src/material-experimental/mdc-progress-bar/progress-bar.spec.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.spec.ts
@@ -17,6 +17,19 @@ describe('MDC-based MatProgressBar', () => {
     return TestBed.createComponent<T>(componentType);
   }
 
+  // All children need to be hidden for screen readers in order to support ChromeVox.
+  // More context in the issue: https://github.com/angular/components/issues/22165.
+  it('should have elements wrapped in aria-hidden div', () => {
+    const fixture = createComponent(BasicProgressBar);
+    const host = fixture.nativeElement as Element;
+    const element = host.children[0];
+    expect(element.children.length).toBe(1);
+
+    const div = element.querySelector('div')!;
+    expect(div).toBeTruthy();
+    expect(div.getAttribute('aria-hidden')).toBe('true');
+  });
+
   describe('with animation', () => {
     describe('basic progress-bar', () => {
       it('should apply a mode of "determinate" if no mode is provided.', () => {

--- a/src/material/progress-bar/progress-bar.html
+++ b/src/material/progress-bar/progress-bar.html
@@ -1,6 +1,6 @@
 <!--
-  The background div is named as such because it appears below the other divs and is not sized based
-  on values.
+  All children need to be hidden for screen readers in order to support ChromeVox.
+  More context in the issue: https://github.com/angular/components/issues/22165.
 -->
 <div aria-hidden="true">
   <svg width="100%" height="4" focusable="false" class="mat-progress-bar-background mat-progress-bar-element">
@@ -11,6 +11,10 @@
     </defs>
     <rect [attr.fill]="_rectangleFillValue" width="100%" height="100%"/>
   </svg>
+  <!--
+    The background div is named as such because it appears below the other divs and is not sized based
+    on values.
+  -->
   <div class="mat-progress-bar-buffer mat-progress-bar-element" [ngStyle]="_bufferTransform()"></div>
   <div class="mat-progress-bar-primary mat-progress-bar-fill mat-progress-bar-element" [ngStyle]="_primaryTransform()" #primaryValueBar></div>
   <div class="mat-progress-bar-secondary mat-progress-bar-fill mat-progress-bar-element"></div>

--- a/src/material/progress-bar/progress-bar.html
+++ b/src/material/progress-bar/progress-bar.html
@@ -2,14 +2,16 @@
   The background div is named as such because it appears below the other divs and is not sized based
   on values.
 -->
-<svg width="100%" height="4" focusable="false" class="mat-progress-bar-background mat-progress-bar-element" aria-hidden="true">
-  <defs>
-    <pattern [id]="progressbarId" x="4" y="0" width="8" height="4" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="2"/>
-    </pattern>
-  </defs>
-  <rect [attr.fill]="_rectangleFillValue" width="100%" height="100%"/>
-</svg>
-<div class="mat-progress-bar-buffer mat-progress-bar-element" [ngStyle]="_bufferTransform()" aria-hidden="true"></div>
-<div class="mat-progress-bar-primary mat-progress-bar-fill mat-progress-bar-element" [ngStyle]="_primaryTransform()" #primaryValueBar aria-hidden="true"></div>
-<div class="mat-progress-bar-secondary mat-progress-bar-fill mat-progress-bar-element" aria-hidden="true"></div>
+<div aria-hidden="true">
+  <svg width="100%" height="4" focusable="false" class="mat-progress-bar-background mat-progress-bar-element">
+    <defs>
+      <pattern [id]="progressbarId" x="4" y="0" width="8" height="4" patternUnits="userSpaceOnUse">
+        <circle cx="2" cy="2" r="2"/>
+      </pattern>
+    </defs>
+    <rect [attr.fill]="_rectangleFillValue" width="100%" height="100%"/>
+  </svg>
+  <div class="mat-progress-bar-buffer mat-progress-bar-element" [ngStyle]="_bufferTransform()"></div>
+  <div class="mat-progress-bar-primary mat-progress-bar-fill mat-progress-bar-element" [ngStyle]="_primaryTransform()" #primaryValueBar></div>
+  <div class="mat-progress-bar-secondary mat-progress-bar-fill mat-progress-bar-element"></div>
+</div>

--- a/src/material/progress-bar/progress-bar.html
+++ b/src/material/progress-bar/progress-bar.html
@@ -2,7 +2,7 @@
   The background div is named as such because it appears below the other divs and is not sized based
   on values.
 -->
-<svg width="100%" height="4" focusable="false" class="mat-progress-bar-background mat-progress-bar-element">
+<svg width="100%" height="4" focusable="false" class="mat-progress-bar-background mat-progress-bar-element" aria-hidden="true">
   <defs>
     <pattern [id]="progressbarId" x="4" y="0" width="8" height="4" patternUnits="userSpaceOnUse">
       <circle cx="2" cy="2" r="2"/>
@@ -10,6 +10,6 @@
   </defs>
   <rect [attr.fill]="_rectangleFillValue" width="100%" height="100%"/>
 </svg>
-<div class="mat-progress-bar-buffer mat-progress-bar-element" [ngStyle]="_bufferTransform()"></div>
-<div class="mat-progress-bar-primary mat-progress-bar-fill mat-progress-bar-element" [ngStyle]="_primaryTransform()" #primaryValueBar></div>
-<div class="mat-progress-bar-secondary mat-progress-bar-fill mat-progress-bar-element"></div>
+<div class="mat-progress-bar-buffer mat-progress-bar-element" [ngStyle]="_bufferTransform()" aria-hidden="true"></div>
+<div class="mat-progress-bar-primary mat-progress-bar-fill mat-progress-bar-element" [ngStyle]="_primaryTransform()" #primaryValueBar aria-hidden="true"></div>
+<div class="mat-progress-bar-secondary mat-progress-bar-fill mat-progress-bar-element" aria-hidden="true"></div>

--- a/src/material/progress-bar/progress-bar.spec.ts
+++ b/src/material/progress-bar/progress-bar.spec.ts
@@ -25,6 +25,19 @@ describe('MatProgressBar', () => {
     return TestBed.createComponent<T>(componentType);
   }
 
+  // All children need to be hidden for screen readers in order to support ChromeVox.
+  // More context in the issue: https://github.com/angular/components/issues/22165.
+  it('should have elements wrapped in aria-hidden div', () => {
+    const fixture = createComponent(BasicProgressBar);
+    const host = fixture.nativeElement as Element;
+    const element = host.children[0];
+    expect(element.children.length).toBe(1);
+
+    const div = element.querySelector('div')!;
+    expect(div).toBeTruthy();
+    expect(div.getAttribute('aria-hidden')).toBe('true');
+  });
+
   describe('with animation', () => {
     describe('basic progress-bar', () => {
       it('should apply a mode of "determinate" if no mode is provided.', () => {


### PR DESCRIPTION
ChromeVox couldn't read a progress bar element without `aria-hidden` attributes set on child elements of `mat-progress-bar`.

Fixes #22165.