### PR TITLE
refactor(material/button): use static string for selector

### DIFF
--- a/src/material-experimental/mdc-button/testing/button-harness.ts
+++ b/src/material-experimental/mdc-button/testing/button-harness.ts
@@ -14,15 +14,8 @@ import {ButtonHarnessFilters} from '@angular/material/button/testing';
 /** Harness for interacting with a MDC-based mat-button in tests. */
 export class MatButtonHarness extends ContentContainerComponentHarness {
   // TODO(jelbourn) use a single class, like `.mat-button-base`
-  static hostSelector = [
-    '[mat-button]',
-    '[mat-raised-button]',
-    '[mat-flat-button]',
-    '[mat-icon-button]',
-    '[mat-stroked-button]',
-    '[mat-fab]',
-    '[mat-mini-fab]',
-  ].join(',');
+  static hostSelector = `[mat-button], [mat-raised-button], [mat-flat-button],
+                         [mat-icon-button], [mat-stroked-button], [mat-fab], [mat-mini-fab]`;
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a button with specific attributes.

--- a/src/material/button/testing/button-harness.ts
+++ b/src/material/button/testing/button-harness.ts
@@ -15,15 +15,8 @@ import {ButtonHarnessFilters} from './button-harness-filters';
 export class MatButtonHarness extends ContentContainerComponentHarness {
   // TODO(jelbourn) use a single class, like `.mat-button-base`
   /** The selector for the host element of a `MatButton` instance. */
-  static hostSelector = [
-    '[mat-button]',
-    '[mat-raised-button]',
-    '[mat-flat-button]',
-    '[mat-icon-button]',
-    '[mat-stroked-button]',
-    '[mat-fab]',
-    '[mat-mini-fab]',
-  ].join(',');
+  static hostSelector = `[mat-button], [mat-raised-button], [mat-flat-button], [mat-icon-button],
+                         [mat-stroked-button], [mat-fab], [mat-mini-fab]`;
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a `MatButtonHarness` that meets


### PR DESCRIPTION
Uses a static string for the selector of the button harness since the `join` call we had previously was showing up in the docs.

For reference:
![Button__Angular_Material_-_Google_Chrome_2021-09-06_17-42-42](https://user-images.githubusercontent.com/4450522/132240590-a32ba0eb-e307-4748-ae2b-ec43d0d75173.png)
