### PR TITLE
build: fix yarn install error if `rules_nodejs` linked local packages

### DIFF
--- a/angular-tsconfig.json
+++ b/angular-tsconfig.json
@@ -27,6 +27,16 @@
     "node_modules/@angular/common/upgrade*",
     "node_modules/@angular/compiler-cli/**",
     "node_modules/@angular/dev-infra-private/**",
-    "node_modules/@angular/router/upgrade*"
+    "node_modules/@angular/router/upgrade*",
+    // We also list the packages built as part of this repository. The Bazel NodeJS rules can link
+    // these packages into the `node_modules/` folder and this would break the summary file generation.
+    "node_modules/@angular/cdk/**",
+    "node_modules/@angular/cdk-experimental/**",
+    "node_modules/@angular/components-examples/**",
+    "node_modules/@angular/google-maps/**",
+    "node_modules/@angular/material/**",
+    "node_modules/@angular/material-experimental/**",
+    "node_modules/@angular/material-moment-adapter/**",
+    "node_modules/@angular/youtube-player/**"
   ]
 }


### PR DESCRIPTION
Currently if a package like `@angular/cdk` is used locally within a
Bazel NodeJS action (e.g. when using with `rollup_bundle`), the Bazel
NodeJS rules link the build output into the local `node_modules/` folder.

This is problematic because later if `yarn` is executed, the linked
packages are incorrectly included in the `angular-tsconfig.json` project
(which is used for summary generation to allow for Bazel View Engine tests)

We fix this by explicitly excluding our local packages to avoid errors
such as:

```
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
 (warning Resolution field "typescript@4.2.3" is incompatible with requested version "typescript@^3.2.2"
node_modules/@angular/components-examples/material/chips/chips-harness/chips-harness-example.d.ts:8:13 - error TS2503: Cannot find namespace 'jasmine'.
```