### PR TITLE
fix(cdk/a11y): Fix the touch/program origin regression introduced in the recent FocusMonitor refactor.

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -340,6 +340,16 @@ export class FocusMonitor implements OnDestroy {
    * @param focusEventTarget The target of the focus event under examination.
    */
   private _shouldBeAttributedToTouch(focusEventTarget: HTMLElement | null): boolean {
+    // Please note that this check is not perfect. Consider the following edge case:
+    //
+    // <div #parent tabindex="0">
+    //   <div #child tabindex="0" (click)="#parent.focus()"></div>
+    // </div>
+    //
+    // Suppose there is a FocusMonitor in IMMEDIATE mode attached to #parent. When the user touches
+    // #child, #parent is programmatically focused. This code will attribute the focus to touch
+    // instead of program. This is a relatively minor edge-case that can be worked around by using
+    // focusVia(parent, 'program') to focus #parent.
     return (this._detectionMode === FocusMonitorDetectionMode.EVENTUAL) ||
         !!focusEventTarget?.contains(this._inputModalityDetector._mostRecentTarget);
   }

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -24,7 +24,11 @@ import {Observable, of as observableOf, Subject, Subscription} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {coerceElement} from '@angular/cdk/coercion';
 import {DOCUMENT} from '@angular/common';
-import {getTarget, InputModalityDetector, TOUCH_BUFFER_MS} from '../input-modality/input-modality-detector';
+import {
+  getTarget,
+  InputModalityDetector,
+  TOUCH_BUFFER_MS,
+} from '../input-modality/input-modality-detector';
 
 
 export type FocusOrigin = 'touch' | 'mouse' | 'keyboard' | 'program' | null;

--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -24,7 +24,7 @@ import {Observable, of as observableOf, Subject, Subscription} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {coerceElement} from '@angular/cdk/coercion';
 import {DOCUMENT} from '@angular/common';
-import {InputModalityDetector, TOUCH_BUFFER_MS} from '../input-modality/input-modality-detector';
+import {getTarget, InputModalityDetector, TOUCH_BUFFER_MS} from '../input-modality/input-modality-detector';
 
 
 export type FocusOrigin = 'touch' | 'mouse' | 'keyboard' | 'program' | null;
@@ -528,14 +528,6 @@ export class FocusMonitor implements OnDestroy {
     return results;
   }
 }
-
-/** Gets the target of an event, accounting for Shadow DOM. */
-export function getTarget(event: Event): HTMLElement|null {
-  // If an event is bound outside the Shadow DOM, the `event.target` will
-  // point to the shadow root so we have to use `composedPath` instead.
-  return (event.composedPath ? event.composedPath()[0] : event.target) as HTMLElement | null;
-}
-
 
 /**
  * Directive that determines how a particular element was focused (via keyboard, mouse, touch, or

--- a/src/cdk/a11y/input-modality/input-modality-detector.ts
+++ b/src/cdk/a11y/input-modality/input-modality-detector.ts
@@ -16,7 +16,6 @@ import {
   isFakeMousedownFromScreenReader,
   isFakeTouchstartFromScreenReader,
 } from '../fake-event-detection';
-import {getTarget} from '../focus-monitor/focus-monitor';
 
 /**
  * The input modalities detected by this service. Null is used if the input modality is unknown.
@@ -203,4 +202,11 @@ export class InputModalityDetector implements OnDestroy {
     document.removeEventListener('mousedown', this._onMousedown, modalityEventListenerOptions);
     document.removeEventListener('touchstart', this._onTouchstart, modalityEventListenerOptions);
   }
+}
+
+/** Gets the target of an event, accounting for Shadow DOM. */
+export function getTarget(event: Event): HTMLElement|null {
+  // If an event is bound outside the Shadow DOM, the `event.target` will
+  // point to the shadow root so we have to use `composedPath` instead.
+  return (event.composedPath ? event.composedPath()[0] : event.target) as HTMLElement | null;
 }

--- a/src/cdk/a11y/input-modality/input-modality-detector.ts
+++ b/src/cdk/a11y/input-modality/input-modality-detector.ts
@@ -16,6 +16,7 @@ import {
   isFakeMousedownFromScreenReader,
   isFakeTouchstartFromScreenReader,
 } from '../fake-event-detection';
+import {getTarget} from '../focus-monitor/focus-monitor';
 
 /**
  * The input modalities detected by this service. Null is used if the input modality is unknown.
@@ -100,6 +101,12 @@ export class InputModalityDetector implements OnDestroy {
     return this._modality.value;
   }
 
+  /**
+   * The most recently detected input modality event target. Is null if no input modality has been
+   * detected or if the associated event target is null for some unknown reason.
+   */
+  _mostRecentTarget: HTMLElement | null = null;
+
   /** The underlying BehaviorSubject that emits whenever an input modality is detected. */
   private readonly _modality = new BehaviorSubject<InputModality>(null);
 
@@ -122,6 +129,7 @@ export class InputModalityDetector implements OnDestroy {
     if (this._options?.ignoreKeys?.some(keyCode => keyCode === event.keyCode)) { return; }
 
     this._modality.next('keyboard');
+    this._mostRecentTarget = getTarget(event);
   }
 
   /**
@@ -137,6 +145,7 @@ export class InputModalityDetector implements OnDestroy {
     // Fake mousedown events are fired by some screen readers when controls are activated by the
     // screen reader. Attribute them to keyboard input modality.
     this._modality.next(isFakeMousedownFromScreenReader(event) ? 'keyboard' : 'mouse');
+    this._mostRecentTarget = getTarget(event);
   }
 
   /**
@@ -156,6 +165,7 @@ export class InputModalityDetector implements OnDestroy {
     this._lastTouchMs = Date.now();
 
     this._modality.next('touch');
+    this._mostRecentTarget = getTarget(event);
   }
 
   constructor(

--- a/tools/public_api_guard/cdk/a11y.d.ts
+++ b/tools/public_api_guard/cdk/a11y.d.ts
@@ -193,6 +193,7 @@ export declare const INPUT_MODALITY_DETECTOR_OPTIONS: InjectionToken<InputModali
 export declare type InputModality = 'keyboard' | 'mouse' | 'touch' | null;
 
 export declare class InputModalityDetector implements OnDestroy {
+    _mostRecentTarget: HTMLElement | null;
     readonly modalityChanged: Observable<InputModality>;
     readonly modalityDetected: Observable<InputModality>;
     get mostRecentModality(): InputModality;


### PR DESCRIPTION
https://github.com/angular/components/pull/22489 purposefully introduced a regression into `FocusMonitor` when touch events are quickly followed by programmatic focus events (read the PR for more details). It was thought this regression was fine because (1) it allowed us to remove a bunch of specialized touch logic from `FocusMonitor`, (2) it allows us to easily integrate `InputModalityDetector`, and (3) we didn't believe that mixing up touch/program attribution was that big of a deal, as not many consumers would style things differently between the two cases.

It turns out that many components display focus overlays on program focus and not on touch focus (these are styles that are built-in to AM). This regression thus led to failures when testing in g3 where tests would open popups via touch that programmatically focus their first focusable element. Given this, I decided to just go ahead and fix the regression. In reviewing this PR, it may help to review how the pre-`InputModalityDetector` `FocusMonitor` handled touch events (this implementation is largely similar but has some minor differences).

This PR also fixes a subtle bug in how the pre-`InputModalityDetector` implementation handled programmatic focus events that quickly follow touch events _in EVENTUAL mode_. This Stackblitz demonstrates and describes the bug: https://stackblitz.com/edit/angular-ivy-syzr9m. Additionally, it fixes an even subtler bug with touch-triggered programmatic focus events _again in EVENTUAL mode_, but I won't bother spinning up a demo unless people are curious.

Note: I also already ran a TPG for this PR on top of the rest of the input modality work and all looks good.