### PR TITLE
test: provide a test component that opens components in a dialog

### DIFF
--- a/src/material-experimental/mdc-dialog/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-dialog/testing/BUILD.bazel
@@ -9,8 +9,11 @@ ts_library(
         exclude = ["**/*.spec.ts"],
     ),
     deps = [
+        "//src/cdk/overlay",
         "//src/cdk/testing",
+        "//src/material-experimental/mdc-dialog",
         "//src/material/dialog/testing",
+        "@npm//@angular/core",
     ],
 )
 
@@ -29,6 +32,7 @@ ng_test_library(
         ":testing",
         "//src/material-experimental/mdc-dialog",
         "//src/material/dialog/testing:harness_tests_lib",
+        "@npm//@angular/platform-browser",
     ],
 )
 

--- a/src/material-experimental/mdc-dialog/testing/BUILD.bazel
+++ b/src/material-experimental/mdc-dialog/testing/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//src/material-experimental/mdc-dialog",
         "//src/material/dialog/testing",
         "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
     ],
 )
 

--- a/src/material-experimental/mdc-dialog/testing/dialog-opener.spec.ts
+++ b/src/material-experimental/mdc-dialog/testing/dialog-opener.spec.ts
@@ -1,0 +1,46 @@
+import {Component, Inject} from '@angular/core';
+import {fakeAsync, TestBed, flush} from '@angular/core/testing';
+import {
+  MatTestDialogOpenerModule,
+  MatTestDialogOpener,
+} from '@angular/material-experimental/mdc-dialog/testing';
+import {MAT_DIALOG_DATA, MatDialogState} from '@angular/material-experimental/mdc-dialog';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+
+describe('MDC-based MatTestDialogOpener', () => {
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [MatTestDialogOpenerModule, NoopAnimationsModule],
+      declarations: [ExampleComponent],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  it('should open a dialog when created', fakeAsync(() => {
+    const fixture = TestBed.createComponent(MatTestDialogOpener.withComponent(ExampleComponent));
+    flush();
+    expect(fixture.componentInstance.dialogRef.getState()).toBe(MatDialogState.OPEN);
+    expect(document.querySelector('mat-dialog-container')).toBeTruthy();
+  }));
+
+  it('should throw an error if no dialog component is provided', () => {
+    expect(() => TestBed.createComponent(MatTestDialogOpener)).toThrow(
+      Error('MatTestDialogOpener does not have a component provided.'),
+    );
+  });
+
+  it('should pass data to the component', fakeAsync(() => {
+    const config = {data: 'test'};
+    TestBed.createComponent(MatTestDialogOpener.withComponent(ExampleComponent, config));
+    flush();
+    const dialogContainer = document.querySelector('mat-dialog-container');
+    expect(dialogContainer!.innerHTML).toContain('Data: test');
+  }));
+});
+
+/** Simple component for testing MatTestDialogOpener. */
+@Component({template: 'Data: {{data}}'})
+class ExampleComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: any) {}
+}

--- a/src/material-experimental/mdc-dialog/testing/dialog-opener.spec.ts
+++ b/src/material-experimental/mdc-dialog/testing/dialog-opener.spec.ts
@@ -4,7 +4,11 @@ import {
   MatTestDialogOpenerModule,
   MatTestDialogOpener,
 } from '@angular/material-experimental/mdc-dialog/testing';
-import {MAT_DIALOG_DATA, MatDialogState} from '@angular/material-experimental/mdc-dialog';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+  MatDialogState,
+} from '@angular/material-experimental/mdc-dialog';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('MDC-based MatTestDialogOpener', () => {
@@ -37,10 +41,41 @@ describe('MDC-based MatTestDialogOpener', () => {
     const dialogContainer = document.querySelector('mat-dialog-container');
     expect(dialogContainer!.innerHTML).toContain('Data: test');
   }));
+
+  it('should get closed result data', fakeAsync(() => {
+    const config = {data: 'test'};
+    const fixture = TestBed.createComponent(
+      MatTestDialogOpener.withComponent<ExampleComponent, ExampleDialogResult>(
+        ExampleComponent,
+        config,
+      ),
+    );
+    flush();
+    const closeButton = document.querySelector('#close-btn') as HTMLElement;
+    closeButton.click();
+    flush();
+    expect(fixture.componentInstance.closedResult).toEqual({reason: 'closed'});
+  }));
 });
 
+interface ExampleDialogResult {
+  reason: string;
+}
+
 /** Simple component for testing MatTestDialogOpener. */
-@Component({template: 'Data: {{data}}'})
+@Component({
+  template: `
+    Data: {{data}}
+    <button id="close-btn" (click)="close()">Close</button>
+  `,
+})
 class ExampleComponent {
-  constructor(@Inject(MAT_DIALOG_DATA) public data: any) {}
+  constructor(
+    public dialogRef: MatDialogRef<ExampleComponent, ExampleDialogResult>,
+    @Inject(MAT_DIALOG_DATA) public data: any,
+  ) {}
+
+  close() {
+    this.dialogRef.close({reason: 'closed'});
+  }
 }

--- a/src/material-experimental/mdc-dialog/testing/dialog-opener.ts
+++ b/src/material-experimental/mdc-dialog/testing/dialog-opener.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentType} from '@angular/cdk/overlay';
+import {ChangeDetectionStrategy, Component, NgModule, ViewEncapsulation} from '@angular/core';
+import {_MatTestDialogOpenerBase} from '@angular/material/dialog/testing';
+import {
+  MatDialog,
+  MatDialogContainer,
+  MatDialogModule,
+  MatDialogConfig,
+} from '@angular/material-experimental/mdc-dialog';
+
+/** Test component that immediately opens a dialog when bootstrapped. */
+@Component({
+  selector: 'mat-test-dialog-opener',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class MatTestDialogOpener extends _MatTestDialogOpenerBase<MatDialogContainer> {
+  constructor(dialog: MatDialog) {
+    super(dialog);
+  }
+
+  /** Static method that prepares this class to open the provided component. */
+  static withComponent(component: ComponentType<unknown>, config?: MatDialogConfig) {
+    _MatTestDialogOpenerBase.component = component;
+    _MatTestDialogOpenerBase.config = config;
+    return MatTestDialogOpener;
+  }
+}
+
+@NgModule({
+  declarations: [MatTestDialogOpener],
+  imports: [MatDialogModule],
+})
+export class MatTestDialogOpenerModule {}

--- a/src/material-experimental/mdc-dialog/testing/dialog-opener.ts
+++ b/src/material-experimental/mdc-dialog/testing/dialog-opener.ts
@@ -15,7 +15,7 @@ import {
   MatDialogModule,
   MatDialogConfig,
 } from '@angular/material-experimental/mdc-dialog';
-import {NoopAnimationsModule} from "@angular/platform-browser/animations";
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 /** Test component that immediately opens a dialog when bootstrapped. */
 @Component({
@@ -24,16 +24,16 @@ import {NoopAnimationsModule} from "@angular/platform-browser/animations";
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatTestDialogOpener extends _MatTestDialogOpenerBase<MatDialogContainer> {
+export class MatTestDialogOpener<T, R> extends _MatTestDialogOpenerBase<MatDialogContainer, T, R> {
   constructor(dialog: MatDialog) {
     super(dialog);
   }
 
   /** Static method that prepares this class to open the provided component. */
-  static withComponent(component: ComponentType<unknown>, config?: MatDialogConfig) {
+  static withComponent<T, R>(component: ComponentType<T>, config?: MatDialogConfig) {
     _MatTestDialogOpenerBase.component = component;
     _MatTestDialogOpenerBase.config = config;
-    return MatTestDialogOpener;
+    return MatTestDialogOpener as ComponentType<MatTestDialogOpener<T, R>>;
   }
 }
 

--- a/src/material-experimental/mdc-dialog/testing/dialog-opener.ts
+++ b/src/material-experimental/mdc-dialog/testing/dialog-opener.ts
@@ -15,6 +15,7 @@ import {
   MatDialogModule,
   MatDialogConfig,
 } from '@angular/material-experimental/mdc-dialog';
+import {NoopAnimationsModule} from "@angular/platform-browser/animations";
 
 /** Test component that immediately opens a dialog when bootstrapped. */
 @Component({
@@ -38,6 +39,6 @@ export class MatTestDialogOpener extends _MatTestDialogOpenerBase<MatDialogConta
 
 @NgModule({
   declarations: [MatTestDialogOpener],
-  imports: [MatDialogModule],
+  imports: [MatDialogModule, NoopAnimationsModule],
 })
 export class MatTestDialogOpenerModule {}

--- a/src/material-experimental/mdc-dialog/testing/dialog-opener.ts
+++ b/src/material-experimental/mdc-dialog/testing/dialog-opener.ts
@@ -24,13 +24,20 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatTestDialogOpener<T, R> extends _MatTestDialogOpenerBase<MatDialogContainer, T, R> {
+export class MatTestDialogOpener<T = unknown, R = unknown> extends _MatTestDialogOpenerBase<
+  MatDialogContainer,
+  T,
+  R
+> {
   constructor(dialog: MatDialog) {
     super(dialog);
   }
 
   /** Static method that prepares this class to open the provided component. */
-  static withComponent<T, R>(component: ComponentType<T>, config?: MatDialogConfig) {
+  static withComponent<T = unknown, R = unknown>(
+    component: ComponentType<T>,
+    config?: MatDialogConfig,
+  ) {
     _MatTestDialogOpenerBase.component = component;
     _MatTestDialogOpenerBase.config = config;
     return MatTestDialogOpener as ComponentType<MatTestDialogOpener<T, R>>;

--- a/src/material-experimental/mdc-dialog/testing/public-api.ts
+++ b/src/material-experimental/mdc-dialog/testing/public-api.ts
@@ -8,3 +8,4 @@
 
 export {DialogHarnessFilters} from '@angular/material/dialog/testing';
 export {MatDialogHarness, MatDialogSection} from './dialog-harness';
+export * from './dialog-opener';

--- a/src/material/dialog/testing/BUILD.bazel
+++ b/src/material/dialog/testing/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//src/cdk/testing",
         "//src/material/dialog",
         "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],
 )

--- a/src/material/dialog/testing/BUILD.bazel
+++ b/src/material/dialog/testing/BUILD.bazel
@@ -10,8 +10,11 @@ ts_library(
     ),
     deps = [
         "//src/cdk/coercion",
+        "//src/cdk/overlay",
         "//src/cdk/testing",
         "//src/material/dialog",
+        "@npm//@angular/core",
+        "@npm//rxjs",
     ],
 )
 
@@ -43,6 +46,7 @@ ng_test_library(
         ":harness_tests_lib",
         ":testing",
         "//src/material/dialog",
+        "@npm//@angular/platform-browser",
     ],
 )
 

--- a/src/material/dialog/testing/dialog-opener.spec.ts
+++ b/src/material/dialog/testing/dialog-opener.spec.ts
@@ -1,0 +1,43 @@
+import {Component, Inject} from '@angular/core';
+import {fakeAsync, flush, TestBed} from '@angular/core/testing';
+import {MatTestDialogOpenerModule, MatTestDialogOpener} from '@angular/material/dialog/testing';
+import {MAT_DIALOG_DATA, MatDialogState} from '@angular/material/dialog';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+
+describe('MDC-based MatTestDialogOpener', () => {
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [MatTestDialogOpenerModule, NoopAnimationsModule],
+      declarations: [ExampleComponent],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  it('should open a dialog when created', fakeAsync(() => {
+    const fixture = TestBed.createComponent(MatTestDialogOpener.withComponent(ExampleComponent));
+    flush();
+    expect(fixture.componentInstance.dialogRef.getState()).toBe(MatDialogState.OPEN);
+    expect(document.querySelector('mat-dialog-container')).toBeTruthy();
+  }));
+
+  it('should throw an error if no dialog component is provided', () => {
+    expect(() => TestBed.createComponent(MatTestDialogOpener)).toThrow(
+      Error('MatTestDialogOpener does not have a component provided.'),
+    );
+  });
+
+  it('should pass data to the component', fakeAsync(() => {
+    const config = {data: 'test'};
+    TestBed.createComponent(MatTestDialogOpener.withComponent(ExampleComponent, config));
+    flush();
+    const dialogContainer = document.querySelector('mat-dialog-container');
+    expect(dialogContainer!.innerHTML).toContain('Data: test');
+  }));
+});
+
+/** Simple component for testing MatTestDialogOpener. */
+@Component({template: 'Data: {{data}}'})
+class ExampleComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: any) {}
+}

--- a/src/material/dialog/testing/dialog-opener.spec.ts
+++ b/src/material/dialog/testing/dialog-opener.spec.ts
@@ -1,7 +1,7 @@
 import {Component, Inject} from '@angular/core';
 import {fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {MatTestDialogOpenerModule, MatTestDialogOpener} from '@angular/material/dialog/testing';
-import {MAT_DIALOG_DATA, MatDialogState} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogRef, MatDialogState} from '@angular/material/dialog';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('MDC-based MatTestDialogOpener', () => {
@@ -34,10 +34,41 @@ describe('MDC-based MatTestDialogOpener', () => {
     const dialogContainer = document.querySelector('mat-dialog-container');
     expect(dialogContainer!.innerHTML).toContain('Data: test');
   }));
+
+  it('should get closed result data', fakeAsync(() => {
+    const config = {data: 'test'};
+    const fixture = TestBed.createComponent(
+      MatTestDialogOpener.withComponent<ExampleComponent, ExampleDialogResult>(
+        ExampleComponent,
+        config,
+      ),
+    );
+    flush();
+    const closeButton = document.querySelector('#close-btn') as HTMLElement;
+    closeButton.click();
+    flush();
+    expect(fixture.componentInstance.closedResult).toEqual({reason: 'closed'});
+  }));
 });
 
+interface ExampleDialogResult {
+  reason: string;
+}
+
 /** Simple component for testing MatTestDialogOpener. */
-@Component({template: 'Data: {{data}}'})
+@Component({
+  template: `
+    Data: {{data}}
+    <button id="close-btn" (click)="close()">Close</button>
+  `,
+})
 class ExampleComponent {
-  constructor(@Inject(MAT_DIALOG_DATA) public data: any) {}
+  constructor(
+    public dialogRef: MatDialogRef<ExampleComponent, ExampleDialogResult>,
+    @Inject(MAT_DIALOG_DATA) public data: any,
+  ) {}
+
+  close() {
+    this.dialogRef.close({reason: 'closed'});
+  }
 }

--- a/src/material/dialog/testing/dialog-opener.ts
+++ b/src/material/dialog/testing/dialog-opener.ts
@@ -25,15 +25,16 @@ import {
   MatDialogRef,
 } from '@angular/material/dialog';
 import {Subscription} from 'rxjs';
+import {NoopAnimationsModule} from "@angular/platform-browser/animations";
 
 /** Base class for a component that immediately opens a dialog when created. */
 @Directive()
 export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase> implements OnDestroy {
   /** Component that should be opened with the MatDialog `open` method. */
-  static component: ComponentType<unknown> | undefined;
+  protected static component: ComponentType<unknown> | undefined;
 
   /** Config that should be provided to the MatDialog `open` method. */
-  static config: MatDialogConfig | undefined;
+  protected static config: MatDialogConfig | undefined;
 
   /** MatDialogRef returned from the MatDialog `open` method. */
   dialogRef: MatDialogRef<unknown>;
@@ -86,7 +87,6 @@ export class MatTestDialogOpener extends _MatTestDialogOpenerBase<MatDialogConta
 
 @NgModule({
   declarations: [MatTestDialogOpener],
-  imports: [MatDialogModule],
-  providers: [{provide: _MatDialogBase, useExisting: MatDialog}],
+  imports: [MatDialogModule, NoopAnimationsModule],
 })
 export class MatTestDialogOpenerModule {}

--- a/src/material/dialog/testing/dialog-opener.ts
+++ b/src/material/dialog/testing/dialog-opener.ts
@@ -74,13 +74,20 @@ export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase, T, R>
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatTestDialogOpener<T, R> extends _MatTestDialogOpenerBase<MatDialogContainer, T, R> {
+export class MatTestDialogOpener<T = unknown, R = unknown> extends _MatTestDialogOpenerBase<
+  MatDialogContainer,
+  T,
+  R
+> {
   constructor(dialog: MatDialog) {
     super(dialog);
   }
 
   /** Static method that prepares this class to open the provided component. */
-  static withComponent<T, R>(component: ComponentType<T>, config?: MatDialogConfig) {
+  static withComponent<T = unknown, R = unknown>(
+    component: ComponentType<T>,
+    config?: MatDialogConfig,
+  ) {
     _MatTestDialogOpenerBase.component = component;
     _MatTestDialogOpenerBase.config = config;
     return MatTestDialogOpener as ComponentType<MatTestDialogOpener<T, R>>;

--- a/src/material/dialog/testing/dialog-opener.ts
+++ b/src/material/dialog/testing/dialog-opener.ts
@@ -25,11 +25,13 @@ import {
   MatDialogRef,
 } from '@angular/material/dialog';
 import {Subscription} from 'rxjs';
-import {NoopAnimationsModule} from "@angular/platform-browser/animations";
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 /** Base class for a component that immediately opens a dialog when created. */
 @Directive()
-export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase> implements OnDestroy {
+export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase, T, R>
+  implements OnDestroy
+{
   /** Component that should be opened with the MatDialog `open` method. */
   protected static component: ComponentType<unknown> | undefined;
 
@@ -37,10 +39,10 @@ export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase> impleme
   protected static config: MatDialogConfig | undefined;
 
   /** MatDialogRef returned from the MatDialog `open` method. */
-  dialogRef: MatDialogRef<unknown>;
+  dialogRef: MatDialogRef<T, R>;
 
   /** Data passed to the `MatDialog` close method. */
-  closedResult: unknown;
+  closedResult: R | undefined;
 
   private readonly _afterClosedSubscription: Subscription;
 
@@ -49,11 +51,11 @@ export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase> impleme
       throw new Error(`MatTestDialogOpener does not have a component provided.`);
     }
 
-    this.dialogRef = this.dialog.open(
-      _MatTestDialogOpenerBase.component,
+    this.dialogRef = this.dialog.open<T, R>(
+      _MatTestDialogOpenerBase.component as ComponentType<T>,
       _MatTestDialogOpenerBase.config || {},
     );
-    this._afterClosedSubscription = this.dialogRef.afterClosed().subscribe((result: unknown) => {
+    this._afterClosedSubscription = this.dialogRef.afterClosed().subscribe(result => {
       this.closedResult = result;
     });
   }
@@ -72,16 +74,16 @@ export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase> impleme
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class MatTestDialogOpener extends _MatTestDialogOpenerBase<MatDialogContainer> {
+export class MatTestDialogOpener<T, R> extends _MatTestDialogOpenerBase<MatDialogContainer, T, R> {
   constructor(dialog: MatDialog) {
     super(dialog);
   }
 
   /** Static method that prepares this class to open the provided component. */
-  static withComponent(component: ComponentType<unknown>, config?: MatDialogConfig) {
+  static withComponent<T, R>(component: ComponentType<T>, config?: MatDialogConfig) {
     _MatTestDialogOpenerBase.component = component;
     _MatTestDialogOpenerBase.config = config;
-    return MatTestDialogOpener;
+    return MatTestDialogOpener as ComponentType<MatTestDialogOpener<T, R>>;
   }
 }
 

--- a/src/material/dialog/testing/dialog-opener.ts
+++ b/src/material/dialog/testing/dialog-opener.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentType} from '@angular/cdk/overlay';
+import {
+  ChangeDetectionStrategy,
+  Directive,
+  Component,
+  NgModule,
+  OnDestroy,
+  ViewEncapsulation,
+} from '@angular/core';
+import {
+  _MatDialogBase,
+  _MatDialogContainerBase,
+  MatDialog,
+  MatDialogConfig,
+  MatDialogContainer,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import {Subscription} from 'rxjs';
+
+/** Base class for a component that immediately opens a dialog when created. */
+@Directive()
+export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase> implements OnDestroy {
+  /** Component that should be opened with the MatDialog `open` method. */
+  static component: ComponentType<unknown> | undefined;
+
+  /** Config that should be provided to the MatDialog `open` method. */
+  static config: MatDialogConfig | undefined;
+
+  /** MatDialogRef returned from the MatDialog `open` method. */
+  dialogRef: MatDialogRef<unknown>;
+
+  /** Data passed to the `MatDialog` close method. */
+  closedResult: unknown;
+
+  private readonly _afterClosedSubscription: Subscription;
+
+  constructor(public dialog: _MatDialogBase<C>) {
+    if (!_MatTestDialogOpenerBase.component) {
+      throw new Error(`MatTestDialogOpener does not have a component provided.`);
+    }
+
+    this.dialogRef = this.dialog.open(
+      _MatTestDialogOpenerBase.component,
+      _MatTestDialogOpenerBase.config || {},
+    );
+    this._afterClosedSubscription = this.dialogRef.afterClosed().subscribe((result: unknown) => {
+      this.closedResult = result;
+    });
+  }
+
+  ngOnDestroy() {
+    this._afterClosedSubscription.unsubscribe();
+    _MatTestDialogOpenerBase.component = undefined;
+    _MatTestDialogOpenerBase.config = undefined;
+  }
+}
+
+/** Test component that immediately opens a dialog when created. */
+@Component({
+  selector: 'mat-test-dialog-opener',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+})
+export class MatTestDialogOpener extends _MatTestDialogOpenerBase<MatDialogContainer> {
+  constructor(dialog: MatDialog) {
+    super(dialog);
+  }
+
+  /** Static method that prepares this class to open the provided component. */
+  static withComponent(component: ComponentType<unknown>, config?: MatDialogConfig) {
+    _MatTestDialogOpenerBase.component = component;
+    _MatTestDialogOpenerBase.config = config;
+    return MatTestDialogOpener;
+  }
+}
+
+@NgModule({
+  declarations: [MatTestDialogOpener],
+  imports: [MatDialogModule],
+  providers: [{provide: _MatDialogBase, useExisting: MatDialog}],
+})
+export class MatTestDialogOpenerModule {}

--- a/src/material/dialog/testing/public-api.ts
+++ b/src/material/dialog/testing/public-api.ts
@@ -8,3 +8,4 @@
 
 export * from './dialog-harness';
 export * from './dialog-harness-filters';
+export * from './dialog-opener';

--- a/tools/public_api_guard/material/dialog-testing.md
+++ b/tools/public_api_guard/material/dialog-testing.md
@@ -60,9 +60,9 @@ export const enum MatDialogSection {
 }
 
 // @public
-export class MatTestDialogOpener<T, R> extends _MatTestDialogOpenerBase<MatDialogContainer, T, R> {
+export class MatTestDialogOpener<T = unknown, R = unknown> extends _MatTestDialogOpenerBase<MatDialogContainer, T, R> {
     constructor(dialog: MatDialog);
-    static withComponent<T, R>(component: ComponentType<T>, config?: MatDialogConfig): ComponentType<MatTestDialogOpener<T, R>>;
+    static withComponent<T = unknown, R = unknown>(component: ComponentType<T>, config?: MatDialogConfig): ComponentType<MatTestDialogOpener<T, R>>;
 }
 
 // @public

--- a/tools/public_api_guard/material/dialog-testing.md
+++ b/tools/public_api_guard/material/dialog-testing.md
@@ -60,20 +60,20 @@ export const enum MatDialogSection {
 }
 
 // @public
-export class MatTestDialogOpener extends _MatTestDialogOpenerBase<MatDialogContainer> {
+export class MatTestDialogOpener<T, R> extends _MatTestDialogOpenerBase<MatDialogContainer, T, R> {
     constructor(dialog: MatDialog);
-    static withComponent(component: ComponentType<unknown>, config?: MatDialogConfig): typeof MatTestDialogOpener;
+    static withComponent<T, R>(component: ComponentType<T>, config?: MatDialogConfig): ComponentType<MatTestDialogOpener<T, R>>;
 }
 
 // @public
-export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase> implements OnDestroy {
+export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase, T, R> implements OnDestroy {
     constructor(dialog: _MatDialogBase<C>);
-    closedResult: unknown;
-    static component: ComponentType<unknown> | undefined;
-    static config: MatDialogConfig | undefined;
+    closedResult: R | undefined;
+    protected static component: ComponentType<unknown> | undefined;
+    protected static config: MatDialogConfig | undefined;
     // (undocumented)
     dialog: _MatDialogBase<C>;
-    dialogRef: MatDialogRef<unknown>;
+    dialogRef: MatDialogRef<T, R>;
     // (undocumented)
     ngOnDestroy(): void;
 }

--- a/tools/public_api_guard/material/dialog-testing.md
+++ b/tools/public_api_guard/material/dialog-testing.md
@@ -6,9 +6,17 @@
 
 import { AsyncFactoryFn } from '@angular/cdk/testing';
 import { BaseHarnessFilters } from '@angular/cdk/testing';
+import { ComponentType } from '@angular/cdk/overlay';
 import { ContentContainerComponentHarness } from '@angular/cdk/testing';
 import { DialogRole } from '@angular/material/dialog';
 import { HarnessPredicate } from '@angular/cdk/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { _MatDialogBase } from '@angular/material/dialog';
+import { MatDialogConfig } from '@angular/material/dialog';
+import { MatDialogContainer } from '@angular/material/dialog';
+import { _MatDialogContainerBase } from '@angular/material/dialog';
+import { MatDialogRef } from '@angular/material/dialog';
+import { OnDestroy } from '@angular/core';
 import { TestElement } from '@angular/cdk/testing';
 
 // @public
@@ -49,6 +57,29 @@ export const enum MatDialogSection {
     CONTENT = ".mat-dialog-content",
     // (undocumented)
     TITLE = ".mat-dialog-title"
+}
+
+// @public
+export class MatTestDialogOpener extends _MatTestDialogOpenerBase<MatDialogContainer> {
+    constructor(dialog: MatDialog);
+    static withComponent(component: ComponentType<unknown>, config?: MatDialogConfig): typeof MatTestDialogOpener;
+}
+
+// @public
+export class _MatTestDialogOpenerBase<C extends _MatDialogContainerBase> implements OnDestroy {
+    constructor(dialog: _MatDialogBase<C>);
+    closedResult: unknown;
+    static component: ComponentType<unknown> | undefined;
+    static config: MatDialogConfig | undefined;
+    // (undocumented)
+    dialog: _MatDialogBase<C>;
+    dialogRef: MatDialogRef<unknown>;
+    // (undocumented)
+    ngOnDestroy(): void;
+}
+
+// @public (undocumented)
+export class MatTestDialogOpenerModule {
 }
 
 // (No @packageDocumentation comment for this package)


### PR DESCRIPTION
This makes it trivial for users to open components in a dialog, avoiding the need to mock or inject dialog properties. See tests for how users could apply it