### PR TITLE
Fixed incorrect theme variable used in theme file

### DIFF
--- a/guides/theming-your-components.md
+++ b/guides/theming-your-components.md
@@ -220,5 +220,5 @@ $my-theme: mat.define-light-theme((
 ));
 
 @include mat.all-component-themes($my-theme);
-@include carousel.theme($theme);
+@include carousel.theme($my-theme);
 ```


### PR DESCRIPTION
docs(material): Code specified in documentation will not compile
  
The code as written in step 4 won't compile, since $theme is not defined.
Should pass $my-theme instead.