### PR TITLE
fix(material-experimental/button): high contrast outline for solitary icon-buttons

### DIFF
--- a/src/material-experimental/mdc-button/BUILD.bazel
+++ b/src/material-experimental/mdc-button/BUILD.bazel
@@ -20,6 +20,7 @@ ng_module(
         ],
     ),
     assets = [
+        ":button_high_contrast_scss",
         ":button_scss",
         ":fab_scss",
         ":icon-button_scss",
@@ -54,10 +55,16 @@ sass_binary(
     ],
     deps = [
         ":button_base_scss_lib",
-        "//src/cdk/a11y:a11y_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_helpers_scss_lib",
         "//src/material-experimental/mdc-helpers:mdc_scss_deps_lib",
     ],
+)
+
+sass_binary(
+    name = "button_high_contrast_scss",
+    src = "button-high-contrast.scss",
+    include_paths = ["external/npm/node_modules"],
+    deps = ["//src/cdk/a11y:a11y_scss_lib"],
 )
 
 sass_binary(

--- a/src/material-experimental/mdc-button/button-high-contrast.scss
+++ b/src/material-experimental/mdc-button/button-high-contrast.scss
@@ -1,0 +1,19 @@
+@use '../../cdk/a11y';
+
+// Add an outline to make buttons more visible in high contrast mode. Stroked buttons and FABs
+// don't need a special look in high-contrast mode, because those already have an outline.
+.mat-mdc-button:not(.mdc-button--outlined),
+.mat-mdc-unelevated-button:not(.mdc-button--outlined),
+.mat-mdc-raised-button:not(.mdc-button--outlined),
+.mat-mdc-outlined-button:not(.mdc-button--outlined),
+.mat-mdc-icon-button {
+  @include a11y.high-contrast(active, off) {
+    outline: solid 1px;
+  }
+}
+
+@include a11y.high-contrast(active, off) {
+  .mat-mdc-button-base:focus {
+    outline: solid 3px;
+  }
+}

--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -2,7 +2,6 @@
 @use '@material/button/variables' as mdc-button-variables;
 @use '../../material/core/style/private';
 @use '../mdc-helpers/mdc-helpers';
-@use '../../cdk/a11y';
 @use 'button-base';
 
 
@@ -39,24 +38,6 @@
 
   .mdc-button__label + .mat-icon {
     @include mdc-button.icon-contained-trailing();
-  }
-}
-
-// Add an outline to make buttons more visible in high contrast mode. Stroked buttons and FABs
-// don't need a special look in high-contrast mode, because those already have an outline.
-.mat-mdc-button:not(.mdc-button--outlined),
-.mat-mdc-unelevated-button:not(.mdc-button--outlined),
-.mat-mdc-raised-button:not(.mdc-button--outlined),
-.mat-mdc-outlined-button:not(.mdc-button--outlined),
-.mat-mdc-icon-button {
-  @include a11y.high-contrast(active, off) {
-    outline: solid 1px;
-  }
-}
-
-@include a11y.high-contrast(active, off) {
-  .mat-mdc-button-base:focus {
-    outline: solid 3px;
   }
 }
 

--- a/src/material-experimental/mdc-button/button.ts
+++ b/src/material-experimental/mdc-button/button.ts
@@ -42,7 +42,7 @@ import {
     button[mat-stroked-button]
   `,
   templateUrl: 'button.html',
-  styleUrls: ['button.css'],
+  styleUrls: ['button.css', 'button-high-contrast.css'],
   inputs: MAT_BUTTON_INPUTS,
   host: MAT_BUTTON_HOST,
   exportAs: 'matButton',
@@ -73,7 +73,7 @@ export class MatButton extends MatButtonBase {
   host: MAT_ANCHOR_HOST,
   inputs: MAT_ANCHOR_INPUTS,
   templateUrl: 'button.html',
-  styleUrls: ['button.css'],
+  styleUrls: ['button.css', 'button-high-contrast.css'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/material-experimental/mdc-button/icon-button.ts
+++ b/src/material-experimental/mdc-button/icon-button.ts
@@ -35,7 +35,7 @@ import {
 @Component({
   selector: `button[mat-icon-button]`,
   templateUrl: 'button.html',
-  styleUrls: ['icon-button.css'],
+  styleUrls: ['icon-button.css', 'button-high-contrast.css'],
   inputs: MAT_BUTTON_INPUTS,
   host: MAT_BUTTON_HOST,
   exportAs: 'matButton',
@@ -61,7 +61,7 @@ export class MatIconButton extends MatButtonBase {
 @Component({
   selector: `a[mat-icon-button]`,
   templateUrl: 'button.html',
-  styleUrls: ['icon-button.css'],
+  styleUrls: ['icon-button.css', 'button-high-contrast.css'],
   inputs: MAT_ANCHOR_INPUTS,
   host: MAT_ANCHOR_HOST,
   exportAs: 'matButton, matAnchor',


### PR DESCRIPTION
The high-contrast style for all buttons was previously defined in
`button.scss`, but icon-buttons load `icon-button.scss`. This means that
the high contrast style for icon buttons was only loaded when another
type of button was on the page. This change moved the icon-button high-contrast
style to `icon-button.scss`.

cc @zarend @amysorto FYI