### PR TITLE
docs(material/table): Correct checkbox label on select all checkbox

### DIFF
--- a/src/components-examples/material/table/table-selection/table-selection-example.ts
+++ b/src/components-examples/material/table/table-selection/table-selection-example.ts
@@ -55,7 +55,7 @@ export class TableSelectionExample {
   /** The label for the checkbox on the passed row */
   checkboxLabel(row?: PeriodicElement): string {
     if (!row) {
-      return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
+      return `${this.isAllSelected() ? 'deselect' : 'select'} all`;
     }
     return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.position + 1}`;
   }


### PR DESCRIPTION
The example label for the select all/deselect all checkbox is reversed.  The select all state is labeled "deselect all" and vice versa.  This will correct those labels.

![image](https://user-images.githubusercontent.com/64983347/119069543-50748f00-b9b4-11eb-9858-fabaca46bf79.png)
