### PR TITLE
feat(google-maps): switch to non-deprecated typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/core": "13.0.0-next.8",
     "@angular/forms": "13.0.0-next.8",
     "@angular/platform-browser": "13.0.0-next.8",
-    "@types/googlemaps": "^3.43.1",
+    "@types/google.maps": "^3.45.6",
     "@types/youtube": "^0.0.42",
     "core-js-bundle": "^3.8.2",
     "material-components-web": "13.0.0-canary.860ad06a1.0",

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -112,11 +112,13 @@ export class GoogleMapDemo {
   }
 
   handleClick(event: google.maps.MapMouseEvent) {
-    this.markerPositions.push(event.latLng.toJSON());
+    if (event.latLng) {
+      this.markerPositions.push(event.latLng.toJSON());
+    }
   }
 
   handleMove(event: google.maps.MapMouseEvent) {
-    this.display = event.latLng.toJSON();
+    this.display = event.latLng?.toJSON();
   }
 
   clickMarker(marker: MapMarker) {

--- a/src/google-maps/BUILD.bazel
+++ b/src/google-maps/BUILD.bazel
@@ -14,7 +14,7 @@ ng_module(
         "//src:dev_mode_types",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@types/googlemaps",
+        "@npm//@types/google.maps",
         "@npm//rxjs",
     ],
 )

--- a/src/google-maps/google-map/google-map.spec.ts
+++ b/src/google-maps/google-map/google-map.spec.ts
@@ -257,7 +257,7 @@ describe('GoogleMap', () => {
 
     const component = fixture.debugElement.query(By.directive(GoogleMap)).componentInstance;
 
-    mapSpy.getBounds.and.returnValue(null);
+    mapSpy.getBounds.and.returnValue(undefined);
     expect(component.getBounds()).toBe(null);
 
     component.getCenter();
@@ -272,7 +272,7 @@ describe('GoogleMap', () => {
     component.getMapTypeId();
     expect(mapSpy.getMapTypeId).toHaveBeenCalled();
 
-    mapSpy.getProjection.and.returnValue(null);
+    mapSpy.getProjection.and.returnValue(undefined);
     expect(component.getProjection()).toBe(null);
 
     component.getStreetView();

--- a/src/google-maps/google-map/google-map.ts
+++ b/src/google-maps/google-map/google-map.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {
   ChangeDetectionStrategy,
@@ -370,7 +370,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.getCenter
    */
-  getCenter(): google.maps.LatLng {
+  getCenter(): google.maps.LatLng | undefined {
     this._assertInitialized();
     return this.googleMap.getCenter();
   }
@@ -379,7 +379,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.getClickableIcons
    */
-  getClickableIcons(): boolean {
+  getClickableIcons(): boolean | undefined {
     this._assertInitialized();
     return this.googleMap.getClickableIcons();
   }
@@ -388,7 +388,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.getHeading
    */
-  getHeading(): number {
+  getHeading(): number | undefined {
     this._assertInitialized();
     return this.googleMap.getHeading();
   }
@@ -397,7 +397,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.getMapTypeId
    */
-  getMapTypeId(): google.maps.MapTypeId|string {
+  getMapTypeId(): google.maps.MapTypeId | string | undefined {
     this._assertInitialized();
     return this.googleMap.getMapTypeId();
   }
@@ -406,9 +406,9 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.getProjection
    */
-  getProjection(): google.maps.Projection|null {
+  getProjection(): google.maps.Projection | null {
     this._assertInitialized();
-    return this.googleMap.getProjection();
+    return this.googleMap.getProjection() || null;
   }
 
   /**
@@ -424,7 +424,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.getTilt
    */
-  getTilt(): number {
+  getTilt(): number | undefined {
     this._assertInitialized();
     return this.googleMap.getTilt();
   }
@@ -433,7 +433,7 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
    * See
    * https://developers.google.com/maps/documentation/javascript/reference/map#Map.getZoom
    */
-  getZoom(): number {
+  getZoom(): number | undefined {
     this._assertInitialized();
     return this.googleMap.getZoom();
   }

--- a/src/google-maps/map-anchor-point.ts
+++ b/src/google-maps/map-anchor-point.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 export interface MapAnchorPoint {
   getAnchor(): google.maps.MVCObject;

--- a/src/google-maps/map-base-layer.ts
+++ b/src/google-maps/map-base-layer.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Directive, NgZone, OnDestroy, OnInit} from '@angular/core';
 

--- a/src/google-maps/map-bicycling-layer/map-bicycling-layer.ts
+++ b/src/google-maps/map-bicycling-layer/map-bicycling-layer.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Directive} from '@angular/core';
 

--- a/src/google-maps/map-circle/map-circle.ts
+++ b/src/google-maps/map-circle/map-circle.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Directive, Input, NgZone, OnDestroy, OnInit, Output} from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
@@ -181,7 +181,7 @@ export class MapCircle implements OnInit, OnDestroy {
    * @see
    * developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getBounds
    */
-  getBounds(): google.maps.LatLngBounds {
+  getBounds(): google.maps.LatLngBounds | null {
     this._assertInitialized();
     return this.circle.getBounds();
   }
@@ -190,7 +190,7 @@ export class MapCircle implements OnInit, OnDestroy {
    * @see
    * developers.google.com/maps/documentation/javascript/reference/polygon#Circle.getCenter
    */
-  getCenter(): google.maps.LatLng {
+  getCenter(): google.maps.LatLng | null {
     this._assertInitialized();
     return this.circle.getCenter();
   }

--- a/src/google-maps/map-directions-renderer/map-directions-renderer.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-renderer.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {
   Directive,
@@ -106,7 +106,7 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
    * See developers.google.com/maps/documentation/javascript/reference/directions
    * #DirectionsRenderer.getDirections
    */
-  getDirections(): google.maps.DirectionsResult {
+  getDirections(): google.maps.DirectionsResult | null {
     this._assertInitialized();
     return this.directionsRenderer.getDirections();
   }
@@ -115,7 +115,7 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
    * See developers.google.com/maps/documentation/javascript/reference/directions
    * #DirectionsRenderer.getPanel
    */
-  getPanel(): Node {
+  getPanel(): Node | null {
     this._assertInitialized();
     return this.directionsRenderer.getPanel();
   }

--- a/src/google-maps/map-directions-renderer/map-directions-service.spec.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-service.spec.ts
@@ -31,19 +31,28 @@ describe('MapDirectionsService', () => {
   });
 
   it('initializes the Google Maps Directions Service when `route` is called', () => {
-    mapDirectionsService.route({}).subscribe();
+    mapDirectionsService.route({
+      origin: 'home',
+      destination: 'work',
+      travelMode: 'BICYCLING' as google.maps.TravelMode
+    }).subscribe();
+
     expect(directionsServiceConstructorSpy).toHaveBeenCalled();
   });
 
   it('calls route on inputs', () => {
-    const result = {};
-    const status = 'OK';
-    directionsServiceSpy.route.and.callFake((_request: google.maps.DirectionsRequest,
-        callback: Function) => {
-      callback(result, status);
+    const result: google.maps.DirectionsResult = {routes: []};
+    const status = 'OK' as google.maps.DirectionsStatus;
+    directionsServiceSpy.route.and.callFake((_request, callback) => {
+      callback?.(result, status);
+      return Promise.resolve(result);
     });
-    const request: google.maps.DirectionsRequest = {};
-    mapDirectionsService.route(request).subscribe(response => {
+
+    mapDirectionsService.route({
+      origin: 'home',
+      destination: 'work',
+      travelMode: 'BICYCLING' as google.maps.TravelMode
+    }).subscribe(response => {
       expect(response).toEqual({result, status} as MapDirectionsResponse);
     });
   });

--- a/src/google-maps/map-directions-renderer/map-directions-service.ts
+++ b/src/google-maps/map-directions-renderer/map-directions-service.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Injectable, NgZone} from '@angular/core';
 import {Observable} from 'rxjs';
@@ -42,17 +42,12 @@ export class MapDirectionsService {
         this._directionsService = new google.maps.DirectionsService();
       }
 
-      const callback =
-          (
-            result: google.maps.DirectionsResult|undefined,
-            status: google.maps.DirectionsStatus
-          ) => {
+      this._directionsService.route(request, (result, status) => {
         this._ngZone.run(() => {
-          observer.next({result, status});
+          observer.next({result: result || undefined, status});
           observer.complete();
         });
-      };
-      this._directionsService.route(request, callback);
+      });
     });
   }
 }

--- a/src/google-maps/map-geocoder/map-geocoder.spec.ts
+++ b/src/google-maps/map-geocoder/map-geocoder.spec.ts
@@ -33,12 +33,13 @@ describe('MapGeocoder', () => {
 
   it('calls geocode on inputs', () => {
     const results: google.maps.GeocoderResult[] = [];
-    const status = 'OK';
-    geocoderSpy.geocode.and.callFake((_: google.maps.GeocoderRequest, callback: Function) => {
-      callback(results, status);
+    const status = 'OK' as google.maps.GeocoderStatus;
+    geocoderSpy.geocode.and.callFake((_request, callback) => {
+      callback?.(results, status);
+      return Promise.resolve({results});
     });
-    const request: google.maps.DirectionsRequest = {};
-    geocoder.geocode(request).subscribe(response => {
+
+    geocoder.geocode({region: 'Europe'}).subscribe(response => {
       expect(response).toEqual({results, status} as MapGeocoderResponse);
     });
   });

--- a/src/google-maps/map-geocoder/map-geocoder.ts
+++ b/src/google-maps/map-geocoder/map-geocoder.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Injectable, NgZone} from '@angular/core';
 import {Observable} from 'rxjs';
@@ -40,7 +40,7 @@ export class MapGeocoder {
 
       this._geocoder.geocode(request, (results, status) => {
         this._ngZone.run(() => {
-          observer.next({results, status});
+          observer.next({results: results || [], status});
           observer.complete();
         });
       });

--- a/src/google-maps/map-ground-overlay/map-ground-overlay.ts
+++ b/src/google-maps/map-ground-overlay/map-ground-overlay.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Directive, Input, NgZone, OnDestroy, OnInit, Output} from '@angular/core';
 import {BehaviorSubject, Observable, Subject} from 'rxjs';
@@ -129,7 +129,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
    * developers.google.com/maps/documentation/javascript/reference/image-overlay
    * #GroundOverlay.getBounds
    */
-  getBounds(): google.maps.LatLngBounds {
+  getBounds(): google.maps.LatLngBounds | null {
     this._assertInitialized();
     return this.groundOverlay.getBounds();
   }

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.spec.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.spec.ts
@@ -162,5 +162,5 @@ describe('MapHeatmapLayer', () => {
 class TestApp {
   @ViewChild(MapHeatmapLayer) heatmap: MapHeatmapLayer;
   options?: Partial<google.maps.visualization.HeatmapLayerOptions>;
-  data?: HeatmapData;
+  data?: HeatmapData|null;
 }

--- a/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
+++ b/src/google-maps/map-heatmap-layer/map-heatmap-layer.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {
   Input,

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {
   Directive,
@@ -145,9 +145,9 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    * See
    * developers.google.com/maps/documentation/javascript/reference/info-window#InfoWindow.getContent
    */
-  getContent(): string|Node {
+  getContent(): string | Node | null {
     this._assertInitialized();
-    return this.infoWindow.getContent();
+    return this.infoWindow.getContent() || null;
   }
 
   /**
@@ -157,7 +157,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    */
   getPosition(): google.maps.LatLng|null {
     this._assertInitialized();
-    return this.infoWindow.getPosition();
+    return this.infoWindow.getPosition() || null;
   }
 
   /**

--- a/src/google-maps/map-kml-layer/map-kml-layer.ts
+++ b/src/google-maps/map-kml-layer/map-kml-layer.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {
   Directive,
@@ -108,7 +108,7 @@ export class MapKmlLayer implements OnInit, OnDestroy {
    * See
    * developers.google.com/maps/documentation/javascript/reference/kml#KmlLayer.getDefaultViewport
    */
-  getDefaultViewport(): google.maps.LatLngBounds {
+  getDefaultViewport(): google.maps.LatLngBounds | null {
     this._assertInitialized();
     return this.kmlLayer.getDefaultViewport();
   }
@@ -116,7 +116,7 @@ export class MapKmlLayer implements OnInit, OnDestroy {
   /**
    * See developers.google.com/maps/documentation/javascript/reference/kml#KmlLayer.getMetadata
    */
-  getMetadata(): google.maps.KmlLayerMetadata {
+  getMetadata(): google.maps.KmlLayerMetadata | null {
     this._assertInitialized();
     return this.kmlLayer.getMetadata();
   }

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 /// <reference path="marker-clusterer-types.ts" />
 
 import {

--- a/src/google-maps/map-marker-clusterer/marker-clusterer-types.ts
+++ b/src/google-maps/map-marker-clusterer/marker-clusterer-types.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
- /// <reference types="googlemaps" />
+ /// <reference types="google.maps" />
 
 /**
  * Class for clustering markers on a Google Map.

--- a/src/google-maps/map-marker/map-marker.spec.ts
+++ b/src/google-maps/map-marker/map-marker.spec.ts
@@ -238,10 +238,10 @@ describe('MapMarker', () => {
 })
 class TestApp {
   @ViewChild(MapMarker) marker: MapMarker;
-  title?: string;
-  position?: google.maps.LatLng|google.maps.LatLngLiteral;
-  label?: string|google.maps.MarkerLabel;
-  clickable?: boolean;
+  title?: string|null;
+  position?: google.maps.LatLng|google.maps.LatLngLiteral|null;
+  label?: string|google.maps.MarkerLabel|null;
+  clickable?: boolean|null;
   options?: google.maps.MarkerOptions;
   icon?: string;
   visible?: boolean;

--- a/src/google-maps/map-marker/map-marker.ts
+++ b/src/google-maps/map-marker/map-marker.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {
   Input,

--- a/src/google-maps/map-polygon/map-polygon.ts
+++ b/src/google-maps/map-polygon/map-polygon.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {
   Directive,

--- a/src/google-maps/map-polyline/map-polyline.ts
+++ b/src/google-maps/map-polyline/map-polyline.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {
   Directive,

--- a/src/google-maps/map-rectangle/map-rectangle.ts
+++ b/src/google-maps/map-rectangle/map-rectangle.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Directive, Input, OnDestroy, OnInit, Output, NgZone} from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
@@ -168,7 +168,7 @@ export class MapRectangle implements OnInit, OnDestroy {
    * See
    * developers.google.com/maps/documentation/javascript/reference/polygon#Rectangle.getBounds
    */
-  getBounds(): google.maps.LatLngBounds {
+  getBounds(): google.maps.LatLngBounds | null {
     this._assertInitialized();
     return this.rectangle.getBounds();
   }

--- a/src/google-maps/map-traffic-layer/map-traffic-layer.ts
+++ b/src/google-maps/map-traffic-layer/map-traffic-layer.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Directive, Input, NgZone, OnDestroy, OnInit} from '@angular/core';
 import {BehaviorSubject, Observable, Subject} from 'rxjs';

--- a/src/google-maps/map-transit-layer/map-transit-layer.ts
+++ b/src/google-maps/map-transit-layer/map-transit-layer.ts
@@ -7,7 +7,7 @@
  */
 
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import {Directive} from '@angular/core';
 

--- a/src/google-maps/package.json
+++ b/src/google-maps/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/angular/components/tree/master/src/google-maps#readme",
   "dependencies": {
-    "@types/googlemaps": "^3.43.1",
+    "@types/google.maps": "^3.45.6",
     "tslib": "0.0.0-TSLIB"
   },
   "peerDependencies": {

--- a/src/google-maps/testing/BUILD.bazel
+++ b/src/google-maps/testing/BUILD.bazel
@@ -8,7 +8,7 @@ ts_library(
     srcs = glob(["**/*.ts"]),
     deps = [
         "//src/google-maps",
-        "@npm//@types/googlemaps",
+        "@npm//@types/google.maps",
         "@npm//@types/jasmine",
     ],
 )

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-/// <reference types="googlemaps" />
+/// <reference types="google.maps" />
 
 import { AfterContentInit } from '@angular/core';
 import { ElementRef } from '@angular/core';
@@ -47,14 +47,14 @@ export class GoogleMap implements OnChanges, OnInit, OnDestroy {
     get data(): google.maps.Data;
     fitBounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral, padding?: number | google.maps.Padding): void;
     getBounds(): google.maps.LatLngBounds | null;
-    getCenter(): google.maps.LatLng;
-    getClickableIcons(): boolean;
-    getHeading(): number;
-    getMapTypeId(): google.maps.MapTypeId | string;
+    getCenter(): google.maps.LatLng | undefined;
+    getClickableIcons(): boolean | undefined;
+    getHeading(): number | undefined;
+    getMapTypeId(): google.maps.MapTypeId | string | undefined;
     getProjection(): google.maps.Projection | null;
     getStreetView(): google.maps.StreetViewPanorama;
-    getTilt(): number;
-    getZoom(): number;
+    getTilt(): number | undefined;
+    getZoom(): number | undefined;
     googleMap?: google.maps.Map;
     readonly headingChanged: Observable<void>;
     height: string | number | null;
@@ -185,9 +185,9 @@ export class MapCircle implements OnInit, OnDestroy {
     // (undocumented)
     readonly circleRightclick: Observable<google.maps.MapMouseEvent>;
     // (undocumented)
-    getBounds(): google.maps.LatLngBounds;
+    getBounds(): google.maps.LatLngBounds | null;
     // (undocumented)
-    getCenter(): google.maps.LatLng;
+    getCenter(): google.maps.LatLng | null;
     // (undocumented)
     getDraggable(): boolean;
     // (undocumented)
@@ -218,8 +218,8 @@ export class MapDirectionsRenderer implements OnInit, OnChanges, OnDestroy {
     set directions(directions: google.maps.DirectionsResult);
     readonly directionsChanged: Observable<void>;
     directionsRenderer?: google.maps.DirectionsRenderer;
-    getDirections(): google.maps.DirectionsResult;
-    getPanel(): Node;
+    getDirections(): google.maps.DirectionsResult | null;
+    getPanel(): Node | null;
     getRouteIndex(): number;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
@@ -276,7 +276,7 @@ export class MapGroundOverlay implements OnInit, OnDestroy {
     get bounds(): google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
     set bounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral);
     clickable: boolean;
-    getBounds(): google.maps.LatLngBounds;
+    getBounds(): google.maps.LatLngBounds | null;
     getOpacity(): number;
     getUrl(): string;
     groundOverlay?: google.maps.GroundOverlay;
@@ -320,7 +320,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     readonly closeclick: Observable<void>;
     readonly contentChanged: Observable<void>;
     readonly domready: Observable<void>;
-    getContent(): string | Node;
+    getContent(): string | Node | null;
     getPosition(): google.maps.LatLng | null;
     getZIndex(): number;
     infoWindow?: google.maps.InfoWindow;
@@ -345,8 +345,8 @@ export class MapInfoWindow implements OnInit, OnDestroy {
 export class MapKmlLayer implements OnInit, OnDestroy {
     constructor(_map: GoogleMap, _ngZone: NgZone);
     readonly defaultviewportChanged: Observable<void>;
-    getDefaultViewport(): google.maps.LatLngBounds;
-    getMetadata(): google.maps.KmlLayerMetadata;
+    getDefaultViewport(): google.maps.LatLngBounds | null;
+    getMetadata(): google.maps.KmlLayerMetadata | null;
     getStatus(): google.maps.KmlLayerStatus;
     getUrl(): string;
     getZIndex(): number;
@@ -598,7 +598,7 @@ export class MapRectangle implements OnInit, OnDestroy {
     // (undocumented)
     set bounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral);
     readonly boundsChanged: Observable<void>;
-    getBounds(): google.maps.LatLngBounds;
+    getBounds(): google.maps.LatLngBounds | null;
     getDraggable(): boolean;
     getEditable(): boolean;
     getVisible(): boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,10 +2002,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/googlemaps@^3.43.1":
-  version "3.43.3"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.43.3.tgz#70cf962154a160fe78bcd69d6ccc296dd9175b1f"
-  integrity sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==
+"@types/google.maps@^3.45.6":
+  version "3.45.6"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.45.6.tgz#441a7bc76424243b307596fc8d282a435a979ebd"
+  integrity sha512-BzGzxs8UXFxeP8uN/0nRgGbsbpYQxSCKsv/7S8OitU7wwhfFcqQSm5aAcL1nbwueMiJ/VVmIZKPq69s0kX5W+Q==
 
 "@types/gulp@4.0.8":
   version "4.0.8"


### PR DESCRIPTION
Moves the `google-maps` package away from the deprecated typings.

Fixes #22818.