### PR TITLE
docs(material/snack-bar): clarify dismissal actions in snackbar and u…

### DIFF
--- a/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.ts
@@ -13,8 +13,6 @@ export class SnackBarOverviewExample {
   constructor(private _snackBar: MatSnackBar) {}
 
   openSnackBar(message: string, action: string) {
-    this._snackBar.open(message, action, {
-      duration: 2000,
-    });
+    this._snackBar.open(message, action);
   }
 }

--- a/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.ts
@@ -20,8 +20,7 @@ export class SnackBarPositionExample {
   constructor(private _snackBar: MatSnackBar) {}
 
   openSnackBar() {
-    this._snackBar.open('Cannonball!!', 'End now', {
-      duration: 500,
+    this._snackBar.open('Cannonball!!', 'Splash', {
       horizontalPosition: this.horizontalPosition,
       verticalPosition: this.verticalPosition,
     });

--- a/src/material/snack-bar/snack-bar.md
+++ b/src/material/snack-bar/snack-bar.md
@@ -90,16 +90,14 @@ Snack-bar messages are announced via an `aria-live` region. By default, the `pol
 used. While `polite` is recommended, this can be customized by setting the `politeness` property of
 the `MatSnackBarConfig`.
 
-Focus is not, and should not be, moved to the snack-bar element. Moving the focus would be
-disruptive to a user in the middle of a workflow. It is recommended that, for any action offered
-in the snack-bar, the application offers the user an alternative way to perform the action.
+Focus is not moved to the snack-bar element as that would be disruptive to a user in the middle of a workflow. 
+It is recommended that, for any action offered in the snack-bar, the application offers the user an 
+alternative way to perform the action.
 Alternative interactions are typically keyboard shortcuts or menu options. When the action is
-performed in this way, the snack-bar should be dismissed.
+performed in this way, the snack-bar should be dismissed. A snack-bar can contain a single action. 
+"Dismiss" or "cancel" actions are optional.
 
 Snack-bars that have an action available should not be given a `duration`, as to accommodate
 screen-reader users that want to navigate to the snack-bar element to activate the action. If the
 user has manually moved their focus within the snackbar, focus should be placed somewhere sensible
 based on the application context when the snack-bar is dismissed.
-
-Don't use "Dismiss" as a snack-bar-action, instead preferring to use a `duration` when there is
-no additional action associated with the notification. 


### PR DESCRIPTION
…pdate examples

Some of the snack bar examples had both an action and a duration which is not accessible.

"Dismiss" actions are not actually discouraged in the specs
https://material.io/components/snackbars#usage