### PR TITLE
refactor: use officially supported `strict_templates` attribute on `ng_module()` and remove local workaround

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -86,6 +86,7 @@ def ng_module(
         tsconfig = None,
         flat_module_out_file = None,
         testonly = False,
+        strict_templates = True,
         **kwargs):
     if not tsconfig:
         tsconfig = _getDefaultTsConfig(testonly)
@@ -139,6 +140,7 @@ def ng_module(
         deps = local_deps,
         tsconfig = tsconfig,
         testonly = testonly,
+        strict_templates = strict_templates,
         **kwargs
     )
 

--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -110,12 +110,6 @@ function applyPatches() {
   // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1208.
   applyPatch(path.join(__dirname, './manifest_externs_hermeticity.patch'));
 
-  // Workaround for https://github.com/angular/angular/issues/33452:
-  searchAndReplace(
-      /angular_compiler_options = {/, `$&
-          "strictTemplates": True,`,
-      'node_modules/@angular/bazel/src/ng_module.bzl');
-
   // More info in https://github.com/angular/angular/pull/33786
   shelljs.rm('-rf', [
     'node_modules/rxjs/add/',


### PR DESCRIPTION
Refs: angular/angular#33452.

This workaround is no longer necessary since `ng_module()` actually supports strict templates now (see angular/angular#43582).

Creating this PR as a draft right now as it is blocked on components upgrading to `@angular/bazel@13.0.0-next.9` or later.