### PR TITLE
fix(material-experimental/mdc-form-field): set explicit text-align

### DIFF
--- a/src/material-experimental/mdc-form-field/form-field.scss
+++ b/src/material-experimental/mdc-form-field/form-field.scss
@@ -37,6 +37,12 @@
   flex-direction: column;
   // This allows the form-field to shrink down when used inside flex or grid layouts.
   min-width: 0;
+  // To avoid problems with text-align.
+  text-align: left;
+
+  [dir='rtl'] & {
+    text-align: right;
+  }
 }
 
 // Container that contains the prefixes, infix and suffixes. These elements should


### PR DESCRIPTION
Sets an explicit `text-align` on the MDC form field so that it isn't affected by the surrounding `text-align`. The issue can be seen by placing an MDC-based `mat-select` in a container with `text-align: center`. We have something similar in the existing form field already.