### PR TITLE
fix(material/core): test environment check not picking up jest (#23722)

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.ts
@@ -99,10 +99,10 @@ export class FocusMonitor implements OnDestroy {
   private _windowFocused = false;
 
   /** The timeout id of the window focus timeout. */
-  private _windowFocusTimeoutId: any;
+  private _windowFocusTimeoutId: number;
 
   /** The timeout id of the origin clearing timeout. */
-  private _originTimeoutId: any;
+  private _originTimeoutId: number;
 
   /**
    * Whether the origin was determined via a touch interaction. Necessary as properly attributing

--- a/src/cdk/a11y/live-announcer/live-announcer.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.ts
@@ -31,7 +31,7 @@ import {
 export class LiveAnnouncer implements OnDestroy {
   private _liveElement: HTMLElement;
   private _document: Document;
-  private _previousTimeout: any;
+  private _previousTimeout: number;
 
   constructor(
       @Optional() @Inject(LIVE_ANNOUNCER_ELEMENT_TOKEN) elementToken: any,

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -425,7 +425,7 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
       return;
     }
 
-    let timeoutId: any;
+    let timeoutId: number;
     const finishDetach = () => {
       // It may not be attached to anything in certain cases (e.g. unit tests).
       if (backdropToDetach) {

--- a/src/cdk/platform/BUILD.bazel
+++ b/src/cdk/platform/BUILD.bazel
@@ -11,7 +11,6 @@ ng_module(
     deps = [
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@types/node",
     ],
 )
 

--- a/src/cdk/platform/features/test-environment.ts
+++ b/src/cdk/platform/features/test-environment.ts
@@ -6,33 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Avoid using `declare const` because it caused conflicts inside Google
-// with the real typings for these symbols. We use `declare interface` instead
-// of just `interface` for interop with Closure Compiler (prevents property renaming):
-// https://github.com/angular/tsickle/blob/master/README.md#differences-from-typescript
-declare interface TestGlobals {
-  jasmine: unknown;
-  __karma__: unknown;
-  jest: unknown;
-  Mocha: unknown;
-}
-
-let testGlobals: TestGlobals;
-
-// We check the Node-specific `global` first, because tools tend to add a fake
-// `window` in Node environments which won't actually receive global variables.
-if (typeof global !== 'undefined') {
-  testGlobals = global as {} as TestGlobals;
-} else if (typeof window !== 'undefined') {
-  testGlobals = window as {} as TestGlobals;
-} else {
-  testGlobals = {} as TestGlobals;
-}
-
 /** Gets whether the code is currently running in a test environment. */
 export function _isTestEnvironment(): boolean {
-  return (typeof testGlobals.__karma__ !== 'undefined' && !!testGlobals.__karma__) ||
-         (typeof testGlobals.jasmine !== 'undefined' && !!testGlobals.jasmine) ||
-         (typeof testGlobals.jest !== 'undefined' && !!testGlobals.jest) ||
-         (typeof testGlobals.Mocha !== 'undefined' && !!testGlobals.Mocha);
+  // We can't use `declare const` because it causes conflicts inside Google with the real typings
+  // for these symbols and we can't read them off the global object, because they don't appear to
+  // be attached there for some runners like Jest.
+  // (see: https://github.com/angular/components/issues/23365#issuecomment-938146643)
+  return (
+    // @ts-ignore
+    (typeof __karma__ !== 'undefined' && !!__karma__) ||
+    // @ts-ignore
+    (typeof jasmine !== 'undefined' && !!jasmine) ||
+    // @ts-ignore
+    (typeof jest !== 'undefined' && !!jest) ||
+    // @ts-ignore
+    (typeof Mocha !== 'undefined' && !!Mocha)
+  );
 }

--- a/src/cdk/tsconfig-tests.json
+++ b/src/cdk/tsconfig-tests.json
@@ -12,7 +12,7 @@
     "importHelpers": false,
     "module": "umd",
     "target": "es5",
-    "types": ["jasmine", "node"],
+    "types": ["jasmine"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "paths": {

--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -103,7 +103,7 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
    * Timeout used to give some time between `focusin` and `focusout`
    * in order to determine whether focus has left the chip.
    */
-  private _focusoutTimeout: any;
+  private _focusoutTimeout: number | null;
 
   constructor(
     @Inject(DOCUMENT) private readonly _document: any,

--- a/src/material-experimental/mdc-dialog/dialog-container.ts
+++ b/src/material-experimental/mdc-dialog/dialog-container.ts
@@ -57,7 +57,7 @@ export class MatDialogContainer extends _MatDialogContainerBase implements OnDes
   private _closeAnimationDuration =
       this._animationsEnabled ? numbers.DIALOG_ANIMATION_CLOSE_TIME_MS : 0;
   /** Current timer for dialog animations. */
-  private _animationTimer: any = null;
+  private _animationTimer: number | null = null;
 
   constructor(
       elementRef: ElementRef,

--- a/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar-container.ts
@@ -69,7 +69,7 @@ export class MatSnackBarContainer extends BasePortalOutlet
   private readonly _announceDelay: number = 150;
 
   /** The timeout for announcing the snack bar's content. */
-  private _announceTimeoutId: any;
+  private _announceTimeoutId: number;
 
   /** Subject for notifying that the snack bar has announced to screen readers. */
   readonly _onAnnounce: Subject<void> = new Subject();

--- a/src/material/bottom-sheet/bottom-sheet-ref.ts
+++ b/src/material/bottom-sheet/bottom-sheet-ref.ts
@@ -39,7 +39,7 @@ export class MatBottomSheetRef<T = any, R = any> {
   private _result: R | undefined;
 
   /** Handle to the timeout that's running as a fallback in case the exit animation doesn't fire. */
-  private _closeFallbackTimeout: any;
+  private _closeFallbackTimeout: number;
 
   constructor(
     containerInstance: MatBottomSheetContainer,

--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -46,7 +46,7 @@ export class MatDialogRef<T, R = any> {
   private _result: R | undefined;
 
   /** Handle to the timeout that's running as a fallback in case the exit animation doesn't fire. */
-  private _closeFallbackTimeout: any;
+  private _closeFallbackTimeout: number;
 
   /** Current state of the dialog. */
   private _state = MatDialogState.OPEN;

--- a/src/material/snack-bar/snack-bar-container.ts
+++ b/src/material/snack-bar/snack-bar-container.ts
@@ -75,7 +75,7 @@ export class MatSnackBarContainer extends BasePortalOutlet
   private readonly _announceDelay: number = 150;
 
   /** The timeout for announcing the snack bar's content. */
-  private _announceTimeoutId: any;
+  private _announceTimeoutId: number;
 
   /** Whether the component has been destroyed. */
   private _destroyed = false;

--- a/src/material/snack-bar/snack-bar-ref.ts
+++ b/src/material/snack-bar/snack-bar-ref.ts
@@ -46,7 +46,7 @@ export class MatSnackBarRef<T> {
    * Timeout ID for the duration setTimeout call. Used to clear the timeout if the snackbar is
    * dismissed before the duration passes.
    */
-  private _durationTimeoutId: any;
+  private _durationTimeoutId: number;
 
   /** Whether the snack bar was dismissed using the action button. */
   private _dismissedByAction = false;

--- a/src/material/tooltip/tooltip.ts
+++ b/src/material/tooltip/tooltip.ts
@@ -248,7 +248,7 @@ export abstract class _MatTooltipBase<T extends _TooltipComponentBase> implement
   private _document: Document;
 
   /** Timer started at the last `touchstart` event. */
-  private _touchstartTimeout: any;
+  private _touchstartTimeout: number;
 
   /** Emits when the component is destroyed. */
   private readonly _destroyed = new Subject<void>();
@@ -766,10 +766,10 @@ export abstract class _TooltipComponentBase implements OnDestroy {
   tooltipClass: string|string[]|Set<string>|{[key: string]: any};
 
   /** The timeout ID of any current timer set to show the tooltip */
-  _showTimeoutId: any;
+  _showTimeoutId: number | undefined;
 
   /** The timeout ID of any current timer set to hide the tooltip */
-  _hideTimeoutId: any;
+  _hideTimeoutId: number | undefined;
 
   /** Property watched by the animation framework to show or hide the tooltip */
   _visibility: TooltipVisibility = 'initial';

--- a/tools/public_api_guard/material/tooltip.md
+++ b/tools/public_api_guard/material/tooltip.md
@@ -183,7 +183,7 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     _animationStart(): void;
     _handleBodyInteraction(): void;
     hide(delay: number): void;
-    _hideTimeoutId: any;
+    _hideTimeoutId: number | undefined;
     isVisible(): boolean;
     _markForCheck(): void;
     message: string;
@@ -191,7 +191,7 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     ngOnDestroy(): void;
     protected _onShow(): void;
     show(delay: number): void;
-    _showTimeoutId: any;
+    _showTimeoutId: number | undefined;
     tooltipClass: string | string[] | Set<string> | {
         [key: string]: any;
     };


### PR DESCRIPTION
**Note:** this is the 12.2.x version of #23722.

In #23636 the test environment check was changed so that it looks for the test objects either on `window` or `global`, however it looks like this isn't enough to pick up Jest which isn't published on either.

These changes simplify the setup by looking up the value globally and disabling the type checking error with `@ts-ignore`. We can't use `declare const` for it, because it causes issues in g3.

I've also reverted some of the `any` types that had to be added in #23636.

Fixes #23365.