### PR TITLE
refactor(multiple): enable `noImplicitOverride` typescript option (#22830)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "check-mdc-tests": "ts-node --project scripts/tsconfig.json scripts/check-mdc-tests.ts",
     "check-mdc-exports": "ts-node --project scripts/tsconfig.json scripts/check-mdc-exports.ts",
     "check-tools": "yarn tsc --project tools/tsconfig-ci.json",
+    "tsc": "node ./node_modules/typescript/bin/tsc",
     "prepare": "husky install"
   },
   "version": "12.1.0",

--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -14,6 +14,7 @@
     "strictNullChecks": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
+    "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/src/cdk-experimental/dialog/dialog-container.ts
+++ b/src/cdk-experimental/dialog/dialog-container.ts
@@ -196,7 +196,7 @@ export class CdkDialogContainer extends BasePortalOutlet implements OnDestroy {
    * @deprecated To be turned into a method.
    * @breaking-change 10.0.0
    */
-  attachDomPortal = (portal: DomPortal) => {
+  override attachDomPortal = (portal: DomPortal) => {
     if (this._portalHost.hasAttached() && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throwDialogContentAlreadyAttachedError();
     }

--- a/src/cdk-experimental/menu/menu-bar.ts
+++ b/src/cdk-experimental/menu/menu-bar.ts
@@ -86,7 +86,7 @@ export class CdkMenuBar extends CdkMenuGroup implements Menu, AfterContentInit, 
     super();
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     super.ngAfterContentInit();
 
     this._setKeyManager();
@@ -287,7 +287,7 @@ export class CdkMenuBar extends CdkMenuGroup implements Menu, AfterContentInit, 
     return !!this._openItem;
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
 
     this._destroyed.next();

--- a/src/cdk-experimental/menu/menu-item-checkbox.ts
+++ b/src/cdk-experimental/menu/menu-item-checkbox.ts
@@ -31,7 +31,7 @@ import {CdkMenuItem} from './menu-item';
 })
 export class CdkMenuItemCheckbox extends CdkMenuItemSelectable {
   /** Toggle the checked state of the checkbox. */
-  trigger() {
+  override trigger() {
     super.trigger();
 
     if (!this.disabled) {

--- a/src/cdk-experimental/menu/menu-item-radio.ts
+++ b/src/cdk-experimental/menu/menu-item-radio.ts
@@ -63,7 +63,7 @@ export class CdkMenuItemRadio extends CdkMenuItemSelectable implements OnDestroy
   }
 
   /** Toggles the checked state of the radio-button. */
-  trigger() {
+  override trigger() {
     super.trigger();
 
     if (!this.disabled) {
@@ -71,7 +71,7 @@ export class CdkMenuItemRadio extends CdkMenuItemSelectable implements OnDestroy
     }
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
     this._removeDispatcherListener();
   }

--- a/src/cdk-experimental/menu/menu-item-selectable.ts
+++ b/src/cdk-experimental/menu/menu-item-selectable.ts
@@ -40,7 +40,7 @@ export abstract class CdkMenuItemSelectable extends CdkMenuItem {
   @Input() id: string = `cdk-selectable-item-${nextId++}`;
 
   /** If the element is not disabled emit the click event */
-  trigger() {
+  override trigger() {
     if (!this.disabled) {
       this.toggled.next(this);
     }

--- a/src/cdk-experimental/menu/menu-stack.ts
+++ b/src/cdk-experimental/menu/menu-stack.ts
@@ -130,5 +130,5 @@ export class MenuStack {
 /** NoopMenuStack is a placeholder MenuStack used for inline menus. */
 export class NoopMenuStack extends MenuStack {
   /** Noop push - does not add elements to the MenuStack. */
-  push(_: MenuStackItem) {}
+  override push(_: MenuStackItem) {}
 }

--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -124,7 +124,7 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnI
     this._registerWithParentPanel();
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     super.ngAfterContentInit();
 
     this._completeChangeEmitter();
@@ -348,7 +348,7 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnI
     return this._menuStack instanceof NoopMenuStack;
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     this._emitClosedEvent();
     this._pointerTracker?.destroy();
   }

--- a/src/cdk-experimental/popover-edit/table-directives.ts
+++ b/src/cdk-experimental/popover-edit/table-directives.ts
@@ -362,7 +362,7 @@ export class CdkPopoverEdit<C> implements AfterViewInit, OnDestroy {
   inputs: POPOVER_EDIT_INPUTS,
 })
 export class CdkPopoverEditTabOut<C> extends CdkPopoverEdit<C> {
-  protected focusTrap?: FocusEscapeNotifier;
+  protected override focusTrap?: FocusEscapeNotifier;
 
   constructor(
       elementRef: ElementRef, viewContainerRef: ViewContainerRef, services: EditServices,
@@ -370,7 +370,7 @@ export class CdkPopoverEditTabOut<C> extends CdkPopoverEdit<C> {
     super(services, elementRef, viewContainerRef);
   }
 
-  protected initFocusTrap(): void {
+  protected override initFocusTrap(): void {
     this.focusTrap = this.focusEscapeNotifierFactory.create(this.overlayRef!.overlayElement);
 
     this.focusTrap.escapes().pipe(takeUntil(this.destroyed)).subscribe(direction => {

--- a/src/cdk/a11y/focus-trap/configurable-focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/configurable-focus-trap.ts
@@ -21,8 +21,8 @@ import {ConfigurableFocusTrapConfig} from './configurable-focus-trap-config';
  */
 export class ConfigurableFocusTrap extends FocusTrap implements ManagedFocusTrap {
   /** Whether the FocusTrap is enabled. */
-  get enabled(): boolean { return this._enabled; }
-  set enabled(value: boolean) {
+  override get enabled(): boolean { return this._enabled; }
+  override set enabled(value: boolean) {
     this._enabled = value;
     if (this._enabled) {
       this._focusTrapManager.register(this);
@@ -44,7 +44,7 @@ export class ConfigurableFocusTrap extends FocusTrap implements ManagedFocusTrap
   }
 
   /** Notifies the FocusTrapManager that this FocusTrap will be destroyed. */
-  destroy() {
+  override destroy() {
     this._focusTrapManager.deregister(this);
     super.destroy();
   }

--- a/src/cdk/a11y/key-manager/activedescendant-key-manager.ts
+++ b/src/cdk/a11y/key-manager/activedescendant-key-manager.ts
@@ -29,7 +29,7 @@ export class ActiveDescendantKeyManager<T> extends ListKeyManager<Highlightable 
    * from the previously active item.
    * @param index Index of the item to be set as active.
    */
-  setActiveItem(index: number): void;
+  override setActiveItem(index: number): void;
 
   /**
    * Sets the active item to the item to the specified one and adds the
@@ -37,9 +37,9 @@ export class ActiveDescendantKeyManager<T> extends ListKeyManager<Highlightable 
    * previously active item.
    * @param item Item to be set as active.
    */
-  setActiveItem(item: T): void;
+  override setActiveItem(item: T): void;
 
-  setActiveItem(index: any): void {
+  override setActiveItem(index: any): void {
     if (this.activeItem) {
       this.activeItem.setInactiveStyles();
     }

--- a/src/cdk/a11y/key-manager/focus-key-manager.ts
+++ b/src/cdk/a11y/key-manager/focus-key-manager.ts
@@ -36,15 +36,15 @@ export class FocusKeyManager<T> extends ListKeyManager<FocusableOption & T> {
    * index and focuses the newly active item.
    * @param index Index of the item to be set as active.
    */
-  setActiveItem(index: number): void;
+  override setActiveItem(index: number): void;
 
   /**
    * Sets the active item to the item that is specified and focuses it.
    * @param item Item to be set as active.
    */
-  setActiveItem(item: T): void;
+  override setActiveItem(item: T): void;
 
-  setActiveItem(item: any): void {
+  override setActiveItem(item: any): void {
     super.setActiveItem(item);
 
     if (this.activeItem) {

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -6711,7 +6711,7 @@ class DraggableWithCanvasInDropZone extends DraggableInDropZone implements After
     super(elementRef);
   }
 
-  ngAfterViewInit() {
+  override ngAfterViewInit() {
     super.ngAfterViewInit();
     const canvases = this._elementRef.nativeElement.querySelectorAll('canvas');
 

--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.ts
@@ -25,7 +25,7 @@ export class OverlayKeyboardDispatcher extends BaseOverlayDispatcher {
   }
 
   /** Add a new overlay to the list of attached overlay refs. */
-  add(overlayRef: OverlayReference): void {
+  override add(overlayRef: OverlayReference): void {
     super.add(overlayRef);
 
     // Lazily start dispatcher once first overlay is added

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.ts
@@ -27,7 +27,7 @@ export class OverlayOutsideClickDispatcher extends BaseOverlayDispatcher {
   }
 
   /** Add a new overlay to the list of attached overlay refs. */
-  add(overlayRef: OverlayReference): void {
+  override add(overlayRef: OverlayReference): void {
     super.add(overlayRef);
 
     // Safari on iOS does not generate click events for non-interactive

--- a/src/cdk/overlay/fullscreen-overlay-container.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.ts
@@ -28,7 +28,7 @@ export class FullscreenOverlayContainer extends OverlayContainer implements OnDe
     super(_document, platform);
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
 
     if (this._fullScreenEventName && this._fullScreenListener) {
@@ -36,7 +36,7 @@ export class FullscreenOverlayContainer extends OverlayContainer implements OnDe
     }
   }
 
-  protected _createContainer(): void {
+  protected override _createContainer(): void {
     super._createContainer();
     this._adjustParentForFullscreenChange();
     this._addFullscreenChangeListener(() => this._adjustParentForFullscreenChange());

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -337,7 +337,7 @@ describe('Overlay', () => {
     class CustomErrorHandler extends ErrorHandler {
       constructor(private _overlay: Overlay) { super(); }
 
-      handleError(error: any) {
+      override handleError(error: any) {
         const overlayRef = this._overlay.create({hasBackdrop: !!error});
         overlayRef.dispose();
       }

--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -115,7 +115,7 @@ export class DomPortalOutlet extends BasePortalOutlet {
    * @deprecated To be turned into a method.
    * @breaking-change 10.0.0
    */
-  attachDomPortal = (portal: DomPortal) => {
+  override attachDomPortal = (portal: DomPortal) => {
     // @breaking-change 10.0.0 Remove check and error once the
     // `_document` constructor parameter is required.
     if (!this._document && (typeof ngDevMode === 'undefined' || ngDevMode)) {
@@ -146,7 +146,7 @@ export class DomPortalOutlet extends BasePortalOutlet {
   /**
    * Clears out a portal from the DOM.
    */
-  dispose(): void {
+  override dispose(): void {
     super.dispose();
     if (this.outletElement.parentNode != null) {
       this.outletElement.parentNode.removeChild(this.outletElement);

--- a/src/cdk/portal/portal-directives.ts
+++ b/src/cdk/portal/portal-directives.ts
@@ -195,7 +195,7 @@ export class CdkPortalOutlet extends BasePortalOutlet implements OnInit, OnDestr
    * @deprecated To be turned into a method.
    * @breaking-change 10.0.0
    */
-  attachDomPortal = (portal: DomPortal) => {
+  override attachDomPortal = (portal: DomPortal) => {
     // @breaking-change 9.0.0 Remove check and error once the
     // `_document` constructor parameter is required.
     if (!this._document && (typeof ngDevMode === 'undefined' || ngDevMode)) {

--- a/src/cdk/portal/portal.ts
+++ b/src/cdk/portal/portal.ts
@@ -144,12 +144,12 @@ export class TemplatePortal<C = any> extends Portal<EmbeddedViewRef<C>> {
    * When a context is provided it will override the `context` property of the `TemplatePortal`
    * instance.
    */
-  attach(host: PortalOutlet, context: C | undefined = this.context): EmbeddedViewRef<C> {
+  override attach(host: PortalOutlet, context: C | undefined = this.context): EmbeddedViewRef<C> {
     this.context = context;
     return super.attach(host);
   }
 
-  detach(): void {
+  override detach(): void {
     this.context = undefined;
     return super.detach();
   }

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -152,7 +152,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   /** Subscription to changes in the viewport size. */
   private _viewportChanges = Subscription.EMPTY;
 
-  constructor(public elementRef: ElementRef<HTMLElement>,
+  constructor(public override elementRef: ElementRef<HTMLElement>,
               private _changeDetectorRef: ChangeDetectorRef,
               ngZone: NgZone,
               @Optional() @Inject(VIRTUAL_SCROLL_STRATEGY)
@@ -171,7 +171,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     });
   }
 
-  ngOnInit() {
+  override ngOnInit() {
     super.ngOnInit();
 
     // It's still too early to measure the viewport at this point. Deferring with a promise allows
@@ -196,7 +196,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     }));
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     this.detach();
     this._scrollStrategy.detach();
 
@@ -350,7 +350,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
    * @param from The edge to measure the offset from. Defaults to 'top' in vertical mode and 'start'
    *     in horizontal mode.
    */
-  measureScrollOffset(from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number {
+  override measureScrollOffset(
+      from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number {
     return from ?
       super.measureScrollOffset(from) :
       super.measureScrollOffset(this.orientation === 'horizontal' ? 'start' : 'top');

--- a/src/cdk/table/row.ts
+++ b/src/cdk/table/row.ts
@@ -104,7 +104,7 @@ export class CdkHeaderRowDef extends _CdkHeaderRowDefBase implements CanStick, O
 
   // Prerender fails to recognize that ngOnChanges in a part of this class through inheritance.
   // Explicitly define it so that the method is called as part of the Angular lifecycle.
-  ngOnChanges(changes: SimpleChanges): void {
+  override ngOnChanges(changes: SimpleChanges): void {
     super.ngOnChanges(changes);
   }
 
@@ -135,7 +135,7 @@ export class CdkFooterRowDef extends _CdkFooterRowDefBase implements CanStick, O
 
   // Prerender fails to recognize that ngOnChanges in a part of this class through inheritance.
   // Explicitly define it so that the method is called as part of the Angular lifecycle.
-  ngOnChanges(changes: SimpleChanges): void {
+  override ngOnChanges(changes: SimpleChanges): void {
     super.ngOnChanges(changes);
   }
 

--- a/src/cdk/testing/private/mock-ng-zone.ts
+++ b/src/cdk/testing/private/mock-ng-zone.ts
@@ -18,17 +18,17 @@ import {EventEmitter, Injectable, NgZone} from '@angular/core';
  */
 @Injectable()
 export class MockNgZone extends NgZone {
-  readonly onStable = new EventEmitter(false);
+  override readonly onStable = new EventEmitter(false);
 
   constructor() {
     super({enableLongStackTrace: false});
   }
 
-  run(fn: Function): any {
+  override run(fn: Function): any {
     return fn();
   }
 
-  runOutsideAngular(fn: Function): any {
+  override runOutsideAngular(fn: Function): any {
     return fn();
   }
 

--- a/src/cdk/testing/tests/harnesses/sub-component-harness.ts
+++ b/src/cdk/testing/tests/harnesses/sub-component-harness.ts
@@ -41,5 +41,5 @@ export class SubComponentHarness extends ComponentHarness {
 }
 
 export class SubComponentSpecialHarness extends SubComponentHarness {
-  static readonly hostSelector = 'test-sub.test-special';
+  static override readonly hostSelector = 'test-sub.test-special';
 }

--- a/src/cdk/tree/control/flat-tree-control.ts
+++ b/src/cdk/tree/control/flat-tree-control.ts
@@ -18,7 +18,8 @@ export class FlatTreeControl<T, K = T> extends BaseTreeControl<T, K> {
 
   /** Construct with flat tree data node functions getLevel and isExpandable. */
   constructor(
-      public getLevel: (dataNode: T) => number, public isExpandable: (dataNode: T) => boolean,
+      public override getLevel: (dataNode: T) => number,
+      public override isExpandable: (dataNode: T) => boolean,
       public options?: FlatTreeControlOptions<T, K>) {
     super();
 

--- a/src/cdk/tree/control/nested-tree-control.ts
+++ b/src/cdk/tree/control/nested-tree-control.ts
@@ -18,7 +18,7 @@ export interface NestedTreeControlOptions<T, K> {
 export class NestedTreeControl<T, K = T> extends BaseTreeControl<T, K> {
   /** Construct with nested tree function getChildren. */
   constructor(
-      public getChildren: (dataNode: T) => (Observable<T[]>| T[] | undefined | null),
+      public override getChildren: (dataNode: T) => (Observable<T[]>| T[] | undefined | null),
       public options?: NestedTreeControlOptions<T, K>) {
     super();
 

--- a/src/cdk/tree/nested-node.ts
+++ b/src/cdk/tree/nested-node.ts
@@ -55,15 +55,15 @@ export class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K>
   })
   nodeOutlet: QueryList<CdkTreeNodeOutlet>;
 
-  constructor(protected _elementRef: ElementRef<HTMLElement>,
-              protected _tree: CdkTree<T, K>,
+  constructor(elementRef: ElementRef<HTMLElement>,
+              tree: CdkTree<T, K>,
               protected _differs: IterableDiffers) {
-    super(_elementRef, _tree);
+    super(elementRef, tree);
     // The classes are directly added here instead of in the host property because classes on
     // the host property are not inherited with View Engine. It is not set as a @HostBinding because
     // it is not set by the time it's children nodes try to read the class from it.
     // TODO: move to host after View Engine deprecation
-    this._elementRef.nativeElement.classList.add('cdk-nested-tree-node');
+    elementRef.nativeElement.classList.add('cdk-nested-tree-node');
   }
 
   ngAfterContentInit() {
@@ -84,15 +84,15 @@ export class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K>
 
   // This is a workaround for https://github.com/angular/angular/issues/23091
   // In aot mode, the lifecycle hooks from parent class are not called.
-  ngOnInit() {
+  override ngOnInit() {
     super.ngOnInit();
   }
 
-  ngDoCheck() {
+  override ngDoCheck() {
     super.ngDoCheck();
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     this._clear();
     super.ngOnDestroy();
   }

--- a/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.ts
+++ b/src/components-examples/material/stepper/stepper-intl/stepper-intl-example.ts
@@ -5,7 +5,7 @@ import {MatStepperIntl} from '@angular/material/stepper';
 @Injectable()
 export class StepperIntl extends MatStepperIntl {
   // the default optional label text, if unspecified is "Optional"
-  optionalLabel = 'Optional Label';
+  override optionalLabel = 'Optional Label';
 }
 
 /**

--- a/src/google-maps/map-bicycling-layer/map-bicycling-layer.ts
+++ b/src/google-maps/map-bicycling-layer/map-bicycling-layer.ts
@@ -30,16 +30,16 @@ export class MapBicyclingLayer extends MapBaseLayer {
    */
   bicyclingLayer?: google.maps.BicyclingLayer;
 
-  protected _initializeObject() {
+  protected override _initializeObject() {
     this.bicyclingLayer = new google.maps.BicyclingLayer();
   }
 
-  protected _setMap() {
+  protected override _setMap() {
     this._assertLayerInitialized();
     this.bicyclingLayer.setMap(this._map.googleMap!);
   }
 
-  protected _unsetMap() {
+  protected override _unsetMap() {
     if (this.bicyclingLayer) {
       this.bicyclingLayer.setMap(null);
     }

--- a/src/google-maps/map-transit-layer/map-transit-layer.ts
+++ b/src/google-maps/map-transit-layer/map-transit-layer.ts
@@ -30,16 +30,16 @@ export class MapTransitLayer extends MapBaseLayer {
    */
   transitLayer?: google.maps.TransitLayer;
 
-  protected _initializeObject() {
+  protected override _initializeObject() {
     this.transitLayer = new google.maps.TransitLayer();
   }
 
-  protected _setMap() {
+  protected override _setMap() {
     this._assertLayerInitialized();
     this.transitLayer.setMap(this._map.googleMap!);
   }
 
-  protected _unsetMap() {
+  protected override _unsetMap() {
     if (this.transitLayer) {
       this.transitLayer.setMap(null);
     }

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -236,17 +236,17 @@ abstract class BaseTestComponent {
 
 @Directive()
 abstract class BaseTestComponentRtl extends BaseTestComponent {
-  direction = 'rtl';
+  override direction = 'rtl';
 
-  getColumnOriginPosition(index: number): number {
+  override getColumnOriginPosition(index: number): number {
     return this.getColumnElement(index).offsetLeft;
   }
 
-  updateResizeWithMouseInProgress(totalDelta: number): void {
+  override updateResizeWithMouseInProgress(totalDelta: number): void {
     super.updateResizeWithMouseInProgress(-totalDelta);
   }
 
-  completeResizeWithMouseInProgress(totalDelta: number): void {
+  override completeResizeWithMouseInProgress(totalDelta: number): void {
     super.completeResizeWithMouseInProgress(-totalDelta);
   }
 }

--- a/src/material-experimental/column-resize/overlay-handle.ts
+++ b/src/material-experimental/column-resize/overlay-handle.ts
@@ -60,7 +60,7 @@ export class MatColumnResizeOverlayHandle extends ResizeOverlayHandle {
     this.document = document;
   }
 
-  protected updateResizeActive(active: boolean): void {
+  protected override updateResizeActive(active: boolean): void {
     super.updateResizeActive(active);
 
     this.resizeRef.overlayRef.updateSize({

--- a/src/material-experimental/column-resize/resizable-directives/common.ts
+++ b/src/material-experimental/column-resize/resizable-directives/common.ts
@@ -11,13 +11,13 @@ import {Resizable} from '@angular/cdk-experimental/column-resize';
 import {MatColumnResizeOverlayHandle} from '../overlay-handle';
 
 export abstract class AbstractMatResizable extends Resizable<MatColumnResizeOverlayHandle> {
-  minWidthPxInternal = 32;
+  override minWidthPxInternal = 32;
 
-  protected getInlineHandleCssClassName(): string {
+  protected override getInlineHandleCssClassName(): string {
     return 'mat-resizable-handle';
   }
 
-  protected getOverlayHandleComponentType(): Type<MatColumnResizeOverlayHandle> {
+  protected override getOverlayHandleComponentType(): Type<MatColumnResizeOverlayHandle> {
     return MatColumnResizeOverlayHandle;
   }
 }

--- a/src/material-experimental/column-resize/resize-strategy.ts
+++ b/src/material-experimental/column-resize/resize-strategy.ts
@@ -32,7 +32,7 @@ export class MatFlexTableResizeStrategy extends CdkFlexTableResizeStrategy {
     super(columnResize, styleScheduler, table, document);
   }
 
-  protected getColumnCssClass(cssFriendlyColumnName: string): string {
+  protected override getColumnCssClass(cssFriendlyColumnName: string): string {
     return `mat-column-${cssFriendlyColumnName}`;
   }
 }

--- a/src/material-experimental/mdc-button/fab.ts
+++ b/src/material-experimental/mdc-button/fab.ts
@@ -85,7 +85,7 @@ const defaults = MAT_FAB_DEFAULT_OPTIONS_FACTORY();
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatFabButton extends MatButtonBase {
-  _isFab = true;
+  override _isFab = true;
 
   private _extended: boolean;
   get extended(): boolean { return this._extended; }
@@ -119,7 +119,7 @@ export class MatFabButton extends MatButtonBase {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatMiniFabButton extends MatButtonBase {
-  _isFab = true;
+  override _isFab = true;
 
   constructor(
     elementRef: ElementRef, platform: Platform, ngZone: NgZone,
@@ -169,7 +169,7 @@ export class MatMiniFabButton extends MatButtonBase {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatFabAnchor extends MatAnchor {
-  _isFab = true;
+  override _isFab = true;
 
   private _extended: boolean;
   get extended(): boolean { return this._extended; }
@@ -204,7 +204,7 @@ export class MatFabAnchor extends MatAnchor {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MatMiniFabAnchor extends MatAnchor {
-  _isFab = true;
+  override _isFab = true;
 
   constructor(
     elementRef: ElementRef, platform: Platform, ngZone: NgZone,

--- a/src/material-experimental/mdc-button/icon-button.ts
+++ b/src/material-experimental/mdc-button/icon-button.ts
@@ -44,7 +44,7 @@ import {
 })
 export class MatIconButton extends MatButtonBase {
   // Set the ripple to be centered for icon buttons
-  _isRippleCentered = true;
+  override _isRippleCentered = true;
 
   constructor(
       elementRef: ElementRef, platform: Platform, ngZone: NgZone,
@@ -70,7 +70,7 @@ export class MatIconButton extends MatButtonBase {
 })
 export class MatIconAnchor extends MatAnchorBase {
   // Set the ripple to be centered for icon buttons
-  _isRippleCentered = true;
+  override _isRippleCentered = true;
 
   constructor(
       elementRef: ElementRef, platform: Platform, ngZone: NgZone,

--- a/src/material-experimental/mdc-checkbox/checkbox.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.ts
@@ -30,7 +30,6 @@ import {
   MatCheckboxDefaultOptions, MAT_CHECKBOX_DEFAULT_OPTIONS_FACTORY
 } from '@angular/material/checkbox';
 import {
-  ThemePalette,
   RippleAnimationConfig,
   mixinColor,
   mixinDisabled,
@@ -104,9 +103,6 @@ export class MatCheckbox extends _MatCheckboxBase implements AfterViewInit, OnDe
 
   /** The 'aria-describedby' attribute is read after the element's label and field type. */
   @Input('aria-describedby') ariaDescribedby: string;
-
-  /** The color palette  for this checkbox ('primary', 'accent', or 'warn'). */
-  @Input() color: ThemePalette;
 
   /** Whether the label should appear after or before the checkbox. Defaults to 'after'. */
   @Input() labelPosition: 'before'|'after' = 'after';

--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -137,8 +137,10 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
    * @docs-private
    */
   @Input()
-  get disabled(): boolean { return this.ngControl ? !!this.ngControl.disabled : this._disabled; }
-  set disabled(value: boolean) {
+  override get disabled(): boolean {
+    return this.ngControl ? !!this.ngControl.disabled : this._disabled;
+  }
+  override set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);
     this._syncChipsState();
   }
@@ -153,13 +155,13 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  get empty(): boolean {
+  override get empty(): boolean {
     return (!this._chipInput || this._chipInput.empty) &&
         (!this._chips || this._chips.length === 0);
   }
 
-    /** The ARIA role applied to the chip grid. */
-  get role(): string | null { return this.empty ? null : 'grid'; }
+  /** The ARIA role applied to the chip grid. */
+  override get role(): string | null { return this.empty ? null : 'grid'; }
 
   /**
    * Implemented as part of MatFormFieldControl.
@@ -177,7 +179,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   protected _placeholder: string;
 
   /** Whether any chips or the matChipInput inside of this chip-grid has focus. */
-  get focused(): boolean { return this._chipInput.focused || this._hasFocusedChip(); }
+  override get focused(): boolean { return this._chipInput.focused || this._hasFocusedChip(); }
 
   /**
    * Implemented as part of MatFormFieldControl.
@@ -209,7 +211,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   protected _value: any[] = [];
 
   /** An object used to control when error messages are shown. */
-  @Input() errorStateMatcher: ErrorStateMatcher;
+  @Input() override errorStateMatcher: ErrorStateMatcher;
 
   /** Combined stream of all of the child chips' blur events. */
   get chipBlurChanges(): Observable<MatChipEvent> {
@@ -237,7 +239,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     // indirect descendants if it's left as false.
     descendants: true
   })
-  _chips: QueryList<MatChipRow>;
+  override _chips: QueryList<MatChipRow>;
 
   constructor(_elementRef: ElementRef,
               _changeDetectorRef: ChangeDetectorRef,
@@ -245,8 +247,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
               @Optional() _parentForm: NgForm,
               @Optional() _parentFormGroup: FormGroupDirective,
               _defaultErrorStateMatcher: ErrorStateMatcher,
-              /** @docs-private */
-              @Optional() @Self() public ngControl: NgControl) {
+              @Optional() @Self() ngControl: NgControl) {
     super(_elementRef, _changeDetectorRef, _dir, _defaultErrorStateMatcher, _parentForm,
         _parentFormGroup, ngControl);
     if (this.ngControl) {
@@ -254,7 +255,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     }
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     super.ngAfterContentInit();
     this._initKeyManager();
 
@@ -266,7 +267,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     });
   }
 
-  ngAfterViewInit() {
+  override ngAfterViewInit() {
     super.ngAfterViewInit();
     if (!this._chipInput && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw Error('mat-chip-grid must be used in combination with matChipInputFor.');
@@ -282,7 +283,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     }
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
     this.stateChanges.complete();
   }
@@ -307,7 +308,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
    * Focuses the first chip in this chip grid, or the associated input when there
    * are no eligible chips.
    */
-  focus(): void {
+  override focus(): void {
     if (this.disabled || this._chipInput.focused) {
       return;
     }
@@ -420,7 +421,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   }
 
   /** Unsubscribes from all chip events. */
-  protected _dropSubscriptions() {
+  protected override _dropSubscriptions() {
     super._dropSubscriptions();
     if (this._chipBlurSubscription) {
       this._chipBlurSubscription.unsubscribe();
@@ -434,7 +435,7 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
   }
 
   /** Subscribes to events on the child chips. */
-  protected _subscribeToChipEvents() {
+  protected override _subscribeToChipEvents() {
     super._subscribeToChipEvents();
     this._listenToChipsFocus();
     this._listenToChipsBlur();
@@ -515,6 +516,8 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     this._chipInput.focus();
   }
 
-  static ngAcceptInputType_disabled: BooleanInput;
+  // Even though this member is inherited, we explicitly need to set it here as the `disabled`
+  // input is overwritten in this class too. This is needed for the lint rule.
+  static override ngAcceptInputType_disabled: BooleanInput;
   static ngAcceptInputType_required: BooleanInput;
 }

--- a/src/material-experimental/mdc-chips/chip-icons.ts
+++ b/src/material-experimental/mdc-chips/chip-icons.ts
@@ -202,7 +202,7 @@ export class MatChipRemove extends _MatChipRemoveMixinBase implements CanDisable
     event.stopPropagation();
   }
 
-  focus() {
+  override focus() {
     this._elementRef.nativeElement.focus();
   }
 

--- a/src/material-experimental/mdc-chips/chip-listbox.ts
+++ b/src/material-experimental/mdc-chips/chip-listbox.ts
@@ -110,7 +110,7 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
   _onChange: (value: any) => void = () => {};
 
   /** The ARIA role applied to the chip listbox. */
-  get role(): string | null { return this.empty ? null : 'listbox'; }
+  override get role(): string | null { return this.empty ? null : 'listbox'; }
 
   /** Whether the user should be allowed to select multiple chips. */
   @Input()
@@ -201,12 +201,12 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
     // indirect descendants if it's left as false.
     descendants: true
   })
-  _chips: QueryList<MatChipOption>;
+  override _chips: QueryList<MatChipOption>;
 
-  constructor(protected _elementRef: ElementRef,
-              _changeDetectorRef: ChangeDetectorRef,
+  constructor(elementRef: ElementRef,
+              changeDetectorRef: ChangeDetectorRef,
               @Optional() _dir: Directionality) {
-    super(_elementRef, _changeDetectorRef, _dir);
+    super(elementRef, changeDetectorRef, _dir);
     this._chipSetAdapter.selectChipAtIndex = (index: number, selected: boolean) => {
       this._setSelected(index, selected);
     };
@@ -215,7 +215,7 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
     this._updateMdcSelectionClasses();
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     super.ngAfterContentInit();
     this._initKeyManager();
 
@@ -235,7 +235,7 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
    * Focuses the first selected chip in this chip listbox, or the first non-disabled chip when there
    * are no selected chips.
    */
-  focus(): void {
+  override focus(): void {
     if (this.disabled) {
       return;
     }
@@ -472,7 +472,7 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
   }
 
   /** Unsubscribes from all chip events. */
-  protected _dropSubscriptions() {
+  protected override _dropSubscriptions() {
     super._dropSubscriptions();
     if (this._chipSelectionSubscription) {
       this._chipSelectionSubscription.unsubscribe();
@@ -491,7 +491,7 @@ export class MatChipListbox extends MatChipSet implements AfterContentInit, Cont
   }
 
   /** Subscribes to events on the child chips. */
-  protected _subscribeToChipEvents() {
+  protected override _subscribeToChipEvents() {
     super._subscribeToChipEvents();
     this._listenToChipsSelection();
     this._listenToChipsFocus();

--- a/src/material-experimental/mdc-chips/chip-option.ts
+++ b/src/material-experimental/mdc-chips/chip-option.ts
@@ -113,13 +113,13 @@ export class MatChipOption extends MatChip implements AfterContentInit {
   }
 
   /** The unstyled chip selector for this component. */
-  protected basicChipAttrName = 'mat-basic-chip-option';
+  protected override basicChipAttrName = 'mat-basic-chip-option';
 
   /** Emitted when the chip is selected or deselected. */
   @Output() readonly selectionChange: EventEmitter<MatChipSelectionChange> =
       new EventEmitter<MatChipSelectionChange>();
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     super.ngAfterContentInit();
 
     if (this.selected && this.leadingIcon) {

--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -76,7 +76,7 @@ export interface MatChipEditedEvent extends MatChipEvent {
 })
 export class MatChipRow extends MatChip implements AfterContentInit, AfterViewInit,
   GridKeyManagerRow<HTMLElement> {
-  protected basicChipAttrName = 'mat-basic-chip-row';
+  protected override basicChipAttrName = 'mat-basic-chip-row';
 
   @Input() editable: boolean = false;
 
@@ -116,7 +116,7 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
     super(changeDetectorRef, elementRef, ngZone, dir, animationMode, globalRippleOptions);
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     super.ngAfterContentInit();
 
     if (this.removeIcon) {
@@ -130,7 +130,7 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
     }
   }
 
-  ngAfterViewInit() {
+  override ngAfterViewInit() {
     super.ngAfterViewInit();
     this.cells = this.removeIcon ?
       [this.chipContent.nativeElement, this.removeIcon._elementRef.nativeElement] :
@@ -225,14 +225,14 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
     return this._chipFoundation.isEditing();
   }
 
-  protected _onEditStart() {
+  protected override _onEditStart() {
     // Defer initializing the input so it has time to be added to the DOM.
     setTimeout(() => {
       this._getEditInput().initialize(this.value);
     });
   }
 
-  protected _onEditFinish() {
+  protected override _onEditFinish() {
     // If the edit input is still focused or focus was returned to the body after it was destroyed,
     // return focus to the chip contents.
     if (this._document.activeElement === this._getEditInput().getNativeElement() ||

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -330,16 +330,16 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
 
   constructor(
       public _changeDetectorRef: ChangeDetectorRef,
-      readonly _elementRef: ElementRef, protected _ngZone: NgZone,
+      elementRef: ElementRef, protected _ngZone: NgZone,
       @Optional() private _dir: Directionality,
       @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
       @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
         private _globalRippleOptions?: RippleGlobalOptions) {
-    super(_elementRef);
+    super(elementRef);
     this._chipFoundation = new deprecated.MDCChipFoundation(this._chipAdapter);
     this._animationsDisabled = animationMode === 'NoopAnimations';
-    this._isBasicChip = _elementRef.nativeElement.hasAttribute(this.basicChipAttrName) ||
-                        _elementRef.nativeElement.tagName.toLowerCase() === this.basicChipAttrName;
+    this._isBasicChip = elementRef.nativeElement.hasAttribute(this.basicChipAttrName) ||
+                        elementRef.nativeElement.tagName.toLowerCase() === this.basicChipAttrName;
   }
 
   ngAfterContentInit() {

--- a/src/material-experimental/mdc-chips/grid-focus-key-manager.ts
+++ b/src/material-experimental/mdc-chips/grid-focus-key-manager.ts
@@ -18,15 +18,15 @@ export class GridFocusKeyManager extends GridKeyManager<HTMLElement> {
    * indices and focuses the newly active cell.
    * @param cell Row and column indices of the cell to be set as active.
    */
-  setActiveCell(cell: {row: number, column: number}): void;
+  override setActiveCell(cell: {row: number, column: number}): void;
 
   /**
    * Sets the active cell to the cell that is specified and focuses it.
    * @param cell Cell to be set as active.
    */
-  setActiveCell(cell: HTMLElement): void;
+  override setActiveCell(cell: HTMLElement): void;
 
-  setActiveCell(cell: any): void {
+  override setActiveCell(cell: any): void {
     super.setActiveCell(cell);
 
     if (this.activeCell) {

--- a/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
@@ -12,7 +12,7 @@ import {ChipOptionHarnessFilters} from './chip-harness-filters';
 
 /** Harness for interacting with a mat-chip-option in tests. */
 export class MatChipOptionHarness extends MatChipHarness {
-  static hostSelector = '.mat-mdc-chip-option';
+  static override hostSelector = '.mat-mdc-chip-option';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip option with specific
@@ -20,7 +20,7 @@ export class MatChipOptionHarness extends MatChipHarness {
    */
   // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
   // methods. See https://github.com/microsoft/TypeScript/issues/5863
-  static with<T extends typeof MatChipHarness>(
+  static override with<T extends typeof MatChipHarness>(
       this: T, options: ChipOptionHarnessFilters = {}): HarnessPredicate<InstanceType<T>> {
     return new HarnessPredicate(MatChipOptionHarness, options)
       .addOption('text', options.text,

--- a/src/material-experimental/mdc-chips/testing/chip-row-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-row-harness.ts
@@ -12,14 +12,14 @@ import {MatChipHarness} from './chip-harness';
 
 /** Harness for interacting with a mat-chip-row in tests. */
 export class MatChipRowHarness extends MatChipHarness {
-  static hostSelector = '.mat-mdc-chip-row';
+  static override hostSelector = '.mat-mdc-chip-row';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip row with specific attributes.
    */
   // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
   // methods. See https://github.com/microsoft/TypeScript/issues/5863
-  static with<T extends typeof MatChipHarness>(
+  static override with<T extends typeof MatChipHarness>(
       this: T, options: ChipRowHarnessFilters = {}): HarnessPredicate<InstanceType<T>> {
     return new HarnessPredicate(MatChipRowHarness, options) as
         unknown as HarnessPredicate<InstanceType<T>>;

--- a/src/material-experimental/mdc-dialog/dialog-container.ts
+++ b/src/material-experimental/mdc-dialog/dialog-container.ts
@@ -70,7 +70,7 @@ export class MatDialogContainer extends _MatDialogContainerBase implements OnDes
     super(elementRef, focusTrapFactory, changeDetectorRef, document, config, focusMonitor);
   }
 
-  _initializeWithAttachedContent() {
+  override _initializeWithAttachedContent() {
     // Delegate to the original dialog-container initialization (i.e. saving the
     // previous element, setting up the focus trap and moving focus to the container).
     super._initializeWithAttachedContent();

--- a/src/material-experimental/mdc-dialog/testing/dialog-harness.ts
+++ b/src/material-experimental/mdc-dialog/testing/dialog-harness.ts
@@ -15,7 +15,7 @@ import {
 /** Harness for interacting with a standard `MatDialog` in tests. */
 export class MatDialogHarness extends NonMdcDialogHarness {
   /** The selector for the host element of a `MatDialog` instance. */
-  static hostSelector = '.mat-mdc-dialog-container';
+  static override hostSelector = '.mat-mdc-dialog-container';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatDialogHarness` that meets
@@ -23,7 +23,7 @@ export class MatDialogHarness extends NonMdcDialogHarness {
    * @param options Options for filtering which dialog instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: DialogHarnessFilters = {}): HarnessPredicate<MatDialogHarness> {
+  static override with(options: DialogHarnessFilters = {}): HarnessPredicate<MatDialogHarness> {
     return new HarnessPredicate(MatDialogHarness, options);
   }
 }

--- a/src/material-experimental/mdc-list/action-list.ts
+++ b/src/material-experimental/mdc-list/action-list.ts
@@ -29,5 +29,5 @@ export class MatActionList extends MatListBase {
   // through keyboard shortcuts. We want all items for the navigation list to be reachable
   // through tab key as we do not intend to provide any special accessibility treatment. The
   // accessibility treatment depends on how the end-user will interact with it.
-  _isNonInteractive = false;
+  override _isNonInteractive = false;
 }

--- a/src/material-experimental/mdc-list/list-option.ts
+++ b/src/material-experimental/mdc-list/list-option.ts
@@ -177,7 +177,7 @@ export class MatListOption extends MatListItemBase implements ListOption, OnInit
     this._inputsInitialized = true;
   }
 
-  ngOnDestroy(): void {
+  override ngOnDestroy(): void {
     if (this.selected) {
       // We have to delay this until the next tick in order
       // to avoid changed after checked errors.

--- a/src/material-experimental/mdc-list/nav-list.ts
+++ b/src/material-experimental/mdc-list/nav-list.ts
@@ -29,5 +29,5 @@ export class MatNavList extends MatListBase {
   // through keyboard shortcuts. We want all items for the navigation list to be reachable
   // through tab key as we do not intend to provide any special accessibility treatment. The
   // accessibility treatment depends on how the end-user will interact with it.
-  _isNonInteractive = false;
+  override _isNonInteractive = false;
 }

--- a/src/material-experimental/mdc-list/selection-list.ts
+++ b/src/material-experimental/mdc-list/selection-list.ts
@@ -136,7 +136,7 @@ export class MatSelectionList extends MatInteractiveListBase<MatListOption>
     super._initWithAdapter(getSelectionListAdapter(this));
   }
 
-  ngAfterViewInit() {
+  override ngAfterViewInit() {
     // Mark the selection list as initialized so that the `multiple`
     // binding can no longer be changed.
     this._initialized = true;
@@ -175,7 +175,7 @@ export class MatSelectionList extends MatInteractiveListBase<MatListOption>
     }
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     this._destroyed.next();
     this._destroyed.complete();
     this._isDestroyed = true;

--- a/src/material-experimental/mdc-list/testing/action-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/action-list-harness.ts
@@ -27,7 +27,7 @@ export class MatActionListHarness extends MatListHarnessBase<
     return new HarnessPredicate(MatActionListHarness, options);
   }
 
-  _itemHarness = MatActionListItemHarness;
+  override _itemHarness = MatActionListItemHarness;
 }
 
 /** Harness for interacting with an action list item. */

--- a/src/material-experimental/mdc-list/testing/list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/list-harness.ts
@@ -27,7 +27,7 @@ export class MatListHarness extends
     return new HarnessPredicate(MatListHarness, options);
   }
 
-  _itemHarness = MatListItemHarness;
+  override _itemHarness = MatListItemHarness;
 }
 
 /** Harness for interacting with a list item. */

--- a/src/material-experimental/mdc-list/testing/nav-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/nav-list-harness.ts
@@ -27,7 +27,7 @@ export class MatNavListHarness extends MatListHarnessBase<
     return new HarnessPredicate(MatNavListHarness, options);
   }
 
-  _itemHarness = MatNavListItemHarness;
+  override _itemHarness = MatNavListItemHarness;
 }
 
 /** Harness for interacting with a MDC-based nav-list item. */

--- a/src/material-experimental/mdc-list/testing/selection-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/selection-list-harness.ts
@@ -33,7 +33,7 @@ export class MatSelectionListHarness extends MatListHarnessBase<
     return new HarnessPredicate(MatSelectionListHarness, options);
   }
 
-  _itemHarness = MatListOptionHarness;
+  override _itemHarness = MatListOptionHarness;
 
   /** Whether the selection list is disabled. */
   async isDisabled(): Promise<boolean> {

--- a/src/material-experimental/mdc-menu/menu.ts
+++ b/src/material-experimental/mdc-menu/menu.ts
@@ -58,8 +58,8 @@ export const MAT_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER: Provider = {
   ]
 })
 export class MatMenu extends _MatMenuBase {
-  protected _elevationPrefix = 'mat-mdc-elevation-z';
-  protected _baseElevation = 8;
+  protected override _elevationPrefix = 'mat-mdc-elevation-z';
+  protected override _baseElevation = 8;
 
   constructor(_elementRef: ElementRef<HTMLElement>,
               _ngZone: NgZone,

--- a/src/material-experimental/mdc-progress-bar/progress-bar.ts
+++ b/src/material-experimental/mdc-progress-bar/progress-bar.ts
@@ -64,11 +64,11 @@ export type ProgressBarMode = 'determinate' | 'indeterminate' | 'buffer' | 'quer
 export class MatProgressBar extends _MatProgressBarBase implements AfterViewInit, OnDestroy,
   CanColor {
 
-  constructor(public _elementRef: ElementRef<HTMLElement>,
+  constructor(elementRef: ElementRef<HTMLElement>,
               private _ngZone: NgZone,
               @Optional() dir?: Directionality,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string) {
-    super(_elementRef);
+    super(elementRef);
     this._isNoopAnimation = _animationMode === 'NoopAnimations';
     if (dir) {
       this._dirChangeSubscription = dir.change.subscribe(() => {

--- a/src/material-experimental/mdc-progress-spinner/progress-spinner.ts
+++ b/src/material-experimental/mdc-progress-spinner/progress-spinner.ts
@@ -106,11 +106,11 @@ export class MatProgressSpinner extends _MatProgressSpinnerBase implements After
       this._determinateCircle.nativeElement.setAttribute(attributeName, value),
   };
 
-  constructor(public _elementRef: ElementRef<HTMLElement>,
+  constructor(elementRef: ElementRef<HTMLElement>,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string,
               @Inject(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS)
                 defaults?: MatProgressSpinnerDefaultOptions) {
-    super(_elementRef);
+    super(elementRef);
     this._noopAnimations = animationMode === 'NoopAnimations' &&
       (!!defaults && !defaults._forceAnimations);
 

--- a/src/material-experimental/mdc-radio/radio.ts
+++ b/src/material-experimental/mdc-radio/radio.ts
@@ -147,12 +147,12 @@ export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit
         this._noopAnimations ? {enterDuration: 0, exitDuration: 0} : RIPPLE_ANIMATION_CONFIG;
   }
 
-  ngAfterViewInit() {
+  override ngAfterViewInit() {
     super.ngAfterViewInit();
     this._radioFoundation.init();
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
     this._radioFoundation.destroy();
   }
@@ -163,10 +163,10 @@ export class MatRadioButton extends _MatRadioButtonBase implements AfterViewInit
   }
 
   /**
-   * Overrides the parent function so that the foundation can be set with the current disabled
-   * state.
+   * Overrides the parent function so that the foundation can be set with the current
+   * disabled state.
    */
-  protected _setDisabled(value: boolean) {
+  protected override _setDisabled(value: boolean) {
     super._setDisabled(value);
     this._radioFoundation.setDisabled(this.disabled);
   }

--- a/src/material-experimental/mdc-select/select.ts
+++ b/src/material-experimental/mdc-select/select.ts
@@ -113,13 +113,13 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
   /** Width of the overlay panel. */
   _overlayWidth: number;
 
-  get shouldLabelFloat(): boolean {
+  override get shouldLabelFloat(): boolean {
     // Since the panel doesn't overlap the trigger, we
     // want the label to only float when there's a value.
     return this.panelOpen || !this.empty || (this.focused && !!this.placeholder);
   }
 
-  ngOnInit() {
+  override ngOnInit() {
     super.ngOnInit();
     this._viewportRuler.change().pipe(takeUntil(this._destroy)).subscribe(() => {
       if (this.panelOpen) {
@@ -144,14 +144,14 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
     }
   }
 
-  open() {
+  override open() {
     this._overlayWidth = this._getOverlayWidth();
     super.open();
     // Required for the MDC form field to pick up when the overlay has been opened.
     this.stateChanges.next();
   }
 
-  close() {
+  override close() {
     super.close();
     // Required for the MDC form field to pick up when the overlay has been closed.
     this.stateChanges.next();

--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -650,7 +650,7 @@ export class MatSlider extends _MatSliderMixinBase
   constructor(
     readonly _ngZone: NgZone,
     readonly _cdr: ChangeDetectorRef,
-    readonly _elementRef: ElementRef<HTMLElement>,
+    elementRef: ElementRef<HTMLElement>,
     private readonly _platform: Platform,
     readonly _globalChangeAndInputListener: GlobalChangeAndInputListener<'input'|'change'>,
     @Inject(DOCUMENT) document: any,
@@ -658,7 +658,7 @@ export class MatSlider extends _MatSliderMixinBase
     @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
       readonly _globalRippleOptions?: RippleGlobalOptions,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string) {
-      super(_elementRef);
+      super(elementRef);
       this._document = document;
       this._window = this._document.defaultView || window;
       this._noopAnimations = animationMode === 'NoopAnimations';

--- a/src/material-experimental/mdc-snack-bar/snack-bar.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar.ts
@@ -17,7 +17,7 @@ import {MatSnackBarContainer} from './snack-bar-container';
  */
 @Injectable({providedIn: MatSnackBarModule})
 export class MatSnackBar extends BaseMatSnackBar {
-  protected simpleSnackBarComponent = MatSimpleSnackBar;
-  protected snackBarContainerComponent = MatSnackBarContainer;
-  protected handsetCssClass = 'mat-mdc-snack-bar-handset';
+  protected override simpleSnackBarComponent = MatSimpleSnackBar;
+  protected override snackBarContainerComponent = MatSnackBarContainer;
+  protected override handsetCssClass = 'mat-mdc-snack-bar-handset';
 }

--- a/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
+++ b/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
@@ -20,10 +20,10 @@ export class MatSnackBarHarness extends BaseMatSnackBarHarness {
   // animation is finished and since it runs outside of Angular, we don't have a way of being
   // notified when it's done.
   /** The selector for the host element of a `MatSnackBar` instance. */
-  static hostSelector = '.mat-mdc-snack-bar-container:not([mat-exit])';
-  protected _messageSelector = '.mat-mdc-simple-snack-bar .mat-mdc-snack-bar-label';
-  protected _simpleSnackBarSelector = '.mat-mdc-simple-snack-bar';
-  protected _actionButtonSelector = '.mat-mdc-simple-snack-bar .mat-mdc-snack-bar-action';
+  static override hostSelector = '.mat-mdc-snack-bar-container:not([mat-exit])';
+  protected override _messageSelector = '.mat-mdc-simple-snack-bar .mat-mdc-snack-bar-label';
+  protected override _simpleSnackBarSelector = '.mat-mdc-simple-snack-bar';
+  protected override _actionButtonSelector = '.mat-mdc-simple-snack-bar .mat-mdc-snack-bar-action';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatSnackBarHarness` that meets
@@ -31,7 +31,8 @@ export class MatSnackBarHarness extends BaseMatSnackBarHarness {
    * @param options Options for filtering which snack bar instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: SnackBarHarnessFilters = {}): HarnessPredicate<BaseMatSnackBarHarness> {
+  static override with(
+      options: SnackBarHarnessFilters = {}): HarnessPredicate<BaseMatSnackBarHarness> {
     return new HarnessPredicate<BaseMatSnackBarHarness>(MatSnackBarHarness, options);
   }
 }

--- a/src/material-experimental/mdc-table/cell.ts
+++ b/src/material-experimental/mdc-table/cell.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {Directive, Input} from '@angular/core';
 import {
   CdkCell,
@@ -61,8 +60,8 @@ export class MatFooterCellDef extends CdkFooterCellDef {}
 export class MatColumnDef extends CdkColumnDef {
   /** Unique name for this column. */
   @Input('matColumnDef')
-  get name(): string { return this._name; }
-  set name(name: string) { this._setNameInput(name); }
+  override get name(): string { return this._name; }
+  override set name(name: string) { this._setNameInput(name); }
 
   /**
    * Add "mat-column-" prefix in addition to "cdk-column-" prefix.
@@ -70,12 +69,10 @@ export class MatColumnDef extends CdkColumnDef {
    * will change from type string[] to string.
    * @docs-private
    */
-  protected _updateColumnCssClassName() {
+  protected override _updateColumnCssClassName() {
     super._updateColumnCssClassName();
     this._columnCssClassName!.push(`mat-column-${this.cssClassFriendlyName}`);
   }
-
-  static ngAcceptInputType_sticky: BooleanInput;
 }
 
 /** Header cell template container that adds the right classes and role. */

--- a/src/material-experimental/mdc-table/row.ts
+++ b/src/material-experimental/mdc-table/row.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {
   CDK_ROW_TEMPLATE,
   CdkFooterRow,
@@ -28,9 +27,7 @@ import {ChangeDetectionStrategy, Component, Directive, ViewEncapsulation} from '
   providers: [{provide: CdkHeaderRowDef, useExisting: MatHeaderRowDef}],
   inputs: ['columns: matHeaderRowDef', 'sticky: matHeaderRowDefSticky'],
 })
-export class MatHeaderRowDef extends CdkHeaderRowDef {
-  static ngAcceptInputType_sticky: BooleanInput;
-}
+export class MatHeaderRowDef extends CdkHeaderRowDef {}
 
 /**
  * Footer row definition for the mat-table.
@@ -41,9 +38,7 @@ export class MatHeaderRowDef extends CdkHeaderRowDef {
   providers: [{provide: CdkFooterRowDef, useExisting: MatFooterRowDef}],
   inputs: ['columns: matFooterRowDef', 'sticky: matFooterRowDefSticky'],
 })
-export class MatFooterRowDef extends CdkFooterRowDef {
-  static ngAcceptInputType_sticky: BooleanInput;
-}
+export class MatFooterRowDef extends CdkFooterRowDef {}
 
 /**
  * Data row definition for the mat-table.

--- a/src/material-experimental/mdc-table/table.ts
+++ b/src/material-experimental/mdc-table/table.ts
@@ -65,12 +65,12 @@ export class MatRecycleRows {}
 })
 export class MatTable<T> extends CdkTable<T> implements OnInit {
   /** Overrides the sticky CSS class set by the `CdkTable`. */
-  protected stickyCssClass = 'mat-mdc-table-sticky';
+  protected override stickyCssClass = 'mat-mdc-table-sticky';
 
   /** Overrides the need to add position: sticky on every sticky cell element in `CdkTable`. */
-  protected needsPositionStickyOnElement = false;
+  protected override needsPositionStickyOnElement = false;
 
-  ngOnInit() {
+  override ngOnInit() {
     super.ngOnInit();
 
     // After ngOnInit, the `CdkTable` has created and inserted the table sections (thead, tbody,

--- a/src/material-experimental/mdc-table/testing/cell-harness.ts
+++ b/src/material-experimental/mdc-table/testing/cell-harness.ts
@@ -17,14 +17,14 @@ import {
 /** Harness for interacting with an MDC-based Angular Material table cell. */
 export class MatCellHarness extends BaseMatCellHarness {
   /** The selector for the host element of a `MatCellHarness` instance. */
-  static hostSelector = '.mat-mdc-cell';
+  static override hostSelector = '.mat-mdc-cell';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a table cell with specific attributes.
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: CellHarnessFilters = {}): HarnessPredicate<MatCellHarness> {
+  static override with(options: CellHarnessFilters = {}): HarnessPredicate<MatCellHarness> {
     return BaseMatCellHarness._getCellPredicate(MatCellHarness, options);
   }
 }
@@ -32,7 +32,7 @@ export class MatCellHarness extends BaseMatCellHarness {
 /** Harness for interacting with an MDC-based Angular Material table header cell. */
 export class MatHeaderCellHarness extends BaseMatHeaderCellHarness {
   /** The selector for the host element of a `MatHeaderCellHarness` instance. */
-  static hostSelector = '.mat-mdc-header-cell';
+  static override hostSelector = '.mat-mdc-header-cell';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for
@@ -40,7 +40,7 @@ export class MatHeaderCellHarness extends BaseMatHeaderCellHarness {
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: CellHarnessFilters = {}): HarnessPredicate<MatHeaderCellHarness> {
+  static override with(options: CellHarnessFilters = {}): HarnessPredicate<MatHeaderCellHarness> {
     return BaseMatHeaderCellHarness._getCellPredicate(MatHeaderCellHarness, options);
   }
 }
@@ -48,7 +48,7 @@ export class MatHeaderCellHarness extends BaseMatHeaderCellHarness {
 /** Harness for interacting with an MDC-based Angular Material table footer cell. */
 export class MatFooterCellHarness extends BaseMatFooterCellHarness {
   /** The selector for the host element of a `MatFooterCellHarness` instance. */
-  static hostSelector = '.mat-mdc-footer-cell';
+  static override hostSelector = '.mat-mdc-footer-cell';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for
@@ -56,7 +56,7 @@ export class MatFooterCellHarness extends BaseMatFooterCellHarness {
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: CellHarnessFilters = {}): HarnessPredicate<MatFooterCellHarness> {
+  static override with(options: CellHarnessFilters = {}): HarnessPredicate<MatFooterCellHarness> {
     return BaseMatFooterCellHarness._getCellPredicate(MatFooterCellHarness, options);
   }
 }

--- a/src/material-experimental/mdc-tabs/tab-group.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.ts
@@ -28,7 +28,7 @@ import {
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {MatTab} from './tab';
 import {MatTabHeader} from './tab-header';
-import {BooleanInput, coerceBooleanProperty, NumberInput} from '@angular/cdk/coercion';
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 
 /**
  * Material design tab-group component. Supports basic tab pairs (label + content) and includes
@@ -77,5 +77,4 @@ export class MatTabGroup extends _MatTabGroupBase {
   }
 
   static ngAcceptInputType_fitInkBarToContent: BooleanInput;
-  static ngAcceptInputType_animationDuration: NumberInput;
 }

--- a/src/material-experimental/mdc-tabs/tab-header.ts
+++ b/src/material-experimental/mdc-tabs/tab-header.ts
@@ -68,7 +68,7 @@ export class MatTabHeader extends _MatTabHeaderBase implements AfterContentInit 
     super(elementRef, changeDetectorRef, viewportRuler, dir, ngZone, platform, animationMode);
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     this._inkBar = new MatInkBar(this._items);
     super.ngAfterContentInit();
   }

--- a/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
+++ b/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
@@ -35,10 +35,10 @@ export class MatTabLabelWrapper extends BaseMatTabLabelWrapper
   get fitInkBarToContent(): boolean { return this._foundation.getFitToContent(); }
   set fitInkBarToContent(v: boolean) { this._foundation.setFitToContent(coerceBooleanProperty(v)); }
 
-  constructor(public elementRef: ElementRef, @Inject(DOCUMENT) _document: any) {
+  constructor(elementRef: ElementRef, @Inject(DOCUMENT) _document: any) {
     super(elementRef);
     this._document = _document;
-    this._foundation = new MatInkBarFoundation(this.elementRef.nativeElement, this._document);
+    this._foundation = new MatInkBarFoundation(elementRef.nativeElement, this._document);
   }
 
   ngOnInit() {
@@ -47,11 +47,6 @@ export class MatTabLabelWrapper extends BaseMatTabLabelWrapper
 
   ngOnDestroy() {
     this._foundation.destroy();
-  }
-
-  /** Sets focus on the wrapper element */
-  focus(): void {
-    this.elementRef.nativeElement.focus();
   }
 
   static ngAcceptInputType_fitInkBarToContent: BooleanInput;

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -98,7 +98,7 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit {
         defaultConfig.fitInkBarToContent : false;
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     this._inkBar = new MatInkBar(this._items);
     super.ngAfterContentInit();
   }
@@ -151,7 +151,7 @@ export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnInit
     this._foundation.init();
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     this._destroyed.next();
     this._destroyed.complete();
     super.ngOnDestroy();

--- a/src/material-experimental/mdc-tabs/tab.ts
+++ b/src/material-experimental/mdc-tabs/tab.ts
@@ -34,10 +34,10 @@ export class MatTab extends BaseMatTab {
    * Template provided in the tab content that will be used if present, used to enable lazy-loading
    */
   @ContentChild(MatTabContent, {read: TemplateRef, static: true})
-  _explicitContent: TemplateRef<any>;
+  override _explicitContent: TemplateRef<any>;
 
   /** Content for the tab label given by `<ng-template mat-tab-label>`. */
   @ContentChild(MatTabLabel)
-  get templateLabel(): MatTabLabel { return this._templateLabel; }
-  set templateLabel(value: MatTabLabel) { this._setTemplateLabelInput(value); }
+  override get templateLabel(): MatTabLabel { return this._templateLabel; }
+  override set templateLabel(value: MatTabLabel) { this._setTemplateLabelInput(value); }
 }

--- a/src/material-experimental/mdc-tabs/testing/tab-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-harness.ts
@@ -79,7 +79,7 @@ export class MatTabHarness extends ContentContainerComponentHarness<string> {
     return this.getRootHarnessLoader();
   }
 
-  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
+  protected override async getRootHarnessLoader(): Promise<HarnessLoader> {
     const contentId = await this._getContentId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${contentId}`);
   }

--- a/src/material-experimental/mdc-tooltip/tooltip.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.ts
@@ -122,8 +122,7 @@ export class TooltipComponent extends _TooltipComponentBase {
     super(changeDetectorRef);
   }
 
-  /** @override */
-  protected _onShow(): void {
+  protected override _onShow(): void {
     this._isMultiline = this._isTooltipMultiline();
   }
 

--- a/src/material-experimental/mdc-tooltip/tooltip.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.ts
@@ -54,8 +54,8 @@ export const TOOLTIP_PANEL_CLASS = 'mat-mdc-tooltip-panel';
   }
 })
 export class MatTooltip extends _MatTooltipBase<TooltipComponent> {
-  protected readonly _tooltipComponent = TooltipComponent;
-  protected readonly _cssClassPrefix = 'mat-mdc';
+  protected override readonly _tooltipComponent = TooltipComponent;
+  protected override readonly _cssClassPrefix = 'mat-mdc';
 
   constructor(
     overlay: Overlay,
@@ -76,7 +76,7 @@ export class MatTooltip extends _MatTooltipBase<TooltipComponent> {
     this._viewportMargin = numbers.MIN_VIEWPORT_TOOLTIP_THRESHOLD;
   }
 
-  protected _addOffset(position: ConnectedPosition): ConnectedPosition {
+  protected override _addOffset(position: ConnectedPosition): ConnectedPosition {
     const offset = numbers.UNBOUNDED_ANCHOR_GAP;
     const isLtr = !this._dir || this._dir.value == 'ltr';
 

--- a/src/material-experimental/popover-edit/table-directives.ts
+++ b/src/material-experimental/popover-edit/table-directives.ts
@@ -46,7 +46,7 @@ const MAT_ROW_HOVER_CELL_CLASS = MAT_ROW_HOVER_CLASS + '-host-cell';
   inputs: POPOVER_EDIT_INPUTS,
 })
 export class MatPopoverEdit<C> extends CdkPopoverEdit<C> {
-  protected panelClass(): string {
+  protected override panelClass(): string {
     return EDIT_PANE_CLASS;
   }
 }
@@ -62,7 +62,7 @@ export class MatPopoverEdit<C> extends CdkPopoverEdit<C> {
   inputs: POPOVER_EDIT_INPUTS,
 })
 export class MatPopoverEditTabOut<C> extends CdkPopoverEditTabOut<C> {
-  protected panelClass(): string {
+  protected override panelClass(): string {
     return EDIT_PANE_CLASS;
   }
 }
@@ -75,16 +75,16 @@ export class MatPopoverEditTabOut<C> extends CdkPopoverEditTabOut<C> {
   selector: '[matRowHoverContent]',
 })
 export class MatRowHoverContent extends CdkRowHoverContent {
-  protected initElement(element: HTMLElement) {
+  protected override initElement(element: HTMLElement) {
     super.initElement(element);
     element.classList.add(MAT_ROW_HOVER_CLASS);
   }
 
-  protected makeElementHiddenButFocusable(element: HTMLElement): void {
+  protected override makeElementHiddenButFocusable(element: HTMLElement): void {
     element.classList.remove(MAT_ROW_HOVER_ANIMATE_CLASS);
   }
 
-  protected makeElementVisible(element: HTMLElement): void {
+  protected override makeElementVisible(element: HTMLElement): void {
     _closest(this.elementRef.nativeElement!, _CELL_SELECTOR)!
         .classList.add(MAT_ROW_HOVER_CELL_CLASS);
 

--- a/src/material-experimental/selection/row-selection.ts
+++ b/src/material-experimental/selection/row-selection.ts
@@ -29,12 +29,12 @@ import {Input, Directive} from '@angular/core';
 // tslint:disable-next-line: coercion-types
 export class MatRowSelection<T> extends CdkRowSelection<T> {
   /** The value that is associated with the row */
-  @Input('matRowSelectionValue') value: T;
+  @Input('matRowSelectionValue') override value: T;
 
   /** The index of the value in the list. Required when used with `trackBy` */
   @Input('matRowSelectionIndex')
-  get index(): number|undefined { return this._index; }
-  set index(index: number|undefined) {
+  override get index(): number|undefined { return this._index; }
+  override set index(index: number|undefined) {
     // TODO: when we remove support for ViewEngine, change this setter to an input
     // alias in the decorator metadata.
     this._index = coerceNumberProperty(index);

--- a/src/material-experimental/selection/selection-toggle.ts
+++ b/src/material-experimental/selection/selection-toggle.ts
@@ -28,12 +28,12 @@ import {Directive, Input} from '@angular/core';
 // tslint:disable-next-line: coercion-types
 export class MatSelectionToggle<T> extends CdkSelectionToggle<T> {
   /** The value that is associated with the toggle */
-  @Input('matSelectionToggleValue') value: T;
+  @Input('matSelectionToggleValue') override value: T;
 
   /** The index of the value in the list. Required when used with `trackBy` */
   @Input('matSelectionToggleIndex')
-  get index(): number|undefined { return this._index; }
-  set index(index: number|undefined) {
+  override get index(): number|undefined { return this._index; }
+  override set index(index: number|undefined) {
     // TODO: when we remove support for ViewEngine, change this setter to an input
     // alias in the decorator metadata.
     this._index = coerceNumberProperty(index);

--- a/src/material-experimental/selection/selection.ts
+++ b/src/material-experimental/selection/selection.ts
@@ -26,11 +26,11 @@ import {Directive, Input, Output, EventEmitter} from '@angular/core';
 export class MatSelection<T> extends CdkSelection<T> {
   /** Whether to support multiple selection */
   @Input('matSelectionMultiple')
-  get multiple(): boolean { return this._multiple; }
-  set multiple(multiple: boolean) { this._multiple = coerceBooleanProperty(multiple); }
+  override get multiple(): boolean { return this._multiple; }
+  override set multiple(multiple: boolean) { this._multiple = coerceBooleanProperty(multiple); }
 
   /** Emits when selection changes. */
-  @Output('matSelectionChange') readonly change = new EventEmitter<SelectionChange<T>>();
+  @Output('matSelectionChange') override readonly change = new EventEmitter<SelectionChange<T>>();
 }
 
 /**

--- a/src/material-moment-adapter/adapter/moment-date-adapter.ts
+++ b/src/material-moment-adapter/adapter/moment-date-adapter.ts
@@ -88,7 +88,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
     this.setLocale(dateLocale || moment.locale());
   }
 
-  setLocale(locale: string) {
+  override setLocale(locale: string) {
     super.setLocale(locale);
 
     let momentLocaleData = moment.localeData(locale);
@@ -217,7 +217,7 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
    * (https://www.ietf.org/rfc/rfc3339.txt) and valid Date objects into valid Moments and empty
    * string into null. Returns an invalid date for all other values.
    */
-  deserialize(value: any): Moment | null {
+  override deserialize(value: any): Moment | null {
     let date;
     if (value instanceof Date) {
       date = this._createMoment(value).locale(this.locale);

--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -132,7 +132,7 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
    * @deprecated To be turned into a method.
    * @breaking-change 10.0.0
    */
-  attachDomPortal = (portal: DomPortal) => {
+  override attachDomPortal = (portal: DomPortal) => {
     this._validatePortalAttached();
     this._setPanelClass();
     this._savePreviouslyFocusedElement();

--- a/src/material/checkbox/checkbox.ts
+++ b/src/material/checkbox/checkbox.ts
@@ -245,8 +245,8 @@ export class MatCheckbox extends _MatCheckboxBase implements ControlValueAccesso
    * mixinDisabled, but the mixin is still required because mixinTabIndex requires it.
    */
   @Input()
-  get disabled() { return this._disabled; }
-  set disabled(value: any) {
+  override get disabled() { return this._disabled; }
+  override set disabled(value: any) {
     const newValue = coerceBooleanProperty(value);
 
     if (newValue !== this.disabled) {

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -161,7 +161,7 @@ export class MatChipList extends _MatChipListBase implements MatFormFieldControl
   get role(): string | null { return this.empty ? null : 'listbox'; }
 
   /** An object used to control when error messages are shown. */
-  @Input() errorStateMatcher: ErrorStateMatcher;
+  @Input() override errorStateMatcher: ErrorStateMatcher;
 
   /** Whether the user should be allowed to select multiple chips. */
   @Input()
@@ -332,8 +332,7 @@ export class MatChipList extends _MatChipListBase implements MatFormFieldControl
               @Optional() _parentForm: NgForm,
               @Optional() _parentFormGroup: FormGroupDirective,
               _defaultErrorStateMatcher: ErrorStateMatcher,
-              /** @docs-private */
-              @Optional() @Self() public ngControl: NgControl) {
+              @Optional() @Self() ngControl: NgControl) {
     super(_defaultErrorStateMatcher, _parentForm, _parentFormGroup, ngControl);
     if (this.ngControl) {
       this.ngControl.valueAccessor = this;

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -273,7 +273,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
         this.selected.toString() : null;
   }
 
-  constructor(public _elementRef: ElementRef<HTMLElement>,
+  constructor(elementRef: ElementRef<HTMLElement>,
               private _ngZone: NgZone,
               platform: Platform,
               @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS)
@@ -282,7 +282,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
               @Inject(DOCUMENT) _document: any,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
               @Attribute('tabindex') tabIndex?: string) {
-    super(_elementRef);
+    super(elementRef);
 
     this._addHostClassName();
 
@@ -293,7 +293,7 @@ export class MatChip extends _MatChipMixinBase implements FocusableOption, OnDes
     this._chipRippleTarget.classList.add('mat-chip-ripple');
     this._elementRef.nativeElement.appendChild(this._chipRippleTarget);
     this._chipRipple = new RippleRenderer(this, _ngZone, this._chipRippleTarget, platform);
-    this._chipRipple.setupTriggerEvents(_elementRef);
+    this._chipRipple.setupTriggerEvents(elementRef);
 
     this.rippleConfig = globalRippleOptions || {};
     this._animationsDisabled = animationMode === 'NoopAnimations';

--- a/src/material/chips/testing/chip-option-harness.ts
+++ b/src/material/chips/testing/chip-option-harness.ts
@@ -12,7 +12,7 @@ import {ChipOptionHarnessFilters} from './chip-harness-filters';
 
 export class MatChipOptionHarness extends MatChipHarness {
   /** The selector for the host element of a selectable chip instance. */
-  static hostSelector = '.mat-chip';
+  static override hostSelector = '.mat-chip';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatChipOptionHarness`
@@ -20,7 +20,7 @@ export class MatChipOptionHarness extends MatChipHarness {
    * @param options Options for filtering which chip instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ChipOptionHarnessFilters = {}):
+  static override with(options: ChipOptionHarnessFilters = {}):
     HarnessPredicate<MatChipOptionHarness> {
     return new HarnessPredicate(MatChipOptionHarness, options)
         .addOption('text', options.text,
@@ -30,26 +30,26 @@ export class MatChipOptionHarness extends MatChipHarness {
   }
 
   /** Whether the chip is selected. */
-  async isSelected(): Promise<boolean> {
+  override async isSelected(): Promise<boolean> {
     return (await this.host()).hasClass('mat-chip-selected');
   }
 
   /** Selects the given chip. Only applies if it's selectable. */
-  async select(): Promise<void> {
+  override async select(): Promise<void> {
     if (!(await this.isSelected())) {
       await this.toggle();
     }
   }
 
   /** Deselects the given chip. Only applies if it's selectable. */
-  async deselect(): Promise<void> {
+  override async deselect(): Promise<void> {
     if (await this.isSelected()) {
       await this.toggle();
     }
   }
 
   /** Toggles the selected state of the given chip. */
-  async toggle(): Promise<void> {
+  override async toggle(): Promise<void> {
     return (await this.host()).sendKeys(' ');
   }
 }

--- a/src/material/core/datetime/native-date-adapter.ts
+++ b/src/material/core/datetime/native-date-adapter.ts
@@ -252,7 +252,7 @@ export class NativeDateAdapter extends DateAdapter<Date> {
    * (https://www.ietf.org/rfc/rfc3339.txt) into valid Dates and empty string into null. Returns an
    * invalid date for all other values.
    */
-  deserialize(value: any): Date | null {
+  override deserialize(value: any): Date | null {
     if (typeof value === 'string') {
       if (!value) {
         return null;

--- a/src/material/datepicker/date-range-input-parts.ts
+++ b/src/material/datepicker/date-range-input-parts.ts
@@ -36,7 +36,6 @@ import {
   MatDateFormats,
   ErrorStateMatcher,
 } from '@angular/material/core';
-import {BooleanInput} from '@angular/cdk/coercion';
 import {BACKSPACE} from '@angular/cdk/keycodes';
 import {MatDatepickerInputBase, DateFilterFn} from './datepicker-input-base';
 import {DateRange, DateSelectionModelChange} from './date-selection-model';
@@ -78,9 +77,9 @@ abstract class MatDateRangeInputPartBase<D>
   /** @docs-private */
   abstract updateErrorState(): void;
 
-  protected abstract _validator: ValidatorFn | null;
-  protected abstract _assignValueToModel(value: D | null): void;
-  protected abstract _getValueFromModel(modelValue: DateRange<D>): D | null;
+  protected abstract override _validator: ValidatorFn | null;
+  protected abstract override _assignValueToModel(value: D | null): void;
+  protected abstract override _getValueFromModel(modelValue: DateRange<D>): D | null;
 
   constructor(
     @Inject(MAT_DATE_RANGE_INPUT_PARENT) public _rangeInput: MatDateRangeInputParent<D>,
@@ -134,7 +133,7 @@ abstract class MatDateRangeInputPartBase<D>
   }
 
   /** Handles `input` events on the input element. */
-  _onInput(value: string) {
+  override _onInput(value: string) {
     super._onInput(value);
     this._rangeInput._handleChildValueChange();
   }
@@ -159,7 +158,7 @@ abstract class MatDateRangeInputPartBase<D>
     return this._rangeInput.dateFilter;
   }
 
-  protected _parentDisabled() {
+  protected override _parentDisabled() {
     return this._rangeInput._groupDisabled;
   }
 
@@ -167,7 +166,7 @@ abstract class MatDateRangeInputPartBase<D>
     return source !== this._rangeInput._startInput && source !== this._rangeInput._endInput;
   }
 
-  protected _assignValueProgrammatically(value: D | null) {
+  protected override _assignValueProgrammatically(value: D | null) {
     super._assignValueProgrammatically(value);
     const opposite = (this === this._rangeInput._startInput ? this._rangeInput._endInput :
         this._rangeInput._startInput) as MatDateRangeInputPartBase<D> | undefined;
@@ -232,7 +231,7 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
         dateAdapter, dateFormats);
   }
 
-  ngOnInit() {
+  override ngOnInit() {
     // Normally this happens automatically, but it seems to break if not added explicitly when all
     // of the criteria below are met:
     // 1) The class extends a TS mixin.
@@ -242,7 +241,7 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
     super.ngOnInit();
   }
 
-  ngDoCheck() {
+  override ngDoCheck() {
     // Normally this happens automatically, but it seems to break if not added explicitly when all
     // of the criteria below are met:
     // 1) The class extends a TS mixin.
@@ -258,7 +257,8 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
     return modelValue.start;
   }
 
-  protected _shouldHandleChangeEvent(change: DateSelectionModelChange<DateRange<D>>): boolean {
+  protected override _shouldHandleChangeEvent(
+      change: DateSelectionModelChange<DateRange<D>>): boolean {
     if (!super._shouldHandleChangeEvent(change)) {
       return false;
     } else {
@@ -275,7 +275,7 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
     }
   }
 
-  protected _formatValue(value: D | null) {
+  protected override _formatValue(value: D | null) {
     super._formatValue(value);
 
     // Any time the input value is reformatted we need to tell the parent.
@@ -288,8 +288,6 @@ export class MatStartDate<D> extends _MatDateRangeInputBase<D> implements
     const value = element.value;
     return value.length > 0 ? value : element.placeholder;
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }
 
 
@@ -346,7 +344,7 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements
         dateAdapter, dateFormats);
   }
 
-  ngOnInit() {
+  override ngOnInit() {
     // Normally this happens automatically, but it seems to break if not added explicitly when all
     // of the criteria below are met:
     // 1) The class extends a TS mixin.
@@ -356,7 +354,7 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements
     super.ngOnInit();
   }
 
-  ngDoCheck() {
+  override ngDoCheck() {
     // Normally this happens automatically, but it seems to break if not added explicitly when all
     // of the criteria below are met:
     // 1) The class extends a TS mixin.
@@ -372,7 +370,8 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements
     return modelValue.end;
   }
 
-  protected _shouldHandleChangeEvent(change: DateSelectionModelChange<DateRange<D>>): boolean {
+  protected override _shouldHandleChangeEvent(
+      change: DateSelectionModelChange<DateRange<D>>): boolean {
     if (!super._shouldHandleChangeEvent(change)) {
       return false;
     } else {
@@ -389,7 +388,7 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements
     }
   }
 
-  _onKeydown(event: KeyboardEvent) {
+  override _onKeydown(event: KeyboardEvent) {
     // If the user is pressing backspace on an empty end input, move focus back to the start.
     if (event.keyCode === BACKSPACE && !this._elementRef.nativeElement.value) {
       this._rangeInput._startInput.focus();
@@ -397,6 +396,4 @@ export class MatEndDate<D> extends _MatDateRangeInputBase<D> implements
 
     super._onKeydown(event);
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/material/datepicker/date-range-picker.ts
+++ b/src/material/datepicker/date-range-picker.ts
@@ -38,7 +38,7 @@ export interface MatDateRangePickerInput<D> extends MatDatepickerControl<D> {
 })
 export class MatDateRangePicker<D> extends MatDatepickerBase<MatDateRangePickerInput<D>,
   DateRange<D>, D> {
-  protected _forwardContentValues(instance: MatDatepickerContent<DateRange<D>, D>) {
+  protected override _forwardContentValues(instance: MatDatepickerContent<DateRange<D>, D>) {
     super._forwardContentValues(instance);
 
     const input = this.datepickerInput;

--- a/src/material/datepicker/datepicker-input.ts
+++ b/src/material/datepicker/datepicker-input.ts
@@ -166,7 +166,7 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
     return this.value;
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
     this._closedSubscription.unsubscribe();
   }
@@ -206,8 +206,4 @@ export class MatDatepickerInput<D> extends MatDatepickerInputBase<D | null, D>
   protected _shouldHandleChangeEvent(event: DateSelectionModelChange<D>) {
     return event.source !== this;
   }
-
-  // Accept `any` to avoid conflicts with other directives on `<input>` that
-  // may accept different types.
-  static ngAcceptInputType_value: any;
 }

--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -140,7 +140,7 @@ export abstract class _MatDialogContainerBase extends BasePortalOutlet {
    * @deprecated To be turned into a method.
    * @breaking-change 10.0.0
    */
-  attachDomPortal = (portal: DomPortal) => {
+  override attachDomPortal = (portal: DomPortal) => {
     if (this._portalOutlet.hasAttached() && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throwMatDialogContentAlreadyAttachedError();
     }

--- a/src/material/expansion/accordion.ts
+++ b/src/material/expansion/accordion.ts
@@ -94,7 +94,7 @@ export class MatAccordion extends CdkAccordion implements MatAccordionBase,
     this._keyManager.updateActiveItem(header);
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
     this._ownHeaders.destroy();
   }

--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -129,7 +129,7 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
   readonly _inputChanges = new Subject<SimpleChanges>();
 
   /** Optionally defined accordion the expansion panel belongs to. */
-  accordion: MatAccordionBase;
+  override accordion: MatAccordionBase;
 
   /** Content that will be rendered lazily. */
   @ContentChild(MatExpansionPanelContent) _lazyContent: MatExpansionPanelContent;
@@ -191,17 +191,17 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
   }
 
   /** Toggles the expanded state of the expansion panel. */
-  toggle(): void {
+  override toggle(): void {
     this.expanded = !this.expanded;
   }
 
   /** Sets the expanded state of the expansion panel to false. */
-  close(): void {
+  override close(): void {
     this.expanded = false;
   }
 
   /** Sets the expanded state of the expansion panel to true. */
-  open(): void {
+  override open(): void {
     this.expanded = true;
   }
 
@@ -222,7 +222,7 @@ export class MatExpansionPanel extends CdkAccordionItem implements AfterContentI
     this._inputChanges.next(changes);
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
     this._bodyAnimationDone.complete();
     this._inputChanges.complete();

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -267,7 +267,7 @@ export class MatFormField extends _MatFormFieldBase
   @ContentChildren(MAT_SUFFIX, {descendants: true}) _suffixChildren: QueryList<MatSuffix>;
 
   constructor(
-      public _elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef,
+      elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef,
       /**
        * @deprecated `_labelOptions` parameter no longer being used. To be removed.
        * @breaking-change 12.0.0
@@ -279,7 +279,7 @@ export class MatFormField extends _MatFormFieldBase
       @Optional() @Inject(MAT_FORM_FIELD_DEFAULT_OPTIONS) private _defaults:
           MatFormFieldDefaultOptions, private _platform: Platform, private _ngZone: NgZone,
       @Optional() @Inject(ANIMATION_MODULE_TYPE) _animationMode: string) {
-    super(_elementRef);
+    super(elementRef);
 
     this.floatLabel = this._getDefaultFloatLabelState();
     this._animationsEnabled = _animationMode !== 'NoopAnimations';

--- a/src/material/grid-list/tile-styler.ts
+++ b/src/material/grid-list/tile-styler.ts
@@ -171,7 +171,7 @@ export class FixedTileStyler extends TileStyler {
 
   constructor(public fixedRowHeight: string) { super(); }
 
-  init(gutterSize: string, tracker: TileCoordinator, cols: number, direction: string) {
+  override init(gutterSize: string, tracker: TileCoordinator, cols: number, direction: string) {
     super.init(gutterSize, tracker, cols, direction);
     this.fixedRowHeight = normalizeUnits(this.fixedRowHeight);
 
@@ -181,18 +181,18 @@ export class FixedTileStyler extends TileStyler {
     }
   }
 
-  setRowStyles(tile: MatGridTile, rowIndex: number): void {
+  override setRowStyles(tile: MatGridTile, rowIndex: number): void {
     tile._setStyle('top', this.getTilePosition(this.fixedRowHeight, rowIndex));
     tile._setStyle('height', calc(this.getTileSize(this.fixedRowHeight, tile.rowspan)));
   }
 
-  getComputedHeight(): [string, string] {
+  override getComputedHeight(): [string, string] {
     return [
       'height', calc(`${this.getTileSpan(this.fixedRowHeight)} + ${this.getGutterSpan()}`)
     ];
   }
 
-  reset(list: TileStyleTarget) {
+  override reset(list: TileStyleTarget) {
     list._setListStyle(['height', null]);
 
     if (list._tiles) {
@@ -233,7 +233,7 @@ export class RatioTileStyler extends TileStyler {
     tile._setStyle('paddingTop', calc(this.getTileSize(this.baseTileHeight, tile.rowspan)));
   }
 
-  getComputedHeight(): [string, string] {
+  override getComputedHeight(): [string, string] {
     return [
       'paddingBottom', calc(`${this.getTileSpan(this.baseTileHeight)} + ${this.getGutterSpan()}`)
     ];

--- a/src/material/input/input.ts
+++ b/src/material/input/input.ts
@@ -117,7 +117,7 @@ export class MatInput extends _MatInputBase implements MatFormFieldControl<any>,
    * Implemented as part of MatFormFieldControl.
    * @docs-private
    */
-  readonly stateChanges: Subject<void> = new Subject<void>();
+  override readonly stateChanges: Subject<void> = new Subject<void>();
 
   /**
    * Implemented as part of MatFormFieldControl.
@@ -195,7 +195,7 @@ export class MatInput extends _MatInputBase implements MatFormFieldControl<any>,
   protected _type = 'text';
 
   /** An object used to control when error messages are shown. */
-  @Input() errorStateMatcher: ErrorStateMatcher;
+  @Input() override errorStateMatcher: ErrorStateMatcher;
 
   /**
    * Implemented as part of MatFormFieldControl.
@@ -234,8 +234,7 @@ export class MatInput extends _MatInputBase implements MatFormFieldControl<any>,
   constructor(
       protected _elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
       protected _platform: Platform,
-      /** @docs-private */
-      @Optional() @Self() public ngControl: NgControl,
+      @Optional() @Self() ngControl: NgControl,
       @Optional() _parentForm: NgForm,
       @Optional() _parentFormGroup: FormGroupDirective,
       _defaultErrorStateMatcher: ErrorStateMatcher,

--- a/src/material/list/testing/action-list-harness.ts
+++ b/src/material/list/testing/action-list-harness.ts
@@ -27,7 +27,7 @@ export class MatActionListHarness extends MatListHarnessBase<
     return new HarnessPredicate(MatActionListHarness, options);
   }
 
-  _itemHarness = MatActionListItemHarness;
+  override _itemHarness = MatActionListItemHarness;
 }
 
 /** Harness for interacting with an action list item. */

--- a/src/material/list/testing/list-harness.ts
+++ b/src/material/list/testing/list-harness.ts
@@ -27,7 +27,7 @@ export class MatListHarness extends
     return new HarnessPredicate(MatListHarness, options);
   }
 
-  _itemHarness = MatListItemHarness;
+  override _itemHarness = MatListItemHarness;
 }
 
 /** Harness for interacting with a list item. */

--- a/src/material/list/testing/nav-list-harness.ts
+++ b/src/material/list/testing/nav-list-harness.ts
@@ -27,7 +27,7 @@ export class MatNavListHarness extends MatListHarnessBase<
     return new HarnessPredicate(MatNavListHarness, options);
   }
 
-  _itemHarness = MatNavListItemHarness;
+  override _itemHarness = MatNavListItemHarness;
 }
 
 /** Harness for interacting with a nav list item. */

--- a/src/material/list/testing/selection-list-harness.ts
+++ b/src/material/list/testing/selection-list-harness.ts
@@ -33,7 +33,7 @@ export class MatSelectionListHarness extends MatListHarnessBase<
     return new HarnessPredicate(MatSelectionListHarness, options);
   }
 
-  _itemHarness = MatListOptionHarness;
+  override _itemHarness = MatListOptionHarness;
 
   /** Whether the selection list is disabled. */
   async isDisabled(): Promise<boolean> {

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -504,8 +504,8 @@ export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>
   ]
 })
 export class MatMenu extends _MatMenuBase {
-  protected _elevationPrefix = 'mat-elevation-z';
-  protected _baseElevation = 4;
+  protected override _elevationPrefix = 'mat-elevation-z';
+  protected override _baseElevation = 4;
 
   constructor(elementRef: ElementRef<HTMLElement>, ngZone: NgZone,
       @Inject(MAT_MENU_DEFAULT_OPTIONS) defaultOptions: MatMenuDefaultOptions) {

--- a/src/material/menu/testing/menu-harness.ts
+++ b/src/material/menu/testing/menu-harness.ts
@@ -121,7 +121,7 @@ export abstract class _MatMenuHarnessBase<
     return menu.clickItem(...subItemFilters as [Omit<ItemFilters, 'ancestor'>]);
   }
 
-  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
+  protected override async getRootHarnessLoader(): Promise<HarnessLoader> {
     const panelId = await this._getPanelId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${panelId}`);
   }

--- a/src/material/progress-bar/progress-bar.ts
+++ b/src/material/progress-bar/progress-bar.ts
@@ -105,14 +105,14 @@ let progressbarId = 0;
 })
 export class MatProgressBar extends _MatProgressBarBase implements CanColor,
                                                       AfterViewInit, OnDestroy {
-  constructor(public _elementRef: ElementRef, private _ngZone: NgZone,
+  constructor(elementRef: ElementRef, private _ngZone: NgZone,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode?: string,
               /**
                * @deprecated `location` parameter to be made required.
                * @breaking-change 8.0.0
                */
               @Optional() @Inject(MAT_PROGRESS_BAR_LOCATION) location?: MatProgressBarLocation) {
-    super(_elementRef);
+    super(elementRef);
 
     // We need to prefix the SVG reference with the current path, otherwise they won't work
     // in Safari if the page has a `<base>` tag. Note that we need quotes inside the `url()`,

--- a/src/material/progress-spinner/progress-spinner.ts
+++ b/src/material/progress-spinner/progress-spinner.ts
@@ -185,14 +185,14 @@ export class MatProgressSpinner extends _MatProgressSpinnerBase implements OnIni
     this._value = Math.max(0, Math.min(100, coerceNumberProperty(newValue)));
   }
 
-  constructor(public _elementRef: ElementRef<HTMLElement>,
+  constructor(elementRef: ElementRef<HTMLElement>,
               platform: Platform,
               @Optional() @Inject(DOCUMENT) private _document: any,
               @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string,
               @Inject(MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS)
                   defaults?: MatProgressSpinnerDefaultOptions) {
 
-    super(_elementRef);
+    super(elementRef);
 
     const trackedDiameters = MatProgressSpinner._diameters;
     this._spinnerAnimationLabel = this._getSpinnerAnimationLabel();

--- a/src/material/select/select.ts
+++ b/src/material/select/select.ts
@@ -384,7 +384,7 @@ export abstract class _MatSelectBase<C> extends _MatSelectMixinBase implements A
   @Input('aria-labelledby') ariaLabelledby: string;
 
   /** Object used to control when error messages are shown. */
-  @Input() errorStateMatcher: ErrorStateMatcher;
+  @Input() override errorStateMatcher: ErrorStateMatcher;
 
   /** Time to wait in milliseconds after the last keystroke before moving focus to an item. */
   @Input()
@@ -455,7 +455,7 @@ export abstract class _MatSelectBase<C> extends _MatSelectMixinBase implements A
     @Optional() _parentForm: NgForm,
     @Optional() _parentFormGroup: FormGroupDirective,
     @Optional() @Inject(MAT_FORM_FIELD) protected _parentFormField: MatFormField,
-    @Self() @Optional() public ngControl: NgControl,
+    @Self() @Optional() ngControl: NgControl,
     @Attribute('tabindex') tabIndex: string,
     @Inject(MAT_SELECT_SCROLL_STRATEGY) scrollStrategyFactory: any,
     private _liveAnnouncer: LiveAnnouncer,
@@ -1169,7 +1169,7 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
     return Math.min(Math.max(0, optimalScrollPosition), maxScroll);
   }
 
-  ngOnInit() {
+  override ngOnInit() {
     super.ngOnInit();
     this._viewportRuler.change().pipe(takeUntil(this._destroy)).subscribe(() => {
       if (this.panelOpen) {
@@ -1179,7 +1179,7 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
     });
   }
 
-  open(): void {
+  override open(): void {
     if (super._canOpen()) {
       super.open();
       this._triggerRect = this.trigger.nativeElement.getBoundingClientRect();
@@ -1217,7 +1217,7 @@ export class MatSelect extends _MatSelectBase<MatSelectChange> implements OnInit
     this.panel.nativeElement.scrollTop = this._scrollTop;
   }
 
-  protected _panelDoneAnimating(isOpen: boolean) {
+  protected override _panelDoneAnimating(isOpen: boolean) {
     if (this.panelOpen) {
       this._scrollTop = 0;
     } else {

--- a/src/material/sidenav/sidenav.ts
+++ b/src/material/sidenav/sidenav.ts
@@ -130,8 +130,7 @@ export class MatSidenavContainer extends MatDrawerContainer {
     // indirect descendants if it's left as false.
     descendants: true
   })
-  _allDrawers: QueryList<MatSidenav>;
+  override _allDrawers: QueryList<MatSidenav>;
 
-  @ContentChild(MatSidenavContent) _content: MatSidenavContent;
-  static ngAcceptInputType_hasBackdrop: BooleanInput;
+  @ContentChild(MatSidenavContent) override _content: MatSidenavContent;
 }

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -155,7 +155,7 @@ export class MatSnackBarContainer extends BasePortalOutlet
    * @deprecated To be turned into a method.
    * @breaking-change 10.0.0
    */
-  attachDomPortal = (portal: DomPortal) => {
+  override attachDomPortal = (portal: DomPortal) => {
     this._assertNotAttached();
     this._applySnackBarClasses();
     return this._portalOutlet.attachDomPortal(portal);

--- a/src/material/stepper/step-header.ts
+++ b/src/material/stepper/step-header.ts
@@ -96,7 +96,7 @@ export class MatStepHeader extends _MatStepHeaderBase implements AfterViewInit, 
   }
 
   /** Focuses the step header. */
-  focus(origin?: FocusOrigin, options?: FocusOptions) {
+  override focus(origin?: FocusOrigin, options?: FocusOptions) {
     if (origin) {
       this._focusMonitor.focusVia(this._elementRef, origin, options);
     } else {

--- a/src/material/stepper/stepper.ts
+++ b/src/material/stepper/stepper.ts
@@ -7,7 +7,6 @@
  */
 
 import {Directionality} from '@angular/cdk/bidi';
-import {BooleanInput} from '@angular/cdk/coercion';
 import {
   CdkStep,
   CdkStepper,
@@ -67,7 +66,7 @@ export class MatStep extends CdkStep implements ErrorStateMatcher, AfterContentI
   private _isSelected = Subscription.EMPTY;
 
   /** Content for step label given by `<ng-template matStepLabel>`. */
-  @ContentChild(MatStepLabel) stepLabel: MatStepLabel;
+  @ContentChild(MatStepLabel) override stepLabel: MatStepLabel;
 
   /** Theme color for the particular step. */
   @Input() color: ThemePalette;
@@ -124,7 +123,7 @@ export class MatStep extends CdkStep implements ErrorStateMatcher, AfterContentI
  */
 @Directive()
 abstract class _MatProxyStepperBase extends CdkStepper {
-  readonly steps: QueryList<MatStep>;
+  override readonly steps: QueryList<MatStep>;
   readonly animationDone: EventEmitter<void>;
   disableRipple: boolean;
   color: ThemePalette;
@@ -176,13 +175,13 @@ export class MatVerticalStepper extends _MatProxyStepperBase {}
 })
 export class MatStepper extends CdkStepper implements AfterContentInit {
   /** The list of step headers of the steps in the stepper. */
-  @ViewChildren(MatStepHeader) _stepHeader: QueryList<MatStepHeader>;
+  @ViewChildren(MatStepHeader) override _stepHeader: QueryList<MatStepHeader>;
 
   /** Full list of steps inside the stepper, including inside nested steppers. */
-  @ContentChildren(MatStep, {descendants: true}) _steps: QueryList<MatStep>;
+  @ContentChildren(MatStep, {descendants: true}) override _steps: QueryList<MatStep>;
 
   /** Steps that belong to the current stepper, excluding ones from nested steppers. */
-  readonly steps: QueryList<MatStep> = new QueryList<MatStep>();
+  override readonly steps: QueryList<MatStep> = new QueryList<MatStep>();
 
   /** Custom icon overrides passed in by the consumer. */
   @ContentChildren(MatStepperIcon, {descendants: true}) _icons: QueryList<MatStepperIcon>;
@@ -219,7 +218,7 @@ export class MatStepper extends CdkStepper implements AfterContentInit {
     this.orientation = nodeName === 'mat-vertical-stepper' ? 'vertical' : 'horizontal';
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     super.ngAfterContentInit();
     this._icons.forEach(({name, templateRef}) => this._iconOverrides[name] = templateRef);
 
@@ -240,9 +239,4 @@ export class MatStepper extends CdkStepper implements AfterContentInit {
       }
     });
   }
-
-  static ngAcceptInputType_editable: BooleanInput;
-  static ngAcceptInputType_optional: BooleanInput;
-  static ngAcceptInputType_completed: BooleanInput;
-  static ngAcceptInputType_hasError: BooleanInput;
 }

--- a/src/material/stepper/testing/step-harness.ts
+++ b/src/material/stepper/testing/step-harness.ts
@@ -89,7 +89,7 @@ export class MatStepHarness extends ContentContainerComponentHarness<string> {
     await (await this.host()).click();
   }
 
-  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
+  protected override async getRootHarnessLoader(): Promise<HarnessLoader> {
     const contentId = await (await this.host()).getAttribute('aria-controls');
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${contentId}`);
   }

--- a/src/material/table/cell.ts
+++ b/src/material/table/cell.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {Directive, Input} from '@angular/core';
 import {
   CdkCell,
@@ -61,8 +60,8 @@ export class MatFooterCellDef extends CdkFooterCellDef {}
 export class MatColumnDef extends CdkColumnDef {
   /** Unique name for this column. */
   @Input('matColumnDef')
-  get name(): string { return this._name; }
-  set name(name: string) { this._setNameInput(name); }
+  override get name(): string { return this._name; }
+  override set name(name: string) { this._setNameInput(name); }
 
   /**
    * Add "mat-column-" prefix in addition to "cdk-column-" prefix.
@@ -70,12 +69,10 @@ export class MatColumnDef extends CdkColumnDef {
    * will change from type string[] to string.
    * @docs-private
    */
-  protected _updateColumnCssClassName() {
+  protected override _updateColumnCssClassName() {
     super._updateColumnCssClassName();
     this._columnCssClassName!.push(`mat-column-${this.cssClassFriendlyName}`);
   }
-
-  static ngAcceptInputType_sticky: BooleanInput;
 }
 
 /** Header cell template container that adds the right classes and role. */

--- a/src/material/table/row.ts
+++ b/src/material/table/row.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BooleanInput} from '@angular/cdk/coercion';
 import {
   CDK_ROW_TEMPLATE,
   CdkFooterRow,
@@ -28,9 +27,7 @@ import {ChangeDetectionStrategy, Component, Directive, ViewEncapsulation} from '
   providers: [{provide: CdkHeaderRowDef, useExisting: MatHeaderRowDef}],
   inputs: ['columns: matHeaderRowDef', 'sticky: matHeaderRowDefSticky'],
 })
-export class MatHeaderRowDef extends CdkHeaderRowDef {
-  static ngAcceptInputType_sticky: BooleanInput;
-}
+export class MatHeaderRowDef extends CdkHeaderRowDef {}
 
 /**
  * Footer row definition for the mat-table.
@@ -41,9 +38,7 @@ export class MatHeaderRowDef extends CdkHeaderRowDef {
   providers: [{provide: CdkFooterRowDef, useExisting: MatFooterRowDef}],
   inputs: ['columns: matFooterRowDef', 'sticky: matFooterRowDefSticky'],
 })
-export class MatFooterRowDef extends CdkFooterRowDef {
-  static ngAcceptInputType_sticky: BooleanInput;
-}
+export class MatFooterRowDef extends CdkFooterRowDef {}
 
 /**
  * Data row definition for the mat-table.

--- a/src/material/table/table.ts
+++ b/src/material/table/table.ts
@@ -60,8 +60,8 @@ export class MatRecycleRows {}
 })
 export class MatTable<T> extends CdkTable<T> {
   /** Overrides the sticky CSS class set by the `CdkTable`. */
-  protected stickyCssClass = 'mat-table-sticky';
+  protected override stickyCssClass = 'mat-table-sticky';
 
   /** Overrides the need to add position: sticky on every sticky cell element in `CdkTable`. */
-  protected needsPositionStickyOnElement = false;
+  protected override needsPositionStickyOnElement = false;
 }

--- a/src/material/table/testing/cell-harness.ts
+++ b/src/material/table/testing/cell-harness.ts
@@ -63,7 +63,7 @@ export class MatCellHarness extends ContentContainerComponentHarness {
 /** Harness for interacting with a standard Angular Material table header cell. */
 export class MatHeaderCellHarness extends MatCellHarness {
   /** The selector for the host element of a `MatHeaderCellHarness` instance. */
-  static hostSelector = '.mat-header-cell';
+  static override hostSelector = '.mat-header-cell';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for
@@ -71,7 +71,7 @@ export class MatHeaderCellHarness extends MatCellHarness {
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: CellHarnessFilters = {}): HarnessPredicate<MatHeaderCellHarness> {
+  static override with(options: CellHarnessFilters = {}): HarnessPredicate<MatHeaderCellHarness> {
     return MatHeaderCellHarness._getCellPredicate(MatHeaderCellHarness, options);
   }
 }
@@ -79,7 +79,7 @@ export class MatHeaderCellHarness extends MatCellHarness {
 /** Harness for interacting with a standard Angular Material table footer cell. */
 export class MatFooterCellHarness extends MatCellHarness {
   /** The selector for the host element of a `MatFooterCellHarness` instance. */
-  static hostSelector = '.mat-footer-cell';
+  static override hostSelector = '.mat-footer-cell';
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for
@@ -87,7 +87,7 @@ export class MatFooterCellHarness extends MatCellHarness {
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: CellHarnessFilters = {}): HarnessPredicate<MatFooterCellHarness> {
+  static override with(options: CellHarnessFilters = {}): HarnessPredicate<MatFooterCellHarness> {
     return MatFooterCellHarness._getCellPredicate(MatFooterCellHarness, options);
   }
 }

--- a/src/material/tabs/tab-body.ts
+++ b/src/material/tabs/tab-body.ts
@@ -76,7 +76,7 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
   }
 
   /** Set initial visibility or set up subscription for changing visibility. */
-  ngOnInit(): void {
+  override ngOnInit(): void {
     super.ngOnInit();
 
     this._centeringSub = this._host._beforeCentering
@@ -93,7 +93,7 @@ export class MatTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
   }
 
   /** Clean up centering subscription. */
-  ngOnDestroy(): void {
+  override ngOnDestroy(): void {
     super.ngOnDestroy();
     this._centeringSub.unsubscribe();
     this._leavingSub.unsubscribe();

--- a/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -58,7 +58,7 @@ export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements Af
   AfterContentInit, OnDestroy {
 
   /** Query list of all tab links of the tab navigation. */
-  abstract _items: QueryList<MatPaginatedTabHeaderItem & {active: boolean}>;
+  abstract override _items: QueryList<MatPaginatedTabHeaderItem & {active: boolean}>;
 
   /** Background color of the tab nav. */
   @Input()
@@ -98,7 +98,7 @@ export abstract class _MatTabNavBase extends MatPaginatedTabHeader implements Af
     // noop
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     // We need this to run before the `changes` subscription in parent to ensure that the
     // selectedIndex is up-to-date by the time the super class starts looking for it.
     this._items.changes.pipe(startWith(null), takeUntil(this._destroyed)).subscribe(() => {
@@ -288,7 +288,7 @@ export class MatTabLink extends _MatTabLinkBase implements OnDestroy {
     this._tabLinkRipple.setupTriggerEvents(elementRef.nativeElement);
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
     this._tabLinkRipple._removeTriggerEvents();
   }

--- a/src/material/tabs/testing/tab-harness.ts
+++ b/src/material/tabs/testing/tab-harness.ts
@@ -79,7 +79,7 @@ export class MatTabHarness extends ContentContainerComponentHarness<string> {
     return this.getRootHarnessLoader();
   }
 
-  protected async getRootHarnessLoader(): Promise<HarnessLoader> {
+  protected override async getRootHarnessLoader(): Promise<HarnessLoader> {
     const contentId = await this._getContentId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${contentId}`);
   }

--- a/src/material/tree/node.ts
+++ b/src/material/tree/node.ts
@@ -46,30 +46,30 @@ export class MatTreeNode<T, K = T> extends _MatTreeNodeBase<T, K>
     implements CanDisable, DoCheck, HasTabIndex, OnInit, OnDestroy {
 
 
-  constructor(protected _elementRef: ElementRef<HTMLElement>,
-              protected _tree: CdkTree<T, K>,
+  constructor(elementRef: ElementRef<HTMLElement>,
+              tree: CdkTree<T, K>,
               @Attribute('tabindex') tabIndex: string) {
-    super(_elementRef, _tree);
+    super(elementRef, tree);
 
     this.tabIndex = Number(tabIndex) || 0;
     // The classes are directly added here instead of in the host property because classes on
     // the host property are not inherited with View Engine. It is not set as a @HostBinding because
     // it is not set by the time it's children nodes try to read the class from it.
     // TODO: move to host after View Engine deprecation
-    this._elementRef.nativeElement.classList.add('mat-tree-node');
+    elementRef.nativeElement.classList.add('mat-tree-node');
   }
 
   // This is a workaround for https://github.com/angular/angular/issues/23091
   // In aot mode, the lifecycle hooks from parent class are not called.
-  ngOnInit() {
+  override ngOnInit() {
     super.ngOnInit();
   }
 
-  ngDoCheck() {
+  override ngDoCheck() {
     super.ngDoCheck();
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
   }
 
@@ -124,35 +124,35 @@ export class MatNestedTreeNode<T, K = T> extends CdkNestedTreeNode<T, K>
   }
   private _tabIndex: number;
 
-  constructor(protected _elementRef: ElementRef<HTMLElement>,
-              protected _tree: CdkTree<T, K>,
-              protected _differs: IterableDiffers,
+  constructor(elementRef: ElementRef<HTMLElement>,
+              tree: CdkTree<T, K>,
+              differs: IterableDiffers,
               @Attribute('tabindex') tabIndex: string) {
-    super(_elementRef, _tree, _differs);
+    super(elementRef, tree, differs);
     this.tabIndex = Number(tabIndex) || 0;
     // The classes are directly added here instead of in the host property because classes on
     // the host property are not inherited with View Engine. It is not set as a @HostBinding because
     // it is not set by the time it's children nodes try to read the class from it.
     // TODO: move to host after View Engine deprecation
-    this._elementRef.nativeElement.classList.add('mat-nested-tree-node');
+    elementRef.nativeElement.classList.add('mat-nested-tree-node');
   }
 
   // This is a workaround for https://github.com/angular/angular/issues/19145
   // In aot mode, the lifecycle hooks from parent class are not called.
   // TODO(tinayuangao): Remove when the angular issue #19145 is fixed
-  ngOnInit() {
+  override ngOnInit() {
     super.ngOnInit();
   }
 
-  ngDoCheck() {
+  override ngDoCheck() {
     super.ngDoCheck();
   }
 
-  ngAfterContentInit() {
+  override ngAfterContentInit() {
     super.ngAfterContentInit();
   }
 
-  ngOnDestroy() {
+  override ngOnDestroy() {
     super.ngOnDestroy();
   }
 

--- a/src/material/tree/padding.ts
+++ b/src/material/tree/padding.ts
@@ -19,11 +19,11 @@ export class MatTreeNodePadding<T, K = T> extends CdkTreeNodePadding<T, K> {
 
   /** The level of depth of the tree node. The padding will be `level * indent` pixels. */
   @Input('matTreeNodePadding')
-  get level(): number { return this._level; }
-  set level(value: number) { this._setLevelInput(value); }
+  override get level(): number { return this._level; }
+  override set level(value: number) { this._setLevelInput(value); }
 
   /** The indent for each level. Default number 40px from material design menu sub-menu spec. */
   @Input('matTreeNodePaddingIndent')
-  get indent(): number | string { return this._indent; }
-  set indent(indent: number | string) { this._setIndentInput(indent); }
+  override get indent(): number | string { return this._indent; }
+  override set indent(indent: number | string) { this._setIndentInput(indent); }
 }

--- a/src/material/tree/toggle.ts
+++ b/src/material/tree/toggle.ts
@@ -20,8 +20,8 @@ import {Directive, Input} from '@angular/core';
 // tslint:disable-next-line: coercion-types
 export class MatTreeNodeToggle<T, K = T> extends CdkTreeNodeToggle<T, K> {
   @Input('matTreeNodeToggleRecursive')
-  get recursive(): boolean { return this._recursive; }
-  set recursive(value: boolean) {
+  override get recursive(): boolean { return this._recursive; }
+  override set recursive(value: boolean) {
     // TODO: when we remove support for ViewEngine, change this setter to an input
     // alias in the decorator metadata.
     this._recursive = coerceBooleanProperty(value);

--- a/src/material/tree/tree.ts
+++ b/src/material/tree/tree.ts
@@ -42,5 +42,5 @@ import {MatTreeNodeOutlet} from './outlet';
 })
 export class MatTree<T, K = T> extends CdkTree<T, K> {
   // Outlets within the tree's template where the dataNodes will be inserted.
-  @ViewChild(MatTreeNodeOutlet, {static: true}) _nodeOutlet: MatTreeNodeOutlet;
+  @ViewChild(MatTreeNodeOutlet, {static: true}) override _nodeOutlet: MatTreeNodeOutlet;
 }

--- a/tools/public_api_guard/cdk/tree.d.ts
+++ b/tools/public_api_guard/cdk/tree.d.ts
@@ -23,10 +23,8 @@ export declare const CDK_TREE_NODE_OUTLET_NODE: InjectionToken<{}>;
 export declare class CdkNestedTreeNode<T, K = T> extends CdkTreeNode<T, K> implements AfterContentInit, DoCheck, OnDestroy, OnInit {
     protected _children: T[];
     protected _differs: IterableDiffers;
-    protected _elementRef: ElementRef<HTMLElement>;
-    protected _tree: CdkTree<T, K>;
     nodeOutlet: QueryList<CdkTreeNodeOutlet>;
-    constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T, K>, _differs: IterableDiffers);
+    constructor(elementRef: ElementRef<HTMLElement>, tree: CdkTree<T, K>, _differs: IterableDiffers);
     protected _clear(): void;
     ngAfterContentInit(): void;
     ngDoCheck(): void;

--- a/tools/public_api_guard/material/chips.d.ts
+++ b/tools/public_api_guard/material/chips.d.ts
@@ -11,7 +11,6 @@ export declare class MatChip extends _MatChipMixinBase implements FocusableOptio
     _chipListDisabled: boolean;
     _chipListMultiple: boolean;
     protected _disabled: boolean;
-    _elementRef: ElementRef<HTMLElement>;
     _hasFocus: boolean;
     readonly _onBlur: Subject<MatChipEvent>;
     readonly _onFocus: Subject<MatChipEvent>;
@@ -39,7 +38,7 @@ export declare class MatChip extends _MatChipMixinBase implements FocusableOptio
     trailingIcon: MatChipTrailingIcon;
     get value(): any;
     set value(value: any);
-    constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, _changeDetectorRef: ChangeDetectorRef, _document: any, animationMode?: string, tabIndex?: string);
+    constructor(elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, platform: Platform, globalRippleOptions: RippleGlobalOptions | null, _changeDetectorRef: ChangeDetectorRef, _document: any, animationMode?: string, tabIndex?: string);
     _addHostClassName(): void;
     _blur(): void;
     _handleClick(event: Event): void;
@@ -144,7 +143,6 @@ export declare class MatChipList extends _MatChipListBase implements MatFormFiel
     get id(): string;
     get multiple(): boolean;
     set multiple(value: boolean);
-    ngControl: NgControl;
     get placeholder(): string;
     set placeholder(value: string);
     get required(): boolean;
@@ -158,8 +156,7 @@ export declare class MatChipList extends _MatChipListBase implements MatFormFiel
     get value(): any;
     set value(value: any);
     readonly valueChange: EventEmitter<any>;
-    constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher,
-    ngControl: NgControl);
+    constructor(_elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, _dir: Directionality, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, ngControl: NgControl);
     _allowFocusEscape(): void;
     _blur(): void;
     _focusInput(options?: FocusOptions): void;

--- a/tools/public_api_guard/material/datepicker.d.ts
+++ b/tools/public_api_guard/material/datepicker.d.ts
@@ -259,7 +259,6 @@ export declare class MatDatepickerInput<D> extends MatDatepickerInputBase<D | nu
     getStartValue(): D | null;
     getThemePalette(): ThemePalette;
     ngOnDestroy(): void;
-    static ngAcceptInputType_value: any;
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatDatepickerInput<any>, "input[matDatepicker]", ["matDatepickerInput"], { "matDatepicker": "matDatepicker"; "min": "min"; "max": "max"; "dateFilter": "matDatepickerFilter"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MatDatepickerInput<any>, [null, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
@@ -412,7 +411,6 @@ export declare class MatEndDate<D> extends _MatDateRangeInputBase<D> implements 
     protected _shouldHandleChangeEvent(change: DateSelectionModelChange<DateRange<D>>): boolean;
     ngDoCheck(): void;
     ngOnInit(): void;
-    static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatEndDate<any>, "input[matEndDate]", never, { "errorStateMatcher": "errorStateMatcher"; }, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MatEndDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }
@@ -525,7 +523,6 @@ export declare class MatStartDate<D> extends _MatDateRangeInputBase<D> implement
     getMirrorValue(): string;
     ngDoCheck(): void;
     ngOnInit(): void;
-    static ngAcceptInputType_disabled: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatStartDate<any>, "input[matStartDate]", never, { "errorStateMatcher": "errorStateMatcher"; }, { "dateChange": "dateChange"; "dateInput": "dateInput"; }, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MatStartDate<any>, [null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; }]>;
 }

--- a/tools/public_api_guard/material/form-field.d.ts
+++ b/tools/public_api_guard/material/form-field.d.ts
@@ -33,7 +33,6 @@ export declare class MatFormField extends _MatFormFieldBase implements AfterCont
     set _control(value: MatFormFieldControl<any>);
     _controlNonStatic: MatFormFieldControl<any>;
     _controlStatic: MatFormFieldControl<any>;
-    _elementRef: ElementRef;
     _errorChildren: QueryList<MatError>;
     _hintChildren: QueryList<MatHint>;
     readonly _hintLabelId: string;
@@ -54,7 +53,7 @@ export declare class MatFormField extends _MatFormFieldBase implements AfterCont
     get hintLabel(): string;
     set hintLabel(value: string);
     underlineRef: ElementRef;
-    constructor(_elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef,
+    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef,
     _labelOptions: any, _dir: Directionality, _defaults: MatFormFieldDefaultOptions, _platform: Platform, _ngZone: NgZone, _animationMode: string);
     _animateAndLockLabel(): void;
     _canLabelFloat(): boolean;

--- a/tools/public_api_guard/material/input.d.ts
+++ b/tools/public_api_guard/material/input.d.ts
@@ -27,7 +27,6 @@ export declare class MatInput extends _MatInputBase implements MatFormFieldContr
     focused: boolean;
     get id(): string;
     set id(value: string);
-    ngControl: NgControl;
     placeholder: string;
     get readonly(): boolean;
     set readonly(value: boolean);
@@ -40,8 +39,7 @@ export declare class MatInput extends _MatInputBase implements MatFormFieldContr
     userAriaDescribedBy: string;
     get value(): string;
     set value(value: string);
-    constructor(_elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>, _platform: Platform,
-    ngControl: NgControl, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined);
+    constructor(_elementRef: ElementRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>, _platform: Platform, ngControl: NgControl, _parentForm: NgForm, _parentFormGroup: FormGroupDirective, _defaultErrorStateMatcher: ErrorStateMatcher, inputValueAccessor: any, _autofillMonitor: AutofillMonitor, ngZone: NgZone, _formField?: MatFormField | undefined);
     protected _dirtyCheckNativeValue(): void;
     _focusChanged(isFocused: boolean): void;
     protected _isBadInput(): boolean;

--- a/tools/public_api_guard/material/progress-bar.d.ts
+++ b/tools/public_api_guard/material/progress-bar.d.ts
@@ -4,7 +4,6 @@ export declare function MAT_PROGRESS_BAR_LOCATION_FACTORY(): MatProgressBarLocat
 
 export declare class MatProgressBar extends _MatProgressBarBase implements CanColor, AfterViewInit, OnDestroy {
     _animationMode?: string | undefined;
-    _elementRef: ElementRef;
     _isNoopAnimation: boolean;
     _primaryValueBar: ElementRef;
     _rectangleFillValue: string;
@@ -15,7 +14,7 @@ export declare class MatProgressBar extends _MatProgressBarBase implements CanCo
     progressbarId: string;
     get value(): number;
     set value(v: number);
-    constructor(_elementRef: ElementRef, _ngZone: NgZone, _animationMode?: string | undefined,
+    constructor(elementRef: ElementRef, _ngZone: NgZone, _animationMode?: string | undefined,
     location?: MatProgressBarLocation);
     _bufferTransform(): {
         transform: string;

--- a/tools/public_api_guard/material/progress-spinner.d.ts
+++ b/tools/public_api_guard/material/progress-spinner.d.ts
@@ -3,7 +3,6 @@ export declare const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatPro
 export declare function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinnerDefaultOptions;
 
 export declare class MatProgressSpinner extends _MatProgressSpinnerBase implements OnInit, CanColor {
-    _elementRef: ElementRef<HTMLElement>;
     _noopAnimations: boolean;
     _spinnerAnimationLabel: string;
     get diameter(): number;
@@ -13,7 +12,7 @@ export declare class MatProgressSpinner extends _MatProgressSpinnerBase implemen
     set strokeWidth(value: number);
     get value(): number;
     set value(newValue: number);
-    constructor(_elementRef: ElementRef<HTMLElement>, platform: Platform, _document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
+    constructor(elementRef: ElementRef<HTMLElement>, platform: Platform, _document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
     _getCircleRadius(): number;
     _getCircleStrokeWidth(): number;
     _getStrokeCircumference(): number;

--- a/tools/public_api_guard/material/select.d.ts
+++ b/tools/public_api_guard/material/select.d.ts
@@ -32,7 +32,6 @@ export declare abstract class _MatSelectBase<C> extends _MatSelectMixinBase impl
     set id(value: string);
     get multiple(): boolean;
     set multiple(value: boolean);
-    ngControl: NgControl;
     readonly openedChange: EventEmitter<boolean>;
     abstract optionGroups: QueryList<MatOptgroup>;
     readonly optionSelectionChanges: Observable<MatOptionSelectionChange>;

--- a/tools/public_api_guard/material/sidenav.d.ts
+++ b/tools/public_api_guard/material/sidenav.d.ts
@@ -113,7 +113,6 @@ export declare class MatSidenav extends MatDrawer {
 export declare class MatSidenavContainer extends MatDrawerContainer {
     _allDrawers: QueryList<MatSidenav>;
     _content: MatSidenavContent;
-    static ngAcceptInputType_hasBackdrop: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDeclaration<MatSidenavContainer, "mat-sidenav-container", ["matSidenavContainer"], {}, {}, ["_content", "_allDrawers"], ["mat-sidenav", "mat-sidenav-content", "*"]>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MatSidenavContainer, never>;
 }

--- a/tools/public_api_guard/material/stepper.d.ts
+++ b/tools/public_api_guard/material/stepper.d.ts
@@ -75,10 +75,6 @@ export declare class MatStepper extends CdkStepper implements AfterContentInit {
     readonly steps: QueryList<MatStep>;
     constructor(dir: Directionality, changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef<HTMLElement>, _document: any);
     ngAfterContentInit(): void;
-    static ngAcceptInputType_completed: BooleanInput;
-    static ngAcceptInputType_editable: BooleanInput;
-    static ngAcceptInputType_hasError: BooleanInput;
-    static ngAcceptInputType_optional: BooleanInput;
     static ɵcmp: i0.ɵɵComponentDeclaration<MatStepper, "mat-stepper, mat-vertical-stepper, mat-horizontal-stepper, [matStepper]", ["matStepper", "matVerticalStepper", "matHorizontalStepper"], { "selectedIndex": "selectedIndex"; "disableRipple": "disableRipple"; "color": "color"; "labelPosition": "labelPosition"; }, { "animationDone": "animationDone"; }, ["_steps", "_icons"], never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MatStepper, [{ optional: true; }, null, null, null]>;
 }

--- a/tools/public_api_guard/material/table.d.ts
+++ b/tools/public_api_guard/material/table.d.ts
@@ -36,7 +36,6 @@ export declare class MatColumnDef extends CdkColumnDef {
     get name(): string;
     set name(name: string);
     protected _updateColumnCssClassName(): void;
-    static ngAcceptInputType_sticky: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatColumnDef, "[matColumnDef]", never, { "sticky": "sticky"; "name": "matColumnDef"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MatColumnDef, never>;
 }
@@ -57,7 +56,6 @@ export declare class MatFooterRow extends CdkFooterRow {
 }
 
 export declare class MatFooterRowDef extends CdkFooterRowDef {
-    static ngAcceptInputType_sticky: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatFooterRowDef, "[matFooterRowDef]", never, { "columns": "matFooterRowDef"; "sticky": "matFooterRowDefSticky"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MatFooterRowDef, never>;
 }
@@ -78,7 +76,6 @@ export declare class MatHeaderRow extends CdkHeaderRow {
 }
 
 export declare class MatHeaderRowDef extends CdkHeaderRowDef {
-    static ngAcceptInputType_sticky: BooleanInput;
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatHeaderRowDef, "[matHeaderRowDef]", never, { "columns": "matHeaderRowDef"; "sticky": "matHeaderRowDefSticky"; }, {}, never>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MatHeaderRowDef, never>;
 }

--- a/tools/public_api_guard/material/tree.d.ts
+++ b/tools/public_api_guard/material/tree.d.ts
@@ -1,13 +1,10 @@
 export declare class MatNestedTreeNode<T, K = T> extends CdkNestedTreeNode<T, K> implements AfterContentInit, DoCheck, OnDestroy, OnInit {
-    protected _differs: IterableDiffers;
-    protected _elementRef: ElementRef<HTMLElement>;
-    protected _tree: CdkTree<T, K>;
     get disabled(): any;
     set disabled(value: any);
     node: T;
     get tabIndex(): number;
     set tabIndex(value: number);
-    constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T, K>, _differs: IterableDiffers, tabIndex: string);
+    constructor(elementRef: ElementRef<HTMLElement>, tree: CdkTree<T, K>, differs: IterableDiffers, tabIndex: string);
     ngAfterContentInit(): void;
     ngDoCheck(): void;
     ngOnDestroy(): void;
@@ -57,9 +54,7 @@ export declare class MatTreeNestedDataSource<T> extends DataSource<T> {
 }
 
 export declare class MatTreeNode<T, K = T> extends _MatTreeNodeBase<T, K> implements CanDisable, DoCheck, HasTabIndex, OnInit, OnDestroy {
-    protected _elementRef: ElementRef<HTMLElement>;
-    protected _tree: CdkTree<T, K>;
-    constructor(_elementRef: ElementRef<HTMLElement>, _tree: CdkTree<T, K>, tabIndex: string);
+    constructor(elementRef: ElementRef<HTMLElement>, tree: CdkTree<T, K>, tabIndex: string);
     ngDoCheck(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;

--- a/tools/tslint-rules/classListSignaturesRule.ts
+++ b/tools/tslint-rules/classListSignaturesRule.ts
@@ -12,7 +12,7 @@ export class Rule extends Lint.Rules.TypedRule {
 }
 
 class Walker extends Lint.ProgramAwareRuleWalker {
-  visitPropertyAccessExpression(propertyAccess: ts.PropertyAccessExpression) {
+  override visitPropertyAccessExpression(propertyAccess: ts.PropertyAccessExpression) {
     const parent = propertyAccess.parent;
 
     // We only care about property accesses inside of calls.

--- a/tools/tslint-rules/coercionTypesRule.ts
+++ b/tools/tslint-rules/coercionTypesRule.ts
@@ -49,14 +49,14 @@ class Walker extends Lint.RuleWalker {
     this._coercionInterfaces = options.ruleArguments[1] || {};
   }
 
-  visitPropertyDeclaration(node: ts.PropertyDeclaration) {
+  override visitPropertyDeclaration(node: ts.PropertyDeclaration) {
     if (ts.isIdentifier(node.name) && node.name.text.startsWith(TYPE_ACCEPT_MEMBER_PREFIX)) {
       this._lintCoercionMember(node);
     }
     super.visitPropertyDeclaration(node);
   }
 
-  visitClassDeclaration(node: ts.ClassDeclaration) {
+  override visitClassDeclaration(node: ts.ClassDeclaration) {
     if (this._shouldLintClass(node)) {
       this._lintClass(node, node, true);
       this._lintSuperClasses(node);

--- a/tools/tslint-rules/memberNamingRule.ts
+++ b/tools/tslint-rules/memberNamingRule.ts
@@ -35,7 +35,7 @@ class Walker extends Lint.RuleWalker {
     }, {} as {[key: string]: RegExp});
   }
 
-  visitClassDeclaration(node: ts.ClassDeclaration) {
+  override visitClassDeclaration(node: ts.ClassDeclaration) {
     node.members.forEach(member => {
       // Members without a modifier are considered public.
       if (!member.modifiers || tsutils.hasModifier(member.modifiers, ts.SyntaxKind.PublicKeyword)) {
@@ -50,7 +50,7 @@ class Walker extends Lint.RuleWalker {
     super.visitClassDeclaration(node);
   }
 
-  visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
+  override visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
     node.parameters.forEach(param => {
       const modifiers = param.modifiers;
 

--- a/tools/tslint-rules/ngOnChangesPropertyAccessRule.ts
+++ b/tools/tslint-rules/ngOnChangesPropertyAccessRule.ts
@@ -13,7 +13,7 @@ export class Rule extends Lint.Rules.TypedRule {
 }
 
 class Walker extends Lint.ProgramAwareRuleWalker {
-  visitMethodDeclaration(method: ts.MethodDeclaration) {
+  override visitMethodDeclaration(method: ts.MethodDeclaration) {
     // Walk through all of the `ngOnChanges` methods that have at least one parameter.
     if (method.name.getText() !== 'ngOnChanges' || !method.parameters.length || !method.body) {
       return;

--- a/tools/tslint-rules/noExposedTodoRule.ts
+++ b/tools/tslint-rules/noExposedTodoRule.ts
@@ -20,7 +20,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoExposedTodoWalker extends Lint.RuleWalker {
 
-  visitSourceFile(sourceFile: ts.SourceFile) {
+  override visitSourceFile(sourceFile: ts.SourceFile) {
     utils.forEachComment(sourceFile, (text, commentRange) => {
       const isTodoComment = text.substring(commentRange.pos, commentRange.end).includes('TODO:');
 

--- a/tools/tslint-rules/noHostDecoratorInConcreteRule.ts
+++ b/tools/tslint-rules/noHostDecoratorInConcreteRule.ts
@@ -8,7 +8,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class Walker extends Lint.RuleWalker {
-  visitClassDeclaration(node: ts.ClassDeclaration) {
+  override visitClassDeclaration(node: ts.ClassDeclaration) {
     if (!node.modifiers || !this.getOptions().length) { return; }
 
     // Do not check the class if its abstract.

--- a/tools/tslint-rules/noLifecycleInvocationRule.ts
+++ b/tools/tslint-rules/noLifecycleInvocationRule.ts
@@ -33,7 +33,7 @@ class Walker extends Lint.RuleWalker {
     this._enabled = fileGlobs.some(p => minimatch(relativeFilePath, p));
   }
 
-  visitPropertyAccessExpression(node: ts.PropertyAccessExpression) {
+  override visitPropertyAccessExpression(node: ts.PropertyAccessExpression) {
     // Flag any accesses of the lifecycle hooks that are
     // inside function call and don't match the allowed criteria.
     if (this._enabled && ts.isCallExpression(node.parent) && hooks.has(node.name.text) &&

--- a/tools/tslint-rules/noPrivateGettersRule.ts
+++ b/tools/tslint-rules/noPrivateGettersRule.ts
@@ -23,7 +23,7 @@ class Walker extends Lint.RuleWalker {
     this._pattern = options.ruleArguments.length ? new RegExp(options.ruleArguments[0]) : null;
   }
 
-  visitGetAccessor(getter: ts.GetAccessorDeclaration) {
+  override visitGetAccessor(getter: ts.GetAccessorDeclaration) {
     const getterName = getter.name.getText();
     const matchesPattern = !this._pattern || this._pattern.test(getterName);
     const isPrivate = getter.modifiers && getter.modifiers.some(modifier => {

--- a/tools/tslint-rules/noUndecoratedBaseClassDiRule.ts
+++ b/tools/tslint-rules/noUndecoratedBaseClassDiRule.ts
@@ -24,7 +24,7 @@ class Walker extends Lint.RuleWalker {
     super(sourceFile, options);
   }
 
-  visitClassDeclaration(node: ts.ClassDeclaration) {
+  override visitClassDeclaration(node: ts.ClassDeclaration) {
     // If the class isn't decorated or it has an explicit constructor we don't need to check it.
     if (!this.hasDirectiveDecorator(node) || this.hasExplicitConstructor(node)) {
       return;

--- a/tools/tslint-rules/noUndecoratedClassWithAngularFeaturesRule.ts
+++ b/tools/tslint-rules/noUndecoratedClassWithAngularFeaturesRule.ts
@@ -27,7 +27,7 @@ class Walker extends Lint.RuleWalker {
     super(sourceFile, options);
   }
 
-  visitClassDeclaration(node: ts.ClassDeclaration) {
+  override visitClassDeclaration(node: ts.ClassDeclaration) {
     if (this._hasAngularDecorator(node)) {
       return;
     }

--- a/tools/tslint-rules/noUnescapedHtmlTagRule.ts
+++ b/tools/tslint-rules/noUnescapedHtmlTagRule.ts
@@ -19,7 +19,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoUnescapedHtmlTagWalker extends Lint.RuleWalker {
 
-  visitSourceFile(sourceFile: ts.SourceFile) {
+  override visitSourceFile(sourceFile: ts.SourceFile) {
     utils.forEachComment(sourceFile, (fullText, commentRange) => {
       const htmlIsEscaped =
         this._parseForHtml(fullText.substring(commentRange.pos, commentRange.end));

--- a/tools/tslint-rules/preferConstEnumRule.ts
+++ b/tools/tslint-rules/preferConstEnumRule.ts
@@ -12,7 +12,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class Walker extends Lint.RuleWalker {
-  visitEnumDeclaration(node: ts.EnumDeclaration) {
+  override visitEnumDeclaration(node: ts.EnumDeclaration) {
     if (!tsutils.hasModifier(node.modifiers, ts.SyntaxKind.ConstKeyword)) {
       this.addFailureAtNode(node.name, 'Enums should be declared as `const enum`.');
     }

--- a/tools/tslint-rules/requireLicenseBannerRule.ts
+++ b/tools/tslint-rules/requireLicenseBannerRule.ts
@@ -44,7 +44,7 @@ class RequireLicenseBannerWalker extends Lint.RuleWalker {
     this._enabled = fileGlobs.some(p => minimatch(relativeFilePath, p));
   }
 
-  visitSourceFile(sourceFile: ts.SourceFile) {
+  override visitSourceFile(sourceFile: ts.SourceFile) {
     if (!this._enabled) {
       return;
     }

--- a/tools/tslint-rules/settersAfterGettersRule.ts
+++ b/tools/tslint-rules/settersAfterGettersRule.ts
@@ -12,7 +12,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class Walker extends Lint.RuleWalker {
-  visitGetAccessor(getter: ts.GetAccessorDeclaration) {
+  override visitGetAccessor(getter: ts.GetAccessorDeclaration) {
     if (getter.parent && tsutils.isClassDeclaration(getter.parent)) {
       const getterName = getter.name.getText();
       const setter = getter.parent.members.find(member => {

--- a/tools/tslint-rules/validateDecoratorsRule.ts
+++ b/tools/tslint-rules/validateDecoratorsRule.ts
@@ -80,7 +80,7 @@ class Walker extends Lint.RuleWalker {
                     fileGlobs.some(p => minimatch(relativeFilePath, p));
   }
 
-  visitClassDeclaration(node: ts.ClassDeclaration) {
+  override visitClassDeclaration(node: ts.ClassDeclaration) {
     if (this._enabled) {
       if (node.decorators) {
         node.decorators.forEach(decorator => this._validateDecorator(decorator));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "noImplicitOverride": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,


### PR DESCRIPTION
* refactor(multiple): enable `noImplicitOverride` typescript option

Enables the TypeScript `noImplicitOverride` option and adds
the `override` keyword where needed.

* build: add yarn script alias for tsc

Adds a `yarn run` alias for the `tsc` binary. Since we have
multiple versions of TypeScript installed, Yarn can pick
another version (e.g. from `typescript-4.2`) for linking
the `tsc` binary. This is unexpected because `yarn tsc` should
resolve to the TypeScript version that is not installed through
a Yarn alias. Changing the order in the Yarn lock file does not
help, and it seems expected in the context of Yarn which does not
know which package (regardless of alias or not) to prefer.