### PR TITLE
docs(material/autocomplete): add descriptions for properties showing up in API docs

### DIFF
--- a/src/material-experimental/mdc-autocomplete/autocomplete.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.ts
@@ -39,7 +39,9 @@ import {panelAnimation} from './animations';
   animations: [panelAnimation],
 })
 export class MatAutocomplete extends _MatAutocompleteBase {
+  /** Reference to all option groups within the autocomplete. */
   @ContentChildren(MAT_OPTGROUP, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  /** Reference to all options within the autocomplete. */
   @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
   protected _visibleClass = 'mat-mdc-autocomplete-visible';
   protected _hiddenClass = 'mat-mdc-autocomplete-hidden';

--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -122,10 +122,10 @@ export abstract class _MatAutocompleteBase extends _MatAutocompleteMixinBase imp
   /** Element for the panel containing the autocomplete options. */
   @ViewChild('panel') panel: ElementRef;
 
-  /** @docs-private */
+  /** Reference to all options within the autocomplete. */
   abstract options: QueryList<_MatOptionBase>;
 
-  /** @docs-private */
+  /** Reference to all option groups within the autocomplete. */
   abstract optionGroups: QueryList<_MatOptgroupBase>;
 
   /** Aria label of the autocomplete. */
@@ -291,7 +291,9 @@ export abstract class _MatAutocompleteBase extends _MatAutocompleteMixinBase imp
   ]
 })
 export class MatAutocomplete extends _MatAutocompleteBase {
+  /** Reference to all option groups within the autocomplete. */
   @ContentChildren(MAT_OPTGROUP, {descendants: true}) optionGroups: QueryList<MatOptgroup>;
+  /** Reference to all options within the autocomplete. */
   @ContentChildren(MatOption, {descendants: true}) options: QueryList<MatOption>;
   protected _visibleClass = 'mat-autocomplete-visible';
   protected _hiddenClass = 'mat-autocomplete-hidden';


### PR DESCRIPTION
Currently the `options` and `optionGroups` properties are showing up
in the docs even though they are marked as `@docs-private` in the
base class. This happens because they are declared in the derived
autocomplete implementations (both non-MDC and MDC). Given these
properties not being prefixed with an underscore anyway, we should
start documenting these.