### PR TITLE
fix(material/slider): first keypress ignored if out-of-bounds value is assigned

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -962,6 +962,7 @@ describe('MatSlider', () => {
     let sliderNativeElement: HTMLElement;
     let testComponent: SliderWithChangeHandler;
     let sliderInstance: MatSlider;
+    let trackFillElement: HTMLElement;
 
     beforeEach(() => {
       fixture = createComponent(SliderWithChangeHandler);
@@ -974,6 +975,7 @@ describe('MatSlider', () => {
       sliderDebugElement = fixture.debugElement.query(By.directive(MatSlider))!;
       sliderNativeElement = sliderDebugElement.nativeElement;
       sliderInstance = sliderDebugElement.injector.get<MatSlider>(MatSlider);
+      trackFillElement = sliderNativeElement.querySelector('.mat-slider-track-fill') as HTMLElement;
     });
 
     it('should increment slider by 1 on up arrow pressed', () => {
@@ -1026,6 +1028,21 @@ describe('MatSlider', () => {
       expect(testComponent.onInput).toHaveBeenCalledTimes(1);
       expect(testComponent.onChange).toHaveBeenCalledTimes(1);
       expect(sliderInstance.value).toBe(99);
+    });
+
+    it('should decrement from max when interacting after out-of-bounds value is assigned', () => {
+      sliderInstance.max = 100;
+      sliderInstance.value = 200;
+      fixture.detectChanges();
+
+      expect(sliderInstance.value).toBe(200);
+      expect(trackFillElement.style.transform).toContain('scale3d(1, 1, 1)');
+
+      dispatchKeyboardEvent(sliderNativeElement, 'keydown', LEFT_ARROW);
+      fixture.detectChanges();
+
+      expect(sliderInstance.value).toBe(99);
+      expect(trackFillElement.style.transform).toContain('scale3d(0.99, 1, 1)');
     });
 
     it('should increment slider by 10 on page up pressed', () => {

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -793,7 +793,10 @@ export class MatSlider
 
   /** Increments the slider by the given number of steps (negative number decrements). */
   private _increment(numSteps: number) {
-    this.value = this._clamp((this.value || 0) + this.step * numSteps, this.min, this.max);
+    // Pre-clamp the current value since it's allowed to be
+    // out of bounds when assigned programmatically.
+    const clampedValue = this._clamp(this.value || 0, this.min, this.max);
+    this.value = this._clamp(clampedValue + this.step * numSteps, this.min, this.max);
   }
 
   /** Calculate the new value from the new physical location. The value will always be snapped. */


### PR DESCRIPTION
We allow for an out-of-bounds value to be assigned to a `mat-slider` programmatically, however our key press logic didn't account for it. This meant that it might appear as if the first key press is ignored if such a value is assigned by the user.

Fixes #23817.