### PR TITLE
refactor(material/sort): explicit sort direction

### DIFF
--- a/src/material/sort/sort-header.ts
+++ b/src/material/sort/sort-header.ts
@@ -137,7 +137,7 @@ export class MatSortHeader
   @Input() arrowPosition: 'before' | 'after' = 'after';
 
   /** Overrides the sort start value of the containing MatSort for this MatSortable. */
-  @Input() start: 'asc' | 'desc';
+  @Input() start: SortDirection;
 
   /**
    * Description applied to MatSortHeader's button element with aria-describedby. This text should

--- a/src/material/sort/sort.ts
+++ b/src/material/sort/sort.ts
@@ -34,7 +34,7 @@ export interface MatSortable {
   id: string;
 
   /** Starting sort direction. */
-  start: 'asc' | 'desc';
+  start: SortDirection;
 
   /** Whether to disable clearing the sorting state. */
   disableClear: boolean;
@@ -88,7 +88,7 @@ export class MatSort
    * The direction to set when an MatSortable is initially sorted.
    * May be overriden by the MatSortable's sort start.
    */
-  @Input('matSortStart') start: 'asc' | 'desc' = 'asc';
+  @Input('matSortStart') start: SortDirection = 'asc';
 
   /** The sort direction of the currently active MatSortable. */
   @Input('matSortDirection')
@@ -203,7 +203,7 @@ export class MatSort
 }
 
 /** Returns the sort direction cycle to use given the provided parameters of order and clear. */
-function getSortDirectionCycle(start: 'asc' | 'desc', disableClear: boolean): SortDirection[] {
+function getSortDirectionCycle(start: SortDirection, disableClear: boolean): SortDirection[] {
   let sortOrder: SortDirection[] = ['asc', 'desc'];
   if (start == 'desc') {
     sortOrder.reverse();

--- a/tools/public_api_guard/material/sort.md
+++ b/tools/public_api_guard/material/sort.md
@@ -70,7 +70,7 @@ export class MatSort extends _MatSortBase implements CanDisable, HasInitialized,
     sort(sortable: MatSortable): void;
     sortables: Map<string, MatSortable>;
     readonly sortChange: EventEmitter<Sort>;
-    start: 'asc' | 'desc';
+    start: SortDirection;
     readonly _stateChanges: Subject<void>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MatSort, "[matSort]", ["matSort"], { "disabled": "matSortDisabled"; "active": "matSortActive"; "start": "matSortStart"; "direction": "matSortDirection"; "disableClear": "matSortDisableClear"; }, { "sortChange": "matSortChange"; }, never>;
@@ -82,7 +82,7 @@ export class MatSort extends _MatSortBase implements CanDisable, HasInitialized,
 export interface MatSortable {
     disableClear: boolean;
     id: string;
-    start: 'asc' | 'desc';
+    start: SortDirection;
 }
 
 // @public
@@ -139,7 +139,7 @@ export class MatSortHeader extends _MatSortHeaderBase implements CanDisable, Mat
     _sort: MatSort;
     get sortActionDescription(): string;
     set sortActionDescription(value: string);
-    start: 'asc' | 'desc';
+    start: SortDirection;
     _toggleOnInteraction(): void;
     _updateArrowDirection(): void;
     _viewState: ArrowViewStateTransition;


### PR DESCRIPTION
Not sure if that is really needed.
Just it feels like it is more consistent with existing `SortDirection`. 🙂