### PR TITLE
build: fix wrong import path

### DIFF
--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -1,4 +1,4 @@
-@use '../../cdk/a11y/a11y';
+@use '../../cdk/a11y';
 
 $padding: 0 8px;
 $page-size-margin-right: 8px;


### PR DESCRIPTION
Fixes a path that is wrong, because the PR was opened before we renamed the file.