### PR TITLE
fix(cdk/stepper/stepper.ts) : Pressing stepper header and setting selectedIndex programmatically does not work correct

### DIFF
--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -485,6 +485,13 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
 
   private _updateSelectedItemIndex(newIndex: number): void {
     const stepsArray = this.steps.toArray();
+        
+    if(newIndex === this.selectedIndex){
+      newIndex=0;
+      this.steps.forEach(step => step.reset());
+      this._stateChanged();
+    }
+
     this.selectionChange.emit({
       selectedIndex: newIndex,
       previouslySelectedIndex: this._selectedIndex,


### PR DESCRIPTION
fix(cdk/stepper/stepper.ts) : Pressing stepper header and setting selectedIndex programmatically does not work correct

![image](https://user-images.githubusercontent.com/46355027/130926206-4404a9f0-6696-4fb1-917c-a94c71f2f4c9.png)
Basically what happens here is that if we choose 3rd step from the tabs and again go and click on Button(selected index=0) it wont work because the value of selected index is already 0 hence it won't change the tabs too. So what I have done is simply reset the steps if we get same index after clicking the button. What this will do is it will allow us to re-select all the tabs again without any issue.
[---------->Please check the solution here<------------](https://github.com/sahilmore-git/components/commit/dd969ea84d23bd96d307401ab96c94f59dec9ac6)

Fixes #15627