### PR TITLE
build: add unlisted dependencies to package.json

### DIFF
--- a/src/material-experimental/package.json
+++ b/src/material-experimental/package.json
@@ -23,7 +23,12 @@
     }
   },
   "peerDependencies": {
+    "@angular/animations": "0.0.0-NG",
+    "@angular/cdk": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-NG",
+    "@angular/common": "0.0.0-NG",
+    "@angular/forms": "0.0.0-NG",
+    "@angular/platform-browser": "0.0.0-NG",
     "@angular/material": "0.0.0-PLACEHOLDER",
     "material-components-web": "0.0.0-MDC"
   },

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -49,6 +49,7 @@
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",
     "@angular/forms": "0.0.0-NG",
+    "@angular/platform-browser": "0.0.0-NG",
     "rxjs": "0.0.0-RXJS"
   },
   "dependencies": {


### PR DESCRIPTION
* Adds `@angular/platform-browser` to the `material` package.json since we have dependencies on it in a lot of modules.
* Adds several missing dependencies (`animations`, `cdk`, `common`, `forms` and `platform-browser`) to the package.json in `material-experimental`.

Fixes #24146.