### PR TITLE
build: require reviews to be completed for all PRs before merging

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -40,7 +40,7 @@ merge:
     # whether the PR shouldn't have a conflict with the base branch
     noConflict: true
     # whether the PR should have all reviews completed.
-    requireReviews: false
+    requireReviews: true
     # list of labels that a PR needs to have, checked with a regexp (e.g. "PR target:" will work for the label "PR target: master")
     requiredLabels:
       - "target: *"


### PR DESCRIPTION
Enable the `requireReviews` option for the Angular Github robot checks,
requiring reviews to be completed before a passing status is provided.