### PR TITLE
build: fix deprecation warning from highlightjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
     "gulp-dart-sass": "^1.0.2",
-    "highlight.js": "^10.4.0",
+    "highlight.js": "^10.7.0",
     "husky": "^7.0.1",
     "inquirer": "^8.0.0",
     "jasmine": "^3.6.0",

--- a/tools/highlight-files/highlight-code-block.ts
+++ b/tools/highlight-files/highlight-code-block.ts
@@ -7,8 +7,9 @@ const highlightJs = require('highlight.js');
  */
 export function highlightCodeBlock(code: string, language: string) {
   if (language) {
-    return highlightJs.highlight(
-      language.toLowerCase() === 'ts' ? 'typescript' : language, code).value;
+    return highlightJs.highlight(code, {
+      language: language.toLowerCase() === 'ts' ? 'typescript' : language
+    }).value;
   }
 
   return code;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7858,10 +7858,10 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
-highlight.js@^10.4.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.6.0.tgz#0073aa71d566906965ba6e1b7be7b2682f5e18b6"
-  integrity sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==
+highlight.js@^10.7.0:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 home-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is a patch-only version of https://github.com/angular/components/pull/23280

Fixes the following deprecation warning that is logged by `highlightjs`:

```
Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated.
Deprecated as of 10.7.0. Please use highlight(code, options) instead.
https://github.com/highlightjs/highlight.js/issues/2277
```