### PR TITLE
Revert "build: update peer dependency for angular framework dependenc…

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -1,7 +1,7 @@
 # Each individual package uses a placeholder for the version of Angular to ensure they're
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
-ANGULAR_PACKAGE_VERSION = "^13.0.0-0 || ^14.0.0-0"
+ANGULAR_PACKAGE_VERSION = "^12.0.0 || ^13.0.0-0"
 MDC_PACKAGE_VERSION = "12.0.0-canary.5f00e454a.0"
 TSLIB_PACKAGE_VERSION = "^2.2.0"
 RXJS_PACKAGE_VERSION = "^6.5.3"


### PR DESCRIPTION
…ies"

This reverts commit ac0b162cb027f6ccdc6718e6f4c9b54eb12bf875.

Reverting the update to the peer dependency because we're supposed to do that after we release minor and patch today. After we release minor and patch today, I'll updated the peer deps, then start the process for creating the 13.0.0-next.0 branch.