### PR TITLE
docs: clarify coordinate parameters for `MatRipple.launch` method.

### DIFF
--- a/src/material/core/ripple/ripple.ts
+++ b/src/material/core/ripple/ripple.ts
@@ -189,9 +189,11 @@ export class MatRipple implements OnInit, OnDestroy, RippleTarget {
   launch(config: RippleConfig): RippleRef;
 
   /**
-   * Launches a manual ripple at the specified coordinates within the element.
-   * @param x Coordinate within the element, along the X axis at which to fade-in the ripple.
-   * @param y Coordinate within the element, along the Y axis at which to fade-in the ripple.
+   * Launches a manual ripple at the specified coordinates relative to the viewport.
+   * @param x Coordinate along the X axis at which to fade-in the ripple. Coordinate
+   *   should be relative to the viewport.
+   * @param y Coordinate along the Y axis at which to fade-in the ripple. Coordinate
+   *   should be relative to the viewport.
    * @param config Optional ripple configuration for the manual ripple.
    */
   launch(x: number, y: number, config?: RippleConfig): RippleRef;


### PR DESCRIPTION
It was never clearly specified whether the coordinates for `MatRipple.launch`
should be relative to the trigger, ripple container or viewport, or even absolute.

This commit clarifies this by explicitly mentioning the viewport.

Fixes #16613.