### PR TITLE
build: enable automatic test module teardown

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('AutocompleteHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/badge/badge-harness/badge-harness-example.spec.ts
+++ b/src/components-examples/material/badge/badge-harness/badge-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('BadgeHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
+++ b/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('BottomSheetHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/button-toggle/button-toggle-harness/button-toggle-harness-example.spec.ts
+++ b/src/components-examples/material/button-toggle/button-toggle-harness/button-toggle-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('ButtonToggleHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
+++ b/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('ButtonHarnessExample', () => {
   let buttonHarness = MatButtonHarness;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
+++ b/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('CardHarnessExample', () => {
   let fixture: ComponentFixture<CardHarnessExample>;
   let loader: HarnessLoader;
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
+++ b/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('CheckboxHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
+++ b/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('ChipsHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
+++ b/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
@@ -17,7 +17,9 @@ describe('DatepickerHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
+++ b/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('DialogHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(waitForAsync(async () => {

--- a/src/components-examples/material/divider/divider-harness/divider-harness-example.spec.ts
+++ b/src/components-examples/material/divider/divider-harness/divider-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('DividerHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
+++ b/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('ExpansionHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
+++ b/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
@@ -18,7 +18,9 @@ describe('FormFieldHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
+++ b/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('GridListHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
+++ b/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
@@ -16,7 +16,9 @@ describe('IconHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
+++ b/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
@@ -16,7 +16,9 @@ describe('InputHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/list/list-harness/list-harness-example.spec.ts
+++ b/src/components-examples/material/list/list-harness/list-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('ListHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
+++ b/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('MenuHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
+++ b/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
@@ -16,7 +16,9 @@ describe('PaginatorHarnessExample', () => {
   let instance: PaginatorHarnessExample;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/progress-bar/progress-bar-harness/progress-bar-harness-example.spec.ts
+++ b/src/components-examples/material/progress-bar/progress-bar-harness/progress-bar-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('ProgressBarHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/progress-spinner/progress-spinner-harness/progress-spinner-harness-example.spec.ts
+++ b/src/components-examples/material/progress-spinner/progress-spinner-harness/progress-spinner-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('ProgressSpinnerHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/radio/radio-harness/radio-harness-example.spec.ts
+++ b/src/components-examples/material/radio/radio-harness/radio-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('RadioHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
+++ b/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('SelectHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
+++ b/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
@@ -18,7 +18,9 @@ describe('SidenavHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/slide-toggle/slide-toggle-harness/slide-toggle-harness-example.spec.ts
+++ b/src/components-examples/material/slide-toggle/slide-toggle-harness/slide-toggle-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('SlideToggleHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
+++ b/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('SliderHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
@@ -16,7 +16,9 @@ describe('SnackBarHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
+++ b/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('SortHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
+++ b/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
@@ -16,7 +16,9 @@ describe('StepperHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/table/table-harness/table-harness-example.spec.ts
+++ b/src/components-examples/material/table/table-harness/table-harness-example.spec.ts
@@ -14,7 +14,9 @@ describe('TableHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
+++ b/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('TabGroupHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.spec.ts
+++ b/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('ToolbarHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
+++ b/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('TooltipHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/components-examples/material/tree/tree-harness/tree-harness-example.spec.ts
+++ b/src/components-examples/material/tree/tree-harness/tree-harness-example.spec.ts
@@ -15,7 +15,9 @@ describe('TreeHarnessExample', () => {
   let loader: HarnessLoader;
 
   beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+      teardown: {destroyAfterEach: true}
+    });
   });
 
   beforeEach(async () => {

--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -37,21 +37,20 @@ interface Point {
 describe('MDC-based MatSlider' , () => {
   let platform: Platform;
 
-  beforeAll(() => {
-    platform = TestBed.inject(Platform);
-    // Mock #setPointerCapture as it throws errors on pointerdown without a real pointerId.
-    spyOn(Element.prototype, 'setPointerCapture');
-  });
-
   function createComponent<T>(
     component: Type<T>,
     providers: Provider[] = [],
-    ): ComponentFixture<T> {
+  ): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [FormsModule, MatSliderModule, ReactiveFormsModule, BidiModule],
       declarations: [component],
       providers: [...providers],
     }).compileComponents();
+
+    platform = TestBed.inject(Platform);
+    // Mock #setPointerCapture as it throws errors on pointerdown without a real pointerId.
+    spyOn(Element.prototype, 'setPointerCapture');
+
     return TestBed.createComponent<T>(component);
   }
 

--- a/test/angular-test-init-spec.ts
+++ b/test/angular-test-init-spec.ts
@@ -1,5 +1,4 @@
-import {NgModuleRef} from '@angular/core';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
@@ -9,64 +8,11 @@ import {
  * Common setup / initialization for all unit tests in Angular Material and CDK.
  */
 
-const testBed =
-    TestBed.initTestEnvironment([BrowserDynamicTestingModule], platformBrowserDynamicTesting());
-patchTestBedToDestroyFixturesAfterEveryTest(testBed);
+TestBed.initTestEnvironment([BrowserDynamicTestingModule], platformBrowserDynamicTesting(), {
+  teardown: {destroyAfterEach: true}
+});
 
 (window as any).module = {};
 (window as any).isNode = false;
 (window as any).isBrowser = true;
 (window as any).global = window;
-
-
-/**
- * Monkey-patches TestBed.resetTestingModule such that any errors that occur during component
- * destruction are thrown instead of silently logged. Also runs TestBed.resetTestingModule after
- * each unit test.
- *
- * Without this patch, the combination of two behaviors is problematic for Angular Material:
- * - TestBed.resetTestingModule catches errors thrown on fixture destruction and logs them without
- *     the errors ever being thrown. This means that any component errors that occur in ngOnDestroy
- *     can encounter errors silently and still pass unit tests.
- * - TestBed.resetTestingModule is only called *before* a test is run, meaning that even *if* the
- *    aforementioned errors were thrown, they would be reported for the wrong test (the test that's
- *    about to start, not the test that just finished).
- */
-function patchTestBedToDestroyFixturesAfterEveryTest(testBedInstance: TestBed) {
-  // Original resetTestingModule function of the TestBed.
-  const _resetTestingModule = testBedInstance.resetTestingModule;
-
-  // Monkey-patch the resetTestingModule to destroy fixtures outside of a try/catch block.
-  // With https://github.com/angular/angular/commit/2c5a67134198a090a24f6671dcdb7b102fea6eba
-  // errors when destroying components are no longer causing Jasmine to fail.
-  testBedInstance.resetTestingModule = function(this: {
-    /** List of active fixtures in the current testing module. */
-    _activeFixtures: ComponentFixture<any>[],
-    /** Module Ref used in the Ivy TestBed for creating components. */
-    _testModuleRef?: NgModuleRef<unknown>|null,
-    /** Module Ref used in the View Engine TestBed for creating components. */
-    _moduleRef?: NgModuleRef<unknown>|null
-  }) {
-    try {
-      const moduleRef = this._testModuleRef || this._moduleRef;
-      this._activeFixtures.forEach((fixture: ComponentFixture<any>) => fixture.destroy());
-      // Destroy the TestBed `NgModule` reference to clear out shared styles that would
-      // otherwise remain in DOM and significantly increase memory consumption in browsers.
-      // This increased consumption then results in noticeable test instability and slow-down.
-      // See: https://github.com/angular/angular/issues/31834.
-      if (moduleRef != null) {
-        moduleRef.destroy();
-      }
-    } finally {
-      this._activeFixtures = [];
-      // Regardless of errors or not, run the original reset testing module function.
-      _resetTestingModule.call(this);
-    }
-  };
-
-  // Angular's testing package resets the testing module before each test. This doesn't work well
-  // for us because it doesn't allow developers to see what test actually failed.
-  // Fixing this by resetting the testing module after each test.
-  // https://github.com/angular/angular/blob/master/packages/core/testing/src/before_each.ts#L25
-  afterEach(() => testBedInstance.resetTestingModule());
-}


### PR DESCRIPTION
Angular 12.1.0 includes [opt-in automatic test module teardown](https://github.com/angular/angular/pull/42566) which is similar to our logic of destroying the current fixture. These changes clean up our monkey patches and use the new option instead.