### PR TITLE
fix(material-experimental/mdc-progress-spinner): set to display block

### DIFF
--- a/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
+++ b/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
@@ -5,6 +5,9 @@
 @include mdc-circular-progress.core-styles($query: mdc-helpers.$mat-base-styles-query);
 
 .mat-mdc-progress-spinner {
+  // Explicitly set to `block` since the browser defaults custom elements to `inline`.
+  display: block;
+
   // Prevents the spinning of the inner element from affecting layout outside of the spinner.
   overflow: hidden;
 


### PR DESCRIPTION
This matches legacy styles and helps users migrate without adding this explicit style (especially when trying to use auto margin on the spinner).

Caretaker: This has been presubmitted with screenshot fixes in cl/371687399