### PR TITLE
release: add luxon adapter back to the changelog. (#23324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@
 | ---------- | --------------------- |
 | feature |  add event emitter for gm_authFailure callback ([#22953](https://github.com/angular/components/issues/22953)) ([224de73bb440e131e687cc493bc52765b3821a0a](https://github.com/angular/components/commit/224de73bb440e131e687cc493bc52765b3821a0a)) |
 
+### material-luxon-adapter
+
+|            |                       |
+| ---------- | --------------------- |
+| feature |  add luxon date adapter ([#23167](https://github.com/angular/components/issues/23167)) ([492268a06e189accfb06354b586416a3b7a2d644](https://github.com/angular/components/commit/492268a06e189accfb06354b586416a3b7a2d644)) |
+
+
 ## 12.1.4 "tallow-wire" (2021-07-28)
 
 ### cdk


### PR DESCRIPTION
This reverts commit b922846ed7b8f678ca85b3addf4ffc04c5e24cb1, which
remote material luxon adapter from the changelog. That was removed by
mistake because I thought the package did not publish correctly. I
confirmed on npmjs.com that we published
@angular/material-luxon-adapter@12.2.0. Since it was published, we add
it to the CHANGELOG.