### PR TITLE
docs(material/checkbox): add description for properties in default options

### DIFF
--- a/src/material/checkbox/checkbox-config.ts
+++ b/src/material/checkbox/checkbox-config.ts
@@ -10,7 +10,9 @@ import {ThemePalette} from '@angular/material/core';
 
 /** Default `mat-checkbox` options that can be overridden. */
 export interface MatCheckboxDefaultOptions {
+  /** Default theme color palette to be used for checkboxes. */
   color?: ThemePalette;
+  /** Default checkbox click action for checkboxes. */
   clickAction?: MatCheckboxClickAction;
 }
 


### PR DESCRIPTION
Developers can specify a color, or click action for all checkboxes using
`MatCheckboxDefaultOptions`. The properties for the default options are
currently not documented. This commit adds the missing descriptions.