### PR TITLE
docs(guides/getting-started): changed value property of default example mat-slider example to avoid invisible slider

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -62,7 +62,7 @@ import { MatSliderModule } from '@angular/material/slider';
 Add the `<mat-slider>` tag to the `app.component.html` like so:
 
 ```html
-<mat-slider min="1" max="100" step="1" value="1"></mat-slider>
+<mat-slider min="1" max="100" step="1" value="50"></mat-slider>
 ```
 
 Run your local dev server:


### PR DESCRIPTION
This addresses a problem that causes the mat-slider from the [Getting Started](https://material.angular.io/guide/getting-started) guide to be invisible even when perfectly following the steps, as shown below:

![Invisible Slider](https://user-images.githubusercontent.com/16341847/127035624-4cf8002e-598d-43ce-b0aa-0530857dff0a.png)

The `app.component.html` from the image is the following:

```html
<p>slider is below:</p>
<mat-slider min="1" max="100" step="1" value="1"></mat-slider>
```

There are no errors so this is especially difficult to debug as a newcomer (the kind of person who would be reading a "Getting Started" tutorial). The problem this causes is that even if you follow the tutorial perfectly you still ended up with a blank screen and no indication of failure.

This is caused because the pre-build material theme `purple-green.css` has the following style to mat-slider's with min-value:

```css
.mat-slider-min-value:not(.mat-slider-thumb-label-showing) .mat-slider-thumb {
    border-color: rgba(255,255,255,.3);
    background-color: transparent
}
```

After this change the example will display the following:
![Corrected mat-slider](https://user-images.githubusercontent.com/16341847/127036375-c78793e0-6c68-4b48-aadd-6c34f03fe5da.png)
