### PR TITLE
ci: instruct renovate to not update/override merge ready PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "automerge": false,
   "baseBranches": ["master"],
   "enabledManagers": ["npm", "bazel", "github-actions"],
+  "stopUpdatingLabel": "merge ready",
   "labels": ["target: patch", "merge safe"],
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
Sometimes Renovate proposes an update and we need to add some
manual fixups, like updating a size golden. For this we push to
same upstream branch.

Renovate will update the PR though when another new revision/version
becomes available, overriding the fixup and discarding it.

This happened quite often now and causes significantly more
work required by the dev-infra time.