### PR TITLE
feat(material/paginator): Add `isNextPageEnabled` and `isPreviousPageEnabled` to `MatPaginatorHarness`

### DIFF
--- a/src/material/paginator/testing/paginator-harness.ts
+++ b/src/material/paginator/testing/paginator-harness.ts
@@ -36,6 +36,18 @@ export abstract class _MatPaginatorHarnessBase extends ComponentHarness {
     return (await this._nextButton()).click();
   }
 
+  /** Returns whether or not the next page button is disabled. */
+  async isNextPageDisabled(): Promise<boolean> {
+    const disabledValue = await (await this._nextButton()).getAttribute('disabled');
+    return disabledValue == 'true';
+  }
+
+  /* Returns whether or not the previous page button is disabled. */
+  async isPreviousPageDisabled(): Promise<boolean> {
+    const disabledValue = await (await this._previousButton()).getAttribute('disabled');
+    return disabledValue == 'true';
+  }
+
   /** Goes to the previous page in the paginator. */
   async goToPreviousPage(): Promise<void> {
     return (await this._previousButton()).click();

--- a/src/material/paginator/testing/shared.spec.ts
+++ b/src/material/paginator/testing/shared.spec.ts
@@ -97,6 +97,17 @@ export function runHarnessTests(
     );
   });
 
+  it('should return whether or not the previous page is disabled', async () => {
+    const paginator = await loader.getHarness(paginatorHarness);
+    expect(await paginator.isPreviousPageDisabled()).toBe(true);
+  });
+
+  it('should return whether or not the next page is disabled', async () => {
+    const paginator = await loader.getHarness(paginatorHarness);
+    await paginator.goToLastPage();
+    expect(await paginator.isNextPageDisabled()).toBe(true);
+  });
+
   it('should throw an error if the last page button is not available', async () => {
     const paginator = await loader.getHarness(paginatorHarness);
 

--- a/tools/public_api_guard/material/paginator-testing.md
+++ b/tools/public_api_guard/material/paginator-testing.md
@@ -41,6 +41,9 @@ export abstract class _MatPaginatorHarnessBase extends ComponentHarness {
     goToLastPage(): Promise<void>;
     goToNextPage(): Promise<void>;
     goToPreviousPage(): Promise<void>;
+    isNextPageDisabled(): Promise<boolean>;
+    // (undocumented)
+    isPreviousPageDisabled(): Promise<boolean>;
     // (undocumented)
     protected abstract _lastPageButton: AsyncFactoryFn<TestElement | null>;
     // (undocumented)


### PR DESCRIPTION
I have some tests that assert this behavior and ran into this when migrating over to component harnesses.