### PR TITLE
refactor(cdk-experimental/dialog): rewrite experimental dialog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -153,6 +153,7 @@
 /src/dev-app/mdc-autocomplete/**                   @crisbeto
 /src/dev-app/button/**                             @andrewseguin
 /src/dev-app/card/**                               @andrewseguin
+/src/dev-app/cdk-dialog/**                         @crisbeto
 /src/dev-app/cdk-experimental-combobox/**          @jelbourn
 /src/dev-app/cdk-experimental-listbox/**           @jelbourn
 /src/dev-app/cdk-experimental-menu/**              @jelbourn

--- a/goldens/ts-circular-deps.json
+++ b/goldens/ts-circular-deps.json
@@ -1,8 +1,4 @@
 [
-  [
-    "src/cdk-experimental/dialog/dialog-config.ts",
-    "src/cdk-experimental/dialog/dialog-container.ts"
-  ],
   ["src/cdk/drag-drop/directives/drag.ts", "src/cdk/drag-drop/directives/drop-list.ts"],
   ["src/cdk/drag-drop/directives/drag.ts", "src/cdk/drag-drop/drag-events.ts"],
   [

--- a/src/cdk-experimental/dialog/BUILD.bazel
+++ b/src/cdk-experimental/dialog/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite", "sass_binary")
+load("//tools:defaults.bzl", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,7 +8,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),
-    assets = [":dialog-container.css"] + glob(["**/*.html"]),
+    assets = glob(["**/*.html"]),
     deps = [
         "//src:dev_mode_types",
         "//src/cdk/a11y",
@@ -21,11 +21,6 @@ ng_module(
         "@npm//@angular/core",
         "@npm//rxjs",
     ],
-)
-
-sass_binary(
-    name = "dialog_container_scss",
-    src = "dialog-container.scss",
 )
 
 ng_test_library(

--- a/src/cdk-experimental/dialog/dialog-container.scss
+++ b/src/cdk-experimental/dialog/dialog-container.scss
@@ -1,6 +1,0 @@
-cdk-dialog-container {
-  background: white;
-  border-radius: 5px;
-  display: block;
-  padding: 10px;
-}

--- a/src/cdk-experimental/dialog/dialog-injectors.ts
+++ b/src/cdk-experimental/dialog/dialog-injectors.ts
@@ -7,9 +7,7 @@
  */
 
 import {InjectionToken} from '@angular/core';
-import {ComponentType, Overlay, ScrollStrategy} from '@angular/cdk/overlay';
-import {DialogRef} from './dialog-ref';
-import {CdkDialogContainer} from './dialog-container';
+import {Overlay, ScrollStrategy} from '@angular/cdk/overlay';
 import {DialogConfig} from './dialog-config';
 
 /** Injection token for the Dialog's ScrollStrategy. */
@@ -20,27 +18,17 @@ export const DIALOG_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrategy>(
 /** Injection token for the Dialog's Data. */
 export const DIALOG_DATA = new InjectionToken<any>('DialogData');
 
-/** Injection token for the DialogRef constructor. */
-export const DIALOG_REF = new InjectionToken<DialogRef<any>>('DialogRef');
-
-/** Injection token for the DialogConfig. */
-export const DIALOG_CONFIG = new InjectionToken<DialogConfig>('DialogConfig');
-
-/** Injection token for the Dialog's DialogContainer component. */
-export const DIALOG_CONTAINER = new InjectionToken<ComponentType<CdkDialogContainer>>(
-  'DialogContainer',
-);
+/** Injection token that can be used to provide default options for the dialog module. */
+export const DEFAULT_DIALOG_CONFIG = new InjectionToken<DialogConfig>('DefaultDialogConfig');
 
 /** @docs-private */
-export function MAT_DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY(
-  overlay: Overlay,
-): () => ScrollStrategy {
+export function DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY(overlay: Overlay): () => ScrollStrategy {
   return () => overlay.scrollStrategies.block();
 }
 
 /** @docs-private */
-export const MAT_DIALOG_SCROLL_STRATEGY_PROVIDER = {
+export const DIALOG_SCROLL_STRATEGY_PROVIDER = {
   provide: DIALOG_SCROLL_STRATEGY,
   deps: [Overlay],
-  useFactory: MAT_DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY,
+  useFactory: DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY,
 };

--- a/src/cdk-experimental/dialog/dialog-module.ts
+++ b/src/cdk-experimental/dialog/dialog-module.ts
@@ -12,14 +12,7 @@ import {PortalModule} from '@angular/cdk/portal';
 import {A11yModule} from '@angular/cdk/a11y';
 import {Dialog} from './dialog';
 import {CdkDialogContainer} from './dialog-container';
-import {DialogConfig} from './dialog-config';
-import {DialogRef} from './dialog-ref';
-import {
-  DIALOG_CONFIG,
-  DIALOG_CONTAINER,
-  DIALOG_REF,
-  MAT_DIALOG_SCROLL_STRATEGY_PROVIDER,
-} from './dialog-injectors';
+import {DIALOG_SCROLL_STRATEGY_PROVIDER} from './dialog-injectors';
 
 @NgModule({
   imports: [OverlayModule, PortalModule, A11yModule],
@@ -30,12 +23,6 @@ import {
     CdkDialogContainer,
   ],
   declarations: [CdkDialogContainer],
-  providers: [
-    Dialog,
-    MAT_DIALOG_SCROLL_STRATEGY_PROVIDER,
-    {provide: DIALOG_REF, useValue: DialogRef},
-    {provide: DIALOG_CONTAINER, useValue: CdkDialogContainer},
-    {provide: DIALOG_CONFIG, useValue: DialogConfig},
-  ],
+  providers: [Dialog, DIALOG_SCROLL_STRATEGY_PROVIDER],
 })
 export class DialogModule {}

--- a/src/dev-app/BUILD.bazel
+++ b/src/dev-app/BUILD.bazel
@@ -23,6 +23,7 @@ ng_module(
         "//src/dev-app/button",
         "//src/dev-app/button-toggle",
         "//src/dev-app/card",
+        "//src/dev-app/cdk-dialog",
         "//src/dev-app/cdk-experimental-combobox",
         "//src/dev-app/cdk-experimental-listbox",
         "//src/dev-app/cdk-experimental-menu",

--- a/src/dev-app/cdk-dialog/BUILD.bazel
+++ b/src/dev-app/cdk-dialog/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//tools:defaults.bzl", "ng_module", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "cdk-dialog",
+    srcs = glob(["**/*.ts"]),
+    assets = [
+        "dialog-demo.html",
+        ":dialog_demo_scss",
+    ],
+    deps = [
+        "//src/cdk-experimental/dialog",
+        "@npm//@angular/forms",
+        "@npm//@angular/router",
+    ],
+)
+
+sass_binary(
+    name = "dialog_demo_scss",
+    src = "dialog-demo.scss",
+)

--- a/src/dev-app/cdk-dialog/dialog-demo-module.ts
+++ b/src/dev-app/cdk-dialog/dialog-demo-module.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DialogModule} from '@angular/cdk-experimental/dialog';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {RouterModule} from '@angular/router';
+import {DialogDemo, JazzDialog} from './dialog-demo';
+
+@NgModule({
+  imports: [DialogModule, FormsModule, RouterModule.forChild([{path: '', component: DialogDemo}])],
+  declarations: [DialogDemo, JazzDialog],
+})
+export class DialogDemoModule {}

--- a/src/dev-app/cdk-dialog/dialog-demo.html
+++ b/src/dev-app/cdk-dialog/dialog-demo.html
@@ -1,0 +1,61 @@
+<div class="demo-container">
+  <h2>Dialog config</h2>
+
+  <div class="demo-field">
+    <label for="width">Width</label>
+    <input id="width" [(ngModel)]="config.width">
+  </div>
+  <div class="demo-field">
+    <label for="height">Height</label>
+    <input id="height" [(ngModel)]="config.height">
+  </div>
+  <div class="demo-field">
+    <label for="min-width">Min width</label>
+    <input id="min-width" [(ngModel)]="config.minWidth">
+  </div>
+  <div class="demo-field">
+    <label for="min-height">Min height</label>
+    <input id="min-height" [(ngModel)]="config.minHeight">
+  </div>
+  <div class="demo-field">
+    <label for="max-width">Max width</label>
+    <input id="max-width" [(ngModel)]="config.maxWidth">
+  </div>
+  <div class="demo-field">
+    <label for="max-height">Max height</label>
+    <input id="max-height" [(ngModel)]="config.maxHeight">
+  </div>
+  <div class="demo-field">
+    <label for="backdrop-class">Backdrop class</label>
+    <input id="backdrop-class" [(ngModel)]="config.backdropClass">
+  </div>
+  <div class="demo-field">
+    <label for="has-backdrop">Has backdrop</label>
+    <input id="has-backdrop" [(ngModel)]="config.hasBackdrop" type="checkbox">
+  </div>
+  <div class="demo-field">
+    <label for="message">Dialog message</label>
+    <input id="message" [(ngModel)]="config.data.message">
+  </div>
+  <div class="demo-field">
+    <label for="disable-close">Disable close</label>
+    <input id="disable-close" [(ngModel)]="config.disableClose" type="checkbox">
+  </div>
+  <p>Last result: {{result}}</p>
+
+  <button (click)="openJazz()">Open dialog</button>
+  <button (click)="openTemplate()">Open dialog with template content</button>
+</div>
+
+<ng-template let-data let-dialogRef="dialogRef">
+  I'm a template dialog. I've been opened {{numTemplateOpens}} times!
+
+  <p>It's Jazz!</p>
+
+  <label for="how-much">How much?</label>
+  <input id="how-much" #howMuch>
+
+  <p> {{ data.message }} </p>
+  <button type="button" (click)="dialogRef.close(howMuch.value)">Close dialog</button>
+  <button (click)="dialogRef.updateSize('500px', '500px');">Change dimensions</button>
+</ng-template>

--- a/src/dev-app/cdk-dialog/dialog-demo.scss
+++ b/src/dev-app/cdk-dialog/dialog-demo.scss
@@ -1,0 +1,23 @@
+.demo-cdk-dialog {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.demo-container {
+  button, label {
+    margin-right: 8px;
+
+    [dir='rtl'] & {
+      margin-left: 8px;
+      margin-right: 0;
+    }
+  }
+}
+
+.demo-field {
+  display: flex;
+  justify-content: space-between;
+  max-width: 300px;
+  margin-bottom: 8px;
+}

--- a/src/dev-app/cdk-dialog/dialog-demo.ts
+++ b/src/dev-app/cdk-dialog/dialog-demo.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Inject, TemplateRef, ViewChild, ViewEncapsulation} from '@angular/core';
+import {DIALOG_DATA, Dialog, DialogConfig, DialogRef} from '@angular/cdk-experimental/dialog';
+
+const defaultDialogConfig = new DialogConfig();
+
+@Component({
+  selector: 'dialog-demo',
+  templateUrl: 'dialog-demo.html',
+  styleUrls: ['dialog-demo.css'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class DialogDemo {
+  dialogRef: DialogRef<string> | null;
+  result: string;
+  actionsAlignment: 'start' | 'center' | 'end';
+  config = {
+    disableClose: defaultDialogConfig.disableClose,
+    panelClass: 'demo-cdk-dialog',
+    hasBackdrop: defaultDialogConfig.hasBackdrop,
+    backdropClass: defaultDialogConfig.backdropClass,
+    width: defaultDialogConfig.width,
+    height: defaultDialogConfig.height,
+    minWidth: defaultDialogConfig.minWidth,
+    minHeight: defaultDialogConfig.maxHeight,
+    maxWidth: defaultDialogConfig.maxWidth,
+    maxHeight: defaultDialogConfig.maxHeight,
+    data: {
+      message: 'Jazzy jazz jazz',
+      hmm: false,
+    },
+  };
+  numTemplateOpens = 0;
+
+  @ViewChild(TemplateRef) template: TemplateRef<any>;
+
+  constructor(public dialog: Dialog) {}
+
+  openJazz() {
+    this.dialogRef = this.dialog.open<string>(JazzDialog, this.config);
+
+    this.dialogRef.closed.subscribe(result => {
+      this.result = result!;
+      this.dialogRef = null;
+    });
+  }
+
+  openTemplate() {
+    this.numTemplateOpens++;
+    this.dialog.open(this.template, this.config);
+  }
+}
+
+@Component({
+  selector: 'demo-jazz-dialog',
+  template: `
+    <div>
+      <p>It's Jazz!</p>
+
+      <label for="how-much">How much?</label>
+      <input id="how-much" #howMuch>
+
+      <p>{{ data.message }}</p>
+      <button type="button" (click)="dialogRef.close(howMuch.value)">Close dialog</button>
+      <button (click)="togglePosition()">Change dimensions</button>
+      <button (click)="temporarilyHide()">Hide for 2 seconds</button>
+    </div>
+  `,
+  encapsulation: ViewEncapsulation.None,
+  styles: [`.hidden-dialog { opacity: 0; }`],
+})
+export class JazzDialog {
+  private _dimesionToggle = false;
+
+  constructor(public dialogRef: DialogRef<string>, @Inject(DIALOG_DATA) public data: any) {}
+
+  togglePosition(): void {
+    this._dimesionToggle = !this._dimesionToggle;
+
+    if (this._dimesionToggle) {
+      this.dialogRef.updateSize('500px', '500px');
+    } else {
+      this.dialogRef.updateSize().updatePosition();
+    }
+  }
+
+  temporarilyHide(): void {
+    this.dialogRef.addPanelClass('hidden-dialog');
+    setTimeout(() => {
+      this.dialogRef.removePanelClass('hidden-dialog');
+    }, 2000);
+  }
+}

--- a/src/dev-app/dev-app/dev-app-layout.ts
+++ b/src/dev-app/dev-app/dev-app-layout.ts
@@ -36,6 +36,7 @@ export class DevAppLayout {
     {name: 'Button Toggle', route: '/button-toggle'},
     {name: 'Button', route: '/button'},
     {name: 'Card', route: '/card'},
+    {name: 'Cdk Dialog', route: '/cdk-dialog'},
     {name: 'Cdk Experimental Combobox', route: '/cdk-experimental-combobox'},
     {name: 'Cdk Experimental Listbox', route: '/cdk-experimental-listbox'},
     {name: 'Cdk Experimental Menu', route: '/cdk-experimental-menu'},

--- a/src/dev-app/routes.ts
+++ b/src/dev-app/routes.ts
@@ -51,6 +51,10 @@ export const DEV_APP_ROUTES: Routes = [
       ),
   },
   {
+    path: 'cdk-dialog',
+    loadChildren: () => import('./cdk-dialog/dialog-demo-module').then(m => m.DialogDemoModule),
+  },
+  {
     path: 'cdk-experimental-listbox',
     loadChildren: () =>
       import('./cdk-experimental-listbox/cdk-listbox-demo-module').then(


### PR DESCRIPTION
Rewrites most of the CDK experimental dialog to prepare it for public release. The changes were largely informed by implementing `material/dialog`, `material-experimental/mdc-dialog` and `material/bottom-sheet` using the new API, however the API can be used directly without having to be wrapped. Overview of the changes:
* The classes for the dialog container, dialog config and dialog data aren't provided using DI anymore. The previous approach could've been a problem for apps that use multiple different versions of a CDK-based dialog.
* Several fixes from the Material dialog that were never backported to the CDK version have been incorporated.
* All animations and styles have been removed from the CDK dialog since they were going to be difficult to override by users. Custom animations can be achieved by extending the dialog container class.
* The public API has been cleaned up to avoid some of the issues that were inherited from the Material dialog.
* A demo has been added to the dev app.

Example of how the new APIs was used to implement the Material components: https://github.com/crisbeto/material2/commit/446a5520f1a0357612a9cc2d9e0c38b506665fb9.