### PR TITLE
docs(cdk/schematics): more precise warning for inexistent tsconfig

### DIFF
--- a/src/cdk/schematics/ng-update/devkit-migration-rule.ts
+++ b/src/cdk/schematics/ng-update/devkit-migration-rule.ts
@@ -91,7 +91,9 @@ export function createMigrationSchematicRule(
       const testTsconfigPath = getTargetTsconfigPath(project, 'test');
 
       if (!buildTsconfigPath && !testTsconfigPath) {
-        logger.warn(`Could not find TypeScript project for project: ${projectName}`);
+        logger.warn(
+          `Skipping migration for project ${projectName}. Unable to determine 'tsconfig.json' file in workspace config.`,
+        );
         continue;
       }
 


### PR DESCRIPTION
Previously the message was not very clear about what happened if reading the warning. The new wording states that a project is skipped during migrations which should be clearer to users.