### PR TITLE
build: update dev-infra package and format json files with prettier

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@8298e121c51960857ef39abc16b743775ff6be68
+      - uses: angular/dev-infra/github-actions/commit-message-based-labels@0fff09d0d3bb34d2b1a535e7be9f32df56cfa6ea
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -9,6 +9,6 @@ jobs:
   lock_closed:
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@8298e121c51960857ef39abc16b743775ff6be68
+      - uses: angular/dev-infra/github-actions/lock-closed@0fff09d0d3bb34d2b1a535e7be9f32df56cfa6ea
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}

--- a/.ng-dev/tsconfig.json
+++ b/.ng-dev/tsconfig.json
@@ -6,5 +6,5 @@
     "noEmit": true,
     "skipLibCheck": true,
     "types": []
-  },
+  }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -17,29 +17,54 @@
     "./tools/stylelint/no-unused-import.ts"
   ],
   "rules": {
-    "material/no-prefixes": [true, {
-      "browsers": ["last 2 versions", "not dead", "not and_qq > 0", "not OperaMini all", "not ie > 0", "not edge < 78"],
-      "filePattern": "**/!(*-example.css)"
-    }],
+    "material/no-prefixes": [
+      true,
+      {
+        "browsers": [
+          "last 2 versions",
+          "not dead",
+          "not and_qq > 0",
+          "not OperaMini all",
+          "not ie > 0",
+          "not edge < 78"
+        ],
+        "filePattern": "**/!(*-example.css)"
+      }
+    ],
     "material/theme-mixin-api": true,
     "material/selector-no-deep": true,
     "material/no-nested-mixin": true,
     "material/no-unused-import": true,
-    "material/single-line-comment-only": [true, {
-      "filePattern": "\\.scss$"
-    }],
-    "material/no-import": [true, {
-      "exclude": "\\.import\\.scss$"
-    }],
-    "material/no-ampersand-beyond-selector-start": [true, {
-      "filePattern": "-theme\\.scss$"
-    }],
-    "material/no-concrete-rules": [true, {
-      "filePattern": "^_.*\\.scss$"
-    }],
-    "material/no-top-level-ampersand-in-mixin": [true, {
-      "filePattern": "-theme\\.scss$"
-    }],
+    "material/single-line-comment-only": [
+      true,
+      {
+        "filePattern": "\\.scss$"
+      }
+    ],
+    "material/no-import": [
+      true,
+      {
+        "exclude": "\\.import\\.scss$"
+      }
+    ],
+    "material/no-ampersand-beyond-selector-start": [
+      true,
+      {
+        "filePattern": "-theme\\.scss$"
+      }
+    ],
+    "material/no-concrete-rules": [
+      true,
+      {
+        "filePattern": "^_.*\\.scss$"
+      }
+    ],
+    "material/no-top-level-ampersand-in-mixin": [
+      true,
+      {
+        "filePattern": "-theme\\.scss$"
+      }
+    ],
 
     "color-hex-case": "lower",
     "color-no-invalid-hex": true,
@@ -71,9 +96,12 @@
     "property-case": "lower",
     "no-duplicate-at-import-rules": true,
 
-    "declaration-block-no-duplicate-properties": [true, {
-      "ignore": ["consecutive-duplicates-with-different-values"]
-    }],
+    "declaration-block-no-duplicate-properties": [
+      true,
+      {
+        "ignore": ["consecutive-duplicates-with-different-values"]
+      }
+    ],
     "declaration-block-trailing-semicolon": "always",
     "declaration-block-single-line-max-declarations": 1,
     "declaration-block-semicolon-space-before": "never",
@@ -105,12 +133,18 @@
     "selector-max-id": 0,
     "no-missing-end-of-source-newline": true,
     "no-eol-whitespace": true,
-    "max-line-length": [100, {
-      "ignorePattern": "/https?://.*/"
-    }],
+    "max-line-length": [
+      100,
+      {
+        "ignorePattern": "/https?://.*/"
+      }
+    ],
     "linebreaks": "unix",
-    "selector-class-pattern": ["^_?(mat-|cdk-|example-|demo-|ng-|mdc-|map-|test-)", {
-      "resolveNestedSelectors": true
-    }]
+    "selector-class-pattern": [
+      "^_?(mat-|cdk-|example-|demo-|ng-|mdc-|map-|test-)",
+      {
+        "resolveNestedSelectors": true
+      }
+    ]
   }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,5 @@
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
   // List of extensions which should be recommended for users of this workspace.
-  "recommendations": [
-    "ms-vscode.vscode-typescript-tslint-plugin",
-    "esbenp.prettier-vscode"
-  ]
+  "recommendations": ["ms-vscode.vscode-typescript-tslint-plugin", "esbenp.prettier-vscode"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,12 +4,12 @@
     "**/.git/subtree-cache/**": true,
     "**/node_modules/**": true,
     "**/bazel-out/**": true,
-    "**/dist/**": true,
+    "**/dist/**": true
   },
   "search.exclude": {
     "**/node_modules": true,
     "**/bazel-out": true,
-    "**/dist": true,
+    "**/dist": true
   },
   "git.ignoreLimitWarning": true,
   "[javascript]": {

--- a/firebase.json
+++ b/firebase.json
@@ -18,8 +18,6 @@
         ]
       }
     ],
-    "ignore": [
-      "firebase.json"
-    ]
+    "ignore": ["firebase.json"]
   }
 }

--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -3,29 +3,14 @@
     "src/cdk-experimental/dialog/dialog-config.ts",
     "src/cdk-experimental/dialog/dialog-container.ts"
   ],
-  [
-    "src/cdk/drag-drop/directives/drag.ts",
-    "src/cdk/drag-drop/directives/drop-list.ts"
-  ],
-  [
-    "src/cdk/drag-drop/directives/drag.ts",
-    "src/cdk/drag-drop/drag-events.ts"
-  ],
+  ["src/cdk/drag-drop/directives/drag.ts", "src/cdk/drag-drop/directives/drop-list.ts"],
+  ["src/cdk/drag-drop/directives/drag.ts", "src/cdk/drag-drop/drag-events.ts"],
   [
     "src/cdk/drag-drop/directives/drag.ts",
     "src/cdk/drag-drop/drag-events.ts",
     "src/cdk/drag-drop/directives/drop-list.ts"
   ],
-  [
-    "src/cdk/drag-drop/drag-ref.ts",
-    "src/cdk/drag-drop/drop-list-ref.ts"
-  ],
-  [
-    "src/cdk/scrolling/scroll-dispatcher.ts",
-    "src/cdk/scrolling/scrollable.ts"
-  ],
-  [
-    "src/cdk/scrolling/virtual-scroll-strategy.ts",
-    "src/cdk/scrolling/virtual-scroll-viewport.ts"
-  ]
+  ["src/cdk/drag-drop/drag-ref.ts", "src/cdk/drag-drop/drop-list-ref.ts"],
+  ["src/cdk/scrolling/scroll-dispatcher.ts", "src/cdk/scrolling/scrollable.ts"],
+  ["src/cdk/scrolling/virtual-scroll-strategy.ts", "src/cdk/scrolling/virtual-scroll-viewport.ts"]
 ]

--- a/goldens/tsec-exemption.json
+++ b/goldens/tsec-exemption.json
@@ -1,10 +1,6 @@
 {
-  "ban-trustedtypes-createpolicy": [
-    "../src/material/icon/trusted-types.ts"
-  ],
-  "ban-element-innerhtml-assignments": [
-    "../src/material/icon/icon-registry.ts"
-  ],
+  "ban-trustedtypes-createpolicy": ["../src/material/icon/trusted-types.ts"],
+  "ban-element-innerhtml-assignments": ["../src/material/icon/icon-registry.ts"],
   "ban-element-setattribute": [
     "../src/cdk/a11y/aria-describer/aria-reference.ts",
     "../src/material-experimental/mdc-checkbox/checkbox.ts",

--- a/integration/harness-e2e-cli/angular.json
+++ b/integration/harness-e2e-cli/angular.json
@@ -26,13 +26,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -94,13 +89,8 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         }

--- a/integration/harness-e2e-cli/e2e/jasmine.json
+++ b/integration/harness-e2e-cli/e2e/jasmine.json
@@ -1,8 +1,6 @@
 {
   "spec_dir": "e2e",
-  "spec_files": [
-    "**/*.spec.ts"
-  ],
+  "spec_files": ["**/*.spec.ts"],
   "env": {
     "random": true
   }

--- a/integration/harness-e2e-cli/e2e/package.json
+++ b/integration/harness-e2e-cli/e2e/package.json
@@ -1,3 +1,3 @@
 {
-    "type": "module"
+  "type": "module"
 }

--- a/integration/harness-e2e-cli/e2e/tsconfig.json
+++ b/integration/harness-e2e-cli/e2e/tsconfig.json
@@ -1,7 +1,7 @@
 {
-    "compilerOptions": {
-        "module": "es2020",
-        "target": "es2020",
-        "moduleResolution": "node",
-    }
+  "compilerOptions": {
+    "module": "es2020",
+    "target": "es2020",
+    "moduleResolution": "node"
+  }
 }

--- a/integration/harness-e2e-cli/tsconfig.app.json
+++ b/integration/harness-e2e-cli/tsconfig.app.json
@@ -5,11 +5,6 @@
     "outDir": "./out-tsc/app",
     "types": []
   },
-  "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.d.ts"]
 }

--- a/integration/harness-e2e-cli/tsconfig.json
+++ b/integration/harness-e2e-cli/tsconfig.json
@@ -18,10 +18,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
-    "lib": [
-      "es2020",
-      "dom"
-    ]
+    "lib": ["es2020", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/integration/harness-e2e-cli/tsconfig.spec.json
+++ b/integration/harness-e2e-cli/tsconfig.spec.json
@@ -3,16 +3,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine"
-    ]
+    "types": ["jasmine"]
   },
-  "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/test.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/integration/ng-add/angular.json
+++ b/integration/ng-add/angular.json
@@ -26,13 +26,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -94,13 +89,8 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": [],
             "watch": false
           }

--- a/integration/ng-add/tsconfig.app.json
+++ b/integration/ng-add/tsconfig.app.json
@@ -5,11 +5,6 @@
     "outDir": "./out-tsc/app",
     "types": []
   },
-  "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.d.ts"]
 }

--- a/integration/ng-add/tsconfig.json
+++ b/integration/ng-add/tsconfig.json
@@ -18,10 +18,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
-    "lib": [
-      "es2018",
-      "dom"
-    ]
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/integration/ng-add/tsconfig.spec.json
+++ b/integration/ng-add/tsconfig.spec.json
@@ -3,16 +3,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine"
-    ]
+    "types": ["jasmine"]
   },
-  "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/test.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/integration/ng-update-v13/angular.json
+++ b/integration/ng-update-v13/angular.json
@@ -26,13 +26,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -94,13 +89,8 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         }

--- a/integration/ng-update-v13/tsconfig.app.json
+++ b/integration/ng-update-v13/tsconfig.app.json
@@ -5,11 +5,6 @@
     "outDir": "./out-tsc/app",
     "types": []
   },
-  "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.d.ts"]
 }

--- a/integration/ng-update-v13/tsconfig.json
+++ b/integration/ng-update-v13/tsconfig.json
@@ -18,10 +18,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
-    "lib": [
-      "es2018",
-      "dom"
-    ]
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/integration/ng-update-v13/tsconfig.spec.json
+++ b/integration/ng-update-v13/tsconfig.spec.json
@@ -3,16 +3,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine"
-    ]
+    "types": ["jasmine"]
   },
-  "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/test.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@angular/bazel": "13.2.0",
     "@angular/cli": "13.2.0",
     "@angular/compiler-cli": "13.2.0",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#2b0196f6ebf6de2e62836e962b9f42007e6cf5d6",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#f589cd87f196e09a775d8be25a0f83672f78fc99",
     "@angular/localize": "13.2.0",
     "@angular/platform-browser-dynamic": "13.2.0",
     "@angular/platform-server": "13.2.0",

--- a/scripts/caretaking/firebase-functions/tsconfig.json
+++ b/scripts/caretaking/firebase-functions/tsconfig.json
@@ -11,7 +11,5 @@
     "types": []
   },
   "compileOnSave": true,
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -22,12 +22,24 @@
     ".": {
       "sass": "./_index.scss"
     },
-    "./a11y-prebuilt.css": {"style": "./a11y-prebuilt.css"},
-    "./a11y-prebuilt": {"style": "./a11y-prebuilt.css"},
-    "./overlay-prebuilt.css": {"style": "./overlay-prebuilt.css"},
-    "./overlay-prebuilt": {"style": "./overlay-prebuilt.css"},
-    "./text-field-prebuilt.css": {"style": "./text-field-prebuilt.css"},
-    "./text-field-prebuilt": {"style": "./text-field-prebuilt.css"},
+    "./a11y-prebuilt.css": {
+      "style": "./a11y-prebuilt.css"
+    },
+    "./a11y-prebuilt": {
+      "style": "./a11y-prebuilt.css"
+    },
+    "./overlay-prebuilt.css": {
+      "style": "./overlay-prebuilt.css"
+    },
+    "./overlay-prebuilt": {
+      "style": "./overlay-prebuilt.css"
+    },
+    "./text-field-prebuilt.css": {
+      "style": "./text-field-prebuilt.css"
+    },
+    "./text-field-prebuilt": {
+      "style": "./text-field-prebuilt.css"
+    },
     "./schematics": {
       "default": "./schematics/index.js"
     }

--- a/src/cdk/schematics/ng-generate/drag-drop/schema.json
+++ b/src/cdk/schematics/ng-generate/drag-drop/schema.json
@@ -78,7 +78,7 @@
       "format": "html-selector",
       "description": "The selector to use for the component."
     },
-    "module":  {
+    "module": {
       "type": "string",
       "description": "Allows specification of the declaring module.",
       "alias": "m"

--- a/src/cdk/schematics/ng-update/devkit-migration.ts
+++ b/src/cdk/schematics/ng-update/devkit-migration.ts
@@ -42,5 +42,6 @@ export abstract class DevkitMigration<Data> extends Migration<Data, DevkitContex
   ): PostMigrationAction;
 }
 
-export type DevkitMigrationCtor<Data> = Constructor<DevkitMigration<Data>> &
-  {[m in keyof typeof DevkitMigration]: typeof DevkitMigration[m]};
+export type DevkitMigrationCtor<Data> = Constructor<DevkitMigration<Data>> & {
+  [m in keyof typeof DevkitMigration]: typeof DevkitMigration[m];
+};

--- a/src/cdk/schematics/tsconfig.json
+++ b/src/cdk/schematics/tsconfig.json
@@ -19,17 +19,9 @@
     "strictFunctionTypes": true,
     "sourceMap": true,
     "target": "es2015",
-    "types": [
-      "jasmine",
-      "node"
-    ]
+    "types": ["jasmine", "node"]
   },
-  "exclude": [
-    "**/files/**/*",
-    "**/*.spec.ts",
-    "ng-update/test-cases/**/*",
-    "testing/**/*.ts"
-  ],
+  "exclude": ["**/files/**/*", "**/*.spec.ts", "ng-update/test-cases/**/*", "testing/**/*.ts"],
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true
   }

--- a/src/components-examples/package.json
+++ b/src/components-examples/package.json
@@ -14,7 +14,9 @@
     "components"
   ],
   "exports": {
-    "./fesm2020": {"default": "./fesm2020"}
+    "./fesm2020": {
+      "default": "./fesm2020"
+    }
   },
   "license": "MIT",
   "bugs": {

--- a/src/google-maps/tsconfig.json
+++ b/src/google-maps/tsconfig.json
@@ -5,12 +5,7 @@
     "rootDir": "..",
     "baseUrl": ".",
     "paths": {},
-    "types": [
-      "jasmine"
-    ]
+    "types": ["jasmine"]
   },
-  "include": [
-    "./**/*.ts",
-    "../dev-mode-types.d.ts"
-  ]
+  "include": ["./**/*.ts", "../dev-mode-types.d.ts"]
 }

--- a/src/material-experimental/mdc-snack-bar/tsconfig-build.json
+++ b/src/material-experimental/mdc-snack-bar/tsconfig-build.json
@@ -1,9 +1,6 @@
 {
   "extends": "../tsconfig-build",
-  "files": [
-    "public-api.ts",
-    "../dev-mode-types.d.ts"
-  ],
+  "files": ["public-api.ts", "../dev-mode-types.d.ts"],
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
     "strictMetadataEmit": true,

--- a/src/material-experimental/mdc-table/tsconfig-build.json
+++ b/src/material-experimental/mdc-table/tsconfig-build.json
@@ -1,9 +1,6 @@
 {
   "extends": "../tsconfig-build",
-  "files": [
-    "public-api.ts",
-    "../dev-mode-types.d.ts"
-  ],
+  "files": ["public-api.ts", "../dev-mode-types.d.ts"],
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,
     "strictMetadataEmit": true,

--- a/src/material/package.json
+++ b/src/material/package.json
@@ -68,4 +68,3 @@
   },
   "sideEffects": false
 }
-

--- a/src/material/schematics/ng-add/schema.json
+++ b/src/material/schematics/ng-add/schema.json
@@ -19,11 +19,23 @@
         "message": "Choose a prebuilt theme name, or \"custom\" for a custom theme:",
         "type": "list",
         "items": [
-          { "value": "indigo-pink",       "label": "Indigo/Pink        [ Preview: https://material.angular.io?theme=indigo-pink ]" },
-          { "value": "deeppurple-amber",  "label": "Deep Purple/Amber  [ Preview: https://material.angular.io?theme=deeppurple-amber ]" },
-          { "value": "pink-bluegrey",     "label": "Pink/Blue Grey     [ Preview: https://material.angular.io?theme=pink-bluegrey ]" },
-          { "value": "purple-green",      "label": "Purple/Green       [ Preview: https://material.angular.io?theme=purple-green ]" },
-          { "value": "custom",            "label": "Custom" }
+          {
+            "value": "indigo-pink",
+            "label": "Indigo/Pink        [ Preview: https://material.angular.io?theme=indigo-pink ]"
+          },
+          {
+            "value": "deeppurple-amber",
+            "label": "Deep Purple/Amber  [ Preview: https://material.angular.io?theme=deeppurple-amber ]"
+          },
+          {
+            "value": "pink-bluegrey",
+            "label": "Pink/Blue Grey     [ Preview: https://material.angular.io?theme=pink-bluegrey ]"
+          },
+          {
+            "value": "purple-green",
+            "label": "Purple/Green       [ Preview: https://material.angular.io?theme=purple-green ]"
+          },
+          {"value": "custom", "label": "Custom"}
         ]
       }
     },

--- a/src/material/schematics/ng-generate/address-form/schema.json
+++ b/src/material/schematics/ng-generate/address-form/schema.json
@@ -78,7 +78,7 @@
       "format": "html-selector",
       "description": "The selector to use for the component."
     },
-    "module":  {
+    "module": {
       "type": "string",
       "description": "Allows specification of the declaring module.",
       "alias": "m"

--- a/src/material/schematics/ng-generate/dashboard/schema.json
+++ b/src/material/schematics/ng-generate/dashboard/schema.json
@@ -78,7 +78,7 @@
       "format": "html-selector",
       "description": "The selector to use for the component."
     },
-    "module":  {
+    "module": {
       "type": "string",
       "description": "Allows specification of the declaring module.",
       "alias": "m"

--- a/src/material/schematics/ng-generate/navigation/schema.json
+++ b/src/material/schematics/ng-generate/navigation/schema.json
@@ -78,7 +78,7 @@
       "format": "html-selector",
       "description": "The selector to use for the component."
     },
-    "module":  {
+    "module": {
       "type": "string",
       "description": "Allows specification of the declaring module.",
       "alias": "m"

--- a/src/material/schematics/ng-generate/table/schema.json
+++ b/src/material/schematics/ng-generate/table/schema.json
@@ -78,7 +78,7 @@
       "format": "html-selector",
       "description": "The selector to use for the component."
     },
-    "module":  {
+    "module": {
       "type": "string",
       "description": "Allows specification of the declaring module.",
       "alias": "m"

--- a/src/material/schematics/ng-generate/tree/schema.json
+++ b/src/material/schematics/ng-generate/tree/schema.json
@@ -78,7 +78,7 @@
       "format": "html-selector",
       "description": "The selector to use for the component."
     },
-    "module":  {
+    "module": {
       "type": "string",
       "description": "Allows specification of the declaring module.",
       "alias": "m"

--- a/src/material/schematics/tsconfig.json
+++ b/src/material/schematics/tsconfig.json
@@ -20,10 +20,7 @@
     "sourceMap": true,
     "declaration": true,
     "target": "es6",
-    "types": [
-      "jasmine",
-      "node"
-    ],
+    "types": ["jasmine", "node"],
     "baseUrl": ".",
     "paths": {
       "@angular/cdk/schematics": ["../../cdk/schematics"]

--- a/src/tsconfig-legacy.json
+++ b/src/tsconfig-legacy.json
@@ -12,11 +12,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true
   },
-  "include": [
-    "**/*.spec.ts",
-    "dev-mode-types.d.ts",
-    "../node_modules/zone.js/zone.d.ts"
-  ],
+  "include": ["**/*.spec.ts", "dev-mode-types.d.ts", "../node_modules/zone.js/zone.d.ts"],
   "exclude": [
     "**/*.e2e.spec.ts",
     "./cdk/schematics/**/*",

--- a/src/tsconfig-tsec.json
+++ b/src/tsconfig-tsec.json
@@ -1,9 +1,6 @@
 {
   "extends": "./bazel-tsconfig-build.json",
   "compilerOptions": {
-    "plugins": [
-      {"name": "tsec", "exemptionConfig": "../goldens/tsec-exemption.json"}
-    ]
+    "plugins": [{"name": "tsec", "exemptionConfig": "../goldens/tsec-exemption.json"}]
   }
 }
-

--- a/tools/dgeni/tsconfig.json
+++ b/tools/dgeni/tsconfig.json
@@ -14,8 +14,6 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "target": "es2020",
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   }
 }

--- a/tools/markdown-to-html/tsconfig.json
+++ b/tools/markdown-to-html/tsconfig.json
@@ -5,14 +5,9 @@
     "target": "es2020",
     "esModuleInterop": true,
     "sourceMap": true,
-    "types": [
-      "jasmine",
-      "node"
-    ]
+    "types": ["jasmine", "node"]
   },
-  "exclude": [
-    "*.spec.ts",
-  ],
+  "exclude": ["*.spec.ts"],
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
     }
   },
   "angularCompilerOptions": {
-    "strictTemplates": true,
+    "strictTemplates": true
   },
   "include": [
     "src/**/*.ts",

--- a/tslint.json
+++ b/tslint.json
@@ -1,28 +1,17 @@
 {
-  "extends": [
-    "rxjs-tslint-rules"
-  ],
+  "extends": ["rxjs-tslint-rules"],
   "rulesDirectory": [
     "./tools/tslint-rules/",
     "node_modules/vrsource-tslint-rules/rules",
     "node_modules/codelyzer"
   ],
   "rules": {
-    "ban-types": [
-      true,
-      [
-        "ReadonlyArray<.+>",
-        "Use 'readonly T[]' instead."
-      ]
-    ],
+    "ban-types": [true, ["ReadonlyArray<.+>", "Use 'readonly T[]' instead."]],
     // Disable this flag because of SHA tslint#48b0c597f9257712c7d1f04b55ed0aa60e333f6a
     // TSLint now shows warnings if types for properties are inferred. This rule needs to be
     // disabled because all properties need to have explicit types set to work for Dgeni.
     "no-inferrable-types": false,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
+    "comment-format": [true, "check-space"],
     "eofline": true,
     "no-construct": true,
     "prefer-literal": [true, "object"],
@@ -56,7 +45,10 @@
       {"name": ["Object", "assign"], "message": "Use the spread operator instead."},
       {"name": ["*", "asObservable"], "message": "Cast to Observable type instead."},
       {"name": ["*", "removeChild"], "message": "Use `remove` instead instead."},
-      {"name": ["isDevMode"], "message": "Use `typeof ngDevMode === 'undefined' || ngDevMode` instead"}
+      {
+        "name": ["isDevMode"],
+        "message": "Use `typeof ngDevMode === 'undefined' || ngDevMode` instead"
+      }
     ],
     // Avoids inconsistent linebreak styles in source files. Forces developers to use LF linebreaks.
     "linebreak-style": [true, "LF"],
@@ -101,47 +93,50 @@
       ["Directionality", "DateAdapter"]
     ],
     "no-coercion-members": true,
-    "no-host-decorator-in-concrete": [
+    "no-host-decorator-in-concrete": [true, "HostBinding", "HostListener"],
+    "member-naming": [
       true,
-      "HostBinding",
-      "HostListener"
-    ],
-    "member-naming": [true, {
-      "private": "^_"
-    }],
-    "symbol-naming": [true, "^_?[A-Z][a-zA-Z0-9]*$"],
-    "validate-decorators": [true, {
-      "Component": {
-        "argument": 0,
-        "properties": {
-          "!host": "\\[class\\]",
-          "!preserveWhitespaces": ".*",
-          "!styles": ".*",
-          "!moduleId": ".*",
-          "changeDetection": "\\.OnPush$",
-          "encapsulation": "\\.None$"
-        }
-      },
-      "Directive": {
-        "argument": 0,
-        "properties": {
-          "!host": "\\[class\\]"
-        }
-      },
-      "NgModule": {
-        "argument": 0,
-        "properties": {
-          "*": "^(?!\\s*$).+"
-        }
-      },
-      "ContentChildren": {
-        "argument": 1,
-        "required": true,
-        "properties": {
-          "descendants": "^(true|false)$"
-        }
+      {
+        "private": "^_"
       }
-    }, "src/!(e2e-app|components-examples|universal-app|dev-app)/**/!(*.spec).ts"],
+    ],
+    "symbol-naming": [true, "^_?[A-Z][a-zA-Z0-9]*$"],
+    "validate-decorators": [
+      true,
+      {
+        "Component": {
+          "argument": 0,
+          "properties": {
+            "!host": "\\[class\\]",
+            "!preserveWhitespaces": ".*",
+            "!styles": ".*",
+            "!moduleId": ".*",
+            "changeDetection": "\\.OnPush$",
+            "encapsulation": "\\.None$"
+          }
+        },
+        "Directive": {
+          "argument": 0,
+          "properties": {
+            "!host": "\\[class\\]"
+          }
+        },
+        "NgModule": {
+          "argument": 0,
+          "properties": {
+            "*": "^(?!\\s*$).+"
+          }
+        },
+        "ContentChildren": {
+          "argument": 1,
+          "required": true,
+          "properties": {
+            "descendants": "^(true|false)$"
+          }
+        }
+      },
+      "src/!(e2e-app|components-examples|universal-app|dev-app)/**/!(*.spec).ts"
+    ],
     "require-license-banner": [
       true,
       "src/!(e2e-app|components-examples|universal-app)/**/!(*.spec).ts",
@@ -154,12 +149,15 @@
       "!src/cdk/testing/+(private|tests)/**/*",
       "!src/google-maps/testing/**/*"
     ],
-    "file-name-casing": [true, {
-      // Exclude custom lint rule files since they have to always be camel-cased and end
-      // with "Rule".
-      "\\w+Rule.ts": "camel-case",
-      ".*": "kebab-case"
-    }],
+    "file-name-casing": [
+      true,
+      {
+        // Exclude custom lint rule files since they have to always be camel-cased and end
+        // with "Rule".
+        "\\w+Rule.ts": "camel-case",
+        ".*": "kebab-case"
+      }
+    ],
     "no-unescaped-html-tag": true,
     // Ensures that all rxjs imports come only from `rxjs` and `rxjs/operators`. Also ensures
     // that no AST utils from `@schematics/angular` are imported. These should be vendored.

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,10 +350,10 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#2b0196f6ebf6de2e62836e962b9f42007e6cf5d6":
-  version "0.0.0-8298e121c51960857ef39abc16b743775ff6be68"
-  uid "2b0196f6ebf6de2e62836e962b9f42007e6cf5d6"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#2b0196f6ebf6de2e62836e962b9f42007e6cf5d6"
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#f589cd87f196e09a775d8be25a0f83672f78fc99":
+  version "0.0.0-0fff09d0d3bb34d2b1a535e7be9f32df56cfa6ea"
+  uid f589cd87f196e09a775d8be25a0f83672f78fc99
+  resolved "https://github.com/angular/dev-infra-private-builds.git#f589cd87f196e09a775d8be25a0f83672f78fc99"
   dependencies:
     "@actions/core" "^1.4.0"
     "@actions/github" "^5.0.0"


### PR DESCRIPTION
Updates the dev-infra package and formats all `.json` files. The `ng-dev format` command will
format `.json` files by default when prettier is enabled.

cc. @Splaktar 