### PR TITLE
fix(material/datepicker): remove CSS content from body cells

### DIFF
--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -52,7 +52,6 @@ $calendar-range-end-body-cell-size:
 .mat-calendar-body-cell::before,
 .mat-calendar-body-cell::after,
 .mat-calendar-body-cell-preview {
-  content: '';
   position: absolute;
   top: $calendar-body-cell-content-margin;
   left: 0;


### PR DESCRIPTION
Attempts to fix unnecessary tab stop with VoiceOver by removing the CSS
content from cells in the calendar body. After testing locally, this did
not remove the duplicate tab stop.

Environment
 - macos 12.0.1 (21A559)
 - Chrome Version 96.0.4664.93 (Official Build) (x86_64)

 - localhost:4200/datepicker

relates to #24082