### PR TITLE
fix(material/card): use more specific selector for divider override

### DIFF
--- a/src/material/card/card.scss
+++ b/src/material/card/card.scss
@@ -17,7 +17,7 @@ $header-size: 40px !default;
   padding: $padding;
   border-radius: $border-radius;
 
-  .mat-divider-horizontal {
+  > .mat-divider-horizontal {
     position: absolute;
     left: 0;
     width: 100%;


### PR DESCRIPTION
Fixes that the card targets all dividers which may include ones placed inside child components.

Fixes #23524.