### PR TITLE
build: fix jasmine_node_test

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -125,6 +125,7 @@ def ng_package(name, data = [], deps = [], globals = ROLLUP_GLOBALS, readme_md =
     )
 
 def jasmine_node_test(**kwargs):
+    kwargs["templated_args"] = ["--bazel_patch_module_resolver"] + kwargs.get("templated_args", [])
     _jasmine_node_test(**kwargs)
 
 def ng_test_library(deps = [], tsconfig = None, **kwargs):


### PR DESCRIPTION
With Bazel NodeJS rules 3.0.0 the require patching was removed by default,
which was addressed in the upgrade to 3.2.1. However this was missed for
jasmine_node_test, which now silently fails. This PR adds the bazel patch for
the module resolver, which ensures spec files are found.