### PR TITLE
Calling mdc-fab.extended_ with $mat-base-styles query by default.

### DIFF
--- a/src/material-experimental/mdc-button/fab.scss
+++ b/src/material-experimental/mdc-button/fab.scss
@@ -29,7 +29,7 @@
 }
 
 .mat-mdc-extended-fab {
-  @include mdc-fab.extended_();
+  @include mdc-fab.extended_($query: mdc-helpers.$mat-base-styles-query);
 
   // stylelint-disable-next-line selector-class-pattern
   .mat-icon, .material-icons {


### PR DESCRIPTION
mdc-fab.extended_ was being called without a query meaning it brought in lots of additional overrides including typography making typography mixins for mdc-fabs ineffective.