### PR TITLE
build: add workaround to support RBE on macOS and windows

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,6 +69,11 @@ sass_repositories()
 # Bring in bazel_toolchains for RBE setup configuration.
 http_archive(
     name = "bazel_toolchains",
+    # Patch `bazel-toolchains` to always consider the host platform as Linux. This is necessary
+    # because the RBE configurations are incorrectly based on the host platform and this breaks
+    # cross-platform remote execution. e.g. using RBE on macOS.
+    # See: https://github.com/bazelbuild/bazel-toolchains/issues/895
+    patches = ["//tools:rbe_cross_platform_workaround.patch"],
     sha256 = "1adf5db506a7e3c465a26988514cfc3971af6d5b3c2218925cd6e71ee443fc3f",
     strip_prefix = "bazel-toolchains-4.0.0",
     urls = [

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
     "system-config-tmpl.js",
     "system-rxjs-operators.js",
+    "rbe_cross_platform_workaround.patch",
 ])
 
 # Workaround for https://github.com/bazelbuild/bazel-toolchains/issues/356. We need the

--- a/tools/rbe_cross_platform_workaround.patch
+++ b/tools/rbe_cross_platform_workaround.patch
@@ -1,0 +1,26 @@
+diff --git rules/rbe_repo/util.bzl rules/rbe_repo/util.bzl
+index 71a0e9e..a7db7bb 100644
+--- rules/rbe_repo/util.bzl
++++ rules/rbe_repo/util.bzl
+@@ -136,20 +136,7 @@ def resolve_project_root(ctx):
+     return mount_project_root, export_project_root, use_default_project
+ 
+ def os_family(ctx):
+-    """Retrieve the OS Family of host environment
+-
+-    Args:
+-      ctx: the Bazel context object.
+-
+-    Returns:
+-      Returns the name of the OS Family
+-    """
+-    os_name = ctx.os.name.lower()
+-    if os_name.find("windows") != -1:
+-        return "Windows"
+-    if os_name == "linux":
+-        return "Linux"
+-    return os_name
++    return "Linux"
+ 
+ def validate_host(ctx):
+     """Perform validations of host environment to be able to run the rule.


### PR DESCRIPTION
Adds a workaround for `bazel-toolchains` that allows us to
use RBE on macOS or Windows. This no longer works with the
recent upgrades to `bazel-toolchains`.
t
It seems like we can remove this workaround once `bazel-toolchains`
supports cross-compilation, or if we start generating the
toolchain configurations our own (needs more investigation).