### PR TITLE
fix(material/table): Sorting of a string column/property breaks if one record contains a number only

### DIFF
--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -183,6 +183,8 @@ export class _MatTableDataSource<T,
       if (valueAType !== valueBType) {
         if (valueAType === 'number') { valueA += ''; }
         if (valueBType === 'number') { valueB += ''; }
+        if ( (valueAType === 'string') && (_isNumberValue(valueA) === true) ) { valueA += ''; }
+        if ( (valueBType === 'string') && (_isNumberValue(valueB) === true) ) { valueB += ''; }
       }
 
       // If both valueA and valueB exist (truthy), then compare the two. Otherwise, check if


### PR DESCRIPTION
fix(material/table): Sorting of a string column/property breaks if one record contains a number only

If the number is a string and in between strings we treat it as a number and group it at the start/end of the table based on it's ascending or descending. [I have fixed the issue in my commit here](https://github.com/sahilmore-git/components/commit/42bacec862d02118557b01fcc19cbcde6079661b) and I think it will work properly.

Fixes #20140