### PR TITLE
fix(material/schematics): don't drop prebuilt imports in theming API migration

### DIFF
--- a/src/material/schematics/ng-update/migrations/theming-api-v12/theming-api-migration.ts
+++ b/src/material/schematics/ng-update/migrations/theming-api-v12/theming-api-migration.ts
@@ -22,7 +22,8 @@ export class ThemingApiMigration extends DevkitMigration<null> {
     if (extname(stylesheet.filePath) === '.scss') {
       const content = stylesheet.content;
       const migratedContent = content ? migrateFileContent(content,
-        '~@angular/material/', '~@angular/cdk/', '~@angular/material', '~@angular/cdk') : content;
+        '~@angular/material/', '~@angular/cdk/', '~@angular/material', '~@angular/cdk',
+        undefined, /material\/prebuilt-themes|cdk\/.*-prebuilt/) : content;
 
       if (migratedContent && migratedContent !== content) {
         this.fileSystem.edit(stylesheet.filePath)

--- a/src/material/schematics/ng-update/test-cases/v12/misc/theming-api-v12.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/v12/misc/theming-api-v12.spec.ts
@@ -716,4 +716,22 @@ describe('v12 theming API migration', () => {
       `@include mat.mdc-button-theme();`,
     ].join('\n'));
   });
+
+  it('should not drop imports of prebuilt styles', async () => {
+    writeLines(THEME_PATH, [
+      `@import '~@angular/material/prebuilt-themes/indigo-pink.css';`,
+      `@import '~@angular/material/theming';`,
+      `@import '~@angular/cdk/overlay-prebuilt.css';`,
+      `@include mat-core();`,
+    ]);
+
+    await runMigration();
+
+    expect(splitFile(THEME_PATH)).toEqual([
+      `@use '~@angular/material' as mat;`,
+      `@import '~@angular/material/prebuilt-themes/indigo-pink.css';`,
+      `@import '~@angular/cdk/overlay-prebuilt.css';`,
+      `@include mat.core();`,
+    ]);
+  });
 });


### PR DESCRIPTION
Currently the theming API migration drops any imports starting with `~@angular/material/`, assuming that they're Sass APIs. This can result in prebuilt style imports being removed by mistake.

These changes add a regex based on which we'll exclude some imports from the migration.

Fixes #22697.