### PR TITLE
fix(cdk/a11y): live announcer promise never resolved if new announcement comes in

### DIFF
--- a/src/cdk/a11y/live-announcer/live-announcer.spec.ts
+++ b/src/cdk/a11y/live-announcer/live-announcer.spec.ts
@@ -112,6 +112,16 @@ describe('LiveAnnouncer', () => {
       expect(spy).toHaveBeenCalled();
     }));
 
+    it('should resolve the returned promise if another announcement is made before the timeout has expired', fakeAsync(() => {
+      const spy = jasmine.createSpy('announce spy');
+      announcer.announce('something').then(spy);
+      tick(10);
+      announcer.announce('something').then(spy);
+      tick(100);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    }));
+
     it('should ensure that there is only one live element at a time', fakeAsync(() => {
       fixture.destroy();
 


### PR DESCRIPTION
We return a promise that indicates when we've added the live announcer content to the DOM, however the promise will never be resolved if a new message comes in during the 100ms that it takes for us to make the announcement.

These changes add some extra logic to ensure it is always resolved.

Note that I was also considering rejecting the old promise instead, but that may be a poor experience for users since they may not have control over messages that are coming in from other places in the app.

Fixes #24686.