### PR TITLE
fix(material/datepicker): add focus indication for selected date

### DIFF
--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -37,7 +37,9 @@ $calendar-weekday-table-font-size: 11px !default;
     }
   }
 
-  .mat-calendar-body-today.mat-calendar-body-selected {
+  .mat-calendar-body-today.mat-calendar-body-selected,
+  .cdk-keyboard-focused .mat-calendar-body-active .mat-calendar-body-selected,
+  .cdk-program-focused .mat-calendar-body-active .mat-calendar-body-selected {
     box-shadow: inset 0 0 0 $selected-today-box-shadow-width
                 theming.get-color-from-palette($palette, default-contrast);
   }


### PR DESCRIPTION
Currently there's no way to tell when the selected date in the calendar has focus. These changes reuse the styling from when the selected date is today (white circle inside the main circle).

Fixes #22883.