### PR TITLE
fix(material/core): `mat-ripple-element` is not fired on disable

### DIFF
--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -206,6 +206,15 @@ export class RippleRenderer implements EventListenerObject {
     this._activeRipples.forEach(ripple => ripple.fadeOut());
   }
 
+  /** Fades out all currently active non-persistent ripples. */
+  fadeOutAllNonPersistent() {
+    this._activeRipples.forEach(ripple => {
+      if(!ripple.config.persistent) {
+        ripple.fadeOut();
+      }
+    });
+  }
+
   /** Sets up the trigger event listeners */
   setupTriggerEvents(elementOrElementRef: HTMLElement | ElementRef<HTMLElement>) {
     const element = coerceElement(elementOrElementRef);

--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -209,7 +209,7 @@ export class RippleRenderer implements EventListenerObject {
   /** Fades out all currently active non-persistent ripples. */
   fadeOutAllNonPersistent() {
     this._activeRipples.forEach(ripple => {
-      if(!ripple.config.persistent) {
+      if (!ripple.config.persistent) {
         ripple.fadeOut();
       }
     });

--- a/src/material/core/ripple/ripple.spec.ts
+++ b/src/material/core/ripple/ripple.spec.ts
@@ -646,6 +646,26 @@ describe('MatRipple', () => {
       expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(1);
     });
 
+    it('fades out all ripples when disabled input is set', fakeAsync(() => {
+      controller.ripple.launch(0, 0);
+      controller.ripple.launch(0, 0);
+
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(2);
+
+      tick(enterDuration);
+
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(2);
+
+      spyOn(controller.ripple, 'fadeOutAll');
+      controller.disabled = true;
+      fixture.detectChanges();
+
+      tick(exitDuration);
+
+      expect(controller.ripple.fadeOutAll).toHaveBeenCalled();
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(0);
+    }));
+
     it('allows specifying custom trigger element', () => {
       let alternateTrigger = fixture.debugElement.nativeElement
         .querySelector('.alternateTrigger') as HTMLElement;

--- a/src/material/core/ripple/ripple.spec.ts
+++ b/src/material/core/ripple/ripple.spec.ts
@@ -646,24 +646,22 @@ describe('MatRipple', () => {
       expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(1);
     });
 
-    it('fades out all ripples when disabled input is set', fakeAsync(() => {
-      controller.ripple.launch(0, 0);
-      controller.ripple.launch(0, 0);
-
-      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(2);
+    it('fades out non-persistent ripples when disabled input is set',
+       fakeAsync(() => {
+      dispatchMouseEvent(rippleTarget, 'mousedown');
+      controller.ripple.launch(0, 0, { persistent: true });
 
       tick(enterDuration);
-
       expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(2);
 
-      spyOn(controller.ripple, 'fadeOutAll');
+      spyOn(controller.ripple, 'fadeOutAllNonPersistent').and.callThrough();
       controller.disabled = true;
       fixture.detectChanges();
 
-      tick(exitDuration);
+      expect(controller.ripple.fadeOutAllNonPersistent).toHaveBeenCalled();
 
-      expect(controller.ripple.fadeOutAll).toHaveBeenCalled();
-      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(0);
+      tick(exitDuration);
+      expect(rippleTarget.querySelectorAll('.mat-ripple-element').length).toBe(1);
     }));
 
     it('allows specifying custom trigger element', () => {

--- a/src/material/core/ripple/ripple.ts
+++ b/src/material/core/ripple/ripple.ts
@@ -92,7 +92,7 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
   get disabled() { return this._disabled; }
   set disabled(value: boolean) {
     if (value) {
-      this.fadeOutAll();
+      this.fadeOutAllNonPersistent();
     }
     this._disabled = value;
     this._setupTriggerEventsIfEnabled();
@@ -142,6 +142,11 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
   /** Fades out all currently showing ripple elements. */
   fadeOutAll() {
     this._rippleRenderer.fadeOutAll();
+  }
+
+  /** Fades out all currently showing non-persistent ripple elements. */
+  fadeOutAllNonPersistent() {
+    this._rippleRenderer.fadeOutAllNonPersistent();
   }
 
   /**

--- a/src/material/core/ripple/ripple.ts
+++ b/src/material/core/ripple/ripple.ts
@@ -91,6 +91,9 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
   @Input('matRippleDisabled')
   get disabled() { return this._disabled; }
   set disabled(value: boolean) {
+    if (value) {
+      this.fadeOutAll();
+    }
     this._disabled = value;
     this._setupTriggerEventsIfEnabled();
   }

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -266,6 +266,7 @@ export declare class MatRipple implements OnInit, OnDestroy, RippleTarget {
     unbounded: boolean;
     constructor(_elementRef: ElementRef<HTMLElement>, ngZone: NgZone, platform: Platform, globalOptions?: RippleGlobalOptions, _animationMode?: string | undefined);
     fadeOutAll(): void;
+    fadeOutAllNonPersistent(): void;
     launch(config: RippleConfig): RippleRef;
     launch(x: number, y: number, config?: RippleConfig): RippleRef;
     ngOnDestroy(): void;
@@ -365,6 +366,7 @@ export declare class RippleRenderer implements EventListenerObject {
     _removeTriggerEvents(): void;
     fadeInRipple(x: number, y: number, config?: RippleConfig): RippleRef;
     fadeOutAll(): void;
+    fadeOutAllNonPersistent(): void;
     fadeOutRipple(rippleRef: RippleRef): void;
     handleEvent(event: Event): void;
     setupTriggerEvents(elementOrElementRef: HTMLElement | ElementRef<HTMLElement>): void;


### PR DESCRIPTION
When button becomes disabled after the ripple initiated and before the
ripple animation is completed, it will somestimes not fire the
`mat-ripple-element` correctly. Adding the `fadeOutAll()` method when
set to disable will fix this issue.

Fixes #22520