### PR TITLE
fix(material/tree): not rendering initial data from flat data source

### DIFF
--- a/src/material/tree/data-source/nested-data-source.ts
+++ b/src/material/tree/data-source/nested-data-source.ts
@@ -18,13 +18,12 @@ import {map} from 'rxjs/operators';
  * or collapse. The expansion/collapsion will be handled by TreeControl and each non-leaf node.
  */
 export class MatTreeNestedDataSource<T> extends DataSource<T> {
-  readonly _data = new BehaviorSubject<T[]>([]);
-
   /**
    * Data for the nested tree
    */
   get data() { return this._data.value; }
   set data(value: T[]) { this._data.next(value); }
+  private readonly _data = new BehaviorSubject<T[]>([]);
 
   connect(collectionViewer: CollectionViewer): Observable<T[]> {
     return merge(...[collectionViewer.viewChange, this._data])

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -785,10 +785,6 @@ class MatTreeWithNullOrUndefinedChild {
 
   dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener, TREE_DATA);
 
-  constructor() {
-    this.dataSource.data = TREE_DATA;
-  }
-
   hasChild = (_: number, node: ExampleFlatNode) => node.expandable;
 }
 

--- a/tools/public_api_guard/material/tree.d.ts
+++ b/tools/public_api_guard/material/tree.d.ts
@@ -24,9 +24,6 @@ export declare class MatTree<T, K = T> extends CdkTree<T, K> {
 }
 
 export declare class MatTreeFlatDataSource<T, F, K = F> extends DataSource<F> {
-    readonly _data: BehaviorSubject<T[]>;
-    readonly _expandedData: BehaviorSubject<F[]>;
-    readonly _flattenedData: BehaviorSubject<F[]>;
     get data(): T[];
     set data(value: T[]);
     constructor(_treeControl: FlatTreeControl<F, K>, _treeFlattener: MatTreeFlattener<T, F, K>, initialData?: T[]);
@@ -53,7 +50,6 @@ export declare class MatTreeModule {
 }
 
 export declare class MatTreeNestedDataSource<T> extends DataSource<T> {
-    readonly _data: BehaviorSubject<T[]>;
     get data(): T[];
     set data(value: T[]);
     connect(collectionViewer: CollectionViewer): Observable<T[]>;


### PR DESCRIPTION
The `MatTreeFlatDataSource` has an `initialData` parameter which doesn't work, because it only assigns the data to one of the three streams used to render the tree.

These changes also make some underscored properties private.

Fixes #22282.