### PR TITLE
docs: add doc string to base signature of `parallel` function

### DIFF
--- a/src/cdk/testing/change-detection.ts
+++ b/src/cdk/testing/change-detection.ts
@@ -167,6 +167,13 @@ export function parallel<T1, T2>(values: () => [T1 | PromiseLike<T1>, T2 | Promi
  */
 export function parallel<T>(values: () => (T | PromiseLike<T>)[]): Promise<T[]>;
 
+/**
+ * Resolves the given list of async values in parallel (i.e. via Promise.all) while batching change
+ * detection over the entire operation such that change detection occurs exactly once before
+ * resolving the values and once after.
+ * @param values A getter for the async values to resolve in parallel with batched change detection.
+ * @return The resolved values.
+ */
 export async function parallel<T>(values: () => Iterable<T | PromiseLike<T>>): Promise<T[]> {
   return batchChangeDetection(() => Promise.all(values()), true);
 }


### PR DESCRIPTION
The `parallel` function docs weren't showing up in the docs site, likely because the base signature didn't have a doc string.

Fixes #22013.