### PR TITLE
refactor: update `$schema` and `id` keyword

### DIFF
--- a/src/cdk/schematics/ng-add/schema.json
+++ b/src/cdk/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "angular-cdk-ng-add",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "angular-cdk-ng-add",
   "title": "Angular CDK ng-add",
   "type": "object",
   "properties": {

--- a/src/cdk/schematics/ng-generate/drag-drop/schema.json
+++ b/src/cdk/schematics/ng-generate/drag-drop/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "CdkSchematicsDragDrop",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "CdkSchematicsDragDrop",
   "title": "Angular CDK Drag and Drop schematic",
   "type": "object",
   "properties": {

--- a/src/material/schematics/ng-add/schema.json
+++ b/src/material/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "angular-material-ng-add",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "angular-material-ng-add",
   "title": "Angular Material ng-add schematic",
   "type": "object",
   "properties": {

--- a/src/material/schematics/ng-generate/address-form/schema.json
+++ b/src/material/schematics/ng-generate/address-form/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsMaterialAddressForm",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsMaterialAddressForm",
   "title": "Material Address Form Options Schema",
   "type": "object",
   "properties": {

--- a/src/material/schematics/ng-generate/dashboard/schema.json
+++ b/src/material/schematics/ng-generate/dashboard/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsMaterialDashboard",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsMaterialDashboard",
   "title": "Material Dashboard Options Schema",
   "type": "object",
   "properties": {

--- a/src/material/schematics/ng-generate/navigation/schema.json
+++ b/src/material/schematics/ng-generate/navigation/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsMaterialNavigation",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsMaterialNavigation",
   "title": "Material Navigation Options Schema",
   "type": "object",
   "properties": {

--- a/src/material/schematics/ng-generate/table/schema.json
+++ b/src/material/schematics/ng-generate/table/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsMaterialTable",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsMaterialTable",
   "title": "Material Table Options Schema",
   "type": "object",
   "properties": {

--- a/src/material/schematics/ng-generate/theming-api/schema.json
+++ b/src/material/schematics/ng-generate/theming-api/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsMaterialThemingApi",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsMaterialThemingApi",
   "title": "Material Theming API migration",
   "type": "object",
   "properties": {}

--- a/src/material/schematics/ng-generate/tree/schema.json
+++ b/src/material/schematics/ng-generate/tree/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsMaterialTree",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsMaterialTree",
   "title": "Material Tree Options Schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
In Angular CLI version 12, JSON Schema `draft-04` will no longer be supported. Therefore `id` will need to be updated to `$id`.

- We replace id with $id, this no longer valid in draft-07.
- Replace all $schemas to http://json-schema.org/draft-07/schema, this is needed to "pin" the schema to draft-07.

More information about this draft can be found https://json-schema.org/draft-07/json-schema-release-notes.html

Note: This change is backwards compatible.