### PR TITLE
docs(material/datepicker): add note about locale data in date-fns

### DIFF
--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -292,6 +292,11 @@ export class MyApp {}
 
 It's also possible to set the locale at runtime using the `setLocale` method of the `DateAdapter`.
 
+**Note:** if you're using the `MatDateFnsModule`, you have to provide the data object for your
+locale to `MAT_DATE_LOCALE` instead of the locale code, in addition to providing a configuration
+compatible with `date-fns` to `MAT_DATE_FORMATS`. Locale data for `date-fns` can be imported
+from `date-fns/locale`.
+
 <!-- example(datepicker-locale) -->
 
 #### Choosing a date implementation and date format settings


### PR DESCRIPTION
Adds a note about how locale data should be provided for users that consume the `date-fns` adapter.

Fixes #24026.