### PR TITLE
fix(material/datepicker): content overflowing when large custom header is provided

### DIFF
--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -1,7 +1,7 @@
 <div
   cdkTrapFocus
   class="mat-datepicker-content-container"
-  [ngClass]="{'mat-datepicker-custom-header' : datepicker.calendarHeaderComponent}"
+  [class.mat-datepicker-content-container-with-custom-header]="datepicker.calendarHeaderComponent"
   [class.mat-datepicker-content-container-with-actions]="_actionsPortal">
   <mat-calendar
     [id]="datepicker.id"

--- a/src/material/datepicker/datepicker-content.html
+++ b/src/material/datepicker/datepicker-content.html
@@ -1,6 +1,7 @@
 <div
   cdkTrapFocus
   class="mat-datepicker-content-container"
+  [ngClass]="{'mat-datepicker-custom-header' : datepicker.calendarHeaderComponent}"
   [class.mat-datepicker-content-container-with-actions]="_actionsPortal">
   <mat-calendar
     [id]="datepicker.id"

--- a/src/material/datepicker/datepicker-content.scss
+++ b/src/material/datepicker/datepicker-content.scss
@@ -5,6 +5,7 @@ $non-touch-calendar-width:
 // Based on the natural height of the calendar in a month with 6 rows of dates
 // (largest the calendar will get).
 $non-touch-calendar-height: 354px;
+$non-touch-custom-header-calendar-height: auto;
 
 // Ideally the calendar would have a constant aspect ratio, no matter its size, and we would base
 // these measurements off the aspect ratio. Unfortunately, the aspect ratio does change a little as
@@ -29,6 +30,10 @@ $touch-max-height: 788px;
   .mat-calendar {
     width: $non-touch-calendar-width;
     height: $non-touch-calendar-height;
+  }
+
+  .mat-datepicker-custom-header .mat-calendar {
+    height: $non-touch-custom-header-calendar-height;
   }
 
   // Note that this selector doesn't technically have to be nested, but we want the slightly

--- a/src/material/datepicker/datepicker-content.scss
+++ b/src/material/datepicker/datepicker-content.scss
@@ -6,10 +6,6 @@ $non-touch-calendar-width:
 // (largest the calendar will get).
 $non-touch-calendar-height: 354px;
 
-// Height should be auto, when the custom header is provided.
-// This will prevent the content from overflowing.
-$non-touch-custom-header-calendar-height: auto;
-
 // Ideally the calendar would have a constant aspect ratio, no matter its size, and we would base
 // these measurements off the aspect ratio. Unfortunately, the aspect ratio does change a little as
 // the calendar grows, since some of the elements have pixel-based sizes. These numbers have been
@@ -36,8 +32,10 @@ $touch-max-height: 788px;
   }
 
   // Override mat-calendar's height when custom header is provided
-  .mat-datepicker-custom-header .mat-calendar {
-    height: $non-touch-custom-header-calendar-height;
+  // Height should be auto, when the custom header is provided.
+  // This will prevent the content from overflowing.
+  .mat-datepicker-content-container-with-custom-header .mat-calendar {
+    height: auto;
   }
 
   // Note that this selector doesn't technically have to be nested, but we want the slightly

--- a/src/material/datepicker/datepicker-content.scss
+++ b/src/material/datepicker/datepicker-content.scss
@@ -5,6 +5,9 @@ $non-touch-calendar-width:
 // Based on the natural height of the calendar in a month with 6 rows of dates
 // (largest the calendar will get).
 $non-touch-calendar-height: 354px;
+
+// Height should be auto, when the custom header is provided.
+// This will prevent the content from overflowing.
 $non-touch-custom-header-calendar-height: auto;
 
 // Ideally the calendar would have a constant aspect ratio, no matter its size, and we would base
@@ -32,6 +35,7 @@ $touch-max-height: 788px;
     height: $non-touch-calendar-height;
   }
 
+  // Override mat-calendar's height when custom header is provided
   .mat-datepicker-custom-header .mat-calendar {
     height: $non-touch-custom-header-calendar-height;
   }


### PR DESCRIPTION
Contents of the datepicker is overflowing outside the boundary when a custom header with large height is provided. This is because of the fixed height provided for the _mat-calendar_ is not enough when custom headers height is big, so added a new class which will override the height of _mat-calendar_ to auto when custom header is given.