### PR TITLE
refactor(cdk/table): expose data source type

### DIFF
--- a/src/cdk/table/table.ts
+++ b/src/cdk/table/table.ts
@@ -101,11 +101,8 @@ export interface RowOutlet {
   viewContainer: ViewContainerRef;
 }
 
-/**
- * Union of the types that can be set as the data source for a `CdkTable`.
- * @docs-private
- */
-type CdkTableDataSourceInput<T> = readonly T[] | DataSource<T> | Observable<readonly T[]>;
+/** Possible types that can be set as the data source for a `CdkTable`. */
+export type CdkTableDataSourceInput<T> = readonly T[] | DataSource<T> | Observable<readonly T[]>;
 
 /**
  * Provides a handle for the table to grab the view container's ng-container to insert data rows.

--- a/tools/public_api_guard/cdk/table.md
+++ b/tools/public_api_guard/cdk/table.md
@@ -366,6 +366,9 @@ export class CdkTable<T> implements AfterContentChecked, CollectionViewer, OnDes
     static ɵfac: i0.ɵɵFactoryDeclaration<CdkTable<any>, [null, null, null, { attribute: "role"; }, { optional: true; }, null, null, null, null, null, { optional: true; skipSelf: true; }, { optional: true; }]>;
 }
 
+// @public
+export type CdkTableDataSourceInput<T> = readonly T[] | DataSource<T> | Observable<readonly T[]>;
+
 // @public (undocumented)
 export class CdkTableModule {
     // (undocumented)


### PR DESCRIPTION
Exposes the `CdkTableDataSourceInput` type since it can be useful for people implementing their own tables.

Fixes #24518.