### PR TITLE
fix(material/schematics): don't replace variables contained within the names of other variables in theming API migration

### DIFF
--- a/src/material/schematics/ng-update/migrations/theming-api-v12/migration.ts
+++ b/src/material/schematics/ng-update/migrations/theming-api-v12/migration.ts
@@ -397,7 +397,7 @@ function replaceRemovedVariables(content: string, variables: Record<string, stri
   Object.keys(variables).forEach(variableName => {
     // Note that the pattern uses a negative lookahead to exclude
     // variable assignments, because they can't be migrated.
-    const regex = new RegExp(`\\$${escapeRegExp(variableName)}(?!\\s+:|:)`, 'g');
+    const regex = new RegExp(`\\$${escapeRegExp(variableName)}(?!\\s+:|[-_a-zA-Z0-9:])`, 'g');
     content = content.replace(regex, variables[variableName]);
   });
 

--- a/src/material/schematics/ng-update/test-cases/v12/misc/theming-api-v12.spec.ts
+++ b/src/material/schematics/ng-update/test-cases/v12/misc/theming-api-v12.spec.ts
@@ -591,6 +591,17 @@ describe('v12 theming API migration', () => {
     ]);
   });
 
+  it('should not replace removed variables whose name overlaps with other variables', async () => {
+    writeLines(THEME_PATH, [
+      `@import '@angular/material/theming';`,
+      `$swift-ease-in-duration: 300ms !default`,
+    ]);
+
+    await runMigration();
+
+    expect(splitFile(THEME_PATH)).toEqual([`$swift-ease-in-duration: 300ms !default`]);
+  });
+
   it('should not replace assignments to removed variables', async () => {
     writeLines(THEME_PATH, [
       `@import '@angular/material/theming';`,


### PR DESCRIPTION
Fixes that the theming API migration would replace the `$swift-ease-in` inside a variable like `$swift-ease-in-duration`, because the regex would partially match the name.

Fixes #24013.