### PR TITLE
docs: remove node-sass references

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -95,7 +95,7 @@ $candy-app-theme: mat-light-theme((
   color: (
     primary: $candy-app-primary,
     accent: $candy-app-accent,
-    warn: $candy-app-warn,  
+    warn: $candy-app-warn,
   ),
   typography: mat-typography-config(),
   density: 0, // Defaults to 0 if omitted, but shown for completeness.
@@ -114,9 +114,9 @@ add a new entry to the `"styles"` list in `angular.json` pointing to the theme
 file (e.g., `unicorn-app-theme.scss`).
 
 If you're not using the Angular CLI, you can use any existing Sass tooling to build the file (such
-as gulp-sass or grunt-sass). The simplest approach is to use the `node-sass` CLI; you simply run:
+as gulp-sass or grunt-sass). The simplest approach is to use the `sass` CLI; you simply run:
 ```
-node-sass src/unicorn-app-theme.scss dist/unicorn-app-theme.css
+sass src/unicorn-app-theme.scss dist/unicorn-app-theme.css
 ```
 Then include the output file in your index.html.
 

--- a/tools/package-tools/gulp/build-scss-pipeline.ts
+++ b/tools/package-tools/gulp/build-scss-pipeline.ts
@@ -4,14 +4,14 @@ import {buildConfig} from '../build-config';
 
 // These imports lack of type definitions.
 const gulpSass = require('gulp-sass');
-const nodeSass = require('sass');
+const sass = require('sass');
 
 const sassIncludePaths = [
   join(buildConfig.projectDir, 'node_modules/')
 ];
 
 // Set the compiler to our version of `sass`, rather than the one that `gulp-sass` depends on.
-gulpSass.compiler = nodeSass;
+gulpSass.compiler = sass;
 
 /** Create a gulp task that builds SCSS files. */
 export function buildScssPipeline(sourceDir: string) {


### PR DESCRIPTION
Removes a couple of references to `node-sass` which doesn't support `@use`.