### PR TITLE
build: use less ambiguous peer dependency to Angular framework

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -1,7 +1,7 @@
 # Each individual package uses a placeholder for the version of Angular to ensure they're
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
-ANGULAR_PACKAGE_VERSION = "^13.0.0 || ^14.0.0-0"
+ANGULAR_PACKAGE_VERSION = "^13.0.0 || ^14.0.0"
 MDC_PACKAGE_VERSION = "14.0.0-canary.9736ddce9.0"
 TSLIB_PACKAGE_VERSION = "^2.3.0"
 RXJS_PACKAGE_VERSION = "^6.5.3 || ^7.4.0"

--- a/tools/release-checks/check-framework-peer-dependency.ts
+++ b/tools/release-checks/check-framework-peer-dependency.ts
@@ -11,16 +11,21 @@ const bzlConfigPath = join(__dirname, '../../packages.bzl');
 /**
  * Ensures that the Angular version placeholder has been correctly updated to support
  * given Angular versions. The following rules apply:
- *   `N.x.x` requires Angular `^N.0.0 || (N+1).0.0-0`
- *   `N.0.0-x` requires Angular `^N.0.0-0 || (N+1).0.0-0`
+ *
+ *   `N.x.x` requires Angular `^N.0.0 || (N+1).0.0`
+ *   `N.0.0-x` requires Angular `^N.0.0-0 || (N+1).0.0`
+ *
+ * The rationale is that we want to satisfy peer dependencies if we are publishing
+ * pre-releases for a major while Angular framework cuts pre-releases as well. e.g.
+ * Angular CDK v14.0.0-rc.1 should also work with `@angular/core@v14.0.0-rc.1`.
  */
 export async function assertValidFrameworkPeerDependency(newVersion: SemVer) {
   const currentVersionRange = _extractAngularVersionPlaceholderOrThrow();
   const isMajorWithPrerelease =
     newVersion.minor === 0 && newVersion.patch === 0 && !!newVersion.prerelease[0];
   const requiredRange = isMajorWithPrerelease
-    ? `^${newVersion.major}.0.0-0 || ^${newVersion.major + 1}.0.0-0`
-    : `^${newVersion.major}.0.0 || ^${newVersion.major + 1}.0.0-0`;
+    ? `^${newVersion.major}.0.0-0 || ^${newVersion.major + 1}.0.0`
+    : `^${newVersion.major}.0.0 || ^${newVersion.major + 1}.0.0`;
 
   if (requiredRange !== currentVersionRange) {
     error(


### PR DESCRIPTION
Our current peer dependency for Angular CDK/Material v13 also allows
for Angular `v14.0.0-0`. This might work practically since Angular FW
v14 is usually compatible with Angular N-1 versions.

Although this peer dependency version is currently a little ambiguous since
it does not allow for all v14 pre-releases. Rather as per NPMs definition, the
current range does only allow for `v14.x.y` and `v14.0.0-(next|rc).X`
(excluding pre-releases for other minors)

It seems like it would be best to avoid this pre-release "range extension" in general
to avoid this ambiguity/inconsistency, while also fixing https://github.com/angular/angular-cli/issues/22654.

In general, it seems reasonable to say that Angular CDK v13 is compatible
with Angular FW v13, and Angular FW v14 (both of these ranges excluding
pre-releases consistently)