### PR TITLE
fix(cdk/overlay): fix positioning when zooming in Safari

### DIFF
--- a/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
+++ b/src/cdk/overlay/position/flexible-connected-position-strategy.spec.ts
@@ -164,6 +164,46 @@ describe('FlexibleConnectedPositionStrategy', () => {
     originElement.remove();
   });
 
+  it('should calculate position with simulated zoom in Safari', () => {
+    let containerElement = overlayContainer.getContainerElement();
+    spyOn(containerElement, 'getBoundingClientRect').and.returnValue({
+      top: -200,
+      bottom: 900,
+      left: -200,
+      right: 100,
+      width: 100,
+      height: 100,
+    } as DOMRect);
+
+    const originElement = createPositionedBlockElement();
+    document.body.appendChild(originElement);
+
+    // Position the element so it would have enough space to fit.
+    originElement.style.top = '200px';
+    originElement.style.left = '70px';
+
+    attachOverlay({
+      positionStrategy: overlay
+        .position()
+        .flexibleConnectedTo(originElement)
+        .withFlexibleDimensions(false)
+        .withPush(false)
+        .withPositions([
+          {
+            originX: 'start',
+            originY: 'top',
+            overlayX: 'start',
+            overlayY: 'top',
+          },
+        ]),
+    });
+
+    expect(getComputedStyle(overlayRef.overlayElement).left).toBe('270px');
+    expect(getComputedStyle(overlayRef.overlayElement).top).toBe('400px');
+
+    originElement.remove();
+  });
+
   it('should clean up after itself when disposed', () => {
     const origin = document.createElement('div');
     const positionStrategy = overlay


### PR DESCRIPTION
Currently, when zooming in Safari in macOS and iOS the overlay is positioned
at the wrong place, offset by the zoom offset (left / top).
This fix corrects this by adding/subtracting the corresponding offset.

Screenshot in Safari 15.1 on macOS with activated zoom:
<img width="951" alt="Bildschirmfoto 2022-01-04 um 15 47 25" src="https://user-images.githubusercontent.com/29278232/148076606-dd84f537-ff1e-41b0-93f7-d2007c7b6cbb.png">

