### PR TITLE
build: flag unnecessary stylelint disable clauses

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,7 @@
 {
   "defaultSeverity": "error",
+  "reportNeedlessDisables": true,
+  "reportInvalidScopeDisables": true,
   "plugins": [
     "./tools/stylelint/loader-rule.js",
     "./tools/stylelint/no-prefixes/index.ts",

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "semver": "^7.3.4",
     "send": "^0.17.1",
     "shelljs": "^0.8.3",
-    "stylelint": "^13.8.0",
+    "stylelint": "^13.13.1",
     "terser": "^4.8.0",
     "ts-node": "^9.1.1",
     "tsickle": "0.39.1",

--- a/src/material-experimental/mdc-helpers/_mdc-helpers.scss
+++ b/src/material-experimental/mdc-helpers/_mdc-helpers.scss
@@ -96,7 +96,6 @@ $mat-typography-mdc-level-mappings: (
 
 // Configures MDC's global variables to reflect the given theme, applies the given styles,
 // then resets the global variables to prevent unintended side effects.
-// stylelint-disable-next-line material/theme-mixin-api
 @mixin mat-using-mdc-theme($config) {
   $primary: theming.get-color-from-palette(map.get($config, primary));
   $accent: theming.get-color-from-palette(map.get($config, accent));
@@ -187,7 +186,6 @@ $mat-typography-mdc-level-mappings: (
 
 // Configures MDC's global variables to reflect the given typography config,
 // applies the given styles, then resets the global variables to prevent unintended side effects.
-// stylelint-disable-next-line material/theme-mixin-api
 @mixin mat-using-mdc-typography($config) {
   // Save the original values.
   $orig-mdc-typography-styles: mdc-typography.$styles;

--- a/src/material/core/typography/_typography.scss
+++ b/src/material/core/typography/_typography.scss
@@ -171,8 +171,6 @@
   @return $config;
 }
 
-// stylelint-disable material/theme-mixin-api
-
 /// Emits baseline typographic styles based on a given config.
 /// @param {Map} $config-or-theme A typography config for an entire theme.
 /// @param {String} $selector Ancestor selector under which native elements, such as h1, will
@@ -263,5 +261,3 @@
     margin: 0 0 64px;
   }
 }
-
-// stylelint-enable material/theme-mixin-api

--- a/src/material/sidenav/drawer.scss
+++ b/src/material/sidenav/drawer.scss
@@ -7,10 +7,8 @@ $drawer-side-drawer-z-index: 2;
 $drawer-backdrop-z-index: 3;
 $drawer-over-drawer-z-index: 4;
 
-// stylelint-disable max-line-length
 // Mixin that creates a new stacking context.
 // see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-// stylelint-enable
 @mixin drawer-stacking-context($z-index: 1) {
   position: relative;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12609,7 +12609,7 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-stylelint@^13.8.0:
+stylelint@^13.13.1:
   version "13.13.1"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-13.13.1.tgz#fca9c9f5de7990ab26a00f167b8978f083a18f3c"
   integrity sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==


### PR DESCRIPTION
Bumps Stylelint to the latest version and turns on an option to flag unnecessary disable clauses.