### PR TITLE
test(multiple): refactor unit tests of several components

### DIFF
--- a/src/material/sort/sort.spec.ts
+++ b/src/material/sort/sort.spec.ts
@@ -74,8 +74,8 @@ describe('MatSort', () => {
     }));
 
     it('should use the column definition if used within a cdk table', () => {
-      let cdkTableMatSortAppFixture = TestBed.createComponent(CdkTableMatSortApp);
-      let cdkTableMatSortAppComponent = cdkTableMatSortAppFixture.componentInstance;
+      const cdkTableMatSortAppFixture = TestBed.createComponent(CdkTableMatSortApp);
+      const cdkTableMatSortAppComponent = cdkTableMatSortAppFixture.componentInstance;
 
       cdkTableMatSortAppFixture.detectChanges();
       cdkTableMatSortAppFixture.detectChanges();
@@ -88,8 +88,8 @@ describe('MatSort', () => {
     });
 
     it('should use the column definition if used within an mat table', () => {
-      let matTableMatSortAppFixture = TestBed.createComponent(MatTableMatSortApp);
-      let matTableMatSortAppComponent = matTableMatSortAppFixture.componentInstance;
+      const matTableMatSortAppFixture = TestBed.createComponent(MatTableMatSortApp);
+      const matTableMatSortAppComponent = matTableMatSortAppFixture.componentInstance;
 
       matTableMatSortAppFixture.detectChanges();
       matTableMatSortAppFixture.detectChanges();
@@ -469,7 +469,7 @@ function testSingleColumnSortDirectionSequence(
   component.matSort.direction = '';
 
   // Run through the sequence to confirm the order
-  let actualSequence = expectedSequence.map(() => {
+  const actualSequence = expectedSequence.map(() => {
     component.sort(id);
 
     // Check that the sort event's active sort is consistent with the MatSort

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -75,8 +75,9 @@ describe('MatStepper', () => {
     });
 
     it('should default to the first step', () => {
-      let stepperComponent = fixture.debugElement
+      const stepperComponent: MatStepper = fixture.debugElement
           .query(By.css('mat-stepper'))!.componentInstance;
+
       expect(stepperComponent.selectedIndex).toBe(0);
     });
 
@@ -101,8 +102,9 @@ describe('MatStepper', () => {
     });
 
     it('should change selected index on header click', () => {
-      let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
-      let stepperComponent =
+      const stepHeaders =
+          fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
@@ -126,27 +128,27 @@ describe('MatStepper', () => {
     });
 
     it('should set the "tablist" role on stepper', () => {
-      let stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
+      const stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('role')).toBe('tablist');
     });
 
     it('should set aria-expanded of content correctly', () => {
-      let stepContents = fixture.debugElement.queryAll(By.css(`.mat-vertical-stepper-content`));
-      let stepperComponent =
+      const stepContents = fixture.debugElement.queryAll(By.css(`.mat-vertical-stepper-content`));
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
-      let firstStepContentEl = stepContents[0].nativeElement;
+      const firstStepContentEl = stepContents[0].nativeElement;
       expect(firstStepContentEl.getAttribute('aria-expanded')).toBe('true');
 
       stepperComponent.selectedIndex = 1;
       fixture.detectChanges();
 
       expect(firstStepContentEl.getAttribute('aria-expanded')).toBe('false');
-      let secondStepContentEl = stepContents[1].nativeElement;
+      const secondStepContentEl = stepContents[1].nativeElement;
       expect(secondStepContentEl.getAttribute('aria-expanded')).toBe('true');
     });
 
     it('should display the correct label', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
       let selectedLabel = fixture.nativeElement.querySelector('[aria-selected="true"]');
       expect(selectedLabel.textContent).toMatch('Step 1');
@@ -165,7 +167,7 @@ describe('MatStepper', () => {
     });
 
     it('should go to next available step when the next button is clicked', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
@@ -198,7 +200,7 @@ describe('MatStepper', () => {
     });
 
     it('should go to previous available step when the previous button is clicked', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent.selectedIndex).toBe(0);
@@ -232,7 +234,7 @@ describe('MatStepper', () => {
     });
 
     it('should set the correct step position for animation', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent._getAnimationDirection(0)).toBe('current');
@@ -255,10 +257,11 @@ describe('MatStepper', () => {
     });
 
     it('should not set focus on header of selected step if header is not clicked', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
-      let stepHeaderEl = fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
-      let nextButtonNativeEl = fixture.debugElement
+      const stepHeaderEl =
+          fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
+      const nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       spyOn(stepHeaderEl, 'focus');
       nextButtonNativeEl.click();
@@ -269,10 +272,11 @@ describe('MatStepper', () => {
     });
 
     it('should focus next step header if focus is inside the stepper', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
-      let stepHeaderEl = fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
-      let nextButtonNativeEl = fixture.debugElement
+      const stepHeaderEl =
+          fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
+      const nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       spyOn(stepHeaderEl, 'focus');
       nextButtonNativeEl.focus();
@@ -284,12 +288,12 @@ describe('MatStepper', () => {
     });
 
     it('should only be able to return to a previous step if it is editable', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       stepperComponent.selectedIndex = 1;
       stepperComponent.steps.toArray()[0].editable = false;
-      let previousButtonNativeEl = fixture.debugElement
+      const previousButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperPrevious))[1].nativeElement;
       previousButtonNativeEl.click();
       fixture.detectChanges();
@@ -304,9 +308,9 @@ describe('MatStepper', () => {
     });
 
     it('should set create icon if step is editable and completed', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
-      let nextButtonNativeEl = fixture.debugElement
+      const nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       expect(stepperComponent._getIndicatorType(0)).toBe('number');
       stepperComponent.steps.toArray()[0].editable = true;
@@ -317,9 +321,9 @@ describe('MatStepper', () => {
     });
 
     it('should set done icon if step is not editable and is completed', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
-      let nextButtonNativeEl = fixture.debugElement
+      const nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       expect(stepperComponent._getIndicatorType(0)).toBe('number');
       stepperComponent.steps.toArray()[0].editable = false;
@@ -330,11 +334,11 @@ describe('MatStepper', () => {
     });
 
     it('should emit an event when the enter animation is done', fakeAsync(() => {
-      let stepper = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
-      let selectionChangeSpy = jasmine.createSpy('selectionChange spy');
-      let animationDoneSpy = jasmine.createSpy('animationDone spy');
-      let selectionChangeSubscription = stepper.selectionChange.subscribe(selectionChangeSpy);
-      let animationDoneSubscription = stepper.animationDone.subscribe(animationDoneSpy);
+      const stepper = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+      const selectionChangeSpy = jasmine.createSpy('selectionChange spy');
+      const animationDoneSpy = jasmine.createSpy('animationDone spy');
+      const selectionChangeSubscription = stepper.selectionChange.subscribe(selectionChangeSpy);
+      const animationDoneSubscription = stepper.animationDone.subscribe(animationDoneSpy);
 
       stepper.selectedIndex = 1;
       fixture.detectChanges();
@@ -495,7 +499,7 @@ describe('MatStepper', () => {
     });
 
     it('should reverse animation in RTL mode', () => {
-      let stepperComponent =
+      const stepperComponent =
           fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
       expect(stepperComponent._getAnimationDirection(0)).toBe('current');
@@ -543,7 +547,7 @@ describe('MatStepper', () => {
       expect(testComponent.oneGroup.invalid).toBe(true);
       expect(stepperComponent.selectedIndex).toBe(0);
 
-      let stepHeaderEl = fixture.debugElement
+      const stepHeaderEl = fixture.debugElement
           .queryAll(By.css('.mat-vertical-stepper-header'))[1].nativeElement;
 
       stepHeaderEl.click();
@@ -551,7 +555,7 @@ describe('MatStepper', () => {
 
       expect(stepperComponent.selectedIndex).toBe(0);
 
-      let nextButtonNativeEl = fixture.debugElement
+      const nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
       nextButtonNativeEl.click();
       fixture.detectChanges();
@@ -567,10 +571,10 @@ describe('MatStepper', () => {
     });
 
     it('should not move to next step if current step is pending', () => {
-      let stepHeaderEl = fixture.debugElement
+      const stepHeaderEl = fixture.debugElement
           .queryAll(By.css('.mat-vertical-stepper-header'))[2].nativeElement;
 
-      let nextButtonNativeEl = fixture.debugElement
+      const nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[1].nativeElement;
 
       testComponent.oneGroup.get('oneCtrl')!.setValue('input');
@@ -616,7 +620,8 @@ describe('MatStepper', () => {
     });
 
     it('should be able to focus step header upon click if it is unable to be selected', () => {
-      let stepHeaderEl = fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
+      const stepHeaderEl =
+          fixture.debugElement.queryAll(By.css('mat-step-header'))[1].nativeElement;
 
       fixture.detectChanges();
 
@@ -834,41 +839,42 @@ describe('MatStepper', () => {
 
   describe('vertical stepper', () => {
     it('should be able to use the legacy classes in queries', () => {
-      let fixture = createComponent(SimpleMatVerticalStepperApp);
+      const fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
+
       expect(fixture.componentInstance.legacyTokenStepper).toBeTruthy();
     });
 
     it('should set the aria-orientation to "vertical"', () => {
-      let fixture = createComponent(SimpleMatVerticalStepperApp);
+      const fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
-      let stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
+      const stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('aria-orientation')).toBe('vertical');
     });
 
     it('should support using the left/right arrows to move focus', () => {
-      let fixture = createComponent(SimpleMatVerticalStepperApp);
+      const fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
-      let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
+      const stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
       assertCorrectKeyboardInteraction(fixture, stepHeaders, 'horizontal');
     });
 
     it('should support using the up/down arrows to move focus', () => {
-      let fixture = createComponent(SimpleMatVerticalStepperApp);
+      const fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
-      let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
+      const stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
       assertCorrectKeyboardInteraction(fixture, stepHeaders, 'vertical');
     });
 
     it('should reverse arrow key focus in RTL mode', () => {
       dir.value = 'rtl';
-      let fixture = createComponent(SimpleMatVerticalStepperApp);
+      const fixture = createComponent(SimpleMatVerticalStepperApp);
       fixture.detectChanges();
 
-      let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
+      const stepHeaders = fixture.debugElement.queryAll(By.css('.mat-vertical-stepper-header'));
       assertArrowKeyInteractionInRtl(fixture, stepHeaders);
     });
 
@@ -941,41 +947,42 @@ describe('MatStepper', () => {
 
   describe('horizontal stepper', () => {
     it('should be able to use the legacy classes in queries', () => {
-      let fixture = createComponent(SimpleMatHorizontalStepperApp);
+      const fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
+
       expect(fixture.componentInstance.legacyTokenStepper).toBeTruthy();
     });
 
     it('should set the aria-orientation to "horizontal"', () => {
-      let fixture = createComponent(SimpleMatHorizontalStepperApp);
+      const fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
-      let stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
+      const stepperEl = fixture.debugElement.query(By.css('mat-stepper'))!.nativeElement;
       expect(stepperEl.getAttribute('aria-orientation')).toBe('horizontal');
     });
 
     it('should support using the left/right arrows to move focus', () => {
-      let fixture = createComponent(SimpleMatHorizontalStepperApp);
+      const fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
-      let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
+      const stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
       assertCorrectKeyboardInteraction(fixture, stepHeaders, 'horizontal');
     });
 
     it('should reverse arrow key focus in RTL mode', () => {
       dir.value = 'rtl';
-      let fixture = createComponent(SimpleMatHorizontalStepperApp);
+      const fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
-      let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
+      const stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
       assertArrowKeyInteractionInRtl(fixture, stepHeaders);
     });
 
     it('should reverse arrow key focus when switching into RTL after init', () => {
-      let fixture = createComponent(SimpleMatHorizontalStepperApp);
+      const fixture = createComponent(SimpleMatHorizontalStepperApp);
       fixture.detectChanges();
 
-      let stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
+      const stepHeaders = fixture.debugElement.queryAll(By.css('.mat-horizontal-stepper-header'));
       assertCorrectKeyboardInteraction(fixture, stepHeaders, 'horizontal');
 
       dir.value = 'rtl';
@@ -1246,7 +1253,7 @@ describe('MatStepper', () => {
     });
 
     it('should show done state when step is completed and its not the current step', () => {
-      let nextButtonNativeEl = fixture.debugElement
+      const nextButtonNativeEl = fixture.debugElement
           .queryAll(By.directive(MatStepperNext))[0].nativeElement;
 
       stepper.selectedIndex = 1;
@@ -1421,9 +1428,9 @@ describe('MatStepper', () => {
 function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
                                           stepHeaders: DebugElement[],
                                           orientation: StepperOrientation) {
-  let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
-  let nextKey = orientation === 'vertical' ? DOWN_ARROW : RIGHT_ARROW;
-  let prevKey = orientation === 'vertical' ? UP_ARROW : LEFT_ARROW;
+  const stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+  const nextKey = orientation === 'vertical' ? DOWN_ARROW : RIGHT_ARROW;
+  const prevKey = orientation === 'vertical' ? UP_ARROW : LEFT_ARROW;
 
   expect(stepperComponent._getFocusIndex()).toBe(0);
   expect(stepperComponent.selectedIndex).toBe(0);
@@ -1492,7 +1499,7 @@ function assertCorrectKeyboardInteraction(fixture: ComponentFixture<any>,
 /** Asserts that arrow key direction works correctly in RTL mode. */
 function assertArrowKeyInteractionInRtl(fixture: ComponentFixture<any>,
                                         stepHeaders: DebugElement[]) {
-  let stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
+  const stepperComponent = fixture.debugElement.query(By.directive(MatStepper))!.componentInstance;
 
   expect(stepperComponent._getFocusIndex()).toBe(0);
 

--- a/src/material/table/table.spec.ts
+++ b/src/material/table/table.spec.ts
@@ -37,7 +37,7 @@ describe('MatTable', () => {
 
   describe('with basic data source', () => {
     it('should be able to create a table with the right content and without when row', () => {
-      let fixture = TestBed.createComponent(MatTableApp);
+      const fixture = TestBed.createComponent(MatTableApp);
       fixture.detectChanges();
 
       const tableElement = fixture.nativeElement.querySelector('.mat-table')!;
@@ -53,7 +53,7 @@ describe('MatTable', () => {
     });
 
     it('should create a table with special when row', () => {
-      let fixture = TestBed.createComponent(MatTableWithWhenRowApp);
+      const fixture = TestBed.createComponent(MatTableWithWhenRowApp);
       fixture.detectChanges();
 
       const tableElement = fixture.nativeElement.querySelector('.mat-table');
@@ -68,7 +68,7 @@ describe('MatTable', () => {
     });
 
     it('should create a table with multiTemplateDataRows true', () => {
-      let fixture = TestBed.createComponent(MatTableWithWhenRowApp);
+      const fixture = TestBed.createComponent(MatTableWithWhenRowApp);
       fixture.componentInstance.multiTemplateDataRows = true;
       fixture.detectChanges();
 
@@ -116,7 +116,7 @@ describe('MatTable', () => {
   });
 
   it('should be able to render a table correctly with native elements', () => {
-    let fixture = TestBed.createComponent(NativeHtmlTableApp);
+    const fixture = TestBed.createComponent(NativeHtmlTableApp);
     fixture.detectChanges();
 
     const tableElement = fixture.nativeElement.querySelector('table');
@@ -168,7 +168,7 @@ describe('MatTable', () => {
   });
 
   it('should render with MatTableDataSource and sort', () => {
-    let fixture = TestBed.createComponent(MatTableWithSortApp);
+    const fixture = TestBed.createComponent(MatTableWithSortApp);
     fixture.detectChanges();
 
     const tableElement = fixture.nativeElement.querySelector('.mat-table')!;
@@ -182,7 +182,7 @@ describe('MatTable', () => {
   });
 
   it('should render with MatTableDataSource and pagination', () => {
-    let fixture = TestBed.createComponent(MatTableWithPaginatorApp);
+    const fixture = TestBed.createComponent(MatTableWithPaginatorApp);
     fixture.detectChanges();
 
     const tableElement = fixture.nativeElement.querySelector('.mat-table')!;
@@ -196,7 +196,7 @@ describe('MatTable', () => {
   });
 
   it('should apply custom sticky CSS class to sticky cells', fakeAsync(() => {
-    let fixture = TestBed.createComponent(StickyTableApp);
+    const fixture = TestBed.createComponent(StickyTableApp);
     fixture.detectChanges();
     flushMicrotasks();
 

--- a/src/material/tabs/tab-group.spec.ts
+++ b/src/material/tabs/tab-group.spec.ts
@@ -65,7 +65,7 @@ describe('MatTabGroup', () => {
     });
 
     it('should change selected index on click', () => {
-      let component = fixture.debugElement.componentInstance;
+      const component = fixture.debugElement.componentInstance;
       component.selectedIndex = 0;
       checkSelectedIndex(0, fixture);
 
@@ -81,12 +81,12 @@ describe('MatTabGroup', () => {
     });
 
     it('should support two-way binding for selectedIndex', fakeAsync(() => {
-      let component = fixture.componentInstance;
+      const component = fixture.componentInstance;
       component.selectedIndex = 0;
 
       fixture.detectChanges();
 
-      let tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
+      const tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
       tabLabel.nativeElement.click();
       fixture.detectChanges();
       tick();
@@ -96,7 +96,7 @@ describe('MatTabGroup', () => {
 
     // Note: needs to be `async` in order to fail when we expect it to.
     it('should set to correct tab on fast change', waitForAsync(() => {
-      let component = fixture.componentInstance;
+      const component = fixture.componentInstance;
       component.selectedIndex = 0;
       fixture.detectChanges();
 
@@ -115,8 +115,8 @@ describe('MatTabGroup', () => {
     }));
 
     it('should change tabs based on selectedIndex', fakeAsync(() => {
-      let component = fixture.componentInstance;
-      let tabComponent = fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
+      const component = fixture.componentInstance;
+      const tabComponent = fixture.debugElement.query(By.css('mat-tab-group'))!.componentInstance;
 
       spyOn(component, 'handleSelection').and.callThrough();
 
@@ -173,7 +173,7 @@ describe('MatTabGroup', () => {
     });
 
     it('should not crash when setting the selected index to NaN', () => {
-      let component = fixture.debugElement.componentInstance;
+      const component = fixture.debugElement.componentInstance;
 
       expect(() => {
         component.selectedIndex = NaN;
@@ -237,7 +237,7 @@ describe('MatTabGroup', () => {
       fixture.detectChanges();
 
       spyOn(fixture.componentInstance, 'animationDone');
-      let tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
+      const tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
       tabLabel.nativeElement.click();
       fixture.detectChanges();
       tick();
@@ -632,7 +632,8 @@ describe('MatTabGroup', () => {
     }));
 
     it('should support setting the header position', () => {
-      let tabGroupNode = fixture.debugElement.query(By.css('mat-tab-group'))!.nativeElement;
+      const tabGroupNode =
+          fixture.debugElement.query(By.css('mat-tab-group'))!.nativeElement;
 
       expect(tabGroupNode.classList).not.toContain('mat-tab-group-inverted-header');
 
@@ -716,7 +717,7 @@ describe('MatTabGroup', () => {
       expect(window.scrollY).toBe(250);
 
       // select the second tab
-      let tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
+      const tabLabel = fixture.debugElement.queryAll(By.css('.mat-tab-label'))[1];
       tabLabel.nativeElement.click();
       checkSelectedIndex(1, fixture);
 
@@ -748,15 +749,15 @@ describe('MatTabGroup', () => {
   function checkSelectedIndex(expectedIndex: number, fixture: ComponentFixture<any>) {
     fixture.detectChanges();
 
-    let tabComponent: MatTabGroup = fixture.debugElement
+    const tabComponent: MatTabGroup = fixture.debugElement
         .query(By.css('mat-tab-group'))!.componentInstance;
     expect(tabComponent.selectedIndex).toBe(expectedIndex);
 
-    let tabLabelElement = fixture.debugElement
+    const tabLabelElement = fixture.debugElement
         .query(By.css(`.mat-tab-label:nth-of-type(${expectedIndex + 1})`))!.nativeElement;
     expect(tabLabelElement.classList.contains('mat-tab-label-active')).toBe(true);
 
-    let tabContentElement = fixture.debugElement
+    const tabContentElement = fixture.debugElement
         .query(By.css(`mat-tab-body:nth-of-type(${expectedIndex + 1})`))!.nativeElement;
     expect(tabContentElement.classList.contains('mat-tab-body-active')).toBe(true);
   }
@@ -807,7 +808,7 @@ describe('nested MatTabGroup with enabled animations', () => {
 
   it('should not throw when creating a component with nested tab groups', fakeAsync(() => {
     expect(() => {
-      let fixture = TestBed.createComponent(NestedTabs);
+      const fixture = TestBed.createComponent(NestedTabs);
       fixture.detectChanges();
       tick();
     }).not.toThrow();
@@ -815,7 +816,7 @@ describe('nested MatTabGroup with enabled animations', () => {
 
   it('should not throw when setting an animationDuration without units', fakeAsync(() => {
     expect(() => {
-      let fixture = TestBed.createComponent(TabsWithCustomAnimationDuration);
+      const fixture = TestBed.createComponent(TabsWithCustomAnimationDuration);
       fixture.detectChanges();
       tick();
     }).not.toThrow();

--- a/src/material/tabs/tab-header.spec.ts
+++ b/src/material/tabs/tab-header.spec.ts
@@ -467,7 +467,7 @@ describe('MatTabHeader', () => {
 
         expect(header.scrollDistance).toBeGreaterThan(0, 'Expected to scroll after some time.');
 
-        let previousDistance = header.scrollDistance;
+        const previousDistance = header.scrollDistance;
 
         dispatchFakeEvent(headerElement, 'mouseleave');
         fixture.detectChanges();
@@ -504,7 +504,7 @@ describe('MatTabHeader', () => {
 
         expect(header.scrollDistance).toBeGreaterThan(0, 'Expected to scroll after some time.');
 
-        let previousDistance = header.scrollDistance;
+        const previousDistance = header.scrollDistance;
 
         tick(100);
 

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -55,8 +55,8 @@ describe('MatTabNavBar', () => {
     });
 
     it('should add the active class if active', () => {
-      let tabLink1 = fixture.debugElement.queryAll(By.css('a'))[0];
-      let tabLink2 = fixture.debugElement.queryAll(By.css('a'))[1];
+      const tabLink1 = fixture.debugElement.queryAll(By.css('a'))[0];
+      const tabLink2 = fixture.debugElement.queryAll(By.css('a'))[1];
       const tabLinkElements = fixture.debugElement.queryAll(By.css('a'))
         .map(tabLinkDebugEl => tabLinkDebugEl.nativeElement);
 
@@ -72,8 +72,8 @@ describe('MatTabNavBar', () => {
     });
 
     it('should toggle aria-current based on active state', () => {
-      let tabLink1 = fixture.debugElement.queryAll(By.css('a'))[0];
-      let tabLink2 = fixture.debugElement.queryAll(By.css('a'))[1];
+      const tabLink1 = fixture.debugElement.queryAll(By.css('a'))[0];
+      const tabLink2 = fixture.debugElement.queryAll(By.css('a'))[1];
       const tabLinkElements = fixture.debugElement.queryAll(By.css('a'))
         .map(tabLinkDebugEl => tabLinkDebugEl.nativeElement);
 
@@ -214,10 +214,10 @@ describe('MatTabNavBar', () => {
   }));
 
   it('should clean up the ripple event handlers on destroy', () => {
-    let fixture: ComponentFixture<TabLinkWithNgIf> = TestBed.createComponent(TabLinkWithNgIf);
+    const fixture: ComponentFixture<TabLinkWithNgIf> = TestBed.createComponent(TabLinkWithNgIf);
     fixture.detectChanges();
 
-    let link = fixture.debugElement.nativeElement.querySelector('.mat-tab-link');
+    const link = fixture.debugElement.nativeElement.querySelector('.mat-tab-link');
 
     fixture.componentInstance.isDestroyed = true;
     fixture.detectChanges();
@@ -229,7 +229,7 @@ describe('MatTabNavBar', () => {
   });
 
   it('should support the native tabindex attribute', () => {
-      const fixture = TestBed.createComponent(TabLinkWithNativeTabindexAttr);
+    const fixture = TestBed.createComponent(TabLinkWithNativeTabindexAttr);
     fixture.detectChanges();
 
     const tabLink = fixture.debugElement.query(By.directive(MatTabLink))!

--- a/src/material/tree/tree.spec.ts
+++ b/src/material/tree/tree.spec.ts
@@ -66,7 +66,7 @@ describe('MatTree', () => {
 
       it('with the right aria-level attrs', () => {
         // add a child to the first node
-        let data = underlyingDataSource.data;
+        const data = underlyingDataSource.data;
         underlyingDataSource.addChild(data[2]);
         component.treeControl.expandAll();
         fixture.detectChanges();
@@ -77,7 +77,7 @@ describe('MatTree', () => {
 
       it('with the right aria-expanded attrs', () => {
         // add a child to the first node
-        let data = underlyingDataSource.data;
+        const data = underlyingDataSource.data;
         underlyingDataSource.addChild(data[2]);
         fixture.detectChanges();
         expect(getNodes(treeElement).every(node => {
@@ -95,7 +95,7 @@ describe('MatTree', () => {
       it('with the right data', () => {
         expect(underlyingDataSource.data.length).toBe(3);
 
-        let data = underlyingDataSource.data;
+        const data = underlyingDataSource.data;
         expectFlatTreeToMatch(treeElement, 28,
             [`topping_1 - cheese_1 + base_1`],
             [`topping_2 - cheese_2 + base_2`],
@@ -341,7 +341,7 @@ describe('MatTree', () => {
       it('with nested child data', () => {
         expect(underlyingDataSource.data.length).toBe(3);
 
-        let data = underlyingDataSource.data;
+        const data = underlyingDataSource.data;
         const child = underlyingDataSource.addChild(data[1]);
         underlyingDataSource.addChild(child);
         fixture.detectChanges();
@@ -372,7 +372,7 @@ describe('MatTree', () => {
           return node.getAttribute('aria-level') === '1';
         })).toBe(true);
 
-        let data = underlyingDataSource.data;
+        const data = underlyingDataSource.data;
         const child = underlyingDataSource.addChild(data[1]);
         underlyingDataSource.addChild(child);
         fixture.detectChanges();
@@ -427,7 +427,7 @@ describe('MatTree', () => {
         })).toBe(true);
 
         component.toggleRecursively = false;
-        let data = underlyingDataSource.data;
+        const data = underlyingDataSource.data;
         const child = underlyingDataSource.addChild(data[1]);
         underlyingDataSource.addChild(child);
         fixture.detectChanges();
@@ -441,7 +441,7 @@ describe('MatTree', () => {
 
       it('should expand/collapse the node', () => {
         component.toggleRecursively = false;
-        let data = underlyingDataSource.data;
+        const data = underlyingDataSource.data;
         const child = underlyingDataSource.addChild(data[1]);
         underlyingDataSource.addChild(child);
 
@@ -477,7 +477,7 @@ describe('MatTree', () => {
       });
 
       it('should expand/collapse the node recursively', () => {
-        let data = underlyingDataSource.data;
+        const data = underlyingDataSource.data;
         const child = underlyingDataSource.addChild(data[1]);
         underlyingDataSource.addChild(child);
         fixture.detectChanges();


### PR DESCRIPTION
**Opening this PR as it is required to:**

- Refactor variables in several component unit tests to have constant type instead of let as this variables are not getting re-initialize during the test life-time.
- All tests within a spec should be consistent with all other tests in repo.