### PR TITLE
fix(material/radio): button index not being read out by some screen readers

### DIFF
--- a/src/material/core/focus-indicators/_focus-indicators.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.scss
@@ -64,7 +64,7 @@
   // Checkboxes, radios, and slide toggles render focus indicators when the
   // associated visually-hidden input is focused.
   .mat-checkbox-input:focus ~ .mat-focus-indicator::before,
-  .mat-radio-input:focus ~ .mat-focus-indicator::before,
+  .mat-radio-input:focus ~ .mat-radio-label .mat-focus-indicator::before,
   .mat-slide-toggle-input:focus ~ .mat-slide-toggle-thumb-container .mat-focus-indicator::before,
 
   // For options, render the focus indicator when the class .mat-active

--- a/src/material/radio/radio.html
+++ b/src/material/radio/radio.html
@@ -1,24 +1,31 @@
 <!-- TODO(jelbourn): render the radio on either side of the content -->
 <!-- TODO(mtlin): Evaluate trade-offs of using native radio vs. cost of additional bindings. -->
+<!--
+  Keep this outside of the <label>, otherwise some screen
+  reader / browser combinations mess up the group index. See #23580.
+-->
+<input
+  #input
+  class="mat-radio-input"
+  type="radio"
+  [id]="inputId"
+  [checked]="checked"
+  [disabled]="disabled"
+  [tabIndex]="tabIndex"
+  [attr.name]="name"
+  [attr.value]="value"
+  [required]="required"
+  [attr.aria-label]="ariaLabel"
+  [attr.aria-labelledby]="ariaLabelledby"
+  [attr.aria-describedby]="ariaDescribedby"
+  (change)="_onInputInteraction($event)"
+  (click)="_onInputClick($event)">
+
 <label [attr.for]="inputId" class="mat-radio-label" #label>
   <!-- The actual 'radio' part of the control. -->
   <span class="mat-radio-container">
     <span class="mat-radio-outer-circle"></span>
     <span class="mat-radio-inner-circle"></span>
-    <input #input class="mat-radio-input" type="radio"
-        [id]="inputId"
-        [checked]="checked"
-        [disabled]="disabled"
-        [tabIndex]="tabIndex"
-        [attr.name]="name"
-        [attr.value]="value"
-        [required]="required"
-        [attr.aria-label]="ariaLabel"
-        [attr.aria-labelledby]="ariaLabelledby"
-        [attr.aria-describedby]="ariaDescribedby"
-        (change)="_onInputInteraction($event)"
-        (click)="_onInputClick($event)">
-
     <!-- The ripple comes after the input so that we can target it with a CSS
          sibling selector when the input is focused. -->
     <span mat-ripple class="mat-radio-ripple mat-focus-indicator"

--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -13,6 +13,7 @@ $ripple-radius: 20px;
   display: inline-block;
   -webkit-tap-highlight-color: transparent;
   outline: 0;
+  position: relative;
 }
 
 // Inner label container, wrapping entire element.
@@ -195,18 +196,38 @@ $ripple-radius: 20px;
 }
 
 .mat-radio-input {
-  opacity: 0;
+  // Move the input in the middle and towards the bottom so
+  // the native validation messages are aligned correctly.
   position: absolute;
-  top: 0;
-  left: 0;
-  margin: 0;
-  width: 100%;
-  height: 100%;
   cursor: inherit;
+  opacity: 0;
+  bottom: 0;
+  left: 0;
+  width: $size;
+  height: $size;
+
+  // Resets the user agent styling.
+  margin: 0;
+  padding: 0;
 
   // Puts the input behind the circle while keeping it visible so that
   // it allows `click` events to propagate up to the `label` wrapper.
   z-index: -1;
+
+  [dir='rtl'] & {
+    left: auto;
+    right: 0;
+  }
+}
+
+.mat-radio-input-before {
+  left: auto;
+  right: 0;
+
+  [dir='rtl'] & {
+    right: auto;
+    left: 0;
+  }
 }
 
 @include a11y.high-contrast(active, off) {

--- a/src/material/radio/testing/radio-harness.ts
+++ b/src/material/radio/testing/radio-harness.ts
@@ -190,7 +190,7 @@ export class MatRadioGroupHarness extends _MatRadioGroupHarnessBase<
 export abstract class _MatRadioButtonHarnessBase extends ComponentHarness {
   protected abstract _textLabel: AsyncFactoryFn<TestElement>;
   protected abstract _clickLabel: AsyncFactoryFn<TestElement>;
-  private _input = this.locatorFor('input');
+  private _input = this.locatorFor('input[type="radio"]');
 
   /** Whether the radio-button is checked. */
   async isChecked(): Promise<boolean> {


### PR DESCRIPTION
It looks like some screen reader / browser combinations (NVDA + Chrome in this case) won't read out the index of the radio button within the group correctly, if it's nested inside a `label`.

These changes fix the issue by moving the input outside of the `label`.

Fixes #23580.