### PR TITLE
fix(material/chips): Make `MatChipInputEvent.chipInput` required.

### DIFF
--- a/src/material-experimental/mdc-chips/chip-input.ts
+++ b/src/material-experimental/mdc-chips/chip-input.ts
@@ -37,11 +37,8 @@ export interface MatChipInputEvent {
   /** The value of the input. */
   value: string;
 
-  /**
-   * Reference to the chip input that emitted the event.
-   * @breaking-change 13.0.0 This property will be made required.
-   */
-  chipInput?: MatChipInput;
+  /** Reference to the chip input that emitted the event. */
+  chipInput: MatChipInput;
 }
 
 // Increasing integer for generating unique ids.

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -35,11 +35,8 @@ export interface MatChipInputEvent {
   /** The value of the input. */
   value: string;
 
-  /**
-   * Reference to the chip input that emitted the event.
-   * @breaking-change 13.0.0 This property will be made required.
-   */
-  chipInput?: MatChipInput;
+  /** Reference to the chip input that emitted the event. */
+  chipInput: MatChipInput;
 }
 
 // Increasing integer for generating unique ids.

--- a/tools/public_api_guard/material/chips.md
+++ b/tools/public_api_guard/material/chips.md
@@ -188,7 +188,7 @@ export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy, A
 
 // @public
 export interface MatChipInputEvent {
-    chipInput?: MatChipInput;
+    chipInput: MatChipInput;
     // @deprecated
     input: HTMLInputElement;
     value: string;


### PR DESCRIPTION
BREAKING CHANGE: `MatChipInputEvent.chipInput` is now a required property.