### PR TITLE
build: clean up MDC exports config

### DIFF
--- a/scripts/check-mdc-exports-config.ts
+++ b/scripts/check-mdc-exports-config.ts
@@ -1,6 +1,9 @@
 export const config = {
   // The MDC sidenav hasn't been implemented yet.
   skippedPackages: ['mdc-sidenav'],
+  // We have to export some underscored symbols so that they can be used with MDC.
+  // Exclude them from this check since they aren't part of the public API.
+  skippedSymbols: [/^_/],
   skippedExports: {
     'mdc-chips': [
       // These components haven't been implemented for MDC due to a different accessibility pattern.
@@ -12,114 +15,11 @@ export const config = {
       'MatChipListHarness',
       'ChipListHarnessFilters'
     ],
-    'mdc-autocomplete': [
-      // Private base classes that are only exported for MDC.
-      '_MatAutocompleteBase',
-      '_MatAutocompleteTriggerBase',
-      '_MatAutocompleteOriginBase'
-    ],
-    'mdc-autocomplete/testing': [
-      // Private base classes that are only exported for MDC.
-      '_MatAutocompleteHarnessBase'
-    ],
-    'mdc-core': [
-      // Private base classes that are only exported for MDC.
-      '_MatOptionBase',
-      '_MatOptgroupBase'
-    ],
-    'mdc-dialog': [
-      // Private base classes and utility function that are only exported for MDC.
-      '_MatDialogBase',
-      '_MatDialogContainerBase',
-      '_closeDialogVia',
-    ],
-    'mdc-form-field/testing': [
-      // Private base class that is only exported for MDC.
-      '_MatFormFieldHarnessBase'
-    ],
-    'mdc-menu': [
-      // Private base class that is only exported for MDC.
-      '_MatMenuBase'
-    ],
-    'mdc-menu/testing': [
-      // Private base class that is only exported for MDC.
-      '_MatMenuHarnessBase',
-      '_MatMenuItemHarnessBase'
-    ],
-    'mdc-paginator': [
-      // Private base class that is only exported for MDC.
-      '_MatPaginatorBase'
-    ],
-    'mdc-paginator/testing': [
-      // Private base class that is only exported for MDC.
-      '_MatPaginatorHarnessBase'
-    ],
-    'mdc-radio': [
-      // Private base classes that are only exported for MDC.
-      '_MatRadioGroupBase',
-      '_MatRadioButtonBase',
-    ],
-    'mdc-radio/testing': [
-      // Private base classes that are only exported for MDC.
-      '_MatRadioGroupHarnessBase',
-      '_MatRadioButtonHarnessBase',
-    ],
-    'mdc-select': [
-      // Private base class that is only exported for MDC.
-      '_MatSelectBase'
-    ],
-    'mdc-select/testing': [
-      // Private base class that is only exported for MDC.
-      '_MatSelectHarnessBase'
-    ],
-    'mdc-slide-toggle': [
-      // Private module used to provide some common functionality.
-      '_MatSlideToggleRequiredValidatorModule'
-    ],
-    'mdc-slide-toggle/testing': [
-      // Private base class that is only exported for MDC.
-      '_MatSlideToggleHarnessBase'
-    ],
     'mdc-slider': [
       // ControlValueAccessor implementation detail.
       'MAT_SLIDER_VALUE_ACCESSOR',
       // Irrelevant for the MDC implementation, because the slider doesn't dispatch any events.
       'MatSliderChange'
-    ],
-    'mdc-snack-bar': [
-      // Private interface used to ensure consistency for MDC package.
-      '_SnackBarContainer'
-    ],
-    'mdc-tabs': [
-      // Private base classes that are only exported for MDC.
-      '_MatTabBodyBase',
-      '_MatTabHeaderBase',
-      '_MatTabNavBase',
-      '_MatTabLinkBase',
-      '_MatTabGroupBase'
-    ],
-    'mdc-table': [
-      // Private symbols that are only exported for MDC.
-      '_MatTableDataSource',
-      '_MAT_TEXT_COLUMN_TEMPLATE'
-    ],
-    'mdc-table/testing': [
-      // Private symbols that are only exported for MDC.
-      '_MatTableHarnessBase',
-      '_MatRowHarnessBase'
-    ],
-    'mdc-tooltip': [
-      // Private symbols that are only exported for MDC.
-      '_MatTooltipBase',
-      '_TooltipComponentBase'
-    ],
-    'mdc-tooltip/testing': [
-      // Private symbols that are only exported for MDC.
-      '_MatTooltipHarnessBase'
-    ],
-    'mdc-checkbox/testing': [
-      // Private symbols that are only exported for MDC.
-      '_MatCheckboxHarnessBase'
     ]
   }
 };

--- a/scripts/check-mdc-exports.ts
+++ b/scripts/check-mdc-exports.ts
@@ -40,7 +40,9 @@ if (hasFailed) {
 
 /** Checks whether the public API of a package matches up with its MDC counterpart. */
 function checkPackage(name: string) {
-  const missingSymbols = getMissingSymbols(name, config.skippedExports[`mdc-${name}`] || []);
+  const missingSymbols = getMissingSymbols(name,
+      config.skippedExports[`mdc-${name}`] || [],
+      config.skippedSymbols || []);
 
   if (missingSymbols.length) {
     console.log(chalk.redBright(`\nMissing symbols from mdc-${name}:`));
@@ -53,7 +55,7 @@ function checkPackage(name: string) {
  * Gets the names of symbols that are present in a Material package,
  * but not its MDC counterpart.
  */
-function getMissingSymbols(name: string, skipped: string[]): string[] {
+function getMissingSymbols(name: string, skipped: string[], skippedPatterns: RegExp[]): string[] {
   const mdcExports = getExports(`material-experimental/mdc-${name}`);
   const materialExports = getExports(`material/${name}`);
 
@@ -66,7 +68,8 @@ function getMissingSymbols(name: string, skipped: string[]): string[] {
   }
 
   return materialExports.filter(exportName => {
-    return !skipped.includes(exportName) && !mdcExports.includes(exportName);
+    return !skipped.includes(exportName) && !mdcExports.includes(exportName) &&
+           !skippedPatterns.some(pattern => pattern.test(exportName));
   });
 }
 


### PR DESCRIPTION
Most of the exports we've excluded from the exports config are underscored APIs. These changes add an option that allows us to exclude exports based on on a regex and removes the underscored APIs from the config since they're private anyway.