### PR TITLE
fix(cdk/drag-drop): error when preview is destroyed before animation completes

### DIFF
--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -1097,7 +1097,7 @@ export class DragRef<T = any> {
         const handler = ((event: TransitionEvent) => {
           if (!event || (_getEventTarget(event) === this._preview &&
               event.propertyName === 'transform')) {
-            this._preview.removeEventListener('transitionend', handler);
+            this._preview?.removeEventListener('transitionend', handler);
             resolve();
             clearTimeout(timeout);
           }


### PR DESCRIPTION
https://github.com/angular/components/issues/23655