### PR TITLE
build: update to husky@6

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "gulp-cli": "^2.3.0",
     "gulp-dart-sass": "^1.0.2",
     "highlight.js": "^10.4.0",
-    "husky": "5.2.0",
+    "husky": "6.0.0",
     "inquirer": "^8.0.0",
     "jasmine": "^3.6.0",
     "jasmine-core": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yarn": ">= 1.0.0"
   },
   "scripts": {
-    "postinstall": "husky install && node tools/postinstall/apply-patches.js && ngcc --properties module main --create-ivy-entry-points && node tools/postinstall/update-ngcc-main-fields.js",
+    "postinstall": "node tools/postinstall/apply-patches.js && ngcc --properties module main --create-ivy-entry-points && node tools/postinstall/update-ngcc-main-fields.js",
     "build": "node ./scripts/build-packages-dist.js",
     "build-docs-content": "node ./scripts/build-docs-content.js",
     "dev-app": "ibazel run //src/dev-app:devserver",
@@ -48,7 +48,8 @@
     "integration-tests:size-test": "bazel test //integration/size-test/...",
     "check-mdc-tests": "ts-node --project scripts/tsconfig.json scripts/check-mdc-tests.ts",
     "check-mdc-exports": "ts-node --project scripts/tsconfig.json scripts/check-mdc-exports.ts",
-    "check-tools": "yarn tsc --project tools/tsconfig-ci.json"
+    "check-tools": "yarn tsc --project tools/tsconfig-ci.json",
+    "prepare": "husky install"
   },
   "version": "12.0.0-next.5",
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6997,10 +6997,10 @@ https-proxy-agent@^4.0.0:
     agent-base "5"
     debug "4"
 
-husky@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-5.2.0.tgz#fc5e1c2300d34855d47de4753607d00943fc0802"
-  integrity sha512-AM8T/auHXRBxlrfPVLKP6jt49GCM2Zz47m8G3FOMsLmTv8Dj/fKVWE0Rh2d4Qrvmy131xEsdQnb3OXRib67PGg==
+husky@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
+  integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.11:
   version "0.4.24"


### PR DESCRIPTION
With typicode/husky#890, the recommended way to install husky is in the
`prepare` script instead of the `postinstall`. This commit moves
the husky installation to the `prepare` script to align with the new
recommendation.