### PR TITLE
docs(button, select): update a11y sections

### DIFF
--- a/src/cdk/stepper/stepper.md
+++ b/src/cdk/stepper/stepper.md
@@ -50,11 +50,12 @@ If you want to reset a stepper to its initial state, you can use the `reset` met
 resetting it will call `reset` on the underlying form control which clears the value.
 
 ### Keyboard interaction
-- <kbd>LEFT_ARROW</kbd>: Focuses the previous step header
-- <kbd>RIGHT_ARROW</kbd>: Focuses the next step header
-- <kbd>ENTER</kbd>, <kbd>SPACE</kbd>: Selects the step that the focus is currently on
-- <kbd>TAB</kbd>: Focuses the next tabbable element
-- <kbd>SHIFT</kbd>+<kbd>TAB</kbd>: Focuses the previous tabbable element
+| Keyboard shortcut      | Action                          |
+|------------------------|---------------------------------|
+| <kbd>Left Arrow</kbd>  | Focus the previous step header. |
+| <kbd>Right Arrow</kbd> | Focus the next step header.     |
+| <kbd>Enter</kbd>       | Select the focused step.        |
+| <kbd>Space</kbd>       | Select the focused step.        |
 
 ### Accessibility
 Apart from the built-in keyboard support, the stepper doesn't apply any treatment. When implementing

--- a/src/material/autocomplete/autocomplete.md
+++ b/src/material/autocomplete/autocomplete.md
@@ -100,12 +100,14 @@ autocomplete is attached to using the `matAutocompleteOrigin` directive together
 ```
 
 ### Keyboard interaction
-- <kbd>Down Arrow</kbd>: Next option becomes active
-- <kbd>Up Arrow</kbd>: Previous option becomes active
-- <kbd>Enter</kbd>: Selects currently active item
-- <kbd>Escape</kbd>: Closes the autocomplete panel
-- <kbd>Alt + Up Arrow</kbd>: Closes the autocomplete panel
-- <kbd>Alt + Down Arrow</kbd>: Open the autocomplete panel if there are any matching options.
+| Keyboard shortcut                      | Action                                                         |
+|----------------------------------------|----------------------------------------------------------------|
+| <kbd>Down Arrow</kbd>                  | Navigate to the next option.                                   |
+| <kbd>Up Arrow</kbd>                    | Navigate to the previous option.                               |
+| <kbd>Enter</kbd>                       | Select the active option.                                      |
+| <kbd>Escape</kbd>                      | Close the autocomplete panel.                                  |
+| <kbd>Alt</kbd> + <kbd>Up Arrow</kbd>   | Close the autocomplete panel.                                  |
+| <kbd>Alt</kbd> + <kbd>Down Arrow</kbd> | Open the autocomplete panel if there are any matching options. |
 
 ### Option groups
 `mat-option` can be collected into groups using the `mat-optgroup` element:
@@ -121,8 +123,8 @@ pattern, you should _not_ put other interactive controls, such as buttons or che
 an autocomplete option. Nesting interactive controls like this interferes with most assistive
 technology.
 
-Always provide an accessible label for the autocomplete. This can be done
-via `<mat-label>` inside of `<mat-form-field>`, a native `<label>` element, the `aria-label`
+Always provide an accessible label for the autocomplete. This can be done by using a
+`<mat-label>` inside of `<mat-form-field>`, a native `<label>` element, the `aria-label`
 attribute, or the `aria-labelledby` attribute.
 
 `MatAutocomplete` preserves focus on the text trigger, using `aria-activedescendant` to support

--- a/src/material/button/button.md
+++ b/src/material/button/button.md
@@ -34,9 +34,22 @@ approach this to the consuming app.
 
 ### Accessibility
 Angular Material uses native `<button>` and `<a>` elements to ensure an accessible experience by
-default. The `<button>` element should be used for any interaction that _performs an action on the
-current page_. The `<a>` element should be used for any interaction that _navigates to another
-view_.
+default. A `<button>` element should be used for any interaction that _performs an action on the
+current page_. An `<a>` element should be used for any interaction that _navigates to another
+URL_. All standard accessibility best practices for buttons and anchors apply to `MatButton`.
 
+#### Disabling anchors
+`MatAnchor` supports disabling an anchor in addition to the features provided by the native
+`<a>` element. When you disable an anchor, the component sets `aria-disabled="true"` and
+`tabindex="-1"`. Always test disabled anchors in your application to ensure compatibility
+with any assistive technology your application supports.
+
+#### Buttons with icons
 Buttons or links containing only icons (such as `mat-fab`, `mat-mini-fab`, and `mat-icon-button`)
-should be given a meaningful label via `aria-label` or `aria-labelledby`.
+should be given a meaningful label via `aria-label` or `aria-labelledby`. [See the documentation
+for `MatIcon`](https://material.angular.io/components/icon) for more
+information on using icons in buttons.
+
+#### Toggle buttons
+[See the documentation for `MatButtonToggle`](https://material.angular.io/components/button-toggle)
+for information on stateful toggle buttons.

--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -582,60 +582,60 @@ additional means of opening the pop-up, such as `MatDatepickerToggle`.
 
 The datepicker supports the following keyboard shortcuts:
 
-| Shortcut                               | Action                     |
+| Keyboard Shortcut                      | Action                     |
 |----------------------------------------|----------------------------|
-| <kbd>ALT</kbd> + <kbd>DOWN_ARROW</kbd> | Open the calendar pop-up   |
-| <kbd>ESCAPE</kbd>                      | Close the calendar pop-up  |
+| <kbd>Alt</kbd> + <kbd>Down Arrow</kbd> | Open the calendar pop-up   |
+| <kbd>Escape</kbd>                      | Close the calendar pop-up  |
 
 
 In month view:
 
 | Shortcut                              | Action                                   |
 |---------------------------------------|------------------------------------------|
-| <kbd>LEFT_ARROW</kbd>                 | Go to previous day                       |
-| <kbd>RIGHT_ARROW</kbd>                | Go to next day                           |
-| <kbd>UP_ARROW</kbd>                   | Go to same day in the previous week      |
-| <kbd>DOWN_ARROW</kbd>                 | Go to same day in the next week          |
-| <kbd>HOME</kbd>                       | Go to the first day of the month         |
-| <kbd>END</kbd>                        | Go to the last day of the month          |
-| <kbd>PAGE_UP</kbd>                    | Go to the same day in the previous month |
-| <kbd>ALT</kbd> + <kbd>PAGE_UP</kbd>   | Go to the same day in the previous year  |
-| <kbd>PAGE_DOWN</kbd>                  | Go to the same day in the next month     |
-| <kbd>ALT</kbd> + <kbd>PAGE_DOWN</kbd> | Go to the same day in the next year      |
-| <kbd>ENTER</kbd>                      | Select current date                      |
+| <kbd>Left Arrow</kbd>                 | Go to previous day                       |
+| <kbd>Right Arrow</kbd>                | Go to next day                           |
+| <kbd>Up Arrow</kbd>                   | Go to same day in the previous week      |
+| <kbd>Down Arrow</kbd>                 | Go to same day in the next week          |
+| <kbd>Home</kbd>                       | Go to the first day of the month         |
+| <kbd>End</kbd>                        | Go to the last day of the month          |
+| <kbd>Page up</kbd>                    | Go to the same day in the previous month |
+| <kbd>Alt</kbd> + <kbd>Page up</kbd>   | Go to the same day in the previous year  |
+| <kbd>Page Down</kbd>                  | Go to the same day in the next month     |
+| <kbd>Alt</kbd> + <kbd>Page Down</kbd> | Go to the same day in the next year      |
+| <kbd>Enter</kbd>                      | Select current date                      |
 
 
 In year view:
 
 | Shortcut                              | Action                                    |
 |---------------------------------------|-------------------------------------------|
-| <kbd>LEFT_ARROW</kbd>                 | Go to previous month                      |
-| <kbd>RIGHT_ARROW</kbd>                | Go to next month                          |
-| <kbd>UP_ARROW</kbd>                   | Go up a row (back 4 months)               |
-| <kbd>DOWN_ARROW</kbd>                 | Go down a row (forward 4 months)          |
-| <kbd>HOME</kbd>                       | Go to the first month of the year         |
-| <kbd>END</kbd>                        | Go to the last month of the year          |
-| <kbd>PAGE_UP</kbd>                    | Go to the same month in the previous year |
-| <kbd>ALT</kbd> + <kbd>PAGE_UP</kbd>   | Go to the same month 10 years back        |
-| <kbd>PAGE_DOWN</kbd>                  | Go to the same month in the next year     |
-| <kbd>ALT</kbd> + <kbd>PAGE_DOWN</kbd> | Go to the same month 10 years forward     |
-| <kbd>ENTER</kbd>                      | Select current month                      |
+| <kbd>Left Arrow</kbd>                 | Go to previous month                      |
+| <kbd>Right Arrow</kbd>                | Go to next month                          |
+| <kbd>Up Arrow</kbd>                   | Go up a row (back 4 months)               |
+| <kbd>Down Arrow</kbd>                 | Go down a row (forward 4 months)          |
+| <kbd>Home</kbd>                       | Go to the first month of the year         |
+| <kbd>End</kbd>                        | Go to the last month of the year          |
+| <kbd>Page Up</kbd>                    | Go to the same month in the previous year |
+| <kbd>Alt</kbd> + <kbd>Page up</kbd>   | Go to the same month 10 years back        |
+| <kbd>Page Down</kbd>                  | Go to the same month in the next year     |
+| <kbd>Alt</kbd> + <kbd>Page Down</kbd> | Go to the same month 10 years forward     |
+| <kbd>Enter</kbd>                      | Select current month                      |
 
 In multi-year view:
 
 | Shortcut                              | Action                                    |
 |---------------------------------------|-------------------------------------------|
-| <kbd>LEFT_ARROW</kbd>                 | Go to previous year                       |
-| <kbd>RIGHT_ARROW</kbd>                | Go to next year                           |
-| <kbd>UP_ARROW</kbd>                   | Go up a row (back 4 years)                |
-| <kbd>DOWN_ARROW</kbd>                 | Go down a row (forward 4 years)           |
-| <kbd>HOME</kbd>                       | Go to the first year in the current range |
-| <kbd>END</kbd>                        | Go to the last year in the current range  |
-| <kbd>PAGE_UP</kbd>                    | Go back 24 years                          |
-| <kbd>ALT</kbd> + <kbd>PAGE_UP</kbd>   | Go back 240 years                         |
-| <kbd>PAGE_DOWN</kbd>                  | Go forward 24 years                       |
-| <kbd>ALT</kbd> + <kbd>PAGE_DOWN</kbd> | Go forward 240 years                      |
-| <kbd>ENTER</kbd>                      | Select current year                       |
+| <kbd>Left Arrow</kbd>                 | Go to previous year                       |
+| <kbd>Right Arrow</kbd>                | Go to next year                           |
+| <kbd>Up Arrow</kbd>                   | Go up a row (back 4 years)                |
+| <kbd>Down Arrow</kbd>                 | Go down a row (forward 4 years)           |
+| <kbd>Home</kbd>                       | Go to the first year in the current range |
+| <kbd>End</kbd>                        | Go to the last year in the current range  |
+| <kbd>Page up</kbd>                    | Go back 24 years                          |
+| <kbd>Alt</kbd> + <kbd>Page up</kbd>   | Go back 240 years                         |
+| <kbd>Page Down</kbd>                  | Go forward 24 years                       |
+| <kbd>Alt</kbd> + <kbd>Page Down</kbd> | Go forward 240 years                      |
+| <kbd>Enter</kbd>                      | Select current year                       |
 
 ### Troubleshooting
 

--- a/src/material/menu/menu.md
+++ b/src/material/menu/menu.md
@@ -90,12 +90,14 @@ with a different set of data, depending on the trigger that opened it:
 ```
 
 ### Keyboard interaction
-- <kbd>DOWN_ARROW</kbd>: Focuses the next menu item
-- <kbd>UP_ARROW</kbd>: Focuses previous menu item
-- <kbd>RIGHT_ARROW</kbd>: Opens the menu item's sub-menu
-- <kbd>LEFT_ARROW</kbd>: Closes the current menu, if it is a sub-menu
-- <kbd>ENTER</kbd>: Activates the focused menu item
-- <kbd>ESCAPE</kbd>: Closes the menu
+| Keyboard shortcut      | Action                                      |
+|------------------------|---------------------------------------------|
+| <kbd>Down Arrow</kbd>  | Focus the next menu item.                   |
+| <kbd>Up Arrow</kbd>    | Focus the previous menu item.               |
+| <kbd>Left Arrow</kbd>  | Close the current menu if it is a sub-menu. |
+| <kbd>Right Arrow</kbd> | Opens the current menu item's sub-menu.     |
+| <kbd>Enter</kbd>       | Activate the focused menu item.             |
+| <kbd>Escape</kbd>      | Close all open menus.                       |
 
 ### Accessibility
 

--- a/src/material/select/select.md
+++ b/src/material/select/select.md
@@ -141,13 +141,22 @@ globally cause input errors to show when the input is dirty and invalid.
 - <kbd>ENTER</kbd> or <kbd>SPACE</kbd>: Select focused item
 
 ### Accessibility
+When possible, prefer a native `<select>` element over `MatSelect`. The native control
+provides the most accessible experience across the widest range of platforms.
 
-The `<mat-select>` component without text or label should be given a meaningful label via
-`aria-label` or `aria-labelledby`.
+`MatSelect` implements the combobox pattern detailed in the [1.2 version of the ARIA
+specification](https://www.w3.org/TR/wai-aria-1.2). The combobox trigger controls a `role="listbox"`
+element opened in a pop-up. Previous versions of the ARIA specification
+required that `role="combobox"` apply to a text input control, but the 1.2 version of the
+specification supports a wider variety of interaction patterns. This newer usage of ARIA works
+in all browser and screen-reader combinations supports by Angular Material.
 
-The `<mat-select>` component has `role="combobox"`, the dropdown panel has `role="listbox"` and options inside select panel have `role="option"`.
+Because the pop-up uses the `role="listbox"` pattern, you should _not_ put other interactive
+controls, such as buttons or checkboxes, inside a select option. Nesting interactive controls like
+this interferes with most assistive technology.
 
-The native `<select>` offers the best accessibility because it is supported directly by screen-readers.
+Always provide an accessible label for the select. This can be done by adding a `<mat-label>`
+inside of `<mat-form-field>`, the `aria-label` attribute, or the `aria-labelledby` attribute.
 
 ### Troubleshooting
 

--- a/src/material/select/select.md
+++ b/src/material/select/select.md
@@ -135,10 +135,14 @@ globally cause input errors to show when the input is dirty and invalid.
 ```
 
 ### Keyboard interaction
-
-- <kbd>DOWN_ARROW</kbd>: Focus next option
-- <kbd>UP_ARROW</kbd>: Focus previous option
-- <kbd>ENTER</kbd> or <kbd>SPACE</kbd>: Select focused item
+| Keyboard shortcut                      | Action                                                                |
+|----------------------------------------|-----------------------------------------------------------------------|
+| <kbd>Down Arrow</kbd>                  | Navigate to the next option.                                          |
+| <kbd>Up Arrow</kbd>                    | Navigate to the previous option.                                      |
+| <kbd>Enter</kbd>                       | If closed, open the select panel. If open, selects the active option. |
+| <kbd>Escape</kbd>                      | Close the select panel.                                               |
+| <kbd>Alt</kbd> + <kbd>Up Arrow</kbd>   | Close the select panel.                                               |
+| <kbd>Alt</kbd> + <kbd>Down Arrow</kbd> | Open the select panel if there are any matching options.              |
 
 ### Accessibility
 When possible, prefer a native `<select>` element over `MatSelect`. The native control
@@ -149,7 +153,7 @@ specification](https://www.w3.org/TR/wai-aria-1.2). The combobox trigger control
 element opened in a pop-up. Previous versions of the ARIA specification
 required that `role="combobox"` apply to a text input control, but the 1.2 version of the
 specification supports a wider variety of interaction patterns. This newer usage of ARIA works
-in all browser and screen-reader combinations supports by Angular Material.
+in all browser and screen-reader combinations supported by Angular Material.
 
 Because the pop-up uses the `role="listbox"` pattern, you should _not_ put other interactive
 controls, such as buttons or checkboxes, inside a select option. Nesting interactive controls like

--- a/src/material/stepper/stepper.md
+++ b/src/material/stepper/stepper.md
@@ -191,13 +191,12 @@ viewport.
 <!-- example(stepper-responsive) -->
 
 ### Keyboard interaction
-- <kbd>LEFT_ARROW</kbd>: Focuses the previous step header
-- <kbd>RIGHT_ARROW</kbd>: Focuses the next step header
-- <kbd>HOME</kbd>: Focuses the first step header
-- <kbd>END</kbd>: Focuses the last step header
-- <kbd>ENTER</kbd>, <kbd>SPACE</kbd>: Selects the step that the focus is currently on
-- <kbd>TAB</kbd>: Focuses the next tabbable element
-- <kbd>SHIFT</kbd>+<kbd>TAB</kbd>: Focuses the previous tabbable element
+| Keyboard shortcut      | Action                          |
+|------------------------|---------------------------------|
+| <kbd>Left Arrow</kbd>  | Focus the previous step header. |
+| <kbd>Right Arrow</kbd> | Focus the next step header.     |
+| <kbd>Enter</kbd>       | Select the focused step.        |
+| <kbd>Space</kbd>       | Select the focused step.        |
 
 ### Localizing labels
 Labels used by the stepper are provided through `MatStepperIntl`. Localization of these messages


### PR DESCRIPTION
Individual commits for your convenience
```
    docs(multiple): table format keyboard shortcuts

    Reformats all keyboard shortcut sections to tables and changes all
    `<kbd>` elements to stop using ALL CAPS, which can be read by
    screen-readers one letter at a time.
```
```
    docs(material/select): expand a11y section

    Expands the select's a11y section with additional guidance and background on its ARIA treatment.
```
```
    docs(material/button): expand a11y section

    Expands the buttons accessibility section with additional information on
    disabling anchors, icons, and toggle buttons.

```

cc @zarend @amysorto 