### PR TITLE
fix(material-experimental/mdc-chips): fix changed after checked error when restoring focus to input

### DIFF
--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -357,7 +357,9 @@ export class MatChipGrid
       this._chips.forEach(chip => chip.primaryAction._updateTabindex(-1));
       this._chips.first.focus();
     } else {
-      this._focusInput();
+      // Delay until the next tick, because this can cause a "changed after checked"
+      // error if the input does something on focus (e.g. opens an autocomplete).
+      Promise.resolve().then(() => this._chipInput.focus());
     }
 
     this.stateChanges.next();
@@ -481,10 +483,5 @@ export class MatChipGrid
     }
 
     this._lastDestroyedChipIndex = null;
-  }
-
-  /** Focus input element. */
-  private _focusInput() {
-    this._chipInput.focus();
   }
 }


### PR DESCRIPTION
Fixes that the MDC chip grid was causing a "changed after checked" error when the last chip is removed, if it is used together with `mat-autocomplete`. The problem is that the chip grid focuses the input when the last chip is removed which then opens the autocomplete panel, resulting in an error.