### PR TITLE
feat(material/dialog): add support for explicit injector

### DIFF
--- a/src/cdk-experimental/dialog/dialog-config.ts
+++ b/src/cdk-experimental/dialog/dialog-config.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ViewContainerRef} from '@angular/core';
+import {Injector, ViewContainerRef} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {ComponentType} from '@angular/cdk/overlay';
 import {CdkDialogContainer} from './dialog-container';
@@ -35,6 +35,12 @@ export class DialogConfig<D = any> {
    * content will be rendered.
    */
   viewContainerRef?: ViewContainerRef;
+
+  /**
+   * Injector used for the instantiation of the component to be attached. If provided,
+   * takes precedence over the injector indirectly provided by `ViewContainerRef`.
+   */
+  injector?: Injector;
 
   /** The id of the dialog. */
   id?: string;

--- a/src/cdk-experimental/dialog/dialog.ts
+++ b/src/cdk-experimental/dialog/dialog.ts
@@ -213,7 +213,7 @@ export class Dialog implements OnDestroy {
    */
   protected _attachDialogContainer(overlay: OverlayRef, config: DialogConfig): CdkDialogContainer {
     const container = config.containerComponent || this._injector.get(DIALOG_CONTAINER);
-    const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
+    const userInjector = config.injector ?? config.viewContainerRef?.injector;
     const injector = Injector.create({
       parent: userInjector || this._injector,
       providers: [{provide: DialogConfig, useValue: config}],

--- a/src/material/dialog/dialog-config.ts
+++ b/src/material/dialog/dialog-config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ViewContainerRef, ComponentFactoryResolver} from '@angular/core';
+import {ViewContainerRef, ComponentFactoryResolver, Injector} from '@angular/core';
 import {Direction} from '@angular/cdk/bidi';
 import {ScrollStrategy} from '@angular/cdk/overlay';
 import {defaultParams} from './dialog-animations';
@@ -43,6 +43,12 @@ export class MatDialogConfig<D = any> {
    * content will be rendered.
    */
   viewContainerRef?: ViewContainerRef;
+
+  /**
+   * Injector used for the instantiation of the component to be attached. If provided,
+   * takes precedence over the injector indirectly provided by `ViewContainerRef`.
+   */
+  injector?: Injector;
 
   /** ID for the dialog. If omitted, a unique one will be generated. */
   id?: string;

--- a/src/material/dialog/dialog.ts
+++ b/src/material/dialog/dialog.ts
@@ -257,7 +257,7 @@ export abstract class _MatDialogBase<C extends _MatDialogContainerBase> implemen
    * @returns A promise resolving to a ComponentRef for the attached container.
    */
   private _attachDialogContainer(overlay: OverlayRef, config: MatDialogConfig): C {
-    const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
+    const userInjector = config.injector ?? config.viewContainerRef?.injector;
     const injector = Injector.create({
       parent: userInjector || this._injector,
       providers: [{provide: MatDialogConfig, useValue: config}],

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -173,6 +173,7 @@ export class MatDialogConfig<D = any> {
     hasBackdrop?: boolean;
     height?: string;
     id?: string;
+    injector?: Injector;
     maxHeight?: number | string;
     maxWidth?: number | string;
     minHeight?: number | string;


### PR DESCRIPTION
Dialog components can be loaded asynchronously through the dynamic import, and they might be declared in the module that lives in the same file. The component might depend on the providers declared in this module. Currently, the `MatDialog` does not allow providing a custom injector. It only allows to pass the `viewContainerRef` and takes its injector if provided.

The real use case from our app:
```ts
export class SomeComponent {
  constructor(private dialog: MatDialog, private injector: Injector) {}

  openDialog(): void {
    import('./dialog').then((m) => {
      const ngModuleRef = createNgModuleRef(
        m.DialogModule,
        this.injector
      );
      this.dialog.open(m.DialogComponent, {
        injector: ngModuleRef.injector,
      });
    });
  }
}
```