### PR TITLE
build: remove leftover manual `module_name` definition

### DIFF
--- a/src/components-examples/material-experimental/mdc-table/BUILD.bazel
+++ b/src/components-examples/material-experimental/mdc-table/BUILD.bazel
@@ -12,7 +12,6 @@ ng_module(
         "**/*.html",
         "**/*.css",
     ]),
-    module_name = "@angular/components-examples/material-experimental/mdc-table",
     deps = [
         "//src/cdk/drag-drop",
         "//src/cdk/table",


### PR DESCRIPTION
Removes a remaining instance of the Bazel `module_name`
property being set.