### PR TITLE
test: write pre-rendered univeral html file to bazel bin dir

### DIFF
--- a/src/universal-app/DEBUG.md
+++ b/src/universal-app/DEBUG.md
@@ -6,5 +6,5 @@ the file will be stored in the `bazel-out` folder.
 
 You can retrieve the path to the file by either running:
 
-* `bazel test //src/universal-app:server_test --test_output=all`
-* `echo $(bazel info bazel-bin)/src/universal-app/index-prerendered.html`
+* `bazel run //src/universal-app:server_test --test_output=all`
+* `echo $(bazel info bazel-testlogs)/src/universal-app/server_test/test.outputs/index-prerendered.html`

--- a/src/universal-app/prerender.ts
+++ b/src/universal-app/prerender.ts
@@ -14,21 +14,21 @@ import {KitchenSinkRootServerModuleNgFactory} from './kitchen-sink-root.ngfactor
 const indexHtmlPath = require.resolve('./index.html');
 
 const result = renderModuleFactory(
-    KitchenSinkRootServerModuleNgFactory,
-    {document: readFileSync(indexHtmlPath, 'utf-8')});
+    KitchenSinkRootServerModuleNgFactory, {document: readFileSync(indexHtmlPath, 'utf-8')});
+const outDir = process.env.TEST_UNDECLARED_OUTPUTS_DIR as string;
 
 result
-  .then(content => {
-    const filename = join(__dirname, 'index-prerendered.html');
+    .then(content => {
+      const filename = join(outDir, 'index-prerendered.html');
 
-    console.log('Inspect pre-rendered page here:');
-    console.log(`file://${filename}`);
-    writeFileSync(filename, content, 'utf-8');
-    console.log('Prerender done.');
-  })
-  // If rendering the module factory fails, print the error and exit the process
-  // with a non-zero exit code.
-  .catch(error => {
-    console.error(error);
-    process.exit(1);
-  });
+      console.log('Inspect pre-rendered page here:');
+      console.log(`file://${filename}`);
+      writeFileSync(filename, content, 'utf-8');
+      console.log('Prerender done.');
+    })
+    // If rendering the module factory fails, print the error and exit the process
+    // with a non-zero exit code.
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    });


### PR DESCRIPTION
Server side rendered kitchen sync app was written inside the test sandbox execution directory, which is deleted after test execution when the is executed without `--sandbox_debug` option thus we couldn't retrieve the `index-prendered.html` file using the command `echo $(bazel info bazel-bin)/src/universal-app/index-prerendered.html`