### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/tools/multiple-node-versions.patch
+++ b/tools/multiple-node-versions.patch
@@ -17,7 +17,7 @@ index 9dcdc60..4927e75 100644
      implementation = _resolved_toolchain_impl,
 -    toolchains = ["@rules_nodejs//nodejs:toolchain_type"],
 +    toolchains = ["@build_bazel_rules_nodejs//nodejs:toolchain_type"],
-     incompatible_use_toolchain_transition = True,
+
  )
  """
 @@ -107,7 +107,7 @@ toolchain(


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.