### PR TITLE
docs(multiple): revise and expand a11y docs

### DIFF
--- a/src/material/autocomplete/autocomplete.md
+++ b/src/material/autocomplete/autocomplete.md
@@ -100,10 +100,12 @@ autocomplete is attached to using the `matAutocompleteOrigin` directive together
 ```
 
 ### Keyboard interaction
-- <kbd>DOWN_ARROW</kbd>: Next option becomes active
-- <kbd>UP_ARROW</kbd>: Previous option becomes active
-- <kbd>ENTER</kbd>: Selects currently active item
-- <kbd>ESCAPE</kbd>: Closes the autocomplete panel
+- <kbd>Down Arrow</kbd>: Next option becomes active
+- <kbd>Up Arrow</kbd>: Previous option becomes active
+- <kbd>Enter</kbd>: Selects currently active item
+- <kbd>Escape</kbd>: Closes the autocomplete panel
+- <kbd>Alt + Up Arrow</kbd>: Closes the autocomplete panel
+- <kbd>Alt + Down Arrow</kbd>: Open the autocomplete panel if there are any matching options.
 
 ### Option groups
 `mat-option` can be collected into groups using the `mat-optgroup` element:
@@ -112,8 +114,16 @@ autocomplete is attached to using the `matAutocompleteOrigin` directive together
               "region":"mat-autocomplete"}) -->
 
 ### Accessibility
-The input for an autocomplete without text or labels should be given a meaningful label via
-`aria-label` or `aria-labelledby`.
 
-The autocomplete trigger is given `role="combobox"`. The trigger sets `aria-owns` to the
-autocomplete's id, and sets `aria-activedescendant` to the active option's id.
+`MatAutocomplete` implements the ARIA combobox interaction pattern. The text input trigger specifies
+`role="combobox"` while the content of the pop-up applies `role="listbox"`. Because of this listbox
+pattern, you should _not_ put other interactive controls, such as buttons or checkboxes, inside
+an autocomplete option. Nesting interactive controls like this interferes with most assistive
+technology.
+
+Always provide an accessible label for the autocomplete. This can be done
+via `<mat-label>` inside of `<mat-form-field>`, a native `<label>` element, the `aria-label`
+attribute, or the `aria-labelledby` attribute.
+
+`MatAutocomplete` preserves focus on the text trigger, using `aria-activedescendant` to support
+navigation though the autocomplete options.

--- a/src/material/bottom-sheet/bottom-sheet.md
+++ b/src/material/bottom-sheet/bottom-sheet.md
@@ -96,20 +96,49 @@ for `MAT_BOTTOM_SHEET_DEFAULT_OPTIONS` in your application's root module.
 
 
 ### Accessibility
-By default, the bottom sheet has `role="dialog"` on the root element and can be labelled using the
-`ariaLabel` property on the `MatBottomSheetConfig`.
 
-When a bottom sheet is opened, it will move focus to the first focusable element that it can find.
-In order to prevent users from tabbing into elements in the background, the Material bottom sheet
-uses a [focus trap](https://material.angular.io/cdk/a11y/overview#focustrap) to contain focus
-within itself. Once a bottom sheet is closed, it will return focus to the element that was focused
-before it was opened.
-
-#### Focus management
-By default, the first tabbable element within the bottom sheet will receive focus upon open.
-This can be configured by setting the `cdkFocusInitial` attribute on another focusable element.
+`MatBottomSheet` creates modal dialogs that implement the ARIA `role="dialog"` pattern. This root
+dialog element should be given an accessible label via the `ariaLabel` property of
+`MatBottomSheetConfig`.
 
 #### Keyboard interaction
-By default pressing the escape key will close the bottom sheet. While this behavior can
-be turned off via the `disableClose` option, users should generally avoid doing so
-as it breaks the expected interaction pattern for screen-reader users.
+By default, the escape key closes `MatBottomSheet`. While you can disable this behavior by using
+the `disableClose` property of `MatBottomSheetConfig`, doing this breaks the expected interaction
+pattern for the ARIA `role="dialog"` pattern.
+
+#### Focus management
+
+When opened, `MatBottomSheet` traps browser focus such that it cannot escape the root
+`role="dialog"` element. By default, the first tabbable element in the bottom sheet receives focus.
+You can customize which element receives focus with the `autoFocus` property of
+`MatBottomSheetConfig`, which supports the following values.
+
+| Value            | Behavior                                                                 |
+|------------------|--------------------------------------------------------------------------|
+| `first-tabbable` | Focus the first tabbable element. This is the default setting.           |
+| `first-header`   | Focus the first header element (`role="heading"`, `h1` through `h6`)     |
+| `dialog`         | Focus the root `role="dialog"` element.                                  |
+| Any CSS selector | Focus the first element matching the given selector.                     |
+
+While the default setting applies the best behavior for most applications, special cases may benefit
+from these alternatives. Always test your application to verify the behavior that works best for
+your users.
+
+#### Focus restoration
+
+When closed, `MatBottomSheet` restores focus to the element that previously held focus when the
+bottom sheet opened. However, if that previously focused element no longer exists, you must
+add additional handling to return focus to an element that makes sense for the user's workflow.
+Opening a bottom sheet from a menu is one common pattern that causes this situation. The menu
+closes upon clicking an item, thus the focused menu item is no longer in the DOM when the bottom
+sheet attempts to restore focus.
+
+You can add handling for this situation with the `afterDismissed()` observable from
+`MatBottomSheetRef`.
+
+```typescript
+const bottomSheetRef = bottomSheet.open(FileTypeChooser);
+bottomSheetRef.afterDismissed().subscribe(() => {
+  // Restore focus to an appropriate element for the user's workflow here.
+});
+```

--- a/src/material/button-toggle/button-toggle.md
+++ b/src/material/button-toggle/button-toggle.md
@@ -28,17 +28,24 @@ be configured globally using the `MAT_BUTTON_TOGGLE_DEFAULT_OPTIONS` injection t
 `<mat-button-toggle-group>` is compatible with `@angular/forms` and supports both `FormsModule`
 and `ReactiveFormsModule`.
 
-### Accessibility
-The button-toggles internally use native `button` elements with `aria-pressed` to convey
-their toggled state. The button-toggle-group surrounding the individual buttons applies
-`role="group"` to convey the association between the individual toggles.
-
-For button toggles containing only icons, each button toggle should be given a meaningful label via
-`aria-label` or `aria-labelledby`.
-
-For button toggle groups, each group should be given a meaningful label via `aria-label` or
-`aria-labelledby`.
-
-
 ### Orientation
 The button-toggles can be rendered in a vertical orientation by adding the `vertical` attribute.
+
+### Accessibility
+`MatButtonToggle` internally uses native `button` elements with `aria-pressed` to convey toggle
+state. If a toggle contains only an icon, you should specify a meaningful label via `aria-label`
+or `aria-labelledby`. For dynamic labels, `MatButtonToggle` provides input properties for binding
+`aria-label` and `aria-labelledby`. This means that you should not use the `attr.` prefix when
+binding these properties, as demonstrated below.
+
+```html
+<mat-button-toggle [aria-label]="alertsEnabled ? 'Disable alerts' : 'Enable alerts'">
+  <mat-icon>notifications</mat-icon>
+</mat-button-toggle>
+```
+
+The `MatButtonToggleGroup` surrounding the individual buttons applies
+`role="group"` to convey the association between the individual toggles. Each
+`<mat-button-toggle-group>` element should be given a label with `aria-label` or `aria-labelledby`
+that communicates the collective meaning of all toggles. For example, if you have toggles for
+"Bold", "Italic", and "Underline", you might label the parent group "Font styles".

--- a/src/material/card/card.md
+++ b/src/material/card/card.md
@@ -44,32 +44,36 @@ This element can contain:
     * `<img mat-card-lg-image>`
 
 ### Accessibility
-Cards can be used in a wide variety of scenarios and can contain many different types of content.
-Due to this dynamic nature, the appropriate accessibility treatment depends on how `<mat-card>` is
-used.
+
+Cards serve a wide variety of scenarios and may contain many different types of content.
+Due to this flexible nature, the appropriate accessibility treatment depends on how you use
+`<mat-card>`.
 
 #### Group, region, and landmarks
-There are several ARIA roles that communicate that a portion of the UI represents some semantically
-meaningful whole. Depending on what the content of the card means to your application,
-[`role="group"`][0], [`role="region"`][1], or [one of the landmark roles][2] should typically be
-applied to the `<mat-card>` element.
 
-A role is not necessary when the card is used as a purely decorative container that does not
+There are several ARIA roles that communicate that a portion of the UI represents some semantically
+meaningful whole. Depending on what the content of the card means to your application, you can apply
+one of [`role="group"`][role-group], [`role="region"`][role-region], or
+[one of the landmark roles][aria-landmarks] to the `<mat-card>` element.
+
+You do not need to apply a role when using a card as a purely decorative container that does not
 convey a meaningful grouping of related content for a single subject. In these cases, the content
 of the card should follow standard practices for document content.
 
-
 #### Focus
+
 Depending on how cards are used, it may be appropriate to apply a `tabindex` to the `<mat-card>`
-element. If cards are a primary mechanism through which user interacts with the application,
-`tabindex="0"` is appropriate. If attention can be sent to the card, but it's not part of the
-document flow, `tabindex="-1"` is appropriate.
+element. 
 
-If the card acts as a purely decorative container, it does not need to be tabbable. In this case,
-the card content should follow normal best practices for tab order.
+* If cards are a primary mechanism through which user interacts with the application, `tabindex="0"`
+  may be appropriate. 
+* If attention can be sent to the card, but it's not part of the document flow, `tabindex="-1"` may
+  be appropriate.
+* If the card acts as a purely decorative container, it does not need to be tabbable. In this case,
+  the card content should follow normal best practices for tab order.
 
+Always test your application to verify the behavior that works best for your users.
 
-
- [0]: https://www.w3.org/TR/wai-aria/#group
- [1]: https://www.w3.org/TR/wai-aria/#region
- [2]: https://www.w3.org/TR/wai-aria/#landmark
+[role-group]: https://www.w3.org/TR/wai-aria/#group
+[role-region]: https://www.w3.org/TR/wai-aria/#region
+[aria-landmarks]: https://www.w3.org/TR/wai-aria/#landmark

--- a/src/material/checkbox/checkbox.md
+++ b/src/material/checkbox/checkbox.md
@@ -56,9 +56,18 @@ The color of a `<mat-checkbox>` can be changed by using the `color` property. By
 use the theme's accent color. This can be changed to `'primary'` or `'warn'`.  
 
 ### Accessibility
-The `<mat-checkbox>` uses an internal `<input type="checkbox">` to provide an accessible experience.
-This internal checkbox receives focus and is automatically labelled by the text content of the
-`<mat-checkbox>` element.
 
-Checkboxes without text or labels should be given a meaningful label via `aria-label` or
-`aria-labelledby`.
+`MatCheckbox` uses an internal `<input type="checkbox">` to provide an accessible experience.
+This internal checkbox receives focus and is automatically labelled by the text content of the
+`<mat-checkbox>` element. Avoid adding other interactive controls into the content of
+`<mat-checkbox>`, as this degrades the experience for users of assistive technology.
+
+Always provide an accessible label via `aria-label` or `aria-labelledby` for checkboxes without
+descriptive text content. For dynamic labels, `MatCheckbox` provides input properties for binding
+`aria-label` and `aria-labelledby`. This means that you should not use the `attr.` prefix when
+binding these properties, as demonstrated below.
+
+```html
+<mat-checkbox [aria-label]="isSubscribedToEmailsMessage">
+</mat-checkbox>
+```

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -562,72 +562,80 @@ value can be anything that is accepted by `ngClass`.
 
 ### Accessibility
 
-The `MatDatepickerInput` and `MatDatepickerToggle` directives add the `aria-haspopup` attribute to
-the native input and toggle button elements respectively, and they trigger a calendar dialog with
-`role="dialog"`.
+The `MatDatepicker` pop-up uses the `role="dialog"` interaction pattern. This dialog then contains
+multiple controls, the most prominent being the calendar itself. This calendar implements the
+`role="grid"` interaction pattern.
 
-`MatDatepickerIntl` includes strings that are used for `aria-label`s. The datepicker input
-should have a placeholder or be given a meaningful label via `aria-label`, `aria-labelledby` or
+The `MatDatepickerInput` and `MatDatepickerToggle` directives both apply the `aria-haspopup`
+attribute to the native input and button elements, respectively.
+
+`MatDatepickerIntl` includes strings that are used for `aria-label` attributes. Always provide
+the datepicker text input a meaningful label via `<mat-label>`, `aria-label`, `aria-labelledby` or
 `MatDatepickerIntl`.
+
+`MatDatepickerInput` adds <kbd>>Alt</kbd> + <kbd>Down Arrow</kbd> as a keyboard short to open the
+datepicker pop-up. However, ChromeOS intercepts this key combination at the OS level such that the
+browser only receives a `PageDown` key event. Because of this behavior, you should always include an
+additional means of opening the pop-up, such as `MatDatepickerToggle`.
 
 #### Keyboard interaction
 
 The datepicker supports the following keyboard shortcuts:
 
-| Shortcut             | Action                                    |
-|----------------------|-------------------------------------------|
-| `ALT` + `DOWN_ARROW` | Open the calendar pop-up                  |
-| `ESCAPE`             | Close the calendar pop-up                 |
+| Shortcut                               | Action                     |
+|----------------------------------------|----------------------------|
+| <kbd>ALT</kbd> + <kbd>DOWN_ARROW</kbd> | Open the calendar pop-up   |
+| <kbd>ESCAPE</kbd>                      | Close the calendar pop-up  |
 
 
 In month view:
 
-| Shortcut             | Action                                    |
-|----------------------|-------------------------------------------|
-| `LEFT_ARROW`         | Go to previous day                        |
-| `RIGHT_ARROW`        | Go to next day                            |
-| `UP_ARROW`           | Go to same day in the previous week       |
-| `DOWN_ARROW`         | Go to same day in the next week           |
-| `HOME`               | Go to the first day of the month          |
-| `END`                | Go to the last day of the month           |
-| `PAGE_UP`            | Go to the same day in the previous month  |
-| `ALT` + `PAGE_UP`    | Go to the same day in the previous year   |
-| `PAGE_DOWN`          | Go to the same day in the next month      |
-| `ALT` + `PAGE_DOWN`  | Go to the same day in the next year       |
-| `ENTER`              | Select current date                       |
+| Shortcut                              | Action                                   |
+|---------------------------------------|------------------------------------------|
+| <kbd>LEFT_ARROW</kbd>                 | Go to previous day                       |
+| <kbd>RIGHT_ARROW</kbd>                | Go to next day                           |
+| <kbd>UP_ARROW</kbd>                   | Go to same day in the previous week      |
+| <kbd>DOWN_ARROW</kbd>                 | Go to same day in the next week          |
+| <kbd>HOME</kbd>                       | Go to the first day of the month         |
+| <kbd>END</kbd>                        | Go to the last day of the month          |
+| <kbd>PAGE_UP</kbd>                    | Go to the same day in the previous month |
+| <kbd>ALT</kbd> + <kbd>PAGE_UP</kbd>   | Go to the same day in the previous year  |
+| <kbd>PAGE_DOWN</kbd>                  | Go to the same day in the next month     |
+| <kbd>ALT</kbd> + <kbd>PAGE_DOWN</kbd> | Go to the same day in the next year      |
+| <kbd>ENTER</kbd>                      | Select current date                      |
 
 
 In year view:
 
-| Shortcut             | Action                                    |
-|----------------------|-------------------------------------------|
-| `LEFT_ARROW`         | Go to previous month                      |
-| `RIGHT_ARROW`        | Go to next month                          |
-| `UP_ARROW`           | Go up a row (back 4 months)               |
-| `DOWN_ARROW`         | Go down a row (forward 4 months)          |
-| `HOME`               | Go to the first month of the year         |
-| `END`                | Go to the last month of the year          |
-| `PAGE_UP`            | Go to the same month in the previous year |
-| `ALT` + `PAGE_UP`    | Go to the same month 10 years back        |
-| `PAGE_DOWN`          | Go to the same month in the next year     |
-| `ALT` + `PAGE_DOWN`  | Go to the same month 10 years forward     |
-| `ENTER`              | Select current month                      |
+| Shortcut                              | Action                                    |
+|---------------------------------------|-------------------------------------------|
+| <kbd>LEFT_ARROW</kbd>                 | Go to previous month                      |
+| <kbd>RIGHT_ARROW</kbd>                | Go to next month                          |
+| <kbd>UP_ARROW</kbd>                   | Go up a row (back 4 months)               |
+| <kbd>DOWN_ARROW</kbd>                 | Go down a row (forward 4 months)          |
+| <kbd>HOME</kbd>                       | Go to the first month of the year         |
+| <kbd>END</kbd>                        | Go to the last month of the year          |
+| <kbd>PAGE_UP</kbd>                    | Go to the same month in the previous year |
+| <kbd>ALT</kbd> + <kbd>PAGE_UP</kbd>   | Go to the same month 10 years back        |
+| <kbd>PAGE_DOWN</kbd>                  | Go to the same month in the next year     |
+| <kbd>ALT</kbd> + <kbd>PAGE_DOWN</kbd> | Go to the same month 10 years forward     |
+| <kbd>ENTER</kbd>                      | Select current month                      |
 
 In multi-year view:
 
-| Shortcut             | Action                                    |
-|----------------------|-------------------------------------------|
-| `LEFT_ARROW`         | Go to previous year                       |
-| `RIGHT_ARROW`        | Go to next year                           |
-| `UP_ARROW`           | Go up a row (back 4 years)                |
-| `DOWN_ARROW`         | Go down a row (forward 4 years)           |
-| `HOME`               | Go to the first year in the current range |
-| `END`                | Go to the last year in the current range  |
-| `PAGE_UP`            | Go back 24 years                          |
-| `ALT` + `PAGE_UP`    | Go back 240 years                         |
-| `PAGE_DOWN`          | Go forward 24 years                       |
-| `ALT` + `PAGE_DOWN`  | Go forward 240 years                      |
-| `ENTER`              | Select current year                       |
+| Shortcut                              | Action                                    |
+|---------------------------------------|-------------------------------------------|
+| <kbd>LEFT_ARROW</kbd>                 | Go to previous year                       |
+| <kbd>RIGHT_ARROW</kbd>                | Go to next year                           |
+| <kbd>UP_ARROW</kbd>                   | Go up a row (back 4 years)                |
+| <kbd>DOWN_ARROW</kbd>                 | Go down a row (forward 4 years)           |
+| <kbd>HOME</kbd>                       | Go to the first year in the current range |
+| <kbd>END</kbd>                        | Go to the last year in the current range  |
+| <kbd>PAGE_UP</kbd>                    | Go back 24 years                          |
+| <kbd>ALT</kbd> + <kbd>PAGE_UP</kbd>   | Go back 240 years                         |
+| <kbd>PAGE_DOWN</kbd>                  | Go forward 24 years                       |
+| <kbd>ALT</kbd> + <kbd>PAGE_DOWN</kbd> | Go forward 240 years                      |
+| <kbd>ENTER</kbd>                      | Select current year                       |
 
 ### Troubleshooting
 

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -151,42 +151,48 @@ You can control which elements are tab stops with the `tabindex` attribute
 <!-- example(dialog-content) -->
 
 ### Accessibility
-By default, each dialog has `role="dialog"` on the root element. The role can be changed to
-`alertdialog` via the `MatDialogConfig` when opening.
 
-The `aria-label`, `aria-labelledby`, and `aria-describedby` attributes can all be set to the
-dialog element via the `MatDialogConfig` as well. Each dialog should typically have a label
-set via `aria-label` or `aria-labelledby`.
+`MatDialog` creates modal dialogs that implements the ARIA `role="dialog"` pattern by default.
+You can change the dialog's role to `alertdialog` via `MatDialogConfig`.
 
-When a dialog is opened, it will move focus to the first focusable element that it can find. In
-order to prevent users from tabbing into elements in the background, the Material dialog uses
-a [focus trap](https://material.angular.io/cdk/a11y/overview#focustrap) to contain focus
-within itself. Once a dialog is closed, it will return focus to the element that was focused
-before the dialog was opened.
+You should provide a an accessible label to this root dialog element by setting the `ariaLabel` or
+`ariaLabelledBy` properties of `MatDialogConfig`. You can additionally specify a description element
+ID via the `ariaDescribedBy` property of `MatDialogConfig`.
 
-If you're adding a close button that doesn't have text (e.g. a purely icon-based button), make sure
-that it has a meaningful `aria-label` so that users with assistive technology know what it is used
-for.
+#### Keyboard interaction
+By default, the escape key closes `MatDialog`. While you can disable this behavior via
+the `disableClose` property of `MatDialogConfig`, doing this breaks the expected interaction
+pattern for the ARIA `role="dialog"` pattern.
 
 #### Focus management
-By default, the first tabbable element within the dialog will receive focus upon open. This can
-be configured by setting the `cdkFocusInitial` attribute on another focusable element.
 
-Tabbing through the elements of the dialog will keep focus inside of the dialog element,
-wrapping back to the first tabbable element when reaching the end of the tab sequence.
+When opened, `MatDialog` traps browser focus such that it cannot escape the root
+`role="dialog"` element. By default, the first tabbable element in the dialog receives focus.
+You can customize which element receives focus with the `autoFocus` property of
+`MatDialogConfig`, which supports the following values.
 
-#### Focus Restoration
-Upon closing, the dialog returns focus to the element that had focus when the dialog opened.
-In some cases, however, this previously focused element no longer exists in the DOM, such as
-menu items. To manually restore focus to an appropriate element in such cases, you can disable 
-`restoreFocus` in `MatDialogConfig` and pass it into the `open` method.
-Then you can return focus manually by subscribing to the `afterClosed` observable on `MatDialogRef`.
+| Value            | Behavior                                                                 |
+|------------------|--------------------------------------------------------------------------|
+| `first-tabbable` | Focus the first tabbable element. This is the default setting.           |
+| `first-header`   | Focus the first header element (`role="heading"`, `h1` through `h6`)     |
+| `dialog`         | Focus the root `role="dialog"` element.                                  |
+| Any CSS selector | Focus the first element matching the given selector.                     |
+
+While the default setting applies the best behavior for most applications, special cases may benefit
+from these alternatives. Always test your application to verify the behavior that works best for
+your users.
+
+#### Focus restoration
+
+When closed, `MatDialog` restores focus to the element that previously held focus when the
+dialog opened. However, if that previously focused element no longer exists, you must
+add additional handling to return focus to an element that makes sense for the user's workflow.
+Opening a dialog from a menu is one common pattern that causes this situation. The menu
+closes upon clicking an item, thus the focused menu item is no longer in the DOM when the bottom
+sheet attempts to restore focus.
+
+You can add handling for this situation with the `afterClosed()` observable from `MatDialogRef`.
 
 <!-- example({"example":"dialog-from-menu",
               "file":"dialog-from-menu-example.ts", 
               "region":"focus-restoration"}) -->
-
-#### Keyboard interaction
-By default pressing the escape key will close the dialog. While this behavior can
-be turned off via the `disableClose` option, users should generally avoid doing so
-as it breaks the expected interaction pattern for screen-reader users.

--- a/src/material/divider/divider.md
+++ b/src/material/divider/divider.md
@@ -53,3 +53,8 @@ in a list, because it will overlap with the section divider.
    </mat-list-item>
 </mat-list>
 ```
+
+### Accessibility
+
+`MatDivider` applies the ARIA `role="separator"` attribute, exclusively implementing the
+non-focusable style of separator that distinguishes sections of content.

--- a/src/material/expansion/expansion.md
+++ b/src/material/expansion/expansion.md
@@ -67,10 +67,10 @@ an `ng-template`:
 ```
 
 ### Accessibility
-The expansion-panel aims to mimic the experience of the native `<details>` and `<summary>` elements.
-The expansion panel header has `role="button"` and also the attribute `aria-controls` with the
-expansion panel's id as value.
 
-The expansion panel headers are buttons. Users can use the keyboard to activate the expansion panel
-header to switch between expanded state and collapsed state. Because the header acts as a button,
-additional interactive elements should not be put inside of the header.
+`MatExpansionPanel` imitates the experience of the native `<details>` and `<summary>` elements.
+The expansion panel header applies `role="button"` and the `aria-controls` attribute with the
+content element's ID.
+
+Because expansion panel headers are buttons, avoid adding interactive controls as children
+of `<mat-expansion-panel-header>`, including buttons and anchors.

--- a/src/material/form-field/form-field.md
+++ b/src/material/form-field/form-field.md
@@ -163,12 +163,22 @@ mat-form-field.mat-form-field {
 
 ### Accessibility
 
+By itself, `MatFormField` does not apply any additional accessibility treatment to a control.
+However, several of the form field's optional features interact with the control contained within
+the form field.
+
+When you provide a label via `<mat-label>`, `MatFormField` automatically associates this label with
+the field's control via a native `<label>` element, using the `for` attribute to reference the
+control's ID.
+
 If a floating label is specified, it will be automatically used as the label for the form
 field control. If no floating label is specified, the user should label the form field control
 themselves using `aria-label`, `aria-labelledby` or `<label for=...>`.
 
-Any errors and hints added to the form field are automatically added to the form field control's
-`aria-describedby` set.
+When you provide informational text via `<mat-hint>` or `<mat-error>`, `MatFormField` automatically
+adds these elements' IDs to the control's `aria-describedby` attribute. Additionally, `MatError`
+applies `aria-live="polite"` by default such that assistive technology will announce errors when
+they appear.
 
 ### Troubleshooting
 

--- a/src/material/list/list.md
+++ b/src/material/list/list.md
@@ -166,21 +166,32 @@ To add a divider, use `<mat-divider>`.
 ```
 
 ### Accessibility
-The type of list used in any given situation depends on how the end-user will be interacting with it.
+
+Angular Material offers multiple varieties of list so that you can choose the type that best applies
+to your use-case.
 
 #### Navigation
-When the list-items navigate somewhere, `<mat-nav-list>` should be used with `<a mat-list-item>`
-elements as the list items. The nav-list will be rendered using `role="navigation"` and can be
-given an `aria-label` to give context on the set of navigation options presented. Additional
-interactive content, such as buttons, should _not_ be added inside the anchors.
+
+You should use `MatNavList` when every item in the list is an anchor that navigate to another URL.
+The root `<mat-nav-list>` element sets `role="navigation"` and should contain only anchor elements
+with the `mat-list-item` attribute. You should not nest any interactive elements inside these
+anchors, including buttons and checkboxes. 
+
+Always provide an accessible label for the `<mat-nav-list>` element via `aria-label` or
+`aria-labelledby`.
 
 #### Selection
-When the list is primarily used to select one or more values, a `<mat-selection-list>` should be
-used with `<mat-list-option>`, which map to `role="listbox"` and `role="option"`, respectively. The
-list should be given an `aria-label` that describes the value or values being selected. Each option
-should _not_ contain any additional interactive elements, such as buttons.
+
+You should use `MatSelectionList` and `MatListOption` for lists that allow the user to select one
+or more values. This list variant uses the `role="listbox"` interaction pattern, handling all
+associated keyboard input and focus management. You should not nest any interactive elements inside
+these options, including buttons and anchors. 
+
+Always provide an accessible label for the `<mat-selection-list>` element via `aria-label` or
+`aria-labelledby` that describes the selection being made.
 
 #### Custom scenarios
+
 By default, the list assumes that it will be used in a purely decorative fashion and thus sets no
 roles, ARIA attributes, or keyboard shortcuts. This is equivalent to having a sequence of `<div>`
 elements on the page. Any interactive content within the list should be given an appropriate

--- a/src/material/menu/menu.md
+++ b/src/material/menu/menu.md
@@ -98,5 +98,18 @@ with a different set of data, depending on the trigger that opened it:
 - <kbd>ESCAPE</kbd>: Closes the menu
 
 ### Accessibility
-Menu triggers or menu items without text or labels should be given a meaningful label via
-`aria-label` or `aria-labelledby`.
+
+Angular Material's menu component consists of two connected parts: the trigger and the pop-up menu.
+
+The menu trigger is a standard button element augmented with `aria-haspopup`, `aria-expanded`, and
+`aria-controls` to create the relationship to the pop-up panel.
+
+The pop-up menu implements the `role="menu"` pattern, handling keyboard interaction and focus
+management. Upon opening, the trigger will focus the first focusable menu item. Upon close, the menu
+will return focus to its trigger. Avoid creating a menu in which all items are disabled, instead
+hiding or disabling the menu trigger. 
+
+Angular Material does not support the `menuitemcheckbox` or `menuitemradio` roles.
+
+Always provide an accessible label via `aria-label` or `aria-labelledby` for any menu
+triggers or menu items without descriptive text content.

--- a/src/material/progress-bar/progress-bar.md
+++ b/src/material/progress-bar/progress-bar.md
@@ -42,4 +42,9 @@ The color of a progress-bar can be changed by using the `color` property. By def
 use the theme's primary color. This can be changed to `'accent'` or `'warn'`.  
 
 ### Accessibility
-Each progress bar should be given a meaningful label via `aria-label` or `aria-labelledby`.
+
+`MatProgressBar` implements the ARIA `role="progressbar"` pattern. By default, the progress bar
+sets `aria-valuemin` to `0` and `aria-valuemax` to `100`. Avoid changing these values, as this may
+cause incompatiblity with some assitive technology.
+
+Always provide an accessible label via `aria-label` or `aria-labelledby` for each progress bar.

--- a/src/material/progress-spinner/progress-spinner.md
+++ b/src/material/progress-spinner/progress-spinner.md
@@ -23,4 +23,9 @@ The color of a progress-spinner can be changed by using the `color` property. By
 progress-spinners use the theme's primary color. This can be changed to `'accent'` or `'warn'`.
 
 ### Accessibility
-Each progress spinner should be given a meaningful label via `aria-label` or `aria-labelledby`.
+
+`MatProgressSpinner` implements the ARIA `role="progressbar"` pattern. By default, the spinner
+sets `aria-valuemin` to `0` and `aria-valuemax` to `100`. Avoid changing these values, as this may
+cause incompatiblity with some assitive technology.
+
+Always provide an accessible label via `aria-label` or `aria-labelledby` for each spinner.

--- a/src/material/radio/radio.md
+++ b/src/material/radio/radio.md
@@ -28,13 +28,6 @@ Individual radio-buttons inside of a radio-group will inherit the `name` of the 
 `<mat-radio-group>` is compatible with `@angular/forms` and supports both `FormsModule`
 and `ReactiveFormsModule`.
 
-### Accessibility
-The `<mat-radio-button>` uses an internal `<input type="radio">` to provide an accessible experience.
-This internal radio button receives focus and is automatically labelled by the text content of the
-`<mat-radio-button>` element.
-
-Radio button groups should be given a meaningful label via `aria-label` or `aria-labelledby`.
-
 ### Default Color Configuration
 The default color for radio buttons can be configured globally using the `MAT_RADIO_DEFAULT_OPTIONS` provider
 
@@ -44,3 +37,26 @@ providers: [{
     useValue: { color: 'accent' },
 }]
 ```
+
+### Accessibility
+
+`MatRadioButton` uses an internal `<input type="radio">` to provide an accessible experience.
+This internal radio button receives focus and is automatically labelled by the text content of the
+`<mat-radio-button>` element. Avoid adding other interactive controls into the content of
+`<mat-radio-button>`, as this degrades the experience for users of assistive technology.
+
+Always provide an accessible label via `aria-label` or `aria-labelledby` for radio buttons without
+descriptive text content. For dynamic labels and descriptions, `MatRadioButton` provides input
+properties for binding `aria-label`, `aria-labelledby`, and `aria-describedby`. This means that you
+should not use the `attr.` prefix when binding these properties, as demonstrated below.
+
+```html
+<mat-radio-button [aria-label]="getMultipleChoiceAnswer()">
+</mat-radio-button>
+```
+
+Prefer placing all radio buttons inside of a `<mat-radio-group>` rather than creating standalone
+radio buttons because groups are easier to use exclusively with a keyboard. 
+
+You should provide an accessible label for all `<mat-radio-group>` elements via `aria-label` or
+`aria-labelledby`. 

--- a/src/material/slide-toggle/slide-toggle.md
+++ b/src/material/slide-toggle/slide-toggle.md
@@ -22,9 +22,18 @@ The color of a `<mat-slide-toggle>` can be changed by using the `color` property
 slide-toggles use the theme's accent color. This can be changed to `'primary'` or `'warn'`.
 
 ### Accessibility
-The `<mat-slide-toggle>` uses an internal `<input type="checkbox">` to provide an accessible
-experience. This internal checkbox receives focus and is automatically labelled by the text content
-of the `<mat-slide-toggle>` element.
 
-Slide toggles without text or labels should be given a meaningful label via `aria-label` or
-`aria-labelledby`.
+`MatSlideToggle` uses an internal `<input type="checkbox">` with `role="switch"` to provide an
+accessible experience. This internal checkbox receives focus and is automatically labelled by the
+text content of the `<mat-slide-toggle>` element. Avoid adding other interactive controls into the
+content of `<mat-slide-toggle>`, as this degrades the experience for users of assistive technology.
+
+Always provide an accessible label via `aria-label` or `aria-labelledby` for toggles without
+descriptive text content. For dynamic labels, `MatSlideToggle` provides input properties for binding
+`aria-label` and `aria-labelledby`. This means that you should not use the `attr.` prefix when
+binding these properties, as demonstrated below.
+
+```html
+<mat-slide-toggle [aria-label]="isSubscribedToEmailsMessage">
+</mat-slide-toggle>
+```

--- a/src/material/slider/slider.md
+++ b/src/material/slider/slider.md
@@ -92,5 +92,7 @@ The slider has the following keyboard bindings:
 | Home        | Set the value to the minimum possible.                                             |
 
 ### Accessibility
-Sliders without text or labels should be given a meaningful label via `aria-label` or
+
+`MatSlider` implements the ARIA `role="slider"` pattern, handling keyboard input and focus
+management. Always provide an accessible label for each slider via `aria-label` or
 `aria-labelledby`.

--- a/src/material/snack-bar/snack-bar.md
+++ b/src/material/snack-bar/snack-bar.md
@@ -2,8 +2,8 @@
 
 <!-- example(snack-bar-overview) -->
 
-### Opening a snack-bar
-A snack-bar can contain either a string message or a given component.
+### Opening a snackbar
+A snackbar can contain either a string message or a given component.
 ```ts
 // Simple message.
 let snackBarRef = snackBar.open('Message archived');
@@ -11,45 +11,45 @@ let snackBarRef = snackBar.open('Message archived');
 // Simple message with an action.
 let snackBarRef = snackBar.open('Message archived', 'Undo');
 
-// Load the given component into the snack-bar.
+// Load the given component into the snackbar.
 let snackBarRef = snackbar.openFromComponent(MessageArchivedComponent);
 ```
 
-In either case, a `MatSnackBarRef` is returned. This can be used to dismiss the snack-bar or to
-receive notification of when the snack-bar is dismissed. For simple messages with an action, the
+In either case, a `MatSnackBarRef` is returned. This can be used to dismiss the snackbar or to
+receive notification of when the snackbar is dismissed. For simple messages with an action, the
 `MatSnackBarRef` exposes an observable for when the action is triggered.
-If you want to close a custom snack-bar that was opened via `openFromComponent`, from within the
+If you want to close a custom snackbar that was opened via `openFromComponent`, from within the
 component itself, you can inject the `MatSnackBarRef`.
 
 ```ts
 snackBarRef.afterDismissed().subscribe(() => {
-  console.log('The snack-bar was dismissed');
+  console.log('The snackbar was dismissed');
 });
 
 
 snackBarRef.onAction().subscribe(() => {
-  console.log('The snack-bar action was triggered!');
+  console.log('The snackbar action was triggered!');
 });
 
 snackBarRef.dismiss();
 ```
 
 ### Dismissal
-A snack-bar can be dismissed manually by calling the `dismiss` method on the `MatSnackBarRef`
+A snackbar can be dismissed manually by calling the `dismiss` method on the `MatSnackBarRef`
 returned from the call to `open`.
 
-Only one snack-bar can ever be opened at one time. If a new snackbar is opened while a previous
+Only one snackbar can ever be opened at one time. If a new snackbar is opened while a previous
 message is still showing, the older message will be automatically dismissed.
 
-A snack-bar can also be given a duration via the optional configuration object:
+A snackbar can also be given a duration via the optional configuration object:
 ```ts
 snackbar.open('Message archived', 'Undo', {
   duration: 3000
 });
 ```
 
-### Sharing data with a custom snack-bar
-You can share data with the custom snack-bar, that you opened via the `openFromComponent` method,
+### Sharing data with a custom snackbar
+You can share data with the custom snackbar, that you opened via the `openFromComponent` method,
 by passing it through the `data` property.
 
 ```ts
@@ -65,7 +65,7 @@ import {Component, Inject} from '@angular/core';
 import {MAT_SNACK_BAR_DATA} from '@angular/material/snack-bar';
 
 @Component({
-  selector: 'your-snack-bar',
+  selector: 'your-snackbar',
   template: 'passed in {{ data }}',
 })
 export class MessageArchivedComponent {
@@ -86,18 +86,19 @@ If you want to override the default snack bar options, you can do so using the
 ```
 
 ### Accessibility
-Snack-bar messages are announced via an `aria-live` region. By default, the `polite` setting is
-used. While `polite` is recommended, this can be customized by setting the `politeness` property of
-the `MatSnackBarConfig`.
 
-Focus is not moved to the snack-bar element as that would be disruptive to a user in the middle of a workflow. 
-It is recommended that, for any action offered in the snack-bar, the application offers the user an 
-alternative way to perform the action.
-Alternative interactions are typically keyboard shortcuts or menu options. When the action is
-performed in this way, the snack-bar should be dismissed. A snack-bar can contain a single action. 
-"Dismiss" or "cancel" actions are optional.
+`MatSnackBar` announces messages via an `aria-live` region. While announcements use the `polite`
+setting by default, you can customize this by setting the `politeness` property of
+`MatSnackBarConfig`.
 
-Snack-bars that have an action available should not be given a `duration`, as to accommodate
-screen-reader users that want to navigate to the snack-bar element to activate the action. If the
-user has manually moved their focus within the snackbar, focus should be placed somewhere sensible
-based on the application context when the snack-bar is dismissed.
+`MatSnackBar` does not move focus to the snackbar element. Moving focus like this would disrupt
+users in the middle of a workflow. For any action offered in the snackbar, your application should
+provide an alternative way to perform the action. Alternative interactions are typically keyboard
+shortcuts or menu options. You should dismiss the snackbar once the user performs its corresponding
+action. A snackbar can contain a single action with an additional optional "dismiss" or "cancel"
+action.
+
+Avoid setting a `duration` for snackbars that have an action available, as screen reader users may
+want to navigate to the snackbar element to activate the action. If the user has manually moved
+their focus within the snackbar, you should return focus somewhere that makes sense in the context
+of the user's workflow.

--- a/src/material/table/table.md
+++ b/src/material/table/table.md
@@ -376,13 +376,15 @@ to resolve this.
 When using the `multiTemplateDataRows` directive to support multiple rows for each data object, the context of `*matRowDef` is the same except that the `index` value is replaced by `dataIndex` and `renderIndex`.
 
 ### Accessibility
-Tables without text or labels should be given a meaningful label via `aria-label` or
-`aria-labelledby`. The `aria-readonly` defaults to `true` if it's not set.
 
-Table's default role is `grid`, and it can be changed to `treegrid` through `role` attribute.
+By default, `MatTable` applies `role="table"`, assuming the table's contains primarily static
+content. You can change the role by explicitly setting `role="grid"` or `role="treegrid"` on the
+table element. While changing the role will update child element roles, such as changing
+`role="cell"` to `role="gridcell"`, this not _not_ apply additional keyboard input handling or
+focus management to the table.
 
-`mat-table` does not manage any focus/keyboard interaction on its own. Users can add desired
-focus/keyboard interactions in their application.
+Always provide an accessible label for your tables via `aria-label` or `aria-labelledby` on the
+table element.
 
 ### Tables with `display: flex`
 

--- a/src/material/tabs/tabs.md
+++ b/src/material/tabs/tabs.md
@@ -85,17 +85,28 @@ duration can be configured globally using the `MAT_TABS_CONFIG` injection token.
                "region": "slow-animation-duration"}) -->
 
 ### Accessibility
-`<mat-tab-group>` and `<mat-nav-tab-bar>` use different interaction patterns. The
-`<mat-tab-group>` component combines `tablist`, `tab`, and `tabpanel` into a single component with
-the appropriate keyboard shortcuts. The `<mat-nav-tab-bar>`, however, use a _navigation_ interaction
-pattern by using a `<nav>` element with anchor elements as the "tabs". The difference
-between these two patterns comes from the fact one updates the page URL while the other does not.
+`MatTabGroup` and `MatTabNavBar` implement different interaction patterns for different use-cases.
+You should choose the component that works best for your application.
+
+`MatTabGroup` combines `tablist`, `tab`, and `tabpanel` into a single component with
+handling for keyboard inputs and focus management. You should use this component for switching
+between content within a single page. 
+
+`MatTabNavBar`, implements a navigation interaction pattern by using a `<nav>` element with anchor
+elements as the "tabs". You should use this component when you want your cross-page navigation to
+look like a tabbed interface. As a rule of thumb, you should consider `MatTabNavBar` if changing
+tabs would change the browser URL.
 
 #### Labels
-Tabs without text or labels should be given a meaningful label via `aria-label` or
-`aria-labelledby`. For `MatTabNav`, the `<nav>` element should have a label as well.
+
+Always provide an accessible label via `aria-label` or `aria-describedby` for tabs without
+descriptive text content.
+
+When using `MatTabNavGroup`, you should also specify a label for the `<nav>` element. 
 
 #### Keyboard interaction
+
+`MatTabGroup` implements the following keyboard interactions.
 
 | Shortcut             | Action                     |
 |----------------------|----------------------------|
@@ -104,3 +115,6 @@ Tabs without text or labels should be given a meaningful label via `aria-label` 
 | `HOME`               | Move focus to first tab    |
 | `END`                | Move focus to last tab     |
 | `SPACE` or `ENTER`   | Switch to focused tab      |
+
+`MatTabNavBar` does not add additional keyboard handling, deferring to the native behavior of
+anchor elements.

--- a/src/material/tooltip/tooltip.md
+++ b/src/material/tooltip/tooltip.md
@@ -66,13 +66,12 @@ shown.
 
 ### Accessibility
 
-Elements with the `matTooltip` will add an `aria-describedby` label that provides a reference
+`MatTooltip` adds an `aria-describedby` description that provides a reference
 to a visually hidden element containing the tooltip's message. This provides screenreaders the
-information needed to read out the tooltip's contents when the end-user focuses on the element
-triggering the tooltip. The element referenced via `aria-describedby` is not the tooltip itself,
+information needed to read out the tooltip's contents when the end-user focuses on tooltip's
+trigger. The element referenced by `aria-describedby` is not the tooltip itself,
 but instead an invisible copy of the tooltip content that is always present in the DOM.
 
-If a tooltip will only be shown manually via click, keypress, etc., then extra care should be taken
-such that the action behaves similarly for screen-reader users. One possible approach would be
-to use the `LiveAnnouncer` from the `cdk/a11y` package to announce the tooltip content on such
-an interaction.
+Avoid interactions that exclusively show a tooltip with pointer events like click and mouseenter.
+Always ensure that keyboard users can perform the same set of actions available to mouse and
+touch users.


### PR DESCRIPTION
This change updates the accessibility docs for 21 components for
correctness, comprehensiveness, and clarity.

I have intentionally omitted several other components either because
they're being worked on by someone else or have significant changes
pending.

cc @zarend @amysorto 