### PR TITLE
fix(material/slider): don't interrupt pointer dragging when keyboard is pressed

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -9,6 +9,7 @@ import {
   PAGE_UP,
   RIGHT_ARROW,
   UP_ARROW,
+  A,
 } from '@angular/cdk/keycodes';
 import {
   createMouseEvent,
@@ -129,6 +130,28 @@ describe('MatSlider', () => {
       expect(sliderNativeElement.classList).not.toContain('mat-slider-sliding');
 
       dispatchSlideStartEvent(sliderNativeElement, 0);
+      fixture.detectChanges();
+
+      expect(sliderNativeElement.classList).toContain('mat-slider-sliding');
+
+      dispatchSlideEndEvent(sliderNativeElement, 0.34);
+      fixture.detectChanges();
+
+      expect(sliderNativeElement.classList).not.toContain('mat-slider-sliding');
+    });
+
+    it('should not interrupt sliding by pressing a key', () => {
+      expect(sliderNativeElement.classList).not.toContain('mat-slider-sliding');
+
+      dispatchSlideStartEvent(sliderNativeElement, 0);
+      fixture.detectChanges();
+
+      expect(sliderNativeElement.classList).toContain('mat-slider-sliding');
+
+      // Any key code will do here. Use A since it isn't associated with other actions.
+      dispatchKeyboardEvent(sliderNativeElement, 'keydown', A);
+      fixture.detectChanges();
+      dispatchKeyboardEvent(sliderNativeElement, 'keyup', A);
       fixture.detectChanges();
 
       expect(sliderNativeElement.classList).toContain('mat-slider-sliding');

--- a/tools/public_api_guard/material/slider.d.ts
+++ b/tools/public_api_guard/material/slider.d.ts
@@ -4,7 +4,7 @@ export declare class MatSlider extends _MatSliderBase implements ControlValueAcc
     _animationMode?: string | undefined;
     protected _document: Document;
     _isActive: boolean;
-    _isSliding: boolean;
+    _isSliding: 'keyboard' | 'pointer' | null;
     readonly change: EventEmitter<MatSliderChange>;
     get displayValue(): string | number;
     displayWith: (value: number) => string | number;


### PR DESCRIPTION
The slider is currently set up to "slide" either with the keyboard or the pointer, but we don't dinstinguish between the two. This means that when a `keyup` fires, it'll interrupt pointer scrolling as well.

These changes add some logic to prevent the two from interfering with each other.

Fixes #22719.