### PR TITLE
fix(cdk/portal): prevent calling `ApplicationRef.detachView` on destroyed instance

### DIFF
--- a/src/cdk/portal/dom-portal-outlet.ts
+++ b/src/cdk/portal/dom-portal-outlet.ts
@@ -87,7 +87,11 @@ export class DomPortalOutlet extends BasePortalOutlet {
       );
       this._appRef!.attachView(componentRef.hostView);
       this.setDisposeFn(() => {
-        this._appRef!.detachView(componentRef.hostView);
+        // Verify that the ApplicationRef has registered views before trying to detach a host view.
+        // This check also protects the `detachView` from being called on a destroyed ApplicationRef.
+        if (this._appRef!.viewCount > 0) {
+          this._appRef!.detachView(componentRef.hostView);
+        }
         componentRef.destroy();
       });
     }


### PR DESCRIPTION
This commit adds a check that ensures that the `ApplicationRef.detachView` is only called when there are some registered views in the `ApplicationRef` instance (thus the instance is not destroyed).

Calling `ApplicationRef` APIs on destroyed instance will result in an error after https://github.com/angular/angular/pull/45624. This commit makes the code forward-compatible with the upcoming changes. The error was discovered in g3 while running a TGP for https://github.com/angular/angular/pull/45624.