### PR TITLE
feat(cdk/table): accept 'center' in justify input in text-column

### DIFF
--- a/src/cdk/table/text-column.ts
+++ b/src/cdk/table/text-column.ts
@@ -85,7 +85,7 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
   @Input() dataAccessor: (data: T, name: string) => string;
 
   /** Alignment of the cell values. */
-  @Input() justify: 'start' | 'end' = 'start';
+  @Input() justify: 'start' | 'end' | 'center' = 'start';
 
   /** @docs-private */
   @ViewChild(CdkColumnDef, {static: true}) columnDef: CdkColumnDef;


### PR DESCRIPTION
Allow user to center text in cells created by text-column by passing 'center'
to justify input. The change allows to same values which are accepted by text-align CSS
property to which the value is passed