### PR TITLE
build: build the core overview file as part of the docs content

### DIFF
--- a/src/material/core/BUILD.bazel
+++ b/src/material/core/BUILD.bazel
@@ -144,7 +144,10 @@ ng_web_test_suite(
 
 markdown_to_html(
     name = "overview",
-    srcs = ["ripple/ripple.md"],
+    srcs = [
+        "core.md",
+        "ripple/ripple.md",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
I forgot to make this change in #22773, so the new overview isn't currently being outputted in the docs content package