### PR TITLE
refactor: enable useUnknownInCatchVariables compiler option

### DIFF
--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -15,6 +15,7 @@
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/src/cdk/schematics/tsconfig.json
+++ b/src/cdk/schematics/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "../../../dist/packages/cdk/schematics",
     "noEmitOnError": false,
     "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noImplicitAny": true,

--- a/src/cdk/schematics/utils/project-tsconfig-paths.ts
+++ b/src/cdk/schematics/utils/project-tsconfig-paths.ts
@@ -43,7 +43,7 @@ export async function getWorkspaceConfigGracefully(
     return await readJsonWorkspace(path, {
       readFile: async filePath => tree.read(filePath)!.toString(),
     } as WorkspaceHost);
-  } catch (e) {
+  } catch {
     return null;
   }
 }

--- a/src/cdk/testing/tests/cross-environment.spec.ts
+++ b/src/cdk/testing/tests/cross-environment.spec.ts
@@ -58,7 +58,7 @@ export function crossEnvironmentSpecs(
         await loader.getChildLoader('error');
         fail('Expected to throw');
       } catch (e) {
-        expect(e.message).toBe(
+        expect((e as Error).message).toBe(
           'Failed to find element matching one of the following queries:' +
             '\n(HarnessLoader for element matching selector: "error")',
         );
@@ -82,7 +82,7 @@ export function crossEnvironmentSpecs(
         await countersLoader.getHarness(SubComponentHarness);
         fail('Expected to throw');
       } catch (e) {
-        expect(e.message).toBe(
+        expect((e as Error).message).toBe(
           'Failed to find element matching one of the following queries:' +
             '\n(SubComponentHarness with host element matching selector: "test-sub")',
         );
@@ -112,7 +112,7 @@ export function crossEnvironmentSpecs(
         await harness.errorItem();
         fail('Expected to throw');
       } catch (e) {
-        expect(e.message).toBe(
+        expect((e as Error).message).toBe(
           'Failed to find element matching one of the following queries:' +
             '\n(TestElement for element matching selector: "wrong locator")',
         );
@@ -147,7 +147,7 @@ export function crossEnvironmentSpecs(
         await harness.errorSubComponent();
         fail('Expected to throw');
       } catch (e) {
-        expect(e.message).toBe(
+        expect((e as Error).message).toBe(
           'Failed to find element matching one of the following queries:' +
             '\n(WrongComponentHarness with host element matching selector: "wrong-selector")',
         );
@@ -211,7 +211,7 @@ export function crossEnvironmentSpecs(
         await harness.requiredAncestorRestrictedMissingSubcomponent();
         fail('Expected to throw');
       } catch (e) {
-        expect(e.message).toBe(
+        expect((e as Error).message).toBe(
           'Failed to find element matching one of the following queries:' +
             '\n(SubComponentHarness with host element matching selector: "test-sub"' +
             ' satisfying the constraints: has ancestor matching selector ".not-found")',
@@ -311,7 +311,7 @@ export function crossEnvironmentSpecs(
         await harness.requiredFourIteamToolsLists();
         fail('Expected to throw');
       } catch (e) {
-        expect(e.message).toBe(
+        expect((e as Error).message).toBe(
           'Failed to find element matching one of the following queries:' +
             '\n(SubComponentHarness with host element matching selector: "test-sub" satisfying' +
             ' the constraints: title = "List of test tools", item count = 4)',
@@ -640,7 +640,7 @@ export function crossEnvironmentSpecs(
         await harness.missingElementsAndHarnesses();
         fail('Expected to throw.');
       } catch (e) {
-        expect(e.message).toBe(
+        expect((e as Error).message).toBe(
           'Failed to find element matching one of the following queries:' +
             '\n(TestElement for element matching selector: ".not-found"),' +
             '\n(SubComponentHarness with host element matching selector: "test-sub" satisfying' +

--- a/src/material/schematics/tsconfig.json
+++ b/src/material/schematics/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "../../../dist/packages/material/schematics",
     "noEmitOnError": false,
     "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
     "noImplicitOverride": true,
     "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,

--- a/tools/dgeni/tsconfig.json
+++ b/tools/dgeni/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitThis": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": false,
     "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
Enables the `useUnknownInCatchVariables` compiler option and fixes a couple of errors.