### PR TITLE
fix(material/tabs): remove CSS content from chevron element

### DIFF
--- a/src/material-experimental/mdc-tabs/_tabs-common.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-common.scss
@@ -128,7 +128,6 @@ $mat-tab-animation-duration: 500ms !default;
   .mat-mdc-tab-header-pagination-chevron {
     border-style: solid;
     border-width: 2px 2px 0 0;
-    content: '';
     height: 8px;
     width: 8px;
   }

--- a/src/material/tabs/_tabs-common.scss
+++ b/src/material/tabs/_tabs-common.scss
@@ -120,7 +120,6 @@ $tab-animation-duration: 500ms !default;
   .mat-tab-header-pagination-chevron {
     border-style: solid;
     border-width: 2px 2px 0 0;
-    content: '';
     height: 8px;
     width: 8px;
   }


### PR DESCRIPTION
Removes the `content` declaration from the tab chevrons. Usually it doesn't have an effect, but according to the discussion on #24085, it may cause an unnecessary tab stop.