### PR TITLE
fix(material-experimental/mdc-slide-toggle): remove aria-required rather than setting to false

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -13,7 +13,7 @@
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="_getAriaLabelledBy()"
     [attr.aria-describedby]="ariaDescribedby"
-    [attr.aria-required]="required"
+    [attr.aria-required]="required || null"
     (click)="_handleClick($event)"
     #switch>
     <div class="mdc-switch__track"></div>

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
@@ -274,7 +274,7 @@ describe('MDC-based MatSlideToggle without forms', () => {
       testComponent.isRequired = false;
       fixture.detectChanges();
 
-      expect(buttonElement.getAttribute('aria-required')).toBe('false');
+      expect(buttonElement.getAttribute('aria-required')).toBe(null);
     });
 
     it('should focus on underlying element when focus() is called', fakeAsync(() => {


### PR DESCRIPTION
Both are equally valid to mark the control as not required, but setting
it to false generates a bunch of false-positive lint errors in google3