### PR TITLE
build: fix devserver sh_binary not working on systems with runfiles enabled

### DIFF
--- a/tools/dev-server/launcher_template.sh
+++ b/tools/dev-server/launcher_template.sh
@@ -14,6 +14,14 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+# If we do not run the devserver as part of a test, we always enforce runfile
+# resolution when invoking the devserver NodeJS binary. This is necessary as
+# runfile trees are disabled as part of this repository. The devserver NodeJS
+# binary would not find a relative runfile tree directory and error out.
+if [[ -z "${TEST_SRCDIR:-""}" ]]; then
+  export RUNFILES_MANIFEST_ONLY="1"
+fi
+
 # Resolve the path of the dev-server binary. Note: usually we either need to
 # resolve the "nodejs_binary" executable with different file extensions on
 # windows, but since we already run this launcher as part of a "sh_binary", we


### PR DESCRIPTION
The devserver currently does not work on systems with runfiles enabled.
This is commonly macOS and Linux. The devserver breaks here because we
do not have a runfile tree directory built as this would cause a significant
slow-down for RBE and caching.

This commit ensures the runfile manifest is consulted _always_, unless the
dev-server runs in a test where a runfile directory is resolved to the test
directory.

Inside the test action, with runfiles enabled, there would be no runfile
manifest file.. causing the devserver to fail. e.g.

```
/b/f/w/bazel-out/k8-fastbuild/bin/src/material-experimental/mdc-table/e2e_tests_chromium.sh.runfiles/angular_material/tools/dev-server/dev-server_bin.sh: line 52: RUNFILES_MANIFEST_FILE: unbound variable

```