### PR TITLE
fix(material-experimental/mdc-button): incorrect metadata for fab anchor

### DIFF
--- a/src/material-experimental/mdc-button/fab.ts
+++ b/src/material-experimental/mdc-button/fab.ts
@@ -142,7 +142,7 @@ export class MatMiniFabButton extends MatButtonBase {
   selector: `a[mat-fab]`,
   templateUrl: 'button.html',
   styleUrls: ['fab.css'],
-  inputs: [...MAT_BUTTON_INPUTS, 'extended'],
+  inputs: [...MAT_ANCHOR_INPUTS, 'extended'],
   host: {
     ...MAT_ANCHOR_HOST,
     '[class.mdc-fab--extended]': 'extended',


### PR DESCRIPTION
Fixes that the FAB anchor was using the button inputs instead of the anchor ones.

Fixes #24145.