### PR TITLE
refactor(material-luxon-adapter): clean up unsupported browser workarounds

### DIFF
--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.spec.ts
@@ -18,11 +18,6 @@ const JAN = 1, FEB = 2, MAR = 3, DEC = 12;
 describe('LuxonDateAdapter', () => {
   let adapter: DateAdapter<DateTime>;
 
-  if (!isSupported()) {
-    it('should pass', () => expect(1).toBe(1));
-    return;
-  }
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [LuxonDateModule]
@@ -205,11 +200,11 @@ describe('LuxonDateAdapter', () => {
   it('should format with a different locale', () => {
     let date = adapter.format(DateTime.local(2017, JAN, 2), 'DD');
 
-    expect(stripDirectionalityCharacters(date)).toEqual('Jan 2, 2017');
+    expect(date).toEqual('Jan 2, 2017');
     adapter.setLocale('da-DK');
 
     date = adapter.format(DateTime.local(2017, JAN, 2), 'DD');
-    expect(stripDirectionalityCharacters(date)).toEqual('2. jan. 2017');
+    expect(date).toEqual('2. jan. 2017');
   });
 
   it('should throw when attempting to format invalid date', () => {
@@ -377,11 +372,6 @@ describe('LuxonDateAdapter', () => {
 describe('LuxonDateAdapter with MAT_DATE_LOCALE override', () => {
   let adapter: DateAdapter<DateTime>;
 
-  if (!isSupported()) {
-    it('should pass', () => expect(1).toBe(1));
-    return;
-  }
-
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [LuxonDateModule],
@@ -393,17 +383,12 @@ describe('LuxonDateAdapter with MAT_DATE_LOCALE override', () => {
 
   it('should take the default locale id from the MAT_DATE_LOCALE injection token', () => {
     const date = adapter.format(DateTime.local(2017, JAN, 2), 'DD');
-    expect(stripDirectionalityCharacters(date)).toEqual('2. jan. 2017');
+    expect(date).toEqual('2. jan. 2017');
   });
 });
 
 describe('LuxonDateAdapter with LOCALE_ID override', () => {
   let adapter: DateAdapter<DateTime>;
-
-  if (!isSupported()) {
-    it('should pass', () => expect(1).toBe(1));
-    return;
-  }
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -416,19 +401,12 @@ describe('LuxonDateAdapter with LOCALE_ID override', () => {
 
   it('should take the default locale id from the LOCALE_ID injection token', () => {
     const date = adapter.format(DateTime.local(2017, JAN, 2), 'DD');
-
-    // Some browsers add extra invisible characters that we should strip before asserting.
-    expect(stripDirectionalityCharacters(date)).toEqual('2 janv. 2017');
+    expect(date).toEqual('2 janv. 2017');
   });
 });
 
 describe('LuxonDateAdapter with MAT_LUXON_DATE_ADAPTER_OPTIONS override', () => {
   let adapter: DateAdapter<DateTime>;
-
-  if (!isSupported()) {
-    it('should pass', () => expect(1).toBe(1));
-    return;
-  }
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -466,16 +444,6 @@ describe('LuxonDateAdapter with MAT_LUXON_DATE_ADAPTER_OPTIONS override', () => 
   });
 
 });
-
-
-function isSupported(): boolean {
-  // As of version 2.0.0 Luxon doesn't support any version of IE so we have to skip the tests there.
-  return typeof navigator !== 'undefined' && !(/(msie|trident|edge)/i.test(navigator.userAgent));
-}
-
-function stripDirectionalityCharacters(str: string) {
-  return str.replace(/[\u200e\u200f]/g, '');
-}
 
 function assertValidDate(adapter: DateAdapter<DateTime>, d: DateTime | null, valid: boolean) {
   expect(adapter.isDateInstance(d)).not

--- a/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
+++ b/src/material-luxon-adapter/adapter/luxon-date-adapter.ts
@@ -88,15 +88,8 @@ export class LuxonDateAdapter extends DateAdapter<LuxonDateTime> {
     // functionality so we have to fall back to the Intl API.
     const dtf = new Intl.DateTimeFormat(this.locale, {day: 'numeric', timeZone: 'utc'});
 
-    return range(31, i => {
-      // Format a UTC date in order to avoid DST issues.
-      const date = LuxonDateTime.utc(2017, 1, i + 1).toJSDate();
-
-      // Strip out unicode LTR and RTL characters. Edge and IE insert these into formatted
-      // dates while other browsers do not. We remove them to make output consistent and
-      // because they interfere with date parsing.
-      return dtf.format(date).replace(/[\u200e\u200f]/g, '');
-    });
+    // Format a UTC date in order to avoid DST issues.
+    return range(31, i => dtf.format(LuxonDateTime.utc(2017, 1, i + 1).toJSDate()));
   }
 
   getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {


### PR DESCRIPTION
Cleans up some code that is no longer necessary now that we don't support IE and Edge.