### PR TITLE
fix(multiple): use ripple theme color for color mixins

### DIFF
--- a/src/material-experimental/mdc-button/_button-theme-private.scss
+++ b/src/material-experimental/mdc-button/_button-theme-private.scss
@@ -12,7 +12,7 @@ $fab-state-target: '.mdc-fab__ripple';
 // which is what the ripple mixin uses. This creates a new theme that sets the color to the
 // foreground base to appropriately color the ink.
 @mixin ripple-ink-color($mdc-color) {
-  @include ripple-theme.theme((
+  @include ripple-theme.color((
     foreground: (
       base: mdc-theme-color.prop-value($mdc-color)
     ),

--- a/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
+++ b/src/material-experimental/mdc-checkbox/_checkbox-theme.scss
@@ -36,7 +36,7 @@
 @mixin _selected-ripple-colors($theme, $mdcColor) {
   .mdc-checkbox--selected ~ {
     .mat-mdc-checkbox-ripple {
-      @include ripple-theme.theme((
+      @include ripple-theme.color((
           foreground: (
               base: mdc-theme-color.prop-value($mdcColor)
           ),
@@ -73,7 +73,7 @@
     .mat-mdc-checkbox {
       @include private-checkbox-styles-with-color(primary);
       @include mdc-form-field.core-styles($query: mdc-helpers.$mat-theme-styles-query);
-      @include ripple-theme.theme((
+      @include ripple-theme.color((
         foreground: (
           base: mdc-theme-color.prop-value(on-surface)
         ),


### PR DESCRIPTION
This fixes warnings when users import the color mixins multiple times since the theming system thinks ripple's `theme` is being called more than once