### PR TITLE
fix(material/input): preserve password autofill icon

### DIFF
--- a/src/material/form-field/form-field-input.scss
+++ b/src/material/form-field/form-field-input.scss
@@ -63,7 +63,8 @@
   // same selector as the IE ones, otherwise Safari will ignore it.
   &::-webkit-contacts-auto-fill-button,
   &::-webkit-caps-lock-indicator,
-  &::-webkit-credentials-auto-fill-button {
+  // Preserve the autofill icon on password inputs since it includes some important functionality.
+  &:not([type='password'])::-webkit-credentials-auto-fill-button {
     visibility: hidden;
   }
 


### PR DESCRIPTION
By default we hide all browser decorations from the input, because they don't usually work well with Material.

These changes exclude the password autofill from password inputs, because it has some UX and security implications, and password inputs don't have any other decorations anyway.

Fixes #20639.