### PR TITLE
test(material/chips): prevent unintentional test success

### DIFF
--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -238,7 +238,7 @@ describe('MDC-based MatChipInput', () => {
     <mat-form-field>
       <mat-chip-grid #chipGrid [required]="required">
         <mat-chip-row>Hello</mat-chip-row>
-        <input matInput [matChipInputFor]="chipGrid"
+        <input [matChipInputFor]="chipGrid"
                   [matChipInputAddOnBlur]="addOnBlur"
                   (matChipInputTokenEnd)="add($event)"
                   [placeholder]="placeholder" />

--- a/src/material/chips/chip-input.spec.ts
+++ b/src/material/chips/chip-input.spec.ts
@@ -247,7 +247,7 @@ describe('MatChipInput', () => {
     <mat-form-field>
       <mat-chip-list #chipList [required]="required">
         <mat-chip>Hello</mat-chip>
-        <input matInput [matChipInputFor]="chipList"
+        <input [matChipInputFor]="chipList"
                   [matChipInputAddOnBlur]="addOnBlur"
                   (matChipInputTokenEnd)="add($event)"
                   [placeholder]="placeholder" />


### PR DESCRIPTION
In 'MatChipInput' test, `MatInputModule` was not imported and therefore the `matInput` directive was not interpreted.
If importing `MatInputModule` into the testing module, the `matInput` directive gets applied and the test '_MatChipInput basic behavior should be aria-required if the list is required_' would fail because of side effects by setting the `aria-required`  attribute. Obviously, `matInput` does not remove the `aria-required` attribute, while the chips implementation is doing so (chips is interpreting false as null, while `matInput` leaves 'false' as-is).