### PR TITLE
fix(material/datepicker): calendar reopening on spacebar selection

### DIFF
--- a/src/material/datepicker/calendar.spec.ts
+++ b/src/material/datepicker/calendar.spec.ts
@@ -221,6 +221,8 @@ describe('MatCalendar', () => {
 
             dispatchKeyboardEvent(tableBodyEl, 'keydown', ENTER);
             fixture.detectChanges();
+            dispatchKeyboardEvent(tableBodyEl, 'keyup', ENTER);
+            fixture.detectChanges();
 
             expect(calendarInstance.currentView).toBe('month');
             expect(calendarInstance.activeDate).toEqual(new Date(2017, FEB, 28));
@@ -234,6 +236,8 @@ describe('MatCalendar', () => {
             fixture.detectChanges();
 
             dispatchKeyboardEvent(tableBodyEl, 'keydown', SPACE);
+            fixture.detectChanges();
+            dispatchKeyboardEvent(tableBodyEl, 'keyup', SPACE);
             fixture.detectChanges();
 
             expect(calendarInstance.currentView).toBe('month');
@@ -258,6 +262,8 @@ describe('MatCalendar', () => {
 
             dispatchKeyboardEvent(tableBodyEl, 'keydown', ENTER);
             fixture.detectChanges();
+            dispatchKeyboardEvent(tableBodyEl, 'keyup', ENTER);
+            fixture.detectChanges();
 
             expect(calendarInstance.currentView).toBe('year');
             expect(calendarInstance.activeDate).toEqual(new Date(2018, JAN, 31));
@@ -271,6 +277,8 @@ describe('MatCalendar', () => {
             fixture.detectChanges();
 
             dispatchKeyboardEvent(tableBodyEl, 'keydown', SPACE);
+            fixture.detectChanges();
+            dispatchKeyboardEvent(tableBodyEl, 'keyup', SPACE);
             fixture.detectChanges();
 
             expect(calendarInstance.currentView).toBe('year');
@@ -581,6 +589,8 @@ describe('MatCalendar', () => {
 
         tableBodyEl = calendarElement.querySelector('.mat-calendar-body') as HTMLElement;
         dispatchKeyboardEvent(tableBodyEl, 'keydown', ENTER);
+        fixture.detectChanges();
+        dispatchKeyboardEvent(tableBodyEl, 'keyup', ENTER);
         fixture.detectChanges();
 
         expect(calendarInstance.currentView).toBe('month');

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -324,6 +324,8 @@ describe('MatDatepicker', () => {
           flush();
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', ENTER);
           fixture.detectChanges();
+          dispatchKeyboardEvent(calendarBodyEl, 'keyup', ENTER);
+          fixture.detectChanges();
           flush();
 
           expect(document.querySelector('.mat-datepicker-dialog')).toBeNull();

--- a/src/material/datepicker/month-view.html
+++ b/src/material/datepicker/month-view.html
@@ -25,6 +25,7 @@
          [activeCell]="_dateAdapter.getDate(activeDate) - 1"
          (selectedValueChange)="_dateSelected($event)"
          (previewChange)="_previewChanged($event)"
+         (keyup)="_handleCalendarBodyKeyup($event)"
          (keydown)="_handleCalendarBodyKeydown($event)">
   </tbody>
 </table>

--- a/src/material/datepicker/month-view.spec.ts
+++ b/src/material/datepicker/month-view.spec.ts
@@ -287,6 +287,8 @@ describe('MatMonthView', () => {
 
             dispatchKeyboardEvent(calendarBodyEl, 'keydown', ENTER);
             fixture.detectChanges();
+            dispatchKeyboardEvent(calendarBodyEl, 'keyup', ENTER);
+            fixture.detectChanges();
 
             expect(testComponent.selected).toEqual(new Date(2017, JAN, 4));
           });
@@ -298,6 +300,8 @@ describe('MatMonthView', () => {
             expect(testComponent.selected).toEqual(new Date(2017, JAN, 10));
 
             dispatchKeyboardEvent(calendarBodyEl, 'keydown', SPACE);
+            fixture.detectChanges();
+            dispatchKeyboardEvent(calendarBodyEl, 'keyup', SPACE);
             fixture.detectChanges();
 
             expect(testComponent.selected).toEqual(new Date(2017, JAN, 4));

--- a/src/material/datepicker/multi-year-view.html
+++ b/src/material/datepicker/multi-year-view.html
@@ -11,6 +11,7 @@
          [cellAspectRatio]="4 / 7"
          [activeCell]="_getActiveCell()"
          (selectedValueChange)="_yearSelected($event)"
+         (keyup)="_handleCalendarBodyKeyup($event)"
          (keydown)="_handleCalendarBodyKeydown($event)">
   </tbody>
 </table>

--- a/src/material/datepicker/year-view.html
+++ b/src/material/datepicker/year-view.html
@@ -13,6 +13,7 @@
          [cellAspectRatio]="4 / 7"
          [activeCell]="_dateAdapter.getMonth(activeDate)"
          (selectedValueChange)="_monthSelected($event)"
+         (keyup)="_handleCalendarBodyKeyup($event)"
          (keydown)="_handleCalendarBodyKeydown($event)">
   </tbody>
 </table>

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -785,6 +785,7 @@ export class MatMonthView<D> implements AfterContentInit, OnChanges, OnDestroy {
     _firstWeekOffset: number;
     _focusActiveCell(movePreview?: boolean): void;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
+    _handleCalendarBodyKeyup(event: KeyboardEvent): void;
     _init(): void;
     _isRange: boolean;
     _matCalendarBody: MatCalendarBody;
@@ -834,6 +835,7 @@ export class MatMultiYearView<D> implements AfterContentInit, OnDestroy {
     // (undocumented)
     _getActiveCell(): number;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
+    _handleCalendarBodyKeyup(event: KeyboardEvent): void;
     _init(): void;
     _matCalendarBody: MatCalendarBody;
     get maxDate(): D | null;
@@ -922,6 +924,7 @@ export class MatYearView<D> implements AfterContentInit, OnDestroy {
     dateFilter: (date: D) => boolean;
     _focusActiveCell(): void;
     _handleCalendarBodyKeydown(event: KeyboardEvent): void;
+    _handleCalendarBodyKeyup(event: KeyboardEvent): void;
     _init(): void;
     _matCalendarBody: MatCalendarBody;
     get maxDate(): D | null;


### PR DESCRIPTION
Fixes that the Material calendar was reopening immediately when a date is selected using the spacebar on Firefox.

Fixes #23305.