### PR TITLE
build: add lint rule to disallow type-only imports/exports

### DIFF
--- a/tools/tslint-rules/noTypeOnlyImportExportRule.ts
+++ b/tools/tslint-rules/noTypeOnlyImportExportRule.ts
@@ -1,0 +1,19 @@
+import ts from 'typescript';
+import * as Lint from 'tslint';
+
+/** Lint rule that doesn't allow usages of type-only imports/exports. */
+export class Rule extends Lint.Rules.AbstractRule {
+  apply(sourceFile: ts.SourceFile) {
+    return this.applyWithFunction(sourceFile, walker);
+  }
+}
+
+function walker(context: Lint.WalkContext): void {
+  (function visitNode(node: ts.Node) {
+    if (ts.isTypeOnlyImportOrExportDeclaration(node)) {
+      context.addFailureAtNode(node, 'Type-only symbols are not allowed.');
+    }
+
+    ts.forEachChild(node, visitNode);
+  })(context.sourceFile);
+}

--- a/tslint.json
+++ b/tslint.json
@@ -75,6 +75,7 @@
     // Custom Rules
     "ts-loader": true,
     "no-exposed-todo": true,
+    "no-type-only-import-export": true,
     "no-private-getters": [true, "^_"],
     "no-undecorated-base-class-di": true,
     "no-undecorated-class-with-angular-features": true,


### PR DESCRIPTION
Type-only imports and exports don't work with Closure so we can't use them.