### PR TITLE
fix(material-experimental/mdc-button): extended fab touch target not covering entire button

### DIFF
--- a/src/material-experimental/mdc-button/fab.scss
+++ b/src/material-experimental/mdc-button/fab.scss
@@ -89,3 +89,9 @@
     );
   }
 }
+
+// All FABs are square except the extended ones so we
+// need to set the touch target back to full-width.
+.mat-mdc-extended-fab .mat-mdc-button-touch-target {
+  width: 100%;
+}


### PR DESCRIPTION
Fixes that the extended FAB touch target was square which meant that it didn't cover the entire button.