### PR TITLE
docs(cdk/layout): add BreakpointObserver example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -175,6 +175,7 @@
 /src/dev-app/grid-list/**                          @jelbourn
 /src/dev-app/icon/**                               @jelbourn
 /src/dev-app/input/**                              @mmalerba
+/src/dev-app/layout/**                             @jelbourn
 /src/dev-app/list/**                               @jelbourn @crisbeto @devversion
 /src/dev-app/live-announcer/**                     @jelbourn
 /src/dev-app/mdc-button/**                         @andrewseguin

--- a/src/cdk/layout/layout.md
+++ b/src/cdk/layout/layout.md
@@ -8,6 +8,8 @@ size ranges between breakpoints correspond to different standard screen sizes.
 `BreakpointObserver` lets you evaluate media queries to determine the current screen size and
 react to changes when the viewport size crosses a breakpoint.
 
+<!-- example(breakpoint-observer-overview) -->
+
 #### Check the current viewport size
 You can use the `isMatched` method to evaluate one or more media queries against the current
 viewport size.

--- a/src/components-examples/BUILD.bazel
+++ b/src/components-examples/BUILD.bazel
@@ -58,6 +58,7 @@ ALL_EXAMPLES = [
     "//src/components-examples/cdk/drag-drop",
     "//src/components-examples/cdk/clipboard",
     "//src/components-examples/cdk/a11y",
+    "//src/components-examples/cdk/layout",
     "//src/components-examples/cdk/overlay",
     "//src/components-examples/cdk-experimental/menu",
     "//src/components-examples/cdk-experimental/popover-edit",

--- a/src/components-examples/cdk/layout/BUILD.bazel
+++ b/src/components-examples/cdk/layout/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "layout",
+    srcs = glob(["**/*.ts"]),
+    assets = glob([
+        "**/*.html",
+        "**/*.css",
+    ]),
+    module_name = "@angular/components-examples/cdk/layout",
+    deps = [
+        "//src/cdk/layout",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob([
+        "**/*.html",
+        "**/*.css",
+        "**/*.ts",
+    ]),
+)

--- a/src/components-examples/cdk/layout/breakpoint-observer-overview/breakpoint-observer-overview-example.css
+++ b/src/components-examples/cdk/layout/breakpoint-observer-overview/breakpoint-observer-overview-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/src/components-examples/cdk/layout/breakpoint-observer-overview/breakpoint-observer-overview-example.html
+++ b/src/components-examples/cdk/layout/breakpoint-observer-overview/breakpoint-observer-overview-example.html
@@ -1,0 +1,6 @@
+<p>
+  Resize your browser window to see the current screen size change.
+</p>
+<p>
+  The current screen size is <strong>{{currentScreenSize}}</strong>
+</p>

--- a/src/components-examples/cdk/layout/breakpoint-observer-overview/breakpoint-observer-overview-example.ts
+++ b/src/components-examples/cdk/layout/breakpoint-observer-overview/breakpoint-observer-overview-example.ts
@@ -1,0 +1,45 @@
+import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
+import {Component, OnDestroy} from '@angular/core';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+
+/** @title Respond to viewport changes with BreakpointObserver */
+@Component({
+  selector: 'breakpoint-observer-overview-example',
+  templateUrl: 'breakpoint-observer-overview-example.html',
+  styleUrls: ['breakpoint-observer-overview-example.css']
+})
+export class BreakpointObserverOverviewExample implements OnDestroy {
+  destroyed = new Subject<void>();
+  currentScreenSize: string;
+
+  // Create a map to display breakpoint names for demonstration purposes.
+  displayNameMap = new Map([
+    [Breakpoints.XSmall, 'XSmall'],
+    [Breakpoints.Small, 'Small'],
+    [Breakpoints.Medium, 'Medium'],
+    [Breakpoints.Large, 'Large'],
+    [Breakpoints.XLarge, 'XLarge'],
+  ]);
+
+  constructor(breakpointObserver: BreakpointObserver) {
+    breakpointObserver.observe([
+      Breakpoints.XSmall,
+      Breakpoints.Small,
+      Breakpoints.Medium,
+      Breakpoints.Large,
+      Breakpoints.XLarge,
+    ]).pipe(takeUntil(this.destroyed)).subscribe(result => {
+        for (const query of Object.keys(result.breakpoints)) {
+          if (result.breakpoints[query]) {
+            this.currentScreenSize = this.displayNameMap.get(query) ?? 'Unknown';
+          }
+        }
+    });
+  }
+
+  ngOnDestroy() {
+    this.destroyed.next();
+    this.destroyed.complete();
+  }
+}

--- a/src/components-examples/cdk/layout/index.ts
+++ b/src/components-examples/cdk/layout/index.ts
@@ -1,0 +1,23 @@
+import {LayoutModule} from '@angular/cdk/layout';
+import {NgModule} from '@angular/core';
+import {
+  BreakpointObserverOverviewExample,
+} from './breakpoint-observer-overview/breakpoint-observer-overview-example';
+
+export {BreakpointObserverOverviewExample};
+
+const EXAMPLES = [
+  BreakpointObserverOverviewExample,
+];
+
+@NgModule({
+  imports: [
+    LayoutModule,
+  ],
+  declarations: EXAMPLES,
+  exports: EXAMPLES,
+  entryComponents: EXAMPLES,
+})
+export class CdkLayoutExamplesModule {
+}
+

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -45,6 +45,7 @@ ng_module(
         "//src/dev-app/grid-list",
         "//src/dev-app/icon",
         "//src/dev-app/input",
+        "//src/dev-app/layout",
         "//src/dev-app/list",
         "//src/dev-app/live-announcer",
         "//src/dev-app/mdc-autocomplete",

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -56,6 +56,7 @@ export class DevAppLayout {
     {name: 'Icon', route: '/icon'},
     {name: 'Input', route: '/input'},
     {name: 'List', route: '/list'},
+    {name: 'Layout', route: '/layout'},
     {name: 'Live Announcer', route: '/live-announcer'},
     {name: 'Menu', route: '/menu'},
     {name: 'Menubar', route: '/menubar'},

--- a/src/dev-app/dev-app/routes.ts
+++ b/src/dev-app/dev-app/routes.ts
@@ -61,6 +61,7 @@ export const DEV_APP_ROUTES: Routes = [
   {path: 'grid-list', loadChildren: 'grid-list/grid-list-demo-module#GridListDemoModule'},
   {path: 'icon', loadChildren: 'icon/icon-demo-module#IconDemoModule'},
   {path: 'input', loadChildren: 'input/input-demo-module#InputDemoModule'},
+  {path: 'layout', loadChildren: 'layout/layout-demo-module#LayoutDemoModule'},
   {path: 'list', loadChildren: 'list/list-demo-module#ListDemoModule'},
   {
     path: 'live-announcer',

--- a/src/dev-app/layout/BUILD.bazel
+++ b/src/dev-app/layout/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "layout",
+    srcs = glob(["**/*.ts"]),
+    assets = [
+        "layout-demo.html",
+        ":layout_demo_scss",
+    ],
+    deps = [
+        "//src/cdk/layout",
+        "//src/components-examples/cdk/layout",
+        "@npm//@angular/router",
+    ],
+)
+
+sass_binary(
+    name = "layout_demo_scss",
+    src = "layout-demo.scss",
+)

--- a/src/dev-app/layout/layout-demo-module.ts
+++ b/src/dev-app/layout/layout-demo-module.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {LayoutDemo} from './layout-demo';
+import {CdkLayoutExamplesModule} from '@angular/components-examples/cdk/layout';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    CdkLayoutExamplesModule,
+    RouterModule.forChild([{path: '', component: LayoutDemo}]),
+  ],
+  declarations: [LayoutDemo],
+})
+export class LayoutDemoModule { }

--- a/src/dev-app/layout/layout-demo.html
+++ b/src/dev-app/layout/layout-demo.html
@@ -1,0 +1,2 @@
+<h2>Respond to viewport changes with BreakpointObserver</h2>
+<breakpoint-observer-overview-example></breakpoint-observer-overview-example>

--- a/src/dev-app/layout/layout-demo.ts
+++ b/src/dev-app/layout/layout-demo.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+
+@Component({
+  selector: 'layout-demo',
+  templateUrl: 'layout-demo.html',
+  styleUrls: ['layout-demo.css'],
+})
+export class LayoutDemo { }


### PR DESCRIPTION
Also adds a layout page to the dev-app since it didn't have one