### PR TITLE
build: switch bazelrc away from deprecated options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -67,7 +67,6 @@ build --define=angular_ivy_enabled=True
 
 # Use the Angular team internal GCP instance for remote execution.
 build:remote --remote_instance_name=projects/internal-200822/instances/primary_instance
-build:remote --project_id=internal-200822
 
 # Needed due to: https://github.com/bazelbuild/bazel/issues/7254
 build:remote --define=EXECUTOR=remote
@@ -80,7 +79,7 @@ build:remote --host_cpu=k8
 # Setup the remote build execution servers.
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com
-build:remote --auth_enabled=true
+build:remote --google_default_credentials=true
 
 # Setup the toolchain and platform for the remote build execution. The platform
 # is provided by the shared dev-infra package and targets k8 remote containers.
@@ -108,6 +107,7 @@ test --sandbox_default_allow_network=false
 # that could cause builds to fail unnecessarily. If desired, build result uploading
 # can be manually uploaded, but given that the build event service server has been
 # less stable than the remote executors, we do not want to degrade CI stability.
+build:build-results --bes_instance_name=internal-200822
 build:build-results --bes_backend=buildeventservice.googleapis.com
 build:build-results --bes_timeout=60s
 build:build-results --bes_results_url="https://source.cloud.google.com/results/invocations/"


### PR DESCRIPTION
Switches the bazelrc away from deprecated options. See:
https://docs.bazel.build/versions/main/command-line-reference.html