### PR TITLE
fix(material/core): disable strong focus indicators in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-helpers/_focus-indicators.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators.scss
@@ -28,6 +28,10 @@
     pointer-events: none;
     border: $border-width $border-style transparent;
     border-radius: $border-radius;
+
+    .cdk-high-contrast-active & {
+      display: none;
+    }
   }
 
   // By default, all focus indicators are flush with the bounding box of their

--- a/src/material/core/focus-indicators/_focus-indicators.scss
+++ b/src/material/core/focus-indicators/_focus-indicators.scss
@@ -28,6 +28,10 @@
     pointer-events: none;
     border: $border-width $border-style transparent;
     border-radius: $border-radius;
+
+    .cdk-high-contrast-active & {
+      display: none;
+    }
   }
 
   // By default, all focus indicators are flush with the bounding box of their


### PR DESCRIPTION
Most components have special handling for high contrast mode which can cause double focus indication when strong focus indication is disabled.

These changes remove the strong focus indicators if such a case is detected.

Fixes #24097.

cc @zelliott 