### PR TITLE
build: install MDC canary dependencies through yarn

### DIFF
--- a/scripts/circleci/setup-mdc-canary.js
+++ b/scripts/circleci/setup-mdc-canary.js
@@ -1,6 +1,8 @@
 const {join} = require('path');
+const {writeFileSync} = require('fs');
 const {spawn, spawnSync} = require('child_process');
-const packageJson = require(join(__dirname, '../../package.json'));
+const packageJsonPath = join(__dirname, '../../package.json');
+const packageJson = require(packageJsonPath);
 const versionsProcess = spawnSync('yarn', [
   'info', 'material-components-web', 'dist-tags.canary', '--json'
 ], {shell: true});
@@ -13,18 +15,18 @@ try {
   throw e;
 }
 
-const pattern = /^material-components-web$|^@material\//;
-const params = Object.keys(packageJson.devDependencies)
-  .filter(dependency => pattern.test(dependency))
-  .reduce((mdcDependencies, dependency) =>
-    [...mdcDependencies, `${dependency}@${latestCanaryVersion}`], []);
+['devDependencies', 'dependencies'].forEach(field => {
+  Object.keys(packageJson[field]).forEach(key => {
+    if (/^material-components-web$|^@material\//.test(key)) {
+      packageJson[field][key] = latestCanaryVersion;
+    }
+  });
+});
 
-if (!params.length) {
-  throw Error(`Could not find MDC dependencies in package.json`);
-}
+writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
 console.log(`Updating all MDC dependencies to version ${latestCanaryVersion}`);
-const childProcess = spawn('yarn', ['add', ...params, '-D'], {shell: true});
+const childProcess = spawn('yarn', ['install', '--non-interactive'], {shell: true});
 childProcess.stdout.on('data', data => console.log(data + ''));
 childProcess.stderr.on('data', data => console.error(data + ''));
 childProcess.on('exit', code => process.exit(code));


### PR DESCRIPTION
Reworks the MDC canary script to use `yarn install` instead of going through `yarn add` in an attempt to avoid flakes on the CI.