### PR TITLE
Revert "fix(material/menu): not interrupting keyboard events to other overlays

### DIFF
--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -437,14 +437,12 @@ describe('MDC-based MatMenu', () => {
     const panel = overlayContainerElement.querySelector('.mat-mdc-menu-panel')!;
     const event = createKeyboardEvent('keydown', ESCAPE);
 
-    spyOn(event, 'stopPropagation').and.callThrough();
     dispatchEvent(panel, event);
     fixture.detectChanges();
     tick(500);
 
     expect(overlayContainerElement.textContent).toBe('');
     expect(event.defaultPrevented).toBe(true);
-    expect(event.stopPropagation).toHaveBeenCalled();
   }));
 
   it('should not close the menu when pressing ESCAPE with a modifier', fakeAsync(() => {

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -436,7 +436,6 @@ describe('MatMenu', () => {
 
     const panel = overlayContainerElement.querySelector('.mat-menu-panel')!;
     const event = createKeyboardEvent('keydown', ESCAPE);
-    spyOn(event, 'stopPropagation').and.callThrough();
 
     dispatchEvent(panel, event);
     fixture.detectChanges();
@@ -444,7 +443,6 @@ describe('MatMenu', () => {
 
     expect(overlayContainerElement.textContent).toBe('');
     expect(event.defaultPrevented).toBe(true);
-    expect(event.stopPropagation).toHaveBeenCalled();
   }));
 
   it('should not close the menu when pressing ESCAPE with a modifier', fakeAsync(() => {

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -337,12 +337,7 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
         }
 
         manager.onKeydown(event);
-        return;
     }
-
-    // Don't allow the event to propagate if we've already handled it, or it may
-    // end up reaching other overlays that were opened earlier (see #22694).
-    event.stopPropagation();
   }
 
   /**


### PR DESCRIPTION
This reverts commit aeecb3ccbde1e679766c7bcc2ba4b2e483c27ac2.

Unfortunately this broke an obscure test that may be difficult to debug. The test appeared as passing because it was already failing at the time we tested.