### PR TITLE
fix(cdk/testing): require at least one argument locator functions

### DIFF
--- a/src/cdk/testing/component-harness.ts
+++ b/src/cdk/testing/component-harness.ts
@@ -137,8 +137,8 @@ export interface LocatorFactory {
    * - `await lf.locatorFor('div', DivHarness)()` gets a `TestElement` instance for `#d1`
    * - `await lf.locatorFor('span')()` throws because the `Promise` rejects.
    */
-  locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T>>;
+  locatorFor<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]>>;
 
   /**
    * Creates an asynchronous locator function that can be used to find a `ComponentHarness` instance
@@ -161,8 +161,8 @@ export interface LocatorFactory {
    * - `await lf.locatorForOptional('div', DivHarness)()` gets a `TestElement` instance for `#d1`
    * - `await lf.locatorForOptional('span')()` gets `null`.
    */
-  locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T> | null>;
+  locatorForOptional<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]> | null>;
 
   /**
    * Creates an asynchronous locator function that can be used to find `ComponentHarness` instances
@@ -200,8 +200,8 @@ export interface LocatorFactory {
    *   ]`
    * - `await lf.locatorForAll('span')()` gets `[]`.
    */
-  locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T>[]>;
+  locatorForAll<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]>[]>;
 
   /** @return A `HarnessLoader` rooted at the root element of this `LocatorFactory`. */
   rootHarnessLoader(): Promise<HarnessLoader>;
@@ -286,8 +286,8 @@ export abstract class ComponentHarness {
    * - `await ch.locatorFor('div', DivHarness)()` gets a `TestElement` instance for `#d1`
    * - `await ch.locatorFor('span')()` throws because the `Promise` rejects.
    */
-  protected locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T>> {
+  protected locatorFor<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]>> {
     return this.locatorFactory.locatorFor(...queries);
   }
 
@@ -312,8 +312,8 @@ export abstract class ComponentHarness {
    * - `await ch.locatorForOptional('div', DivHarness)()` gets a `TestElement` instance for `#d1`
    * - `await ch.locatorForOptional('span')()` gets `null`.
    */
-  protected locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T> | null> {
+  protected locatorForOptional<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]> | null> {
     return this.locatorFactory.locatorForOptional(...queries);
   }
 
@@ -353,8 +353,8 @@ export abstract class ComponentHarness {
    *   ]`
    * - `await ch.locatorForAll('span')()` gets `[]`.
    */
-  protected locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T>[]> {
+  protected locatorForAll<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]>[]> {
     return this.locatorFactory.locatorForAll(...queries);
   }
 

--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -57,22 +57,22 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
   }
 
   // Implemented as part of the `LocatorFactory` interface.
-  locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T>> {
+  locatorFor<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]>> {
     return () => _assertResultFound(
         this._getAllHarnessesAndTestElements(queries),
         _getDescriptionForLocatorForQueries(queries));
   }
 
   // Implemented as part of the `LocatorFactory` interface.
-  locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T> | null> {
+  locatorForOptional<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]> | null> {
     return async () => (await this._getAllHarnessesAndTestElements(queries))[0] || null;
   }
 
   // Implemented as part of the `LocatorFactory` interface.
-  locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T):
-      AsyncFactoryFn<LocatorFnResult<T>[]> {
+  locatorForAll<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]):
+      AsyncFactoryFn<LocatorFnResult<T[]>[]> {
     return () => this._getAllHarnessesAndTestElements(queries);
   }
 

--- a/tools/public_api_guard/cdk/testing.md
+++ b/tools/public_api_guard/cdk/testing.md
@@ -33,9 +33,9 @@ export abstract class ComponentHarness {
     host(): Promise<TestElement>;
     // (undocumented)
     protected readonly locatorFactory: LocatorFactory;
-    protected locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
-    protected locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
-    protected locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
+    protected locatorFor<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]>>;
+    protected locatorForAll<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]>[]>;
+    protected locatorForOptional<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]> | null>;
     protected waitForTasksOutsideAngular(): Promise<void>;
 }
 
@@ -109,11 +109,11 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
     // (undocumented)
     harnessLoaderForOptional(selector: string): Promise<HarnessLoader | null>;
     // (undocumented)
-    locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
+    locatorFor<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]>>;
     // (undocumented)
-    locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
+    locatorForAll<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]>[]>;
     // (undocumented)
-    locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
+    locatorForOptional<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]> | null>;
     // (undocumented)
     protected rawRootElement: E;
     // (undocumented)
@@ -156,9 +156,9 @@ export interface LocatorFactory {
     harnessLoaderFor(selector: string): Promise<HarnessLoader>;
     harnessLoaderForAll(selector: string): Promise<HarnessLoader[]>;
     harnessLoaderForOptional(selector: string): Promise<HarnessLoader | null>;
-    locatorFor<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>>;
-    locatorForAll<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T>[]>;
-    locatorForOptional<T extends (HarnessQuery<any> | string)[]>(...queries: T): AsyncFactoryFn<LocatorFnResult<T> | null>;
+    locatorFor<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]>>;
+    locatorForAll<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]>[]>;
+    locatorForOptional<T extends (HarnessQuery<any> | string)>(...queries: [T, ...T[]]): AsyncFactoryFn<LocatorFnResult<T[]> | null>;
     rootElement: TestElement;
     rootHarnessLoader(): Promise<HarnessLoader>;
     waitForTasksOutsideAngular(): Promise<void>;


### PR DESCRIPTION
Currently the locator functions are written with a single rest parameter which means that no arguments can be passed as well, even though it'll result in an error at runtime.

These changes rework the type so that at least one argument is required to be passed in.