### PR TITLE
fix(material-experimental/mdc-menu): use primary text color for menu icons

### DIFF
--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -28,7 +28,7 @@
     // chevron ourselves, we have to handle the color as well.
     .mat-mdc-menu-item .mat-icon-no-color,
     .mat-mdc-menu-submenu-icon {
-      @include mdc-theme.prop(color, text-icon-on-background);
+      @include mdc-theme.prop(color, text-primary-on-background);
     }
 
     // MDC's hover and focus styles are tied to their ripples which we aren't using.


### PR DESCRIPTION
The spec and MDC implementation use the text color for the icon as well. This changes our MDC-based menu implementation to be in line with those.