### PR TITLE
docs(material/button-toggle): add description for appearance property in default options

### DIFF
--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -54,8 +54,8 @@ export type MatButtonToggleAppearance = 'legacy' | 'standard';
  */
 export interface MatButtonToggleDefaultOptions {
   /**
-   * Default appearance being used by button toggles. Can be overridden by explicitly
-   * setting an appearance on a button-toggle or group.
+   * Default appearance to be used by button toggles. Can be overridden by explicitly
+   * setting an appearance on a button toggle or group.
    */
   appearance?: MatButtonToggleAppearance;
 }

--- a/src/material/button-toggle/button-toggle.ts
+++ b/src/material/button-toggle/button-toggle.ts
@@ -53,6 +53,10 @@ export type MatButtonToggleAppearance = 'legacy' | 'standard';
  * using the `MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS` injection token.
  */
 export interface MatButtonToggleDefaultOptions {
+  /**
+   * Default appearance being used by button toggles. Can be overridden by explicitly
+   * setting an appearance on a button-toggle or group.
+   */
   appearance?: MatButtonToggleAppearance;
 }
 


### PR DESCRIPTION
Developers can specify a default appearance for button toggles
using the `MatButtonToggleDefaultOptions`. The appearance property
within these default options is not documented. This commit adds
a description.