### PR TITLE
fix(cdk/schematics): avoid runtime errors thrown by devkit tree when TypeScript tries non-existent path

### DIFF
--- a/src/cdk/schematics/ng-update/test-cases/misc/module-resolution.spec.ts
+++ b/src/cdk/schematics/ng-update/test-cases/misc/module-resolution.spec.ts
@@ -1,0 +1,24 @@
+import {MIGRATION_PATH} from '../../../paths';
+import {createTestCaseSetup} from '../../../testing';
+
+describe('ng update typescript program module resolution', () => {
+
+  // Regression test for: https://github.com/angular/components/issues/22919.
+  it('should not error if module resolution tries a non-existent path where a path segment ' +
+      'matches an existing file', async () => {
+    const {runFixers, writeFile} = await createTestCaseSetup(
+      'migration-v6', MIGRATION_PATH, []);
+
+    writeFile('/node_modules/some-other-module/package.json', `{}`);
+    writeFile('/node_modules/some-other-module/styles.css', '')
+
+    // We add an import to a non-existent sub-path of `some-other-module/styles`. The TypeScript
+    // module resolution logic could try various sub-paths. This previously resulted in an error
+    // as the devkit tree `getDir` logic accidentally walked up the path and threw an error if
+    // a path segment is an actual file.
+    writeFile('/projects/cdk-testing/src/main.ts',
+        `import 'some-other-module/styles.css/non/existent';`);
+
+    await expectAsync(runFixers()).toBeResolved();
+  });
+});

--- a/src/cdk/schematics/update-tool/component-resource-collector.ts
+++ b/src/cdk/schematics/update-tool/component-resource-collector.ts
@@ -148,7 +148,7 @@ export class ComponentResourceCollector {
 
         // In case the template does not exist in the file system, skip this
         // external template.
-        if (!this._fileSystem.exists(templatePath)) {
+        if (!this._fileSystem.fileExists(templatePath)) {
           return;
         }
 

--- a/src/cdk/schematics/update-tool/file-system.ts
+++ b/src/cdk/schematics/update-tool/file-system.ts
@@ -43,8 +43,10 @@ export interface DirectoryEntry {
  * changes. This is necessary to support virtual file systems as used in the CLI devkit.
  */
 export abstract class FileSystem {
-  /** Checks whether the given file or directory exists. */
-  abstract exists(path: WorkspacePath): boolean;
+  /** Checks whether the given file exists. */
+  abstract fileExists(path: WorkspacePath): boolean;
+  /** Checks whether the given directory exists. */
+  abstract directoryExists(path: WorkspacePath): boolean;
   /** Gets the contents of the given file. */
   abstract read(filePath: WorkspacePath): string|null;
   /** Reads the given directory to retrieve children. */

--- a/src/cdk/schematics/update-tool/utils/virtual-host.ts
+++ b/src/cdk/schematics/update-tool/utils/virtual-host.ts
@@ -40,7 +40,7 @@ export class FileSystemHost implements ts.ParseConfigHost {
   constructor(private _fileSystem: FileSystem) {}
 
   fileExists(path: string): boolean {
-    return this._fileSystem.exists(this._fileSystem.resolve(path));
+    return this._fileSystem.fileExists(this._fileSystem.resolve(path));
   }
 
   readFile(path: string): string|undefined {
@@ -84,7 +84,7 @@ export function createFileSystemCompilerHost(
   host.readFile = virtualHost.readFile.bind(virtualHost);
   host.readDirectory = virtualHost.readDirectory.bind(virtualHost);
   host.fileExists = virtualHost.fileExists.bind(virtualHost);
-  host.directoryExists = (dirPath) => fileSystem.exists(fileSystem.resolve(dirPath));
+  host.directoryExists = (dirPath) => fileSystem.directoryExists(fileSystem.resolve(dirPath));
   host.getCurrentDirectory = () => '/';
   host.getCanonicalFileName = p => fileSystem.resolve(p);
 

--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
@@ -483,13 +483,13 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
    * be stored in the specified file path.
    */
   private _getAvailableGestureConfigFileName(sourceRoot: Path) {
-    if (!this.fileSystem.exists(join(sourceRoot, `${GESTURE_CONFIG_FILE_NAME}.ts`))) {
+    if (!this.fileSystem.fileExists(join(sourceRoot, `${GESTURE_CONFIG_FILE_NAME}.ts`))) {
       return `${GESTURE_CONFIG_FILE_NAME}.ts`;
     }
 
     let possibleName = `${GESTURE_CONFIG_FILE_NAME}-`;
     let index = 1;
-    while (this.fileSystem.exists(join(sourceRoot, `${possibleName}-${index}.ts`))) {
+    while (this.fileSystem.fileExists(join(sourceRoot, `${possibleName}-${index}.ts`))) {
       index++;
     }
     return `${possibleName + index}.ts`;
@@ -630,7 +630,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
   private _removeHammerFromIndexFile() {
     const indexFilePaths = getProjectIndexFiles(this.context.project);
     indexFilePaths.forEach(filePath => {
-      if (!this.fileSystem.exists(filePath)) {
+      if (!this.fileSystem.fileExists(filePath)) {
         return;
       }
 


### PR DESCRIPTION
TypeScript resolves modules using a rather complicated module
resolution algorithm. The algorithm tries various paths to
determine a possible entry-point for a module. e.g. it also
respects a containing `package.json` file, or respects the closest
`node_modules` parent directory.

In some situations, TypeScript could end up trying a path where
a parent directory segment resolves to an existent file. e.g.

consider the following directory structure:

```
node_modules/my-pkg/package.json
node_modules/my-pkg/styles.css
```

TypeScript could end up trying paths like: `node_modules/my-pkg/styles.css/package.json` or
`node_modules/my-pkg/styles.css/a/b/package.json`. This depends on how
the module resolution executes, and how the module is referenced.

In the example above though, TypeScript checks if the files exist. Our update
logic delegates this check to our virtual file system. The virtual file
system currently would throw an error by accident as it walks up the
path and discovers that `styles.css` is not a directory, _but_ a file (https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/src/tree/host-tree.ts#L321)

This results in an error as seen in
https://github.com/angular/components/issues/22919. This seems to have been introduced
accidentally with https://github.com/angular/components/pull/21161.