### PR TITLE
fix(material/dialog): use quoted keys in the animation state object

### DIFF
--- a/src/material/dialog/dialog-container.ts
+++ b/src/material/dialog/dialog-container.ts
@@ -365,9 +365,9 @@ export class MatDialogContainer extends _MatDialogContainerBase {
     return {
       value: this._state,
       params: {
-        enterAnimationDuration:
+        'enterAnimationDuration':
           this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
-        exitAnimationDuration:
+        'exitAnimationDuration':
           this._config.exitAnimationDuration || defaultParams.params.exitAnimationDuration,
       },
     };


### PR DESCRIPTION
Use quoted keys for the return value of `_getAnimationState`. This
resolves an internal issue.