### PR TITLE
feat(cdk/table): allow text column to be centered

### DIFF
--- a/src/cdk/table/text-column.ts
+++ b/src/cdk/table/text-column.ts
@@ -85,7 +85,7 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
   @Input() dataAccessor: (data: T, name: string) => string;
 
   /** Alignment of the cell values. */
-  @Input() justify: 'start' | 'end' = 'start';
+  @Input() justify: 'start' | 'end' | 'center' = 'start';
 
   /** @docs-private */
   @ViewChild(CdkColumnDef, {static: true}) columnDef: CdkColumnDef;

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -382,7 +382,7 @@ export class CdkTextColumn<T> implements OnDestroy, OnInit {
     dataAccessor: (data: T, name: string) => string;
     headerCell: CdkHeaderCellDef;
     headerText: string;
-    justify: 'start' | 'end';
+    justify: 'start' | 'end' | 'center';
     get name(): string;
     set name(name: string);
     // (undocumented)


### PR DESCRIPTION
Allows for the text inside a text column to be centered.

Fixes #23920.