### PR TITLE
fix(material/core): add aria-checked to checkbox options

### DIFF
--- a/src/material-experimental/mdc-core/option/option.ts
+++ b/src/material-experimental/mdc-core/option/option.ts
@@ -37,6 +37,7 @@ import {MatOptgroup} from './optgroup';
     '[class.mat-mdc-option-active]': 'active',
     '[class.mdc-deprecated-list-item--disabled]': 'disabled',
     '[id]': 'id',
+    '[attr.aria-checked]': '_getAriaChecked()',
     '[attr.aria-selected]': '_getAriaSelected()',
     '[attr.aria-disabled]': 'disabled.toString()',
     '(click)': '_selectViaInteraction()',

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -184,6 +184,14 @@ export class _MatOptionBase implements FocusableOption, AfterViewChecked, OnDest
   }
 
   /**
+   * Gets the `aria-checked` value for the option. We explicitly omit the `aria-checked`
+   * attribute from single-selection because there are no checkboxes.
+   */
+  _getAriaChecked(): boolean|null {
+    return this.multiple ? this.selected : null;
+  }
+
+  /**
    * Gets the `aria-selected` value for the option. We explicitly omit the `aria-selected`
    * attribute from single-selection, unselected options. Including the `aria-selected="false"`
    * attributes adds a significant amount of noise to screen-reader users without providing useful
@@ -244,6 +252,7 @@ export class _MatOptionBase implements FocusableOption, AfterViewChecked, OnDest
     '[class.mat-option-multiple]': 'multiple',
     '[class.mat-active]': 'active',
     '[id]': 'id',
+    '[attr.aria-checked]': '_getAriaChecked()',
     '[attr.aria-selected]': '_getAriaSelected()',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[class.mat-option-disabled]': 'disabled',

--- a/tools/public_api_guard/material/core.d.ts
+++ b/tools/public_api_guard/material/core.d.ts
@@ -26,6 +26,7 @@ export declare class _MatOptionBase implements FocusableOption, AfterViewChecked
     value: any;
     get viewValue(): string;
     constructor(_element: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _parent: MatOptionParentComponent, group: _MatOptgroupBase);
+    _getAriaChecked(): boolean | null;
     _getAriaSelected(): boolean | null;
     _getHostElement(): HTMLElement;
     _getTabIndex(): string;


### PR DESCRIPTION
Fixes an issue where the selected status of options are not read out by most SRs. The reason is
that currently we only set aria-selected and some SRs only read the selected state of unselected
options. The fix here is to also set the aria-checked attribute which SRs know to read out regardless
of whether the option is selected or not.

Fixes: #21949