### PR TITLE
fix(material-experimental/mdc-progress-spinner): set line-height

### DIFF
--- a/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
+++ b/src/material-experimental/mdc-progress-spinner/progress-spinner.scss
@@ -11,6 +11,11 @@
   // Prevents the spinning of the inner element from affecting layout outside of the spinner.
   overflow: hidden;
 
+  // Spinners with a diameter less than half the existing line-height will become distorted.
+  // Explicitly set the line-height to 0px to avoid this issue.
+  // https://github.com/material-components/material-components-web/issues/7118
+  line-height: 0;
+
   &._mat-animation-noopable {
     &, .mdc-circular-progress__determinate-circle {
       // The spinner itself has a transition on `opacity`.


### PR DESCRIPTION
When the line-height is much larger than the diameter, the spinner breaks. 

Example: https://stackblitz.com/edit/angular-rgtfre-k7iryu?file=src/app/progress-spinner-overview-example.html

This explicitly sets it to 0 rather than whatever it would inherit.

Filed an issue with MDC: https://github.com/material-components/material-components-web/issues/7118