### PR TITLE
build: ignore integration test sub-projects within renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,9 @@
   "semanticCommitScope": "",
   "semanticCommitType": "build",
   "separateMajorMinor": false,
+  "ignorePaths": [
+    "integration/**"
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
Sub-projects do not necessarily have valid `package.json` files
because they might reference local-built packages through `file:<..>`

Renovate does not install dependencies on the top-level workspace
first, neither does it perform a build. We want to ignore such nested
sub-projects as these should be updated manually, ideally even kept
up-to-date by pointing from the sub-workspace to the root workspace
(using e.g. `file:/../../node_modules/rxjs`).

Relevant issue: https://github.com/angular/components/pull/24318