### PR TITLE
build: don't run tests against edge

### DIFF
--- a/test/browser-providers.js
+++ b/test/browser-providers.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  * Browser Configuration for the different jobs in the legacy Karma tests.
  *
@@ -7,9 +5,8 @@
  *   - `saucelabs`: Launches the browser within Saucelabs
  */
 const browserConfig = {
-  'Edge87':            {unitTest: {target: 'browserstack'}},
-  'iOS14':             {unitTest: {target: 'saucelabs'}},
-  'Safari13':          {unitTest: {target: 'browserstack'}},
+  'iOS14': {unitTest: {target: 'saucelabs'}},
+  'Safari13': {unitTest: {target: 'browserstack'}},
 };
 
 /** Exports all available custom Karma browsers. */
@@ -28,7 +25,5 @@ function buildConfiguration(type, target) {
     .filter(([, config]) => config.target === target)
     .map(([browserName]) => browserName);
 
-  return targetBrowsers.map(browserName => {
-    return `${target.toUpperCase()}_${browserName.toUpperCase()}`;
-  });
+  return targetBrowsers.map(browserName => `${target.toUpperCase()}_${browserName.toUpperCase()}`);
 }

--- a/test/karma-browsers.json
+++ b/test/karma-browsers.json
@@ -8,13 +8,6 @@
     "platformName": "iOS",
     "deviceName": "iPhone 12 Pro Simulator"
   },
-  "BROWSERSTACK_EDGE87": {
-    "base": "BrowserStack",
-    "browser": "Edge",
-    "browser_version": "87.0",
-    "os": "Windows",
-    "os_version": "10"
-  },
   "BROWSERSTACK_SAFARI13": {
     "base": "BrowserStack",
     "browser": "Safari",


### PR DESCRIPTION
Since Edge is based on Chromium now, we don't get much out of running unit tests against it.