### PR TITLE
build: remove flat module bundle workaround from view engine

### DIFF
--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -14,7 +14,7 @@ const chalk = require('chalk');
  * Version of the post install patch. Needs to be incremented when
  * existing patches or edits have been modified.
  */
-const PATCH_VERSION = 13;
+const PATCH_VERSION = 14;
 
 /** Path to the project directory. */
 const projectDir = path.join(__dirname, '../..');
@@ -52,15 +52,6 @@ async function main() {
 }
 
 function applyPatches() {
-  // Workaround for: https://github.com/angular/angular/pull/32650
-  searchAndReplace(
-    'let resolvedEntryPoint = null;',
-    `
-    let resolvedEntryPoint = tsFiles.find(f => f.endsWith('/public-api.ts')) || null;
-  `,
-    'node_modules/@angular/compiler-cli/bundles/index.js',
-  );
-
   // Switches the devmode output for Angular Bazel to ES2020 target and module.
   applyPatch(path.join(__dirname, './devmode-es2020-bazel.patch'));
 


### PR DESCRIPTION
Removes an old flat module bundle workaround that was needed when we
still shipped release packages with View Engine. The Angular compiler
picks the `index.ts` files as entry-point for the flat module bundles
(this whole flat module construct could be removed in the future anyway).

This was problematic because to avoid conflicts, the flat module out
file name was set to something unique that does not conflict with the
index file. The metadata JSON files for the `ng_module` targets (within our repo)
then did not reside next to the `index` files, but rather next to the
auto-generated flat module bundle. This broke the generation of
`defineInjectable` (which was used in VE as well) calls.

We worked around this in the past by patching the Angular compiler to
pick the public API file instead as entry-point; allowing us to let
the Angular compiler generate metadata and the bundle as `index.js` and
`index.metadata.json` (ensuring the release output worked then).

All of this is no longer needed with Ivy, so we can remove the
workaround and unblock https://github.com/angular/angular/pull/43932
(which fails due to us patching some files in the compiler-cli package)