### PR TITLE
fix(material/chips): Declare that MatChipInput.inputElement is always defined

### DIFF
--- a/src/material-experimental/mdc-chips/chip-input.ts
+++ b/src/material-experimental/mdc-chips/chip-input.ts
@@ -136,7 +136,7 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
   }
 
   /** The native input element to which this directive is attached. */
-  readonly inputElement: HTMLInputElement;
+  readonly inputElement!: HTMLInputElement;
 
   constructor(
     protected _elementRef: ElementRef<HTMLInputElement>,

--- a/src/material/chips/chip-input.ts
+++ b/src/material/chips/chip-input.ts
@@ -129,7 +129,7 @@ export class MatChipInput implements MatChipTextControl, OnChanges, OnDestroy, A
   }
 
   /** The native input element to which this directive is attached. */
-  readonly inputElement: HTMLInputElement;
+  readonly inputElement!: HTMLInputElement;
 
   constructor(
     protected _elementRef: ElementRef<HTMLInputElement>,


### PR DESCRIPTION
It is initialized in the constructor, so there is no chance of it being
undefined.