### PR TITLE
docs: theming docs misspells pink-bluegrey.css as pink-bluegray.css

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -286,7 +286,7 @@ $light-theme: mat.define-light-theme((
 
 // Define a dark theme
 $dark-primary: mat.define-palette(mat.$pink-palette);
-$dark-accent: mat.define-palette(mat.$blue-gray-palette);
+$dark-accent: mat.define-palette(mat.$blue-grey-palette);
 $dark-theme: mat.define-dark-theme((
  color: (
    primary: $dark-primary,


### PR DESCRIPTION
Rename `pink-bluegray.css` to `pink-bluegrey.css`

Fixed typo referring to theme file name `pink-bluegrey.css` in theming guide.

Fixes #24378