### PR TITLE
fix(material/checkbox): NVDA reading out clickable before checkbox label

### DIFF
--- a/src/material-experimental/mdc-checkbox/checkbox.html
+++ b/src/material-experimental/mdc-checkbox/checkbox.html
@@ -29,8 +29,15 @@
       </svg>
       <div class="mdc-checkbox__mixedmark"></div>
     </div>
+    <!--
+      Note that we use the input as the ripple target, because some screen readers have a
+      behavior where any parent of an input that has a `mousedown` or `click` listener is
+      considered as being "clickable", causing the screen reader to read out "clickable" before
+      the label. MDC stretches the input to the size of the container so we can bind to it
+      directly for the same result. See https://github.com/nvaccess/nvda/issues/7430
+     -->
     <div class="mat-mdc-checkbox-ripple mat-mdc-focus-indicator" mat-ripple
-      [matRippleTrigger]="checkbox"
+      [matRippleTrigger]="nativeCheckbox"
       [matRippleDisabled]="disableRipple || disabled"
       [matRippleCentered]="true"
       [matRippleAnimation]="_rippleAnimation"></div>

--- a/src/material-experimental/mdc-checkbox/checkbox.spec.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.spec.ts
@@ -39,7 +39,6 @@ describe('MDC-based MatCheckbox', () => {
     let testComponent: SingleCheckbox;
     let inputElement: HTMLInputElement;
     let labelElement: HTMLLabelElement;
-    let checkboxElement: HTMLElement;
 
     beforeEach(() => {
       fixture = createComponent(SingleCheckbox);
@@ -51,7 +50,6 @@ describe('MDC-based MatCheckbox', () => {
       testComponent = fixture.debugElement.componentInstance;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
       labelElement = <HTMLLabelElement>checkboxNativeElement.querySelector('label');
-      checkboxElement = <HTMLLabelElement>checkboxNativeElement.querySelector('.mdc-checkbox');
     });
 
     it('should add and remove the checked state', fakeAsync(() => {
@@ -80,17 +78,17 @@ describe('MDC-based MatCheckbox', () => {
 
       testComponent.isDisabled = true;
       fixture.detectChanges();
-      dispatchFakeEvent(checkboxElement, 'mousedown');
-      dispatchFakeEvent(checkboxElement, 'mouseup');
-      checkboxElement.click();
+      dispatchFakeEvent(inputElement, 'mousedown');
+      dispatchFakeEvent(inputElement, 'mouseup');
+      inputElement.click();
       expect(checkboxNativeElement.querySelectorAll(rippleSelector).length).toBe(0);
 
       flush();
       testComponent.isDisabled = false;
       fixture.detectChanges();
-      dispatchFakeEvent(checkboxElement, 'mousedown');
-      dispatchFakeEvent(checkboxElement, 'mouseup');
-      checkboxElement.click();
+      dispatchFakeEvent(inputElement, 'mousedown');
+      dispatchFakeEvent(inputElement, 'mouseup');
+      inputElement.click();
       expect(checkboxNativeElement.querySelectorAll(rippleSelector).length).toBe(1);
 
       flush();
@@ -407,9 +405,9 @@ describe('MDC-based MatCheckbox', () => {
 
            expect(checkboxNativeElement.querySelector(rippleSelector)).toBeFalsy();
 
-           dispatchFakeEvent(checkboxElement, 'mousedown');
-           dispatchFakeEvent(checkboxElement, 'mouseup');
-           checkboxElement.click();
+           dispatchFakeEvent(inputElement, 'mousedown');
+           dispatchFakeEvent(inputElement, 'mouseup');
+           inputElement.click();
 
            expect(checkboxNativeElement.querySelectorAll(rippleSelector).length).toBe(1);
 
@@ -421,9 +419,9 @@ describe('MDC-based MatCheckbox', () => {
            testComponent.isDisabled = true;
            fixture.detectChanges();
 
-           dispatchFakeEvent(checkboxElement, 'mousedown');
-           dispatchFakeEvent(checkboxElement, 'mouseup');
-           checkboxElement.click();
+           dispatchFakeEvent(inputElement, 'mousedown');
+           dispatchFakeEvent(inputElement, 'mouseup');
+           inputElement.click();
 
            expect(checkboxNativeElement.querySelectorAll(rippleSelector).length).toBe(0);
 
@@ -431,9 +429,9 @@ describe('MDC-based MatCheckbox', () => {
            testComponent.isDisabled = false;
            fixture.detectChanges();
 
-           dispatchFakeEvent(checkboxElement, 'mousedown');
-           dispatchFakeEvent(checkboxElement, 'mouseup');
-           checkboxElement.click();
+           dispatchFakeEvent(inputElement, 'mousedown');
+           dispatchFakeEvent(inputElement, 'mouseup');
+           inputElement.click();
 
            expect(checkboxNativeElement.querySelectorAll(rippleSelector).length).toBe(1);
 
@@ -445,9 +443,9 @@ describe('MDC-based MatCheckbox', () => {
            testComponent.disableRipple = true;
            fixture.detectChanges();
 
-           dispatchFakeEvent(checkboxElement, 'mousedown');
-           dispatchFakeEvent(checkboxElement, 'mouseup');
-           checkboxElement.click();
+           dispatchFakeEvent(inputElement, 'mousedown');
+           dispatchFakeEvent(inputElement, 'mouseup');
+           inputElement.click();
 
            expect(checkboxNativeElement.querySelectorAll(rippleSelector).length).toBe(0);
 
@@ -455,9 +453,9 @@ describe('MDC-based MatCheckbox', () => {
            testComponent.disableRipple = false;
            fixture.detectChanges();
 
-           dispatchFakeEvent(checkboxElement, 'mousedown');
-           dispatchFakeEvent(checkboxElement, 'mouseup');
-           checkboxElement.click();
+           dispatchFakeEvent(inputElement, 'mousedown');
+           dispatchFakeEvent(inputElement, 'mouseup');
+           inputElement.click();
 
            expect(checkboxNativeElement.querySelectorAll(rippleSelector).length).toBe(1);
 

--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -1,21 +1,6 @@
 <label [attr.for]="inputId" class="mat-checkbox-layout" #label>
   <span class="mat-checkbox-inner-container"
        [class.mat-checkbox-inner-container-no-side-margin]="!checkboxLabel.textContent || !checkboxLabel.textContent.trim()">
-    <input #input
-           class="mat-checkbox-input cdk-visually-hidden" type="checkbox"
-           [id]="inputId"
-           [required]="required"
-           [checked]="checked"
-           [attr.value]="value"
-           [disabled]="disabled"
-           [attr.name]="name"
-           [tabIndex]="tabIndex"
-           [attr.aria-label]="ariaLabel || null"
-           [attr.aria-labelledby]="ariaLabelledby"
-           [attr.aria-checked]="_getAriaChecked()"
-           [attr.aria-describedby]="ariaDescribedby"
-           (change)="_onInteractionEvent($event)"
-           (click)="_onInputClick($event)">
     <span matRipple class="mat-checkbox-ripple mat-focus-indicator"
          [matRippleTrigger]="label"
          [matRippleDisabled]="_isRippleDisabled()"
@@ -46,3 +31,27 @@
     <ng-content></ng-content>
   </span>
 </label>
+
+<!--
+  Note that the input is placed outside of the ripple container, because some screen readers have a
+  behavior where any parent of an input that has a `mousedown` or `click` listener is
+  considered as being "clickable", causing the screen reader to read out "clickable" before
+  the label. Since the input is invisible, it doesn't really matter where we place it.
+  See https://github.com/nvaccess/nvda/issues/7430
+ -->
+<input #input
+  class="mat-checkbox-input cdk-visually-hidden"
+  type="checkbox"
+  [id]="inputId"
+  [required]="required"
+  [checked]="checked"
+  [attr.value]="value"
+  [disabled]="disabled"
+  [attr.name]="name"
+  [tabIndex]="tabIndex"
+  [attr.aria-label]="ariaLabel || null"
+  [attr.aria-labelledby]="ariaLabelledby"
+  [attr.aria-checked]="_getAriaChecked()"
+  [attr.aria-describedby]="ariaDescribedby"
+  (change)="_onInteractionEvent($event)"
+  (click)="_onInputClick($event)">

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -176,6 +176,7 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * checkbox-common.$size !default;
 
 .mat-checkbox {
   @include private.private-animation-noop();
+  position: relative;
 
   // The host node defaults to `diplay: inline` so
   // we have to change it in order for margins to work.
@@ -515,6 +516,12 @@ $_mat-checkbox-mark-stroke-size: 2 / 15 * checkbox-common.$size !default;
 .mat-checkbox-input {
   // Move the input to the bottom and in the middle.
   // Visual improvement to properly show browser popups when being required.
-  bottom: 0;
-  left: 50%;
+  $offset: checkbox-common.$size / 2;
+  bottom: $offset;
+  left: $offset;
+
+  [dir='rtl'] & {
+    left: auto;
+    right: $offset;
+  }
 }

--- a/src/material/checkbox/checkbox.spec.ts
+++ b/src/material/checkbox/checkbox.spec.ts
@@ -1188,12 +1188,12 @@ describe('MatCheckbox', () => {
 
     it('should not add the "name" attribute if it is not passed in', () => {
       fixture.detectChanges();
-      expect(checkboxInnerContainer.querySelector('input')!.hasAttribute('name')).toBe(false);
+      expect(fixture.nativeElement.querySelector('input')!.hasAttribute('name')).toBe(false);
     });
 
     it('should not add the "value" attribute if it is not passed in', () => {
       fixture.detectChanges();
-      expect(checkboxInnerContainer.querySelector('input')!.hasAttribute('value')).toBe(false);
+      expect(fixture.nativeElement.querySelector('input')!.hasAttribute('value')).toBe(false);
     });
   });
 

--- a/src/material/core/focus-indicators/_focus-indicators.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.scss
@@ -59,7 +59,7 @@
 
   // Checkboxes, radios, and slide toggles render focus indicators when the
   // associated visually-hidden input is focused.
-  .mat-checkbox-input:focus ~ .mat-focus-indicator::before,
+  .mat-checkbox.cdk-focused .mat-focus-indicator::before,
   .mat-radio-input:focus ~ .mat-focus-indicator::before,
   .mat-slide-toggle-input:focus ~ .mat-slide-toggle-thumb-container .mat-focus-indicator::before,
 


### PR DESCRIPTION
NVDA has some behavior where if an `input` is placed inside an element with a `click` or `mousedown` listener, the screen reader considers it as "clickable" and reads out "clickable" before its label. This is always the case for our checkbox components, because they have ripples on their parent nodes.
These changes include the following fixes to address the issue.
1. For the non-MDC checkbox we move the `input` to the root of the component since it's invisible and it doesn't matter where we put it.
2. For the MDC checkbox we use the `input` as the ripple target. We can move the input around, because MDC uses sibling selectors for the checked styling. Furthermore, we take advantage of the fact the the input is stretched over the checkbox container.