### PR TITLE
fix(material-experimental/mdc-core): incorrect typography for mat-option

### DIFF
--- a/src/material-experimental/mdc-core/option/_option-theme.scss
+++ b/src/material-experimental/mdc-core/option/_option-theme.scss
@@ -55,10 +55,12 @@
       theming.get-typography-config($config-or-theme));
 
   @include mdc-helpers.mat-using-mdc-typography($config) {
-    // MDC uses the `subtitle1` level for list items, but the spec shows `body1` as the correct
-    // level. Class is repeated for increased specificity.
-    .mat-mdc-option .mdc-list-item__primary-text {
-      @include mdc-typography.typography(body1, $query: mdc-helpers.$mat-typography-styles-query);
+    @if (typography.private-typography-is-2014-config($config)) {
+      // MDC uses the `subtitle1` level for list items, but the spec shows `body1` as the correct
+      // level under the 2014 spec. Class is repeated for increased specificity.
+      .mat-mdc-option .mdc-list-item__primary-text {
+        @include mdc-typography.typography(body1, $query: mdc-helpers.$mat-typography-styles-query);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes that `mat-option` uses an incorrect typography config under the most recent spec.