### PR TITLE
fix(material/table): remove last row border

### DIFF
--- a/src/material/table/_table-flex-styles.scss
+++ b/src/material/table/_table-flex-styles.scss
@@ -17,13 +17,29 @@ $row-horizontal-padding: 24px;
     min-height: $row-height;
   }
 
-  mat-row, mat-header-row, mat-footer-row {
-    display: flex;
+  mat-row, mat-header-row {
     // Define a border style, but then widths default to 3px. Reset them to 0px except the bottom
     // which should be 1px;
     border-width: 0;
     border-bottom-width: 1px;
     border-style: solid;
+  }
+
+  mat-row:last-child {
+    // Remove the last row's border to account for the table's border or the footer's top border.
+    border-bottom: none;
+  }
+
+  mat-footer-row {
+    // Define a border style, but then widths default to 3px. Reset them to 0px except the top
+    // which should be 1px;
+    border-width: 0;
+    border-top-width: 1px;
+    border-style: solid;
+  }
+
+  mat-row, mat-header-row, mat-footer-row {
+    display: flex;
     align-items: center;
     box-sizing: border-box;
 

--- a/src/material/table/_table-theme.scss
+++ b/src/material/table/_table-theme.scss
@@ -21,7 +21,7 @@
 
   mat-row, mat-header-row, mat-footer-row,
   th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
-    border-bottom-color: theming.get-color-from-palette($foreground, divider);
+    border-color: theming.get-color-from-palette($foreground, divider);
   }
 
   .mat-header-cell {

--- a/src/material/table/table.scss
+++ b/src/material/table/table.scss
@@ -26,8 +26,6 @@ th.mat-header-cell {
 
 th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
   padding: 0;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
 
   // Note: we use `first-of-type`/`last-of-type` here in order to prevent extra
   // elements like ripples or badges from throwing off the layout (see #11165).
@@ -48,6 +46,20 @@ th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
       padding-left: table-flex-styles.$row-horizontal-padding;
     }
   }
+}
+
+th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+}
+
+.mat-row:last-child td.mat-cell {
+  border-bottom: none;
+}
+
+td.mat-footer-cell {
+  border-top-width: 1px;
+  border-top-style: solid;
 }
 
 .mat-table-sticky {


### PR DESCRIPTION
The last data row's border is removed so that users can apply a border all around the table without having 2px of border on the bottom. This matches the style of MDC table