### PR TITLE
fix(cdk/drag-drop): remove boundary error

### DIFF
--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -370,16 +370,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
       return this.element.nativeElement.closest<HTMLElement>(boundary);
     }
 
-    const element = coerceElement(boundary);
-
-    if (
-      (typeof ngDevMode === 'undefined' || ngDevMode) &&
-      !element.contains(this.element.nativeElement)
-    ) {
-      throw Error('Draggable element is not inside of the node passed into cdkDragBoundary.');
-    }
-
-    return element;
+    return coerceElement(boundary);
   }
 
   /** Syncs the inputs of the CdkDrag with the options of the underlying DragRef. */


### PR DESCRIPTION
When the boundaries were added to the `drag-drop` module, I assumed that users would always want the element to be contained inside the boundary, but it looks like there are some cases where that's not the case. These changes remove the error.

Fixes #23767.