### PR TITLE
refactor(material/core): renaming all .mat-mdc-focus-indicator instances and classes to mat-focus-indicator

### DIFF
--- a/src/material-experimental/mdc-button/_button-base.scss
+++ b/src/material-experimental/mdc-button/_button-base.scss
@@ -45,7 +45,7 @@
   }
 
   // The focus indicator should match the bounds of the entire button.
-  .mat-mdc-focus-indicator {
+  .mat-focus-indicator {
     @include layout-common.fill();
   }
 }

--- a/src/material-experimental/mdc-button/button.html
+++ b/src/material-experimental/mdc-button/button.html
@@ -16,7 +16,7 @@
   The indicator can't be directly on the button, because MDC uses ::before for high contrast
   indication and it can't be on the ripple, because it has a border radius and overflow: hidden.
 -->
-<span class="mat-mdc-focus-indicator"></span>
+<span class="mat-focus-indicator"></span>
 
 <span matRipple class="mat-mdc-button-ripple"
      [matRippleDisabled]="_isRippleDisabled()"

--- a/src/material-experimental/mdc-button/button.spec.ts
+++ b/src/material-experimental/mdc-button/button.spec.ts
@@ -326,7 +326,7 @@ describe('MDC-based MatButton', () => {
     ];
 
     expect(
-      buttonNativeElements.every(element => !!element.querySelector('.mat-mdc-focus-indicator')),
+      buttonNativeElements.every(element => !!element.querySelector('.mat-focus-indicator')),
     ).toBe(true);
   });
 });

--- a/src/material-experimental/mdc-checkbox/checkbox.html
+++ b/src/material-experimental/mdc-checkbox/checkbox.html
@@ -32,7 +32,7 @@
       </svg>
       <div class="mdc-checkbox__mixedmark"></div>
     </div>
-    <div class="mat-mdc-checkbox-ripple mat-mdc-focus-indicator" mat-ripple
+    <div class="mat-mdc-checkbox-ripple mat-focus-indicator" mat-ripple
       [matRippleTrigger]="checkbox"
       [matRippleDisabled]="disableRipple || disabled"
       [matRippleCentered]="true"></div>

--- a/src/material-experimental/mdc-checkbox/checkbox.spec.ts
+++ b/src/material-experimental/mdc-checkbox/checkbox.spec.ts
@@ -582,7 +582,7 @@ describe('MDC-based MatCheckbox', () => {
         '.mat-mdc-checkbox-ripple',
       )!;
 
-      expect(checkboxRippleNativeElement.classList.contains('mat-mdc-focus-indicator')).toBe(true);
+      expect(checkboxRippleNativeElement.classList.contains('mat-focus-indicator')).toBe(true);
     });
   });
 

--- a/src/material-experimental/mdc-chips/chip-icons.ts
+++ b/src/material-experimental/mdc-chips/chip-icons.ts
@@ -92,7 +92,7 @@ export const MAT_CHIP_REMOVE = new InjectionToken<MatChipRemove>('MatChipRemove'
   selector: '[matChipRemove]',
   host: {
     'class':
-      'mat-mdc-chip-remove mat-mdc-chip-trailing-icon mat-mdc-focus-indicator ' +
+      'mat-mdc-chip-remove mat-mdc-chip-trailing-icon mat-focus-indicator ' +
       'mdc-evolution-chip__icon mdc-evolution-chip__icon--trailing',
     'role': 'button',
     '[attr.aria-hidden]': 'null',

--- a/src/material-experimental/mdc-chips/chip-option.html
+++ b/src/material-experimental/mdc-chips/chip-option.html
@@ -25,7 +25,7 @@
     </span>
     <span class="mdc-evolution-chip__text-label mat-mdc-chip-action-label">
       <ng-content></ng-content>
-      <span class="mat-mdc-chip-primary-focus-indicator mat-mdc-focus-indicator"></span>
+      <span class="mat-mdc-chip-primary-focus-indicator mat-focus-indicator"></span>
     </span>
   </button>
 </span>

--- a/src/material-experimental/mdc-chips/chip-option.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-option.spec.ts
@@ -303,7 +303,7 @@ describe('MDC-based Option Chips', () => {
 
     it('should contain a focus indicator inside the text label', () => {
       const label = chipNativeElement.querySelector('.mdc-evolution-chip__text-label');
-      expect(label?.querySelector('.mat-mdc-focus-indicator')).toBeTruthy();
+      expect(label?.querySelector('.mat-focus-indicator')).toBeTruthy();
     });
   });
 });

--- a/src/material-experimental/mdc-chips/chip-remove.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-remove.spec.ts
@@ -123,7 +123,7 @@ describe('MDC-based Chip Remove', () => {
 
     it('should have a focus indicator', fakeAsync(() => {
       const buttonElement = chipNativeElement.querySelector('.mdc-evolution-chip__icon--trailing')!;
-      expect(buttonElement.classList.contains('mat-mdc-focus-indicator')).toBe(true);
+      expect(buttonElement.classList.contains('mat-focus-indicator')).toBe(true);
     }));
   });
 });

--- a/src/material-experimental/mdc-chips/chip-row.html
+++ b/src/material-experimental/mdc-chips/chip-row.html
@@ -25,7 +25,7 @@
         <ng-template #defaultMatChipEditInput><span matChipEditInput></span></ng-template>
       </ng-container>
 
-      <span class="mat-mdc-chip-primary-focus-indicator mat-mdc-focus-indicator"></span>
+      <span class="mat-mdc-chip-primary-focus-indicator mat-focus-indicator"></span>
     </span>
   </button>
 </span>

--- a/src/material-experimental/mdc-chips/chip.html
+++ b/src/material-experimental/mdc-chips/chip.html
@@ -11,7 +11,7 @@
     </span>
     <span class="mdc-evolution-chip__text-label mat-mdc-chip-action-label">
       <ng-content></ng-content>
-      <span class="mat-mdc-chip-primary-focus-indicator mat-mdc-focus-indicator"></span>
+      <span class="mat-mdc-chip-primary-focus-indicator mat-focus-indicator"></span>
     </span>
   </div>
 </span>

--- a/src/material-experimental/mdc-core/option/option.spec.ts
+++ b/src/material-experimental/mdc-core/option/option.spec.ts
@@ -203,7 +203,7 @@ describe('MatOption component', () => {
     const fixture = TestBed.createComponent(BasicOption);
     const optionNativeElement = fixture.debugElement.query(By.directive(MatOption))!.nativeElement;
 
-    expect(optionNativeElement.classList.contains('mat-mdc-focus-indicator')).toBe(true);
+    expect(optionNativeElement.classList.contains('mat-focus-indicator')).toBe(true);
   });
 
   describe('inside inert group', () => {

--- a/src/material-experimental/mdc-core/option/option.ts
+++ b/src/material-experimental/mdc-core/option/option.ts
@@ -41,7 +41,7 @@ import {MatOptgroup} from './optgroup';
     '[attr.aria-disabled]': 'disabled.toString()',
     '(click)': '_selectViaInteraction()',
     '(keydown)': '_handleKeydown($event)',
-    'class': 'mat-mdc-option mat-mdc-focus-indicator mdc-list-item',
+    'class': 'mat-mdc-option mat-focus-indicator mdc-list-item',
   },
   styleUrls: ['option.css'],
   templateUrl: 'option.html',

--- a/src/material-experimental/mdc-helpers/_focus-indicators-theme.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators-theme.scss
@@ -3,7 +3,7 @@
 @use '../../material/core/theming/theming';
 
 @mixin _border-color($color) {
-  .mat-mdc-focus-indicator::before {
+  .mat-focus-indicator::before {
     border-color: $color;
   }
 }

--- a/src/material-experimental/mdc-helpers/_focus-indicators.scss
+++ b/src/material-experimental/mdc-helpers/_focus-indicators.scss
@@ -22,7 +22,7 @@
   $border-radius: map.get($config, border-radius);
 
   // Base styles for focus indicators.
-  .mat-mdc-focus-indicator::before {
+  .mat-focus-indicator::before {
     @include layout-common.fill();
     box-sizing: border-box;
     pointer-events: none;
@@ -39,38 +39,38 @@
   // values are necessary to ensure that the focus indicator is sufficiently
   // contrastive and renders appropriately.
 
-  .mat-mdc-unelevated-button .mat-mdc-focus-indicator::before,
-  .mat-mdc-raised-button .mat-mdc-focus-indicator::before,
-  .mdc-fab .mat-mdc-focus-indicator::before,
-  .mat-mdc-chip-action-label .mat-mdc-focus-indicator::before {
+  .mat-mdc-unelevated-button .mat-focus-indicator::before,
+  .mat-mdc-raised-button .mat-focus-indicator::before,
+  .mdc-fab .mat-focus-indicator::before,
+  .mat-mdc-chip-action-label .mat-focus-indicator::before {
     margin: -($border-width + 2px);
   }
 
-  .mat-mdc-outlined-button .mat-mdc-focus-indicator::before {
+  .mat-mdc-outlined-button .mat-focus-indicator::before {
     margin: -($border-width + 3px);
   }
 
-  .mat-mdc-focus-indicator.mat-mdc-chip-remove::before {
+  .mat-focus-indicator.mat-mdc-chip-remove::before {
     margin: -$border-width;
   }
 
   // MDC sets a padding a on the button which stretches out the focus indicator.
-  .mat-mdc-focus-indicator.mat-mdc-chip-remove::before {
+  .mat-focus-indicator.mat-mdc-chip-remove::before {
     left: 8px;
     right: 8px;
   }
 
-  .mat-mdc-focus-indicator.mat-mdc-tab::before,
-  .mat-mdc-focus-indicator.mat-mdc-tab-link::before {
+  .mat-focus-indicator.mat-mdc-tab::before,
+  .mat-focus-indicator.mat-mdc-tab-link::before {
     margin: 5px;
   }
 
   // These components have to set `border-radius: 50%` in order to support density scaling
   // which will clip a square focus indicator so we have to turn it into a circle.
-  .mat-mdc-checkbox-ripple.mat-mdc-focus-indicator::before,
-  .mat-radio-ripple.mat-mdc-focus-indicator::before,
-  .mat-mdc-slider .mat-mdc-focus-indicator::before,
-  .mat-mdc-slide-toggle .mat-mdc-focus-indicator::before {
+  .mat-mdc-checkbox-ripple.mat-focus-indicator::before,
+  .mat-radio-ripple.mat-focus-indicator::before,
+  .mat-mdc-slider .mat-focus-indicator::before,
+  .mat-mdc-slide-toggle .mat-focus-indicator::before {
     border-radius: 50%;
   }
 
@@ -79,26 +79,26 @@
 
   // For checkboxes, radios and slide toggles, render the focus indicator when we know
   // the hidden input is focused (slightly different for each control).
-  .mdc-checkbox__native-control:focus ~ .mat-mdc-focus-indicator::before,
-  .mat-mdc-slide-toggle-focused .mat-mdc-focus-indicator::before,
-  .mat-mdc-radio-button.cdk-focused .mat-mdc-focus-indicator::before,
+  .mdc-checkbox__native-control:focus ~ .mat-focus-indicator::before,
+  .mat-mdc-slide-toggle-focused .mat-focus-indicator::before,
+  .mat-mdc-radio-button.cdk-focused .mat-focus-indicator::before,
 
   // In the chips the individual actions have focus so we target a different element.
-  .mat-mdc-chip-action:focus .mat-mdc-focus-indicator::before,
+  .mat-mdc-chip-action:focus .mat-focus-indicator::before,
 
   // For buttons and list items, render the focus indicator when the parent
   // button or list item is focused.
-  .mat-mdc-button-base:focus .mat-mdc-focus-indicator::before,
-  .mat-mdc-list-item:focus > .mat-mdc-focus-indicator::before,
+  .mat-mdc-button-base:focus .mat-focus-indicator::before,
+  .mat-mdc-list-item:focus > .mat-focus-indicator::before,
 
   // For options, render the focus indicator when the class .mat-mdc-option-active is present.
-  .mat-mdc-focus-indicator.mat-mdc-option-active::before,
+  .mat-focus-indicator.mat-mdc-option-active::before,
 
   // In the MDC slider the focus indicator is inside the thumb.
-  .mdc-slider__thumb--focused .mat-mdc-focus-indicator::before,
+  .mdc-slider__thumb--focused .mat-focus-indicator::before,
 
     // For all other components, render the focus indicator on focus.
-  .mat-mdc-focus-indicator:focus::before {
+  .mat-focus-indicator:focus::before {
     content: '';
   }
 }

--- a/src/material-experimental/mdc-list/list-item.html
+++ b/src/material-experimental/mdc-list/list-item.html
@@ -17,4 +17,4 @@
   Strong focus indicator element. MDC uses the `::before` pseudo element for the default
   focus/hover/selected state, so we need a separate element.
 -->
-<div class="mat-mdc-focus-indicator"></div>
+<div class="mat-focus-indicator"></div>

--- a/src/material-experimental/mdc-list/list-option.html
+++ b/src/material-experimental/mdc-list/list-option.html
@@ -61,4 +61,4 @@
   Strong focus indicator element. MDC uses the `::before` pseudo element for the default
   focus/hover/selected state, so we need a separate element.
 -->
-<div class="mat-mdc-focus-indicator"></div>
+<div class="mat-focus-indicator"></div>

--- a/src/material-experimental/mdc-list/list.scss
+++ b/src/material-experimental/mdc-list/list.scss
@@ -57,7 +57,7 @@
 // The MDC-based list items already use the `::before` pseudo element for the standard
 // focus/selected/hover state. Hence, we need to have a separate list-item spanning
 // element that can be used for strong focus indicators.
-.mat-mdc-list-item > .mat-mdc-focus-indicator {
+.mat-mdc-list-item > .mat-focus-indicator {
   @include layout-common.fill();
   pointer-events: none;
 }

--- a/src/material-experimental/mdc-list/list.spec.ts
+++ b/src/material-experimental/mdc-list/list.spec.ts
@@ -73,7 +73,7 @@ describe('MDC-based MatList', () => {
       .queryAll(By.css('mat-list-item'))
       .map(debugEl => debugEl.nativeElement as HTMLElement);
 
-    expect(listItems.every(i => i.querySelector('.mat-mdc-focus-indicator') !== null))
+    expect(listItems.every(i => i.querySelector('.mat-focus-indicator') !== null))
       .withContext('Expected all list items to have a strong focus indicator element.')
       .toBe(true);
   });

--- a/src/material-experimental/mdc-list/selection-list.spec.ts
+++ b/src/material-experimental/mdc-list/selection-list.spec.ts
@@ -653,7 +653,7 @@ describe('MDC-based MatSelectionList without forms', () => {
 
       expect(
         optionNativeElements.every(
-          element => element.querySelector('.mat-mdc-focus-indicator') !== null,
+          element => element.querySelector('.mat-focus-indicator') !== null,
         ),
       ).toBe(true);
     });

--- a/src/material-experimental/mdc-menu/menu-item.ts
+++ b/src/material-experimental/mdc-menu/menu-item.ts
@@ -18,11 +18,10 @@ import {MatMenuItem as BaseMatMenuItem} from '@angular/material/menu';
   inputs: ['disabled', 'disableRipple'],
   host: {
     '[attr.role]': 'role',
-    // The MatMenuItem parent class adds `mat-menu-item` and `mat-focus-indicator` to the CSS
+    // The MatMenuItem parent class adds `mat-menu-item` to the CSS
     // classlist, but these should not be added for this MDC equivalent menu item.
     '[class.mat-menu-item]': 'false',
-    '[class.mat-focus-indicator]': 'false',
-    'class': 'mat-mdc-menu-item mat-mdc-focus-indicator mdc-list-item',
+    'class': 'mat-mdc-menu-item mdc-list-item',
     '[class.mat-mdc-menu-item-highlighted]': '_highlighted',
     '[class.mat-mdc-menu-item-submenu-trigger]': '_triggersSubmenu',
     '[attr.tabindex]': '_getTabIndex()',

--- a/src/material-experimental/mdc-menu/menu.spec.ts
+++ b/src/material-experimental/mdc-menu/menu.spec.ts
@@ -2673,9 +2673,7 @@ describe('MDC-based MatMenu', () => {
     );
 
     expect(
-      menuItemNativeElements.every(element =>
-        element.classList.contains('mat-mdc-focus-indicator'),
-      ),
+      menuItemNativeElements.every(element => element.classList.contains('mat-focus-indicator')),
     ).toBe(true);
   }));
 });

--- a/src/material-experimental/mdc-radio/radio.html
+++ b/src/material-experimental/mdc-radio/radio.html
@@ -19,7 +19,7 @@
       <div class="mdc-radio__outer-circle"></div>
       <div class="mdc-radio__inner-circle"></div>
     </div>
-    <div mat-ripple class="mat-radio-ripple mat-mdc-focus-indicator"
+    <div mat-ripple class="mat-radio-ripple mat-focus-indicator"
          [matRippleTrigger]="formField"
          [matRippleDisabled]="_isRippleDisabled()"
          [matRippleCentered]="true">

--- a/src/material-experimental/mdc-radio/radio.spec.ts
+++ b/src/material-experimental/mdc-radio/radio.spec.ts
@@ -431,7 +431,7 @@ describe('MDC-based MatRadio', () => {
 
       expect(
         radioRippleNativeElements.every(element =>
-          element.classList.contains('mat-mdc-focus-indicator'),
+          element.classList.contains('mat-focus-indicator'),
         ),
       ).toBe(true);
     });

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -23,7 +23,7 @@
           <div class="mdc-elevation-overlay"></div>
         </div>
         <div class="mdc-switch__ripple">
-          <div class="mat-mdc-slide-toggle-ripple mat-mdc-focus-indicator" mat-ripple
+          <div class="mat-mdc-slide-toggle-ripple mat-focus-indicator" mat-ripple
             [matRippleTrigger]="switch"
             [matRippleDisabled]="disableRipple || disabled"
             [matRippleCentered]="true"></div>

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
@@ -344,7 +344,7 @@ describe('MDC-based MatSlideToggle without forms', () => {
 
     it('should have a focus indicator', fakeAsync(() => {
       const rippleElement = slideToggleElement.querySelector('.mat-mdc-slide-toggle-ripple')!;
-      expect(rippleElement.classList).toContain('mat-mdc-focus-indicator');
+      expect(rippleElement.classList).toContain('mat-focus-indicator');
     }));
   });
 

--- a/src/material-experimental/mdc-slider/slider-thumb.html
+++ b/src/material-experimental/mdc-slider/slider-thumb.html
@@ -6,5 +6,5 @@
 <div class="mdc-slider__thumb-knob" #knob></div>
 <div
   matRipple
-  class="mat-mdc-focus-indicator"
+  class="mat-focus-indicator"
   [matRippleDisabled]="true"></div>

--- a/src/material-experimental/mdc-slider/slider.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.spec.ts
@@ -180,7 +180,7 @@ describe('MDC-based MatSlider', () => {
 
     it('should have a strong focus indicator in each of the thumbs', () => {
       const indicators = sliderElement.querySelectorAll(
-        '.mat-mdc-slider-visual-thumb .mat-mdc-focus-indicator',
+        '.mat-mdc-slider-visual-thumb .mat-focus-indicator',
       );
       expect(indicators.length).toBe(2);
     });

--- a/src/material-experimental/mdc-tabs/_tabs-theme.scss
+++ b/src/material-experimental/mdc-tabs/_tabs-theme.scss
@@ -77,7 +77,7 @@
 
     .mdc-tab-indicator__content--underline,
     .mat-mdc-tab-header-pagination-chevron,
-    .mat-mdc-focus-indicator::before {
+    .mat-focus-indicator::before {
       @include mdc-theme.prop(border-color, $foreground-color);
     }
   }

--- a/src/material-experimental/mdc-tabs/tab-group.html
+++ b/src/material-experimental/mdc-tabs/tab-group.html
@@ -4,7 +4,7 @@
                 (indexFocused)="_focusChanged($event)"
                 (selectFocusedIndex)="selectedIndex = $event">
 
-  <div class="mdc-tab mat-mdc-tab mat-mdc-focus-indicator"
+  <div class="mdc-tab mat-mdc-tab mat-focus-indicator"
        #tabNode
        role="tab"
        matTabLabelWrapper

--- a/src/material-experimental/mdc-tabs/tab-group.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-group.spec.ts
@@ -324,9 +324,9 @@ describe('MDC-based MatTabGroup', () => {
         ...fixture.debugElement.nativeElement.querySelectorAll('.mat-mdc-tab'),
       ];
 
-      expect(
-        tabLabelNativeElements.every(el => el.classList.contains('mat-mdc-focus-indicator')),
-      ).toBe(true);
+      expect(tabLabelNativeElements.every(el => el.classList.contains('mat-focus-indicator'))).toBe(
+        true,
+      );
     });
 
     it('should emit focusChange when a tab receives focus', fakeAsync(() => {

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.spec.ts
@@ -424,9 +424,7 @@ describe('MDC-based MatTabNavBar', () => {
       ];
 
       expect(
-        tabLinkNativeElements.every(element =>
-          element.classList.contains('mat-mdc-focus-indicator'),
-        ),
+        tabLinkNativeElements.every(element => element.classList.contains('mat-focus-indicator')),
       ).toBe(true);
     });
   });

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -146,7 +146,7 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit, After
   templateUrl: 'tab-link.html',
   styleUrls: ['tab-link.css'],
   host: {
-    'class': 'mdc-tab mat-mdc-tab-link mat-mdc-focus-indicator',
+    'class': 'mdc-tab mat-mdc-tab-link mat-focus-indicator',
     '[attr.aria-controls]': '_getAriaControls()',
     '[attr.aria-current]': '_getAriaCurrent()',
     '[attr.aria-disabled]': 'disabled',

--- a/src/material/core/_core.scss
+++ b/src/material/core/_core.scss
@@ -7,7 +7,7 @@
 @use './focus-indicators/focus-indicators';
 @use './typography/all-typography';
 
-// Mixin that renders all of the core styles that are not theme-dependent.
+// Mixin that renders all core styles that are not theme-dependent.
 @mixin core($typography-config: null) {
   @include all-typography.all-component-typographies($typography-config);
   @include ripple.ripple();
@@ -17,19 +17,4 @@
   @include text-field.text-field-autofill();
 
   @include focus-indicators.private-strong-focus-indicators-positioning();
-  @include _mdc-core();
-}
-
-// Mixin that renders all of the core MDC styles. Private mixin included with `mat-core`.
-@mixin _mdc-core() {
-  @include _mdc-strong-focus-indicators-positioning();
-}
-
-// Mixin that ensures focus indicator host elements are positioned so that the focus indicator
-// pseudo element within is positioned relative to the host. Private mixin included within
-// `_mat-mdc-core`.
-@mixin _mdc-strong-focus-indicators-positioning() {
-  .mat-mdc-focus-indicator {
-    position: relative;
-  }
 }


### PR DESCRIPTION
First step to fixing: [b/209683961](b/209683961)

This is the first step to fixing the double focus indicator bug when in High Contrast Mode. This PR renames all .mat-mdc-focus-indicator instances and classes to .mat-focus-indicator class since .mat-mdc-focus-indicator class does not contain anything specific to MDC.