### PR TITLE
fix(material/datepicker): hover styles not disabled on touch devices

### DIFF
--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -42,13 +42,14 @@ $calendar-weekday-table-font-size: 11px !default;
                 theming.get-color-from-palette($palette, default-contrast);
   }
 
-  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover,
   .cdk-keyboard-focused .mat-calendar-body-active,
   .cdk-program-focused .mat-calendar-body-active {
-    & > .mat-calendar-body-cell-content {
-      @include _unselected-cell {
-        background-color: theming.get-color-from-palette($palette, 0.3);
-      }
+    @include _highlighted-cell($palette);
+  }
+
+  @media (hover: hover) {
+    .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover {
+      @include _highlighted-cell($palette);
     }
   }
 }
@@ -57,6 +58,15 @@ $calendar-weekday-table-font-size: 11px !default;
 @mixin _unselected-cell {
   &:not(.mat-calendar-body-selected):not(.mat-calendar-body-comparison-identical) {
     @content;
+  }
+}
+
+// Styles for a highlighted calendar cell (e.g. hovered or focused).
+@mixin _highlighted-cell($palette) {
+  & > .mat-calendar-body-cell-content {
+    @include _unselected-cell {
+      background-color: theming.get-color-from-palette($palette, 0.3);
+    }
   }
 }
 

--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -274,14 +274,3 @@ $calendar-range-end-body-cell-size:
     text-align: right;
   }
 }
-
-// Disable the hover styles on non-hover devices. Since this is more of a progressive
-// enhancement and not all desktop browsers support this kind of media query, we can't
-// use something like `@media (hover)`.
-@media (hover: none) {
-  .mat-calendar-body-cell:not(.mat-calendar-body-disabled):hover {
-    & > .mat-calendar-body-cell-content:not(.mat-calendar-body-selected) {
-      background-color: transparent;
-    }
-  }
-}


### PR DESCRIPTION
When we introduced the date range picker, some selectors in the calendar became much more specific which ended up overriding the styles that disable the hover indication on touch devices.

Now that we don't need to worry about IE, these changes use the `hover` media query to enable hovering only on non-touch devices instead.

Fixes #23904.