### PR TITLE
feat(material/menu): support zone-less mode

### DIFF
--- a/src/cdk/overlay/overlay-config.ts
+++ b/src/cdk/overlay/overlay-config.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ApplicationRef} from '@angular/core';
 import {PositionStrategy} from './position/position-strategy';
 import {Direction, Directionality} from '@angular/cdk/bidi';
 import {ScrollStrategy, NoopScrollStrategy} from './scroll/index';
@@ -57,6 +58,12 @@ export class OverlayConfig {
    * the `HashLocationStrategy`).
    */
   disposeOnNavigation?: boolean = false;
+
+  /**
+   * The `ApplicationRef` should be provided when the zone is nooped to run the `tick()`
+   * when the content is detached.
+   */
+  appRef?: ApplicationRef;
 
   constructor(config?: OverlayConfig) {
     if (config) {

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -67,7 +67,10 @@ export class Overlay {
     const host = this._createHostElement();
     const pane = this._createPaneElement(host);
     const portalOutlet = this._createPortalOutlet(pane);
-    const overlayConfig = new OverlayConfig(config);
+    const overlayConfig = new OverlayConfig({
+      ...config,
+      appRef: this._appRef,
+    });
 
     overlayConfig.direction = overlayConfig.direction || this._directionality.value;
 

--- a/src/cdk/platform/features/noop-ng-zone.ts
+++ b/src/cdk/platform/features/noop-ng-zone.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Utility class for checking if the user's application is nooped.
+ * Note, this is a class and not an exported function, because we'll be able to mock the
+ * method within unit tests. Unit tests depend on `zone.js` to be imported and there's no
+ * way to run unit tests with a nooped zone. Doing, for instance, `delete ɵglobal.Zone` may
+ * fail unit tests running in parallel.
+ */
+export class NoopNgZoneChecker {
+  /**
+   * Checks whether the user's application uses the `zone.js`, which exports the `Zone`
+   * class into the global scope. This function differs from `NgZone.isInAngularZone()`.
+   * The `NgZone.isInAngularZone()` checks whether the code is running within the Angular zone,
+   * but we can't know if the zone is nooped or not.
+   */
+  static isNoopNgZone(): boolean {
+    // Note: we can't reference `zone.js` types through `/// <reference types="zone.js" />`
+    // since `zone.js` package may be missing.
+    // @ts-ignore
+    return typeof Zone === 'undefined';
+  }
+}

--- a/src/cdk/platform/public-api.ts
+++ b/src/cdk/platform/public-api.ts
@@ -13,3 +13,4 @@ export * from './features/passive-listeners';
 export * from './features/scrolling';
 export * from './features/shadow-dom';
 export * from './features/test-environment';
+export * from './features/noop-ng-zone';

--- a/src/material-experimental/mdc-menu/BUILD.bazel
+++ b/src/material-experimental/mdc-menu/BUILD.bazel
@@ -65,11 +65,13 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/overlay",
+        "//src/cdk/platform",
         "//src/cdk/scrolling",
         "//src/cdk/testing/private",
         "//src/material-experimental/mdc-core",
         "//src/material/menu",
         "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
         "@npm//rxjs",
     ],
 )

--- a/src/material/menu/BUILD.bazel
+++ b/src/material/menu/BUILD.bazel
@@ -64,10 +64,12 @@ ng_test_library(
         "//src/cdk/bidi",
         "//src/cdk/keycodes",
         "//src/cdk/overlay",
+        "//src/cdk/platform",
         "//src/cdk/scrolling",
         "//src/cdk/testing/private",
         "//src/material/core",
         "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
         "@npm//rxjs",
     ],
 )

--- a/tools/public_api_guard/cdk/overlay.md
+++ b/tools/public_api_guard/cdk/overlay.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ApplicationRef } from '@angular/core';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { ComponentFactoryResolver } from '@angular/core';
@@ -275,6 +276,7 @@ export class Overlay {
 // @public
 export class OverlayConfig {
     constructor(config?: OverlayConfig);
+    appRef?: ApplicationRef;
     backdropClass?: string | string[];
     direction?: Direction | Directionality;
     disposeOnNavigation?: boolean;

--- a/tools/public_api_guard/cdk/platform.md
+++ b/tools/public_api_guard/cdk/platform.md
@@ -25,6 +25,11 @@ export function getSupportedInputTypes(): Set<string>;
 export function _isTestEnvironment(): boolean;
 
 // @public
+export class NoopNgZoneChecker {
+    static isNoopNgZone(): boolean;
+}
+
+// @public
 export function normalizePassiveListenerOptions(options: AddEventListenerOptions): AddEventListenerOptions | boolean;
 
 // @public

--- a/tools/public_api_guard/material/menu.md
+++ b/tools/public_api_guard/material/menu.md
@@ -91,7 +91,7 @@ export const matMenuAnimations: {
 
 // @public
 export class _MatMenuBase implements AfterContentInit, MatMenuPanel<MatMenuItem>, OnInit, OnDestroy {
-    constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _defaultOptions: MatMenuDefaultOptions, _changeDetectorRef?: ChangeDetectorRef | undefined);
+    constructor(_elementRef: ElementRef<HTMLElement>, _ngZone: NgZone, _defaultOptions: MatMenuDefaultOptions, _changeDetectorRef?: ChangeDetectorRef | undefined, _appRef?: ApplicationRef | undefined);
     // (undocumented)
     addItem(_item: MatMenuItem): void;
     _allItems: QueryList<MatMenuItem>;


### PR DESCRIPTION
The template:

```html
<button mat-button [matMenuTriggerFor]="menu">Menu</button>
<mat-menu #menu="matMenu">
  <button mat-menu-item>Item 1</button>
  <button mat-menu-item>Item 2</button>
</mat-menu>
```

Basically, the `mat-menu` is never opened when the zone is nooped through `{ ngZone: 'noop' }`. I've left comments near my changes. The CI will prolly fail so I'll fix it after it's run.

### Before
https://user-images.githubusercontent.com/7337691/154817177-e83822d7-6fb1-487c-b101-57385deed9bb.mp4

### After
https://user-images.githubusercontent.com/7337691/154817212-5cc30100-5c74-4b19-9c49-66910238633c.mp4



