### PR TITLE
fix(material/dialog): adding fallback to clean dialog when close animation does not run

### DIFF
--- a/src/material-experimental/mdc-dialog/dialog.spec.ts
+++ b/src/material-experimental/mdc-dialog/dialog.spec.ts
@@ -244,6 +244,18 @@ describe('MDC-based MatDialog', () => {
     expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
   }));
 
+  it('should dispose of dialog if view container is destroyed before animating', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
+
+    dialogRef.close();
+    viewContainerFixture.destroy();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
+    expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBe(null);
+  }));
+
   it(
     'should dispatch the beforeClosed and afterClosed events when the ' +
       'overlay is detached externally',

--- a/src/material/dialog/dialog.spec.ts
+++ b/src/material/dialog/dialog.spec.ts
@@ -247,6 +247,18 @@ describe('MatDialog', () => {
     expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
   }));
 
+  it('should dispose of dialog if view container is destroyed before animating', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg, {viewContainerRef: testViewContainerRef});
+
+    dialogRef.close();
+    viewContainerFixture.destroy();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(overlayContainerElement.querySelector('mat-dialog-container')).toBeNull();
+    expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBe(null);
+  }));
+
   it(
     'should dispatch the beforeClosed and afterClosed events when the ' +
       'overlay is detached externally',

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -188,7 +188,7 @@ export class MatDialogConfig<D = any> {
 }
 
 // @public
-export class MatDialogContainer extends _MatDialogContainerBase {
+export class MatDialogContainer extends _MatDialogContainerBase implements OnDestroy {
     // (undocumented)
     _getAnimationState(): {
         value: "enter" | "void" | "exit";
@@ -197,6 +197,8 @@ export class MatDialogContainer extends _MatDialogContainerBase {
             exitAnimationDuration: string;
         };
     };
+    // (undocumented)
+    ngOnDestroy(): void;
     _onAnimationDone({ toState, totalTime }: AnimationEvent_2): void;
     _onAnimationStart({ toState, totalTime }: AnimationEvent_2): void;
     _startExitAnimation(): void;
@@ -229,6 +231,9 @@ export abstract class _MatDialogContainerBase extends BasePortalOutlet {
     protected _focusTrapFactory: FocusTrapFactory;
     _id: string;
     _initializeWithAttachedContent(): void;
+    // (undocumented)
+    protected readonly _ngZone: NgZone;
+    readonly _onExit: Subject<void>;
     protected _openAnimationDone(totalTime: number): void;
     _portalOutlet: CdkPortalOutlet;
     _recaptureFocus(): void;


### PR DESCRIPTION
Currently the dialog's cleanup logic is tied to its exit animation completing and the close animation starting. This usually isn't a problem since by default the dialog is attached to the application ref, however if the consumer has set a viewContainerRef and that ref is destroyed before animation even starts, the exit animation event will never fire. 

Description of the problem from https://github.com/angular/components/pull/17947.

These changes add an _onExit observable to MatDialogContainer that emits when the container is destroyed or the close animation ended. Similar implementation as in MatSnackBarContainer.

This code also fixes a potential memory leak.
If the MatDialogContainer is destroyed before the animation is complete, containerInstance._animationStateChanged will never return a value, take(1) will never complete, and therefore the subscriptions will never complete.

Fixes https://github.com/angular/components/issues/17891.


I tried to get rid of the _closeFallbackTimeout in the MatDialogRef since the work is now done in the subsequent subscription.
But I didn't manage to adjust the "should return the current state of the dialog" test.