### PR TITLE
fix(material/progress-spinner): animation not working on some zoom levels in Safari

### DIFF
--- a/src/material/progress-spinner/BUILD.bazel
+++ b/src/material/progress-spinner/BUILD.bazel
@@ -22,6 +22,7 @@ ng_module(
     deps = [
         "//src/cdk/coercion",
         "//src/cdk/platform",
+        "//src/cdk/scrolling",
         "//src/material/core",
         "@npm//@angular/animations",
         "@npm//@angular/common",

--- a/src/material/progress-spinner/progress-spinner.html
+++ b/src/material/progress-spinner/progress-spinner.html
@@ -14,7 +14,8 @@
   preserveAspectRatio="xMidYMid meet"
   focusable="false"
   [ngSwitch]="mode === 'indeterminate'"
-  aria-hidden="true">
+  aria-hidden="true"
+  #svg>
 
   <!--
     Technically we can reuse the same `circle` element, however Safari has an issue that breaks
@@ -31,7 +32,8 @@
     [style.animation-name]="'mat-progress-spinner-stroke-rotate-' + _spinnerAnimationLabel"
     [style.stroke-dashoffset.px]="_getStrokeDashOffset()"
     [style.stroke-dasharray.px]="_getStrokeCircumference()"
-    [style.stroke-width.%]="_getCircleStrokeWidth()"></circle>
+    [style.stroke-width.%]="_getCircleStrokeWidth()"
+    [style.transform-origin]="_getCircleTransformOrigin(svg)"></circle>
 
   <circle
     *ngSwitchCase="false"
@@ -40,5 +42,6 @@
     [attr.r]="_getCircleRadius()"
     [style.stroke-dashoffset.px]="_getStrokeDashOffset()"
     [style.stroke-dasharray.px]="_getStrokeCircumference()"
-    [style.stroke-width.%]="_getCircleStrokeWidth()"></circle>
+    [style.stroke-width.%]="_getCircleStrokeWidth()"
+    [style.transform-origin]="_getCircleTransformOrigin(svg)"></circle>
 </svg>

--- a/src/material/progress-spinner/progress-spinner.scss
+++ b/src/material/progress-spinner/progress-spinner.scss
@@ -26,7 +26,6 @@ $_default-circumference: variables.$pi * $_default-radius * 2;
   circle {
     @include private.private-animation-noop();
     fill: transparent;
-    transform-origin: center;
     transition: stroke-dashoffset 225ms linear;
 
     @include a11y.high-contrast(active, off) {

--- a/tools/public_api_guard/material/progress-spinner.md
+++ b/tools/public_api_guard/material/progress-spinner.md
@@ -6,15 +6,19 @@
 
 import { _AbstractConstructor } from '@angular/material/core';
 import { CanColor } from '@angular/material/core';
+import { ChangeDetectorRef } from '@angular/core';
 import { _Constructor } from '@angular/material/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i2 from '@angular/material/core';
 import * as i3 from '@angular/common';
 import { InjectionToken } from '@angular/core';
+import { NgZone } from '@angular/core';
 import { NumberInput } from '@angular/cdk/coercion';
+import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Platform } from '@angular/cdk/platform';
+import { ViewportRuler } from '@angular/cdk/scrolling';
 
 // @public
 export const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatProgressSpinnerDefaultOptions>;
@@ -23,17 +27,20 @@ export const MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS: InjectionToken<MatProgressSpi
 export function MAT_PROGRESS_SPINNER_DEFAULT_OPTIONS_FACTORY(): MatProgressSpinnerDefaultOptions;
 
 // @public
-export class MatProgressSpinner extends _MatProgressSpinnerBase implements OnInit, CanColor {
-    constructor(elementRef: ElementRef<HTMLElement>,
-    _platform: Platform, _document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
+export class MatProgressSpinner extends _MatProgressSpinnerBase implements OnInit, OnDestroy, CanColor {
+    constructor(elementRef: ElementRef<HTMLElement>, _platform: Platform, _document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions,
+    changeDetectorRef?: ChangeDetectorRef, viewportRuler?: ViewportRuler, ngZone?: NgZone);
     get diameter(): number;
     set diameter(size: NumberInput);
     _getCircleRadius(): number;
     _getCircleStrokeWidth(): number;
+    _getCircleTransformOrigin(svg: HTMLElement): string;
     _getStrokeCircumference(): number;
     _getStrokeDashOffset(): number | null;
     _getViewBox(): string;
     mode: ProgressSpinnerMode;
+    // (undocumented)
+    ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
     _noopAnimations: boolean;
@@ -45,7 +52,7 @@ export class MatProgressSpinner extends _MatProgressSpinnerBase implements OnIni
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatProgressSpinner, "mat-progress-spinner", ["matProgressSpinner"], { "color": "color"; "diameter": "diameter"; "strokeWidth": "strokeWidth"; "mode": "mode"; "value": "value"; }, {}, never, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatProgressSpinner, [null, null, { optional: true; }, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatProgressSpinner, [null, null, { optional: true; }, { optional: true; }, null, null, null, null]>;
 }
 
 // @public
@@ -67,11 +74,12 @@ export class MatProgressSpinnerModule {
 
 // @public
 export class MatSpinner extends MatProgressSpinner {
-    constructor(elementRef: ElementRef<HTMLElement>, platform: Platform, document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions);
+    constructor(elementRef: ElementRef<HTMLElement>, platform: Platform, document: any, animationMode: string, defaults?: MatProgressSpinnerDefaultOptions,
+    changeDetectorRef?: ChangeDetectorRef, viewportRuler?: ViewportRuler, ngZone?: NgZone);
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<MatSpinner, "mat-spinner", never, { "color": "color"; }, {}, never, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatSpinner, [null, null, { optional: true; }, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatSpinner, [null, null, { optional: true; }, { optional: true; }, null, null, null, null]>;
 }
 
 // @public


### PR DESCRIPTION
Fixes that the progress spinner animation was broken on Safari on non-default zoom levels. The problem seems to be that the `transform-origin` was being offset by the amount of zoom. These changes work around it by setting the origin based on the zoom level.

Fixes #23668.