### PR TITLE
fix(material-experimental/mdc-dialog): implement delayFocusTrap option

### DIFF
--- a/src/material-experimental/mdc-dialog/dialog-container.ts
+++ b/src/material-experimental/mdc-dialog/dialog-container.ts
@@ -168,8 +168,7 @@ export class MatDialogContainer extends _MatDialogContainerBase implements OnDes
    */
   private _finishDialogOpen = () => {
     this._clearAnimationClasses();
-    this._trapFocus();
-    this._animationStateChanged.emit({state: 'opened', totalTime: this._openAnimationDuration});
+    this._openAnimationDone(this._openAnimationDuration);
   };
 
   /**

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -197,8 +197,6 @@ export class MatDialogContainer extends _MatDialogContainerBase {
             exitAnimationDuration: string;
         };
     };
-    // (undocumented)
-    _initializeWithAttachedContent(): void;
     _onAnimationDone({ toState, totalTime }: AnimationEvent_2): void;
     _onAnimationStart({ toState, totalTime }: AnimationEvent_2): void;
     _startExitAnimation(): void;
@@ -231,6 +229,7 @@ export abstract class _MatDialogContainerBase extends BasePortalOutlet {
     protected _focusTrapFactory: FocusTrapFactory;
     _id: string;
     _initializeWithAttachedContent(): void;
+    protected _openAnimationDone(totalTime: number): void;
     _portalOutlet: CdkPortalOutlet;
     _recaptureFocus(): void;
     protected _restoreFocus(): void;


### PR DESCRIPTION
When I added the `delayFocusTrap` option in #24121, I assumed that it would be inherited into the MDC dialog. Since it looks like that's not actually the case, these changes implement it.