### PR TITLE
build: set up schematics for v13

### DIFF
--- a/src/cdk/schematics/migration.json
+++ b/src/cdk/schematics/migration.json
@@ -36,6 +36,11 @@
       "description": "Updates the Angular CDK to v12",
       "factory": "./ng-update/index#updateToV12"
     },
+    "migration-v13": {
+      "version": "13.0.0-0",
+      "description": "Updates the Angular CDK to v13",
+      "factory": "./ng-update/index#updateToV13"
+    },
     "ng-post-update": {
       "description": "Prints out results after ng-update.",
       "factory": "./ng-update/index#postUpdate",

--- a/src/cdk/schematics/ng-update/index.ts
+++ b/src/cdk/schematics/ng-update/index.ts
@@ -46,6 +46,11 @@ export function updateToV12(): Rule {
   return createMigrationSchematicRule(TargetVersion.V12, [], cdkUpgradeData, onMigrationComplete);
 }
 
+/** Entry point for the migration schematics with target of Angular CDK 13.0.0 */
+export function updateToV13(): Rule {
+  return createMigrationSchematicRule(TargetVersion.V13, [], cdkUpgradeData, onMigrationComplete);
+}
+
 /** Function that will be called when the migration completed. */
 function onMigrationComplete(context: SchematicContext, targetVersion: TargetVersion,
                              hasFailures: boolean) {

--- a/src/cdk/schematics/update-tool/target-version.ts
+++ b/src/cdk/schematics/update-tool/target-version.ts
@@ -17,6 +17,7 @@ export enum TargetVersion {
   V10 = 'version 10',
   V11 = 'version 11',
   V12 = 'version 12',
+  V13 = 'version 13',
 }
 
 /**

--- a/src/material/schematics/migration.json
+++ b/src/material/schematics/migration.json
@@ -36,6 +36,11 @@
       "description": "Updates Angular Material to v12",
       "factory": "./ng-update/index#updateToV12"
     },
+    "migration-v13": {
+      "version": "13.0.0-0",
+      "description": "Updates Angular Material to v13",
+      "factory": "./ng-update/index#updateToV13"
+    },
     "ng-post-update": {
       "description": "Prints out results after ng-update.",
       "factory": "./ng-update/index#postUpdate",

--- a/src/material/schematics/ng-update/index.ts
+++ b/src/material/schematics/ng-update/index.ts
@@ -82,6 +82,12 @@ export function updateToV12(): Rule {
       TargetVersion.V12, materialMigrations, materialUpgradeData, onMigrationComplete);
 }
 
+/** Entry point for the migration schematics with target of Angular Material v13 */
+export function updateToV13(): Rule {
+  return createMigrationSchematicRule(
+      TargetVersion.V13, materialMigrations, materialUpgradeData, onMigrationComplete);
+}
+
 /** Function that will be called when the migration completed. */
 function onMigrationComplete(context: SchematicContext, targetVersion: TargetVersion,
                              hasFailures: boolean) {


### PR DESCRIPTION
Sets up the boilerplate for v13 schematics so that it's in place once we start making breaking changes.