### PR TITLE
fix(material-experimental/mdc-paginator): target page size label with `aria-labelledby`

### DIFF
--- a/src/material-experimental/mdc-paginator/paginator.html
+++ b/src/material-experimental/mdc-paginator/paginator.html
@@ -1,7 +1,7 @@
 <div class="mat-mdc-paginator-outer-container">
   <div class="mat-mdc-paginator-container">
     <div class="mat-mdc-paginator-page-size" *ngIf="!hidePageSize">
-      <div class="mat-mdc-paginator-page-size-label">
+      <div class="mat-mdc-paginator-page-size-label" id="{{_pageSizeLabelId}}">
         {{_intl.itemsPerPageLabel}}
       </div>
 
@@ -13,7 +13,7 @@
         <mat-select
           [value]="pageSize"
           [disabled]="disabled"
-          [aria-label]="_intl.itemsPerPageLabel"
+          [aria-labelledby]="_pageSizeLabelId"
           (selectionChange)="_changePageSize($event.value)">
           <mat-option *ngFor="let pageSizeOption of _displayedPageSizeOptions" [value]="pageSizeOption">
             {{pageSizeOption}}

--- a/src/material-experimental/mdc-paginator/paginator.spec.ts
+++ b/src/material-experimental/mdc-paginator/paginator.spec.ts
@@ -73,11 +73,16 @@ describe('MDC-based MatPaginator', () => {
 
     it('should show right aria-labels for select and buttons', () => {
       const fixture = createComponent(MatPaginatorApp);
-      const select = fixture.nativeElement.querySelector('.mat-mdc-select');
-      expect(select.getAttribute('aria-label')).toBe('Items per page:');
 
       expect(getPreviousButton(fixture).getAttribute('aria-label')).toBe('Previous page');
       expect(getNextButton(fixture).getAttribute('aria-label')).toBe('Next page');
+
+      const select = fixture.nativeElement.querySelector('.mat-mdc-select');
+      const selectLabelIds = select.getAttribute('aria-labelledby')?.split(/\s/g) as string[];
+      const selectLabelTexts = selectLabelIds?.map(labelId => {
+        return fixture.nativeElement.querySelector(`#${labelId}`)?.textContent?.trim();
+      });
+      expect(selectLabelTexts).toContain('Items per page:');
     });
 
     it('should re-render when the i18n labels change', () => {

--- a/src/material-experimental/mdc-paginator/paginator.ts
+++ b/src/material-experimental/mdc-paginator/paginator.ts
@@ -44,6 +44,8 @@ export interface MatPaginatorDefaultOptions {
 export const MAT_PAGINATOR_DEFAULT_OPTIONS =
     new InjectionToken<MatPaginatorDefaultOptions>('MAT_PAGINATOR_DEFAULT_OPTIONS');
 
+let nextUniqueId = 0;
+
 /**
  * Component to provide navigation between paged information. Displays the size of the current
  * page, user-selectable options to change that size, what items are being shown, and
@@ -65,6 +67,10 @@ export const MAT_PAGINATOR_DEFAULT_OPTIONS =
 export class MatPaginator extends _MatPaginatorBase<MatPaginatorDefaultOptions> {
   /** If set, styles the "page size" form field with the designated style. */
   _formFieldAppearance?: MatFormFieldAppearance;
+
+  /** ID for the DOM node containing the pagiators's items per page label. */
+  readonly _pageSizeLabelId = `mat-paginator-page-size-label-${nextUniqueId++}`;
+
 
   constructor(intl: MatPaginatorIntl,
     changeDetectorRef: ChangeDetectorRef,


### PR DESCRIPTION
See commit message for description.

Original bug is filed internally at http://b/188218083

From the bug report:

ENVIRONMENT
OS | Browser | Assistive Technology    
Windows version 20H2,  Firefox version 88.0.1 (64-bit)
JAWS 2021 Version 2021.2102.34 ILM,
NVDA version 2020.4

PREREQUISITES
 Turn on screen reader
 
STEPS TO REPRODUCE
Open Mozilla Firefox
Navigate to https://xap-gallery.googleplex.com/embed/a11y/mdc-paginator
Tab to the number of items combo box.  
Notice the announcement.

EXPECTED RESULT(S)
the value of the combo box should be announced by the screen reader.

ACTUAL RESULT(S)
The screen reader announces the role of the combo box, but not the value .  e.g. “Items per page: Combo box, To change the selection use the Arrow keys”.
 
ADDITIONAL NOTE(S)
This issue is only reproducible in Mozilla Firefox.
 
VIDEO/SCREENSHOT(S)
https://drive.google.com/file/d/1HRDaA8bXKXlduobTUmWUraAUd7v1tZ5h/view?usp=sharing&resourcekey=0-rNDyr76TRjgPc9mEQH-exg 