### PR TITLE
fix(material-experimental/mdc-tooltip): fix text alignment of multili…

### DIFF
--- a/src/material-experimental/mdc-tooltip/tooltip.html
+++ b/src/material-experimental/mdc-tooltip/tooltip.html
@@ -1,6 +1,7 @@
 <div
   class="mdc-tooltip mdc-tooltip--shown mat-mdc-tooltip"
   [ngClass]="tooltipClass"
+  [class.mdc-tooltip--multiline]="_isMultiline"
   [@state]="_visibility"
   (@state.start)="_animationStart()"
   (@state.done)="_animationDone($event)">

--- a/src/material-experimental/mdc-tooltip/tooltip.spec.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.spec.ts
@@ -865,6 +865,23 @@ describe('MDC-based MatTooltip', () => {
       fixture.destroy();
     }));
 
+    it('should set the multiline class on tooltips that have messages that overflow', fakeAsync(() => {
+      fixture.componentInstance.message = 'This is a very long message that should cause the'
+        + 'tooltip message body to overflow onto a new line.';
+      tooltipDirective.show();
+      fixture.detectChanges();
+      tick();
+
+      // Need to detect changes again to wait for the multiline class to be applied.
+      fixture.detectChanges();
+
+      const tooltipElement =
+          overlayContainerElement.querySelector('.mat-mdc-tooltip') as HTMLElement;
+
+      expect(tooltipElement.classList).toContain('mdc-tooltip--multiline');
+      expect(tooltipDirective._tooltipInstance?._isMultiline).toBeTrue();
+    }));
+
   });
 
   describe('fallback positions', () => {

--- a/src/material-experimental/mdc-tooltip/tooltip.spec.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.spec.ts
@@ -865,7 +865,7 @@ describe('MDC-based MatTooltip', () => {
       fixture.destroy();
     }));
 
-    it('should set the multiline class on tooltips that have messages that overflow', fakeAsync(() => {
+    it('should set the multiline class on tooltips with messages that overflow', fakeAsync(() => {
       fixture.componentInstance.message = 'This is a very long message that should cause the'
         + 'tooltip message body to overflow onto a new line.';
       tooltipDirective.show();

--- a/src/material-experimental/mdc-tooltip/tooltip.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.ts
@@ -122,6 +122,7 @@ export class TooltipComponent extends _TooltipComponentBase {
     super(changeDetectorRef);
   }
 
+  /** @override */
   protected _onShow(): void {
     this._isMultiline = this._isTooltipMultiline();
   }

--- a/src/material-experimental/mdc-tooltip/tooltip.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.ts
@@ -115,7 +115,20 @@ export class MatTooltip extends _MatTooltipBase<TooltipComponent> {
   }
 })
 export class TooltipComponent extends _TooltipComponentBase {
-  constructor(changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef) {
-    super(changeDetectorRef, elementRef);
+  /* Whether the tooltip text overflows to multiple lines */
+  _isMultiline: boolean = false;
+
+  constructor(changeDetectorRef: ChangeDetectorRef, private _elementRef: ElementRef) {
+    super(changeDetectorRef);
+  }
+
+  protected _onShow(): void {
+    this._isMultiline = this._isTooltipMultiline();
+  }
+
+  /** Whether the tooltip text has overflown to the next line */
+  private _isTooltipMultiline() {
+    const rect = this._elementRef.nativeElement.getBoundingClientRect();
+    return rect.height > numbers.MIN_HEIGHT && rect.width >= numbers.MAX_WIDTH;
   }
 }

--- a/src/material-experimental/mdc-tooltip/tooltip.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.ts
@@ -115,7 +115,7 @@ export class MatTooltip extends _MatTooltipBase<TooltipComponent> {
   }
 })
 export class TooltipComponent extends _TooltipComponentBase {
-  constructor(changeDetectorRef: ChangeDetectorRef) {
-    super(changeDetectorRef);
+  constructor(changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef) {
+    super(changeDetectorRef, elementRef);
   }
 }

--- a/src/material/tooltip/BUILD.bazel
+++ b/src/material/tooltip/BUILD.bazel
@@ -33,6 +33,7 @@ ng_module(
         "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@material/tooltip",
         "@npm//rxjs",
     ],
 )

--- a/src/material/tooltip/BUILD.bazel
+++ b/src/material/tooltip/BUILD.bazel
@@ -33,7 +33,6 @@ ng_module(
         "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@material/tooltip",
         "@npm//rxjs",
     ],
 )

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -43,6 +43,7 @@ import {
   AfterViewInit,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
+import {numbers} from '@material/tooltip';
 import {Observable, Subject} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
 
@@ -770,13 +771,16 @@ export abstract class _TooltipComponentBase implements OnDestroy {
   /** Property watched by the animation framework to show or hide the tooltip */
   _visibility: TooltipVisibility = 'initial';
 
+  /* Whether the tooltip text overflows to multiple lines */
+  _isMultiline: boolean = false;
+
   /** Whether interactions on the page should close the tooltip */
   private _closeOnInteraction: boolean = false;
 
   /** Subject for notifying that the tooltip has been hidden from the view */
   private readonly _onHide: Subject<void> = new Subject();
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef) {}
+  constructor(private _changeDetectorRef: ChangeDetectorRef, private _elementRef: ElementRef) {}
 
   /**
    * Shows the tooltip with an animation originating from the provided origin
@@ -791,6 +795,7 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     this._showTimeoutId = setTimeout(() => {
       this._visibility = 'visible';
       this._showTimeoutId = undefined;
+      this._isMultiline = this._isTooltipMultiline();
 
       // Mark for check so if any parent component has set the
       // ChangeDetectionStrategy to OnPush it will be checked anyways
@@ -867,6 +872,12 @@ export abstract class _TooltipComponentBase implements OnDestroy {
   _markForCheck(): void {
     this._changeDetectorRef.markForCheck();
   }
+
+  /** Whether the tooltip text has overflown to the next line */
+  private _isTooltipMultiline() {
+    const rect = this._elementRef.nativeElement.getBoundingClientRect();
+    return Number(rect.height) > numbers.MIN_HEIGHT && Number(rect.width) >= numbers.MAX_WIDTH;
+  }
 }
 
 /**
@@ -895,7 +906,8 @@ export class TooltipComponent extends _TooltipComponentBase {
 
   constructor(
     changeDetectorRef: ChangeDetectorRef,
+    elementRef: ElementRef,
     private _breakpointObserver: BreakpointObserver) {
-    super(changeDetectorRef);
+    super(changeDetectorRef, elementRef);
   }
 }

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -869,6 +869,11 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     this._changeDetectorRef.markForCheck();
   }
 
+  /**
+   * Callback for when the timeout in this.show() gets completed.
+   * This method is only needed by the mdc-tooltip, and so it is only implemented
+   * in the mdc-tooltip, not here.
+   */
   protected _onShow(): void {}
 }
 

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -43,7 +43,6 @@ import {
   AfterViewInit,
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
-import {numbers} from '@material/tooltip';
 import {Observable, Subject} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
 
@@ -771,16 +770,13 @@ export abstract class _TooltipComponentBase implements OnDestroy {
   /** Property watched by the animation framework to show or hide the tooltip */
   _visibility: TooltipVisibility = 'initial';
 
-  /* Whether the tooltip text overflows to multiple lines */
-  _isMultiline: boolean = false;
-
   /** Whether interactions on the page should close the tooltip */
   private _closeOnInteraction: boolean = false;
 
   /** Subject for notifying that the tooltip has been hidden from the view */
   private readonly _onHide: Subject<void> = new Subject();
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef, private _elementRef: ElementRef) {}
+  constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 
   /**
    * Shows the tooltip with an animation originating from the provided origin
@@ -795,7 +791,7 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     this._showTimeoutId = setTimeout(() => {
       this._visibility = 'visible';
       this._showTimeoutId = undefined;
-      this._isMultiline = this._isTooltipMultiline();
+      this._onShow();
 
       // Mark for check so if any parent component has set the
       // ChangeDetectionStrategy to OnPush it will be checked anyways
@@ -873,11 +869,7 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     this._changeDetectorRef.markForCheck();
   }
 
-  /** Whether the tooltip text has overflown to the next line */
-  private _isTooltipMultiline() {
-    const rect = this._elementRef.nativeElement.getBoundingClientRect();
-    return Number(rect.height) > numbers.MIN_HEIGHT && Number(rect.width) >= numbers.MAX_WIDTH;
-  }
+  protected _onShow(): void {}
 }
 
 /**
@@ -906,8 +898,7 @@ export class TooltipComponent extends _TooltipComponentBase {
 
   constructor(
     changeDetectorRef: ChangeDetectorRef,
-    elementRef: ElementRef,
     private _breakpointObserver: BreakpointObserver) {
-    super(changeDetectorRef, elementRef);
+    super(changeDetectorRef);
   }
 }

--- a/tools/public_api_guard/material/tooltip.d.ts
+++ b/tools/public_api_guard/material/tooltip.d.ts
@@ -56,6 +56,7 @@ export declare abstract class _TooltipComponentBase implements OnDestroy {
     _animationStart(): void;
     _handleBodyInteraction(): void;
     _markForCheck(): void;
+    protected _onShow(): void;
     afterHidden(): Observable<void>;
     hide(delay: number): void;
     isVisible(): boolean;


### PR DESCRIPTION
…ne tooltips

* Add the 'mdc-tooltip--multiline' class when a tooltip overflows
  to make the text align left (or right in rtl) instead of center