### PR TITLE
build: ship schematics as `es2020` similar to rest of the APF

### DIFF
--- a/src/cdk/schematics/BUILD.bazel
+++ b/src/cdk/schematics/BUILD.bazel
@@ -25,9 +25,7 @@ ts_library(
     # Schematics can not yet run in ESM module. For now we continue to use CommonJS.
     # TODO(ESM): remove this once the Angular CLI supports ESM schematics.
     devmode_module = "commonjs",
-    devmode_target = "es2015",
     prodmode_module = "commonjs",
-    prodmode_target = "es2015",
     tsconfig = ":tsconfig.json",
     deps = [
         "//src/cdk/schematics/update-tool",

--- a/src/cdk/schematics/update-tool/BUILD.bazel
+++ b/src/cdk/schematics/update-tool/BUILD.bazel
@@ -8,9 +8,7 @@ ts_library(
     # Schematics can not yet run in ESM module. For now we continue to use CommonJS.
     # TODO(ESM): remove this once the Angular CLI supports ESM schematics.
     devmode_module = "commonjs",
-    devmode_target = "es2015",
     prodmode_module = "commonjs",
-    prodmode_target = "es2015",
     tsconfig = ":tsconfig.json",
     deps = [
         "@npm//@types/node",

--- a/src/material/schematics/BUILD.bazel
+++ b/src/material/schematics/BUILD.bazel
@@ -26,9 +26,7 @@ ts_library(
     # Schematics do not need to run in browsers and can use `commonjs`
     # as format instead the default `umd` format.
     devmode_module = "commonjs",
-    devmode_target = "es2015",
     prodmode_module = "commonjs",
-    prodmode_target = "es2015",
     tsconfig = ":tsconfig.json",
     deps = [
         "//src/cdk/schematics",


### PR DESCRIPTION
As part of v13, we manually added the prodmode/devmode target to schematic
build targets and set it to `es2015`. This was done since we still supported
NodeJS v12. This is no longer the case with v14 and we already removed the
NodeJS v12 integration test, so we can also remove the target override.