### PR TITLE
feat(cdk/drag-drop): added dropPoint to dropped event

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -376,7 +376,8 @@ describe('CdkDrag', () => {
       // go into an infinite loop trying to stringify the event, if the test fails.
       expect(event).toEqual({
         source: fixture.componentInstance.dragInstance,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -389,7 +390,8 @@ describe('CdkDrag', () => {
 
       expect(event).toEqual({
         source: jasmine.anything(),
-        distance: {x: 25, y: 30}
+        distance: {x: 25, y: 30},
+        dropPosition:  {x: 25, y: 30}
       });
 
       dragElementViaMouse(fixture, fixture.componentInstance.dragElement.nativeElement, 40, 50);
@@ -397,7 +399,8 @@ describe('CdkDrag', () => {
 
       expect(event).toEqual({
         source: jasmine.anything(),
-        distance: {x: 40, y: 50}
+        distance: {x: 40, y: 50},
+        dropPosition:  {x: 40, y: 50}
       });
     }));
 

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1733,6 +1733,7 @@ describe('CdkDrag', () => {
           fixture.componentInstance.droppedSpy.calls.mostRecent().args[0];
 
       expect(event.distance).toEqual({x: 50, y: 60});
+      expect(event.dropPoint).toEqual({x: 50, y: 60});
     }));
 
     it('should expose whether an item was dropped outside of a container', fakeAsync(() => {

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1691,7 +1691,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1734,7 +1734,7 @@ describe('CdkDrag', () => {
           fixture.componentInstance.droppedSpy.calls.mostRecent().args[0];
 
       expect(event.distance).toEqual({x: 50, y: 60});
-      expect(event.dropPoint).toEqual({x: 50, y: 60});
+      expect(event.dropPosition).toEqual({x: 50, y: 60});
     }));
 
     it('should expose whether an item was dropped outside of a container', fakeAsync(() => {
@@ -1819,7 +1819,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1879,7 +1879,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1921,7 +1921,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1959,7 +1959,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -2003,7 +2003,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -2052,7 +2052,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       scrollTo(0, 0);
@@ -3644,7 +3644,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -4077,7 +4077,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4301,7 +4301,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4357,7 +4357,7 @@ describe('CdkDrag', () => {
           previousContainer: fixture.componentInstance.dropInstances.first,
           isPointerOverContainer: true,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4463,7 +4463,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4495,7 +4495,7 @@ describe('CdkDrag', () => {
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4527,7 +4527,7 @@ describe('CdkDrag', () => {
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4664,7 +4664,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4802,7 +4802,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4830,7 +4830,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4863,7 +4863,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4900,7 +4900,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dropContainers[0].contains(item.element.nativeElement)).toBe(true,
@@ -4998,7 +4998,7 @@ describe('CdkDrag', () => {
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -5181,7 +5181,7 @@ describe('CdkDrag', () => {
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
         }));
 
       }));
@@ -5441,7 +5441,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       cleanup();
@@ -5477,7 +5477,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -5512,7 +5512,7 @@ describe('CdkDrag', () => {
           previousContainer: fixture.componentInstance.dropInstances.first,
           isPointerOverContainer: true,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -377,7 +377,7 @@ describe('CdkDrag', () => {
       expect(event).toEqual({
         source: fixture.componentInstance.dragInstance,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -391,7 +391,7 @@ describe('CdkDrag', () => {
       expect(event).toEqual({
         source: jasmine.anything(),
         distance: {x: 25, y: 30},
-        dropPosition:  {x: 25, y: 30}
+        dropPoint:  {x: 25, y: 30}
       });
 
       dragElementViaMouse(fixture, fixture.componentInstance.dragElement.nativeElement, 40, 50);
@@ -400,7 +400,7 @@ describe('CdkDrag', () => {
       expect(event).toEqual({
         source: jasmine.anything(),
         distance: {x: 40, y: 50},
-        dropPosition:  {x: 40, y: 50}
+        dropPoint:  {x: 40, y: 50}
       });
     }));
 
@@ -1694,7 +1694,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1737,7 +1737,7 @@ describe('CdkDrag', () => {
           fixture.componentInstance.droppedSpy.calls.mostRecent().args[0];
 
       expect(event.distance).toEqual({x: 50, y: 60});
-      expect(event.dropPosition).toEqual({x: 50, y: 60});
+      expect(event.dropPoint).toEqual({x: 50, y: 60});
     }));
 
     it('should expose whether an item was dropped outside of a container', fakeAsync(() => {
@@ -1822,7 +1822,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1882,7 +1882,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1924,7 +1924,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1962,7 +1962,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: false,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -2006,7 +2006,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -2055,7 +2055,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       scrollTo(0, 0);
@@ -3647,7 +3647,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -4080,7 +4080,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4304,7 +4304,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4360,7 +4360,7 @@ describe('CdkDrag', () => {
           previousContainer: fixture.componentInstance.dropInstances.first,
           isPointerOverContainer: true,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4466,7 +4466,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4498,7 +4498,7 @@ describe('CdkDrag', () => {
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4530,7 +4530,7 @@ describe('CdkDrag', () => {
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4667,7 +4667,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4805,7 +4805,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4833,7 +4833,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4866,7 +4866,7 @@ describe('CdkDrag', () => {
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4903,7 +4903,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dropContainers[0].contains(item.element.nativeElement)).toBe(true,
@@ -5001,7 +5001,7 @@ describe('CdkDrag', () => {
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -5184,7 +5184,7 @@ describe('CdkDrag', () => {
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         }));
 
       }));
@@ -5444,7 +5444,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       cleanup();
@@ -5480,7 +5480,7 @@ describe('CdkDrag', () => {
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
         distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-        dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -5515,7 +5515,7 @@ describe('CdkDrag', () => {
           previousContainer: fixture.componentInstance.dropInstances.first,
           isPointerOverContainer: true,
           distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
-          dropPosition: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1690,7 +1690,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1817,7 +1818,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: false,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1876,7 +1878,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1917,7 +1920,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1954,7 +1958,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: false,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -1997,7 +2002,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -2045,7 +2051,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       scrollTo(0, 0);
@@ -3636,7 +3643,8 @@ describe('CdkDrag', () => {
         container: dropInstance,
         previousContainer: dropInstance,
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dragItems.map(drag => drag.element.nativeElement.textContent!.trim()))
@@ -4068,7 +4076,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4291,7 +4300,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstance,
         previousContainer: fixture.componentInstance.dropInstance,
         isPointerOverContainer: jasmine.any(Boolean),
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4346,7 +4356,8 @@ describe('CdkDrag', () => {
           container: fixture.componentInstance.dropInstances.toArray()[1],
           previousContainer: fixture.componentInstance.dropInstances.first,
           isPointerOverContainer: true,
-          distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4451,7 +4462,8 @@ describe('CdkDrag', () => {
         container: dropInstances[1],
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4482,7 +4494,8 @@ describe('CdkDrag', () => {
           container: dropInstances[0],
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
-          distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4513,7 +4526,8 @@ describe('CdkDrag', () => {
           container: dropInstances[0],
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
-          distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -4649,7 +4663,8 @@ describe('CdkDrag', () => {
         container: dropInstances[1],
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4786,7 +4801,8 @@ describe('CdkDrag', () => {
         container: dropInstances[1],
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4813,7 +4829,8 @@ describe('CdkDrag', () => {
         container: dropInstances[1],
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4845,7 +4862,8 @@ describe('CdkDrag', () => {
         container: dropInstances[1],
         previousContainer: dropInstances[0],
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -4881,7 +4899,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstances.toArray()[1],
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       expect(dropContainers[0].contains(item.element.nativeElement)).toBe(true,
@@ -4978,7 +4997,8 @@ describe('CdkDrag', () => {
           container: dropInstances[0],
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
-          distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 
@@ -5160,7 +5180,8 @@ describe('CdkDrag', () => {
           container: dropInstances[2],
           previousContainer: dropInstances[0],
           isPointerOverContainer: false,
-          distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         }));
 
       }));
@@ -5419,7 +5440,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstances.toArray()[1],
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
 
       cleanup();
@@ -5454,7 +5476,8 @@ describe('CdkDrag', () => {
         container: fixture.componentInstance.dropInstances.toArray()[1],
         previousContainer: fixture.componentInstance.dropInstances.first,
         isPointerOverContainer: true,
-        distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+        distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+        dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
       });
     }));
 
@@ -5488,7 +5511,8 @@ describe('CdkDrag', () => {
           container: fixture.componentInstance.dropInstances.toArray()[1],
           previousContainer: fixture.componentInstance.dropInstances.first,
           isPointerOverContainer: true,
-          distance: {x: jasmine.any(Number), y: jasmine.any(Number)}
+          distance: {x: jasmine.any(Number), y: jasmine.any(Number)},
+          dropPoint: {x: jasmine.any(Number), y: jasmine.any(Number)}
         });
       }));
 

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -490,7 +490,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
         isPointerOverContainer: event.isPointerOverContainer,
         item: this,
         distance: event.distance,
-        dropPoint: event.dropPoint
+        dropPosition: event.dropPosition
       });
     });
   }

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -459,7 +459,11 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     });
 
     ref.ended.subscribe(event => {
-      this.ended.emit({source: this, distance: event.distance});
+      this.ended.emit({
+        source: this, 
+        distance: event.distance,
+        dropPosition: event.dropPosition
+      });
 
       // Since all of these events run outside of change detection,
       // we need to ensure that everything is marked correctly.

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -460,7 +460,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
     ref.ended.subscribe(event => {
       this.ended.emit({
-        source: this, 
+        source: this,
         distance: event.distance,
         dropPosition: event.dropPosition
       });

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -489,7 +489,8 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
         container: event.container.data,
         isPointerOverContainer: event.isPointerOverContainer,
         item: this,
-        distance: event.distance
+        distance: event.distance,
+        dropPoint: event.dropPoint
       });
     });
   }

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -462,7 +462,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
       this.ended.emit({
         source: this,
         distance: event.distance,
-        dropPosition: event.dropPosition
+        dropPoint: event.dropPoint
       });
 
       // Since all of these events run outside of change detection,
@@ -494,7 +494,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
         isPointerOverContainer: event.isPointerOverContainer,
         item: this,
         distance: event.distance,
-        dropPosition: event.dropPosition
+        dropPoint: event.dropPoint
       });
     });
   }

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -358,7 +358,8 @@ export class CdkDropList<T = any> implements OnDestroy {
         container: event.container.data,
         item: event.item.data,
         isPointerOverContainer: event.isPointerOverContainer,
-        distance: event.distance
+        distance: event.distance,
+        dropPoint: event.dropPoint
       });
 
       // Mark for check since all of these events run outside of change

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -359,7 +359,7 @@ export class CdkDropList<T = any> implements OnDestroy {
         item: event.item.data,
         isPointerOverContainer: event.isPointerOverContainer,
         distance: event.distance,
-        dropPosition: event.dropPosition
+        dropPoint: event.dropPoint
       });
 
       // Mark for check since all of these events run outside of change

--- a/src/cdk/drag-drop/directives/drop-list.ts
+++ b/src/cdk/drag-drop/directives/drop-list.ts
@@ -359,7 +359,7 @@ export class CdkDropList<T = any> implements OnDestroy {
         item: event.item.data,
         isPointerOverContainer: event.isPointerOverContainer,
         distance: event.distance,
-        dropPoint: event.dropPoint
+        dropPosition: event.dropPosition
       });
 
       // Mark for check since all of these events run outside of change

--- a/src/cdk/drag-drop/drag-events.ts
+++ b/src/cdk/drag-drop/drag-events.ts
@@ -67,6 +67,8 @@ export interface CdkDragDrop<T, O = T> {
   isPointerOverContainer: boolean;
   /** Distance in pixels that the user has dragged since the drag sequence started. */
   distance: {x: number, y: number};
+  /** Point where the mouse was when the item was dropped */
+  dropPoint: {x: number, y: number};
 }
 
 /** Event emitted as the user is dragging a draggable item. */

--- a/src/cdk/drag-drop/drag-events.ts
+++ b/src/cdk/drag-drop/drag-events.ts
@@ -67,8 +67,8 @@ export interface CdkDragDrop<T, O = T> {
   isPointerOverContainer: boolean;
   /** Distance in pixels that the user has dragged since the drag sequence started. */
   distance: {x: number, y: number};
-  /** Point where the mouse was when the item was dropped */
-  dropPoint: {x: number, y: number};
+  /** Position where the pointer was when the item was dropped */
+  dropPosition: {x: number, y: number};
 }
 
 /** Event emitted as the user is dragging a draggable item. */

--- a/src/cdk/drag-drop/drag-events.ts
+++ b/src/cdk/drag-drop/drag-events.ts
@@ -27,6 +27,8 @@ export interface CdkDragEnd<T = any> {
   source: CdkDrag<T>;
   /** Distance in pixels that the user has dragged since the drag sequence started. */
   distance: {x: number, y: number};
+  /** Position where the pointer was when the item was dropped */
+  dropPosition: {x: number, y: number};
 }
 
 /** Event emitted when the user moves an item into a new drop container. */

--- a/src/cdk/drag-drop/drag-events.ts
+++ b/src/cdk/drag-drop/drag-events.ts
@@ -28,7 +28,7 @@ export interface CdkDragEnd<T = any> {
   /** Distance in pixels that the user has dragged since the drag sequence started. */
   distance: {x: number, y: number};
   /** Position where the pointer was when the item was dropped */
-  dropPosition: {x: number, y: number};
+  dropPoint: {x: number, y: number};
 }
 
 /** Event emitted when the user moves an item into a new drop container. */
@@ -70,7 +70,7 @@ export interface CdkDragDrop<T, O = T> {
   /** Distance in pixels that the user has dragged since the drag sequence started. */
   distance: {x: number, y: number};
   /** Position where the pointer was when the item was dropped */
-  dropPosition: {x: number, y: number};
+  dropPoint: {x: number, y: number};
 }
 
 /** Event emitted as the user is dragging a draggable item. */

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -294,7 +294,7 @@ export class DragRef<T = any> {
   released = new Subject<{source: DragRef}>();
 
   /** Emits when the user stops dragging an item in the container. */
-  ended = new Subject<{source: DragRef, distance: Point}>();
+  ended = new Subject<{source: DragRef, distance: Point, dropPosition: Point}>();
 
   /** Emits when the user has moved the item into a new container. */
   entered = new Subject<{container: DropListRef, item: DragRef, currentIndex: number}>();
@@ -765,11 +765,13 @@ export class DragRef<T = any> {
       // the user starts dragging the item, its position will be calculated relatively
       // to the new passive transform.
       this._passiveTransform.x = this._activeTransform.x;
+      const pointerPosition = this._getPointerPositionOnPage(event);
       this._passiveTransform.y = this._activeTransform.y;
       this._ngZone.run(() => {
         this.ended.next({
           source: this,
-          distance: this._getDragDistance(this._getPointerPositionOnPage(event))
+          distance: this._getDragDistance(pointerPosition),
+          dropPosition: pointerPosition
         });
       });
       this._cleanupCachedDimensions();
@@ -911,11 +913,11 @@ export class DragRef<T = any> {
       const container = this._dropContainer!;
       const currentIndex = container.getItemIndex(this);
       const pointerPosition = this._getPointerPositionOnPage(event);
-      const distance = this._getDragDistance(this._getPointerPositionOnPage(event));
+      const distance = this._getDragDistance(pointerPosition);
       const isPointerOverContainer = container._isOverContainer(
         pointerPosition.x, pointerPosition.y);
 
-      this.ended.next({source: this, distance});
+      this.ended.next({source: this, distance, dropPosition: pointerPosition});
       this.dropped.next({
         item: this,
         currentIndex,

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -310,7 +310,7 @@ export class DragRef<T = any> {
     container: DropListRef;
     previousContainer: DropListRef;
     distance: Point;
-    dropPoint: Point;
+    dropPosition: Point;
     isPointerOverContainer: boolean;
   }>();
 
@@ -924,7 +924,7 @@ export class DragRef<T = any> {
         previousContainer: this._initialContainer,
         isPointerOverContainer,
         distance,
-        dropPoint: pointerPosition
+        dropPosition: pointerPosition
       });
       container.drop(this, currentIndex, this._initialIndex, this._initialContainer,
         isPointerOverContainer, distance, pointerPosition);

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -310,6 +310,7 @@ export class DragRef<T = any> {
     container: DropListRef;
     previousContainer: DropListRef;
     distance: Point;
+    dropPoint: Point;
     isPointerOverContainer: boolean;
   }>();
 
@@ -922,10 +923,11 @@ export class DragRef<T = any> {
         container: container,
         previousContainer: this._initialContainer,
         isPointerOverContainer,
-        distance
+        distance,
+        dropPoint: pointerPosition
       });
       container.drop(this, currentIndex, this._initialIndex, this._initialContainer,
-        isPointerOverContainer, distance);
+        isPointerOverContainer, distance, pointerPosition);
       this._dropContainer = this._initialContainer;
     });
   }

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -294,7 +294,7 @@ export class DragRef<T = any> {
   released = new Subject<{source: DragRef}>();
 
   /** Emits when the user stops dragging an item in the container. */
-  ended = new Subject<{source: DragRef, distance: Point, dropPosition: Point}>();
+  ended = new Subject<{source: DragRef, distance: Point, dropPoint: Point}>();
 
   /** Emits when the user has moved the item into a new container. */
   entered = new Subject<{container: DropListRef, item: DragRef, currentIndex: number}>();
@@ -310,7 +310,7 @@ export class DragRef<T = any> {
     container: DropListRef;
     previousContainer: DropListRef;
     distance: Point;
-    dropPosition: Point;
+    dropPoint: Point;
     isPointerOverContainer: boolean;
   }>();
 
@@ -771,7 +771,7 @@ export class DragRef<T = any> {
         this.ended.next({
           source: this,
           distance: this._getDragDistance(pointerPosition),
-          dropPosition: pointerPosition
+          dropPoint: pointerPosition
         });
       });
       this._cleanupCachedDimensions();
@@ -917,7 +917,7 @@ export class DragRef<T = any> {
       const isPointerOverContainer = container._isOverContainer(
         pointerPosition.x, pointerPosition.y);
 
-      this.ended.next({source: this, distance, dropPosition: pointerPosition});
+      this.ended.next({source: this, distance, dropPoint: pointerPosition});
       this.dropped.next({
         item: this,
         currentIndex,
@@ -926,7 +926,7 @@ export class DragRef<T = any> {
         previousContainer: this._initialContainer,
         isPointerOverContainer,
         distance,
-        dropPosition: pointerPosition
+        dropPoint: pointerPosition
       });
       container.drop(this, currentIndex, this._initialIndex, this._initialContainer,
         isPointerOverContainer, distance, pointerPosition);

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -120,7 +120,7 @@ export class DropListRef<T = any> {
     previousContainer: DropListRef,
     isPointerOverContainer: boolean,
     distance: Point;
-    dropPosition: Point;
+    dropPoint: Point;
   }>();
 
   /** Emits as the user is swapping items while actively dragging. */
@@ -335,7 +335,7 @@ export class DropListRef<T = any> {
    * @param distance Distance the user has dragged since the start of the dragging sequence.
    */
   drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef,
-    isPointerOverContainer: boolean, distance: Point, dropPosition: Point): void {
+    isPointerOverContainer: boolean, distance: Point, dropPoint: Point): void {
     this._reset();
     this.dropped.next({
       item,
@@ -345,7 +345,7 @@ export class DropListRef<T = any> {
       previousContainer,
       isPointerOverContainer,
       distance,
-      dropPosition
+      dropPoint
     });
   }
 

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -120,7 +120,7 @@ export class DropListRef<T = any> {
     previousContainer: DropListRef,
     isPointerOverContainer: boolean,
     distance: Point;
-    dropPoint: Point;
+    dropPosition: Point;
   }>();
 
   /** Emits as the user is swapping items while actively dragging. */
@@ -335,7 +335,7 @@ export class DropListRef<T = any> {
    * @param distance Distance the user has dragged since the start of the dragging sequence.
    */
   drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef,
-    isPointerOverContainer: boolean, distance: Point, dropPoint: Point): void {
+    isPointerOverContainer: boolean, distance: Point, dropPosition: Point): void {
     this._reset();
     this.dropped.next({
       item,
@@ -345,7 +345,7 @@ export class DropListRef<T = any> {
       previousContainer,
       isPointerOverContainer,
       distance,
-      dropPoint
+      dropPosition
     });
   }
 

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -120,6 +120,7 @@ export class DropListRef<T = any> {
     previousContainer: DropListRef,
     isPointerOverContainer: boolean,
     distance: Point;
+    dropPoint: Point;
   }>();
 
   /** Emits as the user is swapping items while actively dragging. */
@@ -334,7 +335,7 @@ export class DropListRef<T = any> {
    * @param distance Distance the user has dragged since the start of the dragging sequence.
    */
   drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef,
-    isPointerOverContainer: boolean, distance: Point): void {
+    isPointerOverContainer: boolean, distance: Point, dropPoint: Point): void {
     this._reset();
     this.dropped.next({
       item,
@@ -343,7 +344,8 @@ export class DropListRef<T = any> {
       container: this,
       previousContainer,
       isPointerOverContainer,
-      distance
+      distance,
+      dropPoint
     });
   }
 

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -66,6 +66,10 @@ export interface CdkDragDrop<T, O = T> {
         x: number;
         y: number;
     };
+    dropPoint: {
+        x: number;
+        y: number;
+    };
     isPointerOverContainer: boolean;
     item: CdkDrag;
     previousContainer: CdkDropList<O>;
@@ -269,6 +273,7 @@ export declare class DragRef<T = any> {
         container: DropListRef;
         previousContainer: DropListRef;
         distance: Point;
+        dropPoint: Point;
         isPointerOverContainer: boolean;
     }>;
     ended: Subject<{
@@ -356,6 +361,7 @@ export declare class DropListRef<T = any> {
         previousContainer: DropListRef;
         isPointerOverContainer: boolean;
         distance: Point;
+        dropPoint: Point;
     }>;
     element: HTMLElement | ElementRef<HTMLElement>;
     enterPredicate: (drag: DragRef, drop: DropListRef) => boolean;
@@ -391,7 +397,7 @@ export declare class DropListRef<T = any> {
     _stopScrolling(): void;
     connectedTo(connectedTo: DropListRef[]): this;
     dispose(): void;
-    drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point): void;
+    drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, dropPoint: Point): void;
     enter(item: DragRef, pointerX: number, pointerY: number, index?: number): void;
     exit(item: DragRef): void;
     getItemIndex(item: DragRef): number;

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -66,7 +66,7 @@ export interface CdkDragDrop<T, O = T> {
         x: number;
         y: number;
     };
-    dropPosition: {
+    dropPoint: {
         x: number;
         y: number;
     };
@@ -81,7 +81,7 @@ export interface CdkDragEnd<T = any> {
         x: number;
         y: number;
     };
-    dropPosition: {
+    dropPoint: {
         x: number;
         y: number;
     };
@@ -277,13 +277,13 @@ export declare class DragRef<T = any> {
         container: DropListRef;
         previousContainer: DropListRef;
         distance: Point;
-        dropPosition: Point;
+        dropPoint: Point;
         isPointerOverContainer: boolean;
     }>;
     ended: Subject<{
         source: DragRef;
         distance: Point;
-        dropPosition: Point;
+        dropPoint: Point;
     }>;
     entered: Subject<{
         container: DropListRef;
@@ -366,7 +366,7 @@ export declare class DropListRef<T = any> {
         previousContainer: DropListRef;
         isPointerOverContainer: boolean;
         distance: Point;
-        dropPosition: Point;
+        dropPoint: Point;
     }>;
     element: HTMLElement | ElementRef<HTMLElement>;
     enterPredicate: (drag: DragRef, drop: DropListRef) => boolean;
@@ -402,7 +402,7 @@ export declare class DropListRef<T = any> {
     _stopScrolling(): void;
     connectedTo(connectedTo: DropListRef[]): this;
     dispose(): void;
-    drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, dropPosition: Point): void;
+    drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, dropPoint: Point): void;
     enter(item: DragRef, pointerX: number, pointerY: number, index?: number): void;
     exit(item: DragRef): void;
     getItemIndex(item: DragRef): number;

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -283,6 +283,7 @@ export declare class DragRef<T = any> {
     ended: Subject<{
         source: DragRef;
         distance: Point;
+        dropPosition: Point;
     }>;
     entered: Subject<{
         container: DropListRef;

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -66,7 +66,7 @@ export interface CdkDragDrop<T, O = T> {
         x: number;
         y: number;
     };
-    dropPoint: {
+    dropPosition: {
         x: number;
         y: number;
     };
@@ -273,7 +273,7 @@ export declare class DragRef<T = any> {
         container: DropListRef;
         previousContainer: DropListRef;
         distance: Point;
-        dropPoint: Point;
+        dropPosition: Point;
         isPointerOverContainer: boolean;
     }>;
     ended: Subject<{
@@ -361,7 +361,7 @@ export declare class DropListRef<T = any> {
         previousContainer: DropListRef;
         isPointerOverContainer: boolean;
         distance: Point;
-        dropPoint: Point;
+        dropPosition: Point;
     }>;
     element: HTMLElement | ElementRef<HTMLElement>;
     enterPredicate: (drag: DragRef, drop: DropListRef) => boolean;
@@ -397,7 +397,7 @@ export declare class DropListRef<T = any> {
     _stopScrolling(): void;
     connectedTo(connectedTo: DropListRef[]): this;
     dispose(): void;
-    drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, dropPoint: Point): void;
+    drop(item: DragRef, currentIndex: number, previousIndex: number, previousContainer: DropListRef, isPointerOverContainer: boolean, distance: Point, dropPosition: Point): void;
     enter(item: DragRef, pointerX: number, pointerY: number, index?: number): void;
     exit(item: DragRef): void;
     getItemIndex(item: DragRef): number;

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -81,6 +81,10 @@ export interface CdkDragEnd<T = any> {
         x: number;
         y: number;
     };
+    dropPosition: {
+        x: number;
+        y: number;
+    };
     source: CdkDrag<T>;
 }
 


### PR DESCRIPTION
I need to be able to determine the exact point where the mouse pointer was when the Item was dropped. This is not possible to calculate from the distance, because it depends on the position where the item was grabbed at drag start.

_CdkDragDrop_.item.getFreeDragPosition(); does also not work because it gives the position of the element top/left corner at drag start.