### PR TITLE
fix(material/radio): ripple not positioned correctly inside parent with centered text

### DIFF
--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -155,6 +155,10 @@ $ripple-radius: 20px;
   height: 100%;
   transform: none;
 
+  // Needs an explicit top/left so it stays aligned no matter how the text is aligned (see #22389).
+  top: 0;
+  left: 0;
+
   .mat-radio-container:hover & {
     opacity: 0.04;
   }


### PR DESCRIPTION
Fixes that the persistent radio button ripple was being offset if it's placed inside an element with `text-align: center`.

Fixes #22389.