### PR TITLE
refactor(material/schematics): do not print hammer migration message when updating to v13

### DIFF
--- a/src/cdk/schematics/ng-update/devkit-migration-rule.ts
+++ b/src/cdk/schematics/ng-update/devkit-migration-rule.ts
@@ -115,7 +115,7 @@ export function createMigrationSchematicRule(
     migrations.forEach(m => {
       const actionResult =
         isDevkitMigration(m) && m.globalPostMigration !== undefined
-          ? m.globalPostMigration(tree, context)
+          ? m.globalPostMigration(tree, targetVersion, context)
           : null;
       if (actionResult) {
         runPackageManager = runPackageManager || actionResult.runPackageManager;

--- a/src/cdk/schematics/ng-update/devkit-migration.ts
+++ b/src/cdk/schematics/ng-update/devkit-migration.ts
@@ -9,6 +9,7 @@
 import {SchematicContext, Tree} from '@angular-devkit/schematics';
 import {ProjectDefinition} from '@angular-devkit/core/src/workspace';
 import {Constructor, Migration, PostMigrationAction} from '../update-tool/migration';
+import {TargetVersion} from '../update-tool/target-version';
 
 export type DevkitContext = {
   /** Devkit tree for the current migrations. Can be used to insert/remove files. */
@@ -34,7 +35,11 @@ export abstract class DevkitMigration<Data> extends Migration<Data, DevkitContex
    * migration result of all individual targets. e.g. removing HammerJS if it
    * is not needed in any project target.
    */
-  static globalPostMigration?(tree: Tree, context: SchematicContext): PostMigrationAction;
+  static globalPostMigration?(
+    tree: Tree,
+    targetVersion: TargetVersion,
+    context: SchematicContext,
+  ): PostMigrationAction;
 }
 
 export type DevkitMigrationCtor<Data> = Constructor<DevkitMigration<Data>> &

--- a/src/material/schematics/ng-update/migrations/theming-api-v12/theming-api-migration.ts
+++ b/src/material/schematics/ng-update/migrations/theming-api-v12/theming-api-migration.ts
@@ -44,7 +44,11 @@ export class ThemingApiMigration extends DevkitMigration<null> {
   }
 
   /** Logs out the number of migrated files at the end of the migration. */
-  static override globalPostMigration(_tree: unknown, context: SchematicContext): void {
+  static override globalPostMigration(
+    _tree: unknown,
+    _targetVersion: TargetVersion,
+    context: SchematicContext,
+  ): void {
     const count = ThemingApiMigration.migratedFileCount;
 
     if (count > 0) {


### PR DESCRIPTION
The Hammer gesture migration runs only for v9 and v10 but the global
post migration messages are printed regardless of whether the update
runs for v9 or v10. This commit fixes that by providing the target
version to the `globalPostMigration` functions for migrations.