### PR TITLE
refactor(material/core): reduce mixin function boilerplate

### DIFF
--- a/src/material-experimental/mdc-button/button-base.ts
+++ b/src/material-experimental/mdc-button/button-base.ts
@@ -11,11 +11,8 @@ import {Platform} from '@angular/cdk/platform';
 import {Directive, ElementRef, HostListener, NgZone, ViewChild} from '@angular/core';
 import {
   CanColor,
-  CanColorCtor,
   CanDisable,
-  CanDisableCtor,
   CanDisableRipple,
-  CanDisableRippleCtor,
   MatRipple,
   mixinColor,
   mixinDisabled,
@@ -81,17 +78,14 @@ const HOST_SELECTOR_MDC_CLASS_PAIR: {selector: string, mdcClasses: string[]}[] =
 
 // Boilerplate for applying mixins to MatButton.
 /** @docs-private */
-export class MatButtonMixinCore {
+export const _MatButtonMixin = mixinColor(mixinDisabled(mixinDisableRipple(class {
   constructor(public _elementRef: ElementRef) {}
-}
-
-export const _MatButtonBaseMixin: CanDisableRippleCtor&CanDisableCtor&CanColorCtor&
-    typeof MatButtonMixinCore = mixinColor(mixinDisabled(mixinDisableRipple(MatButtonMixinCore)));
+})));
 
 /** Base class for all buttons.  */
 @Directive()
-export class MatButtonBase extends _MatButtonBaseMixin implements CanDisable, CanColor,
-                                                                  CanDisableRipple {
+export class MatButtonBase extends _MatButtonMixin implements CanDisable, CanColor,
+                                                              CanDisableRipple {
   /** The ripple animation configuration to use for the buttons. */
   _rippleAnimation: RippleAnimationConfig =
       this._animationMode === 'NoopAnimations' ?

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -32,8 +32,6 @@ import {
 import {
   ThemePalette,
   RippleAnimationConfig,
-  CanColorCtor,
-  CanDisableCtor,
   mixinColor,
   mixinDisabled,
   CanColor,
@@ -65,14 +63,9 @@ export class MatCheckboxChange {
 
 // Boilerplate for applying mixins to MatCheckbox.
 /** @docs-private */
-class MatCheckboxBase {
+const _MatCheckboxBase = mixinColor(mixinDisabled(class {
   constructor(public _elementRef: ElementRef) {}
-}
-const _MatCheckboxMixinBase:
-    CanColorCtor &
-    CanDisableCtor &
-    typeof MatCheckboxBase =
-        mixinColor(mixinDisabled(MatCheckboxBase));
+}));
 
 
 /** Configuration for the ripple animation. */
@@ -98,7 +91,7 @@ const RIPPLE_ANIMATION_CONFIG: RippleAnimationConfig = {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatCheckbox extends _MatCheckboxMixinBase implements AfterViewInit, OnDestroy,
+export class MatCheckbox extends _MatCheckboxBase implements AfterViewInit, OnDestroy,
   ControlValueAccessor, CanColor, CanDisable {
   /**
    * The `aria-label` attribute to use for the input element. In most cases, `aria-labelledby` will

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -31,12 +31,9 @@ import {
 } from '@angular/core';
 import {
   CanColor,
-  CanColorCtor,
   CanDisable,
   CanDisableRipple,
-  CanDisableRippleCtor,
   HasTabIndex,
-  HasTabIndexCtor,
   MatRipple,
   MAT_RIPPLE_GLOBAL_OPTIONS,
   mixinColor,
@@ -93,12 +90,7 @@ abstract class MatChipBase {
   constructor(public _elementRef: ElementRef) {}
 }
 
-const _MatChipMixinBase:
-  CanColorCtor &
-  CanDisableRippleCtor &
-  HasTabIndexCtor &
-  typeof MatChipBase =
-    mixinTabIndex(mixinColor(mixinDisableRipple(MatChipBase), 'primary'), -1);
+const _MatChipMixinBase = mixinTabIndex(mixinColor(mixinDisableRipple(MatChipBase), 'primary'), -1);
 
 /**
  * Material design styled Chip base component. Used inside the MatChipSet component.

--- a/src/material-experimental/mdc-progress-bar/progress-bar.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.ts
@@ -20,7 +20,7 @@ import {
   AfterViewInit,
   OnDestroy,
 } from '@angular/core';
-import {CanColor, CanColorCtor, mixinColor} from '@angular/material-experimental/mdc-core';
+import {CanColor, mixinColor} from '@angular/material-experimental/mdc-core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {ProgressAnimationEnd} from '@angular/material/progress-bar';
 import {
@@ -34,12 +34,9 @@ import {Directionality} from '@angular/cdk/bidi';
 
 // Boilerplate for applying mixins to MatProgressBar.
 /** @docs-private */
-class MatProgressBarBase {
-  constructor(public _elementRef: ElementRef) { }
-}
-
-const _MatProgressBarMixinBase: CanColorCtor & typeof MatProgressBarBase =
-    mixinColor(MatProgressBarBase, 'primary');
+const _MatProgressBarBase = mixinColor(class {
+  constructor(public _elementRef: ElementRef) {}
+}, 'primary');
 
 export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer' | 'query';
 
@@ -64,7 +61,7 @@ export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer' | 'quer
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatProgressBar extends _MatProgressBarMixinBase implements AfterViewInit, OnDestroy,
+export class MatProgressBar extends _MatProgressBarBase implements AfterViewInit, OnDestroy,
   CanColor {
 
   constructor(public _elementRef: ElementRef<HTMLElement>,

--- a/src/material-experimental/mdc-progress-spinner/progress-spinner.ts
+++ b/src/material-experimental/mdc-progress-spinner/progress-spinner.ts
@@ -22,7 +22,7 @@ import {
   MDCCircularProgressAdapter,
   MDCCircularProgressFoundation
 } from '@material/circular-progress';
-import {CanColor, CanColorCtor, mixinColor} from '@angular/material-experimental/mdc-core';
+import {CanColor, mixinColor} from '@angular/material-experimental/mdc-core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {
   MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS,
@@ -31,13 +31,10 @@ import {
 import {coerceNumberProperty, NumberInput} from '@angular/cdk/coercion';
 
 // Boilerplate for applying mixins to MatProgressBar.
-class MatProgressSpinnerBase {
+const _MatProgressSpinnerBase = mixinColor(class {
   constructor(public _elementRef: ElementRef) {
   }
-}
-
-const _MatProgressSpinnerMixinBase: CanColorCtor & typeof MatProgressSpinnerBase =
-  mixinColor(MatProgressSpinnerBase, 'primary');
+}, 'primary');
 
 /** Possible mode for a progress spinner. */
 export type ProgressSpinnerMode = 'determinate' | 'indeterminate';
@@ -75,7 +72,7 @@ const BASE_STROKE_WIDTH = 10;
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements AfterViewInit,
+export class MatProgressSpinner extends _MatProgressSpinnerBase implements AfterViewInit,
   OnDestroy, CanColor {
 
   /** Whether the _mat-animation-noopable class should be applied, disabling animations.  */

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -30,7 +30,6 @@ import {
 } from '@angular/core';
 import {
   CanDisableRipple,
-  CanDisableRippleCtor,
   MAT_OPTGROUP,
   MAT_OPTION_PARENT_COMPONENT,
   _MatOptgroupBase,
@@ -68,9 +67,7 @@ export interface MatAutocompleteActivatedEvent {
 
 // Boilerplate for applying mixins to MatAutocomplete.
 /** @docs-private */
-class MatAutocompleteBase {}
-const _MatAutocompleteMixinBase: CanDisableRippleCtor & typeof MatAutocompleteBase =
-    mixinDisableRipple(MatAutocompleteBase);
+const _MatAutocompleteMixinBase = mixinDisableRipple(class {});
 
 /** Default `mat-autocomplete` options that can be overridden. */
 export interface MatAutocompleteDefaultOptions {

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -20,7 +20,7 @@ import {
   Renderer2,
   SimpleChanges,
 } from '@angular/core';
-import {CanDisable, CanDisableCtor, mixinDisabled, ThemePalette} from '@angular/material/core';
+import {CanDisable, mixinDisabled, ThemePalette} from '@angular/material/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 
@@ -28,10 +28,7 @@ let nextId = 0;
 
 // Boilerplate for applying mixins to MatBadge.
 /** @docs-private */
-class MatBadgeBase {}
-
-const _MatBadgeMixinBase:
-    CanDisableCtor & typeof MatBadgeBase = mixinDisabled(MatBadgeBase);
+const _MatBadgeBase = mixinDisabled(class {});
 
 /** Allowed position options for matBadgePosition */
 export type MatBadgePosition =
@@ -59,7 +56,7 @@ export type MatBadgeSize = 'small' | 'medium' | 'large';
     '[class.mat-badge-disabled]': 'disabled',
   },
 })
-export class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges, CanDisable {
+export class MatBadge extends _MatBadgeBase implements OnDestroy, OnChanges, CanDisable {
   /** Whether the badge has any content. */
   _hasContent = false;
 

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -36,7 +36,6 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
   CanDisableRipple,
   mixinDisableRipple,
-  CanDisableRippleCtor,
 } from '@angular/material/core';
 
 
@@ -381,9 +380,7 @@ export class MatButtonToggleGroup implements ControlValueAccessor, OnInit, After
 
 // Boilerplate for applying mixins to the MatButtonToggle class.
 /** @docs-private */
-class MatButtonToggleBase {}
-const _MatButtonToggleMixinBase: CanDisableRippleCtor & typeof MatButtonToggleBase =
-    mixinDisableRipple(MatButtonToggleBase);
+const _MatButtonToggleBase = mixinDisableRipple(class {});
 
 /** Single button inside of a toggle group. */
 @Component({
@@ -408,7 +405,7 @@ const _MatButtonToggleMixinBase: CanDisableRippleCtor & typeof MatButtonToggleBa
     'role': 'presentation',
   }
 })
-export class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit, AfterViewInit,
+export class MatButtonToggle extends _MatButtonToggleBase implements OnInit, AfterViewInit,
   CanDisableRipple, OnDestroy {
 
   private _isSingleSelector = false;

--- a/src/material/button/button.ts
+++ b/src/material/button/button.ts
@@ -24,9 +24,6 @@ import {
   CanColor,
   CanDisable,
   CanDisableRipple,
-  CanColorCtor,
-  CanDisableCtor,
-  CanDisableRippleCtor,
   MatRipple,
   mixinColor,
   mixinDisabled,
@@ -52,13 +49,9 @@ const BUTTON_HOST_ATTRIBUTES = [
 ];
 
 // Boilerplate for applying mixins to MatButton.
-/** @docs-private */
-class MatButtonBase {
+const _MatButtonBase = mixinColor(mixinDisabled(mixinDisableRipple(class {
   constructor(public _elementRef: ElementRef) {}
-}
-
-const _MatButtonMixinBase: CanDisableRippleCtor & CanDisableCtor & CanColorCtor &
-    typeof MatButtonBase = mixinColor(mixinDisabled(mixinDisableRipple(MatButtonBase)));
+})));
 
 /**
  * Material design button.
@@ -83,7 +76,7 @@ const _MatButtonMixinBase: CanDisableRippleCtor & CanDisableCtor & CanColorCtor 
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatButton extends _MatButtonMixinBase
+export class MatButton extends _MatButtonBase
     implements AfterViewInit, OnDestroy, CanDisable, CanColor, CanDisableRipple, FocusableOption {
 
   /** Whether the button is round. */

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -30,13 +30,9 @@ import {
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
   CanColor,
-  CanColorCtor,
   CanDisable,
-  CanDisableCtor,
   CanDisableRipple,
-  CanDisableRippleCtor,
   HasTabIndex,
-  HasTabIndexCtor,
   MatRipple,
   mixinColor,
   mixinDisabled,
@@ -93,16 +89,9 @@ export class MatCheckboxChange {
 
 // Boilerplate for applying mixins to MatCheckbox.
 /** @docs-private */
-class MatCheckboxBase {
+const _MatCheckboxBase = mixinTabIndex(mixinColor(mixinDisableRipple(mixinDisabled(class {
   constructor(public _elementRef: ElementRef) {}
-}
-const _MatCheckboxMixinBase:
-    HasTabIndexCtor &
-    CanColorCtor &
-    CanDisableRippleCtor &
-    CanDisableCtor &
-    typeof MatCheckboxBase =
-        mixinTabIndex(mixinColor(mixinDisableRipple(mixinDisabled(MatCheckboxBase))));
+}))));
 
 
 /**
@@ -133,7 +122,7 @@ const _MatCheckboxMixinBase:
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAccessor,
+export class MatCheckbox extends _MatCheckboxBase implements ControlValueAccessor,
     AfterViewInit, AfterViewChecked, OnDestroy, CanColor, CanDisable, HasTabIndex, CanDisableRipple,
     FocusableOption {
 

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -31,7 +31,6 @@ import {
 import {ControlValueAccessor, FormGroupDirective, NgControl, NgForm} from '@angular/forms';
 import {
   CanUpdateErrorState,
-  CanUpdateErrorStateCtor,
   ErrorStateMatcher,
   mixinErrorState,
 } from '@angular/material/core';
@@ -43,15 +42,13 @@ import {MatChipTextControl} from './chip-text-control';
 
 // Boilerplate for applying mixins to MatChipList.
 /** @docs-private */
-class MatChipListBase {
+const _MatChipListBase = mixinErrorState(class {
   constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
               /** @docs-private */
               public ngControl: NgControl) {}
-}
-const _MatChipListMixinBase: CanUpdateErrorStateCtor & typeof MatChipListBase =
-    mixinErrorState(MatChipListBase);
+});
 
 
 // Increasing integer for generating unique ids for chip-list components.
@@ -96,7 +93,7 @@ export class MatChipListChange {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MatChipList extends _MatChipListMixinBase implements MatFormFieldControl<any>,
+export class MatChipList extends _MatChipListBase implements MatFormFieldControl<any>,
   ControlValueAccessor, AfterContentInit, DoCheck, OnInit, OnDestroy, CanUpdateErrorState {
   /**
    * Implemented as part of MatFormFieldControl.

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -28,12 +28,9 @@ import {
 } from '@angular/core';
 import {
   CanColor,
-  CanColorCtor,
   CanDisable,
   CanDisableRipple,
-  CanDisableRippleCtor,
   HasTabIndex,
-  HasTabIndexCtor,
   MAT_RIPPLE_GLOBAL_OPTIONS,
   mixinColor,
   mixinDisableRipple,
@@ -94,9 +91,7 @@ abstract class MatChipBase {
   constructor(public _elementRef: ElementRef) {}
 }
 
-const _MatChipMixinBase: CanColorCtor & CanDisableRippleCtor &
-    HasTabIndexCtor & typeof MatChipBase =
-      mixinTabIndex(mixinColor(mixinDisableRipple(MatChipBase), 'primary'), -1);
+const _MatChipMixinBase = mixinTabIndex(mixinColor(mixinDisableRipple(MatChipBase), 'primary'), -1);
 
 /**
  * Dummy directive to add CSS class to chip avatar.

--- a/src/material/core/common-behaviors/color.ts
+++ b/src/material/core/common-behaviors/color.ts
@@ -18,7 +18,11 @@ export interface CanColor {
   defaultColor: ThemePalette | undefined;
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer necessary to apply to mixin classes. To be made private.
+ * @breaking-change 13.0.0
+ */
 export type CanColorCtor = Constructor<CanColor> & AbstractConstructor<CanColor>;
 
 /** @docs-private */

--- a/src/material/core/common-behaviors/disable-ripple.ts
+++ b/src/material/core/common-behaviors/disable-ripple.ts
@@ -15,7 +15,11 @@ export interface CanDisableRipple {
   disableRipple: boolean;
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer necessary to apply to mixin classes. To be made private.
+ * @breaking-change 13.0.0
+ */
 export type CanDisableRippleCtor = Constructor<CanDisableRipple> &
                                    AbstractConstructor<CanDisableRipple>;
 

--- a/src/material/core/common-behaviors/disabled.ts
+++ b/src/material/core/common-behaviors/disabled.ts
@@ -15,7 +15,11 @@ export interface CanDisable {
   disabled: boolean;
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer necessary to apply to mixin classes. To be made private.
+ * @breaking-change 13.0.0
+ */
 export type CanDisableCtor = Constructor<CanDisable> & AbstractConstructor<CanDisable>;
 
 /** Mixin to augment a directive with a `disabled` property. */

--- a/src/material/core/common-behaviors/error-state.ts
+++ b/src/material/core/common-behaviors/error-state.ts
@@ -20,7 +20,11 @@ export interface CanUpdateErrorState {
   errorStateMatcher: ErrorStateMatcher;
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer necessary to apply to mixin classes. To be made private.
+ * @breaking-change 13.0.0
+ */
 export type CanUpdateErrorStateCtor = Constructor<CanUpdateErrorState> &
                                       AbstractConstructor<CanUpdateErrorState>;
 

--- a/src/material/core/common-behaviors/initialized.ts
+++ b/src/material/core/common-behaviors/initialized.ts
@@ -29,7 +29,11 @@ export interface HasInitialized {
   _markInitialized: () => void;
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer necessary to apply to mixin classes. To be made private.
+ * @breaking-change 13.0.0
+ */
 export type HasInitializedCtor = Constructor<HasInitialized>;
 
 /** Mixin to augment a directive with an initialized property that will emits when ngOnInit ends. */

--- a/src/material/core/common-behaviors/tabindex.ts
+++ b/src/material/core/common-behaviors/tabindex.ts
@@ -20,7 +20,11 @@ export interface HasTabIndex {
   defaultTabIndex: number;
 }
 
-/** @docs-private */
+/**
+ * @docs-private
+ * @deprecated No longer necessary to apply to mixin classes. To be made private.
+ * @breaking-change 13.0.0
+ */
 export type HasTabIndexCtor = Constructor<HasTabIndex> & AbstractConstructor<HasTabIndex>;
 
 /** Mixin to augment a directive with a `tabIndex` property. */

--- a/src/material/core/option/optgroup.ts
+++ b/src/material/core/option/optgroup.ts
@@ -15,7 +15,7 @@ import {
   ViewEncapsulation,
   Directive, Inject, Optional
 } from '@angular/core';
-import {CanDisable, CanDisableCtor, mixinDisabled} from '../common-behaviors/disabled';
+import {CanDisable, mixinDisabled} from '../common-behaviors/disabled';
 import {MatOptionParentComponent, MAT_OPTION_PARENT_COMPONENT} from './option-parent';
 
 // Notes on the accessibility pattern used for `mat-optgroup`.
@@ -40,9 +40,7 @@ import {MatOptionParentComponent, MAT_OPTION_PARENT_COMPONENT} from './option-pa
 
 // Boilerplate for applying mixins to MatOptgroup.
 /** @docs-private */
-class MatOptgroupBase { }
-const _MatOptgroupMixinBase: CanDisableCtor & typeof MatOptgroupBase =
-    mixinDisabled(MatOptgroupBase);
+const _MatOptgroupMixinBase = mixinDisabled(class {});
 
 // Counter for unique group ids.
 let _uniqueOptgroupIdCounter = 0;

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -30,7 +30,6 @@ import {
 } from '@angular/forms';
 import {
   CanUpdateErrorState,
-  CanUpdateErrorStateCtor,
   mixinErrorState,
   MAT_DATE_FORMATS,
   DateAdapter,
@@ -176,10 +175,7 @@ abstract class MatDateRangeInputPartBase<D>
   }
 }
 
-const _MatDateRangeInputBase:
-    CanUpdateErrorStateCtor & typeof MatDateRangeInputPartBase =
-    // Needs to be `as any`, because the base class is abstract.
-    mixinErrorState(MatDateRangeInputPartBase as any);
+const _MatDateRangeInputBase = mixinErrorState(MatDateRangeInputPartBase);
 
 /** Input for entering the start date in a `mat-date-range-input`. */
 @Directive({

--- a/src/material/datepicker/datepicker-base.ts
+++ b/src/material/datepicker/datepicker-base.ts
@@ -43,7 +43,6 @@ import {
 } from '@angular/core';
 import {
   CanColor,
-  CanColorCtor,
   DateAdapter,
   mixinColor,
   ThemePalette,
@@ -93,11 +92,9 @@ export const MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER = {
 
 // Boilerplate for applying mixins to MatDatepickerContent.
 /** @docs-private */
-class MatDatepickerContentBase {
-  constructor(public _elementRef: ElementRef) { }
-}
-const _MatDatepickerContentMixinBase: CanColorCtor & typeof MatDatepickerContentBase =
-    mixinColor(MatDatepickerContentBase);
+const _MatDatepickerContentBase = mixinColor(class {
+  constructor(public _elementRef: ElementRef) {}
+});
 
 /**
  * Component used as the content for the datepicker overlay. We use this instead of using
@@ -126,7 +123,7 @@ const _MatDatepickerContentMixinBase: CanColorCtor & typeof MatDatepickerContent
   inputs: ['color'],
 })
 export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>>
-  extends _MatDatepickerContentMixinBase implements OnInit, AfterViewInit, OnDestroy, CanColor {
+  extends _MatDatepickerContentBase implements OnInit, AfterViewInit, OnDestroy, CanColor {
   private _subscriptions = new Subscription();
   private _model: MatDateSelectionModel<S, D>;
 

--- a/src/material/expansion/expansion-panel-header.ts
+++ b/src/material/expansion/expansion-panel-header.ts
@@ -24,7 +24,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {HasTabIndex, HasTabIndexCtor, mixinTabIndex} from '@angular/material/core';
+import {HasTabIndex, mixinTabIndex} from '@angular/material/core';
 import {NumberInput} from '@angular/cdk/coercion';
 import {EMPTY, merge, Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
@@ -42,9 +42,7 @@ import {
 abstract class MatExpansionPanelHeaderBase {
   abstract readonly disabled: boolean;
 }
-const _MatExpansionPanelHeaderMixinBase:
-    HasTabIndexCtor &
-    typeof MatExpansionPanelHeaderBase = mixinTabIndex(MatExpansionPanelHeaderBase);
+const _MatExpansionPanelHeaderMixinBase = mixinTabIndex(MatExpansionPanelHeaderBase);
 
 /**
  * Header element of a `<mat-expansion-panel>`.

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -29,7 +29,7 @@ import {
   OnDestroy,
 } from '@angular/core';
 import {
-  CanColor, CanColorCtor,
+  CanColor,
   mixinColor,
 } from '@angular/material/core';
 import {fromEvent, merge, Subject} from 'rxjs';
@@ -61,16 +61,9 @@ const outlineGapPadding = 5;
  * Boilerplate for applying mixins to MatFormField.
  * @docs-private
  */
-class MatFormFieldBase {
-  constructor(public _elementRef: ElementRef) { }
-}
-
-/**
- * Base class to which we're applying the form field mixins.
- * @docs-private
- */
-const _MatFormFieldMixinBase: CanColorCtor & typeof MatFormFieldBase =
-    mixinColor(MatFormFieldBase, 'primary');
+const _MatFormFieldnBase = mixinColor(class {
+  constructor(public _elementRef: ElementRef) {}
+}, 'primary');
 
 /** Possible appearance styles for the form field. */
 export type MatFormFieldAppearance = 'legacy' | 'standard' | 'fill' | 'outline';
@@ -154,7 +147,7 @@ export const MAT_FORM_FIELD = new InjectionToken<MatFormField>('MatFormField');
   ]
 })
 
-export class MatFormField extends _MatFormFieldMixinBase
+export class MatFormField extends _MatFormFieldnBase
     implements AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy, CanColor {
 
   /**

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -23,7 +23,7 @@ import {
   OnInit,
   ViewEncapsulation,
 } from '@angular/core';
-import {CanColor, CanColorCtor, mixinColor} from '@angular/material/core';
+import {CanColor, mixinColor} from '@angular/material/core';
 import {Subscription} from 'rxjs';
 import {take} from 'rxjs/operators';
 
@@ -32,10 +32,9 @@ import {MatIconRegistry} from './icon-registry';
 
 // Boilerplate for applying mixins to MatIcon.
 /** @docs-private */
-class MatIconBase {
+const _MatIconBase = mixinColor(class {
   constructor(public _elementRef: ElementRef) {}
-}
-const _MatIconMixinBase: CanColorCtor & typeof MatIconBase = mixinColor(MatIconBase);
+});
 
 /**
  * Injection token used to provide the current location to `MatIcon`.
@@ -135,9 +134,7 @@ const funcIriPattern = /^url\(['"]?#(.*?)['"]?\)$/;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatIcon extends _MatIconMixinBase implements OnInit, AfterViewChecked, CanColor,
-  OnDestroy {
-
+export class MatIcon extends _MatIconBase implements OnInit, AfterViewChecked, CanColor, OnDestroy {
   /**
    * Whether the icon should be inlined, automatically sizing the icon to match the font size of
    * the element the icon is contained in.

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -26,7 +26,6 @@ import {
 import {FormGroupDirective, NgControl, NgForm} from '@angular/forms';
 import {
   CanUpdateErrorState,
-  CanUpdateErrorStateCtor,
   ErrorStateMatcher,
   mixinErrorState,
 } from '@angular/material/core';
@@ -53,15 +52,13 @@ let nextUniqueId = 0;
 
 // Boilerplate for applying mixins to MatInput.
 /** @docs-private */
-class MatInputBase {
+const _MatInputBase = mixinErrorState(class {
   constructor(public _defaultErrorStateMatcher: ErrorStateMatcher,
               public _parentForm: NgForm,
               public _parentFormGroup: FormGroupDirective,
               /** @docs-private */
               public ngControl: NgControl) {}
-}
-const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase =
-    mixinErrorState(MatInputBase);
+});
 
 /** Directive that allows a native input to work inside a `MatFormField`. */
 @Directive({
@@ -91,7 +88,7 @@ const _MatInputMixinBase: CanUpdateErrorStateCtor & typeof MatInputBase =
   },
   providers: [{provide: MatFormFieldControl, useExisting: MatInput}],
 })
-export class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges,
+export class MatInput extends _MatInputBase implements MatFormFieldControl<any>, OnChanges,
     OnDestroy, AfterViewInit, DoCheck, CanUpdateErrorState {
   protected _uid = `mat-input-${nextUniqueId++}`;
   protected _previousNativeValue: any;

--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -27,9 +27,7 @@ import {
 } from '@angular/core';
 import {
   CanDisable,
-  CanDisableCtor,
   CanDisableRipple,
-  CanDisableRippleCtor,
   MatLine,
   setLines,
   mixinDisableRipple,
@@ -40,15 +38,11 @@ import {takeUntil} from 'rxjs/operators';
 
 // Boilerplate for applying mixins to MatList.
 /** @docs-private */
-class MatListBase {}
-const _MatListMixinBase: CanDisableRippleCtor & CanDisableCtor & typeof MatListBase =
-    mixinDisabled(mixinDisableRipple(MatListBase));
+const _MatListBase = mixinDisabled(mixinDisableRipple(class {}));
 
 // Boilerplate for applying mixins to MatListItem.
 /** @docs-private */
-class MatListItemBase {}
-const _MatListItemMixinBase: CanDisableRippleCtor & typeof MatListItemBase =
-    mixinDisableRipple(MatListItemBase);
+const _MatListItemMixinBase = mixinDisableRipple(class {});
 
 /**
  * Injection token that can be used to inject instances of `MatList`. It serves as
@@ -78,7 +72,7 @@ export const MAT_NAV_LIST = new InjectionToken<MatNavList>('MatNavList');
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [{provide: MAT_NAV_LIST, useExisting: MatNavList}],
 })
-export class MatNavList extends _MatListMixinBase implements CanDisable, CanDisableRipple,
+export class MatNavList extends _MatListBase implements CanDisable, CanDisableRipple,
   OnChanges, OnDestroy {
   /** Emits when the state of the list changes. */
   readonly _stateChanges = new Subject<void>();
@@ -108,7 +102,7 @@ export class MatNavList extends _MatListMixinBase implements CanDisable, CanDisa
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [{provide: MAT_LIST, useExisting: MatList}],
 })
-export class MatList extends _MatListMixinBase implements CanDisable, CanDisableRipple, OnChanges,
+export class MatList extends _MatListBase implements CanDisable, CanDisableRipple, OnChanges,
   OnDestroy {
   /** Emits when the state of the list changes. */
   readonly _stateChanges = new Subject<void>();

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -42,7 +42,6 @@ import {
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
   CanDisableRipple,
-  CanDisableRippleCtor,
   MatLine,
   mixinDisableRipple,
   setLines,
@@ -52,13 +51,8 @@ import {Subject} from 'rxjs';
 import {startWith, takeUntil} from 'rxjs/operators';
 import {MatListAvatarCssMatStyler, MatListIconCssMatStyler} from './list';
 
-class MatSelectionListBase {}
-const _MatSelectionListMixinBase: CanDisableRippleCtor & typeof MatSelectionListBase =
-    mixinDisableRipple(MatSelectionListBase);
-
-class MatListOptionBase {}
-const _MatListOptionMixinBase: CanDisableRippleCtor & typeof MatListOptionBase =
-    mixinDisableRipple(MatListOptionBase);
+const _MatSelectionListBase = mixinDisableRipple(class {});
+const _MatListOptionBase = mixinDisableRipple(class {});
 
 /** @docs-private */
 export const MAT_SELECTION_LIST_VALUE_ACCESSOR: any = {
@@ -122,7 +116,7 @@ export type MatListOptionCheckboxPosition = 'before'|'after';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatListOption extends _MatListOptionMixinBase implements AfterContentInit, OnDestroy,
+export class MatListOption extends _MatListOptionBase implements AfterContentInit, OnDestroy,
                                                                       OnInit, FocusableOption,
                                                                       CanDisableRipple {
   private _selected = false;
@@ -346,7 +340,7 @@ export class MatListOption extends _MatListOptionMixinBase implements AfterConte
   providers: [MAT_SELECTION_LIST_VALUE_ACCESSOR],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MatSelectionList extends _MatSelectionListMixinBase implements CanDisableRipple,
+export class MatSelectionList extends _MatSelectionListBase implements CanDisableRipple,
   AfterContentInit, ControlValueAccessor, OnDestroy, OnChanges {
   private _multiple = true;
   private _contentInitialized = false;

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -21,8 +21,8 @@ import {
   AfterViewInit,
 } from '@angular/core';
 import {
-  CanDisable, CanDisableCtor,
-  CanDisableRipple, CanDisableRippleCtor,
+  CanDisable,
+  CanDisableRipple,
   mixinDisabled,
   mixinDisableRipple,
 } from '@angular/material/core';
@@ -32,9 +32,7 @@ import {MAT_MENU_PANEL, MatMenuPanel} from './menu-panel';
 
 // Boilerplate for applying mixins to MatMenuItem.
 /** @docs-private */
-class MatMenuItemBase {}
-const _MatMenuItemMixinBase: CanDisableRippleCtor & CanDisableCtor & typeof MatMenuItemBase =
-    mixinDisableRipple(mixinDisabled(MatMenuItemBase));
+const _MatMenuItemBase = mixinDisableRipple(mixinDisabled(class {}));
 
 /**
  * Single item inside of a `mat-menu`. Provides the menu item styling and accessibility treatment.
@@ -57,7 +55,7 @@ const _MatMenuItemMixinBase: CanDisableRippleCtor & CanDisableCtor & typeof MatM
   encapsulation: ViewEncapsulation.None,
   templateUrl: 'menu-item.html',
 })
-export class MatMenuItem extends _MatMenuItemMixinBase
+export class MatMenuItem extends _MatMenuItemBase
     implements FocusableOption, CanDisable, CanDisableRipple, AfterViewInit, OnDestroy {
 
   /** ARIA role for the menu item. */

--- a/src/material/paginator/paginator.ts
+++ b/src/material/paginator/paginator.ts
@@ -31,11 +31,9 @@ import {Subscription} from 'rxjs';
 import {MatPaginatorIntl} from './paginator-intl';
 import {
   HasInitialized,
-  HasInitializedCtor,
   mixinInitialized,
   ThemePalette,
   mixinDisabled,
-  CanDisableCtor,
   CanDisable,
 } from '@angular/material/core';
 import {MatFormFieldAppearance} from '@angular/material/form-field';
@@ -89,9 +87,7 @@ export const MAT_PAGINATOR_DEFAULT_OPTIONS =
 
 // Boilerplate for applying mixins to _MatPaginatorBase.
 /** @docs-private */
-class MatPaginatorMixinBase {}
-const _MatPaginatorMixinBase: CanDisableCtor & HasInitializedCtor & typeof MatPaginatorMixinBase =
-    mixinDisabled(mixinInitialized(MatPaginatorMixinBase));
+const _MatPaginatorMixinBase = mixinDisabled(mixinInitialized(class {}));
 
 /**
  * Base class with all of the `MatPaginator` functionality.

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -24,7 +24,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import {CanColor, CanColorCtor, mixinColor} from '@angular/material/core';
+import {CanColor, mixinColor} from '@angular/material/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {fromEvent, Observable, Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
@@ -40,12 +40,9 @@ export interface ProgressAnimationEnd {
 
 // Boilerplate for applying mixins to MatProgressBar.
 /** @docs-private */
-class MatProgressBarBase {
-  constructor(public _elementRef: ElementRef) { }
-}
-
-const _MatProgressBarMixinBase: CanColorCtor & typeof MatProgressBarBase =
-    mixinColor(MatProgressBarBase, 'primary');
+const _MatProgressBarBase = mixinColor(class {
+  constructor(public _elementRef: ElementRef) {}
+}, 'primary');
 
 /**
  * Injection token used to provide the current location to `MatProgressBar`.
@@ -106,7 +103,7 @@ let progressbarId = 0;
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatProgressBar extends _MatProgressBarMixinBase implements CanColor,
+export class MatProgressBar extends _MatProgressBarBase implements CanColor,
                                                       AfterViewInit, OnDestroy {
   constructor(public _elementRef: ElementRef, private _ngZone: NgZone,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -20,7 +20,7 @@ import {
   ViewEncapsulation,
   OnInit,
 } from '@angular/core';
-import {CanColor, CanColorCtor, mixinColor} from '@angular/material/core';
+import {CanColor, mixinColor} from '@angular/material/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 
 
@@ -41,11 +41,9 @@ const BASE_STROKE_WIDTH = 10;
 
 // Boilerplate for applying mixins to MatProgressSpinner.
 /** @docs-private */
-class MatProgressSpinnerBase {
+const _MatProgressSpinnerBase = mixinColor(class {
   constructor(public _elementRef: ElementRef) {}
-}
-const _MatProgressSpinnerMixinBase: CanColorCtor & typeof MatProgressSpinnerBase =
-    mixinColor(MatProgressSpinnerBase, 'primary');
+}, 'primary');
 
 /** Default `mat-progress-spinner` options that can be overridden. */
 export interface MatProgressSpinnerDefaultOptions {
@@ -126,7 +124,7 @@ const INDETERMINATE_ANIMATION_TEMPLATE = `
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements OnInit, CanColor {
+export class MatProgressSpinner extends _MatProgressSpinnerBase implements OnInit, CanColor {
   private _diameter = BASE_SIZE;
   private _value = 0;
   private _strokeWidth: number;

--- a/src/material/radio/radio.ts
+++ b/src/material/radio/radio.ts
@@ -40,9 +40,7 @@ import {
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
   CanDisableRipple,
-  CanDisableRippleCtor,
   HasTabIndex,
-  HasTabIndexCtor,
   mixinDisableRipple,
   mixinTabIndex,
   ThemePalette,
@@ -347,11 +345,8 @@ abstract class MatRadioButtonBase {
   abstract disabled: boolean;
   constructor(public _elementRef: ElementRef) {}
 }
-// As per Material design specifications the selection control radio should use the accent color
-// palette by default. https://material.io/guidelines/components/selection-controls.html
-const _MatRadioButtonMixinBase:
-    CanDisableRippleCtor & HasTabIndexCtor & typeof MatRadioButtonBase =
-        mixinDisableRipple(mixinTabIndex(MatRadioButtonBase));
+
+const _MatRadioButtonMixinBase = mixinDisableRipple(mixinTabIndex(MatRadioButtonBase));
 
 /**
  * Base class with all of the `MatRadioButton` functionality.
@@ -451,6 +446,8 @@ export abstract class _MatRadioButtonBase extends _MatRadioButtonMixinBase imple
   /** Theme color of the radio button. */
   @Input()
   get color(): ThemePalette {
+    // As per Material design specifications the selection control radio should use the accent color
+    // palette by default. https://material.io/guidelines/components/selection-controls.html
     return this._color ||
       (this.radioGroup && this.radioGroup.color) ||
       this._providerOverride && this._providerOverride.color || 'accent';

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -64,14 +64,10 @@ import {
   _countGroupLabelsBeforeOption,
   _getOptionScrollPosition,
   CanDisable,
-  CanDisableCtor,
   CanDisableRipple,
-  CanDisableRippleCtor,
   CanUpdateErrorState,
-  CanUpdateErrorStateCtor,
   ErrorStateMatcher,
   HasTabIndex,
-  HasTabIndexCtor,
   MAT_OPTGROUP,
   MAT_OPTION_PARENT_COMPONENT,
   MatOptgroup,
@@ -183,20 +179,14 @@ export class MatSelectChange {
 
 // Boilerplate for applying mixins to MatSelect.
 /** @docs-private */
-class MatSelectBase {
-  constructor(public _elementRef: ElementRef,
-              public _defaultErrorStateMatcher: ErrorStateMatcher,
-              public _parentForm: NgForm,
-              public _parentFormGroup: FormGroupDirective,
-              public ngControl: NgControl) {}
-}
-const _MatSelectMixinBase:
-    CanDisableCtor &
-    HasTabIndexCtor &
-    CanDisableRippleCtor &
-    CanUpdateErrorStateCtor &
-    typeof MatSelectBase =
-        mixinDisableRipple(mixinTabIndex(mixinDisabled(mixinErrorState(MatSelectBase))));
+const _MatSelectMixinBase =
+  mixinDisableRipple(mixinTabIndex(mixinDisabled(mixinErrorState(class {
+    constructor(public _elementRef: ElementRef,
+                public _defaultErrorStateMatcher: ErrorStateMatcher,
+                public _parentForm: NgForm,
+                public _parentFormGroup: FormGroupDirective,
+                public ngControl: NgControl) {}
+  }))));
 
 
 

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -27,10 +27,10 @@ import {
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
-  CanColor, CanColorCtor,
-  CanDisable, CanDisableCtor,
-  CanDisableRipple, CanDisableRippleCtor,
-  HasTabIndex, HasTabIndexCtor,
+  CanColor,
+  CanDisable,
+  CanDisableRipple,
+  HasTabIndex,
   mixinColor,
   mixinDisabled,
   mixinDisableRipple,
@@ -63,16 +63,10 @@ export class MatSlideToggleChange {
 
 // Boilerplate for applying mixins to MatSlideToggle.
 /** @docs-private */
-class MatSlideToggleBase {
-  constructor(public _elementRef: ElementRef) {}
-}
-const _MatSlideToggleMixinBase:
-    HasTabIndexCtor &
-    CanColorCtor &
-    CanDisableRippleCtor &
-    CanDisableCtor &
-    typeof MatSlideToggleBase =
-        mixinTabIndex(mixinColor(mixinDisableRipple(mixinDisabled(MatSlideToggleBase))));
+const _MatSlideToggleBase =
+  mixinTabIndex(mixinColor(mixinDisableRipple(mixinDisabled(class {
+    constructor(public _elementRef: ElementRef) {}
+  }))));
 
 /** Represents a slidable "switch" toggle that can be moved between on and off. */
 @Component({
@@ -97,11 +91,11 @@ const _MatSlideToggleMixinBase:
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestroy, AfterContentInit,
-                                                                        ControlValueAccessor,
-                                                                        CanDisable, CanColor,
-                                                                        HasTabIndex,
-                                                                        CanDisableRipple {
+export class MatSlideToggle extends _MatSlideToggleBase implements OnDestroy, AfterContentInit,
+                                                                   ControlValueAccessor,
+                                                                   CanDisable, CanColor,
+                                                                   HasTabIndex,
+                                                                   CanDisableRipple {
   private _onChange = (_: any) => {};
   private _onTouched = () => {};
 

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -46,11 +46,8 @@ import {
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
   CanColor,
-  CanColorCtor,
   CanDisable,
-  CanDisableCtor,
   HasTabIndex,
-  HasTabIndexCtor,
   mixinColor,
   mixinDisabled,
   mixinTabIndex,
@@ -99,15 +96,9 @@ export class MatSliderChange {
 
 // Boilerplate for applying mixins to MatSlider.
 /** @docs-private */
-class MatSliderBase {
+const _MatSliderBase = mixinTabIndex(mixinColor(mixinDisabled(class {
   constructor(public _elementRef: ElementRef) {}
-}
-const _MatSliderMixinBase:
-    HasTabIndexCtor &
-    CanColorCtor &
-    CanDisableCtor &
-    typeof MatSliderBase =
-        mixinTabIndex(mixinColor(mixinDisabled(MatSliderBase), 'accent'));
+}), 'accent'));
 
 /**
  * Allows users to select from a range of values by moving the slider thumb. It is similar in
@@ -163,7 +154,7 @@ const _MatSliderMixinBase:
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatSlider extends _MatSliderMixinBase
+export class MatSlider extends _MatSliderBase
     implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, AfterViewInit, HasTabIndex {
   /** Whether the slider is inverted. */
   @Input()

--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -20,7 +20,7 @@ import {
   ElementRef,
   AfterViewInit,
 } from '@angular/core';
-import {CanDisable, CanDisableCtor, mixinDisabled} from '@angular/material/core';
+import {CanDisable, mixinDisabled} from '@angular/material/core';
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {ENTER, SPACE} from '@angular/cdk/keycodes';
 import {merge, Subscription} from 'rxjs';
@@ -33,9 +33,7 @@ import {MatSortHeaderIntl} from './sort-header-intl';
 
 // Boilerplate for applying mixins to the sort header.
 /** @docs-private */
-class MatSortHeaderBase {}
-const _MatSortHeaderMixinBase: CanDisableCtor & typeof MatSortHeaderBase =
-    mixinDisabled(MatSortHeaderBase);
+const _MatSortHeaderBase = mixinDisabled(class {});
 
 /**
  * Valid positions for the arrow to be in for its opacity and translation. If the state is a
@@ -97,7 +95,7 @@ interface MatSortHeaderColumnDef {
     matSortAnimations.allowChildren,
   ]
 })
-export class MatSortHeader extends _MatSortHeaderMixinBase
+export class MatSortHeader extends _MatSortHeaderBase
     implements CanDisable, MatSortable, OnDestroy, OnInit, AfterViewInit {
   private _rerenderSubscription: Subscription;
 

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -21,9 +21,7 @@ import {
 } from '@angular/core';
 import {
   CanDisable,
-  CanDisableCtor,
   HasInitialized,
-  HasInitializedCtor,
   mixinDisabled,
   mixinInitialized,
 } from '@angular/material/core';
@@ -69,9 +67,7 @@ export const MAT_SORT_DEFAULT_OPTIONS =
 
 // Boilerplate for applying mixins to MatSort.
 /** @docs-private */
-class MatSortBase {}
-const _MatSortMixinBase: HasInitializedCtor & CanDisableCtor & typeof MatSortBase =
-    mixinInitialized(mixinDisabled(MatSortBase));
+const _MatSortBase = mixinInitialized(mixinDisabled(class {}));
 
 /** Container for MatSortables to manage the sort state and provide default sort parameters. */
 @Directive({
@@ -80,7 +76,7 @@ const _MatSortMixinBase: HasInitializedCtor & CanDisableCtor & typeof MatSortBas
   host: {'class': 'mat-sort'},
   inputs: ['disabled: matSortDisabled']
 })
-export class MatSort extends _MatSortMixinBase
+export class MatSort extends _MatSortBase
     implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit {
   /** Collection of all registered sortables that this directive manages. */
   sortables = new Map<string, MatSortable>();

--- a/src/material/stepper/step-header.ts
+++ b/src/material/stepper/step-header.ts
@@ -23,19 +23,16 @@ import {MatStepLabel} from './step-label';
 import {MatStepperIntl} from './stepper-intl';
 import {MatStepperIconContext} from './stepper-icon';
 import {CdkStepHeader, StepState} from '@angular/cdk/stepper';
-import {CanColorCtor, mixinColor, CanColor} from '@angular/material/core';
+import {mixinColor, CanColor} from '@angular/material/core';
 
 
 // Boilerplate for applying mixins to MatStepHeader.
 /** @docs-private */
-class MatStepHeaderBase extends CdkStepHeader {
+const _MatStepHeaderBase = mixinColor(class MatStepHeaderBase extends CdkStepHeader {
   constructor(elementRef: ElementRef) {
     super(elementRef);
   }
-}
-
-const _MatStepHeaderMixinBase: CanColorCtor & typeof MatStepHeaderBase =
-    mixinColor(MatStepHeaderBase, 'primary');
+}, 'primary');
 
 @Component({
   selector: 'mat-step-header',
@@ -49,7 +46,7 @@ const _MatStepHeaderMixinBase: CanColorCtor & typeof MatStepHeaderBase =
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatStepHeader extends _MatStepHeaderMixinBase implements AfterViewInit, OnDestroy,
+export class MatStepHeader extends _MatStepHeaderBase implements AfterViewInit, OnDestroy,
   CanColor {
   private _intlSubscription: Subscription;
 

--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -34,9 +34,7 @@ import {
 import {FocusOrigin} from '@angular/cdk/a11y';
 import {
   CanColor,
-  CanColorCtor,
   CanDisableRipple,
-  CanDisableRippleCtor,
   mixinColor,
   mixinDisableRipple,
   ThemePalette,
@@ -64,11 +62,9 @@ export type MatTabHeaderPosition = 'above' | 'below';
 
 // Boilerplate for applying mixins to MatTabGroup.
 /** @docs-private */
-class MatTabGroupMixinBase {
+const _MatTabGroupMixinBase = mixinColor(mixinDisableRipple(class {
   constructor(public _elementRef: ElementRef) {}
-}
-const _MatTabGroupMixinBase: CanColorCtor & CanDisableRippleCtor & typeof MatTabGroupMixinBase =
-    mixinColor(mixinDisableRipple(MatTabGroupMixinBase), 'primary');
+}), 'primary');
 
 interface MatTabGroupBaseHeader {
   _alignInkBarToSelectedTab: () => void;

--- a/src/material/tabs/tab-label-wrapper.ts
+++ b/src/material/tabs/tab-label-wrapper.ts
@@ -8,14 +8,12 @@
 
 import {BooleanInput} from '@angular/cdk/coercion';
 import {Directive, ElementRef} from '@angular/core';
-import {CanDisable, CanDisableCtor, mixinDisabled} from '@angular/material/core';
+import {CanDisable, mixinDisabled} from '@angular/material/core';
 
 
 // Boilerplate for applying mixins to MatTabLabelWrapper.
 /** @docs-private */
-class MatTabLabelWrapperBase {}
-const _MatTabLabelWrapperMixinBase: CanDisableCtor & typeof MatTabLabelWrapperBase =
-    mixinDisabled(MatTabLabelWrapperBase);
+const _MatTabLabelWrapperBase = mixinDisabled(class {});
 
 /**
  * Used in the `mat-tab-group` view to display tab labels.
@@ -29,7 +27,7 @@ const _MatTabLabelWrapperMixinBase: CanDisableCtor & typeof MatTabLabelWrapperBa
     '[attr.aria-disabled]': '!!disabled',
   }
 })
-export class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase implements CanDisable {
+export class MatTabLabelWrapper extends _MatTabLabelWrapperBase implements CanDisable {
   constructor(public elementRef: ElementRef) {
     super();
   }

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -32,9 +32,9 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {
-  CanDisable, CanDisableCtor,
-  CanDisableRipple, CanDisableRippleCtor,
-  HasTabIndex, HasTabIndexCtor,
+  CanDisable,
+  CanDisableRipple,
+  HasTabIndex,
   MAT_RIPPLE_GLOBAL_OPTIONS,
   mixinDisabled,
   mixinDisableRipple,
@@ -175,10 +175,7 @@ export class MatTabNav extends _MatTabNavBase {
 }
 
 // Boilerplate for applying mixins to MatTabLink.
-class MatTabLinkMixinBase {}
-const _MatTabLinkMixinBase:
-    HasTabIndexCtor & CanDisableRippleCtor & CanDisableCtor & typeof MatTabLinkMixinBase =
-        mixinTabIndex(mixinDisableRipple(mixinDisabled(MatTabLinkMixinBase)));
+const _MatTabLinkMixinBase = mixinTabIndex(mixinDisableRipple(mixinDisabled(class {})));
 
 /** Base class with all of the `MatTabLink` functionality. */
 @Directive()

--- a/src/material/tabs/tab.ts
+++ b/src/material/tabs/tab.ts
@@ -25,7 +25,7 @@ import {
   Inject,
   Optional,
 } from '@angular/core';
-import {CanDisable, CanDisableCtor, mixinDisabled} from '@angular/material/core';
+import {CanDisable, mixinDisabled} from '@angular/material/core';
 import {Subject} from 'rxjs';
 import {MAT_TAB_CONTENT} from './tab-content';
 import {MAT_TAB_LABEL, MatTabLabel} from './tab-label';
@@ -33,9 +33,7 @@ import {MAT_TAB_LABEL, MatTabLabel} from './tab-label';
 
 // Boilerplate for applying mixins to MatTab.
 /** @docs-private */
-class MatTabBase {}
-const _MatTabMixinBase: CanDisableCtor & typeof MatTabBase =
-    mixinDisabled(MatTabBase);
+const _MatTabBase = mixinDisabled(class {});
 
 /**
  * Used to provide a tab group to a tab without causing a circular dependency.
@@ -52,7 +50,7 @@ export const MAT_TAB_GROUP = new InjectionToken<any>('MAT_TAB_GROUP');
   encapsulation: ViewEncapsulation.None,
   exportAs: 'matTab',
 })
-export class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnChanges, OnDestroy {
+export class MatTab extends _MatTabBase implements OnInit, CanDisable, OnChanges, OnDestroy {
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
   @ContentChild(MAT_TAB_LABEL)
   get templateLabel(): MatTabLabel { return this._templateLabel; }

--- a/src/material/toolbar/toolbar.ts
+++ b/src/material/toolbar/toolbar.ts
@@ -19,15 +19,14 @@ import {
   QueryList,
   ViewEncapsulation,
 } from '@angular/core';
-import {CanColor, CanColorCtor, mixinColor} from '@angular/material/core';
+import {CanColor, mixinColor} from '@angular/material/core';
 
 
 // Boilerplate for applying mixins to MatToolbar.
 /** @docs-private */
-class MatToolbarBase {
+const _MatToolbarBase = mixinColor(class {
   constructor(public _elementRef: ElementRef) {}
-}
-const _MatToolbarMixinBase: CanColorCtor & typeof MatToolbarBase = mixinColor(MatToolbarBase);
+});
 
 @Directive({
   selector: 'mat-toolbar-row',
@@ -50,7 +49,7 @@ export class MatToolbarRow {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatToolbar extends _MatToolbarMixinBase implements CanColor, AfterViewInit {
+export class MatToolbar extends _MatToolbarBase implements CanColor, AfterViewInit {
   private _document: Document;
 
   /** Reference to all toolbar row elements that have been projected. */

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -25,16 +25,13 @@ import {
 } from '@angular/core';
 import {
   CanDisable,
-  CanDisableCtor,
   HasTabIndex,
-  HasTabIndexCtor,
   mixinDisabled,
   mixinTabIndex,
 } from '@angular/material/core';
 import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coercion';
 
-const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNode =
-    mixinTabIndex(mixinDisabled(CdkTreeNode));
+const _MatTreeNodeBase = mixinTabIndex(mixinDisabled(CdkTreeNode));
 
 /**
  * Wrapper for the CdkTree node with Material design styles.
@@ -45,7 +42,7 @@ const _MatTreeNodeMixinBase: HasTabIndexCtor & CanDisableCtor & typeof CdkTreeNo
   inputs: ['role', 'disabled', 'tabIndex'],
   providers: [{provide: CdkTreeNode, useExisting: MatTreeNode}]
 })
-export class MatTreeNode<T, K = T> extends _MatTreeNodeMixinBase<T, K>
+export class MatTreeNode<T, K = T> extends _MatTreeNodeBase<T, K>
     implements CanDisable, DoCheck, HasTabIndex, OnInit, OnDestroy {
 
 

--- a/tools/public_api_guard/material/badge.d.ts
+++ b/tools/public_api_guard/material/badge.d.ts
@@ -1,4 +1,4 @@
-export declare class MatBadge extends _MatBadgeMixinBase implements OnDestroy, OnChanges, CanDisable {
+export declare class MatBadge extends _MatBadgeBase implements OnDestroy, OnChanges, CanDisable {
     _hasContent: boolean;
     _id: number;
     get color(): ThemePalette;

--- a/tools/public_api_guard/material/button-toggle.d.ts
+++ b/tools/public_api_guard/material/button-toggle.d.ts
@@ -4,7 +4,7 @@ export declare const MAT_BUTTON_TOGGLE_GROUP: InjectionToken<MatButtonToggleGrou
 
 export declare const MAT_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any;
 
-export declare class MatButtonToggle extends _MatButtonToggleMixinBase implements OnInit, AfterViewInit, CanDisableRipple, OnDestroy {
+export declare class MatButtonToggle extends _MatButtonToggleBase implements OnInit, AfterViewInit, CanDisableRipple, OnDestroy {
     _buttonElement: ElementRef<HTMLButtonElement>;
     get appearance(): MatButtonToggleAppearance;
     set appearance(value: MatButtonToggleAppearance);

--- a/tools/public_api_guard/material/button.d.ts
+++ b/tools/public_api_guard/material/button.d.ts
@@ -6,7 +6,7 @@ export declare class MatAnchor extends MatButton {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatAnchor, [null, null, { optional: true; }]>;
 }
 
-export declare class MatButton extends _MatButtonMixinBase implements AfterViewInit, OnDestroy, CanDisable, CanColor, CanDisableRipple, FocusableOption {
+export declare class MatButton extends _MatButtonBase implements AfterViewInit, OnDestroy, CanDisable, CanColor, CanDisableRipple, FocusableOption {
     _animationMode: string;
     readonly isIconButton: boolean;
     readonly isRoundButton: boolean;

--- a/tools/public_api_guard/material/checkbox.d.ts
+++ b/tools/public_api_guard/material/checkbox.d.ts
@@ -12,7 +12,7 @@ export declare function MAT_CHECKBOX_DEFAULT_OPTIONS_FACTORY(): MatCheckboxDefau
 
 export declare const MAT_CHECKBOX_REQUIRED_VALIDATOR: Provider;
 
-export declare class MatCheckbox extends _MatCheckboxMixinBase implements ControlValueAccessor, AfterViewInit, AfterViewChecked, OnDestroy, CanColor, CanDisable, HasTabIndex, CanDisableRipple, FocusableOption {
+export declare class MatCheckbox extends _MatCheckboxBase implements ControlValueAccessor, AfterViewInit, AfterViewChecked, OnDestroy, CanColor, CanDisable, HasTabIndex, CanDisableRipple, FocusableOption {
     _animationMode?: string | undefined;
     _inputElement: ElementRef<HTMLInputElement>;
     _onTouched: () => any;

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -110,7 +110,7 @@ export interface MatChipInputEvent {
     value: string;
 }
 
-export declare class MatChipList extends _MatChipListMixinBase implements MatFormFieldControl<any>, ControlValueAccessor, AfterContentInit, DoCheck, OnInit, OnDestroy, CanUpdateErrorState {
+export declare class MatChipList extends _MatChipListBase implements MatFormFieldControl<any>, ControlValueAccessor, AfterContentInit, DoCheck, OnInit, OnDestroy, CanUpdateErrorState {
     _ariaDescribedby: string;
     protected _chipInput: MatChipTextControl;
     protected _disabled: boolean;

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -213,7 +213,7 @@ export declare class MatDatepickerCancel {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatDatepickerCancel, never>;
 }
 
-export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> extends _MatDatepickerContentMixinBase implements OnInit, AfterViewInit, OnDestroy, CanColor {
+export declare class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> extends _MatDatepickerContentBase implements OnInit, AfterViewInit, OnDestroy, CanColor {
     _actionsPortal: TemplatePortal | null;
     readonly _animationDone: Subject<void>;
     _animationState: 'enter-dropdown' | 'enter-dialog' | 'void';

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -25,7 +25,7 @@ export declare class MatError {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatError, [{ attribute: "aria-live"; }, null]>;
 }
 
-export declare class MatFormField extends _MatFormFieldMixinBase implements AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy, CanColor {
+export declare class MatFormField extends _MatFormFieldnBase implements AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy, CanColor {
     _animationsEnabled: boolean;
     _appearance: MatFormFieldAppearance;
     _connectionContainerRef: ElementRef;

--- a/tools/public_api_guard/material/icon.d.ts
+++ b/tools/public_api_guard/material/icon.d.ts
@@ -25,7 +25,7 @@ export declare const MAT_ICON_LOCATION: InjectionToken<MatIconLocation>;
 
 export declare function MAT_ICON_LOCATION_FACTORY(): MatIconLocation;
 
-export declare class MatIcon extends _MatIconMixinBase implements OnInit, AfterViewChecked, CanColor, OnDestroy {
+export declare class MatIcon extends _MatIconBase implements OnInit, AfterViewChecked, CanColor, OnDestroy {
     _svgName: string | null;
     _svgNamespace: string | null;
     get fontIcon(): string;

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -4,7 +4,7 @@ export declare const MAT_INPUT_VALUE_ACCESSOR: InjectionToken<{
     value: any;
 }>;
 
-export declare class MatInput extends _MatInputMixinBase implements MatFormFieldControl<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck, CanUpdateErrorState {
+export declare class MatInput extends _MatInputBase implements MatFormFieldControl<any>, OnChanges, OnDestroy, AfterViewInit, DoCheck, CanUpdateErrorState {
     protected _disabled: boolean;
     protected _elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>;
     protected _id: string;

--- a/tools/public_api_guard/material/list.d.ts
+++ b/tools/public_api_guard/material/list.d.ts
@@ -4,7 +4,7 @@ export declare const MAT_NAV_LIST: InjectionToken<MatNavList>;
 
 export declare const MAT_SELECTION_LIST_VALUE_ACCESSOR: any;
 
-export declare class MatList extends _MatListMixinBase implements CanDisable, CanDisableRipple, OnChanges, OnDestroy {
+export declare class MatList extends _MatListBase implements CanDisable, CanDisableRipple, OnChanges, OnDestroy {
     readonly _stateChanges: Subject<void>;
     constructor(_elementRef: ElementRef<HTMLElement>);
     _getListType(): 'list' | 'action-list' | null;
@@ -49,7 +49,7 @@ export declare class MatListModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<MatListModule, [typeof i1.MatList, typeof i1.MatNavList, typeof i1.MatListItem, typeof i1.MatListAvatarCssMatStyler, typeof i1.MatListIconCssMatStyler, typeof i1.MatListSubheaderCssMatStyler, typeof i2.MatSelectionList, typeof i2.MatListOption], [typeof i3.MatLineModule, typeof i3.MatRippleModule, typeof i3.MatCommonModule, typeof i3.MatPseudoCheckboxModule, typeof i4.CommonModule], [typeof i1.MatList, typeof i1.MatNavList, typeof i1.MatListItem, typeof i1.MatListAvatarCssMatStyler, typeof i3.MatLineModule, typeof i3.MatCommonModule, typeof i1.MatListIconCssMatStyler, typeof i1.MatListSubheaderCssMatStyler, typeof i3.MatPseudoCheckboxModule, typeof i2.MatSelectionList, typeof i2.MatListOption, typeof i5.MatDividerModule]>;
 }
 
-export declare class MatListOption extends _MatListOptionMixinBase implements AfterContentInit, OnDestroy, OnInit, FocusableOption, CanDisableRipple {
+export declare class MatListOption extends _MatListOptionBase implements AfterContentInit, OnDestroy, OnInit, FocusableOption, CanDisableRipple {
     _avatar: MatListAvatarCssMatStyler;
     _icon: MatListIconCssMatStyler;
     _lines: QueryList<MatLine>;
@@ -93,7 +93,7 @@ export declare class MatListSubheaderCssMatStyler {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatListSubheaderCssMatStyler, never>;
 }
 
-export declare class MatNavList extends _MatListMixinBase implements CanDisable, CanDisableRipple, OnChanges, OnDestroy {
+export declare class MatNavList extends _MatListBase implements CanDisable, CanDisableRipple, OnChanges, OnDestroy {
     readonly _stateChanges: Subject<void>;
     ngOnChanges(): void;
     ngOnDestroy(): void;
@@ -103,7 +103,7 @@ export declare class MatNavList extends _MatListMixinBase implements CanDisable,
     static ɵfac: i0.ɵɵFactoryDeclaration<MatNavList, never>;
 }
 
-export declare class MatSelectionList extends _MatSelectionListMixinBase implements CanDisableRipple, AfterContentInit, ControlValueAccessor, OnDestroy, OnChanges {
+export declare class MatSelectionList extends _MatSelectionListBase implements CanDisableRipple, AfterContentInit, ControlValueAccessor, OnDestroy, OnChanges {
     _keyManager: FocusKeyManager<MatListOption>;
     _onTouched: () => void;
     _tabIndex: number;

--- a/tools/public_api_guard/material/menu.d.ts
+++ b/tools/public_api_guard/material/menu.d.ts
@@ -102,7 +102,7 @@ export interface MatMenuDefaultOptions {
     yPosition: MenuPositionY;
 }
 
-export declare class MatMenuItem extends _MatMenuItemMixinBase implements FocusableOption, CanDisable, CanDisableRipple, AfterViewInit, OnDestroy {
+export declare class MatMenuItem extends _MatMenuItemBase implements FocusableOption, CanDisable, CanDisableRipple, AfterViewInit, OnDestroy {
     readonly _focused: Subject<MatMenuItem>;
     _highlighted: boolean;
     readonly _hovered: Subject<MatMenuItem>;

--- a/tools/public_api_guard/material/progress-bar.d.ts
+++ b/tools/public_api_guard/material/progress-bar.d.ts
@@ -2,7 +2,7 @@ export declare const MAT_PROGRESS_BAR_LOCATION: InjectionToken<MatProgressBarLoc
 
 export declare function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocation;
 
-export declare class MatProgressBar extends _MatProgressBarMixinBase implements CanColor, AfterViewInit, OnDestroy {
+export declare class MatProgressBar extends _MatProgressBarBase implements CanColor, AfterViewInit, OnDestroy {
     _animationMode?: string | undefined;
     _elementRef: ElementRef;
     _isNoopAnimation: boolean;

--- a/tools/public_api_guard/material/progress-spinner.d.ts
+++ b/tools/public_api_guard/material/progress-spinner.d.ts
@@ -2,7 +2,7 @@ export declare const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatPro
 
 export declare function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinnerDefaultOptions;
 
-export declare class MatProgressSpinner extends _MatProgressSpinnerMixinBase implements OnInit, CanColor {
+export declare class MatProgressSpinner extends _MatProgressSpinnerBase implements OnInit, CanColor {
     _elementRef: ElementRef<HTMLElement>;
     _noopAnimations: boolean;
     _spinnerAnimationLabel: string;

--- a/tools/public_api_guard/material/slide-toggle.d.ts
+++ b/tools/public_api_guard/material/slide-toggle.d.ts
@@ -10,7 +10,7 @@ export declare const MAT_SLIDE_TOGGLE_REQUIRED_VALIDATOR: Provider;
 
 export declare const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: any;
 
-export declare class MatSlideToggle extends _MatSlideToggleMixinBase implements OnDestroy, AfterContentInit, ControlValueAccessor, CanDisable, CanColor, HasTabIndex, CanDisableRipple {
+export declare class MatSlideToggle extends _MatSlideToggleBase implements OnDestroy, AfterContentInit, ControlValueAccessor, CanDisable, CanColor, HasTabIndex, CanDisableRipple {
     _inputElement: ElementRef<HTMLInputElement>;
     _noopAnimations: boolean;
     _thumbBarEl: ElementRef;

--- a/tools/public_api_guard/material/slider.d.ts
+++ b/tools/public_api_guard/material/slider.d.ts
@@ -1,6 +1,6 @@
 export declare const MAT_SLIDER_VALUE_ACCESSOR: any;
 
-export declare class MatSlider extends _MatSliderMixinBase implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, AfterViewInit, HasTabIndex {
+export declare class MatSlider extends _MatSliderBase implements ControlValueAccessor, OnDestroy, CanDisable, CanColor, AfterViewInit, HasTabIndex {
     _animationMode?: string | undefined;
     protected _document: Document;
     _isActive: boolean;

--- a/tools/public_api_guard/material/sort.d.ts
+++ b/tools/public_api_guard/material/sort.d.ts
@@ -15,7 +15,7 @@ export declare const MAT_SORT_HEADER_INTL_PROVIDER: {
 
 export declare function MAT_SORT_HEADER_INTL_PROVIDER_FACTORY(parentIntl: MatSortHeaderIntl): MatSortHeaderIntl;
 
-export declare class MatSort extends _MatSortMixinBase implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit {
+export declare class MatSort extends _MatSortBase implements CanDisable, HasInitialized, OnChanges, OnDestroy, OnInit {
     readonly _stateChanges: Subject<void>;
     active: string;
     get direction(): SortDirection;
@@ -58,7 +58,7 @@ export interface MatSortDefaultOptions {
     disableClear?: boolean;
 }
 
-export declare class MatSortHeader extends _MatSortHeaderMixinBase implements CanDisable, MatSortable, OnDestroy, OnInit, AfterViewInit {
+export declare class MatSortHeader extends _MatSortHeaderBase implements CanDisable, MatSortable, OnDestroy, OnInit, AfterViewInit {
     _arrowDirection: SortDirection;
     _columnDef: MatSortHeaderColumnDef;
     _disableViewStateAnimation: boolean;

--- a/tools/public_api_guard/material/stepper.d.ts
+++ b/tools/public_api_guard/material/stepper.d.ts
@@ -31,7 +31,7 @@ export declare class MatStepContent {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatStepContent, never>;
 }
 
-export declare class MatStepHeader extends _MatStepHeaderMixinBase implements AfterViewInit, OnDestroy, CanColor {
+export declare class MatStepHeader extends _MatStepHeaderBase implements AfterViewInit, OnDestroy, CanColor {
     _intl: MatStepperIntl;
     active: boolean;
     disableRipple: boolean;

--- a/tools/public_api_guard/material/tabs.d.ts
+++ b/tools/public_api_guard/material/tabs.d.ts
@@ -133,7 +133,7 @@ export declare class MatInkBar {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatInkBar, [null, null, null, { optional: true; }]>;
 }
 
-export declare class MatTab extends _MatTabMixinBase implements OnInit, CanDisable, OnChanges, OnDestroy {
+export declare class MatTab extends _MatTabBase implements OnInit, CanDisable, OnChanges, OnDestroy {
     _closestTabGroup: any;
     _explicitContent: TemplateRef<any>;
     _implicitContent: TemplateRef<any>;
@@ -217,7 +217,7 @@ export declare class MatTabLabel extends CdkPortal {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatTabLabel, never>;
 }
 
-export declare class MatTabLabelWrapper extends _MatTabLabelWrapperMixinBase implements CanDisable {
+export declare class MatTabLabelWrapper extends _MatTabLabelWrapperBase implements CanDisable {
     elementRef: ElementRef;
     constructor(elementRef: ElementRef);
     focus(): void;

--- a/tools/public_api_guard/material/toolbar.d.ts
+++ b/tools/public_api_guard/material/toolbar.d.ts
@@ -1,4 +1,4 @@
-export declare class MatToolbar extends _MatToolbarMixinBase implements CanColor, AfterViewInit {
+export declare class MatToolbar extends _MatToolbarBase implements CanColor, AfterViewInit {
     _toolbarRows: QueryList<MatToolbarRow>;
     constructor(elementRef: ElementRef, _platform: Platform, document?: any);
     ngAfterViewInit(): void;

--- a/tools/public_api_guard/material/tree.d.ts
+++ b/tools/public_api_guard/material/tree.d.ts
@@ -56,7 +56,7 @@ export declare class MatTreeNestedDataSource<T> extends DataSource<T> {
     disconnect(): void;
 }
 
-export declare class MatTreeNode<T, K = T> extends _MatTreeNodeMixinBase<T, K> implements CanDisable, DoCheck, HasTabIndex, OnInit, OnDestroy {
+export declare class MatTreeNode<T, K = T> extends _MatTreeNodeBase<T, K> implements CanDisable, DoCheck, HasTabIndex, OnInit, OnDestroy {
     protected _elementRef: ElementRef<HTMLElement>;
     protected _tree: CdkTree<T, K>;
     constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T, K>, tabIndex: string);


### PR DESCRIPTION
It seems like the various `*Ctor` interfaces for mixins aren't necessary anymore, because TS infers the type correctly without them. These changes clean up all the usages.