### PR TITLE
Fixed a typo in the spec. MatCheckbox.change($event) *should* fire when the native input changes value.

### DIFF
--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -330,8 +330,7 @@ describe('MatCheckbox', () => {
       fixture.detectChanges();
       flush();
 
-      // The change event shouldn't fire, because the value change was not caused
-      // by any interaction.
+      // The change event should fire, because the value change was caused by an interaction.
       expect(testComponent.onCheckboxChange).toHaveBeenCalledTimes(1);
     }));
 


### PR DESCRIPTION
I was very confused by the spec until I realized there was a typo.

The spec comments indicate that a native checkbox input should trigger a change event, but the comment in the spec indicates that it shouldn't. This inverts the wording to make it correct.

See the next test case to understand when a change event should not be called.