### PR TITLE
fix(material/list): wrong order of arguments when calling custom compareWith function

### DIFF
--- a/src/material-experimental/mdc-list/list-option.ts
+++ b/src/material-experimental/mdc-list/list-option.ts
@@ -179,7 +179,7 @@ export class MatListOption extends MatListItemBase implements ListOption, OnInit
   ngOnInit() {
     const list = this._selectionList;
 
-    if (list._value && list._value.some(value => list.compareWith(value, this._value))) {
+    if (list._value && list._value.some(value => list.compareWith(this._value, value))) {
       this._setSelected(true);
     }
 

--- a/src/material/list/selection-list.ts
+++ b/src/material/list/selection-list.ts
@@ -205,7 +205,7 @@ export class MatListOption
   ngOnInit() {
     const list = this.selectionList;
 
-    if (list._value && list._value.some(value => list.compareWith(value, this._value))) {
+    if (list._value && list._value.some(value => list.compareWith(this._value, value))) {
       this._setSelected(true);
     }
 


### PR DESCRIPTION
Fixes a bug in Angular Material `selection-list` component where the order of arguments passed to a custom compareWith function was mixed up during initialization of a MatListOption.
Expected order based on documentation is:
1. value of the respective option
2. value of the selection