### PR TITLE
build: update peer dependency for angular framework dependencies

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -1,7 +1,7 @@
 # Each individual package uses a placeholder for the version of Angular to ensure they're
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
-ANGULAR_PACKAGE_VERSION = "^12.0.0 || ^13.0.0-0"
+ANGULAR_PACKAGE_VERSION = "^13.0.0-0 || ^14.0.0-0"
 MDC_PACKAGE_VERSION = "12.0.0-canary.5f00e454a.0"
 TSLIB_PACKAGE_VERSION = "^2.2.0"
 RXJS_PACKAGE_VERSION = "^6.5.3"


### PR DESCRIPTION
The release tool will require us to update the peer dependencies to no longer
allow for v12 when cutting v13 major pre-releases.