### PR TITLE
Revert "fix(material/checkbox): incorrect text color when placed inside an overlay with a dark theme (#19054)"

### DIFF
--- a/src/material/checkbox/_checkbox-theme.scss
+++ b/src/material/checkbox/_checkbox-theme.scss
@@ -32,12 +32,6 @@
     fill: $checkbox-mark-color;
   }
 
-  .mat-checkbox-label {
-    // Explicitly set the text color since the checkbox may be
-    // inside an overlay that doesn't have the proper theme text color.
-    color: theming.get-color-from-palette($foreground, 'text');
-  }
-
   .mat-checkbox-checkmark-path {
     // !important is needed here because a stroke must be set as an
     // attribute on the SVG in order for line animation to work properly.


### PR DESCRIPTION
This reverts commit f20122a4998f65c46452dc680adaec49cea7c0f5 which has some internal issues.