### PR TITLE
refactor(cdk/table): unable to access custom CdkColumnDefinitions

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -245,7 +245,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
    * name. Collection populated by the column definitions gathered by `ContentChildren` as well as
    * any custom column definitions added to `_customColumnDefs`.
    */
-  private _columnDefsByName = new Map<string, CdkColumnDef>();
+  protected _columnDefsByName = new Map<string, CdkColumnDef>();
 
   /**
    * Set of all row definitions that can be used by this table. Populated by the rows gathered by

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -310,6 +310,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     _contentHeaderRowDefs: QueryList<CdkHeaderRowDef>;
     _contentRowDefs: QueryList<CdkRowDef<T>>;
     protected _data: readonly T[];
+    protected _columnDefsByName: Map<string, CdkColumnDef>;
     get dataSource(): CdkTableDataSourceInput<T>;
     set dataSource(dataSource: CdkTableDataSourceInput<T>);
     // (undocumented)


### PR DESCRIPTION
Provides access to the property `_columnDefsByName` within the CDK table. Classes extending the CdkTable class now have access to all CdkColumnDefinitions.

fixes #23142