### PR TITLE
fix(material/table): move flex-based borders from rows to cells

### DIFF
--- a/src/material/table/_table-flex-styles.scss
+++ b/src/material/table/_table-flex-styles.scss
@@ -19,11 +19,6 @@ $row-horizontal-padding: 24px;
 
   mat-row, mat-header-row, mat-footer-row {
     display: flex;
-    // Define a border style, but then widths default to 3px. Reset them to 0px except the bottom
-    // which should be 1px;
-    border-width: 0;
-    border-bottom-width: 1px;
-    border-style: solid;
     align-items: center;
     box-sizing: border-box;
 
@@ -38,6 +33,12 @@ $row-horizontal-padding: 24px;
   }
 
   mat-cell, mat-header-cell, mat-footer-cell {
+    // Define a border style, but then widths default to 3px. Reset them to 0px except the bottom
+    // which should be 1px;
+    border-width: 0;
+    border-bottom-width: 1px;
+    border-style: solid;
+
     // Note: we use `first-of-type`/`last-of-type` here in order to prevent extra
     // elements like ripples or badges from throwing off the layout (see #11165).
     &:first-of-type {

--- a/src/material/table/_table-theme.scss
+++ b/src/material/table/_table-theme.scss
@@ -19,7 +19,7 @@
     background: inherit;
   }
 
-  mat-row, mat-header-row, mat-footer-row,
+  mat-cell, mat-header-cell, mat-footer-cell,
   th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
     border-bottom-color: theming.get-color-from-palette($foreground, divider);
   }


### PR DESCRIPTION
This matches the current `<table>` styles