### PR TITLE
fix(material/slider): Ticks updated wrongly if the max property 0

### DIFF
--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -450,6 +450,26 @@ describe('MatSlider', () => {
         expect(sliderInstance.percent).toBe(1);
       },
     );
+    it('should properly update ticks when max value changed to 0', () => {
+      testComponent.min = 0;
+      testComponent.max = 100;
+      fixture.detectChanges();
+
+      dispatchMouseenterEvent(sliderNativeElement);
+      fixture.detectChanges();
+
+      expect(ticksElement.style.backgroundSize).toBe('6% 2px');
+      expect(ticksElement.style.transform).toContain('translateX(3%)');
+
+      testComponent.max = 0;
+      fixture.detectChanges();
+
+      dispatchMouseenterEvent(sliderNativeElement);
+      fixture.detectChanges();
+
+      expect(ticksElement.style.backgroundSize).toBe('0% 2px');
+      expect(ticksElement.style.transform).toContain('translateX(0%)');
+    });
   });
 
   describe('slider with set value', () => {

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -424,7 +424,7 @@ export class MatSlider
     // For a horizontal slider in RTL languages we push the ticks container off the left edge
     // instead of the right edge to avoid causing a horizontal scrollbar to appear.
     let sign = !this.vertical && this._getDirection() == 'rtl' ? '' : '-';
-    let offset = (this._getTickIntervalPercent() / 2) * 100;
+    let offset = (this._tickIntervalPercent / 2) * 100;
     return {
       'transform': `translate${axis}(${sign}${offset}%)`,
     };
@@ -432,7 +432,7 @@ export class MatSlider
 
   /** CSS styles for the ticks element. */
   _getTicksStyles(): {[key: string]: string} {
-    let tickSize = this._getTickIntervalPercent() * 100;
+    let tickSize = this._tickIntervalPercent * 100;
     let backgroundSize = this.vertical ? `2px ${tickSize}%` : `${tickSize}% 2px`;
     let axis = this.vertical ? 'Y' : 'X';
     // Depending on the direction we pushed the ticks container, push the ticks the opposite
@@ -502,10 +502,6 @@ export class MatSlider
   _shouldInvertMouseCoords() {
     const shouldInvertAxis = this._shouldInvertAxis();
     return this._getDirection() == 'rtl' && !this.vertical ? !shouldInvertAxis : shouldInvertAxis;
-  }
-  /** It returns safe tick interval percent coercing NaN and Infinity to fallback */
-  private _getTickIntervalPercent(fallback = 0) {
-    return isSafeNumber(this._tickIntervalPercent) ? this._tickIntervalPercent : fallback;
   }
 
   /** The language direction for this slider element. */
@@ -864,15 +860,17 @@ export class MatSlider
       return;
     }
 
+    let tickIntervalPercent: number;
     if (this.tickInterval == 'auto') {
       let trackSize = this.vertical ? this._sliderDimensions.height : this._sliderDimensions.width;
       let pixelsPerStep = (trackSize * this.step) / (this.max - this.min);
       let stepsPerTick = Math.ceil(MIN_AUTO_TICK_SEPARATION / pixelsPerStep);
       let pixelsPerTick = stepsPerTick * this.step;
-      this._tickIntervalPercent = pixelsPerTick / trackSize;
+      tickIntervalPercent = pixelsPerTick / trackSize;
     } else {
-      this._tickIntervalPercent = (this.tickInterval * this.step) / (this.max - this.min);
+      tickIntervalPercent = (this.tickInterval * this.step) / (this.max - this.min);
     }
+    this._tickIntervalPercent = isSafeNumber(tickIntervalPercent) ? tickIntervalPercent : 0;
   }
 
   /** Creates a slider change object from the specified value. */

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -424,7 +424,7 @@ export class MatSlider
     // For a horizontal slider in RTL languages we push the ticks container off the left edge
     // instead of the right edge to avoid causing a horizontal scrollbar to appear.
     let sign = !this.vertical && this._getDirection() == 'rtl' ? '' : '-';
-    let offset = (this._tickIntervalPercent / 2) * 100;
+    let offset = (this._getTickIntervalPercent() / 2) * 100;
     return {
       'transform': `translate${axis}(${sign}${offset}%)`,
     };
@@ -432,7 +432,7 @@ export class MatSlider
 
   /** CSS styles for the ticks element. */
   _getTicksStyles(): {[key: string]: string} {
-    let tickSize = this._tickIntervalPercent * 100;
+    let tickSize = this._getTickIntervalPercent() * 100;
     let backgroundSize = this.vertical ? `2px ${tickSize}%` : `${tickSize}% 2px`;
     let axis = this.vertical ? 'Y' : 'X';
     // Depending on the direction we pushed the ticks container, push the ticks the opposite
@@ -502,6 +502,10 @@ export class MatSlider
   _shouldInvertMouseCoords() {
     const shouldInvertAxis = this._shouldInvertAxis();
     return this._getDirection() == 'rtl' && !this.vertical ? !shouldInvertAxis : shouldInvertAxis;
+  }
+  /** It returns safe tick interval percent coercing NaN and Infinity to fallback */
+  private _getTickIntervalPercent(fallback = 0) {
+    return isSafeNumber(this._tickIntervalPercent) ? this._tickIntervalPercent : fallback;
   }
 
   /** The language direction for this slider element. */
@@ -883,7 +887,8 @@ export class MatSlider
 
   /** Calculates the percentage of the slider that a value is. */
   private _calculatePercentage(value: number | null) {
-    return ((value || 0) - this.min) / (this.max - this.min);
+    const percentage = ((value || 0) - this.min) / (this.max - this.min);
+    return isSafeNumber(percentage) ? percentage : 0;
   }
 
   /** Calculates the value a percentage of the slider corresponds to. */
@@ -952,6 +957,11 @@ export class MatSlider
   setDisabledState(isDisabled: boolean) {
     this.disabled = isDisabled;
   }
+}
+
+/** Checks if number is safe for calculation */
+function isSafeNumber(value: number) {
+  return !isNaN(value) && isFinite(value);
 }
 
 /** Returns whether an event is a touch event. */


### PR DESCRIPTION
When we get equal min & max value for the slider then we can get division by zero which leads to an improper style value for the background-size (Infinity%). This fix introduces a tiny function that checks if we deal with finite numbers during calculations where potentially division by zero may occur.

Fixes #23913