### PR TITLE
refactor(multiple): remove PlatformModule usages

### DIFF
--- a/src/cdk/a11y/a11y-module.ts
+++ b/src/cdk/a11y/a11y-module.ts
@@ -7,7 +7,6 @@
  */
 
 import {ObserversModule} from '@angular/cdk/observers';
-import {PlatformModule} from '@angular/cdk/platform';
 import {NgModule} from '@angular/core';
 import {CdkMonitorFocus} from './focus-monitor/focus-monitor';
 import {CdkTrapFocus} from './focus-trap/focus-trap';
@@ -15,7 +14,7 @@ import {HighContrastModeDetector} from './high-contrast-mode/high-contrast-mode-
 import {CdkAriaLive} from './live-announcer/live-announcer';
 
 @NgModule({
-  imports: [PlatformModule, ObserversModule],
+  imports: [ObserversModule],
   declarations: [CdkAriaLive, CdkTrapFocus, CdkMonitorFocus],
   exports: [CdkAriaLive, CdkTrapFocus, CdkMonitorFocus],
 })

--- a/src/cdk/scrolling/scrolling-module.ts
+++ b/src/cdk/scrolling/scrolling-module.ts
@@ -7,7 +7,6 @@
  */
 
 import {BidiModule} from '@angular/cdk/bidi';
-import {PlatformModule} from '@angular/cdk/platform';
 import {NgModule} from '@angular/core';
 import {CdkFixedSizeVirtualScroll} from './fixed-size-virtual-scroll';
 import {CdkScrollable} from './scrollable';
@@ -24,7 +23,7 @@ export class CdkScrollableModule {}
  * @docs-primary-export
  */
 @NgModule({
-  imports: [BidiModule, PlatformModule, CdkScrollableModule],
+  imports: [BidiModule, CdkScrollableModule],
   exports: [
     BidiModule,
     CdkScrollableModule,

--- a/src/cdk/text-field/text-field-module.ts
+++ b/src/cdk/text-field/text-field-module.ts
@@ -6,14 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PlatformModule} from '@angular/cdk/platform';
 import {NgModule} from '@angular/core';
 import {CdkAutofill} from './autofill';
 import {CdkTextareaAutosize} from './autosize';
 
 @NgModule({
   declarations: [CdkAutofill, CdkTextareaAutosize],
-  imports: [PlatformModule],
   exports: [CdkAutofill, CdkTextareaAutosize],
 })
 export class TextFieldModule {}

--- a/src/components-examples/cdk/platform/index.ts
+++ b/src/components-examples/cdk/platform/index.ts
@@ -1,4 +1,3 @@
-import {PlatformModule} from '@angular/cdk/platform';
 import {NgModule} from '@angular/core';
 import {CdkPlatformOverviewExample} from './cdk-platform-overview/cdk-platform-overview-example';
 
@@ -7,7 +6,6 @@ export {CdkPlatformOverviewExample};
 const EXAMPLES = [CdkPlatformOverviewExample];
 
 @NgModule({
-  imports: [PlatformModule],
   declarations: EXAMPLES,
   exports: EXAMPLES,
 })

--- a/src/dev-app/platform/platform-demo-module.ts
+++ b/src/dev-app/platform/platform-demo-module.ts
@@ -6,18 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PlatformModule} from '@angular/cdk/platform';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {PlatformDemo} from './platform-demo';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    PlatformModule,
-    RouterModule.forChild([{path: '', component: PlatformDemo}]),
-  ],
+  imports: [CommonModule, RouterModule.forChild([{path: '', component: PlatformDemo}])],
   declarations: [PlatformDemo],
 })
 export class PlatformDemoModule {}

--- a/src/material/core/datetime/index.ts
+++ b/src/material/core/datetime/index.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PlatformModule} from '@angular/cdk/platform';
 import {NgModule} from '@angular/core';
 import {DateAdapter} from './date-adapter';
 import {MAT_DATE_FORMATS} from './date-formats';
@@ -19,7 +18,6 @@ export * from './native-date-adapter';
 export * from './native-date-formats';
 
 @NgModule({
-  imports: [PlatformModule],
   providers: [{provide: DateAdapter, useClass: NativeDateAdapter}],
 })
 export class NativeDateModule {}

--- a/src/material/core/ripple/index.ts
+++ b/src/material/core/ripple/index.ts
@@ -7,7 +7,6 @@
  */
 
 import {NgModule} from '@angular/core';
-import {PlatformModule} from '@angular/cdk/platform';
 import {MatCommonModule} from '../common-behaviors/common-module';
 import {MatRipple} from './ripple';
 
@@ -16,7 +15,7 @@ export * from './ripple-ref';
 export * from './ripple-renderer';
 
 @NgModule({
-  imports: [MatCommonModule, PlatformModule],
+  imports: [MatCommonModule],
   exports: [MatRipple, MatCommonModule],
   declarations: [MatRipple],
 })

--- a/src/material/sidenav/sidenav-module.ts
+++ b/src/material/sidenav/sidenav-module.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {PlatformModule} from '@angular/cdk/platform';
 import {CdkScrollableModule} from '@angular/cdk/scrolling';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
@@ -14,7 +13,7 @@ import {MatDrawer, MatDrawerContainer, MatDrawerContent} from './drawer';
 import {MatSidenav, MatSidenavContainer, MatSidenavContent} from './sidenav';
 
 @NgModule({
-  imports: [CommonModule, MatCommonModule, PlatformModule, CdkScrollableModule],
+  imports: [CommonModule, MatCommonModule, CdkScrollableModule],
   exports: [
     CdkScrollableModule,
     MatCommonModule,

--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -12,8 +12,7 @@ import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i4 from '@angular/cdk/platform';
-import * as i5 from '@angular/cdk/observers';
+import * as i4 from '@angular/cdk/observers';
 import { InjectionToken } from '@angular/core';
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -32,7 +31,7 @@ export class A11yModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<A11yModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<A11yModule, [typeof i1.CdkAriaLive, typeof i2.CdkTrapFocus, typeof i3.CdkMonitorFocus], [typeof i4.PlatformModule, typeof i5.ObserversModule], [typeof i1.CdkAriaLive, typeof i2.CdkTrapFocus, typeof i3.CdkMonitorFocus]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<A11yModule, [typeof i1.CdkAriaLive, typeof i2.CdkTrapFocus, typeof i3.CdkMonitorFocus], [typeof i4.ObserversModule], [typeof i1.CdkAriaLive, typeof i2.CdkTrapFocus, typeof i3.CdkMonitorFocus]>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -13,7 +13,6 @@ import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i5 from '@angular/cdk/bidi';
-import * as i6 from '@angular/cdk/platform';
 import { InjectionToken } from '@angular/core';
 import { IterableDiffers } from '@angular/core';
 import { ListRange } from '@angular/cdk/collections';
@@ -251,7 +250,7 @@ export class ScrollingModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<ScrollingModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ScrollingModule, [typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport], [typeof i5.BidiModule, typeof i6.PlatformModule, typeof CdkScrollableModule], [typeof i5.BidiModule, typeof CdkScrollableModule, typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ScrollingModule, [typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport], [typeof i5.BidiModule, typeof CdkScrollableModule], [typeof i5.BidiModule, typeof CdkScrollableModule, typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport]>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/cdk/text-field.md
+++ b/tools/public_api_guard/cdk/text-field.md
@@ -10,7 +10,6 @@ import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i3 from '@angular/cdk/platform';
 import { NgZone } from '@angular/core';
 import { NumberInput } from '@angular/cdk/coercion';
 import { Observable } from 'rxjs';
@@ -92,7 +91,7 @@ export class TextFieldModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<TextFieldModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<TextFieldModule, [typeof i1.CdkAutofill, typeof i2.CdkTextareaAutosize], [typeof i3.PlatformModule], [typeof i1.CdkAutofill, typeof i2.CdkTextareaAutosize]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<TextFieldModule, [typeof i1.CdkAutofill, typeof i2.CdkTextareaAutosize], never, [typeof i1.CdkAutofill, typeof i2.CdkTextareaAutosize]>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/tools/public_api_guard/material/core.md
+++ b/tools/public_api_guard/material/core.md
@@ -19,7 +19,6 @@ import { FormGroupDirective } from '@angular/forms';
 import { HighContrastModeDetector } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/cdk/bidi';
-import * as i1_2 from '@angular/cdk/platform';
 import * as i4 from '@angular/common';
 import { InjectionToken } from '@angular/core';
 import { NgControl } from '@angular/forms';
@@ -232,7 +231,7 @@ export class MatLineModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatLineModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatLineModule, [typeof MatLine], [typeof i1_3.MatCommonModule], [typeof MatLine, typeof i1_3.MatCommonModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatLineModule, [typeof MatLine], [typeof i1_2.MatCommonModule], [typeof MatLine, typeof i1_2.MatCommonModule]>;
 }
 
 // @public (undocumented)
@@ -318,7 +317,7 @@ export class MatOptionModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatOptionModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatOptionModule, [typeof i1_4.MatOption, typeof i2.MatOptgroup], [typeof i3.MatRippleModule, typeof i4.CommonModule, typeof i1_3.MatCommonModule, typeof i6.MatPseudoCheckboxModule], [typeof i1_4.MatOption, typeof i2.MatOptgroup]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatOptionModule, [typeof i1_3.MatOption, typeof i2.MatOptgroup], [typeof i3.MatRippleModule, typeof i4.CommonModule, typeof i1_2.MatCommonModule, typeof i6.MatPseudoCheckboxModule], [typeof i1_3.MatOption, typeof i2.MatOptgroup]>;
 }
 
 // @public
@@ -360,7 +359,7 @@ export class MatPseudoCheckboxModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatPseudoCheckboxModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatPseudoCheckboxModule, [typeof i1_6.MatPseudoCheckbox], [typeof i1_3.MatCommonModule], [typeof i1_6.MatPseudoCheckbox]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatPseudoCheckboxModule, [typeof i1_5.MatPseudoCheckbox], [typeof i1_2.MatCommonModule], [typeof i1_5.MatPseudoCheckbox]>;
 }
 
 // @public
@@ -401,7 +400,7 @@ export class MatRippleModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatRippleModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatRippleModule, [typeof i1_5.MatRipple], [typeof i1_3.MatCommonModule, typeof i1_2.PlatformModule], [typeof i1_5.MatRipple, typeof i1_3.MatCommonModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatRippleModule, [typeof i1_4.MatRipple], [typeof i1_2.MatCommonModule], [typeof i1_4.MatRipple, typeof i1_2.MatCommonModule]>;
 }
 
 // @public
@@ -486,7 +485,7 @@ export class NativeDateModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<NativeDateModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<NativeDateModule, never, [typeof i1_2.PlatformModule], never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<NativeDateModule, never, never, never>;
 }
 
 // @public

--- a/tools/public_api_guard/material/sidenav.md
+++ b/tools/public_api_guard/material/sidenav.md
@@ -22,8 +22,7 @@ import { FocusTrapFactory } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
 import * as i3 from '@angular/common';
 import * as i4 from '@angular/material/core';
-import * as i5 from '@angular/cdk/platform';
-import * as i6 from '@angular/cdk/scrolling';
+import * as i5 from '@angular/cdk/scrolling';
 import { InjectionToken } from '@angular/core';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { NgZone } from '@angular/core';
@@ -207,7 +206,7 @@ export class MatSidenavModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<MatSidenavModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MatSidenavModule, [typeof i1.MatDrawer, typeof i1.MatDrawerContainer, typeof i1.MatDrawerContent, typeof i2.MatSidenav, typeof i2.MatSidenavContainer, typeof i2.MatSidenavContent], [typeof i3.CommonModule, typeof i4.MatCommonModule, typeof i5.PlatformModule, typeof i6.CdkScrollableModule], [typeof i6.CdkScrollableModule, typeof i4.MatCommonModule, typeof i1.MatDrawer, typeof i1.MatDrawerContainer, typeof i1.MatDrawerContent, typeof i2.MatSidenav, typeof i2.MatSidenavContainer, typeof i2.MatSidenavContent]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatSidenavModule, [typeof i1.MatDrawer, typeof i1.MatDrawerContainer, typeof i1.MatDrawerContent, typeof i2.MatSidenav, typeof i2.MatSidenavContainer, typeof i2.MatSidenavContent], [typeof i3.CommonModule, typeof i4.MatCommonModule, typeof i5.CdkScrollableModule], [typeof i5.CdkScrollableModule, typeof i4.MatCommonModule, typeof i1.MatDrawer, typeof i1.MatDrawerContainer, typeof i1.MatDrawerContent, typeof i2.MatSidenav, typeof i2.MatSidenavContainer, typeof i2.MatSidenavContent]>;
 }
 
 // @public


### PR DESCRIPTION
The `PlatformModule` is a noop so we don't need to import it.