### PR TITLE
build: use github access token for docs site monitoring

### DIFF
--- a/scripts/docs-deploy/github-versioning.ts
+++ b/scripts/docs-deploy/github-versioning.ts
@@ -7,10 +7,12 @@ import {
   getNextBranchName,
 } from '@angular/dev-infra-private/ng-dev';
 
+import {githubAccessToken} from './utils';
+
 export function getReleaseRepoWithApi(): ReleaseRepoWithApi {
   const githubClient =
-    process.env.GITHUB_TOKEN !== undefined
-      ? new AuthenticatedGithubClient(process.env.GITHUB_TOKEN)
+    githubAccessToken !== undefined
+      ? new AuthenticatedGithubClient(githubAccessToken)
       : new GithubClient();
   const {github} = getConfig([assertValidGithubConfig]);
 

--- a/scripts/docs-deploy/utils.ts
+++ b/scripts/docs-deploy/utils.ts
@@ -23,6 +23,9 @@ export const sites = {
     new SiteTarget(`v${major}-material-angular-io`, `https://v${major}.material.angular.io`),
 };
 
+/** Optional Github access token. Can be used for querying the active release trains. */
+export const githubAccessToken: string | undefined = process.env.DOCS_DEPLOY_GITHUB_TOKEN;
+
 /** Configuration describing the Firebase project that we deploy to. */
 export const firebaseConfig = {
   projectId: 'material-angular-io',


### PR DESCRIPTION
We recently seemed to hit the rate limit in the docs site monitoring
job. We can use a Github access token to avoid these rate limit failures.

We move the token extraction to a common location where the GCP key is
also extracted, and we use a more granular variable name to make sure it's
obvious where the key is used (when added to CircleCI)