### PR TITLE
fix(material/datepicker): use lighter palette color for hovered or focused calendar cells instead of 0.3 opacity

### DIFF
--- a/src/material/datepicker/_datepicker-theme.scss
+++ b/src/material/datepicker/_datepicker-theme.scss
@@ -65,7 +65,7 @@ $calendar-weekday-table-font-size: 11px !default;
 @mixin _highlighted-cell($palette) {
   & > .mat-calendar-body-cell-content {
     @include _unselected-cell {
-      background-color: theming.get-color-from-palette($palette, 0.3);
+      background-color: theming.get-color-from-palette($palette, lighter);
     }
   }
 }


### PR DESCRIPTION
If a custom material theme is defined with css variables, the hover color und the selected color for calendar cells will be the same.
Is there a reason not to use the lighter palette color? 