### PR TITLE
fix(material/core): Option should not have tabindex attribute.

### DIFF
--- a/src/material-experimental/mdc-core/option/option.ts
+++ b/src/material-experimental/mdc-core/option/option.ts
@@ -31,7 +31,6 @@ import {MatOptgroup} from './optgroup';
   exportAs: 'matOption',
   host: {
     'role': 'option',
-    '[attr.tabindex]': '_getTabIndex()',
     '[class.mdc-list-item--selected]': 'selected',
     '[class.mat-mdc-option-multiple]': 'multiple',
     '[class.mat-mdc-option-active]': 'active',

--- a/src/material-experimental/mdc-select/select.spec.ts
+++ b/src/material-experimental/mdc-select/select.spec.ts
@@ -672,8 +672,8 @@ describe('MDC-based MatSelect', () => {
               flush();
             }));
 
-        it('should not shift focus when the selected options are updated programmatically ' +
-            'in a multi select', fakeAsync(() => {
+        it('should not shift active option when the selected options are updated ' +
+            'programmatically in a multi select', fakeAsync(() => {
           fixture.destroy();
 
           const multiFixture = TestBed.createComponent(MultiSelect);
@@ -686,14 +686,14 @@ describe('MDC-based MatSelect', () => {
           const options =
               overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
 
-          options[3].focus();
-          expect(document.activeElement).toBe(options[3], 'Expected fourth option to be focused.');
+          expect(select.getAttribute('aria-activedescendant'))
+              .toBe(options[0].id, 'Expected first option to be active.');
 
           multiFixture.componentInstance.control.setValue(['steak-0', 'sushi-7']);
           multiFixture.detectChanges();
 
-          expect(document.activeElement)
-              .toBe(options[3], 'Expected fourth option to remain focused.');
+          expect(select.getAttribute('aria-activedescendant'))
+              .toBe(options[0].id, 'Expected first option to remain active.');
         }));
 
         it('should not cycle through the options if the control is disabled', fakeAsync(() => {
@@ -1082,12 +1082,6 @@ describe('MDC-based MatSelect', () => {
             option.getAttribute('aria-selected') === 'false')).toBe(true,
             'Expected all unselected multi-select options to have aria-selected="false".');
           }));
-
-        it('should set the tabindex of each option according to disabled state', fakeAsync(() => {
-          expect(options[0].getAttribute('tabindex')).toEqual('0');
-          expect(options[1].getAttribute('tabindex')).toEqual('0');
-          expect(options[2].getAttribute('tabindex')).toEqual('-1');
-        }));
 
         it('should set aria-disabled for disabled options', fakeAsync(() => {
           expect(options[0].getAttribute('aria-disabled')).toEqual('false');

--- a/src/material/core/option/option.ts
+++ b/src/material/core/option/option.ts
@@ -193,11 +193,6 @@ export class _MatOptionBase implements FocusableOption, AfterViewChecked, OnDest
     return this.selected || (this.multiple ? false : null);
   }
 
-  /** Returns the correct tabindex for the option depending on disabled state. */
-  _getTabIndex(): string {
-    return this.disabled ? '-1' : '0';
-  }
-
   /** Gets the host DOM element. */
   _getHostElement(): HTMLElement {
     return this._element.nativeElement;
@@ -239,7 +234,6 @@ export class _MatOptionBase implements FocusableOption, AfterViewChecked, OnDest
   exportAs: 'matOption',
   host: {
     'role': 'option',
-    '[attr.tabindex]': '_getTabIndex()',
     '[class.mat-selected]': 'selected',
     '[class.mat-option-multiple]': 'multiple',
     '[class.mat-active]': 'active',

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -674,8 +674,8 @@ describe('MatSelect', () => {
               flush();
             }));
 
-        it('should not shift focus when the selected options are updated programmatically ' +
-            'in a multi select', fakeAsync(() => {
+        it('should not shift active option when the selected options are updated ' +
+            'programmatically in a multi select', fakeAsync(() => {
           fixture.destroy();
 
           const multiFixture = TestBed.createComponent(MultiSelect);
@@ -688,14 +688,14 @@ describe('MatSelect', () => {
           const options =
               overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
 
-          options[3].focus();
-          expect(document.activeElement).toBe(options[3], 'Expected fourth option to be focused.');
+          expect(select.getAttribute('aria-activedescendant'))
+              .toBe(options[0].id, 'Expected first option to be active.');
 
           multiFixture.componentInstance.control.setValue(['steak-0', 'sushi-7']);
           multiFixture.detectChanges();
 
-          expect(document.activeElement)
-              .toBe(options[3], 'Expected fourth option to remain focused.');
+          expect(select.getAttribute('aria-activedescendant'))
+              .toBe(options[0].id, 'Expected first option to remain active.');
         }));
 
         it('should not cycle through the options if the control is disabled', fakeAsync(() => {
@@ -1084,12 +1084,6 @@ describe('MatSelect', () => {
             option.getAttribute('aria-selected') === 'false')).toBe(true,
             'Expected all unselected multi-select options to have aria-selected="false".');
           }));
-
-        it('should set the tabindex of each option according to disabled state', fakeAsync(() => {
-          expect(options[0].getAttribute('tabindex')).toEqual('0');
-          expect(options[1].getAttribute('tabindex')).toEqual('0');
-          expect(options[2].getAttribute('tabindex')).toEqual('-1');
-        }));
 
         it('should set aria-disabled for disabled options', fakeAsync(() => {
           expect(options[0].getAttribute('aria-disabled')).toEqual('false');

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -301,7 +301,6 @@ export class _MatOptionBase implements FocusableOption, AfterViewChecked, OnDest
     _getAriaSelected(): boolean | null;
     _getHostElement(): HTMLElement;
     getLabel(): string;
-    _getTabIndex(): string;
     // (undocumented)
     readonly group: _MatOptgroupBase;
     _handleKeydown(event: KeyboardEvent): void;


### PR DESCRIPTION
When a `MatSelect` or a `MatAutocomplete` opens, focus stays on the input. The attribute `aria-activedescendant` is used to identify the active option. It's not necessary for the options to _also_ be focusable, so we can clean up the component a bit by just removing the `tabindex` attribute and any related tests.

This could break a good amount of stuff in g3, so I'm testing beforehand.