### PR TITLE
docs(guides/getting-started): changed value property of mat-slider fr…

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -62,7 +62,7 @@ import { MatSliderModule } from '@angular/material/slider';
 Add the `<mat-slider>` tag to the `app.component.html` like so:
 
 ```html
-<mat-slider min="1" max="100" step="1" value="1"></mat-slider>
+<mat-slider min="1" max="100" step="1" value="50"></mat-slider>
 ```
 
 Run your local dev server:


### PR DESCRIPTION
…om getting-started guide

The mat-slider is invisible when value is 1 on the purple-green  pre-built template after following the "getting started" guide. Since the white background is default nothing can be seen, which is especially bad for newbies.

This addresses a problem that causes the mat-slider from the Getting Started guide to be invisible even when perfectly following the steps, as shown below:

![problematic demo](https://user-images.githubusercontent.com/16341847/127547504-1e9e039a-5308-4bee-9945-b6f0b1297b24.png)

This is caused because the pre-build material theme purple-green.css has the following style to mat-slider's with min-value:

```css
.mat-slider-min-value:not(.mat-slider-thumb-label-showing) .mat-slider-thumb {
    border-color: rgba(255,255,255,.3);
    background-color: transparent
}
```

Following the getting-started tutorial after this change yields this:
![working demo](https://user-images.githubusercontent.com/16341847/127547555-decda61a-7b62-45ae-acb7-6b829b3d3a0c.png)
