### PR TITLE
fix(mdc/expansion-panel): add bottom border to header in high contras…

### DIFF
--- a/src/material/expansion/expansion-panel-header.scss
+++ b/src/material/expansion/expansion-panel-header.scss
@@ -92,4 +92,9 @@
       content: '';
     }
   }
+  .mat-expansion-panel-content {
+    border-top: 1px solid;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
 }


### PR DESCRIPTION
…t mode

This works great when the content below the header had top padding, but looks like a mistake when there is no space between the content and the header. We could compensate for this by margin below the header, but maybe is should be up to the application developer to decide how to style this. There might be situations where we don't want any padding under the header, of we might add duplicate padding that results in too much padding.

This change only affects high-contrast mode. YDYT?

# Screenshots

## Before
![Screen Shot 2021-09-21 at 2 01 02 PM](https://user-images.githubusercontent.com/7720245/134248655-e8ad5987-1530-4fb4-98af-9beaef1963d0.png)
## After
![image](https://user-images.githubusercontent.com/7720245/134587398-7710d49e-2c1f-48a4-8812-30f24cb41c57.png)

![image](https://user-images.githubusercontent.com/7720245/134587303-c847beee-023b-4a35-a8f9-5e236a0988f1.png)

