### PR TITLE
fix(material/stepper): accessibility of errors in step selection

### DIFF
--- a/src/cdk/stepper/stepper.ts
+++ b/src/cdk/stepper/stepper.ts
@@ -487,7 +487,7 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
   }
 
   private _getDefaultIndicatorLogic(step: CdkStep, isCurrentStep: boolean): StepState {
-    if (step._showError() && step.hasError && !isCurrentStep) {
+    if (step._showError() && step.hasError) {
       return STEP_STATE.ERROR;
     } else if (!step.completed || isCurrentStep) {
       return STEP_STATE.NUMBER;
@@ -501,7 +501,7 @@ export class CdkStepper implements AfterContentInit, AfterViewInit, OnDestroy {
     isCurrentStep: boolean,
     state: StepState = STEP_STATE.NUMBER,
   ): StepState {
-    if (step._showError() && step.hasError && !isCurrentStep) {
+    if (step._showError() && step.hasError) {
       return STEP_STATE.ERROR;
     } else if (step.completed && !isCurrentStep) {
       return STEP_STATE.DONE;

--- a/src/dev-app/stepper/BUILD.bazel
+++ b/src/dev-app/stepper/BUILD.bazel
@@ -7,6 +7,7 @@ ng_module(
     srcs = glob(["**/*.ts"]),
     assets = ["stepper-demo.html"],
     deps = [
+        "//src/components-examples/material/stepper",
         "//src/material/button",
         "//src/material/checkbox",
         "//src/material/core",

--- a/src/dev-app/stepper/stepper-demo-module.ts
+++ b/src/dev-app/stepper/stepper-demo-module.ts
@@ -17,6 +17,7 @@ import {MatStepperModule} from '@angular/material/stepper';
 import {MatSelectModule} from '@angular/material/select';
 import {RouterModule} from '@angular/router';
 import {StepperDemo} from './stepper-demo';
+import {StepperExamplesModule} from '@angular/components-examples/material/stepper';
 
 @NgModule({
   imports: [
@@ -30,6 +31,7 @@ import {StepperDemo} from './stepper-demo';
     MatSelectModule,
     ReactiveFormsModule,
     RouterModule.forChild([{path: '', component: StepperDemo}]),
+    StepperExamplesModule,
   ],
   declarations: [StepperDemo],
 })

--- a/src/dev-app/stepper/stepper-demo.html
+++ b/src/dev-app/stepper/stepper-demo.html
@@ -254,3 +254,5 @@
   </mat-step>
 </mat-stepper>
 
+<h3>Stepper with errors displayed in step</h3>
+<stepper-errors-example></stepper-errors-example>

--- a/src/material/stepper/step-header.html
+++ b/src/material/stepper/step-header.html
@@ -19,7 +19,7 @@
 <div class="mat-step-label"
      [class.mat-step-label-active]="active"
      [class.mat-step-label-selected]="selected"
-     [class.mat-step-label-error]="state == 'error'">
+     [class.mat-step-label-error]="state === 'error'" aria-live="assertive">
   <!-- If there is a label template, use it. -->
   <div class="mat-step-text-label" *ngIf="_templateLabel()">
     <ng-container [ngTemplateOutlet]="_templateLabel()!.template"></ng-container>
@@ -28,6 +28,6 @@
   <div class="mat-step-text-label" *ngIf="_stringLabel()">{{label}}</div>
 
   <div class="mat-step-optional" *ngIf="optional && state != 'error'">{{_intl.optionalLabel}}</div>
-  <div class="mat-step-sub-label-error" *ngIf="state == 'error'">{{errorMessage}}</div>
+  <div id="{{'headerError' + index}}" class="mat-step-sub-label-error" role="alert" *ngIf="state === 'error'">{{errorMessage}}</div>
 </div>
 

--- a/src/material/stepper/step-header.ts
+++ b/src/material/stepper/step-header.ts
@@ -93,6 +93,7 @@ export class MatStepHeader
 
   ngAfterViewInit() {
     this._focusMonitor.monitor(this._elementRef, true);
+    this._elementRef.nativeElement.setAttribute('aria-describedby', 'headerError' + this.index);
   }
 
   ngOnDestroy() {

--- a/src/material/stepper/stepper.spec.ts
+++ b/src/material/stepper/stepper.spec.ts
@@ -1356,6 +1356,40 @@ describe('MatStepper', () => {
       expect(stepper._getIndicatorType(0)).toBe(STEP_STATE.ERROR);
     });
 
+    it('should show error state after jumping back to error State', () => {
+      createFixture(true);
+      const nextButtonNativeEl = fixture.debugElement.queryAll(By.directive(MatStepperNext))[0]
+        .nativeElement;
+
+      const prevButtonNativeEl = fixture.debugElement.queryAll(By.directive(MatStepperNext))[0]
+        .nativeElement;
+
+      stepper.selectedIndex = 1;
+      stepper.steps.first.hasError = true;
+      nextButtonNativeEl.click();
+      fixture.detectChanges();
+
+      expect(stepper._getIndicatorType(0)).toBe(STEP_STATE.ERROR);
+      expect(stepper._getIndicatorType(1)).toBe(STEP_STATE.NUMBER);
+      expect(fixture.debugElement.query(By.css('#headerError0')).nativeElement.textContent).toBe(
+        'This field is required',
+      );
+
+      stepper.selectedIndex = 0;
+      stepper.steps.get(1)!.hasError = true;
+      prevButtonNativeEl.click();
+      fixture.detectChanges();
+
+      expect(stepper._getIndicatorType(0)).toBe(STEP_STATE.ERROR);
+      expect(stepper._getIndicatorType(1)).toBe(STEP_STATE.ERROR);
+      expect(fixture.debugElement.query(By.css('#headerError0')).nativeElement.textContent).toBe(
+        'This field is required',
+      );
+      expect(fixture.debugElement.query(By.css('#headerError1')).nativeElement.textContent).toBe(
+        'field2 is required too',
+      );
+    });
+
     it('should respect a custom falsy hasError value', () => {
       createFixture(true);
       const nextButtonNativeEl = fixture.debugElement.queryAll(By.directive(MatStepperNext))[0]
@@ -1797,7 +1831,7 @@ function createComponent<T>(
           <button mat-button matStepperNext>Next</button>
         </div>
       </mat-step>
-      <mat-step>
+      <mat-step errorMessage="field2 is required too">
         <ng-template matStepLabel>Step 2</ng-template>
         Content 2
         <div>


### PR DESCRIPTION
Hello together,

This PR is a suggestion for the issue #23033. I think with this solution it is possible to handle this temporarily. My solution is to use the "errors before form style" for accessibility.

In my opinion there is the general question, if this stepper method is really needed to be provided.

Best regards,

Martin