### PR TITLE
refactor(multiple): add non-null assertions first and last

### DIFF
--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -262,7 +262,7 @@ export class CdkTree<T, K = T> implements AfterContentChecked, CollectionViewer,
    */
   _getNodeDef(data: T, i: number): CdkTreeNodeDef<T> {
     if (this._nodeDefs.length === 1) {
-      return this._nodeDefs.first;
+      return this._nodeDefs.first!;
     }
 
     const nodeDef =

--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -847,7 +847,7 @@ export class MatSlider
 
   /** Gets the slider thumb input of the given thumb position. */
   _getInput(thumbPosition: Thumb): MatSliderThumb {
-    return thumbPosition === Thumb.END ? this._inputs.last : this._inputs.first;
+    return thumbPosition === Thumb.END ? this._inputs.last! : this._inputs.first!;
   }
 
   /** Gets the slider thumb HTML input element of the given thumb position. */
@@ -856,7 +856,7 @@ export class MatSlider
   }
 
   _getThumb(thumbPosition: Thumb): MatSliderVisualThumb {
-    return thumbPosition === Thumb.END ? this._thumbs.last : this._thumbs.first;
+    return thumbPosition === Thumb.END ? this._thumbs.last! : this._thumbs.first!;
   }
 
   /** Gets the slider thumb HTML element of the given thumb position. */

--- a/src/material/menu/menu.ts
+++ b/src/material/menu/menu.ts
@@ -386,7 +386,7 @@ export class _MatMenuBase
     // Move focus to the menu panel so keyboard events like Escape still work. Also this will
     // give _some_ feedback to screen readers.
     if (!manager.activeItem && this._directDescendantItems.length) {
-      let element = this._directDescendantItems.first._getHostElement().parentElement;
+      let element = this._directDescendantItems.first!._getHostElement().parentElement;
 
       // Because the `mat-menu` is at the DOM insertion point, not inside the overlay, we don't
       // have a nice way of getting a hold of the menu panel. We can't use a `ViewChild` either


### PR DESCRIPTION
Angular's QueryList first and last can actually be `undefined`,
although this is not reflected by their type
(this is a current bug in Angular: angular/angular#42563)
this commit adds non-null assertions to first and last references within the codebase
in preparation for solving the Angular bug without causing too many breaking changes

For more information see: angular/angular#43604