### PR TITLE
fix(material/dialog): mat-dialog-actions don't stick to bottom

### DIFF
--- a/src/material/dialog/dialog.scss
+++ b/src/material/dialog/dialog.scss
@@ -48,6 +48,7 @@ $button-margin: 8px !default;
   flex-wrap: wrap;
   min-height: 52px;
   align-items: center;
+  margin-top: auto;
 
   // Explicitly set a box-sizing since people commonly set `border-box`
   // on all elements which will break the height of the dialog actions.


### PR DESCRIPTION
Fixes a bug in the Material `dialog` component where mat-dialog-actions
don't stick to the bottom of the dialog window, but it is being placed
just after the mat-dialog-content instead.

Fixes #4609