### PR TITLE
docs(cdk/scrolling): note that ViewportRuler.change emits outside the zone

### DIFF
--- a/src/cdk/scrolling/viewport-ruler.ts
+++ b/src/cdk/scrolling/viewport-ruler.ts
@@ -142,6 +142,7 @@ export class ViewportRuler implements OnDestroy {
 
   /**
    * Returns a stream that emits whenever the size of the viewport changes.
+   * This stream emits outside of the Angular zone.
    * @param throttleTime Time in milliseconds to throttle the stream.
    */
   change(throttleTime: number = DEFAULT_RESIZE_TIME): Observable<Event> {


### PR DESCRIPTION
Fixes #8279