### PR TITLE
fix(cdk/overlay): disable backdrop animation when noop animations are enabled

### DIFF
--- a/src/cdk/overlay/_index.scss
+++ b/src/cdk/overlay/_index.scss
@@ -111,6 +111,10 @@ $backdrop-animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1) !default;
     }
   }
 
+  .cdk-overlay-backdrop-noop-animation {
+    transition: none;
+  }
+
   // Overlay parent element used with the connected position strategy. Used to constrain the
   // overlay element's size to fit within the viewport.
   .cdk-overlay-connected-position-bounding-box {

--- a/src/cdk/overlay/overlay-ref.ts
+++ b/src/cdk/overlay/overlay-ref.ts
@@ -65,6 +65,7 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     private _document: Document,
     private _location: Location,
     private _outsideClickDispatcher: OverlayOutsideClickDispatcher,
+    private _animationsDisabled = false,
   ) {
     if (_config.scrollStrategy) {
       this._scrollStrategy = _config.scrollStrategy;
@@ -375,6 +376,10 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     this._backdropElement = this._document.createElement('div');
     this._backdropElement.classList.add('cdk-overlay-backdrop');
 
+    if (this._animationsDisabled) {
+      this._backdropElement.classList.add('cdk-overlay-backdrop-noop-animation');
+    }
+
     if (this._config.backdropClass) {
       this._toggleClasses(this._backdropElement, this._config.backdropClass, true);
     }
@@ -388,7 +393,7 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     this._backdropElement.addEventListener('click', this._backdropClickHandler);
 
     // Add class to fade-in the backdrop after one frame.
-    if (typeof requestAnimationFrame !== 'undefined') {
+    if (!this._animationsDisabled && typeof requestAnimationFrame !== 'undefined') {
       this._ngZone.runOutsideAngular(() => {
         requestAnimationFrame(() => {
           if (this._backdropElement) {
@@ -419,6 +424,11 @@ export class OverlayRef implements PortalOutlet, OverlayReference {
     const backdropToDetach = this._backdropElement;
 
     if (!backdropToDetach) {
+      return;
+    }
+
+    if (this._animationsDisabled) {
+      this._disposeBackdrop(backdropToDetach);
       return;
     }
 

--- a/src/cdk/overlay/overlay.ts
+++ b/src/cdk/overlay/overlay.ts
@@ -16,6 +16,8 @@ import {
   Injectable,
   Injector,
   NgZone,
+  ANIMATION_MODULE_TYPE,
+  Optional,
 } from '@angular/core';
 import {OverlayKeyboardDispatcher} from './dispatchers/overlay-keyboard-dispatcher';
 import {OverlayOutsideClickDispatcher} from './dispatchers/overlay-outside-click-dispatcher';
@@ -56,6 +58,7 @@ export class Overlay {
     private _directionality: Directionality,
     private _location: Location,
     private _outsideClickDispatcher: OverlayOutsideClickDispatcher,
+    @Inject(ANIMATION_MODULE_TYPE) @Optional() private _animationsModuleType?: string,
   ) {}
 
   /**
@@ -81,6 +84,7 @@ export class Overlay {
       this._document,
       this._location,
       this._outsideClickDispatcher,
+      this._animationsModuleType === 'NoopAnimations',
     );
   }
 

--- a/tools/public_api_guard/cdk/overlay.md
+++ b/tools/public_api_guard/cdk/overlay.md
@@ -262,12 +262,12 @@ export interface OriginConnectionPosition {
 // @public
 export class Overlay {
     constructor(
-    scrollStrategies: ScrollStrategyOptions, _overlayContainer: OverlayContainer, _componentFactoryResolver: ComponentFactoryResolver, _positionBuilder: OverlayPositionBuilder, _keyboardDispatcher: OverlayKeyboardDispatcher, _injector: Injector, _ngZone: NgZone, _document: any, _directionality: Directionality, _location: Location_2, _outsideClickDispatcher: OverlayOutsideClickDispatcher);
+    scrollStrategies: ScrollStrategyOptions, _overlayContainer: OverlayContainer, _componentFactoryResolver: ComponentFactoryResolver, _positionBuilder: OverlayPositionBuilder, _keyboardDispatcher: OverlayKeyboardDispatcher, _injector: Injector, _ngZone: NgZone, _document: any, _directionality: Directionality, _location: Location_2, _outsideClickDispatcher: OverlayOutsideClickDispatcher, _animationsModuleType?: string | undefined);
     create(config?: OverlayConfig): OverlayRef;
     position(): OverlayPositionBuilder;
     scrollStrategies: ScrollStrategyOptions;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<Overlay, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Overlay, [null, null, null, null, null, null, null, null, null, null, null, { optional: true; }]>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<Overlay>;
 }
@@ -364,7 +364,7 @@ export class OverlayPositionBuilder {
 
 // @public
 export class OverlayRef implements PortalOutlet, OverlayReference {
-    constructor(_portalOutlet: PortalOutlet, _host: HTMLElement, _pane: HTMLElement, _config: ImmutableObject<OverlayConfig>, _ngZone: NgZone, _keyboardDispatcher: OverlayKeyboardDispatcher, _document: Document, _location: Location_2, _outsideClickDispatcher: OverlayOutsideClickDispatcher);
+    constructor(_portalOutlet: PortalOutlet, _host: HTMLElement, _pane: HTMLElement, _config: ImmutableObject<OverlayConfig>, _ngZone: NgZone, _keyboardDispatcher: OverlayKeyboardDispatcher, _document: Document, _location: Location_2, _outsideClickDispatcher: OverlayOutsideClickDispatcher, _animationsDisabled?: boolean);
     addPanelClass(classes: string | string[]): void;
     // (undocumented)
     attach<T>(portal: ComponentPortal<T>): ComponentRef<T>;


### PR DESCRIPTION
Fixes that we weren't disabling the CDK backdrop transition when the noop animations module is used. This has caused test flakes in the past.