### PR TITLE
refactor(material/chips): remove deprecated APIs for v13

### DIFF
--- a/src/material-experimental/mdc-chips/chip-input.ts
+++ b/src/material-experimental/mdc-chips/chip-input.ts
@@ -27,21 +27,13 @@ import {MatChipTextControl} from './chip-text-control';
 
 /** Represents an input event on a `matChipInput`. */
 export interface MatChipInputEvent {
-  /**
-   * The native `<input>` element that the event is being fired for.
-   * @deprecated Use `MatChipInputEvent#chipInput.inputElement` instead.
-   * @breaking-change 13.0.0 This property will be removed.
-   */
-  input: HTMLInputElement;
-
   /** The value of the input. */
   value: string;
 
   /**
    * Reference to the chip input that emitted the event.
-   * @breaking-change 13.0.0 This property will be made required.
    */
-  chipInput?: MatChipInput;
+  chipInput: MatChipInput;
 }
 
 // Increasing integer for generating unique ids.
@@ -215,7 +207,6 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
 
     if (!event || this._isSeparatorKey(event)) {
       this.chipEnd.emit({
-        input: this.inputElement,
         value: this.inputElement.value,
         chipInput: this,
       });

--- a/src/material-experimental/mdc-chips/testing/chip-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-harness.ts
@@ -19,11 +19,11 @@ import {MatChipRemoveHarness} from './chip-remove-harness';
 export class MatChipHarness extends ContentContainerComponentHarness {
   static hostSelector = '.mat-mdc-basic-chip, .mat-mdc-chip';
 
+  // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
+  // methods. See https://github.com/microsoft/TypeScript/issues/5863
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip with specific attributes.
    */
-  // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
-  // methods. See https://github.com/microsoft/TypeScript/issues/5863
   static with<T extends typeof MatChipHarness>(this: T, options: ChipHarnessFilters = {}):
       HarnessPredicate<InstanceType<T>> {
     return new HarnessPredicate(MatChipHarness, options)

--- a/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
@@ -14,12 +14,12 @@ import {ChipOptionHarnessFilters} from './chip-harness-filters';
 export class MatChipOptionHarness extends MatChipHarness {
   static override hostSelector = '.mat-mdc-chip-option';
 
+  // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
+  // methods. See https://github.com/microsoft/TypeScript/issues/5863
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip option with specific
    * attributes.
    */
-  // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
-  // methods. See https://github.com/microsoft/TypeScript/issues/5863
   static override with<T extends typeof MatChipHarness>(
       this: T, options: ChipOptionHarnessFilters = {}): HarnessPredicate<InstanceType<T>> {
     return new HarnessPredicate(MatChipOptionHarness, options)

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -25,21 +25,13 @@ import {MatChipTextControl} from './chip-text-control';
 
 /** Represents an input event on a `matChipInput`. */
 export interface MatChipInputEvent {
-  /**
-   * The native `<input>` element that the event is being fired for.
-   * @deprecated Use `MatChipInputEvent#chipInput.inputElement` instead.
-   * @breaking-change 13.0.0 This property will be removed.
-   */
-  input: HTMLInputElement;
-
   /** The value of the input. */
   value: string;
 
   /**
    * Reference to the chip input that emitted the event.
-   * @breaking-change 13.0.0 This property will be made required.
    */
-  chipInput?: MatChipInput;
+  chipInput: MatChipInput;
 }
 
 // Increasing integer for generating unique ids.
@@ -201,7 +193,6 @@ export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy, A
 
     if (!event || this._isSeparatorKey(event)) {
       this.chipEnd.emit({
-        input: this.inputElement,
         value: this.inputElement.value,
         chipInput: this,
       });

--- a/src/material/chips/testing/chip-harness-filters.ts
+++ b/src/material/chips/testing/chip-harness-filters.ts
@@ -11,12 +11,6 @@ import {BaseHarnessFilters} from '@angular/cdk/testing';
 export interface ChipHarnessFilters extends BaseHarnessFilters {
   /** Only find instances whose text matches the given value. */
   text?: string | RegExp;
-  /**
-   * Only find chip instances whose selected state matches the given value.
-   * @deprecated Use `MatChipOptionHarness` together with `ChipOptionHarnessFilters`.
-   * @breaking-change 12.0.0
-   */
-  selected?: boolean;
 }
 
 /** A set of criteria that can be used to filter a list of selectable chip instances. */

--- a/src/material/chips/testing/chip-harness.ts
+++ b/src/material/chips/testing/chip-harness.ts
@@ -26,12 +26,12 @@ export class MatChipHarness extends ContentContainerComponentHarness {
    * @param options Options for filtering which chip instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ChipHarnessFilters = {}): HarnessPredicate<MatChipHarness> {
+  static with<T extends typeof MatChipHarness>(options: ChipHarnessFilters = {}):
+    HarnessPredicate<InstanceType<T>> {
     return new HarnessPredicate(MatChipHarness, options)
-        .addOption('text', options.text,
-            (harness, label) => HarnessPredicate.stringMatches(harness.getText(), label))
-        .addOption('selected', options.selected,
-            async (harness, selected) => (await harness.isSelected()) === selected);
+      .addOption('text', options.text, (harness, label) => {
+        return HarnessPredicate.stringMatches(harness.getText(), label);
+      }) as unknown as HarnessPredicate<InstanceType<T>>;
   }
 
   /** Gets the text of the chip. */
@@ -41,49 +41,9 @@ export class MatChipHarness extends ContentContainerComponentHarness {
     });
   }
 
-  /**
-   * Whether the chip is selected.
-   * @deprecated Use `MatChipOptionHarness.isSelected` instead.
-   * @breaking-change 12.0.0
-   */
-  async isSelected(): Promise<boolean> {
-    return (await this.host()).hasClass('mat-chip-selected');
-  }
-
   /** Whether the chip is disabled. */
   async isDisabled(): Promise<boolean> {
     return (await this.host()).hasClass('mat-chip-disabled');
-  }
-
-  /**
-   * Selects the given chip. Only applies if it's selectable.
-   * @deprecated Use `MatChipOptionHarness.select` instead.
-   * @breaking-change 12.0.0
-   */
-  async select(): Promise<void> {
-    if (!(await this.isSelected())) {
-      await this.toggle();
-    }
-  }
-
-  /**
-   * Deselects the given chip. Only applies if it's selectable.
-   * @deprecated Use `MatChipOptionHarness.deselect` instead.
-   * @breaking-change 12.0.0
-   */
-  async deselect(): Promise<void> {
-    if (await this.isSelected()) {
-      await this.toggle();
-    }
-  }
-
-  /**
-   * Toggles the selected state of the given chip. Only applies if it's selectable.
-   * @deprecated Use `MatChipOptionHarness.toggle` instead.
-   * @breaking-change 12.0.0
-   */
-  async toggle(): Promise<void> {
-    return (await this.host()).sendKeys(' ');
   }
 
   /** Removes the given chip. Only applies if it's removable. */

--- a/src/material/chips/testing/chip-list-harness.ts
+++ b/src/material/chips/testing/chip-list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
+import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
 import {MatChipHarness} from './chip-harness';
 import {MatChipInputHarness} from './chip-input-harness';
 import {
@@ -65,21 +65,6 @@ export class MatChipListHarness extends _MatChipListHarnessBase {
    */
   async getChips(filter: ChipHarnessFilters = {}): Promise<MatChipHarness[]> {
     return this.locatorForAll(MatChipHarness.with(filter))();
-  }
-
-  /**
-   * Selects a chip inside the chip list.
-   * @param filter An optional filter to apply to the child chips.
-   *    All the chips matching the filter will be selected.
-   * @deprecated Use `MatChipListboxHarness.selectChips` instead.
-   * @breaking-change 12.0.0
-   */
-  async selectChips(filter: ChipHarnessFilters = {}): Promise<void> {
-    const chips = await this.getChips(filter);
-    if (!chips.length) {
-      throw Error(`Cannot find chip matching filter ${JSON.stringify(filter)}`);
-    }
-    await parallel(() => chips.map(chip => chip.select()));
   }
 
   /**

--- a/src/material/chips/testing/chip-option-harness.ts
+++ b/src/material/chips/testing/chip-option-harness.ts
@@ -14,42 +14,46 @@ export class MatChipOptionHarness extends MatChipHarness {
   /** The selector for the host element of a selectable chip instance. */
   static override hostSelector = '.mat-chip';
 
+  // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
+  // methods. See https://github.com/microsoft/TypeScript/issues/5863
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatChipOptionHarness`
    * that meets certain criteria.
    * @param options Options for filtering which chip instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static override with(options: ChipOptionHarnessFilters = {}):
-    HarnessPredicate<MatChipOptionHarness> {
+  static override with<T extends typeof MatChipHarness>(
+    this: T, options: ChipOptionHarnessFilters = {}):
+    HarnessPredicate<InstanceType<T>> {
     return new HarnessPredicate(MatChipOptionHarness, options)
         .addOption('text', options.text,
             (harness, label) => HarnessPredicate.stringMatches(harness.getText(), label))
         .addOption('selected', options.selected,
-            async (harness, selected) => (await harness.isSelected()) === selected);
+            async (harness, selected) => (await harness.isSelected()) === selected) as
+            unknown as HarnessPredicate<InstanceType<T>>;
   }
 
   /** Whether the chip is selected. */
-  override async isSelected(): Promise<boolean> {
+  async isSelected(): Promise<boolean> {
     return (await this.host()).hasClass('mat-chip-selected');
   }
 
   /** Selects the given chip. Only applies if it's selectable. */
-  override async select(): Promise<void> {
+  async select(): Promise<void> {
     if (!(await this.isSelected())) {
       await this.toggle();
     }
   }
 
   /** Deselects the given chip. Only applies if it's selectable. */
-  override async deselect(): Promise<void> {
+  async deselect(): Promise<void> {
     if (await this.isSelected()) {
       await this.toggle();
     }
   }
 
   /** Toggles the selected state of the given chip. */
-  override async toggle(): Promise<void> {
+  async toggle(): Promise<void> {
     return (await this.host()).sendKeys(' ');
   }
 }

--- a/tools/public_api_guard/material/chips-testing.md
+++ b/tools/public_api_guard/material/chips-testing.md
@@ -16,8 +16,6 @@ export interface ChipAvatarHarnessFilters extends BaseHarnessFilters {
 
 // @public
 export interface ChipHarnessFilters extends BaseHarnessFilters {
-    // @deprecated
-    selected?: boolean;
     text?: string | RegExp;
 }
 
@@ -46,21 +44,13 @@ export interface ChipRemoveHarnessFilters extends BaseHarnessFilters {
 
 // @public
 export class MatChipHarness extends ContentContainerComponentHarness {
-    // @deprecated
-    deselect(): Promise<void>;
     getAvatar(filter?: ChipAvatarHarnessFilters): Promise<MatChipAvatarHarness | null>;
     getRemoveButton(filter?: ChipRemoveHarnessFilters): Promise<MatChipRemoveHarness>;
     getText(): Promise<string>;
     static hostSelector: string;
     isDisabled(): Promise<boolean>;
-    // @deprecated
-    isSelected(): Promise<boolean>;
     remove(): Promise<void>;
-    // @deprecated
-    select(): Promise<void>;
-    // @deprecated
-    toggle(): Promise<void>;
-    static with(options?: ChipHarnessFilters): HarnessPredicate<MatChipHarness>;
+    static with<T extends typeof MatChipHarness>(options?: ChipHarnessFilters): HarnessPredicate<InstanceType<T>>;
 }
 
 // @public
@@ -92,8 +82,6 @@ export class MatChipListHarness extends _MatChipListHarnessBase {
     getChips(filter?: ChipHarnessFilters): Promise<MatChipHarness[]>;
     getInput(filter?: ChipInputHarnessFilters): Promise<MatChipInputHarness>;
     static hostSelector: string;
-    // @deprecated
-    selectChips(filter?: ChipHarnessFilters): Promise<void>;
     static with(options?: ChipListHarnessFilters): HarnessPredicate<MatChipListHarness>;
 }
 
@@ -104,7 +92,7 @@ export class MatChipOptionHarness extends MatChipHarness {
     isSelected(): Promise<boolean>;
     select(): Promise<void>;
     toggle(): Promise<void>;
-    static with(options?: ChipOptionHarnessFilters): HarnessPredicate<MatChipOptionHarness>;
+    static with<T extends typeof MatChipHarness>(this: T, options?: ChipOptionHarnessFilters): HarnessPredicate<InstanceType<T>>;
 }
 
 // @public

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -188,9 +188,7 @@ export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy, A
 
 // @public
 export interface MatChipInputEvent {
-    chipInput?: MatChipInput;
-    // @deprecated
-    input: HTMLInputElement;
+    chipInput: MatChipInput;
     value: string;
 }
 


### PR DESCRIPTION
Removes the APIs that were marked for removal in v13 in the `material/chips` module.

BREAKING CHANGE:
* `MatChipInputEvent.input` has been removed. Use `MatChipInputEvent.chipInput` instead. (changed in g3 with copybara transform)
* `MatChipInputEvent.chipInput` is now a required property. (changed in g3 with copybara transform)
* `ChipHarnessFilters.selected` has been removed. Use `MatChipOptionHarness` together with `ChipOptionHarnessFilters` instead.
* `MatChipHarness.isSelected` has been removed. Use `MatChipOptionHarness.isSelected` instead.
* `MatChipHarness.select` has been removed. Use `MatChipOptionHarness.select` instead.
* `MatChipHarness.deselect` has been removed. Use `MatChipOptionHarness.deselect` instead.
* `MatChipHarness.toggle` has been removed. Use `MatChipOptionHarness.toggle` instead.
* `MatChipListHarness.selectChips` has been removed. Use `MatChipListboxHarness.selectChips` instead.