### PR TITLE
refactor(material/paginator): refactor tests for paginator texts

### DIFF
--- a/src/material-experimental/mdc-paginator/paginator.spec.ts
+++ b/src/material-experimental/mdc-paginator/paginator.spec.ts
@@ -23,52 +23,72 @@ describe('MDC-based MatPaginator', () => {
   }
 
   describe('with the default internationalization provider', () => {
-    it('should show the right range text', () => {
-      const fixture = createComponent(MatPaginatorApp);
-      const component = fixture.componentInstance;
-      const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
+    describe('showing the right range text', () => {
+      it('should show second page of list of 100, each page contains 10 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
+        component.length = 100;
+        component.pageSize = 10;
+        component.pageIndex = 1;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('11 – 20 of 100');
+      });
 
-      // View second page of list of 100, each page contains 10 items.
-      component.length = 100;
-      component.pageSize = 10;
-      component.pageIndex = 1;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('11 – 20 of 100');
+      it('should show third page of list of 200, each page contains 20 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
+        component.length = 200;
+        component.pageSize = 20;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('41 – 60 of 200');
+      });
 
-      // View third page of list of 200, each page contains 20 items.
-      component.length = 200;
-      component.pageSize = 20;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('41 – 60 of 200');
+      it('should show first page of list of 0, each page contains 5 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
+        component.length = 0;
+        component.pageSize = 5;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('0 of 0');
+      });
 
-      // View first page of list of 0, each page contains 5 items.
-      component.length = 0;
-      component.pageSize = 5;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('0 of 0');
+      it('should show third page of list of 12, each page contains 5 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
+        component.length = 12;
+        component.pageSize = 5;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('11 – 12 of 12');
+      });
 
-      // View third page of list of 12, each page contains 5 items.
-      component.length = 12;
-      component.pageSize = 5;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('11 – 12 of 12');
+      it('should show third page of list of 10, each page contains 5 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
+        component.length = 10;
+        component.pageSize = 5;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('11 – 15 of 10');
+      });
 
-      // View third page of list of 10, each page contains 5 items.
-      component.length = 10;
-      component.pageSize = 5;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('11 – 15 of 10');
-
-      // View third page of list of -5, each page contains 5 items.
-      component.length = -5;
-      component.pageSize = 5;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('11 – 15 of 0');
+      it('should show third page of list of -5, each page contains 5 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-mdc-paginator-range-label');
+        component.length = -5;
+        component.pageSize = 5;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('11 – 15 of 0');
+      });
     });
 
     it('should show right aria-labels for select and buttons', () => {

--- a/src/material/paginator/paginator.spec.ts
+++ b/src/material/paginator/paginator.spec.ts
@@ -1,11 +1,11 @@
-import {ComponentFixture, TestBed, tick, fakeAsync} from '@angular/core/testing';
-import {Component, ViewChild, Type, Provider} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {Component, Provider, Type, ViewChild} from '@angular/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {dispatchMouseEvent} from '../../cdk/testing/private';
 import {ThemePalette} from '@angular/material/core';
 import {MatSelect} from '@angular/material/select';
 import {By} from '@angular/platform-browser';
-import {MatPaginatorModule, MatPaginator, MatPaginatorIntl} from './index';
+import {MatPaginator, MatPaginatorIntl, MatPaginatorModule} from './index';
 import {MAT_PAGINATOR_DEFAULT_OPTIONS, MatPaginatorDefaultOptions} from './paginator';
 
 
@@ -23,52 +23,72 @@ describe('MatPaginator', () => {
   }
 
   describe('with the default internationalization provider', () => {
-    it('should show the right range text', () => {
-      const fixture = createComponent(MatPaginatorApp);
-      const component = fixture.componentInstance;
-      const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+    describe('showing the right range text', () => {
+      it('should show second page of list of 100, each page contains 10 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+        component.length = 100;
+        component.pageSize = 10;
+        component.pageIndex = 1;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('11 – 20 of 100');
+      });
 
-      // View second page of list of 100, each page contains 10 items.
-      component.length = 100;
-      component.pageSize = 10;
-      component.pageIndex = 1;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('11 – 20 of 100');
+      it('should show third page of list of 200, each page contains 20 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+        component.length = 200;
+        component.pageSize = 20;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('41 – 60 of 200');
+      });
 
-      // View third page of list of 200, each page contains 20 items.
-      component.length = 200;
-      component.pageSize = 20;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('41 – 60 of 200');
+      it('should show first page of list of 0, each page contains 5 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+        component.length = 0;
+        component.pageSize = 5;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('0 of 0');
+      });
 
-      // View first page of list of 0, each page contains 5 items.
-      component.length = 0;
-      component.pageSize = 5;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('0 of 0');
+      it('should show third page of list of 12, each page contains 5 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+        component.length = 12;
+        component.pageSize = 5;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('11 – 12 of 12');
+      });
 
-      // View third page of list of 12, each page contains 5 items.
-      component.length = 12;
-      component.pageSize = 5;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('11 – 12 of 12');
+      it('should show third page of list of 10, each page contains 5 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+        component.length = 10;
+        component.pageSize = 5;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('11 – 15 of 10');
+      });
 
-      // View third page of list of 10, each page contains 5 items.
-      component.length = 10;
-      component.pageSize = 5;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('11 – 15 of 10');
-
-      // View third page of list of -5, each page contains 5 items.
-      component.length = -5;
-      component.pageSize = 5;
-      component.pageIndex = 2;
-      fixture.detectChanges();
-      expect(rangeElement.innerText.trim()).toBe('11 – 15 of 0');
+      it('should show third page of list of -5, each page contains 5 items', () => {
+        const fixture = createComponent(MatPaginatorApp);
+        const component = fixture.componentInstance;
+        const rangeElement = fixture.nativeElement.querySelector('.mat-paginator-range-label');
+        component.length = -5;
+        component.pageSize = 5;
+        component.pageIndex = 2;
+        fixture.detectChanges();
+        expect(rangeElement.textContent!.trim()).toBe('11 – 15 of 0');
+      });
     });
 
     it('should show right aria-labels for select and buttons', () => {


### PR DESCRIPTION
Refactored tests of the Angular Material `paginator` component. Removed comments and instead extracted tested behaviours into separate test cases, to keep them simple and isolated.