### PR TITLE
fix(material-experimental/mdc-chips): expose avatar harness

### DIFF
--- a/src/material-experimental/mdc-chips/testing/public-api.ts
+++ b/src/material-experimental/mdc-chips/testing/public-api.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export * from './chip-avatar-harness';
 export * from './chip-harness';
 export * from './chip-harness-filters';
 export * from './chip-input-harness';


### PR DESCRIPTION
This harness was missing from the export list - I assume it was done unintentionally