### PR TITLE
build: update to tslib 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rxjs": "^6.5.3",
     "rxjs-tslint-rules": "^4.33.1",
     "systemjs": "0.19.43",
-    "tslib": "^2.1.0",
+    "tslib": "^2.2.0",
     "zone.js": "~0.11.3"
   },
   "devDependencies": {

--- a/packages.bzl
+++ b/packages.bzl
@@ -3,7 +3,7 @@
 # version for the placeholders.
 ANGULAR_PACKAGE_VERSION = "^12.0.0 || ^13.0.0-0"
 MDC_PACKAGE_VERSION = "^12.0.0-canary.00b5899dc.0"
-TSLIB_PACKAGE_VERSION = "^2.1.0"
+TSLIB_PACKAGE_VERSION = "^2.2.0"
 RXJS_PACKAGE_VERSION = "^6.5.3"
 
 # Each placer holder is used to stamp versions during the build process, replacing the key with it's

--- a/yarn.lock
+++ b/yarn.lock
@@ -12986,7 +12986,7 @@ tsickle@^0.38.0:
   resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.38.1.tgz#30762db759d40c435943093b6972c7f2efb384ef"
   integrity sha512-4xZfvC6+etRu6ivKCNqMOd1FqcY/m6JY3Y+yr5+Xw+i751ciwrWINi6x/3l1ekcODH9GZhlf0ny2LpzWxnjWYA==
 
-tslib@2.2.0:
+tslib@2.2.0, tslib@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==


### PR DESCRIPTION
The Angular framework dependencies will soon start to use
tslib 2.2.0 as dependency. We want to also update our
dependencies to tslib v2.2.0 as otherwise multiple versions
of tslib would end up in application bundles. The v2.2.0
version of tslib is backwards compatible, so we can update
even though we do not use TS 4.3 in the project yet.