### PR TITLE
fix(material/dialog) add generic for close method

### DIFF
--- a/src/material/dialog/dialog-ref.ts
+++ b/src/material/dialog/dialog-ref.ts
@@ -119,7 +119,7 @@ export class MatDialogRef<T, R = any> {
    * Close the dialog.
    * @param dialogResult Optional result to return to the dialog opener.
    */
-  close(dialogResult?: R): void {
+  close<R>(dialogResult?: R): void {
     this._result = dialogResult;
 
     // Transition the backdrop in parallel to the dialog.

--- a/tools/public_api_guard/material/dialog.md
+++ b/tools/public_api_guard/material/dialog.md
@@ -268,7 +268,7 @@ export class MatDialogRef<T, R = any> {
     afterOpened(): Observable<void>;
     backdropClick(): Observable<MouseEvent>;
     beforeClosed(): Observable<R | undefined>;
-    close(dialogResult?: R): void;
+    close<R>(dialogResult?: R): void;
     componentInstance: T;
     // (undocumented)
     _containerInstance: _MatDialogContainerBase;


### PR DESCRIPTION
Fixes a bug in the Angular Material 'dialog' component where the generic type was missing for the close method