### PR TITLE
fix(material-experimental/mdc-slider): remove deep imports

### DIFF
--- a/rollup-globals.bzl
+++ b/rollup-globals.bzl
@@ -39,10 +39,6 @@ ROLLUP_GLOBALS = {
     "@angular/material-date-fns-adapter": "ng.materialDateFnsAdapter",
     "@angular/youtube-player": "ng.youtubePlayer",
 
-    # This UMD module name would not match with anything that MDC provides, but we just
-    # add this to make the linter happy. This module resolves to a type-only file anyways.
-    "@material/base/types": "mdc.base.types",
-
     # Third-party libraries.
     "kagekiri": "kagekiri",
     "moment": "moment",

--- a/src/material-experimental/mdc-slider/BUILD.bazel
+++ b/src/material-experimental/mdc-slider/BUILD.bazel
@@ -27,6 +27,7 @@ ng_module(
         "//src/cdk/platform",
         "//src/material-experimental/mdc-core",
         "@npm//@angular/forms",
+        "@npm//@material/base",
         "@npm//@material/slider",
     ],
 )

--- a/src/material-experimental/mdc-slider/global-change-and-input-listener.ts
+++ b/src/material-experimental/mdc-slider/global-change-and-input-listener.ts
@@ -8,7 +8,7 @@
 
 import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, NgZone, OnDestroy} from '@angular/core';
-import {SpecificEventListener} from '@material/base/types';
+import {SpecificEventListener} from '@material/base';
 import {fromEvent, Observable, Subject, Subscription} from 'rxjs';
 import {finalize, share, takeUntil} from 'rxjs/operators';
 

--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -50,7 +50,7 @@ import {
   RippleState,
 } from '@angular/material/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {SpecificEventListener, EventType} from '@material/base/types';
+import {SpecificEventListener, EventType} from '@material/base';
 import {MDCSliderAdapter, MDCSliderFoundation, Thumb, TickMark} from '@material/slider';
 import {Subscription} from 'rxjs';
 import {GlobalChangeAndInputListener} from './global-change-and-input-listener';


### PR DESCRIPTION
Fixes a couple of deep imports in the `mdc-slider` package that were causing the CLI to log a warning when the package is installed.