### PR TITLE
fix(material/schematics): remove usages of deprecated defaultProject option

### DIFF
--- a/integration/harness-e2e-cli/angular.json
+++ b/integration/harness-e2e-cli/angular.json
@@ -96,6 +96,5 @@
         }
       }
     }
-  },
-  "defaultProject": "harness-e2e-cli"
+  }
 }

--- a/integration/ng-add/angular.json
+++ b/integration/ng-add/angular.json
@@ -97,6 +97,5 @@
         }
       }
     }
-  },
-  "defaultProject": "ng-add"
+  }
 }

--- a/integration/ng-update-v13/angular.json
+++ b/integration/ng-update-v13/angular.json
@@ -96,6 +96,5 @@
         }
       }
     }
-  },
-  "defaultProject": "ng-update"
+  }
 }

--- a/src/cdk/schematics/ng-generate/drag-drop/index.spec.ts
+++ b/src/cdk/schematics/ng-generate/drag-drop/index.spec.ts
@@ -60,7 +60,6 @@ describe('CDK drag-drop schematic', () => {
         'angular.json',
         JSON.stringify({
           version: 1,
-          defaultProject: 'material',
           projects: {
             material: {
               projectType: 'application',
@@ -173,7 +172,6 @@ describe('CDK drag-drop schematic', () => {
         'angular.json',
         JSON.stringify({
           version: 1,
-          defaultProject: 'material',
           projects: {
             material: {
               projectType: 'application',

--- a/src/cdk/schematics/utils/get-project.ts
+++ b/src/cdk/schematics/utils/get-project.ts
@@ -15,8 +15,14 @@ import {SchematicsException} from '@angular-devkit/schematics';
  */
 export function getProjectFromWorkspace(
   workspace: WorkspaceDefinition,
-  projectName = workspace.extensions.defaultProject as string,
+  projectName: string | undefined,
 ): ProjectDefinition {
+  if (!projectName) {
+    // TODO(crisbeto): some schematics APIs have the project name as optional so for now it's
+    // simpler to allow undefined and checking it at runtime. Eventually we should clean this up.
+    throw new SchematicsException('Project name is required.');
+  }
+
   const project = workspace.projects.get(projectName);
 
   if (!project) {


### PR DESCRIPTION
The CLI has deprecated the `defaultProject` option which is causing errors in the snapshot check. These changes fix up our usages.