### PR TITLE
fix(material/tabs): pagination not updating on resize

### DIFF
--- a/src/material/tabs/paginated-tab-header.ts
+++ b/src/material/tabs/paginated-tab-header.ts
@@ -201,8 +201,10 @@ export abstract class MatPaginatedTabHeader implements AfterContentChecked, Afte
     // On dir change or window resize, realign the ink bar and update the orientation of
     // the key manager if the direction has changed.
     merge(dirChange, resize, this._items.changes).pipe(takeUntil(this._destroyed)).subscribe(() => {
-      // We need to defer this to give the browser some time to recalculate the element dimensions.
-      Promise.resolve().then(realign);
+      // We need to defer this to give the browser some time to recalculate
+      // the element dimensions. The call has to be wrapped in `NgZone.run`,
+      // because the viewport change handler runs outside of Angular.
+      this._ngZone.run(() => Promise.resolve().then(realign));
       this._keyManager.withHorizontalOrientation(this._getLayoutDirection());
     });
 


### PR DESCRIPTION
The tab header pagination wasn't updating when the page is resized, because the resize listener runs outside of Angular.

Fixes #22399.