### PR TITLE
refactor(material/list): remove deprecated APIs for version 13

### DIFF
--- a/src/material/list/list.ts
+++ b/src/material/list/list.ts
@@ -176,8 +176,6 @@ export class MatListSubheaderCssMatStyler {}
   host: {
     'class': 'mat-list-item mat-focus-indicator',
     '[class.mat-list-item-disabled]': 'disabled',
-    // @breaking-change 8.0.0 Remove `mat-list-item-avatar` in favor of `mat-list-item-with-avatar`.
-    '[class.mat-list-item-avatar]': '_avatar || _icon',
     '[class.mat-list-item-with-avatar]': '_avatar || _icon',
   },
   inputs: ['disableRipple'],

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -12,7 +12,6 @@ import {SelectionModel} from '@angular/cdk/collections';
 import {A, DOWN_ARROW, ENTER, hasModifierKey, SPACE, UP_ARROW} from '@angular/cdk/keycodes';
 import {
   AfterContentInit,
-  Attribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -59,12 +58,6 @@ export class MatSelectionListChange {
   constructor(
     /** Reference to the selection list that emitted the event. */
     public source: MatSelectionList,
-    /**
-     * Reference to the option that has been changed.
-     * @deprecated Use `options` instead, because some events may change more than one option.
-     * @breaking-change 12.0.0
-     */
-    public option: MatListOption,
     /** Reference to the options that have been changed. */
     public options: MatListOption[],
   ) {}
@@ -368,12 +361,6 @@ export class MatSelectionList
   @Output() readonly selectionChange: EventEmitter<MatSelectionListChange> =
     new EventEmitter<MatSelectionListChange>();
 
-  /**
-   * Tabindex of the selection list.
-   * @breaking-change 11.0.0 Remove `tabIndex` input.
-   */
-  @Input() tabIndex: number = 0;
-
   /** Theme color of the selection list. This sets the checkbox color for all list options. */
   @Input() color: ThemePalette = 'accent';
 
@@ -443,11 +430,8 @@ export class MatSelectionList
 
   constructor(
     private _element: ElementRef<HTMLElement>,
-    // @breaking-change 11.0.0 Remove `tabIndex` parameter.
-    @Attribute('tabindex') tabIndex: string,
     private _changeDetector: ChangeDetectorRef,
-    // @breaking-change 11.0.0 `_focusMonitor` parameter to become required.
-    private _focusMonitor?: FocusMonitor,
+    private _focusMonitor: FocusMonitor,
   ) {
     super();
   }
@@ -493,9 +477,8 @@ export class MatSelectionList
       }
     });
 
-    // @breaking-change 11.0.0 Remove null assertion once _focusMonitor is required.
     this._focusMonitor
-      ?.monitor(this._element)
+      .monitor(this._element)
       .pipe(takeUntil(this._destroyed))
       .subscribe(origin => {
         if (origin === 'keyboard' || origin === 'program') {
@@ -524,8 +507,7 @@ export class MatSelectionList
   }
 
   ngOnDestroy() {
-    // @breaking-change 11.0.0 Remove null assertion once _focusMonitor is required.
-    this._focusMonitor?.stopMonitoring(this._element);
+    this._focusMonitor.stopMonitoring(this._element);
     this._destroyed.next();
     this._destroyed.complete();
     this._isDestroyed = true;
@@ -626,7 +608,7 @@ export class MatSelectionList
 
   /** Emits a change event if the selected state of an option changed. */
   _emitChangeEvent(options: MatListOption[]) {
-    this.selectionChange.emit(new MatSelectionListChange(this, options[0], options));
+    this.selectionChange.emit(new MatSelectionListChange(this, options));
   }
 
   /** Implemented as part of ControlValueAccessor. */

--- a/src/material/list/testing/list-item-harness-base.ts
+++ b/src/material/list/testing/list-item-harness-base.ts
@@ -9,7 +9,6 @@
 import {
   ComponentHarness,
   ComponentHarnessConstructor,
-  HarnessLoader,
   HarnessPredicate,
   ContentContainerComponentHarness,
   parallel,
@@ -95,14 +94,5 @@ export abstract class MatListItemHarnessBase extends ContentContainerComponentHa
   /** Whether this list option is disabled. */
   async isDisabled(): Promise<boolean> {
     return (await this.host()).hasClass('mat-list-item-disabled');
-  }
-
-  /**
-   * Gets a `HarnessLoader` used to get harnesses within the list item's content.
-   * @deprecated Use `getChildLoader(MatListItemSection.CONTENT)` or `getHarness` instead.
-   * @breaking-change 12.0.0
-   */
-  async getHarnessLoaderForContent(): Promise<HarnessLoader> {
-    return this.getChildLoader(MatListItemSection.CONTENT);
   }
 }

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -14,6 +14,12 @@ import {ConstructorChecksUpgradeData, TargetVersion, VersionChanges} from '@angu
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V14]: [
+    {
+      pr: 'https://github.com/angular/components/pull/23327',
+      changes: ['MatSelectionList', 'MatSelectionListChange'],
+    },
+  ],
   [TargetVersion.V13]: [
     {
       pr: 'https://github.com/angular/components/pull/23389',

--- a/src/material/schematics/ng-update/data/css-selectors.ts
+++ b/src/material/schematics/ng-update/data/css-selectors.ts
@@ -28,6 +28,12 @@ export interface MaterialCssSelectorData {
 }
 
 export const cssSelectors: VersionChanges<MaterialCssSelectorData> = {
+  [TargetVersion.V14]: [
+    {
+      pr: 'https://github.com/angular/components/pull/23327',
+      changes: [{replace: '.mat-list-item-avatar', replaceWith: '.mat-list-item-with-avatar'}],
+    },
+  ],
   [TargetVersion.V6]: [
     {
       pr: 'https://github.com/angular/components/pull/10296',

--- a/tools/public_api_guard/material/list-testing.md
+++ b/tools/public_api_guard/material/list-testing.md
@@ -9,7 +9,6 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { ComponentHarnessConstructor } from '@angular/cdk/testing';
 import { ContentContainerComponentHarness } from '@angular/cdk/testing';
 import { DividerHarnessFilters } from '@angular/material/divider/testing';
-import { HarnessLoader } from '@angular/cdk/testing';
 import { HarnessPredicate } from '@angular/cdk/testing';
 import { MatDividerHarness } from '@angular/material/divider/testing';
 import { MatListOptionCheckboxPosition } from '@angular/material/list';

--- a/tools/public_api_guard/material/list.md
+++ b/tools/public_api_guard/material/list.md
@@ -179,7 +179,7 @@ export class MatNavList extends _MatListBase implements CanDisable, CanDisableRi
 
 // @public
 export class MatSelectionList extends _MatSelectionListBase implements CanDisableRipple, AfterContentInit, ControlValueAccessor, OnDestroy, OnChanges {
-    constructor(_element: ElementRef<HTMLElement>, tabIndex: string, _changeDetector: ChangeDetectorRef, _focusMonitor?: FocusMonitor | undefined);
+    constructor(_element: ElementRef<HTMLElement>, _changeDetector: ChangeDetectorRef, _focusMonitor: FocusMonitor);
     color: ThemePalette;
     compareWith: (o1: any, o2: any) => boolean;
     deselectAll(): MatListOption[];
@@ -208,24 +208,20 @@ export class MatSelectionList extends _MatSelectionListBase implements CanDisabl
     readonly selectionChange: EventEmitter<MatSelectionListChange>;
     setDisabledState(isDisabled: boolean): void;
     _setFocusedOption(option: MatListOption): void;
-    tabIndex: number;
     _tabIndex: number;
     _value: string[] | null;
     writeValue(values: string[]): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSelectionList, "mat-selection-list", ["matSelectionList"], { "disableRipple": "disableRipple"; "tabIndex": "tabIndex"; "color": "color"; "compareWith": "compareWith"; "disabled": "disabled"; "multiple": "multiple"; }, { "selectionChange": "selectionChange"; }, ["options"], ["*"]>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSelectionList, "mat-selection-list", ["matSelectionList"], { "disableRipple": "disableRipple"; "color": "color"; "compareWith": "compareWith"; "disabled": "disabled"; "multiple": "multiple"; }, { "selectionChange": "selectionChange"; }, ["options"], ["*"]>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatSelectionList, [null, { attribute: "tabindex"; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatSelectionList, never>;
 }
 
 // @public
 export class MatSelectionListChange {
     constructor(
     source: MatSelectionList,
-    option: MatListOption,
     options: MatListOption[]);
-    // @deprecated
-    option: MatListOption;
     options: MatListOption[];
     source: MatSelectionList;
 }


### PR DESCRIPTION
Removes the APIs that were marked for removal in version 13 in the `material/list` package.

BREAKING CHANGE:
* `mat-list-item-avatar` CSS class has been renamed to `mat-list-item-with-avatar`.
* `MatSelectionListChange.option` has been removed. Use `MatSelectionListChange.options` instead.
* `MatSelectionList.tabIndex` input has been removed.
* `tabIndex` parameter of the `MatSelectionList` constructor has been removed.
* `_focusMonitor` parameter of the `MatSelectionList` constructor is now required.
* `getHarnessLoaderForContent` has been removed from the various test item harnesses. Use `getChildLoader(MatListItemSection.CONTENT)` instead.