### PR TITLE
build: update dev-infra package and format mjs files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,5 @@
   "quoteProps": "preserve",
   "bracketSpacing": false,
   "arrowParens": "avoid",
-  "embeddedLanguageFormatting": "off",
+  "embeddedLanguageFormatting": "off"
 }

--- a/integration/linker/link-packages-test.mjs
+++ b/integration/linker/link-packages-test.mjs
@@ -76,17 +76,19 @@ function testPackage(pkg) {
         ast: true,
         filename: diskFilePath,
         filenameRelative: debugFileName,
-        plugins: [linkerPlugin]
+        plugins: [linkerPlugin],
       });
 
       // Naively check if there are any Angular declarations left that haven't been linked.
       traverse(ast, {
-        Identifier: (astPath) => {
+        Identifier: astPath => {
           if (astPath.node.name.startsWith('ɵɵngDeclare')) {
             throw astPath.buildCodeFrameError(
-                'Found Angular declaration that has not been linked.', Error);
+              'Found Angular declaration that has not been linked.',
+              Error,
+            );
           }
-        }
+        },
       });
 
       passedFiles.push(debugFileName);
@@ -95,5 +97,5 @@ function testPackage(pkg) {
     }
   }
 
-  return {passedFiles, failures}
+  return {passedFiles, failures};
 }

--- a/integration/npm-packages-from-runfiles.mjs
+++ b/integration/npm-packages-from-runfiles.mjs
@@ -20,12 +20,14 @@ export function getNpmPackagesFromRunfiles() {
   const workspacePath = 'angular_material/src';
   if (!runfilesManifestPath) {
     const packageRunfilesDir = path.join(process.env.RUNFILES, workspacePath);
-    return fs.readdirSync(packageRunfilesDir)
+    return fs
+      .readdirSync(packageRunfilesDir)
       .map(name => ({name, pkgPath: path.join(packageRunfilesDir, name, 'npm_package/')}))
       .filter(({pkgPath}) => fs.existsSync(pkgPath));
   }
   const workspaceManifestPathRegex = new RegExp(`^${workspacePath}/[\\w-]+/npm_package$`);
-  return fs.readFileSync(runfilesManifestPath, 'utf8')
+  return fs
+    .readFileSync(runfilesManifestPath, 'utf8')
     .split('\n')
     .map(mapping => mapping.split(' '))
     .filter(([runfilePath]) => runfilePath.match(workspaceManifestPathRegex))

--- a/integration/ts-compat/helpers.mjs
+++ b/integration/ts-compat/helpers.mjs
@@ -1,8 +1,8 @@
-import {join}  from 'path';
-import {unlinkSync}  from 'fs';
+import {join} from 'path';
+import {unlinkSync} from 'fs';
 import shelljs from 'shelljs';
-import {fork}  from 'child_process';
-import {getNpmPackagesFromRunfiles}  from '../npm-packages-from-runfiles.mjs';
+import {fork} from 'child_process';
+import {getNpmPackagesFromRunfiles} from '../npm-packages-from-runfiles.mjs';
 import {runfiles} from '@bazel/runfiles';
 
 // Exit if any command fails.
@@ -14,7 +14,8 @@ const npmPackages = getNpmPackagesFromRunfiles();
 const nodeModulesDir = runfiles.resolve('npm/node_modules');
 // Path to the generated file that imports all entry-points.
 const testFilePath = runfiles.resolveWorkspaceRelative(
-  'integration/ts-compat/import-all-entry-points.ts');
+  'integration/ts-compat/import-all-entry-points.ts',
+);
 
 /**
  * Runs the TypeScript compatibility test with the specified tsc binary. The
@@ -40,17 +41,19 @@ export async function runTypeScriptCompatibilityTest(tscBinPath) {
       // Disables automatic type resolution. In non-sandbox environments, the node modules
       // are accessible and types could end up as part of the program.
       '--types',
-      '--lib', 'es2015,dom',
+      '--lib',
+      'es2015,dom',
       // Ensures that `node_modules` can be resolved. By default, in sandbox environments the
       // node modules cannot be resolved because they are wrapped in the `npm/node_modules` folder
-      '--baseUrl', nodeModulesDir,
-      testFilePath
+      '--baseUrl',
+      nodeModulesDir,
+      testFilePath,
     ];
     // Run `tsc` to compile the project. The stdout/stderr output is inherited, so that
     // warnings and errors are printed to the console.
     const tscProcess = fork(tscBinPath, tscArgs, {stdio: 'inherit'});
 
-    tscProcess.on('exit', (exitCode) => {
+    tscProcess.on('exit', exitCode => {
       // Remove symlinks to keep a clean repository state.
       for (const {name} of npmPackages) {
         console.info(`Removing link for "@angular/${name}"..`);
@@ -60,5 +63,4 @@ export async function runTypeScriptCompatibilityTest(tscBinPath) {
       exitCode === 0 ? resolve() : reject();
     });
   });
-};
-
+}

--- a/scripts/create-legacy-tests-bundle.mjs
+++ b/scripts/create-legacy-tests-bundle.mjs
@@ -21,7 +21,6 @@ const outFile = join(distDir, 'legacy-test-bundle.spec.js');
 const ngcBinFile = join(nodeModulesDir, '@angular/compiler-cli/bundles/src/bin/ngc.js');
 const legacyOutputDir = join(distDir, 'legacy-test-out');
 
-
 /**
  * This script builds the whole library in `angular/components` together with its
  * spec files into a single IIFE bundle.
@@ -72,10 +71,10 @@ async function compileSassFiles() {
   for (const file of sassFiles) {
     const outRelativePath = relative(projectDir, file).replace(/\.scss$/, '.css');
     const outPath = join(projectDir, outRelativePath);
-    const task = renderSassFileAsync(file).then(async (content) => {
+    const task = renderSassFileAsync(file).then(async content => {
       console.info('Compiled, now writing:', outRelativePath);
       await fs.promises.mkdir(dirname(outPath), {recursive: true});
-      await fs.promises.writeFile(outPath, content)
+      await fs.promises.writeFile(outPath, content);
     });
 
     sassTasks.push(task);
@@ -93,7 +92,10 @@ async function compileSassFiles() {
 async function compileProjectWithNgtsc() {
   // Build the project with Ngtsc so that external resources are inlined.
   const ngcProcess = child_process.spawnSync(
-      'node', [ngcBinFile, '--project', legacyTsconfigPath], {shell: true, stdio: 'inherit'});
+    'node',
+    [ngcBinFile, '--project', legacyTsconfigPath],
+    {shell: true, stdio: 'inherit'},
+  );
 
   if (ngcProcess.error || ngcProcess.status !== 0) {
     throw Error('Unable to compile tests and library. See error above.');
@@ -137,9 +139,9 @@ async function createEntryPointSpecFile() {
 /** Helper function to render a Sass file asynchronously using promises. */
 async function renderSassFileAsync(inputFile) {
   return new Promise((resolve, reject) => {
-    sass.render(
-        {file: inputFile, includePaths: [nodeModulesDir]},
-        (err, result) => err ? reject(err) : resolve(result.css));
+    sass.render({file: inputFile, includePaths: [nodeModulesDir]}, (err, result) =>
+      err ? reject(err) : resolve(result.css),
+    );
   });
 }
 
@@ -149,10 +151,11 @@ async function renderSassFileAsync(inputFile) {
  */
 async function createResolveEsbuildPlugin() {
   return {
-    name: 'ng-resolve-esbuild', setup: (build) => {
-      build.onResolve({filter: /@angular\//}, async (args) => {
+    name: 'ng-resolve-esbuild',
+    setup: build => {
+      build.onResolve({filter: /@angular\//}, async args => {
         const pkgName = args.path.substr('@angular/'.length);
-        let resolvedPath = join(legacyOutputDir, pkgName)
+        let resolvedPath = join(legacyOutputDir, pkgName);
         let stats = await statGraceful(resolvedPath);
 
         // If the resolved path points to a directory, resolve the contained `index.js` file
@@ -168,8 +171,8 @@ async function createResolveEsbuildPlugin() {
 
         return stats !== null ? {path: resolvedPath} : undefined;
       });
-    }
-  }
+    },
+  };
 }
 
 /** Creates an ESBuild plugin that runs the Angular linker on framework packages. */
@@ -183,8 +186,8 @@ async function createLinkerEsbuildPlugin() {
 
   return {
     name: 'ng-linker-esbuild',
-    setup: (build) => {
-      build.onLoad({filter: /fesm2020/}, async (args) => {
+    setup: build => {
+      build.onLoad({filter: /fesm2020/}, async args => {
         const filePath = args.path;
         const content = await fs.promises.readFile(filePath, 'utf8');
         const {code} = await transformAsync(content, {

--- a/scripts/github/fetch-workflow-artifact.mjs
+++ b/scripts/github/fetch-workflow-artifact.mjs
@@ -20,9 +20,7 @@ async function main() {
     run_id: workflowId,
   });
 
-  const matchArtifact = artifacts.data.artifacts.find(
-    artifact => artifact.name === artifactName,
-  );
+  const matchArtifact = artifacts.data.artifacts.find(artifact => artifact.name === artifactName);
 
   const download = await github.actions.downloadArtifact({
     owner,

--- a/tools/angular/esbuild.config.mjs
+++ b/tools/angular/esbuild.config.mjs
@@ -15,6 +15,6 @@ export default {
   plugins: [
     // Only run the linker on `fesm2020/` bundles. This should not have an effect on
     // the bundle output, but helps speeding up ESBuild when it visits other modules.
-    await createLinkerEsbuildPlugin(/fesm2020/)
-  ]
+    await createLinkerEsbuildPlugin(/fesm2020/),
+  ],
 };

--- a/tools/esbuild/esbuild-amd-config.mjs
+++ b/tools/esbuild/esbuild-amd-config.mjs
@@ -2,7 +2,7 @@ import url from 'url';
 import path from 'path';
 
 /** Path to the ESBuild configuration maintained by the user. */
-const userConfigExecPath = "TMPL_CONFIG_PATH"
+const userConfigExecPath = 'TMPL_CONFIG_PATH';
 
 /** User ESBuild config. Empty if none is loaded. */
 let userConfig = {};
@@ -17,7 +17,7 @@ if (userConfigExecPath !== '') {
 
 export default {
   ...userConfig,
-  globalName: "__exports",
+  globalName: '__exports',
   format: 'iife',
   banner: {js: 'define("TMPL_MODULE_NAME", [], function() {'},
   footer: {js: 'return __exports;})'},

--- a/tools/spec-bundling/esbuild.config-tmpl.mjs
+++ b/tools/spec-bundling/esbuild.config-tmpl.mjs
@@ -8,14 +8,13 @@
 
 // Note: This needs to be a workspace manifest path as this ESBuild config
 // is generated and can end up in arbitrary Bazel packages.
-import {
-  createLinkerEsbuildPlugin
-} from 'angular_material/tools/angular/create_linker_esbuild_plugin.mjs';
+import {createLinkerEsbuildPlugin} from 'angular_material/tools/angular/create_linker_esbuild_plugin.mjs';
 
 // Conditionally, based on whether partial compilation is enabled, we run the
 // linker on all files part of the test.
-const plugins = TMPL_PARTIAL_COMPILATION_ENABLED ?
-  [await createLinkerEsbuildPlugin(/.*/, /* ensureNoPartialDeclaration */ true)] : []
+const plugins = TMPL_PARTIAL_COMPILATION_ENABLED
+  ? [await createLinkerEsbuildPlugin(/.*/, /* ensureNoPartialDeclaration */ true)]
+  : [];
 
 export default {
   // `tslib` sets the `module` condition to resolve to ESM.


### PR DESCRIPTION
Updates to the latest version of the `dev-infra` package and fixes that we weren't enforcing formatting on `.mjs` files.