### PR TITLE
fix(material/form-field): update outline gap when prefix changes

### DIFF
--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -16,7 +16,11 @@
       </div>
     </ng-container>
 
-    <div class="mat-form-field-prefix" *ngIf="_prefixChildren.length">
+    <div
+      class="mat-form-field-prefix"
+      *ngIf="_prefixChildren.length"
+      (cdkObserveContent)="updateOutlineGap()"
+      [cdkObserveContentDisabled]="appearance != 'outline'">
       <ng-content select="[matPrefix]"></ng-content>
     </div>
 


### PR DESCRIPTION
The position of the outline gap depends on the size of the prefix, but we weren't set up to update it when that happens.

Fixes #23863.