### PR TITLE
fix(cdk/table): revert breaking change of CdkTable constructor

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -531,7 +531,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
      * @breaking-change 14.0.0
      */
     @Optional()
-    protected readonly _ngZone: NgZone,
+    protected readonly _ngZone?: NgZone,
   ) {
     if (!role) {
       this._elementRef.nativeElement.setAttribute('role', 'table');

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -290,7 +290,7 @@ export class CdkRowDef<T> extends BaseRowDef {
 export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDestroy, OnInit {
     constructor(_differs: IterableDiffers, _changeDetectorRef: ChangeDetectorRef, _elementRef: ElementRef, role: string, _dir: Directionality, _document: any, _platform: Platform, _viewRepeater: _ViewRepeater<T, RenderRow<T>, RowContext<T>>, _coalescedStyleScheduler: _CoalescedStyleScheduler, _viewportRuler: ViewportRuler,
     _stickyPositioningListener: StickyPositioningListener,
-    _ngZone: NgZone);
+    _ngZone?: NgZone | undefined);
     addColumnDef(columnDef: CdkColumnDef): void;
     addFooterRowDef(footerRowDef: CdkFooterRowDef): void;
     addHeaderRowDef(headerRowDef: CdkHeaderRowDef): void;
@@ -334,7 +334,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     // (undocumented)
     ngOnInit(): void;
     // @deprecated (undocumented)
-    protected readonly _ngZone: NgZone;
+    protected readonly _ngZone?: NgZone | undefined;
     _noDataRow: CdkNoDataRow;
     // (undocumented)
     _noDataRowOutlet: NoDataRowOutlet;


### PR DESCRIPTION
With Release 13.1.2 a breaking change was introduced in cdk/table.
If a consumer has a class which extends CdkTable, compilation breaks
due to the newly introduced required constructor parameter _ngZone.
See PR: https://github.com/angular/components/pull/23885