### PR TITLE
build: cleanup leftover from `esModuleInterop` in `tools`

### DIFF
--- a/scripts/generate-schematic-imports-map.ts
+++ b/scripts/generate-schematic-imports-map.ts
@@ -1,7 +1,7 @@
 import {sync as glob} from 'glob';
 import {readFileSync, writeFileSync} from 'fs';
 import {join, basename} from 'path';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 // Script that generates mappings from our publicly-exported symbols to their entry points. The
 // mappings are intended to be used by the secondary entry points schematic and should be committed

--- a/tools/tslint-rules/noHostDecoratorInConcreteRule.ts
+++ b/tools/tslint-rules/noHostDecoratorInConcreteRule.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as Lint from 'tslint';
 
 export class Rule extends Lint.Rules.AbstractRule {

--- a/tools/tslint-rules/noLifecycleInvocationRule.ts
+++ b/tools/tslint-rules/noLifecycleInvocationRule.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as Lint from 'tslint';
-import * as ts from 'typescript';
+import ts from 'typescript';
 import minimatch from 'minimatch';
 
 const hooks = new Set([

--- a/tools/tslint-rules/noNestedTernaryRule.ts
+++ b/tools/tslint-rules/noNestedTernaryRule.ts
@@ -1,5 +1,5 @@
 import * as Lint from 'tslint';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 /** Rule that enforces that ternary expressions aren't being nested. */
 export class Rule extends Lint.Rules.AbstractRule {

--- a/tools/tslint-rules/noPrivateGettersRule.ts
+++ b/tools/tslint-rules/noPrivateGettersRule.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as Lint from 'tslint';
 import * as tsutils from 'tsutils';
 

--- a/tools/tslint-rules/noUndecoratedBaseClassDiRule.ts
+++ b/tools/tslint-rules/noUndecoratedBaseClassDiRule.ts
@@ -1,5 +1,5 @@
 import * as Lint from 'tslint';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 const RULE_FAILURE =
   `Class inherits constructor using dependency injection from ` +

--- a/tools/tslint-rules/noUndecoratedClassWithAngularFeaturesRule.ts
+++ b/tools/tslint-rules/noUndecoratedClassWithAngularFeaturesRule.ts
@@ -1,5 +1,5 @@
 import * as Lint from 'tslint';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 const RULE_FAILURE =
   `Undecorated class uses Angular features. Undecorated ` +

--- a/tools/tslint-rules/noUnescapedHtmlTagRule.ts
+++ b/tools/tslint-rules/noUnescapedHtmlTagRule.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as Lint from 'tslint';
 import * as utils from 'tsutils';
 

--- a/tools/tslint-rules/preferConstEnumRule.ts
+++ b/tools/tslint-rules/preferConstEnumRule.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as Lint from 'tslint';
 import * as tsutils from 'tsutils';
 

--- a/tools/tslint-rules/requireBreakingChangeVersionRule.ts
+++ b/tools/tslint-rules/requireBreakingChangeVersionRule.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as Lint from 'tslint';
 import * as utils from 'tsutils';
 

--- a/tools/tslint-rules/settersAfterGettersRule.ts
+++ b/tools/tslint-rules/settersAfterGettersRule.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as Lint from 'tslint';
 import * as tsutils from 'tsutils';
 

--- a/tools/tslint-rules/symbolNamingRule.ts
+++ b/tools/tslint-rules/symbolNamingRule.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import * as Lint from 'tslint';
 
 /** Lint rule that checks the names of classes and interfaces against a pattern. */


### PR DESCRIPTION
Cleans up a few leftovers that were accidentally missed in:
0f8d5296cef49b5b7300b9523e350db2a151c5e5

FYI: I will set up a lint rule (we have on in dev-infra) once schematics are also migrated. For now this
is not really critical and the lint rule does not support globbing yet.