### PR TITLE
Fix missing method parameter documentation

### DIFF
--- a/tools/dgeni/templates/method.template.html
+++ b/tools/dgeni/templates/method.template.html
@@ -50,7 +50,7 @@
     </td>
     <td class="docs-api-method-parameter-description-cell">
       <p class="docs-api-method-parameter-description">
-        {$ parameter.content | marked | safe $}
+        {$ parameter.description | marked | safe $}
       </p>
     </td>
   </tr>


### PR DESCRIPTION
The 'parameter.description' => 'parameter.content' change was made earlier, but as I see now there is no documentation for method parameters on material.angular.io site.
I found that the information for method parameters are stored in the 'description' field.