### PR TITLE
fix(material-experimental/mdc-slider): remove pointerdown passive eve…

### DIFF
--- a/src/e2e-app/mdc-slider/mdc-slider-e2e.ts
+++ b/src/e2e-app/mdc-slider/mdc-slider-e2e.ts
@@ -11,7 +11,7 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'mdc-slider-e2e',
   template: `
-    <mat-slider id="standard-slider">
+    <mat-slider id="standard-slider" discrete>
       <input aria-label="Standard slider" matSliderThumb>
     </mat-slider>
 

--- a/src/material-experimental/mdc-slider/slider.e2e.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.e2e.spec.ts
@@ -53,12 +53,7 @@ describe('MDC-based MatSlider', () => {
       await setValueByClick(slider, 15);
 
       expect(await browser.manage().logs().get('browser')).not.toContain(
-        jasmine.objectContaining({
-          level: logging.Level.SEVERE,
-          message: jasmine.stringMatching(
-            'Unable to preventDefault inside passive event listener invocation.',
-          ),
-        }),
+        jasmine.objectContaining({level: logging.Level.SEVERE}),
       );
     });
   });

--- a/src/material-experimental/mdc-slider/slider.e2e.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.e2e.spec.ts
@@ -125,7 +125,6 @@ async function getSliderValue(slider: ElementFinder, thumbPosition: Thumb): Prom
 
 /** Focuses on the MatSlider at the coordinates corresponding to the given thumb. */
 async function focusSliderThumb(slider: ElementFinder, thumbPosition: Thumb): Promise<void> {
-  const value = await getSliderValue(slider, thumbPosition);
   const webElement = await getElement(slider).getWebElement();
   const coords = await getCoordsForValue(slider, await getSliderValue(slider, thumbPosition));
   return await browser.actions().mouseMove(webElement, coords).mouseDown().perform();

--- a/src/material-experimental/mdc-slider/slider.e2e.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.e2e.spec.ts
@@ -9,6 +9,7 @@
 import {clickElementAtPoint, getElement, Point} from '../../cdk/testing/private/e2e';
 import {Thumb} from '@material/slider';
 import {$, browser, by, element, ElementFinder} from 'protractor';
+import {logging} from 'selenium-webdriver';
 
 describe('MDC-based MatSlider', () => {
   const getStandardSlider = () => element(by.id('standard-slider'));
@@ -53,6 +54,7 @@ describe('MDC-based MatSlider', () => {
 
       expect(await browser.manage().logs().get('browser')).not.toContain(
         jasmine.objectContaining({
+          level: logging.Level.SEVERE,
           message: jasmine.stringMatching(
             'Unable to preventDefault inside passive event listener invocation.',
           ),

--- a/src/material-experimental/mdc-slider/slider.e2e.spec.ts
+++ b/src/material-experimental/mdc-slider/slider.e2e.spec.ts
@@ -8,7 +8,7 @@
 
 import {clickElementAtPoint, getElement, Point} from '../../cdk/testing/private/e2e';
 import {Thumb} from '@material/slider';
-import {browser, by, element, ElementFinder} from 'protractor';
+import {$, browser, by, element, ElementFinder} from 'protractor';
 
 describe('MDC-based MatSlider', () => {
   const getStandardSlider = () => element(by.id('standard-slider'));
@@ -31,6 +31,33 @@ describe('MDC-based MatSlider', () => {
     it('should update the value on slide', async () => {
       await slideToValue(slider, 35, Thumb.END);
       expect(await getSliderValue(slider, Thumb.END)).toBe(35);
+    });
+
+    it('should display the value indicator when focused', async () => {
+      await focusSliderThumb(slider, Thumb.END);
+      const rect: DOMRect = await browser.executeScript(
+        'return arguments[0].getBoundingClientRect();',
+        $('.mdc-slider__value-indicator'),
+      );
+
+      expect(rect.width).not.toBe(0);
+      expect(rect.height).not.toBe(0);
+
+      await browser.actions().mouseUp().perform();
+    });
+
+    it('should not cause passive event listener errors when changing the value', async () => {
+      // retrieving the logs clears the collection
+      await browser.manage().logs().get('browser');
+      await setValueByClick(slider, 15);
+
+      expect(await browser.manage().logs().get('browser')).not.toContain(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching(
+            'Unable to preventDefault inside passive event listener invocation.',
+          ),
+        }),
+      );
     });
   });
 
@@ -94,6 +121,14 @@ async function getSliderValue(slider: ElementFinder, thumbPosition: Thumb): Prom
   return thumbPosition === Thumb.END
     ? Number(await inputs[inputs.length - 1].getAttribute('value'))
     : Number(await inputs[0].getAttribute('value'));
+}
+
+/** Focuses on the MatSlider at the coordinates corresponding to the given thumb. */
+async function focusSliderThumb(slider: ElementFinder, thumbPosition: Thumb): Promise<void> {
+  const value = await getSliderValue(slider, thumbPosition);
+  const webElement = await getElement(slider).getWebElement();
+  const coords = await getCoordsForValue(slider, await getSliderValue(slider, thumbPosition));
+  return await browser.actions().mouseMove(webElement, coords).mouseDown().perform();
 }
 
 /** Clicks on the MatSlider at the coordinates corresponding to the given value. */

--- a/src/material-experimental/mdc-slider/slider.ts
+++ b/src/material-experimental/mdc-slider/slider.ts
@@ -781,11 +781,7 @@ export class MatSlider
     // would prefer to use "mousedown" as the default, for some reason it does not work (the
     // callback is never triggered).
     if (this._SUPPORTS_POINTER_EVENTS) {
-      this._elementRef.nativeElement.addEventListener(
-        'pointerdown',
-        this._layout,
-        passiveEventListenerOptions,
-      );
+      this._elementRef.nativeElement.addEventListener('pointerdown', this._layout);
     } else {
       this._elementRef.nativeElement.addEventListener('mouseenter', this._layout);
       this._elementRef.nativeElement.addEventListener(
@@ -799,11 +795,7 @@ export class MatSlider
   /** Removes the event listener that keeps sync the slider UI and the foundation in sync. */
   _removeUISyncEventListener(): void {
     if (this._SUPPORTS_POINTER_EVENTS) {
-      this._elementRef.nativeElement.removeEventListener(
-        'pointerdown',
-        this._layout,
-        passiveEventListenerOptions,
-      );
+      this._elementRef.nativeElement.removeEventListener('pointerdown', this._layout);
     } else {
       this._elementRef.nativeElement.removeEventListener('mouseenter', this._layout);
       this._elementRef.nativeElement.removeEventListener(
@@ -1134,10 +1126,10 @@ class SliderAdapter implements MDCSliderAdapter {
   getThumbKnobWidth = (thumbPosition: Thumb): number => {
     return this._delegate._getKnobElement(thumbPosition).getBoundingClientRect().width;
   };
-  getThumbBoundingClientRect = (thumbPosition: Thumb): ClientRect => {
+  getThumbBoundingClientRect = (thumbPosition: Thumb): DOMRect => {
     return this._delegate._getThumbElement(thumbPosition).getBoundingClientRect();
   };
-  getBoundingClientRect = (): ClientRect => {
+  getBoundingClientRect = (): DOMRect => {
     return this._delegate._elementRef.nativeElement.getBoundingClientRect();
   };
   getValueIndicatorContainerWidth = (thumbPosition: Thumb): number => {


### PR DESCRIPTION
…nt listener options

* setting {passive: true} causes the slider foundation to
  error when it calls event.preventDefault