### PR TITLE
test(material/expansion): fix failing unit test on iOS14 safari

### DIFF
--- a/src/material/expansion/expansion.spec.ts
+++ b/src/material/expansion/expansion.spec.ts
@@ -201,6 +201,11 @@ describe('MatExpansionPanel', () => {
     fixture.detectChanges();
     tick(250);
 
+    // Enforce a style recalculation as otherwise browsers like Safari on iOS 14 require
+    // us to wait until the next tick using actual async/await. Not retrieving the computed
+    // styles would result in the `visibility: hidden` on the expansion content to not apply.
+    getComputedStyle(button).getPropertyValue('visibility');
+
     button.focus();
     expect(document.activeElement).not.toBe(button, 'Expected button to no longer be focusable.');
   }));

--- a/test/bazel-karma-local-config.js
+++ b/test/bazel-karma-local-config.js
@@ -3,8 +3,6 @@
  * want to launch any browser and just enable manual browser debugging.
  */
 
-const bazelKarma = require('@bazel/concatjs');
-
 module.exports = config => {
   const overwrites = {};
 
@@ -30,8 +28,21 @@ module.exports = config => {
   // relies on ibazel to write to the `stdin` interface. When running without ibazel, the
   // watcher will kill concatjs since there is no data written to the `stdin` interface.
   if (process.env['IBAZEL_NOTIFY_CHANGES'] !== 'y') {
-    delete bazelKarma['watcher'];
+    // We pre-define a plugins array that captures registration of Karma plugins
+    // and unsets the watcher definitions so that no watcher can be configured.
+    overwrites.plugins = new KarmaPluginArrayWithoutWatchers();
   }
 
   config.set(overwrites);
 };
+
+class KarmaPluginArrayWithoutWatchers extends Array {
+  // The Bazel Karma rules only register new plugins using `.push`.
+  push(...plugins) {
+    plugins
+      .filter(p => typeof p === 'object')
+      .forEach(p => delete p.watcher);
+
+    super.push(...plugins);
+  }
+}


### PR DESCRIPTION
An expansion test seems to be flaky/failing in Safari on iOS14
because the `visibility: hidden` style from the expansion panel
content is not applied immediately. We fix this by enforcing
a style recalculation like we do in the ripple. An alternative
would have been to switch the test to actual async/await where
we then need to wait at least until the next tick. It seems more
idiomatic to stick with `fakeAsync` here though.

Example failing build: https://app.circleci.com/pipelines/github/angular/components/27478/workflows/76466fd9-9f92-40a7-8626-58a99351d018/jobs/296976