### PR TITLE
fix(cdk/testing): Dispatch correct events with support of bubbling and cancelling

### DIFF
--- a/src/cdk/testing/protractor/protractor-element.ts
+++ b/src/cdk/testing/protractor/protractor-element.ts
@@ -297,14 +297,27 @@ export class ProtractorElement implements TestElement {
  * Protractor and is executed inside the browser.
  */
 function _dispatchEvent(name: string, element: ElementFinder, data?: Record<string, EventData>) {
-  const event = document.createEvent('Event');
-  event.initEvent(name);
-
-  if (data) {
-    // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the original object.
-    Object.assign(event, data);
+  // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the original object.
+  const richEventData = Object.assign({view: window}, data || {});
+  let event: Event;
+  if (name.match(/^dblclick|click|mouse(over|enter|down|move|up|out|leave)$/)) {
+    event = new MouseEvent(name, richEventData);
+  } else if (name.match(/^pointer(over|enter|down|move|up|cancel|out|leave)/)) {
+    event = new PointerEvent(name, richEventData);
+  } else if (name.match(/^key(down|up|press)$/)) {
+    event = new KeyboardEvent(name, richEventData);
+  } else if (name === 'wheel') {
+    event = new WheelEvent(name, richEventData);
+  } else {
+    event = document.createEvent('Event');
+    event.initEvent(name, !!data?.bubbles, !!data?.cancelable);
+    // Try-catch in case readonly properties are being set.
+    try {
+      // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the original object.
+      Object.assign(event, data || {});
+    } catch {
+    }
   }
-
   // This type has a string index signature, so we cannot access it using a dotted property access.
   element['dispatchEvent'](event);
 }

--- a/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
+++ b/src/cdk/testing/selenium-webdriver/selenium-web-driver-element.ts
@@ -275,9 +275,26 @@ export class SeleniumWebDriverElement implements TestElement {
  * pure function, because it gets stringified by WebDriver and is executed inside the browser.
  */
 function dispatchEvent(name: string, element: Element, data?: Record<string, EventData>) {
-  const event = document.createEvent('Event');
-  event.initEvent(name);
   // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the original object.
-  Object.assign(event, data || {});
+  const richEventData = Object.assign({view: window}, data || {});
+  let event: Event;
+  if (name.match(/^dblclick|click|mouse(over|enter|down|move|up|out|leave)$/)) {
+    event = new MouseEvent(name, richEventData);
+  } else if (name.match(/^pointer(over|enter|down|move|up|cancel|out|leave)/)) {
+    event = new PointerEvent(name, richEventData);
+  } else if (name.match(/^key(down|up|press)$/)) {
+    event = new KeyboardEvent(name, richEventData);
+  } else if (name === 'wheel') {
+    event = new WheelEvent(name, richEventData);
+  } else {
+    event = document.createEvent('Event');
+    event.initEvent(name, !!data?.bubbles, !!data?.cancelable);
+    // Try-catch in case readonly properties are being set.
+    try {
+      // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the original object.
+      Object.assign(event, data || {});
+    } catch {
+    }
+  }
   element.dispatchEvent(event);
 }

--- a/src/cdk/testing/testbed/unit-test-element.ts
+++ b/src/cdk/testing/testbed/unit-test-element.ts
@@ -246,13 +246,26 @@ export class UnitTestElement implements TestElement {
    * @param name Name of the event to be dispatched.
    */
   async dispatchEvent(name: string, data?: Record<string, EventData>): Promise<void> {
-    const event = createFakeEvent(name);
-
-    if (data) {
-      // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the original object.
-      Object.assign(event, data);
+    // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the original object.
+    const richEventData = Object.assign({view: window}, data || {});
+    let event: Event;
+    if (name.match(/^dblclick|click|mouse(over|enter|down|move|up|out|leave)$/)) {
+      event = new MouseEvent(name, richEventData);
+    } else if (name.match(/^pointer(over|enter|down|move|up|cancel|out|leave)/)) {
+      event = new PointerEvent(name, richEventData);
+    } else if (name.match(/^key(down|up|press)$/)) {
+      event = new KeyboardEvent(name, richEventData);
+    } else if (name === 'wheel') {
+      event = new WheelEvent(name, richEventData);
+    } else {
+      event = createFakeEvent(name, !!data?.bubbles, !!data?.cancelable);
+      // Try-catch in case readonly properties are being set.
+      try {
+        // tslint:disable-next-line:ban Have to use `Object.assign` to preserve the original object.
+        Object.assign(event, data || {});
+      } catch {
+      }
     }
-
     dispatchEvent(this.element, event);
     await this._stabilize();
   }


### PR DESCRIPTION
With the previous dispatchEvent implementation, developers weren't able to set `bubbling` and `cancelable`, these are readonly properties that can only be set when constructing an Event.

This PR will add support for setting bubbling/cancelable, and change the implementation of the dispatchEvent method to trigger correct events (MouseEvent, KeyboardEvent, ...). This compatible with all modern browsers (matching the IE deprecation goal).  The `view` property is set to a default `window`, which should cover almost all use-cases. 

Addresses #22067, and Google's internal needs. 