### PR TITLE
feat(multiple): add options to autoFocus field for dialogs

### DIFF
--- a/src/cdk-experimental/dialog/dialog-config.ts
+++ b/src/cdk-experimental/dialog/dialog-config.ts
@@ -10,6 +10,9 @@ import {Direction} from '@angular/cdk/bidi';
 import {ComponentType} from '@angular/cdk/overlay';
 import {CdkDialogContainer} from './dialog-container';
 
+/** Options for where to set focus to automatically on dialog open */
+export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
+
 /** Valid ARIA roles for a dialog element. */
 export type DialogRole = 'dialog' | 'alertdialog';
 
@@ -84,8 +87,12 @@ export class DialogConfig<D = any> {
   /** Aria label to assign to the dialog element */
   ariaLabel?: string | null = null;
 
-  /** Whether the dialog should focus the first focusable element on open. */
-  autoFocus?: boolean = true;
+  /**
+   * Where the dialog should focus on open.
+   * @breaking-change 14.0.0 Remove boolean option from autoFocus. Use string or
+   * AutoFocusTarget instead.
+   */
+  autoFocus?: AutoFocusTarget | string | boolean = 'first-tabbable';
 
   /** Duration of the enter animation. Has to be a valid CSS value (e.g. 100ms). */
   enterAnimationDuration?: string = '225ms';

--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -882,7 +882,8 @@ describe('Dialog', () => {
     beforeEach(() => document.body.appendChild(overlayContainerElement));
     afterEach(() => document.body.removeChild(overlayContainerElement));
 
-    it('should focus the first tabbable element of the dialog on open', fakeAsync(() => {
+    it('should focus the first tabbable element of the dialog on open (the default)',
+      fakeAsync(() => {
       dialog.openFromComponent(PizzaMsg, {
         viewContainerRef: testViewContainerRef
       });
@@ -894,16 +895,52 @@ describe('Dialog', () => {
           .toBe('INPUT', 'Expected first tabbable element (input) in the dialog to be focused.');
     }));
 
-    it('should allow disabling focus of the first tabbable element', fakeAsync(() => {
+    it('should focus the dialog element on open', fakeAsync(() => {
       dialog.openFromComponent(PizzaMsg, {
         viewContainerRef: testViewContainerRef,
-        autoFocus: false
+        autoFocus: 'dialog'
       });
 
       viewContainerFixture.detectChanges();
       flushMicrotasks();
 
-      expect(document.activeElement!.tagName).not.toBe('INPUT');
+      let container =
+        overlayContainerElement.querySelector('cdk-dialog-container') as HTMLInputElement;
+
+      expect(document.activeElement).toBe(container, 'Expected container to be focused on open');
+    }));
+
+    it('should focus the first header element on open', fakeAsync(() => {
+      dialog.openFromComponent(ContentElementDialog, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'first-heading'
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let firstHeader =
+        overlayContainerElement.querySelector('h1[tabindex="-1"]') as HTMLInputElement;
+
+      expect(document.activeElement)
+        .toBe(firstHeader, 'Expected first header to be focused on open');
+    }));
+
+    it('should focus the first element that matches the css selector from autoFocus on open',
+      fakeAsync(() => {
+      dialog.openFromComponent(PizzaMsg, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'p'
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let firstParagraph =
+        overlayContainerElement.querySelector('p[tabindex="-1"]') as HTMLInputElement;
+
+      expect(document.activeElement)
+        .toBe(firstParagraph, 'Expected first paragraph to be focused on open');
     }));
 
     it('should re-focus trigger element when dialog closes', fakeAsync(() => {

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -128,8 +128,7 @@ export class FocusTrap {
   }
 
   /**
-   * Waits for the zone to stabilize, then either focuses the first element that the
-   * user specified, or the first tabbable element.
+   * Waits for the zone to stabilize, then focuses the first tabbable element.
    * @returns Returns a promise that resolves with a boolean, depending
    * on whether focus was moved successfully.
    */

--- a/src/material-experimental/mdc-dialog/dialog-container.ts
+++ b/src/material-experimental/mdc-dialog/dialog-container.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FocusMonitor, FocusTrapFactory} from '@angular/cdk/a11y';
+import {FocusMonitor, FocusTrapFactory, InteractivityChecker} from '@angular/cdk/a11y';
 import {DOCUMENT} from '@angular/common';
 import {
   ChangeDetectionStrategy,
@@ -16,7 +16,8 @@ import {
   Inject,
   OnDestroy,
   Optional,
-  ViewEncapsulation
+  ViewEncapsulation,
+  NgZone
 } from '@angular/core';
 import {MatDialogConfig, _MatDialogContainerBase} from '@angular/material/dialog';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
@@ -65,9 +66,21 @@ export class MatDialogContainer extends _MatDialogContainerBase implements OnDes
       changeDetectorRef: ChangeDetectorRef,
       @Optional() @Inject(DOCUMENT) document: any,
       config: MatDialogConfig,
+      checker: InteractivityChecker,
+      ngZone: NgZone,
       @Optional() @Inject(ANIMATION_MODULE_TYPE) private _animationMode?: string,
-      focusMonitor?: FocusMonitor) {
-    super(elementRef, focusTrapFactory, changeDetectorRef, document, config, focusMonitor);
+      focusMonitor?: FocusMonitor
+      ) {
+    super(
+      elementRef,
+      focusTrapFactory,
+      changeDetectorRef,
+      document,
+      config,
+      checker,
+      ngZone,
+      focusMonitor
+    );
   }
 
   override _initializeWithAttachedContent() {

--- a/src/material-experimental/mdc-dialog/dialog.spec.ts
+++ b/src/material-experimental/mdc-dialog/dialog.spec.ts
@@ -934,32 +934,113 @@ describe('MDC-based MatDialog', () => {
          expect(document.activeElement).toBe(input, 'Expected input to stay focused after click');
        }));
 
+    it('should recapture focus to the first tabbable element when clicking on the backdrop with ' +
+      'autoFocus set to "first-tabbable" (the default)', fakeAsync(() => {
+      dialog.open(PizzaMsg, {
+        disableClose: true,
+        viewContainerRef: testViewContainerRef
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+      let input = overlayContainerElement.querySelector('input') as HTMLInputElement;
+
+      expect(document.activeElement).toBe(input, 'Expected input to be focused on open');
+
+      input.blur(); // Programmatic clicks might not move focus so we simulate it.
+      backdrop.click();
+      viewContainerFixture.detectChanges();
+      flush();
+
+      expect(document.activeElement).toBe(input, 'Expected input to stay focused after click');
+    }));
+
     it('should recapture focus to the container when clicking on the backdrop with ' +
-           'autoFocus disabled',
-       fakeAsync(() => {
-         dialog.open(
-             PizzaMsg,
-             {disableClose: true, viewContainerRef: testViewContainerRef, autoFocus: false});
+      'autoFocus set to "dialog"',
+      fakeAsync(() => {
+        dialog.open(PizzaMsg, {
+          disableClose: true,
+          viewContainerRef: testViewContainerRef,
+          autoFocus: 'dialog'
+        });
 
-         viewContainerFixture.detectChanges();
-         flushMicrotasks();
+        viewContainerFixture.detectChanges();
+        flushMicrotasks();
 
-         let backdrop =
-             overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-         let container =
-             overlayContainerElement.querySelector('.mat-mdc-dialog-container') as HTMLInputElement;
+        let backdrop =
+            overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+        let container =
+            overlayContainerElement.querySelector('.mat-mdc-dialog-container') as HTMLInputElement;
 
-         expect(document.activeElement).toBe(container, 'Expected container to be focused on open');
+        expect(document.activeElement).toBe(container, 'Expected container to be focused on open');
 
-         container.blur();  // Programmatic clicks might not move focus so we simulate it.
-         backdrop.click();
-         viewContainerFixture.detectChanges();
-         flush();
+        container.blur();  // Programmatic clicks might not move focus so we simulate it.
+        backdrop.click();
+        viewContainerFixture.detectChanges();
+        flush();
 
-         expect(document.activeElement)
-             .toBe(container, 'Expected container to stay focused after click');
-       }));
+        expect(document.activeElement)
+            .toBe(container, 'Expected container to stay focused after click');
+      }));
   });
+
+  it('should recapture focus to the first header when clicking on the backdrop with ' +
+    'autoFocus set to "first-heading"', fakeAsync(() => {
+    dialog.open(ContentElementDialog, {
+      disableClose: true,
+      viewContainerRef: testViewContainerRef,
+      autoFocus: 'first-heading'
+    });
+
+    viewContainerFixture.detectChanges();
+    flushMicrotasks();
+
+    let backdrop =
+      overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+    let firstHeader = overlayContainerElement
+      .querySelector('.mat-mdc-dialog-title[tabindex="-1"]') as HTMLInputElement;
+
+    expect(document.activeElement)
+      .toBe(firstHeader, 'Expected first header to be focused on open');
+
+    firstHeader.blur(); // Programmatic clicks might not move focus so we simulate it.
+    backdrop.click();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(document.activeElement)
+        .toBe(firstHeader, 'Expected first header to stay focused after click');
+  }));
+
+  it('should recapture focus to the first element that matches the css selector when ' +
+  'clicking on the backdrop with autoFocus set to a css selector', fakeAsync(() => {
+    dialog.open(ContentElementDialog, {
+      disableClose: true,
+      viewContainerRef: testViewContainerRef,
+      autoFocus: 'button'
+    });
+
+    viewContainerFixture.detectChanges();
+    flushMicrotasks();
+
+    let backdrop =
+      overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+    let firstButton =
+      overlayContainerElement.querySelector('[mat-dialog-close]') as HTMLInputElement;
+
+    expect(document.activeElement)
+      .toBe(firstButton, 'Expected first button to be focused on open');
+
+    firstButton.blur(); // Programmatic clicks might not move focus so we simulate it.
+    backdrop.click();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(document.activeElement)
+        .toBe(firstButton, 'Expected first button to stay focused after click');
+  }));
 
   describe('hasBackdrop option', () => {
     it('should have a backdrop', () => {
@@ -1015,34 +1096,77 @@ describe('MDC-based MatDialog', () => {
     beforeEach(() => document.body.appendChild(overlayContainerElement));
     afterEach(() => document.body.removeChild(overlayContainerElement));
 
-    it('should focus the first tabbable element of the dialog on open', fakeAsync(() => {
-         dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
+    it('should focus the first tabbable element of the dialog on open (the default)',
+    fakeAsync(() => {
+      dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
 
-         viewContainerFixture.detectChanges();
-         flushMicrotasks();
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
 
-         expect(document.activeElement!.tagName)
-             .toBe('INPUT', 'Expected first tabbable element (input) in the dialog to be focused.');
-       }));
+      expect(document.activeElement!.tagName)
+          .toBe('INPUT', 'Expected first tabbable element (input) in the dialog to be focused.');
+    }));
 
-    it('should allow disabling focus of the first tabbable element', fakeAsync(() => {
-         dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef, autoFocus: false});
+    it('should focus the dialog element on open', fakeAsync(() => {
+      dialog.open(PizzaMsg, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'dialog'
+      });
 
-         viewContainerFixture.detectChanges();
-         flushMicrotasks();
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
 
-         expect(document.activeElement!.tagName).not.toBe('INPUT');
-       }));
+      let container =
+        overlayContainerElement.querySelector('.mat-mdc-dialog-container') as HTMLInputElement;
+
+      expect(document.activeElement).toBe(container, 'Expected container to be focused on open');
+    }));
+
+    it('should focus the first header element on open', fakeAsync(() => {
+      dialog.open(ContentElementDialog, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'first-heading'
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let firstHeader =
+        overlayContainerElement.querySelector('h1[tabindex="-1"]') as HTMLInputElement;
+
+      expect(document.activeElement)
+        .toBe(firstHeader, 'Expected first header to be focused on open');
+    }));
+
+    it('should focus the first element that matches the css selector from autoFocus on open',
+      fakeAsync(() => {
+      dialog.open(PizzaMsg, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'p'
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let firstParagraph =
+        overlayContainerElement.querySelector('p[tabindex="-1"]') as HTMLInputElement;
+
+      expect(document.activeElement)
+        .toBe(firstParagraph, 'Expected first paragraph to be focused on open');
+    }));
 
     it('should attach the focus trap even if automatic focus is disabled', fakeAsync(() => {
-         dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef, autoFocus: false});
+      dialog.open(PizzaMsg, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'false'
+      });
 
-         viewContainerFixture.detectChanges();
-         flushMicrotasks();
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
 
-         expect(overlayContainerElement.querySelectorAll('.cdk-focus-trap-anchor').length)
-             .toBeGreaterThan(0);
-       }));
+      expect(overlayContainerElement.querySelectorAll('.cdk-focus-trap-anchor').length)
+          .toBeGreaterThan(0);
+    }));
 
     it('should re-focus trigger element when dialog closes', fakeAsync(() => {
          // Create a element that has focus before the dialog is opened.
@@ -1655,7 +1779,7 @@ describe('MDC-based MatDialog with default options', () => {
       minHeight: '50px',
       maxWidth: '150px',
       maxHeight: '150px',
-      autoFocus: false,
+      autoFocus: 'dialog',
     };
 
     TestBed.configureTestingModule({

--- a/src/material-experimental/mdc-dialog/public-api.ts
+++ b/src/material-experimental/mdc-dialog/public-api.ts
@@ -13,6 +13,7 @@ export * from './dialog-container';
 export * from './module';
 
 export {
+  AutoFocusTarget,
   MatDialogState,
   MatDialogConfig,
   matDialogAnimations,

--- a/src/material/bottom-sheet/bottom-sheet-config.ts
+++ b/src/material/bottom-sheet/bottom-sheet-config.ts
@@ -10,6 +10,9 @@ import {Direction} from '@angular/cdk/bidi';
 import {ScrollStrategy} from '@angular/cdk/overlay';
 import {InjectionToken, ViewContainerRef} from '@angular/core';
 
+/** Options for where to set focus to automatically on dialog open */
+export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
+
 /** Injection token that can be used to access the data that was passed in to a bottom sheet. */
 export const MAT_BOTTOM_SHEET_DATA = new InjectionToken<any>('MatBottomSheetData');
 
@@ -48,11 +51,15 @@ export class MatBottomSheetConfig<D = any> {
    */
   closeOnNavigation?: boolean = true;
 
-  // Note that this is disabled by default, because while the a11y recommendations are to focus
-  // the first focusable element, doing so prevents screen readers from reading out the
+  // Note that this is set to 'dialog' by default, because while the a11y recommendations
+  // are to focus the first focusable element, doing so prevents screen readers from reading out the
   // rest of the bottom sheet content.
-  /** Whether the bottom sheet should focus the first focusable element on open. */
-  autoFocus?: boolean = false;
+  /**
+   * Where the bottom sheet should focus on open.
+   * @breaking-change 14.0.0 Remove boolean option from autoFocus. Use string or
+   * AutoFocusTarget instead.
+   */
+  autoFocus?: AutoFocusTarget | string | boolean = 'dialog';
 
   /**
    * Whether the bottom sheet should restore focus to the

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -610,7 +610,7 @@ describe('MatBottomSheet', () => {
     it('should create a focus trap if autoFocus is disabled', fakeAsync(() => {
       bottomSheet.open(PizzaMsg, {
         viewContainerRef: testViewContainerRef,
-        autoFocus: false
+        autoFocus: false,
       });
 
       viewContainerFixture.detectChanges();
@@ -622,29 +622,66 @@ describe('MatBottomSheet', () => {
     }));
 
     it('should focus the first tabbable element of the bottom sheet on open when' +
-      'autoFocus is enabled', fakeAsync(() => {
-        bottomSheet.open(PizzaMsg, {
-          viewContainerRef: testViewContainerRef,
-          autoFocus: true
-        });
-
-        viewContainerFixture.detectChanges();
-        flushMicrotasks();
-
-        expect(document.activeElement!.tagName).toBe('INPUT',
-            'Expected first tabbable element (input) in the sheet to be focused.');
-      }));
-
-    it('should allow disabling focus of the first tabbable element', fakeAsync(() => {
+      'autoFocus is set to "first-tabbable"', fakeAsync(() => {
       bottomSheet.open(PizzaMsg, {
         viewContainerRef: testViewContainerRef,
-        autoFocus: false
+        autoFocus: 'first-tabbable'
       });
 
       viewContainerFixture.detectChanges();
       flushMicrotasks();
 
-      expect(document.activeElement!.tagName).not.toBe('INPUT');
+      expect(document.activeElement!.tagName)
+        .toBe('INPUT', 'Expected first tabbable element (input) in the dialog to be focused.');
+    }));
+
+    it('should focus the bottom sheet element on open when autoFocus is set to ' +
+      '"dialog" (the default)', fakeAsync(() => {
+      bottomSheet.open(PizzaMsg, {
+        viewContainerRef: testViewContainerRef,
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let container =
+        overlayContainerElement.querySelector('.mat-bottom-sheet-container') as HTMLInputElement;
+
+      expect(document.activeElement).toBe(container, 'Expected container to be focused on open');
+    }));
+
+    it('should focus the bottom sheet element on open when autoFocus is set to ' +
+      '"first-heading"', fakeAsync(() => {
+      bottomSheet.open(ContentElementDialog, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'first-heading'
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let firstHeader =
+        overlayContainerElement.querySelector('h1[tabindex="-1"]') as HTMLInputElement;
+
+      expect(document.activeElement)
+        .toBe(firstHeader, 'Expected first header to be focused on open');
+    }));
+
+    it('should focus the first element that matches the css selector on open when ' +
+      'autoFocus is set to a css selector', fakeAsync(() => {
+      bottomSheet.open(ContentElementDialog, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'p'
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let firstParagraph =
+      overlayContainerElement.querySelector('p[tabindex="-1"]') as HTMLInputElement;
+
+      expect(document.activeElement)
+        .toBe(firstParagraph, 'Expected first paragraph to be focused on open');
     }));
 
     it('should re-focus trigger element when bottom sheet closes', fakeAsync(() => {
@@ -867,7 +904,7 @@ describe('MatBottomSheet with default options', () => {
     const defaultConfig: MatBottomSheetConfig = {
       hasBackdrop: false,
       disableClose: true,
-      autoFocus: false
+      autoFocus: 'dialog'
     };
 
     TestBed.configureTestingModule({
@@ -974,6 +1011,14 @@ class PizzaMsg {
 class TacoMsg {}
 
 @Component({
+  template: `
+    <h1>This is the title</h1>
+    <p>This is the paragraph</p>
+  `
+})
+class ContentElementDialog {}
+
+@Component({
   template: '',
   providers: [MatBottomSheet]
 })
@@ -997,6 +1042,7 @@ class ShadowDomComponent {}
 const TEST_DIRECTIVES = [
   ComponentWithChildViewContainer,
   ComponentWithTemplateRef,
+  ContentElementDialog,
   PizzaMsg,
   TacoMsg,
   DirectiveWithViewContainer,
@@ -1011,6 +1057,7 @@ const TEST_DIRECTIVES = [
   entryComponents: [
     ComponentWithChildViewContainer,
     ComponentWithTemplateRef,
+    ContentElementDialog,
     PizzaMsg,
     TacoMsg,
     BottomSheetWithInjectedData,

--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -10,6 +10,9 @@ import {ViewContainerRef, ComponentFactoryResolver} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {ScrollStrategy} from '@angular/cdk/overlay';
 
+/** Options for where to set focus to automatically on dialog open */
+export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
+
 /** Valid ARIA roles for a dialog element. */
 export type DialogRole = 'dialog' | 'alertdialog';
 
@@ -95,8 +98,12 @@ export class MatDialogConfig<D = any> {
   /** Aria label to assign to the dialog element. */
   ariaLabel?: string | null = null;
 
-  /** Whether the dialog should focus the first focusable element on open. */
-  autoFocus?: boolean = true;
+  /**
+   * Where the dialog should focus on open.
+   * @breaking-change 14.0.0 Remove boolean option from autoFocus. Use string or
+   * AutoFocusTarget instead.
+   */
+  autoFocus?: AutoFocusTarget | string | boolean = 'first-tabbable';
 
   /**
    * Whether the dialog should restore focus to the

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -998,7 +998,8 @@ describe('MatDialog', () => {
       expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeFalsy();
     }));
 
-    it('should recapture focus when clicking on the backdrop', fakeAsync(() => {
+    it('should recapture focus to the first tabbable element when clicking on the backdrop with ' +
+      'autoFocus set to "first-tabbable" (the default)', fakeAsync(() => {
       dialog.open(PizzaMsg, {
         disableClose: true,
         viewContainerRef: testViewContainerRef
@@ -1022,11 +1023,11 @@ describe('MatDialog', () => {
     }));
 
     it('should recapture focus to the container when clicking on the backdrop with ' +
-      'autoFocus disabled', fakeAsync(() => {
+      'autoFocus set to "dialog"', fakeAsync(() => {
         dialog.open(PizzaMsg, {
           disableClose: true,
           viewContainerRef: testViewContainerRef,
-          autoFocus: false
+          autoFocus: 'dialog'
         });
 
         viewContainerFixture.detectChanges();
@@ -1048,6 +1049,61 @@ describe('MatDialog', () => {
             .toBe(container, 'Expected container to stay focused after click');
       }));
 
+      it('should recapture focus to the first header when clicking on the backdrop with ' +
+      'autoFocus set to "first-heading"', fakeAsync(() => {
+        dialog.open(ContentElementDialog, {
+          disableClose: true,
+          viewContainerRef: testViewContainerRef,
+          autoFocus: 'first-heading'
+        });
+
+        viewContainerFixture.detectChanges();
+        flushMicrotasks();
+
+        let backdrop =
+          overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+        let firstHeader = overlayContainerElement
+          .querySelector('.mat-dialog-title[tabindex="-1"]') as HTMLInputElement;
+
+        expect(document.activeElement)
+          .toBe(firstHeader, 'Expected first header to be focused on open');
+
+        firstHeader.blur(); // Programmatic clicks might not move focus so we simulate it.
+        backdrop.click();
+        viewContainerFixture.detectChanges();
+        flush();
+
+        expect(document.activeElement)
+            .toBe(firstHeader, 'Expected first header to stay focused after click');
+      }));
+
+      it('should recapture focus to the first element that matches the css selector when ' +
+      'clicking on the backdrop with autoFocus set to a css selector', fakeAsync(() => {
+        dialog.open(ContentElementDialog, {
+          disableClose: true,
+          viewContainerRef: testViewContainerRef,
+          autoFocus: 'button'
+        });
+
+        viewContainerFixture.detectChanges();
+        flushMicrotasks();
+
+        let backdrop =
+          overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+        let firstButton =
+          overlayContainerElement.querySelector('[mat-dialog-close]') as HTMLInputElement;
+
+        expect(document.activeElement)
+          .toBe(firstButton, 'Expected first button to be focused on open');
+
+        firstButton.blur(); // Programmatic clicks might not move focus so we simulate it.
+        backdrop.click();
+        viewContainerFixture.detectChanges();
+        flush();
+
+        expect(document.activeElement)
+            .toBe(firstButton, 'Expected first button to stay focused after click');
+      }));
   });
 
   describe('hasBackdrop option', () => {
@@ -1116,7 +1172,8 @@ describe('MatDialog', () => {
     beforeEach(() => document.body.appendChild(overlayContainerElement));
     afterEach(() => document.body.removeChild(overlayContainerElement));
 
-    it('should focus the first tabbable element of the dialog on open', fakeAsync(() => {
+    it('should focus the first tabbable element of the dialog on open (the default)',
+      fakeAsync(() => {
       dialog.open(PizzaMsg, {
         viewContainerRef: testViewContainerRef
       });
@@ -1128,16 +1185,52 @@ describe('MatDialog', () => {
           .toBe('INPUT', 'Expected first tabbable element (input) in the dialog to be focused.');
     }));
 
-    it('should allow disabling focus of the first tabbable element', fakeAsync(() => {
+    it('should focus the dialog element on open', fakeAsync(() => {
       dialog.open(PizzaMsg, {
         viewContainerRef: testViewContainerRef,
-        autoFocus: false
+        autoFocus: 'dialog'
       });
 
       viewContainerFixture.detectChanges();
       flushMicrotasks();
 
-      expect(document.activeElement!.tagName).not.toBe('INPUT');
+      let container =
+        overlayContainerElement.querySelector('.mat-dialog-container') as HTMLInputElement;
+
+      expect(document.activeElement).toBe(container, 'Expected container to be focused on open');
+    }));
+
+    it('should focus the first header element on open', fakeAsync(() => {
+      dialog.open(ContentElementDialog, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'first-heading'
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let firstHeader =
+        overlayContainerElement.querySelector('h1[tabindex="-1"]') as HTMLInputElement;
+
+      expect(document.activeElement)
+        .toBe(firstHeader, 'Expected first header to be focused on open');
+    }));
+
+    it('should focus the first element that matches the css selector from autoFocus on open',
+      fakeAsync(() => {
+      dialog.open(PizzaMsg, {
+        viewContainerRef: testViewContainerRef,
+        autoFocus: 'p'
+      });
+
+      viewContainerFixture.detectChanges();
+      flushMicrotasks();
+
+      let firstParagraph =
+        overlayContainerElement.querySelector('p[tabindex="-1"]') as HTMLInputElement;
+
+      expect(document.activeElement)
+        .toBe(firstParagraph, 'Expected first paragraph to be focused on open');
     }));
 
     it('should attach the focus trap even if automatic focus is disabled', fakeAsync(() => {

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -582,8 +582,9 @@ describe('MatDrawer', () => {
       expect(document.activeElement).toBe(lastFocusableElement);
     }));
 
-    it('should auto-focus when opened in "side" mode when enabled explicitly', fakeAsync(() => {
-      drawer.autoFocus = true;
+    it('should auto-focus to first tabbable element when opened in "side" mode' +
+      'when enabled explicitly', fakeAsync(() => {
+      drawer.autoFocus = 'first-tabbable';
       testComponent.mode = 'side';
       fixture.detectChanges();
       lastFocusableElement.focus();
@@ -610,7 +611,7 @@ describe('MatDrawer', () => {
     }));
 
     it('should be able to disable auto focus', fakeAsync(() => {
-      drawer.autoFocus = false;
+      drawer.autoFocus = 'dialog';
       testComponent.mode = 'push';
       fixture.detectChanges();
       lastFocusableElement.focus();

--- a/tools/public_api_guard/material/bottom-sheet.md
+++ b/tools/public_api_guard/material/bottom-sheet.md
@@ -25,6 +25,8 @@ import * as i3 from '@angular/material/core';
 import * as i4 from '@angular/cdk/portal';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { Overlay } from '@angular/cdk/overlay';
@@ -33,6 +35,9 @@ import { ScrollStrategy } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { TemplateRef } from '@angular/core';
 import { ViewContainerRef } from '@angular/core';
+
+// @public
+export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 
 // @public
 export const MAT_BOTTOM_SHEET_DATA: InjectionToken<any>;
@@ -64,7 +69,7 @@ export const matBottomSheetAnimations: {
 // @public
 export class MatBottomSheetConfig<D = any> {
     ariaLabel?: string | null;
-    autoFocus?: boolean;
+    autoFocus?: AutoFocusTarget | string | boolean;
     backdropClass?: string;
     closeOnNavigation?: boolean;
     data?: D | null;
@@ -79,7 +84,7 @@ export class MatBottomSheetConfig<D = any> {
 
 // @public
 export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestroy {
-    constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _focusTrapFactory: FocusTrapFactory, breakpointObserver: BreakpointObserver, document: any,
+    constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _focusTrapFactory: FocusTrapFactory, _interactivityChecker: InteractivityChecker, _ngZone: NgZone, breakpointObserver: BreakpointObserver, document: any,
     bottomSheetConfig: MatBottomSheetConfig);
     _animationState: 'void' | 'visible' | 'hidden';
     _animationStateChanged: EventEmitter<AnimationEvent_2>;
@@ -100,7 +105,7 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatBottomSheetContainer, "mat-bottom-sheet-container", never, {}, {}, never, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatBottomSheetContainer, [null, null, null, null, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatBottomSheetContainer, [null, null, null, null, null, null, { optional: true; }, null]>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -27,7 +27,9 @@ import * as i4 from '@angular/cdk/portal';
 import * as i5 from '@angular/material/core';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
+import { InteractivityChecker } from '@angular/cdk/a11y';
 import { Location as Location_2 } from '@angular/common';
+import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
@@ -42,6 +44,9 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import { TemplateRef } from '@angular/core';
 import { Type } from '@angular/core';
 import { ViewContainerRef } from '@angular/core';
+
+// @public
+export type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 
 // @public
 export function _closeDialogVia<R>(ref: MatDialogRef<R>, interactionType: FocusOrigin, result?: R): void;
@@ -152,7 +157,7 @@ export class MatDialogConfig<D = any> {
     ariaDescribedBy?: string | null;
     ariaLabel?: string | null;
     ariaLabelledBy?: string | null;
-    autoFocus?: boolean;
+    autoFocus?: AutoFocusTarget | string | boolean;
     backdropClass?: string | string[];
     closeOnNavigation?: boolean;
     componentFactoryResolver?: ComponentFactoryResolver;
@@ -190,7 +195,7 @@ export class MatDialogContainer extends _MatDialogContainerBase {
 // @public
 export abstract class _MatDialogContainerBase extends BasePortalOutlet {
     constructor(_elementRef: ElementRef, _focusTrapFactory: FocusTrapFactory, _changeDetectorRef: ChangeDetectorRef, _document: any,
-    _config: MatDialogConfig, _focusMonitor?: FocusMonitor | undefined);
+    _config: MatDialogConfig, _interactivityChecker: InteractivityChecker, _ngZone: NgZone, _focusMonitor?: FocusMonitor | undefined);
     _animationStateChanged: EventEmitter<DialogAnimationEvent>;
     _ariaLabelledBy: string | null;
     attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T>;
@@ -217,7 +222,7 @@ export abstract class _MatDialogContainerBase extends BasePortalOutlet {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<_MatDialogContainerBase, never, never, {}, {}, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<_MatDialogContainerBase, [null, null, null, { optional: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<_MatDialogContainerBase, [null, null, null, { optional: true; }, null, null, null, null]>;
 }
 
 // @public

--- a/tools/public_api_guard/material/sidenav.md
+++ b/tools/public_api_guard/material/sidenav.md
@@ -24,6 +24,7 @@ import * as i4 from '@angular/material/core';
 import * as i5 from '@angular/cdk/platform';
 import * as i6 from '@angular/cdk/scrolling';
 import { InjectionToken } from '@angular/core';
+import { InteractivityChecker } from '@angular/cdk/a11y';
 import { NgZone } from '@angular/core';
 import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
@@ -33,6 +34,9 @@ import { QueryList } from '@angular/core';
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { Subject } from 'rxjs';
 import { ViewportRuler } from '@angular/cdk/scrolling';
+
+// @public
+type AutoFocusTarget = 'dialog' | 'first-tabbable' | 'first-heading';
 
 // @public
 const MAT_DRAWER_CONTAINER: InjectionToken<unknown>;
@@ -45,7 +49,7 @@ export function MAT_DRAWER_DEFAULT_AUTOSIZE_FACTORY(): boolean;
 
 // @public
 export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestroy {
-    constructor(_elementRef: ElementRef<HTMLElement>, _focusTrapFactory: FocusTrapFactory, _focusMonitor: FocusMonitor, _platform: Platform, _ngZone: NgZone, _doc: any, _container?: MatDrawerContainer | undefined);
+    constructor(_elementRef: ElementRef<HTMLElement>, _focusTrapFactory: FocusTrapFactory, _focusMonitor: FocusMonitor, _platform: Platform, _ngZone: NgZone, _interactivityChecker: InteractivityChecker, _doc: any, _container?: MatDrawerContainer | undefined);
     // (undocumented)
     _animationDoneListener(event: AnimationEvent_2): void;
     readonly _animationEnd: Subject<AnimationEvent_2>;
@@ -53,8 +57,8 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
     // (undocumented)
     _animationStartListener(event: AnimationEvent_2): void;
     _animationState: 'open-instant' | 'open' | 'void';
-    get autoFocus(): boolean;
-    set autoFocus(value: boolean);
+    get autoFocus(): AutoFocusTarget | string | boolean;
+    set autoFocus(value: AutoFocusTarget | string | boolean);
     close(): Promise<MatDrawerToggleResult>;
     readonly closedStart: Observable<void>;
     readonly _closedStream: Observable<void>;
@@ -69,7 +73,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
     set mode(value: MatDrawerMode);
     readonly _modeChanged: Subject<void>;
     // (undocumented)
-    static ngAcceptInputType_autoFocus: BooleanInput;
+    static ngAcceptInputType_autoFocus: AutoFocusTarget | string | BooleanInput;
     // (undocumented)
     static ngAcceptInputType_disableClose: BooleanInput;
     // (undocumented)
@@ -93,7 +97,7 @@ export class MatDrawer implements AfterContentInit, AfterContentChecked, OnDestr
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatDrawer, "mat-drawer", ["matDrawer"], { "position": "position"; "mode": "mode"; "disableClose": "disableClose"; "autoFocus": "autoFocus"; "opened": "opened"; }, { "openedChange": "openedChange"; "_openedStream": "opened"; "openedStart": "openedStart"; "_closedStream": "closed"; "closedStart": "closedStart"; "onPositionChanged": "positionChanged"; }, never, ["*"]>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatDrawer, [null, null, null, null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatDrawer, [null, null, null, null, null, null, { optional: true; }, { optional: true; }]>;
 }
 
 // @public


### PR DESCRIPTION
Before this PR, autoFocus was a boolean that allowed users to specify whether the container element or the first tabbable element is focused on dialog open. Now you can also specify focusing the first header element or use a CSS selector and focus the first element that matches that. If these elements can't be focused, then the container element is focused by default.

This applies to other components that are similar to dialog and also have a autoFocus field.