### PR TITLE
build: allow for some schematics code to be linted

### DIFF
--- a/src/cdk/schematics/ng-update/test-cases/misc/module-resolution.spec.ts
+++ b/src/cdk/schematics/ng-update/test-cases/misc/module-resolution.spec.ts
@@ -10,7 +10,7 @@ describe('ng update typescript program module resolution', () => {
       'migration-v6', MIGRATION_PATH, []);
 
     writeFile('/node_modules/some-other-module/package.json', `{}`);
-    writeFile('/node_modules/some-other-module/styles.css', '')
+    writeFile('/node_modules/some-other-module/styles.css', '');
 
     // We add an import to a non-existent sub-path of `some-other-module/styles`. The TypeScript
     // module resolution logic could try various sub-paths. This previously resulted in an error

--- a/src/material/schematics/ng-update/test-cases/misc/class-inheritance.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/misc/class-inheritance.spec.ts
@@ -10,10 +10,12 @@ describe('class inheritance misc checks', () => {
 
       const {logOutput} = await runFixers();
 
+      // tslint:disable:max-line-length
       expect(logOutput).toMatch(
           /Found class "WithoutLabelProp".*extends "MatFormFieldControl.*must define "shouldLabelFloat"/);
       expect(logOutput).not.toMatch(
           /Found class "WithLabelProp".*extends "MatFormFieldControl".*must define "shouldLabelFloat"/);
+      // tslint:enable:max-line-length
     });
   });
 });

--- a/src/material/schematics/ng-update/test-cases/v12/misc/theming-api-v12.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/v12/misc/theming-api-v12.spec.ts
@@ -1,6 +1,8 @@
 import {UnitTestTree} from '@angular-devkit/schematics/testing';
 import {createTestCaseSetup} from '@angular/cdk/schematics/testing';
-import {migrateFileContent} from '@angular/material/schematics/ng-update/migrations/theming-api-v12/migration';
+import {
+  migrateFileContent
+} from '@angular/material/schematics/ng-update/migrations/theming-api-v12/migration';
 import {join} from 'path';
 import {MIGRATION_PATH} from '../../../../paths';
 

--- a/src/material/schematics/ng-update/test-cases/v9/misc/material-imports.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/v9/misc/material-imports.spec.ts
@@ -1,4 +1,8 @@
-import {createTestCaseSetup, readFileContent, resolveBazelPath} from '@angular/cdk/schematics/testing';
+import {
+  createTestCaseSetup,
+  readFileContent,
+  resolveBazelPath,
+} from '@angular/cdk/schematics/testing';
 import {MIGRATION_PATH} from '../../../../paths';
 
 describe('v9 material imports', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,7 +58,9 @@
     // Exclude schematic template files and test cases which aren't valid TS files.
     "src/material/schematics/ng-generate/*/files/**/*",
     "src/cdk/schematics/ng-generate/*/files/**/*",
-    "src/cdk/schematics/ng-update/test-cases/**/*",
-    "src/material/schematics/ng-update/test-cases/**/*"
+    "src/cdk/schematics/ng-update/test-cases/**/*_input.ts",
+    "src/cdk/schematics/ng-update/test-cases/**/*_expected_output.ts",
+    "src/material/schematics/ng-update/test-cases/**/*_input.ts",
+    "src/material/schematics/ng-update/test-cases/**/*_expected_output.ts"
   ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -224,8 +224,10 @@
       // Exclude schematic template files and test cases that can't be linted.
       "src/material/schematics/ng-generate/*/files/**/*",
       "src/cdk/schematics/ng-generate/*/files/**/*",
-      "src/cdk/schematics/ng-update/test-cases/**/*",
-      "src/material/schematics/ng-update/test-cases/**/*"
+      "src/cdk/schematics/ng-update/test-cases/**/*_input.ts",
+      "src/cdk/schematics/ng-update/test-cases/**/*_expected_output.ts",
+      "src/material/schematics/ng-update/test-cases/**/*_input.ts",
+      "src/material/schematics/ng-update/test-cases/**/*_expected_output.ts"
     ]
   }
 }


### PR DESCRIPTION
The linting setup was excluding all of the code under `schematics/test-cases`, however we only need to do it for the `_input` and `_expected_output` files.

These changes allow the files to be linted and fixes some errors that went undetected.