### PR TITLE
build: fix firebase deployment of dev-app

### DIFF
--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
 load("//tools:create-system-config.bzl", "create_system_config")
 load("//tools:defaults.bzl", "ng_module", "sass_binary")
-load("//tools:es5-named-output.bzl", "es5_named_output")
+load("//tools:es5-module-output.bzl", "es5_module_output")
 load("//tools/dev-server:index.bzl", "dev_server")
 
 package(default_visibility = ["//visibility:public"])
@@ -200,7 +200,7 @@ dev_server(
 
 # Collects all ES5 JavaScript files which are required to serve the dev-app. By default,
 # ts_library and ng_module targets only expose the type definition files as outputs.
-es5_named_output(
+es5_module_output(
     name = "dev_app_js_sources",
     tags = ["manual"],
     deps = [":dev-app"],

--- a/tools/es5-module-output.bzl
+++ b/tools/es5-module-output.bzl
@@ -1,30 +1,30 @@
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo")
 
-"""Implementation of the es5_named_output rule.
+"""Implementation of the es5_module_output rule.
 Direct and transitive JavaScript files and sourcemaps are collected via ts_library
-JSNamedModuleInfo provider.
-https://github.com/bazelbuild/rules_nodejs/blob/a167311c025be2a77ba0d84e6a2ddcafe1c0564d/packages/typescript/src/internal/build_defs.bzl#L312
+JSModuleInfo provider.
+https://github.com/bazelbuild/rules_nodejs/blob/stable/packages/typescript/internal/build_defs.bzl#L334-L337
 """
 
-def _es5_named_output_impl(ctx):
+def _es5_module_output_impl(ctx):
     depsets = []
     for dep in ctx.attr.deps:
-        if JSNamedModuleInfo in dep:
-            depsets.append(dep[JSNamedModuleInfo].sources)
+        if JSModuleInfo in dep:
+            depsets.append(dep[JSModuleInfo].sources)
         if hasattr(dep, "files"):
             depsets.append(dep.files)
     sources = depset(transitive = depsets)
 
     return [DefaultInfo(files = sources)]
 
-"""Rule that collects all ES5 named outputs from a list of deps.
+"""Rule that collects all ES5 module outputs from a list of deps.
 It can be used as input for all those rules that require named JavaScript sources (such as
 pkg_web).
 We need this because ts_library and ng_module targets output only expose the type definition files
 as outputs.
 """
-es5_named_output = rule(
-    implementation = _es5_named_output_impl,
+es5_module_output = rule(
+    implementation = _es5_module_output_impl,
     attrs = {
         "deps": attr.label_list(
             allow_files = True,


### PR DESCRIPTION
The `@angular/localize` package does not contain any `.metadata.json`
files, or an `ANGULAR_PACKAGE` marker file. This results in the NodeJS
bazel rules not capturing the UMD files within the `NamedModule` provider.

We fix this by using the standard module provider for extracting JS
sources from TS targets and its transitive dependencies. This is more
long-term proof as the hard-coded Angular package logic within Rules
NodeJS is most likely not a long-term solution.

see: https://github.com/bazelbuild/rules_nodejs/blob/stable/internal/npm_install/generate_build_file.ts#L1080-L1081

Fixes #22943.