### PR TITLE
refactor(cdk/clipboard): clean up deprecated APIs for v13

### DIFF
--- a/src/cdk/clipboard/copy-to-clipboard.ts
+++ b/src/cdk/clipboard/copy-to-clipboard.ts
@@ -31,12 +31,6 @@ export const CDK_COPY_TO_CLIPBOARD_CONFIG =
     new InjectionToken<CdkCopyToClipboardConfig>('CDK_COPY_TO_CLIPBOARD_CONFIG');
 
 /**
- * @deprecated Use `CDK_COPY_TO_CLIPBOARD_CONFIG` instead.
- * @breaking-change 13.0.0
- */
-export const CKD_COPY_TO_CLIPBOARD_CONFIG = CDK_COPY_TO_CLIPBOARD_CONFIG;
-
-/**
  * Provides behavior for a button that when clicked copies content into user's
  * clipboard.
  */
@@ -74,7 +68,7 @@ export class CdkCopyToClipboard implements OnDestroy {
   constructor(
     private _clipboard: Clipboard,
     private _ngZone: NgZone,
-    @Optional() @Inject(CKD_COPY_TO_CLIPBOARD_CONFIG) config?: CdkCopyToClipboardConfig) {
+    @Optional() @Inject(CDK_COPY_TO_CLIPBOARD_CONFIG) config?: CdkCopyToClipboardConfig) {
 
     if (config && config.attempts != null) {
       this.attempts = config.attempts;

--- a/tools/public_api_guard/cdk/clipboard.md
+++ b/tools/public_api_guard/cdk/clipboard.md
@@ -33,9 +33,6 @@ export interface CdkCopyToClipboardConfig {
     attempts?: number;
 }
 
-// @public @deprecated (undocumented)
-export const CKD_COPY_TO_CLIPBOARD_CONFIG: InjectionToken<CdkCopyToClipboardConfig>;
-
 // @public
 class Clipboard_2 {
     constructor(document: any);


### PR DESCRIPTION
Cleans up the APIs that were marked for removal for v13.

BREAKING CHANGE:
* `CKD_COPY_TO_CLIPBOARD_CONFIG` has been removed. Use `CDK_COPY_TO_CLIPBOARD_CONFIG` instead.