### PR TITLE
docs(a11y): fix typo

### DIFF
--- a/src/cdk/a11y/_index.scss
+++ b/src/cdk/a11y/_index.scss
@@ -1,5 +1,5 @@
 /// Emits a CSS class, `.cdk-visually-hidden`. This class can be applied to an element
-/// to make that element visually hidden while remaining available to assitive technology.
+/// to make that element visually hidden while remaining available to assistive technology.
 @mixin a11y-visually-hidden() {
   .cdk-visually-hidden {
     border: 0;


### PR DESCRIPTION
fix `assitive` -> `assistive`. 

There are no same typo in public API documentation. https://material.angular.io/cdk/a11y/overview