### PR TITLE
fix(material/icon): disable text selection

### DIFF
--- a/src/material/icon/icon.scss
+++ b/src/material/icon/icon.scss
@@ -1,7 +1,10 @@
+@use '../core/style/vendor-prefixes';
+
 // The width/height of the icon element.
 $size: 24px !default;
 
 .mat-icon {
+  @include vendor-prefixes.user-select(none);
   background-repeat: no-repeat;
   display: inline-block;
   fill: currentColor;


### PR DESCRIPTION
Disables text selection inside `mat-icon` so that the text inside font icons can't be selected by accident.