### PR TITLE
feat(material/schematics): add migration to switch to the new theming API

### DIFF
--- a/src/cdk/_index.scss
+++ b/src/cdk/_index.scss
@@ -1,4 +1,8 @@
-@forward './overlay/overlay' show overlay;
+@forward './overlay/overlay' show overlay, $z-index-overlay-container, $z-index-overlay,
+  $z-index-overlay-backdrop, $dark-backdrop-background;
 @forward './a11y/a11y' show a11y-visually-hidden, high-contrast;
 @forward './text-field/text-field' show text-field-autosize, text-field-autofill,
-  text-field-autofill-color;
+  text-field-autofill-color,
+  // `text-field` is deprecated, but we have to export it
+  // here in order for the theming API schematic to work.
+  text-field;

--- a/src/material/schematics/collection.json
+++ b/src/material/schematics/collection.json
@@ -42,6 +42,12 @@
       "factory": "./ng-generate/address-form/index",
       "schema": "./ng-generate/address-form/schema.json",
       "aliases": ["address-form", "material-address-form", "material-addressForm"]
+    },
+    "themingApi": {
+      "description": "Switch the project to the new @use-based Material theming API",
+      "factory": "./ng-generate/theming-api/index",
+      "schema": "./ng-generate/theming-api/schema.json",
+      "aliases": ["theming-api", "sass-api"]
     }
   }
 }

--- a/src/material/schematics/ng-generate/theming-api/index.spec.ts
+++ b/src/material/schematics/ng-generate/theming-api/index.spec.ts
@@ -1,0 +1,487 @@
+import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
+import {createTestApp, getFileContent} from '@angular/cdk/schematics/testing';
+import {COLLECTION_PATH} from '../../paths';
+import {Schema} from './schema';
+
+describe('Material theming API schematic', () => {
+  const options: Schema = {};
+  let runner: SchematicTestRunner;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('schematics', COLLECTION_PATH);
+  });
+
+  it('should migrate a theme based on the theming API', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import '~@angular/material/theming';`,
+
+      `@include mat-core();`,
+
+      `$candy-app-primary: mat-palette($mat-indigo);`,
+      `$candy-app-accent: mat-palette($mat-pink, A200, A100, A400);`,
+      `$candy-app-theme: mat-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include angular-material-theme($candy-app-theme);`,
+
+      `$dark-primary: mat-palette($mat-blue-grey);`,
+      `$dark-accent: mat-palette($mat-amber, A200, A100, A400);`,
+      `$dark-warn: mat-palette($mat-deep-orange);`,
+      `$dark-theme: mat-dark-theme((`,
+        `color: (`,
+          `primary: $dark-primary,`,
+          `accent: $dark-accent,`,
+          `warn: $dark-warn,`,
+        `)`,
+      `));`,
+
+      `.unicorn-dark-theme {`,
+        `@include angular-material-color($dark-theme);`,
+      `}`
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+
+      `@include mat.core();`,
+
+      `$candy-app-primary: mat.define-palette(mat.$indigo-palette);`,
+      `$candy-app-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);`,
+      `$candy-app-theme: mat.define-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include mat.all-component-themes($candy-app-theme);`,
+
+      `$dark-primary: mat.define-palette(mat.$blue-grey-palette);`,
+      `$dark-accent: mat.define-palette(mat.$amber-palette, A200, A100, A400);`,
+      `$dark-warn: mat.define-palette(mat.$deep-orange-palette);`,
+      `$dark-theme: mat.define-dark-theme((`,
+        `color: (`,
+          `primary: $dark-primary,`,
+          `accent: $dark-accent,`,
+          `warn: $dark-warn,`,
+        `)`,
+      `));`,
+
+      `.unicorn-dark-theme {`,
+        `@include mat.all-component-colors($dark-theme);`,
+      `}`
+    ]);
+  });
+
+  it('should migrate files using CDK APIs through the theming import', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import '~@angular/material/theming';`,
+      ``,
+      `@include cdk-overlay();`,
+      ``,
+
+      `.my-dialog {`,
+        `z-index: $cdk-z-index-overlay-container + 1;`,
+      `}`,
+      ``,
+      `@include cdk-high-contrast(active, off) {`,
+        `button {`,
+          `outline: solid 1px;`,
+        `}`,
+      `}`
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/cdk' as cdk;`,
+      `@include cdk.overlay();`,
+      ``,
+      `.my-dialog {`,
+        `z-index: cdk.$z-index-overlay-container + 1;`,
+      `}`,
+      ``,
+      `@include cdk.high-contrast(active, off) {`,
+        `button {`,
+          `outline: solid 1px;`,
+        `}`,
+      `}`
+    ]);
+  });
+
+  it('should migrate files using both Material and CDK APIs', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import './foo'`,
+      `@import '~@angular/material/theming';`,
+      ``,
+      `@include cdk-overlay();`,
+      `@include mat-core();`,
+
+      `$candy-app-primary: mat-palette($mat-indigo);`,
+      `$candy-app-accent: mat-palette($mat-pink, A200, A100, A400);`,
+      `$candy-app-theme: mat-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include angular-material-theme($candy-app-theme);`,
+
+      `.my-dialog {`,
+        `z-index: $cdk-z-index-overlay-container + 1;`,
+      `}`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/cdk' as cdk;`,
+      `@use '~@angular/material' as mat;`,
+      `@import './foo'`,
+      ``,
+      `@include cdk.overlay();`,
+      `@include mat.core();`,
+
+      `$candy-app-primary: mat.define-palette(mat.$indigo-palette);`,
+      `$candy-app-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);`,
+      `$candy-app-theme: mat.define-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include mat.all-component-themes($candy-app-theme);`,
+
+      `.my-dialog {`,
+        `z-index: cdk.$z-index-overlay-container + 1;`,
+      `}`
+    ]);
+  });
+
+  it('should detect imports using double quotes', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import "~@angular/material/theming";`,
+      `@include mat-core();`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `@include mat.core();`,
+    ]);
+  });
+
+  it('should migrate mixins that are invoked without parentheses', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import '~@angular/material/theming';`,
+      `@include mat-base-typography;`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `@include mat.typography-hierarchy;`,
+    ]);
+  });
+
+  it('should allow an arbitrary number of spaces after @include and @import', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import                  '~@angular/material/theming';`,
+      `@include     mat-core;`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `@include mat.core;`,
+    ]);
+  });
+
+  it('should insert the new @use statement above other @import statements', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import './foo'`,
+      `@import "~@angular/material/theming";`,
+      `@import './bar'`,
+      `@include mat-core();`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `@import './foo'`,
+      `@import './bar'`,
+      `@include mat.core();`,
+    ]);
+  });
+
+  it('should account for other @use statements when inserting the new Material @use', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@use './foo'`,
+      `@import './bar'`,
+      `@import "~@angular/material/theming";`,
+      `@include mat-core();`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use './foo'`,
+      `@use '~@angular/material' as mat;`,
+      `@import './bar'`,
+      `@include mat.core();`,
+    ]);
+  });
+
+  it('should account for file headers placed aboved the @import statements', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `/** This is a license. */`,
+      `@import './foo'`,
+      `@import '~@angular/material/theming';`,
+      `@include mat-core();`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `/** This is a license. */`,
+      `@use '~@angular/material' as mat;`,
+      `@import './foo'`,
+      `@include mat.core();`,
+    ]);
+  });
+
+  it('should migrate multiple files within the same project', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import '~@angular/material/theming';`,
+      `@include angular-material-theme();`,
+    ].join('\n'));
+
+    app.create('/components/dialog.scss', [
+      `@import '~@angular/material/theming';`,
+      `.my-dialog {`,
+        `z-index: $cdk-z-index-overlay-container + 1;`,
+      `}`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `@include mat.all-component-themes();`,
+    ]);
+    expect(getFileContent(tree, '/components/dialog.scss').split('\n')).toEqual([
+      `@use '~@angular/cdk' as cdk;`,
+      `.my-dialog {`,
+        `z-index: cdk.$z-index-overlay-container + 1;`,
+      `}`,
+    ]);
+  });
+
+  it('should handle variables whose names overlap', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import '~@angular/material/theming';`,
+      `$one: $mat-blue-grey;`,
+      `$two: $mat-blue;`,
+      '$three: $mat-blue',
+      '$four: $mat-blue-gray',
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `$one: mat.$blue-grey-palette;`,
+      `$two: mat.$blue-palette;`,
+      '$three: mat.$blue-palette',
+      '$four: mat.$blue-gray-palette',
+    ]);
+  });
+
+  it('should migrate individual component themes', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import '~@angular/material/theming';`,
+
+      `@include mat-core();`,
+
+      `$candy-app-primary: mat-palette($mat-indigo);`,
+      `$candy-app-accent: mat-palette($mat-pink, A200, A100, A400);`,
+      `$candy-app-theme: mat-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include mat-button-theme($candy-app-theme);`,
+      `@include mat-table-theme($candy-app-theme);`,
+      `@include mat-expansion-panel-theme($candy-app-theme);`,
+      `@include mat-datepicker-theme($candy-app-theme);`,
+      `@include mat-option-theme($candy-app-theme);`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+
+      `@include mat.core();`,
+
+      `$candy-app-primary: mat.define-palette(mat.$indigo-palette);`,
+      `$candy-app-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);`,
+      `$candy-app-theme: mat.define-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include mat.button-theme($candy-app-theme);`,
+      `@include mat.table-theme($candy-app-theme);`,
+      // This one is a special case, because the migration also fixes an incorrect name.
+      `@include mat.expansion-theme($candy-app-theme);`,
+      `@include mat.datepicker-theme($candy-app-theme);`,
+      `@include mat.option-theme($candy-app-theme);`,
+    ]);
+  });
+
+  it('should migrate deep imports', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@import '~@angular/material/core/theming/palette';`,
+      `@import '~@angular/material/core/theming/theming';`,
+      `@import '~@angular/material/button/button-theme';`,
+      `@import '~@angular/material/table/table-theme';`,
+      `@import '~@angular/cdk/overlay';`,
+      `@import '~@angular/material/datepicker/datepicker-theme';`,
+      `@import '~@angular/material/option/option-theme';`,
+
+      `@include cdk-overlay();`,
+
+      `$candy-app-primary: mat-palette($mat-indigo);`,
+      `$candy-app-accent: mat-palette($mat-pink, A200, A100, A400);`,
+      `$candy-app-theme: mat-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include mat-button-theme($candy-app-theme);`,
+      `@include mat-table-theme($candy-app-theme);`,
+      `@include mat-datepicker-theme($candy-app-theme);`,
+      `@include mat-option-theme($candy-app-theme);`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `@use '~@angular/cdk' as cdk;`,
+
+      `@include cdk.overlay();`,
+
+      `$candy-app-primary: mat.define-palette(mat.$indigo-palette);`,
+      `$candy-app-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);`,
+      `$candy-app-theme: mat.define-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include mat.button-theme($candy-app-theme);`,
+      `@include mat.table-theme($candy-app-theme);`,
+      `@include mat.datepicker-theme($candy-app-theme);`,
+      `@include mat.option-theme($candy-app-theme);`,
+    ]);
+  });
+
+  it('should migrate usages of @use, with and without namespaces', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@use '~@angular/material/core/theming/palette' as palette;`,
+      `@use '~@angular/material/core/theming/theming';`,
+      `@use '~@angular/material/button/button-theme' as button;`,
+      `@use '~@angular/material/table/table-theme' as table;`,
+      // Leave one `@import` here to verify mixed usage.
+      `@import '~@angular/material/option/option-theme';`,
+      `@use '~@angular/cdk/overlay' as cdk;`,
+      `@use '~@angular/material/datepicker/datepicker-theme' as datepicker;`,
+
+      `@include cdk.cdk-overlay();`,
+
+      `$candy-app-primary: theming.mat-palette(palette.$mat-indigo);`,
+      `$candy-app-accent: theming.mat-palette(palette.$mat-pink, A200, A100, A400);`,
+      `$candy-app-theme: theming.mat-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include button.mat-button-theme($candy-app-theme);`,
+      `@include table.mat-table-theme($candy-app-theme);`,
+      `@include datepicker.mat-datepicker-theme($candy-app-theme);`,
+      `@include mat-option-theme($candy-app-theme);`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `@use '~@angular/cdk' as cdk;`,
+
+      `@include cdk.overlay();`,
+
+      `$candy-app-primary: mat.define-palette(mat.$indigo-palette);`,
+      `$candy-app-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);`,
+      `$candy-app-theme: mat.define-light-theme((`,
+        `color: (`,
+          `primary: $candy-app-primary,`,
+          `accent: $candy-app-accent,`,
+        `)`,
+      `));`,
+
+      `@include mat.button-theme($candy-app-theme);`,
+      `@include mat.table-theme($candy-app-theme);`,
+      `@include mat.datepicker-theme($candy-app-theme);`,
+      `@include mat.option-theme($candy-app-theme);`,
+    ]);
+  });
+
+  it('should handle edge case inferred Sass import namespaces', async () => {
+    const app = await createTestApp(runner);
+    app.create('/theme.scss', [
+      `@use '~@angular/material/core/index';`,
+      `@use '~@angular/material/button/_button-theme';`,
+      `@use '~@angular/material/table/table-theme.import';`,
+      `@use '~@angular/material/datepicker/datepicker-theme.scss';`,
+
+      `@include core.mat-core();`,
+      `@include button-theme.mat-button-theme();`,
+      `@include table-theme.mat-table-theme();`,
+      `@include datepicker-theme.mat-datepicker-theme();`,
+    ].join('\n'));
+
+    const tree = await runner.runSchematicAsync('theming-api', options, app).toPromise();
+    expect(getFileContent(tree, '/theme.scss').split('\n')).toEqual([
+      `@use '~@angular/material' as mat;`,
+
+      `@include mat.core();`,
+      `@include mat.button-theme();`,
+      `@include mat.table-theme();`,
+      `@include mat.datepicker-theme();`,
+    ]);
+  });
+
+});

--- a/src/material/schematics/ng-generate/theming-api/index.ts
+++ b/src/material/schematics/ng-generate/theming-api/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {extname} from '@angular-devkit/core';
+import {Rule, Tree} from '@angular-devkit/schematics';
+import {Schema} from './schema';
+import {migrateFileContent} from './migration';
+
+export default function(_options: Schema): Rule {
+  return (tree: Tree) => {
+    tree.visit((path, entry) => {
+      if (extname(path) === '.scss') {
+        const content = entry?.content.toString();
+        const migratedContent = content ? migrateFileContent(content,
+          '~@angular/material/', '~@angular/cdk/', '~@angular/material', '~@angular/cdk') : content;
+
+        if (migratedContent && migratedContent !== content) {
+          tree.overwrite(path, migratedContent);
+        }
+      }
+    });
+  };
+}

--- a/src/material/schematics/ng-generate/theming-api/migration.ts
+++ b/src/material/schematics/ng-generate/theming-api/migration.ts
@@ -1,0 +1,341 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Mapping of Material mixins that should be renamed. */
+const materialMixins: Record<string, string> = {
+  'mat-core': 'core',
+  'mat-core-color': 'core-color',
+  'mat-core-theme': 'core-theme',
+  'angular-material-theme': 'all-component-themes',
+  'angular-material-typography': 'all-component-typographies',
+  'angular-material-color': 'all-component-colors',
+  'mat-base-typography': 'typography-hierarchy',
+  'mat-typography-level-to-styles': 'typography-level',
+  'mat-elevation': 'elevation',
+  'mat-overridable-elevation': 'overridable-elevation',
+  'mat-ripple': 'ripple',
+  'mat-ripple-color': 'ripple-color',
+  'mat-ripple-theme': 'ripple-theme',
+  'mat-strong-focus-indicators': 'strong-focus-indicators',
+  'mat-strong-focus-indicators-color': 'strong-focus-indicators-color',
+  'mat-strong-focus-indicators-theme': 'strong-focus-indicators-theme',
+  'mat-font-shorthand': 'font-shorthand',
+  // The expansion panel is a special case, because the package is called `expansion`, but the
+  // mixins were prefixed with `expansion-panel`. This was corrected by the Sass module migration.
+  'mat-expansion-panel-theme': 'expansion-theme',
+  'mat-expansion-panel-color': 'expansion-color',
+  'mat-expansion-panel-typography': 'expansion-typography',
+};
+
+// The component themes all follow the same pattern so we can spare ourselves some typing.
+[
+  'option', 'optgroup', 'pseudo-checkbox', 'autocomplete', 'badge', 'bottom-sheet', 'button',
+  'button-toggle', 'card', 'checkbox', 'chips', 'divider', 'table', 'datepicker', 'dialog',
+  'grid-list', 'icon', 'input', 'list', 'menu', 'paginator', 'progress-bar', 'progress-spinner',
+  'radio', 'select', 'sidenav', 'slide-toggle', 'slider', 'stepper', 'sort', 'tabs', 'toolbar',
+  'tooltip', 'snack-bar', 'form-field', 'tree'
+].forEach(name => {
+  materialMixins[`mat-${name}-theme`] = `${name}-theme`;
+  materialMixins[`mat-${name}-color`] = `${name}-color`;
+  materialMixins[`mat-${name}-typography`] = `${name}-typography`;
+});
+
+/** Mapping of Material functions that should be renamed. */
+const materialFunctions: Record<string, string> = {
+  'mat-color': 'get-color-from-palette',
+  'mat-contrast': 'get-contrast-color-from-palette',
+  'mat-palette': 'define-palette',
+  'mat-dark-theme': 'define-dark-theme',
+  'mat-light-theme': 'define-light-theme',
+  'mat-typography-level': 'define-typography-level',
+  'mat-typography-config': 'define-typography-config',
+  'mat-font-size': 'font-size',
+  'mat-line-height': 'line-height',
+  'mat-font-weight': 'font-weight',
+  'mat-letter-spacing': 'letter-spacing',
+  'mat-font-family': 'font-family',
+};
+
+/** Mapping of Material variables that should be renamed. */
+const materialVariables: Record<string, string> = {
+  'mat-light-theme-background': 'light-theme-background-palette',
+  'mat-dark-theme-background': 'dark-theme-background-palette',
+  'mat-light-theme-foreground': 'light-theme-foreground-palette',
+  'mat-dark-theme-foreground': 'dark-theme-foreground-palette',
+};
+
+// The palettes all follow the same pattern.
+[
+  'red', 'pink', 'indigo', 'purple', 'deep-purple', 'blue', 'light-blue', 'cyan', 'teal', 'green',
+  'light-green', 'lime', 'yellow', 'amber', 'orange', 'deep-orange', 'brown', 'grey', 'gray',
+  'blue-grey', 'blue-gray'
+].forEach(name => materialVariables[`mat-${name}`] = `${name}-palette`);
+
+/** Mapping of CDK variables that should be renamed. */
+const cdkVariables: Record<string, string> = {
+  'cdk-z-index-overlay-container': 'z-index-overlay-container',
+  'cdk-z-index-overlay': 'z-index-overlay',
+  'cdk-z-index-overlay-backdrop': 'z-index-overlay-backdrop',
+  'cdk-overlay-dark-backdrop-background': 'overlay-dark-backdrop-background',
+};
+
+/** Mapping of CDK mixins that should be renamed. */
+const cdkMixins: Record<string, string> = {
+  'cdk-overlay': 'overlay',
+  'cdk-a11y': 'a11y-visually-hidden',
+  'cdk-high-contrast': 'high-contrast',
+  'cdk-text-field-autofill-color': 'text-field-autofill-color',
+  // This one was split up into two mixins which is trickier to
+  // migrate so for now we forward to the deprecated variant.
+  'cdk-text-field': 'text-field',
+};
+
+/**
+ * Migrates the content of a file to the new theming API. Note that this migration is using plain
+ * string manipulation, rather than the AST from PostCSS and the schematics string manipulation
+ * APIs, because it allows us to run it inside g3 and to avoid introducing new dependencies.
+ * @param content Content of the file.
+ * @param oldMaterialPrefix Prefix with which the old Material imports should start.
+ *   Has to end with a slash. E.g. if `@import '~@angular/material/theming'` should be
+ *   matched, the prefix would be `~@angular/material/`.
+ * @param oldCdkPrefix Prefix with which the old CDK imports should start.
+ *   Has to end with a slash. E.g. if `@import '~@angular/cdk/overlay'` should be
+ *   matched, the prefix would be `~@angular/cdk/`.
+ * @param newMaterialImportPath New import to the Material theming API (e.g. `~@angular/material`).
+ * @param newCdkImportPath New import to the CDK Sass APIs (e.g. `~@angular/cdk`).
+ */
+export function migrateFileContent(content: string,
+                                   oldMaterialPrefix: string,
+                                   oldCdkPrefix: string,
+                                   newMaterialImportPath: string,
+                                   newCdkImportPath: string): string {
+  // Drop the CDK imports and detect their namespaces.
+  const cdkResults = detectAndDropImports(content, oldCdkPrefix);
+  content = cdkResults.content;
+
+  // Drop the Material imports and detect their namespaces.
+  const materialResults = detectAndDropImports(content, oldMaterialPrefix);
+  content = materialResults.content;
+
+  // If nothing has changed, then the file doesn't import the Material theming API.
+  if (materialResults.hasChanged || cdkResults.hasChanged) {
+    // Replacing the imports may have resulted in leading whitespace.
+    content = content.replace(/^\s+/, '');
+    content = migrateCdkSymbols(content, newCdkImportPath, cdkResults.namespaces);
+    content = migrateMaterialSymbols(content, newMaterialImportPath, materialResults.namespaces);
+  }
+
+  return content;
+}
+
+/**
+ * Finds all of the imports matching a prefix, removes them from
+ * the content string and returns some information about them.
+ * @param content Content from which to remove the imports.
+ * @param prefix Prefix that the imports should start with.
+ */
+function detectAndDropImports(content: string, prefix: string):
+  {content: string, hasChanged: boolean, namespaces: string[]} {
+  if (prefix[prefix.length - 1] !== '/') {
+    // Some of the logic further down makes assumptions about the import depth.
+    throw Error(`Prefix "${prefix}" has to end in a slash.`);
+  }
+
+  // List of `@use` namespaces from which Angular CDK/Material APIs may be referenced.
+  // Since we know that the library doesn't have any name collisions, we can treat all of these
+  // namespaces as equivalent.
+  const namespaces: string[] = [];
+  const pattern = new RegExp(`@(import|use) +['"]${escapeRegExp(prefix)}.*['"].*;?\n`, 'g');
+  let hasChanged = false;
+
+  content = content.replace(pattern, (fullImport, type: 'import' | 'use') => {
+    if (type === 'use') {
+      const namespace = extractNamespaceFromUseStatement(fullImport);
+
+      if (namespaces.indexOf(namespace) === -1) {
+        namespaces.push(namespace);
+      }
+    }
+
+    hasChanged = true;
+    return '';
+  });
+
+  return {content, hasChanged, namespaces};
+}
+
+/** Migrates the Material symbls in a file. */
+function migrateMaterialSymbols(content: string, importPath: string, namespaces: string[]): string {
+  const initialContent = content;
+  const namespace = 'mat';
+
+  // Migrate the mixins.
+  content = renameSymbols(content, materialMixins, namespaces, mixinKeyFormatter,
+    getMixinValueFormatter(namespace));
+
+  // Migrate the functions.
+  content = renameSymbols(content, materialFunctions, namespaces, functionKeyFormatter,
+    getFunctionValueFormatter(namespace));
+
+  // Migrate the variables.
+  content = renameSymbols(content, materialVariables, namespaces, variableKeyFormatter,
+    getVariableValueFormatter(namespace));
+
+  if (content !== initialContent) {
+    // Add an import to the new API only if any of the APIs were being used.
+    content = insertUseStatement(content, importPath, namespace);
+  }
+
+  return content;
+}
+
+/** Migrates the CDK symbols in a file. */
+function migrateCdkSymbols(content: string, importPath: string, namespaces: string[]): string {
+  const initialContent = content;
+  const namespace = 'cdk';
+
+  // Migrate the mixins.
+  content = renameSymbols(content, cdkMixins, namespaces, mixinKeyFormatter,
+    getMixinValueFormatter(namespace));
+
+  // Migrate the variables.
+  content = renameSymbols(content, cdkVariables, namespaces, variableKeyFormatter,
+    getVariableValueFormatter(namespace));
+
+  // Previously the CDK symbols were exposed through `material/theming`, but now we have a
+  // dedicated entrypoint for the CDK. Only add an import for it if any of the symbols are used.
+  if (content !== initialContent) {
+    content = insertUseStatement(content, importPath, namespace);
+  }
+
+  return content;
+}
+
+/**
+ * Renames all Sass symbols in a file based on a pre-defined mapping.
+ * @param content Content of a file to be migrated.
+ * @param mapping Mapping between symbol names and their replacements.
+ * @param getKeyPattern Function used to turn each of the keys into a regex.
+ * @param formatValue Formats the value that will replace any matches of the pattern returned by
+ *  `getKeyPattern`.
+ */
+function renameSymbols(content: string,
+                       mapping: Record<string, string>,
+                       namespaces: string[],
+                       getKeyPattern: (namespace: string|null, key: string) => RegExp,
+                       formatValue: (key: string) => string): string {
+  // The null at the end is so that we make one last pass to cover non-namespaced symbols.
+  [...namespaces.slice().sort(sortLengthDescending), null].forEach(namespace => {
+    // Migrate the longest keys first so that our regex-based replacements don't accidentally
+    // capture keys that contain other keys. E.g. `$mat-blue` is contained within `$mat-blue-grey`.
+    Object.keys(mapping).sort(sortLengthDescending).forEach(key => {
+      const pattern = getKeyPattern(namespace, key);
+
+      // Sanity check since non-global regexes will only replace the first match.
+      if (pattern.flags.indexOf('g') === -1) {
+        throw Error('Replacement pattern must be global.');
+      }
+
+      content = content.replace(pattern, formatValue(mapping[key]));
+    });
+  });
+
+  return content;
+}
+
+/** Inserts an `@use` statement in a string. */
+function insertUseStatement(content: string, importPath: string, namespace: string): string {
+  // Sass has a limitation that all `@use` declarations have to come before `@import` so we have
+  // to find the first import and insert before it. Technically we can get away with always
+  // inserting at 0, but the file may start with something like a license header.
+  const newImportIndex = Math.max(0, content.indexOf('@import '));
+  return content.slice(0, newImportIndex) + `@use '${importPath}' as ${namespace};\n` +
+         content.slice(newImportIndex);
+}
+
+/** Formats a migration key as a Sass mixin invocation. */
+function mixinKeyFormatter(namespace: string|null, name: string): RegExp {
+  // Note that adding a `(` at the end of the pattern would be more accurate, but mixin
+  // invocations don't necessarily have to include the parantheses. We could add `[(;]`,
+  // but then we won't know which character to include in the replacement string.
+  return new RegExp(`@include +${escapeRegExp((namespace ? namespace + '.' : '') + name)}`, 'g');
+}
+
+/** Returns a function that can be used to format a Sass mixin replacement. */
+function getMixinValueFormatter(namespace: string): (name: string) => string {
+  // Note that adding a `(` at the end of the pattern would be more accurate,
+  // but mixin invocations don't necessarily have to include the parantheses.
+  return name => `@include ${namespace}.${name}`;
+}
+
+/** Formats a migration key as a Sass function invocation. */
+function functionKeyFormatter(namespace: string|null, name: string): RegExp {
+  return new RegExp(escapeRegExp(`${namespace ? namespace + '.' : ''}${name}(`), 'g');
+}
+
+/** Returns a function that can be used to format a Sass function replacement. */
+function getFunctionValueFormatter(namespace: string): (name: string) => string {
+  return name => `${namespace}.${name}(`;
+}
+
+/** Formats a migration key as a Sass variable. */
+function variableKeyFormatter(namespace: string|null, name: string): RegExp {
+  return new RegExp(escapeRegExp(`${namespace ? namespace + '.' : ''}$${name}`), 'g');
+}
+
+/** Returns a function that can be used to format a Sass variable replacement. */
+function getVariableValueFormatter(namespace: string): (name: string) => string {
+  return name => `${namespace}.$${name}`;
+}
+
+/** Escapes special regex characters in a string. */
+function escapeRegExp(str: string): string {
+  return str.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1');
+}
+
+/** Used with `Array.prototype.sort` to order strings in descending length. */
+function sortLengthDescending(a: string, b: string) {
+  return b.length - a.length;
+}
+
+/** Parses out the namespace from a Sass `@use` statement. */
+function extractNamespaceFromUseStatement(fullImport: string): string {
+  const closeQuoteIndex = Math.max(fullImport.lastIndexOf(`"`), fullImport.lastIndexOf(`'`));
+
+  if (closeQuoteIndex > -1) {
+    const asExpression = 'as ';
+    const asIndex = fullImport.indexOf(asExpression, closeQuoteIndex);
+
+    // If we found an ` as ` expression, we consider the rest of the text as the namespace.
+    if (asIndex > -1) {
+      return fullImport.slice(asIndex + asExpression.length).split(';')[0].trim();
+    }
+
+    // Otherwise the namespace is the name of the file that is being imported.
+    const lastSlashIndex = fullImport.lastIndexOf('/', closeQuoteIndex);
+
+    if (lastSlashIndex > -1) {
+      const fileName = fullImport.slice(lastSlashIndex + 1, closeQuoteIndex)
+        // Sass allows for leading underscores to be omitted and it technically supports .scss.
+        .replace(/^_|(\.import)?\.scss$|\.import$/g, '');
+
+      // Sass ignores `/index` and infers the namespace as the next segment in the path.
+      if (fileName === 'index') {
+        const nextSlashIndex = fullImport.lastIndexOf('/', lastSlashIndex - 1);
+
+        if (nextSlashIndex > -1) {
+          return fullImport.slice(nextSlashIndex + 1, lastSlashIndex);
+        }
+      } else {
+        return fileName;
+      }
+    }
+  }
+
+  throw Error(`Could not extract namespace from import "${fullImport}".`);
+}

--- a/src/material/schematics/ng-generate/theming-api/schema.json
+++ b/src/material/schematics/ng-generate/theming-api/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsMaterialThemingApi",
+  "title": "Material Theming API migration",
+  "type": "object",
+  "properties": {}
+}

--- a/src/material/schematics/ng-generate/theming-api/schema.ts
+++ b/src/material/schematics/ng-generate/theming-api/schema.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface Schema {}


### PR DESCRIPTION
Adds an `ng-generate` schematic that will switch over existing stylesheets to the new `@use`-based API. Furthermore, the migration code is set up in a way that should allow us to run it in g3 if necessary.