### PR TITLE
docs(material/datepicker): fix custom class example

### DIFF
--- a/src/components-examples/material/datepicker/datepicker-date-class/datepicker-date-class-example.css
+++ b/src/components-examples/material/datepicker/datepicker-date-class/datepicker-date-class-example.css
@@ -1,4 +1,4 @@
-.example-custom-date-class {
+button.example-custom-date-class {
   background: orange;
   border-radius: 100%;
 }


### PR DESCRIPTION
The changes in #24171 added a `background: none` to the datepicker cell which broke one of the examples, because it increased the specificity. I don't think that there's a good way to reduce the specificity without moving the entire cell template around again so these changes update the example to be more specific.

Fixes #24383.