### PR TITLE
fix(material-experimental/mdc-table): add background inherit to header cells

### DIFF
--- a/src/material-experimental/mdc-table/table.scss
+++ b/src/material-experimental/mdc-table/table.scss
@@ -31,8 +31,9 @@ mat-row.mat-mdc-row, mat-header-row.mat-mdc-header-row, mat-footer-row.mat-mdc-f
 // Cells need to inherit their background in order to overlap each other when sticky.
 // The background needs to be inherited from the table, tbody/tfoot, row
 // (already set in MDC), and cell.
-.mat-mdc-table tbody, .mat-mdc-table tfoot,
-.mat-mdc-cell, .mat-mdc-footer-cell {
+.mat-mdc-table tbody, .mat-mdc-table tfoot, .mat-mdc-table thead,
+.mat-mdc-cell, .mat-mdc-footer-cell,
+.mat-mdc-table .mat-mdc-header-cell {
   background: inherit;
 }
 


### PR DESCRIPTION
MDC explicitly sets a color on the header cells - this aligns all cells to be inheriting from the table element itself (which uses background card by default)