### PR TITLE
Made slide-toggle label non user selectable

### DIFF
--- a/src/material/slide-toggle/slide-toggle.scss
+++ b/src/material/slide-toggle/slide-toggle.scss
@@ -1,3 +1,4 @@
+@use '../core/style/vendor-prefixes';
 @use '../core/style/variables';
 @use '../core/ripple/ripple';
 @use '../core/style/list-common';
@@ -47,6 +48,7 @@ $bar-track-width: $bar-width - $thumb-size;
 // The label element is our root container for the slide-toggle / switch indicator and label text.
 // It has to be a label, to support accessibility for the visual hidden input.
 .mat-slide-toggle-label {
+  @include vendor-prefixes.user-select(none);
   display: flex;
   flex: 1;
   flex-direction: row;


### PR DESCRIPTION
Since checkbox labels aren't user-selectable, I've thought it would be a more consistent behavior if slide toggles aren't either.