### PR TITLE
build: add commit message scope for multiple components

### DIFF
--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -8,6 +8,7 @@ export const commitMessage: CommitMessageConfig = {
   minBodyLength: 0,
   minBodyLengthTypeExcludes: ['docs'],
   scopes: [
+    'multiple', // For when a commit applies to multiple components.
     'cdk-experimental/column-resize',
     'cdk-experimental/combobox',
     'cdk-experimental/dialog',


### PR DESCRIPTION
As discussed, adds a new `multiple` scope for commits that cover more than one area.