### PR TITLE
fix(multiple): correct tooltip and table MDC style import paths

### DIFF
--- a/src/material-experimental/mdc-table/_table-theme.scss
+++ b/src/material-experimental/mdc-table/_table-theme.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use '@material/theme/theme-color' as mdc-theme-color;
 @use '@material/data-table/data-table' as mdc-data-table;
-@use '@material/data-table/data-table-theme' as mdc-data-table-theme;
+@use '@material/data-table' as mdc-data-table-theme;
 @use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/typography/typography';
 @use '../../material/core/theming/theming';

--- a/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
+++ b/src/material-experimental/mdc-tooltip/_tooltip-theme.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 @use '@material/tooltip/tooltip';
-@use '@material/tooltip/tooltip-theme';
+@use '@material/tooltip' as tooltip-theme;
 @use '../mdc-helpers/mdc-helpers';
 @use '../../material/core/theming/theming';
 @use '../../material/core/theming/palette';


### PR DESCRIPTION
These imports internally are not meant to be visible to us. Changing to be the intended MDC-approved import path for getting theme files

CARETAKER NOTE: Patch this change with cl/413151231 to correct the dependencies and enable strict dependency checks for the future.