### PR TITLE
feat(google-maps): add event emitter for gm_authFailure callback

### DIFF
--- a/src/dev-app/google-map/google-map-demo.html
+++ b/src/dev-app/google-map/google-map-demo.html
@@ -3,6 +3,7 @@
               width="750px"
               [center]="center"
               [zoom]="zoom"
+              (authFailure)="authFailure()"
               (mapClick)="handleClick($event)"
               (mapMousemove)="handleMove($event)"
               (mapRightclick)="handleRightclick()"

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -107,6 +107,10 @@ export class GoogleMapDemo {
 
   constructor(private readonly _mapDirectionsService: MapDirectionsService) {}
 
+  authFailure() {
+    console.log('Auth failure event emitted');
+  }
+
   handleClick(event: google.maps.MapMouseEvent) {
     this.markerPositions.push(event.latLng.toJSON());
   }

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -39,6 +39,7 @@ describe('GoogleMap', () => {
 
   afterEach(() => {
     (window.google as any) = undefined;
+    (window as any).gm_authFailure = undefined;
   });
 
   it('throws an error is the Google Maps JavaScript API was not loaded', () => {
@@ -358,6 +359,28 @@ describe('GoogleMap', () => {
     expect(mapConstructorSpy.calls.mostRecent()?.args[1].mapTypeId).toBe('satellite');
   });
 
+  it('should emit authFailure event when window.gm_authFailure is called', () => {
+    mapSpy = createMapSpy(DEFAULT_OPTIONS);
+    mapConstructorSpy = createMapConstructorSpy(mapSpy);
+
+    expect((window as any).gm_authFailure).toBeUndefined();
+
+    const createFixture = () => {
+      const fixture = TestBed.createComponent(TestApp);
+      fixture.detectChanges();
+      spyOn(fixture.componentInstance.map.authFailure, 'emit');
+      return fixture;
+    };
+
+    const fixture1 = createFixture();
+    const fixture2 = createFixture();
+
+    expect((window as any).gm_authFailure).toBeDefined();
+    (window as any).gm_authFailure();
+
+    expect(fixture1.componentInstance.map.authFailure.emit).toHaveBeenCalled();
+    expect(fixture2.componentInstance.map.authFailure.emit).toHaveBeenCalled();
+  });
 });
 
 @Component({

--- a/tools/public_api_guard/google-maps/google-maps.d.ts
+++ b/tools/public_api_guard/google-maps/google-maps.d.ts
@@ -1,5 +1,6 @@
 export declare class GoogleMap implements OnChanges, OnInit, OnDestroy {
     _isBrowser: boolean;
+    readonly authFailure: EventEmitter<void>;
     readonly boundsChanged: Observable<void>;
     set center(center: google.maps.LatLngLiteral | google.maps.LatLng);
     readonly centerChanged: Observable<void>;
@@ -46,7 +47,7 @@ export declare class GoogleMap implements OnChanges, OnInit, OnDestroy {
     panBy(x: number, y: number): void;
     panTo(latLng: google.maps.LatLng | google.maps.LatLngLiteral): void;
     panToBounds(latLngBounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral, padding?: number | google.maps.Padding): void;
-    static ɵcmp: i0.ɵɵComponentDeclaration<GoogleMap, "google-map", ["googleMap"], { "height": "height"; "width": "width"; "mapTypeId": "mapTypeId"; "center": "center"; "zoom": "zoom"; "options": "options"; }, { "boundsChanged": "boundsChanged"; "centerChanged": "centerChanged"; "mapClick": "mapClick"; "mapDblclick": "mapDblclick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "mapDragstart": "mapDragstart"; "headingChanged": "headingChanged"; "idle": "idle"; "maptypeidChanged": "maptypeidChanged"; "mapMousemove": "mapMousemove"; "mapMouseout": "mapMouseout"; "mapMouseover": "mapMouseover"; "projectionChanged": "projectionChanged"; "mapRightclick": "mapRightclick"; "tilesloaded": "tilesloaded"; "tiltChanged": "tiltChanged"; "zoomChanged": "zoomChanged"; }, never, ["*"]>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<GoogleMap, "google-map", ["googleMap"], { "height": "height"; "width": "width"; "mapTypeId": "mapTypeId"; "center": "center"; "zoom": "zoom"; "options": "options"; }, { "authFailure": "authFailure"; "boundsChanged": "boundsChanged"; "centerChanged": "centerChanged"; "mapClick": "mapClick"; "mapDblclick": "mapDblclick"; "mapDrag": "mapDrag"; "mapDragend": "mapDragend"; "mapDragstart": "mapDragstart"; "headingChanged": "headingChanged"; "idle": "idle"; "maptypeidChanged": "maptypeidChanged"; "mapMousemove": "mapMousemove"; "mapMouseout": "mapMouseout"; "mapMouseover": "mapMouseover"; "projectionChanged": "projectionChanged"; "mapRightclick": "mapRightclick"; "tilesloaded": "tilesloaded"; "tiltChanged": "tiltChanged"; "zoomChanged": "zoomChanged"; }, never, ["*"]>;
     static ɵfac: i0.ɵɵFactoryDeclaration<GoogleMap, never>;
 }
 


### PR DESCRIPTION
Emit event from the `GoogleMap` component when the `gm_authFailure` callback is called.

Fixes #22163