### PR TITLE
refactor(material/schematics): replace usages of deprecated TypeScript APIs

### DIFF
--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
@@ -762,9 +762,9 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
       HAMMER_CONFIG_TOKEN_NAME,
       HAMMER_CONFIG_TOKEN_MODULE,
     );
-    const newProviderNode = ts.createObjectLiteral([
-      ts.createPropertyAssignment('provide', hammerConfigTokenExpr),
-      ts.createPropertyAssignment('useClass', gestureConfigExpr),
+    const newProviderNode = ts.factory.createObjectLiteralExpression([
+      ts.factory.createPropertyAssignment('provide', hammerConfigTokenExpr),
+      ts.factory.createPropertyAssignment('useClass', gestureConfigExpr),
     ]);
 
     // If the providers field exists and already contains references to the hammer gesture

--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/import-manager.ts
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/import-manager.ts
@@ -210,15 +210,15 @@ export class ImportManager {
       // If no symbol name has been specified, the default import is requested. In that
       // case we search for non-namespace and non-specifier imports.
       if (!symbolName && !importData.namespace && !importData.specifiers) {
-        return ts.createIdentifier(importData.name!.text);
+        return ts.factory.createIdentifier(importData.name!.text);
       }
 
       // In case a "Type" symbol is imported, we can't use namespace imports
       // because these only export symbols available at runtime (no types)
       if (importData.namespace && !typeImport) {
-        return ts.createPropertyAccess(
-          ts.createIdentifier(importData.name!.text),
-          ts.createIdentifier(symbolName || 'default'),
+        return ts.factory.createPropertyAccessExpression(
+          ts.factory.createIdentifier(importData.name!.text),
+          ts.factory.createIdentifier(symbolName || 'default'),
         );
       } else if (importData.specifiers && symbolName) {
         const existingSpecifier = importData.specifiers.find(s =>
@@ -226,7 +226,7 @@ export class ImportManager {
         );
 
         if (existingSpecifier) {
-          return ts.createIdentifier(existingSpecifier.name.text);
+          return ts.factory.createIdentifier(existingSpecifier.name.text);
         }
 
         // In case the symbol could not be found in an existing import, we
@@ -239,7 +239,7 @@ export class ImportManager {
     // If there is an existing import that matches the specified module, we
     // just update the import specifiers to also import the requested symbol.
     if (existingImport) {
-      const propertyIdentifier = ts.createIdentifier(symbolName!);
+      const propertyIdentifier = ts.factory.createIdentifier(symbolName!);
       const generatedUniqueIdentifier = this._getUniqueIdentifier(
         sourceFile,
         symbolName!,
@@ -267,7 +267,7 @@ export class ImportManager {
     let newImport: AnalyzedImport | null = null;
 
     if (symbolName) {
-      const propertyIdentifier = ts.createIdentifier(symbolName);
+      const propertyIdentifier = ts.factory.createIdentifier(symbolName);
       const generatedUniqueIdentifier = this._getUniqueIdentifier(
         sourceFile,
         symbolName,
@@ -276,11 +276,11 @@ export class ImportManager {
       const needsGeneratedUniqueName = generatedUniqueIdentifier.text !== symbolName;
       identifier = needsGeneratedUniqueName ? generatedUniqueIdentifier : propertyIdentifier;
 
-      const newImportDecl = ts.createImportDeclaration(
+      const newImportDecl = ts.factory.createImportDeclaration(
         undefined,
         undefined,
-        ts.createImportClause(undefined, ts.createNamedImports([])),
-        ts.createStringLiteral(moduleName),
+        ts.factory.createImportClause(false, undefined, ts.factory.createNamedImports([])),
+        ts.factory.createStringLiteral(moduleName),
       );
 
       newImport = {
@@ -300,11 +300,11 @@ export class ImportManager {
         'defaultExport',
         ignoreIdentifierCollisions,
       );
-      const newImportDecl = ts.createImportDeclaration(
+      const newImportDecl = ts.factory.createImportDeclaration(
         undefined,
         undefined,
-        ts.createImportClause(identifier, undefined),
-        ts.createStringLiteral(moduleName),
+        ts.factory.createImportClause(false, identifier, undefined),
+        ts.factory.createStringLiteral(moduleName),
       );
       newImport = {
         moduleName,
@@ -351,19 +351,19 @@ export class ImportManager {
           const importSpecifiers = importData.specifiers.map(s =>
             createImportSpecifier(s.propertyName, s.name),
           );
-          const updatedBindings = ts.updateNamedImports(namedBindings, importSpecifiers);
+          const updatedBindings = ts.factory.updateNamedImports(namedBindings, importSpecifiers);
 
           // In case an import has been added newly, we need to print the whole import
           // declaration and insert it at the import start index. Otherwise, we just
           // update the named bindings to not re-print the whole import (which could
           // cause unnecessary formatting changes)
           if (hasFlag(importData, ImportState.ADDED)) {
-            const updatedImport = ts.updateImportDeclaration(
+            const updatedImport = ts.factory.updateImportDeclaration(
               importData.node,
               undefined,
               undefined,
-              ts.createImportClause(undefined, updatedBindings),
-              ts.createStringLiteral(importData.moduleName),
+              ts.factory.createImportClause(false, undefined, updatedBindings),
+              ts.factory.createStringLiteral(importData.moduleName),
               undefined,
             );
             const newImportText = this._printer.printNode(
@@ -452,7 +452,7 @@ export class ImportManager {
   ): ts.Identifier {
     if (this._isUniqueIdentifierName(sourceFile, symbolName, ignoreIdentifierCollisions)) {
       this._recordUsedIdentifier(sourceFile, symbolName);
-      return ts.createIdentifier(symbolName);
+      return ts.factory.createIdentifier(symbolName);
     }
 
     let name: string | null = null;
@@ -462,7 +462,7 @@ export class ImportManager {
     } while (!this._isUniqueIdentifierName(sourceFile, name, ignoreIdentifierCollisions));
 
     this._recordUsedIdentifier(sourceFile, name!);
-    return ts.createIdentifier(name!);
+    return ts.factory.createIdentifier(name!);
   }
 
   /**
@@ -535,6 +535,6 @@ function createImportSpecifier(
   name: ts.Identifier,
 ): ts.ImportSpecifier {
   return PARSED_TS_VERSION > 4.4
-    ? ts.createImportSpecifier(false, propertyName, name)
+    ? ts.factory.createImportSpecifier(false, propertyName, name)
     : (ts.createImportSpecifier as any)(propertyName, name);
 }

--- a/src/material/schematics/ng-update/migrations/package-imports-v8/secondary-entry-points-migration.ts
+++ b/src/material/schematics/ng-update/migrations/package-imports-v8/secondary-entry-points-migration.ts
@@ -121,11 +121,11 @@ export class SecondaryEntryPointsMigration extends Migration<null> {
     const newImportStatements = Array.from(importMap.entries())
       .sort()
       .map(([name, elements]) => {
-        const newImport = ts.createImportDeclaration(
+        const newImport = ts.factory.createImportDeclaration(
           undefined,
           undefined,
-          ts.createImportClause(undefined, ts.createNamedImports(elements)),
-          createStringLiteral(`${materialModuleSpecifier}/${name}`, singleQuoteImport),
+          ts.factory.createImportClause(false, undefined, ts.factory.createNamedImports(elements)),
+          ts.factory.createStringLiteral(`${materialModuleSpecifier}/${name}`, singleQuoteImport),
         );
         return this.printer.printNode(
           ts.EmitHint.Unspecified,
@@ -151,18 +151,6 @@ export class SecondaryEntryPointsMigration extends Migration<null> {
     recorder.remove(declaration.getStart(), declaration.getWidth());
     recorder.insertRight(declaration.getStart(), newImportStatements);
   }
-}
-
-/**
- * Creates a string literal from the specified text.
- * @param text Text of the string literal.
- * @param singleQuotes Whether single quotes should be used when printing the literal node.
- */
-function createStringLiteral(text: string, singleQuotes: boolean): ts.StringLiteral {
-  const literal = ts.createStringLiteral(text);
-  // See: https://github.com/microsoft/TypeScript/blob/master/src/compiler/utilities.ts#L584-L590
-  (literal as any).singleQuote = singleQuotes;
-  return literal;
 }
 
 /** Gets the symbol that contains the value declaration of the given node. */


### PR DESCRIPTION
Replaces all of our usages of deprecated `ts.create*` and `ts.update*` APIs with their non-deprecated counterparts.