### PR TITLE
fix(multiple): some experimental components not cleaned up completely

### DIFF
--- a/src/cdk-experimental/menu/menu.ts
+++ b/src/cdk-experimental/menu/menu.ts
@@ -340,6 +340,7 @@ export class CdkMenu extends CdkMenuGroup implements Menu, AfterContentInit, OnI
   }
 
   override ngOnDestroy() {
+    super.ngOnDestroy();
     this._emitClosedEvent();
     this._pointerTracker?.destroy();
   }

--- a/src/material-experimental/mdc-form-field/form-field.ts
+++ b/src/material-experimental/mdc-form-field/form-field.ts
@@ -408,6 +408,7 @@ export class MatFormField
   }
 
   ngOnDestroy() {
+    this._foundation?.destroy();
     this._destroyed.next();
     this._destroyed.complete();
   }

--- a/src/material-experimental/mdc-list/list-option.ts
+++ b/src/material-experimental/mdc-list/list-option.ts
@@ -201,6 +201,8 @@ export class MatListOption extends MatListItemBase implements ListOption, OnInit
   }
 
   override ngOnDestroy(): void {
+    super.ngOnDestroy();
+
     if (this.selected) {
       // We have to delay this until the next tick in order
       // to avoid changed after checked errors.

--- a/src/material-experimental/mdc-list/selection-list.ts
+++ b/src/material-experimental/mdc-list/selection-list.ts
@@ -183,6 +183,7 @@ export class MatSelectionList
   }
 
   override ngOnDestroy() {
+    super.ngOnDestroy();
     this._destroyed.next();
     this._destroyed.complete();
     this._isDestroyed = true;


### PR DESCRIPTION
Fixes a few cases where we weren't destroying the MDC foundation in our own components. There's also a case where we were overriding the `ngOnDestroy` from a parent component, but we weren't calling it from the override.