### PR TITLE
fix(cdk/testing): strongly type return value of TestElement.getProperty

### DIFF
--- a/src/cdk/testing/protractor/protractor-element.ts
+++ b/src/cdk/testing/protractor/protractor-element.ts
@@ -206,7 +206,7 @@ export class ProtractorElement implements TestElement {
   }
 
   /** Gets the value of a property of an element. */
-  async getProperty(name: string): Promise<any> {
+  async getProperty<T = any>(name: string): Promise<T> {
     return browser.executeScript(`return arguments[0][arguments[1]]`, this.element, name);
   }
 

--- a/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
+++ b/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
@@ -163,7 +163,7 @@ export class SeleniumWebDriverElement implements TestElement {
   }
 
   /** Gets the value of a property of an element. */
-  async getProperty(name: string): Promise<any> {
+  async getProperty<T = any>(name: string): Promise<T> {
     await this._stabilize();
     return this._executeScript(
         (element: Element, property: keyof Element) => element[property],

--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -137,7 +137,7 @@ export interface TestElement {
   getDimensions(): Promise<ElementDimensions>;
 
   /** Gets the value of a property of an element. */
-  getProperty(name: string): Promise<any>;
+  getProperty<T = any>(name: string): Promise<T>;
 
   /** Checks whether this element matches the given selector. */
   matchesSelector(selector: string): Promise<boolean>;

--- a/src/cdk/testing/testbed/unit-test-element.ts
+++ b/src/cdk/testing/testbed/unit-test-element.ts
@@ -191,7 +191,7 @@ export class UnitTestElement implements TestElement {
   }
 
   /** Gets the value of a property of an element. */
-  async getProperty(name: string): Promise<any> {
+  async getProperty<T = any>(name: string): Promise<T> {
     await this._stabilize();
     return (this.element as any)[name];
   }

--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -323,10 +323,10 @@ export function crossEnvironmentSpecs(
     it('should be able to clear', async () => {
       const input = await harness.input();
       await input.sendKeys('Yi');
-      expect(await input.getProperty('value')).toBe('Yi');
+      expect(await input.getProperty<string>('value')).toBe('Yi');
 
       await input.clear();
-      expect(await input.getProperty('value')).toBe('');
+      expect(await input.getProperty<string>('value')).toBe('');
     });
 
     it('should be able to click', async () => {
@@ -401,7 +401,7 @@ export function crossEnvironmentSpecs(
       const value = await harness.value();
       await input.sendKeys('Yi');
 
-      expect(await input.getProperty('value')).toBe('Yi');
+      expect(await input.getProperty<string>('value')).toBe('Yi');
       expect(await value.text()).toBe('Input: Yi');
     });
 
@@ -416,7 +416,7 @@ export function crossEnvironmentSpecs(
       const value = await harness.numberInputValue();
       await input.sendKeys('123.456');
 
-      expect(await input.getProperty('value')).toBe('123.456');
+      expect(await input.getProperty<string>('value')).toBe('123.456');
       expect(await value.text()).toBe('Number value: 123.456');
     });
 
@@ -453,7 +453,7 @@ export function crossEnvironmentSpecs(
       `;
       const memo = await harness.memo();
       await memo.sendKeys(memoStr);
-      expect(await memo.getProperty('value')).toBe(memoStr);
+      expect(await memo.getProperty<string>('value')).toBe(memoStr);
     });
 
     it('should be able to getCssValue', async () => {
@@ -474,14 +474,14 @@ export function crossEnvironmentSpecs(
     it('should be able to get the value of a property', async () => {
       const input = await harness.input();
       await input.sendKeys('Hello');
-      expect(await input.getProperty('value')).toBe('Hello');
+      expect(await input.getProperty<string>('value')).toBe('Hello');
     });
 
     it('should be able to set the value of an input', async () => {
       const input = await harness.input();
 
       await input.setInputValue('hello');
-      expect(await input.getProperty('value')).toBe('hello');
+      expect(await input.getProperty<string>('value')).toBe('hello');
     });
 
     it('should be able to set the value of a select in single selection mode', async () => {

--- a/src/material-experimental/mdc-chips/testing/chip-input-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-input-harness.ts
@@ -31,23 +31,23 @@ export class MatChipInputHarness extends ComponentHarness {
 
   /** Whether the input is disabled. */
   async isDisabled(): Promise<boolean> {
-    return (await this.host()).getProperty('disabled')!;
+    return (await this.host()).getProperty<boolean>('disabled');
   }
 
   /** Whether the input is required. */
   async isRequired(): Promise<boolean> {
-    return (await this.host()).getProperty('required')!;
+    return (await this.host()).getProperty<boolean>('required');
   }
 
   /** Gets the value of the input. */
   async getValue(): Promise<string> {
     // The "value" property of the native input is never undefined.
-    return (await (await this.host()).getProperty('value'))!;
+    return (await (await this.host()).getProperty<string>('value'));
   }
 
   /** Gets the placeholder of the input. */
   async getPlaceholder(): Promise<string> {
-    return (await (await this.host()).getProperty('placeholder'));
+    return (await (await this.host()).getProperty<string>('placeholder'));
   }
 
   /**

--- a/src/material-experimental/mdc-slider/testing/slider-harness.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-harness.ts
@@ -52,7 +52,7 @@ export class MatSliderHarness extends ComponentHarness {
   async getStep(): Promise<number> {
     // The same step value is forwarded to both thumbs.
     const startHost = await (await this.getEndThumb()).host();
-    return coerceNumberProperty(await startHost.getProperty('step'));
+    return coerceNumberProperty(await startHost.getProperty<string>('step'));
   }
 
   /** Gets the maximum value of the slider. */

--- a/src/material-experimental/mdc-slider/testing/slider-thumb-harness.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-thumb-harness.ts
@@ -38,7 +38,7 @@ export class MatSliderThumbHarness extends ComponentHarness {
 
   /** Gets the value of the thumb. */
   async getValue(): Promise<number> {
-    return (await (await this.host()).getProperty('valueAsNumber'));
+    return (await (await this.host()).getProperty<number>('valueAsNumber'));
   }
 
   /** Sets the value of the thumb. */
@@ -65,12 +65,12 @@ export class MatSliderThumbHarness extends ComponentHarness {
 
   /** Gets the maximum value of the thumb. */
   async getMaxValue(): Promise<number> {
-    return coerceNumberProperty(await (await this.host()).getProperty('max'));
+    return coerceNumberProperty(await (await this.host()).getProperty<number>('max'));
   }
 
   /** Gets the minimum value of the thumb. */
   async getMinValue(): Promise<number> {
-    return coerceNumberProperty(await (await this.host()).getProperty('min'));
+    return coerceNumberProperty(await (await this.host()).getProperty<number>('min'));
   }
 
   /** Gets the text representation of the slider's value. */
@@ -80,17 +80,17 @@ export class MatSliderThumbHarness extends ComponentHarness {
 
   /** Whether the thumb is disabled. */
   async isDisabled(): Promise<boolean> {
-    return (await this.host()).getProperty('disabled');
+    return (await this.host()).getProperty<boolean>('disabled');
   }
 
   /** Gets the name of the thumb. */
   async getName(): Promise<string> {
-    return (await (await this.host()).getProperty('name'));
+    return (await (await this.host()).getProperty<string>('name'));
   }
 
   /** Gets the id of the thumb. */
   async getId(): Promise<string> {
-    return (await (await this.host()).getProperty('id'));
+    return (await (await this.host()).getProperty<string>('id'));
   }
 
   /**

--- a/src/material/autocomplete/testing/autocomplete-harness.ts
+++ b/src/material/autocomplete/testing/autocomplete-harness.ts
@@ -38,7 +38,7 @@ export abstract class _MatAutocompleteHarnessBase<
 
   /** Gets the value of the autocomplete input. */
   async getValue(): Promise<string> {
-    return (await this.host()).getProperty('value');
+    return (await this.host()).getProperty<string>('value');
   }
 
   /** Whether the autocomplete input is disabled. */

--- a/src/material/checkbox/testing/checkbox-harness.ts
+++ b/src/material/checkbox/testing/checkbox-harness.ts
@@ -21,13 +21,13 @@ export abstract class _MatCheckboxHarnessBase extends ComponentHarness {
 
   /** Whether the checkbox is checked. */
   async isChecked(): Promise<boolean> {
-    const checked = (await this._input()).getProperty('checked');
+    const checked = (await this._input()).getProperty<boolean>('checked');
     return coerceBooleanProperty(await checked);
   }
 
   /** Whether the checkbox is in an indeterminate state. */
   async isIndeterminate(): Promise<boolean> {
-    const indeterminate = (await this._input()).getProperty('indeterminate');
+    const indeterminate = (await this._input()).getProperty<string>('indeterminate');
     return coerceBooleanProperty(await indeterminate);
   }
 
@@ -39,7 +39,7 @@ export abstract class _MatCheckboxHarnessBase extends ComponentHarness {
 
   /** Whether the checkbox is required. */
   async isRequired(): Promise<boolean> {
-    const required = (await this._input()).getProperty('required');
+    const required = (await this._input()).getProperty<boolean>('required');
     return coerceBooleanProperty(await required);
   }
 
@@ -56,7 +56,7 @@ export abstract class _MatCheckboxHarnessBase extends ComponentHarness {
 
   /** Gets the checkbox's value. */
   async getValue(): Promise<string|null> {
-    return (await this._input()).getProperty('value');
+    return (await this._input()).getProperty<string|null>('value');
   }
 
   /** Gets the checkbox's aria-label. */

--- a/src/material/datepicker/testing/datepicker-input-harness-base.ts
+++ b/src/material/datepicker/testing/datepicker-input-harness-base.ts
@@ -31,18 +31,18 @@ export function getInputPredicate<T extends MatDatepickerInputHarnessBase>(
 export abstract class MatDatepickerInputHarnessBase extends MatFormFieldControlHarness {
   /** Whether the input is disabled. */
   async isDisabled(): Promise<boolean> {
-    return (await this.host()).getProperty('disabled')!;
+    return (await this.host()).getProperty<boolean>('disabled');
   }
 
   /** Whether the input is required. */
   async isRequired(): Promise<boolean> {
-    return (await this.host()).getProperty('required')!;
+    return (await this.host()).getProperty<boolean>('required');
   }
 
   /** Gets the value of the input. */
   async getValue(): Promise<string> {
     // The "value" property of the native input is always defined.
-    return (await (await this.host()).getProperty('value'))!;
+    return (await (await this.host()).getProperty<string>('value'));
   }
 
   /**
@@ -65,7 +65,7 @@ export abstract class MatDatepickerInputHarnessBase extends MatFormFieldControlH
 
   /** Gets the placeholder of the input. */
   async getPlaceholder(): Promise<string> {
-    return (await (await this.host()).getProperty('placeholder'));
+    return (await (await this.host()).getProperty<string>('placeholder'));
   }
 
   /**

--- a/src/material/input/testing/input-harness.ts
+++ b/src/material/input/testing/input-harness.ts
@@ -35,29 +35,29 @@ export class MatInputHarness extends MatFormFieldControlHarness {
 
   /** Whether the input is disabled. */
   async isDisabled(): Promise<boolean> {
-    return (await this.host()).getProperty('disabled')!;
+    return (await this.host()).getProperty<boolean>('disabled');
   }
 
   /** Whether the input is required. */
   async isRequired(): Promise<boolean> {
-    return (await this.host()).getProperty('required')!;
+    return (await this.host()).getProperty<boolean>('required');
   }
 
   /** Whether the input is readonly. */
   async isReadonly(): Promise<boolean> {
-    return (await this.host()).getProperty('readOnly')!;
+    return (await this.host()).getProperty<boolean>('readOnly');
   }
 
   /** Gets the value of the input. */
   async getValue(): Promise<string> {
     // The "value" property of the native input is never undefined.
-    return (await (await this.host()).getProperty('value'))!;
+    return (await (await this.host()).getProperty<string>('value'));
   }
 
   /** Gets the name of the input. */
   async getName(): Promise<string> {
     // The "name" property of the native input is never undefined.
-    return (await (await this.host()).getProperty('name'))!;
+    return (await (await this.host()).getProperty<string>('name'));
   }
 
   /**
@@ -66,7 +66,7 @@ export class MatInputHarness extends MatFormFieldControlHarness {
    */
   async getType(): Promise<string> {
     // The "type" property of the native input is never undefined.
-    return (await (await this.host()).getProperty('type'))!;
+    return (await (await this.host()).getProperty<string>('type'));
   }
 
   /** Gets the placeholder of the input. */
@@ -83,7 +83,7 @@ export class MatInputHarness extends MatFormFieldControlHarness {
   async getId(): Promise<string> {
     // The input directive always assigns a unique id to the input in
     // case no id has been explicitly specified.
-    return (await (await this.host()).getProperty('id'))!;
+    return (await (await this.host()).getProperty<string>('id'));
   }
 
   /**

--- a/src/material/input/testing/native-option-harness.ts
+++ b/src/material/input/testing/native-option-harness.ts
@@ -34,21 +34,21 @@ export class MatNativeOptionHarness extends ComponentHarness {
 
   /** Gets the option's label text. */
   async getText(): Promise<string> {
-    return (await this.host()).getProperty('label');
+    return (await this.host()).getProperty<string>('label');
   }
 
   /** Index of the option within the native `select` element. */
   async getIndex(): Promise<number> {
-    return (await this.host()).getProperty('index');
+    return (await this.host()).getProperty<number>('index');
   }
 
   /** Gets whether the option is disabled. */
   async isDisabled(): Promise<boolean> {
-    return (await this.host()).getProperty('disabled');
+    return (await this.host()).getProperty<boolean>('disabled');
   }
 
   /** Gets whether the option is selected. */
   async isSelected(): Promise<boolean> {
-    return (await this.host()).getProperty('selected');
+    return (await this.host()).getProperty<boolean>('selected');
   }
 }

--- a/src/material/input/testing/native-select-harness.ts
+++ b/src/material/input/testing/native-select-harness.ts
@@ -31,29 +31,29 @@ export class MatNativeSelectHarness extends MatFormFieldControlHarness {
 
   /** Gets a boolean promise indicating if the select is disabled. */
   async isDisabled(): Promise<boolean> {
-    return (await this.host()).getProperty('disabled');
+    return (await this.host()).getProperty<boolean>('disabled');
   }
 
   /** Gets a boolean promise indicating if the select is required. */
   async isRequired(): Promise<boolean> {
-    return (await this.host()).getProperty('required');
+    return (await this.host()).getProperty<boolean>('required');
   }
 
   /** Gets a boolean promise indicating if the select is in multi-selection mode. */
   async isMultiple(): Promise<boolean> {
-    return (await this.host()).getProperty('multiple');
+    return (await this.host()).getProperty<boolean>('multiple');
   }
 
   /** Gets the name of the select. */
   async getName(): Promise<string> {
     // The "name" property of the native select is never undefined.
-    return (await (await this.host()).getProperty('name'))!;
+    return (await (await this.host()).getProperty<string>('name'));
   }
 
   /** Gets the id of the select. */
   async getId(): Promise<string> {
     // We're guaranteed to have an id, because the `matNativeControl` always assigns one.
-    return (await (await this.host()).getProperty('id'))!;
+    return (await (await this.host()).getProperty<string>('id'));
   }
 
   /** Focuses the select and returns a void promise that indicates when the action is complete. */

--- a/src/material/radio/testing/radio-harness.ts
+++ b/src/material/radio/testing/radio-harness.ts
@@ -52,7 +52,7 @@ export abstract class _MatRadioGroupHarnessBase<
 
   /** Gets the id of the radio-group. */
   async getId(): Promise<string|null> {
-    return (await this.host()).getProperty('id');
+    return (await this.host()).getProperty<string|null>('id');
   }
 
   /** Gets the checked radio-button in a radio-group. */
@@ -185,7 +185,7 @@ export abstract class _MatRadioButtonHarnessBase extends ComponentHarness {
 
   /** Whether the radio-button is checked. */
   async isChecked(): Promise<boolean> {
-    const checked = (await this._input()).getProperty('checked');
+    const checked = (await this._input()).getProperty<boolean>('checked');
     return coerceBooleanProperty(await checked);
   }
 
@@ -208,7 +208,7 @@ export abstract class _MatRadioButtonHarnessBase extends ComponentHarness {
 
   /** Gets the radio-button's id. */
   async getId(): Promise<string|null> {
-    return (await this.host()).getProperty('id');
+    return (await this.host()).getProperty<string>('id');
   }
 
   /**

--- a/src/material/slide-toggle/testing/slide-toggle-harness.ts
+++ b/src/material/slide-toggle/testing/slide-toggle-harness.ts
@@ -19,7 +19,7 @@ export abstract class _MatSlideToggleHarnessBase extends ComponentHarness {
 
   /** Whether the slide-toggle is checked. */
   async isChecked(): Promise<boolean> {
-    const checked = (await this._input()).getProperty('checked');
+    const checked = (await this._input()).getProperty<boolean>('checked');
     return coerceBooleanProperty(await checked);
   }
 

--- a/tools/public_api_guard/cdk/testing-protractor.d.ts
+++ b/tools/public_api_guard/cdk/testing-protractor.d.ts
@@ -11,7 +11,7 @@ export declare class ProtractorElement implements TestElement {
     getAttribute(name: string): Promise<string | null>;
     getCssValue(property: string): Promise<string>;
     getDimensions(): Promise<ElementDimensions>;
-    getProperty(name: string): Promise<any>;
+    getProperty<T = any>(name: string): Promise<T>;
     hasClass(name: string): Promise<boolean>;
     hover(): Promise<void>;
     isFocused(): Promise<boolean>;

--- a/tools/public_api_guard/cdk/testing-selenium-webdriver.d.ts
+++ b/tools/public_api_guard/cdk/testing-selenium-webdriver.d.ts
@@ -11,7 +11,7 @@ export declare class SeleniumWebDriverElement implements TestElement {
     getAttribute(name: string): Promise<string | null>;
     getCssValue(property: string): Promise<string>;
     getDimensions(): Promise<ElementDimensions>;
-    getProperty(name: string): Promise<any>;
+    getProperty<T = any>(name: string): Promise<T>;
     hasClass(name: string): Promise<boolean>;
     hover(): Promise<void>;
     isFocused(): Promise<boolean>;

--- a/tools/public_api_guard/cdk/testing-testbed.d.ts
+++ b/tools/public_api_guard/cdk/testing-testbed.d.ts
@@ -29,7 +29,7 @@ export declare class UnitTestElement implements TestElement {
     getAttribute(name: string): Promise<string | null>;
     getCssValue(property: string): Promise<string>;
     getDimensions(): Promise<ElementDimensions>;
-    getProperty(name: string): Promise<any>;
+    getProperty<T = any>(name: string): Promise<T>;
     hasClass(name: string): Promise<boolean>;
     hover(): Promise<void>;
     isFocused(): Promise<boolean>;

--- a/tools/public_api_guard/cdk/testing.d.ts
+++ b/tools/public_api_guard/cdk/testing.d.ts
@@ -159,7 +159,7 @@ export interface TestElement {
     getAttribute(name: string): Promise<string | null>;
     getCssValue(property: string): Promise<string>;
     getDimensions(): Promise<ElementDimensions>;
-    getProperty(name: string): Promise<any>;
+    getProperty<T = any>(name: string): Promise<T>;
     hasClass(name: string): Promise<boolean>;
     hover(): Promise<void>;
     isFocused(): Promise<boolean>;


### PR DESCRIPTION
Allows for the return value of `TestElement.getProperty` to be typed strongly through a generic parameter.