### PR TITLE
docs(material/table): fix table example tags

### DIFF
--- a/src/components-examples/material/table/table-generated-columns/table-generated-columns-example.html
+++ b/src/components-examples/material/table/table-generated-columns/table-generated-columns-example.html
@@ -1,11 +1,11 @@
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8 demo-table">
-  <ng-container *ngFor="let column of columns" [cdkColumnDef]="column.columnDef">
-    <mat-header-cell *cdkHeaderCellDef>
+  <ng-container *ngFor="let column of columns" [matColumnDef]="column.columnDef">
+    <th mat-header-cell *matHeaderCellDef>
       {{column.header}}
-    </mat-header-cell>
-    <mat-cell *cdkCellDef="let row">
+    </th>
+    <td mat-cell *matCellDef="let row">
       {{column.cell(row)}}
-    </mat-cell>
+    </td>
   </ng-container>
 
   <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>


### PR DESCRIPTION
Fix table example that is mixing the table and flex table selectors plus using cdk instead of mat - switch to use the native table selectors