### PR TITLE
build: add peer dependency to rxjs

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -4,6 +4,7 @@
 ANGULAR_PACKAGE_VERSION = "^12.0.0-0 || ^13.0.0-0"
 MDC_PACKAGE_VERSION = "^11.0.0-canary.15604bd0d.0"
 TSLIB_PACKAGE_VERSION = "^2.1.0"
+RXJS_PACKAGE_VERSION = "^6.5.3"
 
 # Each placer holder is used to stamp versions during the build process, replacing the key with it's
 # value pair. These replacements occur during building of `npm_package` and `ng_package` stamping in
@@ -17,6 +18,8 @@ VERSION_PLACEHOLDER_REPLACEMENTS = {
     "0.0.0-TSLIB": TSLIB_PACKAGE_VERSION,
     # Version of the local package being built, generated via the `--workspace_status_command` flag.
     "0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}",
+    # Version of `rxjs`
+    "0.0.0-RXJS": RXJS_PACKAGE_VERSION,
 }
 
 # List of default Angular library UMD bundles which are not processed by ngcc.

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://github.com/angular/components#readme",
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
-    "@angular/common": "0.0.0-NG"
+    "@angular/common": "0.0.0-NG",
+    "rxjs": "0.0.0-RXJS"
   },
   "dependencies": {
     "tslib": "0.0.0-TSLIB"

--- a/src/google-maps/package.json
+++ b/src/google-maps/package.json
@@ -22,7 +22,8 @@
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
-    "@angular/common": "0.0.0-NG"
+    "@angular/common": "0.0.0-NG",
+    "rxjs": "0.0.0-RXJS"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -22,7 +22,8 @@
     "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",
-    "@angular/forms": "0.0.0-NG"
+    "@angular/forms": "0.0.0-NG",
+    "rxjs": "0.0.0-RXJS"
   },
   "dependencies": {
     "tslib": "0.0.0-TSLIB"

--- a/src/youtube-player/package.json
+++ b/src/youtube-player/package.json
@@ -22,7 +22,8 @@
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",
-    "@angular/common": "0.0.0-NG"
+    "@angular/common": "0.0.0-NG",
+    "rxjs": "0.0.0-RXJS"
   },
   "sideEffects": false,
   "publishConfig":{


### PR DESCRIPTION
Adds a peer dependency to `rxjs` to all packages since not having it can mess with Yarn 2's PnP feature.