### PR TITLE
build: setup renovate to update shared dev-infra code

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "automerge": false,
+  "baseBranches": ["master"],
+  "enabledManagers": ["npm", "bazel", "github-actions"],
+  "labels": ["target: patch", "merge safe"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "pinDigests": true,
+  "prHourlyLimit": 2,
+  "rebaseWhen": "behind-base-branch",
+  "semanticCommits": "enabled",
+  "semanticCommitScope": "",
+  "semanticCommitType": "build",
+  "separateMajorMinor": false,
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["@angular/dev-infra-private", "angular/dev-infra"],
+      "groupName": "angular shared dev-infra code",
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Sets up renovate so that we stay up-to-date with the frequently
changing dev-infra changes in `angular/dev-infra`. For this dependency
it would be painful managing it manually since we consume it through
snapshot builds being pushed to a Github builds repo.

@josephperrott I think we would need to add this repo to the configured repositories
for the org-wide renovate application. I tested the config in my fork.