### PR TITLE
fix(material/table): header cells match data font color and increase size

### DIFF
--- a/src/material/table/_table-theme.scss
+++ b/src/material/table/_table-theme.scss
@@ -24,11 +24,7 @@
     border-bottom-color: theming.get-color-from-palette($foreground, divider);
   }
 
-  .mat-header-cell {
-    color: theming.get-color-from-palette($foreground, secondary-text);
-  }
-
-  .mat-cell, .mat-footer-cell {
+  .mat-cell, .mat-header-cell, .mat-footer-cell {
     color: theming.get-color-from-palette($foreground, text);
   }
 }
@@ -41,7 +37,7 @@
   }
 
   .mat-header-cell {
-    font-size: typography-utils.font-size($config, caption);
+    font-size: typography-utils.font-size($config, subheading-1);
     font-weight: typography-utils.font-weight($config, body-2);
   }
 


### PR DESCRIPTION
Header cells are currently a grey color and small font.

This changes them so that they are black (same as data cells) and have the right size (15px).

This aligns with the current data table spec: https://material.io/components/data-tables#specs

