### PR TITLE
docs(material/datepicker): use two-way data-binding

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-inline-calendar/datepicker-inline-calendar-example.html
+++ b/src/components-examples/material/datepicker/datepicker-inline-calendar/datepicker-inline-calendar-example.html
@@ -1,4 +1,4 @@
 <mat-card class="demo-inline-calendar-card">
-  <mat-calendar (selectedChange)="selected = $event"></mat-calendar>
+  <mat-calendar [(selected)]="selected"></mat-calendar>
 </mat-card>
 <p>Selected date: {{selected}}</p>


### PR DESCRIPTION
Fixes the calendar UI not updating on selection