### PR TITLE
docs: explicitly set form field appearance

### DIFF
--- a/src/components-examples/cdk/a11y/focus-monitor-focus-via/focus-monitor-focus-via-example.html
+++ b/src/components-examples/cdk/a11y/focus-monitor-focus-via/focus-monitor-focus-via-example.html
@@ -3,7 +3,7 @@
   <button #unmonitored>2. Not Monitored</button>
 </div>
 
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Simulated focus origin</mat-label>
   <mat-select #simulatedOrigin value="mouse">
     <mat-option value="mouse">Mouse</mat-option>

--- a/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autofill-directive/text-field-autofill-directive-example.html
@@ -1,10 +1,10 @@
 <form (submit)="$event.preventDefault()">
-  <mat-form-field>
+  <mat-form-field appearance="fill">
     <mat-label>First name</mat-label>
     <input matInput (cdkAutofill)="firstNameAutofilled = $event.isAutofilled">
     <mat-hint *ngIf="firstNameAutofilled">Autofilled!</mat-hint>
   </mat-form-field>
-  <mat-form-field>
+  <mat-form-field appearance="fill">
     <mat-label>Last name</mat-label>
     <input matInput (cdkAutofill)="lastNameAutofilled = $event.isAutofilled">
     <mat-hint *ngIf="lastNameAutofilled">Autofilled!</mat-hint>

--- a/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autofill-monitor/text-field-autofill-monitor-example.html
@@ -1,10 +1,10 @@
 <form (submit)="$event.preventDefault()">
-  <mat-form-field>
+  <mat-form-field appearance="fill">
     <mat-label>First name</mat-label>
     <input matInput #first>
     <mat-hint *ngIf="firstNameAutofilled">Autofilled!</mat-hint>
   </mat-form-field>
-  <mat-form-field>
+  <mat-form-field appearance="fill">
     <mat-label>Last name</mat-label>
     <input matInput #last>
     <mat-hint *ngIf="lastNameAutofilled">Autofilled!</mat-hint>

--- a/src/components-examples/cdk/text-field/text-field-autosize-textarea/text-field-autosize-textarea-example.html
+++ b/src/components-examples/cdk/text-field/text-field-autosize-textarea/text-field-autosize-textarea-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Font size</mat-label>
   <mat-select #fontSize value="16px" (selectionChange)="triggerResize()">
     <mat-option value="10px">10px</mat-option>
@@ -10,7 +10,7 @@
   </mat-select>
 </mat-form-field>
 
-<mat-form-field [style.fontSize]="fontSize.value">
+<mat-form-field [style.fontSize]="fontSize.value" appearance="fill">
   <mat-label>Autosize textarea</mat-label>
   <textarea matInput
             cdkTextareaAutosize

--- a/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.html
+++ b/src/components-examples/material-experimental/mdc-form-field/mdc-form-field-custom-control/form-field-custom-control-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Phone number</mat-label>
   <example-tel-input required></example-tel-input>
   <mat-icon matSuffix>phone</mat-icon>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-cell-span-mat-table/popover-edit-cell-span-mat-table-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-cell-span-mat-table/popover-edit-cell-span-mat-table-example.html
@@ -7,15 +7,15 @@
           [matEditLensPreservedFormValue]="preservedValues.get(ctx.person)"
           (matEditLensPreservedFormValueChange)="preservedValues.set(ctx.person, $event)">
         <div mat-edit-content class="example-input-container">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input matInput [ngModel]="ctx.person.firstName" name="firstName" required
                 [attr.cdkFocusInitial]="ctx.focus === 'firstName' || null">
           </mat-form-field>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input matInput [ngModel]="ctx.person.middleName" name="middleName"
                 [attr.cdkFocusInitial]="ctx.focus === 'middleName' || null">
           </mat-form-field>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input matInput [ngModel]="ctx.person.lastName" name="lastName" required
                 [attr.cdkFocusInitial]="ctx.focus === 'lastName' || null">
           </mat-form-field>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table-flex/popover-edit-mat-table-flex-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table-flex/popover-edit-mat-table-flex-example.html
@@ -11,7 +11,7 @@
           [matEditLensPreservedFormValue]="preservedWeightValues.get(element)"
           (matEditLensPreservedFormValueChange)="preservedWeightValues.set(element, $event)">
         <div mat-edit-content>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input matInput type="number" [ngModel]="element.weight" name="weight" required>
           </mat-form-field>
         </div>
@@ -31,7 +31,7 @@
     <mat-cell *matCellDef="let element"
         [matPopoverEdit]="nameEdit">
       {{element.name}}
-      
+
       <!-- This edit is defined in the cell and can implicitly access element -->
       <ng-template #nameEdit>
         <div>
@@ -42,7 +42,7 @@
               (matEditLensPreservedFormValueChange)="preservedNameValues.set(element, $event)">
             <h2 mat-edit-title>Name</h2>
             <div mat-edit-content>
-              <mat-form-field>
+              <mat-form-field appearance="fill">
                 <input matInput [ngModel]="element.name" name="name" required>
               </mat-form-field>
             </div>
@@ -67,7 +67,7 @@
     <mat-cell *matCellDef="let element"
         [matPopoverEdit]="weightEdit" [matPopoverEditContext]="element">
       {{element.weight}}
-      
+
       <span *matRowHoverContent>
         <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
       </span>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.html
@@ -10,7 +10,7 @@
           (ngSubmit)="onSubmitWeight(element, f)"
           [(matEditLensPreservedFormValue)]="weightValues.for(element).value">
         <div mat-edit-content>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input matInput type="number" [ngModel]="element.weight" name="weight" required>
           </mat-form-field>
         </div>
@@ -47,7 +47,7 @@
         [matPopoverEdit]="nameEdit"
         [matPopoverEditDisabled]="!nameEditEnabled">
       {{element.name}}
-      
+
       <!-- This edit is defined in the cell and can implicitly access element -->
       <ng-template #nameEdit>
         <div>
@@ -57,7 +57,7 @@
               [(matEditLensPreservedFormValue)]="nameValues.for(element).value">
             <h2 mat-edit-title>Name</h2>
             <div mat-edit-content>
-              <mat-form-field>
+              <mat-form-field appearance="fill">
                 <input matInput [ngModel]="element.name" name="name" required>
               </mat-form-field>
             </div>
@@ -121,7 +121,7 @@
     <td mat-cell *matCellDef="let element"
         [matPopoverEdit]="weightEdit" [matPopoverEditContext]="element">
       {{element.weight}}
-      
+
       <span *matRowHoverContent>
         <button mat-icon-button matEditOpen><mat-icon>edit</mat-icon></button>
       </span>

--- a/src/components-examples/material-experimental/popover-edit/popover-edit-tab-out-mat-table/popover-edit-tab-out-mat-table-example.html
+++ b/src/components-examples/material-experimental/popover-edit/popover-edit-tab-out-mat-table/popover-edit-tab-out-mat-table-example.html
@@ -12,7 +12,7 @@
           [matEditLensPreservedFormValue]="preservedWeightValues.get(element)"
           (matEditLensPreservedFormValueChange)="preservedWeightValues.set(element, $event)">
         <div mat-edit-content>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input matInput type="number" [ngModel]="element.weight" name="weight" required>
           </mat-form-field>
         </div>
@@ -33,7 +33,7 @@
         [matPopoverEdit]="nameEdit" matPopoverEditTabOut
         matEditOpen>
       {{element.name}}
-      
+
       <!-- This edit is defined in the cell and can implicitly access element -->
       <ng-template #nameEdit>
         <div>
@@ -44,7 +44,7 @@
               [matEditLensPreservedFormValue]="preservedNameValues.get(element)"
               (matEditLensPreservedFormValueChange)="preservedNameValues.set(element, $event)">
             <div mat-edit-content>
-              <mat-form-field>
+              <mat-form-field appearance="fill">
                 <input matInput [ngModel]="element.name" name="name" required>
               </mat-form-field>
             </div>
@@ -66,7 +66,7 @@
         [matPopoverEditContext]="element"
         matEditOpen>
       {{element.weight}}
-      
+
       <span *matRowHoverContent>
         <mat-icon>edit</mat-icon>
       </span>

--- a/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Number</mat-label>
     <input type="text"
            placeholder="Pick one"

--- a/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Assignee</mat-label>
     <input type="text" matInput [formControl]="myControl" [matAutocomplete]="auto">
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">

--- a/src/components-examples/material/autocomplete/autocomplete-filter/autocomplete-filter-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-filter/autocomplete-filter-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Number</mat-label>
     <input type="text"
            placeholder="Pick one"

--- a/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.html
@@ -1,5 +1,5 @@
 <form [formGroup]="stateForm">
-  <mat-form-field>
+  <mat-form-field appearance="fill">
     <mat-label>States Group</mat-label>
     <input type="text"
            matInput

--- a/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>State</mat-label>
     <input matInput
            aria-label="State"

--- a/src/components-examples/material/autocomplete/autocomplete-simple/autocomplete-simple-example.html
+++ b/src/components-examples/material/autocomplete/autocomplete-simple/autocomplete-simple-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Number</mat-label>
 <!-- #docregion input -->
     <input type="text"

--- a/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
+++ b/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-chip-list">
+<mat-form-field class="example-chip-list" appearance="fill">
   <mat-label>Favorite Fruits</mat-label>
   <mat-chip-list #chipList aria-label="Fruit selection">
     <mat-chip

--- a/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
+++ b/src/components-examples/material/chips/chips-form-control/chips-form-control-example.html
@@ -7,7 +7,7 @@
   Selected keywords: {{formControl.value}}
 </p>
 
-<mat-form-field class="example-chip-list">
+<mat-form-field class="example-chip-list" appearance="fill">
   <mat-label>Video keywords</mat-label>
   <mat-chip-list #chipList aria-label="Video keywords" multiple [formControl]="formControl">
     <mat-chip

--- a/src/components-examples/material/chips/chips-input/chips-input-example.html
+++ b/src/components-examples/material/chips/chips-input/chips-input-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-chip-list">
+<mat-form-field class="example-chip-list" appearance="fill">
   <mat-label>Favorite Fruits</mat-label>
   <mat-chip-list #chipList aria-label="Fruit selection">
     <mat-chip *ngFor="let fruit of fruits" [selectable]="selectable"

--- a/src/components-examples/material/core/ripple-overview/ripple-overview-example.html
+++ b/src/components-examples/material/core/ripple-overview/ripple-overview-example.html
@@ -2,10 +2,10 @@
 <mat-checkbox [(ngModel)]="disabled" class="example-ripple-checkbox">Disabled</mat-checkbox>
 <mat-checkbox [(ngModel)]="unbounded" class="example-ripple-checkbox">Unbounded</mat-checkbox>
 
-<mat-form-field class="example-ripple-form-field">
+<mat-form-field class="example-ripple-form-field" appearance="fill">
   <input matInput [(ngModel)]="radius" type="number" placeholder="Radius">
 </mat-form-field>
-<mat-form-field class="example-ripple-form-field">
+<mat-form-field class="example-ripple-form-field" appearance="fill">
   <input matInput [(ngModel)]="color" type="text" placeholder="Color">
 </mat-form-field>
 

--- a/src/components-examples/material/dialog/dialog-overview/dialog-overview-example-dialog.html
+++ b/src/components-examples/material/dialog/dialog-overview/dialog-overview-example-dialog.html
@@ -1,7 +1,7 @@
 <h1 mat-dialog-title>Hi {{data.name}}</h1>
 <div mat-dialog-content>
   <p>What's your favorite animal?</p>
-  <mat-form-field>
+  <mat-form-field appearance="fill">
     <mat-label>Favorite Animal</mat-label>
     <input matInput [(ngModel)]="data.animal">
   </mat-form-field>

--- a/src/components-examples/material/dialog/dialog-overview/dialog-overview-example.html
+++ b/src/components-examples/material/dialog/dialog-overview/dialog-overview-example.html
@@ -1,6 +1,6 @@
 <ol>
   <li>
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>What's your name?</mat-label>
       <input matInput [(ngModel)]="name">
     </mat-form-field>

--- a/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.html
+++ b/src/components-examples/material/expansion/expansion-expand-collapse-all/expansion-expand-collapse-all-example.html
@@ -16,12 +16,12 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>First name</mat-label>
       <input matInput>
     </mat-form-field>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>Age</mat-label>
       <input matInput type="number" min="1">
     </mat-form-field>
@@ -40,7 +40,7 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>Country</mat-label>
       <input matInput>
     </mat-form-field>
@@ -57,7 +57,7 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>Date</mat-label>
       <input matInput [matDatepicker]="picker" (focus)="picker.open()" readonly>
     </mat-form-field>

--- a/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.html
+++ b/src/components-examples/material/expansion/expansion-steps/expansion-steps-example.html
@@ -10,12 +10,12 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>First name</mat-label>
       <input matInput>
     </mat-form-field>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>Age</mat-label>
       <input matInput type="number" min="1">
     </mat-form-field>
@@ -37,7 +37,7 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>Country</mat-label>
       <input matInput>
     </mat-form-field>
@@ -59,7 +59,7 @@
       </mat-panel-description>
     </mat-expansion-panel-header>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>Date</mat-label>
       <input matInput [matDatepicker]="picker" (focus)="picker.open()" readonly>
     </mat-form-field>

--- a/src/components-examples/material/input/input-clearable/input-clearable-example.html
+++ b/src/components-examples/material/input/input-clearable/input-clearable-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-form-field">
+<mat-form-field class="example-form-field" appearance="fill">
   <mat-label>Clearable input</mat-label>
   <input matInput type="text" [(ngModel)]="value">
   <button *ngIf="value" matSuffix mat-icon-button aria-label="Clear" (click)="value=''">

--- a/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.html
+++ b/src/components-examples/material/input/input-error-state-matcher/input-error-state-matcher-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Email</mat-label>
     <input type="email" matInput [formControl]="emailFormControl" [errorStateMatcher]="matcher"
            placeholder="Ex. pat@example.com">

--- a/src/components-examples/material/input/input-errors/input-errors-example.html
+++ b/src/components-examples/material/input/input-errors/input-errors-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Email</mat-label>
     <input type="email" matInput [formControl]="emailFormControl" placeholder="Ex. pat@example.com">
     <mat-error *ngIf="emailFormControl.hasError('email') && !emailFormControl.hasError('required')">

--- a/src/components-examples/material/input/input-form/input-form-example.html
+++ b/src/components-examples/material/input/input-form/input-form-example.html
@@ -1,41 +1,41 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Company (disabled)</mat-label>
     <input matInput disabled value="Google">
   </mat-form-field>
 
   <table class="example-full-width" cellspacing="0"><tr>
-    <td><mat-form-field class="example-full-width">
+    <td><mat-form-field class="example-full-width" appearance="fill">
       <mat-label>First name</mat-label>
       <input matInput>
     </mat-form-field></td>
-    <td><mat-form-field class="example-full-width">
+    <td><mat-form-field class="example-full-width" appearance="fill">
       <mat-label>Long Last Name That Will Be Truncated</mat-label>
       <input matInput>
     </mat-form-field></td>
   </tr></table>
 
   <p>
-    <mat-form-field class="example-full-width">
+    <mat-form-field class="example-full-width" appearance="fill">
       <mat-label>Address</mat-label>
       <textarea matInput placeholder="Ex. 100 Main St">1600 Amphitheatre Pkwy</textarea>
     </mat-form-field>
-    <mat-form-field class="example-full-width">
+    <mat-form-field class="example-full-width" appearance="fill">
       <mat-label>Address 2</mat-label>
       <textarea matInput></textarea>
     </mat-form-field>
   </p>
 
   <table class="example-full-width" cellspacing="0"><tr>
-    <td><mat-form-field class="example-full-width">
+    <td><mat-form-field class="example-full-width" appearance="fill">
       <mat-label>City</mat-label>
       <input matInput placeholder="Ex. San Francisco">
     </mat-form-field></td>
-    <td><mat-form-field class="example-full-width">
+    <td><mat-form-field class="example-full-width" appearance="fill">
       <mat-label>State</mat-label>
       <input matInput placeholder="Ex. California">
     </mat-form-field></td>
-    <td><mat-form-field class="example-full-width">
+    <td><mat-form-field class="example-full-width" appearance="fill">
       <mat-label>Postal Code</mat-label>
       <input matInput #postalCode maxlength="5" placeholder="Ex. 94105" value="94043">
       <mat-hint align="end">{{postalCode.value.length}} / 5</mat-hint>

--- a/src/components-examples/material/input/input-harness/input-harness-example.html
+++ b/src/components-examples/material/input/input-harness/input-harness-example.html
@@ -1,14 +1,14 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Favorite food</mat-label>
   <input matInput value="Sushi" name="favorite-food">
 </mat-form-field>
 
-<mat-form-field>
+<mat-form-field appearance="fill">
   <input matInput [type]="inputType"
          [disabled]="disabled">
 </mat-form-field>
 
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Leave a comment</mat-label>
   <textarea matInput></textarea>
 </mat-form-field>

--- a/src/components-examples/material/input/input-hint/input-hint-example.html
+++ b/src/components-examples/material/input/input-hint/input-hint-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Message</mat-label>
     <input matInput #message maxlength="256" placeholder="Ex. I need help with...">
     <mat-hint align="start"><strong>Don't disclose personal info</strong> </mat-hint>

--- a/src/components-examples/material/input/input-overview/input-overview-example.html
+++ b/src/components-examples/material/input/input-overview/input-overview-example.html
@@ -1,10 +1,10 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Favorite food</mat-label>
     <input matInput placeholder="Ex. Pizza" value="Sushi">
   </mat-form-field>
 
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Leave a comment</mat-label>
     <textarea matInput placeholder="Ex. It makes me feel..."></textarea>
   </mat-form-field>

--- a/src/components-examples/material/input/input-prefix-suffix/input-prefix-suffix-example.html
+++ b/src/components-examples/material/input/input-prefix-suffix/input-prefix-suffix-example.html
@@ -1,5 +1,5 @@
 <form class="example-form">
-  <mat-form-field class="example-full-width">
+  <mat-form-field class="example-full-width" appearance="fill">
     <mat-label>Telephone</mat-label>
     <span matPrefix>+1 &nbsp;</span>
     <input type="tel" matInput placeholder="555-555-1234">

--- a/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.html
+++ b/src/components-examples/material/paginator/paginator-configurable/paginator-configurable-example.html
@@ -1,13 +1,13 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>List length</mat-label>
   <input matInput [(ngModel)]="length" type="number">
 </mat-form-field>
 
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Page size</mat-label>
   <input matInput [(ngModel)]="pageSize" type="number">
 </mat-form-field>
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Page size options</mat-label>
   <input matInput [ngModel]="pageSizeOptions" (ngModelChange)="setPageSizeOptions($event)"
          [ngModelOptions]="{updateOn: 'blur'}" placeholder="Ex. 10,25,50">

--- a/src/components-examples/material/sidenav/sidenav-backdrop/sidenav-backdrop-example.html
+++ b/src/components-examples/material/sidenav/sidenav-backdrop/sidenav-backdrop-example.html
@@ -1,7 +1,7 @@
 <mat-drawer-container class="example-container" [hasBackdrop]="hasBackdrop.value">
   <mat-drawer #drawer [mode]="mode.value">I'm a drawer</mat-drawer>
   <mat-drawer-content>
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>Sidenav mode</mat-label>
       <mat-select #mode value="side">
         <mat-option value="side">Side</mat-option>
@@ -9,7 +9,7 @@
         <mat-option value="push">Push</mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>Has backdrop</mat-label>
       <mat-select #hasBackdrop>
         <mat-option>Unset</mat-option>

--- a/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.html
+++ b/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.html
@@ -10,11 +10,11 @@
 
     <mat-sidenav-content [formGroup]="options">
       <p><mat-checkbox formControlName="fixed">Fixed</mat-checkbox></p>
-      <p><mat-form-field>
+      <p><mat-form-field appearance="fill">
         <mat-label>Top gap</mat-label>
         <input matInput type="number" formControlName="top">
       </mat-form-field></p>
-      <p><mat-form-field>
+      <p><mat-form-field appearance="fill">
         <mat-label>Bottom gap</mat-label>
         <input matInput type="number" formControlName="bottom">
       </mat-form-field></p>

--- a/src/components-examples/material/slider/slider-configurable/slider-configurable-example.html
+++ b/src/components-examples/material/slider/slider-configurable/slider-configurable-example.html
@@ -3,19 +3,19 @@
     <h2 class="example-h2">Slider configuration</h2>
 
     <section class="example-section">
-      <mat-form-field class="example-margin">
+      <mat-form-field class="example-margin" appearance="fill">
         <mat-label>Value</mat-label>
         <input matInput type="number" [(ngModel)]="value">
       </mat-form-field>
-      <mat-form-field class="example-margin">
+      <mat-form-field class="example-margin" appearance="fill">
         <mat-label>Min value</mat-label>
         <input matInput type="number" [(ngModel)]="min">
       </mat-form-field>
-      <mat-form-field class="example-margin">
+      <mat-form-field class="example-margin" appearance="fill">
         <mat-label>Max value</mat-label>
         <input matInput type="number" [(ngModel)]="max">
       </mat-form-field>
-      <mat-form-field class="example-margin">
+      <mat-form-field class="example-margin" appearance="fill">
         <mat-label>Step size</mat-label>
         <input matInput type="number" [(ngModel)]="step">
       </mat-form-field>
@@ -26,7 +26,7 @@
       <mat-checkbox class="example-margin" [(ngModel)]="autoTicks" *ngIf="showTicks">
         Auto ticks
       </mat-checkbox>
-      <mat-form-field class="example-margin" *ngIf="showTicks && !autoTicks">
+      <mat-form-field class="example-margin" appearance="fill" *ngIf="showTicks && !autoTicks">
         <mat-label>Tick interval</mat-label>
         <input matInput type="number" [(ngModel)]="tickInterval">
       </mat-form-field>

--- a/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-component/snack-bar-component-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Snack bar duration (seconds)</mat-label>
   <input type="number" [(ngModel)]="durationInSeconds" matInput>
 </mat-form-field>

--- a/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-overview/snack-bar-overview-example.html
@@ -1,9 +1,9 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Message</mat-label>
   <input matInput value="Disco party!" #message>
 </mat-form-field>
 
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Action</mat-label>
   <input matInput value="Dance" #action>
 </mat-form-field>

--- a/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.html
+++ b/src/components-examples/material/snack-bar/snack-bar-position/snack-bar-position-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Horizontal position</mat-label>
   <mat-select [(value)]="horizontalPosition">
     <mat-option value="start">Start</mat-option>
@@ -8,7 +8,7 @@
     <mat-option value="right">Right</mat-option>
   </mat-select>
 </mat-form-field>
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Vertical position</mat-label>
   <mat-select [(value)]="verticalPosition">
     <mat-option value="top">Top</mat-option>

--- a/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
+++ b/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
@@ -10,7 +10,7 @@
 <!-- #docregion step-label -->
       <ng-template matStepLabel>Fill out your name</ng-template>
 <!-- #enddocregion step-label -->
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput formControlName="firstCtrl" placeholder="Last name, First name" required>
       </mat-form-field>
@@ -22,7 +22,7 @@
   <mat-step [stepControl]="secondFormGroup" [editable]="isEditable">
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
+++ b/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
@@ -2,7 +2,7 @@
   <mat-step [stepControl]="firstFormGroup" errorMessage="Name is required.">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -15,7 +15,7 @@
   <mat-step [stepControl]="secondFormGroup" errorMessage="Address is required.">
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input matInput placeholder="Ex. 1 Main St, New York, NY" formControlName="secondCtrl"
                required>

--- a/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.html
+++ b/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.html
@@ -15,7 +15,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field class="demo-form-field">
+      <mat-form-field class="demo-form-field" appearance="fill">
         <mat-label>Name</mat-label>
         <input
           matInput
@@ -34,7 +34,7 @@
     label="Fill out your address"
     optional>
     <form [formGroup]="secondFormGroup">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input
           matInput

--- a/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
+++ b/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
@@ -4,7 +4,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -16,7 +16,7 @@
   <mat-step [stepControl]="secondFormGroup" optional>
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
+++ b/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
@@ -6,7 +6,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -20,7 +20,7 @@
   <!-- #enddocregion optional -->
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
+++ b/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
@@ -5,7 +5,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -18,7 +18,7 @@
   <mat-step [stepControl]="secondFormGroup" label="Fill out your address">
   <!-- #enddocregion label -->
     <form [formGroup]="secondFormGroup">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-responsive/stepper-responsive-example.html
+++ b/src/components-examples/material/stepper/stepper-responsive/stepper-responsive-example.html
@@ -8,7 +8,7 @@
   [orientation]="(stepperOrientation | async)!">
   <mat-step [stepControl]="firstFormGroup" label="Fill out your name">
     <form [formGroup]="firstFormGroup">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -19,7 +19,7 @@
   </mat-step>
   <mat-step [stepControl]="secondFormGroup" label="Fill out your address">
     <form [formGroup]="secondFormGroup">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>
@@ -32,7 +32,7 @@
   </mat-step>
   <mat-step [stepControl]="thirdFormGroup" label="Fill out your phone number">
     <form [formGroup]="thirdFormGroup">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Phone number</mat-label>
         <input matInput formControlName="thirdCtrl" placeholder="Ex. 12345678" required>
       </mat-form-field>

--- a/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
+++ b/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
@@ -2,7 +2,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -14,7 +14,7 @@
   <mat-step [stepControl]="secondFormGroup">
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
+++ b/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
@@ -5,7 +5,7 @@
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
       </mat-form-field>
@@ -17,7 +17,7 @@
   <mat-step [stepControl]="secondFormGroup">
     <form [formGroup]="secondFormGroup">
       <ng-template matStepLabel>Fill out your address</ng-template>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <mat-label>Address</mat-label>
         <input matInput formControlName="secondCtrl" placeholder="Ex. 1 Main St, New York, NY"
                required>

--- a/src/components-examples/material/table/table-filtering/table-filtering-example.html
+++ b/src/components-examples/material/table/table-filtering/table-filtering-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="standard">
   <mat-label>Filter</mat-label>
   <input matInput (keyup)="applyFilter($event)" placeholder="Ex. ium" #input>
 </mat-form-field>

--- a/src/components-examples/material/table/table-overview/table-overview-example.html
+++ b/src/components-examples/material/table/table-overview/table-overview-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="standard">
   <mat-label>Filter</mat-label>
   <input matInput (keyup)="applyFilter($event)" placeholder="Ex. Mia" #input>
 </mat-form-field>

--- a/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.html
+++ b/src/components-examples/material/tabs/tab-group-dynamic/tab-group-dynamic-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Selected tab index</mat-label>
   <input matInput type="number" [formControl]="selected">
 </mat-form-field>

--- a/src/components-examples/material/tooltip/tooltip-auto-hide/tooltip-auto-hide-example.html
+++ b/src/components-examples/material/tooltip/tooltip-auto-hide/tooltip-auto-hide-example.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>Tooltip position</mat-label>
   <mat-select [formControl]="position">
     <mat-option *ngFor="let positionOption of positionOptions" [value]="positionOption">

--- a/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.html
+++ b/src/components-examples/material/tooltip/tooltip-delay/tooltip-delay-example.html
@@ -1,11 +1,11 @@
-<mat-form-field class="example-user-input">
+<mat-form-field class="example-user-input" appearance="fill">
   <mat-label>Show delay</mat-label>
   <input matInput type="number" [formControl]="showDelay"
          aria-label="Adds a delay between hovering over the button and displaying the tooltip">
   <mat-hint>milliseconds</mat-hint>
 </mat-form-field>
 
-<mat-form-field class="example-user-input">
+<mat-form-field class="example-user-input" appearance="fill">
   <mat-label>Hide delay</mat-label>
   <input matInput type="number" [formControl]="hideDelay"
          aria-label="Adds a delay between hovering away from the button and hiding the tooltip">

--- a/src/components-examples/material/tooltip/tooltip-message/tooltip-message-example.html
+++ b/src/components-examples/material/tooltip/tooltip-message/tooltip-message-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-user-input">
+<mat-form-field class="example-user-input" appearance="fill">
   <mat-label>Tooltip message</mat-label>
   <input matInput [formControl]="message">
 </mat-form-field>

--- a/src/components-examples/material/tooltip/tooltip-position/tooltip-position-example.html
+++ b/src/components-examples/material/tooltip/tooltip-position/tooltip-position-example.html
@@ -1,4 +1,4 @@
-<mat-form-field class="example-user-input">
+<mat-form-field class="example-user-input" appearance="fill">
   <mat-label>Tooltip position</mat-label>
   <mat-select [formControl]="position">
     <mat-option *ngFor="let positionOption of positionOptions" [value]="positionOption">

--- a/src/components-examples/material/tree/tree-checklist/tree-checklist-example.html
+++ b/src/components-examples/material/tree/tree-checklist/tree-checklist-example.html
@@ -8,7 +8,7 @@
 
   <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>
     <button mat-icon-button disabled></button>
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>New item...</mat-label>
       <input matInput #itemValue placeholder="Ex. Lettuce">
     </mat-form-field>


### PR DESCRIPTION
Currently the default form field appearance is `legacy`, but we switch it to `fill` only in Stackblitz since that's what we want to change the default to eventually. The problem with this approach is that the default is only changed on Stackblitz, not the docs site that user has to go through.

These changes set the appearance to `fill` explicitly so that it is consistent.

Companion PR for the docs site: https://github.com/angular/material.angular.io/pull/1002