### PR TITLE
refactor(material/tabs): remove deprecated APIs for v13

### DIFF
--- a/src/material-experimental/mdc-tabs/testing/tab-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-harness.ts
@@ -69,16 +69,6 @@ export class MatTabHarness extends ContentContainerComponentHarness<string> {
     return contentEl.text();
   }
 
-  /**
-   * Gets a `HarnessLoader` that can be used to load harnesses for components within the tab's
-   * content area.
-   * @deprecated Use `getHarness` or `getChildLoader` instead.
-   * @breaking-change 12.0.0
-   */
-  async getHarnessLoaderForContent(): Promise<HarnessLoader> {
-    return this.getRootHarnessLoader();
-  }
-
   protected override async getRootHarnessLoader(): Promise<HarnessLoader> {
     const contentId = await this._getContentId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${contentId}`);

--- a/src/material/tabs/testing/tab-harness.ts
+++ b/src/material/tabs/testing/tab-harness.ts
@@ -69,16 +69,6 @@ export class MatTabHarness extends ContentContainerComponentHarness<string> {
     return contentEl.text();
   }
 
-  /**
-   * Gets a `HarnessLoader` that can be used to load harnesses for components within the tab's
-   * content area.
-   * @deprecated Use `getHarness` or `getChildLoader` instead.
-   * @breaking-change 12.0.0
-   */
-  async getHarnessLoaderForContent(): Promise<HarnessLoader> {
-    return this.getRootHarnessLoader();
-  }
-
   protected override async getRootHarnessLoader(): Promise<HarnessLoader> {
     const contentId = await this._getContentId();
     return this.documentRootLocatorFactory().harnessLoaderFor(`#${contentId}`);

--- a/tools/public_api_guard/material/tabs-testing.md
+++ b/tools/public_api_guard/material/tabs-testing.md
@@ -23,8 +23,6 @@ export class MatTabGroupHarness extends ComponentHarness {
 export class MatTabHarness extends ContentContainerComponentHarness<string> {
     getAriaLabel(): Promise<string | null>;
     getAriaLabelledby(): Promise<string | null>;
-    // @deprecated
-    getHarnessLoaderForContent(): Promise<HarnessLoader>;
     getLabel(): Promise<string>;
     // (undocumented)
     protected getRootHarnessLoader(): Promise<HarnessLoader>;


### PR DESCRIPTION
Removes the APIs that were marked for removal in v13.

BREAKING CHANGE:
* `MatTabHarness.getHarnessLoaderForContent` has been removed. Use `MatTabHarness.getRootHarnessLoader` instead.