### PR TITLE
perf(cdk/a11y): only check for high contrast mode once

### DIFF
--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -40,6 +40,11 @@ export const HIGH_CONTRAST_MODE_ACTIVE_CSS_CLASS = 'cdk-high-contrast-active';
  */
 @Injectable({providedIn: 'root'})
 export class HighContrastModeDetector {
+  /**
+   * Figuring out the high contrast mode and adding the body classes can cause
+   * some expensive layouts. This flag is used to ensure that we only do it once.
+   */
+  private _hasCheckedHighContrastMode: boolean;
   private _document: Document;
 
   constructor(private _platform: Platform, @Inject(DOCUMENT) document: any) {
@@ -80,12 +85,13 @@ export class HighContrastModeDetector {
 
   /** Applies CSS classes indicating high-contrast mode to document body (browser-only). */
   _applyBodyHighContrastModeCssClasses(): void {
-    if (this._platform.isBrowser && this._document.body) {
+    if (!this._hasCheckedHighContrastMode && this._platform.isBrowser && this._document.body) {
       const bodyClasses = this._document.body.classList;
       // IE11 doesn't support `classList` operations with multiple arguments
       bodyClasses.remove(HIGH_CONTRAST_MODE_ACTIVE_CSS_CLASS);
       bodyClasses.remove(BLACK_ON_WHITE_CSS_CLASS);
       bodyClasses.remove(WHITE_ON_BLACK_CSS_CLASS);
+      this._hasCheckedHighContrastMode = true;
 
       const mode = this.getHighContrastMode();
       if (mode === HighContrastMode.BLACK_ON_WHITE) {


### PR DESCRIPTION
I noticed this in the profiler while working on https://github.com/angular/material.angular.io/pull/961. The `_applyBodyHighContrastModeCssClasses` method is called in the constructor of the `A11yModule` and `MatCommonModule` which means that it'll be invoked whenever a new root injector is created for a module importing any Material module (e.g. lazy-loaded route or dynamically-created component). Since it calls into `getHighContrastMode` and it touches the class list of `document.body`, it has the potential of causing some some slow layouts. This can be observed either when switching pages in the dev app or by profiling the example creation on material.angular.io.

These changes resolve the issue by ensuring that we only run the logic once.