### PR TITLE
refactor: clean up removeChild usages

### DIFF
--- a/src/cdk-experimental/column-resize/resizable.ts
+++ b/src/cdk-experimental/column-resize/resizable.ts
@@ -108,14 +108,8 @@ export abstract class Resizable<HandleComponent extends ResizeOverlayHandle>
   ngOnDestroy(): void {
     this.destroyed.next();
     this.destroyed.complete();
-
-    if (this.inlineHandle) {
-      this.elementRef.nativeElement!.removeChild(this.inlineHandle);
-    }
-
-    if (this.overlayRef) {
-      this.overlayRef.dispose();
-    }
+    this.inlineHandle?.remove();
+    this.overlayRef?.dispose();
   }
 
   protected abstract getInlineHandleCssClassName(): string;

--- a/src/cdk-experimental/column-resize/resize-strategy.ts
+++ b/src/cdk-experimental/column-resize/resize-strategy.ts
@@ -178,11 +178,8 @@ export class CdkFlexTableResizeStrategy extends ResizeStrategy implements OnDest
   }
 
   ngOnDestroy(): void {
-    // TODO: Use remove() once we're off IE11.
-    if (this._styleElement && this._styleElement.parentNode) {
-      this._styleElement.parentNode.removeChild(this._styleElement);
-      this._styleElement = undefined;
-    }
+    this._styleElement?.remove();
+    this._styleElement = undefined;
   }
 
   private _getPropertyValue(cssFriendlyColumnName: string, key: string): string|undefined {

--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -877,7 +877,7 @@ describe('Dialog', () => {
   describe('focus management', () => {
     // When testing focus, all of the elements must be in the DOM.
     beforeEach(() => document.body.appendChild(overlayContainerElement));
-    afterEach(() => document.body.removeChild(overlayContainerElement));
+    afterEach(() => overlayContainerElement.remove());
 
     it('should focus the first tabbable element of the dialog on open (the default)',
       fakeAsync(() => {
@@ -971,7 +971,7 @@ describe('Dialog', () => {
         .withContext('Expected that the trigger was refocused after the dialog is closed.')
         .toBe('dialog-trigger');
 
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should re-focus trigger element inside the shadow DOM when dialog closes', fakeAsync(() => {
@@ -1036,8 +1036,8 @@ describe('Dialog', () => {
       expect(document.activeElement!.id)
         .withContext('Expected focus to stay on the alternate button.').toBe('other-button');
 
-      body.removeChild(button);
-      body.removeChild(otherButton);
+      button.remove();
+      otherButton.remove();
     }));
 
     it('should allow the consumer to shift focus in afterClosed', fakeAsync(() => {
@@ -1069,8 +1069,8 @@ describe('Dialog', () => {
         .withContext('Expected that the trigger was refocused after the dialog is closed.')
         .toBe('input-to-be-focused');
 
-      document.body.removeChild(button);
-      document.body.removeChild(input);
+      button.remove();
+      input.remove();
       flush();
     }));
 

--- a/src/cdk-experimental/listbox/listbox.ts
+++ b/src/cdk-experimental/listbox/listbox.ts
@@ -174,7 +174,7 @@ export class CdkOption<T = unknown> implements ListKeyManagerOption, Highlightab
   private _removeIcons(element: Element) {
     // TODO: make this a configurable function that can removed any desired type of node.
     for (const icon of Array.from(element.querySelectorAll('mat-icon, .material-icons'))) {
-      icon.parentNode?.removeChild(icon);
+      icon.remove();
     }
   }
 

--- a/src/cdk-experimental/menu/menu-item.ts
+++ b/src/cdk-experimental/menu/menu-item.ts
@@ -35,7 +35,7 @@ import {Toggler, MENU_AIM, MenuAim} from './menu-aim';
 /** Removes all icons from within the given element. */
 function removeIcons(element: Element) {
   for (const icon of Array.from(element.querySelectorAll('mat-icon, .material-icons'))) {
-    icon.parentNode?.removeChild(icon);
+    icon.remove();
   }
 }
 

--- a/src/cdk-experimental/table-scroll-container/table-scroll-container.ts
+++ b/src/cdk-experimental/table-scroll-container/table-scroll-container.ts
@@ -67,11 +67,8 @@ export class CdkTableScrollContainer implements StickyPositioningListener,
   }
 
   ngOnDestroy(): void {
-    // TODO: Use remove() once we're off IE11.
-    if (this._styleElement?.parentNode) {
-      this._styleElement.parentNode.removeChild(this._styleElement);
-      this._styleElement = undefined;
-    }
+    this._styleElement?.remove();
+    this._styleElement = undefined;
   }
 
   stickyColumnsUpdated({sizes}: StickyUpdate): void {

--- a/src/cdk/a11y/aria-describer/aria-describer.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.spec.ts
@@ -214,10 +214,7 @@ describe('AriaDescriber', () => {
 
     // Use `querySelectorAll` with an attribute since `getElementById` will stop at the first match.
     expect(document.querySelectorAll(`[id='${MESSAGES_CONTAINER_ID}']`).length).toBe(1);
-
-    if (extraContainer.parentNode) {
-      extraContainer.parentNode.removeChild(extraContainer);
-    }
+    extraContainer.remove();
   });
 
   it('should not describe messages that match up with the aria-label of the element', () => {

--- a/src/cdk/a11y/aria-describer/aria-describer.ts
+++ b/src/cdk/a11y/aria-describer/aria-describer.ts
@@ -156,10 +156,7 @@ export class AriaDescriber implements OnDestroy {
   /** Deletes the message element from the global messages container. */
   private _deleteMessageElement(key: string|Element) {
     const registeredMessage = messageRegistry.get(key);
-    const messageElement = registeredMessage && registeredMessage.messageElement;
-    if (messagesContainer && messageElement) {
-      messagesContainer.removeChild(messageElement);
-    }
+    registeredMessage?.messageElement?.remove();
     messageRegistry.delete(key);
   }
 
@@ -172,9 +169,7 @@ export class AriaDescriber implements OnDestroy {
       // already a container on the page, but we don't have a reference to it. Clear the
       // old container so we don't get duplicates. Doing this, instead of emptying the previous
       // container, should be slightly faster.
-      if (preExistingContainer && preExistingContainer.parentNode) {
-        preExistingContainer.parentNode.removeChild(preExistingContainer);
-      }
+      preExistingContainer?.remove();
 
       messagesContainer = this._document.createElement('div');
       messagesContainer.id = MESSAGES_CONTAINER_ID;
@@ -193,8 +188,8 @@ export class AriaDescriber implements OnDestroy {
 
   /** Deletes the global messages container. */
   private _deleteMessagesContainer() {
-    if (messagesContainer && messagesContainer.parentNode) {
-      messagesContainer.parentNode.removeChild(messagesContainer);
+    if (messagesContainer) {
+      messagesContainer.remove();
       messagesContainer = null;
     }
   }

--- a/src/cdk/a11y/aria-describer/aria-reference.spec.ts
+++ b/src/cdk/a11y/aria-describer/aria-reference.spec.ts
@@ -9,7 +9,7 @@ describe('AriaReference', () => {
   });
 
   afterEach(() => {
-    document.body.removeChild(testElement!);
+    testElement?.remove();
   });
 
   it('should be able to append/remove aria reference IDs', () => {

--- a/src/cdk/a11y/focus-trap/focus-trap.ts
+++ b/src/cdk/a11y/focus-trap/focus-trap.ts
@@ -76,18 +76,12 @@ export class FocusTrap {
 
     if (startAnchor) {
       startAnchor.removeEventListener('focus', this.startAnchorListener);
-
-      if (startAnchor.parentNode) {
-        startAnchor.parentNode.removeChild(startAnchor);
-      }
+      startAnchor.remove();
     }
 
     if (endAnchor) {
       endAnchor.removeEventListener('focus', this.endAnchorListener);
-
-      if (endAnchor.parentNode) {
-        endAnchor.parentNode.removeChild(endAnchor);
-      }
+      endAnchor.remove();
     }
 
     this._startAnchor = this._endAnchor = null;

--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -74,7 +74,7 @@ export class HighContrastModeDetector {
         documentWindow.getComputedStyle(testElement) : null;
     const computedColor =
         (computedStyle && computedStyle.backgroundColor || '').replace(/ /g, '');
-    this._document.body.removeChild(testElement);
+    testElement.remove();
 
     switch (computedColor) {
       case 'rgb(0,0,0)': return HighContrastMode.WHITE_ON_BLACK;

--- a/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
+++ b/src/cdk/a11y/interactivity-checker/interactivity-checker.spec.ts
@@ -16,7 +16,7 @@ describe('InteractivityChecker', () => {
   }));
 
   afterEach(() => {
-    document.body.removeChild(testContainerElement);
+    testContainerElement.remove();
     testContainerElement.innerHTML = '';
   });
 
@@ -529,8 +529,7 @@ describe('InteractivityChecker', () => {
     tmpRoot.innerHTML = template;
 
     const element = tmpRoot.firstElementChild!;
-
-    tmpRoot.removeChild(element);
+    element.remove();
 
     if (append) {
       appendElements([element]);

--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -133,10 +133,7 @@ describe('LiveAnnouncer', () => {
       expect(document.body.querySelectorAll('.cdk-live-announcer-element').length)
         .withContext('Expected only one live announcer element in the DOM.')
         .toBe(1);
-
-      if (extraElement.parentNode) {
-        extraElement.parentNode.removeChild(extraElement);
-      }
+      extraElement.remove();
     }));
 
     it('should clear any previous timers when a new one is started', fakeAsync(() => {

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -142,11 +142,8 @@ export class LiveAnnouncer implements OnDestroy {
 
   ngOnDestroy() {
     clearTimeout(this._previousTimeout);
-
-    if (this._liveElement && this._liveElement.parentNode) {
-      this._liveElement.parentNode.removeChild(this._liveElement);
-      this._liveElement = null!;
-    }
+    this._liveElement?.remove();
+    this._liveElement = null!;
   }
 
   private _createLiveElement(): HTMLElement {
@@ -156,7 +153,7 @@ export class LiveAnnouncer implements OnDestroy {
 
     // Remove any old containers. This can happen when coming in from a server-side-rendered page.
     for (let i = 0; i < previousElements.length; i++) {
-      previousElements[i].parentNode!.removeChild(previousElements[i]);
+      previousElements[i].remove();
     }
 
     liveEl.classList.add(elementClass);

--- a/src/cdk/clipboard/clipboard.spec.ts
+++ b/src/cdk/clipboard/clipboard.spec.ts
@@ -28,9 +28,7 @@ describe('Clipboard', () => {
   });
 
   afterEach(() => {
-    if (focusedInput.parentNode) {
-      focusedInput.parentNode.removeChild(focusedInput);
-    }
+    focusedInput.remove();
   });
 
   describe('#beginCopy', () => {
@@ -79,8 +77,7 @@ describe('Clipboard', () => {
 
       clipboard.copy(COPY_CONTENT);
       expect(document.activeElement).toBe(svg);
-
-      svg.parentNode!.removeChild(svg);
+      svg.remove();
     });
 
     describe('when execCommand fails', () => {

--- a/src/cdk/clipboard/pending-copy.ts
+++ b/src/cdk/clipboard/pending-copy.ts
@@ -67,10 +67,7 @@ export class PendingCopy {
     const textarea = this._textarea;
 
     if (textarea) {
-      if (textarea.parentNode) {
-        textarea.parentNode.removeChild(textarea);
-      }
-
+      textarea.remove();
       this._textarea = undefined;
     }
   }

--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -2336,7 +2336,7 @@ expect(item.style.top)
         const preview = document.querySelector('.cdk-drag-preview')! as HTMLElement;
 
         expect(preview.parentNode).toBe(fakeDocument.fullscreenElement);
-        fakeDocument.fullscreenElement.parentNode!.removeChild(fakeDocument.fullscreenElement);
+        fakeDocument.fullscreenElement.remove();
       }));
 
     it('should be able to constrain the preview position', fakeAsync(() => {
@@ -5831,7 +5831,7 @@ expect(sourceCanvas.getContext('2d')!
           targetRect.left + 1, targetRect.top + 1);
 
         // Remove the extra node after the element was dropped, but before the animation is over.
-        extraSibling.parentNode!.removeChild(extraSibling);
+        extraSibling.remove();
 
         expect(() => {
           flush();
@@ -7286,7 +7286,7 @@ function makeScrollable(
 
   return () => {
     scrollTo(0, 0);
-    veryTallElement.parentNode!.removeChild(veryTallElement);
+    veryTallElement.remove();
   };
 }
 

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -485,10 +485,10 @@ export class DragRef<T = any> {
     if (this.isDragging()) {
       // Since we move out the element to the end of the body while it's being
       // dragged, we have to make sure that it's removed if it gets destroyed.
-      removeNode(this._rootElement);
+      this._rootElement?.remove();
     }
 
-    removeNode(this._anchor);
+    this._anchor?.remove();
     this._destroyPreview();
     this._destroyPlaceholder();
     this._dragDropRegistry.removeDragItem(this);
@@ -606,27 +606,15 @@ export class DragRef<T = any> {
 
   /** Destroys the preview element and its ViewRef. */
   private _destroyPreview() {
-    if (this._preview) {
-      removeNode(this._preview);
-    }
-
-    if (this._previewRef) {
-      this._previewRef.destroy();
-    }
-
+    this._preview?.remove();
+    this._previewRef?.destroy();
     this._preview = this._previewRef = null!;
   }
 
   /** Destroys the placeholder element and its ViewRef. */
   private _destroyPlaceholder() {
-    if (this._placeholder) {
-      removeNode(this._placeholder);
-    }
-
-    if (this._placeholderRef) {
-      this._placeholderRef.destroy();
-    }
-
+    this._placeholder?.remove();
+    this._placeholderRef?.destroy();
     this._placeholder = this._placeholderRef = null!;
   }
 
@@ -1479,16 +1467,6 @@ function getTransform(x: number, y: number): string {
 /** Clamps a value between a minimum and a maximum. */
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
-}
-
-/**
- * Helper to remove a node from the DOM and to do all the necessary null checks.
- * @param node Node to be removed.
- */
-function removeNode(node: Node | null) {
-  if (node && node.parentNode) {
-    node.parentNode.removeChild(node);
-  }
 }
 
 /** Determines whether an event is a touch event. */

--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
@@ -80,8 +80,7 @@ describe('OverlayKeyboardDispatcher', () => {
     dispatchKeyboardEvent(button, 'keydown', ESCAPE);
 
     expect(spy).not.toHaveBeenCalled();
-
-    button.parentNode!.removeChild(button);
+    button.remove();
   });
 
   it('should complete the keydown stream on dispose', () => {

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
@@ -69,7 +69,7 @@ describe('OverlayOutsideClickDispatcher', () => {
     expect(overlayOneSpy).toHaveBeenCalled();
     expect(overlayTwoSpy).toHaveBeenCalled();
 
-    button.parentNode!.removeChild(button);
+    button.remove();
     overlayOne.dispose();
     overlayTwo.dispose();
   });
@@ -96,7 +96,7 @@ describe('OverlayOutsideClickDispatcher', () => {
     expect(overlayOneSpy).toHaveBeenCalled();
     expect(overlayTwoSpy).toHaveBeenCalled();
 
-    button.parentNode!.removeChild(button);
+    button.remove();
     overlayOne.dispose();
     overlayTwo.dispose();
   });
@@ -117,7 +117,7 @@ describe('OverlayOutsideClickDispatcher', () => {
 
       expect(spy).toHaveBeenCalled();
 
-      button.parentNode!.removeChild(button);
+      button.remove();
       overlayRef.dispose();
     });
 
@@ -162,7 +162,7 @@ describe('OverlayOutsideClickDispatcher', () => {
     button.click();
     expect(spy).toHaveBeenCalled();
 
-    button.parentNode!.removeChild(button);
+    button.remove();
     overlayRef.dispose();
   });
 
@@ -193,7 +193,7 @@ describe('OverlayOutsideClickDispatcher', () => {
     dispatchMouseEvent(context, 'contextmenu');
     expect(spy).toHaveBeenCalled();
 
-    context.parentNode!.removeChild(context);
+    context.remove();
     overlayRef.dispose();
   });
 
@@ -236,7 +236,7 @@ describe('OverlayOutsideClickDispatcher', () => {
 
       expect(spy).toHaveBeenCalled();
 
-      backgroundElement.parentNode!.removeChild(backgroundElement);
+      backgroundElement.remove();
       firstOverlayRef.dispose();
       secondOverlayRef.dispose();
       thirdOverlayRef.dispose();

--- a/src/cdk/overlay/overlay-container.spec.ts
+++ b/src/cdk/overlay/overlay-container.spec.ts
@@ -60,10 +60,7 @@ describe('OverlayContainer', () => {
 
     overlayContainer.getContainerElement();
     expect(document.querySelectorAll('.cdk-overlay-container').length).toBe(1);
-
-    if (extraContainer.parentNode) {
-      extraContainer.parentNode.removeChild(extraContainer);
-    }
+    extraContainer.remove();
   });
 
   it('should remove overlay containers from other unit tests', () => {
@@ -74,10 +71,7 @@ describe('OverlayContainer', () => {
 
     overlayContainer.getContainerElement();
     expect(document.querySelectorAll('.cdk-overlay-container').length).toBe(1);
-
-    if (extraContainer.parentNode) {
-      extraContainer.parentNode.removeChild(extraContainer);
-    }
+    extraContainer.remove();
   });
 
   it('should not remove extra containers that were created on the browser', () => {
@@ -88,8 +82,7 @@ describe('OverlayContainer', () => {
     overlayContainer.getContainerElement();
 
     expect(document.querySelectorAll('.cdk-overlay-container').length).toBe(2);
-
-    extraContainer.parentNode!.removeChild(extraContainer);
+    extraContainer.remove();
   });
 
 });

--- a/src/cdk/overlay/overlay-container.ts
+++ b/src/cdk/overlay/overlay-container.ts
@@ -21,11 +21,7 @@ export class OverlayContainer implements OnDestroy {
   }
 
   ngOnDestroy() {
-    const container = this._containerElement;
-
-    if (container && container.parentNode) {
-      container.parentNode.removeChild(container);
-    }
+    this._containerElement?.remove();
   }
 
   /**
@@ -60,7 +56,7 @@ export class OverlayContainer implements OnDestroy {
       // Remove any old containers from the opposite platform.
       // This can happen when transitioning from the server to the client.
       for (let i = 0; i < oppositePlatformContainers.length; i++) {
-        oppositePlatformContainers[i].parentNode!.removeChild(oppositePlatformContainers[i]);
+        oppositePlatformContainers[i].remove();
       }
     }
 

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -216,13 +216,9 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     this._keydownEvents.complete();
     this._outsidePointerEvents.complete();
     this._outsideClickDispatcher.remove(this);
+    this._host?.remove();
 
-    if (this._host && this._host.parentNode) {
-      this._host.parentNode.removeChild(this._host);
-      this._host = null!;
-    }
-
-    this._previousHostParent = this._pane = null!;
+    this._previousHostParent = this._pane = this._host = null!;
 
     if (isAttached) {
       this._detachments.next();
@@ -487,7 +483,7 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
 
             if (this._host && this._host.parentElement) {
               this._previousHostParent = this._host.parentElement;
-              this._previousHostParent.removeChild(this._host);
+              this._host.remove();
             }
 
             subscription.unsubscribe();
@@ -512,9 +508,7 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
   /** Removes a backdrop element from the DOM. */
   private _disposeBackdrop(backdrop: HTMLElement | null) {
     if (backdrop) {
-      if (backdrop.parentNode) {
-        backdrop.parentNode.removeChild(backdrop);
-      }
+      backdrop.remove();
 
       // It is possible that a new portal has been attached to this overlay since we started
       // removing the backdrop. If that is the case, only clear the backdrop reference if it

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -72,7 +72,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
     expect(() => attachOverlay({positionStrategy})).toThrow();
 
-    document.body.removeChild(origin);
+    origin.remove();
   });
 
   it('should not throw when trying to apply after being disposed', () => {
@@ -93,7 +93,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
     expect(() => positionStrategy.apply()).not.toThrow();
 
-    document.body.removeChild(origin);
+    origin.remove();
   });
 
   it('should not throw when trying to re-apply the last position after being disposed', () => {
@@ -114,7 +114,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
     expect(() => positionStrategy.reapplyLastPosition()).not.toThrow();
 
-    document.body.removeChild(origin);
+    origin.remove();
   });
 
   it('should for the virtual keyboard offset when positioning the overlay', () => {
@@ -147,7 +147,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
     expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.bottom));
 
-    document.body.removeChild(originElement);
+    originElement.remove();
   });
 
   it('should clean up after itself when disposed', () => {
@@ -190,7 +190,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     expect(pane.style.transform).toBeFalsy();
 
     overlayRef.dispose();
-    document.body.removeChild(origin);
+    origin.remove();
   });
 
   describe('without flexible dimensions and pushing', () => {
@@ -213,7 +213,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     afterEach(() => {
-      document.body.removeChild(originElement);
+      originElement.remove();
     });
 
     describe('when not near viewport edge, not scrolled', () => {
@@ -254,7 +254,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
       afterEach(() => {
         window.scroll(0, 0);
-        document.body.removeChild(veryLargeElement);
+        veryLargeElement.remove();
       });
 
       // Preconditions are set, now just run the full set of simple position tests.
@@ -770,7 +770,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     it('should position the panel correctly when the origin is an SVG element', () => {
-      document.body.removeChild(originElement);
+      originElement.remove();
       originElement = createBlockElement('svg', 'http://www.w3.org/2000/svg');
       document.body.appendChild(originElement);
 
@@ -1155,7 +1155,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     afterEach(() => {
-      document.body.removeChild(originElement);
+      originElement.remove();
     });
 
     it('should be able to push an overlay into the viewport when it goes out on the right', () => {
@@ -1385,7 +1385,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
           .withContext('Expected overlay to stay in the viewport after scrolling.').toBe(0);
 
         window.scroll(0, 0);
-        document.body.removeChild(veryLargeElement);
+        veryLargeElement.remove();
       });
 
       it('should not continue pushing the overlay as the user scrolls, if position ' +
@@ -1431,7 +1431,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
           .toBe(initialOverlayTop - scrollBy);
 
         window.scroll(0, 0);
-        document.body.removeChild(veryLargeElement);
+        veryLargeElement.remove();
       });
 
   });
@@ -1450,7 +1450,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     afterEach(() => {
-      document.body.removeChild(originElement);
+      originElement.remove();
     });
 
     it('should align the overlay to `flex-start` when the content is flowing to the right', () => {
@@ -1711,7 +1711,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
         expect(Math.floor(overlayRect.bottom)).toBe(Math.floor(originRect.bottom));
 
         window.scroll(0, 0);
-        document.body.removeChild(veryLargeElement);
+        veryLargeElement.remove();
       });
 
     it('should set the proper styles when the `bottom` value is exactly zero', () => {
@@ -1876,7 +1876,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
           .toBe(Math.floor(originRect.left - originRect.width / 2));
 
       window.scroll(0, 0);
-      document.body.removeChild(veryLargeElement);
+      veryLargeElement.remove();
     });
 
     it('should size the bounding box correctly when opening downwards on a scrolled page', () => {
@@ -1918,7 +1918,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
           .toBe(Math.floor(viewportHeight - originRect.bottom + viewportMargin));
 
       window.scroll(0, 0);
-      document.body.removeChild(veryLargeElement);
+      veryLargeElement.remove();
     });
 
     it('should not push the overlay if it is exactly as wide as the viewport', () => {
@@ -2004,7 +2004,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
         expect(Math.floor(overlayRect.top)).toBe(Math.floor(originRect.top));
 
         window.scroll(0, 0);
-        document.body.removeChild(veryLargeElement);
+        veryLargeElement.remove();
       });
 
     it('should size the bounding box that is flowing to the left correctly on a page that is ' +
@@ -2045,7 +2045,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
         expect(Math.floor(originRect.right)).toBe(Math.floor(boundingBoxRect.width));
 
         window.scroll(0, 0);
-        document.body.removeChild(veryLargeElement);
+        veryLargeElement.remove();
       });
 
     it('should set the maxWidth and maxHeight on the bounding box when exact dimension are ' +
@@ -2288,7 +2288,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
     afterEach(() => {
       onPositionChangeSubscription.unsubscribe();
-      document.body.removeChild(scrollable);
+      scrollable.remove();
     });
 
     it('should not have origin or overlay clipped or out of view without scroll', () => {
@@ -2348,7 +2348,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     afterEach(() => {
-      document.body.removeChild(originElement);
+      originElement.remove();
     });
 
     describe('in ltr', () => {
@@ -2458,7 +2458,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     afterEach(() => {
-      document.body.removeChild(originElement);
+      originElement.remove();
       positionStrategy.dispose();
     });
 
@@ -2513,7 +2513,7 @@ describe('FlexibleConnectedPositionStrategy', () => {
     });
 
     afterEach(() => {
-      document.body.removeChild(originElement);
+      originElement.remove();
     });
 
     it('should be able to apply a class based on the position', () => {

--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -43,9 +43,9 @@ describe('BlockScrollStrategy', () => {
 
   afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
     overlayRef.dispose();
-    document.body.removeChild(forceScrollElement);
+    forceScrollElement.remove();
     window.scroll(0, 0);
-    container.getContainerElement().parentNode!.removeChild(container.getContainerElement());
+    container.getContainerElement().remove();
   }));
 
   it('should toggle scroll blocking along the y axis', skipIOS(() => {

--- a/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
@@ -44,7 +44,7 @@ describe('CloseScrollStrategy', () => {
 
   afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
     overlayRef.dispose();
-    container.getContainerElement().parentNode!.removeChild(container.getContainerElement());
+    container.getContainerElement().remove();
   }));
 
   it('should detach the overlay as soon as the user scrolls', () => {

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -38,7 +38,7 @@ describe('RepositionScrollStrategy', () => {
 
   afterEach(inject([OverlayContainer], (container: OverlayContainer) => {
     overlayRef.dispose();
-    container.getContainerElement().parentNode!.removeChild(container.getContainerElement());
+    container.getContainerElement().remove();
   }));
 
   it('should update the overlay position when the page is scrolled', () => {

--- a/src/cdk/platform/features/scrolling.ts
+++ b/src/cdk/platform/features/scrolling.ts
@@ -108,7 +108,7 @@ export function getRtlScrollAxisType(): RtlScrollAxisType {
           scrollContainer.scrollLeft === 0 ? RtlScrollAxisType.NEGATED : RtlScrollAxisType.INVERTED;
     }
 
-    scrollContainer.parentNode!.removeChild(scrollContainer);
+    scrollContainer.remove();
   }
   return rtlScrollAxisType;
 }

--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -148,9 +148,7 @@ export class DomPortalOutlet extends BasePortalOutlet {
    */
   override dispose(): void {
     super.dispose();
-    if (this.outletElement.parentNode != null) {
-      this.outletElement.parentNode.removeChild(this.outletElement);
-    }
+    this.outletElement.remove();
   }
 
   /** Gets the root HTMLElement for an instantiated component. */

--- a/src/cdk/scrolling/viewport-ruler.spec.ts
+++ b/src/cdk/scrolling/viewport-ruler.spec.ts
@@ -55,7 +55,7 @@ describe('ViewportRuler', () => {
     // successfully constrain its size. As such, skip assertions in environments where the
     // window size has changed since the start of the test.
     if (window.innerWidth > startingWindowWidth || window.innerHeight > startingWindowHeight) {
-      document.body.removeChild(veryLargeElement);
+      veryLargeElement.remove();
       return;
     }
 
@@ -64,7 +64,7 @@ describe('ViewportRuler', () => {
     expect(bounds.bottom).toBe(2000 + window.innerHeight);
     expect(bounds.right).toBe(1500 + window.innerWidth);
 
-    document.body.removeChild(veryLargeElement);
+    veryLargeElement.remove();
   });
 
   it('should get the bounds based on client coordinates when the page is pinch-zoomed', () => {
@@ -89,7 +89,7 @@ describe('ViewportRuler', () => {
     // successfully constrain its size. As such, skip assertions in environments where the
     // window size has changed since the start of the test.
     if (window.innerWidth > startingWindowWidth || window.innerHeight > startingWindowHeight) {
-      document.body.removeChild(veryLargeElement);
+      veryLargeElement.remove();
       return;
     }
 
@@ -97,7 +97,7 @@ describe('ViewportRuler', () => {
     expect(scrollPos.top).toBe(2000);
     expect(scrollPos.left).toBe(1500);
 
-    document.body.removeChild(veryLargeElement);
+    veryLargeElement.remove();
   });
 
   describe('changed event', () => {

--- a/src/cdk/testing/tests/test-main-component.ts
+++ b/src/cdk/testing/tests/test-main-component.ts
@@ -72,7 +72,7 @@ export class TestMainComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
-    document.body.removeChild(this._fakeOverlayElement);
+    this._fakeOverlayElement.remove();
   }
 
   click() {

--- a/src/cdk/testing/text-filtering.ts
+++ b/src/cdk/testing/text-filtering.ts
@@ -15,8 +15,7 @@ export function _getTextWithExcludedElements(element: Element, excludeSelector: 
   const clone = element.cloneNode(true) as Element;
   const exclusions = clone.querySelectorAll(excludeSelector);
   for (let i = 0; i < exclusions.length; i++) {
-    let child = exclusions[i];
-    child.parentNode?.removeChild(child);
+    exclusions[i].remove();
   }
   return (clone.textContent || '').trim();
 }

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -204,7 +204,7 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
 
     this._textareaElement.parentNode!.appendChild(textareaClone);
     this._cachedLineHeight = textareaClone.clientHeight;
-    this._textareaElement.parentNode!.removeChild(textareaClone);
+    textareaClone.remove();
 
     // Min and max heights have to be re-calculated if the cached line height changes
     this._setMinHeight();

--- a/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
@@ -1790,7 +1790,7 @@ expect(scrollContainer.scrollTop)
         .withContext('Expected panel top to match input bottom after scrolling.')
         .toEqual(Math.floor(panelTop));
 
-      document.body.removeChild(spacer);
+      spacer.remove();
       window.scroll(0, 0);
     });
 

--- a/src/material-experimental/mdc-dialog/dialog.spec.ts
+++ b/src/material-experimental/mdc-dialog/dialog.spec.ts
@@ -811,7 +811,7 @@ describe('MDC-based MatDialog', () => {
 
        expect(sibling.hasAttribute('aria-hidden'))
         .withContext('Expected sibling to no longer be hidden.').toBe(false);
-       sibling.parentNode!.removeChild(sibling);
+       sibling.remove();
      }));
 
   it('should restore `aria-hidden` to the overlay container siblings on close', fakeAsync(() => {
@@ -833,7 +833,7 @@ describe('MDC-based MatDialog', () => {
 
        expect(sibling.getAttribute('aria-hidden'))
         .withContext('Expected sibling to remain hidden.').toBe('true');
-       sibling.parentNode!.removeChild(sibling);
+       sibling.remove();
      }));
 
   it('should not set `aria-hidden` on `aria-live` elements', fakeAsync(() => {
@@ -848,7 +848,7 @@ describe('MDC-based MatDialog', () => {
 
        expect(sibling.hasAttribute('aria-hidden'))
         .withContext('Expected live element not to be hidden.').toBe(false);
-       sibling.parentNode!.removeChild(sibling);
+       sibling.remove();
      }));
 
   it('should add and remove classes while open', () => {
@@ -1098,7 +1098,7 @@ describe('MDC-based MatDialog', () => {
   describe('focus management', () => {
     // When testing focus, all of the elements must be in the DOM.
     beforeEach(() => document.body.appendChild(overlayContainerElement));
-    afterEach(() => document.body.removeChild(overlayContainerElement));
+    afterEach(() => overlayContainerElement.remove());
 
     it('should focus the first tabbable element of the dialog on open (the default)',
     fakeAsync(() => {
@@ -1204,7 +1204,7 @@ describe('MDC-based MatDialog', () => {
           .withContext('Expected that the trigger was refocused after the dialog is closed.')
           .toBe('dialog-trigger');
 
-         document.body.removeChild(button);
+         button.remove();
        }));
 
     it('should re-focus trigger element inside the shadow DOM when dialog closes', fakeAsync(() => {
@@ -1265,7 +1265,7 @@ describe('MDC-based MatDialog', () => {
           .withContext('Expected the trigger button to be focused via keyboard').toBe('keyboard');
 
          focusMonitor.stopMonitoring(button);
-         document.body.removeChild(button);
+         button.remove();
        }));
 
     it('should re-focus the trigger via mouse when backdrop has been clicked', fakeAsync(() => {
@@ -1301,7 +1301,7 @@ describe('MDC-based MatDialog', () => {
           .withContext('Expected the trigger button to be focused via mouse').toBe('mouse');
 
          focusMonitor.stopMonitoring(button);
-         document.body.removeChild(button);
+         button.remove();
        }));
 
     it('should re-focus via keyboard if the close button has been triggered through keyboard',
@@ -1341,7 +1341,7 @@ describe('MDC-based MatDialog', () => {
           .withContext('Expected the trigger button to be focused via keyboard').toBe('keyboard');
 
          focusMonitor.stopMonitoring(button);
-         document.body.removeChild(button);
+         button.remove();
        }));
 
     it('should re-focus via mouse if the close button has been clicked', fakeAsync(() => {
@@ -1381,7 +1381,7 @@ describe('MDC-based MatDialog', () => {
           .withContext('Expected the trigger button to be focused via mouse').toBe('mouse');
 
          focusMonitor.stopMonitoring(button);
-         document.body.removeChild(button);
+         button.remove();
        }));
 
     it('should allow the consumer to shift focus in afterClosed', fakeAsync(() => {
@@ -1412,8 +1412,8 @@ describe('MDC-based MatDialog', () => {
           .withContext('Expected that the trigger was refocused after the dialog is closed.')
           .toBe('input-to-be-focused');
 
-         document.body.removeChild(button);
-         document.body.removeChild(input);
+         button.remove();
+         input.remove();
          flush();
        }));
 
@@ -1453,7 +1453,7 @@ describe('MDC-based MatDialog', () => {
          expect(document.activeElement!.id)
              .not.toBe('dialog-trigger', 'Expected focus not to have been restored.');
 
-         document.body.removeChild(button);
+         button.remove();
        }));
 
     it('should not move focus if it was moved outside the dialog while animating', fakeAsync(() => {
@@ -1490,8 +1490,8 @@ describe('MDC-based MatDialog', () => {
          expect(document.activeElement!.id)
           .withContext('Expected focus to stay on the alternate button.').toBe('other-button');
 
-         body.removeChild(button);
-         body.removeChild(otherButton);
+         button.remove();
+         otherButton.remove();
        }));
   });
 

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -208,7 +208,7 @@ describe('MDC-based MatMenu', () => {
     tick(500);
 
     expect(document.activeElement).toBe(button);
-    document.body.removeChild(button);
+    button.remove();
     subscription.unsubscribe();
   }));
 

--- a/src/material-experimental/mdc-tabs/ink-bar.ts
+++ b/src/material-experimental/mdc-tabs/ink-bar.ts
@@ -116,10 +116,7 @@ export class MatInkBarFoundation {
 
   /** Destroys the foundation. */
   destroy() {
-    if (this._inkBarElement.parentNode) {
-      this._inkBarElement.parentNode.removeChild(this._inkBarElement);
-    }
-
+    this._inkBarElement.remove();
     this._hostElement = this._inkBarElement = this._inkBarContentElement = null!;
     this._foundation.destroy();
     this._destroyed = true;

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1774,7 +1774,7 @@ expect(container.scrollTop)
         .withContext('Expected panel top to match input bottom after scrolling.')
         .toEqual(Math.floor(panelTop));
 
-      document.body.removeChild(spacer);
+      spacer.remove();
       window.scroll(0, 0);
     });
 

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -587,7 +587,7 @@ describe('MatBottomSheet', () => {
   describe('focus management', () => {
     // When testing focus, all of the elements must be in the DOM.
     beforeEach(() => document.body.appendChild(overlayContainerElement));
-    afterEach(() => document.body.removeChild(overlayContainerElement));
+    afterEach(() => overlayContainerElement.remove());
 
     it('should focus the bottom sheet container by default', fakeAsync(() => {
       bottomSheet.open(PizzaMsg, {
@@ -708,7 +708,7 @@ describe('MatBottomSheet', () => {
         .withContext('Expected that the trigger was refocused after the sheet is closed.')
         .toBe('bottom-sheet-trigger');
 
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should be able to disable focus restoration', fakeAsync(() => {
@@ -740,7 +740,7 @@ describe('MatBottomSheet', () => {
       expect(document.activeElement!.id).not.toBe('bottom-sheet-trigger',
           'Expected the trigger not to be refocused on close.');
 
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should not move focus if it was moved outside the sheet while animating', fakeAsync(() => {
@@ -777,8 +777,8 @@ describe('MatBottomSheet', () => {
       expect(document.activeElement!.id)
         .withContext('Expected focus to stay on the alternate button.').toBe('other-button');
 
-      body.removeChild(button);
-      body.removeChild(otherButton);
+      button.remove();
+      otherButton.remove();
     }));
 
     it('should re-focus trigger element inside the shadow DOM when the bottom sheet is dismissed',

--- a/src/material/core/common-behaviors/common-module.ts
+++ b/src/material/core/common-behaviors/common-module.ts
@@ -137,7 +137,7 @@ export class MatCommonModule {
       );
     }
 
-    this._document.body.removeChild(testElement);
+    testElement.remove();
   }
 
   /** Checks whether the material version matches the cdk version */

--- a/src/material/core/ripple/ripple-renderer.ts
+++ b/src/material/core/ripple/ripple-renderer.ts
@@ -199,7 +199,7 @@ export class RippleRenderer implements EventListenerObject {
     // Once the ripple faded out, the ripple can be safely removed from the DOM.
     this._runTimeoutOutsideZone(() => {
       rippleRef.state = RippleState.HIDDEN;
-      rippleEl.parentNode!.removeChild(rippleEl);
+      rippleEl.remove();
     }, animationConfig.exitDuration);
   }
 

--- a/src/material/core/ripple/ripple.spec.ts
+++ b/src/material/core/ripple/ripple.spec.ts
@@ -320,7 +320,7 @@ describe('MatRipple', () => {
       });
 
       afterEach(() => {
-        document.body.removeChild(veryLargeElement);
+        veryLargeElement.remove();
         document.body.scrollTop = 0;
         document.body.scrollLeft = 0;
 

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -1248,7 +1248,7 @@ expect(firstCalendarCell.textContent!.trim())
             .withContext('Expected alternate focus target to be focused after closing.')
             .toBe(focusTarget);
 
-          focusTarget.parentNode!.removeChild(focusTarget);
+          focusTarget.remove();
           subscription.unsubscribe();
         }));
 

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -888,7 +888,7 @@ describe('MatDialog', () => {
 
     expect(sibling.hasAttribute('aria-hidden'))
       .withContext('Expected sibling to no longer be hidden.').toBe(false);
-    sibling.parentNode!.removeChild(sibling);
+    sibling.remove();
   }));
 
   it('should restore `aria-hidden` to the overlay container siblings on close', fakeAsync(() => {
@@ -910,7 +910,7 @@ describe('MatDialog', () => {
 
     expect(sibling.getAttribute('aria-hidden'))
       .withContext('Expected sibling to remain hidden.').toBe('true');
-    sibling.parentNode!.removeChild(sibling);
+    sibling.remove();
   }));
 
   it('should not set `aria-hidden` on `aria-live` elements', fakeAsync(() => {
@@ -925,7 +925,7 @@ describe('MatDialog', () => {
 
     expect(sibling.hasAttribute('aria-hidden'))
       .withContext('Expected live element not to be hidden.').toBe(false);
-    sibling.parentNode!.removeChild(sibling);
+    sibling.remove();
   }));
 
   it('should add and remove classes while open', () => {
@@ -1175,7 +1175,7 @@ describe('MatDialog', () => {
   describe('focus management', () => {
     // When testing focus, all of the elements must be in the DOM.
     beforeEach(() => document.body.appendChild(overlayContainerElement));
-    afterEach(() => document.body.removeChild(overlayContainerElement));
+    afterEach(() => overlayContainerElement.remove());
 
     it('should focus the first tabbable element of the dialog on open (the default)',
       fakeAsync(() => {
@@ -1281,7 +1281,7 @@ describe('MatDialog', () => {
         .withContext('Expected that the trigger was refocused after the dialog is closed.')
         .toBe('dialog-trigger');
 
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should re-focus trigger element inside the shadow DOM when dialog closes', fakeAsync(() => {
@@ -1340,7 +1340,7 @@ describe('MatDialog', () => {
         .withContext('Expected the trigger button to be focused via keyboard').toBe('keyboard');
 
       focusMonitor.stopMonitoring(button);
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should re-focus the trigger via mouse when backdrop has been clicked', fakeAsync(() => {
@@ -1374,7 +1374,7 @@ describe('MatDialog', () => {
         .withContext('Expected the trigger button to be focused via mouse').toBe('mouse');
 
       focusMonitor.stopMonitoring(button);
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should re-focus via keyboard if the close button has been triggered through keyboard',
@@ -1420,7 +1420,7 @@ describe('MatDialog', () => {
         .toBe('keyboard');
 
       focusMonitor.stopMonitoring(button);
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should re-focus via mouse if the close button has been clicked', fakeAsync(() => {
@@ -1464,7 +1464,7 @@ describe('MatDialog', () => {
         .toBe('mouse');
 
       focusMonitor.stopMonitoring(button);
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should allow the consumer to shift focus in afterClosed', fakeAsync(() => {
@@ -1495,8 +1495,8 @@ describe('MatDialog', () => {
         .withContext('Expected that the trigger was refocused after the dialog is closed.')
         .toBe('input-to-be-focused');
 
-      document.body.removeChild(button);
-      document.body.removeChild(input);
+      button.remove();
+      input.remove();
       flush();
     }));
 
@@ -1538,7 +1538,7 @@ describe('MatDialog', () => {
       expect(document.activeElement!.id).not.toBe('dialog-trigger',
           'Expected focus not to have been restored.');
 
-      document.body.removeChild(button);
+      button.remove();
     }));
 
     it('should not move focus if it was moved outside the dialog while animating', fakeAsync(() => {
@@ -1575,8 +1575,8 @@ describe('MatDialog', () => {
       expect(document.activeElement!.id)
         .withContext('Expected focus to stay on the alternate button.').toBe('other-button');
 
-      body.removeChild(button);
-      body.removeChild(otherButton);
+      button.remove();
+      otherButton.remove();
     }));
 
   });

--- a/src/material/icon/icon.ts
+++ b/src/material/icon/icon.ts
@@ -317,7 +317,7 @@ export class MatIcon extends _MatIconBase implements OnInit, AfterViewChecked, C
       // 1 corresponds to Node.ELEMENT_NODE. We remove all non-element nodes in order to get rid
       // of any loose text nodes, as well as any SVG elements in order to remove any old icons.
       if (child.nodeType !== 1 || child.nodeName.toLowerCase() === 'svg') {
-        layoutElement.removeChild(child);
+        child.remove();
       }
     }
   }

--- a/src/material/menu/menu-item.ts
+++ b/src/material/menu/menu-item.ts
@@ -172,8 +172,7 @@ export class MatMenuItem extends _MatMenuItemBase
 
     // Strip away icons so they don't show up in the text.
     for (let i = 0; i < icons.length; i++) {
-      const icon = icons[i];
-      icon.parentNode?.removeChild(icon);
+      icons[i].remove();
     }
 
     return clone.textContent?.trim() || '';

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -209,7 +209,7 @@ describe('MatMenu', () => {
     tick(500);
 
     expect(document.activeElement).toBe(button);
-    document.body.removeChild(button);
+    button.remove();
     subscription.unsubscribe();
   }));
 

--- a/tslint.json
+++ b/tslint.json
@@ -99,6 +99,7 @@
       {"name": ["first"], "message": "Use take(1) instead."},
       {"name": ["Object", "assign"], "message": "Use the spread operator instead."},
       {"name": ["*", "asObservable"], "message": "Cast to Observable type instead."},
+      {"name": ["*", "removeChild"], "message": "Use `remove` instead instead."},
       {"name": ["isDevMode"], "message": "Use `typeof ngDevMode === 'undefined' || ngDevMode` instead"}
     ],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.


### PR DESCRIPTION
Now that we don't have to support IE11 anymore, we can use `Element.remove` instead of `removeChild`.