### PR TITLE
build: expose static methods and properties in docs

### DIFF
--- a/tools/dgeni/processors/categorizer.ts
+++ b/tools/dgeni/processors/categorizer.ts
@@ -108,6 +108,14 @@ export class Categorizer implements Processor {
     classDoc.directiveMetadata = getDirectiveMetadata(classDoc);
     classDoc.inheritedDocs = getInheritedDocsOfClass(classDoc, this._exportSymbolsToDocsMap);
 
+    classDoc.methods.push(...classDoc.statics
+      .filter(isMethod)
+      .filter(filterDuplicateMembers) as CategorizedMethodMemberDoc[]);
+
+    classDoc.properties.push(...classDoc.statics
+      .filter(isProperty)
+      .filter(filterDuplicateMembers) as CategorizedPropertyMemberDoc[]);
+
     // In case the extended document is not public, we don't want to print it in the
     // rendered class API doc. This causes confusion and also is not helpful as the
     // extended document is not part of the docs and cannot be viewed.

--- a/tools/dgeni/templates/method.template.html
+++ b/tools/dgeni/templates/method.template.html
@@ -9,8 +9,13 @@
             Deprecated
           </div>
         {%- endif -%}
+        {%- if method.isStatic -%}
+        <div class="docs-api-modifier-method-marker">
+          static
+        </div>
+        {%- endif -%}
         {%- if method.isAsync -%}
-        <div class="docs-api-async-method-marker">
+        <div class="docs-api-modifier-method-marker">
           async
         </div>
         {%- endif -%}

--- a/tools/dgeni/templates/property.template.html
+++ b/tools/dgeni/templates/property.template.html
@@ -27,7 +27,7 @@
     {%- endif -%}
 
     <p class="docs-api-property-name">
-      <code>{$ property.name $}: {$ property.type $}</code>
+      <code>{%- if property.isStatic -%}static {%- endif -%}{$ property.name $}: {$ property.type $}</code>
     </p>
   </td>
   <td class="docs-api-property-description">{$ property.description | marked | safe $}</td>


### PR DESCRIPTION
Exposes information about static members/properties in the API docs.

Fixes #20270.