### PR TITLE
fix(cdk/a11y): error on firefox

### DIFF
--- a/src/cdk/a11y/focus-trap/event-listener-inert-strategy.ts
+++ b/src/cdk/a11y/focus-trap/event-listener-inert-strategy.ts
@@ -52,8 +52,7 @@ export class EventListenerFocusTrapInertStrategy implements FocusTrapInertStrate
 
     // Don't refocus if target was in an overlay, because the overlay might be associated
     // with an element inside the FocusTrap, ex. mat-select.
-    if (target && !focusTrapRoot.contains(target) &&
-        target.closest('div.cdk-overlay-pane') === null) {
+    if (target && !focusTrapRoot.contains(target) && !target.closest?.('div.cdk-overlay-pane')) {
         // Some legacy FocusTrap usages have logic that focuses some element on the page
         // just before FocusTrap is destroyed. For backwards compatibility, wait
         // to be sure FocusTrap is still enabled before refocusing.


### PR DESCRIPTION
We seem to hitting an error on Firefox when calling `closest` inside a unit test. These changes add a null check to work around the issue.