### PR TITLE
build: handle top-level packages in API approval script

### DIFF
--- a/scripts/approve-api-golden.js
+++ b/scripts/approve-api-golden.js
@@ -26,9 +26,8 @@ if (!packageNameGuess.result) {
 }
 
 const [packageName, ...entryPointTail] = packageNameGuess.result.split('/');
-const apiGoldenTargetName = `//tools/public_api_guard:${packageName}/${entryPointTail.join(
-  '-',
-)}.md_api.accept`;
+const suffix = entryPointTail.length ? entryPointTail.join('-') : packageName;
+const apiGoldenTargetName = `//tools/public_api_guard:${packageName}/${suffix}.md_api.accept`;
 
 // ShellJS should exit if any command fails.
 shelljs.set('-e');


### PR DESCRIPTION
Fixes that the `approve-api` script was generating the wrong Bazel target for `google-maps` and `youtube-player`.

Fixes #23782.