### PR TITLE
build: remove commit message line length limit

### DIFF
--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -4,7 +4,7 @@ import {CommitMessageConfig} from '@angular/dev-infra-private/commit-message/con
  * The configuration for `ng-dev commit-message` commands.
  */
 export const commitMessage: CommitMessageConfig = {
-  maxLineLength: 120,
+  maxLineLength: Infinity,
   minBodyLength: 0,
   minBodyLengthTypeExcludes: ['docs'],
   scopes: [


### PR DESCRIPTION
Similar to https://github.com/angular/angular/pull/41157, removes the limit on commit message lines.