### PR TITLE
fix(badge): put `matBadgeDescription` on host instead of badge element

### DIFF
--- a/src/dev-app/badge/badge-demo.html
+++ b/src/dev-app/badge/badge-demo.html
@@ -26,7 +26,7 @@
       Aria
     </span>
 
-    <span [matBadge]="badgeContent" matBadgeHidden="true">
+    <span [matBadge]="badgeContent" matBadgeHidden="true" matBadgeDescription="This badge is visually hidden">
       Hidden
     </span>
 
@@ -66,6 +66,10 @@
 
     <button mat-raised-button>
       <mat-icon matBadge="22" color="accent">home</mat-icon>
+    </button>
+
+    <button mat-button matBadge="11" matBadgeDescription="I've got 11 problems.">
+	    Aria
     </button>
   </div>
 

--- a/src/dev-app/badge/badge-demo.scss
+++ b/src/dev-app/badge/badge-demo.scss
@@ -2,7 +2,7 @@
   margin-bottom: 25px;
 }
 
-.mat-badge {
+.mat-badge, .mat-button {
   margin-right: 22px;
 
   [dir='rtl'] & {

--- a/src/material/badge/badge.ts
+++ b/src/material/badge/badge.ts
@@ -94,11 +94,6 @@ export class MatBadge extends _MatBadgeBase implements OnDestroy, OnChanges, Can
       const badgeElement = this._badgeElement;
       this._updateHostAriaDescription(newDescription, this._description);
       this._description = newDescription;
-
-      if (badgeElement) {
-        newDescription ? badgeElement.setAttribute('aria-label', newDescription) :
-            badgeElement.removeAttribute('aria-label');
-      }
     }
   }
   private _description: string;
@@ -160,7 +155,7 @@ export class MatBadge extends _MatBadgeBase implements OnDestroy, OnChanges, Can
 
     if (badgeElement) {
       if (this.description) {
-        this._ariaDescriber.removeDescription(badgeElement, this.description);
+        this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this.description);
       }
 
       // When creating a badge through the Renderer, Angular will keep it in an index.
@@ -197,16 +192,14 @@ export class MatBadge extends _MatBadgeBase implements OnDestroy, OnChanges, Can
 
     // Clear any existing badges which may have persisted from a server-side render.
     this._clearExistingBadges(contentClass);
+    // Hide badge element from screen readers.
+    badgeElement.setAttribute('aria-hidden', 'true');
     badgeElement.setAttribute('id', `mat-badge-content-${this._id}`);
     badgeElement.classList.add(contentClass);
     badgeElement.textContent = this._stringifyContent();
 
     if (this._animationMode === 'NoopAnimations') {
       badgeElement.classList.add('_mat-animation-noopable');
-    }
-
-    if (this.description) {
-      badgeElement.setAttribute('aria-label', this.description);
     }
 
     this._elementRef.nativeElement.appendChild(badgeElement);
@@ -225,17 +218,17 @@ export class MatBadge extends _MatBadgeBase implements OnDestroy, OnChanges, Can
     return badgeElement;
   }
 
-  /** Sets the aria-label property on the element */
+  /** Sets the aria-describedby property on the host element */
   private _updateHostAriaDescription(newDescription: string, oldDescription: string): void {
     // ensure content available before setting label
-    const content = this._updateTextContent();
+    this._updateTextContent();
 
     if (oldDescription) {
-      this._ariaDescriber.removeDescription(content, oldDescription);
+      this._ariaDescriber.removeDescription(this._elementRef.nativeElement, oldDescription);
     }
 
     if (newDescription) {
-      this._ariaDescriber.describe(content, newDescription);
+      this._ariaDescriber.describe(this._elementRef.nativeElement, newDescription);
     }
   }
 


### PR DESCRIPTION
# Description from git commit

Fixes a screenreader issue on the mat-badge component where
screenreaders did not read the `matBadgeDescription` for badges hosted
on `button` elements.

Example:
```
<button mat-badge="2" matBadgeDescription="2 unread messages">open
messages</button>
```

As tested on Chromevox with Chrome browser, screenreader reads "open
messages" and does *not* read "2 unread messages". Screenreader does not
allow navigation to the badge element.

This happens because `button`'s are not supposed to have multiple lines.

Solution is to align with tooltip by making the badge element
aria-hidden and applying the `matBadgeDescription` to the host element.

# Why this is a draft

This is still a draft because we need to determine how to handle when a `matBadgeDescription` is *not* provided.

Exhibit A
`<span matBadge=”2”>Open messages</span>`
Previously, screenreaders could navigate to the badge element, which would be announced as "2" in this example. This change hides the badge element from screenreaders, so the button would be announced as "Open messages"

Our options are to either not put an aria-describedby at all when `matBadgeDescription` is missing, or fallback to using the content of `matBadge` for the `aria-describedby`.

I'm leaning towards no doing a fallback. If the app developer does not provide a `matBadgeDescription` then screenreaders will not read the badge. A developer might want to explicitly hide the badge from screen readers and there is nothing in the API that exposes `aria-hidden`.

