### PR TITLE
fix(material-experimental/mdc-snack-bar): increase the specificity of styles targeting the action buttons

### DIFF
--- a/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
+++ b/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
@@ -36,7 +36,7 @@
   mdc-snackbar.$dismiss-ink-color: $orig-dismiss-ink-color;
 
   // The extra level of nesting here is to increase the specificity.
-  .mat-mdc-simple-snack-bar .mat-mdc-snack-bar-actions .mdc-snackbar__action {
+  .mat-mdc-simple-snack-bar .mat-mdc-snack-bar-actions .mdc-snackbar__action.mdc-snackbar__action {
     $is-dark-theme: map.get($config, is-dark);
     $accent: map.get($config, accent);
     color: if($is-dark-theme, inherit, theming.get-color-from-palette($accent, text));

--- a/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
+++ b/src/material-experimental/mdc-snack-bar/_snack-bar-theme.scss
@@ -35,7 +35,9 @@
   mdc-snackbar.$label-ink-color: $orig-label-ink-color;
   mdc-snackbar.$dismiss-ink-color: $orig-dismiss-ink-color;
 
-  // The extra level of nesting here is to increase the specificity.
+  // Four classes is necessary to make it higher specificity than the mdc-button theme styles.
+  // This ensures the correct styles will be applied regardless of the order te mixins are
+  // @included.
   .mat-mdc-simple-snack-bar .mat-mdc-snack-bar-actions .mdc-snackbar__action.mdc-snackbar__action {
     $is-dark-theme: map.get($config, is-dark);
     $accent: map.get($config, accent);


### PR DESCRIPTION
Currently the order of the button theme vs the snackbar theme matters,
this will make the snackbar theme always take precedence