### PR TITLE
refactor(material-experimental/mdc-tooltip): add override keyword to satisfy noImplicitOverride check

### DIFF
--- a/src/material-experimental/mdc-tooltip/tooltip.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.ts
@@ -122,8 +122,7 @@ export class TooltipComponent extends _TooltipComponentBase {
     super(changeDetectorRef);
   }
 
-  /** @override */
-  protected _onShow(): void {
+  protected override _onShow(): void {
     this._isMultiline = this._isTooltipMultiline();
   }
 


### PR DESCRIPTION
…satisfy noImplicitOverride

Given we merged the `noImplicitOverride` PR together with a couple of
other PRs, new methods could have been introduced that did not use
the `override` keyword. This is the case for the MDC tooltip `_onShow`
method. This commit adds the necessary `override` keyword.