### PR TITLE
fix(material-experimental/mdc-snack-bar): avoid multiple snack bars on the page if opened in quick succession

### DIFF
--- a/src/material/snack-bar/snack-bar-ref.ts
+++ b/src/material/snack-bar/snack-bar-ref.ts
@@ -52,8 +52,6 @@ export class MatSnackBarRef<T> {
 
   constructor(containerInstance: _SnackBarContainer, private _overlayRef: OverlayRef) {
     this.containerInstance = containerInstance;
-    // Dismiss snackbar on action.
-    this.onAction().subscribe(() => this.dismiss());
     containerInstance._onExit.subscribe(() => this._finishDismiss());
   }
 
@@ -71,6 +69,7 @@ export class MatSnackBarRef<T> {
       this._dismissedByAction = true;
       this._onAction.next();
       this._onAction.complete();
+      this.dismiss();
     }
     clearTimeout(this._durationTimeoutId);
   }

--- a/src/material/snack-bar/snack-bar.spec.ts
+++ b/src/material/snack-bar/snack-bar.spec.ts
@@ -465,13 +465,15 @@ describe('MatSnackBar', () => {
   }));
 
   it('should dismiss the snackbar when the action is called, notifying of both action and dismiss', fakeAsync(() => {
+    const dismissNextSpy = jasmine.createSpy('dismiss next spy');
     const dismissCompleteSpy = jasmine.createSpy('dismiss complete spy');
+    const actionNextSpy = jasmine.createSpy('action next spy');
     const actionCompleteSpy = jasmine.createSpy('action complete spy');
     const snackBarRef = snackBar.open('Some content', 'Dismiss');
     viewContainerFixture.detectChanges();
 
-    snackBarRef.afterDismissed().subscribe({complete: dismissCompleteSpy});
-    snackBarRef.onAction().subscribe({complete: actionCompleteSpy});
+    snackBarRef.afterDismissed().subscribe({next: dismissNextSpy, complete: dismissCompleteSpy});
+    snackBarRef.onAction().subscribe({next: actionNextSpy, complete: actionCompleteSpy});
 
     const actionButton = overlayContainerElement.querySelector(
       'button.mat-button',
@@ -480,7 +482,9 @@ describe('MatSnackBar', () => {
     viewContainerFixture.detectChanges();
     tick();
 
+    expect(dismissNextSpy).toHaveBeenCalled();
     expect(dismissCompleteSpy).toHaveBeenCalled();
+    expect(actionNextSpy).toHaveBeenCalled();
     expect(actionCompleteSpy).toHaveBeenCalled();
 
     tick(500);
@@ -649,6 +653,16 @@ describe('MatSnackBar', () => {
     expect(window.setTimeout).toHaveBeenCalledWith(jasmine.any(Function), Math.pow(2, 31) - 1);
 
     flush();
+  }));
+
+  it('should only keep one snack bar in the DOM if multiple are opened at the same time', fakeAsync(() => {
+    for (let i = 0; i < 10; i++) {
+      snackBar.open('Snack time!', 'Chew');
+      viewContainerFixture.detectChanges();
+    }
+
+    flush();
+    expect(overlayContainerElement.querySelectorAll('snack-bar-container').length).toBe(1);
   }));
 
   describe('with custom component', () => {


### PR DESCRIPTION
Fixes an issue where opening a snack bar while the previous one was being animated caused the former to remain in the DOM. The problem was that MDC always waits for an animation, even if it is interrupted.

Caretaker note: Fixes internal issue b/225379279