### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/create-legacy-tests-bundle.mjs
+++ b/scripts/create-legacy-tests-bundle.mjs
@@ -152,7 +152,7 @@ async function createResolveEsbuildPlugin() {
     name: 'ng-resolve-esbuild',
     setup: build => {
       build.onResolve({filter: /@angular\//}, async args => {
-        const pkgName = args.path.substr('@angular/'.length);
+        const pkgName = args.path.slice('@angular/'.length);
         let resolvedPath = join(legacyOutputDir, pkgName);
         let stats = await statGraceful(resolvedPath);
 

--- a/src/circular-deps-test.conf.js
+++ b/src/circular-deps-test.conf.js
@@ -25,7 +25,7 @@ module.exports = {
  */
 function resolveModule(specifier) {
   if (specifier.startsWith('@angular/')) {
-    return path.join(__dirname, specifier.substr('@angular/'.length));
+    return path.join(__dirname, specifier.slice('@angular/'.length));
   }
   return null;
 }

--- a/tools/markdown-to-html/docs-marked-renderer.ts
+++ b/tools/markdown-to-html/docs-marked-renderer.ts
@@ -48,7 +48,7 @@ export class DocsMarkdownRenderer extends Renderer {
 
     // Keep track of all fragments discovered in a file.
     if (href.startsWith('#')) {
-      this._referencedFragments.add(href.substr(1));
+      this._referencedFragments.add(href.slice(1));
     }
 
     return super.link(href, title, text);

--- a/tools/region-parser/region-parser.ts
+++ b/tools/region-parser/region-parser.ts
@@ -126,5 +126,5 @@ function leftAlign(lines: string[]): string[] {
       indent = Math.min(lineIndent, indent);
     }
   });
-  return lines.map(line => line.substr(indent));
+  return lines.map(line => line.slice(indent));
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.