### PR TITLE
fix(material-experimental/mdc-slider): fix change and input events on…

### DIFF
--- a/src/material-experimental/mdc-slider/global-change-and-input-listener.ts
+++ b/src/material-experimental/mdc-slider/global-change-and-input-listener.ts
@@ -9,16 +9,16 @@
 import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, NgZone} from '@angular/core';
 import {SpecificEventListener} from '@material/base';
-import {Subject, Subscription} from 'rxjs';
-import {finalize} from 'rxjs/operators';
+import {fromEvent, Observable, Subscription} from 'rxjs';
+import {finalize, share} from 'rxjs/operators';
 
 /**
  * Handles listening for all change and input events that occur on the document.
  *
  * This service exposes a single method #listen to allow users to subscribe to change and input
- * events that occur on the document. Since listening for these events on the document can be
- * expensive, we lazily attach listeners to the document when the first subscription is made, and
- * remove the listeners once the last observer unsubscribes.
+ * events that occur on the document. Since listening for these events can be expensive, we use
+ * #fromEvent which will lazily attach a listener when the first subscription is made and remove the
+ * listener once the last observer unsubscribes.
  */
 @Injectable({providedIn: 'root'})
 export class GlobalChangeAndInputListener<K extends 'change'|'input'> {
@@ -27,44 +27,27 @@ export class GlobalChangeAndInputListener<K extends 'change'|'input'> {
   private _document: Document;
 
   /** Stores the subjects that emit the events that occur on the global document. */
-  private _subjects = new Map<K, Subject<Event>>();
-
-  /** Stores the event handlers that emit the events that occur on the global document. */
-  private _handlers = new Map<K, ((event: Event) => void)>();
+  private _observables = new Map<K, Observable<Event>>();
 
   constructor(@Inject(DOCUMENT) document: any, private _ngZone: NgZone) {
     this._document = document;
   }
 
-  /** Returns a function for handling the given type of event. */
-  private _createHandlerFn(type: K): ((event: Event) => void) {
-    return (event: Event) => {
-      this._subjects.get(type)!.next(event);
-    };
-  }
-
   /** Returns a subscription to global change or input events. */
   listen(type: K, callback: SpecificEventListener<K>): Subscription {
-    // This is the first subscription to these events.
-    if (!this._subjects.get(type)) {
-      const handlerFn = this._createHandlerFn(type).bind(this);
-      this._subjects.set(type, new Subject<Event>());
-      this._handlers.set(type, handlerFn);
-      this._ngZone.runOutsideAngular(() => {
-        this._document.addEventListener(type, handlerFn, true);
-      });
+    // If this is the first time we are listening to this event, create the observable for it.
+    if (!this._observables.has(type)) {
+      const observable = fromEvent(this._document, type, {capture: true}).pipe(
+        share(),
+        finalize(() => this._observables.delete(type)),
+      );
+      this._observables.set(type, observable);
     }
 
-    const subject = this._subjects.get(type)!;
-    const handler = this._handlers.get(type)!;
-
-    return subject.pipe(finalize(() => {
-        // This is the last event listener unsubscribing.
-        if (subject.observers.length === 1) {
-          this._document.removeEventListener(type, handler, true);
-          this._subjects.delete(type);
-          this._handlers.delete(type);
-        }
-    })).subscribe(callback);
+    return this._ngZone.runOutsideAngular(() =>
+      this._observables.get(type)!.subscribe((event: Event) =>
+        this._ngZone.run(() => callback(event))
+      )
+    );
   }
 }

--- a/src/material-experimental/mdc-slider/global-change-and-input-listener.ts
+++ b/src/material-experimental/mdc-slider/global-change-and-input-listener.ts
@@ -58,7 +58,7 @@ export class GlobalChangeAndInputListener<K extends 'change'|'input'> implements
 
   /** Creates an observable that emits all events of the given type. */
   private _createGlobalEventObservable(type: K) {
-    return fromEvent(this._document, type, {capture: true}).pipe(
+    return fromEvent(this._document, type, {capture: true, passive: true}).pipe(
       takeUntil(this._destroyed),
       finalize(() => this._observables.delete(type)),
       share(),

--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -6,10 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LEFT_ARROW, RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {Platform} from '@angular/cdk/platform';
 import {
-  dispatchFakeEvent,
   dispatchMouseEvent,
   dispatchPointerEvent,
   dispatchTouchEvent,
@@ -524,11 +522,12 @@ describe('MDC-based MatSlider' , () => {
   });
 
   describe('slider with set step', () => {
+    let fixture: ComponentFixture<SliderWithStep>;
     let sliderInstance: MatSlider;
     let inputInstance: MatSliderThumb;
 
     beforeEach(waitForAsync(() => {
-      const fixture = createComponent(SliderWithStep);
+      fixture = createComponent(SliderWithStep);
       fixture.detectChanges();
       const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderInstance = sliderDebugElement.componentInstance;
@@ -553,28 +552,20 @@ describe('MDC-based MatSlider' , () => {
     });
 
     it('should truncate long decimal values when using a decimal step', () => {
-      // TODO(wagnermaciel): Uncomment this test once b/182504575 is resolved.
-      // sliderInstance.step = 0.1;
-      // slideToValue(sliderInstance, 33.3333, Thumb.END, platform.IOS);
-      // expect(inputInstance.value).toBe(33);
-    });
-
-    it('should truncate long decimal values when using a decimal step and the arrow keys', () => {
       sliderInstance.step = 0.1;
-      changeValueUsingArrowKeys(sliderInstance, RIGHT_ARROW, Thumb.END);
-      changeValueUsingArrowKeys(sliderInstance, RIGHT_ARROW, Thumb.END);
-      changeValueUsingArrowKeys(sliderInstance, RIGHT_ARROW, Thumb.END);
-      expect(inputInstance.value).toBe(0.3);
+      slideToValue(sliderInstance, 66.3333, Thumb.END, platform.IOS);
+      expect(inputInstance.value).toBe(66.3);
     });
   });
 
   describe('range slider with set step', () => {
+    let fixture: ComponentFixture<RangeSliderWithStep>;
     let sliderInstance: MatSlider;
     let startInputInstance: MatSliderThumb;
     let endInputInstance: MatSliderThumb;
 
     beforeEach(waitForAsync(() => {
-      const fixture = createComponent(RangeSliderWithStep);
+      fixture = createComponent(RangeSliderWithStep);
       fixture.detectChanges();
       const sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider));
       sliderInstance = sliderDebugElement.componentInstance;
@@ -617,33 +608,23 @@ describe('MDC-based MatSlider' , () => {
     });
 
     it('should truncate long decimal start values when using a decimal step', () => {
-      // TODO(wagnermaciel): Uncomment this test once b/182504575 is resolved.
-      // sliderInstance.step = 0.1;
-      // slideToValue(sliderInstance, 33.3333, Thumb.START, platform.IOS);
-      // expect(startInputInstance.value).toBe(33);
+      sliderInstance.step = 0.1;
+      slideToValue(sliderInstance, 66.3333, Thumb.START, platform.IOS);
+      expect(startInputInstance.value).toBe(66.3);
     });
 
     it('should truncate long decimal end values when using a decimal step', () => {
-      // TODO(wagnermaciel): Uncomment this test once b/182504575 is resolved.
-      // sliderInstance.step = 0.1;
-      // slideToValue(sliderInstance, 66.6666, Thumb.END, platform.IOS);
-      // expect(endInputInstance.value).toBe(66);
-    });
-
-    it('should truncate long decimal start values when using a decimal step arrow keys', () => {
       sliderInstance.step = 0.1;
-      changeValueUsingArrowKeys(sliderInstance, RIGHT_ARROW, Thumb.START);
-      changeValueUsingArrowKeys(sliderInstance, RIGHT_ARROW, Thumb.START);
-      changeValueUsingArrowKeys(sliderInstance, RIGHT_ARROW, Thumb.START);
-      expect(startInputInstance.value).toBe(0.3);
-    });
+      slideToValue(sliderInstance, 66.3333, Thumb.END, platform.IOS);
+      expect(endInputInstance.value).toBe(66.3);
 
-    it('should truncate long decimal end values when using a decimal step arrow keys', () => {
-      sliderInstance.step = 0.1;
-      changeValueUsingArrowKeys(sliderInstance, LEFT_ARROW, Thumb.END);
-      changeValueUsingArrowKeys(sliderInstance, LEFT_ARROW, Thumb.END);
-      changeValueUsingArrowKeys(sliderInstance, LEFT_ARROW, Thumb.END);
-      expect(endInputInstance.value).toBe(99.7);
+      // NOTE(wagnermaciel): Different browsers treat the clientX dispatched by us differently.
+      // Below is an example of a case that should work but because Firefox rounds the clientX
+      // down, the clientX that gets dispatched (1695.998...) is not the same clientX that the MDC
+      // Foundation receives (1695). This means the test will pass on chromium but fail on Firefox.
+      //
+      // slideToValue(sliderInstance, 66.66, Thumb.END, platform.IOS);
+      // expect(endInputInstance.value).toBe(66.7);
     });
   });
 
@@ -977,22 +958,6 @@ function slideToValue(slider: MatSlider, value: number, thumbPosition: Thumb, is
   dispatchPointerOrTouchEvent(sliderElement, PointerEventType.POINTER_DOWN, startX, startY, isIOS);
   dispatchPointerOrTouchEvent(sliderElement, PointerEventType.POINTER_MOVE, endX, endY, isIOS);
   dispatchPointerOrTouchEvent(sliderElement, PointerEventType.POINTER_UP, endX, endY, isIOS);
-}
-
-/**
- * Mimics changing the slider value using arrow keys.
- *
- * Dispatching keydown events on inputs do not trigger value changes. Thus, to mimic this behavior,
- * we manually change the slider inputs value and then dispatch a change event (which is what the
- * MDC Foundation is listening for & how it handles these updates).
- */
-function changeValueUsingArrowKeys(slider: MatSlider, arrow: number, thumbPosition: Thumb) {
-  const input = slider._getInput(thumbPosition);
-  const value = arrow === RIGHT_ARROW
-    ? input.value + slider.step
-    : input.value - slider.step;
-  input._hostElement.value = value.toString();
-  dispatchFakeEvent(input._hostElement, 'change');
 }
 
 /** Dispatch a pointerdown or pointerup event if supported, otherwise dispatch the touch event. */

--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -384,8 +384,7 @@ export class MatSliderThumb implements AfterViewInit, ControlValueAccessor, OnIn
   _emitFakeEvent(type: 'change'|'input') {
     const event = new Event(type) as any;
     event.isFake = true;
-    const emitter = type === 'change' ? this.change : this.input;
-    emitter.emit(event);
+    this._hostElement.dispatchEvent(event);
   }
 
   /**
@@ -773,9 +772,53 @@ export class MatSlider extends _MatSliderMixinBase
 class SliderAdapter implements MDCSliderAdapter {
 
   /** The global change listener subscription used to handle change events on the slider inputs. */
-  changeSubscription: Subscription;
+  private _changeSubscription: Subscription;
 
-  constructor(private readonly _delegate: MatSlider) {}
+  /** The global input listener subscription used to handle input events on the slider inputs. */
+  private _inputSubscription: Subscription;
+
+  /** The MDC Foundations handler function for input change events. */
+  private _inputChangeEventHandlers = new Map<Thumb, SpecificEventListener<EventType>>();
+
+  constructor(private readonly _delegate: MatSlider) {
+    this._changeSubscription = this._subscribeToInputEvents('change',
+      (event: Event, thumbPosition: Thumb) => {
+        const handler = this._inputChangeEventHandlers.get(thumbPosition)!;
+        handler(event);
+      }
+    );
+    this._inputSubscription = this._subscribeToInputEvents('input');
+  }
+
+  /**
+   * Handles "change" and "input" events on the slider inputs.
+   *
+   * Exposes a callback to allow the MDC Foundations "change" event handler to be called for "real"
+   * events.
+   *
+   * ** IMPORTANT NOTE **
+   *
+   * We block all "real" change and input events and emit fake events from #emitChangeEvent and
+   * #emitInputEvent, instead. We do this because interacting with the MDC slider won't trigger all
+   * of the correct change and input events, but it will call #emitChangeEvent and #emitInputEvent
+   * at the correct times. This allows users to listen for these events directly on the slider
+   * input as they would with a native range input.
+   */
+  private _subscribeToInputEvents
+    (type: 'change'|'input', callback?: (event: Event, thumbPosition: Thumb) => void) {
+      return this._delegate._globalChangeAndInputListener.listen(type, (event: Event) => {
+        const targetIsEndInput = event.target === this._delegate._getInputElement(Thumb.END);
+        const targetIsStartInput = this._delegate._isRange() &&
+          event.target === this._delegate._getInputElement(Thumb.START);
+        if (targetIsEndInput || targetIsStartInput) {
+          if ((event as any).isFake) { return; }
+          event.stopImmediatePropagation();
+          if (callback) {
+            callback(event, targetIsStartInput ? Thumb.START : Thumb.END);
+          }
+        }
+      });
+  }
 
   // We manually assign functions instead of using prototype methods because
   // MDC clobbers the values otherwise.
@@ -901,21 +944,13 @@ class SliderAdapter implements MDCSliderAdapter {
   }
   registerInputEventHandler = <K extends EventType>
     (thumbPosition: Thumb, evtType: K, handler: SpecificEventListener<K>): void => {
-      if (evtType === 'change' || evtType === 'input') {
-        this.changeSubscription = this._delegate._globalChangeAndInputListener
-          .listen(evtType as 'change'|'input', (event: Event) => {
-            // We block all real change and input events and emit fake events from #emitChangeEvent
-            // and #emitInputEvent, instead. We do this because interacting with the MDC slider
-            // won't trigger all of the correct change and input events, but it will call
-            // #emitChangeEvent and #emitInputEvent at the correct times. This allows users to
-            // listen for these events directly on the slider input as they would with a native
-            // range input.
-            if (event.target === this._delegate._getInputElement(thumbPosition)) {
-              if ((event as any).isFake) { return; }
-              event.stopImmediatePropagation();
-              handler(event as GlobalEventHandlersEventMap[K]);
-            }
-        });
+      if (evtType === 'change') {
+        // Store the event handler so it can be used by
+        // the custom event listener defined in the constructor.
+        this._inputChangeEventHandlers.set(
+          thumbPosition,
+          handler as SpecificEventListener<EventType>,
+        );
       } else {
         this._delegate._getInputElement(thumbPosition).addEventListener(evtType, handler);
       }
@@ -923,7 +958,10 @@ class SliderAdapter implements MDCSliderAdapter {
   deregisterInputEventHandler = <K extends EventType>
     (thumbPosition: Thumb, evtType: K, handler: SpecificEventListener<K>): void => {
       if (evtType === 'change') {
-        this.changeSubscription.unsubscribe();
+        // Since the "input" event does not get registered/deregistered, we just unsubscribe
+        // from the "input" event subscription at the same time as the "change" event.
+        this._changeSubscription.unsubscribe();
+        this._inputSubscription.unsubscribe();
       } else {
         this._delegate._getInputElement(thumbPosition).removeEventListener(evtType, handler);
       }


### PR DESCRIPTION
… the mdc slider

* use #fromEvent to simplify the global change and input listener
* go back to dispatching real events instead of using angulars event emitter system
* fix how the global change and input listener is used in the slider adapter
* remove arrow key unit tests
* uncomment and fix tests that were previously blocked by b/182504575