### PR TITLE
fix(material/select): empty space read out by VoiceOver on Chrome

### DIFF
--- a/src/material-experimental/mdc-select/select.scss
+++ b/src/material-experimental/mdc-select/select.scss
@@ -170,8 +170,9 @@ $scale: 0.75 !default;
   content: ' ';
   white-space: pre;
   width: 1px;
-
-  // Prevents some browsers from rendering the element in high contrast mode.
   display: inline-block;
-  opacity: 0;
+
+  // Prevents some browsers from rendering the element in high contrast mode. Use `visibility`
+  // instead of `opacity` since VoiceOver + Chrome still reads out the space with the latter.
+  visibility: hidden;
 }

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -168,8 +168,9 @@ $placeholder-arrow-space: 2 * ($arrow-size + $arrow-margin);
   content: ' ';
   white-space: pre;
   width: 1px;
-
-  // Prevents some browsers from rendering the element in high contrast mode.
   display: inline-block;
-  opacity: 0;
+
+  // Prevents some browsers from rendering the element in high contrast mode. Use `visibility`
+  // instead of `opacity` since VoiceOver + Chrome still reads out the space with the latter.
+  visibility: hidden;
 }


### PR DESCRIPTION
We use an empty space to prevent the select from collapsing when it doesn't have a value, but the approach we were using was being read out as a blank space by VoiceOver on Chrome. These changes switch to using `visibility: hidden` so that it isn't read out.

Fixes #24731.