### PR TITLE
feat(material/core): change ErrorStateMatcher to accept AbstractForm

### DIFF
--- a/src/material/core/error/error-options.ts
+++ b/src/material/core/error/error-options.ts
@@ -7,12 +7,12 @@
  */
 
 import {Injectable} from '@angular/core';
-import {FormGroupDirective, NgForm, FormControl} from '@angular/forms';
+import {FormGroupDirective, NgForm, AbstractControl} from '@angular/forms';
 
 /** Error state matcher that matches when a control is invalid and dirty. */
 @Injectable()
 export class ShowOnDirtyErrorStateMatcher implements ErrorStateMatcher {
-  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+  isErrorState(control: AbstractControl | null, form: FormGroupDirective | NgForm | null): boolean {
     return !!(control && control.invalid && (control.dirty || (form && form.submitted)));
   }
 }
@@ -20,7 +20,7 @@ export class ShowOnDirtyErrorStateMatcher implements ErrorStateMatcher {
 /** Provider that defines how form controls behave with regards to displaying error messages. */
 @Injectable({providedIn: 'root'})
 export class ErrorStateMatcher {
-  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+  isErrorState(control: AbstractControl | null, form: FormGroupDirective | NgForm | null): boolean {
     return !!(control && control.invalid && (control.touched || (form && form.submitted)));
   }
 }

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { _AbstractConstructor as _AbstractConstructor_2 } from '@angular/material/core';
+import { AbstractControl } from '@angular/forms';
 import { AfterViewChecked } from '@angular/core';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { ChangeDetectorRef } from '@angular/core';
@@ -14,7 +15,6 @@ import { EventEmitter } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
 import { FocusOptions as FocusOptions_2 } from '@angular/cdk/a11y';
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { FormControl } from '@angular/forms';
 import { FormGroupDirective } from '@angular/forms';
 import { HighContrastModeDetector } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
@@ -133,7 +133,7 @@ export const defaultRippleAnimationConfig: {
 // @public
 export class ErrorStateMatcher {
     // (undocumented)
-    isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean;
+    isErrorState(control: AbstractControl | null, form: FormGroupDirective | NgForm | null): boolean;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ErrorStateMatcher, never>;
     // (undocumented)
@@ -568,7 +568,7 @@ export function setLines(lines: QueryList<unknown>, element: ElementRef<HTMLElem
 // @public
 export class ShowOnDirtyErrorStateMatcher implements ErrorStateMatcher {
     // (undocumented)
-    isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean;
+    isErrorState(control: AbstractControl | null, form: FormGroupDirective | NgForm | null): boolean;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ShowOnDirtyErrorStateMatcher, never>;
     // (undocumented)


### PR DESCRIPTION
To be able to use the `ErrorStateMatcher` also for determining the state of `FormGroups`, I think the signature might be changed to accept `AbstractForm` instead of `FormControl`. The relevant properties are all part of the `AbstractForm`, so I don't expect any breaking behavior.