### PR TITLE
fix(material-experimental/mdc-select): target correct element with typography

### DIFF
--- a/src/material-experimental/mdc-select/_select-theme.scss
+++ b/src/material-experimental/mdc-select/_select-theme.scss
@@ -71,7 +71,7 @@
       @include mdc-list.list-base(mdc-helpers.$mat-typography-styles-query);
     }
 
-    .mat-mdc-select-value {
+    .mat-mdc-select {
       @include mdc-typography.typography(body1, $query: mdc-helpers.$mat-typography-styles-query);
     }
   }


### PR DESCRIPTION
Targets the MDC select host node instead of just the value with the typography mixin. The previous approach would've broken any overrides and it didn't cover the select placeholder.