### PR TITLE
Revert "fix(cdk/testing): simulate focusin/focusout events"

### DIFF
--- a/src/cdk/testing/testbed/fake-events/element-focus.ts
+++ b/src/cdk/testing/testbed/fake-events/element-focus.ts
@@ -14,18 +14,9 @@ function triggerFocusChange(element: HTMLElement, event: 'focus' | 'blur') {
   element.addEventListener(event, handler);
   element[event]();
   element.removeEventListener(event, handler);
-
-  // Some browsers won't move focus if the browser window is blurred while other will move it
-  // asynchronously. If that is the case, we fake the event sequence as a fallback.
   if (!eventFired) {
-    simulateFocusSequence(element, event);
+    dispatchFakeEvent(element, event);
   }
-}
-
-/** Simulates the full event sequence for a focus event. */
-function simulateFocusSequence(element: HTMLElement, event: 'focus' | 'blur') {
-  dispatchFakeEvent(element, event);
-  dispatchFakeEvent(element, event === 'focus' ? 'focusin' : 'focusout');
 }
 
 /**
@@ -37,8 +28,8 @@ function simulateFocusSequence(element: HTMLElement, event: 'focus' | 'blur') {
 // TODO: Check if this element focus patching is still needed for local testing,
 // where browser is not necessarily focused.
 export function patchElementFocus(element: HTMLElement) {
-  element.focus = () => simulateFocusSequence(element, 'focus');
-  element.blur = () => simulateFocusSequence(element, 'blur');
+  element.focus = () => dispatchFakeEvent(element, 'focus');
+  element.blur = () => dispatchFakeEvent(element, 'blur');
 }
 
 /** @docs-private */


### PR DESCRIPTION
This reverts commit ef7d9e0c1a5b1990a4da2dce1d7ff24aef13fade.

I misread the test results and it looks like there was about 5 tests that ended up failing because of this. Need to do more investigation of why these failed.