### PR TITLE
build: don't show import path if there is no primary export

### DIFF
--- a/tools/dgeni/templates/entry-point.template.html
+++ b/tools/dgeni/templates/entry-point.template.html
@@ -36,11 +36,15 @@
     API reference for Angular {$ doc.packageDisplayName $} {$ doc.displayName $}
   </h2>
 
-  <p class="docs-api-module-import">
-    <code>
-      import {{$ doc.primaryExportName $}} from '{$ doc.moduleImportPath $}';
-    </code>
-  </p>
+  {%- if doc.primaryExportName -%}
+    <p class="docs-api-module-import">
+      <code>
+        import {{$ doc.primaryExportName $}} from '{$ doc.moduleImportPath $}';
+      </code>
+    </p>
+  {% else %}
+    <p>Import symbols from <code>{$ doc.moduleImportPath $}</code></p>
+  {%- endif -%}
 
   {%- if doc.services.length -%}
     <h3 id="{$ doc.name $}-services" class="docs-header-link docs-api-h3">


### PR DESCRIPTION
Currently we show something like `import {} from '@angular/cdk/coercion'` for imports that don't have a primary export. These changes remove the line if there is no primary export.