### PR TITLE
build: ampersand selector lint rule not catching some cases

### DIFF
--- a/src/material/badge/_badge-theme.scss
+++ b/src/material/badge/_badge-theme.scss
@@ -18,6 +18,8 @@ $large-size: $default-size + 6;
 
 // Mixin for building offset given different sizes
 @mixin _badge-size($size) {
+  // This mixin isn't used in the context of a theme so we can disable the ampersand check.
+  // stylelint-disable material/no-ampersand-beyond-selector-start
   .mat-badge-content {
     width: $size;
     height: $size;
@@ -89,6 +91,7 @@ $large-size: $default-size + 6;
       }
     }
   }
+  // stylelint-enable
 }
 
 @mixin color($config-or-theme) {


### PR DESCRIPTION
I noticed this while working on something else. The ampersand selector mixin looks for one `&` instance and then gives up, but there might be other ampersands inside the same selector which are invalid.

These changes update the logic to be a bit more robust and remove the limitation where failures weren't reported on private mixins.