### PR TITLE
fix(cdk/testing): simulate focusin/focusout events

### DIFF
--- a/src/cdk/testing/testbed/fake-events/element-focus.ts
+++ b/src/cdk/testing/testbed/fake-events/element-focus.ts
@@ -9,14 +9,29 @@
 import {dispatchFakeEvent} from './dispatch-events';
 
 function triggerFocusChange(element: HTMLElement, event: 'focus' | 'blur') {
+  const hasFocus = document.activeElement === element;
+
+  if ((event === 'focus' && hasFocus) || (event === 'blur' && !hasFocus)) {
+    return;
+  }
+
   let eventFired = false;
   const handler = () => (eventFired = true);
   element.addEventListener(event, handler);
   element[event]();
   element.removeEventListener(event, handler);
+
+  // Some browsers won't move focus if the browser window is blurred while other will move it
+  // asynchronously. If that is the case, we fake the event sequence as a fallback.
   if (!eventFired) {
-    dispatchFakeEvent(element, event);
+    simulateFocusSequence(element, event);
   }
+}
+
+/** Simulates the full event sequence for a focus event. */
+function simulateFocusSequence(element: HTMLElement, event: 'focus' | 'blur') {
+  dispatchFakeEvent(element, event);
+  dispatchFakeEvent(element, event === 'focus' ? 'focusin' : 'focusout');
 }
 
 /**
@@ -28,8 +43,8 @@ function triggerFocusChange(element: HTMLElement, event: 'focus' | 'blur') {
 // TODO: Check if this element focus patching is still needed for local testing,
 // where browser is not necessarily focused.
 export function patchElementFocus(element: HTMLElement) {
-  element.focus = () => dispatchFakeEvent(element, 'focus');
-  element.blur = () => dispatchFakeEvent(element, 'blur');
+  element.focus = () => simulateFocusSequence(element, 'focus');
+  element.blur = () => simulateFocusSequence(element, 'blur');
 }
 
 /** @docs-private */

--- a/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
+++ b/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
@@ -35,11 +35,13 @@ describe('FormFieldHarnessExample', () => {
 
   it('should be able to get error messages and hints of form-field', async () => {
     const formField = await loader.getHarness(MatFormFieldHarness);
+    const control = (await formField.getControl()) as MatInputHarness;
     expect(await formField.getTextErrors()).toEqual([]);
     expect(await formField.getTextHints()).toEqual(['Hint']);
 
     fixture.componentInstance.requiredControl.setValue('');
-    await ((await formField.getControl()) as MatInputHarness)?.blur();
+    await control.focus();
+    await control.blur();
     expect(await formField.getTextErrors()).toEqual(['Error']);
     expect(await formField.getTextHints()).toEqual([]);
   });


### PR DESCRIPTION
This is a resubmit of https://github.com/angular/components/pull/23768.

Fixes that our fake fallback focus events weren't dispatching `focusin` and `focusout` events as well.

Fixes #23757.

Caretaking Note: spent a couple of hours looking into this, but it turned out to be trickier than expected. The extra events trigger a "changed after checked" error in some apps. Tried to simulate browser events even closer by only emitting the events when elements have focus, but that broke even more apps.