### PR TITLE
build: lay foundation for migrating to ng-dev release tooling

### DIFF
--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -3,6 +3,7 @@ import {github} from './github';
 import {merge} from './merge';
 import {commitMessage} from './commit-message';
 import {caretaker} from './caretaker';
+import {release} from './release';
 
 module.exports = {
   commitMessage,
@@ -10,4 +11,5 @@ module.exports = {
   github,
   merge,
   caretaker,
+  release,
 };

--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -1,6 +1,7 @@
 import {DevInfraMergeConfig} from '@angular/dev-infra-private/pr/merge/config';
 import {getDefaultTargetLabelConfiguration} from '@angular/dev-infra-private/pr/merge/defaults';
 import {github} from './github';
+import {release} from './release';
 
 /**
  * Configuration for the merge tool in `ng-dev`. This sets up the labels which
@@ -22,6 +23,6 @@ export const merge: DevInfraMergeConfig['merge'] = async api => {
     mergeReadyLabel: 'merge ready',
     commitMessageFixupLabel: 'commit message fixup',
     caretakerNoteLabel: 'caretaker note',
-    labels: await getDefaultTargetLabelConfiguration(api, github, '@angular/cdk'),
+    labels: await getDefaultTargetLabelConfiguration(api, github, release),
   };
 };

--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -1,0 +1,20 @@
+import {join} from 'path';
+import {ReleaseConfig} from '@angular/dev-infra-private/release/config';
+import {releasePackages} from '../tools/release/release-output/release-packages';
+import {promptAndGenerateChangelog} from '../tools/release/changelog';
+
+/** Configuration for the `ng-dev release` command. */
+export const release: ReleaseConfig = {
+  publishRegistry: 'https://wombat-dressing-room.appspot.com',
+  npmPackages: releasePackages.map(pkg => `@angular/${pkg}`),
+  buildPackages: async () => {
+    // The performNpmReleaseBuild function is loaded at runtime as the loading the script causes an
+    // invocation of bazel.
+    const {performNpmReleaseBuild} = require(join(__dirname, '../scripts/build-packages-dist'));
+    return performNpmReleaseBuild();
+  },
+  // TODO: This can be removed once there is an org-wide tool for changelog generation.
+  generateReleaseNotesForHead: async () => {
+    await promptAndGenerateChangelog(join(__dirname, '../CHANGELOG.md'));
+  },
+};

--- a/scripts/build-packages-dist.js
+++ b/scripts/build-packages-dist.js
@@ -44,7 +44,7 @@ if (module === require.main) {
 
 /** Builds the release packages for NPM. */
 function performNpmReleaseBuild() {
-  buildReleasePackages(false, defaultDistPath, /* isSnapshotBuild */ false);
+  return buildReleasePackages(false, defaultDistPath, /* isSnapshotBuild */ false);
 }
 
 /**
@@ -52,7 +52,7 @@ function performNpmReleaseBuild() {
  * Git HEAD SHA is included in the version (for easier debugging and back tracing).
  */
 function performDefaultSnapshotBuild() {
-  buildReleasePackages(false, defaultDistPath, /* isSnapshotBuild */ true);
+  return buildReleasePackages(false, defaultDistPath, /* isSnapshotBuild */ true);
 }
 
 /**
@@ -103,6 +103,14 @@ function buildReleasePackages(useIvy, distPath, isSnapshotBuild) {
     cp('-R', outputPath, targetFolder);
     chmod('-R', 'u+w', targetFolder);
   });
+
+  return packageNames.map(pkg => {
+    const outputPath = getOutputPath(pkg);
+    return {
+      name: `@angular/${pkg}`,
+      outputPath
+    }
+  })
 }
 
 /**


### PR DESCRIPTION
Configure the release tooling from ng-dev.