### PR TITLE
fix(material-experimental/mdc-menu): Use body1 typography for menu content

### DIFF
--- a/src/material-experimental/mdc-menu/_menu-theme.scss
+++ b/src/material-experimental/mdc-menu/_menu-theme.scss
@@ -57,6 +57,7 @@
 
       // MDC uses the `subtitle1` level for list items, but the spec shows `body1` as the correct
       // level.
+      &,
       .mat-mdc-menu-item .mdc-list-item__primary-text {
         @include mdc-typography.typography(body1, $query: mdc-helpers.$mat-typography-styles-query);
       }


### PR DESCRIPTION
We already fixed this for menu items, but MDC also sets the wrong
typography level on the menu content element, which can bleed through
into people's custom menu content.