### PR TITLE
build: install snapshot builds for angular-devkit and schematics

### DIFF
--- a/scripts/circleci/setup-angular-snapshots.js
+++ b/scripts/circleci/setup-angular-snapshots.js
@@ -15,14 +15,16 @@
  */
 
 /**
- * Regular expression matching packages we would like to install snapshots for.
+ * Array defining the packages we would like to install snapshots for.
  *
- * Assumes that all matched packages will have corresponding snapshot Github
- * repositories under the Angular organization.
- *
- * Note that specific packages can be excluded in the `ignorePackages` array below.
+ * Additionally each entry will have a mapping to the corresponding snapshot
+ * builds repo name. This is necessary as the repository names are inconsistent.
  */
-const targetPackageRegex = /^@(angular|angular-devkit|schematics)\//;
+const snapshotPackages = [
+  {matcher: /^@angular\/(.+)$/, repoName: `angular/$1-builds`},
+  {matcher: /^@angular-devkit\/(.+)$/, repoName: `angular/angular-devkit-$1-builds`},
+  {matcher: /^@schematics\/(.+)$/, repoName: `angular/schematics-$1-builds`},
+];
 
 /** List of packages which should not be updated to a snapshot build. */
 const ignorePackages = [
@@ -45,36 +47,45 @@ const packageSuffix = tag ? ` (${tag})` : '';
 // See: https://yarnpkg.com/lang/en/docs/package-json/#toc-resolutions for the API.
 packageJson['resolutions'] = packageJson['resolutions'] || {};
 
-// List of packages which should be updated to their most recent snapshot version, or
-// snapshot version based on the specified tag.
-const snapshotPackages = Object.keys({
+const packagesToConsider = Object.keys({
   ...packageJson.dependencies,
   ...packageJson.devDependencies,
-}).filter(
-  packageName => targetPackageRegex.test(packageName) && !ignorePackages.includes(packageName),
-);
+});
+
+// List of packages which should be updated to their most recent snapshot version, or
+// snapshot version based on the specified tag.
+const packagesToUpdate = packagesToConsider.reduce((result, name) => {
+  if (ignorePackages.includes(name)) {
+    return result;
+  }
+
+  const matchedEntry = snapshotPackages.find(p => p.matcher.test(name));
+  if (matchedEntry === undefined) {
+    return result;
+  }
+  const repoName = name.replace(matchedEntry.matcher, matchedEntry.repoName);
+
+  return result.concat([{name, repoName}]);
+}, []);
 
 console.log('Setting up snapshot builds for:\n');
-console.log(`  ${snapshotPackages.map(n => `${n}${packageSuffix}`).join('\n  ')}\n`);
+console.log(`  ${packagesToUpdate.map(p => `${p.name}${packageSuffix}`).join('\n  ')}\n`);
 
 // Setup the snapshot version for each Angular package specified in the "package.json" file.
-snapshotPackages.forEach(packageName => {
-  const parts = packageName.split('/');
-  const scopeName = parts[0].substring(1);
-  const snapshotRepoPrefix = scopeName === 'angular' ? parts[1] : `${scopeName}-${parts[1]}`;
-  const buildsUrl = `github:angular/${snapshotRepoPrefix}-builds${tag ? `#${tag}` : ''}`;
+packagesToUpdate.forEach(({name, repoName}) => {
+  const buildsUrl = `github:angular/${repoName}${tag ? `#${tag}` : ''}`;
 
   // Add resolutions for each package in the format "**/{PACKAGE}" so that all
   // nested versions of that specific Angular package will have the same version.
-  packageJson.resolutions[`**/${packageName}`] = buildsUrl;
+  packageJson.resolutions[`**/${name}`] = buildsUrl;
 
   // Since the resolutions only cover the version of all nested installs, we also need
   // to explicitly set the version for the package listed in the project "package.json".
-  packageJson.dependencies[packageName] = buildsUrl;
+  packageJson.dependencies[name] = buildsUrl;
 
   // In case this dependency was previously a dev dependency, just remove it because we
   // re-added it as a normal dependency for simplicity.
-  delete packageJson.devDependencies[packageName];
+  delete packageJson.devDependencies[name];
 });
 
 // Write changes to the "packageJson", so that we can install the new versions afterwards.


### PR DESCRIPTION
Our snapshot build jobs should also install the snapshots for the devkit
and schematics packages (owned by the tooling team). These need to match
up with the CLI package that is currently already updated by the snapshot
setup script.