### PR TITLE
refactor(youtube-player): remove deprecated APIs for v13

### DIFF
--- a/src/youtube-player/youtube-player.ts
+++ b/src/youtube-player/youtube-player.ts
@@ -278,14 +278,6 @@ export class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     (playerObs as ConnectableObservable<Player>).connect();
   }
 
-  /**
-   * @deprecated No longer being used. To be removed.
-   * @breaking-change 11.0.0
-   */
-  createEventsBoundInZone(): YT.Events {
-    return {};
-  }
-
   ngAfterViewInit() {
     this._youtubeContainer.next(this.youtubeContainer.nativeElement);
   }

--- a/tools/public_api_guard/youtube-player/youtube-player.md
+++ b/tools/public_api_guard/youtube-player/youtube-player.md
@@ -25,8 +25,6 @@ export class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     constructor(_ngZone: NgZone, platformId: Object);
     // (undocumented)
     readonly apiChange: Observable<YT.PlayerEvent>;
-    // @deprecated (undocumented)
-    createEventsBoundInZone(): YT.Events;
     set endSeconds(endSeconds: number | undefined);
     // (undocumented)
     readonly error: Observable<YT.OnErrorEvent>;


### PR DESCRIPTION
Removes the APIs that were marked for removal in v13 in the `youtube-player` package.

BREAKING CHANGE:
* `YouTubePlayer.createEventsBoundInZone` has been removed.