### PR TITLE
test(material/menu): referring to wrong overlay element

### DIFF
--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -1244,7 +1244,7 @@ describe('MDC-based MatMenu', () => {
       TestBed.resetTestingModule();
 
       const newFixture = createComponent(SimpleMenu, [], [FakeIcon]);
-
+      overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
       newFixture.detectChanges();
       newFixture.componentInstance.trigger.openMenu();
       newFixture.detectChanges();

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -1241,7 +1241,7 @@ describe('MatMenu', () => {
       TestBed.resetTestingModule();
 
       const newFixture = createComponent(SimpleMenu, [], [FakeIcon]);
-
+      overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
       newFixture.detectChanges();
       newFixture.componentInstance.trigger.openMenu();
       newFixture.detectChanges();


### PR DESCRIPTION
Attempts to fix the recent flakiness in menu tests. It seems like we were destroying and recreating an overlay container at one point, but we were referring to the element of the previous.