### PR TITLE
fix(material/slide-toggle): NVDA reading out clickable before label

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -3,8 +3,15 @@
   <div class="mdc-switch mat-mdc-switch" #switch>
     <div class="mdc-switch__track"></div>
     <div class="mdc-switch__thumb-underlay mat-mdc-focus-indicator">
+      <!--
+        Note that we use the input as the ripple target, because some screen readers have a
+        behavior where any parent of an input that has a `mousedown` or `click` listener is
+        considered as being "clickable", causing the screen reader to read out "clickable" before
+        the label. MDC stretches the input to the size of the slide toggle so we can bind to it
+        directly for the same result. See https://github.com/nvaccess/nvda/issues/7430
+      -->
       <div class="mat-mdc-slide-toggle-ripple" mat-ripple
-        [matRippleTrigger]="switch"
+        [matRippleTrigger]="input"
         [matRippleDisabled]="disableRipple || disabled"
         [matRippleCentered]="true"
         [matRippleAnimation]="_rippleAnimation"></div>

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
@@ -338,26 +338,24 @@ describe('MDC-based MatSlideToggle without forms', () => {
 
     it('should show ripples', () => {
       const rippleSelector = '.mat-ripple-element';
-      const switchElement = slideToggleElement.querySelector('.mdc-switch')!;
 
       expect(slideToggleElement.querySelectorAll(rippleSelector).length).toBe(0);
 
-      dispatchFakeEvent(switchElement, 'mousedown');
-      dispatchFakeEvent(switchElement, 'mouseup');
+      dispatchFakeEvent(inputElement, 'mousedown');
+      dispatchFakeEvent(inputElement, 'mouseup');
 
       expect(slideToggleElement.querySelectorAll(rippleSelector).length).toBe(1);
     });
 
     it('should not show ripples when disableRipple is set', () => {
-      const switchElement = slideToggleElement.querySelector('.mdc-switch')!;
       const rippleSelector = '.mat-ripple-element';
       testComponent.disableRipple = true;
       fixture.detectChanges();
 
       expect(slideToggleElement.querySelectorAll(rippleSelector).length).toBe(0);
 
-      dispatchFakeEvent(switchElement, 'mousedown');
-      dispatchFakeEvent(switchElement, 'mouseup');
+      dispatchFakeEvent(inputElement, 'mousedown');
+      dispatchFakeEvent(inputElement, 'mouseup');
 
       expect(slideToggleElement.querySelectorAll(rippleSelector).length).toBe(0);
     });

--- a/src/material/core/focus-indicators/_focus-indicators.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.scss
@@ -61,7 +61,7 @@
   // associated visually-hidden input is focused.
   .mat-checkbox-input:focus ~ .mat-focus-indicator::before,
   .mat-radio-input:focus ~ .mat-focus-indicator::before,
-  .mat-slide-toggle-input:focus ~ .mat-slide-toggle-thumb-container .mat-focus-indicator::before,
+  .mat-slide-toggle.cdk-focused .mat-slide-toggle-thumb-container .mat-focus-indicator::before,
 
   // For options, render the focus indicator when the class .mat-active
   // is present.

--- a/src/material/slide-toggle/slide-toggle.html
+++ b/src/material/slide-toggle/slide-toggle.html
@@ -2,21 +2,6 @@
   <div #toggleBar class="mat-slide-toggle-bar"
        [class.mat-slide-toggle-bar-no-side-margin]="!labelContent.textContent || !labelContent.textContent.trim()">
 
-    <input #input class="mat-slide-toggle-input cdk-visually-hidden" type="checkbox"
-           role="switch"
-           [id]="inputId"
-           [required]="required"
-           [tabIndex]="tabIndex"
-           [checked]="checked"
-           [disabled]="disabled"
-           [attr.name]="name"
-           [attr.aria-checked]="checked.toString()"
-           [attr.aria-label]="ariaLabel"
-           [attr.aria-labelledby]="ariaLabelledby"
-           [attr.aria-describedby]="ariaDescribedby"
-           (change)="_onChangeEvent($event)"
-           (click)="_onInputClick($event)">
-
     <div class="mat-slide-toggle-thumb-container" #thumbContainer>
       <div class="mat-slide-toggle-thumb"></div>
       <div class="mat-slide-toggle-ripple mat-focus-indicator" mat-ripple
@@ -38,3 +23,25 @@
     <ng-content></ng-content>
   </span>
 </label>
+
+<!--
+  Note that the input is placed outside of the ripple container, because some screen readers have a
+  behavior where any parent of an input that has a `mousedown` or `click` listener is
+  considered as being "clickable", causing the screen reader to read out "clickable" before
+  the label. Since the input is invisible, it doesn't really matter where we place it.
+  See https://github.com/nvaccess/nvda/issues/7430
+ -->
+<input #input class="mat-slide-toggle-input cdk-visually-hidden" type="checkbox"
+  role="switch"
+  [id]="inputId"
+  [required]="required"
+  [tabIndex]="tabIndex"
+  [checked]="checked"
+  [disabled]="disabled"
+  [attr.name]="name"
+  [attr.aria-checked]="checked.toString()"
+  [attr.aria-label]="ariaLabel"
+  [attr.aria-labelledby]="ariaLabelledby"
+  [attr.aria-describedby]="ariaDescribedby"
+  (change)="_onChangeEvent($event)"
+  (click)="_onInputClick($event)">

--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -23,6 +23,7 @@ $bar-track-width: $bar-width - $thumb-size;
   line-height: $height;
   white-space: nowrap;
   outline: none;
+  position: relative;
 
   -webkit-tap-highlight-color: transparent;
 


### PR DESCRIPTION
Similar fix to #22446 for the slide toggle. Moves around the DOM in order to avoid the behavior where NVDA will read out "clickable" before the label, if the `input` parent has a `click` or `mousedown` listener. Includes the following changes:
1. Moving the `input` out of the ripple target for the current slide toggle. The input is invisible so it doesn't really matter where we put it.
2. Using the `input` as the ripple target in the MDC slide toggle. The `input` covers the entire container so the result is the same.