### PR TITLE
fix(material/checkbox): inconsistent disabled color

### DIFF
--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -71,7 +71,7 @@
     }
 
     .mat-checkbox-label {
-      color: theming.get-color-from-palette($foreground, secondary-text);
+      color: theming.get-color-from-palette($foreground, disabled);
     }
   }
 


### PR DESCRIPTION
The checkbox was using `secondary` text when it's disabled which is inconsistent and incorrect, because all other components use `disabled`.

Fixes #23081.