### PR TITLE
refactor(material/slider): refactor variable type to const in slider component unit tests

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -331,7 +331,7 @@ describe('MatSlider', () => {
 
       // Computed by multiplying the difference between the min and the max by the percentage from
       // the mousedown and adding that to the minimum.
-      let value = Math.round(4 + (0.09 * (6 - 4)));
+      const value = Math.round(4 + (0.09 * (6 - 4)));
       expect(sliderInstance.value).toBe(value);
     });
 
@@ -341,7 +341,7 @@ describe('MatSlider', () => {
 
       // Computed by multiplying the difference between the min and the max by the percentage from
       // the mousedown and adding that to the minimum.
-      let value = Math.round(4 + (0.62 * (6 - 4)));
+      const value = Math.round(4 + (0.62 * (6 - 4)));
       expect(sliderInstance.value).toBe(value);
     });
 
@@ -1136,10 +1136,10 @@ describe('MatSlider', () => {
       testComponent.dir = 'rtl';
       fixture.detectChanges();
 
-      let initialTrackFillStyles = sliderInstance._getTrackFillStyles();
-      let initialTicksContainerStyles = sliderInstance._getTicksContainerStyles();
-      let initialTicksStyles = sliderInstance._getTicksStyles();
-      let initialThumbContainerStyles = sliderInstance._getThumbContainerStyles();
+      const initialTrackFillStyles = sliderInstance._getTrackFillStyles();
+      const initialTicksContainerStyles = sliderInstance._getTicksContainerStyles();
+      const initialTicksStyles = sliderInstance._getTicksStyles();
+      const initialThumbContainerStyles = sliderInstance._getThumbContainerStyles();
 
       testComponent.dir = 'ltr';
       fixture.detectChanges();
@@ -1449,7 +1449,7 @@ describe('MatSlider', () => {
     });
 
     it('should have the correct control state initially and after interaction', () => {
-      let sliderControl = testComponent.control;
+      const sliderControl = testComponent.control;
 
       // The control should start off valid, pristine, and untouched.
       expect(sliderControl.valid).toBe(true);


### PR DESCRIPTION
**Opening this PR as it is required to:**

- Refactor variables in slider component unit tests to have constant type instead of let as this variables are not getting re-initialize during the test life-time.
- All tests within a spec should be consistent with all other tests in file.