### PR TITLE
fix(material/chips): error if selected value is accessed too early

### DIFF
--- a/src/material/chips/chip-list.spec.ts
+++ b/src/material/chips/chip-list.spec.ts
@@ -1380,7 +1380,7 @@ describe('MatChipList', () => {
     });
   });
 
-  it('should preselected chip as selected inside an OnPush component', fakeAsync(() => {
+  it('should preselect chip as selected inside an OnPush component', fakeAsync(() => {
     fixture = createComponent(PreselectedChipInsideOnPush);
     fixture.detectChanges();
     tick();
@@ -1389,6 +1389,21 @@ describe('MatChipList', () => {
     expect(fixture.nativeElement.querySelector('.mat-chip').classList)
       .withContext('Expected first chip to be selected.').toContain('mat-chip-selected');
   }));
+
+  it('should not throw when accessing the selected value too early in single selection mode',
+    fakeAsync(() => {
+      fixture = createComponent(StandardChipList);
+      const chipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
+      expect(() => chipList.selected).not.toThrow();
+    }));
+
+  it('should not throw when accessing the selected value too early in multi selection mode',
+    fakeAsync(() => {
+      fixture = createComponent(StandardChipList);
+      const chipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
+      chipList.multiple = true;
+      expect(() => chipList.selected).not.toThrow();
+    }));
 
   function createComponent<T>(component: Type<T>, providers: Provider[] = [], animationsModule:
       Type<NoopAnimationsModule> | Type<BrowserAnimationsModule> = NoopAnimationsModule):

--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -154,7 +154,8 @@ export class MatChipList extends _MatChipListBase implements MatFormFieldControl
 
   /** The array of selected chips inside chip list. */
   get selected(): MatChip[] | MatChip {
-    return this.multiple ? this._selectionModel.selected : this._selectionModel.selected[0];
+    return this.multiple ? (this._selectionModel?.selected || []) :
+                            this._selectionModel?.selected[0];
   }
 
   /** The ARIA role applied to the chip list. */


### PR DESCRIPTION
Similar issue to #23378. The chip list will throw an error if the `selected` value is accessed before the selection model has been initialized.