### PR TITLE
fix(material-experimental/mdc-select): resolve a couple of visual issues in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-select/select.scss
+++ b/src/material-experimental/mdc-select/select.scss
@@ -72,6 +72,12 @@ $scale: 0.75 !default;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+
+    @include a11y.high-contrast(active, off) {
+      // On Chromium browsers the `currentColor` blends in with the
+      // background for SVGs so we have to fall back to `CanvasText`.
+      fill: CanvasText;
+    }
   }
 }
 
@@ -161,4 +167,8 @@ $scale: 0.75 !default;
   content: ' ';
   white-space: pre;
   width: 1px;
+
+  // Prevents some browsers from rendering the element in high contrast mode.
+  display: inline-block;
+  opacity: 0;
 }

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -158,4 +158,8 @@ $placeholder-arrow-space: 2 * ($arrow-size + $arrow-margin);
   content: ' ';
   white-space: pre;
   width: 1px;
+
+  // Prevents some browsers from rendering the element in high contrast mode.
+  display: inline-block;
+  opacity: 0;
 }


### PR DESCRIPTION
* Fixes that a small rectangle is rendered over the select placeholder text.
* Fixes that the dropdown arrow wasn't visible.

For reference:
![bug](https://user-images.githubusercontent.com/4450522/122450890-d54ccb80-cfa7-11eb-85d2-a03735b7ebd8.png)
