### PR TITLE
build: speed up docs deployment by not running a11y audit tests

### DIFF
--- a/scripts/docs-deploy/monitoring/index.ts
+++ b/scripts/docs-deploy/monitoring/index.ts
@@ -8,13 +8,12 @@ import {installDepsForDocsSite} from '../docs-deps-install';
 import {sites} from '../utils';
 
 /**
- * Runs all audit tests from the given docs repository, ensuring that the
+ * Runs monitoring tests for the given docs repository, ensuring that the
  * specified remote URL is properly functioning.
  */
 export async function runMonitorTests(docsRepoDir: string, remoteUrl: string) {
   cd(docsRepoDir);
 
-  await $`node ./tools/audit-docs-a11y.js ${remoteUrl}`;
   await $`node ./tools/audit-docs.js ${remoteUrl}`;
 }
 


### PR DESCRIPTION
We can speed up the docs deployment & monitor jobs by not running the
rather slower a11y audit tests. These should just be run in the docs
repo. The standard audit lighthouse tests should be a sufficient
indicator of whether the page is up-and-running properly.

Ideally in the future we would have proper e2e tests for the docs
site, but even those will never guarantee a 100%-working page.