### PR TITLE
docs(material/dialog): add missing descriptions

### DIFF
--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -46,6 +46,12 @@ export class MatDialogClose implements OnInit, OnChanges {
   @Input('matDialogClose') _matDialogClose: any;
 
   constructor(
+
+    /**
+     * Reference to the containing dialog.
+     * @deprecated `dialogRef` property to become private.
+     * @breaking-change 13.0.0
+     */
     // The dialog title directive is always used in combination with a `MatDialogRef`.
     // tslint:disable-next-line: lightweight-tokens
     @Optional() public dialogRef: MatDialogRef<any>,
@@ -93,6 +99,7 @@ export class MatDialogClose implements OnInit, OnChanges {
   },
 })
 export class MatDialogTitle implements OnInit {
+  /** Unique id for the dialog title. If none is supplied, it will be auto-generated. */
   @Input() id: string = `mat-dialog-title-${dialogElementUid++}`;
 
   constructor(

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -54,6 +54,7 @@ export class MatDialogRef<T, R = any> {
   constructor(
     private _overlayRef: OverlayRef,
     public _containerInstance: _MatDialogContainerBase,
+    /** Id of the dialog. */
     readonly id: string = `mat-dialog-${uniqueId++}`) {
 
     // Pass the id along to the container.

--- a/tools/public_api_guard/material/dialog.d.ts
+++ b/tools/public_api_guard/material/dialog.d.ts
@@ -88,7 +88,8 @@ export declare class MatDialogClose implements OnInit, OnChanges {
     dialogRef: MatDialogRef<any>;
     dialogResult: any;
     type: 'submit' | 'button' | 'reset';
-    constructor(dialogRef: MatDialogRef<any>, _elementRef: ElementRef<HTMLElement>, _dialog: MatDialog);
+    constructor(
+    dialogRef: MatDialogRef<any>, _elementRef: ElementRef<HTMLElement>, _dialog: MatDialog);
     _onButtonClick(event: MouseEvent): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnInit(): void;
@@ -148,7 +149,8 @@ export declare class MatDialogRef<T, R = any> {
     componentInstance: T;
     disableClose: boolean | undefined;
     readonly id: string;
-    constructor(_overlayRef: OverlayRef, _containerInstance: _MatDialogContainerBase, id?: string);
+    constructor(_overlayRef: OverlayRef, _containerInstance: _MatDialogContainerBase,
+    id?: string);
     addPanelClass(classes: string | string[]): this;
     afterClosed(): Observable<R | undefined>;
     afterOpened(): Observable<void>;


### PR DESCRIPTION
Adds descriptions for public properties showing up in the
API docs. Deprecates the `dialogRef` member of `MatDialogClose`.
All other content directives do not expose the dialog ref, and users
should just inject the `MatDialogRef` if needed, instead of accessing
it through a `MatDialogClose` instance.

DEPRECATED: `MatDialogClose#dialogRef` class member to become private.