### PR TITLE
fix(material-experimental/mdc-button): not disabling animations under noop animations module

### DIFF
--- a/src/material-experimental/mdc-button/button.scss
+++ b/src/material-experimental/mdc-button/button.scss
@@ -1,5 +1,6 @@
 @use '@material/button/button' as mdc-button;
 @use '@material/button/variables' as mdc-button-variables;
+@use '../../material/core/style/private';
 @use '../mdc-helpers/mdc-helpers';
 @use '../../cdk/a11y';
 @use 'button-base';
@@ -11,6 +12,7 @@
   @include button-base.mat-private-button-interactive();
   @include button-base.mat-private-button-disabled();
   @include button-base.mat-private-button-touch-target(false);
+  @include private.private-animation-noop();
 }
 
 // MDC expects button icons to contain this HTML content:

--- a/src/material-experimental/mdc-button/fab.scss
+++ b/src/material-experimental/mdc-button/fab.scss
@@ -1,4 +1,5 @@
 @use '@material/fab' as mdc-fab;
+@use '../../material/core/style/private';
 @use '../mdc-helpers/mdc-helpers';
 @use 'button-base';
 
@@ -8,6 +9,7 @@
   @include button-base.mat-private-button-interactive();
   @include button-base.mat-private-button-disabled();
   @include button-base.mat-private-button-touch-target(true);
+  @include private.private-animation-noop();
 
   // MDC adds some styles to fab and mini-fab that conflict with some of our focus indicator
   // styles and don't actually do anything. This undoes those conflicting styles.

--- a/src/material-experimental/mdc-button/icon-button.scss
+++ b/src/material-experimental/mdc-button/icon-button.scss
@@ -1,4 +1,5 @@
 @use '@material/icon-button' as mdc-icon-button;
+@use '../../material/core/style/private';
 @use '../mdc-helpers/mdc-helpers';
 @use 'button-base';
 
@@ -14,6 +15,7 @@
 
   @include button-base.mat-private-button-disabled();
   @include button-base.mat-private-button-touch-target(true);
+  @include private.private-animation-noop();
 
   // MDC adds some styles to icon buttons that conflict with some of our focus indicator styles
   // and don't actually do anything. This undoes those conflicting styles.


### PR DESCRIPTION
Fixes that the MDC-based buttons weren't disabling their animations when noop animations are enabled.