### PR TITLE
fix(material/form-field) : correct placeholder-shown pseudo class

### DIFF
--- a/src/material/form-field/_form-field-fill-theme.scss
+++ b/src/material/form-field/_form-field-fill-theme.scss
@@ -97,7 +97,7 @@ $fill-dedupe: 0;
 
       // Server-side rendered matInput with a label attribute but label not shown
       // (used as a pure CSS stand-in for mat-form-field-should-float).
-      .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
+      .mat-input-server[label]:not(:placeholder-shown) + .mat-form-field-label-wrapper
       .mat-form-field-label {
         @include _label-floating(
                 $subscript-font-scale, $infix-padding-top + $fill-appearance-label-offset,

--- a/src/material/form-field/_form-field-legacy-theme.scss
+++ b/src/material/form-field/_form-field-legacy-theme.scss
@@ -119,7 +119,7 @@ $legacy-dedupe: 0;
 
       // Server-side rendered matInput with a label attribute but label not shown
       // (used as a pure CSS stand-in for mat-form-field-should-float).
-      .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
+      .mat-input-server[label]:not(:placeholder-shown) + .mat-form-field-label-wrapper
       .mat-form-field-label {
         @include _label-floating(
                 $subscript-font-scale, $infix-padding, $infix-margin-top);
@@ -165,7 +165,7 @@ $legacy-dedupe: 0;
 
         // Server-side rendered matInput with a label attribute but label not shown
         // (used as a pure CSS stand-in for mat-form-field-should-float).
-        .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
+        .mat-input-server[label]:not(:placeholder-shown) + .mat-form-field-label-wrapper
         .mat-form-field-label {
           @include _label-floating-print(
                   $subscript-font-scale, $infix-padding, $infix-margin-top);

--- a/src/material/form-field/_form-field-outline-theme.scss
+++ b/src/material/form-field/_form-field-outline-theme.scss
@@ -127,7 +127,7 @@ $outline-dedupe: 0;
 
       // Server-side rendered matInput with a label attribute but label not shown
       // (used as a pure CSS stand-in for mat-form-field-should-float).
-      .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
+      .mat-input-server[label]:not(:placeholder-shown) + .mat-form-field-label-wrapper
       .mat-form-field-label {
         @include _label-floating(
                 $subscript-font-scale, $infix-padding + $outline-appearance-label-offset,

--- a/src/material/form-field/_form-field-theme.scss
+++ b/src/material/form-field/_form-field-theme.scss
@@ -206,7 +206,7 @@ $dedupe: 0;
 
     // Server-side rendered matInput with a label attribute but label not shown
     // (used as a pure CSS stand-in for mat-form-field-should-float).
-    .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper
+    .mat-input-server[label]:not(:placeholder-shown) + .mat-form-field-label-wrapper
         .mat-form-field-label {
       @include _label-floating(
               $subscript-font-scale, $infix-padding, $infix-margin-top);


### PR DESCRIPTION
fix(material/form-field) : correct placeholder-shown pseudo class

Replace an invalid pseudo class `:label-shown` by a valid `:placeholder-shown` pseudo class to correct styles of a form-field label

Fixes #24181