### PR TITLE
fix(material/table): Make table data source interface generic

### DIFF
--- a/src/material-experimental/mdc-table/public-api.ts
+++ b/src/material-experimental/mdc-table/public-api.ts
@@ -12,3 +12,5 @@ export * from './cell';
 export * from './row';
 export * from './table-data-source';
 export * from './text-column';
+
+export {MatTableDataSourcePageEvent, MatTableDataSourcePaginator} from '@angular/material/table';

--- a/src/material-experimental/mdc-table/table-data-source.ts
+++ b/src/material-experimental/mdc-table/table-data-source.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MatPaginator} from '@angular/material-experimental/mdc-paginator';
-import {_MatTableDataSource} from '@angular/material/table';
+import {_MatTableDataSource, MatTableDataSourcePaginator} from '@angular/material/table';
 
 /**
  * Data source that accepts a client-side data array and includes native support of filtering,
@@ -22,4 +21,5 @@ import {_MatTableDataSource} from '@angular/material/table';
  * interactions. If your app needs to support more advanced use cases, consider implementing your
  * own `DataSource`.
  */
-export class MatTableDataSource<T> extends _MatTableDataSource<T, MatPaginator> {}
+export class MatTableDataSource<T, P extends MatTableDataSourcePaginator =
+    MatTableDataSourcePaginator> extends _MatTableDataSource<T, P> {}

--- a/src/material-experimental/mdc-table/table-data-source.ts
+++ b/src/material-experimental/mdc-table/table-data-source.ts
@@ -23,3 +23,4 @@ import {_MatTableDataSource, MatTableDataSourcePaginator} from '@angular/materia
  */
 export class MatTableDataSource<T, P extends MatTableDataSourcePaginator =
     MatTableDataSourcePaginator> extends _MatTableDataSource<T, P> {}
+

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -8,7 +8,7 @@
 
 import {_isNumberValue} from '@angular/cdk/coercion';
 import {DataSource} from '@angular/cdk/table';
-import {MatPaginator, PageEvent} from '@angular/material/paginator';
+import {MatPaginator} from '@angular/material/paginator';
 import {MatSort, Sort} from '@angular/material/sort';
 import {
   BehaviorSubject,
@@ -27,8 +27,22 @@ import {map} from 'rxjs/operators';
  */
 const MAX_SAFE_INTEGER = 9007199254740991;
 
-interface Paginator {
-  page: Subject<PageEvent>;
+/**
+ * Interface that matches the required API parts for the MatPaginator's PageEvent.
+ * Decoupled so that users can depend on either the legacy or MDC-based paginator.
+ */
+export interface MatTableDataSourcePageEvent {
+  pageIndex: number;
+  pageSize: number;
+  length: number;
+}
+
+/**
+ * Interface that matches the required API parts of the MatPaginator.
+ * Decoupled so that users can depend on either the legacy or MDC-based paginator.
+ */
+export interface MatTableDataSourcePaginator {
+  page: Subject<MatTableDataSourcePageEvent>;
   pageIndex: number;
   initialized: Observable<void>;
   pageSize: number;
@@ -36,7 +50,9 @@ interface Paginator {
 }
 
 /** Shared base class with MDC-based implementation. */
-export class _MatTableDataSource<T, P extends Paginator> extends DataSource<T> {
+export class _MatTableDataSource<T,
+    P extends MatTableDataSourcePaginator = MatTableDataSourcePaginator>
+    extends DataSource<T> {
   /** Stream that emits when a new data array is set on the data source. */
   private readonly _data: BehaviorSubject<T[]>;
 
@@ -240,12 +256,12 @@ export class _MatTableDataSource<T, P extends Paginator> extends DataSource<T> {
     const sortChange: Observable<Sort|null|void> = this._sort ?
         merge(this._sort.sortChange, this._sort.initialized) as Observable<Sort|void> :
         observableOf(null);
-    const pageChange: Observable<PageEvent|null|void> = this._paginator ?
+    const pageChange: Observable<MatTableDataSourcePageEvent|null|void> = this._paginator ?
         merge(
           this._paginator.page,
           this._internalPageChanges,
           this._paginator.initialized
-        ) as Observable<PageEvent|void> :
+        ) as Observable<MatTableDataSourcePageEvent|void> :
         observableOf(null);
     const dataStream = this._data;
     // Watch for base data or filter changes to provide a filtered set of data.

--- a/tools/public_api_guard/material/table.d.ts
+++ b/tools/public_api_guard/material/table.d.ts
@@ -1,4 +1,4 @@
-export declare class _MatTableDataSource<T, P extends Paginator> extends DataSource<T> {
+export declare class _MatTableDataSource<T, P extends MatTableDataSourcePaginator = MatTableDataSourcePaginator> extends DataSource<T> {
     _renderChangesSubscription: Subscription | null;
     get data(): T[];
     set data(data: T[]);
@@ -111,6 +111,20 @@ export declare class MatTable<T> extends CdkTable<T> {
 }
 
 export declare class MatTableDataSource<T> extends _MatTableDataSource<T, MatPaginator> {
+}
+
+export interface MatTableDataSourcePageEvent {
+    length: number;
+    pageIndex: number;
+    pageSize: number;
+}
+
+export interface MatTableDataSourcePaginator {
+    initialized: Observable<void>;
+    length: number;
+    page: Subject<MatTableDataSourcePageEvent>;
+    pageIndex: number;
+    pageSize: number;
 }
 
 export declare class MatTableModule {


### PR DESCRIPTION
Modify the `MatTableDataSource` interface so that instead of expecting either the legacy `MatPaginator` or MDC-based `MatPaginator`, it accepts something with the right API interface and defaults to that.

This change enables users to migrate from the legacy table to the MDC-based table without requiring them to also migrate the pagintor (which then also includes select, thus all form field elements, and button and tooltip).
