### PR TITLE
fix(cdk/testing): require at least one argument for locator functions

### DIFF
--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -181,6 +181,10 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
   private async _getAllHarnessesAndTestElements<T extends (HarnessQuery<any> | string)[]>(
     queries: T,
   ): Promise<LocatorFnResult<T>[]> {
+    if (!queries.length) {
+      throw Error('CDK Component harness query must contain at least one element.');
+    }
+
     const {allQueries, harnessQueries, elementQueries, harnessTypes} = _parseQueries(queries);
 
     // Combine all of the queries into one large comma-delimited selector and use it to get all raw


### PR DESCRIPTION
Currently locator functions accept a spread argument which technically allows for zero selectors to be passed in. This can result in weird runtime errors.

These changes add a runtime error if no selectors are passed in. 

Note that a previous iteration of these changes tried to enforce this with typings, but it resulted in breaking changes.