### PR TITLE
build: set up prettier in default editor config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,10 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-  
+
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
     "ms-vscode.vscode-typescript-tslint-plugin",
-    "xaver.clang-format",
-  ],
+    "esbenp.prettier-vscode"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-  // Please install https://marketplace.visualstudio.com/items?itemName=xaver.clang-format to take advantage of `clang-format` in VSCode.
-  // (See https://clang.llvm.org/docs/ClangFormat.html for more info `clang-format`.)
-  "clang-format.executable": "${workspaceRoot}/node_modules/.bin/clang-format",
   "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/.git/subtree-cache/**": true,
@@ -11,9 +8,16 @@
   },
   "search.exclude": {
     "**/node_modules": true,
-    "**/bower_components": true,
     "**/bazel-out": true,
     "**/dist": true,
   },
   "git.ignoreLimitWarning": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  }
 }


### PR DESCRIPTION
Updates the default editor settings to format on save and to recommend the Prettier extension.