### PR TITLE
test(multiple): refactor unit tests of several components

### DIFF
--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -95,7 +95,7 @@ describe('MatDialog', () => {
   });
 
   it('should open a dialog with a component', () => {
-    let dialogRef = dialog.open(PizzaMsg, {
+    const dialogRef = dialog.open(PizzaMsg, {
       viewContainerRef: testViewContainerRef
     });
 
@@ -106,7 +106,7 @@ describe('MatDialog', () => {
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
 
     viewContainerFixture.detectChanges();
-    let dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
+    const dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
     expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
   });
 
@@ -117,7 +117,7 @@ describe('MatDialog', () => {
 
     const data = {value: 'Knees'};
 
-    let dialogRef = dialog.open(templateRefFixture.componentInstance.templateRef, { data });
+    const dialogRef = dialog.open(templateRefFixture.componentInstance.templateRef, { data });
 
     viewContainerFixture.detectChanges();
 
@@ -126,7 +126,7 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
+    const dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
     expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
 
     dialogRef.close();
@@ -148,13 +148,13 @@ describe('MatDialog', () => {
   }));
 
   it('should use injector from viewContainerRef for DialogInjector', () => {
-    let dialogRef = dialog.open(PizzaMsg, {
+    const dialogRef = dialog.open(PizzaMsg, {
       viewContainerRef: testViewContainerRef
     });
 
     viewContainerFixture.detectChanges();
 
-    let dialogInjector = dialogRef.componentInstance.dialogInjector;
+    const dialogInjector = dialogRef.componentInstance.dialogInjector;
 
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
     expect(dialogInjector.get<DirectiveWithViewContainer>(DirectiveWithViewContainer)).toBeTruthy(
@@ -163,7 +163,7 @@ describe('MatDialog', () => {
   });
 
   it('should open a dialog with a component and no ViewContainerRef', () => {
-    let dialogRef = dialog.open(PizzaMsg);
+    const dialogRef = dialog.open(PizzaMsg);
 
     viewContainerFixture.detectChanges();
 
@@ -172,7 +172,7 @@ describe('MatDialog', () => {
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
 
     viewContainerFixture.detectChanges();
-    let dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
+    const dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
     expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
   });
 
@@ -181,7 +181,7 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
+    const dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
     expect(dialogContainerElement.getAttribute('role')).toBe('alertdialog');
   });
 
@@ -190,13 +190,13 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
+    const dialogContainerElement = overlayContainerElement.querySelector('mat-dialog-container')!;
     expect(dialogContainerElement.getAttribute('aria-describedby')).toBe('description-element');
   });
 
   it('should close a dialog and get back a result', fakeAsync(() => {
-    let dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
-    let afterCloseCallback = jasmine.createSpy('afterClose callback');
+    const dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
+    const afterCloseCallback = jasmine.createSpy('afterClose callback');
 
     dialogRef.afterClosed().subscribe(afterCloseCallback);
     dialogRef.close('Charmander');
@@ -335,7 +335,7 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+    const backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
 
     backdrop.click();
     viewContainerFixture.detectChanges();
@@ -354,7 +354,7 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+    const backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
 
     backdrop.click();
     expect(spy).toHaveBeenCalledTimes(1);
@@ -375,8 +375,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-    let container = overlayContainerElement.querySelector('mat-dialog-container') as HTMLElement;
+    const backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+    const container = overlayContainerElement.querySelector('mat-dialog-container') as HTMLElement;
     dispatchKeyboardEvent(document.body, 'keydown', A);
     dispatchKeyboardEvent(backdrop, 'keydown', A);
     dispatchKeyboardEvent(container, 'keydown', A);
@@ -426,7 +426,7 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.width).toBe('500px');
   });
@@ -438,7 +438,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.height).toBe('100px');
   });
@@ -450,7 +451,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.minWidth).toBe('500px');
   });
@@ -489,7 +491,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.minHeight).toBe('300px');
   });
@@ -501,7 +504,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.maxHeight).toBe('100px');
   });
@@ -515,7 +519,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.marginTop).toBe('100px');
   });
@@ -529,7 +534,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.marginBottom).toBe('200px');
   });
@@ -543,7 +549,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.marginLeft).toBe('250px');
   });
@@ -557,13 +564,14 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.marginRight).toBe('125px');
   });
 
   it('should allow for the position to be updated', () => {
-    let dialogRef = dialog.open(PizzaMsg, {
+    const dialogRef = dialog.open(PizzaMsg, {
       position: {
         left: '250px'
       }
@@ -571,7 +579,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.marginLeft).toBe('250px');
 
@@ -581,11 +590,12 @@ describe('MatDialog', () => {
   });
 
   it('should allow for the dimensions to be updated', () => {
-    let dialogRef = dialog.open(PizzaMsg, { width: '100px' });
+    const dialogRef = dialog.open(PizzaMsg, { width: '100px' });
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.width).toBe('100px');
 
@@ -595,11 +605,12 @@ describe('MatDialog', () => {
   });
 
   it('should reset the overlay dimensions to their initial size', () => {
-    let dialogRef = dialog.open(PizzaMsg);
+    const dialogRef = dialog.open(PizzaMsg);
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
 
     expect(overlayPane.style.width).toBeFalsy();
     expect(overlayPane.style.height).toBeFalsy();
@@ -620,7 +631,8 @@ describe('MatDialog', () => {
 
     viewContainerFixture.detectChanges();
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-global-overlay-wrapper')!;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-global-overlay-wrapper')!;
 
     expect(overlayPane.getAttribute('dir')).toBe('rtl');
   });
@@ -671,8 +683,8 @@ describe('MatDialog', () => {
   }));
 
   it('should set the proper animation states', () => {
-    let dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
-    let dialogContainer: MatDialogContainer =
+    const dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
+    const dialogContainer: MatDialogContainer =
         viewContainerFixture.debugElement.query(By.directive(MatDialogContainer))!
         .componentInstance;
 
@@ -754,8 +766,8 @@ describe('MatDialog', () => {
   }));
 
   it('should have the componentInstance available in the afterClosed callback', fakeAsync(() => {
-    let dialogRef = dialog.open(PizzaMsg);
-    let spy = jasmine.createSpy('afterClosed spy');
+    const dialogRef = dialog.open(PizzaMsg);
+    const spy = jasmine.createSpy('afterClosed spy');
 
     flushMicrotasks();
     viewContainerFixture.detectChanges();
@@ -802,14 +814,14 @@ describe('MatDialog', () => {
 
   describe('passing in data', () => {
     it('should be able to pass in data', () => {
-      let config = {
+      const config = {
         data: {
           stringParam: 'hello',
           dateParam: new Date()
         }
       };
 
-      let instance = dialog.open(DialogWithInjectedData, config).componentInstance;
+      const instance = dialog.open(DialogWithInjectedData, config).componentInstance;
 
       expect(instance.data.stringParam).toBe(config.data.stringParam);
       expect(instance.data.dateParam).toBe(config.data.dateParam);
@@ -817,14 +829,14 @@ describe('MatDialog', () => {
 
     it('should default to null if no data is passed', () => {
       expect(() => {
-        let dialogRef = dialog.open(DialogWithInjectedData);
+        const dialogRef = dialog.open(DialogWithInjectedData);
         expect(dialogRef.componentInstance.data).toBeNull();
       }).not.toThrow();
     });
   });
 
   it('should not keep a reference to the component after the dialog is closed', fakeAsync(() => {
-    let dialogRef = dialog.open(PizzaMsg);
+    const dialogRef = dialog.open(PizzaMsg);
 
     expect(dialogRef.componentInstance).toBeTruthy();
 
@@ -916,7 +928,7 @@ describe('MatDialog', () => {
   }));
 
   it('should add and remove classes while open', () => {
-    let dialogRef = dialog.open(PizzaMsg, {
+    const dialogRef = dialog.open(PizzaMsg, {
       disableClose: true,
       viewContainerRef: testViewContainerRef
     });
@@ -941,7 +953,8 @@ describe('MatDialog', () => {
 
       viewContainerFixture.detectChanges();
 
-      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+      const backdrop =
+          overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
       backdrop.click();
       viewContainerFixture.detectChanges();
       flush();
@@ -964,14 +977,15 @@ describe('MatDialog', () => {
     }));
 
     it('should allow for the disableClose option to be updated while open', fakeAsync(() => {
-      let dialogRef = dialog.open(PizzaMsg, {
+      const dialogRef = dialog.open(PizzaMsg, {
         disableClose: true,
         viewContainerRef: testViewContainerRef
       });
 
       viewContainerFixture.detectChanges();
 
-      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+      const backdrop =
+          overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
       backdrop.click();
 
       expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeTruthy();
@@ -993,8 +1007,9 @@ describe('MatDialog', () => {
       viewContainerFixture.detectChanges();
       flushMicrotasks();
 
-      let backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-      let input = overlayContainerElement.querySelector('input') as HTMLInputElement;
+      const backdrop =
+          overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
+      const input = overlayContainerElement.querySelector('input') as HTMLInputElement;
 
       expect(document.activeElement).toBe(input, 'Expected input to be focused on open');
 
@@ -1017,9 +1032,9 @@ describe('MatDialog', () => {
         viewContainerFixture.detectChanges();
         flushMicrotasks();
 
-        let backdrop =
+        const backdrop =
           overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-        let container =
+        const container =
           overlayContainerElement.querySelector('.mat-dialog-container') as HTMLInputElement;
 
         expect(document.activeElement).toBe(container, 'Expected container to be focused on open');
@@ -1140,12 +1155,12 @@ describe('MatDialog', () => {
 
     it('should re-focus trigger element when dialog closes', fakeAsync(() => {
       // Create a element that has focus before the dialog is opened.
-      let button = document.createElement('button');
+      const button = document.createElement('button');
       button.id = 'dialog-trigger';
       document.body.appendChild(button);
       button.focus();
 
-      let dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
+      const dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
 
       flushMicrotasks();
       viewContainerFixture.detectChanges();
@@ -1340,8 +1355,8 @@ describe('MatDialog', () => {
 
     it('should allow the consumer to shift focus in afterClosed', fakeAsync(() => {
       // Create a element that has focus before the dialog is opened.
-      let button = document.createElement('button');
-      let input = document.createElement('input');
+      const button = document.createElement('button');
+      const input = document.createElement('input');
 
       button.id = 'dialog-trigger';
       input.id = 'input-to-be-focused';
@@ -1350,7 +1365,7 @@ describe('MatDialog', () => {
       document.body.appendChild(input);
       button.focus();
 
-      let dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
+      const dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
 
       tick(500);
       viewContainerFixture.detectChanges();
@@ -1500,25 +1515,26 @@ describe('MatDialog', () => {
       });
 
       it('should allow for a user-specified aria-label on the close button', fakeAsync(() => {
-        let button = overlayContainerElement.querySelector('.close-with-aria-label')!;
+        const button = overlayContainerElement.querySelector('.close-with-aria-label')!;
+
         expect(button.getAttribute('aria-label')).toBe('Best close button ever');
       }));
 
       it('should set the "type" attribute of the close button if not set manually', () => {
-        let button = overlayContainerElement.querySelector('button[mat-dialog-close]')!;
+        const button = overlayContainerElement.querySelector('button[mat-dialog-close]')!;
 
         expect(button.getAttribute('type')).toBe('button');
       });
 
       it('should not override type attribute of the close button if set manually', () => {
-        let button = overlayContainerElement.querySelector('button.with-submit')!;
+        const button = overlayContainerElement.querySelector('button.with-submit')!;
 
         expect(button.getAttribute('type')).toBe('submit');
       });
 
       it('should return the [mat-dialog-close] result when clicking the close button',
         fakeAsync(() => {
-          let afterCloseCallback = jasmine.createSpy('afterClose callback');
+          const afterCloseCallback = jasmine.createSpy('afterClose callback');
           dialogRef.afterClosed().subscribe(afterCloseCallback);
 
           (overlayContainerElement.querySelector('button.close-with-true') as HTMLElement).click();
@@ -1529,8 +1545,8 @@ describe('MatDialog', () => {
         }));
 
       it('should set the aria-labelledby attribute to the id of the title', fakeAsync(() => {
-        let title = overlayContainerElement.querySelector('[mat-dialog-title]')!;
-        let container = overlayContainerElement.querySelector('mat-dialog-container')!;
+        const title = overlayContainerElement.querySelector('[mat-dialog-title]')!;
+        const container = overlayContainerElement.querySelector('mat-dialog-container')!;
 
         flush();
         viewContainerFixture.detectChanges();
@@ -1577,8 +1593,8 @@ describe('MatDialog', () => {
         });
         viewContainerFixture.detectChanges();
         flush();
-        let title = overlayContainerElement.querySelector('[mat-dialog-title]')!;
-        let container = overlayContainerElement.querySelector('mat-dialog-container')!;
+        const title = overlayContainerElement.querySelector('[mat-dialog-title]')!;
+        const container = overlayContainerElement.querySelector('mat-dialog-container')!;
         flush();
         viewContainerFixture.detectChanges();
 
@@ -1784,7 +1800,8 @@ describe('MatDialog with default options', () => {
 
     expect(document.activeElement!.tagName).not.toBe('INPUT');
 
-    let overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
+    const overlayPane =
+        overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
     expect(overlayPane.style.width).toBe('100px');
     expect(overlayPane.style.height).toBe('100px');
     expect(overlayPane.style.minWidth).toBe('50px');

--- a/src/material/icon/icon.spec.ts
+++ b/src/material/icon/icon.spec.ts
@@ -332,7 +332,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
       let svgChild: any;
 
       testComponent.iconName = 'farm:pig';
@@ -365,7 +365,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
       let svgChild: any;
 
       testComponent.iconName = 'farm:pig with spaces';
@@ -408,7 +408,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
       let svgChild: any;
 
       testComponent.iconName = 'farm:pig';
@@ -498,7 +498,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
 
       testComponent.iconName = 'left-arrow';
       fixture.detectChanges();
@@ -516,7 +516,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
 
       testComponent.iconName = 'left-arrow';
       fixture.detectChanges();
@@ -563,7 +563,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
 
       testComponent.iconName = 'left-arrow';
       fixture.detectChanges();
@@ -714,7 +714,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
       let svgChild: any;
 
       testComponent.iconName = 'farm:pig';
@@ -749,7 +749,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
       let svgChild: any;
 
       testComponent.iconName = 'farm:pig';
@@ -787,7 +787,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
 
       testComponent.iconName = 'left-arrow';
       fixture.detectChanges();
@@ -817,7 +817,7 @@ describe('MatIcon', () => {
       const fixture = TestBed.createComponent(IconFromSvgName);
       const testComponent = fixture.componentInstance;
       const matIconElement = fixture.debugElement.nativeElement.querySelector('mat-icon');
-      let svgElement: any;
+      let svgElement: SVGElement;
 
       testComponent.iconName = 'left-arrow';
       fixture.detectChanges();

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -52,22 +52,22 @@ import {MatTextareaAutosize} from './autosize';
 
 describe('MatInput without forms', () => {
   it('should default to floating labels', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithId);
+    const fixture = createComponent(MatInputWithId);
     fixture.detectChanges();
 
-    let formField = fixture.debugElement.query(By.directive(MatFormField))!
+    const formField = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
     expect(formField.floatLabel).toBe('auto',
         'Expected MatInput to set floatingLabel to auto by default.');
   }));
 
   it('should default to floating label type provided by global default options', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithId, [{
+    const fixture = createComponent(MatInputWithId, [{
       provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {floatLabel: 'always'}
     }]);
     fixture.detectChanges();
 
-    let formField = fixture.debugElement.query(By.directive(MatFormField))!
+    const formField = fixture.debugElement.query(By.directive(MatFormField))!
       .componentInstance as MatFormField;
     expect(formField.floatLabel).toBe('always',
       'Expected MatInput to set floatingLabel to always from global option.');
@@ -99,56 +99,59 @@ describe('MatInput without forms', () => {
   }));
 
   it('should treat text input type as empty at init', fakeAsync(() => {
-    let fixture = createComponent(MatInputTextTestController);
+    const fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
-    expect(el).not.toBeNull();
-    expect(el.classList.contains('mat-form-field-empty')).toBe(true);
+    const labelEl =
+        fixture.debugElement.query(By.css('label'))!.nativeElement;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.classList.contains('mat-form-field-empty')).toBe(true);
   }));
 
   it('should treat password input type as empty at init', fakeAsync(() => {
-    let fixture = createComponent(MatInputPasswordTestController);
+    const fixture = createComponent(MatInputPasswordTestController);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
-    expect(el).not.toBeNull();
-    expect(el.classList.contains('mat-form-field-empty')).toBe(true);
+    const labelEl =
+        fixture.debugElement.query(By.css('label'))!.nativeElement;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.classList.contains('mat-form-field-empty')).toBe(true);
   }));
 
   it('should treat number input type as empty at init', fakeAsync(() => {
-    let fixture = createComponent(MatInputNumberTestController);
+    const fixture = createComponent(MatInputNumberTestController);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
-    expect(el).not.toBeNull();
-    expect(el.classList.contains('mat-form-field-empty')).toBe(true);
+    const labelEl =
+        fixture.debugElement.query(By.css('label'))!.nativeElement;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.classList.contains('mat-form-field-empty')).toBe(true);
   }));
 
   it('should not be empty after input entered', fakeAsync(() => {
-    let fixture = createComponent(MatInputTextTestController);
+    const fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'))!;
-    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
-    expect(el).not.toBeNull();
-    expect(el.classList.contains('mat-form-field-empty')).toBe(true, 'should be empty');
+    const inputElement = fixture.debugElement.query(By.css('input'))!;
+    let labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.classList.contains('mat-form-field-empty')).toBe(true, 'should be empty');
 
-    inputEl.nativeElement.value = 'hello';
+    inputElement.nativeElement.value = 'hello';
     // Simulate input event.
-    inputEl.triggerEventHandler('input', {target: inputEl.nativeElement});
+    inputElement.triggerEventHandler('input', { target: inputElement.nativeElement});
     fixture.detectChanges();
 
-    el = fixture.debugElement.query(By.css('label'))!.nativeElement;
-    expect(el.classList.contains('mat-form-field-empty')).toBe(false, 'should not be empty');
+    labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
+    expect(labelEl.classList.contains('mat-form-field-empty')).toBe(false, 'should not be empty');
   }));
 
   it('should update the placeholder when input entered', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithStaticLabel);
+    const fixture = createComponent(MatInputWithStaticLabel);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'))!;
-    let labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
+    const inputEl = fixture.debugElement.query(By.css('input'))!;
+    const labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
     expect(labelEl.classList).toContain('mat-form-field-empty');
     expect(labelEl.classList).not.toContain('mat-form-field-float');
@@ -164,9 +167,9 @@ describe('MatInput without forms', () => {
   }));
 
   it('should not be empty when the value set before view init', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithValueBinding);
+    const fixture = createComponent(MatInputWithValueBinding);
     fixture.detectChanges();
-    let labelEl = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
+    const labelEl = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
 
     expect(labelEl.classList).not.toContain('mat-form-field-empty');
 
@@ -177,7 +180,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('should add id', fakeAsync(() => {
-    let fixture = createComponent(MatInputTextTestController);
+    const fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
     const inputElement: HTMLInputElement =
@@ -190,7 +193,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('should add aria-owns to the label for the associated control', fakeAsync(() => {
-    let fixture = createComponent(MatInputTextTestController);
+    const fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
     const inputElement: HTMLInputElement =
@@ -219,7 +222,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('should not overwrite existing id', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithId);
+    const fixture = createComponent(MatInputWithId);
     fixture.detectChanges();
 
     const inputElement: HTMLInputElement =
@@ -232,7 +235,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('validates there\'s only one hint label per side', fakeAsync(() => {
-    let fixture = createComponent(MatInputInvalidHintTestController);
+    const fixture = createComponent(MatInputInvalidHintTestController);
 
     expect(() => {
       try {
@@ -246,7 +249,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('validates there\'s only one hint label per side (attribute)', fakeAsync(() => {
-    let fixture = createComponent(MatInputInvalidHint2TestController);
+    const fixture = createComponent(MatInputInvalidHint2TestController);
 
     expect(() => {
       try {
@@ -260,7 +263,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('validates there\'s only one placeholder', fakeAsync(() => {
-    let fixture = createComponent(MatInputInvalidPlaceholderTestController);
+    const fixture = createComponent(MatInputInvalidPlaceholderTestController);
 
     expect(() => {
       try {
@@ -274,14 +277,14 @@ describe('MatInput without forms', () => {
   }));
 
   it('validates that matInput child is present', fakeAsync(() => {
-    let fixture = createComponent(MatInputMissingMatInputTestController);
+    const fixture = createComponent(MatInputMissingMatInputTestController);
 
     expect(() => fixture.detectChanges()).toThrowError(
         wrappedErrorMessage(getMatFormFieldMissingControlError()));
   }));
 
   it('validates that matInput child is present after initialization', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithNgIf);
+    const fixture = createComponent(MatInputWithNgIf);
 
     expect(() => fixture.detectChanges()).not.toThrowError(
         wrappedErrorMessage(getMatFormFieldMissingControlError()));
@@ -293,7 +296,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('validates the type', fakeAsync(() => {
-    let fixture = createComponent(MatInputInvalidTypeTestController);
+    const fixture = createComponent(MatInputInvalidTypeTestController);
 
     // Technically this throws during the OnChanges detection phase,
     // so the error is really a ChangeDetectionError and it becomes
@@ -304,7 +307,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('supports hint labels attribute', fakeAsync(() => {
-    let fixture = createComponent(MatInputHintLabelTestController);
+    const fixture = createComponent(MatInputHintLabelTestController);
     fixture.detectChanges();
 
     // If the hint label is empty, expect no label.
@@ -316,43 +319,43 @@ describe('MatInput without forms', () => {
   }));
 
   it('sets an id on hint labels', fakeAsync(() => {
-    let fixture = createComponent(MatInputHintLabelTestController);
+    const fixture = createComponent(MatInputHintLabelTestController);
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
 
-    let hint = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement;
+    const hint = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement;
 
     expect(hint.getAttribute('id')).toBeTruthy();
   }));
 
   it('supports hint labels elements', fakeAsync(() => {
-    let fixture = createComponent(MatInputHintLabel2TestController);
+    const fixture = createComponent(MatInputHintLabel2TestController);
     fixture.detectChanges();
 
     // In this case, we should have an empty <mat-hint>.
-    let el = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
-    expect(el.textContent).toBeFalsy();
+    let hintLabelEl = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
+    expect(hintLabelEl.textContent).toBeFalsy();
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
-    el = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
-    expect(el.textContent).toBe('label');
+    hintLabelEl = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
+    expect(hintLabelEl.textContent).toBe('label');
   }));
 
   it('sets an id on the hint element', fakeAsync(() => {
-    let fixture = createComponent(MatInputHintLabel2TestController);
+    const fixture = createComponent(MatInputHintLabel2TestController);
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
 
-    let hint = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
+    const hint = fixture.debugElement.query(By.css('mat-hint'))!.nativeElement;
 
     expect(hint.getAttribute('id')).toBeTruthy();
   }));
 
   it('supports placeholder attribute', fakeAsync(() => {
-    let fixture = createComponent(MatInputPlaceholderAttrTestComponent);
+    const fixture = createComponent(MatInputPlaceholderAttrTestComponent);
     fixture.detectChanges();
 
     expect(fixture.debugElement.query(By.css('label'))).toBeNull();
@@ -360,7 +363,7 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.placeholder = 'Other placeholder';
     fixture.detectChanges();
 
-    let labelEl = fixture.debugElement.query(By.css('label'))!;
+    const labelEl = fixture.debugElement.query(By.css('label'))!;
 
     expect(labelEl).not.toBeNull();
     expect(labelEl.nativeElement.textContent).toBe('Other placeholder');
@@ -380,28 +383,28 @@ describe('MatInput without forms', () => {
     }));
 
   it('supports placeholder element', fakeAsync(() => {
-    let fixture = createComponent(MatInputPlaceholderElementTestComponent);
+    const fixture = createComponent(MatInputPlaceholderElementTestComponent);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'))!;
-    expect(el).not.toBeNull();
-    expect(el.nativeElement.textContent).toMatch('Default Placeholder');
+    let labelEl = fixture.debugElement.query(By.css('label'))!;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.nativeElement.textContent).toMatch('Default Placeholder');
 
     fixture.componentInstance.placeholder = 'Other placeholder';
     fixture.detectChanges();
 
-    el = fixture.debugElement.query(By.css('label'))!;
-    expect(el).not.toBeNull();
-    expect(el.nativeElement.textContent).toBe('Other placeholder');
+    labelEl = fixture.debugElement.query(By.css('label'))!;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.nativeElement.textContent).toBe('Other placeholder');
   }));
 
   it('supports placeholder required star', fakeAsync(() => {
-    let fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
+    const fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'))!;
-    expect(el).not.toBeNull();
-    expect(el.nativeElement.textContent).toBe('hello *');
+    const labelEl = fixture.debugElement.query(By.css('label'))!;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.nativeElement.textContent).toBe('hello *');
   }));
 
   it('should hide the required star if input is disabled', () => {
@@ -410,33 +413,34 @@ describe('MatInput without forms', () => {
     fixture.componentInstance.disabled = true;
     fixture.detectChanges();
 
-    const el = fixture.debugElement.query(By.css('label'))!;
+    const labelEl = fixture.debugElement.query(By.css('label'))!;
 
-    expect(el).not.toBeNull();
-    expect(el.nativeElement.textContent).toBe('hello');
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.nativeElement.textContent).toBe('hello');
   });
 
   it('should hide the required star from screen readers', fakeAsync(() => {
-    let fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
+    const fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!.nativeElement;
+    const matFormFieldElement =
+        fixture.debugElement.query(By.css('.mat-form-field-required-marker'))!.nativeElement;
 
-    expect(el.getAttribute('aria-hidden')).toBe('true');
+    expect(matFormFieldElement.getAttribute('aria-hidden')).toBe('true');
   }));
 
   it('hide placeholder required star when set to hide the required marker', fakeAsync(() => {
-    let fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
+    const fixture = createComponent(MatInputPlaceholderRequiredTestComponent);
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'))!;
-    expect(el).not.toBeNull();
-    expect(el.nativeElement.textContent).toBe('hello *');
+    const labelEl = fixture.debugElement.query(By.css('label'))!;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.nativeElement.textContent).toBe('hello *');
 
     fixture.componentInstance.hideRequiredMarker = true;
     fixture.detectChanges();
 
-    expect(el.nativeElement.textContent).toBe('hello');
+    expect(labelEl.nativeElement.textContent).toBe('hello');
   }));
 
   it('supports the disabled attribute as binding', fakeAsync(() => {
@@ -489,10 +493,10 @@ describe('MatInput without forms', () => {
   }));
 
   it('supports the required attribute as binding', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithRequired);
+    const fixture = createComponent(MatInputWithRequired);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(inputEl.required).toBe(false);
 
@@ -517,10 +521,10 @@ describe('MatInput without forms', () => {
   }));
 
   it('supports the type attribute as binding', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithType);
+    const fixture = createComponent(MatInputWithType);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(inputEl.type).toBe('text');
 
@@ -531,7 +535,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('supports textarea', fakeAsync(() => {
-    let fixture = createComponent(MatInputTextareaWithBindings);
+    const fixture = createComponent(MatInputTextareaWithBindings);
     fixture.detectChanges();
 
     const textarea: HTMLTextAreaElement = fixture.nativeElement.querySelector('textarea');
@@ -547,7 +551,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('sets the aria-describedby when a hintLabel is set', fakeAsync(() => {
-    let fixture = createComponent(MatInputHintLabelTestController);
+    const fixture = createComponent(MatInputHintLabelTestController);
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
@@ -560,7 +564,7 @@ describe('MatInput without forms', () => {
   }));
 
   it('supports user binding to aria-describedby', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithSubscriptAndAriaDescribedBy);
+    const fixture = createComponent(MatInputWithSubscriptAndAriaDescribedBy);
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
@@ -593,25 +597,25 @@ describe('MatInput without forms', () => {
   }));
 
   it('sets the aria-describedby to the id of the mat-hint', fakeAsync(() => {
-    let fixture = createComponent(MatInputHintLabel2TestController);
+    const fixture = createComponent(MatInputHintLabel2TestController);
 
     fixture.componentInstance.label = 'label';
     fixture.detectChanges();
 
-    let hint = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement;
-    let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    const hint = fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement;
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(input.getAttribute('aria-describedby')).toBe(hint.getAttribute('id'));
   }));
 
   it('sets the aria-describedby with multiple mat-hint instances', fakeAsync(() => {
-    let fixture = createComponent(MatInputMultipleHintTestController);
+    const fixture = createComponent(MatInputMultipleHintTestController);
 
     fixture.componentInstance.startId = 'start';
     fixture.componentInstance.endId = 'end';
     fixture.detectChanges();
 
-    let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
     expect(input.getAttribute('aria-describedby')).toBe('start end');
   }));
@@ -632,26 +636,26 @@ describe('MatInput without forms', () => {
 
   it('sets the aria-describedby when a hintLabel is set, in addition to a mat-hint',
     fakeAsync(() => {
-      let fixture = createComponent(MatInputMultipleHintMixedTestController);
+      const fixture = createComponent(MatInputMultipleHintMixedTestController);
 
       fixture.detectChanges();
 
-      let hintLabel = fixture.debugElement
+      const hintLabel = fixture.debugElement
           .query(By.css('.mat-hint:not(.mat-form-field-hint-end)'))!.nativeElement;
-      let endLabel = fixture.debugElement
+      const endLabel = fixture.debugElement
           .query(By.css('.mat-hint.mat-form-field-hint-end'))!.nativeElement;
-      let input = fixture.debugElement.query(By.css('input'))!.nativeElement;
-      let ariaValue = input.getAttribute('aria-describedby');
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      const ariaValue = input.getAttribute('aria-describedby');
 
       expect(ariaValue).toBe(`${hintLabel.getAttribute('id')} ${endLabel.getAttribute('id')}`);
     }));
 
   it('should float when floatLabel is set to default and text is entered', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithDynamicLabel);
+    const fixture = createComponent(MatInputWithDynamicLabel);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
-    let formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
+    const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
 
     expect(formFieldEl.classList).toContain('mat-form-field-can-float');
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
@@ -673,11 +677,11 @@ describe('MatInput without forms', () => {
   }));
 
   it('should always float the label when floatLabel is set to true', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithDynamicLabel);
+    const fixture = createComponent(MatInputWithDynamicLabel);
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
-    let formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
+    const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    const formFieldEl = fixture.debugElement.query(By.css('.mat-form-field'))!.nativeElement;
 
     expect(formFieldEl.classList).toContain('mat-form-field-can-float');
     expect(formFieldEl.classList).toContain('mat-form-field-should-float');
@@ -751,13 +755,13 @@ describe('MatInput without forms', () => {
   }));
 
   it('should never float the label when floatLabel is set to false', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithDynamicLabel);
+    const fixture = createComponent(MatInputWithDynamicLabel);
 
     fixture.componentInstance.shouldFloat = 'never';
     fixture.detectChanges();
 
-    let inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
-    let labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
+    const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    const labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
     expect(labelEl.classList).toContain('mat-form-field-empty');
     expect(labelEl.classList).not.toContain('mat-form-field-float');
@@ -793,11 +797,11 @@ describe('MatInput without forms', () => {
   }));
 
   it('should not have prefix and suffix elements when none are specified', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithId);
+    const fixture = createComponent(MatInputWithId);
     fixture.detectChanges();
 
-    let prefixEl = fixture.debugElement.query(By.css('.mat-form-field-prefix'));
-    let suffixEl = fixture.debugElement.query(By.css('.mat-form-field-suffix'));
+    const prefixEl = fixture.debugElement.query(By.css('.mat-form-field-prefix'));
+    const suffixEl = fixture.debugElement.query(By.css('.mat-form-field-suffix'));
 
     expect(prefixEl).toBeNull();
     expect(suffixEl).toBeNull();
@@ -817,11 +821,11 @@ describe('MatInput without forms', () => {
   }));
 
   it('should update empty class when value changes programmatically and OnPush', fakeAsync(() => {
-    let fixture = createComponent(MatInputOnPush);
+    const fixture = createComponent(MatInputOnPush);
     fixture.detectChanges();
 
-    let component = fixture.componentInstance;
-    let label = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
+    const component = fixture.componentInstance;
+    const label = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
 
     expect(label.classList).toContain('mat-form-field-empty', 'Input initially empty');
 
@@ -832,12 +836,12 @@ describe('MatInput without forms', () => {
   }));
 
   it('should set the focused class when the input is focused', fakeAsync(() => {
-    let fixture = createComponent(MatInputTextTestController);
+    const fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
-    let input = fixture.debugElement.query(By.directive(MatInput))!
+    const input = fixture.debugElement.query(By.directive(MatInput))!
       .injector.get<MatInput>(MatInput);
-    let container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+    const container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
     // Call the focus handler directly to avoid flakyness where
     // browsers don't focus elements if the window is minimized.
@@ -870,12 +874,12 @@ describe('MatInput without forms', () => {
     }));
 
   it('should be able to animate the label up and lock it in position', fakeAsync(() => {
-    let fixture = createComponent(MatInputTextTestController);
+    const fixture = createComponent(MatInputTextTestController);
     fixture.detectChanges();
 
-    let inputContainer = fixture.debugElement.query(By.directive(MatFormField))!
+    const inputContainer = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
-    let label = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
+    const label = fixture.debugElement.query(By.css('.mat-form-field-label'))!.nativeElement;
 
     expect(inputContainer.floatLabel).toBe('auto');
 
@@ -902,12 +906,12 @@ describe('MatInput without forms', () => {
   }));
 
   it('should not highlight when focusing a readonly input', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithReadonlyInput);
+    const fixture = createComponent(MatInputWithReadonlyInput);
     fixture.detectChanges();
 
-    let input =
+    const input =
         fixture.debugElement.query(By.directive(MatInput))!.injector.get<MatInput>(MatInput);
-    let container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+    const container = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
     // Call the focus handler directly to avoid flakyness where
     // browsers don't focus elements if the window is minimized.
@@ -1015,9 +1019,9 @@ describe('MatInput without forms', () => {
 
   it('should use the native input value when determining whether ' +
     'the element is empty with a custom accessor', fakeAsync(() => {
-      let fixture = createComponent(MatInputWithCustomAccessor, [], [], [CustomMatInputAccessor]);
+      const fixture = createComponent(MatInputWithCustomAccessor, [], [], [CustomMatInputAccessor]);
       fixture.detectChanges();
-      let label = fixture.debugElement.query(By.css('label'))!.nativeElement;
+      const label = fixture.debugElement.query(By.css('label'))!.nativeElement;
 
       expect(label.classList).toContain('mat-form-field-empty');
 
@@ -1124,7 +1128,7 @@ describe('MatInput with forms', () => {
       fixture.destroy();
       TestBed.resetTestingModule();
 
-      let groupFixture = createComponent(MatInputWithFormGroupErrorMessages);
+      const groupFixture = createComponent(MatInputWithFormGroupErrorMessages);
       let component: MatInputWithFormGroupErrorMessages;
 
       groupFixture.detectChanges();
@@ -1201,7 +1205,7 @@ describe('MatInput with forms', () => {
     }));
 
     it('sets the aria-describedby to reference errors when in error state', fakeAsync(() => {
-      let hintId =
+      const hintId =
           fixture.debugElement.query(By.css('.mat-hint'))!.nativeElement.getAttribute('id');
       let describedBy = inputEl.getAttribute('aria-describedby');
 
@@ -1211,7 +1215,7 @@ describe('MatInput with forms', () => {
       fixture.componentInstance.formControl.markAsTouched();
       fixture.detectChanges();
 
-      let errorIds = fixture.debugElement.queryAll(By.css('.mat-error'))
+      const errorIds = fixture.debugElement.queryAll(By.css('.mat-error'))
           .map(el => el.nativeElement.getAttribute('id')).join(' ');
       describedBy = inputEl.getAttribute('aria-describedby');
 
@@ -1243,11 +1247,11 @@ describe('MatInput with forms', () => {
   describe('custom error behavior', () => {
 
     it('should display an error message when a custom error matcher returns true', fakeAsync(() => {
-      let fixture = createComponent(MatInputWithCustomErrorStateMatcher);
+      const fixture = createComponent(MatInputWithCustomErrorStateMatcher);
       fixture.detectChanges();
 
-      let component = fixture.componentInstance;
-      let containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+      const component = fixture.componentInstance;
+      const containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
 
       const control = component.formGroup.get('name')!;
 
@@ -1269,14 +1273,14 @@ describe('MatInput with forms', () => {
     }));
 
     it('should display an error message when global error matcher returns true', fakeAsync(() => {
-      let fixture = createComponent(MatInputWithFormErrorMessages, [{
+      const fixture = createComponent(MatInputWithFormErrorMessages, [{
         provide: ErrorStateMatcher, useValue: {isErrorState: () => true}}
       ]);
 
       fixture.detectChanges();
 
-      let containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
-      let testComponent = fixture.componentInstance;
+      const containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+      const testComponent = fixture.componentInstance;
 
       // Expect the control to still be untouched but the error to show due to the global setting
       expect(testComponent.formControl.untouched).toBe(true, 'Expected untouched form control');
@@ -1284,13 +1288,13 @@ describe('MatInput with forms', () => {
     }));
 
     it('should display an error message when using ShowOnDirtyErrorStateMatcher', fakeAsync(() => {
-      let fixture = createComponent(MatInputWithFormErrorMessages, [{
+      const fixture = createComponent(MatInputWithFormErrorMessages, [{
         provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher
       }]);
       fixture.detectChanges();
 
-      let containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
-      let testComponent = fixture.componentInstance;
+      const containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
+      const testComponent = fixture.componentInstance;
 
       expect(testComponent.formControl.invalid).toBe(true, 'Expected form control to be invalid');
       expect(containerEl.querySelectorAll('mat-error').length).toBe(0, 'Expected no error message');
@@ -1310,10 +1314,10 @@ describe('MatInput with forms', () => {
   });
 
   it('should update the value when using FormControl.setValue', fakeAsync(() => {
-    let fixture = createComponent(MatInputWithFormControl);
+    const fixture = createComponent(MatInputWithFormControl);
     fixture.detectChanges();
 
-    let input = fixture.debugElement.query(By.directive(MatInput))!
+    const input = fixture.debugElement.query(By.directive(MatInput))!
       .injector.get<MatInput>(MatInput);
 
     expect(input.value).toBeFalsy();
@@ -1344,15 +1348,15 @@ describe('MatInput with forms', () => {
   }));
 
   it('should not treat the number 0 as empty', fakeAsync(() => {
-    let fixture = createComponent(MatInputZeroTestController);
+    const fixture = createComponent(MatInputZeroTestController);
     fixture.detectChanges();
     flush();
 
     fixture.detectChanges();
 
-    let el = fixture.debugElement.query(By.css('label'))!.nativeElement;
-    expect(el).not.toBeNull();
-    expect(el.classList.contains('mat-form-field-empty')).toBe(false);
+    const labelEl = fixture.debugElement.query(By.css('label'))!.nativeElement;
+    expect(labelEl).not.toBeNull();
+    expect(labelEl.classList.contains('mat-form-field-empty')).toBe(false);
   }));
 
   it('should update when the form field value is patched without emitting', fakeAsync(() => {

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -630,7 +630,7 @@ describe('MatMenu', () => {
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
 
-    let [firstMenuItemDebugEl, secondMenuItemDebugEl] =
+    const [firstMenuItemDebugEl, secondMenuItemDebugEl] =
            fixture.debugElement.queryAll(By.css('.mat-menu-item'))!;
 
     const firstMenuItemInstance = firstMenuItemDebugEl.componentInstance as MatMenuItem;
@@ -1063,7 +1063,7 @@ describe('MatMenu', () => {
 
     it('should focus the first menu item when opening a lazy menu via keyboard', fakeAsync(() => {
       let zone: MockNgZone;
-      let fixture = createComponent(SimpleLazyMenu, [{
+      const fixture = createComponent(SimpleLazyMenu, [{
         provide: NgZone, useFactory: () => zone = new MockNgZone()
       }]);
 
@@ -1109,14 +1109,14 @@ describe('MatMenu', () => {
 
     it('should respect the DOM order, rather than insertion order, when moving focus using ' +
       'the arrow keys', fakeAsync(() => {
-        let fixture = createComponent(SimpleMenuWithRepeater);
+        const fixture = createComponent(SimpleMenuWithRepeater);
 
         fixture.detectChanges();
         fixture.componentInstance.trigger.openMenu();
         fixture.detectChanges();
         tick(500);
 
-        let menuPanel = document.querySelector('.mat-menu-panel')!;
+        const menuPanel = document.querySelector('.mat-menu-panel')!;
         let items = menuPanel.querySelectorAll('.mat-menu-panel [mat-menu-item]');
 
         expect(document.activeElement).toBe(items[0], 'Expected first item to be focused on open');

--- a/src/material/radio/radio.spec.ts
+++ b/src/material/radio/radio.spec.ts
@@ -758,8 +758,8 @@ describe('MatRadio', () => {
     });
 
     it('should forward focus to native input', () => {
-      let radioButtonEl = fixture.debugElement.query(By.css('.mat-radio-button'))!.nativeElement;
-      let inputEl = fixture.debugElement.query(By.css('.mat-radio-input'))!.nativeElement;
+      const radioButtonEl = fixture.debugElement.query(By.css('.mat-radio-button'))!.nativeElement;
+      const inputEl = fixture.debugElement.query(By.css('.mat-radio-input'))!.nativeElement;
 
       radioButtonEl.focus();
       // Focus events don't always fire in tests, so we need to fake it.

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -1155,8 +1155,8 @@ describe('MatSelect', () => {
         }));
 
         it('should set the `aria-labelledby` attribute', fakeAsync(() => {
-          let group = groups[0];
-          let label = group.querySelector('span')!;
+          const group = groups[0];
+          const label = group.querySelector('span')!;
 
           expect(label.getAttribute('id')).toBeTruthy('Expected label to have an id.');
           expect(group.getAttribute('aria-labelledby'))
@@ -1533,8 +1533,8 @@ describe('MatSelect', () => {
       }));
 
       it('should deselect other options when one is programmatically selected', fakeAsync(() => {
-        let control = fixture.componentInstance.control;
-        let foods = fixture.componentInstance.foods;
+        const control = fixture.componentInstance.control;
+        const foods = fixture.componentInstance.foods;
 
         trigger.click();
         fixture.detectChanges();
@@ -1570,13 +1570,14 @@ describe('MatSelect', () => {
       }));
 
       it('should remove selection if option has been removed', fakeAsync(() => {
-        let select = fixture.componentInstance.select;
+        const select = fixture.componentInstance.select;
 
         trigger.click();
         fixture.detectChanges();
         flush();
 
-        let firstOption = overlayContainerElement.querySelectorAll('mat-option')[0] as HTMLElement;
+        const firstOption =
+            overlayContainerElement.querySelectorAll('mat-option')[0] as HTMLElement;
 
         firstOption.click();
         fixture.detectChanges();
@@ -1712,7 +1713,7 @@ describe('MatSelect', () => {
           fixture.destroy();
           fixture = TestBed.createComponent(BasicSelect);
 
-          let spy = jasmine.createSpy('option selection spy');
+          const spy = jasmine.createSpy('option selection spy');
           let subscription: Subscription;
 
           expect(fixture.componentInstance.select.options).toBeFalsy();
@@ -1739,9 +1740,10 @@ describe('MatSelect', () => {
 
       it('should emit to `optionSelectionChanges` after the list of options has changed',
         fakeAsync(() => {
-          let spy = jasmine.createSpy('option selection spy');
-          let subscription = fixture.componentInstance.select.optionSelectionChanges.subscribe(spy);
-          let selectFirstOption = () => {
+          const spy = jasmine.createSpy('option selection spy');
+          const subscription =
+              fixture.componentInstance.select.optionSelectionChanges.subscribe(spy);
+          const selectFirstOption = () => {
             trigger.click();
             fixture.detectChanges();
             flush();
@@ -2000,7 +2002,7 @@ describe('MatSelect', () => {
 
         fixture.componentInstance.control.disable();
         fixture.detectChanges();
-        let trigger =
+        const trigger =
             fixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
         expect(getComputedStyle(trigger).getPropertyValue('cursor'))
             .toEqual('default', `Expected cursor to be default arrow on disabled control.`);
@@ -2338,7 +2340,7 @@ describe('MatSelect', () => {
       }));
 
       it('should set the option id', fakeAsync(() => {
-        let firstOptionID = options[0].id;
+        const firstOptionID = options[0].id;
 
         expect(options[0].id)
             .toContain('mat-option', `Expected option ID to have the correct prefix.`);
@@ -3562,7 +3564,7 @@ describe('MatSelect', () => {
 
         fixture.destroy();
 
-        let groupFixture = TestBed.createComponent(SelectWithGroups);
+        const groupFixture = TestBed.createComponent(SelectWithGroups);
         groupFixture.detectChanges();
         trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
         formField = groupFixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
@@ -3601,7 +3603,7 @@ describe('MatSelect', () => {
 
           fixture.destroy();
 
-          let groupFixture = TestBed.createComponent(SelectWithIndirectDescendantGroups);
+          const groupFixture = TestBed.createComponent(SelectWithIndirectDescendantGroups);
           groupFixture.detectChanges();
           trigger = groupFixture.debugElement.query(By.css('.mat-select-trigger'))!.nativeElement;
           formField = groupFixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
@@ -4257,7 +4259,7 @@ describe('MatSelect', () => {
         // There appears to be a small rounding error on IE, so we verify that the value is close,
         // not exact.
         if (platform.TRIDENT) {
-          let difference =
+          const difference =
               Math.abs(optionTop + (menuItemHeight - triggerHeight) / 2 - triggerTop);
           expect(difference)
               .toBeLessThan(0.1, 'Expected trigger to align with the first option.');

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -151,18 +151,18 @@ describe('MatDrawer', () => {
 
     it('does not throw when created without a drawer', fakeAsync(() => {
       expect(() => {
-        let fixture = TestBed.createComponent(BasicTestApp);
+        const fixture = TestBed.createComponent(BasicTestApp);
         fixture.detectChanges();
         tick();
       }).not.toThrow();
     }));
 
     it('should emit the backdropClick event when the backdrop is clicked', fakeAsync(() => {
-      let fixture = TestBed.createComponent(BasicTestApp);
+      const fixture = TestBed.createComponent(BasicTestApp);
       fixture.detectChanges();
 
-      let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      let openButtonElement = fixture.debugElement.query(By.css('.open'))!.nativeElement;
+      const testComponent: BasicTestApp = fixture.debugElement.componentInstance;
+      const openButtonElement = fixture.debugElement.query(By.css('.open'))!.nativeElement;
 
       openButtonElement.click();
       fixture.detectChanges();
@@ -188,12 +188,12 @@ describe('MatDrawer', () => {
     }));
 
     it('should close when pressing escape', fakeAsync(() => {
-      let fixture = TestBed.createComponent(BasicTestApp);
+      const fixture = TestBed.createComponent(BasicTestApp);
 
       fixture.detectChanges();
 
-      let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
+      const testComponent: BasicTestApp = fixture.debugElement.componentInstance;
+      const drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
 
       drawer.componentInstance.open();
       fixture.detectChanges();
@@ -214,12 +214,12 @@ describe('MatDrawer', () => {
     }));
 
     it('should not close when pressing escape with a modifier', fakeAsync(() => {
-      let fixture = TestBed.createComponent(BasicTestApp);
+      const fixture = TestBed.createComponent(BasicTestApp);
 
       fixture.detectChanges();
 
-      let testComponent: BasicTestApp = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
+      const testComponent: BasicTestApp = fixture.debugElement.componentInstance;
+      const drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
 
       drawer.componentInstance.open();
       fixture.detectChanges();
@@ -239,7 +239,7 @@ describe('MatDrawer', () => {
     }));
 
     it('should fire the open event when open on init', fakeAsync(() => {
-      let fixture = TestBed.createComponent(DrawerSetToOpenedTrue);
+      const fixture = TestBed.createComponent(DrawerSetToOpenedTrue);
 
       fixture.detectChanges();
       tick();
@@ -248,9 +248,9 @@ describe('MatDrawer', () => {
     }));
 
     it('should not close by pressing escape when disableClose is set', fakeAsync(() => {
-      let fixture = TestBed.createComponent(BasicTestApp);
-      let testComponent = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
+      const fixture = TestBed.createComponent(BasicTestApp);
+      const testComponent = fixture.debugElement.componentInstance;
+      const drawer = fixture.debugElement.query(By.directive(MatDrawer))!;
 
       drawer.componentInstance.disableClose = true;
       drawer.componentInstance.open();
@@ -266,9 +266,9 @@ describe('MatDrawer', () => {
     }));
 
     it('should not close by clicking on the backdrop when disableClose is set', fakeAsync(() => {
-      let fixture = TestBed.createComponent(BasicTestApp);
-      let testComponent = fixture.debugElement.componentInstance;
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
+      const fixture = TestBed.createComponent(BasicTestApp);
+      const testComponent = fixture.debugElement.componentInstance;
+      const drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
 
       drawer.disableClose = true;
       drawer.open();
@@ -313,13 +313,13 @@ describe('MatDrawer', () => {
     }));
 
     it('should restore focus on close if focus is on drawer', fakeAsync(() => {
-      let fixture = TestBed.createComponent(BasicTestApp);
+      const fixture = TestBed.createComponent(BasicTestApp);
 
       fixture.detectChanges();
 
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
-      let openButton = fixture.componentInstance.openButton.nativeElement;
-      let drawerButton = fixture.componentInstance.drawerButton.nativeElement;
+      const drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
+      const openButton = fixture.componentInstance.openButton.nativeElement;
+      const drawerButton = fixture.componentInstance.drawerButton.nativeElement;
 
       openButton.focus();
       drawer.open();
@@ -358,13 +358,13 @@ describe('MatDrawer', () => {
     }));
 
     it('should not restore focus on close if focus is outside drawer', fakeAsync(() => {
-      let fixture = TestBed.createComponent(BasicTestApp);
-      let drawer: MatDrawer = fixture.debugElement
+      const fixture = TestBed.createComponent(BasicTestApp);
+      const drawer: MatDrawer = fixture.debugElement
           .query(By.directive(MatDrawer))!.componentInstance;
       fixture.detectChanges();
 
-      let openButton = fixture.componentInstance.openButton.nativeElement;
-      let closeButton = fixture.componentInstance.closeButton.nativeElement;
+      const openButton = fixture.componentInstance.openButton.nativeElement;
+      const closeButton = fixture.componentInstance.closeButton.nativeElement;
 
       openButton.focus();
       drawer.open();
@@ -424,21 +424,23 @@ describe('MatDrawer', () => {
 
   describe('attributes', () => {
     it('should correctly parse opened="false"', () => {
-      let fixture = TestBed.createComponent(DrawerSetToOpenedFalse);
+      const fixture = TestBed.createComponent(DrawerSetToOpenedFalse);
 
       fixture.detectChanges();
 
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
+      const drawer =
+          fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
 
       expect((drawer as MatDrawer).opened).toBe(false);
     });
 
     it('should correctly parse opened="true"', () => {
-      let fixture = TestBed.createComponent(DrawerSetToOpenedTrue);
+      const fixture = TestBed.createComponent(DrawerSetToOpenedTrue);
 
       fixture.detectChanges();
 
-      let drawer = fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
+      const drawer =
+          fixture.debugElement.query(By.directive(MatDrawer))!.componentInstance;
 
       expect((drawer as MatDrawer).opened).toBe(true);
     });
@@ -485,7 +487,7 @@ describe('MatDrawer', () => {
       const fixture = TestBed.createComponent(DrawerOpenBinding);
       fixture.detectChanges();
 
-      let drawer: MatDrawer = fixture.debugElement
+      const drawer: MatDrawer = fixture.debugElement
           .query(By.directive(MatDrawer))!.componentInstance;
 
       drawer.open();


### PR DESCRIPTION
**Opening this PR as it is required to:**

- Refactor variables in various component unit tests to have constant type instead of let as this variables are not getting re-initialize during the test life-time.
- Added type annotations to variables instead of any.
- Renamed variables.
- All tests within a spec should be consistent with all other tests in repo.