### PR TITLE
fix(material-experimental/mdc-tooltip): make background color opaque

### DIFF
--- a/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
+++ b/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
@@ -10,13 +10,12 @@
   $config: theming.get-color-config($config-or-theme);
   @include mdc-helpers.mat-using-mdc-theme($config) {
     @include tooltip.core-styles($query: mdc-helpers.$mat-theme-styles-query);
+    // We are defining our own tooltip background color because of concerns
+    // surrounding the 0.6 background color opacity of the MDC tooltip styles.
+    @include tooltip-theme.fill-color(
+      map.get(palette.$light-theme-background-palette, tooltip)
+    );
   }
-
-  // We are defining our own tooltip background color because of concerns
-  // surrounding the 0.6 background color opacity of the MDC tooltip styles.
-  @include tooltip-theme.fill-color(
-    map.get(palette.$light-theme-background-palette, tooltip)
-  );
 }
 
 @mixin typography($config-or-theme) {

--- a/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
+++ b/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
@@ -1,6 +1,9 @@
+@use 'sass:map';
 @use '@material/tooltip/tooltip';
+@use '@material/tooltip/tooltip-theme';
 @use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/theming/theming';
+@use '../../material/core/theming/palette';
 @use '../../material/core/typography/typography';
 
 @mixin color($config-or-theme) {
@@ -8,6 +11,12 @@
   @include mdc-helpers.mat-using-mdc-theme($config) {
     @include tooltip.core-styles($query: mdc-helpers.$mat-theme-styles-query);
   }
+
+  // We are defining our own tooltip background color because of concerns
+  // surrounding the 0.6 background color opacity of the MDC tooltip styles.
+  @include tooltip-theme.fill-color(
+    map.get(palette.$light-theme-background-palette, tooltip)
+  );
 }
 
 @mixin typography($config-or-theme) {

--- a/src/material-experimental/mdc-tooltip/tooltip.scss
+++ b/src/material-experimental/mdc-tooltip/tooltip.scss
@@ -1,7 +1,4 @@
-@use 'sass:map';
 @use '@material/tooltip/tooltip';
-@use '@material/tooltip/tooltip-theme';
-@use '../../material/core/theming/palette';
 
 // Only include the structural styles, because we handle the animation ourselves.
 @include tooltip.core-styles($query: structure);
@@ -14,8 +11,4 @@
   // depending on the state of the overlay. For tooltips the overlay panel should never enable
   // pointer events. To overwrite the inline CSS from the overlay reference `!important` is needed.
   pointer-events: none !important;
-
-  @include tooltip-theme.fill-color(
-    map.get(palette.$light-theme-background-palette, tooltip)
-  );
 }

--- a/src/material-experimental/mdc-tooltip/tooltip.scss
+++ b/src/material-experimental/mdc-tooltip/tooltip.scss
@@ -1,4 +1,7 @@
+@use 'sass:map';
 @use '@material/tooltip/tooltip';
+@use '@material/tooltip/tooltip-theme';
+@use '../../material/core/theming/palette';
 
 // Only include the structural styles, because we handle the animation ourselves.
 @include tooltip.core-styles($query: structure);
@@ -11,4 +14,8 @@
   // depending on the state of the overlay. For tooltips the overlay panel should never enable
   // pointer events. To overwrite the inline CSS from the overlay reference `!important` is needed.
   pointer-events: none !important;
+
+  @include tooltip-theme.fill-color(
+    map.get(palette.$light-theme-background-palette, tooltip)
+  );
 }


### PR DESCRIPTION
* due to a11y concerns surrounding the 0.6 background color opacity of the
  mdc-tooltip, we are switching to using our own custom background color
  instead of the one defined in the MDC styles.