### PR TITLE
refactor(cdk/a11y): remove InteractivityChecker ie11 special case

### DIFF
--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.ts
@@ -208,12 +208,6 @@ function hasValidTabIndex(element: HTMLElement): boolean {
   }
 
   let tabIndex = element.getAttribute('tabindex');
-
-  // IE11 parses tabindex="" as the value "-32768"
-  if (tabIndex == '-32768') {
-    return false;
-  }
-
   return !!(tabIndex && !isNaN(parseInt(tabIndex, 10)));
 }
 


### PR DESCRIPTION
As of v13, we no longer support IE11. Related to #7374