### PR TITLE
fix(cdk/platform): avoid error during server-side rendering if document is stubbed out

### DIFF
--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -34,8 +34,9 @@ let scrollBehaviorSupported: boolean|undefined;
 /** Check whether the browser supports scroll behaviors. */
 export function supportsScrollBehavior(): boolean {
   if (scrollBehaviorSupported == null) {
-    // If we're not in the browser, it can't be supported.
-    if (typeof document !== 'object' || !document) {
+    // If we're not in the browser, it can't be supported. Also check for `Element`, because
+    // some projects stub out the global `document` during SSR which can throw us off.
+    if (typeof document !== 'object' || !document || typeof Element !== 'function' || !Element) {
       scrollBehaviorSupported = false;
       return scrollBehaviorSupported;
     }


### PR DESCRIPTION
Fixes an error that can be thrown by the `supportsScrollBehavior` helper if the global `document` variable is stubbed out.

Fixes #22259.