### PR TITLE
test(multiple): clean up manual ngOnDestroy calls

### DIFF
--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -42,7 +42,6 @@ describe('Dialog', () => {
   let testViewContainerRef: ViewContainerRef;
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
   let mockLocation: SpyLocation;
-  let overlayContainer: OverlayContainer;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -59,7 +58,6 @@ describe('Dialog', () => {
       (d: Dialog, l: Location, o: OverlayContainer) => {
     dialog = d;
     mockLocation = l as SpyLocation;
-    overlayContainer = o;
     overlayContainerElement = o.getContainerElement();
   }));
 
@@ -69,8 +67,6 @@ describe('Dialog', () => {
     viewContainerFixture.detectChanges();
     testViewContainerRef = viewContainerFixture.componentInstance.childViewContainer;
   });
-
-  afterEach(() => overlayContainer.ngOnDestroy());
 
   it('should open a dialog with a component', () => {
     let dialogRef = dialog.openFromComponent(PizzaMsg, {

--- a/src/cdk-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/cdk-experimental/popover-edit/popover-edit.spec.ts
@@ -4,10 +4,9 @@ import {CdkTableModule} from '@angular/cdk/table';
 import {dispatchKeyboardEvent} from '../../cdk/testing/private';
 import {CommonModule} from '@angular/common';
 import {Component, Directive, ElementRef, ViewChild} from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, TestBed, tick, inject} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
 import {FormsModule, NgForm} from '@angular/forms';
 import {BidiModule, Direction} from '@angular/cdk/bidi';
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {BehaviorSubject} from 'rxjs';
 
 import {
@@ -371,28 +370,17 @@ describe('CDK Popover Edit', () => {
     describe(label, () => {
       let component: BaseTestComponent;
       let fixture: ComponentFixture<BaseTestComponent>;
-      let overlayContainer: OverlayContainer;
 
       beforeEach(fakeAsync(() => {
         TestBed.configureTestingModule({
           imports: [CdkTableModule, CdkPopoverEditModule, CommonModule, FormsModule, BidiModule],
           declarations: [componentClass],
         }).compileComponents();
-        inject([OverlayContainer], (oc: OverlayContainer) => {
-          overlayContainer = oc;
-        })();
         fixture = TestBed.createComponent<BaseTestComponent>(componentClass);
         component = fixture.componentInstance;
         fixture.detectChanges();
         tick(10);
       }));
-
-      afterEach(() => {
-        // The overlay container's `ngOnDestroy` won't be called between test runs so we need
-        // to call it ourselves, in order to avoid leaking containers between tests and potentially
-        // throwing off `querySelector` calls.
-        overlayContainer.ngOnDestroy();
-      });
 
       describe('row hover content', () => {
         it('makes the first and last rows focusable but invisible', fakeAsync(() => {

--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -21,10 +21,6 @@ describe('AriaDescriber', () => {
     fixture.detectChanges();
   }
 
-  afterEach(() => {
-    ariaDescriber.ngOnDestroy();
-  });
-
   it('should initialize without the message container', () => {
     createFixture();
     expect(getMessagesContainer()).toBeNull();

--- a/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
@@ -247,7 +247,6 @@ describe('FocusMonitor', () => {
     tick();
 
     expect(buttonElement.classList.length)
-
       .withContext('button should have exactly 2 focus classes')
       .toBe(2);
 
@@ -255,7 +254,6 @@ describe('FocusMonitor', () => {
     fixture.detectChanges();
 
     expect(buttonElement.classList.length)
-
       .withContext('button should not have any focus classes')
       .toBe(0);
   }));
@@ -266,7 +264,6 @@ describe('FocusMonitor', () => {
     tick();
 
     expect(buttonElement.classList.length)
-
       .withContext('button should have exactly 2 focus classes')
       .toBe(2);
 
@@ -275,7 +272,6 @@ describe('FocusMonitor', () => {
     fixture.detectChanges();
 
     expect(buttonElement.classList.length)
-
       .withContext('button should not have any focus classes')
       .toBe(0);
   }));

--- a/src/cdk/a11y/input-modality/input-modality-detector.spec.ts
+++ b/src/cdk/a11y/input-modality/input-modality-detector.spec.ts
@@ -32,11 +32,6 @@ describe('InputModalityDetector', () => {
     detector = TestBed.inject(InputModalityDetector);
   }
 
-  afterEach(() => {
-    detector?.ngOnDestroy();
-    detector = undefined!;
-  });
-
   it('should do nothing on non-browser platforms', () => {
     setupTest(false);
     expect(detector.mostRecentModality).toBe(null);

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -28,12 +28,6 @@ describe('LiveAnnouncer', () => {
       fixture = TestBed.createComponent(TestApp);
     })));
 
-    afterEach(() => {
-      // In our tests we always remove the current live element, in
-      // order to avoid having multiple announcer elements in the DOM.
-      announcer.ngOnDestroy();
-    });
-
     it('should correctly update the announce text', fakeAsync(() => {
       let buttonElement = fixture.debugElement.query(By.css('button'))!.nativeElement;
       buttonElement.click();
@@ -116,7 +110,6 @@ describe('LiveAnnouncer', () => {
     }));
 
     it('should ensure that there is only one live element at a time', fakeAsync(() => {
-      announcer.ngOnDestroy();
       fixture.destroy();
 
       TestBed.resetTestingModule().configureTestingModule({
@@ -277,12 +270,6 @@ describe('CdkAriaLive', () => {
     fixture.detectChanges();
     flush();
   })));
-
-  afterEach(fakeAsync(() => {
-    // In our tests we always remove the current live element, in
-    // order to avoid having multiple announcer elements in the DOM.
-    announcer.ngOnDestroy();
-  }));
 
   it('should default politeness to polite', fakeAsync(() => {
     fixture.componentInstance.content = 'New content';

--- a/src/cdk/drag-drop/drag-drop-registry.spec.ts
+++ b/src/cdk/drag-drop/drag-drop-registry.spec.ts
@@ -28,10 +28,6 @@ describe('DragDropRegistry', () => {
     })();
   }));
 
-  afterEach(() => {
-    registry.ngOnDestroy();
-  });
-
   it('should be able to start dragging an item', () => {
     const item = new DragItem();
 

--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
@@ -2,7 +2,7 @@ import {TestBed, inject} from '@angular/core/testing';
 import {dispatchKeyboardEvent} from '../../testing/private';
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {Component, NgModule} from '@angular/core';
-import {OverlayModule, OverlayContainer, Overlay} from '../index';
+import {OverlayModule, Overlay} from '../index';
 import {OverlayKeyboardDispatcher} from './overlay-keyboard-dispatcher';
 import {ComponentPortal} from '@angular/cdk/portal';
 
@@ -21,10 +21,6 @@ describe('OverlayKeyboardDispatcher', () => {
       overlay = o;
     })();
   });
-
-  afterEach(inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
-    overlayContainer.ngOnDestroy();
-  }));
 
   it('should track overlays in order as they are attached and detached', () => {
     const overlayOne = overlay.create();

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
@@ -1,7 +1,7 @@
 import {TestBed, inject, fakeAsync} from '@angular/core/testing';
 import {Component, NgModule} from '@angular/core';
 import {dispatchFakeEvent, dispatchMouseEvent} from '../../testing/private';
-import {OverlayModule, OverlayContainer, Overlay} from '../index';
+import {OverlayModule, Overlay} from '../index';
 import {OverlayOutsideClickDispatcher} from './overlay-outside-click-dispatcher';
 import {ComponentPortal} from '@angular/cdk/portal';
 
@@ -20,10 +20,6 @@ describe('OverlayOutsideClickDispatcher', () => {
       overlay = o;
     })();
   });
-
-  afterEach(inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
-    overlayContainer.ngOnDestroy();
-  }));
 
   it('should track overlays in order as they are attached and detached', () => {
     const overlayOne = overlay.create();

--- a/src/cdk/overlay/fullscreen-overlay-container.spec.ts
+++ b/src/cdk/overlay/fullscreen-overlay-container.spec.ts
@@ -6,7 +6,6 @@ import {Overlay, OverlayContainer, OverlayModule, FullscreenOverlayContainer} fr
 
 describe('FullscreenOverlayContainer', () => {
   let overlay: Overlay;
-  let overlayContainer: FullscreenOverlayContainer;
   let fullscreenListeners: Set<Function>;
   let fakeDocument: any;
 
@@ -58,13 +57,11 @@ describe('FullscreenOverlayContainer', () => {
     }).compileComponents();
   }));
 
-  beforeEach(inject([Overlay, OverlayContainer], (o: Overlay, oc: OverlayContainer) => {
+  beforeEach(inject([Overlay], (o: Overlay) => {
     overlay = o;
-    overlayContainer = oc as FullscreenOverlayContainer;
   }));
 
   afterEach(() => {
-    overlayContainer.ngOnDestroy();
     fakeDocument = null;
   });
 

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -18,10 +18,6 @@ describe('OverlayContainer', () => {
     overlayContainer = oc;
   }));
 
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
-
   it('should remove the overlay container element from the DOM on destruction', () => {
     const fixture = TestBed.createComponent(TestComponentWithTemplatePortals);
     fixture.detectChanges();

--- a/src/cdk/overlay/overlay-directives.spec.ts
+++ b/src/cdk/overlay/overlay-directives.spec.ts
@@ -37,7 +37,6 @@ import {Subject} from 'rxjs';
 
 describe('Overlay directives', () => {
   let overlay: Overlay;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let fixture: ComponentFixture<ConnectedOverlayDirectiveTest>;
   let dir: {value: string};
@@ -61,14 +60,9 @@ describe('Overlay directives', () => {
   });
 
   beforeEach(inject([OverlayContainer, Overlay], (oc: OverlayContainer, o: Overlay) => {
-    overlayContainer = oc;
     overlay = o;
     overlayContainerElement = oc.getContainerElement();
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   /** Returns the current open overlay pane element. */
   function getPaneElement() {

--- a/src/cdk/overlay/position/global-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/global-position-strategy.spec.ts
@@ -1,8 +1,8 @@
 import {NgModule, NgZone, Component} from '@angular/core';
-import {TestBed, inject} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {MockNgZone} from '../../testing/private';
 import {PortalModule, ComponentPortal} from '@angular/cdk/portal';
-import {OverlayModule, Overlay, OverlayConfig, OverlayRef, OverlayContainer} from '../index';
+import {OverlayModule, Overlay, OverlayConfig, OverlayRef} from '../index';
 
 
 describe('GlobalPositonStrategy', () => {
@@ -16,19 +16,15 @@ describe('GlobalPositonStrategy', () => {
       providers: [{provide: NgZone, useFactory: () => zone = new MockNgZone()}]
     });
 
-    inject([Overlay], (o: Overlay) => {
-      overlay = o;
-    })();
+    overlay = TestBed.inject(Overlay);
   });
 
-  afterEach(inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
+  afterEach(() => {
     if (overlayRef) {
       overlayRef.dispose();
       overlayRef = null!;
     }
-
-    overlayContainer.ngOnDestroy();
-  }));
+  });
 
   function attachOverlay(config: OverlayConfig): OverlayRef {
     const portal = new ComponentPortal(BlankPortal);

--- a/src/cdk/scrolling/viewport-ruler.spec.ts
+++ b/src/cdk/scrolling/viewport-ruler.spec.ts
@@ -28,10 +28,6 @@ describe('ViewportRuler', () => {
     scrollTo(0, 0);
   }));
 
-  afterEach(() => {
-    viewportRuler.ngOnDestroy();
-  });
-
   it('should get the viewport size', () => {
     let size = viewportRuler.getViewportSize();
     expect(size.width).toBe(window.innerWidth);

--- a/src/cdk/text-field/autofill.spec.ts
+++ b/src/cdk/text-field/autofill.spec.ts
@@ -41,11 +41,6 @@ describe('AutofillMonitor', () => {
     }
   }));
 
-  afterEach(() => {
-    // Call destroy to make sure we clean up all listeners.
-    autofillMonitor.ngOnDestroy();
-  });
-
   it('should add monitored class and listener upon monitoring', () => {
     const inputEl = testComponent.input1.nativeElement;
     expect(inputEl.addEventListener).not.toHaveBeenCalled();

--- a/src/material-experimental/column-resize/column-resize.spec.ts
+++ b/src/material-experimental/column-resize/column-resize.spec.ts
@@ -5,12 +5,11 @@ import {
   ViewChild,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import {ComponentFixture, TestBed, fakeAsync, flushMicrotasks, inject} from '@angular/core/testing';
+import {ComponentFixture, TestBed, fakeAsync, flushMicrotasks} from '@angular/core/testing';
 import {BidiModule} from '@angular/cdk/bidi';
 import {DataSource} from '@angular/cdk/collections';
 import {dispatchKeyboardEvent} from '../../cdk/testing/private';
 import {ESCAPE} from '@angular/cdk/keycodes';
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {MatTableModule} from '@angular/material/table';
 import {BehaviorSubject} from 'rxjs';
 
@@ -348,7 +347,6 @@ describe('Material Popover Edit', () => {
     describe(label, () => {
       let component: BaseTestComponent;
       let fixture: ComponentFixture<BaseTestComponent>;
-      let overlayContainer: OverlayContainer;
 
       beforeEach(fakeAsync(() => {
         jasmine.addMatchers(approximateMatcher);
@@ -357,21 +355,11 @@ describe('Material Popover Edit', () => {
           imports: [BidiModule, MatTableModule, resizeModule],
           declarations: [componentClass],
         }).compileComponents();
-        inject([OverlayContainer], (oc: OverlayContainer) => {
-          overlayContainer = oc;
-        })();
         fixture = TestBed.createComponent(componentClass);
         component = fixture.componentInstance;
         fixture.detectChanges();
         flushMicrotasks();
       }));
-
-      afterEach(() => {
-        // The overlay container's `ngOnDestroy` won't be called between test runs so we need
-        // to call it ourselves, in order to avoid leaking containers between tests and potentially
-        // throwing `querySelector` calls.
-        overlayContainer.ngOnDestroy();
-      });
 
       it('shows resize handle overlays on header row hover and while a resize handle is in use',
           fakeAsync(() => {

--- a/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
@@ -55,7 +55,6 @@ import {
 
 
 describe('MDC-based MatAutocomplete', () => {
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let zone: MockNgZone;
 
@@ -80,19 +79,11 @@ describe('MDC-based MatAutocomplete', () => {
     TestBed.compileComponents();
 
     inject([OverlayContainer], (oc: OverlayContainer) => {
-      overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
     })();
 
     return TestBed.createComponent<T>(component);
   }
-
-  afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
-    // Since we're resetting the testing module in some of the tests,
-    // we can potentially have multiple overlay containers.
-    currentOverlayContainer.ngOnDestroy();
-    overlayContainer.ngOnDestroy();
-  }));
 
   describe('panel toggling', () => {
     let fixture: ComponentFixture<SimpleAutocomplete>;
@@ -857,7 +848,6 @@ describe('MDC-based MatAutocomplete', () => {
     });
 
     it('should disable the input when used with a value accessor and without `matInput`', () => {
-      overlayContainer.ngOnDestroy();
       fixture.destroy();
       TestBed.resetTestingModule();
 
@@ -2160,7 +2150,6 @@ expect(scrollContainer.scrollTop)
       }));
 
     it('should be able to configure preselecting the first option globally', fakeAsync(() => {
-      overlayContainer.ngOnDestroy();
       fixture.destroy();
       TestBed.resetTestingModule();
       fixture = createComponent(SimpleAutocomplete, [
@@ -2178,7 +2167,6 @@ expect(scrollContainer.scrollTop)
     }));
 
     it('should handle `optionSelections` being accessed too early', fakeAsync(() => {
-      overlayContainer.ngOnDestroy();
       fixture.destroy();
       fixture = TestBed.createComponent(SimpleAutocomplete);
 

--- a/src/material-experimental/mdc-dialog/dialog.spec.ts
+++ b/src/material-experimental/mdc-dialog/dialog.spec.ts
@@ -51,7 +51,6 @@ import {
 
 describe('MDC-based MatDialog', () => {
   let dialog: MatDialog;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let scrolledSubject = new Subject();
   let focusMonitor: FocusMonitor;
@@ -80,14 +79,9 @@ describe('MDC-based MatDialog', () => {
       (d: MatDialog, l: Location, oc: OverlayContainer, fm: FocusMonitor) => {
         dialog = d;
         mockLocation = l as SpyLocation;
-        overlayContainer = oc;
         overlayContainerElement = oc.getContainerElement();
         focusMonitor = fm;
       }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
@@ -1779,7 +1773,6 @@ describe('MDC-based MatDialog with a parent MatDialog', () => {
 
 describe('MDC-based MatDialog with default options', () => {
   let dialog: MatDialog;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
 
   let testViewContainerRef: ViewContainerRef;
@@ -1810,13 +1803,8 @@ describe('MDC-based MatDialog with default options', () => {
 
   beforeEach(inject([MatDialog, OverlayContainer], (d: MatDialog, oc: OverlayContainer) => {
     dialog = d;
-    overlayContainer = oc;
     overlayContainerElement = oc.getContainerElement();
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
@@ -1866,7 +1854,6 @@ describe('MDC-based MatDialog with default options', () => {
 
 describe('MDC-based MatDialog with animations enabled', () => {
   let dialog: MatDialog;
-  let overlayContainer: OverlayContainer;
 
   let testViewContainerRef: ViewContainerRef;
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
@@ -1879,18 +1866,13 @@ describe('MDC-based MatDialog with animations enabled', () => {
     TestBed.compileComponents();
   }));
 
-  beforeEach(inject([MatDialog, OverlayContainer], (d: MatDialog, oc: OverlayContainer) => {
+  beforeEach(inject([MatDialog], (d: MatDialog) => {
     dialog = d;
-    overlayContainer = oc;
 
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
     viewContainerFixture.detectChanges();
     testViewContainerRef = viewContainerFixture.componentInstance.childViewContainer;
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   it('should emit when dialog opening animation is complete', fakeAsync(() => {
     const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, fakeAsync, flush, inject, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
@@ -55,7 +55,6 @@ import {
 const MENU_PANEL_TOP_PADDING = 8;
 
 describe('MDC-based MatMenu', () => {
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let focusMonitor: FocusMonitor;
 
@@ -68,20 +67,12 @@ describe('MDC-based MatMenu', () => {
       providers
     }).compileComponents();
 
-    overlayContainer = TestBed.inject(OverlayContainer);
-    overlayContainerElement = overlayContainer.getContainerElement();
+    overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
     focusMonitor = TestBed.inject(FocusMonitor);
     const fixture = TestBed.createComponent<T>(component);
     window.scroll(0, 0);
     return fixture;
   }
-
-  afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
-    // Since we're resetting the testing module in some of the tests,
-    // we can potentially have multiple overlay containers.
-    currentOverlayContainer.ngOnDestroy();
-    overlayContainer.ngOnDestroy();
-  }));
 
   it('should aria-controls the menu panel', fakeAsync(() => {
     const fixture = createComponent(SimpleMenu, [], [FakeIcon]);

--- a/src/material-experimental/mdc-select/select.spec.ts
+++ b/src/material-experimental/mdc-select/select.spec.ts
@@ -79,7 +79,6 @@ import {
 const DEFAULT_TYPEAHEAD_DEBOUNCE_INTERVAL = 200;
 
 describe('MDC-based MatSelect', () => {
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let dir: {value: 'ltr'|'rtl', change: Observable<string>};
   let scrolledSubject = new Subject();
@@ -113,14 +112,9 @@ describe('MDC-based MatSelect', () => {
     }).compileComponents();
 
     inject([OverlayContainer], (oc: OverlayContainer) => {
-      overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
     })();
   }
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   describe('core', () => {
     beforeEach(waitForAsync(() => {

--- a/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
@@ -26,7 +26,6 @@ import {Platform} from '@angular/cdk/platform';
 describe('MatSnackBar', () => {
   let snackBar: MatSnackBar;
   let liveAnnouncer: LiveAnnouncer;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
 
   let testViewContainerRef: ViewContainerRef;
@@ -48,14 +47,8 @@ describe('MatSnackBar', () => {
       (sb: MatSnackBar, la: LiveAnnouncer, oc: OverlayContainer) => {
         snackBar = sb;
         liveAnnouncer = la;
-        overlayContainer = oc;
         overlayContainerElement = oc.getContainerElement();
       }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-    liveAnnouncer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
@@ -516,7 +509,6 @@ describe('MatSnackBar', () => {
   });
 
   it('should be able to override the default config', fakeAsync(() => {
-    overlayContainer.ngOnDestroy();
     viewContainerFixture.destroy();
 
     TestBed
@@ -530,7 +522,6 @@ describe('MatSnackBar', () => {
 
     inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {
       snackBar = sb;
-      overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
     })();
 
@@ -671,10 +662,8 @@ describe('MatSnackBar', () => {
 describe('MatSnackBar with parent MatSnackBar', () => {
   let parentSnackBar: MatSnackBar;
   let childSnackBar: MatSnackBar;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let fixture: ComponentFixture<ComponentThatProvidesMatSnackBar>;
-  let liveAnnouncer: LiveAnnouncer;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -683,22 +672,14 @@ describe('MatSnackBar with parent MatSnackBar', () => {
     }).compileComponents();
   }));
 
-  beforeEach(inject([MatSnackBar, LiveAnnouncer, OverlayContainer],
-      (sb: MatSnackBar, la: LiveAnnouncer, oc: OverlayContainer) => {
-        parentSnackBar = sb;
-        liveAnnouncer = la;
-        overlayContainer = oc;
-        overlayContainerElement = oc.getContainerElement();
+  beforeEach(inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {
+    parentSnackBar = sb;
+    overlayContainerElement = oc.getContainerElement();
 
-        fixture = TestBed.createComponent(ComponentThatProvidesMatSnackBar);
-        childSnackBar = fixture.componentInstance.snackBar;
-        fixture.detectChanges();
-      }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-    liveAnnouncer.ngOnDestroy();
-  });
+    fixture = TestBed.createComponent(ComponentThatProvidesMatSnackBar);
+    childSnackBar = fixture.componentInstance.snackBar;
+    fixture.detectChanges();
+  }));
 
   it('should close snackBars opened by parent when opening from child', fakeAsync(() => {
     parentSnackBar.open('Pizza');
@@ -749,8 +730,6 @@ describe('MatSnackBar with parent MatSnackBar', () => {
 
 describe('MatSnackBar Positioning', () => {
   let snackBar: MatSnackBar;
-  let liveAnnouncer: LiveAnnouncer;
-  let overlayContainer: OverlayContainer;
   let overlayContainerEl: HTMLElement;
 
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
@@ -764,18 +743,10 @@ describe('MatSnackBar Positioning', () => {
     }).compileComponents();
   }));
 
-  beforeEach(inject([MatSnackBar, LiveAnnouncer, OverlayContainer],
-      (sb: MatSnackBar, la: LiveAnnouncer, oc: OverlayContainer) => {
-        snackBar = sb;
-        liveAnnouncer = la;
-        overlayContainer = oc;
-        overlayContainerEl = oc.getContainerElement();
-      }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-    liveAnnouncer.ngOnDestroy();
-  });
+  beforeEach(inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {
+    snackBar = sb;
+    overlayContainerEl = oc.getContainerElement();
+  }));
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);

--- a/src/material-experimental/mdc-tooltip/tooltip.spec.ts
+++ b/src/material-experimental/mdc-tooltip/tooltip.spec.ts
@@ -47,7 +47,6 @@ import {
 const initialTooltipMessage = 'initial tooltip message';
 
 describe('MDC-based MatTooltip', () => {
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let dir: {value: Direction, change: Subject<Direction>};
   let platform: Platform;
@@ -76,18 +75,10 @@ describe('MDC-based MatTooltip', () => {
 
     inject([OverlayContainer, FocusMonitor, Platform],
       (oc: OverlayContainer, fm: FocusMonitor, pl: Platform) => {
-        overlayContainer = oc;
         overlayContainerElement = oc.getContainerElement();
         focusMonitor = fm;
         platform = pl;
       })();
-  }));
-
-  afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
-    // Since we're resetting the testing module in some of the tests,
-    // we can potentially have multiple overlay containers.
-    currentOverlayContainer.ngOnDestroy();
-    overlayContainer.ngOnDestroy();
   }));
 
   describe('basic usage', () => {

--- a/src/material-experimental/popover-edit/popover-edit.spec.ts
+++ b/src/material-experimental/popover-edit/popover-edit.spec.ts
@@ -4,9 +4,8 @@ import {MatTableModule} from '@angular/material/table';
 import {dispatchKeyboardEvent} from '../../cdk/testing/private';
 import {CommonModule} from '@angular/common';
 import {Component, Directive, ElementRef, ViewChild} from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, TestBed, tick, inject} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
 import {FormsModule, NgForm} from '@angular/forms';
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {BehaviorSubject} from 'rxjs';
 
 import {
@@ -292,28 +291,17 @@ describe('Material Popover Edit', () => {
     describe(label, () => {
       let component: BaseTestComponent;
       let fixture: ComponentFixture<BaseTestComponent>;
-      let overlayContainer: OverlayContainer;
 
       beforeEach(fakeAsync(() => {
         TestBed.configureTestingModule({
           imports: [MatTableModule, MatPopoverEditModule, CommonModule, FormsModule],
           declarations: [componentClass],
         }).compileComponents();
-        inject([OverlayContainer], (oc: OverlayContainer) => {
-          overlayContainer = oc;
-        })();
         fixture = TestBed.createComponent(componentClass);
         component = fixture.componentInstance;
         fixture.detectChanges();
         tick(10);
       }));
-
-      afterEach(() => {
-        // The overlay container's `ngOnDestroy` won't be called between test runs so we need
-        // to call it ourselves, in order to avoid leaking containers between tests and potentially
-        // throwing `querySelector` calls.
-        overlayContainer.ngOnDestroy();
-      });
 
       describe('row hover content', () => {
         it('makes the first and last rows focusable but invisible', fakeAsync(() => {

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -88,13 +88,6 @@ describe('MatAutocomplete', () => {
     return TestBed.createComponent<T>(component);
   }
 
-  afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
-    // Since we're resetting the testing module in some of the tests,
-    // we can potentially have multiple overlay containers.
-    currentOverlayContainer.ngOnDestroy();
-    overlayContainer.ngOnDestroy();
-  }));
-
   describe('panel toggling', () => {
     let fixture: ComponentFixture<SimpleAutocomplete>;
     let input: HTMLInputElement;
@@ -2140,7 +2133,6 @@ expect(container.scrollTop)
       }));
 
     it('should be able to configure preselecting the first option globally', fakeAsync(() => {
-      overlayContainer.ngOnDestroy();
       fixture.destroy();
       TestBed.resetTestingModule();
       fixture = createComponent(SimpleAutocomplete, [

--- a/src/material/autocomplete/testing/shared.spec.ts
+++ b/src/material/autocomplete/testing/shared.spec.ts
@@ -1,8 +1,7 @@
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
-import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatAutocompleteHarness} from '@angular/material/autocomplete/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -16,7 +15,6 @@ export function runHarnessTests(
     autocompleteHarness: typeof MatAutocompleteHarness) {
   let fixture: ComponentFixture<AutocompleteHarnessTest>;
   let loader: HarnessLoader;
-  let overlayContainer: OverlayContainer;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -30,15 +28,6 @@ export function runHarnessTests(
     fixture = TestBed.createComponent(AutocompleteHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.loader(fixture);
-    inject([OverlayContainer], (oc: OverlayContainer) => {
-      overlayContainer = oc;
-    })();
-  });
-
-  afterEach(() => {
-    // Angular won't call this for us so we need to do it ourselves to avoid leaks.
-    overlayContainer.ngOnDestroy();
-    overlayContainer = null!;
   });
 
   it('should load all autocomplete harnesses', async () => {

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -41,7 +41,6 @@ import {MatBottomSheetRef} from './bottom-sheet-ref';
 
 describe('MatBottomSheet', () => {
   let bottomSheet: MatBottomSheet;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let viewportRuler: ViewportRuler;
 
@@ -61,15 +60,10 @@ describe('MatBottomSheet', () => {
   beforeEach(inject([MatBottomSheet, OverlayContainer, ViewportRuler, Location],
     (bs: MatBottomSheet, oc: OverlayContainer, vr: ViewportRuler, l: Location) => {
       bottomSheet = bs;
-      overlayContainer = oc;
       viewportRuler = vr;
       overlayContainerElement = oc.getContainerElement();
       mockLocation = l as SpyLocation;
     }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
@@ -821,7 +815,6 @@ describe('MatBottomSheet', () => {
 describe('MatBottomSheet with parent MatBottomSheet', () => {
   let parentBottomSheet: MatBottomSheet;
   let childBottomSheet: MatBottomSheet;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let fixture: ComponentFixture<ComponentThatProvidesMatBottomSheet>;
 
@@ -835,16 +828,11 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
   beforeEach(inject([MatBottomSheet, OverlayContainer],
     (bs: MatBottomSheet, oc: OverlayContainer) => {
     parentBottomSheet = bs;
-    overlayContainer = oc;
     overlayContainerElement = oc.getContainerElement();
     fixture = TestBed.createComponent(ComponentThatProvidesMatBottomSheet);
     childBottomSheet = fixture.componentInstance.bottomSheet;
     fixture.detectChanges();
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   it('should close bottom sheets opened by parent when opening from child', fakeAsync(() => {
     parentBottomSheet.open(PizzaMsg);
@@ -900,7 +888,6 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
 
 describe('MatBottomSheet with default options', () => {
   let bottomSheet: MatBottomSheet;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
 
   let testViewContainerRef: ViewContainerRef;
@@ -926,13 +913,8 @@ describe('MatBottomSheet with default options', () => {
   beforeEach(inject([MatBottomSheet, OverlayContainer],
     (b: MatBottomSheet, oc: OverlayContainer) => {
       bottomSheet = b;
-      overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
     }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);

--- a/src/material/bottom-sheet/testing/shared.spec.ts
+++ b/src/material/bottom-sheet/testing/shared.spec.ts
@@ -1,14 +1,13 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component, TemplateRef, ViewChild} from '@angular/core';
-import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   MatBottomSheet,
   MatBottomSheetConfig,
   MatBottomSheetModule,
 } from '@angular/material/bottom-sheet';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {MatBottomSheetHarness} from './bottom-sheet-harness';
 
 /** Shared tests to run on both the original and MDC-based bottom sheets. */
@@ -16,7 +15,6 @@ export function runHarnessTests(
     bottomSheetModule: typeof MatBottomSheetModule, harness: typeof MatBottomSheetHarness) {
   let fixture: ComponentFixture<BottomSheetHarnessTest>;
   let loader: HarnessLoader;
-  let overlayContainer: OverlayContainer;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -27,20 +25,6 @@ export function runHarnessTests(
     fixture = TestBed.createComponent(BottomSheetHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
-    inject([OverlayContainer], (oc: OverlayContainer) => {
-      overlayContainer = oc;
-    })();
-  });
-
-  afterEach(() => {
-    // Dismiss the bottom sheet once the tests are done. This is necessary because the
-    // "MatBottomSheet" service is not destroyed automatically by TestBed, and it could
-    // mean that bottom sheets are left in the DOM.
-    fixture.componentInstance.bottomSheet.dismiss();
-    fixture.detectChanges();
-
-    // Angular won't call this for us so we need to do it ourselves to avoid leaks.
-    overlayContainer.ngOnDestroy();
   });
 
   it('should load harness for a bottom sheet', async () => {

--- a/src/material/datepicker/date-range-input.spec.ts
+++ b/src/material/datepicker/date-range-input.spec.ts
@@ -43,10 +43,6 @@ describe('MatDateRangeInput', () => {
     return TestBed.createComponent(component);
   }
 
-  afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
-    container.ngOnDestroy();
-  }));
-
   it('should mirror the input value from the start into the mirror element', () => {
     const fixture = createComponent(StandardRangePicker);
     fixture.detectChanges();

--- a/src/material/datepicker/datepicker-actions.spec.ts
+++ b/src/material/datepicker/datepicker-actions.spec.ts
@@ -1,6 +1,5 @@
 import {Component, ElementRef, Type, ViewChild} from '@angular/core';
-import {OverlayContainer} from '@angular/cdk/overlay';
-import {ComponentFixture, TestBed, inject, flush, fakeAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed, flush, fakeAsync} from '@angular/core/testing';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatNativeDateModule} from '@angular/material/core';
@@ -28,10 +27,6 @@ describe('MatDatepickerActions', () => {
 
     return TestBed.createComponent(component);
   }
-
-  afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
-    container.ngOnDestroy();
-  }));
 
   it('should render the actions inside calendar panel in popup mode', () => {
     const fixture = createComponent(DatepickerWithActions);

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -1,6 +1,6 @@
 import {Directionality} from '@angular/cdk/bidi';
 import {DOWN_ARROW, ENTER, ESCAPE, RIGHT_ARROW, UP_ARROW} from '@angular/cdk/keycodes';
-import {Overlay, OverlayContainer} from '@angular/cdk/overlay';
+import {Overlay} from '@angular/cdk/overlay';
 import {ScrollDispatcher} from '@angular/cdk/scrolling';
 import {
   createKeyboardEvent,
@@ -76,10 +76,6 @@ describe('MatDatepicker', () => {
 
     return TestBed.createComponent(component);
   }
-
-  afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
-    container.ngOnDestroy();
-  }));
 
   describe('with MatNativeDateModule', () => {
     describe('standard datepicker', () => {
@@ -453,43 +449,38 @@ describe('MatDatepicker', () => {
         subscription.unsubscribe();
       }));
 
-      it('should reset the datepicker when it is closed externally',
-        fakeAsync(inject([OverlayContainer], (oldOverlayContainer: OverlayContainer) => {
+      it('should reset the datepicker when it is closed externally', fakeAsync(() => {
+        TestBed.resetTestingModule();
 
-          // Destroy the old container manually since resetting the testing module won't do it.
-          oldOverlayContainer.ngOnDestroy();
-          TestBed.resetTestingModule();
+        const scrolledSubject = new Subject();
 
-          const scrolledSubject = new Subject();
+        // Stub out a `CloseScrollStrategy` so we can trigger a detachment via the `OverlayRef`.
+        fixture = createComponent(StandardDatepicker, [MatNativeDateModule], [
+          {
+            provide: ScrollDispatcher,
+            useValue: {scrolled: () => scrolledSubject}
+          },
+          {
+            provide: MAT_DATEPICKER_SCROLL_STRATEGY,
+            deps: [Overlay],
+            useFactory: (overlay: Overlay) => () => overlay.scrollStrategies.close()
+          }
+        ]);
 
-          // Stub out a `CloseScrollStrategy` so we can trigger a detachment via the `OverlayRef`.
-          fixture = createComponent(StandardDatepicker, [MatNativeDateModule], [
-            {
-              provide: ScrollDispatcher,
-              useValue: {scrolled: () => scrolledSubject}
-            },
-            {
-              provide: MAT_DATEPICKER_SCROLL_STRATEGY,
-              deps: [Overlay],
-              useFactory: (overlay: Overlay) => () => overlay.scrollStrategies.close()
-            }
-          ]);
+        fixture.detectChanges();
+        testComponent = fixture.componentInstance;
 
-          fixture.detectChanges();
-          testComponent = fixture.componentInstance;
+        testComponent.datepicker.open();
+        fixture.detectChanges();
 
-          testComponent.datepicker.open();
-          fixture.detectChanges();
+        expect(testComponent.datepicker.opened).toBe(true);
 
-          expect(testComponent.datepicker.opened).toBe(true);
+        scrolledSubject.next();
+        flush();
+        fixture.detectChanges();
 
-          scrolledSubject.next();
-          flush();
-          fixture.detectChanges();
-
-          expect(testComponent.datepicker.opened).toBe(false);
-        }))
-      );
+        expect(testComponent.datepicker.opened).toBe(false);
+      }));
 
       it('should close the datepicker using ALT + UP_ARROW', fakeAsync(() => {
         testComponent.datepicker.open();

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -51,7 +51,6 @@ import {Subject} from 'rxjs';
 
 describe('MatDialog', () => {
   let dialog: MatDialog;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let scrolledSubject = new Subject();
   let focusMonitor: FocusMonitor;
@@ -78,14 +77,9 @@ describe('MatDialog', () => {
     (d: MatDialog, l: Location, oc: OverlayContainer, fm: FocusMonitor) => {
       dialog = d;
       mockLocation = l as SpyLocation;
-      overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
       focusMonitor = fm;
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
@@ -1864,7 +1858,6 @@ describe('MatDialog with a parent MatDialog', () => {
 
 describe('MatDialog with default options', () => {
   let dialog: MatDialog;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
 
   let testViewContainerRef: ViewContainerRef;
@@ -1896,13 +1889,8 @@ describe('MatDialog with default options', () => {
   beforeEach(inject([MatDialog, OverlayContainer],
     (d: MatDialog, oc: OverlayContainer) => {
       dialog = d;
-      overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
     }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
@@ -1955,7 +1943,6 @@ describe('MatDialog with default options', () => {
 
 describe('MatDialog with animations enabled', () => {
   let dialog: MatDialog;
-  let overlayContainer: OverlayContainer;
 
   let testViewContainerRef: ViewContainerRef;
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
@@ -1970,16 +1957,10 @@ describe('MatDialog with animations enabled', () => {
 
   beforeEach(inject([MatDialog, OverlayContainer], (d: MatDialog, oc: OverlayContainer) => {
     dialog = d;
-    overlayContainer = oc;
-
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
     viewContainerFixture.detectChanges();
     testViewContainerRef = viewContainerFixture.componentInstance.childViewContainer;
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   it('should return the current state of the dialog', fakeAsync(() => {
     const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});

--- a/src/material/dialog/testing/shared.spec.ts
+++ b/src/material/dialog/testing/shared.spec.ts
@@ -1,10 +1,9 @@
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component, TemplateRef, ViewChild} from '@angular/core';
-import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatDialog, MatDialogConfig, MatDialogModule} from '@angular/material/dialog';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {MatDialogHarness} from './dialog-harness';
 
 /** Shared tests to run on both the original and MDC-based dialog's. */
@@ -13,7 +12,6 @@ export function runHarnessTests(
     dialogService: typeof MatDialog) {
   let fixture: ComponentFixture<DialogHarnessTest>;
   let loader: HarnessLoader;
-  let overlayContainer: OverlayContainer;
 
   beforeEach(async () => {
     // If the specified dialog service does not match the default `MatDialog` service
@@ -33,20 +31,6 @@ export function runHarnessTests(
     fixture = TestBed.createComponent(DialogHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
-    inject([OverlayContainer], (oc: OverlayContainer) => {
-      overlayContainer = oc;
-    })();
-  });
-
-  afterEach(() => {
-    // Close all dialogs upon test exit. This is necessary because the "MatDialog"
-    // service is not destroyed in TestBed automatically, and it could mean that
-    // dialogs are left in the DOM.
-    fixture.componentInstance.dialog.closeAll();
-    fixture.detectChanges();
-
-    // Angular won't call this for us so we need to do it ourselves to avoid leaks.
-    overlayContainer.ngOnDestroy();
   });
 
   it('should load harness for dialog', async () => {

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -37,7 +37,7 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
-import {ComponentFixture, fakeAsync, flush, inject, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
 import {MatRipple} from '@angular/material/core';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -56,7 +56,6 @@ import {MAT_MENU_SCROLL_STRATEGY, MENU_PANEL_TOP_PADDING} from './menu-trigger';
 
 
 describe('MatMenu', () => {
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let focusMonitor: FocusMonitor;
 
@@ -69,20 +68,12 @@ describe('MatMenu', () => {
       providers
     }).compileComponents();
 
-    overlayContainer = TestBed.inject(OverlayContainer);
-    overlayContainerElement = overlayContainer.getContainerElement();
+    overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
     focusMonitor = TestBed.inject(FocusMonitor);
     const fixture = TestBed.createComponent<T>(component);
     window.scroll(0, 0);
     return fixture;
   }
-
-  afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
-    // Since we're resetting the testing module in some of the tests,
-    // we can potentially have multiple overlay containers.
-    currentOverlayContainer.ngOnDestroy();
-    overlayContainer.ngOnDestroy();
-  }));
 
   it('should aria-controls the menu panel', fakeAsync(() => {
     const fixture = createComponent(SimpleMenu, [], [FakeIcon]);

--- a/src/material/menu/testing/shared.spec.ts
+++ b/src/material/menu/testing/shared.spec.ts
@@ -1,8 +1,7 @@
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
-import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatMenuModule} from '@angular/material/menu';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatMenuHarness} from './menu-harness';
@@ -10,8 +9,6 @@ import {MatMenuHarness} from './menu-harness';
 /** Shared tests to run on both the original and MDC-based menues. */
 export function runHarnessTests(
     menuModule: typeof MatMenuModule, menuHarness: typeof MatMenuHarness) {
-  let overlayContainer: OverlayContainer;
-
   describe('single-level menu', () => {
     let fixture: ComponentFixture<MenuHarnessTest>;
     let loader: HarnessLoader;
@@ -21,10 +18,6 @@ export function runHarnessTests(
         imports: [menuModule, NoopAnimationsModule],
         declarations: [MenuHarnessTest],
       }).compileComponents();
-
-      inject([OverlayContainer], (oc: OverlayContainer) => {
-        overlayContainer = oc;
-      })();
 
       fixture = TestBed.createComponent(MenuHarnessTest);
       fixture.detectChanges();
@@ -107,19 +100,9 @@ export function runHarnessTests(
         declarations: [NestedMenuHarnessTest],
       }).compileComponents();
 
-      inject([OverlayContainer], (oc: OverlayContainer) => {
-        overlayContainer = oc;
-      })();
-
       fixture = TestBed.createComponent(NestedMenuHarnessTest);
       fixture.detectChanges();
       loader = TestbedHarnessEnvironment.loader(fixture);
-    });
-
-    afterEach(() => {
-      // Angular won't call this for us so we need to do it ourselves to avoid leaks.
-      overlayContainer.ngOnDestroy();
-      overlayContainer = null!;
     });
 
     it('should get submenus', async () => {

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -79,7 +79,6 @@ import {
 const DEFAULT_TYPEAHEAD_DEBOUNCE_INTERVAL = 200;
 
 describe('MatSelect', () => {
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let dir: {value: 'ltr'|'rtl', change: Observable<string>};
   let scrolledSubject = new Subject();
@@ -115,15 +114,10 @@ describe('MatSelect', () => {
     }).compileComponents();
 
     inject([OverlayContainer, Platform], (oc: OverlayContainer, p: Platform) => {
-      overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
       platform = p;
     })();
   }
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-  });
 
   describe('core', () => {
     beforeEach(waitForAsync(() => {

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -27,7 +27,6 @@ import {Platform} from '@angular/cdk/platform';
 describe('MatSnackBar', () => {
   let snackBar: MatSnackBar;
   let liveAnnouncer: LiveAnnouncer;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
 
   let testViewContainerRef: ViewContainerRef;
@@ -48,14 +47,8 @@ describe('MatSnackBar', () => {
     (sb: MatSnackBar, la: LiveAnnouncer, oc: OverlayContainer) => {
     snackBar = sb;
     liveAnnouncer = la;
-    overlayContainer = oc;
     overlayContainerElement = oc.getContainerElement();
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-    liveAnnouncer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);
@@ -576,7 +569,6 @@ describe('MatSnackBar', () => {
   });
 
   it('should be able to override the default config', fakeAsync(() => {
-    overlayContainer.ngOnDestroy();
     viewContainerFixture.destroy();
 
     TestBed
@@ -590,7 +582,6 @@ describe('MatSnackBar', () => {
 
     inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {
       snackBar = sb;
-      overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
     })();
 
@@ -724,10 +715,8 @@ describe('MatSnackBar', () => {
 describe('MatSnackBar with parent MatSnackBar', () => {
   let parentSnackBar: MatSnackBar;
   let childSnackBar: MatSnackBar;
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let fixture: ComponentFixture<ComponentThatProvidesMatSnackBar>;
-  let liveAnnouncer: LiveAnnouncer;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -736,22 +725,14 @@ describe('MatSnackBar with parent MatSnackBar', () => {
     }).compileComponents();
   }));
 
-  beforeEach(inject([MatSnackBar, LiveAnnouncer, OverlayContainer],
-    (sb: MatSnackBar, la: LiveAnnouncer, oc: OverlayContainer) => {
+  beforeEach(inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {
     parentSnackBar = sb;
-    liveAnnouncer = la;
-    overlayContainer = oc;
     overlayContainerElement = oc.getContainerElement();
 
     fixture = TestBed.createComponent(ComponentThatProvidesMatSnackBar);
     childSnackBar = fixture.componentInstance.snackBar;
     fixture.detectChanges();
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-    liveAnnouncer.ngOnDestroy();
-  });
 
   it('should close snackBars opened by parent when opening from child', fakeAsync(() => {
     parentSnackBar.open('Pizza');
@@ -802,8 +783,6 @@ describe('MatSnackBar with parent MatSnackBar', () => {
 
 describe('MatSnackBar Positioning', () => {
   let snackBar: MatSnackBar;
-  let liveAnnouncer: LiveAnnouncer;
-  let overlayContainer: OverlayContainer;
   let overlayContainerEl: HTMLElement;
 
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
@@ -817,18 +796,10 @@ describe('MatSnackBar Positioning', () => {
     }).compileComponents();
   }));
 
-  beforeEach(inject([MatSnackBar, LiveAnnouncer, OverlayContainer],
-    (sb: MatSnackBar, la: LiveAnnouncer, oc: OverlayContainer) => {
+  beforeEach(inject([MatSnackBar, OverlayContainer], (sb: MatSnackBar, oc: OverlayContainer) => {
     snackBar = sb;
-    liveAnnouncer = la;
-    overlayContainer = oc;
     overlayContainerEl = oc.getContainerElement();
   }));
-
-  afterEach(() => {
-    overlayContainer.ngOnDestroy();
-    liveAnnouncer.ngOnDestroy();
-  });
 
   beforeEach(() => {
     viewContainerFixture = TestBed.createComponent(ComponentWithChildViewContainer);

--- a/src/material/snack-bar/testing/shared.spec.ts
+++ b/src/material/snack-bar/testing/shared.spec.ts
@@ -1,8 +1,7 @@
-import {OverlayContainer} from '@angular/cdk/overlay';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component, TemplateRef, ViewChild, Injector} from '@angular/core';
-import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatSnackBar, MatSnackBarConfig, MatSnackBarModule} from '@angular/material/snack-bar';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatSnackBarHarness} from './snack-bar-harness';
@@ -17,7 +16,6 @@ export function runHarnessTests(
     snackBarHarness: typeof MatSnackBarHarness) {
   let fixture: ComponentFixture<SnackbarHarnessTest>;
   let loader: HarnessLoader;
-  let overlayContainer: OverlayContainer;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -28,15 +26,6 @@ export function runHarnessTests(
     fixture = TestBed.createComponent(SnackbarHarnessTest);
     fixture.detectChanges();
     loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
-    inject([OverlayContainer], (oc: OverlayContainer) => {
-      overlayContainer = oc;
-    })();
-  });
-
-  afterEach(() => {
-    // Angular won't call this for us so we need to do it ourselves to avoid leaks.
-    overlayContainer.ngOnDestroy();
-    overlayContainer = null!;
   });
 
   it('should load harness for simple snack-bar', async () => {

--- a/src/material/tooltip/tooltip.spec.ts
+++ b/src/material/tooltip/tooltip.spec.ts
@@ -47,7 +47,6 @@ import {
 const initialTooltipMessage = 'initial tooltip message';
 
 describe('MatTooltip', () => {
-  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let dir: {value: Direction, change: Subject<Direction>};
   let platform: Platform;
@@ -76,18 +75,10 @@ describe('MatTooltip', () => {
 
     inject([OverlayContainer, FocusMonitor, Platform],
       (oc: OverlayContainer, fm: FocusMonitor, pl: Platform) => {
-        overlayContainer = oc;
         overlayContainerElement = oc.getContainerElement();
         focusMonitor = fm;
         platform = pl;
       })();
-  }));
-
-  afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
-    // Since we're resetting the testing module in some of the tests,
-    // we can potentially have multiple overlay containers.
-    currentOverlayContainer.ngOnDestroy();
-    overlayContainer.ngOnDestroy();
   }));
 
   describe('basic usage', () => {

--- a/test/karma-test-shim.js
+++ b/test/karma-test-shim.js
@@ -48,7 +48,7 @@ function configureTestBed() {
 
     console.log('Running tests using Angular version: ' + core.VERSION.full);
 
-    var testBed = testing.TestBed.initTestEnvironment(
+    testing.TestBed.initTestEnvironment(
       testingBrowser.BrowserDynamicTestingModule,
       testingBrowser.platformBrowserDynamicTesting(),
       {teardown: {destroyAfterEach: true}}


### PR DESCRIPTION
We used to have to call `ngOnDestroy` manually on providers, because `TestBed` wouldn't do it for us. Now that we're using the `teardown` flag, we don't have to do it anymore.