### PR TITLE
fix(material/core): sanity checks not disabled for node-based test environments

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -99,10 +99,10 @@ export class FocusMonitor implements OnDestroy {
   private _windowFocused = false;
 
   /** The timeout id of the window focus timeout. */
-  private _windowFocusTimeoutId: number;
+  private _windowFocusTimeoutId: any;
 
   /** The timeout id of the origin clearing timeout. */
-  private _originTimeoutId: number;
+  private _originTimeoutId: any;
 
   /**
    * Whether the origin was determined via a touch interaction. Necessary as properly attributing

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -31,7 +31,7 @@ import {
 export class LiveAnnouncer implements OnDestroy {
   private _liveElement: HTMLElement;
   private _document: Document;
-  private _previousTimeout?: number;
+  private _previousTimeout: any;
 
   constructor(
       @Optional() @Inject(LIVE_ANNOUNCER_ELEMENT_TOKEN) elementToken: any,

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -425,7 +425,7 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
       return;
     }
 
-    let timeoutId: number;
+    let timeoutId: any;
     const finishDetach = () => {
       // It may not be attached to anything in certain cases (e.g. unit tests).
       if (backdropToDetach) {

--- a/src/cdk/platform/BUILD.bazel
+++ b/src/cdk/platform/BUILD.bazel
@@ -11,6 +11,7 @@ ng_module(
     deps = [
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@types/node",
     ],
 )
 

--- a/src/cdk/platform/features/test-environment.ts
+++ b/src/cdk/platform/features/test-environment.ts
@@ -17,7 +17,17 @@ declare interface TestGlobals {
   Mocha: unknown;
 }
 
-const testGlobals = (typeof window !== 'undefined' ? window : {}) as {} as TestGlobals;
+let testGlobals: TestGlobals;
+
+// We check the Node-specific `global` first, because tools tend to add a fake
+// `window` in Node environments which won't actually receive global variables.
+if (typeof global !== 'undefined') {
+  testGlobals = global as {} as TestGlobals;
+} else if (typeof window !== 'undefined') {
+  testGlobals = window as {} as TestGlobals;
+} else {
+  testGlobals = {} as TestGlobals;
+}
 
 /** Gets whether the code is currently running in a test environment. */
 export function _isTestEnvironment(): boolean {

--- a/src/cdk/tsconfig-tests.json
+++ b/src/cdk/tsconfig-tests.json
@@ -12,7 +12,7 @@
     "importHelpers": false,
     "module": "umd",
     "target": "es5",
-    "types": ["jasmine"],
+    "types": ["jasmine", "node"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "paths": {

--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -103,7 +103,7 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
    * Timeout used to give some time between `focusin` and `focusout`
    * in order to determine whether focus has left the chip.
    */
-  private _focusoutTimeout: number | null;
+  private _focusoutTimeout: any;
 
   constructor(
     @Inject(DOCUMENT) private readonly _document: any,

--- a/src/material-experimental/mdc-dialog/dialog-container.ts
+++ b/src/material-experimental/mdc-dialog/dialog-container.ts
@@ -58,7 +58,7 @@ export class MatDialogContainer extends _MatDialogContainerBase implements OnDes
   private _closeAnimationDuration =
       this._animationsEnabled ? numbers.DIALOG_ANIMATION_CLOSE_TIME_MS : 0;
   /** Current timer for dialog animations. */
-  private _animationTimer: number|null = null;
+  private _animationTimer: any = null;
 
   constructor(
       elementRef: ElementRef,

--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
@@ -69,7 +69,7 @@ export class MatSnackBarContainer extends BasePortalOutlet
   private readonly _announceDelay: number = 150;
 
   /** The timeout for announcing the snack bar's content. */
-  private _announceTimeoutId: number;
+  private _announceTimeoutId: any;
 
   /** Subject for notifying that the snack bar has announced to screen readers. */
   readonly _onAnnounce: Subject<void> = new Subject();

--- a/src/material/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/material/bottom-sheet/bottom-sheet-ref.ts
@@ -39,7 +39,7 @@ export class MatBottomSheetRef<T = any, R = any> {
   private _result: R | undefined;
 
   /** Handle to the timeout that's running as a fallback in case the exit animation doesn't fire. */
-  private _closeFallbackTimeout: number;
+  private _closeFallbackTimeout: any;
 
   constructor(
     containerInstance: MatBottomSheetContainer,

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -46,7 +46,7 @@ export class MatDialogRef<T, R = any> {
   private _result: R | undefined;
 
   /** Handle to the timeout that's running as a fallback in case the exit animation doesn't fire. */
-  private _closeFallbackTimeout: number;
+  private _closeFallbackTimeout: any;
 
   /** Current state of the dialog. */
   private _state = MatDialogState.OPEN;

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -75,7 +75,7 @@ export class MatSnackBarContainer extends BasePortalOutlet
   private readonly _announceDelay: number = 150;
 
   /** The timeout for announcing the snack bar's content. */
-  private _announceTimeoutId: number;
+  private _announceTimeoutId: any;
 
   /** Whether the component has been destroyed. */
   private _destroyed = false;

--- a/src/material/snack-bar/snack-bar-ref.ts
+++ b/src/material/snack-bar/snack-bar-ref.ts
@@ -46,7 +46,7 @@ export class MatSnackBarRef<T> {
    * Timeout ID for the duration setTimeout call. Used to clear the timeout if the snackbar is
    * dismissed before the duration passes.
    */
-  private _durationTimeoutId: number;
+  private _durationTimeoutId: any;
 
   /** Whether the snack bar was dismissed using the action button. */
   private _dismissedByAction = false;

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -248,7 +248,7 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase> implement
   private _document: Document;
 
   /** Timer started at the last `touchstart` event. */
-  private _touchstartTimeout: number;
+  private _touchstartTimeout: any;
 
   /** Emits when the component is destroyed. */
   private readonly _destroyed = new Subject<void>();
@@ -766,10 +766,10 @@ export abstract class _TooltipComponentBase implements OnDestroy {
   tooltipClass: string|string[]|Set<string>|{[key: string]: any};
 
   /** The timeout ID of any current timer set to show the tooltip */
-  _showTimeoutId: number | undefined;
+  _showTimeoutId: any;
 
   /** The timeout ID of any current timer set to hide the tooltip */
-  _hideTimeoutId: number | undefined;
+  _hideTimeoutId: any;
 
   /** Property watched by the animation framework to show or hide the tooltip */
   _visibility: TooltipVisibility = 'initial';

--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -183,7 +183,7 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     _animationStart(): void;
     _handleBodyInteraction(): void;
     hide(delay: number): void;
-    _hideTimeoutId: number | undefined;
+    _hideTimeoutId: any;
     isVisible(): boolean;
     _markForCheck(): void;
     message: string;
@@ -191,7 +191,7 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     ngOnDestroy(): void;
     protected _onShow(): void;
     show(delay: number): void;
-    _showTimeoutId: number | undefined;
+    _showTimeoutId: any;
     tooltipClass: string | string[] | Set<string> | {
         [key: string]: any;
     };


### PR DESCRIPTION
In #23374 we expanded the logic that checks for test environments to cover Jest and Mocha. The problem is that we were checking against the `window` which won't work in a Node environment, because the global variables are attached to the `global` object, not the `window`, even though there may be a fake `window` declared by the test tooling.

These changes resolve the issue by first checking against `global` before falling back to `window`.

Fixes #23365.