### PR TITLE
fix(readme): Added GoogleMap Import

### DIFF
--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -70,6 +70,7 @@ import { Component } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+import { GoogleMap } from '@angular/google-maps';
 
 @Component({
   selector: 'google-maps-demo',


### PR DESCRIPTION
I found this import needed in order to use the 'google.maps' namespace in the ts file.