### PR TITLE
feat(google-maps): add visible input to marker

### DIFF
--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -46,6 +46,7 @@ describe('MapMarker', () => {
       label: undefined,
       clickable: undefined,
       icon: undefined,
+      visible: undefined,
       map: mapSpy,
     });
   });
@@ -57,6 +58,7 @@ describe('MapMarker', () => {
       label: 'marker label',
       clickable: false,
       icon: 'icon.png',
+      visible: false,
       map: mapSpy,
     };
     const markerSpy = createMarkerSpy(options);
@@ -68,6 +70,7 @@ describe('MapMarker', () => {
     fixture.componentInstance.label = options.label;
     fixture.componentInstance.clickable = options.clickable;
     fixture.componentInstance.icon = 'icon.png';
+    fixture.componentInstance.visible = false;
     fixture.detectChanges();
 
     expect(markerConstructorSpy).toHaveBeenCalledWith(options);
@@ -80,6 +83,7 @@ describe('MapMarker', () => {
       label: 'marker label',
       clickable: false,
       icon: 'icon name',
+      visible: undefined
     };
     const markerSpy = createMarkerSpy(options);
     const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
@@ -106,6 +110,7 @@ describe('MapMarker', () => {
       clickable: true,
       icon: 'icon name',
       map: mapSpy,
+      visible: undefined
     };
     const markerSpy = createMarkerSpy(options);
     const markerConstructorSpy = createMarkerConstructorSpy(markerSpy).and.callThrough();
@@ -225,6 +230,7 @@ describe('MapMarker', () => {
                            [clickable]="clickable"
                            [options]="options"
                            [icon]="icon"
+                           [visible]="visible"
                            (mapClick)="handleClick()"
                            (positionChanged)="handlePositionChanged()">
                </map-marker>
@@ -238,6 +244,7 @@ class TestApp {
   clickable?: boolean;
   options?: google.maps.MarkerOptions;
   icon?: string;
+  visible?: boolean;
 
   handleClick() {}
 

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -106,6 +106,16 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
   private _icon: string | google.maps.Icon | google.maps.Symbol;
 
   /**
+   * Whether the marker is visible.
+   * See: developers.google.com/maps/documentation/javascript/reference/marker#MarkerOptions.visible
+   */
+  @Input()
+  set visible(value: boolean) {
+    this._visible = value;
+  }
+  private _visible: boolean;
+
+  /**
    * See
    * developers.google.com/maps/documentation/javascript/reference/marker#Marker.animation_changed
    */
@@ -278,7 +288,7 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const {marker, _title, _position, _label, _clickable, _icon} = this;
+    const {marker, _title, _position, _label, _clickable, _icon, _visible} = this;
 
     if (marker) {
       if (changes['options']) {
@@ -303,6 +313,10 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
 
       if (changes['icon'] && _icon) {
         marker.setIcon(_icon);
+      }
+
+      if (changes['visible'] && _visible !== undefined) {
+        marker.setVisible(_visible);
       }
     }
   }
@@ -438,7 +452,8 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
       label: this._label || options.label,
       clickable: this._clickable ?? options.clickable,
       map: this._googleMap.googleMap,
-      icon: this._icon || options.icon
+      icon: this._icon || options.icon,
+      visible: this._visible ?? options.visible
     };
   }
 

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -254,6 +254,7 @@ export declare class MapMarker implements OnInit, OnChanges, OnDestroy, MapAncho
     readonly shapeChanged: Observable<void>;
     set title(title: string);
     readonly titleChanged: Observable<void>;
+    set visible(value: boolean);
     readonly visibleChanged: Observable<void>;
     readonly zindexChanged: Observable<void>;
     constructor(_googleMap: GoogleMap, _ngZone: NgZone);
@@ -273,7 +274,7 @@ export declare class MapMarker implements OnInit, OnChanges, OnDestroy, MapAncho
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MapMarker, "map-marker", ["mapMarker"], { "title": "title"; "position": "position"; "label": "label"; "clickable": "clickable"; "options": "options"; "icon": "icon"; }, { "animationChanged": "animationChanged"; "mapClick": "mapClick"; "clickableChanged": "clickableChanged"; "cursorChanged": "cursorChanged"; "mapDblclick": "mapDblclick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "draggableChanged": "draggableChanged"; "mapDragstart": "mapDragstart"; "flatChanged": "flatChanged"; "iconChanged": "iconChanged"; "mapMousedown": "mapMousedown"; "mapMouseout": "mapMouseout"; "mapMouseover": "mapMouseover"; "mapMouseup": "mapMouseup"; "positionChanged": "positionChanged"; "mapRightclick": "mapRightclick"; "shapeChanged": "shapeChanged"; "titleChanged": "titleChanged"; "visibleChanged": "visibleChanged"; "zindexChanged": "zindexChanged"; }, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MapMarker, "map-marker", ["mapMarker"], { "title": "title"; "position": "position"; "label": "label"; "clickable": "clickable"; "options": "options"; "icon": "icon"; "visible": "visible"; }, { "animationChanged": "animationChanged"; "mapClick": "mapClick"; "clickableChanged": "clickableChanged"; "cursorChanged": "cursorChanged"; "mapDblclick": "mapDblclick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "draggableChanged": "draggableChanged"; "mapDragstart": "mapDragstart"; "flatChanged": "flatChanged"; "iconChanged": "iconChanged"; "mapMousedown": "mapMousedown"; "mapMouseout": "mapMouseout"; "mapMouseover": "mapMouseover"; "mapMouseup": "mapMouseup"; "positionChanged": "positionChanged"; "mapRightclick": "mapRightclick"; "shapeChanged": "shapeChanged"; "titleChanged": "titleChanged"; "visibleChanged": "visibleChanged"; "zindexChanged": "zindexChanged"; }, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MapMarker, never>;
 }
 


### PR DESCRIPTION
Currently the marker visibile can only be controlled through the `options` object. These changes add a dedicated input for convenience.

Fixes #22488.