### PR TITLE
docs: improve API rate-limit error handling in table-http-example

### DIFF
--- a/src/components-examples/material/table/table-http/table-http-example.css
+++ b/src/components-examples/material/table/table-http/table-http-example.css
@@ -1,11 +1,11 @@
 /* Structure */
 .example-container {
   position: relative;
-  min-height: 200px;
 }
 
 .example-table-container {
   position: relative;
+  min-height: 200px;
   max-height: 400px;
   overflow: auto;
 }


### PR DESCRIPTION
There are currently three issues with the `table-http-example`:

1. If a user hits the rate limit within this example, an overlay
will be displayed mentioning the rate limit issue. This overlay
intends to overlap the whole table, except for the paginator. Right
now this is broken as there is a minium height throwing off the
assumption that the paginator is at the bottom of the example.

2. If a user hits the rate limit, the paginator length is reset to
zero. This means that the user is unable to trigger new requests
as the previous/next page buttons become disabled.

3. Due to incorrect error handling, the observable will be
replaced by a new one that will always return an empty list.
The rate limit/API errors should be caught within the switch
map to not prevent future API requests on errors.

Updated StackBlitz: https://stackblitz.com/edit/angular-vf4jjs?file=src/app/table-http-example.ts

Fixes #11547.