### PR TITLE
fix(material-date-fns-adapter): locale not passed into parse function

### DIFF
--- a/src/material-date-fns-adapter/adapter/date-fns-adapter.spec.ts
+++ b/src/material-date-fns-adapter/adapter/date-fns-adapter.spec.ts
@@ -9,7 +9,7 @@
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
 import {Locale} from 'date-fns';
-import {ja, enUS, da} from 'date-fns/locale';
+import {ja, enUS, da, de} from 'date-fns/locale';
 import {DateFnsModule} from './index';
 
 const JAN = 0, FEB = 1, MAR = 2, DEC = 11;
@@ -173,6 +173,11 @@ describe('DateFnsAdapter', () => {
 
   it('should parse empty string as null', () => {
     expect(adapter.parse('', 'MM/dd/yyyy')).toBeNull();
+  });
+
+  it('should parse based on the specified locale', () => {
+    adapter.setLocale(de);
+    expect(adapter.parse('02.01.2017', 'P')).toEqual(new Date(2017, JAN, 2));
   });
 
   it('should parse invalid value as invalid', () => {

--- a/src/material-date-fns-adapter/adapter/date-fns-adapter.ts
+++ b/src/material-date-fns-adapter/adapter/date-fns-adapter.ts
@@ -54,7 +54,7 @@ const DAY_OF_WEEK_FORMATS = {
 export class DateFnsAdapter extends DateAdapter<Date, Locale> {
   constructor(@Optional() @Inject(MAT_DATE_LOCALE) matDateLocale: {}) {
     super();
-    super.setLocale(matDateLocale);
+    this.setLocale(matDateLocale);
   }
 
   getYear(date: Date): number {
@@ -165,7 +165,7 @@ export class DateFnsAdapter extends DateAdapter<Date, Locale> {
       }
 
       for (const currentFormat of formats) {
-        const fromFormat = parse(value, currentFormat, new Date());
+        const fromFormat = parse(value, currentFormat, new Date(), {locale: this.locale});
 
         if (this.isValid(fromFormat)) {
           return fromFormat;


### PR DESCRIPTION
Fixes that the locale wasn't being passed into the parsing function of `date-fns`.

Fixes #23652.