### PR TITLE
docs(material/expansion): fix typo in doc string

### DIFF
--- a/src/material/expansion/expansion-panel.ts
+++ b/src/material/expansion/expansion-panel.ts
@@ -63,7 +63,7 @@ export interface MatExpansionPanelDefaultOptions {
 }
 
 /**
- * Injection token that can be used to configure the defalt
+ * Injection token that can be used to configure the default
  * options for the expansion panel component.
  */
 export const MAT_EXPANSION_PANEL_DEFAULT_OPTIONS =


### PR DESCRIPTION
Fixes a typo in one of the doc strings.

Fixes #23339.