### PR TITLE
fix(cdk/drag-drop): add generic parameter for item type in CdkDragDrop

### DIFF
--- a/src/cdk/drag-drop/drag-events.ts
+++ b/src/cdk/drag-drop/drag-events.ts
@@ -54,13 +54,13 @@ export interface CdkDragExit<T = any, I = T> {
 
 
 /** Event emitted when the user drops a draggable item inside a drop container. */
-export interface CdkDragDrop<T, O = T> {
+export interface CdkDragDrop<T, O = T, I = any> {
   /** Index of the item when it was picked up. */
   previousIndex: number;
   /** Current index of the item. */
   currentIndex: number;
   /** Item that is being dropped. */
-  item: CdkDrag;
+  item: CdkDrag<I>;
   /** Container in which the item was dropped. */
   container: CdkDropList<T>;
   /** Container from which the item was picked up. Can be the same as the `container`. */

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -103,7 +103,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 }
 
 // @public
-export interface CdkDragDrop<T, O = T> {
+export interface CdkDragDrop<T, O = T, I = any> {
     container: CdkDropList<T>;
     currentIndex: number;
     distance: {
@@ -115,7 +115,7 @@ export interface CdkDragDrop<T, O = T> {
         y: number;
     };
     isPointerOverContainer: boolean;
-    item: CdkDrag;
+    item: CdkDrag<I>;
     previousContainer: CdkDropList<O>;
     previousIndex: number;
 }


### PR DESCRIPTION
Fixes that the `CdkDragDrop` event didn't have a way of typing the item.

Fixes #23208.