### PR TITLE
build: fix unformatted files

### DIFF
--- a/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
+++ b/src/cdk/a11y/focus-monitor/focus-monitor.spec.ts
@@ -196,11 +196,14 @@ describe('FocusMonitor', () => {
     flush();
 
     expect(buttonElement.classList.length)
-      .withContext('button should have exactly 2 focus classes').toBe(2);
+      .withContext('button should have exactly 2 focus classes')
+      .toBe(2);
     expect(buttonElement.classList.contains('cdk-focused'))
-      .withContext('button should have cdk-focused class').toBe(true);
+      .withContext('button should have cdk-focused class')
+      .toBe(true);
     expect(buttonElement.classList.contains('cdk-keyboard-focused'))
-      .withContext('button should have cdk-keyboard-focused class').toBe(true);
+      .withContext('button should have cdk-keyboard-focused class')
+      .toBe(true);
     expect(changeHandler).toHaveBeenCalledWith('keyboard');
   }));
 

--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -620,7 +620,7 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
       this._customRowDefs,
       this._customHeaderRowDefs,
       this._customFooterRowDefs,
-      this._columnDefsByName
+      this._columnDefsByName,
     ].forEach(def => {
       def.clear();
     });

--- a/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
+++ b/src/material-experimental/mdc-autocomplete/autocomplete.spec.ts
@@ -1088,8 +1088,8 @@ describe('MDC-based MatAutocomplete', () => {
     it('should not interfere with the ENTER key when pressing a modifier', fakeAsync(() => {
       const trigger = fixture.componentInstance.trigger;
 
-      expect(input.value).toBeFalsy('Expected input to start off blank.');
-      expect(trigger.panelOpen).toBe(true, 'Expected panel to start off open.');
+      expect(input.value).withContext('Expected input to start off blank.').toBeFalsy();
+      expect(trigger.panelOpen).withContext('Expected panel to start off open.').toBe(true);
 
       fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
       flush();
@@ -1099,12 +1099,11 @@ describe('MDC-based MatAutocomplete', () => {
       fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
       fixture.detectChanges();
 
-      expect(trigger.panelOpen).toBe(true, 'Expected panel to remain open.');
-      expect(input.value).toBeFalsy('Expected input to remain blank.');
-      expect(ENTER_EVENT.defaultPrevented).toBe(
-        false,
-        'Expected the default ENTER action not to have been prevented.',
-      );
+      expect(trigger.panelOpen).withContext('Expected panel to remain open.').toBe(true);
+      expect(input.value).withContext('Expected input to remain blank.').toBeFalsy();
+      expect(ENTER_EVENT.defaultPrevented)
+        .withContext('Expected the default ENTER action not to have been prevented.')
+        .toBe(false);
     }));
 
     it('should fill the text field, not select an option, when SPACE is entered', () => {

--- a/src/material/autocomplete/autocomplete.spec.ts
+++ b/src/material/autocomplete/autocomplete.spec.ts
@@ -1084,8 +1084,8 @@ describe('MatAutocomplete', () => {
     it('should not interfere with the ENTER key when pressing a modifier', fakeAsync(() => {
       const trigger = fixture.componentInstance.trigger;
 
-      expect(input.value).toBeFalsy('Expected input to start off blank.');
-      expect(trigger.panelOpen).toBe(true, 'Expected panel to start off open.');
+      expect(input.value).withContext('Expected input to start off blank.').toBeFalsy();
+      expect(trigger.panelOpen).withContext('Expected panel to start off open.').toBe(true);
 
       fixture.componentInstance.trigger._handleKeydown(DOWN_ARROW_EVENT);
       flush();
@@ -1095,12 +1095,11 @@ describe('MatAutocomplete', () => {
       fixture.componentInstance.trigger._handleKeydown(ENTER_EVENT);
       fixture.detectChanges();
 
-      expect(trigger.panelOpen).toBe(true, 'Expected panel to remain open.');
-      expect(input.value).toBeFalsy('Expected input to remain blank.');
-      expect(ENTER_EVENT.defaultPrevented).toBe(
-        false,
-        'Expected the default ENTER action not to have been prevented.',
-      );
+      expect(trigger.panelOpen).withContext('Expected panel to remain open.').toBe(true);
+      expect(input.value).withContext('Expected input to remain blank.').toBeFalsy();
+      expect(ENTER_EVENT.defaultPrevented)
+        .withContext('Expected the default ENTER action not to have been prevented.')
+        .toBe(false);
     }));
 
     it('should fill the text field, not select an option, when SPACE is entered', () => {

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -3184,7 +3184,6 @@ describe('MatSelect', () => {
       expect(fixture.componentInstance.control.value).toBe('pizza-1');
       expect(fixture.componentInstance.select.value).toBe('pizza-1');
     }));
-
   });
 
   describe('with custom trigger', () => {


### PR DESCRIPTION
The formatting CI check only verifies changed files which means that some failures snuck in when we merged a passing commit after them. I also fixed a couple of deprecated signature usages in tests.