### PR TITLE
build: add `exports` entry for cdk schematics utilities

### DIFF
--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -27,7 +27,10 @@
     "./overlay-prebuilt.css": {"style": "./overlay-prebuilt.css"},
     "./overlay-prebuilt": {"style": "./overlay-prebuilt.css"},
     "./text-field-prebuilt.css": {"style": "./text-field-prebuilt.css"},
-    "./text-field-prebuilt": {"style": "./text-field-prebuilt.css"}
+    "./text-field-prebuilt": {"style": "./text-field-prebuilt.css"},
+    "./schematics": {
+      "default": "./schematics/index.js"
+    }
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-NG",


### PR DESCRIPTION
An `exports` entry within the `@angular/cdk` package for the schematics utilities has been added. This entry is required for the schematics present in the `@angular/material` package to function. `@angular/material` schematics leverage a variety of the utilities and helper functions within `@angular/cdk/schematics`.
This change was successfully tested against the latest `-next` release of the Angular CLI via `ng add @angular/material`.