### PR TITLE
docs(google-maps/map-directions-renderer): remove readonly property type

### DIFF
--- a/src/google-maps/map-directions-renderer/README.md
+++ b/src/google-maps/map-directions-renderer/README.md
@@ -32,7 +32,7 @@ export class GoogleMapDemo {
   center: google.maps.LatLngLiteral = {lat: 24, lng: 12};
   zoom = 4;
 
-  readonly directionsResults$: Observable<google.maps.DirectionsResult|undefined>;
+  directionsResults$: Observable<google.maps.DirectionsResult|undefined>;
 
   constructor(mapDirectionsService: MapDirectionsService) {
     const request: google.maps.DirectionsRequest = {


### PR DESCRIPTION
Setting `directionsResults$` property as `readonly` didn't allow to make the assignation 

        this.directionsResults$ = mapDirectionsService.route(request).pipe(map(response => response.result));

at line :43