### PR TITLE
docs(material/datepicker): require confirmation buttons for a11y 

### DIFF
--- a/src/material/datepicker/datepicker.md
+++ b/src/material/datepicker/datepicker.md
@@ -566,6 +566,9 @@ The `MatDatepicker` pop-up uses the `role="dialog"` interaction pattern. This di
 multiple controls, the most prominent being the calendar itself. This calendar implements the
 `role="grid"` interaction pattern.
 
+Always enable [_confirmation action buttons_](#confirmation-action-buttons). This allows assistive
+technology users to explicitly confirm their selection before committing a value.
+
 The `MatDatepickerInput` and `MatDatepickerToggle` directives both apply the `aria-haspopup`
 attribute to the native input and button elements, respectively.
 


### PR DESCRIPTION
docs(material/datepicker): require confirmation buttons for a11y

For the datepicker accessiblity documentation, add instructions to always
provide confirmation buttons. This prevents an accessibility issue where
selecting a date on the calendar gives no audio feedback of the selected date
(https://github.com/angular/components/issues/23568).

This commit only affects the docs and does not change source code.

Addresses https://github.com/angular/components/issues/23568