### PR TITLE
refactor(material/stepper): remove all usages of deprecated selectors

### DIFF
--- a/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
+++ b/src/components-examples/material/stepper/stepper-editable/stepper-editable-example.html
@@ -2,7 +2,7 @@
   {{!isEditable ? 'Enable edit mode' : 'Disable edit mode'}}
 </button>
 
-<mat-horizontal-stepper linear #stepper>
+<mat-stepper linear #stepper>
 <!-- #docregion editable -->
   <mat-step [stepControl]="firstFormGroup" [editable]="isEditable">
 <!-- #enddocregion editable -->
@@ -41,4 +41,4 @@
       <button mat-button (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>

--- a/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
+++ b/src/components-examples/material/stepper/stepper-errors/stepper-errors-example.html
@@ -1,4 +1,4 @@
-<mat-horizontal-stepper #stepper>
+<mat-stepper #stepper>
   <mat-step [stepControl]="firstFormGroup" errorMessage="Name is required.">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
@@ -35,4 +35,4 @@
       <button mat-button (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>

--- a/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.html
+++ b/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.html
@@ -1,4 +1,4 @@
-<mat-horizontal-stepper>
+<mat-stepper>
   <mat-step>
     <ng-template matStepLabel>One</ng-template>
     <button matStepperNext>Next</button>
@@ -12,4 +12,4 @@
     <ng-template matStepLabel>Three</ng-template>
     <button matStepperPrevious>Previous</button>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>

--- a/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.html
+++ b/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.html
@@ -11,7 +11,7 @@
     {{optionalLabelTextChoice}}
   </mat-radio-button>
 </mat-radio-group>
-<mat-horizontal-stepper class="demo-stepper" #stepper>
+<mat-stepper class="demo-stepper" #stepper>
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
@@ -56,4 +56,4 @@
       <button mat-button (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>

--- a/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
+++ b/src/components-examples/material/stepper/stepper-label-position-bottom/stepper-label-position-bottom-example.html
@@ -1,5 +1,5 @@
 <!-- #docregion label-position -->
-<mat-horizontal-stepper labelPosition="bottom" #stepper>
+<mat-stepper labelPosition="bottom" #stepper>
 <!-- #enddocregion label-position -->
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
@@ -37,4 +37,4 @@
       <button mat-button (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>

--- a/src/components-examples/material/stepper/stepper-lazy-content/stepper-lazy-content-example.html
+++ b/src/components-examples/material/stepper/stepper-lazy-content/stepper-lazy-content-example.html
@@ -1,4 +1,4 @@
-<mat-vertical-stepper>
+<mat-stepper orientation="vertical">
   <mat-step>
     <ng-template matStepLabel>Step 1</ng-template>
     <ng-template matStepContent>
@@ -19,4 +19,4 @@
     <p>This content was rendered eagerly</p>
     <button mat-button matStepperPrevious>Back</button>
   </mat-step>
-</mat-vertical-stepper>
+</mat-stepper>

--- a/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
+++ b/src/components-examples/material/stepper/stepper-optional/stepper-optional-example.html
@@ -2,7 +2,7 @@
   {{!isOptional ? 'Enable optional steps' : 'Disable optional steps'}}
 </button>
 
-<mat-horizontal-stepper linear #stepper>
+<mat-stepper linear #stepper>
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
@@ -39,4 +39,4 @@
       <button mat-button (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>

--- a/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
+++ b/src/components-examples/material/stepper/stepper-overview/stepper-overview-example.html
@@ -1,7 +1,7 @@
 <button mat-raised-button (click)="isLinear = !isLinear" id="toggle-linear">
   {{!isLinear ? 'Enable linear mode' : 'Disable linear mode'}}
 </button>
-<mat-horizontal-stepper [linear]="isLinear" #stepper>
+<mat-stepper [linear]="isLinear" #stepper>
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
@@ -37,4 +37,4 @@
       <button mat-button (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>

--- a/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
+++ b/src/components-examples/material/stepper/stepper-states/stepper-states-example.html
@@ -1,4 +1,4 @@
-<mat-horizontal-stepper #stepper>
+<mat-stepper #stepper>
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
@@ -33,10 +33,10 @@
       <button mat-button (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>
 
 <!-- #docregion states -->
-<mat-horizontal-stepper>
+<mat-stepper>
 <!-- #docregion label -->
   <mat-step label="Step 1" state="phone">
     <p>Put down your phones.</p>
@@ -64,6 +64,6 @@
   <ng-template matStepperIcon="chat">
     <mat-icon>forum</mat-icon>
   </ng-template>
-</mat-horizontal-stepper>
+</mat-stepper>
 <!-- #enddocregion override-icons -->
 <!-- #enddocregion states -->

--- a/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
+++ b/src/components-examples/material/stepper/stepper-vertical/stepper-vertical-example.html
@@ -1,7 +1,7 @@
 <button mat-raised-button (click)="isLinear = !isLinear" id="toggle-linear">
   {{!isLinear ? 'Enable linear mode' : 'Disable linear mode'}}
 </button>
-<mat-vertical-stepper [linear]="isLinear" #stepper>
+<mat-stepper orientation="vertical" [linear]="isLinear" #stepper>
   <mat-step [stepControl]="firstFormGroup">
     <form [formGroup]="firstFormGroup">
       <ng-template matStepLabel>Fill out your name</ng-template>
@@ -36,4 +36,4 @@
       <button mat-button (click)="stepper.reset()">Reset</button>
     </div>
   </mat-step>
-</mat-vertical-stepper>
+</mat-stepper>

--- a/src/dev-app/stepper/stepper-demo.html
+++ b/src/dev-app/stepper/stepper-demo.html
@@ -76,7 +76,7 @@
 </form>
 
 <h3>Linear Horizontal Stepper Demo using a different form for each step</h3>
-<mat-horizontal-stepper #linearHorizontalStepper="matHorizontalStepper" [linear]="!isNonLinear"
+<mat-stepper #linearHorizontalStepper="matHorizontalStepper" [linear]="!isNonLinear"
                         [disableRipple]="disableRipple"
                         [labelPosition]="showLabelBottom ? 'bottom' : 'end'"
                         [color]="theme">
@@ -124,11 +124,11 @@
       </div>
     </form>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>
 
 <h3>Vertical Stepper Demo</h3>
 <mat-checkbox [(ngModel)]="isNonEditable">Make steps non-editable</mat-checkbox>
-<mat-vertical-stepper [color]="theme">
+<mat-stepper orientation="vertical" [color]="theme">
   <mat-step [editable]="!isNonEditable">
     <ng-template matStepLabel>Fill out your name</ng-template>
     <mat-form-field>
@@ -180,10 +180,10 @@
       <button mat-button>Done</button>
     </div>
   </mat-step>
-</mat-vertical-stepper>
+</mat-stepper>
 
 <h3>Horizontal Stepper Demo with Text Label</h3>
-<mat-horizontal-stepper [color]="theme">
+<mat-stepper [color]="theme">
   <mat-step label="Fill out your name">
     <mat-form-field>
       <mat-label>First name</mat-label>
@@ -227,10 +227,10 @@
       <button mat-button>Done</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>
 
 <h3>Horizontal Stepper Demo with Templated Label</h3>
-<mat-horizontal-stepper [color]="theme">
+<mat-stepper [color]="theme">
   <mat-step *ngFor="let step of steps">
     <ng-template matStepLabel>{{step.label}}</ng-template>
     <mat-form-field>
@@ -242,15 +242,15 @@
       <button mat-button matStepperNext>Next</button>
     </div>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>
 
 <h3>Stepper with autosize textarea</h3>
-<mat-horizontal-stepper [color]="theme">
+<mat-stepper [color]="theme">
   <mat-step label="Step 1">
     <mat-form-field>
       <mat-label>Autosize textarea</mat-label>
       <textarea matInput cdkTextareaAutosize>This is an autosize textarea, it should adjust to the size of its content.</textarea>
     </mat-form-field>
   </mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>
 

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -2245,7 +2245,7 @@ class AutosizeTextareaInATab {}
 
 @Component({
   template: `
-    <mat-horizontal-stepper>
+    <mat-stepper>
       <mat-step label="Step 1">
         <mat-form-field>
           <textarea matInput matTextareaAautosize>
@@ -2253,7 +2253,7 @@ class AutosizeTextareaInATab {}
           </textarea>
         </mat-form-field>
       </mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
   `
 })
 class AutosizeTextareaInAStep {}

--- a/src/material/stepper/stepper.e2e.spec.ts
+++ b/src/material/stepper/stepper.e2e.spec.ts
@@ -5,7 +5,7 @@ describe('stepper', () => {
   beforeEach(async () => await browser.get('/stepper'));
 
   it('should render a stepper', async () => {
-    await expectToExist('mat-horizontal-stepper');
+    await expectToExist('mat-stepper');
   });
 
   describe('basic behavior', () => {

--- a/src/material/stepper/stepper.md
+++ b/src/material/stepper/stepper.md
@@ -5,16 +5,12 @@ that drives a stepped workflow. Material stepper extends the CDK stepper and has
 styling.
 
 ### Stepper variants
-There are two stepper components: `mat-horizontal-stepper` and `mat-vertical-stepper`. They
-can be used the same way. The only difference is the orientation of stepper.
+There are two stepper variants: `horizontal` and `vertical`. You can switch between the two using
+the `orientation` attribute.
 
 <!-- example(stepper-overview) -->
 
 <!-- example(stepper-vertical) -->
-
-`mat-horizontal-stepper` selector can be used to create a horizontal stepper, and
-`mat-vertical-stepper` can be used to create a vertical stepper. `mat-step` components need to be
-placed inside either one of the two stepper components.
 
 ### Labels
 If a step's label is only text, then the `label` attribute can be used.
@@ -29,7 +25,7 @@ For more complex labels, add a template with the `matStepLabel` directive inside
               "region": "step-label"}) -->
 
 #### Label position
-For `mat-horizontal-stepper` it's possible to define the position of the label. `end` is the
+For a horizontal `mat-stepper` it's possible to define the position of the label. `end` is the
 default value, while `bottom` will place it under the step icon instead of at its side.
 This behaviour is controlled by `labelPosition` property.
 
@@ -45,10 +41,10 @@ There are two button directives to support navigation between different steps:
               "region": "buttons"}) -->
 
 ### Linear stepper
-The `linear` attribute can be set on `mat-horizontal-stepper` and `mat-vertical-stepper` to create
-a linear stepper that requires the user to complete previous steps before proceeding to following
-steps. For each `mat-step`, the `stepControl` attribute can be set to the top level
-`AbstractControl` that is used to check the validity of the step.
+The `linear` attribute can be set on `mat-stepper` to create a linear stepper that requires the
+user to complete previous steps before proceeding to following steps. For each `mat-step`, the
+`stepControl` attribute can be set to the top level `AbstractControl` that is used to check the
+validity of the step.
 
 There are two possible approaches. One is using a single form for stepper, and the other is
 using a different form for each step.
@@ -64,7 +60,7 @@ are completed.
 
 ```html
 <form [formGroup]="formGroup">
-  <mat-horizontal-stepper formArrayName="formArray" linear>
+  <mat-stepper formArrayName="formArray" linear>
     <mat-step formGroupName="0" [stepControl]="formArray.get([0])">
       ...
       <div>
@@ -79,13 +75,13 @@ are completed.
       </div>
     </mat-step>
     ...
-  </mat-horizontal-stepper>
+  </mat-stepper>
 </form>
 ```
 
 #### Using a different form for each step
 ```html
-<mat-vertical-stepper linear>
+<mat-stepper orientation="vertical" linear>
   <mat-step [stepControl]="formGroup1">
     <form [formGroup]="formGroup1">
       ...
@@ -96,7 +92,7 @@ are completed.
       ...
     </form>
   </mat-step>
-</mat-vertical-stepper>
+</mat-stepper>
 ```
 ### Types of steps
 

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -76,13 +76,13 @@ describe('MatStepper', () => {
 
     it('should default to the first step', () => {
       let stepperComponent = fixture.debugElement
-          .query(By.css('mat-vertical-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
       expect(stepperComponent.selectedIndex).toBe(0);
     });
 
     it('should throw when a negative `selectedIndex` is assigned', () => {
       const stepperComponent: MatStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
 
       expect(() => {
         stepperComponent.selectedIndex = -10;
@@ -92,7 +92,7 @@ describe('MatStepper', () => {
 
     it('should throw when an out-of-bounds `selectedIndex` is assigned', () => {
       const stepperComponent: MatStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
 
       expect(() => {
         stepperComponent.selectedIndex = 1337;
@@ -126,7 +126,7 @@ describe('MatStepper', () => {
     });
 
     it('should set the "tablist" role on stepper', () => {
-      let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper'))!.nativeElement;
+      let stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('role')).toBe('tablist');
     });
 
@@ -361,7 +361,7 @@ describe('MatStepper', () => {
 
     it('should adjust the index when removing a step before the current one', () => {
       const stepperComponent: MatStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
 
       stepperComponent.selectedIndex = 2;
       fixture.detectChanges();
@@ -401,7 +401,7 @@ describe('MatStepper', () => {
     it('should not throw', () => {
       const fixture = createComponent(SimpleMatVerticalStepperApp);
       const stepperComponent: MatStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
 
       expect(() => stepperComponent.selected).not.toThrow();
     });
@@ -411,7 +411,7 @@ describe('MatStepper', () => {
     it('should not throw', () => {
       const fixture = createComponent(SimpleMatVerticalStepperApp);
       const stepperComponent: MatStepper = fixture.debugElement
-          .query(By.css('mat-vertical-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
 
       expect(() => stepperComponent.selected = null!).not.toThrow();
       expect(stepperComponent.selectedIndex).toBe(-1);
@@ -529,7 +529,7 @@ describe('MatStepper', () => {
 
       testComponent = fixture.componentInstance;
       stepperComponent = fixture.debugElement
-          .query(By.css('mat-vertical-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
     });
 
     it('should have true linear attribute', () => {
@@ -843,7 +843,7 @@ describe('MatStepper', () => {
       let fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
-      let stepperEl = fixture.debugElement.query(By.css('mat-vertical-stepper'))!.nativeElement;
+      let stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('aria-orientation')).toBe('vertical');
     });
 
@@ -950,7 +950,7 @@ describe('MatStepper', () => {
       let fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
-      let stepperEl = fixture.debugElement.query(By.css('mat-horizontal-stepper'))!.nativeElement;
+      let stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('aria-orientation')).toBe('horizontal');
     });
 
@@ -1098,7 +1098,7 @@ describe('MatStepper', () => {
 
       testComponent = fixture.componentInstance;
       stepper = fixture.debugElement
-          .query(By.css('mat-horizontal-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
     });
 
     it('must be visited if not optional', () => {
@@ -1179,7 +1179,7 @@ describe('MatStepper', () => {
       );
       fixture.detectChanges();
       stepper = fixture.debugElement
-          .query(By.css('mat-horizontal-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
     }
 
     it('should show error state', () => {
@@ -1242,7 +1242,7 @@ describe('MatStepper', () => {
       );
       fixture.detectChanges();
       stepper = fixture.debugElement
-          .query(By.css('mat-horizontal-stepper'))!.componentInstance;
+          .query(By.css('mat-stepper'))!.componentInstance;
     });
 
     it('should show done state when step is completed and its not the current step', () => {
@@ -1573,7 +1573,7 @@ function createComponent<T>(component: Type<T>,
 @Component({
   template: `
   <form [formGroup]="formGroup">
-    <mat-horizontal-stepper>
+    <mat-stepper>
       <mat-step errorMessage="This field is required"
         [stepControl]="formGroup.get('firstNameCtrl')">
         <ng-template matStepLabel>Step 1</ng-template>
@@ -1595,7 +1595,7 @@ function createComponent<T>(component: Type<T>,
           <button mat-button matStepperNext>Next</button>
         </div>
       </mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
   </form>
   `
 })
@@ -1614,7 +1614,7 @@ class MatHorizontalStepperWithErrorsApp implements OnInit {
 
 @Component({
   template: `
-    <mat-horizontal-stepper [disableRipple]="disableRipple" [color]="stepperTheme">
+    <mat-stepper [disableRipple]="disableRipple" [color]="stepperTheme">
       <mat-step>
         <ng-template matStepLabel>Step 1</ng-template>
         Content 1
@@ -1638,7 +1638,7 @@ class MatHorizontalStepperWithErrorsApp implements OnInit {
           <button mat-button matStepperNext>Next</button>
         </div>
       </mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
   `
 })
 class SimpleMatHorizontalStepperApp {
@@ -1651,7 +1651,7 @@ class SimpleMatHorizontalStepperApp {
 
 @Component({
   template: `
-    <mat-vertical-stepper [disableRipple]="disableRipple" [color]="stepperTheme">
+    <mat-stepper orientation="vertical" [disableRipple]="disableRipple" [color]="stepperTheme">
       <mat-step>
         <ng-template matStepLabel>Step 1</ng-template>
         Content 1
@@ -1675,7 +1675,7 @@ class SimpleMatHorizontalStepperApp {
           <button mat-button matStepperNext>Next</button>
         </div>
       </mat-step>
-    </mat-vertical-stepper>
+    </mat-stepper>
   `
 })
 class SimpleMatVerticalStepperApp {
@@ -1689,7 +1689,7 @@ class SimpleMatVerticalStepperApp {
 
 @Component({
   template: `
-    <mat-vertical-stepper linear>
+    <mat-stepper orientation="vertical" linear>
       <mat-step [stepControl]="oneGroup">
         <form [formGroup]="oneGroup">
           <ng-template matStepLabel>Step one</ng-template>
@@ -1723,7 +1723,7 @@ class SimpleMatVerticalStepperApp {
       <mat-step>
         Done
       </mat-step>
-    </mat-vertical-stepper>
+    </mat-stepper>
   `
 })
 class LinearMatVerticalStepperApp implements OnInit {
@@ -1748,11 +1748,11 @@ class LinearMatVerticalStepperApp implements OnInit {
 
 @Component({
   template: `
-    <mat-horizontal-stepper [linear]="true" [selectedIndex]="index">
+    <mat-stepper [linear]="true" [selectedIndex]="index">
       <mat-step label="One"></mat-step>
       <mat-step label="Two"></mat-step>
       <mat-step label="Three"></mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
   `
 })
 class SimplePreselectedMatHorizontalStepperApp {
@@ -1761,12 +1761,12 @@ class SimplePreselectedMatHorizontalStepperApp {
 
 @Component({
   template: `
-    <mat-horizontal-stepper linear>
+    <mat-stepper linear>
       <mat-step
         *ngFor="let step of steps"
         [label]="step.label"
         [completed]="step.completed"></mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
   `
 })
 class SimpleStepperWithoutStepControl {
@@ -1779,13 +1779,13 @@ class SimpleStepperWithoutStepControl {
 
 @Component({
   template: `
-    <mat-horizontal-stepper linear>
+    <mat-stepper linear>
       <mat-step
         *ngFor="let step of steps"
         [label]="step.label"
         [stepControl]="step.control"
         [completed]="step.completed"></mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
   `
 })
 class SimpleStepperWithStepControlAndCompletedBinding {
@@ -1798,7 +1798,7 @@ class SimpleStepperWithStepControlAndCompletedBinding {
 
 @Component({
   template: `
-    <mat-horizontal-stepper>
+    <mat-stepper>
       <ng-template matStepperIcon="edit">Custom edit</ng-template>
       <ng-template matStepperIcon="done">Custom done</ng-template>
       <ng-template matStepperIcon="number" let-index="index">
@@ -1808,7 +1808,7 @@ class SimpleStepperWithStepControlAndCompletedBinding {
       <mat-step>Content 1</mat-step>
       <mat-step>Content 2</mat-step>
       <mat-step>Content 3</mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
 `
 })
 class IconOverridesStepper {
@@ -1831,7 +1831,7 @@ class IconOverridesStepper {
 
 @Component({
   template: `
-    <mat-horizontal-stepper>
+    <mat-stepper>
       <ng-container [ngSwitch]="true">
         <ng-template matStepperIcon="edit">Custom edit</ng-template>
         <ng-template matStepperIcon="done">Custom done</ng-template>
@@ -1843,7 +1843,7 @@ class IconOverridesStepper {
       <mat-step>Content 1</mat-step>
       <mat-step>Content 2</mat-step>
       <mat-step>Content 3</mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
 `
 })
 class IndirectDescendantIconOverridesStepper extends IconOverridesStepper {
@@ -1851,11 +1851,11 @@ class IndirectDescendantIconOverridesStepper extends IconOverridesStepper {
 
 @Component({
   template: `
-    <mat-horizontal-stepper linear>
+    <mat-stepper linear>
       <mat-step label="Step 1" [stepControl]="controls[0]"></mat-step>
       <mat-step label="Step 2" [stepControl]="controls[1]" [optional]="step2Optional"></mat-step>
       <mat-step label="Step 3" [stepControl]="controls[2]"></mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
   `
 })
 class LinearStepperWithValidOptionalStep {
@@ -1866,9 +1866,9 @@ class LinearStepperWithValidOptionalStep {
 
 @Component({
   template: `
-    <mat-horizontal-stepper>
+    <mat-stepper>
       <mat-step [aria-label]="ariaLabel" [aria-labelledby]="ariaLabelledby" label="One"></mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
   `
 })
 class StepperWithAriaInputs {
@@ -1879,13 +1879,13 @@ class StepperWithAriaInputs {
 
 @Component({
   template: `
-    <mat-vertical-stepper>
+    <mat-stepper orientation="vertical">
       <ng-container [ngSwitch]="true">
         <mat-step label="Step 1">Content 1</mat-step>
         <mat-step label="Step 2">Content 2</mat-step>
         <mat-step label="Step 3">Content 3</mat-step>
       </ng-container>
-    </mat-vertical-stepper>
+    </mat-stepper>
   `
 })
 class StepperWithIndirectDescendantSteps {
@@ -1894,7 +1894,7 @@ class StepperWithIndirectDescendantSteps {
 
 @Component({
   template: `
-    <mat-vertical-stepper>
+    <mat-stepper orientation="vertical">
       <mat-step>
         <ng-template matStepLabel>Step 1</ng-template>
       </mat-step>
@@ -1902,7 +1902,7 @@ class StepperWithIndirectDescendantSteps {
       <mat-step *ngIf="showStep2">
         <ng-template matStepLabel>Step 2</ng-template>
       </mat-step>
-    </mat-vertical-stepper>
+    </mat-stepper>
   `
 })
 class StepperWithNgIf {
@@ -1912,16 +1912,16 @@ class StepperWithNgIf {
 
 @Component({
   template: `
-    <mat-vertical-stepper>
+    <mat-stepper orientation="vertical">
       <mat-step label="Step 1">Content 1</mat-step>
       <mat-step label="Step 2">Content 2</mat-step>
       <mat-step label="Step 3">
-        <mat-horizontal-stepper>
+        <mat-stepper>
           <mat-step label="Sub-Step 1">Sub-Content 1</mat-step>
           <mat-step label="Sub-Step 2">Sub-Content 2</mat-step>
-        </mat-horizontal-stepper>
+        </mat-stepper>
       </mat-step>
-    </mat-vertical-stepper>
+    </mat-stepper>
   `
 })
 class NestedSteppers {
@@ -1931,11 +1931,11 @@ class NestedSteppers {
 
 @Component({
   template: `
-    <mat-vertical-stepper selectedIndex="1337">
+    <mat-stepper orientation="vertical" selectedIndex="1337">
       <mat-step label="Step 1">Content 1</mat-step>
       <mat-step label="Step 2">Content 2</mat-step>
       <mat-step label="Step 3">Content 3</mat-step>
-    </mat-vertical-stepper>
+    </mat-stepper>
   `
 })
 class StepperWithStaticOutOfBoundsIndex {
@@ -1945,7 +1945,7 @@ class StepperWithStaticOutOfBoundsIndex {
 
 @Component({
   template: `
-    <mat-vertical-stepper [selectedIndex]="selectedIndex">
+    <mat-stepper orientation="vertical" [selectedIndex]="selectedIndex">
       <mat-step>
         <ng-template matStepLabel>Step 1</ng-template>
         <ng-template matStepContent>Step 1 content</ng-template>
@@ -1958,7 +1958,7 @@ class StepperWithStaticOutOfBoundsIndex {
         <ng-template matStepLabel>Step 3</ng-template>
         <ng-template matStepContent>Step 3 content</ng-template>
       </mat-step>
-    </mat-vertical-stepper>
+    </mat-stepper>
   `
 })
 class StepperWithLazyContent {

--- a/src/material/stepper/testing/shared.spec.ts
+++ b/src/material/stepper/testing/shared.spec.ts
@@ -262,7 +262,7 @@ export function runHarnessTests(
 
 @Component({
   template: `
-    <mat-vertical-stepper id="one-stepper">
+    <mat-stepper orientation="vertical" id="one-stepper">
       <mat-step label="One">
         <button matStepperNext>Next</button>
       </mat-step>
@@ -277,9 +277,9 @@ export function runHarnessTests(
       <mat-step label="Four" aria-label="Fourth step">
         <button matStepperPrevious>Previous</button>
       </mat-step>
-    </mat-vertical-stepper>
+    </mat-stepper>
 
-    <mat-horizontal-stepper id="two-stepper">
+    <mat-stepper id="two-stepper">
       <mat-step>
         <ng-template matStepLabel>One</ng-template>
       </mat-step>
@@ -289,9 +289,9 @@ export function runHarnessTests(
       <mat-step optional>
         <ng-template matStepLabel>Three</ng-template>
       </mat-step>
-    </mat-horizontal-stepper>
+    </mat-stepper>
 
-    <mat-vertical-stepper id="three-stepper">
+    <mat-stepper orientation="vertical" id="three-stepper">
       <mat-step [stepControl]="oneGroup" label="One">
         <form [formGroup]="oneGroup">
           <input formControlName="oneCtrl" required>
@@ -302,7 +302,7 @@ export function runHarnessTests(
           <input formControlName="twoCtrl" required>
         </form>
       </mat-step>
-    </mat-vertical-stepper>
+    </mat-stepper>
   `
 })
 class StepperHarnessTest {

--- a/src/universal-app/kitchen-sink/kitchen-sink.html
+++ b/src/universal-app/kitchen-sink/kitchen-sink.html
@@ -332,14 +332,14 @@
 
 <h2>Vertical Stepper</h2>
 
-<mat-vertical-stepper>
+<mat-stepper orientation="vertical">
   <mat-step label="Step 1">Content 1</mat-step>
   <mat-step label="Step 1">Content 2</mat-step>
-</mat-vertical-stepper>
+</mat-stepper>
 
 <h2>Vertical Stepper (with label template)</h2>
 
-<mat-vertical-stepper>
+<mat-stepper orientation="vertical">
   <mat-step>
     <ng-template matStepLabel>NgTemplate Label #1</ng-template>
     Content 1
@@ -348,14 +348,14 @@
     <ng-template matStepLabel>NgTemplate Label #2</ng-template>
     Content 2
   </mat-step>
-</mat-vertical-stepper>
+</mat-stepper>
 
 <h2>Horizontal Stepper</h2>
 
-<mat-horizontal-stepper>
+<mat-stepper>
   <mat-step label="Step 1">Content 1</mat-step>
   <mat-step label="Step 2">Content 2</mat-step>
-</mat-horizontal-stepper>
+</mat-stepper>
 
 <h2>Focus trap</h2>
 


### PR DESCRIPTION
The `mat-horizontal-stepper` and `mat-vertical-stepper` were deprecated after we introduced the `orientation` input on `mat-stepper`. These changes update all docs and tests to use the new approach.