### PR TITLE
fix(material/tabs): pagination not working inside flex container

### DIFF
--- a/src/material-experimental/mdc-tabs/tab-group.scss
+++ b/src/material-experimental/mdc-tabs/tab-group.scss
@@ -27,6 +27,9 @@
   display: flex;
   flex-direction: column;
 
+  // Fixes pagination issues inside flex containers (see #23157).
+  max-width: 100%;
+
   &.mat-mdc-tab-group-inverted-header {
     flex-direction: column-reverse;
 

--- a/src/material/tabs/tab-group.scss
+++ b/src/material/tabs/tab-group.scss
@@ -7,6 +7,9 @@
   display: flex;
   flex-direction: column;
 
+  // Fixes pagination issues inside flex containers (see #23157).
+  max-width: 100%;
+
   &.mat-tab-group-inverted-header {
     flex-direction: column-reverse;
   }


### PR DESCRIPTION
Fixes that the tab header doesn't collapse inside a flex container which prevents it from showing the pagination.

Fixes #23157.