### PR TITLE
fix(material/slider): fix slider jumps back while dragging

### DIFF
--- a/src/dev-app/slider/slider-demo.html
+++ b/src/dev-app/slider/slider-demo.html
@@ -63,3 +63,12 @@ Label <mat-slider #slidey aria-label="Basic slider"></mat-slider>
     <mat-slider min="1" max="5" value="3" aria-label="Slider in a tab"></mat-slider>
   </mat-tab>
 </mat-tab-group>
+
+<h1>Slider that gets updated every second</h1>
+<button (click)="startInterval()">Start interval</button>
+<button (click)="stopInterval()">Stop interval</button>
+<mat-slider
+  [max]="maxValueForSliderThatGetsUpdatedByInterval"
+  [(ngModel)]="valueThatGetsUpdatedByInterval"
+></mat-slider>
+{{valueThatGetsUpdatedByInterval}}

--- a/src/dev-app/slider/slider-demo.ts
+++ b/src/dev-app/slider/slider-demo.ts
@@ -18,4 +18,35 @@ export class SliderDemo {
   min: number = 0;
   max: number = 100;
   disabledValue = 0;
+
+  valueThatGetsUpdatedByInterval: number = 25;
+  maxValueForSliderThatGetsUpdatedByInterval: number = 100;
+  intervalThatUpdatesValue: number | undefined = undefined;
+
+  startInterval(): void {
+    if (this.intervalThatUpdatesValue != undefined) {
+      return;
+    }
+
+    this.intervalThatUpdatesValue = setInterval(() => {
+      if (this.intervalThatUpdatesValue == undefined) {
+        return;
+      }
+
+      this.valueThatGetsUpdatedByInterval++;
+
+      if (this.valueThatGetsUpdatedByInterval === this.maxValueForSliderThatGetsUpdatedByInterval) {
+        this.valueThatGetsUpdatedByInterval = 0;
+      }
+    }, 1000);
+  }
+
+  stopInterval(): void {
+    if (this.intervalThatUpdatesValue == undefined) {
+      return;
+    }
+
+    clearInterval(this.intervalThatUpdatesValue);
+    this.intervalThatUpdatesValue = undefined;
+  }
 }

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -801,6 +801,16 @@ describe('MatSlider', () => {
       expect(sliderInstance.value).toBe(75);
       expect(trackFillElement.style.transform).toContain('scale3d(0.75, 1, 1)');
     });
+
+    it('should not overwrite the value while user is dragging', () => {
+      dispatchMousedownEventSequence(sliderNativeElement, 0.25);
+      fixture.detectChanges();
+      expect(sliderInstance.value).toBe(25);
+
+      fixture.componentInstance.val = 100;
+      fixture.detectChanges();
+      expect(sliderInstance.value).toBe(25);
+    });
   });
 
   describe('slider with set min and max and a value smaller than min', () => {

--- a/src/material/slider/slider.ts
+++ b/src/material/slider/slider.ts
@@ -254,25 +254,15 @@ export class MatSlider
   get value(): number {
     // If the value needs to be read and it is still uninitialized, initialize it to the min.
     if (this._value === null) {
-      this.value = this._min;
+      this._updateValue(this._min);
     }
     return this._value as number;
   }
   set value(v: NumberInput) {
-    if (v !== this._value) {
-      let value = coerceNumberProperty(v, 0);
-
-      // While incrementing by a decimal we can end up with values like 33.300000000000004.
-      // Truncate it to ensure that it matches the label and to make it easier to work with.
-      if (this._roundToDecimal && value !== this.min && value !== this.max) {
-        value = parseFloat(value.toFixed(this._roundToDecimal));
-      }
-
-      this._value = value;
-      this._percent = this._calculatePercentage(this._value);
-
-      // Since this also modifies the percentage, we need to let the change detection know.
-      this._changeDetectorRef.markForCheck();
+    // Don't overwrite the value if the user is currently
+    // dragging so the selection doesn't jump around.
+    if (!this._isSliding) {
+      this._updateValue(v);
     }
   }
   private _value: number | null = null;
@@ -608,10 +598,10 @@ export class MatSlider
         this._increment(-10);
         break;
       case END:
-        this.value = this.max;
+        this._updateValue(this.max);
         break;
       case HOME:
-        this.value = this.min;
+        this._updateValue(this.min);
         break;
       case LEFT_ARROW:
         // NOTE: For a sighted user it would make more sense that when they press an arrow key on an
@@ -802,7 +792,7 @@ export class MatSlider
     // Pre-clamp the current value since it's allowed to be
     // out of bounds when assigned programmatically.
     const clampedValue = this._clamp(this.value || 0, this.min, this.max);
-    this.value = this._clamp(clampedValue + this.step * numSteps, this.min, this.max);
+    this._updateValue(this._clamp(clampedValue + this.step * numSteps, this.min, this.max));
   }
 
   /** Calculate the new value from the new physical location. The value will always be snapped. */
@@ -827,9 +817,9 @@ export class MatSlider
     // is slightly more intuitive than using `Math.ceil` below, because it
     // follows the user's pointer closer.
     if (percent === 0) {
-      this.value = this.min;
+      this._updateValue(this.min);
     } else if (percent === 1) {
-      this.value = this.max;
+      this._updateValue(this.max);
     } else {
       const exactValue = this._calculateValue(percent);
 
@@ -838,7 +828,7 @@ export class MatSlider
       const closestValue = Math.round((exactValue - this.min) / this.step) * this.step + this.min;
 
       // The value needs to snap to the min and max.
-      this.value = this._clamp(closestValue, this.min, this.max);
+      this._updateValue(this._clamp(closestValue, this.min, this.max));
     }
   }
 
@@ -921,12 +911,35 @@ export class MatSlider
     this._elementRef.nativeElement.blur();
   }
 
+  /** Updates the control value and any related properties. */
+  private _updateValue(v: NumberInput) {
+    if (v !== this._value) {
+      let value = coerceNumberProperty(v, 0);
+
+      // While incrementing by a decimal we can end up with values like 33.300000000000004.
+      // Truncate it to ensure that it matches the label and to make it easier to work with.
+      if (this._roundToDecimal && value !== this.min && value !== this.max) {
+        value = parseFloat(value.toFixed(this._roundToDecimal));
+      }
+
+      this._value = value;
+      this._percent = this._calculatePercentage(this._value);
+
+      // Since this also modifies the percentage, we need to let the change detection know.
+      this._changeDetectorRef.markForCheck();
+    }
+  }
+
   /**
    * Sets the model value. Implemented as part of ControlValueAccessor.
    * @param value
    */
   writeValue(value: any) {
-    this.value = value;
+    // Don't overwrite the value if the user is currently
+    // dragging so the selection doesn't jump around.
+    if (!this._isSliding) {
+      this._updateValue(value);
+    }
   }
 
   /**


### PR DESCRIPTION
Fix a bug in the Angular Material `slider` component where slider jumps back while the user is dragging the slider and the sliders value gets updated manually somewhere else at the same time.

Fixes #19842

I saw the issue and I thought I'd tackle it, @crisbeto had also worked on it a long time ago, but there was no pull request yet if I see it correctly and since then something has changed in the code a bit. 