### PR TITLE
fix(material/tabs): tab header border reset when parent has a background color

### DIFF
--- a/src/material/tabs/_tabs-theme.scss
+++ b/src/material/tabs/_tabs-theme.scss
@@ -42,7 +42,7 @@
   }
 
   // Remove header border when there is a background color
-  .mat-tab-group[class*='mat-background-'] .mat-tab-header,
+  .mat-tab-group[class*='mat-background-'] > .mat-tab-header,
   .mat-tab-nav-bar[class*='mat-background-'] {
     border-bottom: none;
     border-top: none;


### PR DESCRIPTION
When a background color is set on a tab group, we reset the tab header's bottom border. The problem is that the selector was too broad which made it apply to nested tabs as well.

These changes fix the issue by making the selector more specific.

Fixes #23432.