### PR TITLE
docs(material/form-field): fix typo in form-field overview

### DIFF
--- a/src/material/form-field/form-field.md
+++ b/src/material/form-field/form-field.md
@@ -16,7 +16,7 @@ The following Angular Material components are designed to work inside a `<mat-fo
 
 ### Form field appearance variants
 The `mat-form-field` supports 4 different appearance variants which can be set via the `appearance`
-input. The `fill` an `outline` appearances implement the current version of the spec. The `fill`
+input. The `fill` and `outline` appearances implement the current version of the spec. The `fill`
 appearance displays the form field with a filled background box and an underline, while the
 `outline` appearance shows the form field with a border all the way around.
 


### PR DESCRIPTION
Fixes a typo under Form field appearance variants overview.

Fixes #24379.