### PR TITLE
feat(google-maps): allow for info window focus behavior to be customized

### DIFF
--- a/src/google-maps/map-info-window/map-info-window.spec.ts
+++ b/src/google-maps/map-info-window/map-info-window.spec.ts
@@ -129,7 +129,13 @@ describe('MapInfoWindow', () => {
     expect(infoWindowSpy.close).toHaveBeenCalled();
 
     infoWindowComponent.open(fakeMarkerComponent);
-    expect(infoWindowSpy.open).toHaveBeenCalledWith(mapSpy, fakeMarker);
+    expect(infoWindowSpy.open).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        map: mapSpy,
+        anchor: fakeMarker,
+        shouldFocus: undefined,
+      }),
+    );
   });
 
   it('should not try to reopen info window multiple times for the same marker', () => {
@@ -223,6 +229,29 @@ describe('MapInfoWindow', () => {
 
     infoWindowComponent.open();
     expect(infoWindowSpy.open).toHaveBeenCalledTimes(1);
+  });
+
+  it('should allow for the focus behavior to be changed when opening the info window', () => {
+    const fakeMarker = {} as unknown as google.maps.Marker;
+    const fakeMarkerComponent = {
+      marker: fakeMarker,
+      getAnchor: () => fakeMarker,
+    } as unknown as MapMarker;
+    const infoWindowSpy = createInfoWindowSpy({});
+    createInfoWindowConstructorSpy(infoWindowSpy).and.callThrough();
+
+    const fixture = TestBed.createComponent(TestApp);
+    const infoWindowComponent = fixture.debugElement
+      .query(By.directive(MapInfoWindow))!
+      .injector.get<MapInfoWindow>(MapInfoWindow);
+    fixture.detectChanges();
+
+    infoWindowComponent.open(fakeMarkerComponent, false);
+    expect(infoWindowSpy.open).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        shouldFocus: false,
+      }),
+    );
   });
 });
 

--- a/src/google-maps/map-info-window/map-info-window.ts
+++ b/src/google-maps/map-info-window/map-info-window.ts
@@ -168,7 +168,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
    * Opens the MapInfoWindow using the provided anchor. If the anchor is not set,
    * then the position property of the options input is used instead.
    */
-  open(anchor?: MapAnchorPoint) {
+  open(anchor?: MapAnchorPoint, shouldFocus?: boolean) {
     this._assertInitialized();
     const anchorObject = anchor ? anchor.getAnchor() : undefined;
 
@@ -178,7 +178,13 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     // case where the window doesn't have an anchor, but is placed at a particular position.
     if (this.infoWindow.get('anchor') !== anchorObject || !anchorObject) {
       this._elementRef.nativeElement.style.display = '';
-      this.infoWindow.open(this._googleMap.googleMap, anchorObject);
+
+      // The config is cast to `any`, because the internal typings are out of date.
+      this.infoWindow.open({
+        map: this._googleMap.googleMap,
+        anchor: anchorObject,
+        shouldFocus,
+      } as any);
     }
   }
 

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -148,7 +148,7 @@ export function createInfoWindowSpy(
     'get',
   ]);
   infoWindowSpy.addListener.and.returnValue({remove: () => {}});
-  infoWindowSpy.open.and.callFake((_map: any, target: any) => (anchor = target));
+  infoWindowSpy.open.and.callFake((config: any) => (anchor = config.anchor));
   infoWindowSpy.close.and.callFake(() => (anchor = null));
   infoWindowSpy.get.and.callFake((key: string) => (key === 'anchor' ? anchor : null));
   return infoWindowSpy;

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -329,7 +329,7 @@ export class MapInfoWindow implements OnInit, OnDestroy {
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    open(anchor?: MapAnchorPoint): void;
+    open(anchor?: MapAnchorPoint, shouldFocus?: boolean): void;
     // (undocumented)
     set options(options: google.maps.InfoWindowOptions);
     // (undocumented)


### PR DESCRIPTION
Allows for the `shouldFocus` flag to be passed when opening the info window.

Fixes #23829.