### PR TITLE
fix(cdk/testing): prevent duplicate subscription

### DIFF
--- a/src/cdk/testing/change-detection.ts
+++ b/src/cdk/testing/change-detection.ts
@@ -69,7 +69,7 @@ async function batchChangeDetection<T>(fn: () => Promise<T>, triggerBeforeAndAft
 
   // If nothing is handling change detection batching, install the default handler.
   if (!autoChangeDetectionSubscription) {
-    autoChangeDetectionSubject.subscribe(defaultAutoChangeDetectionHandler);
+    handleAutoChangeDetectionStatus(defaultAutoChangeDetectionHandler);
   }
 
   if (triggerBeforeAndAfter) {


### PR DESCRIPTION
If the actual subscription provided by the environment comes after the first batched function call, the default function is installed and without this change it'll stay installed forever, even if another handler is installed afterwards.

I looked for a location to add a test for this, but I don't think it's currently possible to test this. The only harness environment in this repo that supports the change detection status is the TestBed variant, and that environment registers its change detection status handler eagerly.