### PR TITLE
fix(material/table): set row height to 52px

### DIFF
--- a/src/material/table/_table-flex-styles.scss
+++ b/src/material/table/_table-flex-styles.scss
@@ -1,6 +1,6 @@
 // Flex-based table structure
 $header-row-height: 56px;
-$row-height: 48px;
+$row-height: 52px;
 $row-horizontal-padding: 24px;
 
 // Only use tag name selectors here since the styles are shared between MDC and non-MDC


### PR DESCRIPTION
This aligns with the current data table spec: https://material.io/components/data-tables#specs