### PR TITLE
fix(material-experimental/mdc-progress-bar): buffer animation not disabled under noop animations module

### DIFF
--- a/src/material-experimental/mdc-progress-bar/progress-bar.scss
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.scss
@@ -16,7 +16,8 @@
       animation: none;
     }
 
-    .mdc-linear-progress__primary-bar {
+    .mdc-linear-progress__primary-bar,
+    .mdc-linear-progress__buffer-bar {
       // There's a `transitionend` event that depends on this element. Add a very short
       // transition when animations are disabled so that the event can still fire.
       transition: transform 1ms;


### PR DESCRIPTION
Fixes that the buffer bar in the MDC-based `mat-progress-bar` still animates when animations are disabled.