### PR TITLE
perf(material/bottom-sheet): do not run change detection when focusing element

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-container.ts
+++ b/src/material/bottom-sheet/bottom-sheet-container.ts
@@ -306,7 +306,9 @@ export class MatBottomSheetContainer extends BasePortalOutlet implements OnDestr
 
     // The `focus` method isn't available during server-side rendering.
     if (this._elementRef.nativeElement.focus) {
-      Promise.resolve().then(() => this._elementRef.nativeElement.focus());
+      this._ngZone.runOutsideAngular(() => {
+        Promise.resolve().then(() => this._elementRef.nativeElement.focus());
+      });
     }
   }
 }


### PR DESCRIPTION
Currently, Angular runs change detection each time the microtask is resolved within the `_savePreviouslyFocusedElement`. It runs `element.focus()` after the microtask is resolved, which is a native DOM API and doesn't require Angular to run `tick()`.