### PR TITLE
refactor(material/dialog): use embedded injector to provide ref to template dialogs

### DIFF
--- a/src/material/dialog/dialog-content-directives.ts
+++ b/src/material/dialog/dialog-content-directives.ts
@@ -158,6 +158,10 @@ export class MatDialogActions {
   @Input() align?: 'start' | 'center' | 'end' = 'start';
 }
 
+// TODO(crisbeto): this utility shouldn't be necessary anymore, because the dialog ref is provided
+// both to component and template dialogs through DI. We need to keep it around, because there are
+// some internal wrappers around `MatDialog` that happened to work by accident, because we had this
+// fallback logic in place.
 /**
  * Finds the closest MatDialogRef to an element by looking at the DOM.
  * @param element Element relative to which to look for a dialog.

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -292,16 +292,21 @@ export abstract class _MatDialogBase<C extends _MatDialogContainerBase> implemen
     // Create a reference to the dialog we're creating in order to give the user a handle
     // to modify and close it.
     const dialogRef = new this._dialogRefConstructor(overlayRef, dialogContainer, config.id);
+    const injector = this._createInjector<T>(config, dialogRef, dialogContainer);
 
     if (componentOrTemplateRef instanceof TemplateRef) {
       dialogContainer.attachTemplatePortal(
-        new TemplatePortal<T>(componentOrTemplateRef, null!, <any>{
-          $implicit: config.data,
-          dialogRef,
-        }),
+        new TemplatePortal<T>(
+          componentOrTemplateRef,
+          null!,
+          <any>{
+            $implicit: config.data,
+            dialogRef,
+          },
+          injector,
+        ),
       );
     } else {
-      const injector = this._createInjector<T>(config, dialogRef, dialogContainer);
       const contentRef = dialogContainer.attachComponentPortal<T>(
         new ComponentPortal(
           componentOrTemplateRef,


### PR DESCRIPTION
Previously we had to walk the DOM in order to figure out which dialog ref belonged to a specific template dialog. We no longer need to do that if we provide an injector to the template portal.