### PR TITLE
build: fix size-test integration tooling

### DIFF
--- a/integration/size-test/BUILD.bazel
+++ b/integration/size-test/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
     name = "check-size",
     srcs = ["check-size.ts"],
     deps = [
+        "@npm//@bazel/runfiles",
         "@npm//@types/node",
         "@npm//@types/yaml",
         "@npm//chalk",

--- a/integration/size-test/check-size.ts
+++ b/integration/size-test/check-size.ts
@@ -7,6 +7,7 @@
 import * as chalk from 'chalk';
 import {readFileSync, statSync, writeFileSync} from 'fs';
 import {parse, stringify} from 'yaml';
+import {runfiles} from '@bazel/runfiles';
 
 /**
  * Absolute byte deviation from the expected value that is allowed. If the
@@ -30,8 +31,8 @@ type Golden = {[testId: string]: number};
  *                 with the actual measured size.
  */
 const [testId, testFileRootpath, isApprove] = process.argv.slice(2);
-const testFilePath = require.resolve(`angular_material/${testFileRootpath}`);
-const goldenFilePath = require.resolve('../../goldens/size-test.yaml');
+const testFilePath = runfiles.resolveWorkspaceRelative(testFileRootpath);
+const goldenFilePath = runfiles.resolveWorkspaceRelative('goldens/size-test.yaml');
 
 const golden: Golden = parse(readFileSync(goldenFilePath, 'utf8')) || {};
 const fileStat = statSync(testFilePath);

--- a/integration/size-test/index.bzl
+++ b/integration/size-test/index.bzl
@@ -52,6 +52,8 @@ def size_test(name, file, deps):
             "@npm//rollup-plugin-node-resolve",
             "@npm//@angular-devkit/build-optimizer",
         ],
+        # Link the workspace root so that files can be loaded from the workspace.
+        link_workspace_root = True,
         sourcemap = "false",
     )
 

--- a/integration/size-test/rollup.config.js
+++ b/integration/size-test/rollup.config.js
@@ -1,7 +1,6 @@
-const {buildOptimizer} = require('@angular-devkit/build-optimizer');
+const {buildOptimizer} = require('@angular-devkit/build-optimizer/src/build-optimizer/build-optimizer');
 const node = require('rollup-plugin-node-resolve');
-const path = require('path');
-const {ivyEnabled} = require(getIvyEnabledHelperPath());
+const {ivyEnabled} = require('angular_material/tools/angular_ivy_enabled');
 
 console.info(`Processing rollup bundle in ${ivyEnabled ? 'Ivy' : 'View Engine'} mode.`);
 
@@ -37,14 +36,3 @@ module.exports = {
     }),
   ],
 };
-
-function getIvyEnabledHelperPath() {
-  const parts = path.normalize(__dirname).split(path.sep);
-  const binIndex = parts.indexOf('bin');
-
-  if (binIndex === -1) {
-    throw Error('Cannot resolve Ivy helper path.');
-  }
-
-  return path.join(parts.slice(0, binIndex).join(path.sep), 'bin/tools/angular_ivy_enabled');
-}


### PR DESCRIPTION
Even though the size integration tests do not run
in a blocking way on CI, we should ensure they
can be run and do not fail. The tests are still
useful for local debugging and comparisons.

This commit fixes that NodeJS throws about `webpack`
not being found. The build optimizer imports from webpack
if we go through the public entry-point. Also simplifies the
logic for finding the `angular_ivy_enabled.js` file.

```
Error: Cannot find module 'webpack'
Require stack:
- /b/f/w/node_modules/@angular-devkit/build-optimizer/src/build-optimizer/webpack-loader.js
- /b/f/w/node_modules/@angular-devkit/build-optimizer/src/index.js
- /b/f/w/bazel-out/k8-fastbuild/bin/integration/size-test/cdk/drag-drop/_all-directives_bundle.rollup_config.js
- /b/f/w/node_modules/rollup/dist/shared/loadConfigFile.js
- /b/f/w/node_modules/rollup/dist/bin/rollup
```