### PR TITLE
refactor(material/tooltip): use overlay outside click tracking

### DIFF
--- a/src/material-experimental/mdc-tooltip/tooltip.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.ts
@@ -109,8 +109,6 @@ export class MatTooltip extends _MatTooltipBase<TooltipComponent> {
     // Forces the element to have a layout in IE and Edge. This fixes issues where the element
     // won't be rendered if the animations are disabled or there is no web animations polyfill.
     '[style.zoom]': '_visibility === "visible" ? 1 : null',
-    '(body:click)': 'this._handleBodyInteraction()',
-    '(body:auxclick)': 'this._handleBodyInteraction()',
     'aria-hidden': 'true',
   }
 })

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -426,6 +426,10 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase> implement
       .pipe(takeUntil(this._destroyed))
       .subscribe(() => this._detach());
 
+    this._overlayRef.outsidePointerEvents()
+      .pipe(takeUntil(this._destroyed))
+      .subscribe(() => this._tooltipInstance?._handleBodyInteraction());
+
     return this._overlayRef;
   }
 
@@ -892,8 +896,6 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     // Forces the element to have a layout in IE and Edge. This fixes issues where the element
     // won't be rendered if the animations are disabled or there is no web animations polyfill.
     '[style.zoom]': '_visibility === "visible" ? 1 : null',
-    '(body:click)': 'this._handleBodyInteraction()',
-    '(body:auxclick)': 'this._handleBodyInteraction()',
     'aria-hidden': 'true',
   }
 })


### PR DESCRIPTION
Switches the tooltip to the outside click tracking from the `OverlayRef`, rather than having to maintain its own. This also results in fewer listeners on the `body`.