### PR TITLE
refactor(cdk/testing): reuse stabilize callback when creating test element

### DIFF
--- a/src/cdk/testing/harness-environment.ts
+++ b/src/cdk/testing/harness-environment.ts
@@ -45,11 +45,16 @@ type ParsedQueries<T extends ComponentHarness> = {
  */
 export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFactory {
   // Implemented as part of the `LocatorFactory` interface.
-  rootElement: TestElement;
-
-  protected constructor(protected rawRootElement: E) {
-    this.rootElement = this.createTestElement(rawRootElement);
+  get rootElement(): TestElement {
+    this._rootElement = this._rootElement || this.createTestElement(this.rawRootElement);
+    return this._rootElement;
   }
+  set rootElement(element: TestElement) {
+    this._rootElement = element;
+  }
+  private _rootElement: TestElement | undefined;
+
+  protected constructor(protected rawRootElement: E) {}
 
   // Implemented as part of the `LocatorFactory` interface.
   documentRootLocatorFactory(): LocatorFactory {

--- a/src/cdk/testing/selenium-webdriver/selenium-web-driver-harness-environment.ts
+++ b/src/cdk/testing/selenium-webdriver/selenium-web-driver-harness-environment.ts
@@ -74,12 +74,16 @@ export class SeleniumWebDriverHarnessEnvironment extends HarnessEnvironment<
   /** The options for this environment. */
   private _options: WebDriverHarnessEnvironmentOptions;
 
+  /** Environment stabilization callback passed to the created test elements. */
+  private _stabilizeCallback: () => Promise<void>;
+
   protected constructor(
     rawRootElement: () => webdriver.WebElement,
     options?: WebDriverHarnessEnvironmentOptions,
   ) {
     super(rawRootElement);
     this._options = {...defaultEnvironmentOptions, ...options};
+    this._stabilizeCallback = () => this.forceStabilize();
   }
 
   /** Gets the ElementFinder corresponding to the given TestElement. */
@@ -123,7 +127,7 @@ export class SeleniumWebDriverHarnessEnvironment extends HarnessEnvironment<
 
   /** Creates a `TestElement` from a raw element. */
   protected createTestElement(element: () => webdriver.WebElement): TestElement {
-    return new SeleniumWebDriverElement(element, () => this.forceStabilize());
+    return new SeleniumWebDriverElement(element, this._stabilizeCallback);
   }
 
   /** Creates a `HarnessLoader` rooted at the given raw element. */

--- a/src/cdk/testing/testbed/testbed-harness-environment.ts
+++ b/src/cdk/testing/testbed/testbed-harness-environment.ts
@@ -96,6 +96,9 @@ export class TestbedHarnessEnvironment extends HarnessEnvironment<Element> {
   /** The options for this environment. */
   private _options: TestbedHarnessEnvironmentOptions;
 
+  /** Environment stabilization callback passed to the created test elements. */
+  private _stabilizeCallback: () => Promise<void>;
+
   protected constructor(
     rawRootElement: Element,
     private _fixture: ComponentFixture<unknown>,
@@ -104,6 +107,7 @@ export class TestbedHarnessEnvironment extends HarnessEnvironment<Element> {
     super(rawRootElement);
     this._options = {...defaultEnvironmentOptions, ...options};
     this._taskState = TaskStateZoneInterceptor.setup();
+    this._stabilizeCallback = () => this.forceStabilize();
     installAutoChangeDetectionStatusHandler(_fixture);
     _fixture.componentRef.onDestroy(() => {
       uninstallAutoChangeDetectionStatusHandler(_fixture);
@@ -198,7 +202,7 @@ export class TestbedHarnessEnvironment extends HarnessEnvironment<Element> {
 
   /** Creates a `TestElement` from a raw element. */
   protected createTestElement(element: Element): TestElement {
-    return new UnitTestElement(element, () => this.forceStabilize());
+    return new UnitTestElement(element, this._stabilizeCallback);
   }
 
   /** Creates a `HarnessLoader` rooted at the given raw element. */

--- a/tools/public_api_guard/cdk/testing.md
+++ b/tools/public_api_guard/cdk/testing.md
@@ -117,7 +117,8 @@ export abstract class HarnessEnvironment<E> implements HarnessLoader, LocatorFac
     // (undocumented)
     protected rawRootElement: E;
     // (undocumented)
-    rootElement: TestElement;
+    get rootElement(): TestElement;
+    set rootElement(element: TestElement);
     // (undocumented)
     rootHarnessLoader(): Promise<HarnessLoader>;
     // (undocumented)


### PR DESCRIPTION
Any time we were creating a new test element, we were giving it a new stabilization callback. These changes reuse the same one between all elements in order to reduce the amount of memory for each element.