### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/build-dev-app.yml
+++ b/.github/workflows/build-dev-app.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event.action == 'labeled' && github.event.label.name == 'dev-app preview') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dev-app preview'))
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # renovate: tag=v2.0.0
       - uses: ./.github/actions/yarn-install
 
       - run: ./scripts/bazel/setup-remote-execution.sh
@@ -42,7 +42,7 @@ jobs:
           echo ${{github.event.pull_request.head.sha}} > dist/devapp/pr_sha
 
       # Upload the generated dev-app archive.
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # renovate: tag=v2.0.0
         with:
           name: devapp
           path: dist/devapp

--- a/.github/workflows/build-dev-app.yml
+++ b/.github/workflows/build-dev-app.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event.action == 'labeled' && github.event.label.name == 'dev-app preview') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dev-app preview'))
     steps:
-      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # renovate: tag=v2.0.0
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.0.0
       - uses: ./.github/actions/yarn-install
 
       - run: ./scripts/bazel/setup-remote-execution.sh

--- a/.github/workflows/deploy-dev-app.yml
+++ b/.github/workflows/deploy-dev-app.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5  # renovate: tag=v2.0.0
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.0.0
       - uses: ./.github/actions/yarn-install
 
       - name: 'Download artifact from build job'
@@ -36,7 +36,7 @@ jobs:
           echo "::set-output name=number::$(cat ./dist/dev-app-web-pkg/pr_number)"
           echo "::set-output name=sha::$(cat ./dist/dev-app-web-pkg/pr_sha)"
 
-      - uses: FirebaseExtended/action-hosting-deploy@3a02c012c6a9b183828eeb456247327a894fc698 # renovate: tag=v0.0.0
+      - uses: FirebaseExtended/action-hosting-deploy@276388dd6c2cde23455b30293105cc866c22282d # renovate: tag=v0.0.0
         id: deploy
         with:
           repoToken: '${{secrets.GITHUB_TOKEN}}'

--- a/.github/workflows/deploy-dev-app.yml
+++ b/.github/workflows/deploy-dev-app.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5  # renovate: tag=v2.0.0
       - uses: ./.github/actions/yarn-install
 
       - name: 'Download artifact from build job'
@@ -36,7 +36,7 @@ jobs:
           echo "::set-output name=number::$(cat ./dist/dev-app-web-pkg/pr_number)"
           echo "::set-output name=sha::$(cat ./dist/dev-app-web-pkg/pr_sha)"
 
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@3a02c012c6a9b183828eeb456247327a894fc698 # renovate: tag=v0.0.0
         id: deploy
         with:
           repoToken: '${{secrets.GITHUB_TOKEN}}'
@@ -45,7 +45,7 @@ jobs:
           projectId: ng-comp-dev
           channelId: pr-${{steps.pr_info.outputs.number}}-${{steps.pr_info.outputs.sha}}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # renovate: tag=v2.0.0
         with:
           message: |
             Deployed dev-app to: ${{ steps.deploy.outputs.details_url }}

--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -8,7 +8,7 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # renovate: tag=v2.0.0
       - uses: angular/dev-infra/github-actions/commit-message-based-labels@138ec743c342cd2a4a75443d19e0ccd47244ee07
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -8,7 +8,7 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # renovate: tag=v2.0.0
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579  # renovate: tag=v2.0.0
       - uses: angular/dev-infra/github-actions/commit-message-based-labels@138ec743c342cd2a4a75443d19e0ccd47244ee07
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

Other angular projects are doing similar stuff https://github.com/angular/angular-cli/blob/366cabc66c3dd836e2fdfea8dad6c4c7c2096b1d/.github/workflows/dev-infra.yml#L16

https://github.com/angular/angular/blob/8155428ba65c38c0c15f2666727202a7b360c1bd/.github/workflows/feature-requests.yml#L10
