### PR TITLE
fix(cdk/drag-drop): allow using cdkDragRootElement w/ comment tag

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -636,6 +636,19 @@ describe('CdkDrag', () => {
         expect(dragElement.style.transform).toBeFalsy();
       }));
 
+    it('should be able to set an alternate drag root element for ng-container', fakeAsync(() => {
+      const fixture = createComponent(DraggableNgContainerWithAlternateRoot);
+      fixture.detectChanges();
+
+      const dragRoot = fixture.componentInstance.dragRoot.nativeElement;
+
+      expect(dragRoot.style.transform).toBeFalsy();
+
+      dragElementViaMouse(fixture, dragRoot, 50, 100);
+
+      expect(dragRoot.style.transform).toBe('translate3d(50px, 100px, 0px)');
+    }));
+
     it('should preserve the initial transform if the root element changes', fakeAsync(() => {
       const fixture = createComponent(DraggableWithAlternateRoot);
       fixture.detectChanges();
@@ -7148,6 +7161,21 @@ class DraggableWithRadioInputsInDropZone {
     {id: 2, checked: false},
     {id: 3, checked: true},
   ];
+}
+
+
+@Component({
+  template: `
+    <div #dragRoot class="alternate-root" style="width: 200px; height: 200px; background: hotpink">
+      <ng-container cdkDrag cdkDragRootElement=".alternate-root">
+        <div style="width: 100px; height: 100px; background: red;"></div>
+      </ng-container>
+    </div>
+  `
+})
+class DraggableNgContainerWithAlternateRoot {
+  @ViewChild('dragRoot') dragRoot: ElementRef<HTMLElement>;
+  @ViewChild(CdkDrag) dragInstance: CdkDrag;
 }
 
 /**

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -330,9 +330,14 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
 
   /** Syncs the root element with the `DragRef`. */
   private _updateRootElement() {
-    const element = this.element.nativeElement;
-    const rootElement = this.rootElementSelector ?
-      element.closest<HTMLElement>(this.rootElementSelector) : element;
+    const element = this.element.nativeElement as HTMLElement;
+    let rootElement = element;
+    if (this.rootElementSelector) {
+      rootElement = element.closest !== undefined
+        ? element.closest(this.rootElementSelector) as HTMLElement
+        // Comment tag doesn't have closest method, so use parent's one.
+        : element.parentElement?.closest(this.rootElementSelector) as HTMLElement;
+    }
 
     if (rootElement && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       assertElementNode(rootElement, 'cdkDrag');


### PR DESCRIPTION
Makes possible to use the following syntax to make dialogs draggable:
```html
<ng-container cdkDrag cdkDragRootElement=".cdk-overlay-pane">
  <h1 mat-dialog-title class="dialog-draggable" cdkDragHandle>Title</h1>
  <div mat-dialog-content>Content</div>
</ng-container>
```

Because of `ng-container` renders to comment and HTML comment doesn't have `.closest()` method we can use `element.parentElement.closest` for `rootElementSelector` searching.

**P.S.:** provided HTML code was working till cdk **v12.2.6** and stopped working on **>= v13.0.0-next.2**. Not sure what was changed.