### PR TITLE
fix(material/schematics): migrate more cases in the theming API schematic

### DIFF
--- a/src/material/schematics/ng-generate/theming-api/config.ts
+++ b/src/material/schematics/ng-generate/theming-api/config.ts
@@ -103,8 +103,8 @@ export const cdkMixins: Record<string, string> = {
 export const removedMaterialVariables: Record<string, string> = {
   // Note: there's also a usage of a variable called `$pi`, but the name is short enough that
   // it matches things like `$mat-pink`. Don't migrate it since it's unlikely to be used.
-  'mat-xsmall': `'max-width: 599px'`,
-  'mat-small': `'max-width: 959px'`,
+  'mat-xsmall': 'max-width: 599px',
+  'mat-small': 'max-width: 959px',
   'mat-toggle-padding': '8px',
   'mat-toggle-size': '20px',
   'mat-linear-out-slow-in-timing-function': 'cubic-bezier(0, 0, 0.2, 0.1)',

--- a/src/material/schematics/ng-generate/theming-api/index.ts
+++ b/src/material/schematics/ng-generate/theming-api/index.ts
@@ -14,7 +14,7 @@ import {migrateFileContent} from './migration';
 export default function(_options: Schema): Rule {
   return (tree: Tree) => {
     tree.visit((path, entry) => {
-      if (extname(path) === '.scss') {
+      if (extname(path) === '.scss' && path.indexOf('node_modules') === -1) {
         const content = entry?.content.toString();
         const migratedContent = content ? migrateFileContent(content,
           '~@angular/material/', '~@angular/cdk/', '~@angular/material', '~@angular/cdk') : content;


### PR DESCRIPTION
Includes the following improvements to the `themingApi` schematic:

1. No longer runs against files in the `node_modules`. This was happening by accident.
2. Remove the quotes around the values of `$mat-small` and `$mat-xsmall` since they were causing Sass syntax errors.
3. Migrates Material/CDK symbols, even if there are no imports for the old theming bundle. This allows us to handle symbols that were imported transitively.
4. Reverts the logic from #22438 that doesn't drop imports if there are no Material/CDK symbol usages within the file. I think that we want to do this after all, because the old import could slow down build times and we can be relatively certain that any usages have been migrated.

Fixes #22599.