### PR TITLE
fix(material-experimental/mdc-chips): Mirror aria-describedby to matChipInput

### DIFF
--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -853,13 +853,18 @@ describe('MDC-based MatChipGrid', () => {
     let errorTestComponent: ChipGridWithFormErrorMessages;
     let containerEl: HTMLElement;
     let chipGridEl: HTMLElement;
+    let inputEl: HTMLElement;
 
-    beforeEach(() => {
+    beforeEach(fakeAsync(() => {
       fixture = createComponent(ChipGridWithFormErrorMessages);
+      flush();
+      fixture.detectChanges();
+
       errorTestComponent = fixture.componentInstance;
       containerEl = fixture.debugElement.query(By.css('mat-form-field'))!.nativeElement;
       chipGridEl = fixture.debugElement.query(By.css('mat-chip-grid'))!.nativeElement;
-    });
+      inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    }));
 
     it('should not show any errors if the user has not interacted', () => {
       expect(errorTestComponent.formControl.untouched)
@@ -908,6 +913,7 @@ describe('MDC-based MatChipGrid', () => {
         .toBe(0);
 
       dispatchFakeEvent(fixture.debugElement.query(By.css('form'))!.nativeElement, 'submit');
+      flush();
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {
@@ -924,10 +930,12 @@ describe('MDC-based MatChipGrid', () => {
           .withContext('Expected aria-invalid to be set to "true".')
           .toBe('true');
       });
+      flush();
     }));
 
     it('should hide the errors and show the hints once the chip grid becomes valid', fakeAsync(() => {
       errorTestComponent.formControl.markAsTouched();
+      flush();
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {
@@ -942,6 +950,7 @@ describe('MDC-based MatChipGrid', () => {
           .toBe(0);
 
         errorTestComponent.formControl.setValue('something');
+        flush();
         fixture.detectChanges();
 
         fixture.whenStable().then(() => {
@@ -956,6 +965,8 @@ describe('MDC-based MatChipGrid', () => {
             .withContext('Expected one hint to be shown once the input is valid.')
             .toBe(1);
         });
+
+        flush();
       });
     }));
 
@@ -966,11 +977,11 @@ describe('MDC-based MatChipGrid', () => {
       expect(containerEl.querySelector('mat-error')!.getAttribute('aria-live')).toBe('polite');
     });
 
-    it('sets the aria-describedby to reference errors when in error state', () => {
+    it('sets the aria-describedby on the input to reference errors when in error state', fakeAsync(() => {
       let hintId = fixture.debugElement
         .query(By.css('.mat-mdc-form-field-hint'))!
         .nativeElement.getAttribute('id');
-      let describedBy = chipGridEl.getAttribute('aria-describedby');
+      let describedBy = inputEl.getAttribute('aria-describedby');
 
       expect(hintId).withContext('hint should be shown').toBeTruthy();
       expect(describedBy).toBe(hintId);
@@ -978,15 +989,19 @@ describe('MDC-based MatChipGrid', () => {
       fixture.componentInstance.formControl.markAsTouched();
       fixture.detectChanges();
 
+      // Flush the describedby timer and detect changes caused by it.
+      flush();
+      fixture.detectChanges();
+
       let errorIds = fixture.debugElement
         .queryAll(By.css('.mat-mdc-form-field-error'))
         .map(el => el.nativeElement.getAttribute('id'))
         .join(' ');
-      describedBy = chipGridEl.getAttribute('aria-describedby');
+      let errorDescribedBy = inputEl.getAttribute('aria-describedby');
 
       expect(errorIds).withContext('errors should be shown').toBeTruthy();
-      expect(describedBy).toBe(errorIds);
-    });
+      expect(errorDescribedBy).toBe(errorIds);
+    }));
   });
 
   function createComponent<T>(

--- a/src/material-experimental/mdc-chips/chip-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-input.spec.ts
@@ -25,39 +25,35 @@ describe('MDC-based MatChipInput', () => {
   let chipInputDirective: MatChipInput;
   let dir = 'ltr';
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [PlatformModule, MatChipsModule, MatFormFieldModule, NoopAnimationsModule],
-        declarations: [TestChipInput],
-        providers: [
-          {
-            provide: Directionality,
-            useFactory: () => {
-              return {
-                value: dir.toLowerCase(),
-                change: new Subject(),
-              };
-            },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [PlatformModule, MatChipsModule, MatFormFieldModule, NoopAnimationsModule],
+      declarations: [TestChipInput],
+      providers: [
+        {
+          provide: Directionality,
+          useFactory: () => {
+            return {
+              value: dir.toLowerCase(),
+              change: new Subject(),
+            };
           },
-        ],
-      });
+        },
+      ],
+    });
 
-      TestBed.compileComponents();
-    }),
-  );
+    TestBed.compileComponents();
+  }));
 
-  beforeEach(
-    waitForAsync(() => {
-      fixture = TestBed.createComponent(TestChipInput);
-      testChipInput = fixture.debugElement.componentInstance;
-      fixture.detectChanges();
+  beforeEach(waitForAsync(() => {
+    fixture = TestBed.createComponent(TestChipInput);
+    testChipInput = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
 
-      inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput))!;
-      chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
-      inputNativeElement = inputDebugElement.nativeElement;
-    }),
-  );
+    inputDebugElement = fixture.debugElement.query(By.directive(MatChipInput))!;
+    chipInputDirective = inputDebugElement.injector.get<MatChipInput>(MatChipInput);
+    inputNativeElement = inputDebugElement.nativeElement;
+  }));
 
   describe('basic behavior', () => {
     it('emits the (chipEnd) on enter keyup', () => {
@@ -230,6 +226,26 @@ describe('MDC-based MatChipInput', () => {
       dispatchKeyboardEvent(inputNativeElement, 'keydown', ENTER, undefined, {shift: true});
       expect(testChipInput.add).not.toHaveBeenCalled();
     });
+
+    it('should set aria-describedby correctly when a non-empty list of ids is passed to setDescribedByIds', fakeAsync(() => {
+      const ids = ['a', 'b', 'c'];
+
+      testChipInput.chipGridInstance.setDescribedByIds(ids);
+      flush();
+      fixture.detectChanges();
+
+      expect(inputNativeElement.getAttribute('aria-describedby')).toEqual('a b c');
+    }));
+
+    it('should set aria-describedby correctly when an empty list of ids is passed to setDescribedByIds', fakeAsync(() => {
+      const ids: string[] = [];
+
+      testChipInput.chipGridInstance.setDescribedByIds(ids);
+      flush();
+      fixture.detectChanges();
+
+      expect(inputNativeElement.getAttribute('aria-describedby')).toBeNull();
+    }));
   });
 });
 

--- a/src/material-experimental/mdc-chips/chip-input.ts
+++ b/src/material-experimental/mdc-chips/chip-input.ts
@@ -65,6 +65,7 @@ let nextUniqueId = 0;
     '[attr.disabled]': 'disabled || null',
     '[attr.placeholder]': 'placeholder || null',
     '[attr.aria-invalid]': '_chipGrid && _chipGrid.ngControl ? _chipGrid.ngControl.invalid : null',
+    '[attr.aria-describedby]': '_ariaDescribedby || null',
     '[attr.aria-required]': '_chipGrid && _chipGrid.required || null',
     '[attr.required]': '_chipGrid && _chipGrid.required || null',
   },
@@ -72,6 +73,9 @@ let nextUniqueId = 0;
 export class MatChipInput implements MatChipTextControl, AfterContentInit, OnChanges, OnDestroy {
   /** Used to prevent focus moving to chips while user is holding backspace */
   private _focusLastChipOnBackspace: boolean;
+
+  /** Value for ariaDescribedby property */
+  _ariaDescribedby?: string;
 
   /** Whether the control is focused. */
   focused: boolean = false;
@@ -238,6 +242,10 @@ export class MatChipInput implements MatChipTextControl, AfterContentInit, OnCha
   clear(): void {
     this.inputElement.value = '';
     this._focusLastChipOnBackspace = true;
+  }
+
+  setDescribedByIds(ids: string[]): void {
+    this._ariaDescribedby = ids.join(' ');
   }
 
   /** Checks whether a keycode is one of the configured separators. */

--- a/src/material-experimental/mdc-chips/chip-set.ts
+++ b/src/material-experimental/mdc-chips/chip-set.ts
@@ -65,8 +65,6 @@ const _MatChipSetMixinBase = mixinTabIndex(MatChipSetBase);
   host: {
     'class': 'mat-mdc-chip-set mdc-evolution-chip-set',
     '[attr.role]': 'role',
-    // TODO: replace this binding with use of AriaDescriber
-    '[attr.aria-describedby]': '_ariaDescribedby || null',
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -137,9 +135,6 @@ export class MatChipSet
       this._chipFoundation(index)?.startAnimation(animation);
     },
   };
-
-  /** The aria-describedby attribute on the chip list for improved a11y. */
-  _ariaDescribedby: string;
 
   /**
    * Map from class to whether the class is enabled.

--- a/src/material-experimental/mdc-chips/chip-text-control.ts
+++ b/src/material-experimental/mdc-chips/chip-text-control.ts
@@ -22,4 +22,7 @@ export interface MatChipTextControl {
 
   /** Focuses the text control. */
   focus(): void;
+
+  /** Sets the list of ids the input is described by. */
+  setDescribedByIds(ids: string[]): void;
 }


### PR DESCRIPTION
Updates mat-chip-grid to associate any ids set for aria-describedby to the matChipInput instance within the grid, if one exists.  See #24542 for information on why this is necessary.

Currently this PR creates a `setAriaDescribedBy` method on `matChipInput` and calls it from `mat-chip-grid` whenever `mat-chip-grid`'s `setAriaDescribedBy` method is called.  The internal logic mirrors that of `mat-chip-grid`.  This may not be the best way to go about this change; let me know if there's a better way to do it!

Fixes #24542