### PR TITLE
fix(material/progress-spinner): not visible in high contrast mode on chromium browsers

### DIFF
--- a/src/material/progress-spinner/progress-spinner.scss
+++ b/src/material/progress-spinner/progress-spinner.scss
@@ -38,6 +38,9 @@ $_mat-progress-spinner-default-circumference:
       // SVG colors aren't inverted automatically in high contrast mode. Set the
       // stroke to currentColor in order to respect the user's color settings.
       stroke: currentColor;
+      // currentColor blends in with the background in Chromium-based browsers
+      // so we have to fall back to `CanvasText` which isn't supported on IE.
+      stroke: CanvasText;
     }
   }
 


### PR DESCRIPTION
Fixes that progress spinner blends in with the background, because `currentColor` doesn't work as expected on SVGs on Chromium browsers in high contrast mode.