### PR TITLE
build: clean up leftover debug log

### DIFF
--- a/src/material-experimental/mdc-core/_elevation.scss
+++ b/src/material-experimental/mdc-core/_elevation.scss
@@ -22,7 +22,6 @@ $color: black !default;
 }
 
 @mixin private-theme-elevation($zValue, $config) {
-  @debug $config;
   $foreground: map.get($config, foreground);
   $elevation-color: map.get($foreground, elevation);
   $elevation-color-or-default: if($elevation-color == null, $color, $elevation-color);


### PR DESCRIPTION
I left an `@debug` by accident and now it's spamming the logs.