### PR TITLE
feat(material/autocomplete): add clear method to test harness

### DIFF
--- a/src/material/autocomplete/testing/autocomplete-harness.ts
+++ b/src/material/autocomplete/testing/autocomplete-harness.ts
@@ -70,6 +70,11 @@ export abstract class _MatAutocompleteHarnessBase<
     return (await this.host()).sendKeys(value);
   }
 
+  /** Clears the input value. */
+  async clear(): Promise<void> {
+    return (await this.host()).clear();
+  }
+
   /** Gets the options inside the autocomplete panel. */
   async getOptions(filters?: Omit<OptionFilters, 'ancestor'>): Promise<Option[]> {
     if (!(await this.isOpen())) {

--- a/src/material/autocomplete/testing/shared.spec.ts
+++ b/src/material/autocomplete/testing/shared.spec.ts
@@ -67,6 +67,14 @@ export function runHarnessTests(
     expect(await input.getValue()).toBe('Hello there');
   });
 
+  it('should be able to clear the input', async () => {
+    const input = await loader.getHarness(autocompleteHarness.with({selector: '#plain'}));
+    await input.enterText('Hello there');
+    expect(await input.getValue()).toBe('Hello there');
+    await input.clear();
+    expect(await input.getValue()).toBe('');
+  });
+
   it('should be able to get the autocomplete panel options', async () => {
     const input = await loader.getHarness(autocompleteHarness.with({selector: '#plain'}));
     await input.focus();

--- a/tools/public_api_guard/material/autocomplete-testing.md
+++ b/tools/public_api_guard/material/autocomplete-testing.md
@@ -39,6 +39,7 @@ export abstract class _MatAutocompleteHarnessBase<OptionType extends ComponentHa
     with: (options?: OptionGroupFilters) => HarnessPredicate<OptionGroup>;
 }, OptionGroup extends ComponentHarness, OptionGroupFilters extends BaseHarnessFilters> extends ComponentHarness {
     blur(): Promise<void>;
+    clear(): Promise<void>;
     enterText(value: string): Promise<void>;
     focus(): Promise<void>;
     getOptionGroups(filters?: Omit<OptionGroupFilters, 'ancestor'>): Promise<OptionGroup[]>;


### PR DESCRIPTION
Adds a `clear` method to the autocomplete harness, because currently it's only possible to enter text into it.

Fixes #24751.