### PR TITLE
refactor: fix examples not recognizing webcontainer stackblitz instances

### DIFF
--- a/src/components-examples/material/sidenav/sidenav-disable-close/sidenav-disable-close-example.ts
+++ b/src/components-examples/material/sidenav/sidenav-disable-close/sidenav-disable-close-example.ts
@@ -17,5 +17,5 @@ export class SidenavDisableCloseExample {
     this.sidenav.close();
   }
 
-  shouldRun = [/(^|\.)plnkr\.co$/, /(^|\.)stackblitz\.io$/].some(h => h.test(window.location.host));
+  shouldRun = /(^|.)(stackblitz|webcontainer).(io|com)$/.test(window.location.host);
 }

--- a/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.ts
+++ b/src/components-examples/material/sidenav/sidenav-fixed/sidenav-fixed-example.ts
@@ -18,5 +18,5 @@ export class SidenavFixedExample {
     });
   }
 
-  shouldRun = [/(^|\.)plnkr\.co$/, /(^|\.)stackblitz\.io$/].some(h => h.test(window.location.host));
+  shouldRun = /(^|.)(stackblitz|webcontainer).(io|com)$/.test(window.location.host);
 }

--- a/src/components-examples/material/sidenav/sidenav-mode/sidenav-mode-example.ts
+++ b/src/components-examples/material/sidenav/sidenav-mode/sidenav-mode-example.ts
@@ -9,5 +9,5 @@ import {FormControl} from '@angular/forms';
 })
 export class SidenavModeExample {
   mode = new FormControl('over');
-  shouldRun = [/(^|\.)plnkr\.co$/, /(^|\.)stackblitz\.io$/].some(h => h.test(window.location.host));
+  shouldRun = /(^|.)(stackblitz|webcontainer).(io|com)$/.test(window.location.host);
 }

--- a/src/components-examples/material/sidenav/sidenav-open-close/sidenav-open-close-example.ts
+++ b/src/components-examples/material/sidenav/sidenav-open-close/sidenav-open-close-example.ts
@@ -10,5 +10,5 @@ export class SidenavOpenCloseExample {
   events: string[] = [];
   opened: boolean;
 
-  shouldRun = [/(^|\.)plnkr\.co$/, /(^|\.)stackblitz\.io$/].some(h => h.test(window.location.host));
+  shouldRun = /(^|.)(stackblitz|webcontainer).(io|com)$/.test(window.location.host);
 }

--- a/src/components-examples/material/sidenav/sidenav-overview/sidenav-overview-example.ts
+++ b/src/components-examples/material/sidenav/sidenav-overview/sidenav-overview-example.ts
@@ -7,5 +7,5 @@ import {Component} from '@angular/core';
   styleUrls: ['sidenav-overview-example.css'],
 })
 export class SidenavOverviewExample {
-  shouldRun = [/(^|\.)plnkr\.co$/, /(^|\.)stackblitz\.io$/].some(h => h.test(window.location.host));
+  shouldRun = /(^|.)(stackblitz|webcontainer).(io|com)$/.test(window.location.host);
 }

--- a/src/components-examples/material/sidenav/sidenav-position/sidenav-position-example.ts
+++ b/src/components-examples/material/sidenav/sidenav-position/sidenav-position-example.ts
@@ -7,5 +7,5 @@ import {Component} from '@angular/core';
   styleUrls: ['sidenav-position-example.css'],
 })
 export class SidenavPositionExample {
-  shouldRun = [/(^|\.)plnkr\.co$/, /(^|\.)stackblitz\.io$/].some(h => h.test(window.location.host));
+  shouldRun = /(^|.)(stackblitz|webcontainer).(io|com)$/.test(window.location.host);
 }

--- a/src/components-examples/material/sidenav/sidenav-responsive/sidenav-responsive-example.ts
+++ b/src/components-examples/material/sidenav/sidenav-responsive/sidenav-responsive-example.ts
@@ -34,5 +34,5 @@ export class SidenavResponsiveExample implements OnDestroy {
     this.mobileQuery.removeListener(this._mobileQueryListener);
   }
 
-  shouldRun = [/(^|\.)plnkr\.co$/, /(^|\.)stackblitz\.io$/].some(h => h.test(window.location.host));
+  shouldRun = /(^|.)(stackblitz|webcontainer).(io|com)$/.test(window.location.host);
 }


### PR DESCRIPTION
Fixes that examples do not properly recognize webcontainer Stackblitz
instances. This causes some sidenav examples to not even work within
Stackblitz as a message `Please open on Stackblitz` is displayed.

Fixes #23895.