### PR TITLE
fix(cdk/testing): incorrectly handling ancestor of compound selector

### DIFF
--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -246,6 +246,22 @@ export function crossEnvironmentSpecs(
       const subcomps = await harness.directAncestorSelectorSubcomponent();
       expect(subcomps.length).toBe(2);
     });
+
+    it('should handle a compound selector with an ancestor', async () => {
+      const elements = await harness.compoundSelectorWithAncestor();
+
+      expect(await parallel(() => elements.map(element => element.getText()))).toEqual([
+        'Div inside parent',
+        'Span inside parent'
+      ]);
+    });
+
+    it('should handle a selector with comma inside attribute with an ancestor', async () => {
+      const element = await harness.quotedContentSelectorWithAncestor();
+
+      expect(element).toBeTruthy();
+      expect(await element.getText()).toBe('Has comma inside attribute');
+    });
   });
 
   describe('HarnessPredicate', () => {

--- a/src/cdk/testing/tests/harnesses/compound-selector-harness.ts
+++ b/src/cdk/testing/tests/harnesses/compound-selector-harness.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '../../component-harness';
+
+export class CompoundSelectorHarness extends ComponentHarness {
+  static readonly hostSelector = '.some-div, .some-span';
+
+  static with(options = {}) {
+    return new HarnessPredicate(CompoundSelectorHarness, options);
+  }
+
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+}

--- a/src/cdk/testing/tests/harnesses/main-component-harness.ts
+++ b/src/cdk/testing/tests/harnesses/main-component-harness.ts
@@ -8,6 +8,8 @@
 
 import {ComponentHarness} from '../../component-harness';
 import {TestElement, TestKey} from '../../test-element';
+import {CompoundSelectorHarness} from './compound-selector-harness';
+import {QuotedCommaSelectorHarness} from './quoted-comma-selector-harness';
 import {SubComponentHarness, SubComponentSpecialHarness} from './sub-component-harness';
 
 export class WrongComponentHarness extends ComponentHarness {
@@ -81,6 +83,10 @@ export class MainComponentHarness extends ComponentHarness {
       this.locatorForAll(SubComponentHarness.with({ancestor: '.other, .subcomponents'}));
   readonly directAncestorSelectorSubcomponent =
       this.locatorForAll(SubComponentHarness.with({ancestor: '.other >'}));
+  readonly compoundSelectorWithAncestor =
+      this.locatorForAll(CompoundSelectorHarness.with({ancestor: '.parent'}));
+  readonly quotedContentSelectorWithAncestor =
+      this.locatorFor(QuotedCommaSelectorHarness.with({ancestor: '.quoted-comma-parent'}));
 
   readonly subcomponentHarnessesAndElements =
       this.locatorForAll('#counter', SubComponentHarness);

--- a/src/cdk/testing/tests/harnesses/quoted-comma-selector-harness.ts
+++ b/src/cdk/testing/tests/harnesses/quoted-comma-selector-harness.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentHarness, HarnessPredicate} from '../../component-harness';
+
+export class QuotedCommaSelectorHarness extends ComponentHarness {
+  static readonly hostSelector = 'div[has-comma="a,b"]';
+
+  static with(options = {}) {
+    return new HarnessPredicate(QuotedCommaSelectorHarness, options);
+  }
+
+  async getText(): Promise<string> {
+    return (await this.host()).text();
+  }
+}

--- a/src/cdk/testing/tests/test-main-component.html
+++ b/src/cdk/testing/tests/test-main-component.html
@@ -57,6 +57,15 @@
   <test-sub title="other 1"></test-sub>
   <test-sub title="other 2"></test-sub>
 </div>
+<div class="parent">
+  <div class="some-div">Div inside parent</div>
+  <div class="some-span">Span inside parent</div>
+</div>
+<div class="some-div">Div outside parent</div>
+<div class="some-span">Span outside parent</div>
+<div class="quoted-comma-parent">
+  <div has-comma="a,b">Has comma inside attribute</div>
+</div>
 <div class="task-state-tests">
   <button (click)="runTaskOutsideZone()" id="task-state-test-trigger">
     Run task outside zone


### PR DESCRIPTION
Currently the component harness handles the `ancestor` option by prepending it to the `hostSelector` of the harness. This breaks down if the `hostSelector` is a compound selector, because we end up with something like `.parent .a, .b`, rather than `.parent .a, .parent .b`.

These changes resolve the issue and add a bit of extra logic to account for the case where the selector might include commas inside quotes which will break us, because we split compound selectors on the comma. The logic is loosely based on my changes from https://github.com/angular/angular/pull/38716.

Fixes #22475.