### PR TITLE
README CHANGE: Added GoogleMap import

### DIFF
--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -70,6 +70,7 @@ import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+import { GoogleMap } from '@angular/google-maps';
 
 @Component({
   selector: 'google-maps-demo',


### PR DESCRIPTION
README CHANGE: I found that we need to import the 'GoogleMap' namespace so that we can use the 'google' namespace in the google-maps-demp.component.ts file