### PR TITLE
fix(material/slider): Track fill style should only be applied when slider is focused, as opposed to when any ancestor is focused.

### DIFF
--- a/src/material/slider/_slider-theme.scss
+++ b/src/material/slider/_slider-theme.scss
@@ -65,7 +65,7 @@
   }
 
   .mat-slider:hover,
-  .cdk-focused {
+  .mat-slider.cdk-focused {
     .mat-slider-track-background {
       background-color: $mat-slider-off-focused-color;
     }


### PR DESCRIPTION
Stackblitz repro of original bug: https://stackblitz.com/edit/angular-yrsz1m?file=src/app/slider-overview-example.html
