### PR TITLE
fix(multiple): support macOS Hover Text a11y feature

### DIFF
--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -2,7 +2,7 @@
   <span class="mat-checkbox-inner-container"
        [class.mat-checkbox-inner-container-no-side-margin]="!checkboxLabel.textContent || !checkboxLabel.textContent.trim()">
     <input #input
-           class="mat-checkbox-input cdk-visually-hidden" type="checkbox"
+           class="mat-checkbox-input" type="checkbox"
            [id]="inputId"
            [required]="required"
            [checked]="checked"

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -512,8 +512,12 @@ $_mark-stroke-size: private.private-div(2, 15) * checkbox-common.$size !default;
 }
 
 .mat-checkbox-input {
-  // Move the input to the bottom and in the middle.
-  // Visual improvement to properly show browser popups when being required.
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  position: absolute;
+  // Keep the input aligned with the bottom so the native validation messages are aligned correctly.
   bottom: 0;
-  left: 50%;
+  left: 0;
+  opacity: 0;
 }

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -569,7 +569,7 @@ export class MatFormField extends _MatFormFieldBase
       // invisible and we can't calculate the outline gap. Mark the element as needing
       // to be checked the next time the zone stabilizes. We can't do this immediately
       // on the next change detection, because even if the element becomes visible,
-      // the `ClientRect` won't be reclaculated immediately. We reset the
+      // the `ClientRect` won't be recalculated immediately. We reset the
       // `_outlineGapCalculationNeededImmediately` flag some we don't run the checks twice.
       if (containerRect.width === 0 && containerRect.height === 0) {
         this._outlineGapCalculationNeededOnStable = true;

--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -5,7 +5,7 @@
   <span class="mat-radio-container">
     <span class="mat-radio-outer-circle"></span>
     <span class="mat-radio-inner-circle"></span>
-    <input #input class="mat-radio-input cdk-visually-hidden" type="radio"
+    <input #input class="mat-radio-input" type="radio"
         [id]="inputId"
         [checked]="checked"
         [disabled]="disabled"

--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -170,7 +170,7 @@ $ripple-radius: 20px;
 
   // We do this here, rather than having a `:not(.mat-radio-disabled)`
   // above in the `:hover`, because the `:not` will bump the specificity
-  // a lot and will cause it to overide the focus styles.
+  // a lot and will cause it to override the focus styles.
   &, .mat-radio-disabled .mat-radio-container:hover & {
     opacity: 0;
   }
@@ -187,10 +187,14 @@ $ripple-radius: 20px;
 }
 
 .mat-radio-input {
-  // Move the input in the middle and towards the bottom so
-  // the native validation messages are aligned correctly.
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  position: absolute;
+  // Keep the input aligned with the bottom so the native validation messages are aligned correctly.
   bottom: 0;
-  left: 50%;
+  left: 0;
+  opacity: 0;
 }
 
 @include a11y.high-contrast(active, off) {


### PR DESCRIPTION
- remove `cdk-visually-hidden` class from native inputs,
  size/position them correctly for hovering, and hide them with `opacity`
- this approach is based on what MDC Web uses and how our mdc-radio and
  mdc-checkbox components are designed
- fix minor typos

Fixes #22950

## Questions for reviewers

- Where should I put these common styles that in this case could potentially be shared across radio and checkbox?
- Should we update the `cdk-visually-hidden` style to use this approach instead? Likely too risky.