### PR TITLE
fix(cdk/drag-drop): last item not returned at initial index when sorting is disabled

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -5972,6 +5972,63 @@ describe('CdkDrag', () => {
       }),
     );
 
+    it('should return the last item to initial position when dragging back into a container with disabled sorting', fakeAsync(() => {
+      const fixture = createComponent(ConnectedDropZones);
+      fixture.detectChanges();
+
+      const groups = fixture.componentInstance.groupedDragItems;
+      const dropZones = fixture.componentInstance.dropInstances.map(d => d.element.nativeElement);
+      const lastIndex = groups[0].length - 1;
+      const lastItem = groups[0][lastIndex];
+      const targetRect = groups[1][2].element.nativeElement.getBoundingClientRect();
+
+      fixture.componentInstance.dropInstances.first.sortingDisabled = true;
+      startDraggingViaMouse(fixture, lastItem.element.nativeElement);
+
+      const placeholder = dropZones[0].querySelector('.cdk-drag-placeholder')!;
+
+      expect(placeholder).toBeTruthy();
+      expect(dropZones[0].contains(placeholder))
+        .withContext('Expected placeholder to be inside the first container.')
+        .toBe(true);
+      expect(getElementIndexByPosition(placeholder, 'top'))
+        .withContext('Expected placeholder to be at item index.')
+        .toBe(lastIndex);
+
+      dispatchMouseEvent(document, 'mousemove', targetRect.left + 1, targetRect.top + 1);
+      fixture.detectChanges();
+
+      expect(dropZones[1].contains(placeholder))
+        .withContext('Expected placeholder to be inside second container.')
+        .toBe(true);
+      expect(getElementIndexByPosition(placeholder, 'top'))
+        .withContext('Expected placeholder to be at the target index.')
+        .toBe(3);
+
+      const firstInitialSiblingRect = groups[0][0].element.nativeElement.getBoundingClientRect();
+
+      // Return the item to an index that is different from the initial one.
+      dispatchMouseEvent(
+        document,
+        'mousemove',
+        firstInitialSiblingRect.left,
+        firstInitialSiblingRect.top,
+      );
+      fixture.detectChanges();
+
+      expect(dropZones[0].contains(placeholder))
+        .withContext('Expected placeholder to be back inside first container.')
+        .toBe(true);
+      expect(getElementIndexByPosition(placeholder, 'top'))
+        .withContext('Expected placeholder to be back at the initial index.')
+        .toBe(lastIndex);
+
+      dispatchMouseEvent(document, 'mouseup');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.droppedSpy).not.toHaveBeenCalled();
+    }));
+
     it(
       'should toggle a class when dragging an item inside a wrapper component component ' +
         'with OnPush change detection',

--- a/src/cdk/drag-drop/drop-list-ref.ts
+++ b/src/cdk/drag-drop/drop-list-ref.ts
@@ -299,6 +299,16 @@ export class DropListRef<T = any> {
       newPositionReference = activeDraggables[newIndex + 1];
     }
 
+    // If we didn't find a new position reference, it means that either the item didn't start off
+    // in this container, or that the item requested to be inserted at the end of the list.
+    if (
+      !newPositionReference &&
+      (newIndex == null || newIndex === -1 || newIndex < activeDraggables.length - 1) &&
+      this._shouldEnterAsFirstChild(pointerX, pointerY)
+    ) {
+      newPositionReference = activeDraggables[0];
+    }
+
     // Since the item may be in the `activeDraggables` already (e.g. if the user dragged it
     // into another container and back again), we have to ensure that it isn't duplicated.
     if (currentIndex > -1) {
@@ -311,10 +321,6 @@ export class DropListRef<T = any> {
       const element = newPositionReference.getRootElement();
       element.parentElement!.insertBefore(placeholder, element);
       activeDraggables.splice(newIndex, 0, item);
-    } else if (this._shouldEnterAsFirstChild(pointerX, pointerY)) {
-      const reference = activeDraggables[0].getRootElement();
-      reference.parentNode!.insertBefore(placeholder, reference);
-      activeDraggables.unshift(item);
     } else {
       coerceElement(this.element).appendChild(placeholder);
       activeDraggables.push(item);


### PR DESCRIPTION
Fixes a regression caused by #19116 where dragging the last item into another container and returning it back to the initial one would insert the item into the first index of the list, rather than the last one. The issue was caused by the fact that we relied on the item to always be inserted at the end of the list of there is no position reference, but the condition was superseded by the condition that inserts it at the beginning of the list.

Fixes #23865.