### PR TITLE
fix(MatSelect): Cannot clear the value of mat-select when [multiple] …

### DIFF
--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -963,6 +963,13 @@ export abstract class _MatSelectBase<C> extends _MatSelectMixinBase implements A
 
     if (this.multiple) {
       valueToEmit = (this.selected as MatOption[]).map(option => option.value);
+      let clearSelection : Array<any> = valueToEmit.filter((value : any) => value == undefined);
+      if (clearSelection.length) {
+        valueToEmit = [];
+        this._selectionModel.clear();
+        this.close();
+        this.focus();
+      }
     } else {
       valueToEmit = this.selected ? (this.selected as MatOption).value : fallbackValue;
     }


### PR DESCRIPTION
…is specified

Fixes a bug in the Angular Material `select` component where options are not cleared when the multiple attribute is specified. This is because the change event doesn't handle the undefined or null value getting in the selected array. Currently, which is handled in propagateChanges method.

Fixes #22453