### PR TITLE
build: align MDC version requirement

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -2,7 +2,7 @@
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
 ANGULAR_PACKAGE_VERSION = "^12.0.0-0 || ^13.0.0-0"
-MDC_PACKAGE_VERSION = "^9.0.0-canary.419e03572.0"
+MDC_PACKAGE_VERSION = "^11.0.0-canary.0cde52f5a.0"
 TSLIB_PACKAGE_VERSION = "^2.1.0"
 
 # Each placer holder is used to stamp versions during the build process, replacing the key with it's


### PR DESCRIPTION
The required version for MDC was 2 major versions behind the one we're using for development.

Fixes #22320.