### PR TITLE
test: clean up IE/Edge test workarounds

### DIFF
--- a/src/material-experimental/mdc-input/input.spec.ts
+++ b/src/material-experimental/mdc-input/input.spec.ts
@@ -1,4 +1,3 @@
-import {Platform, PlatformModule} from '@angular/cdk/platform';
 import {dispatchFakeEvent, wrappedErrorMessage} from '../../cdk/testing/private';
 import {
   ChangeDetectionStrategy,
@@ -38,6 +37,7 @@ import {MatIconModule} from '@angular/material/icon';
 import {By} from '@angular/platform-browser';
 import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MAT_INPUT_VALUE_ACCESSOR, MatInput, MatInputModule} from './index';
+import {getSupportedInputTypes} from '@angular/cdk/platform';
 
 describe('MatMdcInput without forms', () => {
   it('should default to floating labels', fakeAsync(() => {
@@ -69,10 +69,9 @@ describe('MatMdcInput without forms', () => {
 
   it('should not be treated as empty if type is date', fakeAsync(() => {
     const fixture = createComponent(MatInputDateTestController);
-    const platform = TestBed.inject(Platform);
     fixture.detectChanges();
 
-    if (!(platform.TRIDENT || (platform.SAFARI && !platform.IOS))) {
+    if (getSupportedInputTypes().has('date')) {
       const formField = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
       expect(formField).toBeTruthy();
@@ -80,13 +79,11 @@ describe('MatMdcInput without forms', () => {
     }
   }));
 
-  // Safari Desktop and IE don't support type="date" and fallback to type="text".
-  it('should be treated as empty if type is date in Safari Desktop or IE', fakeAsync(() => {
+  it('should be treated as empty if type is date on unsupported browser', fakeAsync(() => {
     const fixture = createComponent(MatInputDateTestController);
-    const platform = TestBed.inject(Platform);
     fixture.detectChanges();
 
-    if (platform.TRIDENT || (platform.SAFARI && !platform.IOS)) {
+    if (!getSupportedInputTypes().has('date')) {
       const formField = fixture.debugElement.query(By.directive(MatFormField))!
         .componentInstance as MatFormField;
       expect(formField).toBeTruthy();
@@ -1486,7 +1483,6 @@ function configureTestingModule(
       MatIconModule,
       MatInputModule,
       animations ? BrowserAnimationsModule : NoopAnimationsModule,
-      PlatformModule,
       ReactiveFormsModule,
       ...imports,
     ],

--- a/src/material/button/testing/shared.spec.ts
+++ b/src/material/button/testing/shared.spec.ts
@@ -93,7 +93,7 @@ export function runHarnessTests(
     // cancel dispatched click events on disabled buttons. We skip this check on Edge and Firefox.
     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1582570 and:
     // https://stackoverflow.com/questions/32377026/disabled-button-is-clickable-on-edge-browser
-    if (platform.EDGE || platform.FIREFOX) {
+    if (platform.FIREFOX) {
       return;
     }
 

--- a/src/material/grid-list/BUILD.bazel
+++ b/src/material/grid-list/BUILD.bazel
@@ -49,7 +49,6 @@ ng_test_library(
     deps = [
         ":grid-list",
         "//src/cdk/bidi",
-        "//src/cdk/platform",
         "@npm//@angular/platform-browser",
     ],
 )

--- a/src/material/grid-list/grid-list.spec.ts
+++ b/src/material/grid-list/grid-list.spec.ts
@@ -1,34 +1,19 @@
-import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {Component, DebugElement, Type, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {MatGridList, MatGridListModule} from './index';
 import {MatGridTile, MatGridTileText} from './grid-tile';
 import {Directionality} from '@angular/cdk/bidi';
-import {Platform} from '@angular/cdk/platform';
 
 describe('MatGridList', () => {
-  let disableComputedStyleTests = false;
-
   function createComponent<T>(componentType: Type<T>): ComponentFixture<T> {
     TestBed.configureTestingModule({
       imports: [MatGridListModule],
       declarations: [componentType],
     }).compileComponents();
 
-    const fixture = TestBed.createComponent<T>(componentType);
-
-    inject([Platform], (platform: Platform) => {
-      // IE and Edge aren't consistent in the values that they return from `getComputedStyle`.
-      // In some cases they return the computed values, and in others the passed-in ones. We use
-      // this flag to disable the tests that depend on `getComputedStyle` in order to avoid flakes.
-      // TODO: we can re-enable them when we start testing against the Chromium-based Edge.
-      disableComputedStyleTests = platform.EDGE || platform.TRIDENT;
-    })();
-
-    return fixture;
+    return TestBed.createComponent<T>(componentType);
   }
-
-  afterEach(() => (disableComputedStyleTests = false));
 
   it('should throw error if cols is not defined', () => {
     const fixture = createComponent(GridListWithoutCols);
@@ -86,10 +71,6 @@ describe('MatGridList', () => {
   it('should default to 1:1 row height if undefined ', () => {
     const fixture = createComponent(GridListWithUnspecifiedRowHeight);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.detectChanges();
     const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     const inlineStyles = tile.nativeElement.style;
@@ -102,10 +83,6 @@ describe('MatGridList', () => {
 
   it('should use a ratio row height if passed in', () => {
     const fixture = createComponent(GirdListWithRowHeightRatio);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.componentInstance.rowHeight = '4:1';
     fixture.detectChanges();
@@ -128,10 +105,6 @@ describe('MatGridList', () => {
   it('should divide row height evenly in "fit" mode', () => {
     const fixture = createComponent(GridListWithFitRowHeightMode);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.componentInstance.totalHeight = '300px';
     fixture.detectChanges();
     const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
@@ -149,10 +122,6 @@ describe('MatGridList', () => {
   it('should use the fixed row height if passed in', () => {
     const fixture = createComponent(GridListWithFixedRowHeightMode);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.componentInstance.rowHeight = '100px';
     fixture.detectChanges();
 
@@ -168,10 +137,6 @@ describe('MatGridList', () => {
   it('should default to pixels if row height units are missing', () => {
     const fixture = createComponent(GridListWithUnitlessFixedRowHeight);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.detectChanges();
     const tile = fixture.debugElement.query(By.directive(MatGridTile))!;
     expect(getDimension(tile, 'height')).toBe(100);
@@ -179,10 +144,6 @@ describe('MatGridList', () => {
 
   it('should default gutter size to 1px', () => {
     const fixture = createComponent(GridListWithUnspecifiedGutterSize);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.detectChanges();
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
@@ -199,10 +160,6 @@ describe('MatGridList', () => {
   it('should be able to set the gutter size to zero', () => {
     const fixture = createComponent(GridListWithUnspecifiedGutterSize);
     const gridList = fixture.debugElement.query(By.directive(MatGridList))!;
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     gridList.componentInstance.gutterSize = 0;
     fixture.detectChanges();
@@ -221,10 +178,6 @@ describe('MatGridList', () => {
   it('should lay out the tiles correctly for a nested grid list', () => {
     const fixture = createComponent(NestedGridList);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.detectChanges();
     const innerTiles = fixture.debugElement.queryAll(
       By.css('mat-grid-tile mat-grid-list mat-grid-tile'),
@@ -237,10 +190,6 @@ describe('MatGridList', () => {
 
   it('should set the gutter size if passed', () => {
     const fixture = createComponent(GridListWithGutterSize);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.detectChanges();
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
@@ -256,10 +205,6 @@ describe('MatGridList', () => {
 
   it('should use pixels if gutter units are missing', () => {
     const fixture = createComponent(GridListWithUnitlessGutterSize);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.detectChanges();
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
@@ -277,10 +222,6 @@ describe('MatGridList', () => {
     const fixture = createComponent(GridListWithUnspecifiedGutterSize);
     const gridList = fixture.debugElement.query(By.directive(MatGridList))!;
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     gridList.componentInstance.gutterSize = '10%';
     fixture.detectChanges();
 
@@ -292,10 +233,6 @@ describe('MatGridList', () => {
 
   it('should set the correct list height in ratio mode', () => {
     const fixture = createComponent(GridListWithRatioHeightAndMulipleRows);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.detectChanges();
     const list = fixture.debugElement.query(By.directive(MatGridList))!;
@@ -309,10 +246,6 @@ describe('MatGridList', () => {
   it('should set the correct list height in fixed mode', () => {
     const fixture = createComponent(GridListWithFixRowHeightAndMultipleRows);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.detectChanges();
     const list = fixture.debugElement.query(By.directive(MatGridList))!;
     expect(getDimension(list, 'height')).toBe(201);
@@ -320,10 +253,6 @@ describe('MatGridList', () => {
 
   it('should allow adjustment of tile colspan', () => {
     const fixture = createComponent(GridListWithColspanBinding);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.componentInstance.colspan = 2;
     fixture.detectChanges();
@@ -339,10 +268,6 @@ describe('MatGridList', () => {
   it('should allow adjustment of tile rowspan', () => {
     const fixture = createComponent(GridListWithRowspanBinding);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.componentInstance.rowspan = 2;
     fixture.detectChanges();
 
@@ -356,10 +281,6 @@ describe('MatGridList', () => {
 
   it('should lay out tiles correctly for a complex layout', () => {
     const fixture = createComponent(GridListWithComplexLayout);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.componentInstance.tiles = [
       {cols: 3, rows: 1},
@@ -395,10 +316,6 @@ describe('MatGridList', () => {
   it('should lay out tiles correctly', () => {
     const fixture = createComponent(GridListWithLayout);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.detectChanges();
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
 
@@ -430,10 +347,6 @@ describe('MatGridList', () => {
 
   it('should lay out tiles correctly when single cell to be placed at the beginning', () => {
     const fixture = createComponent(GridListWithSingleCellAtBeginning);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.detectChanges();
     const tiles = fixture.debugElement.queryAll(By.css('mat-grid-tile'));
@@ -497,10 +410,6 @@ describe('MatGridList', () => {
   it('should reset the old styles when switching to a new tile styler', () => {
     const fixture = createComponent(GirdListWithRowHeightRatio);
 
-    if (disableComputedStyleTests) {
-      return;
-    }
-
     fixture.componentInstance.rowHeight = '4:1';
     fixture.detectChanges();
 
@@ -561,10 +470,6 @@ describe('MatGridList', () => {
 
   it('should lay out the tiles if they are not direct descendants of the list', () => {
     const fixture = createComponent(GridListWithIndirectTileDescendants);
-
-    if (disableComputedStyleTests) {
-      return;
-    }
 
     fixture.detectChanges();
     const tile = fixture.debugElement.query(By.directive(MatGridTile))!;

--- a/src/material/input/input.spec.ts
+++ b/src/material/input/input.spec.ts
@@ -1,4 +1,4 @@
-import {Platform, PlatformModule, _supportsShadowDom} from '@angular/cdk/platform';
+import {getSupportedInputTypes, _supportsShadowDom} from '@angular/cdk/platform';
 import {
   createFakeEvent,
   dispatchFakeEvent,
@@ -77,23 +77,20 @@ describe('MatInput without forms', () => {
 
   it('should not be treated as empty if type is date', fakeAsync(() => {
     const fixture = createComponent(MatInputDateTestController);
-    const platform = TestBed.inject(Platform);
     fixture.detectChanges();
 
-    if (!(platform.TRIDENT || (platform.SAFARI && !platform.IOS))) {
+    if (getSupportedInputTypes().has('date')) {
       const el = fixture.debugElement.query(By.css('label'))!.nativeElement;
       expect(el).not.toBeNull();
       expect(el.classList.contains('mat-form-field-empty')).toBe(false);
     }
   }));
 
-  // Safari Desktop and IE don't support type="date" and fallback to type="text".
-  it('should be treated as empty if type is date in Safari Desktop or IE', fakeAsync(() => {
+  it('should be treated as empty if type is date on unsupported browser', fakeAsync(() => {
     const fixture = createComponent(MatInputDateTestController);
-    const platform = TestBed.inject(Platform);
     fixture.detectChanges();
 
-    if (platform.TRIDENT || (platform.SAFARI && !platform.IOS)) {
+    if (!getSupportedInputTypes().has('date')) {
       const el = fixture.debugElement.query(By.css('label'))!.nativeElement;
       expect(el).not.toBeNull();
       expect(el.classList.contains('mat-form-field-empty')).toBe(true);
@@ -1862,7 +1859,6 @@ function createComponent<T>(
       MatFormFieldModule,
       MatInputModule,
       BrowserAnimationsModule,
-      PlatformModule,
       ReactiveFormsModule,
       ...imports,
     ],

--- a/src/material/select/BUILD.bazel
+++ b/src/material/select/BUILD.bazel
@@ -63,7 +63,6 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/overlay",
-        "//src/cdk/platform",
         "//src/cdk/scrolling",
         "//src/cdk/testing/private",
         "//src/material/core",

--- a/src/material/select/select.spec.ts
+++ b/src/material/select/select.spec.ts
@@ -13,7 +13,6 @@ import {
   ESCAPE,
 } from '@angular/cdk/keycodes';
 import {OverlayContainer} from '@angular/cdk/overlay';
-import {Platform} from '@angular/cdk/platform';
 import {ScrollDispatcher, ViewportRuler} from '@angular/cdk/scrolling';
 import {
   createKeyboardEvent,
@@ -78,7 +77,6 @@ describe('MatSelect', () => {
   let dir: {value: 'ltr' | 'rtl'; change: Observable<string>};
   let scrolledSubject = new Subject();
   let viewportRuler: ViewportRuler;
-  let platform: Platform;
 
   /**
    * Configures the test module for MatSelect with the given declarations. This is broken out so
@@ -109,9 +107,8 @@ describe('MatSelect', () => {
       ],
     }).compileComponents();
 
-    inject([OverlayContainer, Platform], (oc: OverlayContainer, p: Platform) => {
+    inject([OverlayContainer], (oc: OverlayContainer) => {
       overlayContainerElement = oc.getContainerElement();
-      platform = p;
     })();
   }
 
@@ -3890,12 +3887,6 @@ describe('MatSelect', () => {
       }));
 
       it('should account for preceding label groups when aligning the option', fakeAsync(() => {
-        // Test is off-by-one on edge for some reason, but verified that it looks correct through
-        // manual testing.
-        if (platform.EDGE) {
-          return;
-        }
-
         fixture.destroy();
 
         const groupFixture = TestBed.createComponent(SelectWithGroups);
@@ -3933,12 +3924,6 @@ describe('MatSelect', () => {
       }));
 
       it('should account for indirect preceding label groups when aligning the option', fakeAsync(() => {
-        // Test is off-by-one on edge for some reason, but verified that it looks correct through
-        // manual testing.
-        if (platform.EDGE) {
-          return;
-        }
-
         fixture.destroy();
 
         const groupFixture = TestBed.createComponent(SelectWithIndirectDescendantGroups);
@@ -4642,20 +4627,9 @@ describe('MatSelect', () => {
         const option = overlayContainerElement.querySelector('.cdk-overlay-pane mat-option');
         const optionTop = option ? option.getBoundingClientRect().top : 0;
 
-        // There appears to be a small rounding error on IE, so we verify that the value is close,
-        // not exact.
-        if (platform.TRIDENT) {
-          const difference = Math.abs(
-            optionTop + (menuItemHeight - triggerHeight) / 2 - triggerTop,
-          );
-          expect(difference)
-            .withContext('Expected trigger to align with the first option.')
-            .toBeLessThan(0.1);
-        } else {
-          expect(Math.floor(optionTop + (menuItemHeight - triggerHeight) / 2))
-            .withContext('Expected trigger to align with the first option.')
-            .toBe(Math.floor(triggerTop));
-        }
+        expect(Math.floor(optionTop + (menuItemHeight - triggerHeight) / 2))
+          .withContext('Expected trigger to align with the first option.')
+          .toBe(Math.floor(triggerTop));
       }));
 
       it('should not adjust if option centering is disabled any option under a group is selected', fakeAsync(() => {

--- a/src/material/sidenav/BUILD.bazel
+++ b/src/material/sidenav/BUILD.bazel
@@ -25,7 +25,6 @@ ng_module(
         "//src/cdk/bidi",
         "//src/cdk/coercion",
         "//src/cdk/keycodes",
-        "//src/cdk/platform",
         "//src/cdk/scrolling",
         "//src/material/core",
         "@npm//@angular/animations",

--- a/src/material/sidenav/drawer.spec.ts
+++ b/src/material/sidenav/drawer.spec.ts
@@ -6,7 +6,6 @@ import {
   TestBed,
   discardPeriodicTasks,
   flush,
-  inject,
 } from '@angular/core/testing';
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
@@ -14,7 +13,6 @@ import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-b
 import {MatDrawer, MatSidenavModule, MatDrawerContainer} from './index';
 import {Direction} from '@angular/cdk/bidi';
 import {A11yModule} from '@angular/cdk/a11y';
-import {PlatformModule, Platform} from '@angular/cdk/platform';
 import {ESCAPE} from '@angular/cdk/keycodes';
 import {dispatchKeyboardEvent, createKeyboardEvent, dispatchEvent} from '../../cdk/testing/private';
 import {CdkScrollable} from '@angular/cdk/scrolling';
@@ -24,7 +22,7 @@ describe('MatDrawer', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [MatSidenavModule, A11yModule, PlatformModule, NoopAnimationsModule, CommonModule],
+        imports: [MatSidenavModule, A11yModule, NoopAnimationsModule, CommonModule],
         declarations: [
           BasicTestApp,
           DrawerContainerNoDrawerTestApp,
@@ -805,7 +803,7 @@ describe('MatDrawerContainer', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [MatSidenavModule, A11yModule, PlatformModule, NoopAnimationsModule],
+        imports: [MatSidenavModule, A11yModule, NoopAnimationsModule],
         declarations: [
           DrawerContainerTwoDrawerTestApp,
           DrawerDelayed,
@@ -944,42 +942,28 @@ describe('MatDrawerContainer', () => {
     expect(container.classList).not.toContain('mat-drawer-transition');
   }));
 
-  it('should recalculate the margin if a drawer changes size while open in autosize mode', fakeAsync(
-    inject([Platform], (platform: Platform) => {
-      const fixture = TestBed.createComponent(AutosizeDrawer);
+  it('should recalculate the margin if a drawer changes size while open in autosize mode', fakeAsync(() => {
+    const fixture = TestBed.createComponent(AutosizeDrawer);
 
-      fixture.detectChanges();
-      fixture.componentInstance.drawer.open();
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
+    fixture.detectChanges();
+    fixture.componentInstance.drawer.open();
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
 
-      // IE and Edge are flaky in when they update the styles.
-      // For them we fall back to checking whether the proper method was called.
-      const isFlaky = platform.EDGE || platform.TRIDENT;
-      const contentEl = fixture.debugElement.nativeElement.querySelector('.mat-drawer-content');
-      const initialMargin = parseInt(contentEl.style.marginLeft);
+    const contentEl = fixture.debugElement.nativeElement.querySelector('.mat-drawer-content');
+    const initialMargin = parseInt(contentEl.style.marginLeft);
 
-      if (isFlaky) {
-        spyOn(fixture.componentInstance.drawerContainer, 'updateContentMargins');
-      } else {
-        expect(initialMargin).toBeGreaterThan(0);
-      }
+    expect(initialMargin).toBeGreaterThan(0);
 
-      fixture.componentInstance.fillerWidth = 200;
-      fixture.detectChanges();
-      tick(10);
-      fixture.detectChanges();
+    fixture.componentInstance.fillerWidth = 200;
+    fixture.detectChanges();
+    tick(10);
+    fixture.detectChanges();
 
-      if (isFlaky) {
-        expect(fixture.componentInstance.drawerContainer.updateContentMargins).toHaveBeenCalled();
-      } else {
-        expect(parseInt(contentEl.style.marginLeft)).toBeGreaterThan(initialMargin);
-      }
-
-      discardPeriodicTasks();
-    }),
-  ));
+    expect(parseInt(contentEl.style.marginLeft)).toBeGreaterThan(initialMargin);
+    discardPeriodicTasks();
+  }));
 
   it('should not set a style property if it would be zero', fakeAsync(() => {
     const fixture = TestBed.createComponent(AutosizeDrawer);


### PR DESCRIPTION
The workarounds shouldn't be necessary since we don't run tests against IE and legacy Edge anymore.