### PR TITLE
build: disable renovate lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "stopUpdatingLabel": "merge ready",
   "labels": ["target: patch", "merge safe"],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   },
   "pinDigests": true,
   "prHourlyLimit": 2,


### PR DESCRIPTION
We found renovate lock file maintenance to be non-ideal for our
branching in Angular. Going forward we will disable this and start
managing the lock file manually like in the past.