### PR TITLE
fix(material-experimental/mdc-core): update the required MDC version

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -2,7 +2,7 @@
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
 ANGULAR_PACKAGE_VERSION = "^11.0.0 || ^12.0.0-0"
-MDC_PACKAGE_VERSION = "^9.0.0-canary.419e03572.0"
+MDC_PACKAGE_VERSION = "^11.0.0-canary.3201cae47.0"
 TSLIB_PACKAGE_VERSION = "^2.0.0"
 
 VERSION_PLACEHOLDER_REPLACEMENTS = {


### PR DESCRIPTION
- `11.0.0-canary.3201cae47.0` is required due to the use of
  the `mdc-list-deprecated-item-disabled-text-color` mixin

Fixes #22409. Related to #21968.