### PR TITLE
fix(material-experimental/mdc-card): reset native header margin

### DIFF
--- a/src/material-experimental/mdc-card/card.scss
+++ b/src/material-experimental/mdc-card/card.scss
@@ -22,6 +22,10 @@ $mat-card-default-padding: 16px !default;
   // Apply default padding for a text content region. Omit any bottom padding because we assume
   // this region will be followed by another region that includes top padding.
   padding: $mat-card-default-padding $mat-card-default-padding 0;
+
+  // Titles and subtitles can be set on native header elements which come with
+  // their own margin. Clear it since the spacing is done using `padding`.
+  margin: 0;
 }
 
 // Header section at the top of a card. MDC does not have a pre-made header section for cards.


### PR DESCRIPTION
`mat-card` supports using native header elements for the title and subtitle, but doing so throws off the alignment, because we weren't clearing the user agent margin.