### PR TITLE
build: fix standalone release checks failing due to missing global `ReleaseAction` instance

### DIFF
--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -1,6 +1,7 @@
 import {
   BuiltPackage,
   ReleaseConfig,
+  ReleaseAction as _ReleaseAction,
   FatalReleaseActionError,
 } from '@angular/dev-infra-private/ng-dev';
 import {SemVer} from 'semver';
@@ -11,7 +12,7 @@ import {join} from 'path';
 // The `ng-dev` release tool exposes the `ReleaseAction` instance through `global`,
 // allowing it to be monkey-patched for our release checks. This can be removed
 // when the release tool has a public API for release checks.
-const actionProto = (global as any).ReleaseAction.prototype;
+const actionProto = ((global as any).ReleaseAction ?? _ReleaseAction).prototype;
 const _origStageFn = actionProto.stageVersionForBranchAndCreatePullRequest;
 const _origVerifyFn = actionProto._verifyPackageVersions;
 


### PR DESCRIPTION
Fixes the standalone release checks running outside of the `.ng-dev` config load (which
comes with the `global.ReleaseAction`). In standalone checks this variable is not
defined and therefore currently causes errors like:

```
/.ng-dev/release.ts:14
const actionProto = (global as any).ReleaseAction.prototype;
                                                  ^
TypeError: Cannot read properties of undefined (reading 'prototype')
    at Object.<anonymous>
```

We can fallback to the imported `ReleaseAction` constructor object if the global reference
is not provided. In such cases the monkey-patching is a noop anyway.