### PR TITLE
build: remove leftover log

### DIFF
--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -437,7 +437,6 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     // either async or fakeAsync.
     this._backdropTimeout = this._ngZone.runOutsideAngular(() =>
       setTimeout(() => {
-        console.log('fallback');
         this._disposeBackdrop(backdropToDetach);
       }, 500),
     );


### PR DESCRIPTION
Cleans up a `console.log` that was accidentally left in as a part of bbe63555560df252b8f98cfa87adf443201e4cb5.