### PR TITLE
build: enable strictFunctionTypes in schematics

### DIFF
--- a/src/cdk/schematics/ng-update/devkit-migration-rule.ts
+++ b/src/cdk/schematics/ng-update/devkit-migration-rule.ts
@@ -75,7 +75,7 @@ export function createMigrationSchematicRule(
     const analyzedFiles = new Set<WorkspacePath>();
     const fileSystem = new DevkitFileSystem(tree);
     const projectNames = workspace.projects.keys();
-    const migrations: NullableDevkitMigration[] = [...cdkMigrations, ...extraMigrations];
+    const migrations = [...cdkMigrations, ...extraMigrations] as NullableDevkitMigration[];
     let hasFailures = false;
 
     for (const projectName of projectNames) {

--- a/src/cdk/schematics/ng-update/html-parsing/elements.ts
+++ b/src/cdk/schematics/ng-update/html-parsing/elements.ts
@@ -17,7 +17,9 @@ export function findElementsWithAttribute(html: string, attributeName: string) {
   const elements: Element[] = [];
 
   const visitNodes = (nodes: ChildNode[]) => {
-    nodes.forEach((node: Element) => {
+    nodes.forEach(n => {
+      const node = n as Element;
+
       if (node.childNodes) {
         visitNodes(node.childNodes);
       }

--- a/src/cdk/schematics/ng-update/typescript/base-types.ts
+++ b/src/cdk/schematics/ng-update/typescript/base-types.ts
@@ -18,5 +18,5 @@ export function determineBaseTypes(node: ts.ClassDeclaration): string[]|null {
       .reduce((types, clause) => types.concat(clause.types), [] as ts.ExpressionWithTypeArguments[])
       .map(typeExpression => typeExpression.expression)
       .filter(expression => expression && ts.isIdentifier(expression))
-      .map((identifier: ts.Identifier) => identifier.text);
+      .map(identifier => (identifier as ts.Identifier).text);
 }

--- a/src/cdk/schematics/tsconfig.json
+++ b/src/cdk/schematics/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedLocals": false,
     "noImplicitThis": true,
     "skipLibCheck": true,
+    "strictFunctionTypes": true,
     "sourceMap": true,
     "target": "es2015",
     "types": [

--- a/src/cdk/schematics/update-tool/migration.ts
+++ b/src/cdk/schematics/update-tool/migration.ts
@@ -27,9 +27,9 @@ export type PostMigrationAction = void | {
 /** Creates a constructor type for the specified type. */
 export type Constructor<T> = (new (...args: any[]) => T);
 /** Gets a constructor type for the passed migration data. */
-export type MigrationCtor<Data, Context = never> = Constructor<Migration<Data, Context>>;
+export type MigrationCtor<Data, Context = any> = Constructor<Migration<Data, Context>>;
 
-export abstract class Migration<Data, Context = never> {
+export abstract class Migration<Data, Context = any> {
   /** List of migration failures that need to be reported. */
   failures: MigrationFailure[] = [];
 

--- a/src/cdk/schematics/utils/build-component.ts
+++ b/src/cdk/schematics/utils/build-component.ts
@@ -156,7 +156,8 @@ function indentTextContent(text: string, numSpaces: number): string {
 export function buildComponent(options: ComponentOptions,
                                additionalFiles: {[key: string]: string} = {}): Rule {
 
-  return async (host: Tree, context: FileSystemSchematicContext) => {
+  return async (host, ctx) => {
+    const context = ctx as FileSystemSchematicContext;
     const workspace = await getWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
     const defaultComponentOptions = getDefaultComponentOptions(project);
@@ -175,12 +176,10 @@ export function buildComponent(options: ComponentOptions,
     // Add the default component option values to the options if an option is not explicitly
     // specified but a default component option is available.
     Object.keys(options)
-      .filter((optionName: keyof ComponentOptions) => {
-        return options[optionName] == null && defaultComponentOptions[optionName];
-      })
-      .forEach((optionName: keyof ComponentOptions) => {
-        (options as any)[optionName] = (defaultComponentOptions as ComponentOptions)[optionName];
-      });
+      .filter(key => options[key as keyof ComponentOptions] == null &&
+                     defaultComponentOptions[key as keyof ComponentOptions])
+      .forEach(key => (options as any)[key] =
+          (defaultComponentOptions as ComponentOptions)[key as keyof ComponentOptions]);
 
     if (options.path === undefined) {
       // TODO(jelbourn): figure out if the need for this `as any` is a bug due to two different

--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-template-check.ts
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-template-check.ts
@@ -34,25 +34,31 @@ export function isHammerJsUsedInTemplate(html: string):
   let customEvents = false;
   let standardEvents = false;
   const visitNodes = (nodes: parse5.ChildNode[]) => {
-    nodes.forEach((node: parse5.Element) => {
-      if (node.attrs) {
-        for (let attr of node.attrs) {
-          if (!customEvents && CUSTOM_MATERIAL_HAMMERJS_EVENS.some(e => `(${e})` === attr.name)) {
-            customEvents = true;
-          }
-          if (!standardEvents && STANDARD_HAMMERJS_EVENTS.some(e => `(${e})` === attr.name)) {
-            standardEvents = true;
-          }
+    nodes.forEach(node => {
+      if (!isElement(node)) {
+        return;
+      }
+
+      for (let attr of node.attrs) {
+        if (!customEvents && CUSTOM_MATERIAL_HAMMERJS_EVENS.some(e => `(${e})` === attr.name)) {
+          customEvents = true;
+        }
+        if (!standardEvents && STANDARD_HAMMERJS_EVENTS.some(e => `(${e})` === attr.name)) {
+          standardEvents = true;
         }
       }
 
       // Do not continue traversing the AST if both type of HammerJS
       // usages have been detected already.
-      if (node.childNodes && (!customEvents || !standardEvents)) {
+      if (!customEvents || !standardEvents) {
         visitNodes(node.childNodes);
       }
     });
   };
   visitNodes(document.childNodes);
   return {customEvents, standardEvents};
+}
+
+function isElement(node: any): node is parse5.Element {
+  return !!node.attrs;
 }

--- a/src/material/schematics/tsconfig.json
+++ b/src/material/schematics/tsconfig.json
@@ -14,6 +14,7 @@
     "skipDefaultLibCheck": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
+    "strictFunctionTypes": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
Makes the schematics code compliant with the `strictFunctionTypes` compiler option.