### PR TITLE
fix(material-experimental/mdc-dialog): align change detection with non-MDC version

### DIFF
--- a/src/material-experimental/mdc-dialog/dialog-container.ts
+++ b/src/material-experimental/mdc-dialog/dialog-container.ts
@@ -32,7 +32,9 @@ import {cssClasses, numbers} from '@material/dialog';
   templateUrl: 'dialog-container.html',
   styleUrls: ['dialog.css'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
+  // Disabled for consistency with the non-MDC dialog container.
+  // tslint:disable-next-line:validate-decorators
+  changeDetection: ChangeDetectionStrategy.Default,
   host: {
     'class': 'mat-mdc-dialog-container mdc-dialog',
     'tabindex': '-1',


### PR DESCRIPTION
The non-MDC dialog container uses `Default` change detection while the MDC one uses `OnPush` which causes issues for users trying to migrate. These changes align the behavior to make things easier.