### PR TITLE
Revert "fix(material-experimental/mdc-list): export missing harness s…

### DIFF
--- a/src/material-experimental/mdc-list/testing/public-api.ts
+++ b/src/material-experimental/mdc-list/testing/public-api.ts
@@ -11,4 +11,4 @@ export * from './list-harness';
 export * from './list-harness-filters';
 export * from './nav-list-harness';
 export * from './selection-list-harness';
-export {MatListItemSection, MatSubheaderHarness, MatListItemType} from './list-item-harness-base';
+export {MatListItemSection} from './list-item-harness-base';


### PR DESCRIPTION
…ymbols (#24175)"

This reverts commit 12f427cdca4e436ee55a6adcc0ece2f77d53db22.