### PR TITLE
test(material/tabs): Add `getAriaLabel` to MatTabLinkHarness

### DIFF
--- a/src/material-experimental/mdc-tabs/testing/tab-link-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-link-harness.ts
@@ -33,6 +33,11 @@ export class MatTabLinkHarness extends ComponentHarness {
     return (await this.host()).text();
   }
 
+  /** Gets the aria-label of the tab. */
+  async getAriaLabel(): Promise<string | null> {
+    return (await this.host()).getAttribute('aria-label');
+  }
+
   /** Whether the link is active. */
   async isActive(): Promise<boolean> {
     const host = await this.host();

--- a/src/material/tabs/testing/tab-link-harness.ts
+++ b/src/material/tabs/testing/tab-link-harness.ts
@@ -33,6 +33,11 @@ export class MatTabLinkHarness extends ComponentHarness {
     return (await this.host()).text();
   }
 
+  /** Gets the aria-label of the tab. */
+  async getAriaLabel(): Promise<string | null> {
+    return (await this.host()).getAttribute('aria-label');
+  }
+
   /** Whether the link is active. */
   async isActive(): Promise<boolean> {
     const host = await this.host();

--- a/src/material/tabs/testing/tab-nav-bar-shared.spec.ts
+++ b/src/material/tabs/testing/tab-nav-bar-shared.spec.ts
@@ -1,5 +1,4 @@
 import {HarnessLoader} from '@angular/cdk/testing';
-import {expectAlignedWith} from '@angular/cdk/testing/private/e2e';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';

--- a/src/material/tabs/testing/tab-nav-bar-shared.spec.ts
+++ b/src/material/tabs/testing/tab-nav-bar-shared.spec.ts
@@ -1,4 +1,5 @@
 import {HarnessLoader} from '@angular/cdk/testing';
+import {expectAlignedWith} from '@angular/cdk/testing/private/e2e';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -65,6 +66,12 @@ export function runTabNavBarHarnessTests(
     expect(await links[2].getLabel()).toBe('Third');
   });
 
+  it('should be able to get the aria label of links', () => {
+    const navBar = await loader.getHarness(tabNavBarHarness);
+    const links = await navBar.getLinks();
+    expect(await links[0].getAriaLabel()).toBe('The first tab');
+  });
+
   it('should be able to get disabled state of link', async () => {
     const navBar = await loader.getHarness(tabNavBarHarness);
     const links = await navBar.getLinks();
@@ -97,7 +104,7 @@ export function runTabNavBarHarnessTests(
 @Component({
   template: `
     <nav mat-tab-nav-bar>
-      <a href="#" (click)="select(0, $event)" [active]="activeLink === 0" matTabLink>First</a>
+      <a href="#" (click)="select(0, $event)" aria-label="The first tab" [active]="activeLink === 0" matTabLink>First</a>
       <a href="#" (click)="select(1, $event)" [active]="activeLink === 1" matTabLink>Second</a>
       <a
         href="#"

--- a/src/material/tabs/testing/tab-nav-bar-shared.spec.ts
+++ b/src/material/tabs/testing/tab-nav-bar-shared.spec.ts
@@ -66,7 +66,7 @@ export function runTabNavBarHarnessTests(
     expect(await links[2].getLabel()).toBe('Third');
   });
 
-  it('should be able to get the aria label of links', () => {
+  it('should be able to get the aria label of links', async () => {
     const navBar = await loader.getHarness(tabNavBarHarness);
     const links = await navBar.getLinks();
     expect(await links[0].getAriaLabel()).toBe('The first tab');


### PR DESCRIPTION
Adds `getAriaLabel` to MatTabLinkHarness