### PR TITLE
docs: improve paginator-intl example

### DIFF
--- a/src/components-examples/material/paginator/paginator-intl/paginator-intl-example.html
+++ b/src/components-examples/material/paginator/paginator-intl/paginator-intl-example.html
@@ -1,2 +1,2 @@
-<mat-paginator [length]="0" [pageSizeOptions]="[10, 50, 100]">
+<mat-paginator [length]="200" [pageSizeOptions]="[10, 50, 100]">
 </mat-paginator>


### PR DESCRIPTION
We recently added a new example for paginator with internationalization.
For testing, the paginator has been set to `length = 0`. The example
paginator should have some items so that the various labels can be
seen in the paginator (currently there are no pages to iterate through).