### PR TITLE
perf(material/core): tree shake sanity checks

### DIFF
--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -188,8 +188,7 @@ export const MAT_RIPPLE_GLOBAL_OPTIONS: InjectionToken<RippleGlobalOptions>;
 
 // @public
 export class MatCommonModule {
-    constructor(highContrastModeDetector: HighContrastModeDetector, sanityChecks: any, document: any);
-    protected _document: Document;
+    constructor(highContrastModeDetector: HighContrastModeDetector, _sanityChecks: SanityChecks, _document: Document);
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MatCommonModule, [null, { optional: true; }, null]>;
     // (undocumented)


### PR DESCRIPTION
Now that we don't need to think about ViewEngine, we can use `ngDevMode` to tree shake the sanity check messages.