### PR TITLE
build: remove init test environment calls from harness examples

### DIFF
--- a/src/components-examples/material-experimental/mdc-table/BUILD.bazel
+++ b/src/components-examples/material-experimental/mdc-table/BUILD.bazel
@@ -58,6 +58,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material-experimental/mdc-table/table-harness/table-harness-example.spec.ts
+++ b/src/components-examples/material-experimental/mdc-table/table-harness/table-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTableHarness} from '@angular/material/table/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatTableModule} from '@angular/material/table';
 import {TableHarnessExample} from './table-harness-example';
 
 describe('TableHarnessExample', () => {
   let fixture: ComponentFixture<TableHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/autocomplete/BUILD.bazel
+++ b/src/components-examples/material/autocomplete/BUILD.bazel
@@ -52,6 +52,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-harness/autocomplete-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatAutocompleteHarness} from '@angular/material/autocomplete/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {AutocompleteHarnessExample} from './autocomplete-harness-example';
 
 describe('AutocompleteHarnessExample', () => {
   let fixture: ComponentFixture<AutocompleteHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/badge/BUILD.bazel
+++ b/src/components-examples/material/badge/BUILD.bazel
@@ -49,6 +49,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/badge/badge-harness/badge-harness-example.spec.ts
+++ b/src/components-examples/material/badge/badge-harness/badge-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatBadgeHarness} from '@angular/material/badge/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatBadgeModule} from '@angular/material/badge';
 import {BadgeHarnessExample} from './badge-harness-example';
 
 describe('BadgeHarnessExample', () => {
   let fixture: ComponentFixture<BadgeHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/bottom-sheet/BUILD.bazel
+++ b/src/components-examples/material/bottom-sheet/BUILD.bazel
@@ -51,6 +51,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
+++ b/src/components-examples/material/bottom-sheet/bottom-sheet-harness/bottom-sheet-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatBottomSheetHarness} from '@angular/material/bottom-sheet/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatBottomSheetModule} from '@angular/material/bottom-sheet';
 import {BottomSheetHarnessExample} from './bottom-sheet-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,10 +9,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('BottomSheetHarnessExample', () => {
   let fixture: ComponentFixture<BottomSheetHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/button-toggle/BUILD.bazel
+++ b/src/components-examples/material/button-toggle/BUILD.bazel
@@ -48,6 +48,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/button-toggle/button-toggle-harness/button-toggle-harness-example.spec.ts
+++ b/src/components-examples/material/button-toggle/button-toggle-harness/button-toggle-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatButtonToggleGroupHarness} from '@angular/material/button-toggle/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {ButtonToggleHarnessExample} from './button-toggle-harness-example';
 
 describe('ButtonToggleHarnessExample', () => {
   let fixture: ComponentFixture<ButtonToggleHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/button/BUILD.bazel
+++ b/src/components-examples/material/button/BUILD.bazel
@@ -49,6 +49,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
+++ b/src/components-examples/material/button/button-harness/button-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatButtonHarness} from '@angular/material/button/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {ButtonHarnessExample} from './button-harness-example';
 
@@ -13,10 +9,6 @@ describe('ButtonHarnessExample', () => {
   let fixture: ComponentFixture<ButtonHarnessExample>;
   let loader: HarnessLoader;
   let buttonHarness = MatButtonHarness;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/card/BUILD.bazel
+++ b/src/components-examples/material/card/BUILD.bazel
@@ -52,6 +52,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
+++ b/src/components-examples/material/card/card-harness/card-harness-example.spec.ts
@@ -1,21 +1,15 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatButtonHarness} from '@angular/material/button/testing';
 import {MatCardHarness} from '@angular/material/card/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatCardModule} from '@angular/material/card';
 import {CardHarnessExample} from './card-harness-example';
 
 describe('CardHarnessExample', () => {
   let fixture: ComponentFixture<CardHarnessExample>;
   let loader: HarnessLoader;
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatCardModule],

--- a/src/components-examples/material/checkbox/BUILD.bazel
+++ b/src/components-examples/material/checkbox/BUILD.bazel
@@ -51,6 +51,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
+++ b/src/components-examples/material/checkbox/checkbox-harness/checkbox-harness-example.spec.ts
@@ -1,22 +1,14 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatCheckboxHarness} from '@angular/material/checkbox/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {ReactiveFormsModule} from '@angular/forms';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {CheckboxHarnessExample} from './checkbox-harness-example';
 
 describe('CheckboxHarnessExample', () => {
   let fixture: ComponentFixture<CheckboxHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/chips/BUILD.bazel
+++ b/src/components-examples/material/chips/BUILD.bazel
@@ -54,6 +54,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
+++ b/src/components-examples/material/chips/chips-harness/chips-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatChipHarness, MatChipListboxHarness} from '@angular/material/chips/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {ChipsHarnessExample} from './chips-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatChipsModule} from '@angular/material/chips';
@@ -13,10 +9,6 @@ import {MatChipsModule} from '@angular/material/chips';
 describe('ChipsHarnessExample', () => {
   let fixture: ComponentFixture<ChipsHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/datepicker/BUILD.bazel
+++ b/src/components-examples/material/datepicker/BUILD.bazel
@@ -58,6 +58,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
+++ b/src/components-examples/material/datepicker/datepicker-harness/datepicker-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatDatepickerInputHarness} from '@angular/material/datepicker/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 import {DatepickerHarnessExample} from './datepicker-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -15,10 +11,6 @@ import {FormsModule} from '@angular/forms';
 describe('DatepickerHarnessExample', () => {
   let fixture: ComponentFixture<DatepickerHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/dialog/BUILD.bazel
+++ b/src/components-examples/material/dialog/BUILD.bazel
@@ -52,6 +52,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
+++ b/src/components-examples/material/dialog/dialog-harness/dialog-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatDialogModule} from '@angular/material/dialog';
 import {DialogHarnessExample} from './dialog-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,10 +9,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('DialogHarnessExample', () => {
   let fixture: ComponentFixture<DialogHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(
     waitForAsync(async () => {

--- a/src/components-examples/material/divider/BUILD.bazel
+++ b/src/components-examples/material/divider/BUILD.bazel
@@ -48,6 +48,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/divider/divider-harness/divider-harness-example.spec.ts
+++ b/src/components-examples/material/divider/divider-harness/divider-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatDividerHarness} from '@angular/material/divider/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatDividerModule} from '@angular/material/divider';
 import {DividerHarnessExample} from './divider-harness-example';
 
 describe('DividerHarnessExample', () => {
   let fixture: ComponentFixture<DividerHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/expansion/BUILD.bazel
+++ b/src/components-examples/material/expansion/BUILD.bazel
@@ -52,6 +52,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
+++ b/src/components-examples/material/expansion/expansion-harness/expansion-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {MatExpansionPanelHarness, MatAccordionHarness} from '@angular/material/expansion/testing';
+import {MatAccordionHarness, MatExpansionPanelHarness} from '@angular/material/expansion/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ExpansionHarnessExample} from './expansion-harness-example';
@@ -13,10 +9,6 @@ import {ExpansionHarnessExample} from './expansion-harness-example';
 describe('ExpansionHarnessExample', () => {
   let fixture: ComponentFixture<ExpansionHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/form-field/BUILD.bazel
+++ b/src/components-examples/material/form-field/BUILD.bazel
@@ -59,6 +59,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
+++ b/src/components-examples/material/form-field/form-field-harness/form-field-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatFormFieldHarness} from '@angular/material/form-field/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {FormFieldHarnessExample} from './form-field-harness-example';
 import {MatInputModule} from '@angular/material/input';
@@ -16,10 +12,6 @@ import {MatInputHarness} from '@angular/material/input/testing';
 describe('FormFieldHarnessExample', () => {
   let fixture: ComponentFixture<FormFieldHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/grid-list/BUILD.bazel
+++ b/src/components-examples/material/grid-list/BUILD.bazel
@@ -47,6 +47,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
+++ b/src/components-examples/material/grid-list/grid-list-harness/grid-list-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatGridListHarness, MatGridTileHarness} from '@angular/material/grid-list/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatGridListModule} from '@angular/material/grid-list';
 import {GridListHarnessExample} from './grid-list-harness-example';
 
 describe('GridListHarnessExample', () => {
   let fixture: ComponentFixture<GridListHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/icon/BUILD.bazel
+++ b/src/components-examples/material/icon/BUILD.bazel
@@ -48,6 +48,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
+++ b/src/components-examples/material/icon/icon-harness/icon-harness-example.spec.ts
@@ -1,10 +1,6 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {IconHarnessExample} from './icon-harness-example';
 import {MatIconModule, MatIconRegistry} from '@angular/material/icon';
 import {MatIconHarness} from '@angular/material/icon/testing';
@@ -13,10 +9,6 @@ import {DomSanitizer} from '@angular/platform-browser';
 describe('IconHarnessExample', () => {
   let fixture: ComponentFixture<IconHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/input/BUILD.bazel
+++ b/src/components-examples/material/input/BUILD.bazel
@@ -52,6 +52,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
+++ b/src/components-examples/material/input/input-harness/input-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatInputHarness} from '@angular/material/input/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatInputModule} from '@angular/material/input';
 import {InputHarnessExample} from './input-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -14,10 +10,6 @@ import {ReactiveFormsModule} from '@angular/forms';
 describe('InputHarnessExample', () => {
   let fixture: ComponentFixture<InputHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/list/BUILD.bazel
+++ b/src/components-examples/material/list/BUILD.bazel
@@ -48,6 +48,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/list/list-harness/list-harness-example.spec.ts
+++ b/src/components-examples/material/list/list-harness/list-harness-example.spec.ts
@@ -1,21 +1,13 @@
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatListHarness} from '@angular/material/list/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatListModule} from '@angular/material/list';
 import {ListHarnessExample} from './list-harness-example';
 
 describe('ListHarnessExample', () => {
   let fixture: ComponentFixture<ListHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/menu/BUILD.bazel
+++ b/src/components-examples/material/menu/BUILD.bazel
@@ -51,6 +51,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
+++ b/src/components-examples/material/menu/menu-harness/menu-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatMenuHarness} from '@angular/material/menu/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatMenuModule} from '@angular/material/menu';
 import {MenuHarnessExample} from './menu-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,10 +9,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('MenuHarnessExample', () => {
   let fixture: ComponentFixture<MenuHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/paginator/BUILD.bazel
+++ b/src/components-examples/material/paginator/BUILD.bazel
@@ -51,6 +51,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
+++ b/src/components-examples/material/paginator/paginator-harness/paginator-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatPaginatorHarness} from '@angular/material/paginator/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatPaginatorModule} from '@angular/material/paginator';
 import {PaginatorHarnessExample} from './paginator-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -14,10 +10,6 @@ describe('PaginatorHarnessExample', () => {
   let fixture: ComponentFixture<PaginatorHarnessExample>;
   let loader: HarnessLoader;
   let instance: PaginatorHarnessExample;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/progress-bar/BUILD.bazel
+++ b/src/components-examples/material/progress-bar/BUILD.bazel
@@ -51,6 +51,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/progress-bar/progress-bar-harness/progress-bar-harness-example.spec.ts
+++ b/src/components-examples/material/progress-bar/progress-bar-harness/progress-bar-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatProgressBarHarness} from '@angular/material/progress-bar/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {ProgressBarHarnessExample} from './progress-bar-harness-example';
 
 describe('ProgressBarHarnessExample', () => {
   let fixture: ComponentFixture<ProgressBarHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/progress-spinner/BUILD.bazel
+++ b/src/components-examples/material/progress-spinner/BUILD.bazel
@@ -51,6 +51,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/progress-spinner/progress-spinner-harness/progress-spinner-harness-example.spec.ts
+++ b/src/components-examples/material/progress-spinner/progress-spinner-harness/progress-spinner-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatProgressSpinnerHarness} from '@angular/material/progress-spinner/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {ProgressSpinnerHarnessExample} from './progress-spinner-harness-example';
 
 describe('ProgressSpinnerHarnessExample', () => {
   let fixture: ComponentFixture<ProgressSpinnerHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/radio/BUILD.bazel
+++ b/src/components-examples/material/radio/BUILD.bazel
@@ -49,6 +49,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/radio/radio-harness/radio-harness-example.spec.ts
+++ b/src/components-examples/material/radio/radio-harness/radio-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatRadioButtonHarness, MatRadioGroupHarness} from '@angular/material/radio/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatRadioModule} from '@angular/material/radio';
 import {RadioHarnessExample} from './radio-harness-example';
 import {ReactiveFormsModule} from '@angular/forms';
@@ -13,10 +9,6 @@ import {ReactiveFormsModule} from '@angular/forms';
 describe('RadioHarnessExample', () => {
   let fixture: ComponentFixture<RadioHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/select/BUILD.bazel
+++ b/src/components-examples/material/select/BUILD.bazel
@@ -52,6 +52,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
+++ b/src/components-examples/material/select/select-harness/select-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSelectHarness} from '@angular/material/select/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatSelectModule} from '@angular/material/select';
 import {SelectHarnessExample} from './select-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,10 +9,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('SelectHarnessExample', () => {
   let fixture: ComponentFixture<SelectHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/sidenav/BUILD.bazel
+++ b/src/components-examples/material/sidenav/BUILD.bazel
@@ -56,6 +56,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
+++ b/src/components-examples/material/sidenav/sidenav-harness/sidenav-harness-example.spec.ts
@@ -1,15 +1,11 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {
-  MatDrawerHarness,
   MatDrawerContainerHarness,
   MatDrawerContentHarness,
+  MatDrawerHarness,
 } from '@angular/material/sidenav/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatSidenavModule} from '@angular/material/sidenav';
 import {SidenavHarnessExample} from './sidenav-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -17,10 +13,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('SidenavHarnessExample', () => {
   let fixture: ComponentFixture<SidenavHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/slide-toggle/BUILD.bazel
+++ b/src/components-examples/material/slide-toggle/BUILD.bazel
@@ -53,6 +53,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/slide-toggle/slide-toggle-harness/slide-toggle-harness-example.spec.ts
+++ b/src/components-examples/material/slide-toggle/slide-toggle-harness/slide-toggle-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSlideToggleHarness} from '@angular/material/slide-toggle/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {SlideToggleHarnessExample} from './slide-toggle-harness-example';
 import {ReactiveFormsModule} from '@angular/forms';
@@ -13,10 +9,6 @@ import {ReactiveFormsModule} from '@angular/forms';
 describe('SlideToggleHarnessExample', () => {
   let fixture: ComponentFixture<SlideToggleHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/slider/BUILD.bazel
+++ b/src/components-examples/material/slider/BUILD.bazel
@@ -51,6 +51,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
+++ b/src/components-examples/material/slider/slider-harness/slider-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSliderHarness} from '@angular/material/slider/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatSliderModule} from '@angular/material/slider';
 import {SliderHarnessExample} from './slider-harness-example';
 
 describe('SliderHarnessExample', () => {
   let fixture: ComponentFixture<SliderHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/snack-bar/BUILD.bazel
+++ b/src/components-examples/material/snack-bar/BUILD.bazel
@@ -52,6 +52,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
+++ b/src/components-examples/material/snack-bar/snack-bar-harness/snack-bar-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSnackBarHarness} from '@angular/material/snack-bar/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {SnackBarHarnessExample} from './snack-bar-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,10 +9,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('SnackBarHarnessExample', () => {
   let fixture: ComponentFixture<SnackBarHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/sort/BUILD.bazel
+++ b/src/components-examples/material/sort/BUILD.bazel
@@ -48,6 +48,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
+++ b/src/components-examples/material/sort/sort-harness/sort-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatSortHarness} from '@angular/material/sort/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatSortModule} from '@angular/material/sort';
 import {SortHarnessExample} from './sort-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,10 +9,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('SortHarnessExample', () => {
   let fixture: ComponentFixture<SortHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/stepper/BUILD.bazel
+++ b/src/components-examples/material/stepper/BUILD.bazel
@@ -57,6 +57,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
+++ b/src/components-examples/material/stepper/stepper-harness/stepper-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatStepperHarness, MatStepperNextHarness} from '@angular/material/stepper/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatStepperModule} from '@angular/material/stepper';
 import {StepperHarnessExample} from './stepper-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -14,10 +10,6 @@ import {ReactiveFormsModule} from '@angular/forms';
 describe('StepperHarnessExample', () => {
   let fixture: ComponentFixture<StepperHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/table/BUILD.bazel
+++ b/src/components-examples/material/table/BUILD.bazel
@@ -58,6 +58,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/table/table-harness/table-harness-example.spec.ts
+++ b/src/components-examples/material/table/table-harness/table-harness-example.spec.ts
@@ -1,21 +1,13 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTableHarness} from '@angular/material/table/testing';
 import {HarnessLoader, parallel} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatTableModule} from '@angular/material/table';
 import {TableHarnessExample} from './table-harness-example';
 
 describe('TableHarnessExample', () => {
   let fixture: ComponentFixture<TableHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/tabs/BUILD.bazel
+++ b/src/components-examples/material/tabs/BUILD.bazel
@@ -54,6 +54,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
+++ b/src/components-examples/material/tabs/tab-group-harness/tab-group-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTabGroupHarness} from '@angular/material/tabs/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatTabsModule} from '@angular/material/tabs';
 import {TabGroupHarnessExample} from './tab-group-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,10 +9,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('TabGroupHarnessExample', () => {
   let fixture: ComponentFixture<TabGroupHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/toolbar/BUILD.bazel
+++ b/src/components-examples/material/toolbar/BUILD.bazel
@@ -50,6 +50,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.spec.ts
+++ b/src/components-examples/material/toolbar/toolbar-harness/toolbar-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatToolbarHarness} from '@angular/material/toolbar/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {ToolbarHarnessExample} from './toolbar-harness-example';
 import {MatIconModule} from '@angular/material/icon';
@@ -13,10 +9,6 @@ import {MatIconModule} from '@angular/material/icon';
 describe('ToolbarHarnessExample', () => {
   let fixture: ComponentFixture<ToolbarHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/tooltip/BUILD.bazel
+++ b/src/components-examples/material/tooltip/BUILD.bazel
@@ -54,6 +54,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
+++ b/src/components-examples/material/tooltip/tooltip-harness/tooltip-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTooltipHarness} from '@angular/material/tooltip/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {TooltipHarnessExample} from './tooltip-harness-example';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -13,10 +9,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 describe('TooltipHarnessExample', () => {
   let fixture: ComponentFixture<TooltipHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/components-examples/material/tree/BUILD.bazel
+++ b/src/components-examples/material/tree/BUILD.bazel
@@ -53,6 +53,5 @@ ng_test_library(
 
 ng_web_test_suite(
     name = "unit_tests",
-    exclude_init_script = True,
     deps = [":unit_tests_lib"],
 )

--- a/src/components-examples/material/tree/tree-harness/tree-harness-example.spec.ts
+++ b/src/components-examples/material/tree/tree-harness/tree-harness-example.spec.ts
@@ -1,11 +1,7 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {MatTreeHarness} from '@angular/material/tree/testing';
 import {HarnessLoader} from '@angular/cdk/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {MatTreeModule} from '@angular/material/tree';
 import {TreeHarnessExample} from './tree-harness-example';
 import {MatIconModule} from '@angular/material/icon';
@@ -13,10 +9,6 @@ import {MatIconModule} from '@angular/material/icon';
 describe('TreeHarnessExample', () => {
   let fixture: ComponentFixture<TreeHarnessExample>;
   let loader: HarnessLoader;
-
-  beforeAll(() => {
-    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({


### PR DESCRIPTION
Removes the init test environment calls from the harness examples. This
is meant to make the examples a little more readable, and easier to
integrate within CLI projects (especially when are starting to use
a plain CLI project as foundation for our StackBlitz examples).

The CLI sets up the test environment in a global test init file, so
we should make this assumption in our examples as well. This also helps
with reducing duplication in our code base.