### PR TITLE
build: add vim swamp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ node_modules
 /.vscode/launch.json
 /*.iml
 /.vs
+*.swo
+*.swp
 
 # misc
 .DS_Store


### PR DESCRIPTION
Adds vim swamp files to .gitignore. This aligns us with the framework repo: https://github.com/angular/angular/blob/master/.gitignore#L21