### PR TITLE
docs(material/core): Add a brief overview that refers users to the API docs

### DIFF
--- a/src/material/core/core.md
+++ b/src/material/core/core.md
@@ -1,0 +1,2 @@
+The `@angular/material/core` package contains common components and services used by multiple other
+components in the library. See the API tab for a listing of components and classes available.


### PR DESCRIPTION
This will allow us to publish a section on the docs site for `@angular/material/core`.

Related to #8790