### PR TITLE
Configure dialog content font

### DIFF
--- a/src/material/dialog/_dialog-theme.scss
+++ b/src/material/dialog/_dialog-theme.scss
@@ -23,6 +23,9 @@
   .mat-dialog-title {
     @include typography-utils.typography-level($config, title);
   }
+  .mat-dialog-content {
+    @include typography-utils.typography-level($config, body-1);
+  }
 }
 
 @mixin _density($config-or-theme) {}


### PR DESCRIPTION
The contents of the font is currently unconfigured which yields inconsistent dialogs by default.