### PR TITLE
refactor(material/datepicker): unit test with not the first of the month

### DIFF
--- a/src/material/datepicker/multi-year-view.spec.ts
+++ b/src/material/datepicker/multi-year-view.spec.ts
@@ -116,7 +116,7 @@ describe('MatMultiYearView', () => {
           ) as HTMLElement;
           expect(calendarBodyEl).not.toBeNull();
           dir.value = 'ltr';
-          fixture.componentInstance.date = new Date(2017, JAN, 1);
+          fixture.componentInstance.date = new Date(2017, JAN, 3);
           dispatchFakeEvent(calendarBodyEl, 'focus');
           fixture.detectChanges();
         });
@@ -125,96 +125,96 @@ describe('MatMultiYearView', () => {
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2016, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2016, JAN, 3));
 
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', LEFT_ARROW);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2015, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2015, JAN, 3));
         });
 
         it('should increment year on right arrow press', () => {
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2018, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2018, JAN, 3));
 
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', RIGHT_ARROW);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2019, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2019, JAN, 3));
         });
 
         it('should go up a row on up arrow press', () => {
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2017 - yearsPerRow, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2017 - yearsPerRow, JAN, 3));
 
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', UP_ARROW);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2017 - yearsPerRow * 2, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2017 - yearsPerRow * 2, JAN, 3));
         });
 
         it('should go down a row on down arrow press', () => {
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2017 + yearsPerRow, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2017 + yearsPerRow, JAN, 3));
 
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', DOWN_ARROW);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2017 + yearsPerRow * 2, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2017 + yearsPerRow * 2, JAN, 3));
         });
 
         it('should go to first year in current range on home press', () => {
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2016, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2016, JAN, 3));
 
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', HOME);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2016, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2016, JAN, 3));
         });
 
         it('should go to last year in current range on end press', () => {
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2039, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2039, JAN, 3));
 
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', END);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2039, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2039, JAN, 3));
         });
 
         it('should go to same index in previous year range page up press', () => {
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2017 - yearsPerPage, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2017 - yearsPerPage, JAN, 3));
 
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_UP);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2017 - yearsPerPage * 2, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2017 - yearsPerPage * 2, JAN, 3));
         });
 
         it('should go to same index in next year range on page down press', () => {
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2017 + yearsPerPage, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2017 + yearsPerPage, JAN, 3));
 
           dispatchKeyboardEvent(calendarBodyEl, 'keydown', PAGE_DOWN);
           fixture.detectChanges();
 
-          expect(calendarInstance.date).toEqual(new Date(2017 + yearsPerPage * 2, JAN, 1));
+          expect(calendarInstance.date).toEqual(new Date(2017 + yearsPerPage * 2, JAN, 3));
         });
       });
     });


### PR DESCRIPTION
This change only affects the unit tests and doesn't not affect
application code. It's a small improvement to the unit tests in the
multi-year view to use Jan 3 instead of Jan 1. This can catch more bugs
because we could catch that we're setting a date to the first of the
month when we're not supposed to.