### PR TITLE
refactor(material/form-field): fix incorrectly named mixin base constant

### DIFF
--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -61,7 +61,7 @@ const outlineGapPadding = 5;
  * Boilerplate for applying mixins to MatFormField.
  * @docs-private
  */
-const _MatFormFieldnBase = mixinColor(class {
+const _MatFormFieldBase = mixinColor(class {
   constructor(public _elementRef: ElementRef) {}
 }, 'primary');
 
@@ -147,7 +147,7 @@ export const MAT_FORM_FIELD = new InjectionToken<MatFormField>('MatFormField');
   ]
 })
 
-export class MatFormField extends _MatFormFieldnBase
+export class MatFormField extends _MatFormFieldBase
     implements AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy, CanColor {
 
   /**

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -25,7 +25,7 @@ export declare class MatError {
     static ɵfac: i0.ɵɵFactoryDeclaration<MatError, [{ attribute: "aria-live"; }, null]>;
 }
 
-export declare class MatFormField extends _MatFormFieldnBase implements AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy, CanColor {
+export declare class MatFormField extends _MatFormFieldBase implements AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy, CanColor {
     _animationsEnabled: boolean;
     _appearance: MatFormFieldAppearance;
     _connectionContainerRef: ElementRef;


### PR DESCRIPTION
With the recent changes to the mixins, a typo has sneaked into the
form-field mixin logic. This commit fixes that.