### PR TITLE
build: use top-level theming entrypoint for theming test

### DIFF
--- a/src/material/core/theming/tests/test-theming-api.scss
+++ b/src/material/core/theming/tests/test-theming-api.scss
@@ -1,24 +1,20 @@
 @use 'sass:map';
-@use '../../density/private/all-density';
-@use '../../color/all-color';
-@use '../../typography/all-typography';
-@use '../all-theme';
-@use '../../typography/typography';
-@use '../palette';
+@use '../../../index' as mat;
 @use '../theming';
+@use '../../density/private/all-density';
 
 // Disable theme style duplication warnings. This test intentionally generates
 // the same themes multiple times.
-theming.$theme-ignore-duplication-warnings: true;
+mat.$theme-ignore-duplication-warnings: true;
 
 // A new way to configure themes has been introduced. This Sass file ensures that the theming
 // API is backwards compatible, so that the old pattern for configuring themes can be still
 // used. The Sass compilation of this file will fail if one of the tests/assertions fails.
 
-$primary: theming.define-palette(palette.$blue-palette);
-$accent: theming.define-palette(palette.$grey-palette);
-$warn: theming.define-palette(palette.$indigo-palette);
-$default-warn: theming.define-palette(palette.$red-palette);
+$primary: mat.define-palette(mat.$blue-palette);
+$accent: mat.define-palette(mat.$grey-palette);
+$warn: mat.define-palette(mat.$indigo-palette);
+$default-warn: mat.define-palette(mat.$red-palette);
 
 // Asserts that a given value matches the expected value. If not, an error is
 // thrown with the given error message.
@@ -41,30 +37,30 @@ $default-warn: theming.define-palette(palette.$red-palette);
       'Expected color config `is-dark` to be: #{$is-dark}');
 }
 
-$legacy-light-theme: theming.define-light-theme($primary, $accent, $warn);
-$legacy-dark-theme: theming.define-dark-theme($primary, $accent, $warn);
-$legacy-light-theme-default-warn: theming.define-light-theme($primary, $accent);
-$legacy-dark-theme-default-warn: theming.define-dark-theme($primary, $accent);
+$legacy-light-theme: mat.define-light-theme($primary, $accent, $warn);
+$legacy-dark-theme: mat.define-dark-theme($primary, $accent, $warn);
+$legacy-light-theme-default-warn: mat.define-light-theme($primary, $accent);
+$legacy-dark-theme-default-warn: mat.define-dark-theme($primary, $accent);
 
-$new-api-light-theme: theming.define-light-theme((
+$new-api-light-theme: mat.define-light-theme((
   color: (primary: $primary, accent: $accent, warn: $warn)
 ));
-$new-api-dark-theme: theming.define-dark-theme((
+$new-api-dark-theme: mat.define-dark-theme((
   color: (primary: $primary, accent: $accent, warn: $warn)
 ));
-$new-api-light-theme-default-warn: theming.define-light-theme((
+$new-api-light-theme-default-warn: mat.define-light-theme((
   color: (primary: $primary, accent: $accent)
 ));
-$new-api-dark-theme-default-warn: theming.define-dark-theme((
+$new-api-dark-theme-default-warn: mat.define-dark-theme((
   color: (primary: $primary, accent: $accent)
 ));
 
-$light-theme-only-density: theming.define-light-theme((density: -3));
-$dark-theme-only-density: theming.define-dark-theme((density: -3));
+$light-theme-only-density: mat.define-light-theme((density: -3));
+$dark-theme-only-density: mat.define-dark-theme((density: -3));
 
-$typography-config: typography.define-typography-config();
-$light-theme-only-typography: theming.define-light-theme((typography: $typography-config));
-$dark-theme-only-typography: theming.define-dark-theme((typography: $typography-config));
+$typography-config: mat.define-typography-config();
+$light-theme-only-typography: mat.define-light-theme((typography: $typography-config));
+$dark-theme-only-typography: mat.define-dark-theme((typography: $typography-config));
 
 // Test which ensures that constructed themes by default do not set configurations
 // for the individual parts of the theming system (color, density, typography).
@@ -118,23 +114,23 @@ $dark-theme-only-typography: theming.define-dark-theme((typography: $typography-
 // theme objects passed to individual component theme mixins.
 @mixin test-get-color-config() {
   $color-config: map.get($legacy-light-theme, color);
-  $no-color-light-theme: theming.define-light-theme((color: null));
-  $no-color-dark-theme: theming.define-dark-theme((color: null));
-  @include assert(theming.get-color-config($color-config), $color-config,
+  $no-color-light-theme: mat.define-light-theme((color: null));
+  $no-color-dark-theme: mat.define-dark-theme((color: null));
+  @include assert(mat.get-color-config($color-config), $color-config,
       'Expected that passing a color config to a theme will work for backwards compatibility.');
   // For legacy constructed themes, the color configuration is the actual `$theme` object.
   // This is done for backwards compatibility because developers could modify colors directly
   // by updating immediate properties on the `$theme` object.
-  @include assert(theming.get-color-config($legacy-light-theme), $legacy-light-theme,
+  @include assert(mat.get-color-config($legacy-light-theme), $legacy-light-theme,
       'Expected that the theme object is used for the color configuration.');
-  @include assert(theming.get-color-config($new-api-dark-theme),
+  @include assert(mat.get-color-config($new-api-dark-theme),
     map.get($new-api-dark-theme, color),
     'Expected that a color config can be read from a theme object.');
-  @include assert(theming.get-color-config($light-theme-only-density), null,
+  @include assert(mat.get-color-config($light-theme-only-density), null,
       'Expected that by default, no color configuration is used.');
-  @include assert(theming.get-color-config($no-color-light-theme), null,
+  @include assert(mat.get-color-config($no-color-light-theme), null,
       'Expected that no color configuration can be explicitly specified.');
-  @include assert(theming.get-color-config($no-color-dark-theme), null,
+  @include assert(mat.get-color-config($no-color-dark-theme), null,
     'Expected that no color configuration can be explicitly specified.');
 }
 
@@ -142,68 +138,68 @@ $dark-theme-only-typography: theming.define-dark-theme((typography: $typography-
 // theme objects passed to individual component theme mixins.
 @mixin test-get-density-config() {
   $density-config: map.get($light-theme-only-density, density);
-  $no-density-light-theme: theming.define-light-theme((density: null));
-  $no-density-dark-theme: theming.define-dark-theme((density: null));
-  @include assert(theming.get-density-config($light-theme-only-density), -3,
+  $no-density-light-theme: mat.define-light-theme((density: null));
+  $no-density-dark-theme: mat.define-dark-theme((density: null));
+  @include assert(mat.get-density-config($light-theme-only-density), -3,
     'Expected that a density config can be read from a theme object.');
-  @include assert(theming.get-density-config($light-theme-only-typography), 0,
+  @include assert(mat.get-density-config($light-theme-only-typography), 0,
     'Expected that by default, the density system will be configured.');
-  @include assert(theming.get-density-config($no-density-light-theme), null,
+  @include assert(mat.get-density-config($no-density-light-theme), null,
     'Expected that no density configuration can be explicitly specified.');
-  @include assert(theming.get-density-config($no-density-dark-theme), null,
+  @include assert(mat.get-density-config($no-density-dark-theme), null,
     'Expected that no density configuration can be explicitly specified.');
 }
 
 // Test which ensures that typography configurations can be properly read from
 // theme objects passed to individual component theme mixins.
 @mixin test-get-typography-config() {
-  $no-typography-light-theme: theming.define-light-theme((density: null));
-  $no-typography-dark-theme: theming.define-dark-theme((density: null));
-  @include assert(theming.get-typography-config($light-theme-only-typography), $typography-config,
+  $no-typography-light-theme: mat.define-light-theme((density: null));
+  $no-typography-dark-theme: mat.define-dark-theme((density: null));
+  @include assert(mat.get-typography-config($light-theme-only-typography), $typography-config,
     'Expected that a typography config can be read from a theme object.');
-  @include assert(theming.get-typography-config($legacy-light-theme), null,
+  @include assert(mat.get-typography-config($legacy-light-theme), null,
     'Expected that by default, no typography configuration is used.');
-  @include assert(theming.get-typography-config($no-typography-light-theme), null,
+  @include assert(mat.get-typography-config($no-typography-light-theme), null,
     'Expected that no typography configuration can be explicitly specified.');
-  @include assert(theming.get-typography-config($no-typography-dark-theme), null,
+  @include assert(mat.get-typography-config($no-typography-dark-theme), null,
     'Expected that no typography configuration can be explicitly specified.');
 }
 
 // Test which ensures that all Angular Material theme mixins accept a theme
 // object without throwing any exception.
 @mixin test-theme-mixins-successful-compilation() {
-  @include all-theme.all-component-themes($legacy-light-theme);
-  @include all-theme.all-component-themes($legacy-light-theme-default-warn);
-  @include all-theme.all-component-themes($legacy-dark-theme);
-  @include all-theme.all-component-themes($legacy-dark-theme-default-warn);
-  @include all-theme.all-component-themes($new-api-light-theme);
-  @include all-theme.all-component-themes($new-api-light-theme-default-warn);
-  @include all-theme.all-component-themes($new-api-dark-theme);
-  @include all-theme.all-component-themes($new-api-dark-theme-default-warn);
-  @include all-theme.all-component-themes($light-theme-only-density);
-  @include all-theme.all-component-themes($dark-theme-only-density);
-  @include all-theme.all-component-themes($light-theme-only-typography);
-  @include all-theme.all-component-themes($dark-theme-only-typography);
+  @include mat.all-component-themes($legacy-light-theme);
+  @include mat.all-component-themes($legacy-light-theme-default-warn);
+  @include mat.all-component-themes($legacy-dark-theme);
+  @include mat.all-component-themes($legacy-dark-theme-default-warn);
+  @include mat.all-component-themes($new-api-light-theme);
+  @include mat.all-component-themes($new-api-light-theme-default-warn);
+  @include mat.all-component-themes($new-api-dark-theme);
+  @include mat.all-component-themes($new-api-dark-theme-default-warn);
+  @include mat.all-component-themes($light-theme-only-density);
+  @include mat.all-component-themes($dark-theme-only-density);
+  @include mat.all-component-themes($light-theme-only-typography);
+  @include mat.all-component-themes($dark-theme-only-typography);
 }
 
 // Custom theme mixin used by the custom theme backwards compatibility test.
 // This replicates a custom theme that expects legacy theme objects.
 @mixin _my-custom-theme-legacy($theme) {
   .demo-custom-comp {
-    border-color: theming.get-color-from-palette(map.get($theme, primary));
+    border-color: mat.get-color-from-palette(map.get($theme, primary));
   }
 }
 
 @mixin _my-custom-theme-new-api-color($config-or-theme) {
-  $config: theming.get-color-config($config-or-theme);
+  $config: mat.get-color-config($config-or-theme);
 
   .demo-custom-comp {
-    border-color: theming.get-color-from-palette(map.get($config, primary));
+    border-color: mat.get-color-from-palette(map.get($config, primary));
   }
 }
 
 @mixin _my-custom-theme-new-api-density($config-or-theme) {
-  $density-scale: theming.get-density-config($config-or-theme);
+  $density-scale: mat.get-density-config($config-or-theme);
 
   .demo-custom-comp {
     // Simulates logic for computing density according to the Material Design
@@ -215,8 +211,8 @@ $dark-theme-only-typography: theming.define-dark-theme((typography: $typography-
 // Custom theme mixin used by the custom theme backwards compatibility test.
 @mixin _my-custom-theme-new-api($theme-or-color-config) {
   $theme: theming.private-legacy-get-theme($theme-or-color-config);
-  $color: theming.get-color-config($theme);
-  $density: theming.get-density-config($theme);
+  $color: mat.get-color-config($theme);
+  $density: mat.get-density-config($theme);
 
   @if $color != null {
     @include _my-custom-theme-new-api-color($color);
@@ -248,20 +244,19 @@ $dark-theme-only-typography: theming.define-dark-theme((typography: $typography-
   );
 
   @each $theme in $test-themes {
-    @include all-typography.all-component-typographies($theme);
-    @include all-color.all-component-colors($theme);
+    @include mat.all-component-typographies($theme);
+    @include mat.all-component-colors($theme);
     @include all-density.all-component-densities($theme);
   }
 
-  @include all-typography.all-component-typographies(
-    map.get($light-theme-only-typography, typography));
-  @include all-typography.all-component-typographies($light-theme-only-typography);
+  @include mat.all-component-typographies(map.get($light-theme-only-typography, typography));
+  @include mat.all-component-typographies($light-theme-only-typography);
 
   @include all-density.all-component-densities(map.get($light-theme-only-density, density));
   @include all-density.all-component-densities($light-theme-only-density);
 
-  @include all-color.all-component-colors(map.get($new-api-dark-theme, color));
-  @include all-color.all-component-colors($new-api-dark-theme);
+  @include mat.all-component-colors(map.get($new-api-dark-theme, color));
+  @include mat.all-component-colors($new-api-dark-theme);
 }
 
 @mixin test-individual-system-mixins-unwrap() {
@@ -270,8 +265,8 @@ $dark-theme-only-typography: theming.define-dark-theme((typography: $typography-
   @include _my-custom-theme-new-api($new-api-dark-theme);
   @include _my-custom-theme-new-api(map.get($new-api-dark-theme, color));
 
-  @include all-theme.all-component-themes($new-api-dark-theme);
-  @include all-theme.all-component-themes(map.get($new-api-dark-theme, color));
+  @include mat.all-component-themes($new-api-dark-theme);
+  @include mat.all-component-themes(map.get($new-api-dark-theme, color));
 }
 
 // Include all tests. Sass will throw if one of the tests fails.


### PR DESCRIPTION
Switches the theming API test to use the top-level entry point in order to match it closer to how users would consume it.
