### PR TITLE
build: do not accidentally cache undesired files in github action

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -7,12 +7,12 @@ runs:
     - uses: actions/cache@v2
       with:
         path: |
-          **/node_modules
+          ./node_modules/
         # Cache key. Whenever the postinstall patches change, the cache needs to be invalidated.
         # If just the `yarn.lock` file changes, the most recent cache can be restored though.
         # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action.
-        key: v2-${{hashFiles('tools/postinstall/apply-patches.js')}}-${{hashFiles('yarn.lock')}}
-        restore-keys: v2-${{hashFiles('tools/postinstall/apply-patches.js')}}-
+        key: v3-${{hashFiles('tools/postinstall/apply-patches.js')}}-${{hashFiles('yarn.lock')}}
+        restore-keys: v3-${{hashFiles('tools/postinstall/apply-patches.js')}}-
 
     - run: yarn install --frozen-lockfile --non-interactive
       shell: bash

--- a/.github/workflows/build-dev-app.yml
+++ b/.github/workflows/build-dev-app.yml
@@ -28,11 +28,13 @@ jobs:
           GCP_DECRYPT_TOKEN: angular
 
       # Build the web package. Note that we also need to make the Github environment
-      # variables available so that the RBE is configured.
+      # variables available so that the RBE is configured. Note: We run Bazel from a
+      # low-resource Github action container, so we manually need to instruct Bazel to run
+      # more actions concurrently as by default this is computed based on the host resources.
       - name: Building dev-app
         run: |
           source ${GITHUB_ENV}
-          bazel build //src/dev-app:web_package --symlink_prefix=dist/
+          bazel build //src/dev-app:web_package --symlink_prefix=dist/ --jobs=32
 
       # Prepare the workflow artifact that is available for the deploy workflow. We store the pull
       # request number and SHA in a file that can be read by the deploy workflow. This is necessary


### PR DESCRIPTION
This commit fixes that the Github actions currently may cache undesired
files. e.g. when Bazel runs the `dist/` folder is populated and
symlinked with the execroot, where another clone of the `node_modules`
would be cached accidentally then. We use an explicit path instead of a
pattern as it has been recommended by the Github action documentation.

Additionally, we fix that the dev-app building on RBE occurs with 2
concurrent jobs due to the host containers only having 2 cores. We can
run more jobs in the RBE containers.