### PR TITLE
fix(material/slider): incorrectly attributing touches for multiple touch events

### DIFF
--- a/src/cdk/testing/testbed/fake-events/event-objects.ts
+++ b/src/cdk/testing/testbed/fake-events/event-objects.ts
@@ -8,6 +8,9 @@
 
 import {ModifierKeys} from '@angular/cdk/testing';
 
+/** Used to generate unique IDs for events. */
+let uniqueIds = 0;
+
 /**
  * Creates a browser MouseEvent with the specified options.
  * @docs-private
@@ -83,7 +86,7 @@ export function createTouchEvent(type: string, pageX = 0, pageY = 0, clientX = 0
   // In favor of creating events that work for most of the browsers, the event is created
   // as a basic UI Event. The necessary details for the event will be set manually.
   const event = document.createEvent('UIEvent');
-  const touchDetails = {pageX, pageY, clientX, clientY};
+  const touchDetails = {pageX, pageY, clientX, clientY, id: uniqueIds++};
 
   // TS3.6 removes the initUIEvent method and suggests porting to "new UIEvent()".
   (event as any).initUIEvent(type, true, true, window, 0);


### PR DESCRIPTION
`mat-slider` is set up so that it binds global `touchmove` and `touchend` events after dragging starts so that the user can drag while not keeping their finger right on top of the slider. The problem is that currently we only use the first touch from the list of touches which means that if the user is dragging more than one slider on a multi-touch device, they'll all have the same value.

These changes add some logic that attributes the events to the slider that started the dragging sequence.

**Note:** I haven't included unit tests for this, because we don't seem to have any tests for touch events on the slider (not sure if there are historical reasons for this). I've been testing the fix against a real touch device.

Fixes #22614.