### PR TITLE
fix(material/button-toggle): toggle buttons except for first toggle button have margin left

### DIFF
--- a/src/material/button-toggle/button-toggle.scss
+++ b/src/material/button-toggle/button-toggle.scss
@@ -35,6 +35,10 @@ $legacy-border-radius: 2px !default;
 
 .mat-button-toggle-vertical {
   flex-direction: column;
+  
+  .mat-button-toggle {
+    margin-left: 0px !important;
+  }
 
   .mat-button-toggle-label-content {
     // Vertical button toggles shouldn't be an inline-block, because the toggles should


### PR DESCRIPTION
The toggle buttons after the first toggle button inherit the margin-left property from the mat-toggle-button-group class when the `vertical` attribute is set to `true` and makes the toggle buttons look uneven.