### PR TITLE
fix(material/tabs): stop scrolling on tab change

### DIFF
--- a/src/material-experimental/mdc-tabs/tab-group.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.spec.ts
@@ -39,6 +39,7 @@ describe('MDC-based MatTabGroup', () => {
         TabGroupWithIsActiveBinding,
         NestedTabs,
         TabGroupWithIndirectDescendantTabs,
+        TabGroupWithSpaceAbove,
       ],
     });
 
@@ -701,6 +702,45 @@ describe('MDC-based MatTabGroup', () => {
     }));
   });
 
+  describe('high tabs', () => {
+    beforeEach(() => {
+      window.scrollTo({top: 0});
+    });
+
+    it('should not scroll when changing tabs by clicking', fakeAsync(() => {
+      const fixture = TestBed.createComponent(TabGroupWithSpaceAbove);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      window.scrollBy(0, 250);
+      expect(window.scrollY).toBe(250);
+
+      // select the second tab
+      let tabLabel = fixture.debugElement.queryAll(By.css('.mat-mdc-tab'))[1];
+      tabLabel.nativeElement.click();
+      checkSelectedIndex(1, fixture);
+
+      expect(window.scrollY).toBe(250);
+      tick();
+    }));
+
+    it('should not scroll when changing tabs programatically', fakeAsync(() => {
+      const fixture = TestBed.createComponent(TabGroupWithSpaceAbove);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      window.scrollBy(0, 250);
+      expect(window.scrollY).toBe(250);
+
+      fixture.componentInstance.tabGroup.selectedIndex = 1;
+      fixture.detectChanges();
+
+      expect(window.scrollY).toBe(250);
+      tick();
+    }));
+  });
 
   /**
    * Checks that the `selectedIndex` has been updated; checks that the label and body have their
@@ -1104,4 +1144,25 @@ class TabGroupWithIndirectDescendantTabs {
 })
 class TabGroupWithInkBarFitToContent {
   fitInkBarToContent = true;
+}
+
+@Component({
+  template: `
+    <div style="height: 300px; background-color: aqua">
+      Top Content here
+    </div>
+    <mat-tab-group>
+      <ng-container>
+        <mat-tab label="One">
+          <div style="height: 3000px; background-color: red"></div>
+        </mat-tab>
+        <mat-tab label="Two">
+          <div style="height: 3000px; background-color: green"></div>
+        </mat-tab>
+      </ng-container>
+    </mat-tab-group>
+  `,
+})
+class TabGroupWithSpaceAbove {
+  @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
 }

--- a/src/material-experimental/mdc-tabs/tab-group.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.spec.ts
@@ -702,7 +702,7 @@ describe('MDC-based MatTabGroup', () => {
     }));
   });
 
-  describe('high tabs', () => {
+  describe('tall tabs', () => {
     beforeEach(() => {
       window.scrollTo({top: 0});
     });

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -701,7 +701,7 @@ describe('MatTabGroup', () => {
     }));
   });
 
-  describe('high tabs', () => {
+  describe('tall tabs', () => {
     beforeEach(() => {
       window.scrollTo({top: 0});
     });

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -39,6 +39,7 @@ describe('MatTabGroup', () => {
         TabGroupWithIsActiveBinding,
         NestedTabs,
         TabGroupWithIndirectDescendantTabs,
+        TabGroupWithSpaceAbove,
       ],
     });
 
@@ -700,6 +701,46 @@ describe('MatTabGroup', () => {
     }));
   });
 
+  describe('high tabs', () => {
+    beforeEach(() => {
+      window.scrollTo({top: 0});
+    });
+
+    it('should not scroll when changing tabs by clicking', fakeAsync(() => {
+      const fixture = TestBed.createComponent(TabGroupWithSpaceAbove);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      window.scrollBy(0, 250);
+      expect(window.scrollY).toBe(250);
+
+      // select the second tab
+      let tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
+      tabLabel.nativeElement.click();
+      checkSelectedIndex(1, fixture);
+
+      expect(window.scrollY).toBe(250);
+      tick();
+    }));
+
+    it('should not scroll when changing tabs programatically', fakeAsync(() => {
+      const fixture = TestBed.createComponent(TabGroupWithSpaceAbove);
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      window.scrollBy(0, 250);
+      expect(window.scrollY).toBe(250);
+
+      fixture.componentInstance.tabGroup.selectedIndex = 1;
+      fixture.detectChanges();
+
+      expect(window.scrollY).toBe(250);
+      tick();
+    }));
+  });
+
   /**
    * Checks that the `selectedIndex` has been updated; checks that the label and body have their
    * respective `active` classes
@@ -1034,5 +1075,26 @@ class TabsWithCustomAnimationDuration {}
   `,
 })
 class TabGroupWithIndirectDescendantTabs {
+  @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
+}
+
+@Component({
+  template: `
+    <div style="height: 300px; background-color: aqua">
+      Top Content here
+    </div>
+    <mat-tab-group>
+      <ng-container>
+        <mat-tab label="One">
+          <div style="height: 3000px; background-color: red"></div>
+        </mat-tab>
+        <mat-tab label="Two">
+          <div style="height: 3000px; background-color: green"></div>
+        </mat-tab>
+      </ng-container>
+    </mat-tab-group>
+  `,
+})
+class TabGroupWithSpaceAbove {
   @ViewChild(MatTabGroup) tabGroup: MatTabGroup;
 }

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -217,6 +217,7 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
       if (!isFirstRun) {
         this.selectedTabChange.emit(this._createChangeEvent(indexToSelect));
         // Preserve the height so page doesn't scroll up during tab change.
+        // Fixes https://stackblitz.com/edit/mat-tabs-scroll-page-top-on-tab-change
         const wrapper = this._tabBodyWrapper.nativeElement;
         wrapper.style.minHeight = wrapper.clientHeight + 'px';
       }

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -216,6 +216,9 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
 
       if (!isFirstRun) {
         this.selectedTabChange.emit(this._createChangeEvent(indexToSelect));
+        // Preserve the height so page doesn't scroll up during tab change.
+        const wrapper = this._tabBodyWrapper.nativeElement;
+        wrapper.style.minHeight = wrapper.clientHeight + 'px';
       }
 
       // Changing these values after change detection has run
@@ -225,6 +228,9 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
 
         if (!isFirstRun) {
           this.selectedIndexChange.emit(indexToSelect);
+          // Clear the min-height, this was needed during tab change to avoid
+          // unnecessary scrolling.
+          this._tabBodyWrapper.nativeElement.style.minHeight = '';
         }
       });
     }


### PR DESCRIPTION
Adds min-height to the mat-tab-group wrapper, so page height is preserved
as tabs change, and page doesn't scroll up.

Fixes #9592