### PR TITLE
Resolve style conflicts with MDC-based list

### DIFF
--- a/src/material-experimental/mdc-core/option/option.scss
+++ b/src/material-experimental/mdc-core/option/option.scss
@@ -13,6 +13,13 @@
   @include mat.private-user-select(none);
   cursor: pointer;
 
+  // If the MDC list is loaded after the option, this gets overwritten which breaks the text
+  // alignment. Ideally we'd wrap all the MDC mixins above with this selector, but the increased
+  // specificity breaks some internal overrides.
+  &.mdc-list-item {
+    align-items: center;
+  }
+
   // Set the `min-height` here ourselves, instead of going through
   // the `mdc-list-one-line-item-density` mixin, because it sets a `height`
   // which doesn't work well with multi-line options.

--- a/src/material-experimental/mdc-menu/menu.scss
+++ b/src/material-experimental/mdc-menu/menu.scss
@@ -66,6 +66,13 @@ mat-menu {
   $height-config: map.get(mdc-list-variables.$one-line-item-density-config, height);
   min-height: map.get($height-config, default);
 
+  // If the MDC list is loaded after the menu, this gets overwritten which breaks the text
+  // alignment. Ideally we'd wrap all the MDC mixins above with this selector, but the increased
+  // specificity breaks some internal overrides.
+  &.mdc-list-item {
+    align-items: center;
+  }
+
   &[disabled] {
     cursor: default;
 
@@ -107,6 +114,10 @@ mat-menu {
     white-space: normal;
   }
 
+  &.mat-mdc-menu-item-submenu-trigger {
+    @include mat.private-menu-common-item-submenu-trigger(mdc-list-variables.$side-padding);
+  }
+
   @include cdk.high-contrast(active, off) {
     $outline-width: 1px;
 
@@ -120,10 +131,6 @@ mat-menu {
       outline: dotted $outline-width;
     }
   }
-}
-
-.mat-mdc-menu-item-submenu-trigger {
-  @include mat.private-menu-common-item-submenu-trigger(mdc-list-variables.$side-padding);
 }
 
 .mat-mdc-menu-submenu-icon {


### PR DESCRIPTION
Fixes a couple of cases where the MDC list styles will override the styles of other components if they're loaded after them.