### PR TITLE
fix(material/datepicker): fix duplicate nav stop with Voiceover

### DIFF
--- a/src/material/datepicker/calendar-body.html
+++ b/src/material/datepicker/calendar-body.html
@@ -60,6 +60,6 @@
         [class.mat-calendar-body-today]="todayValue === item.compareValue">
         {{item.displayValue}}
       </div>
-      <div class="mat-calendar-body-cell-preview"></div>
+      <div class="mat-calendar-body-cell-preview" aria-hidden="true"></div>
   </td>
 </tr>


### PR DESCRIPTION
Fixes double nav stops when navigating the calendar-body with voiceover
. Fixes this by putting `aria-hidden="true"` on the
`.mat-calendar-body-cell-preview`, since that element is only visual,
and is not for giving semantic info to the a11y tree.

fixes #24082