### PR TITLE
docs(material/chips): use defaults for input bindings

### DIFF
--- a/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
+++ b/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.html
@@ -3,11 +3,9 @@
   <mat-chip-list #chipList aria-label="Fruit selection">
     <mat-chip
       *ngFor="let fruit of fruits"
-      [selectable]="selectable"
-      [removable]="removable"
       (removed)="remove(fruit)">
       {{fruit}}
-      <button matChipRemove *ngIf="removable">
+      <button matChipRemove>
         <mat-icon>cancel</mat-icon>
       </button>
     </mat-chip>

--- a/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/components-examples/material/chips/chips-autocomplete/chips-autocomplete-example.ts
@@ -15,8 +15,6 @@ import {map, startWith} from 'rxjs/operators';
   styleUrls: ['chips-autocomplete-example.css'],
 })
 export class ChipsAutocompleteExample {
-  selectable = true;
-  removable = true;
   separatorKeysCodes: number[] = [ENTER, COMMA];
   fruitCtrl = new FormControl();
   filteredFruits: Observable<string[]>;

--- a/src/components-examples/material/chips/chips-input/chips-input-example.html
+++ b/src/components-examples/material/chips/chips-input/chips-input-example.html
@@ -1,10 +1,9 @@
 <mat-form-field class="example-chip-list" appearance="fill">
   <mat-label>Favorite Fruits</mat-label>
   <mat-chip-list #chipList aria-label="Fruit selection">
-    <mat-chip *ngFor="let fruit of fruits" [selectable]="selectable"
-             [removable]="removable" (removed)="remove(fruit)">
+    <mat-chip *ngFor="let fruit of fruits" (removed)="remove(fruit)">
       {{fruit.name}}
-      <button matChipRemove *ngIf="removable">
+      <button matChipRemove>
         <mat-icon>cancel</mat-icon>
       </button>
     </mat-chip>

--- a/src/components-examples/material/chips/chips-input/chips-input-example.ts
+++ b/src/components-examples/material/chips/chips-input/chips-input-example.ts
@@ -15,8 +15,6 @@ export interface Fruit {
   styleUrls: ['chips-input-example.css'],
 })
 export class ChipsInputExample {
-  selectable = true;
-  removable = true;
   addOnBlur = true;
   readonly separatorKeysCodes = [ENTER, COMMA] as const;
   fruits: Fruit[] = [


### PR DESCRIPTION
Do not set the `selectable` and `removable` default values explicitly in the examples.