### PR TITLE
docs(cdk/testing): expand JsDoc for sendKeys with limitations

### DIFF
--- a/src/cdk/testing/test-element.ts
+++ b/src/cdk/testing/test-element.ts
@@ -117,7 +117,8 @@ export interface TestElement {
 
   /**
    * Sends the given string to the input as a series of key presses. Also fires input events
-   * and attempts to add the string to the Element's value.
+   * and attempts to add the string to the Element's value. Note that some environments cannot
+   * reproduce native browser behavior for keyboard shortcuts such as Tab, Ctrl + A, etc.
    */
   sendKeys(...keys: (string | TestKey)[]): Promise<void>;
 

--- a/src/cdk/testing/testbed/unit-test-element.ts
+++ b/src/cdk/testing/testbed/unit-test-element.ts
@@ -148,7 +148,8 @@ export class UnitTestElement implements TestElement {
 
   /**
    * Sends the given string to the input as a series of key presses. Also fires input events
-   * and attempts to add the string to the Element's value.
+   * and attempts to add the string to the Element's value. Note that this cannot
+   * reproduce native browser behavior for keyboard shortcuts such as Tab, Ctrl + A, etc.
    */
   async sendKeys(...keys: (string | TestKey)[]): Promise<void>;
   /**


### PR DESCRIPTION
This change is in response to feedback that it's not obvious that `TestElement.sendKeys` may behave differently in different environments. To help a tiny bit, we expand the JsDoc for `sendKeys` to mentions that it cannot reproduce native keyboard shortcuts in all environments.