### PR TITLE
test(cdk/layout): fix test failure

### DIFF
--- a/src/cdk/layout/media-matcher.spec.ts
+++ b/src/cdk/layout/media-matcher.spec.ts
@@ -21,17 +21,17 @@ describe('MediaMatcher', () => {
     expect(mediaMatcher.matchMedia('(max-width: 1px)').matches).toBeFalsy();
   });
 
-  it('should add CSS rules for provided queries when the platform is webkit',
+  it('should add CSS rules for provided queries when the platform is webkit or blink',
     inject([Platform], (platform: Platform) => {
-      const randomWidth = `${Math.random()}px`;
+      const width = '123456px';
 
-      expect(getStyleTagByString(randomWidth)).toBeFalsy();
-      mediaMatcher.matchMedia(`(width: ${randomWidth})`);
+      expect(getStyleTagByString(width)).toBeFalsy();
+      mediaMatcher.matchMedia(`(width: ${width})`);
 
-      if (platform.WEBKIT) {
-        expect(getStyleTagByString(randomWidth)).toBeTruthy();
+      if (platform.WEBKIT || platform.BLINK) {
+        expect(getStyleTagByString(width)).toBeTruthy();
       } else {
-        expect(getStyleTagByString(randomWidth)).toBeFalsy();
+        expect(getStyleTagByString(width)).toBeFalsy();
       }
 
       function getStyleTagByString(str: string): HTMLStyleElement | undefined {


### PR DESCRIPTION
Fixes a test failure that seems to have snuck into master because of #23571.