### PR TITLE
fix(cdk/testing): extract hidden text in web driver element

### DIFF
--- a/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
+++ b/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
@@ -136,7 +136,9 @@ export class SeleniumWebDriverElement implements TestElement {
     if (options?.exclude) {
       return this._executeScript(_getTextWithExcludedElements, this.element(), options.exclude);
     }
-    return this.element().getText();
+    // We don't go through the WebDriver `getText`, because it excludes text from hidden elements.
+    return this._executeScript(
+      (element: Element) => (element.textContent || '').trim(), this.element());
   }
 
   /** Gets the value for the given attribute from the element. */


### PR DESCRIPTION
In #21540 we added support for extracting text from hidden elements in Protractor, but before the PR could be merged, we introduced the WebDriver environment which didn't include the fix and is failing the e2e tests.

These changes port over the fix.