### PR TITLE
build: add .vimrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ node_modules
 /.vs
 *.swo
 *.swp
+.vimrc
+.nvimrc
 
 # misc
 .DS_Store


### PR DESCRIPTION
Adds .vimrc and .nvrc to the .gitignore file. This aligns components with how
angular/angular does it
https://github.com/angular/angular/blob/master/.gitignore.