### PR TITLE
fix(material-experimental/chips): replace innerText w/ textContent

### DIFF
--- a/src/material-experimental/mdc-chips/chip-edit-input.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.ts
@@ -38,7 +38,7 @@ export class MatChipEditInput {
   }
 
   setValue(value: string) {
-    this.getNativeElement().innerText = value;
+    this.getNativeElement().textContent = value;
     this._moveCursorToEndOfInput();
   }
 


### PR DESCRIPTION
The chip edit input was using innerText to set the text of an element. This change was prompted by a Google-internal check that warns about `innerText`, but we generally want to use `textContent` anyway as it is more standard.