### PR TITLE
build: enable angular strict template checking for IDE tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
       "@angular/components-examples/*": ["./src/components-examples/*"]
     }
   },
+  "angularCompilerOptions": {
+    "strictTemplates": true,
+  },
   "include": [
     "src/**/*.ts",
     "e2e/**/*.ts",


### PR DESCRIPTION
Enables Angular strict template type checking for the IDE tsconfig,
matching with the flag set within the Bazel compilations.