### PR TITLE
docs(material/autocomplete): fix incorrect title for autocomplete opt…

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-optgroup/autocomplete-optgroup-example.ts
@@ -19,7 +19,7 @@ export const _filter = (opt: string[], value: string): string[] => {
  */
 @Component({
   selector: 'autocomplete-optgroup-example',
-  templateUrl: './autocomplete-optgroup-example.html',
+  templateUrl: 'autocomplete-optgroup-example.html',
 })
 export class AutocompleteOptgroupExample implements OnInit {
   stateForm: FormGroup = this._formBuilder.group({


### PR DESCRIPTION
…group example code

Fixes a bug in the Options groups autocomplete example by making templateUrl of autocomplete option groups example component match material components.