### PR TITLE
fix(material/table): Sorting of a string column/property breaks if one record contains a number only

### DIFF
--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -485,14 +485,6 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
 
   private _updateSelectedItemIndex(newIndex: number): void {
     const stepsArray = this.steps.toArray();
-    
-    
-    if(newIndex === this.selectedIndex){
-      newIndex=0;
-      this.steps.forEach(step => step.reset());
-      this._stateChanged();
-    }
-    
     this.selectionChange.emit({
       selectedIndex: newIndex,
       previouslySelectedIndex: this._selectedIndex,


### PR DESCRIPTION
fix(material/table): Sorting of a string column/property breaks if one record contains a number only

If the number is a string and in between strings we treat it as a number and group it at the start/end of the table based on it's ascending or descending. [I have fixed the issue in my commit here](https://github.com/sahilmore-git/components/commit/42bacec862d02118557b01fcc19cbcde6079661b) and I think it will work properly.

Fixes #20140