### PR TITLE
fix(material/input): only apply styles inside a mat-form-field

### DIFF
--- a/src/material/form-field/form-field-input.scss
+++ b/src/material/form-field/form-field-input.scss
@@ -4,7 +4,7 @@
 @use '../../cdk/a11y';
 
 // The Input element proper.
-.mat-input-element {
+.mat-form-field .mat-input-element {
   // Font needs to be inherited, because by default <input> has a system font.
   font: inherit;
 
@@ -129,7 +129,7 @@
 }
 
 // Prevents IE from always adding a scrollbar by default.
-textarea.mat-input-element {
+.mat-form-field textarea.mat-input-element {
   // Only allow resizing along the Y axis.
   resize: vertical;
   overflow: auto;
@@ -139,7 +139,7 @@ textarea.mat-input-element {
   }
 }
 
-textarea.mat-input-element {
+.mat-form-field textarea.mat-input-element {
   // The 2px padding prevents scrollbars from appearing on Chrome even when they aren't needed.
   // We also add a negative margin to negate the effect of the padding on the layout.
   padding: 2px 0;
@@ -147,7 +147,7 @@ textarea.mat-input-element {
 }
 
 // Remove the native select down arrow and replace it with material design arrow
-select.mat-input-element {
+.mat-form-field select.mat-input-element {
   -moz-appearance: none;
   -webkit-appearance: none;
   position: relative;
@@ -170,7 +170,7 @@ select.mat-input-element {
   }
 }
 
-.mat-form-field-type-mat-native-select {
+.mat-form-field.mat-form-field-type-mat-native-select {
   $arrow-size: 5px;
 
   .mat-form-field-infix::after {


### PR DESCRIPTION
Constraining the `.mat-input-element` class inside `.mat-form-field` ensures that any inputs using the `matInput` or `matNativeControl` directives are not styled outside a `mat-form-field` element, which is expected behaviour.

Material input elements only need to be styled when used in material form fields.

Example use case:
A small team is building a custom form component. The component uses matInput to communicate with inputs. If the page also has a material form field component, un-needed extra styles are applied to all inputs with `matInput` directive including the custom form component.