### PR TITLE
docs(material/slider): adjust CSS of configurable slider example

### DIFF
--- a/src/components-examples/material/slider/slider-configurable/slider-configurable-example.css
+++ b/src/components-examples/material/slider/slider-configurable/slider-configurable-example.css
@@ -13,11 +13,13 @@
   margin: 8px;
 }
 .example-width {
-  width: min(calc(100% - 16px), 300px);
+  max-width: 180px;
+  width: 100%;
 }
 
 .mat-slider-horizontal {
-  width: min(calc(100% - 16px), 300px);
+  max-width: 300px;
+  width: 100%;
 }
 
 .mat-slider-vertical {

--- a/src/components-examples/material/slider/slider-configurable/slider-configurable-example.css
+++ b/src/components-examples/material/slider/slider-configurable/slider-configurable-example.css
@@ -4,17 +4,20 @@
 
 .example-section {
   display: flex;
+  flex-wrap: wrap;
   align-content: center;
   align-items: center;
-  height: 60px;
 }
 
 .example-margin {
   margin: 8px;
 }
+.example-width {
+  width: min(calc(100% - 16px), 300px);
+}
 
 .mat-slider-horizontal {
-  width: 300px;
+  width: min(calc(100% - 16px), 300px);
 }
 
 .mat-slider-vertical {

--- a/src/components-examples/material/slider/slider-configurable/slider-configurable-example.html
+++ b/src/components-examples/material/slider/slider-configurable/slider-configurable-example.html
@@ -3,19 +3,19 @@
     <h2 class="example-h2">Slider configuration</h2>
 
     <section class="example-section">
-      <mat-form-field class="example-margin" appearance="fill">
+      <mat-form-field class="example-margin example-width" appearance="fill">
         <mat-label>Value</mat-label>
         <input matInput type="number" [(ngModel)]="value">
       </mat-form-field>
-      <mat-form-field class="example-margin" appearance="fill">
+      <mat-form-field class="example-margin example-width" appearance="fill">
         <mat-label>Min value</mat-label>
         <input matInput type="number" [(ngModel)]="min">
       </mat-form-field>
-      <mat-form-field class="example-margin" appearance="fill">
+      <mat-form-field class="example-margin example-width" appearance="fill">
         <mat-label>Max value</mat-label>
         <input matInput type="number" [(ngModel)]="max">
       </mat-form-field>
-      <mat-form-field class="example-margin" appearance="fill">
+      <mat-form-field class="example-margin example-width" appearance="fill">
         <mat-label>Step size</mat-label>
         <input matInput type="number" [(ngModel)]="step">
       </mat-form-field>
@@ -26,7 +26,7 @@
       <mat-checkbox class="example-margin" [(ngModel)]="autoTicks" *ngIf="showTicks">
         Auto ticks
       </mat-checkbox>
-      <mat-form-field class="example-margin" appearance="fill" *ngIf="showTicks && !autoTicks">
+      <mat-form-field class="example-margin example-width" appearance="fill" *ngIf="showTicks && !autoTicks">
         <mat-label>Tick interval</mat-label>
         <input matInput type="number" [(ngModel)]="tickInterval">
       </mat-form-field>


### PR DESCRIPTION
modify CSS of configurable slider example to adjust according to device
![Screenshot1](https://user-images.githubusercontent.com/91653057/147939453-76f44abf-c650-4f16-b2e1-0122cf034516.jpg)
![Screenshot2](https://user-images.githubusercontent.com/91653057/147939465-6d72952f-68de-4e44-baa2-5f0732c40719.jpg)

