### PR TITLE
feat(material/form-field): Allow mat-hint to persist alongside errors

### DIFF
--- a/src/material/form-field/form-field.html
+++ b/src/material/form-field/form-field.html
@@ -74,13 +74,13 @@
           [class.mat-warn]="color == 'warn'"></span>
   </div>
 
-  <div class="mat-form-field-subscript-wrapper"
-       [ngSwitch]="_getDisplayedMessages()">
-    <div *ngSwitchCase="'error'" [@transitionMessages]="_subscriptAnimationState">
+  <div class="mat-form-field-subscript-wrapper">
+    <div *ngIf="_getDisplayedMessages() == 'error'" [@transitionMessages]="_subscriptAnimationState">
       <ng-content select="mat-error"></ng-content>
     </div>
 
-    <div class="mat-form-field-hint-wrapper" *ngSwitchCase="'hint'"
+    <div class="mat-form-field-hint-wrapper"
+      [class.mat-form-field-hint-wrapper-inactive]="_getDisplayedMessages() != 'hint'"
       [@transitionMessages]="_subscriptAnimationState">
       <!-- TODO(mmalerba): use an actual <mat-hint> once all selectors are switched to mat-* -->
       <div *ngIf="hintLabel" [id]="_hintLabelId" class="mat-hint">{{hintLabel}}</div>

--- a/src/material/form-field/form-field.scss
+++ b/src/material/form-field/form-field.scss
@@ -220,6 +220,11 @@ $default-infix-width: 180px !default;
   display: flex;
 }
 
+// Hide mat-hint when errors are shown.
+.mat-form-field-hint-wrapper-inactive {
+  display: none;
+}
+
 // Spacer used to make sure start and end hints have enough space between them.
 .mat-form-field-hint-spacer {
   flex: 1 0 $hint-min-space;

--- a/src/material/form-field/testing/form-field-harness.ts
+++ b/src/material/form-field/testing/form-field-harness.ts
@@ -236,7 +236,9 @@ export class MatFormFieldHarness extends _MatFormFieldHarnessBase<FormFieldContr
   protected _suffixContainer = this.locatorForOptional('.mat-form-field-suffix');
   protected _label = this.locatorForOptional('.mat-form-field-label');
   protected _errors = this.locatorForAll('.mat-error');
-  protected _hints = this.locatorForAll('mat-hint, .mat-hint');
+  protected _hints = this.locatorForAll(
+    '.mat-form-field-hint-wrapper:not(.mat-form-field-hint-wrapper-inactive) mat-hint, .mat-form-field-hint-wrapper:not(.mat-form-field-hint-wrapper-inactive) .mat-hint',
+  );
   protected _inputControl = this.locatorForOptional(MatInputHarness);
   protected _selectControl = this.locatorForOptional(MatSelectHarness);
   protected _datepickerInputControl = this.locatorForOptional(MatDatepickerInputHarness);


### PR DESCRIPTION
Uses CSS to hide hints when errors are displayed, rather than removing them from the DOM altogether.

Fixes #24319