### PR TITLE
test(material/select): fix failing unit test

### DIFF
--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -4407,7 +4407,7 @@ describe('MatSelect', () => {
 
       it('should fall back to "below" positioning properly when scrolled', fakeAsync(() => {
         // Give plenty of space for the select to open below the trigger
-        fixture.componentInstance.heightBelow = 650;
+        fixture.componentInstance.heightBelow = 2000;
         fixture.detectChanges();
 
         // Select an option too low in the list to fit in limited space above


### PR DESCRIPTION
Fixes a unit test that started failing, because it tries to scroll the page down, but there isn't enough content for it to scroll.