### PR TITLE
build: update peer dependency ranges for v13 stable release

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -1,10 +1,10 @@
 # Each individual package uses a placeholder for the version of Angular to ensure they're
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
-ANGULAR_PACKAGE_VERSION = "^13.0.0-0 || ^14.0.0-0"
+ANGULAR_PACKAGE_VERSION = "^13.0.0 || ^14.0.0-0"
 MDC_PACKAGE_VERSION = "14.0.0-canary.1af7c1c4a.0"
 TSLIB_PACKAGE_VERSION = "^2.3.0"
-RXJS_PACKAGE_VERSION = "^6.5.3 || ^7.0.0"
+RXJS_PACKAGE_VERSION = "^6.5.3 || ^7.4.0"
 
 # Each placeholder is used to stamp versions during the build process, replacing the key with it's
 # value pair. These replacements occur during building of `npm_package` and `ng_package` stamping in


### PR DESCRIPTION
Updates the peer dependency ranges for the v13 stable version:

* v13.0.0 of Angular Components requires at minimum a stable v13 version
  of Angular framework (no pre-releases allowed once we hit stable)

* For RxJS v7, minimum `7.4.0` is needed as that version comes with a
  ES2015 distibution wired up in the `package.json`, allowing for better
  optimized applications. This matches with `@angular/core` and the CLI.

https://github.com/angular/angular/commit/48aa0039ea75693f751b26474029efdb6c22377://github.com/angular/angular/commit/48aa0039ea75693f751b26474029efdb6c223770