### PR TITLE
build: prevent * expansion for static css content in ng_web_test_suite

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -390,7 +390,7 @@ def ng_web_test_suite(deps = [], static_css = [], exclude_init_script = False, *
                     cssElement.type = "text/css"; \
                     cssElement.innerHTML = "'"$$css_content"'"; \
                     document.head.appendChild(cssElement);'
-         echo $$js_template > $@
+         echo "$$js_template" > $@
       """ % css_label,
         )
 


### PR DESCRIPTION
Currently when using a `*` inside css code (e.g. `calc(... * ...)` in the typography) it will be expanded to files in the current directory (e.g. `calc ... bazel-out external ...`), which will break the tests. This PR fixes this by wrapping the variable usage with quotes.