### PR TITLE
build: some public API docs missing descriptions

### DIFF
--- a/tools/dgeni/common/dgeni-definitions.ts
+++ b/tools/dgeni/common/dgeni-definitions.ts
@@ -40,7 +40,6 @@ export interface CategorizedClassDoc extends ClassExportDoc, CategorizedClassLik
 
 /** Extended Dgeni property-member document that includes extracted Angular metadata. */
 export interface CategorizedPropertyMemberDoc extends PropertyMemberDoc, DeprecationInfo {
-  description: string;
   isDirectiveInput: boolean;
   isDirectiveOutput: boolean;
   directiveInputAlias: string;

--- a/tools/dgeni/templates/method.template.html
+++ b/tools/dgeni/templates/method.template.html
@@ -18,10 +18,10 @@
       </th>
     </tr>
   </thead>
-  {%- if method.description -%}
+  {%- if method.content -%}
   <tr class="docs-api-method-description-row">
     <td colspan="2" class="docs-api-method-description-cell">
-      {$ method.description | marked | safe $}
+      {$ method.content | marked | safe $}
     </td>
   </tr>
   {%- endif -%}
@@ -45,7 +45,7 @@
     </td>
     <td class="docs-api-method-parameter-description-cell">
       <p class="docs-api-method-parameter-description">
-        {$ parameter.description | marked | safe $}
+        {$ parameter.content | marked | safe $}
       </p>
     </td>
   </tr>

--- a/tools/dgeni/templates/property.template.html
+++ b/tools/dgeni/templates/property.template.html
@@ -24,11 +24,11 @@
       <div class="docs-api-deprecated-marker" {$ macros.deprecationTitle(property) $}>
         Deprecated
       </div>
-    {%- endif -%}   
+    {%- endif -%}
 
     <p class="docs-api-property-name">
       <code>{$ property.name $}: {$ property.type $}</code>
     </p>
   </td>
-  <td class="docs-api-property-description">{$ property.description | marked | safe $}</td>
+  <td class="docs-api-property-description">{$ property.content | marked | safe $}</td>
 </tr>


### PR DESCRIPTION
Fixes that some inherited class members didn't have descriptions in the generated docs. The problem seems to be that we were using the `description` field, whereas the text was in the `content` field. I don't have the context behind why we were using `description`, but the field doesn't exist in Dgeni's typings and `content` seems to work in all the cases I tried.