### PR TITLE
fix(material-experimental/mdc-input): remove color override for native select in dark

### DIFF
--- a/src/material-experimental/mdc-form-field/_form-field-native-select.scss
+++ b/src/material-experimental/mdc-form-field/_form-field-native-select.scss
@@ -1,7 +1,5 @@
-@use 'sass:map';
 @use 'sass:math';
 @use '../mdc-helpers/mdc-helpers';
-@use '../../material/core/theming/palette';
 @use '@material/theme/theme-color' as mdc-theme-color;
 
 // Width of the Material Design form-field select arrow.


### PR DESCRIPTION
This change reverts #19232. I tried reproducing the issue on MacOS and LInux but couldn't see this style changing the native select color.

This override causes an issue for the native select's `size` attribute where options can be presented outside of the panel. In dark theme, they appear with the wrong color. See here: https://stackblitz.com/edit/angular-wxzhvx-t7qaaa?file=src%2Fstyles.scss

@crisbeto Is there a use case I didn't check to make sure this is okay? Additionally I checked against a global test run internally but didn't get any failures.