### PR TITLE
fix(material/grid-list): remove mat-figure class

### DIFF
--- a/src/dev-app/screen-type/screen-type-demo.scss
+++ b/src/dev-app/screen-type/screen-type-demo.scss
@@ -7,7 +7,7 @@
 .mat-grid-tile {
   outline: 1px solid lightgray;
 
-  .mat-figure {
+  .mat-grid-tile-content {
     flex-direction: column;
   }
 }

--- a/src/material/grid-list/grid-tile.html
+++ b/src/material/grid-list/grid-tile.html
@@ -1,4 +1,3 @@
-<!-- The `mat-figure` class is only used for backwards compatibility. -->
-<div class="mat-grid-tile-content mat-figure">
+<div class="mat-grid-tile-content">
   <ng-content></ng-content>
 </div>


### PR DESCRIPTION
Remove `mat-figure` class now that internal references have been removed.
(Follow up to https://github.com/angular/components/pull/21826)