### PR TITLE
refactor(material/form-field): remove deprecated APIs for version 13

### DIFF
--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -63,7 +63,7 @@
   </div>
 
   <!-- Underline used for legacy, standard, and box appearances. -->
-  <div class="mat-form-field-underline" #underline
+  <div class="mat-form-field-underline"
        *ngIf="appearance != 'outline'">
     <span class="mat-form-field-ripple"
           [class.mat-accent]="color == 'accent'"

--- a/src/material/form-field/form-field.ts
+++ b/src/material/form-field/form-field.ts
@@ -235,12 +235,6 @@ export class MatFormField extends _MatFormFieldBase
   /** Whether the Angular animations are enabled. */
   _animationsEnabled: boolean;
 
-  /**
-   * @deprecated
-   * @breaking-change 8.0.0
-   */
-  @ViewChild('underline') underlineRef: ElementRef;
-
   @ViewChild('connectionContainer', {static: true}) _connectionContainerRef: ElementRef;
   @ViewChild('inputContainer') _inputContainerRef: ElementRef;
   @ViewChild('label') private _label: ElementRef<HTMLElement>;
@@ -268,13 +262,6 @@ export class MatFormField extends _MatFormFieldBase
 
   constructor(
       elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef,
-      /**
-       * @deprecated `_labelOptions` parameter no longer being used. To be removed.
-       * @breaking-change 12.0.0
-       */
-      @Inject(ElementRef)
-          // Use `ElementRef` here so Angular has something to inject.
-          _labelOptions: any,
       @Optional() private _dir: Directionality,
       @Optional() @Inject(MAT_FORM_FIELD_DEFAULT_OPTIONS) private _defaults:
           MatFormFieldDefaultOptions, private _platform: Platform, private _ngZone: NgZone,

--- a/src/material/form-field/testing/form-field-harness.ts
+++ b/src/material/form-field/testing/form-field-harness.ts
@@ -134,30 +134,10 @@ export abstract class _MatFormFieldHarnessBase<ControlHarness extends MatFormFie
     return parallel(() => hints.map(e => e.text()));
   }
 
-  /**
-   * Gets a reference to the container element which contains all projected
-   * prefixes of the form-field.
-   * @deprecated Use `getPrefixText` instead.
-   * @breaking-change 11.0.0
-   */
-  async getHarnessLoaderForPrefix(): Promise<TestElement|null> {
-    return this._prefixContainer();
-  }
-
   /** Gets the text inside the prefix element. */
   async getPrefixText(): Promise<string> {
     const prefix = await this._prefixContainer();
     return prefix ? prefix.text() : '';
-  }
-
-  /**
-   * Gets a reference to the container element which contains all projected
-   * suffixes of the form-field.
-   * @deprecated Use `getSuffixText` instead.
-   * @breaking-change 11.0.0
-   */
-  async getHarnessLoaderForSuffix(): Promise<TestElement|null> {
-    return this._suffixContainer();
   }
 
   /** Gets the text inside the suffix element. */

--- a/src/material/schematics/ng-update/data/constructor-checks.ts
+++ b/src/material/schematics/ng-update/data/constructor-checks.ts
@@ -14,6 +14,12 @@ import {ConstructorChecksUpgradeData, TargetVersion, VersionChanges} from '@angu
  * automatically through type checking.
  */
 export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
+  [TargetVersion.V13]: [
+    {
+      pr: 'https://github.com/angular/components/pull/23389',
+      changes: ['MatFormField']
+    }
+  ],
   [TargetVersion.V12]: [
     {
       pr: 'https://github.com/angular/components/pull/21897',

--- a/tools/public_api_guard/material/form-field-testing.md
+++ b/tools/public_api_guard/material/form-field-testing.md
@@ -65,10 +65,6 @@ export abstract class _MatFormFieldHarnessBase<ControlHarness extends MatFormFie
     getControl(): Promise<ControlHarness | null>;
     getControl<X extends MatFormFieldControlHarness>(type: ComponentHarnessConstructor<X>): Promise<X | null>;
     getControl<X extends MatFormFieldControlHarness>(type: HarnessPredicate<X>): Promise<X | null>;
-    // @deprecated
-    getHarnessLoaderForPrefix(): Promise<TestElement | null>;
-    // @deprecated
-    getHarnessLoaderForSuffix(): Promise<TestElement | null>;
     getLabel(): Promise<string | null>;
     getPrefixText(): Promise<string>;
     getSuffixText(): Promise<string>;

--- a/tools/public_api_guard/material/form-field.md
+++ b/tools/public_api_guard/material/form-field.md
@@ -70,8 +70,7 @@ export class MatError {
 
 // @public
 export class MatFormField extends _MatFormFieldBase implements AfterContentInit, AfterContentChecked, AfterViewInit, OnDestroy, CanColor {
-    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef,
-    _labelOptions: any, _dir: Directionality, _defaults: MatFormFieldDefaultOptions, _platform: Platform, _ngZone: NgZone, _animationMode: string);
+    constructor(elementRef: ElementRef, _changeDetectorRef: ChangeDetectorRef, _dir: Directionality, _defaults: MatFormFieldDefaultOptions, _platform: Platform, _ngZone: NgZone, _animationMode: string);
     _animateAndLockLabel(): void;
     _animationsEnabled: boolean;
     get appearance(): MatFormFieldAppearance;
@@ -140,14 +139,12 @@ export class MatFormField extends _MatFormFieldBase implements AfterContentInit,
     _subscriptAnimationState: string;
     // (undocumented)
     _suffixChildren: QueryList<MatSuffix>;
-    // @deprecated (undocumented)
-    underlineRef: ElementRef;
     updateOutlineGap(): void;
     protected _validateControlChild(): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatFormField, "mat-form-field", ["matFormField"], { "color": "color"; "appearance": "appearance"; "hideRequiredMarker": "hideRequiredMarker"; "hintLabel": "hintLabel"; "floatLabel": "floatLabel"; }, {}, ["_controlNonStatic", "_controlStatic", "_labelChildNonStatic", "_labelChildStatic", "_placeholderChild", "_errorChildren", "_hintChildren", "_prefixChildren", "_suffixChildren"], ["[matPrefix]", "*", "mat-placeholder", "mat-label", "[matSuffix]", "mat-error", "mat-hint:not([align='end'])", "mat-hint[align='end']"]>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatFormField, [null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatFormField, [null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; }]>;
 }
 
 // @public


### PR DESCRIPTION
BREAKING CHANGE:
* `MatFormFieldHarness.getHarnessLoaderForPrefix` has been removed. Use `MatFormFieldHarness.getPrefixText` instead.
* `MatFormFieldHarness.getHarnessLoaderForSuffix` has been removed. Use `MatFormFieldHarness.getSuffixText` instead.
* The `_labelOptions` parameter of the `MatFormField` constructor has been removed.
* `MatFormField.underlineRef` has been removed.