### PR TITLE
docs(material/form-field): add placeholder to prefix/suffix example for better alignment

### DIFF
--- a/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.html
+++ b/src/components-examples/material/form-field/form-field-prefix-suffix/form-field-prefix-suffix-example.html
@@ -7,9 +7,9 @@
     </button>
   </mat-form-field>
 
-  <mat-form-field appearance="fill">
+  <mat-form-field appearance="fill" floatLabel="always">
     <mat-label>Amount</mat-label>
-    <input matInput type="number" class="example-right-align">
+    <input matInput type="number" class="example-right-align" placeholder="0">
     <span matPrefix>$&nbsp;</span>
     <span matSuffix>.00</span>
   </mat-form-field>


### PR DESCRIPTION
 https://github.com/angular/components/issues/21846

Note: MDC form field should hide text prefix/suffix when label is floating


