### PR TITLE
fix(material/schematics): prevent themingApi renaming functions that …

### DIFF
--- a/src/material/schematics/ng-update/migrations/theming-api-v12/migration.ts
+++ b/src/material/schematics/ng-update/migrations/theming-api-v12/migration.ts
@@ -231,7 +231,7 @@ function getMixinValueFormatter(namespace: string): (name: string) => string {
 
 /** Formats a migration key as a Sass function invocation. */
 function functionKeyFormatter(namespace: string|null, name: string): RegExp {
-  return new RegExp(escapeRegExp(`${namespace ? namespace + '.' : ''}${name}(`), 'g');
+  return new RegExp(escapeRegExp(`${namespace ? namespace + '.' : ''}[^a-zA-Z]${name}(`), 'g');
 }
 
 /** Returns a function that can be used to format a Sass function replacement. */


### PR DESCRIPTION
…don't start with `mat`

The function key regex for the `themingApi` schematic looks only looks for the function name. This causes an issue when running in google where we have some functions that start with `gmat` (in particular, we have a `gmat-typography-config`). This change filters out strings where the matched function name has another "a" through "z" character immediately before the function name.