### PR TITLE
fix(material/core): move pseudo-checkbox module to same directory

### DIFF
--- a/src/material/core/selection/index.ts
+++ b/src/material/core/selection/index.ts
@@ -6,15 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
-import {MatPseudoCheckbox} from './pseudo-checkbox/pseudo-checkbox';
-import {MatCommonModule} from '../common-behaviors/common-module';
-
-@NgModule({
-  imports: [MatCommonModule],
-  exports: [MatPseudoCheckbox],
-  declarations: [MatPseudoCheckbox],
-})
-export class MatPseudoCheckboxModule {}
-
 export * from './pseudo-checkbox/pseudo-checkbox';
+export * from './pseudo-checkbox/pseudo-checkbox-module';

--- a/src/material/core/selection/pseudo-checkbox/pseudo-checkbox-module.ts
+++ b/src/material/core/selection/pseudo-checkbox/pseudo-checkbox-module.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+import {MatPseudoCheckbox} from './pseudo-checkbox';
+import {MatCommonModule} from '../../common-behaviors/common-module';
+
+@NgModule({
+  imports: [MatCommonModule],
+  exports: [MatPseudoCheckbox],
+  declarations: [MatPseudoCheckbox],
+})
+export class MatPseudoCheckboxModule {}


### PR DESCRIPTION
Move the module definition next to the component definition so that the BUILD can be correctly defined (and enable taze). 

Caretaker note: Must patch cl/417987200 with this change