### PR TITLE
refactor(material/checkbox): remove xml:space attr from svg checkmark

### DIFF
--- a/src/material/checkbox/checkbox.html
+++ b/src/material/checkbox/checkbox.html
@@ -30,7 +30,6 @@
            focusable="false"
            class="mat-checkbox-checkmark"
            viewBox="0 0 24 24"
-           xml:space="preserve"
            aria-hidden="true">
         <path class="mat-checkbox-checkmark-path"
               fill="none"


### PR DESCRIPTION
It seems that it was accidentally added in the first version of the component. unneeded attribute `xml:space` is removed.

Info about `xml:space`: http://www.xmlplease.com/xml/xmlspace/