### PR TITLE
feat(cdk/scrolling): make scroller element configurable for virtual scrolling

### DIFF
--- a/src/cdk/scrolling/public-api.ts
+++ b/src/cdk/scrolling/public-api.ts
@@ -15,3 +15,6 @@ export * from './virtual-for-of';
 export * from './virtual-scroll-strategy';
 export * from './virtual-scroll-viewport';
 export * from './virtual-scroll-repeater';
+export * from './virtual-scrollable';
+export * from './virtual-scrollable-element';
+export * from './virtual-scrollable-window';

--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -49,7 +49,13 @@ export class CdkScrollable implements OnInit, OnDestroy {
 
   private _elementScrolled: Observable<Event> = new Observable((observer: Observer<Event>) =>
     this.ngZone.runOutsideAngular(() =>
-      fromEvent(this.elementRef.nativeElement, 'scroll')
+      /* it seems like scroll-events are not fired on the documentElement, event if it's the actual scrolling element */
+      fromEvent(
+        this.elementRef.nativeElement === document.documentElement
+          ? document
+          : this.elementRef.nativeElement,
+        'scroll',
+      )
         .pipe(takeUntil(this._destroyed))
         .subscribe(observer),
     ),

--- a/src/cdk/scrolling/scrollable.ts
+++ b/src/cdk/scrolling/scrollable.ts
@@ -45,17 +45,11 @@ export type ExtendedScrollToOptions = _XAxis & _YAxis & ScrollOptions;
   selector: '[cdk-scrollable], [cdkScrollable]',
 })
 export class CdkScrollable implements OnInit, OnDestroy {
-  private readonly _destroyed = new Subject<void>();
+  protected readonly _destroyed = new Subject<void>();
 
-  private _elementScrolled: Observable<Event> = new Observable((observer: Observer<Event>) =>
+  protected _elementScrolled: Observable<Event> = new Observable((observer: Observer<Event>) =>
     this.ngZone.runOutsideAngular(() =>
-      /* it seems like scroll-events are not fired on the documentElement, event if it's the actual scrolling element */
-      fromEvent(
-        this.elementRef.nativeElement === document.documentElement
-          ? document
-          : this.elementRef.nativeElement,
-        'scroll',
-      )
+      fromEvent(this.elementRef.nativeElement, 'scroll')
         .pipe(takeUntil(this._destroyed))
         .subscribe(observer),
     ),

--- a/src/cdk/scrolling/scrolling-module.ts
+++ b/src/cdk/scrolling/scrolling-module.ts
@@ -12,6 +12,8 @@ import {CdkFixedSizeVirtualScroll} from './fixed-size-virtual-scroll';
 import {CdkScrollable} from './scrollable';
 import {CdkVirtualForOf} from './virtual-for-of';
 import {CdkVirtualScrollViewport} from './virtual-scroll-viewport';
+import {CdkVirtualScrollableElement} from './virtual-scrollable-element';
+import {CdkVirtualScrollableWindow} from './virtual-scrollable-window';
 
 @NgModule({
   exports: [CdkScrollable],
@@ -30,7 +32,15 @@ export class CdkScrollableModule {}
     CdkFixedSizeVirtualScroll,
     CdkVirtualForOf,
     CdkVirtualScrollViewport,
+    CdkVirtualScrollableWindow,
+    CdkVirtualScrollableElement,
   ],
-  declarations: [CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport],
+  declarations: [
+    CdkFixedSizeVirtualScroll,
+    CdkVirtualForOf,
+    CdkVirtualScrollViewport,
+    CdkVirtualScrollableWindow,
+    CdkVirtualScrollableElement,
+  ],
 })
 export class ScrollingModule {}

--- a/src/cdk/scrolling/virtual-scroll-viewport.scss
+++ b/src/cdk/scrolling/virtual-scroll-viewport.scss
@@ -75,13 +75,12 @@ cdk-virtual-scroll-viewport {
 .cdk-virtual-scroll-spacer {
   height: 1px;
   transform-origin: 0 0;
+  flex: 0 0 auto; // prevents spacer from collapsing if display: flex is applied
 
   // Note: We can't put `will-change: transform;` here because it causes Safari to not update the
   // viewport's `scrollHeight` when the spacer's transform changes.
 
   [dir='rtl'] & {
-    right: 0;
-    left: auto;
     transform-origin: 100% 0;
   }
 }

--- a/src/cdk/scrolling/virtual-scroll-viewport.scss
+++ b/src/cdk/scrolling/virtual-scroll-viewport.scss
@@ -27,14 +27,18 @@
 }
 
 
-// Scrolling container.
+// viewport
 cdk-virtual-scroll-viewport {
   display: block;
   position: relative;
-  overflow: auto;
-  contain: strict;
   transform: translateZ(0);
+}
+
+// Scrolling container.
+.cdk-virtual-scrollable {
+  overflow: auto;
   will-change: scroll-position;
+  contain: strict;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -69,11 +73,7 @@ cdk-virtual-scroll-viewport {
 // set if it were rendered all at once. This ensures that the scrollable content region is the
 // correct size.
 .cdk-virtual-scroll-spacer {
-  position: absolute;
-  top: 0;
-  left: 0;
   height: 1px;
-  width: 1px;
   transform-origin: 0 0;
 
   // Note: We can't put `will-change: transform;` here because it causes Safari to not update the

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -772,9 +772,9 @@ describe('CdkVirtualScrollViewport', () => {
         spyOn(dispatcher, 'register').and.callThrough();
         spyOn(dispatcher, 'deregister').and.callThrough();
         finishInit(fixture);
-        expect(dispatcher.register).toHaveBeenCalledWith(testComponent.viewport);
+        expect(dispatcher.register).toHaveBeenCalledWith(testComponent.viewport.scrollable);
         fixture.destroy();
-        expect(dispatcher.deregister).toHaveBeenCalledWith(testComponent.viewport);
+        expect(dispatcher.deregister).toHaveBeenCalledWith(testComponent.viewport.scrollable);
       }),
     ));
 

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -1086,6 +1086,80 @@ describe('CdkVirtualScrollViewport', () => {
       expect(viewport.getOffsetToRenderedContentStart()).toBe(0);
     }));
   });
+
+  describe('with custom scrolling element', () => {
+    let fixture: ComponentFixture<VirtualScrollWithCustomScrollingElement>;
+    let testComponent: VirtualScrollWithCustomScrollingElement;
+    let viewport: CdkVirtualScrollViewport;
+
+    beforeEach(
+      waitForAsync(() => {
+        TestBed.configureTestingModule({
+          imports: [ScrollingModule],
+          declarations: [VirtualScrollWithCustomScrollingElement],
+        }).compileComponents();
+      }),
+    );
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(VirtualScrollWithCustomScrollingElement);
+      testComponent = fixture.componentInstance;
+      viewport = testComponent.viewport;
+    });
+
+    it('should measure viewport offset', fakeAsync(() => {
+      finishInit(fixture);
+
+      expect(viewport.measureViewportOffset('top'))
+        .withContext('with scrolling-element padding-top: 50 offset should be 50')
+        .toBe(50);
+    }));
+
+    it('should measure scroll offset', fakeAsync(() => {
+      finishInit(fixture);
+      triggerScroll(viewport, 100);
+      fixture.detectChanges();
+      flush();
+
+      expect(viewport.measureScrollOffset('top'))
+        .withContext('should be 50 (actual scroll offset - viewport offset)')
+        .toBe(50);
+    }));
+  });
+
+  describe('with scrollable window', () => {
+    let fixture: ComponentFixture<VirtualScrollWithScrollableWindow>;
+    let testComponent: VirtualScrollWithScrollableWindow;
+    let viewport: CdkVirtualScrollViewport;
+
+    beforeEach(
+      waitForAsync(() => {
+        TestBed.configureTestingModule({
+          imports: [ScrollingModule],
+          declarations: [VirtualScrollWithScrollableWindow],
+        }).compileComponents();
+      }),
+    );
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(VirtualScrollWithScrollableWindow);
+      testComponent = fixture.componentInstance;
+      viewport = testComponent.viewport;
+    });
+
+    it('should measure scroll offset', fakeAsync(() => {
+      finishInit(fixture);
+      viewport.scrollToOffset(100 + 8); // the +8 is due to a horizontal scrollbar
+      dispatchFakeEvent(window, 'scroll', true);
+      tick();
+      fixture.detectChanges();
+      flush();
+
+      expect(viewport.measureScrollOffset('top'))
+        .withContext('should be 50 (actual scroll offset - viewport offset)')
+        .toBe(50);
+    }));
+  });
 });
 
 /** Finish initializing the virtual scroll component at the beginning of a test. */
@@ -1109,7 +1183,7 @@ function triggerScroll(viewport: CdkVirtualScrollViewport, offset?: number) {
   if (offset !== undefined) {
     viewport.scrollToOffset(offset);
   }
-  dispatchFakeEvent(viewport.elementRef.nativeElement, 'scroll');
+  dispatchFakeEvent(viewport.scrollable.getElementRef().nativeElement, 'scroll');
   animationFrameScheduler.flush();
 }
 
@@ -1385,6 +1459,91 @@ class DelayedInitializationVirtualScroll {
   encapsulation: ViewEncapsulation.None,
 })
 class VirtualScrollWithAppendOnly {
+  @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport: CdkVirtualScrollViewport;
+  itemSize = 50;
+  items = Array(20000)
+    .fill(0)
+    .map((_, i) => i);
+}
+
+@Component({
+  template: `
+    <div cdk-virtual-scrollable-element class="scrolling-element">
+      <cdk-virtual-scroll-viewport itemSize="50">
+        <div class="item" *cdkVirtualFor="let item of items">{{item}}</div>
+      </cdk-virtual-scroll-viewport>
+    </div>
+  `,
+  styles: [
+    `
+        .cdk-virtual-scroll-content-wrapper {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .cdk-virtual-scroll-viewport {
+            width: 200px;
+            height: 200px;
+            background-color: #f5f5f5;
+        }
+
+        .item {
+            width: 100%;
+            height: 50px;
+            box-sizing: border-box;
+            border: 1px dashed #ccc;
+        }
+
+        .scrolling-element {
+            padding-top: 50px;
+        }
+    `,
+  ],
+  encapsulation: ViewEncapsulation.None,
+})
+class VirtualScrollWithCustomScrollingElement {
+  @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport: CdkVirtualScrollViewport;
+  itemSize = 50;
+  items = Array(20000)
+    .fill(0)
+    .map((_, i) => i);
+}
+
+@Component({
+  template: `
+    <div class="before-virtual-viewport"></div>
+    <cdk-virtual-scroll-viewport scrollable-window itemSize="50">
+      <div class="item" *cdkVirtualFor="let item of items">{{item}}</div>
+    </cdk-virtual-scroll-viewport>
+  `,
+  styles: [
+    `
+        .cdk-virtual-scroll-content-wrapper {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .cdk-virtual-scroll-viewport {
+            width: 200px;
+            height: 200px;
+            background-color: #f5f5f5;
+        }
+
+        .item {
+            width: 100%;
+            height: 50px;
+            box-sizing: border-box;
+            border: 1px dashed #ccc;
+        }
+
+        .before-virtual-viewport {
+            height: 50px;
+        }
+    `,
+  ],
+  encapsulation: ViewEncapsulation.None,
+})
+class VirtualScrollWithScrollableWindow {
   @ViewChild(CdkVirtualScrollViewport, {static: true}) viewport: CdkVirtualScrollViewport;
   itemSize = 50;
   items = Array(20000)

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -1464,7 +1464,7 @@ class VirtualScrollWithAppendOnly {
 
 @Component({
   template: `
-    <div cdk-virtual-scrollable-element class="scrolling-element">
+    <div cdkVirtualScrollingElement class="scrolling-element">
       <cdk-virtual-scroll-viewport itemSize="50">
         <div class="item" *cdkVirtualFor="let item of items">{{item}}</div>
       </cdk-virtual-scroll-viewport>
@@ -1508,7 +1508,7 @@ class VirtualScrollWithCustomScrollingElement {
 @Component({
   template: `
     <div class="before-virtual-viewport"></div>
-    <cdk-virtual-scroll-viewport scrollable-window itemSize="50">
+    <cdk-virtual-scroll-viewport scrollWindow itemSize="50">
       <div class="item" *cdkVirtualFor="let item of items">{{item}}</div>
     </cdk-virtual-scroll-viewport>
   `,

--- a/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.spec.ts
@@ -1092,14 +1092,12 @@ describe('CdkVirtualScrollViewport', () => {
     let testComponent: VirtualScrollWithCustomScrollingElement;
     let viewport: CdkVirtualScrollViewport;
 
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          imports: [ScrollingModule],
-          declarations: [VirtualScrollWithCustomScrollingElement],
-        }).compileComponents();
-      }),
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ScrollingModule],
+        declarations: [VirtualScrollWithCustomScrollingElement],
+      }).compileComponents();
+    }));
 
     beforeEach(() => {
       fixture = TestBed.createComponent(VirtualScrollWithCustomScrollingElement);
@@ -1132,14 +1130,12 @@ describe('CdkVirtualScrollViewport', () => {
     let testComponent: VirtualScrollWithScrollableWindow;
     let viewport: CdkVirtualScrollViewport;
 
-    beforeEach(
-      waitForAsync(() => {
-        TestBed.configureTestingModule({
-          imports: [ScrollingModule],
-          declarations: [VirtualScrollWithScrollableWindow],
-        }).compileComponents();
-      }),
-    );
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ScrollingModule],
+        declarations: [VirtualScrollWithScrollableWindow],
+      }).compileComponents();
+    }));
 
     beforeEach(() => {
       fixture = TestBed.createComponent(VirtualScrollWithScrollableWindow);

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -20,6 +20,7 @@ import {
   OnInit,
   Optional,
   Output,
+  Renderer2,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -38,6 +39,7 @@ import {VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy} from './virtual-scroll-s
 import {ViewportRuler} from './viewport-ruler';
 import {CdkVirtualScrollRepeater} from './virtual-scroll-repeater';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
 
 /** Checks if the given ranges are equal. */
 function rangesEqual(r1: ListRange, r2: ListRange): boolean {
@@ -67,11 +69,12 @@ const SCROLL_SCHEDULER =
   providers: [
     {
       provide: CdkScrollable,
-      useExisting: CdkVirtualScrollViewport,
+      useFactory: (scrollViewport: CdkVirtualScrollViewport) => scrollViewport.scrollable,
+      deps: [CdkVirtualScrollViewport],
     },
   ],
 })
-export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, OnDestroy {
+export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements OnInit, OnDestroy {
   /** Emits when the viewport is detached from a CdkVirtualForOf. */
   private readonly _detachedSubject = new Subject<void>();
 
@@ -179,6 +182,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     @Optional() dir: Directionality,
     scrollDispatcher: ScrollDispatcher,
     viewportRuler: ViewportRuler,
+    renderer: Renderer2,
+    @Optional() @Inject(VIRTUAL_SCROLLABLE) public scrollable: CdkVirtualScrollable,
   ) {
     super(elementRef, scrollDispatcher, ngZone, dir);
 
@@ -189,11 +194,18 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     this._viewportChanges = viewportRuler.change().subscribe(() => {
       this.checkViewportSize();
     });
+
+    if (!this.scrollable) {
+      // No scrollable is provided, so the virtual-scroll-viewport needs to become a scrollable
+      renderer.addClass(this.elementRef.nativeElement, 'cdk-virtual-scrollable');
+      this.scrollable = this;
+    }
   }
 
   override ngOnInit() {
-    super.ngOnInit();
-
+    if (this.scrollable === this) {
+      super.ngOnInit();
+    }
     // It's still too early to measure the viewport at this point. Deferring with a promise allows
     // the Viewport to be rendered with the correct size before we measure. We run this outside the
     // zone to avoid causing more change detection cycles. We handle the change detection loop
@@ -203,7 +215,8 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
         this._measureViewportSize();
         this._scrollStrategy.attach(this);
 
-        this.elementScrolled()
+        this.scrollable
+          .elementScrolled()
           .pipe(
             // Start off with a fake scroll event so we properly detect our initial position.
             startWith(null),
@@ -361,7 +374,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     } else {
       options.top = offset;
     }
-    this.scrollTo(options);
+    this.scrollable.scrollTo(options);
   }
 
   /**
@@ -374,16 +387,50 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
   }
 
   /**
-   * Gets the current scroll offset from the start of the viewport (in pixels).
+   * Gets the current scroll offset from the start of the scrollable (in pixels).
    * @param from The edge to measure the offset from. Defaults to 'top' in vertical mode and 'start'
    *     in horizontal mode.
    */
   override measureScrollOffset(
     from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end',
   ): number {
-    return from
-      ? super.measureScrollOffset(from)
-      : super.measureScrollOffset(this.orientation === 'horizontal' ? 'start' : 'top');
+    // This is to break the call cycle
+    let measureScrollOffset: InstanceType<typeof CdkVirtualScrollable>['measureScrollOffset'];
+    if (this.scrollable == this) {
+      measureScrollOffset = (_from: NonNullable<typeof from>) => super.measureScrollOffset(_from);
+    } else {
+      measureScrollOffset = (_from: NonNullable<typeof from>) =>
+        this.scrollable.measureScrollOffset(_from);
+    }
+
+    return Math.max(
+      0,
+      measureScrollOffset(from ?? (this.orientation === 'horizontal' ? 'start' : 'top')) -
+        this.measureViewportOffset(),
+    );
+  }
+
+  measureViewportOffset(from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end') {
+    let fromRect: 'left' | 'top' | 'right' | 'bottom';
+    const LEFT = 'left';
+    const RIGHT = 'right';
+    const isRtl = this.dir?.value == 'rtl';
+    if (from == 'start') {
+      fromRect = isRtl ? RIGHT : LEFT;
+    } else if (from == 'end') {
+      fromRect = isRtl ? LEFT : RIGHT;
+    } else if (from) {
+      fromRect = from;
+    } else {
+      fromRect = this.orientation === 'horizontal' ? 'left' : 'top';
+    }
+
+    const scrollerClientRect = this.scrollable
+      .getElementRef()
+      .nativeElement.getBoundingClientRect()[fromRect];
+    const viewportClientRect = this.elementRef.nativeElement.getBoundingClientRect()[fromRect];
+
+    return viewportClientRect - scrollerClientRect;
   }
 
   /** Measure the combined size of all of the rendered items. */
@@ -412,9 +459,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
 
   /** Measure the viewport size. */
   private _measureViewportSize() {
-    const viewportEl = this.elementRef.nativeElement;
-    this._viewportSize =
-      this.orientation === 'horizontal' ? viewportEl.clientWidth : viewportEl.clientHeight;
+    this._viewportSize = this.scrollable.measureViewportSize(this.orientation);
   }
 
   /** Queue up change detection to run. */

--- a/src/cdk/scrolling/virtual-scroll-viewport.ts
+++ b/src/cdk/scrolling/virtual-scroll-viewport.ts
@@ -294,7 +294,7 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
     return this._renderedRange;
   }
 
-  getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number {
+  measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number {
     return this.getElementRef().nativeElement.getBoundingClientRect()[from];
   }
 
@@ -416,6 +416,10 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
     );
   }
 
+  /**
+   * Measures the offset of the viewport from the scrolling container
+   * @param from The edge to measure from.
+   */
   measureViewportOffset(from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end') {
     let fromRect: 'left' | 'top' | 'right' | 'bottom';
     const LEFT = 'left';
@@ -431,7 +435,7 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
       fromRect = this.orientation === 'horizontal' ? 'left' : 'top';
     }
 
-    const scrollerClientRect = this.scrollable.getBoundingClientRectWithScrollOffset(fromRect);
+    const scrollerClientRect = this.scrollable.measureBoundingClientRectWithScrollOffset(fromRect);
     const viewportClientRect = this.elementRef.nativeElement.getBoundingClientRect()[fromRect];
 
     return viewportClientRect - scrollerClientRect;

--- a/src/cdk/scrolling/virtual-scrollable-element.ts
+++ b/src/cdk/scrolling/virtual-scrollable-element.ts
@@ -15,7 +15,7 @@ import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
  * Provides a virtual scrollable for the element it is attached to.
  */
 @Directive({
-  selector: '[cdk-virtual-scrollable-element], [cdkVirtualScrollableElement]',
+  selector: '[cdkVirtualScrollingElement]',
   providers: [{provide: VIRTUAL_SCROLLABLE, useExisting: CdkVirtualScrollableElement}],
   host: {
     'class': 'cdk-virtual-scrollable',

--- a/src/cdk/scrolling/virtual-scrollable-element.ts
+++ b/src/cdk/scrolling/virtual-scrollable-element.ts
@@ -27,4 +27,11 @@ export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
   ) {
     super(elementRef, scrollDispatcher, ngZone, dir);
   }
+
+  getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number {
+    return (
+      this.getElementRef().nativeElement.getBoundingClientRect()[from] -
+      this.measureScrollOffset(from)
+    );
+  }
 }

--- a/src/cdk/scrolling/virtual-scrollable-element.ts
+++ b/src/cdk/scrolling/virtual-scrollable-element.ts
@@ -11,6 +11,9 @@ import {Directive, ElementRef, NgZone, Optional} from '@angular/core';
 import {ScrollDispatcher} from './scroll-dispatcher';
 import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
 
+/**
+ * Provides a virtual scrollable for the element it is attached to.
+ */
 @Directive({
   selector: '[cdk-virtual-scrollable-element], [cdkVirtualScrollableElement]',
   providers: [{provide: VIRTUAL_SCROLLABLE, useExisting: CdkVirtualScrollableElement}],
@@ -28,7 +31,9 @@ export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
     super(elementRef, scrollDispatcher, ngZone, dir);
   }
 
-  getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number {
+  override measureBoundingClientRectWithScrollOffset(
+    from: 'left' | 'top' | 'right' | 'bottom',
+  ): number {
     return (
       this.getElementRef().nativeElement.getBoundingClientRect()[from] -
       this.measureScrollOffset(from)

--- a/src/cdk/scrolling/virtual-scrollable-element.ts
+++ b/src/cdk/scrolling/virtual-scrollable-element.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directionality} from '@angular/cdk/bidi';
+import {Directive, ElementRef, NgZone, Optional} from '@angular/core';
+import {ScrollDispatcher} from './scroll-dispatcher';
+import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
+
+@Directive({
+  selector: '[cdk-virtual-scrollable-element], [cdkVirtualScrollableElement]',
+  providers: [{provide: VIRTUAL_SCROLLABLE, useExisting: CdkVirtualScrollableElement}],
+  host: {
+    'class': 'cdk-virtual-scrollable',
+  },
+})
+export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
+  constructor(
+    elementRef: ElementRef,
+    scrollDispatcher: ScrollDispatcher,
+    ngZone: NgZone,
+    @Optional() dir: Directionality,
+  ) {
+    super(elementRef, scrollDispatcher, ngZone, dir);
+  }
+}

--- a/src/cdk/scrolling/virtual-scrollable-window.ts
+++ b/src/cdk/scrolling/virtual-scrollable-window.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directionality} from '@angular/cdk/bidi';
+import {Directive, ElementRef, NgZone, Optional} from '@angular/core';
+import {ScrollDispatcher} from './scroll-dispatcher';
+import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
+
+@Directive({
+  selector: 'cdk-virtual-scroll-viewport[scrollable-window]',
+  providers: [{provide: VIRTUAL_SCROLLABLE, useExisting: CdkVirtualScrollableWindow}],
+})
+export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
+  constructor(scrollDispatcher: ScrollDispatcher, ngZone: NgZone, @Optional() dir: Directionality) {
+    super(new ElementRef(document.documentElement), scrollDispatcher, ngZone, dir);
+  }
+}

--- a/src/cdk/scrolling/virtual-scrollable-window.ts
+++ b/src/cdk/scrolling/virtual-scrollable-window.ts
@@ -17,7 +17,7 @@ import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
  * Provides as virtual scrollable for the global / window scrollbar.
  */
 @Directive({
-  selector: 'cdk-virtual-scroll-viewport[scrollable-window]',
+  selector: 'cdk-virtual-scroll-viewport[scrollWindow]',
   providers: [{provide: VIRTUAL_SCROLLABLE, useExisting: CdkVirtualScrollableWindow}],
 })
 export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {

--- a/src/cdk/scrolling/virtual-scrollable-window.ts
+++ b/src/cdk/scrolling/virtual-scrollable-window.ts
@@ -13,6 +13,9 @@ import {takeUntil} from 'rxjs/operators';
 import {ScrollDispatcher} from './scroll-dispatcher';
 import {CdkVirtualScrollable, VIRTUAL_SCROLLABLE} from './virtual-scrollable';
 
+/**
+ * Provides as virtual scrollable for the global / window scrollbar.
+ */
 @Directive({
   selector: 'cdk-virtual-scroll-viewport[scrollable-window]',
   providers: [{provide: VIRTUAL_SCROLLABLE, useExisting: CdkVirtualScrollableWindow}],
@@ -29,7 +32,9 @@ export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
     super(new ElementRef(document.documentElement), scrollDispatcher, ngZone, dir);
   }
 
-  getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number {
+  override measureBoundingClientRectWithScrollOffset(
+    from: 'left' | 'top' | 'right' | 'bottom',
+  ): number {
     return this.getElementRef().nativeElement.getBoundingClientRect()[from];
   }
 }

--- a/src/cdk/scrolling/virtual-scrollable.ts
+++ b/src/cdk/scrolling/virtual-scrollable.ts
@@ -28,4 +28,6 @@ export abstract class CdkVirtualScrollable extends CdkScrollable {
     const viewportEl = this.elementRef.nativeElement;
     return orientation === 'horizontal' ? viewportEl.clientWidth : viewportEl.clientHeight;
   }
+
+  abstract getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
 }

--- a/src/cdk/scrolling/virtual-scrollable.ts
+++ b/src/cdk/scrolling/virtual-scrollable.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directionality} from '@angular/cdk/bidi';
+import {Directive, ElementRef, InjectionToken, NgZone, Optional} from '@angular/core';
+import {ScrollDispatcher} from './scroll-dispatcher';
+import {CdkScrollable} from './scrollable';
+
+export const VIRTUAL_SCROLLABLE = new InjectionToken<CdkVirtualScrollable>('VIRTUAL_SCROLLABLE');
+
+@Directive()
+export abstract class CdkVirtualScrollable extends CdkScrollable {
+  constructor(
+    elementRef: ElementRef<HTMLElement>,
+    scrollDispatcher: ScrollDispatcher,
+    ngZone: NgZone,
+    @Optional() dir?: Directionality,
+  ) {
+    super(elementRef, scrollDispatcher, ngZone, dir);
+  }
+
+  measureViewportSize(orientation: 'horizontal' | 'vertical') {
+    const viewportEl = this.elementRef.nativeElement;
+    return orientation === 'horizontal' ? viewportEl.clientWidth : viewportEl.clientHeight;
+  }
+}

--- a/src/cdk/scrolling/virtual-scrollable.ts
+++ b/src/cdk/scrolling/virtual-scrollable.ts
@@ -13,6 +13,9 @@ import {CdkScrollable} from './scrollable';
 
 export const VIRTUAL_SCROLLABLE = new InjectionToken<CdkVirtualScrollable>('VIRTUAL_SCROLLABLE');
 
+/**
+ * Extending the {@link CdkScrollable} to be used as scrolling container for virtual scrolling.
+ */
 @Directive()
 export abstract class CdkVirtualScrollable extends CdkScrollable {
   constructor(
@@ -24,10 +27,22 @@ export abstract class CdkVirtualScrollable extends CdkScrollable {
     super(elementRef, scrollDispatcher, ngZone, dir);
   }
 
+  /**
+   * Measure the viewport size for the provided orientation.
+   *
+   * @param orientation The orientation to measure the size from.
+   */
   measureViewportSize(orientation: 'horizontal' | 'vertical') {
     const viewportEl = this.elementRef.nativeElement;
     return orientation === 'horizontal' ? viewportEl.clientWidth : viewportEl.clientHeight;
   }
 
-  abstract getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
+  /**
+   * Measure the bounding ClientRect size including the scroll offset.
+   *
+   * @param from The edge to measure from.
+   */
+  abstract measureBoundingClientRectWithScrollOffset(
+    from: 'left' | 'top' | 'right' | 'bottom',
+  ): number;
 }

--- a/src/dev-app/virtual-scroll/virtual-scroll-demo.html
+++ b/src/dev-app/virtual-scroll/virtual-scroll-demo.html
@@ -181,7 +181,7 @@
 
 <h2>Custom virtual scroller</h2>
 
-<div class="demo-viewport" cdk-virtual-scrollable-element>
+<div class="demo-viewport" cdkVirtualScrollingElement>
   <p>Content before virtual scrolling items</p>
   <cdk-virtual-scroll-viewport itemSize="50">
     <div *cdkVirtualFor="let size of fixedSizeData; let i = index" class="demo-item"
@@ -194,7 +194,7 @@
 
 <h2>Window virtual scroller</h2>
 
-<cdk-virtual-scroll-viewport scrollable-window itemSize="50">
+<cdk-virtual-scroll-viewport scrollWindow itemSize="50">
   <div *cdkVirtualFor="let size of fixedSizeData; let i = index" class="demo-item"
        [style.height.px]="size">
     Item #{{i}} - ({{size}}px)

--- a/src/dev-app/virtual-scroll/virtual-scroll-demo.html
+++ b/src/dev-app/virtual-scroll/virtual-scroll-demo.html
@@ -178,3 +178,25 @@
     Item #{{i}} - ({{size}}px)
   </div>
 </cdk-virtual-scroll-viewport>
+
+<h2>Custom virtual scroller</h2>
+
+<div class="demo-viewport" cdk-virtual-scrollable-element>
+  <p>Content before virtual scrolling items</p>
+  <cdk-virtual-scroll-viewport itemSize="50">
+    <div *cdkVirtualFor="let size of fixedSizeData; let i = index" class="demo-item"
+         [style.height.px]="size">
+      Item #{{i}} - ({{size}}px)
+    </div>
+  </cdk-virtual-scroll-viewport>
+  <p>Content after virtual scrolling items</p>
+</div>
+
+<h2>Window virtual scroller</h2>
+
+<cdk-virtual-scroll-viewport scrollable-window itemSize="50">
+  <div *cdkVirtualFor="let size of fixedSizeData; let i = index" class="demo-item"
+       [style.height.px]="size">
+    Item #{{i}} - ({{size}}px)
+  </div>
+</cdk-virtual-scroll-viewport>

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -146,7 +146,7 @@ export abstract class CdkVirtualScrollable extends CdkScrollable {
     abstract measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     measureViewportSize(orientation: 'horizontal' | 'vertical'): number;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollable, never, never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollable, never, never, {}, {}, never, never, false>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollable, [null, null, null, { optional: true; }]>;
 }
@@ -157,7 +157,7 @@ export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
     // (undocumented)
     measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableElement, "[cdkVirtualScrollingElement]", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableElement, "[cdkVirtualScrollingElement]", never, {}, {}, never, never, false>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableElement, [null, null, null, { optional: true; }]>;
 }
@@ -170,7 +170,7 @@ export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
     // (undocumented)
     measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableWindow, "cdk-virtual-scroll-viewport[scrollWindow]", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableWindow, "cdk-virtual-scroll-viewport[scrollWindow]", never, {}, {}, never, never, false>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableWindow, [null, null, { optional: true; }]>;
 }

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -136,6 +136,35 @@ export type CdkVirtualForOfContext<T> = {
     odd: boolean;
 };
 
+// @public (undocumented)
+export abstract class CdkVirtualScrollable extends CdkScrollable {
+    constructor(elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir?: Directionality);
+    // (undocumented)
+    measureViewportSize(orientation: 'horizontal' | 'vertical'): number;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollable, never, never, {}, {}, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollable, [null, null, null, { optional: true; }]>;
+}
+
+// @public (undocumented)
+export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
+    constructor(elementRef: ElementRef, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir: Directionality);
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableElement, "[cdk-virtual-scrollable-element], [cdkVirtualScrollableElement]", never, {}, {}, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableElement, [null, null, null, { optional: true; }]>;
+}
+
+// @public (undocumented)
+export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
+    constructor(scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir: Directionality);
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableWindow, "cdk-virtual-scroll-viewport[scrollable-window]", never, {}, {}, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableWindow, [null, null, { optional: true; }]>;
+}
+
 // @public
 export interface CdkVirtualScrollRepeater<T> {
     // (undocumented)
@@ -145,8 +174,8 @@ export interface CdkVirtualScrollRepeater<T> {
 }
 
 // @public
-export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, OnDestroy {
-    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher, viewportRuler: ViewportRuler);
+export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements OnInit, OnDestroy {
+    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher, viewportRuler: ViewportRuler, renderer: Renderer2, scrollable: CdkVirtualScrollable);
     get appendOnly(): boolean;
     set appendOnly(value: BooleanInput);
     attach(forOf: CdkVirtualScrollRepeater<any>): void;
@@ -163,12 +192,16 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     measureRenderedContentSize(): number;
     measureScrollOffset(from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number;
     // (undocumented)
+    measureViewportOffset(from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number;
+    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
     get orientation(): 'horizontal' | 'vertical';
     set orientation(orientation: 'horizontal' | 'vertical');
     readonly renderedRangeStream: Observable<ListRange>;
+    // (undocumented)
+    scrollable: CdkVirtualScrollable;
     readonly scrolledIndexChange: Observable<number>;
     scrollToIndex(index: number, behavior?: ScrollBehavior): void;
     scrollToOffset(offset: number, behavior?: ScrollBehavior): void;
@@ -180,7 +213,7 @@ export class CdkVirtualScrollViewport extends CdkScrollable implements OnInit, O
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkVirtualScrollViewport, "cdk-virtual-scroll-viewport", never, { "orientation": "orientation"; "appendOnly": "appendOnly"; }, { "scrolledIndexChange": "scrolledIndexChange"; }, never, ["*"], false>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollViewport, [null, null, null, { optional: true; }, { optional: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollViewport, [null, null, null, { optional: true; }, { optional: true; }, null, null, null, { optional: true; }]>;
 }
 
 // @public
@@ -299,6 +332,9 @@ export interface ViewportScrollPosition {
 
 // @public
 export const VIRTUAL_SCROLL_STRATEGY: InjectionToken<VirtualScrollStrategy>;
+
+// @public (undocumented)
+export const VIRTUAL_SCROLLABLE: InjectionToken<CdkVirtualScrollable>;
 
 // @public
 export interface VirtualScrollStrategy {

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -12,7 +12,7 @@ import { Directionality } from '@angular/cdk/bidi';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i5 from '@angular/cdk/bidi';
+import * as i7 from '@angular/cdk/bidi';
 import { InjectionToken } from '@angular/core';
 import { IterableDiffers } from '@angular/core';
 import { ListRange } from '@angular/cdk/collections';
@@ -63,10 +63,14 @@ export class CdkFixedSizeVirtualScroll implements OnChanges {
 export class CdkScrollable implements OnInit, OnDestroy {
     constructor(elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir?: Directionality | undefined);
     // (undocumented)
+    protected readonly _destroyed: Subject<void>;
+    // (undocumented)
     protected dir?: Directionality | undefined;
     // (undocumented)
     protected elementRef: ElementRef<HTMLElement>;
     elementScrolled(): Observable<Event>;
+    // (undocumented)
+    protected _elementScrolled: Observable<Event>;
     getElementRef(): ElementRef<HTMLElement>;
     measureScrollOffset(from: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number;
     // (undocumented)
@@ -140,6 +144,8 @@ export type CdkVirtualForOfContext<T> = {
 export abstract class CdkVirtualScrollable extends CdkScrollable {
     constructor(elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir?: Directionality);
     // (undocumented)
+    abstract getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
+    // (undocumented)
     measureViewportSize(orientation: 'horizontal' | 'vertical'): number;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollable, never, never, {}, {}, never>;
@@ -151,6 +157,8 @@ export abstract class CdkVirtualScrollable extends CdkScrollable {
 export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
     constructor(elementRef: ElementRef, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir: Directionality);
     // (undocumented)
+    getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
+    // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableElement, "[cdk-virtual-scrollable-element], [cdkVirtualScrollableElement]", never, {}, {}, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableElement, [null, null, null, { optional: true; }]>;
@@ -159,6 +167,10 @@ export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
 // @public (undocumented)
 export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
     constructor(scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir: Directionality);
+    // (undocumented)
+    protected _elementScrolled: Observable<Event>;
+    // (undocumented)
+    getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableWindow, "cdk-virtual-scroll-viewport[scrollable-window]", never, {}, {}, never>;
     // (undocumented)
@@ -175,7 +187,7 @@ export interface CdkVirtualScrollRepeater<T> {
 
 // @public
 export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements OnInit, OnDestroy {
-    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher, viewportRuler: ViewportRuler, renderer: Renderer2, scrollable: CdkVirtualScrollable);
+    constructor(elementRef: ElementRef<HTMLElement>, _changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, _scrollStrategy: VirtualScrollStrategy, dir: Directionality, scrollDispatcher: ScrollDispatcher, viewportRuler: ViewportRuler, scrollable: CdkVirtualScrollable);
     get appendOnly(): boolean;
     set appendOnly(value: BooleanInput);
     attach(forOf: CdkVirtualScrollRepeater<any>): void;
@@ -184,6 +196,8 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
     detach(): void;
     // (undocumented)
     elementRef: ElementRef<HTMLElement>;
+    // (undocumented)
+    getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     getDataLength(): number;
     getOffsetToRenderedContentStart(): number | null;
     getRenderedRange(): ListRange;
@@ -213,7 +227,7 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<CdkVirtualScrollViewport, "cdk-virtual-scroll-viewport", never, { "orientation": "orientation"; "appendOnly": "appendOnly"; }, { "scrolledIndexChange": "scrolledIndexChange"; }, never, ["*"], false>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollViewport, [null, null, null, { optional: true; }, { optional: true; }, null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollViewport, [null, null, null, { optional: true; }, { optional: true; }, null, null, { optional: true; }]>;
 }
 
 // @public
@@ -283,7 +297,7 @@ export class ScrollingModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<ScrollingModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ScrollingModule, [typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport], [typeof i5.BidiModule, typeof CdkScrollableModule], [typeof i5.BidiModule, typeof CdkScrollableModule, typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ScrollingModule, [typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport, typeof i5.CdkVirtualScrollableWindow, typeof i6.CdkVirtualScrollableElement], [typeof i7.BidiModule, typeof CdkScrollableModule], [typeof i7.BidiModule, typeof CdkScrollableModule, typeof i2.CdkFixedSizeVirtualScroll, typeof i3.CdkVirtualForOf, typeof i4.CdkVirtualScrollViewport, typeof i5.CdkVirtualScrollableWindow, typeof i6.CdkVirtualScrollableElement]>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -140,12 +140,10 @@ export type CdkVirtualForOfContext<T> = {
     odd: boolean;
 };
 
-// @public (undocumented)
+// @public
 export abstract class CdkVirtualScrollable extends CdkScrollable {
     constructor(elementRef: ElementRef<HTMLElement>, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir?: Directionality);
-    // (undocumented)
-    abstract getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
-    // (undocumented)
+    abstract measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     measureViewportSize(orientation: 'horizontal' | 'vertical'): number;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollable, never, never, {}, {}, never>;
@@ -153,24 +151,24 @@ export abstract class CdkVirtualScrollable extends CdkScrollable {
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollable, [null, null, null, { optional: true; }]>;
 }
 
-// @public (undocumented)
+// @public
 export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
     constructor(elementRef: ElementRef, scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir: Directionality);
     // (undocumented)
-    getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
+    measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableElement, "[cdk-virtual-scrollable-element], [cdkVirtualScrollableElement]", never, {}, {}, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableElement, [null, null, null, { optional: true; }]>;
 }
 
-// @public (undocumented)
+// @public
 export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
     constructor(scrollDispatcher: ScrollDispatcher, ngZone: NgZone, dir: Directionality);
     // (undocumented)
     protected _elementScrolled: Observable<Event>;
     // (undocumented)
-    getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
+    measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableWindow, "cdk-virtual-scroll-viewport[scrollable-window]", never, {}, {}, never>;
     // (undocumented)
@@ -196,16 +194,15 @@ export class CdkVirtualScrollViewport extends CdkVirtualScrollable implements On
     detach(): void;
     // (undocumented)
     elementRef: ElementRef<HTMLElement>;
-    // (undocumented)
-    getBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     getDataLength(): number;
     getOffsetToRenderedContentStart(): number | null;
     getRenderedRange(): ListRange;
     getViewportSize(): number;
+    // (undocumented)
+    measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     measureRangeSize(range: ListRange): number;
     measureRenderedContentSize(): number;
     measureScrollOffset(from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number;
-    // (undocumented)
     measureViewportOffset(from?: 'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'): number;
     // (undocumented)
     ngOnDestroy(): void;

--- a/tools/public_api_guard/cdk/scrolling.md
+++ b/tools/public_api_guard/cdk/scrolling.md
@@ -157,7 +157,7 @@ export class CdkVirtualScrollableElement extends CdkVirtualScrollable {
     // (undocumented)
     measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableElement, "[cdk-virtual-scrollable-element], [cdkVirtualScrollableElement]", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableElement, "[cdkVirtualScrollingElement]", never, {}, {}, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableElement, [null, null, null, { optional: true; }]>;
 }
@@ -170,7 +170,7 @@ export class CdkVirtualScrollableWindow extends CdkVirtualScrollable {
     // (undocumented)
     measureBoundingClientRectWithScrollOffset(from: 'left' | 'top' | 'right' | 'bottom'): number;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableWindow, "cdk-virtual-scroll-viewport[scrollable-window]", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CdkVirtualScrollableWindow, "cdk-virtual-scroll-viewport[scrollWindow]", never, {}, {}, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkVirtualScrollableWindow, [null, null, { optional: true; }]>;
 }


### PR DESCRIPTION
Decouples the scroller from the virtual-scroll-viewport which allows library consumers
to use any parent element as a scroller. This is especially helpful when building SPAs
with a single global scrollbar.

Closes #13862

@mmalerba this is first draft, test and docs updates are missing. But I would like to have your feedback regarding certain points.

1. WDYT about the API changes in general?

2. There are a couple of lines, only to maintain backward compatibility. I am not sure if it's worth it, as I would expect that the required changes on applications could be done using schematics.  Changing `<cdk-virtual-scroll-viewport ...` to `<cdk-virtual-scroll-viewport cdk-virtual-scrollable-element ...` should be sufficient.

3. I had some problems linking it to the global-scrollbar. As commented in the code, although documentElement is the scrolling element, no scroll event is fired. The current approach is the shortest one, but seems a little ugly to me. Instead of using html-elements in scrollable, using an adaptor could be an option as well.

4. As done multiple times, the conversion from `'top' | 'left' | 'right' | 'bottom' | 'start' | 'end'` to `'left' | 'top' | 'right' | 'bottom'` can be extracted to a new method. But where should I put this? Is `cdk/src/platform/features/scrolling` the correct place?