### PR TITLE
fix(material-experimental/mdc-button): set proper touch target

### DIFF
--- a/src/material-experimental/mdc-button/_button-base.scss
+++ b/src/material-experimental/mdc-button/_button-base.scss
@@ -1,3 +1,5 @@
+@use '@material/touch-target' as mdc-touch-target;
+@use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/style/layout-common';
 
 // Adds styles necessary to provide stateful interactions with the button. This includes providing
@@ -57,5 +59,19 @@
   &[disabled] {
     cursor: default;
     pointer-events: none;
+  }
+}
+
+@mixin mat-private-button-touch-target($is-square) {
+  // Element used to ensure that the button has a touch target that meets the required minimum.
+  // Note that we use this, instead of MDC's built-in `mdc-button--touch` class, because the MDC
+  // class is implemented as `margin-top: 6px; margin-bottom: 6px` on the host element which
+  // goes against our rule of not having margins on the host node. Furthermore, having the margin on
+  // the button itself would require us to wrap it in another div. See:
+  // https://github.com/material-components/material-components-web/tree/master/packages/mdc-button#making-buttons-accessible
+  .mat-mdc-button-touch-target {
+    @include mdc-touch-target.touch-target(
+      $set-width: $is-square,
+      $query: mdc-helpers.$mat-base-styles-query);
   }
 }

--- a/src/material-experimental/mdc-button/button.html
+++ b/src/material-experimental/mdc-button/button.html
@@ -21,3 +21,5 @@
      [matRippleDisabled]="_isRippleDisabled()"
      [matRippleCentered]="_isRippleCentered"
      [matRippleTrigger]="_elementRef.nativeElement"></span>
+
+<span class="mat-mdc-button-touch-target"></span>

--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -2,7 +2,7 @@
 @use '@material/button/variables' as mdc-button-variables;
 @use '../mdc-helpers/mdc-helpers';
 @use '../../cdk/a11y';
-@use '_button-base';
+@use 'button-base';
 
 
 @include mdc-button.without-ripple($query: mdc-helpers.$mat-base-styles-query);
@@ -10,6 +10,7 @@
 .mat-mdc-button, .mat-mdc-unelevated-button, .mat-mdc-raised-button, .mat-mdc-outlined-button {
   @include button-base.mat-private-button-interactive();
   @include button-base.mat-private-button-disabled();
+  @include button-base.mat-private-button-touch-target(false);
 }
 
 // MDC expects button icons to contain this HTML content:

--- a/src/material-experimental/mdc-button/fab.scss
+++ b/src/material-experimental/mdc-button/fab.scss
@@ -1,12 +1,13 @@
 @use '@material/fab' as mdc-fab;
 @use '../mdc-helpers/mdc-helpers';
-@use '_button-base';
+@use 'button-base';
 
 @include mdc-fab.without-ripple($query: mdc-helpers.$mat-base-styles-query);
 
 .mat-mdc-fab, .mat-mdc-mini-fab {
   @include button-base.mat-private-button-interactive();
   @include button-base.mat-private-button-disabled();
+  @include button-base.mat-private-button-touch-target(true);
 
   // MDC adds some styles to fab and mini-fab that conflict with some of our focus indicator
   // styles and don't actually do anything. This undoes those conflicting styles.

--- a/src/material-experimental/mdc-button/icon-button.scss
+++ b/src/material-experimental/mdc-button/icon-button.scss
@@ -13,6 +13,7 @@
   border-radius: 50%;
 
   @include button-base.mat-private-button-disabled();
+  @include button-base.mat-private-button-touch-target(true);
 
   // MDC adds some styles to icon buttons that conflict with some of our focus indicator styles
   // and don't actually do anything. This undoes those conflicting styles.


### PR DESCRIPTION
Adds some styles to ensure that the MDC-based button always has a touch target of at least 48px. Note that I decided against using MDC's built-in touch target class, because it would've added a margin on the button host node.

Fixes #22799.

For reference, here's what the touch targets look like at different densities:
![Angular_Material_-_Google_Chrome_2021-05-31_17-50-16](https://user-images.githubusercontent.com/4450522/120220684-6e0be900-c23d-11eb-8945-8cc286c045cf.png)
![Angular_Material_-_Google_Chrome_2021-05-31_17-50-35](https://user-images.githubusercontent.com/4450522/120220686-6ea47f80-c23d-11eb-9ade-849728f5760d.png)
![Angular_Material_-_Google_Chrome_2021-05-31_17-50-44](https://user-images.githubusercontent.com/4450522/120220687-6f3d1600-c23d-11eb-8556-a4d987a04772.png)
![Angular_Material_-_Google_Chrome_2021-05-31_17-50-53](https://user-images.githubusercontent.com/4450522/120220689-6f3d1600-c23d-11eb-9d6e-36a3d7a4fc6a.png)
