### PR TITLE
build: bump required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=12.0.0 <16.0.0",
+    "node": ">=14.0.0 <16.0.0",
     "yarn": ">= 1.0.0",
     "npm": "Please use Yarn instead of NPM to install dependencies. See: https://yarnpkg.com/lang/en/docs/install/"
   },


### PR DESCRIPTION
Our current requirement asks for at least Node 12, however the `dev-infra-private` package includes some syntax that is only available in Node 14.

These changes bump the minimum required version to 14.

Fixes #23434.