### PR TITLE
build: update peerDependencies to allow rxjs 7

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -4,7 +4,7 @@
 ANGULAR_PACKAGE_VERSION = "^13.0.0-0 || ^14.0.0-0"
 MDC_PACKAGE_VERSION = "12.0.0-canary.5f00e454a.0"
 TSLIB_PACKAGE_VERSION = "^2.2.0"
-RXJS_PACKAGE_VERSION = "^6.5.3"
+RXJS_PACKAGE_VERSION = "^6.5.3 || ^7.0.0"
 
 # Each placer holder is used to stamp versions during the build process, replacing the key with it's
 # value pair. These replacements occur during building of `npm_package` and `ng_package` stamping in


### PR DESCRIPTION
In https://github.com/angular/angular/pull/42991 which went out in version 12.2.0 we made it possible to opt into rxjs 7, however the change only affects the core packages. These changes apply the same version range to the Components packages.