### PR TITLE
fix(cdk/a11y): visually hidden element affecting scrolling

### DIFF
--- a/src/cdk/a11y/_index.scss
+++ b/src/cdk/a11y/_index.scss
@@ -21,6 +21,17 @@
     // Avoid some cases where the browser will still render the native controls (see #9049).
     -webkit-appearance: none;
     -moz-appearance: none;
+
+    // We need at least one of top/bottom/left/right in order to prevent cases where the
+    // absolute-positioned element is pushed down and can affect scrolling (see #24597).
+    // `left` was chosen here, because it's the least likely to break overrides where the
+    // element might have been positioned (e.g. `mat-checkbox`).
+    left: 0;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: 0;
+    }
   }
 }
 


### PR DESCRIPTION
We had a `position: absolute` on the visually-hidden element, but it didn't have an actual position which can cause unnecessary scrolling in some cases.

Fixes #24597.