### PR TITLE
feat(material/theming): support for additional palettes

### DIFF
--- a/src/material/badge/_badge-theme.scss
+++ b/src/material/badge/_badge-theme.scss
@@ -95,9 +95,8 @@ $large-size: $default-size + 6;
 }
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $primary: map.get($config, primary);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
@@ -112,17 +111,13 @@ $large-size: $default-size + 6;
     }
   }
 
-  .mat-badge-accent {
-    .mat-badge-content {
-      background: theming.get-color-from-palette($accent);
-      color: theming.get-color-from-palette($accent, default-contrast);
-    }
-  }
-
-  .mat-badge-warn {
-    .mat-badge-content {
-      color: theming.get-color-from-palette($warn, default-contrast);
-      background: theming.get-color-from-palette($warn);
+  @each $palette-key in $palettes {
+    $palette: map.get($config, $palette-key);
+    .mat-badge-#{$palette-key} {
+      .mat-badge-content {
+        background: theming.get-color-from-palette($palette);
+        color: theming.get-color-from-palette($palette, default-contrast);
+      }
     }
   }
 

--- a/src/material/button/_button-theme.scss
+++ b/src/material/button/_button-theme.scss
@@ -9,21 +9,15 @@ $_ripple-opacity: 0.1;
 
 // Applies a focus style to an mat-button element for each of the supported palettes.
 @mixin _focus-overlay-color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
 
-  &.mat-primary .mat-button-focus-overlay {
-    background-color: theming.get-color-from-palette($primary);
-  }
+  @each $palette-key in $palettes {
+    $palette: map.get($config, $palette-key);
 
-  &.mat-accent .mat-button-focus-overlay {
-    background-color: theming.get-color-from-palette($accent);
-  }
-
-  &.mat-warn .mat-button-focus-overlay {
-    background-color: theming.get-color-from-palette($warn);
+    &.mat-#{$palette-key} .mat-button-focus-overlay {
+      background-color: theming.get-color-from-palette($palette);
+    }
   }
 
   &.mat-button-disabled .mat-button-focus-overlay {
@@ -43,42 +37,36 @@ $_ripple-opacity: 0.1;
 }
 
 @mixin _ripple-color($theme, $hue, $opacity: $_ripple-opacity) {
-  $primary: map.get($theme, primary);
-  $accent: map.get($theme, accent);
-  $warn: map.get($theme, warn);
+  $palettes: theming.get-theme-palettes($theme);
 
-  &.mat-primary .mat-ripple-element {
-    @include _ripple-background($primary, $hue, $opacity);
-  }
+  @each $palette-key in $palettes {
+    $palette: map.get($theme, $palette-key);
 
-  &.mat-accent .mat-ripple-element {
-    @include _ripple-background($accent, $hue, $opacity);
-  }
-
-  &.mat-warn .mat-ripple-element {
-    @include _ripple-background($warn, $hue, $opacity);
+    &.mat-#{$palette-key} .mat-ripple-element {
+      @include _ripple-background($palette, $hue, $opacity);
+    }
   }
 }
 
 // Applies a property to an mat-button element for each of the supported palettes.
 @mixin _theme-property($theme, $property, $hue) {
-  $primary: map.get($theme, primary);
-  $accent: map.get($theme, accent);
-  $warn: map.get($theme, warn);
+  $palettes: theming.get-theme-palettes($theme);
   $background: map.get($theme, background);
   $foreground: map.get($theme, foreground);
 
-  &.mat-primary {
-    #{$property}: theming.get-color-from-palette($primary, $hue);
-  }
-  &.mat-accent {
-    #{$property}: theming.get-color-from-palette($accent, $hue);
-  }
-  &.mat-warn {
-    #{$property}: theming.get-color-from-palette($warn, $hue);
+  @each $palette-key in $palettes {
+    $palette: map.get($theme, $palette-key);
+    &.mat-#{$palette-key} {
+      #{$property}: theming.get-color-from-palette($palette, $hue);
+
+      &.mat-button-disabled {
+        $palette: if($property == 'color', $foreground, $background);
+        #{$property}: theming.get-color-from-palette($palette, disabled-button);
+      }
+    }
   }
 
-  &.mat-primary, &.mat-accent, &.mat-warn, &.mat-button-disabled {
+  &.mat-button-disabled {
     &.mat-button-disabled {
       $palette: if($property == 'color', $foreground, $background);
       #{$property}: theming.get-color-from-palette($palette, disabled-button);
@@ -88,9 +76,6 @@ $_ripple-opacity: 0.1;
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 

--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -5,11 +5,9 @@
 
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $is-dark-theme: map.get($config, is-dark);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 
@@ -43,16 +41,12 @@
   }
 
   .mat-checkbox-indeterminate, .mat-checkbox-checked {
-    &.mat-primary .mat-checkbox-background {
-      background-color: theming.get-color-from-palette($primary);
-    }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    &.mat-accent .mat-checkbox-background {
-      background-color: theming.get-color-from-palette($accent);
-    }
-
-    &.mat-warn .mat-checkbox-background {
-      background-color: theming.get-color-from-palette($warn);
+      &.mat-#{$palette-key} .mat-checkbox-background {
+        background-color: theming.get-color-from-palette($palette);
+      }
     }
   }
 
@@ -83,16 +77,12 @@
 
   .mat-checkbox-checked:not(.mat-checkbox-disabled),
   .mat-checkbox:active:not(.mat-checkbox-disabled) {
-    &.mat-primary .mat-ripple-element {
-      background: theming.get-color-from-palette($primary);
-    }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    &.mat-accent .mat-ripple-element {
-      background: theming.get-color-from-palette($accent);
-    }
-
-    &.mat-warn .mat-ripple-element {
-      background: theming.get-color-from-palette($warn);
+      &.mat-#{$palette-key} .mat-ripple-element {
+        background: theming.get-color-from-palette($palette);
+      }
     }
   }
 }

--- a/src/material/chips/_chips-theme.scss
+++ b/src/material/chips/_chips-theme.scss
@@ -41,11 +41,9 @@ $chip-remove-font-size: 18px;
 }
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $is-dark-theme: map.get($config, is-dark);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 
@@ -75,16 +73,12 @@ $chip-remove-font-size: 18px;
   }
 
   .mat-chip.mat-standard-chip.mat-chip-selected {
-    &.mat-primary {
-      @include _palette-styles($primary);
-    }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    &.mat-warn {
-      @include _palette-styles($warn);
-    }
-
-    &.mat-accent {
-      @include _palette-styles($accent);
+      &.mat-#{$palette-key} {
+        @include _palette-styles($palette);
+      }
     }
   }
 }

--- a/src/material/core/option/_option-theme.scss
+++ b/src/material/core/option/_option-theme.scss
@@ -4,12 +4,10 @@
 @use '../typography/typography-utils';
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $foreground: map.get($config, foreground);
   $background: map.get($config, background);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
 
   .mat-option {
     color: theming.get-color-from-palette($foreground, text);
@@ -34,16 +32,12 @@
     }
   }
 
-  .mat-primary .mat-option.mat-selected:not(.mat-option-disabled) {
-    color: theming.get-color-from-palette($primary, text);
-  }
+  @each $palette-key in $palettes {
+    $palette: map.get($config, $palette-key);
 
-  .mat-accent .mat-option.mat-selected:not(.mat-option-disabled) {
-    color: theming.get-color-from-palette($accent, text);
-  }
-
-  .mat-warn .mat-option.mat-selected:not(.mat-option-disabled) {
-    color: theming.get-color-from-palette($warn, text);
+    .mat-#{$palette-key} .mat-option.mat-selected:not(.mat-option-disabled) {
+      color: theming.get-color-from-palette($palette, text);
+    }
   }
 }
 

--- a/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/src/material/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -2,11 +2,9 @@
 @use '../../theming/theming';
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $is-dark-theme: map.get($config, is-dark);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
 
   // NOTE(traviskaufman): While the spec calls for translucent blacks/whites for disabled colors,
@@ -29,26 +27,23 @@
     color: $disabled-color;
   }
 
-  .mat-primary .mat-pseudo-checkbox-checked,
-  .mat-primary .mat-pseudo-checkbox-indeterminate {
-    background: theming.get-color-from-palette(map.get($config, primary));
-  }
-
   // Default to the accent color. Note that the pseudo checkboxes are meant to inherit the
   // theme from their parent, rather than implementing their own theming, which is why we
   // don't attach to the `mat-*` classes. Also note that this needs to be below `.mat-primary`
   // in order to allow for the color to be overwritten if the checkbox is inside a parent that
   // has `mat-accent` and is placed inside another parent that has `mat-primary`.
   .mat-pseudo-checkbox-checked,
-  .mat-pseudo-checkbox-indeterminate,
-  .mat-accent .mat-pseudo-checkbox-checked,
-  .mat-accent .mat-pseudo-checkbox-indeterminate {
+  .mat-pseudo-checkbox-indeterminate {
     background: theming.get-color-from-palette(map.get($config, accent));
   }
 
-  .mat-warn .mat-pseudo-checkbox-checked,
-  .mat-warn .mat-pseudo-checkbox-indeterminate {
-    background: theming.get-color-from-palette(map.get($config, warn));
+  @each $palette-key in $palettes {
+    $palette: map.get($config, $palette-key);
+
+    .mat-#{$palette-key} .mat-pseudo-checkbox-checked,
+    .mat-#{$palette-key} .mat-pseudo-checkbox-indeterminate {
+      background: theming.get-color-from-palette($palette);
+    }
   }
 
   .mat-pseudo-checkbox-checked,

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -109,28 +109,44 @@ $_emitted-density: () !default;
 
 // Creates a light-themed color configuration from the specified
 // primary, accent and warn palettes.
-@function _mat-create-light-color-config($primary, $accent, $warn: null) {
-  @return (
-    primary: $primary,
-    accent: $accent,
+@function _mat-create-light-color-config($primary, $accent: null, $warn: null) {
+  @if $accent != null {
+    $primary: (
+      primary: $primary,
+      accent: $accent,
+      warn: $warn
+    );
+  }
+
+  $warn: map.get($primary, warn);
+
+  @return map.merge($primary, (
     warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
     is-dark: false,
     foreground: palette.$light-theme-foreground-palette,
     background: palette.$light-theme-background-palette,
-  );
+  ));
 }
 
 // Creates a dark-themed color configuration from the specified
 // primary, accent and warn palettes.
-@function _mat-create-dark-color-config($primary, $accent, $warn: null) {
-  @return (
-    primary: $primary,
-    accent: $accent,
+@function _mat-create-dark-color-config($primary, $accent: null, $warn: null) {
+  @if $accent != null {
+    $primary: (
+      primary: $primary,
+      accent: $accent,
+      warn: $warn
+    );
+  }
+
+  $warn: map.get($primary, warn);
+
+  @return map.merge($primary, (
     warn: if($warn != null, $warn, define-palette(palette.$red-palette)),
     is-dark: true,
     foreground: palette.$dark-theme-foreground-palette,
     background: palette.$dark-theme-background-palette,
-  );
+  ));
 }
 
 // TODO: Remove legacy API and rename `$primary` below to `$config`. Currently it cannot be renamed
@@ -154,21 +170,22 @@ $_emitted-density: () !default;
   // If the legacy pattern is used, we generate a container object only with a light-themed
   // configuration for the `color` theming part.
   @if $accent != null {
+    $palettes: private-create-theme-palette-keys($primary);
     @return private-create-backwards-compatibility-theme(_mat-validate-theme((
       _is-legacy-theme: true,
-      color: _mat-create-light-color-config($primary, $accent, $warn),
+      color: map.merge($palettes, _mat-create-light-color-config($primary, $accent, $warn)),
     )));
   }
-  // If the map pattern is used (1), we just pass-through the configurations for individual
-  // parts of the theming system, but update the `color` configuration if set. As explained
-  // above, the color shorthand will be expanded to an actual light-themed color configuration.
+  // If the map pattern is used (1), we just pass-through the configurations, but update the
+  // `color` configuration if set. As explained above, the color shorthand will be expanded to
+  // an actual light-themed color configuration.
   $result: $primary;
   @if map.get($primary, color) {
     $color-settings: map.get($primary, color);
-    $primary: map.get($color-settings, primary);
-    $accent: map.get($color-settings, accent);
-    $warn: map.get($color-settings, warn);
-    $result: map.merge($result, (color: _mat-create-light-color-config($primary, $accent, $warn)));
+    $palettes: private-create-theme-palette-keys($primary);
+    $result: map.merge($result, (
+      color: map.merge($palettes, _mat-create-light-color-config($color-settings))
+    ));
   }
   @return private-create-backwards-compatibility-theme(_mat-validate-theme($result));
 }
@@ -194,23 +211,41 @@ $_emitted-density: () !default;
   // If the legacy pattern is used, we generate a container object only with a dark-themed
   // configuration for the `color` theming part.
   @if $accent != null {
+    $palettes: private-create-theme-palette-keys($primary);
     @return private-create-backwards-compatibility-theme(_mat-validate-theme((
       _is-legacy-theme: true,
-      color: _mat-create-dark-color-config($primary, $accent, $warn),
+      color: map.merge($palettes, _mat-create-dark-color-config($primary, $accent, $warn)),
     )));
   }
-  // If the map pattern is used (1), we just pass-through the configurations for individual
-  // parts of the theming system, but update the `color` configuration if set. As explained
-  // above, the color shorthand will be expanded to an actual dark-themed color configuration.
+  // If the map pattern is used (1), we just pass-through the configurations, but update the
+  // `color` configuration if set. As explained above, the color shorthand will be expanded to
+  // an actual dark-themed color configuration.
   $result: $primary;
   @if map.get($primary, color) {
     $color-settings: map.get($primary, color);
-    $primary: map.get($color-settings, primary);
-    $accent: map.get($color-settings, accent);
-    $warn: map.get($color-settings, warn);
-    $result: map.merge($result, (color: _mat-create-dark-color-config($primary, $accent, $warn)));
+    $palettes: private-create-theme-palette-keys($primary);
+    $result: map.merge($result, (
+      color: map.merge($palettes, _mat-create-dark-color-config($color-settings))
+    ));
   }
   @return private-create-backwards-compatibility-theme(_mat-validate-theme($result));
+}
+
+/// Gets the list of palette keys used in the theme. If the list does not exist it returns
+/// the defaults.
+/// @param {Map} $theme-or-config  The theme map returned from `define-light-theme` or
+///     `define-dark-theme`.
+/// @returns {List} List of palette keys.
+@function get-theme-palettes($theme-or-config) {
+  $palettes: map.get($theme-or-config, palettes);
+  @if not $palettes {
+    $palettes: primary accent warn;
+  }
+  @if null == index($palettes, primary) {
+    $palettes: primary accent warn;
+  }
+
+  @return $palettes;
 }
 
 /// Gets the color configuration from the given theme or configuration.
@@ -423,4 +458,23 @@ $_emitted-density: () !default;
     _is-legacy-theme: true,
     color: $theme-or-color-config
   ));
+}
+
+// Creates a list of palette keys used in the theme. This allows for extra palettes to be used
+// in theming by creating a list that can be iterated over. If a legacy theme is created without
+// the color configuration, the list contains the existing keys of `primary accent warn`.
+@function private-create-theme-palette-keys($theme) {
+  $color-settings: map.get($theme, color);
+
+  @if not $color-settings {
+    @return ( palettes: primary accent warn );
+  }
+
+  $palette-keys: primary accent warn;
+  @each $key, $palette in $color-settings {
+    @if null == index($palette-keys, $key) {
+      $palette-keys: list.append($palette-keys, $key);
+    }
+  }
+  @return ( palettes: $palette-keys);
 }

--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -61,6 +61,7 @@ $calendar-weekday-table-font-size: 11px !default;
 }
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $foreground: map.get($config, foreground);
   $background: map.get($config, background);
@@ -152,12 +153,10 @@ $calendar-weekday-table-font-size: 11px !default;
     background-color: theming.get-color-from-palette($background, card);
     color: theming.get-color-from-palette($foreground, text);
 
-    &.mat-accent {
-      @include _color(map.get($config, accent));
-    }
-
-    &.mat-warn {
-      @include _color(map.get($config, warn));
+    @each $palette-key in $palettes {
+      &.mat-#{$palette-key} {
+        @include _color(map.get($config, $palette-key));
+      }
     }
   }
 
@@ -168,12 +167,10 @@ $calendar-weekday-table-font-size: 11px !default;
   .mat-datepicker-toggle-active {
     color: theming.get-color-from-palette(map.get($config, primary), text);
 
-    &.mat-accent {
-      color: theming.get-color-from-palette(map.get($config, accent), text);
-    }
-
-    &.mat-warn {
-      color: theming.get-color-from-palette(map.get($config, warn), text);
+    @each $palette-key in $palettes {
+      &.mat-#{$palette-key} {
+        color: theming.get-color-from-palette(map.get($config, $palette-key), text);
+      }
     }
   }
 

--- a/src/material/form-field/_form-field-outline-theme.scss
+++ b/src/material/form-field/_form-field-outline-theme.scss
@@ -8,9 +8,9 @@
 // Theme styles that only apply to the outline appearance of the form-field.
 
 @mixin outline-color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
   $warn: map.get($config, warn);
   $foreground: map.get($config, foreground);
   $is-dark-theme: map.get($config, is-dark);
@@ -21,7 +21,6 @@
   $outline-color-hover:
     theming.get-color-from-palette($foreground, divider, if($is-dark-theme, 1, 0.87));
   $outline-color-primary: theming.get-color-from-palette($primary);
-  $outline-color-accent: theming.get-color-from-palette($accent);
   $outline-color-warn: theming.get-color-from-palette($warn);
   $outline-color-disabled:
     theming.get-color-from-palette($foreground, divider, if($is-dark-theme, 0.15, 0.06));
@@ -40,12 +39,10 @@
         color: $outline-color-primary;
       }
 
-      &.mat-accent .mat-form-field-outline-thick {
-        color: $outline-color-accent;
-      }
-
-      &.mat-warn .mat-form-field-outline-thick {
-        color: $outline-color-warn;
+      @each $palette-key in $palettes {
+        &.mat-#{$palette-key} .mat-form-field-outline-thick {
+          color: theming.get-color-from-palette(map.get($config, $palette-key));
+        }
       }
     }
 

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -11,6 +11,7 @@
 
 // Color styles that apply to all appearances of the form-field.
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $primary: map.get($config, primary);
   $accent: map.get($config, accent);
@@ -28,7 +29,6 @@
   // Underline colors.
   $underline-color-base:
     theming.get-color-from-palette($foreground, divider, if($is-dark-theme, 1, 0.87));
-  $underline-color-accent: theming.get-color-from-palette($accent, text);
   $underline-color-warn: theming.get-color-from-palette($warn, text);
   $underline-focused-color: theming.get-color-from-palette($primary, text);
 
@@ -43,12 +43,10 @@
   .mat-form-field.mat-focused .mat-form-field-label {
     color: $focused-label-color;
 
-    &.mat-accent {
-      color: $underline-color-accent;
-    }
-
-    &.mat-warn {
-      color: $underline-color-warn;
+    @each $palette-key in $palettes {
+      &.mat-#{$palette-key} {
+        color: theming.get-color-from-palette(map.get($config, $palette-key), text);
+      }
     }
   }
 
@@ -64,12 +62,10 @@
     .mat-form-field-ripple {
       background-color: $underline-focused-color;
 
-      &.mat-accent {
-        background-color: $underline-color-accent;
-      }
-
-      &.mat-warn {
-        background-color: $underline-color-warn;
+      @each $palette-key in $palettes {
+        &.mat-#{$palette-key} {
+          color: theming.get-color-from-palette(map.get($config, $palette-key), text);
+        }
       }
     }
   }
@@ -79,12 +75,10 @@
       color: $underline-focused-color;
     }
 
-    &.mat-accent .mat-form-field-infix::after {
-      color: $underline-color-accent;
-    }
-
-    &.mat-warn .mat-form-field-infix::after {
-      color: $underline-color-warn;
+    @each $palette-key in $palettes {
+      &.mat-#{$palette-key} .mat-form-field-infix::after {
+        color: theming.get-color-from-palette(map.get($config, $palette-key), text);
+      }
     }
   }
 
@@ -95,15 +89,17 @@
     .mat-form-field-label {
       color: $underline-color-warn;
 
-      &.mat-accent,
-      .mat-form-field-required-marker {
-        color: $underline-color-warn;
+      @each $palette-key in $palettes {
+        &.mat-#{$palette-key} .mat-form-field-required-marker {
+          color: $underline-color-warn;
+        }
       }
     }
 
-    .mat-form-field-ripple,
-    .mat-form-field-ripple.mat-accent {
-      background-color: $underline-color-warn;
+    @each $palette-key in $palettes {
+      .mat-form-field-ripple, .mat-form-field-ripple.mat-#{$palette-key} {
+        background-color: $underline-color-warn;
+      }
     }
   }
 

--- a/src/material/icon/_icon-theme.scss
+++ b/src/material/icon/_icon-theme.scss
@@ -2,24 +2,19 @@
 @use '../core/theming/theming';
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 
   .mat-icon {
-    &.mat-primary {
-      color: theming.get-color-from-palette($primary, text);
-    }
 
-    &.mat-accent {
-      color: theming.get-color-from-palette($accent, text);
-    }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    &.mat-warn {
-      color: theming.get-color-from-palette($warn, text);
+      &.mat-#{$palette-key} {
+        color: theming.get-color-from-palette($palette, text);
+      }
     }
   }
 }

--- a/src/material/input/_input-theme.scss
+++ b/src/material/input/_input-theme.scss
@@ -9,9 +9,9 @@
 
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
   $warn: map.get($config, warn);
   $foreground: map.get($config, foreground);
 
@@ -47,11 +47,14 @@
     }
   }
 
-  .mat-form-field.mat-accent .mat-input-element {
-    caret-color: theming.get-color-from-palette($accent, text);
+  @each $palette-key in $palettes {
+    $palette: map.get($config, $palette-key);
+
+    .mat-form-field.mat-#{$palette-key} .mat-input-element {
+      caret-color: theming.get-color-from-palette($palette, text);
+    }
   }
 
-  .mat-form-field.mat-warn .mat-input-element,
   .mat-form-field-invalid .mat-input-element {
     caret-color: theming.get-color-from-palette($warn, text);
   }

--- a/src/material/progress-bar/_progress-bar-theme.scss
+++ b/src/material/progress-bar/_progress-bar-theme.scss
@@ -15,10 +15,9 @@
 }
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get(map.get($config, background), background);
 
   .mat-progress-bar-background {
@@ -33,31 +32,21 @@
     background-color: theming.get-color-from-palette($primary);
   }
 
-  .mat-progress-bar.mat-accent {
-    .mat-progress-bar-background {
-      fill: _get-buffer-color($accent, $background);
-    }
+  @each $palette-key in $palettes {
+    $palette: map.get($config, $palette-key);
 
-    .mat-progress-bar-buffer {
-      background-color: _get-buffer-color($accent, $background);
-    }
+    .mat-progress-bar.mat-#{$palette-key} {
+      .mat-progress-bar-background {
+        fill: _get-buffer-color($palette, $background);
+      }
 
-    .mat-progress-bar-fill::after {
-      background-color: theming.get-color-from-palette($accent);
-    }
-  }
+      .mat-progress-bar-buffer {
+        background-color: _get-buffer-color($palette, $background);
+      }
 
-  .mat-progress-bar.mat-warn {
-    .mat-progress-bar-background {
-      fill: _get-buffer-color($warn, $background);
-    }
-
-    .mat-progress-bar-buffer {
-      background-color: _get-buffer-color($warn, $background);
-    }
-
-    .mat-progress-bar-fill::after {
-      background-color: theming.get-color-from-palette($warn);
+      .mat-progress-bar-fill::after {
+        background-color: theming.get-color-from-palette($palette);
+      }
     }
   }
 }

--- a/src/material/progress-spinner/_progress-spinner-theme.scss
+++ b/src/material/progress-spinner/_progress-spinner-theme.scss
@@ -2,22 +2,21 @@
 @use '../core/theming/theming';
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
 
   .mat-progress-spinner, .mat-spinner {
     circle {
       stroke: theming.get-color-from-palette($primary);
     }
 
-    &.mat-accent circle {
-      stroke: theming.get-color-from-palette($accent);
-    }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    &.mat-warn circle {
-      stroke: theming.get-color-from-palette($warn);
+      &.mat-#{$palette-key} circle {
+        stroke: theming.get-color-from-palette($palette);
+      }
     }
   }
 }

--- a/src/material/radio/_radio-theme.scss
+++ b/src/material/radio/_radio-theme.scss
@@ -17,10 +17,8 @@
 }
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 
@@ -29,16 +27,13 @@
   }
 
   .mat-radio-button {
-    &.mat-primary {
-      @include _color($primary);
-    }
 
-    &.mat-accent {
-      @include _color($accent);
-    }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    &.mat-warn {
-      @include _color($warn);
+      &.mat-#{$palette-key} {
+        @include _color($palette);
+      }
     }
 
     // This needs extra specificity, because the classes above are combined

--- a/src/material/select/_select-theme.scss
+++ b/src/material/select/_select-theme.scss
@@ -7,11 +7,10 @@
 
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $foreground: map.get($config, foreground);
   $background: map.get($config, background);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
   $warn: map.get($config, warn);
 
   .mat-select-value {
@@ -41,16 +40,11 @@
 
   .mat-form-field {
     &.mat-focused {
-      &.mat-primary .mat-select-arrow {
-        color: theming.get-color-from-palette($primary, text);
-      }
-
-      &.mat-accent .mat-select-arrow {
-        color: theming.get-color-from-palette($accent, text);
-      }
-
-      &.mat-warn .mat-select-arrow {
-        color: theming.get-color-from-palette($warn, text);
+      @each $palette-key in $palettes {
+        $palette: map.get($config, $palette-key);
+        &.mat-#{$palette-key} .mat-select-arrow {
+          color: theming.get-color-from-palette($palette, text);
+        }
       }
     }
 

--- a/src/material/sidenav/_sidenav-theme.scss
+++ b/src/material/sidenav/_sidenav-theme.scss
@@ -6,9 +6,6 @@
 
 @mixin color($config-or-theme) {
   $config: theming.get-color-config($config-or-theme);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 

--- a/src/material/slide-toggle/_slide-toggle-theme.scss
+++ b/src/material/slide-toggle/_slide-toggle-theme.scss
@@ -26,11 +26,10 @@
 }
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $is-dark: map.get($config, is-dark);
-  $primary: map.get($config, primary);
   $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 
@@ -49,12 +48,12 @@
   .mat-slide-toggle {
     @include _checked-color($accent, $thumb-checked-hue);
 
-    &.mat-primary {
-      @include _checked-color($primary, $thumb-checked-hue);
-    }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    &.mat-warn {
-      @include _checked-color($warn, $thumb-checked-hue);
+      &.mat-#{$palette-key} {
+        @include _checked-color($palette, $thumb-checked-hue);
+      }
     }
 
     &:not(.mat-checked) .mat-ripple-element {

--- a/src/material/slider/_slider-theme.scss
+++ b/src/material/slider/_slider-theme.scss
@@ -29,10 +29,8 @@
 }
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 
@@ -52,16 +50,12 @@
     background-color: $mat-slider-off-color;
   }
 
-  .mat-primary {
-    @include _inner-content-theme($primary);
-  }
+  @each $palette-key in $palettes {
+    $palette: map.get($config, $palette-key);
 
-  .mat-accent {
-    @include _inner-content-theme($accent);
-  }
-
-  .mat-warn {
-    @include _inner-content-theme($warn);
+    .mat-#{$palette-key} {
+      @include _inner-content-theme($palette);
+    }
   }
 
   .mat-slider:hover,

--- a/src/material/stepper/_stepper-theme.scss
+++ b/src/material/stepper/_stepper-theme.scss
@@ -7,11 +7,11 @@
 @use './stepper-variables';
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
   $foreground: map.get($config, foreground);
   $background: map.get($config, background);
   $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
   $warn: map.get($config, warn);
 
   .mat-step-header {
@@ -51,29 +51,20 @@
       color: theming.get-color-from-palette($primary, default-contrast);
     }
 
-    &.mat-accent {
-      .mat-step-icon {
-        color: theming.get-color-from-palette($accent, default-contrast);
-      }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-      .mat-step-icon-selected,
-      .mat-step-icon-state-done,
-      .mat-step-icon-state-edit {
-        background-color: theming.get-color-from-palette($accent);
-        color: theming.get-color-from-palette($accent, default-contrast);
-      }
-    }
+      &.mat-#{$palette-key} {
+        .mat-step-icon {
+          color: theming.get-color-from-palette($palette, default-contrast);
+        }
 
-    &.mat-warn {
-      .mat-step-icon {
-        color: theming.get-color-from-palette($warn, default-contrast);
-      }
-
-      .mat-step-icon-selected,
-      .mat-step-icon-state-done,
-      .mat-step-icon-state-edit {
-        background-color: theming.get-color-from-palette($warn);
-        color: theming.get-color-from-palette($warn, default-contrast);
+        .mat-step-icon-selected,
+        .mat-step-icon-state-done,
+        .mat-step-icon-state-edit {
+          background-color: theming.get-color-from-palette($palette);
+          color: theming.get-color-from-palette($palette, default-contrast);
+        }
       }
     }
 

--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -4,10 +4,8 @@
 @use '../core/typography/typography-utils';
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
   $header-border: 1px solid theming.get-color-from-palette($foreground, divider);
@@ -49,32 +47,26 @@
   }
 
   .mat-tab-group, .mat-tab-nav-bar {
-    $theme-colors: (
-      primary: $primary,
-      accent: $accent,
-      warn: $warn
-    );
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    @each $name, $color in $theme-colors {
       // Set the foreground color of the tabs
-      &.mat-#{$name} {
-        @include _label-focus-color($color);
-        @include _ink-bar-color($color);
+      &.mat-#{$palette-key} {
+        @include _label-focus-color($palette);
+        @include _ink-bar-color($palette);
 
         // Override ink bar when background color is the same
-        &.mat-background-#{$name} {
+        &.mat-background-#{$palette-key} {
           > .mat-tab-header, > .mat-tab-link-container {
-            @include _ink-bar-color($color, default-contrast);
+            @include _ink-bar-color($palette, default-contrast);
           }
         }
       }
-    }
 
-    @each $name, $color in $theme-colors {
       // Set background color of the tabs and override focus color
-      &.mat-background-#{$name} {
-        @include _label-focus-color($color);
-        @include _tabs-background($color);
+      &.mat-background-#{$palette-key} {
+        @include _label-focus-color($palette);
+        @include _tabs-background($palette);
       }
     }
   }

--- a/src/material/toolbar/_toolbar-theme.scss
+++ b/src/material/toolbar/_toolbar-theme.scss
@@ -41,10 +41,8 @@
 }
 
 @mixin color($config-or-theme) {
+  $palettes: theming.get-theme-palettes($config-or-theme);
   $config: theming.get-color-config($config-or-theme);
-  $primary: map.get($config, primary);
-  $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
   $background: map.get($config, background);
   $foreground: map.get($config, foreground);
 
@@ -52,16 +50,12 @@
     background: theming.get-color-from-palette($background, app-bar);
     color: theming.get-color-from-palette($foreground, text);
 
-    &.mat-primary {
-      @include _palette-styles($primary);
-    }
+    @each $palette-key in $palettes {
+      $palette: map.get($config, $palette-key);
 
-    &.mat-accent {
-      @include _palette-styles($accent);
-    }
-
-    &.mat-warn {
-      @include _palette-styles($warn);
+      &.mat-#{$palette-key} {
+        @include _palette-styles($palette);
+      }
     }
 
     @include _form-field-overrides;


### PR DESCRIPTION
Add support for additional palettes outside of the
standard primary, accent, and warn palettes.

Closes #22430