### PR TITLE
fix(material/list): fix action-list focus state for high contrast fir…

### DIFF
--- a/src/material/list/list.scss
+++ b/src/material/list/list.scss
@@ -319,6 +319,7 @@ mat-action-list {
   mat-action-list .mat-list-item {
     &:hover, &:focus {
       outline: dotted 1px;
+      z-index: 1;
     }
   }
 


### PR DESCRIPTION
…efox

# From the commit message

Fixes the focus state on the action-list for firefox in high-contrast
mode. In firefox, the outline only renders on the top, right and left –
not the bottom. This fixes the bottom of the outline being cut-off by
setting the z-index of the focused list item to 1.

fixes #23583

## Other things I've tried
Also tried using margin but that turned out to be harder than this because we would also have to update the background of the list. This seems to only happen with buttons inside the list, but works fine with divs. I know that outline works differently between Firefox and Chrome, but I couldn't find a specific bug report for this situation.

I also considered ditching outline and using a box-shadow instead, but then the action-list's focus state would match our nav-list and other lists.