### PR TITLE
build: fix staging sanity release checks picking up incorrect packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "postinstall": "node tools/postinstall/apply-patches.js && ngcc --properties module main --create-ivy-entry-points && node tools/postinstall/update-ngcc-main-fields.js",
-    "build": "ts-node --project scripts/tsconfig.json ./scripts/build-packages-dist.js",
+    "build": "ts-node --project scripts/tsconfig.json ./scripts/build-packages-dist.ts",
     "build-and-check-release-output": "ts-node --project scripts/tsconfig.json scripts/build-and-check-release-output.ts",
     "build-docs-content": "node ./scripts/build-docs-content.js",
     "dev-app": "ibazel run //src/dev-app:devserver",

--- a/tools/release-checks/index.js
+++ b/tools/release-checks/index.js
@@ -1,0 +1,27 @@
+require('ts-node').register({
+  dir: __dirname,
+  transpileOnly: true,
+  compilerOptions: {module: 'commonjs'},
+})
+
+const {parse} = require('semver');
+const {assertValidFrameworkPeerDependency} = require('./check-framework-peer-dependency');
+const {assertValidUpdateMigrationCollections} = require('./check-migration-collections');
+
+async function main(newVersion) {
+  await assertValidFrameworkPeerDependency(newVersion);
+  await assertValidUpdateMigrationCollections(newVersion);
+}
+
+if (require.main === module) {
+  const newVersion = parse(process.argv[2]);
+
+  if (newVersion === null) {
+    throw Error('No proper version specified for release checks.');
+  }
+
+  main(newVersion).catch(e => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Currently the new release tool hacks around the ng-dev publish
tool in order to run staging sanity checks. The logic is
currently running in the same Node process that started
the publish process from `master`. This results in the
sanity checks accidentally receiving a cached list of
release packages, instead of the one local to the publish
branch (like `12.2.x`build: fix staging sanity release checks picking up
incorrect packages

Currently the new release tool hacks around the ng-dev publish
tool in order to run staging sanity checks. The logic is
currently running in the same Node process that started
the publish process from `master`. This results in the
sanity checks accidentally receiving a cached list of
release packages, instead of the one local to the publish
branch (like `12.2.x`)