### PR TITLE
fix: form field placeholders not hidden in contrast mode

### DIFF
--- a/src/material/datepicker/date-range-input.scss
+++ b/src/material/datepicker/date-range-input.scss
@@ -1,5 +1,6 @@
 @use '../core/style/variables';
 @use '../core/style/vendor-prefixes';
+@use '../../cdk/a11y';
 
 $date-range-input-separator-spacing: 4px;
 $date-range-input-part-max-width: calc(50% - #{$date-range-input-separator-spacing});
@@ -80,6 +81,12 @@ $date-range-input-part-max-width: calc(50% - #{$date-range-input-separator-spaci
       color: transparent !important;
       -webkit-text-fill-color: transparent;
       transition: none;
+
+      @include a11y.high-contrast(active, off) {
+        // In high contrast mode the browser will render the
+        // placeholder despite the `color: transparent` above.
+        opacity: 0;
+      }
     }
   }
 }

--- a/src/material/form-field/form-field-input.scss
+++ b/src/material/form-field/form-field-input.scss
@@ -128,6 +128,12 @@
       // Remove the transition to prevent the placeholder
       // from overlapping when the label comes back down.
       transition: none;
+
+      @include a11y.high-contrast(active, off) {
+        // In high contrast mode the browser will render the
+        // placeholder despite the `color: transparent` above.
+        opacity: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes that the placeholders in the date range picker and form field were visible behind the label in high contrast mode.