### PR TITLE
refactor(cdk/testing): remove deprecated protractor harness environment from public API

### DIFF
--- a/scripts/check-entry-point-setup.js
+++ b/scripts/check-entry-point-setup.js
@@ -21,7 +21,13 @@ const packagesDir = join(__dirname, '../src');
  * Globs that matches directories which should never be considered
  * as entry-points.
  */
-const excludeGlobs = ['cdk/testing/private', '*/schematics/**'];
+const excludeGlobs = [
+  'cdk/testing/private',
+  '*/schematics/**',
+  // The protractor testing entry-point is no longer publicly available,
+  // but exists in the repository until it can be removed in g3.
+  'cdk/testing/protractor',
+];
 
 /** List of detected entry-points which are not properly configured. */
 const nonConfigured = [];

--- a/src/cdk/config.bzl
+++ b/src/cdk/config.bzl
@@ -19,7 +19,6 @@ CDK_ENTRYPOINTS = [
     "text-field",
     "tree",
     "testing",
-    "testing/protractor",
     "testing/testbed",
     "testing/selenium-webdriver",
 ]

--- a/src/cdk/testing/protractor/README.md
+++ b/src/cdk/testing/protractor/README.md
@@ -1,0 +1,4 @@
+### No longer publicly available
+
+The protractor harness environment is no longer part of the public API. It was
+deprecated in v12 and removed from the API in v14.


### PR DESCRIPTION
This commit removes the deprecated protractor harness environment from the
public NPM package. Keeping the code in the repository until it can be removed
internally as well.

BREAKING CHANGE: The deprecated `angular/cdk/testing/protractor` entry-point has been removed.