### PR TITLE
docs(material/radio): fix button width

### DIFF
--- a/src/components-examples/material/radio/radio-ng-model/radio-ng-model-example.css
+++ b/src/components-examples/material/radio/radio-ng-model/radio-ng-model-example.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   margin: 15px 0;
+  align-items: flex-start;
 }
 
 .example-radio-button {


### PR DESCRIPTION
Fixes that the radio button width spans the entire page in one of the live examples.

Fixes #24158.