### PR TITLE
build: don't require all reviewers to approve PRs

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -40,7 +40,7 @@ merge:
     # whether the PR shouldn't have a conflict with the base branch
     noConflict: true
     # whether the PR should have all reviews completed.
-    requireReviews: true
+    requireReviews: false
     # list of labels that a PR needs to have, checked with a regexp (e.g. "PR target:" will work for the label "PR target: master")
     requiredLabels:
       - "target: *"


### PR DESCRIPTION
This setting has been causing friction on PRs, requiring reviewers to be
manually approved. The "merge ready" label should only be applied once
a PR is approved.

@josephperrott similar to the discussion the framework team had last week, people are running into friction with applying "merge ready" as a type of auto-submit. This PR disables the setting for requiring all reviewers; we want to keep the "merge ready" label explicitly as meaning approved and ready to be merged, not that the PR will be ready to merge after review. 