### PR TITLE
refactor(cdk/a11y): Move component-specific focus indicator rendering to each component

### DIFF
--- a/src/material-experimental/mdc-button/button-base.ts
+++ b/src/material-experimental/mdc-button/button-base.ts
@@ -39,6 +39,8 @@ export const MAT_BUTTON_HOST = {
   // Add a class that applies to all buttons. This makes it easier to target if somebody
   // wants to target all Material buttons.
   '[class.mat-mdc-button-base]': 'true',
+  '(focus)': '_focused = true',
+  '(blur)': '_focused = false',
 };
 
 /** Configuration for the ripple animation. */
@@ -104,6 +106,9 @@ export class MatButtonBase extends _MatButtonBaseMixin implements CanDisable, Ca
   /** Whether this button is a FAB. Used to apply the correct class on the ripple. */
   _isFab = false;
 
+  /** Whether the button is focused. */
+  _focused = false;
+
   /** Reference to the MatRipple instance of the button. */
   @ViewChild(MatRipple) ripple: MatRipple;
 
@@ -163,6 +168,8 @@ export const MAT_ANCHOR_HOST = {
   // Add a class that applies to all buttons. This makes it easier to target if somebody
   // wants to target all Material buttons.
   '[class.mat-mdc-button-base]': 'true',
+  '(focus)': '_focused = true',
+  '(blur)': '_focused = false',
 };
 
 /**

--- a/src/material-experimental/mdc-button/button.html
+++ b/src/material-experimental/mdc-button/button.html
@@ -14,7 +14,8 @@
   The indicator can't be directly on the button, because MDC uses ::before for high contrast
   indication and it can't be on the ripple, because it has a border radius and overflow: hidden.
 -->
-<span class="mat-mdc-focus-indicator"></span>
+<span class="mat-mdc-focus-indicator"
+      [class.mat-mdc-focus-indicator-render]="_focused"></span>
 
 <span matRipple class="mat-mdc-button-ripple"
      [matRippleAnimation]="_rippleAnimation"

--- a/src/material-experimental/mdc-button/button.spec.ts
+++ b/src/material-experimental/mdc-button/button.spec.ts
@@ -282,6 +282,21 @@ describe('MDC-based MatButton', () => {
     expect(buttonNativeElements
         .every(element => !!element.querySelector('.mat-mdc-focus-indicator'))).toBe(true);
   });
+
+  it('should toggle the focus indicator render class on focus and blur', () => {
+    const fixture = TestBed.createComponent(TestApp);
+    const buttonNativeElement =
+        [...fixture.debugElement.nativeElement.querySelectorAll('a, button')][0];
+    const buttonFocusIndicatorHost = buttonNativeElement.querySelector('.mat-mdc-focus-indicator');
+
+    buttonNativeElement.focus();
+    fixture.detectChanges();
+    expect(buttonFocusIndicatorHost.classList).toContain('mat-mdc-focus-indicator-render');
+
+    buttonNativeElement.blur();
+    fixture.detectChanges();
+    expect(buttonFocusIndicatorHost.classList).not.toContain('mat-mdc-focus-indicator-render');
+  });
 });
 
 describe('MatFabDefaultOptions', () => {

--- a/src/material-experimental/mdc-button/fab.ts
+++ b/src/material-experimental/mdc-button/fab.ts
@@ -79,6 +79,8 @@ const defaults = MAT_FAB_DEFAULT_OPTIONS_FACTORY();
     // Add a class that applies to all buttons. This makes it easier to target if somebody
     // wants to target all Material buttons.
     '[class.mat-mdc-button-base]': 'true',
+    '(focus)': '_focused = true',
+    '(blur)': '_focused = false',
   },
   exportAs: 'matButton',
   encapsulation: ViewEncapsulation.None,
@@ -163,6 +165,8 @@ export class MatMiniFabButton extends MatButtonBase {
     // Add a class that applies to all buttons. This makes it easier to target if somebody
     // wants to target all Material buttons.
     '[class.mat-mdc-button-base]': 'true',
+    '(focus)': '_focused = true',
+    '(blur)': '_focused = false',
   },
   exportAs: 'matButton, matAnchor',
   encapsulation: ViewEncapsulation.None,

--- a/src/material-experimental/mdc-checkbox/checkbox.html
+++ b/src/material-experimental/mdc-checkbox/checkbox.html
@@ -15,6 +15,7 @@
            [id]="inputId"
            [required]="required"
            [tabIndex]="tabIndex"
+           (focus)="_inputFocused = true"
            (blur)="_onBlur()"
            (click)="_onClick()"
            (change)="$event.stopPropagation()"/>
@@ -29,7 +30,9 @@
       </svg>
       <div class="mdc-checkbox__mixedmark"></div>
     </div>
-    <div class="mat-mdc-checkbox-ripple mat-mdc-focus-indicator" mat-ripple
+    <div class="mat-mdc-checkbox-ripple mat-mdc-focus-indicator"
+      [class.mat-mdc-focus-indicator-render]="_inputFocused"
+      mat-ripple
       [matRippleTrigger]="checkbox"
       [matRippleDisabled]="disableRipple || disabled"
       [matRippleCentered]="true"

--- a/src/material-experimental/mdc-checkbox/checkbox.spec.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.spec.ts
@@ -581,6 +581,19 @@ describe('MDC-based MatCheckbox', () => {
 
       expect(checkboxRippleNativeElement.classList.contains('mat-mdc-focus-indicator')).toBe(true);
     });
+
+    it('should toggle the focus indicator render class on focus and blur', () => {
+      const checkboxRippleNativeElement =
+          checkboxNativeElement.querySelector('.mat-mdc-checkbox-ripple')!;
+
+      inputElement.focus();
+      fixture.detectChanges();
+      expect(checkboxRippleNativeElement.classList).toContain('mat-mdc-focus-indicator-render');
+
+      inputElement.blur();
+      fixture.detectChanges();
+      expect(checkboxRippleNativeElement.classList).not.toContain('mat-mdc-focus-indicator-render');
+    });
   });
 
   describe('with change event and no initial value', () => {

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -211,6 +211,9 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements AfterViewInit,
   /** Animation config for the ripple. */
   _rippleAnimation = RIPPLE_ANIMATION_CONFIG;
 
+  /** Whether the underlying input element is focused. */
+  _inputFocused = false;
+
   /** ControlValueAccessor onChange */
   private _cvaOnChange = (_: boolean) => {};
 
@@ -321,6 +324,8 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements AfterViewInit,
 
   /** Handles blur events on the native input. */
   _onBlur() {
+    this._inputFocused = false;
+
     // When a focused element becomes disabled, the browser *immediately* fires a blur event.
     // Angular does not expect events to be raised during change detection, so any state change
     // (such as a form control's 'ng-touched') will cause a changed-after-checked error.

--- a/src/material-experimental/mdc-helpers/_focus-indicators.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators.scss
@@ -64,28 +64,6 @@
     border-radius: 50%;
   }
 
-  // Render the focus indicator on focus. Defining a pseudo element's
-  // content will cause it to render.
-
-  // For checkboxes, radios and slide toggles, render the focus indicator when we know
-  // the hidden input is focused (slightly different for each control).
-  // .mdc-checkbox__native-control:focus ~ .mat-mdc-focus-indicator::before,
-  // .mat-mdc-slide-toggle-focused .mat-mdc-focus-indicator::before,
-  // .mat-mdc-radio-button.cdk-focused .mat-mdc-focus-indicator::before,
-
-  // // For buttons and list items, render the focus indicator when the parent
-  // // button or list item is focused.
-  // .mat-mdc-button-base:focus .mat-mdc-focus-indicator::before,
-  // .mat-mdc-list-item:focus > .mat-mdc-focus-indicator::before,
-
-  // // For options, render the focus indicator when the class .mat-mdc-option-active is present.
-  // .mat-mdc-focus-indicator.mat-mdc-option-active::before,
-
-  //   // For all other components, render the focus indicator on focus.
-  // .mat-mdc-focus-indicator:focus::before {
-  //   content: '';
-  // }
-
   // Render a focus indicator when either:
   //
   // 1. The host element is focused.

--- a/src/material-experimental/mdc-helpers/_focus-indicators.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators.scss
@@ -69,20 +69,33 @@
 
   // For checkboxes, radios and slide toggles, render the focus indicator when we know
   // the hidden input is focused (slightly different for each control).
-  .mdc-checkbox__native-control:focus ~ .mat-mdc-focus-indicator::before,
-  .mat-mdc-slide-toggle-focused .mat-mdc-focus-indicator::before,
-  .mat-mdc-radio-button.cdk-focused .mat-mdc-focus-indicator::before,
+  // .mdc-checkbox__native-control:focus ~ .mat-mdc-focus-indicator::before,
+  // .mat-mdc-slide-toggle-focused .mat-mdc-focus-indicator::before,
+  // .mat-mdc-radio-button.cdk-focused .mat-mdc-focus-indicator::before,
 
-  // For buttons and list items, render the focus indicator when the parent
-  // button or list item is focused.
-  .mat-mdc-button-base:focus .mat-mdc-focus-indicator::before,
-  .mat-mdc-list-item:focus > .mat-mdc-focus-indicator::before,
+  // // For buttons and list items, render the focus indicator when the parent
+  // // button or list item is focused.
+  // .mat-mdc-button-base:focus .mat-mdc-focus-indicator::before,
+  // .mat-mdc-list-item:focus > .mat-mdc-focus-indicator::before,
 
-  // For options, render the focus indicator when the class .mat-mdc-option-active is present.
-  .mat-mdc-focus-indicator.mat-mdc-option-active::before,
+  // // For options, render the focus indicator when the class .mat-mdc-option-active is present.
+  // .mat-mdc-focus-indicator.mat-mdc-option-active::before,
 
-    // For all other components, render the focus indicator on focus.
-  .mat-mdc-focus-indicator:focus::before {
+  //   // For all other components, render the focus indicator on focus.
+  // .mat-mdc-focus-indicator:focus::before {
+  //   content: '';
+  // }
+
+  // Render a focus indicator when either:
+  //
+  // 1. The host element is focused.
+  // 2. The host element gains the class `.mat-mdc-focus-indicator-render`.
+  // 3. The host element gains the class `.mat-mdc-option-active`.
+  //
+  // Setting the pseudo element's content to the empty string renders the focus indicator.
+  .mat-mdc-focus-indicator:focus::before,
+  .mat-mdc-focus-indicator.mat-mdc-focus-indicator-render::before,
+  .mat-mdc-focus-indicator.mat-mdc-option-active::before {
     content: '';
   }
 }

--- a/src/material-experimental/mdc-list/list-base.ts
+++ b/src/material-experimental/mdc-list/list-base.ts
@@ -53,6 +53,9 @@ export abstract class MatListItemBase implements AfterContentInit, OnDestroy, Ri
   /** Host element for the list item. */
   _hostElement: HTMLElement;
 
+  /** Whether the list item is focused. */
+  _itemFocused = false;
+
   @ContentChildren(MatListAvatarCssMatStyler, {descendants: false}) _avatars: QueryList<never>;
   @ContentChildren(MatListIconCssMatStyler, {descendants: false}) _icons: QueryList<never>;
 

--- a/src/material-experimental/mdc-list/list-item.html
+++ b/src/material-experimental/mdc-list/list-item.html
@@ -20,4 +20,5 @@
   Strong focus indicator element. MDC uses the `::before` pseudo element for the default
   focus/hover/selected state, so we need a separate element.
 -->
-<div class="mat-mdc-focus-indicator"></div>
+<div class="mat-mdc-focus-indicator"
+     [class.mat-mdc-focus-indicator-render]="_itemFocused"></div>

--- a/src/material-experimental/mdc-list/list-option.html
+++ b/src/material-experimental/mdc-list/list-option.html
@@ -55,4 +55,5 @@
   Strong focus indicator element. MDC uses the `::before` pseudo element for the default
   focus/hover/selected state, so we need a separate element.
 -->
-<div class="mat-mdc-focus-indicator"></div>
+<div class="mat-mdc-focus-indicator"
+     [class.mat-mdc-focus-indicator-render]="_itemFocused"></div>

--- a/src/material-experimental/mdc-list/list-option.ts
+++ b/src/material-experimental/mdc-list/list-option.ts
@@ -70,6 +70,7 @@ export interface SelectionList extends MatListBase {
     '[class.mat-mdc-list-item-with-avatar]': '_hasIconOrAvatar()',
     '[class.mat-accent]': 'color !== "primary" && color !== "warn"',
     '[class.mat-warn]': 'color === "warn"',
+    '(focus)': '_itemFocused = true',
     '(blur)': '_handleBlur()',
   },
   templateUrl: 'list-option.html',
@@ -196,6 +197,7 @@ export class MatListOption extends MatListItemBase implements ListOption, OnInit
   }
 
   _handleBlur() {
+    this._itemFocused = false;
     this._selectionList._onTouched();
   }
 

--- a/src/material-experimental/mdc-list/list.spec.ts
+++ b/src/material-experimental/mdc-list/list.spec.ts
@@ -79,6 +79,22 @@ describe('MDC-based MatList', () => {
       .toBe(true, 'Expected all list items to have a strong focus indicator element.');
   });
 
+  it('should toggle the focus indicator render class on focus and blur', () => {
+    const fixture = TestBed.createComponent(ActionListWithoutType);
+    fixture.detectChanges();
+    const listItem = fixture.debugElement.children[0].queryAll(By.css('.mat-mdc-list-item'))
+      .map(debugEl => debugEl.nativeElement as HTMLElement)[0];
+    const listItemFocusIndicatorHost = listItem.querySelector('.mat-mdc-focus-indicator')!;
+
+    listItem.focus();
+    fixture.detectChanges();
+    expect(listItemFocusIndicatorHost.classList).toContain('mat-mdc-focus-indicator-render');
+
+    listItem.blur();
+    fixture.detectChanges();
+    expect(listItemFocusIndicatorHost.classList).not.toContain('mat-mdc-focus-indicator-render');
+  });
+
   it('should not clear custom classes provided by user', () => {
     const fixture = TestBed.createComponent(ListWithItemWithCssClass);
     fixture.detectChanges();

--- a/src/material-experimental/mdc-list/list.spec.ts
+++ b/src/material-experimental/mdc-list/list.spec.ts
@@ -83,7 +83,7 @@ describe('MDC-based MatList', () => {
     const fixture = TestBed.createComponent(ActionListWithoutType);
     fixture.detectChanges();
     const listItem = fixture.debugElement.children[0].queryAll(By.css('.mat-mdc-list-item'))
-      .map(debugEl => debugEl.nativeElement as HTMLElement)[0];
+        .map(debugEl => debugEl.nativeElement as HTMLElement)[0];
     const listItemFocusIndicatorHost = listItem.querySelector('.mat-mdc-focus-indicator')!;
 
     listItem.focus();

--- a/src/material-experimental/mdc-list/list.ts
+++ b/src/material-experimental/mdc-list/list.ts
@@ -48,6 +48,8 @@ export class MatList extends MatListBase {}
   host: {
     'class': 'mat-mdc-list-item mdc-deprecated-list-item',
     '[class.mat-mdc-list-item-with-avatar]': '_hasIconOrAvatar()',
+    '(focus)': '_itemFocused = true',
+    '(blur)': '_itemFocused = false',
   },
   templateUrl: 'list-item.html',
   encapsulation: ViewEncapsulation.None,

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -563,6 +563,20 @@ describe('MDC-based MatSelectionList without forms', () => {
         .every(element => element.querySelector('.mat-mdc-focus-indicator') !== null)).toBe(true);
     });
 
+    it('should toggle the focus indicator render class on focus and blur', () => {
+      const optionNativeElement = listOptions.map(option =>
+        option.nativeElement as HTMLElement)[0];
+      const optionFocusIndicatorHost =
+        optionNativeElement.querySelector('.mat-mdc-focus-indicator')!;
+
+      optionNativeElement.focus();
+      fixture.detectChanges();
+      expect(optionFocusIndicatorHost.classList).toContain('mat-mdc-focus-indicator-render');
+
+      optionNativeElement.blur();
+      fixture.detectChanges();
+      expect(optionFocusIndicatorHost.classList).not.toContain('mat-mdc-focus-indicator-render');
+    });
   });
 
   describe('with list option selected', () => {

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -565,9 +565,9 @@ describe('MDC-based MatSelectionList without forms', () => {
 
     it('should toggle the focus indicator render class on focus and blur', () => {
       const optionNativeElement = listOptions.map(option =>
-        option.nativeElement as HTMLElement)[0];
+          option.nativeElement as HTMLElement)[0];
       const optionFocusIndicatorHost =
-        optionNativeElement.querySelector('.mat-mdc-focus-indicator')!;
+          optionNativeElement.querySelector('.mat-mdc-focus-indicator')!;
 
       optionNativeElement.focus();
       fixture.detectChanges();

--- a/src/material-experimental/mdc-radio/radio.html
+++ b/src/material-experimental/mdc-radio/radio.html
@@ -12,13 +12,16 @@
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"
            [attr.aria-describedby]="ariaDescribedby"
-           (change)="_onInputChange($event)">
+           (change)="_onInputChange($event)"
+           (focus)="_inputFocused = true"
+           (blur)="_inputFocused = false">
     <div class="mdc-radio__background">
       <div class="mdc-radio__outer-circle"></div>
       <div class="mdc-radio__inner-circle"></div>
     </div>
     <div class="mdc-radio__ripple"></div>
     <div mat-ripple class="mat-radio-ripple mat-mdc-focus-indicator"
+         [class.mat-mdc-focus-indicator-render]="_inputFocused"
          [matRippleTrigger]="formField"
          [matRippleDisabled]="_isRippleDisabled()"
          [matRippleCentered]="true"

--- a/src/material-experimental/mdc-radio/radio.spec.ts
+++ b/src/material-experimental/mdc-radio/radio.spec.ts
@@ -402,6 +402,19 @@ describe('MDC-based MatRadio', () => {
           .every(element => element.classList.contains('mat-mdc-focus-indicator'))).toBe(true);
     });
 
+    it('should toggle the focus indicator render class on focus and blur', () => {
+      const radioRippleNativeElements =
+          radioNativeElements.map(element => element.querySelector('.mat-radio-ripple')!);
+
+      radioInputElements[0].focus();
+      fixture.detectChanges();
+      expect(radioRippleNativeElements[0].classList).toContain('mat-mdc-focus-indicator-render');
+
+      radioInputElements[0].blur();
+      fixture.detectChanges();
+      expect(radioRippleNativeElements[0].classList).not
+        .toContain('mat-mdc-focus-indicator-render');
+    });
   });
 
   describe('group with ngModel', () => {

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -2,7 +2,8 @@
      [class.mdc-form-field--align-end]="labelPosition == 'before'">
   <div class="mdc-switch mat-mdc-switch" #switch>
     <div class="mdc-switch__track"></div>
-    <div class="mdc-switch__thumb-underlay mat-mdc-focus-indicator">
+    <div class="mdc-switch__thumb-underlay mat-mdc-focus-indicator"
+         [class.mat-mdc-focus-indicator-render]="_inputFocused">
       <div class="mat-mdc-slide-toggle-ripple" mat-ripple
         [matRippleTrigger]="switch"
         [matRippleDisabled]="disableRipple || disabled"
@@ -21,7 +22,9 @@
             [attr.aria-label]="ariaLabel"
             [attr.aria-labelledby]="ariaLabelledby"
             (change)="_onChangeEvent($event)"
-            (click)="_onInputClick($event)">
+            (click)="_onInputClick($event)"
+            (focus)="_inputFocused = true"
+            (blur)="_inputFocused = false">
       </div>
     </div>
   </div>

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
@@ -354,6 +354,18 @@ describe('MDC-based MatSlideToggle without forms', () => {
       const underlayElement = slideToggleElement.querySelector('.mdc-switch__thumb-underlay')!;
       expect(underlayElement.classList.contains('mat-mdc-focus-indicator')).toBe(true);
     });
+
+    it('should toggle the focus indicator render class on focus and blur', fakeAsync(() => {
+      const underlayElement = slideToggleElement.querySelector('.mdc-switch__thumb-underlay')!;
+
+      inputElement.focus();
+      fixture.detectChanges();
+      expect(underlayElement.classList).toContain('mat-mdc-focus-indicator-render');
+
+      inputElement.blur();
+      fixture.detectChanges();
+      expect(underlayElement.classList).not.toContain('mat-mdc-focus-indicator-render');
+    }));
   });
 
   describe('custom template', () => {

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
@@ -107,6 +107,9 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
     }
   };
 
+  /** Whether the underlying input element is focused. */
+  _inputFocused = false;
+
   /** Whether the slide toggle is currently focused. */
   _focused: boolean;
 

--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -19,12 +19,12 @@
            (focus)="_inputFocused = true"
            (blur)="_inputFocused = false">
     <span matRipple class="mat-checkbox-ripple mat-focus-indicator"
-         [class.mat-focus-indicator-render]="_inputFocused"
-         [matRippleTrigger]="label"
-         [matRippleDisabled]="_isRippleDisabled()"
-         [matRippleRadius]="20"
-         [matRippleCentered]="true"
-         [matRippleAnimation]="{enterDuration: 150}">
+          [class.mat-focus-indicator-render]="_inputFocused"
+          [matRippleTrigger]="label"
+          [matRippleDisabled]="_isRippleDisabled()"
+          [matRippleRadius]="20"
+          [matRippleCentered]="true"
+          [matRippleAnimation]="{enterDuration: 150}">
       <span class="mat-ripple-element mat-checkbox-persistent-ripple"></span>
     </span>
     <span class="mat-checkbox-frame"></span>

--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -15,8 +15,11 @@
            [attr.aria-checked]="_getAriaChecked()"
            [attr.aria-describedby]="ariaDescribedby"
            (change)="_onInteractionEvent($event)"
-           (click)="_onInputClick($event)">
+           (click)="_onInputClick($event)"
+           (focus)="_inputFocused = true"
+           (blur)="_inputFocused = false">
     <span matRipple class="mat-checkbox-ripple mat-focus-indicator"
+         [class.mat-focus-indicator-render]="_inputFocused"
          [matRippleTrigger]="label"
          [matRippleDisabled]="_isRippleDisabled()"
          [matRippleRadius]="20"

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -653,6 +653,19 @@ describe('MatCheckbox', () => {
 
       expect(checkboxRippleNativeElement.classList.contains('mat-focus-indicator')).toBe(true);
     });
+
+    it('should toggle the focus indicator render class on focus and blur', () => {
+      const checkboxRippleNativeElement =
+          checkboxNativeElement.querySelector('.mat-checkbox-ripple')!;
+
+      inputElement.focus();
+      fixture.detectChanges();
+      expect(checkboxRippleNativeElement.classList).toContain('mat-focus-indicator-render');
+
+      inputElement.blur();
+      fixture.detectChanges();
+      expect(checkboxRippleNativeElement.classList).not.toContain('mat-focus-indicator-render');
+    });
   });
 
   describe('with change event and no initial value', () => {

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -193,6 +193,9 @@ export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAc
    */
   _onTouched: () => any = () => {};
 
+  /** Whether the underlying input element is focused. */
+  _inputFocused = false;
+
   private _currentAnimationClass: string = '';
 
   private _currentCheckState: TransitionCheckState = TransitionCheckState.Init;

--- a/src/material/core/focus-indicators/_focus-indicators.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.scss
@@ -54,25 +54,16 @@
     margin: 5px;
   }
 
-  // Render the focus indicator on focus. Defining a pseudo element's
-  // content will cause it to render.
-
-  // Checkboxes, radios, and slide toggles render focus indicators when the
-  // associated visually-hidden input is focused.
-  .mat-checkbox-input:focus ~ .mat-focus-indicator::before,
-  .mat-radio-input:focus ~ .mat-focus-indicator::before,
-  .mat-slide-toggle-input:focus ~ .mat-slide-toggle-thumb-container .mat-focus-indicator::before,
-
-  // For options, render the focus indicator when the class .mat-active
-  // is present.
-  .mat-focus-indicator.mat-option.mat-active::before,
-
-  // For calendar cells, render the focus indicator when the parent cell is
-  // focused.
-  .mat-calendar-body-cell:focus .mat-focus-indicator::before,
-
-  // For all other components, render the focus indicator on focus.
-  .mat-focus-indicator:focus::before {
+  // Render a focus indicator when either:
+  //
+  // 1. The host element is focused.
+  // 2. The host element gains the class `.mat-focus-indicator-render`.
+  // 3. The host element gains the class `.mat-active`.
+  //
+  // Setting the pseudo element's content to the empty string renders the focus indicator.
+  .mat-focus-indicator:focus::before,
+  .mat-focus-indicator.mat-focus-indicator-render::before,
+  .mat-focus-indicator.mat-active::before {
     content: '';
   }
 }

--- a/src/material/datepicker/calendar-body.html
+++ b/src/material/datepicker/calendar-body.html
@@ -51,10 +51,13 @@
       [attr.aria-disabled]="!item.enabled || null"
       [attr.aria-selected]="_isSelected(item.compareValue)"
       (click)="_cellClicked(item, $event)"
+      (focus)="item.focused = true"
+      (blur)="item.focused = false"
       [style.width]="_cellWidth"
       [style.paddingTop]="_cellPadding"
       [style.paddingBottom]="_cellPadding">
       <div class="mat-calendar-body-cell-content mat-focus-indicator"
+        [class.mat-focus-indicator-render]="item.focused"
         [class.mat-calendar-body-selected]="_isSelected(item.compareValue)"
         [class.mat-calendar-body-comparison-identical]="_isComparisonIdentical(item.compareValue)"
         [class.mat-calendar-body-today]="todayValue === item.compareValue">

--- a/src/material/datepicker/calendar-body.spec.ts
+++ b/src/material/datepicker/calendar-body.spec.ts
@@ -111,6 +111,18 @@ describe('MatCalendarBody', () => {
           .toBe(true);
     });
 
+    it('should toggle the focus indicator render class on focus and blur', () => {
+      const cellEl = cellEls[0];
+      const cellContentEl = cellEl.querySelector('.mat-calendar-body-cell-content')!;
+
+      (cellEl as HTMLElement).focus();
+      fixture.detectChanges();
+      expect(cellContentEl.classList).toContain('mat-focus-indicator-render');
+
+      (cellEl as HTMLElement).blur();
+      fixture.detectChanges();
+      expect(cellContentEl.classList).not.toContain('mat-focus-indicator-render');
+    });
   });
 
   describe('range calendar body', () => {
@@ -676,7 +688,7 @@ function createCalendarCells(weeks: number): MatCalendarCell[][] {
   }
 
   return rows.map(row => row.map(cell => {
-    return new MatCalendarCell(cell, `${cell}`, `${cell}-label`, true,
+    return new MatCalendarCell(cell, `${cell}`, `${cell}-label`, true, false,
         cell % 2 === 0 ? 'even' : undefined);
   }));
 }

--- a/src/material/datepicker/calendar-body.ts
+++ b/src/material/datepicker/calendar-body.ts
@@ -37,6 +37,7 @@ export class MatCalendarCell<D = any> {
               public displayValue: string,
               public ariaLabel: string,
               public enabled: boolean,
+              public focused: boolean,
               public cssClasses: MatCalendarCellCssClasses = {},
               public compareValue = value,
               public rawValue?: D) {}

--- a/src/material/datepicker/month-view.ts
+++ b/src/material/datepicker/month-view.ts
@@ -390,7 +390,7 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
       const cellClasses = this.dateClass ? this.dateClass(date, 'month') : undefined;
 
       this._weeks[this._weeks.length - 1].push(new MatCalendarCell<D>(i + 1, dateNames[i],
-          ariaLabel, enabled, cellClasses, this._getCellCompareValue(date)!, date));
+          ariaLabel, enabled, false, cellClasses, this._getCellCompareValue(date)!, date));
     }
   }
 

--- a/src/material/datepicker/multi-year-view.ts
+++ b/src/material/datepicker/multi-year-view.ts
@@ -263,7 +263,8 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
     const yearName = this._dateAdapter.getYearName(date);
     const cellClasses = this.dateClass ? this.dateClass(date, 'multi-year') : undefined;
 
-    return new MatCalendarCell(year, yearName, yearName, this._shouldEnableYear(year), cellClasses);
+    return new MatCalendarCell(
+        year, yearName, yearName, this._shouldEnableYear(year), false, cellClasses);
   }
 
   /** Whether the given year is enabled. */

--- a/src/material/datepicker/year-view.ts
+++ b/src/material/datepicker/year-view.ts
@@ -270,7 +270,7 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
     const cellClasses = this.dateClass ? this.dateClass(date, 'year') : undefined;
 
     return new MatCalendarCell(month, monthName.toLocaleUpperCase(), ariaLabel,
-        this._shouldEnableMonth(month), cellClasses);
+        this._shouldEnableMonth(month), false, cellClasses);
   }
 
   /** Whether the given month is enabled. */

--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -24,12 +24,12 @@
     <!-- The ripple comes after the input so that we can target it with a CSS
          sibling selector when the input is focused. -->
     <span mat-ripple class="mat-radio-ripple mat-focus-indicator"
-         [class.mat-focus-indicator-render]="_inputFocused"
-         [matRippleTrigger]="label"
-         [matRippleDisabled]="_isRippleDisabled()"
-         [matRippleCentered]="true"
-         [matRippleRadius]="20"
-         [matRippleAnimation]="{enterDuration: 150}">
+          [class.mat-focus-indicator-render]="_inputFocused"
+          [matRippleTrigger]="label"
+          [matRippleDisabled]="_isRippleDisabled()"
+          [matRippleCentered]="true"
+          [matRippleRadius]="20"
+          [matRippleAnimation]="{enterDuration: 150}">
 
       <span class="mat-ripple-element mat-radio-persistent-ripple"></span>
     </span>

--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -17,11 +17,14 @@
         [attr.aria-labelledby]="ariaLabelledby"
         [attr.aria-describedby]="ariaDescribedby"
         (change)="_onInputChange($event)"
-        (click)="_onInputClick($event)">
+        (click)="_onInputClick($event)"
+        (focus)="_inputFocused = true"
+        (blur)="_inputFocused = false">
 
     <!-- The ripple comes after the input so that we can target it with a CSS
          sibling selector when the input is focused. -->
     <span mat-ripple class="mat-radio-ripple mat-focus-indicator"
+         [class.mat-focus-indicator-render]="_inputFocused"
          [matRippleTrigger]="label"
          [matRippleDisabled]="_isRippleDisabled()"
          [matRippleCentered]="true"

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -395,6 +395,18 @@ describe('MatRadio', () => {
           .every(element => element.classList.contains('mat-focus-indicator'))).toBe(true);
     });
 
+    it('should toggle the focus indicator render class on focus and blur', () => {
+      const radioRippleNativeElements =
+          radioNativeElements.map(element => element.querySelector('.mat-radio-ripple')!);
+
+      radioInputElements[0].focus();
+      fixture.detectChanges();
+      expect(radioRippleNativeElements[0].classList).toContain('mat-focus-indicator-render');
+
+      radioInputElements[0].blur();
+      fixture.detectChanges();
+      expect(radioRippleNativeElements[0].classList).not.toContain('mat-focus-indicator-render');
+    });
   });
 
   describe('group with ngModel', () => {

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -489,6 +489,9 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
   /** The native `<input type=radio>` element */
   @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
 
+  /** Whether the underlying input element is focused. */
+  _inputFocused = false;
+
   constructor(radioGroup: _MatRadioGroupBase<_MatRadioButtonBase>,
               elementRef: ElementRef,
               protected _changeDetector: ChangeDetectorRef,

--- a/src/material/slide-toggle/slide-toggle.html
+++ b/src/material/slide-toggle/slide-toggle.html
@@ -14,11 +14,14 @@
            [attr.aria-label]="ariaLabel"
            [attr.aria-labelledby]="ariaLabelledby"
            (change)="_onChangeEvent($event)"
-           (click)="_onInputClick($event)">
+           (click)="_onInputClick($event)"
+           (focus)="_inputFocused = true"
+           (blur)="_inputFocused = false">
 
     <div class="mat-slide-toggle-thumb-container" #thumbContainer>
       <div class="mat-slide-toggle-thumb"></div>
       <div class="mat-slide-toggle-ripple mat-focus-indicator" mat-ripple
+           [class.mat-focus-indicator-render]="_inputFocused"
            [matRippleTrigger]="label"
            [matRippleDisabled]="disableRipple || disabled"
            [matRippleCentered]="true"

--- a/src/material/slide-toggle/slide-toggle.spec.ts
+++ b/src/material/slide-toggle/slide-toggle.spec.ts
@@ -363,6 +363,19 @@ describe('MatSlideToggle without forms', () => {
 
       expect(slideToggleRippleNativeElement.classList.contains('mat-focus-indicator')).toBe(true);
     });
+
+    it('should toggle the focus indicator render class on focus and blur', () => {
+      const slideToggleRippleNativeElement =
+          slideToggleElement.querySelector('.mat-slide-toggle-ripple')!;
+
+      inputElement.focus();
+      fixture.detectChanges();
+      expect(slideToggleRippleNativeElement.classList).toContain('mat-focus-indicator-render');
+
+      inputElement.blur();
+      fixture.detectChanges();
+      expect(slideToggleRippleNativeElement.classList).not.toContain('mat-focus-indicator-render');
+    });
   });
 
   describe('custom template', () => {

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -159,6 +159,9 @@ export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestro
   /** Reference to the underlying input element. */
   @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
 
+  /** Whether the underlying input element is focused. */
+  _inputFocused = false;
+
   constructor(elementRef: ElementRef,
               private _focusMonitor: FocusMonitor,
               private _changeDetectorRef: ChangeDetectorRef,

--- a/tools/public_api_guard/material/checkbox.d.ts
+++ b/tools/public_api_guard/material/checkbox.d.ts
@@ -15,6 +15,7 @@ export declare const MAT_CHECKBOX_REQUIRED_VALIDATOR: Provider;
 export declare class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAccessor, AfterViewInit, AfterViewChecked, OnDestroy, CanColor, CanDisable, HasTabIndex, CanDisableRipple, FocusableOption {
     _animationMode?: string | undefined;
     _inputElement: ElementRef<HTMLInputElement>;
+    _inputFocused: boolean;
     _onTouched: () => any;
     ariaDescribedby: string;
     ariaLabel: string;

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -144,9 +144,10 @@ export declare class MatCalendarCell<D = any> {
     cssClasses: MatCalendarCellCssClasses;
     displayValue: string;
     enabled: boolean;
+    focused: boolean;
     rawValue?: D | undefined;
     value: number;
-    constructor(value: number, displayValue: string, ariaLabel: string, enabled: boolean, cssClasses?: MatCalendarCellCssClasses, compareValue?: number, rawValue?: D | undefined);
+    constructor(value: number, displayValue: string, ariaLabel: string, enabled: boolean, focused: boolean, cssClasses?: MatCalendarCellCssClasses, compareValue?: number, rawValue?: D | undefined);
 }
 
 export declare type MatCalendarCellClassFunction<D> = (date: D, view: 'month' | 'year' | 'multi-year') => MatCalendarCellCssClasses;

--- a/tools/public_api_guard/material/radio.d.ts
+++ b/tools/public_api_guard/material/radio.d.ts
@@ -2,6 +2,7 @@ export declare abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBa
     _animationMode?: string | undefined;
     protected _changeDetector: ChangeDetectorRef;
     _inputElement: ElementRef<HTMLInputElement>;
+    _inputFocused: boolean;
     ariaDescribedby: string;
     ariaLabel: string;
     ariaLabelledby: string;

--- a/tools/public_api_guard/material/slide-toggle.d.ts
+++ b/tools/public_api_guard/material/slide-toggle.d.ts
@@ -13,6 +13,7 @@ export declare const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: any;
 export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestroy, AfterContentInit, ControlValueAccessor, CanDisable, CanColor, HasTabIndex, CanDisableRipple {
     _animationMode?: string | undefined;
     _inputElement: ElementRef<HTMLInputElement>;
+    _inputFocused: boolean;
     _thumbBarEl: ElementRef;
     _thumbEl: ElementRef;
     ariaLabel: string | null;


### PR DESCRIPTION
The motivation behind this PR is two-fold:

1. It's not ideal to have component-specific DOM structure leaking into the global focus indicators stylesheet. We've had a number of bugs come up where tweaking a component's DOM structure has led to focus indicators breaking when we forget to update the stylesheet. Thus, this PR removes the component-specific focus indicator rendering conditions from the global stylesheet, and instead, moves this logic into the components that need it.
2. If a developer wants to add Material focus indicators to a new custom component, they can manually add the `.mat-focus-indicator` class to the appropriate element. However, currently we expect this element to be the actual element that receives focus. We provide no mechanism for a developer to add a focus indicator to an element that doesn't actually receive focus, but should render a focus indicator when some associated element receives focus (e.g. see `mat-checkbox`). This PR introduces a new public CSS class `.mat-focus-indicator-render` that developers can use to "manually" render a focus indicator in these cases.

The downside to this change is that a handful of components now have `focus` and `blur` event listeners bound to them in order to update the `.mat-focus-indicator-render` class properly. We might be able to avoid these event listeners by instead updating these components to check something like `inputElement === document.activeElement`, but I wasn't sure which to prefer (and I wasn't sure if CD would work properly).