### PR TITLE
fix(cdk/drag-drop): resolve various event tracking issues inside the shadow dom

### DIFF
--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -224,7 +224,7 @@ describe('DragDropRegistry', () => {
 
   it('should dispatch `scroll` events if the viewport is scrolled while dragging', () => {
     const spy = jasmine.createSpy('scroll spy');
-    const subscription = registry.scroll.subscribe(spy);
+    const subscription = registry.scrolled().subscribe(spy);
     const item = new DragItem();
 
     registry.startDragging(item, createMouseEvent('mousedown'));
@@ -236,7 +236,7 @@ describe('DragDropRegistry', () => {
 
   it('should not dispatch `scroll` events when not dragging', () => {
     const spy = jasmine.createSpy('scroll spy');
-    const subscription = registry.scroll.subscribe(spy);
+    const subscription = registry.scrolled().subscribe(spy);
 
     dispatchFakeEvent(document, 'scroll');
 

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -899,33 +899,35 @@ export class DropListRef<T = any> {
    * Used for updating the internal state of the list.
    */
   private _listenToScrollEvents() {
-    this._viewportScrollSubscription = this._dragDropRegistry.scroll.subscribe(event => {
-      if (this.isDragging()) {
-        const scrollDifference = this._parentPositions.handleScroll(event);
+    this._viewportScrollSubscription = this._dragDropRegistry
+      .scrolled(this._getShadowRoot())
+      .subscribe(event => {
+        if (this.isDragging()) {
+          const scrollDifference = this._parentPositions.handleScroll(event);
 
-        if (scrollDifference) {
-          // Since we know the amount that the user has scrolled we can shift all of the
-          // client rectangles ourselves. This is cheaper than re-measuring everything and
-          // we can avoid inconsistent behavior where we might be measuring the element before
-          // its position has changed.
-          this._itemPositions.forEach(({clientRect}) => {
-            adjustClientRect(clientRect, scrollDifference.top, scrollDifference.left);
-          });
+          if (scrollDifference) {
+            // Since we know the amount that the user has scrolled we can shift all of the
+            // client rectangles ourselves. This is cheaper than re-measuring everything and
+            // we can avoid inconsistent behavior where we might be measuring the element before
+            // its position has changed.
+            this._itemPositions.forEach(({clientRect}) => {
+              adjustClientRect(clientRect, scrollDifference.top, scrollDifference.left);
+            });
 
-          // We need two loops for this, because we want all of the cached
-          // positions to be up-to-date before we re-sort the item.
-          this._itemPositions.forEach(({drag}) => {
-            if (this._dragDropRegistry.isDragging(drag)) {
-              // We need to re-sort the item manually, because the pointer move
-              // events won't be dispatched while the user is scrolling.
-              drag._sortFromLastPointerPosition();
-            }
-          });
+            // We need two loops for this, because we want all of the cached
+            // positions to be up-to-date before we re-sort the item.
+            this._itemPositions.forEach(({drag}) => {
+              if (this._dragDropRegistry.isDragging(drag)) {
+                // We need to re-sort the item manually, because the pointer move
+                // events won't be dispatched while the user is scrolling.
+                drag._sortFromLastPointerPosition();
+              }
+            });
+          }
+        } else if (this.isReceiving()) {
+          this._cacheParentPositions();
         }
-      } else if (this.isReceiving()) {
-        this._cacheParentPositions();
-      }
-    });
+      });
   }
 
   /**

--- a/src/cdk/drag-drop/parent-position-tracker.ts
+++ b/src/cdk/drag-drop/parent-position-tracker.ts
@@ -47,7 +47,7 @@ export class ParentPositionTracker {
 
   /** Handles scrolling while a drag is taking place. */
   handleScroll(event: Event): ScrollPosition | null {
-    const target = event.target as HTMLElement | Document;
+    const target = getEventTarget(event);
     const cachedPosition = this.positions.get(target);
 
     if (!cachedPosition) {
@@ -87,4 +87,9 @@ export class ParentPositionTracker {
 
     return {top: topDifference, left: leftDifference};
   }
+}
+
+/** Gets the target of an event while accounting for shadow dom. */
+export function getEventTarget(event: Event): HTMLElement | Document {
+  return (event.composedPath ? event.composedPath()[0] : event.target) as HTMLElement | Document;
 }

--- a/tools/public_api_guard/cdk/drag-drop.d.ts
+++ b/tools/public_api_guard/cdk/drag-drop.d.ts
@@ -254,6 +254,7 @@ export declare class DragDropRegistry<I extends {
     registerDropContainer(drop: C): void;
     removeDragItem(drag: I): void;
     removeDropContainer(drop: C): void;
+    scrolled(shadowRoot?: DocumentOrShadowRoot | null): Observable<Event>;
     startDragging(drag: I, event: TouchEvent | MouseEvent): void;
     stopDragging(drag: I): void;
     static ɵfac: i0.ɵɵFactoryDeclaration<DragDropRegistry<any, any>, never>;


### PR DESCRIPTION
The `drag-drop` module depends on a single document-level `scroll` listener in order to adjust itself when the page or an element is scrolled. The problem is that the events won't be picked up if they come from inside a shadow root.

These changes add some logic to bind an extra event at the shadow root level. Furthermore, they fix several places where we were reading the `Event.target` while not accounting for shadow DOM.

Fixes #22939.