### PR TITLE
docs(cdk/accordion): define string type for cdkaccordion property `id`

### DIFF
--- a/src/cdk/accordion/accordion.ts
+++ b/src/cdk/accordion/accordion.ts
@@ -36,7 +36,7 @@ export class CdkAccordion implements OnDestroy, OnChanges {
   readonly _openCloseAllActions: Subject<boolean> = new Subject<boolean>();
 
   /** A readonly id value to use for unique selection coordination. */
-  readonly id = `cdk-accordion-${nextId++}`;
+  readonly id: string = `cdk-accordion-${nextId++}`;
 
   /** Whether the accordion should allow multiple expanded accordion items simultaneously. */
   @Input()


### PR DESCRIPTION
Fixes a bug in accordian/api documentation in CdkAccordian where `id` property is not loosley defined.
This is because `id` property is not explicitly defined as `string`.

Fixes #24639