### PR TITLE
feat(multiple): add ng-update entry for `google-maps` and `youtube-player` package

### DIFF
--- a/src/google-maps/package.json
+++ b/src/google-maps/package.json
@@ -28,5 +28,6 @@
   "sideEffects": false,
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
-  }
+  },
+  "ng-update": {}
 }

--- a/src/youtube-player/package.json
+++ b/src/youtube-player/package.json
@@ -28,5 +28,6 @@
   "sideEffects": false,
   "publishConfig":{
     "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  },
+  "ng-update": {}
 }


### PR DESCRIPTION
Currently if developers run `ng update` without specifying a package,
the CLI will analyze the current workspace and find packages that
provide migrations and need to be updated. For the `youtube-player`
and `google-maps` package we do not provide any migrations, so
`ng update` will not report this package.

Since these packages are part of the `@angular` scope, we
want these packages to be highlighted when users run `ng update`.
There aren't any migrations for these packages yet, but we are setting
up the integration with `ng update` in order to make these packages
visible to the CLI.

Fixes #22689.