### PR TITLE
build: prevent binding BrowserSync UI server during test execution

### DIFF
--- a/tools/dev-server/dev-server.ts
+++ b/tools/dev-server/dev-server.ts
@@ -38,8 +38,12 @@ export class DevServer {
   };
 
   constructor(
-      readonly port: number, private _rootPaths: string[],
-      private _historyApiFallback: boolean = false) {}
+      readonly port: number, private _rootPaths: string[], bindUi: boolean,
+      private _historyApiFallback: boolean = false) {
+    if (bindUi === false) {
+      this.options.ui = false;
+    }
+  }
 
   /** Starts the server on the given port. */
   start() {

--- a/tools/dev-server/main.ts
+++ b/tools/dev-server/main.ts
@@ -16,7 +16,8 @@ const {root_paths: _rootPathsRaw, port, historyApiFallback} =
     minimist(args, {boolean: 'historyApiFallback'});
 const rootPaths = _rootPathsRaw ? _rootPathsRaw.split(',') : ['/'];
 
-const server = new DevServer(port, rootPaths, historyApiFallback);
+const bindUi = process.env.TEST_TARGET === undefined;
+const server = new DevServer(port, rootPaths, bindUi, historyApiFallback);
 
 // Setup ibazel support.
 setupBazelWatcherSupport(server);
@@ -24,4 +25,3 @@ setupBazelWatcherSupport(server);
 // Start the devserver. The server will always bind to the loopback and
 // the public interface of the current host.
 server.start();
-


### PR DESCRIPTION
Running e2e tests locally on macOS raises various EADDRINUSE errors due to browsersync UI server trying to bind multiple times on the same port. furthermore it's not really useful having ui server running in ci tests execution