### PR TITLE
build: fix being unable to run e2e tests locally on windows

### DIFF
--- a/src/e2e-app/start-devserver.js
+++ b/src/e2e-app/start-devserver.js
@@ -1,37 +1,16 @@
 const protractor = require('protractor');
-const utils = require('@bazel/protractor/protractor-utils');
-const spawn = require('child_process').spawn;
 
-/**
- * Runs the specified server binary from a given workspace and waits for the server
- * being ready. The server binary will be resolved from the runfiles.
- */
-async function runBazelServer(workspace, serverPath, timeout) {
-  const serverBinary = require.resolve(`${workspace}/${serverPath}`);
-  const port = await utils.findFreeTcpPort();
-
-  // Start the Bazel server binary with a random free TCP port.
-  const serverProcess = spawn(serverBinary, ['-port', port], {stdio: 'inherit'});
-
-  // In case the process exited with an error, we want to propagate the error.
-  serverProcess.on('exit', exitCode => {
-    if (exitCode !== 0) {
-      throw new Error(`Server exited with error code: ${exitCode}`);
-    }
-  });
-
-  // Wait for the server to be bound to the given port.
-  await utils.waitForServer(port, timeout);
-
-  return port;
-}
+// Note: We need to specify an explicit file extension here because otherwise
+// the Bazel-patched NodeJS module resolution would resolve to the `.mjs` file
+// in non-sandbox environments (as usually with Bazel and Windows).
+const utils = require('@bazel/protractor/protractor-utils.js');
 
 /**
  * Called by Protractor before starting any tests. This is script is responsible for
  * starting up the devserver and updating the Protractor base URL to the proper port.
  */
 module.exports = async function(config) {
-  const port = await runBazelServer(config.workspace, config.server);
+  const {port} = await utils.runServer(config.workspace, config.server, '-port', []);
   const baseUrl = `http://localhost:${port}`;
   const processedConfig = await protractor.browser.getProcessedConfig();
 


### PR DESCRIPTION
Fixes that e2e tests cannot be run locally on Windows right now.
This happens because there is no sandbox on Windows w/ Bazel and
the `start-devserver.js` utility accidentally resolves to a `.mjs`
file due to the patched NodeJS module resolution. We specify an
explicit file extension to avoid resolving an ESM module.

Also simplifies the server launching because the Protractor utils
now expose a method for starting the server.