### PR TITLE
fix(cdk/overlay): expand test environment check

### DIFF
--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -10,12 +10,20 @@ import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, OnDestroy} from '@angular/core';
 import {Platform} from '@angular/cdk/platform';
 
+declare const __karma__: unknown;
+declare const jasmine: unknown;
+declare const jest: unknown;
+declare const Mocha: unknown;
+
 /**
  * Whether we're in a testing environment.
- * TODO(crisbeto): remove this once we have an overlay testing module.
+ * TODO(crisbeto): remove this once we have an overlay testing module or Angular starts tearing
+ * down the testing `NgModule` (see https://github.com/angular/angular/issues/18831).
  */
-const isTestEnvironment: boolean = typeof window !== 'undefined' && !!window &&
-  !!((window as any).__karma__ || (window as any).jasmine);
+const isTestEnvironment = (typeof __karma__ !== 'undefined' && !!__karma__) ||
+                          (typeof jasmine !== 'undefined' && !!jasmine) ||
+                          (typeof jest !== 'undefined' && !!jest) ||
+                          (typeof Mocha !== 'undefined' && !!Mocha);
 
 /** Container inside which all overlays will render. */
 @Injectable({providedIn: 'root'})


### PR DESCRIPTION
We have some logic in the overlay container that tries to prevent overlays from leaking between tests. The logic is currently limited to Jasmine tests and it happened to work by accident for Jest. Jest has made some changes that will break our check so these changes rework the logic to detect Jest and Mocha correctly.

Fixes #22926.