### PR TITLE
test(material/snack-bar): fix error logs in tests

### DIFF
--- a/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
+++ b/src/material-experimental/mdc-snack-bar/snack-bar.spec.ts
@@ -691,7 +691,7 @@ describe('MatSnackBar with parent MatSnackBar', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
-      declarations: [ComponentThatProvidesMatSnackBar],
+      declarations: [ComponentThatProvidesMatSnackBar, DirectiveWithViewContainer],
     }).compileComponents();
   }));
 
@@ -765,7 +765,7 @@ describe('MatSnackBar Positioning', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
-      declarations: [ComponentWithChildViewContainer],
+      declarations: [ComponentWithChildViewContainer, DirectiveWithViewContainer],
     }).compileComponents();
   }));
 

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -751,7 +751,7 @@ describe('MatSnackBar with parent MatSnackBar', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
-      declarations: [ComponentThatProvidesMatSnackBar],
+      declarations: [ComponentThatProvidesMatSnackBar, DirectiveWithViewContainer],
     }).compileComponents();
   }));
 
@@ -825,7 +825,7 @@ describe('MatSnackBar Positioning', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MatSnackBarModule, CommonModule, NoopAnimationsModule],
-      declarations: [ComponentWithChildViewContainer],
+      declarations: [ComponentWithChildViewContainer, DirectiveWithViewContainer],
     }).compileComponents();
   }));
 


### PR DESCRIPTION
The snack bar tests were logging `'dir-with-view-container' is not a known element` errors, because the component wasn't added to the `declarations` after the `entryComponents` cleanup. This didn't break the CI, because Angular uses `console.error` for unknown element errors.