### PR TITLE
test(material-experimental/mdc-slider): add tests for sliders with ng…

### DIFF
--- a/src/material-experimental/mdc-slider/slider.scss
+++ b/src/material-experimental/mdc-slider/slider.scss
@@ -1,7 +1,7 @@
 @use '@material/slider/slider' as mdc-slider;
-@import '../mdc-helpers/mdc-helpers';
+@use '../mdc-helpers/mdc-helpers';
 
-@include mdc-slider.without-ripple($query: $mat-base-styles-query);
+@include mdc-slider.without-ripple($query: mdc-helpers.$mat-base-styles-query);
 
 .mat-mdc-slider {
   display: block;

--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -15,7 +15,14 @@ import {
   dispatchTouchEvent,
 } from '@angular/cdk/testing/private';
 import {Component, Type} from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync} from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  TestBed,
+  tick,
+  waitForAsync,
+} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {Thumb} from '@material/slider';

--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -377,7 +377,7 @@ export class MatSliderThumb implements AfterViewInit, ControlValueAccessor, OnIn
 
   _emitFakeEvent(type: 'change'|'input') {
     const event = new Event(type);
-    (event as any).isFake = true;
+    (event as any)._matIsFake = true;
     this._hostElement.dispatchEvent(event);
   }
 
@@ -906,7 +906,7 @@ class SliderAdapter implements MDCSliderAdapter {
             // listen for these events directly on the slider input as they would with a native
             // range input.
             if (event.target === this._delegate._getInputElement(thumbPosition)) {
-              if ((event as any).isFake) { return; }
+              if ((event as any)._matIsFake) { return; }
               event.stopImmediatePropagation();
               handler(event as GlobalEventHandlersEventMap[K]);
             }

--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -321,12 +321,6 @@ export class MatSliderThumb implements AfterViewInit, ControlValueAccessor, OnIn
   /** Event emitted every time the MatSliderThumb is focused. */
   @Output() readonly _focus: EventEmitter<void> = new EventEmitter<void>();
 
-  /** Event emitted on pointer up or after left or right arrow key presses. */
-  @Output() readonly change: EventEmitter<Event> = new EventEmitter<Event>();
-
-  /** Event emitted on each value change that happens to the slider. */
-  @Output() readonly input: EventEmitter<Event> = new EventEmitter<Event>();
-
   _disabled: boolean = false;
 
   /**
@@ -382,10 +376,9 @@ export class MatSliderThumb implements AfterViewInit, ControlValueAccessor, OnIn
   }
 
   _emitFakeEvent(type: 'change'|'input') {
-    const event = new Event(type) as any;
-    event.isFake = true;
-    const emitter = type === 'change' ? this.change : this.input;
-    emitter.emit(event);
+    const event = new Event(type);
+    (event as any).isFake = true;
+    this._hostElement.dispatchEvent(event);
   }
 
   /**
@@ -393,7 +386,9 @@ export class MatSliderThumb implements AfterViewInit, ControlValueAccessor, OnIn
    * @param value
    */
   writeValue(value: any): void {
-    this.value = value;
+    if (this._slider._initialized) {
+      this.value = coerceNumberProperty(value);
+    }
   }
 
   /**


### PR DESCRIPTION
…Model

* Fix a bug where using an Angular event emitter for change and input events was
  causing .target to be null. This bug was showing up in the unit tests for
  ngModel where somewhere inside @angular/forms we were trying to use
  .target.value. The bug was fixed by using node.dispatchEvent instead of
  using an eventEmitter.
* Add a check to ensure the slider is initialized before we try setting the value
  of the slider in #writeValue.
* Add unit tests for sliders with ngModel