### PR TITLE
fix(material-experimental/mdc-card): action alignment not working

### DIFF
--- a/src/material-experimental/mdc-card/card.scss
+++ b/src/material-experimental/mdc-card/card.scss
@@ -143,3 +143,8 @@ $mat-card-default-padding: 16px !default;
 .mat-mdc-card-content > :last-child:not(.mat-mdc-card-footer) {
   margin-bottom: 0;
 }
+
+// Support for actions aligned to the end of the card.
+.mat-mdc-card-actions-align-end {
+  justify-content: flex-end;
+}


### PR DESCRIPTION
We were adding the `mat-mdc-card-actions-align-end` class, but we weren't using it which meant that `<mat-card-actions align="end">` didn't work.