### PR TITLE
build: fix formatting for static properties and filter out coercion members

### DIFF
--- a/tools/dgeni/common/private-docs.ts
+++ b/tools/dgeni/common/private-docs.ts
@@ -30,7 +30,8 @@ export function isPublicDoc(doc: ApiDoc) {
   if (_isEnforcedPublicDoc(doc)) {
     return true;
   }
-  if (_hasDocsPrivateTag(doc) || doc.name.startsWith('_')) {
+  if (_hasDocsPrivateTag(doc) || doc.name.startsWith('_') ||
+      doc.name.startsWith('ngAcceptInputType_')) {
     return false;
   } else if (doc instanceof MemberDoc) {
     return !_isInternalMember(doc);

--- a/tools/dgeni/processors/docs-private-filter.ts
+++ b/tools/dgeni/processors/docs-private-filter.ts
@@ -27,7 +27,8 @@ export class DocsPrivateFilter implements Processor {
       // Filter out private class members which could be annotated
       // with the "@docs-private" tag.
       if (isPublic && doc instanceof ClassExportDoc) {
-        doc.members = doc.members.filter(memberDoc => isPublicDoc(memberDoc));
+        doc.members = doc.members.filter(isPublicDoc);
+        doc.statics = doc.statics.filter(isPublicDoc);
       }
 
       return isPublic;

--- a/tools/dgeni/templates/property.template.html
+++ b/tools/dgeni/templates/property.template.html
@@ -27,7 +27,7 @@
     {%- endif -%}
 
     <p class="docs-api-property-name">
-      <code>{%- if property.isStatic -%}static {%- endif -%}{$ property.name $}: {$ property.type $}</code>
+      <code>{%- if property.isStatic -%}static&nbsp;{%- endif -%}{$ property.name $}: {$ property.type $}</code>
     </p>
   </td>
   <td class="docs-api-property-description">{$ property.description | marked | safe $}</td>


### PR DESCRIPTION
* Fixes that there's no space between `static` and the property name.
* Filters out the `ngAcceptInputType_` properties from the docs.

Fixes #22816.