### PR TITLE
fix(cdk/a11y): not restoring focus to elements inside the shadow DOM

### DIFF
--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -454,7 +454,11 @@ export class CdkTrapFocus implements OnDestroy, AfterContentInit, OnChanges, DoC
   }
 
   private _captureFocus() {
-    this._previouslyFocusedElement = this._document.activeElement as HTMLElement;
+    // If the `activeElement` is inside a shadow root, `document.activeElement` will
+    // point to the shadow root so we have to descend into it ourselves.
+    const activeElement = this._document?.activeElement as HTMLElement|null;
+    this._previouslyFocusedElement =
+      activeElement?.shadowRoot?.activeElement as HTMLElement || activeElement;
     this.focusTrap.focusInitialElementWhenReady();
   }
 


### PR DESCRIPTION
The focus trap directive has the ability to restore focus to the previously-focused element on destroy automatically, however the logic doesn't account for the fact that `document.activeElement` will point to the shadow root if the element is inside the shadow DOM.