### PR TITLE
fix(cdk/stepper/stepper.ts) : Pressing stepper header and setting selectedIndex programmatically does not work correctStepper fix

### DIFF
--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -485,6 +485,13 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
 
   private _updateSelectedItemIndex(newIndex: number): void {
     const stepsArray = this.steps.toArray();
+
+    if(newIndex === this.selectedIndex){
+      newIndex=0;
+      this.steps.forEach(step => step.reset());
+      this._stateChanged();
+    }
+
     this.selectionChange.emit({
       selectedIndex: newIndex,
       previouslySelectedIndex: this._selectedIndex,

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -183,8 +183,6 @@ export class _MatTableDataSource<T,
       if (valueAType !== valueBType) {
         if (valueAType === 'number') { valueA += ''; }
         if (valueBType === 'number') { valueB += ''; }
-        if ( (valueAType === 'string') && (_isNumberValue(valueA) === true) ) { valueA += ''; }
-        if ( (valueBType === 'string') && (_isNumberValue(valueB) === true) ) { valueB += ''; }
       }
 
       // If both valueA and valueB exist (truthy), then compare the two. Otherwise, check if


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/46355027/130842813-379b2ada-8bbf-47a5-bd59-50b97eb5c2e2.png)

Basically what happens here is that if we choose 3rd step from the tabs and again go and click on Button(selected index=0) it wont work because the value of selected index is already 0 hence it won't change the tabs too. So what I have done is simply reset the steps if we get same index after clicking the button. What this will do is it will allow us to re-select all the tabs again without any issue.
[---------->Please check the solution here<------------](https://github.com/sahilmore-git/components/commit/dd969ea84d23bd96d307401ab96c94f59dec9ac6)

Fixes #15627