### PR TITLE
refactor(multiple): clean up entryComponents usages

### DIFF
--- a/src/cdk-experimental/dialog/dialog.spec.ts
+++ b/src/cdk-experimental/dialog/dialog.spec.ts
@@ -13,7 +13,6 @@ import {
   Directive,
   Inject,
   Injector,
-  NgModule,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -45,7 +44,16 @@ describe('Dialog', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [DialogModule, DialogTestModule],
+      imports: [DialogModule, NoopAnimationsModule],
+      declarations: [
+        ComponentWithChildViewContainer,
+        ComponentWithTemplateRef,
+        PizzaMsg,
+        ContentElementDialog,
+        DialogWithInjectedData,
+        DialogWithoutFocusableElements,
+        DirectiveWithViewContainer,
+      ],
       providers: [{provide: Location, useClass: SpyLocation}],
     });
 
@@ -1138,7 +1146,7 @@ describe('Dialog with a parent Dialog', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [DialogModule, DialogTestModule],
+      imports: [DialogModule, NoopAnimationsModule],
       declarations: [ComponentThatProvidesMatDialog],
       providers: [
         {
@@ -1315,32 +1323,3 @@ class DialogWithoutFocusableElements {}
   encapsulation: ViewEncapsulation.ShadowDom,
 })
 class ShadowDomComponent {}
-
-// Create a real (non-test) NgModule as a workaround for
-// https://github.com/angular/angular/issues/10760
-const TEST_DIRECTIVES = [
-  ComponentWithChildViewContainer,
-  ComponentWithTemplateRef,
-  PizzaMsg,
-  DirectiveWithViewContainer,
-  ComponentWithOnPushViewContainer,
-  ContentElementDialog,
-  DialogWithInjectedData,
-  DialogWithoutFocusableElements,
-  ShadowDomComponent,
-];
-
-@NgModule({
-  imports: [DialogModule, NoopAnimationsModule],
-  exports: TEST_DIRECTIVES,
-  declarations: TEST_DIRECTIVES,
-  entryComponents: [
-    ComponentWithChildViewContainer,
-    ComponentWithTemplateRef,
-    PizzaMsg,
-    ContentElementDialog,
-    DialogWithInjectedData,
-    DialogWithoutFocusableElements,
-  ],
-})
-class DialogTestModule {}

--- a/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-keyboard-dispatcher.spec.ts
@@ -1,7 +1,7 @@
 import {TestBed, inject} from '@angular/core/testing';
 import {dispatchKeyboardEvent} from '../../testing/private';
 import {ESCAPE} from '@angular/cdk/keycodes';
-import {Component, NgModule} from '@angular/core';
+import {Component} from '@angular/core';
 import {OverlayModule, Overlay} from '../index';
 import {OverlayKeyboardDispatcher} from './overlay-keyboard-dispatcher';
 import {ComponentPortal} from '@angular/cdk/portal';
@@ -12,7 +12,8 @@ describe('OverlayKeyboardDispatcher', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, TestComponentModule],
+      imports: [OverlayModule],
+      declarations: [TestComponent],
     });
 
     inject([OverlayKeyboardDispatcher, Overlay], (kbd: OverlayKeyboardDispatcher, o: Overlay) => {
@@ -184,12 +185,3 @@ describe('OverlayKeyboardDispatcher', () => {
   template: 'Hello',
 })
 class TestComponent {}
-
-// Create a real (non-test) NgModule as a workaround for
-// https://github.com/angular/angular/issues/10760
-@NgModule({
-  exports: [TestComponent],
-  declarations: [TestComponent],
-  entryComponents: [TestComponent],
-})
-class TestComponentModule {}

--- a/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
+++ b/src/cdk/overlay/dispatchers/overlay-outside-click-dispatcher.spec.ts
@@ -1,5 +1,5 @@
 import {TestBed, inject, fakeAsync} from '@angular/core/testing';
-import {Component, NgModule} from '@angular/core';
+import {Component} from '@angular/core';
 import {dispatchFakeEvent, dispatchMouseEvent} from '../../testing/private';
 import {OverlayModule, Overlay} from '../index';
 import {OverlayOutsideClickDispatcher} from './overlay-outside-click-dispatcher';
@@ -11,7 +11,8 @@ describe('OverlayOutsideClickDispatcher', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [OverlayModule, TestComponentModule],
+      imports: [OverlayModule],
+      declarations: [TestComponent],
     });
 
     inject(
@@ -186,78 +187,90 @@ describe('OverlayOutsideClickDispatcher', () => {
     overlayRef.dispose();
   });
 
-  it('should dispatch an event when a click is started outside the overlay and ' +
-    'released outside of it', () => {
-    const portal = new ComponentPortal(TestComponent);
-    const overlayRef = overlay.create();
-    overlayRef.attach(portal);
-    const context = document.createElement('div');
-    document.body.appendChild(context);
+  it(
+    'should dispatch an event when a click is started outside the overlay and ' +
+      'released outside of it',
+    () => {
+      const portal = new ComponentPortal(TestComponent);
+      const overlayRef = overlay.create();
+      overlayRef.attach(portal);
+      const context = document.createElement('div');
+      document.body.appendChild(context);
 
-    const spy = jasmine.createSpy('overlay mouse click event spy');
-    overlayRef.outsidePointerEvents().subscribe(spy);
+      const spy = jasmine.createSpy('overlay mouse click event spy');
+      overlayRef.outsidePointerEvents().subscribe(spy);
 
-    dispatchMouseEvent(context, 'pointerdown');
-    context.click();
-    expect(spy).toHaveBeenCalled();
+      dispatchMouseEvent(context, 'pointerdown');
+      context.click();
+      expect(spy).toHaveBeenCalled();
 
-    context.remove();
-    overlayRef.dispose();
-  });
+      context.remove();
+      overlayRef.dispose();
+    },
+  );
 
-  it('should not dispatch an event when a click is started inside the overlay and ' +
-    'released inside of it', () => {
-    const portal = new ComponentPortal(TestComponent);
-    const overlayRef = overlay.create();
-    overlayRef.attach(portal);
+  it(
+    'should not dispatch an event when a click is started inside the overlay and ' +
+      'released inside of it',
+    () => {
+      const portal = new ComponentPortal(TestComponent);
+      const overlayRef = overlay.create();
+      overlayRef.attach(portal);
 
-    const spy = jasmine.createSpy('overlay mouse click event spy');
-    overlayRef.outsidePointerEvents().subscribe(spy);
+      const spy = jasmine.createSpy('overlay mouse click event spy');
+      overlayRef.outsidePointerEvents().subscribe(spy);
 
-    dispatchMouseEvent(overlayRef.overlayElement, 'pointerdown');
-    overlayRef.overlayElement.click();
-    expect(spy).not.toHaveBeenCalled();
+      dispatchMouseEvent(overlayRef.overlayElement, 'pointerdown');
+      overlayRef.overlayElement.click();
+      expect(spy).not.toHaveBeenCalled();
 
-    overlayRef.dispose();
-  });
+      overlayRef.dispose();
+    },
+  );
 
-  it('should not dispatch an event when a click is started inside the overlay and ' +
-    'released outside of it', () => {
-    const portal = new ComponentPortal(TestComponent);
-    const overlayRef = overlay.create();
-    overlayRef.attach(portal);
-    const context = document.createElement('div');
-    document.body.appendChild(context);
+  it(
+    'should not dispatch an event when a click is started inside the overlay and ' +
+      'released outside of it',
+    () => {
+      const portal = new ComponentPortal(TestComponent);
+      const overlayRef = overlay.create();
+      overlayRef.attach(portal);
+      const context = document.createElement('div');
+      document.body.appendChild(context);
 
-    const spy = jasmine.createSpy('overlay mouse click event spy');
-    overlayRef.outsidePointerEvents().subscribe(spy);
+      const spy = jasmine.createSpy('overlay mouse click event spy');
+      overlayRef.outsidePointerEvents().subscribe(spy);
 
-    dispatchMouseEvent(overlayRef.overlayElement, 'pointerdown');
-    context.click();
-    expect(spy).not.toHaveBeenCalled();
+      dispatchMouseEvent(overlayRef.overlayElement, 'pointerdown');
+      context.click();
+      expect(spy).not.toHaveBeenCalled();
 
-    context.remove();
-    overlayRef.dispose();
-  });
+      context.remove();
+      overlayRef.dispose();
+    },
+  );
 
-  it('should not dispatch an event when a click is started outside the overlay and ' +
-    'released inside of it', () => {
-    const portal = new ComponentPortal(TestComponent);
-    const overlayRef = overlay.create();
-    overlayRef.attach(portal);
-    const context = document.createElement('div');
-    document.body.appendChild(context);
+  it(
+    'should not dispatch an event when a click is started outside the overlay and ' +
+      'released inside of it',
+    () => {
+      const portal = new ComponentPortal(TestComponent);
+      const overlayRef = overlay.create();
+      overlayRef.attach(portal);
+      const context = document.createElement('div');
+      document.body.appendChild(context);
 
-    const spy = jasmine.createSpy('overlay mouse click event spy');
-    overlayRef.outsidePointerEvents().subscribe(spy);
+      const spy = jasmine.createSpy('overlay mouse click event spy');
+      overlayRef.outsidePointerEvents().subscribe(spy);
 
-    dispatchMouseEvent(context, 'pointerdown');
-    overlayRef.overlayElement.click();
-    expect(spy).not.toHaveBeenCalled();
+      dispatchMouseEvent(context, 'pointerdown');
+      overlayRef.overlayElement.click();
+      expect(spy).not.toHaveBeenCalled();
 
-    context.remove();
-    overlayRef.dispose();
-  });
+      context.remove();
+      overlayRef.dispose();
+    },
+  );
 
   it('should dispatch an event when a context menu is triggered outside the overlay', () => {
     const portal = new ComponentPortal(TestComponent);
@@ -329,12 +342,3 @@ describe('OverlayOutsideClickDispatcher', () => {
   template: 'Hello',
 })
 class TestComponent {}
-
-// Create a real (non-test) NgModule as a workaround for
-// https://github.com/angular/angular/issues/10760
-@NgModule({
-  exports: [TestComponent],
-  declarations: [TestComponent],
-  entryComponents: [TestComponent],
-})
-class TestComponentModule {}

--- a/src/cdk/overlay/overlay.spec.ts
+++ b/src/cdk/overlay/overlay.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core/testing';
 import {
   Component,
-  NgModule,
   ViewChild,
   ViewContainerRef,
   ErrorHandler,
@@ -47,7 +46,8 @@ describe('Overlay', () => {
     waitForAsync(() => {
       dir = 'ltr';
       TestBed.configureTestingModule({
-        imports: [OverlayModule, PortalModule, OverlayTestModule],
+        imports: [OverlayModule, PortalModule],
+        declarations: [PizzaMsg, TestComponentWithTemplatePortals],
         providers: [
           {
             provide: Directionality,
@@ -1079,17 +1079,6 @@ class TestComponentWithTemplatePortals {
 
   constructor(public viewContainerRef: ViewContainerRef) {}
 }
-
-// Create a real (non-test) NgModule as a workaround for
-// https://github.com/angular/angular/issues/10760
-const TEST_COMPONENTS = [PizzaMsg, TestComponentWithTemplatePortals];
-@NgModule({
-  imports: [OverlayModule, PortalModule],
-  exports: TEST_COMPONENTS,
-  declarations: TEST_COMPONENTS,
-  entryComponents: TEST_COMPONENTS,
-})
-class OverlayTestModule {}
 
 class FakePositionStrategy implements PositionStrategy {
   element: HTMLElement;

--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -1,7 +1,7 @@
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
 import {CdkScrollable, ScrollingModule, ViewportRuler} from '@angular/cdk/scrolling';
 import {dispatchFakeEvent, MockNgZone} from '../../testing/private';
-import {Component, ElementRef, NgModule, NgZone} from '@angular/core';
+import {Component, ElementRef, NgZone} from '@angular/core';
 import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
@@ -28,7 +28,8 @@ describe('FlexibleConnectedPositionStrategy', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ScrollingModule, OverlayModule, OverlayTestModule],
+      imports: [ScrollingModule, OverlayModule, PortalModule],
+      declarations: [TestOverlay],
       providers: [{provide: NgZone, useFactory: () => (zone = new MockNgZone())}],
     });
 
@@ -2889,11 +2890,3 @@ function createOverflowContainerElement() {
   `,
 })
 class TestOverlay {}
-
-@NgModule({
-  imports: [OverlayModule, PortalModule],
-  exports: [TestOverlay],
-  declarations: [TestOverlay],
-  entryComponents: [TestOverlay],
-})
-class OverlayTestModule {}

--- a/src/cdk/overlay/position/global-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/global-position-strategy.spec.ts
@@ -1,4 +1,4 @@
-import {NgModule, NgZone, Component} from '@angular/core';
+import {NgZone, Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MockNgZone} from '../../testing/private';
 import {PortalModule, ComponentPortal} from '@angular/cdk/portal';
@@ -11,7 +11,8 @@ describe('GlobalPositonStrategy', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [GlobalOverlayTestModule],
+      imports: [OverlayModule, PortalModule],
+      declarations: [BlankPortal],
       providers: [{provide: NgZone, useFactory: () => (zone = new MockNgZone())}],
     });
 
@@ -370,11 +371,3 @@ describe('GlobalPositonStrategy', () => {
 
 @Component({template: ''})
 class BlankPortal {}
-
-@NgModule({
-  imports: [OverlayModule, PortalModule],
-  exports: [BlankPortal],
-  declarations: [BlankPortal],
-  entryComponents: [BlankPortal],
-})
-class GlobalOverlayTestModule {}

--- a/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/block-scroll-strategy.spec.ts
@@ -1,4 +1,4 @@
-import {Component, NgModule} from '@angular/core';
+import {Component} from '@angular/core';
 import {waitForAsync, inject, TestBed} from '@angular/core/testing';
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
 import {Platform} from '@angular/cdk/platform';
@@ -21,7 +21,8 @@ describe('BlockScrollStrategy', () => {
       documentElement.classList.remove('cdk-global-scrollblock');
 
       TestBed.configureTestingModule({
-        imports: [OverlayModule, PortalModule, OverlayTestModule],
+        imports: [OverlayModule, PortalModule],
+        declarations: [FocacciaMsg],
       }).compileComponents();
     }),
   );
@@ -217,11 +218,3 @@ describe('BlockScrollStrategy', () => {
 /** Simple component that we can attach to the overlay. */
 @Component({template: '<p>Focaccia</p>'})
 class FocacciaMsg {}
-
-/** Test module to hold the component. */
-@NgModule({
-  imports: [OverlayModule, PortalModule],
-  declarations: [FocacciaMsg],
-  entryComponents: [FocacciaMsg],
-})
-class OverlayTestModule {}

--- a/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/close-scroll-strategy.spec.ts
@@ -1,5 +1,5 @@
 import {inject, TestBed, fakeAsync} from '@angular/core/testing';
-import {NgModule, Component, NgZone} from '@angular/core';
+import {Component, NgZone} from '@angular/core';
 import {Subject} from 'rxjs';
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
 import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
@@ -15,7 +15,8 @@ describe('CloseScrollStrategy', () => {
     scrollPosition = 0;
 
     TestBed.configureTestingModule({
-      imports: [OverlayModule, PortalModule, OverlayTestModule],
+      imports: [OverlayModule, PortalModule],
+      declarations: [MozarellaMsg],
       providers: [
         {
           provide: ScrollDispatcher,
@@ -138,11 +139,3 @@ describe('CloseScrollStrategy', () => {
 /** Simple component that we can attach to the overlay. */
 @Component({template: '<p>Mozarella</p>'})
 class MozarellaMsg {}
-
-/** Test module to hold the component. */
-@NgModule({
-  imports: [OverlayModule, PortalModule],
-  declarations: [MozarellaMsg],
-  entryComponents: [MozarellaMsg],
-})
-class OverlayTestModule {}

--- a/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
+++ b/src/cdk/overlay/scroll/reposition-scroll-strategy.spec.ts
@@ -1,5 +1,5 @@
 import {waitForAsync, inject, TestBed} from '@angular/core/testing';
-import {Component, NgModule} from '@angular/core';
+import {Component} from '@angular/core';
 import {Subject} from 'rxjs';
 import {ComponentPortal, PortalModule} from '@angular/cdk/portal';
 import {
@@ -20,7 +20,8 @@ describe('RepositionScrollStrategy', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [OverlayModule, PortalModule, OverlayTestModule],
+        imports: [OverlayModule, PortalModule],
+        declarations: [PastaMsg],
         providers: [
           {
             provide: ScrollDispatcher,
@@ -119,11 +120,3 @@ describe('RepositionScrollStrategy', () => {
 /** Simple component that we can attach to the overlay. */
 @Component({template: '<p>Pasta</p>'})
 class PastaMsg {}
-
-/** Test module to hold the component. */
-@NgModule({
-  imports: [OverlayModule, PortalModule],
-  declarations: [PastaMsg],
-  entryComponents: [PastaMsg],
-})
-class OverlayTestModule {}

--- a/src/cdk/portal/portal.spec.ts
+++ b/src/cdk/portal/portal.spec.ts
@@ -6,7 +6,6 @@ import {
   ComponentRef,
   ElementRef,
   Injector,
-  NgModule,
   Optional,
   QueryList,
   TemplateRef,
@@ -24,7 +23,16 @@ import {CdkPortal, CdkPortalOutlet, PortalModule} from './portal-directives';
 
 describe('Portals', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({imports: [PortalModule, PortalTestModule]}).compileComponents();
+    TestBed.configureTestingModule({
+      imports: [PortalModule, CommonModule],
+      declarations: [
+        PortalTestApp,
+        UnboundPortalTestApp,
+        ArbitraryViewContainerRefComponent,
+        PizzaMsg,
+        SaveParentNodeOnInit,
+      ],
+    }).compileComponents();
   });
 
   describe('CdkPortalOutlet', () => {
@@ -802,20 +810,3 @@ class PortalTestApp {
 class UnboundPortalTestApp {
   @ViewChild(CdkPortalOutlet) portalOutlet: CdkPortalOutlet;
 }
-
-// Create a real (non-test) NgModule as a workaround for
-// https://github.com/angular/angular/issues/10760
-const TEST_COMPONENTS = [
-  PortalTestApp,
-  UnboundPortalTestApp,
-  ArbitraryViewContainerRefComponent,
-  PizzaMsg,
-];
-
-@NgModule({
-  imports: [CommonModule, PortalModule],
-  exports: TEST_COMPONENTS,
-  declarations: [...TEST_COMPONENTS, SaveParentNodeOnInit],
-  entryComponents: TEST_COMPONENTS,
-})
-class PortalTestModule {}

--- a/src/cdk/scrolling/scroll-dispatcher.spec.ts
+++ b/src/cdk/scrolling/scroll-dispatcher.spec.ts
@@ -6,7 +6,7 @@ import {
   ComponentFixture,
   tick,
 } from '@angular/core/testing';
-import {NgModule, Component, ViewChild, ElementRef} from '@angular/core';
+import {Component, ViewChild, ElementRef} from '@angular/core';
 import {CdkScrollable, ScrollDispatcher, ScrollingModule} from './public-api';
 import {dispatchFakeEvent} from '../testing/private';
 
@@ -14,7 +14,8 @@ describe('ScrollDispatcher', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [ScrollTestModule],
+        imports: [ScrollingModule],
+        declarations: [ScrollingComponent, NestedScrollingComponent],
       });
 
       TestBed.compileComponents();
@@ -308,13 +309,3 @@ class ScrollingComponent {
 class NestedScrollingComponent {
   @ViewChild('interestingElement') interestingElement: ElementRef<HTMLElement>;
 }
-
-const TEST_COMPONENTS = [ScrollingComponent, NestedScrollingComponent];
-@NgModule({
-  imports: [ScrollingModule],
-  providers: [ScrollDispatcher],
-  exports: TEST_COMPONENTS,
-  declarations: TEST_COMPONENTS,
-  entryComponents: TEST_COMPONENTS,
-})
-class ScrollTestModule {}

--- a/src/components-examples/cdk-experimental/popover-edit/index.ts
+++ b/src/components-examples/cdk-experimental/popover-edit/index.ts
@@ -32,6 +32,5 @@ const EXAMPLES = [
   imports: [CdkPopoverEditModule, CdkTableModule, FormsModule, CommonModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkPopoverEditExamplesModule {}

--- a/src/components-examples/cdk/a11y/index.ts
+++ b/src/components-examples/cdk/a11y/index.ts
@@ -17,6 +17,5 @@ const EXAMPLES = [
   imports: [A11yModule, MatSelectModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkA11yExamplesModule {}

--- a/src/components-examples/cdk/accordion/index.ts
+++ b/src/components-examples/cdk/accordion/index.ts
@@ -11,6 +11,5 @@ const EXAMPLES = [CdkAccordionOverviewExample];
   imports: [CommonModule, CdkAccordionModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkAccordionExamplesModule {}

--- a/src/components-examples/cdk/clipboard/index.ts
+++ b/src/components-examples/cdk/clipboard/index.ts
@@ -11,6 +11,5 @@ const EXAMPLES = [CdkClipboardOverviewExample];
   imports: [ClipboardModule, FormsModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkClipboardExamplesModule {}

--- a/src/components-examples/cdk/drag-drop/index.ts
+++ b/src/components-examples/cdk/drag-drop/index.ts
@@ -64,6 +64,5 @@ const EXAMPLES = [
   imports: [DragDropModule, OverlayModule, CommonModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkDragDropExamplesModule {}

--- a/src/components-examples/cdk/layout/index.ts
+++ b/src/components-examples/cdk/layout/index.ts
@@ -10,6 +10,5 @@ const EXAMPLES = [BreakpointObserverOverviewExample];
   imports: [LayoutModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkLayoutExamplesModule {}

--- a/src/components-examples/cdk/overlay/index.ts
+++ b/src/components-examples/cdk/overlay/index.ts
@@ -11,6 +11,5 @@ const EXAMPLES = [CdkOverlayBasicExample];
   imports: [OverlayModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkOverlayExamplesModule {}

--- a/src/components-examples/cdk/platform/index.ts
+++ b/src/components-examples/cdk/platform/index.ts
@@ -10,6 +10,5 @@ const EXAMPLES = [CdkPlatformOverviewExample];
   imports: [PlatformModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkPlatformExamplesModule {}

--- a/src/components-examples/cdk/portal/index.ts
+++ b/src/components-examples/cdk/portal/index.ts
@@ -13,6 +13,5 @@ const EXAMPLES = [CdkPortalOverviewExample, ComponentPortalExample];
   imports: [PortalModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkPortalExamplesModule {}

--- a/src/components-examples/cdk/scrolling/index.ts
+++ b/src/components-examples/cdk/scrolling/index.ts
@@ -38,6 +38,5 @@ const EXAMPLES = [
   imports: [ScrollingModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkScrollingExamplesModule {}

--- a/src/components-examples/cdk/stepper/index.ts
+++ b/src/components-examples/cdk/stepper/index.ts
@@ -29,6 +29,5 @@ const EXAMPLES = [
   imports: [CdkStepperModule, CommonModule, ReactiveFormsModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkStepperExamplesModule {}

--- a/src/components-examples/cdk/table/index.ts
+++ b/src/components-examples/cdk/table/index.ts
@@ -22,6 +22,5 @@ const EXAMPLES = [
   imports: [CdkTableModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkTableExamplesModule {}

--- a/src/components-examples/cdk/text-field/index.ts
+++ b/src/components-examples/cdk/text-field/index.ts
@@ -24,6 +24,5 @@ const EXAMPLES = [
   imports: [CommonModule, TextFieldModule, MatButtonModule, MatInputModule, MatSelectModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkTextFieldExamplesModule {}

--- a/src/components-examples/cdk/tree/index.ts
+++ b/src/components-examples/cdk/tree/index.ts
@@ -13,6 +13,5 @@ const EXAMPLES = [CdkTreeFlatExample, CdkTreeNestedExample];
   imports: [CdkTreeModule, MatButtonModule, MatIconModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CdkTreeExamplesModule {}

--- a/src/components-examples/material-experimental/mdc-card/index.ts
+++ b/src/components-examples/material-experimental/mdc-card/index.ts
@@ -11,6 +11,5 @@ const EXAMPLES = [MdcCardFancyExample];
   imports: [MatButtonModule, MatCardModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class MdcCardExamplesModule {}

--- a/src/components-examples/material-experimental/mdc-form-field/index.ts
+++ b/src/components-examples/material-experimental/mdc-form-field/index.ts
@@ -16,6 +16,5 @@ const EXAMPLES = [MdcFormFieldCustomControlExample];
   imports: [CommonModule, MatFormFieldModule, MatIconModule, ReactiveFormsModule],
   declarations: [...EXAMPLES, MyTelInput],
   exports: [...EXAMPLES, MyTelInput],
-  entryComponents: EXAMPLES,
 })
 export class MdcFormFieldExamplesModule {}

--- a/src/components-examples/material-experimental/mdc-table/index.ts
+++ b/src/components-examples/material-experimental/mdc-table/index.ts
@@ -133,6 +133,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class MdcTableExamplesModule {}

--- a/src/components-examples/material-experimental/popover-edit/index.ts
+++ b/src/components-examples/material-experimental/popover-edit/index.ts
@@ -43,6 +43,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class PopoverEditExamplesModule {}

--- a/src/components-examples/material/autocomplete/index.ts
+++ b/src/components-examples/material/autocomplete/index.ts
@@ -48,6 +48,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class AutocompleteExamplesModule {}

--- a/src/components-examples/material/badge/index.ts
+++ b/src/components-examples/material/badge/index.ts
@@ -13,6 +13,5 @@ const EXAMPLES = [BadgeOverviewExample, BadgeHarnessExample];
   imports: [MatBadgeModule, MatButtonModule, MatIconModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class BadgeExamplesModule {}

--- a/src/components-examples/material/bottom-sheet/index.ts
+++ b/src/components-examples/material/bottom-sheet/index.ts
@@ -20,6 +20,5 @@ const EXAMPLES = [
   imports: [MatBottomSheetModule, MatButtonModule, MatListModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class BottomSheetExamplesModule {}

--- a/src/components-examples/material/button-toggle/index.ts
+++ b/src/components-examples/material/button-toggle/index.ts
@@ -31,6 +31,5 @@ const EXAMPLES = [
   imports: [FormsModule, MatButtonToggleModule, MatIconModule, ReactiveFormsModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class ButtonToggleExamplesModule {}

--- a/src/components-examples/material/button/index.ts
+++ b/src/components-examples/material/button/index.ts
@@ -14,6 +14,5 @@ const EXAMPLES = [ButtonOverviewExample, ButtonTypesExample, ButtonHarnessExampl
   imports: [MatButtonModule, MatDividerModule, MatIconModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class ButtonExamplesModule {}

--- a/src/components-examples/material/card/index.ts
+++ b/src/components-examples/material/card/index.ts
@@ -35,6 +35,5 @@ const EXAMPLES = [
   imports: [MatButtonModule, MatCardModule, MatDividerModule, MatProgressBarModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CardExamplesModule {}

--- a/src/components-examples/material/checkbox/index.ts
+++ b/src/components-examples/material/checkbox/index.ts
@@ -34,6 +34,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CheckboxExamplesModule {}

--- a/src/components-examples/material/chips/index.ts
+++ b/src/components-examples/material/chips/index.ts
@@ -48,6 +48,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class ChipsExamplesModule {}

--- a/src/components-examples/material/core/index.ts
+++ b/src/components-examples/material/core/index.ts
@@ -15,6 +15,5 @@ const EXAMPLES = [ElevationOverviewExample, RippleOverviewExample];
   imports: [MatButtonModule, MatCheckboxModule, MatInputModule, MatRippleModule, FormsModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class CoreExamplesModule {}

--- a/src/components-examples/material/datepicker/index.ts
+++ b/src/components-examples/material/datepicker/index.ts
@@ -106,6 +106,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class DatepickerExamplesModule {}

--- a/src/components-examples/material/dialog/index.ts
+++ b/src/components-examples/material/dialog/index.ts
@@ -63,6 +63,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class DialogExamplesModule {}

--- a/src/components-examples/material/divider/index.ts
+++ b/src/components-examples/material/divider/index.ts
@@ -12,6 +12,5 @@ const EXAMPLES = [DividerHarnessExample, DividerOverviewExample];
   imports: [MatDividerModule, MatListModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class DividerExamplesModule {}

--- a/src/components-examples/material/expansion/index.ts
+++ b/src/components-examples/material/expansion/index.ts
@@ -35,6 +35,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class ExpansionExamplesModule {}

--- a/src/components-examples/material/form-field/index.ts
+++ b/src/components-examples/material/form-field/index.ts
@@ -60,6 +60,5 @@ const EXAMPLES = [
   ],
   declarations: [...EXAMPLES, MyTelInput],
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class FormFieldExamplesModule {}

--- a/src/components-examples/material/grid-list/index.ts
+++ b/src/components-examples/material/grid-list/index.ts
@@ -13,6 +13,5 @@ const EXAMPLES = [GridListDynamicExample, GridListHarnessExample, GridListOvervi
   imports: [CommonModule, MatGridListModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class GridListExamplesModule {}

--- a/src/components-examples/material/icon/index.ts
+++ b/src/components-examples/material/icon/index.ts
@@ -12,6 +12,5 @@ const EXAMPLES = [IconHarnessExample, IconOverviewExample, IconSvgExample];
   imports: [MatIconModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class IconExamplesModule {}

--- a/src/components-examples/material/input/index.ts
+++ b/src/components-examples/material/input/index.ts
@@ -46,6 +46,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class InputExamplesModule {}

--- a/src/components-examples/material/list/index.ts
+++ b/src/components-examples/material/list/index.ts
@@ -28,6 +28,5 @@ const EXAMPLES = [
   imports: [CommonModule, MatIconModule, MatListModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class ListExamplesModule {}

--- a/src/components-examples/material/menu/index.ts
+++ b/src/components-examples/material/menu/index.ts
@@ -28,6 +28,5 @@ const EXAMPLES = [
   imports: [MatButtonModule, MatIconModule, MatMenuModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class MenuExamplesModule {}

--- a/src/components-examples/material/paginator/index.ts
+++ b/src/components-examples/material/paginator/index.ts
@@ -35,6 +35,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class PaginatorExamplesModule {}

--- a/src/components-examples/material/progress-bar/index.ts
+++ b/src/components-examples/material/progress-bar/index.ts
@@ -41,6 +41,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class ProgressBarExamplesModule {}

--- a/src/components-examples/material/progress-spinner/index.ts
+++ b/src/components-examples/material/progress-spinner/index.ts
@@ -32,6 +32,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class ProgressSpinnerExamplesModule {}

--- a/src/components-examples/material/radio/index.ts
+++ b/src/components-examples/material/radio/index.ts
@@ -14,6 +14,5 @@ const EXAMPLES = [RadioHarnessExample, RadioNgModelExample, RadioOverviewExample
   imports: [ReactiveFormsModule, CommonModule, MatRadioModule, FormsModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class RadioExamplesModule {}

--- a/src/components-examples/material/select/index.ts
+++ b/src/components-examples/material/select/index.ts
@@ -69,6 +69,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class SelectExamplesModule {}

--- a/src/components-examples/material/sidenav/index.ts
+++ b/src/components-examples/material/sidenav/index.ts
@@ -65,6 +65,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class SidenavExamplesModule {}

--- a/src/components-examples/material/slide-toggle/index.ts
+++ b/src/components-examples/material/slide-toggle/index.ts
@@ -36,6 +36,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class SlideToggleExamplesModule {}

--- a/src/components-examples/material/slider/index.ts
+++ b/src/components-examples/material/slider/index.ts
@@ -35,6 +35,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class SliderExamplesModule {}

--- a/src/components-examples/material/snack-bar/index.ts
+++ b/src/components-examples/material/snack-bar/index.ts
@@ -31,6 +31,5 @@ const EXAMPLES = [
   imports: [FormsModule, MatButtonModule, MatInputModule, MatSelectModule, MatSnackBarModule],
   declarations: [...EXAMPLES, PizzaPartyComponent],
   exports: EXAMPLES,
-  entryComponents: [...EXAMPLES, PizzaPartyComponent],
 })
 export class SnackBarExamplesModule {}

--- a/src/components-examples/material/sort/index.ts
+++ b/src/components-examples/material/sort/index.ts
@@ -12,6 +12,5 @@ const EXAMPLES = [SortHarnessExample, SortOverviewExample];
   imports: [CommonModule, MatSortModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class SortExamplesModule {}

--- a/src/components-examples/material/stepper/index.ts
+++ b/src/components-examples/material/stepper/index.ts
@@ -59,6 +59,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class StepperExamplesModule {}

--- a/src/components-examples/material/table/index.ts
+++ b/src/components-examples/material/table/index.ts
@@ -130,6 +130,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class TableExamplesModule {}

--- a/src/components-examples/material/tabs/index.ts
+++ b/src/components-examples/material/tabs/index.ts
@@ -66,6 +66,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class TabGroupExamplesModule {}

--- a/src/components-examples/material/toolbar/index.ts
+++ b/src/components-examples/material/toolbar/index.ts
@@ -20,6 +20,5 @@ const EXAMPLES = [
   imports: [MatButtonModule, MatIconModule, MatToolbarModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class ToolbarExamplesModule {}

--- a/src/components-examples/material/tooltip/index.ts
+++ b/src/components-examples/material/tooltip/index.ts
@@ -57,6 +57,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class TooltipExamplesModule {}

--- a/src/components-examples/material/tree/index.ts
+++ b/src/components-examples/material/tree/index.ts
@@ -43,6 +43,5 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
-  entryComponents: EXAMPLES,
 })
 export class TreeExamplesModule {}

--- a/src/material-experimental/mdc-dialog/dialog.spec.ts
+++ b/src/material-experimental/mdc-dialog/dialog.spec.ts
@@ -20,7 +20,6 @@ import {
   Directive,
   Inject,
   Injector,
-  NgModule,
   NgZone,
   TemplateRef,
   ViewChild,
@@ -61,7 +60,17 @@ describe('MDC-based MatDialog', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, DialogTestModule],
+      imports: [MatDialogModule, NoopAnimationsModule],
+      declarations: [
+        ComponentWithChildViewContainer,
+        ComponentWithTemplateRef,
+        PizzaMsg,
+        ContentElementDialog,
+        DialogWithInjectedData,
+        DialogWithoutFocusableElements,
+        DirectiveWithViewContainer,
+        ComponentWithContentElementTemplateRef,
+      ],
       providers: [
         {provide: Location, useClass: SpyLocation},
         {
@@ -1762,7 +1771,7 @@ describe('MDC-based MatDialog with a parent MatDialog', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, DialogTestModule],
+      imports: [MatDialogModule, NoopAnimationsModule],
       declarations: [ComponentThatProvidesMatDialog],
       providers: [
         {
@@ -1876,7 +1885,8 @@ describe('MDC-based MatDialog with default options', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, DialogTestModule],
+      imports: [MatDialogModule, NoopAnimationsModule],
+      declarations: [ComponentWithChildViewContainer, DirectiveWithViewContainer],
       providers: [{provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: defaultConfig}],
     });
 
@@ -1943,7 +1953,8 @@ describe('MDC-based MatDialog with animations enabled', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, DialogTestModule, BrowserAnimationsModule],
+      imports: [MatDialogModule, BrowserAnimationsModule],
+      declarations: [ComponentWithChildViewContainer, DirectiveWithViewContainer],
     });
 
     TestBed.compileComponents();
@@ -2116,33 +2127,3 @@ class DialogWithoutFocusableElements {}
   encapsulation: ViewEncapsulation.ShadowDom,
 })
 class ShadowDomComponent {}
-
-// Create a real (non-test) NgModule as a workaround for
-// https://github.com/angular/angular/issues/10760
-const TEST_DIRECTIVES = [
-  ComponentWithChildViewContainer,
-  ComponentWithTemplateRef,
-  PizzaMsg,
-  DirectiveWithViewContainer,
-  ComponentWithOnPushViewContainer,
-  ContentElementDialog,
-  DialogWithInjectedData,
-  DialogWithoutFocusableElements,
-  ComponentWithContentElementTemplateRef,
-  ShadowDomComponent,
-];
-
-@NgModule({
-  imports: [MatDialogModule, NoopAnimationsModule],
-  exports: TEST_DIRECTIVES,
-  declarations: TEST_DIRECTIVES,
-  entryComponents: [
-    ComponentWithChildViewContainer,
-    ComponentWithTemplateRef,
-    PizzaMsg,
-    ContentElementDialog,
-    DialogWithInjectedData,
-    DialogWithoutFocusableElements,
-  ],
-})
-class DialogTestModule {}

--- a/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
@@ -5,7 +5,6 @@ import {
   Component,
   Directive,
   Inject,
-  NgModule,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -40,7 +39,12 @@ describe('MatSnackBar', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
+      imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
+      declarations: [
+        ComponentWithChildViewContainer,
+        BurritosNotification,
+        DirectiveWithViewContainer,
+      ],
     }).compileComponents();
   }));
 
@@ -686,7 +690,7 @@ describe('MatSnackBar with parent MatSnackBar', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
+      imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
       declarations: [ComponentThatProvidesMatSnackBar],
     }).compileComponents();
   }));
@@ -760,7 +764,8 @@ describe('MatSnackBar Positioning', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
+      imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
+      declarations: [ComponentWithChildViewContainer],
     }).compileComponents();
   }));
 
@@ -1052,22 +1057,3 @@ class BurritosNotification {
 class ComponentThatProvidesMatSnackBar {
   constructor(public snackBar: MatSnackBar) {}
 }
-
-/**
- * Simple component to open snack bars from.
- * Create a real (non-test) NgModule as a workaround forRoot
- * https://github.com/angular/angular/issues/10760
- */
-const TEST_DIRECTIVES = [
-  ComponentWithChildViewContainer,
-  BurritosNotification,
-  DirectiveWithViewContainer,
-  ComponentWithTemplateRef,
-];
-@NgModule({
-  imports: [CommonModule, MatSnackBarModule],
-  exports: TEST_DIRECTIVES,
-  declarations: TEST_DIRECTIVES,
-  entryComponents: [ComponentWithChildViewContainer, BurritosNotification],
-})
-class SnackBarTestModule {}

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -11,7 +11,6 @@ import {
   Directive,
   Inject,
   Injector,
-  NgModule,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -45,7 +44,17 @@ describe('MatBottomSheet', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatBottomSheetModule, BottomSheetTestModule],
+      imports: [MatBottomSheetModule, NoopAnimationsModule],
+      declarations: [
+        ComponentWithChildViewContainer,
+        ComponentWithTemplateRef,
+        ContentElementDialog,
+        PizzaMsg,
+        TacoMsg,
+        DirectiveWithViewContainer,
+        BottomSheetWithInjectedData,
+        ShadowDomComponent,
+      ],
       providers: [{provide: Location, useClass: SpyLocation}],
     }).compileComponents();
   }));
@@ -845,7 +854,7 @@ describe('MatBottomSheet with parent MatBottomSheet', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatBottomSheetModule, BottomSheetTestModule, NoopAnimationsModule],
+      imports: [MatBottomSheetModule, NoopAnimationsModule],
       declarations: [ComponentThatProvidesMatBottomSheet],
     }).compileComponents();
   }));
@@ -931,7 +940,8 @@ describe('MatBottomSheet with default options', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [MatBottomSheetModule, BottomSheetTestModule],
+      imports: [MatBottomSheetModule, NoopAnimationsModule],
+      declarations: [ComponentWithChildViewContainer, DirectiveWithViewContainer],
       providers: [{provide: MAT_BOTTOM_SHEET_DEFAULT_OPTIONS, useValue: defaultConfig}],
     });
 
@@ -1054,31 +1064,3 @@ class BottomSheetWithInjectedData {
   encapsulation: ViewEncapsulation.ShadowDom,
 })
 class ShadowDomComponent {}
-
-// Create a real (non-test) NgModule as a workaround for
-// https://github.com/angular/angular/issues/10760
-const TEST_DIRECTIVES = [
-  ComponentWithChildViewContainer,
-  ComponentWithTemplateRef,
-  ContentElementDialog,
-  PizzaMsg,
-  TacoMsg,
-  DirectiveWithViewContainer,
-  BottomSheetWithInjectedData,
-  ShadowDomComponent,
-];
-
-@NgModule({
-  imports: [MatBottomSheetModule, NoopAnimationsModule],
-  exports: TEST_DIRECTIVES,
-  declarations: TEST_DIRECTIVES,
-  entryComponents: [
-    ComponentWithChildViewContainer,
-    ComponentWithTemplateRef,
-    ContentElementDialog,
-    PizzaMsg,
-    TacoMsg,
-    BottomSheetWithInjectedData,
-  ],
-})
-class BottomSheetTestModule {}

--- a/src/material/datepicker/datepicker.spec.ts
+++ b/src/material/datepicker/datepicker.spec.ts
@@ -24,7 +24,6 @@ import {MatFormField, MatFormFieldModule} from '@angular/material/form-field';
 import {DEC, JAN, JUL, JUN, SEP} from '../testing';
 import {By} from '@angular/platform-browser';
 import {_supportsShadowDom} from '@angular/cdk/platform';
-import {BrowserDynamicTestingModule} from '@angular/platform-browser-dynamic/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 import {MatInputModule} from '../input/index';
@@ -47,7 +46,6 @@ describe('MatDatepicker', () => {
     component: Type<T>,
     imports: Type<any>[] = [],
     providers: Provider[] = [],
-    entryComponents: Type<any>[] = [],
     declarations: Type<any>[] = [],
   ): ComponentFixture<T> {
     TestBed.configureTestingModule({
@@ -61,14 +59,8 @@ describe('MatDatepicker', () => {
         ...imports,
       ],
       providers,
-      declarations: [component, ...declarations, ...entryComponents],
+      declarations: [component, ...declarations],
     });
-
-    TestBed.overrideModule(BrowserDynamicTestingModule, {
-      set: {
-        entryComponents: [entryComponents],
-      },
-    }).compileComponents();
 
     return TestBed.createComponent(component);
   }
@@ -2198,7 +2190,6 @@ describe('MatDatepicker', () => {
       DatepickerInputWithCustomValidator,
       [MatNativeDateModule],
       undefined,
-      undefined,
       [CustomValidator],
     );
     fixture.detectChanges();
@@ -2220,7 +2211,6 @@ describe('MatDatepicker', () => {
     const fixture = createComponent(
       DatepickerInputWithCustomValidator,
       [MatNativeDateModule],
-      undefined,
       undefined,
       [CustomValidator],
     );

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -14,7 +14,6 @@ import {
   Directive,
   Inject,
   Injector,
-  NgModule,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -61,7 +60,17 @@ describe('MatDialog', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, DialogTestModule],
+      imports: [MatDialogModule, NoopAnimationsModule],
+      declarations: [
+        ComponentWithChildViewContainer,
+        ComponentWithTemplateRef,
+        PizzaMsg,
+        ContentElementDialog,
+        DialogWithInjectedData,
+        DialogWithoutFocusableElements,
+        DirectiveWithViewContainer,
+        ComponentWithContentElementTemplateRef,
+      ],
       providers: [
         {provide: Location, useClass: SpyLocation},
         {
@@ -1828,8 +1837,8 @@ describe('MatDialog with a parent MatDialog', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, DialogTestModule],
-      declarations: [ComponentThatProvidesMatDialog],
+      imports: [MatDialogModule, NoopAnimationsModule],
+      declarations: [ComponentThatProvidesMatDialog, DirectiveWithViewContainer],
       providers: [
         {
           provide: OverlayContainer,
@@ -1942,8 +1951,9 @@ describe('MatDialog with default options', () => {
     };
 
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, DialogTestModule],
+      imports: [MatDialogModule, NoopAnimationsModule],
       providers: [{provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: defaultConfig}],
+      declarations: [ComponentWithChildViewContainer, DirectiveWithViewContainer],
     });
 
     TestBed.compileComponents();
@@ -2009,7 +2019,8 @@ describe('MatDialog with animations enabled', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule, DialogTestModule, BrowserAnimationsModule],
+      imports: [MatDialogModule, BrowserAnimationsModule],
+      declarations: [ComponentWithChildViewContainer, DirectiveWithViewContainer],
     });
 
     TestBed.compileComponents();
@@ -2163,33 +2174,3 @@ class DialogWithoutFocusableElements {}
   encapsulation: ViewEncapsulation.ShadowDom,
 })
 class ShadowDomComponent {}
-
-// Create a real (non-test) NgModule as a workaround for
-// https://github.com/angular/angular/issues/10760
-const TEST_DIRECTIVES = [
-  ComponentWithChildViewContainer,
-  ComponentWithTemplateRef,
-  PizzaMsg,
-  DirectiveWithViewContainer,
-  ComponentWithOnPushViewContainer,
-  ContentElementDialog,
-  DialogWithInjectedData,
-  DialogWithoutFocusableElements,
-  ComponentWithContentElementTemplateRef,
-  ShadowDomComponent,
-];
-
-@NgModule({
-  imports: [MatDialogModule, NoopAnimationsModule],
-  exports: TEST_DIRECTIVES,
-  declarations: TEST_DIRECTIVES,
-  entryComponents: [
-    ComponentWithChildViewContainer,
-    ComponentWithTemplateRef,
-    PizzaMsg,
-    ContentElementDialog,
-    DialogWithInjectedData,
-    DialogWithoutFocusableElements,
-  ],
-})
-class DialogTestModule {}

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -5,7 +5,6 @@ import {
   Component,
   Directive,
   Inject,
-  NgModule,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -39,7 +38,12 @@ describe('MatSnackBar', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
+      imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
+      declarations: [
+        ComponentWithChildViewContainer,
+        BurritosNotification,
+        DirectiveWithViewContainer,
+      ],
     }).compileComponents();
   }));
 
@@ -746,7 +750,7 @@ describe('MatSnackBar with parent MatSnackBar', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
+      imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
       declarations: [ComponentThatProvidesMatSnackBar],
     }).compileComponents();
   }));
@@ -820,7 +824,8 @@ describe('MatSnackBar Positioning', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatSnackBarModule, SnackBarTestModule, NoopAnimationsModule],
+      imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
+      declarations: [ComponentWithChildViewContainer],
     }).compileComponents();
   }));
 
@@ -1157,22 +1162,3 @@ class BurritosNotification {
 class ComponentThatProvidesMatSnackBar {
   constructor(public snackBar: MatSnackBar) {}
 }
-
-/**
- * Simple component to open snack bars from.
- * Create a real (non-test) NgModule as a workaround forRoot
- * https://github.com/angular/angular/issues/10760
- */
-const TEST_DIRECTIVES = [
-  ComponentWithChildViewContainer,
-  BurritosNotification,
-  DirectiveWithViewContainer,
-  ComponentWithTemplateRef,
-];
-@NgModule({
-  imports: [CommonModule, MatSnackBarModule],
-  exports: TEST_DIRECTIVES,
-  declarations: TEST_DIRECTIVES,
-  entryComponents: [ComponentWithChildViewContainer, BurritosNotification],
-})
-class SnackBarTestModule {}


### PR DESCRIPTION
Cleans up all the usages of `entryComponents` since they aren't necessary anymore.