### PR TITLE
feat(google-maps): add clusterer click event

### DIFF
--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.spec.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.spec.ts
@@ -260,6 +260,8 @@ describe('MapMarkerClusterer', () => {
         .toHaveBeenCalledWith('clusteringbegin', jasmine.any(Function));
     expect(markerClustererSpy.addListener)
         .not.toHaveBeenCalledWith('clusteringend', jasmine.any(Function));
+    expect(markerClustererSpy.addListener)
+        .toHaveBeenCalledWith('click', jasmine.any(Function));
   });
 });
 
@@ -285,7 +287,8 @@ describe('MapMarkerClusterer', () => {
                                      [zIndex]="zIndex"
                                      [zoomOnClick]="zoomOnClick"
                                      [options]="options"
-                                     (clusteringbegin)="onClusteringBegin()">
+                                     (clusteringbegin)="onClusteringBegin()"
+                                     (clusterClick)="onClusterClick()">
                  <map-marker *ngIf="state === 'state1'"></map-marker>
                  <map-marker *ngIf="state === 'state1' || state === 'state2'"></map-marker>
                  <map-marker *ngIf="state === 'state2'"></map-marker>
@@ -318,4 +321,5 @@ class TestApp {
   state = 'state1';
 
   onClusteringBegin() {}
+  onClusterClick() {}
 }

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
@@ -177,6 +177,10 @@ export class MapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, 
   @Output()
   clusteringend: Observable<void> = this._eventManager.getLazyEmitter<void>('clusteringend');
 
+  /** Emits when a cluster has been clicked. */
+  @Output()
+  clusterClick: Observable<Cluster> = this._eventManager.getLazyEmitter<Cluster>('click');
+
   @ContentChildren(MapMarker, {descendants: true}) _markers: QueryList<MapMarker>;
 
   /**

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -284,6 +284,7 @@ export declare class MapMarkerClusterer implements OnInit, AfterContentInit, OnC
     set batchSizeIE(batchSizeIE: number);
     set calculator(calculator: Calculator);
     set clusterClass(clusterClass: string);
+    clusterClick: Observable<Cluster>;
     clusteringbegin: Observable<void>;
     clusteringend: Observable<void>;
     set enableRetinaIcons(enableRetinaIcons: boolean);
@@ -325,7 +326,7 @@ export declare class MapMarkerClusterer implements OnInit, AfterContentInit, OnC
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵcmp: i0.ɵɵComponentDefWithMeta<MapMarkerClusterer, "map-marker-clusterer", ["mapMarkerClusterer"], { "ariaLabelFn": "ariaLabelFn"; "averageCenter": "averageCenter"; "batchSize": "batchSize"; "batchSizeIE": "batchSizeIE"; "calculator": "calculator"; "clusterClass": "clusterClass"; "enableRetinaIcons": "enableRetinaIcons"; "gridSize": "gridSize"; "ignoreHidden": "ignoreHidden"; "imageExtension": "imageExtension"; "imagePath": "imagePath"; "imageSizes": "imageSizes"; "maxZoom": "maxZoom"; "minimumClusterSize": "minimumClusterSize"; "styles": "styles"; "title": "title"; "zIndex": "zIndex"; "zoomOnClick": "zoomOnClick"; "options": "options"; }, { "clusteringbegin": "clusteringbegin"; "clusteringend": "clusteringend"; }, ["_markers"], ["*"]>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MapMarkerClusterer, "map-marker-clusterer", ["mapMarkerClusterer"], { "ariaLabelFn": "ariaLabelFn"; "averageCenter": "averageCenter"; "batchSize": "batchSize"; "batchSizeIE": "batchSizeIE"; "calculator": "calculator"; "clusterClass": "clusterClass"; "enableRetinaIcons": "enableRetinaIcons"; "gridSize": "gridSize"; "ignoreHidden": "ignoreHidden"; "imageExtension": "imageExtension"; "imagePath": "imagePath"; "imageSizes": "imageSizes"; "maxZoom": "maxZoom"; "minimumClusterSize": "minimumClusterSize"; "styles": "styles"; "title": "title"; "zIndex": "zIndex"; "zoomOnClick": "zoomOnClick"; "options": "options"; }, { "clusteringbegin": "clusteringbegin"; "clusteringend": "clusteringend"; "clusterClick": "clusterClick"; }, ["_markers"], ["*"]>;
     static ɵfac: i0.ɵɵFactoryDef<MapMarkerClusterer, never>;
 }
 


### PR DESCRIPTION
Adds an event that emits when a cluster has been clicked.

Fixes #22020.