### PR TITLE
ci: skip ci failure slack notifications for renovate branches

### DIFF
--- a/scripts/circleci/notify-slack-job-failure.js
+++ b/scripts/circleci/notify-slack-job-failure.js
@@ -5,18 +5,34 @@
  * will be a noop when running for forked builds (i.e. PRs).
  */
 
+const {
+  isVersionBranch,
+  getConfig,
+  assertValidGithubConfig,
+} = require('@angular/dev-infra-private/ng-dev');
+
 if (process.env.CIRCLE_PR_NUMBER) {
   console.info('Skipping notifications for pull requests.');
   process.exit(0);
 }
 
-const {echo, set} = require('shelljs');
 const {
   CIRCLE_JOB: jobName,
   CIRCLE_BRANCH: branchName,
   CIRCLE_BUILD_URL: jobUrl,
   SLACK_COMPONENTS_CI_FAILURES_WEBHOOK_URL: webhookUrl,
 } = process.env;
+
+const {github} = getConfig([assertValidGithubConfig]);
+const isPublishBranch = isVersionBranch(branchName) || branchName === github.mainBranchName;
+
+// We don't want to spam the CI failures channel with e.g. Renovate branch failures.
+if (isPublishBranch === false) {
+  console.info('Skipping notifications for non-publish branches.');
+  process.exit(0);
+}
+
+const {echo, set} = require('shelljs');
 
 const text = `\`${jobName}\` failed in branch: ${branchName}: ${jobUrl}`;
 const payload = {text};


### PR DESCRIPTION
We want to skip CI failure Slack notifications for upstream branches
which are not actual publish branches.

Please enter the commit message for your changes. Lines starting