### PR TITLE
fix(material/core): handle hues inferred as numbers

### DIFF
--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -77,7 +77,9 @@ $_emitted-density: () !default;
     @return get-color-from-palette($palette, default, $hue);
   }
 
-  $color: map.get($palette, $hue);
+  // We cast the $hue to a string, because some hues starting with a number, like `700-contrast`,
+  // might be inferred as numbers by Sass. Casting them to string fixes the map lookup.
+  $color: if(map.has-key($palette, $hue), map.get($palette, $hue), map.get($palette, $hue + ''));
 
   @if (meta.type-of($color) != color) {
     // If the $color resolved to something different from a color (e.g. a CSS variable),


### PR DESCRIPTION
We have some hues that start with a number (e.g. `700-contrast`), which can break the map lookup in `get-color-from-palette`, because Sass infers them as numbers.

These changes make it so that the key is cast to a string before we do the lookup.

Fixes #23230.