### PR TITLE
fix(cdk/overlay): expand `OverlayReference` interface to cover more properties

### DIFF
--- a/src/cdk/overlay/overlay-reference.ts
+++ b/src/cdk/overlay/overlay-reference.ts
@@ -8,7 +8,7 @@
 
 import {Portal} from '@angular/cdk/portal';
 import {Direction, Directionality} from '@angular/cdk/bidi';
-import {Subject} from 'rxjs';
+import {Observable, Subject} from 'rxjs';
 
 /**
  * Basic interface for an overlay. Used to avoid circular type references between
@@ -21,12 +21,20 @@ export interface OverlayReference {
   dispose: () => void;
   overlayElement: HTMLElement;
   hostElement: HTMLElement;
+  backdropElement: HTMLElement | null;
   getConfig: () => any;
   hasAttached: () => boolean;
   updateSize: (config: any) => void;
   updatePosition: () => void;
   getDirection: () => Direction;
   setDirection: (dir: Direction | Directionality) => void;
+  backdropClick: () => Observable<MouseEvent>;
+  attachments: () => Observable<void>;
+  detachments: () => Observable<void>;
+  keydownEvents: () => Observable<KeyboardEvent>;
+  outsidePointerEvents: () => Observable<MouseEvent>;
+  addPanelClass: (classes: string | string[]) => void;
+  removePanelClass: (classes: string | string[]) => void;
   readonly _outsidePointerEvents: Subject<MouseEvent>;
   readonly _keydownEvents: Subject<KeyboardEvent>;
 }


### PR DESCRIPTION
We have an interface called `OverlayReference` which is meant to mimic `OverlayRef` while allowing us to break the circular dependency of `ScrollStrategy -> OverlayRef -> OverlayConfig -> ScrollStrategy`. The problem is that it currently doesn't expose some useful members.

These changes expand the interface to cover more of the `OverlayRef` API surface.

Fixes #23234.