### PR TITLE
build: fix wrong variable reference

### DIFF
--- a/src/material-experimental/mdc-menu/menu.scss
+++ b/src/material-experimental/mdc-menu/menu.scss
@@ -98,7 +98,7 @@ mat-menu {
 }
 
 .mat-mdc-menu-submenu-icon {
-  @include menu-common.item-submenu-icon(mdc-list.$deprecated-side-padding);
+  @include menu-common.item-submenu-icon(mdc-list-variables.$side-padding);
 }
 
 // Increase specificity because ripple styles are part of the `mat-core` mixin and can


### PR DESCRIPTION
A couple of conflicting PRs were merged in at the same time which is causing a build error, because an import was removed.