### PR TITLE
fix(material/input): Do not set `aria-invalid` on empty `matInput`s

### DIFF
--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -928,7 +928,7 @@ describe('MatMdcInput with forms', () => {
       expect(testComponent.formControl.untouched).toBe(true, 'Expected untouched form control');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
       expect(inputEl.getAttribute('aria-invalid'))
-        .toBe(null, 'Expected aria-invalid not to be present.');
+        .toBe('false', 'Expected aria-invalid to be set to "false".');
     }));
 
     it('should display an error message when the input is touched and invalid', fakeAsync(() => {
@@ -997,7 +997,7 @@ describe('MatMdcInput with forms', () => {
       expect(component.formGroup.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
       expect(inputEl.getAttribute('aria-invalid'))
-        .toBe(null, 'Expected aria-invalid not to be present');
+        .toBe('false', 'Expected aria-invalid to be set to "false".');
       expect(component.formGroupDirective.submitted)
         .toBe(false, 'Expected form not to have been submitted');
 
@@ -1081,7 +1081,7 @@ describe('MatMdcInput with forms', () => {
       expect(describedBy).toBe(errorIds);
     }));
 
-    it('should not set `aria-invalid` if the input is empty', fakeAsync(() => {
+    it('should set `aria-invalid` to true if the input is empty', fakeAsync(() => {
       // Submit the form since it's the one that triggers the default error state matcher.
       dispatchFakeEvent(fixture.nativeElement.querySelector('form'), 'submit');
       fixture.detectChanges();
@@ -1090,7 +1090,7 @@ describe('MatMdcInput with forms', () => {
       expect(testComponent.formControl.invalid).toBe(true, 'Expected form control to be invalid');
       expect(inputEl.value).toBeFalsy();
       expect(inputEl.getAttribute('aria-invalid'))
-          .toBe(null, 'Expected aria-invalid not to be present');
+          .toBe('true', 'Expected aria-invalid to be set to "true"');
 
       inputEl.value = 'not valid';
       fixture.detectChanges();
@@ -1298,6 +1298,48 @@ describe('MatFormField default options', () => {
     expect(fixture.componentInstance.formField.appearance).toBe('outline');
   });
 
+});
+
+describe('MatInput that is requried with a formControl', () => {
+  let fixture: ComponentFixture<MatInputWithRequiredAndFormControl>;
+  let input: HTMLInputElement;
+  let formControl: FormControl;
+
+  beforeEach(() => {
+    fixture = createComponent(MatInputWithRequiredAndFormControl);
+    formControl = fixture.componentInstance.formControl;
+    input = fixture.debugElement.query(By.css('input')).nativeElement!;
+    fixture.detectChanges();
+  });
+
+  it('should set aria-required.', () => {
+    expect(input.getAttribute('aria-required'))
+      .toBe('true', 'Expected "aria-required" to be "true"');
+  });
+
+  it('should not set any value for aria-invalid.', () => {
+    expect(input.getAttribute('aria-invalid'))
+      .toBe(null, 'Expected "aria-invalid" not to be set');
+  });
+
+  it('should not set aria-invalid when empty and invalid.', () => {
+    formControl.setErrors({error: 'True!'});
+    formControl.markAsTouched();
+    fixture.detectChanges();
+
+    expect(input.getAttribute('aria-invalid'))
+      .toBe(null, 'Expected "aria-invalid" not to be set');
+  });
+
+  it('should set aria-invalid when not empty and invalid.', () => {
+    input.value = 'Some value';
+    formControl.setErrors({error: 'True!'});
+    formControl.markAsTouched();
+    fixture.detectChanges();
+
+    expect(input.getAttribute('aria-invalid'))
+      .toBe('true', 'Expected "aria-invalid" to be "true"');
+  });
 });
 
 function configureTestingModule(component: Type<any>, options:
@@ -1823,3 +1865,14 @@ class MatInputWithColor {
   `
 })
 class MatInputInsideOutsideFormField {}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput required [formControl]="formControl">
+    </mat-form-field>
+  `
+})
+class MatInputWithRequiredAndFormControl {
+  formControl = new FormControl();
+}

--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -928,7 +928,7 @@ describe('MatMdcInput with forms', () => {
       expect(testComponent.formControl.untouched).toBe(true, 'Expected untouched form control');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
       expect(inputEl.getAttribute('aria-invalid'))
-        .toBe('false', 'Expected aria-invalid to be set to "false".');
+        .toBe(null, 'Expected aria-invalid not to be present.');
     }));
 
     it('should display an error message when the input is touched and invalid', fakeAsync(() => {
@@ -997,7 +997,7 @@ describe('MatMdcInput with forms', () => {
       expect(component.formGroup.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
       expect(inputEl.getAttribute('aria-invalid'))
-        .toBe('false', 'Expected aria-invalid to be set to "false".');
+        .toBe(null, 'Expected aria-invalid not to be present');
       expect(component.formGroupDirective.submitted)
         .toBe(false, 'Expected form not to have been submitted');
 
@@ -1081,7 +1081,7 @@ describe('MatMdcInput with forms', () => {
       expect(describedBy).toBe(errorIds);
     }));
 
-    it('should not set `aria-invalid` to true if the input is empty', fakeAsync(() => {
+    it('should not set `aria-invalid` if the input is empty', fakeAsync(() => {
       // Submit the form since it's the one that triggers the default error state matcher.
       dispatchFakeEvent(fixture.nativeElement.querySelector('form'), 'submit');
       fixture.detectChanges();
@@ -1090,7 +1090,7 @@ describe('MatMdcInput with forms', () => {
       expect(testComponent.formControl.invalid).toBe(true, 'Expected form control to be invalid');
       expect(inputEl.value).toBeFalsy();
       expect(inputEl.getAttribute('aria-invalid'))
-          .toBe('false', 'Expected aria-invalid to be set to "false".');
+          .toBe(null, 'Expected aria-invalid not to be present');
 
       inputEl.value = 'not valid';
       fixture.detectChanges();

--- a/src/material-experimental/mdc-input/input.ts
+++ b/src/material-experimental/mdc-input/input.ts
@@ -39,7 +39,7 @@ import {MatInput as BaseMatInput} from '@angular/material/input';
     '[attr.readonly]': 'readonly && !_isNativeSelect || null',
     // Only mark the input as invalid for assistive technology if it has a value since the
     // state usually overlaps with `aria-required` when the input is empty and can be redundant.
-    '[attr.aria-invalid]': 'errorState && !empty',
+    '[attr.aria-invalid]': 'empty ? null : errorState',
     '[attr.aria-required]': 'required',
   },
   providers: [{provide: MatFormFieldControl, useExisting: MatInput}],

--- a/src/material-experimental/mdc-input/input.ts
+++ b/src/material-experimental/mdc-input/input.ts
@@ -39,7 +39,7 @@ import {MatInput as BaseMatInput} from '@angular/material/input';
     '[attr.readonly]': 'readonly && !_isNativeSelect || null',
     // Only mark the input as invalid for assistive technology if it has a value since the
     // state usually overlaps with `aria-required` when the input is empty and can be redundant.
-    '[attr.aria-invalid]': 'empty ? null : errorState',
+    '[attr.aria-invalid]': '(empty && required) ? null : errorState',
     '[attr.aria-required]': 'required',
   },
   providers: [{provide: MatFormFieldControl, useExisting: MatInput}],

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1081,7 +1081,7 @@ describe('MatInput with forms', () => {
       expect(testComponent.formControl.untouched).toBe(true, 'Expected untouched form control');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
       expect(inputEl.getAttribute('aria-invalid'))
-        .toBe(null, 'Expected aria-invalid not to be present.');
+        .toBe('false', 'Expected aria-invalid to be set to "false".');
     }));
 
     it('should display an error message when the input is touched and invalid', fakeAsync(() => {
@@ -1135,7 +1135,7 @@ describe('MatInput with forms', () => {
       expect(component.formGroup.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
       expect(inputEl.getAttribute('aria-invalid'))
-        .toBe(null, 'Expected aria-invalid not to be present.');
+        .toBe('false', 'Expected aria-invalid to be set to "false".');
       expect(component.formGroupDirective.submitted)
         .toBe(false, 'Expected form not to have been submitted');
 
@@ -1219,7 +1219,7 @@ describe('MatInput with forms', () => {
       expect(describedBy).toBe(errorIds);
     }));
 
-    it('should not set `aria-invalid` if the input is empty', fakeAsync(() => {
+    it('should set `aria-invalid` to true if the input is empty', fakeAsync(() => {
       // Submit the form since it's the one that triggers the default error state matcher.
       dispatchFakeEvent(fixture.nativeElement.querySelector('form'), 'submit');
       fixture.detectChanges();
@@ -1228,7 +1228,7 @@ describe('MatInput with forms', () => {
       expect(testComponent.formControl.invalid).toBe(true, 'Expected form control to be invalid');
       expect(inputEl.value).toBeFalsy();
       expect(inputEl.getAttribute('aria-invalid'))
-          .toBe(null, 'Expected aria-invalid not to be present.');
+          .toBe('true', 'Expected aria-invalid to be set to "true".');
 
       inputEl.value = 'not valid';
       fixture.detectChanges();
@@ -1751,6 +1751,48 @@ describe('MatInput with textarea autosize', () => {
     fixture.detectChanges();
     const textarea = fixture.nativeElement.querySelector('textarea');
     expect(textarea.getBoundingClientRect().height).toBeGreaterThan(1);
+  });
+});
+
+describe('MatInput that is requried with a formControl', () => {
+  let fixture: ComponentFixture<MatInputWithRequiredAndFormControl>;
+  let input: HTMLInputElement;
+  let formControl: FormControl;
+
+  beforeEach(() => {
+    fixture = createComponent(MatInputWithRequiredAndFormControl);
+    formControl = fixture.componentInstance.formControl;
+    input = fixture.debugElement.query(By.css('input')).nativeElement!;
+    fixture.detectChanges();
+  });
+
+  it('should set aria-required.', () => {
+    expect(input.getAttribute('aria-required'))
+      .toBe('true', 'Expected "aria-required" to be "true"');
+  });
+
+  it('should not set any value for aria-invalid.', () => {
+    expect(input.getAttribute('aria-invalid'))
+      .toBe(null, 'Expected "aria-invalid" not to be set');
+  });
+
+  it('should not set aria-invalid when empty and invalid.', () => {
+    formControl.setErrors({error: 'True!'});
+    formControl.markAsTouched();
+    fixture.detectChanges();
+
+    expect(input.getAttribute('aria-invalid'))
+      .toBe(null, 'Expected "aria-invalid" not to be set');
+  });
+
+  it('should set aria-invalid when not empty and invalid.', () => {
+    input.value = 'Some value';
+    formControl.setErrors({error: 'True!'});
+    formControl.markAsTouched();
+    fixture.detectChanges();
+
+    expect(input.getAttribute('aria-invalid'))
+      .toBe('true', 'Expected "aria-invalid" to be "true"');
   });
 });
 
@@ -2384,4 +2426,15 @@ class MatInputWithAnotherNgIf {
 })
 class MatInputWithColor {
   color: ThemePalette;
+}
+
+@Component({
+  template: `
+    <mat-form-field>
+      <input matInput required [formControl]="formControl">
+    </mat-form-field>
+  `
+})
+class MatInputWithRequiredAndFormControl {
+  formControl = new FormControl();
 }

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1081,7 +1081,7 @@ describe('MatInput with forms', () => {
       expect(testComponent.formControl.untouched).toBe(true, 'Expected untouched form control');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
       expect(inputEl.getAttribute('aria-invalid'))
-        .toBe('false', 'Expected aria-invalid to be set to "false".');
+        .toBe(null, 'Expected aria-invalid not to be present.');
     }));
 
     it('should display an error message when the input is touched and invalid', fakeAsync(() => {
@@ -1135,7 +1135,7 @@ describe('MatInput with forms', () => {
       expect(component.formGroup.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
       expect(inputEl.getAttribute('aria-invalid'))
-        .toBe('false', 'Expected aria-invalid to be set to "false".');
+        .toBe(null, 'Expected aria-invalid not to be present.');
       expect(component.formGroupDirective.submitted)
         .toBe(false, 'Expected form not to have been submitted');
 
@@ -1219,7 +1219,7 @@ describe('MatInput with forms', () => {
       expect(describedBy).toBe(errorIds);
     }));
 
-    it('should not set `aria-invalid` to true if the input is empty', fakeAsync(() => {
+    it('should not set `aria-invalid` if the input is empty', fakeAsync(() => {
       // Submit the form since it's the one that triggers the default error state matcher.
       dispatchFakeEvent(fixture.nativeElement.querySelector('form'), 'submit');
       fixture.detectChanges();
@@ -1228,7 +1228,7 @@ describe('MatInput with forms', () => {
       expect(testComponent.formControl.invalid).toBe(true, 'Expected form control to be invalid');
       expect(inputEl.value).toBeFalsy();
       expect(inputEl.getAttribute('aria-invalid'))
-          .toBe('false', 'Expected aria-invalid to be set to "false".');
+          .toBe(null, 'Expected aria-invalid not to be present.');
 
       inputEl.value = 'not valid';
       fixture.detectChanges();

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -83,7 +83,7 @@ const _MatInputBase = mixinErrorState(class {
     '[attr.readonly]': 'readonly && !_isNativeSelect || null',
     // Only mark the input as invalid for assistive technology if it has a value since the
     // state usually overlaps with `aria-required` when the input is empty and can be redundant.
-    '[attr.aria-invalid]': 'empty ? null : errorState',
+    '[attr.aria-invalid]': '(empty && required) ? null : errorState',
     '[attr.aria-required]': 'required',
   },
   providers: [{provide: MatFormFieldControl, useExisting: MatInput}],

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -83,7 +83,7 @@ const _MatInputBase = mixinErrorState(class {
     '[attr.readonly]': 'readonly && !_isNativeSelect || null',
     // Only mark the input as invalid for assistive technology if it has a value since the
     // state usually overlaps with `aria-required` when the input is empty and can be redundant.
-    '[attr.aria-invalid]': 'errorState && !empty',
+    '[attr.aria-invalid]': 'empty ? null : errorState',
     '[attr.aria-required]': 'required',
   },
   providers: [{provide: MatFormFieldControl, useExisting: MatInput}],


### PR DESCRIPTION
Updates the logic for setting `aria-invalid` on `matInput` to not set
the value at all if the input has no value.

Prior to this PR `matInput` sets `aria-invalid="false"` for any empty
`matInput`, including `required` ones.  This suppresses screen readers'
announcement to users that such inputs are in an invalid state.

Fixes #22777