### PR TITLE
fix(material-experimental/mdc-form-field): incorrect alignment with border-box alignment

### DIFF
--- a/src/material-experimental/mdc-form-field/form-field.scss
+++ b/src/material-experimental/mdc-form-field/form-field.scss
@@ -87,6 +87,9 @@
 .mat-mdc-form-field-icon-suffix {
   & > .mat-icon {
     padding: 12px;
+    // It's common for apps to apply `box-sizing: border-box`
+    // globally which will break the alignment.
+    box-sizing: content-box;
   }
 }
 


### PR DESCRIPTION
This came up in an internal discussion. The alignment of the prefix/suffix breaks if an app has `* { box-sizing: border-box }` which is fairly common.