### PR TITLE
fix(material-experimental/mdc-slider): delete isRequired function

### DIFF
--- a/src/material-experimental/mdc-slider/testing/slider-harness.spec.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-harness.spec.ts
@@ -145,11 +145,6 @@ describe('MDC-based MatSliderHarness', () => {
     expect(await (await slider.getStartThumb()).getId()).toBe('price-input');
   });
 
-  it('should get whether a slider thumb is required', async () => {
-    const slider = await loader.getHarness(MatSliderHarness);
-    expect(await (await slider.getStartThumb()).isRequired()).toBe(true);
-  });
-
   it('should be able to focus and blur a slider thumb', async () => {
     const slider = await loader.getHarness(MatSliderHarness);
     const thumb = await slider.getStartThumb();
@@ -169,7 +164,6 @@ describe('MDC-based MatSliderHarness', () => {
       <input
         name="price"
         id="price-input"
-        required
         matSliderThumb
         (input)="inputListener()"
         (change)="changeListener()">

--- a/src/material-experimental/mdc-slider/testing/slider-thumb-harness.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-thumb-harness.ts
@@ -82,11 +82,6 @@ export class MatSliderThumbHarness extends ComponentHarness {
     return (await this.host()).getProperty('disabled');
   }
 
-  /** Whether the thumb is required. */
-  async isRequired(): Promise<boolean> {
-    return (await this.host()).getProperty('required');
-  }
-
   /** Gets the name of the thumb. */
   async getName(): Promise<string> {
     return (await (await this.host()).getProperty('name'));


### PR DESCRIPTION
* delete the isRequired function from the MatSliderThumbHarness since
  the 'required' attribute is ignored on range inputs