### PR TITLE
fix(material/datepicker): change calendar cells to buttons

### DIFF
--- a/src/material/datepicker/calendar-body.html
+++ b/src/material/datepicker/calendar-body.html
@@ -26,40 +26,43 @@
       [style.paddingBottom]="_cellPadding">
     {{_firstRowOffset >= labelMinRequiredCells ? label : ''}}
   </td>
-  <td *ngFor="let item of row; let colIndex = index"
-      role="gridcell"
-      class="mat-calendar-body-cell"
-      [ngClass]="item.cssClasses"
-      [tabindex]="_isActiveCell(rowIndex, colIndex) ? 0 : -1"
-      [attr.data-mat-row]="rowIndex"
-      [attr.data-mat-col]="colIndex"
-      [class.mat-calendar-body-disabled]="!item.enabled"
-      [class.mat-calendar-body-active]="_isActiveCell(rowIndex, colIndex)"
-      [class.mat-calendar-body-range-start]="_isRangeStart(item.compareValue)"
-      [class.mat-calendar-body-range-end]="_isRangeEnd(item.compareValue)"
-      [class.mat-calendar-body-in-range]="_isInRange(item.compareValue)"
-      [class.mat-calendar-body-comparison-bridge-start]="_isComparisonBridgeStart(item.compareValue, rowIndex, colIndex)"
-      [class.mat-calendar-body-comparison-bridge-end]="_isComparisonBridgeEnd(item.compareValue, rowIndex, colIndex)"
-      [class.mat-calendar-body-comparison-start]="_isComparisonStart(item.compareValue)"
-      [class.mat-calendar-body-comparison-end]="_isComparisonEnd(item.compareValue)"
-      [class.mat-calendar-body-in-comparison-range]="_isInComparisonRange(item.compareValue)"
-      [class.mat-calendar-body-preview-start]="_isPreviewStart(item.compareValue)"
-      [class.mat-calendar-body-preview-end]="_isPreviewEnd(item.compareValue)"
-      [class.mat-calendar-body-in-preview]="_isInPreview(item.compareValue)"
-      [attr.aria-label]="item.ariaLabel"
-      [attr.aria-disabled]="!item.enabled || null"
-      [attr.aria-selected]="_isSelected(item.compareValue)"
-      [attr.aria-current]="todayValue === item.compareValue ? 'date' : null"
-      (click)="_cellClicked(item, $event)"
-      [style.width]="_cellWidth"
-      [style.paddingTop]="_cellPadding"
-      [style.paddingBottom]="_cellPadding">
-      <div class="mat-calendar-body-cell-content mat-focus-indicator"
-        [class.mat-calendar-body-selected]="_isSelected(item.compareValue)"
-        [class.mat-calendar-body-comparison-identical]="_isComparisonIdentical(item.compareValue)"
-        [class.mat-calendar-body-today]="todayValue === item.compareValue">
-        {{item.displayValue}}
-      </div>
-      <div class="mat-calendar-body-cell-preview"></div>
+  <td role="gridcell" *ngFor="let item of row; let colIndex = index" style="display: contents;">
+	  <!-- TODO(zarend): install prettier -->
+	  <div 
+	      role="button"
+	      class="mat-calendar-body-cell"
+	      [ngClass]="item.cssClasses"
+	      [tabindex]="_isActiveCell(rowIndex, colIndex) ? 0 : -1"
+	      [attr.data-mat-row]="rowIndex"
+	      [attr.data-mat-col]="colIndex"
+	      [class.mat-calendar-body-disabled]="!item.enabled"
+	      [class.mat-calendar-body-active]="_isActiveCell(rowIndex, colIndex)"
+	      [class.mat-calendar-body-range-start]="_isRangeStart(item.compareValue)"
+	      [class.mat-calendar-body-range-end]="_isRangeEnd(item.compareValue)"
+	      [class.mat-calendar-body-in-range]="_isInRange(item.compareValue)"
+	      [class.mat-calendar-body-comparison-bridge-start]="_isComparisonBridgeStart(item.compareValue, rowIndex, colIndex)"
+	      [class.mat-calendar-body-comparison-bridge-end]="_isComparisonBridgeEnd(item.compareValue, rowIndex, colIndex)"
+	      [class.mat-calendar-body-comparison-start]="_isComparisonStart(item.compareValue)"
+	      [class.mat-calendar-body-comparison-end]="_isComparisonEnd(item.compareValue)"
+	      [class.mat-calendar-body-in-comparison-range]="_isInComparisonRange(item.compareValue)"
+	      [class.mat-calendar-body-preview-start]="_isPreviewStart(item.compareValue)"
+	      [class.mat-calendar-body-preview-end]="_isPreviewEnd(item.compareValue)"
+	      [class.mat-calendar-body-in-preview]="_isInPreview(item.compareValue)"
+	      [attr.aria-label]="item.ariaLabel"
+	      [attr.aria-disabled]="!item.enabled || null"
+	      [attr.aria-selected]="_isSelected(item.compareValue)"
+	      [attr.aria-current]="todayValue === item.compareValue ? 'date' : null"
+	      (click)="_cellClicked(item, $event)"
+	      [style.width]="_cellWidth"
+	      [style.paddingTop]="_cellPadding"
+	      [style.paddingBottom]="_cellPadding">
+	      <div class="mat-calendar-body-cell-content mat-focus-indicator"
+		[class.mat-calendar-body-selected]="_isSelected(item.compareValue)"
+		[class.mat-calendar-body-comparison-identical]="_isComparisonIdentical(item.compareValue)"
+		[class.mat-calendar-body-today]="todayValue === item.compareValue">
+		{{item.displayValue}}
+	      </div>
+	      <div class="mat-calendar-body-cell-preview"></div>
+	  </div>
   </td>
 </tr>

--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -38,6 +38,7 @@ $calendar-range-end-body-cell-size:
   text-align: center;
   outline: none;
   cursor: pointer;
+  display: table-cell;
 }
 
 // We use ::before to apply a background to the body cell, because we need to apply a border


### PR DESCRIPTION
Makes changes to the DOM structure of calendar cells. Previously, the DOM
structure looksed like this

```
<!-- Existing DOM structure of each calendar body cell -->
<td
 role="gridcell"
 aria-disabled="false"
 aria-current="date"
 aria-selected="true"
 <!-- ... -->
>
 <!-- additional details ommited -->
</>
```

Using the `gridcell` role allows screenreaders to use table specific
navigation and some screenreaders would announce that the cells are
interactible because of the presence of `aria-selected`. However, some
screenreaders did not announce the cells as interactable and treated it
the same as a cell in a static table (e.g. VoiceOver announces element
type incorrectly angular#23476).

This changes the DOM structure to nest buttons
inside of a gridcell to make it more explicit that the table cells can
be interacted with and are not static content. The gridcell role is
still present, so table navigation will continue to work, but the
interaction is done with buttons nested inside the `td` elements.
The `td` element is only for adding information to the a11y tree and not used for visual purposes.

Updated DOM structure:

```
<td
  role="gridcell"
  style="display: contents;"
>
  <div
   role="button"
   aria-disabled="false"
   aria-current="date"
   aria-selected="true"
   <!-- ... -->
  >
   <!-- additional details ommited -->
  </div>
</td>
```

Fixes #23476