### PR TITLE
refactor(cdk/a11y): use correct method when updating active item

### DIFF
--- a/src/cdk/a11y/key-manager/list-key-manager.ts
+++ b/src/cdk/a11y/key-manager/list-key-manager.ts
@@ -73,7 +73,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
           if (newIndex !== this._activeItemIndex) {
             // Timeout is required to avoid "changed after checked" errors.
             setTimeout(() => {
-              this.updateActiveItem(newIndex > -1 ? newIndex : this._activeItemIndex);
+              this.setActiveItem(newIndex > -1 ? newIndex : this._activeItemIndex);
             }, 0);
           }
         }


### PR DESCRIPTION
Follow-up to #14471. Uses `setActiveItem` instead of `updateActiveItem` which was missed when addressing the feedback.