### PR TITLE
fix(material/tabs): fix contentTabIndex input type

### DIFF
--- a/src/material/tabs/tab-group.ts
+++ b/src/material/tabs/tab-group.ts
@@ -420,7 +420,7 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
   static ngAcceptInputType_animationDuration: NumberInput;
   static ngAcceptInputType_selectedIndex: NumberInput;
   static ngAcceptInputType_disableRipple: BooleanInput;
-  static ngAcceptInputType_contentTabIndex: BooleanInput;
+  static ngAcceptInputType_contentTabIndex: NumberInput;
 }
 
 /**

--- a/tools/public_api_guard/material/tabs.md
+++ b/tools/public_api_guard/material/tabs.md
@@ -244,7 +244,7 @@ export abstract class _MatTabGroupBase extends _MatTabGroupMixinBase implements 
     // (undocumented)
     static ngAcceptInputType_animationDuration: NumberInput;
     // (undocumented)
-    static ngAcceptInputType_contentTabIndex: BooleanInput;
+    static ngAcceptInputType_contentTabIndex: NumberInput;
     // (undocumented)
     static ngAcceptInputType_disableRipple: BooleanInput;
     // (undocumented)


### PR DESCRIPTION
MatTabGroup's property `contentTabIndex` specifies its type as `number |
null`. However, the `ngAcceptInputType` is specified as `BooleanInput`.
Fixes the input type to be `NumberInput` to align with property type.