### PR TITLE
fix(cdk/text-field): handle undefined placeholder

### DIFF
--- a/src/cdk/text-field/autosize.spec.ts
+++ b/src/cdk/text-field/autosize.spec.ts
@@ -373,6 +373,13 @@ describe('CdkTextareaAutosize', () => {
       .withContext('Expected textarea to have a scrollbar.')
       .toBeLessThan(textarea.scrollHeight);
   }));
+
+  it('should handle an undefined placeholder', () => {
+    fixture.componentInstance.placeholder = undefined!;
+    fixture.detectChanges();
+
+    expect(textarea.hasAttribute('placeholder')).toBe(false);
+  });
 });
 
 // Styles to reset padding and border to make measurement comparisons easier.

--- a/src/cdk/text-field/autosize.ts
+++ b/src/cdk/text-field/autosize.ts
@@ -100,7 +100,13 @@ export class CdkTextareaAutosize implements AfterViewInit, DoCheck, OnDestroy {
   }
   set placeholder(value: string) {
     this._cachedPlaceholderHeight = undefined;
-    this._textareaElement.placeholder = value;
+
+    if (value) {
+      this._textareaElement.setAttribute('placeholder', value);
+    } else {
+      this._textareaElement.removeAttribute('placeholder');
+    }
+
     this._cacheTextareaPlaceholderHeight();
   }
 


### PR DESCRIPTION
Fixes that the string "undefined" would be used as the placeholder of an autosize `textarea` if the value is `undefined`.

Fixes #24154.