### PR TITLE
docs(material/table): fix table formatting in ngFor example

### DIFF
--- a/src/components-examples/material/table/table-generated-columns/table-generated-columns-example.html
+++ b/src/components-examples/material/table/table-generated-columns/table-generated-columns-example.html
@@ -8,6 +8,6 @@
     </td>
   </ng-container>
 
-  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-  <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>


### PR DESCRIPTION
Fixes a bug in the example of Angular Material `mat-table` with columns generated via ngFor.
The fix changes the tags over to native table selectors, which brings the example into alignment
with other examples of `mat-table` usage and allows for Angular Material formatting to apply.