### PR TITLE
build: group commits by package name in changelog

### DIFF
--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -72,7 +72,22 @@ export const releasePackages = [
 
 /** Configuration for the `ng-dev release` command. */
 export const release: ReleaseConfig = {
-  releaseNotes: {useReleaseTitle: true, groupOrder: releasePackages},
+  releaseNotes: {
+    useReleaseTitle: true,
+    groupOrder: releasePackages,
+    categorizeCommit: commit => {
+      const [packageName, entryPointName] = commit.scope.split('/');
+      const entryPointPrefix = entryPointName ? `**${entryPointName}:** ` : '';
+
+      // In the `angular/components` repository, commit messages may include entry-point
+      // information in the scope. We expect commits to be grouped based on their package
+      // name. Commits are then described with their subject and optional entry-point name.
+      return {
+        groupName: packageName,
+        description: `${entryPointPrefix}${commit.subject}`,
+      };
+    },
+  },
   publishRegistry: 'https://wombat-dressing-room.appspot.com',
   npmPackages: releasePackages.map(pkg => `@angular/${pkg}`),
   buildPackages: async () => {
@@ -80,5 +95,5 @@ export const release: ReleaseConfig = {
     // script results in an invocation of Bazel for any `yarn ng-dev` command.
     const {performNpmReleaseBuild} = await import('../scripts/build-packages-dist');
     return performNpmReleaseBuild();
-  }
+  },
 };


### PR DESCRIPTION
Currently the new release tooling groups changes in the
changelog based on their commit scope. This is the default
behavior that works well for FW and the CLI repo.

For the components repository, we also include secondary entry-point
information in commit messages. This currently results in
many unnecessary groups, while ideally we'd want to group
based on the package name in the scope. This commit implements
that.