### PR TITLE
refactor(material-experimental/mdc-slider): clean up leftover deprecated function usage

### DIFF
--- a/src/material-experimental/mdc-slider/_slider-theme.scss
+++ b/src/material-experimental/mdc-slider/_slider-theme.scss
@@ -15,7 +15,7 @@
 
     .mat-mdc-slider {
       &.mat-primary, &.mat-accent, &.mat-warn {
-        $is-dark: map-get($config, is-dark);
+        $is-dark: map.get($config, is-dark);
         $indicator-color: if($is-dark, white, black);
         $indicator-text-color: if($is-dark, black, white);
         $indicator-opacity: if($is-dark, 0.9, 0.6);

--- a/src/material/core/theming/_theming.scss
+++ b/src/material/core/theming/_theming.scss
@@ -395,7 +395,7 @@ $_emitted-density: () !default;
 //
 //    @mixin my-custom-component-theme($theme) {
 //      .my-comp {
-//        background-color: mat-color(map-get($theme, primary));
+//        background-color: mat.get-color-from-palette(map.get($theme, primary));
 //      }
 //    }
 //


### PR DESCRIPTION
Fixes a couple of places where we were using the deprecated `map-get` function from Sass.