### PR TITLE
ci: remove `cla: yes` from required labels

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -44,7 +44,6 @@ merge:
     # list of labels that a PR needs to have, checked with a regexp (e.g. "PR target:" will work for the label "PR target: master")
     requiredLabels:
       - "target: *"
-      - "cla: yes"
 
     # list of labels that a PR shouldn't have, checked after the required labels with a regexp
     forbiddenLabels:
@@ -52,7 +51,6 @@ merge:
       - "pr: blocked"
       - "pr: needs*"
       - "presubmit failures"
-      - "cla: no"
 
     # list of PR statuses that need to be successful
     requiredStatuses:


### PR DESCRIPTION
Remove `cla: yes` from the require labels for merging as the CLACheck
tool no longer relies on labels.

Enforcement of the CLA being signed is still enforced by the status check
which is visible both in Github as well as checked by merge tooling.