### PR TITLE
fix(material/radio): clicks not propagating to wrapper elements

### DIFF
--- a/src/material/radio/radio.scss
+++ b/src/material/radio/radio.scss
@@ -203,6 +203,10 @@ $ripple-radius: 20px;
   width: 100%;
   height: 100%;
   cursor: inherit;
+
+  // Puts the input behind the circle while keeping it visible so that
+  // it allows `click` events to propagate up to the `label` wrapper.
+  z-index: -1;
 }
 
 @include a11y.high-contrast(active, off) {


### PR DESCRIPTION
Fixes a regression caused by #19505 where clicking directly on the `input` element will prevent the click from reaching custom `click` listeners outside the radio button.