### PR TITLE
fix(material/table): apply horizontal padding to each cell

### DIFF
--- a/src/material/table/_table-flex-styles.scss
+++ b/src/material/table/_table-flex-styles.scss
@@ -1,7 +1,7 @@
 // Flex-based table structure
 $header-row-height: 56px;
 $row-height: 48px;
-$row-horizontal-padding: 24px;
+$row-horizontal-padding: 16px;
 
 // Only use tag name selectors here since the styles are shared between MDC and non-MDC
 @mixin private-table-flex-styles {
@@ -38,25 +38,7 @@ $row-horizontal-padding: 24px;
   }
 
   mat-cell, mat-header-cell, mat-footer-cell {
-    // Note: we use `first-of-type`/`last-of-type` here in order to prevent extra
-    // elements like ripples or badges from throwing off the layout (see #11165).
-    &:first-of-type {
-      padding-left: $row-horizontal-padding;
-
-      [dir='rtl'] &:not(:only-of-type) {
-        padding-left: 0;
-        padding-right: $row-horizontal-padding;
-      }
-    }
-
-    &:last-of-type {
-      padding-right: $row-horizontal-padding;
-
-      [dir='rtl'] &:not(:only-of-type) {
-        padding-right: 0;
-        padding-left: $row-horizontal-padding;
-      }
-    }
+    padding: 0 $row-horizontal-padding;
   }
 
   mat-cell, mat-header-cell, mat-footer-cell {

--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -25,29 +25,9 @@ th.mat-header-cell {
 }
 
 th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
-  padding: 0;
+  padding: 0 table-flex-styles.$row-horizontal-padding;
   border-bottom-width: 1px;
   border-bottom-style: solid;
-
-  // Note: we use `first-of-type`/`last-of-type` here in order to prevent extra
-  // elements like ripples or badges from throwing off the layout (see #11165).
-  &:first-of-type {
-    padding-left: table-flex-styles.$row-horizontal-padding;
-
-    [dir='rtl'] &:not(:only-of-type) {
-      padding-left: 0;
-      padding-right: table-flex-styles.$row-horizontal-padding;
-    }
-  }
-
-  &:last-of-type {
-    padding-right: table-flex-styles.$row-horizontal-padding;
-
-    [dir='rtl'] &:not(:only-of-type) {
-      padding-right: 0;
-      padding-left: table-flex-styles.$row-horizontal-padding;
-    }
-  }
 }
 
 .mat-table-sticky {


### PR DESCRIPTION
Padding currently only shows up as 24px on the left of the first cell and 24px on the right-side of the last cell.

This changes the padding so each cell gets 16px on each side

This aligns with the current data table spec: https://material.io/components/data-tables#specs