### PR TITLE
fix(material/checkbox): disable ripple animation under noop animations module

### DIFF
--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -21,7 +21,7 @@
          [matRippleDisabled]="_isRippleDisabled()"
          [matRippleRadius]="20"
          [matRippleCentered]="true"
-         [matRippleAnimation]="{enterDuration: 150}">
+         [matRippleAnimation]="{enterDuration: _animationMode === 'NoopAnimations' ? 0 : 150}">
       <span class="mat-ripple-element mat-checkbox-persistent-ripple"></span>
     </span>
     <span class="mat-checkbox-frame"></span>


### PR DESCRIPTION
Fixes that the checkbox doesn't disable its ripple animation when the noop animations module is enabled.