### PR TITLE
fix(material/datepicker): add focus indication to calendar selected date in high contrast mode

### DIFF
--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -204,8 +204,12 @@ $calendar-range-end-body-cell-size:
 
   .cdk-keyboard-focused .mat-calendar-body-active,
   .cdk-program-focused .mat-calendar-body-active {
-    & > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
+    & > .mat-calendar-body-cell-content {
       outline: dotted 2px;
+
+      &.mat-calendar-body-selected {
+        outline: solid 3px;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes that selected dates in the calendar didn't have focus indication in high contrast mode.

Fixes #22873.