### PR TITLE
refactor(examples): use `includes` instead of `indexOf` to check whet…

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-auto-active-first-option/autocomplete-auto-active-first-option-example.ts
@@ -26,6 +26,6 @@ export class AutocompleteAutoActiveFirstOptionExample implements OnInit {
   private _filter(value: string): string[] {
     const filterValue = value.toLowerCase();
 
-    return this.options.filter(option => option.toLowerCase().indexOf(filterValue) === 0);
+    return this.options.filter(option => option.toLowerCase().includes(filterValue));
   }
 }

--- a/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.ts
@@ -40,6 +40,6 @@ export class AutocompleteDisplayExample implements OnInit {
   private _filter(name: string): User[] {
     const filterValue = name.toLowerCase();
 
-    return this.options.filter(option => option.name.toLowerCase().indexOf(filterValue) === 0);
+    return this.options.filter(option => option.name.toLowerCase().includes(filterValue));
   }
 }

--- a/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.ts
@@ -11,7 +11,7 @@ export interface StateGroup {
 export const _filter = (opt: string[], value: string): string[] => {
   const filterValue = value.toLowerCase();
 
-  return opt.filter(item => item.toLowerCase().indexOf(filterValue) === 0);
+  return opt.filter(item => item.toLowerCase().includes(filterValue));
 };
 
 /**

--- a/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-overview/autocomplete-overview-example.ts
@@ -59,6 +59,6 @@ export class AutocompleteOverviewExample {
   private _filterStates(value: string): State[] {
     const filterValue = value.toLowerCase();
 
-    return this.states.filter(state => state.name.toLowerCase().indexOf(filterValue) === 0);
+    return this.states.filter(state => state.name.toLowerCase().includes(filterValue));
   }
 }

--- a/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.ts
@@ -64,6 +64,6 @@ export class ChipsAutocompleteExample {
   private _filter(value: string): string[] {
     const filterValue = value.toLowerCase();
 
-    return this.allFruits.filter(fruit => fruit.toLowerCase().indexOf(filterValue) === 0);
+    return this.allFruits.filter(fruit => fruit.toLowerCase().includes(filterValue));
   }
 }


### PR DESCRIPTION
…her a string contains a given substring