### PR TITLE
Fix fake events inside shadow DOM and drag handles with shadow DOM children

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1581,6 +1581,26 @@ describe('CdkDrag', () => {
         flush();
       }).toThrowError(/^cdkDragHandle must be attached to an element node/);
     }));
+
+    it('should be able to drag an element using a handle with a shadow DOM child', fakeAsync(() => {
+      if (!_supportsShadowDom()) {
+        return;
+      }
+
+      const fixture = createComponent(
+        StandaloneDraggableWithShadowInsideHandle,
+        undefined,
+        undefined,
+        [ShadowWrapper],
+      );
+      fixture.detectChanges();
+      const dragElement = fixture.componentInstance.dragElement.nativeElement;
+      const handleChild = fixture.componentInstance.handleChild.nativeElement;
+
+      expect(dragElement.style.transform).toBeFalsy();
+      dragElementViaMouse(fixture, handleChild, 50, 100);
+      expect(dragElement.style.transform).toBe('translate3d(50px, 100px, 0px)');
+    }));
   });
 
   describe('in a drop container', () => {
@@ -6470,6 +6490,29 @@ class StandaloneDraggableWithDelayedHandle {
 class StandaloneDraggableWithIndirectHandle {
   @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
   @ViewChild('handleElement') handleElement: ElementRef<HTMLElement>;
+}
+
+@Component({
+  selector: 'shadow-wrapper',
+  template: '<ng-content></ng-content>',
+  encapsulation: ViewEncapsulation.ShadowDom,
+})
+class ShadowWrapper {}
+
+@Component({
+  template: `
+    <div #dragElement cdkDrag style="width: 100px; height: 100px; background: red;">
+      <div cdkDragHandle style="width: 10px; height: 10px;">
+        <shadow-wrapper>
+          <div #handleChild style="width: 10px; height: 10px; background: green;"></div>
+        </shadow-wrapper>
+      </div>
+    </div>
+  `,
+})
+class StandaloneDraggableWithShadowInsideHandle {
+  @ViewChild('dragElement') dragElement: ElementRef<HTMLElement>;
+  @ViewChild('handleChild') handleChild: ElementRef<HTMLElement>;
 }
 
 @Component({

--- a/src/cdk/drag-drop/drag-ref.ts
+++ b/src/cdk/drag-drop/drag-ref.ts
@@ -629,8 +629,7 @@ export class DragRef<T = any> {
     // Delegate the event based on whether it started from a handle or the element itself.
     if (this._handles.length) {
       const targetHandle = this._handles.find(handle => {
-        const target = _getEventTarget(event);
-        return !!target && (target === handle || handle.contains(target as HTMLElement));
+        return event.target && (event.target === handle || handle.contains(event.target as Node));
       });
 
       if (targetHandle && !this._disabledHandles.has(targetHandle) && !this.disabled) {

--- a/src/cdk/testing/testbed/fake-events/event-objects.spec.ts
+++ b/src/cdk/testing/testbed/fake-events/event-objects.spec.ts
@@ -1,3 +1,9 @@
+import {
+  dispatchMouseEvent,
+  dispatchKeyboardEvent,
+  dispatchPointerEvent,
+  dispatchFakeEvent,
+} from './dispatch-events';
 import {createKeyboardEvent, createMouseEvent} from './event-objects';
 
 describe('event objects', () => {
@@ -38,6 +44,72 @@ describe('event objects', () => {
         testElement.dispatchEvent(createKeyboardEvent('keydown'));
       }).not.toThrow();
       expect(preventDefaultSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('shadow DOM', () => {
+    it('should allow dispatched mouse events to propagate through the shadow root', () => {
+      if (!testElement.attachShadow) {
+        return;
+      }
+
+      const spy = jasmine.createSpy('listener');
+      const shadowRoot = testElement.attachShadow({mode: 'open'});
+      const child = document.createElement('div');
+      shadowRoot.appendChild(child);
+
+      testElement.addEventListener('mousedown', spy);
+      dispatchMouseEvent(child, 'mousedown');
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should allow dispatched keyboard events to propagate through the shadow root', () => {
+      if (!testElement.attachShadow) {
+        return;
+      }
+
+      const spy = jasmine.createSpy('listener');
+      const shadowRoot = testElement.attachShadow({mode: 'open'});
+      const child = document.createElement('div');
+      shadowRoot.appendChild(child);
+
+      testElement.addEventListener('keydown', spy);
+      dispatchKeyboardEvent(child, 'keydown');
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should allow dispatched pointer events to propagate through the shadow root', () => {
+      if (!testElement.attachShadow) {
+        return;
+      }
+
+      const spy = jasmine.createSpy('listener');
+      const shadowRoot = testElement.attachShadow({mode: 'open'});
+      const child = document.createElement('div');
+      shadowRoot.appendChild(child);
+
+      testElement.addEventListener('pointerdown', spy);
+      dispatchPointerEvent(child, 'pointerdown');
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should allow dispatched fake events to propagate through the shadow root', () => {
+      if (!testElement.attachShadow) {
+        return;
+      }
+
+      const spy = jasmine.createSpy('listener');
+      const shadowRoot = testElement.attachShadow({mode: 'open'});
+      const child = document.createElement('div');
+      shadowRoot.appendChild(child);
+
+      testElement.addEventListener('fake', spy);
+      dispatchFakeEvent(child, 'fake');
+
+      expect(spy).toHaveBeenCalled();
     });
   });
 });

--- a/src/cdk/testing/testbed/fake-events/event-objects.ts
+++ b/src/cdk/testing/testbed/fake-events/event-objects.ts
@@ -32,6 +32,7 @@ export function createMouseEvent(
   const event = new MouseEvent(type, {
     bubbles: true,
     cancelable: true,
+    composed: true, // Required for shadow DOM events.
     view: window,
     detail: 0,
     relatedTarget: null,
@@ -74,6 +75,7 @@ export function createPointerEvent(
   return new PointerEvent(type, {
     bubbles: true,
     cancelable: true,
+    composed: true, // Required for shadow DOM events.
     view: window,
     clientX,
     clientY,
@@ -116,6 +118,7 @@ export function createKeyboardEvent(
   return new KeyboardEvent(type, {
     bubbles: true,
     cancelable: true,
+    composed: true, // Required for shadow DOM events.
     view: window,
     keyCode: keyCode,
     key: key,
@@ -130,8 +133,8 @@ export function createKeyboardEvent(
  * Creates a fake event object with any desired event type.
  * @docs-private
  */
-export function createFakeEvent(type: string, bubbles = false, cancelable = true) {
-  return new Event(type, {bubbles, cancelable});
+export function createFakeEvent(type: string, bubbles = false, cancelable = true, composed = true) {
+  return new Event(type, {bubbles, cancelable, composed});
 }
 
 /**


### PR DESCRIPTION
Includes the following fixes:

**fix(cdk/testing): fake events not propagating through shadow DOM**
Adds the `composed` flag to the fake event objects so that they can propagate through a `mode: 'open'` shadow root.

**fix(cdk/drag-drop): handle not working when it has a child inside shadom DOM**
Fixes that the children of the drag handle inside a shadow root weren't being detected. The problem was that we were using `_getEventTarget` to resolve the actual event target and using `contains` to verify that it's inside the handle. Since `contains` doesn't descend into shadow root, the call failed. These changes remove the `_getEventTarget` call since we can use the event `target` directly.

Fixes #23680.