### PR TITLE
fix(material/datepicker): incorrect appearance when used in MDC form field

### DIFF
--- a/src/material/datepicker/date-range-input.ts
+++ b/src/material/datepicker/date-range-input.ts
@@ -247,7 +247,9 @@ export class MatDateRangeInput<D> implements MatFormFieldControl<DateRange<D>>,
     // The datepicker module can be used both with MDC and non-MDC form fields. We have
     // to conditionally add the MDC input class so that the range picker looks correctly.
     if (_formField?._elementRef.nativeElement.classList.contains('mat-mdc-form-field')) {
-      _elementRef.nativeElement.classList.add('mat-mdc-input-element');
+      const classList = _elementRef.nativeElement.classList;
+      classList.add('mat-mdc-input-element');
+      classList.add('mat-mdc-form-field-control');
     }
 
     // TODO(crisbeto): remove `as any` after #18206 lands.


### PR DESCRIPTION
We were missing the `mat-mdc-form-field-control` class on the date range input which caused its start input to disappear, because it didn't have a line height.