### PR TITLE
docs(material/chips): use correct terminology

### DIFF
--- a/src/material/chips/chip-list.ts
+++ b/src/material/chips/chip-list.ts
@@ -372,7 +372,7 @@ export class MatChipList
    */
   @Output() readonly valueChange = new EventEmitter<any>();
 
-  /** The chip components contained within this chip list. */
+  /** The chips contained within this chip list. */
   @ContentChildren(MatChip, {
     // We need to use `descendants: true`, because Ivy will no longer match
     // indirect descendants if it's left as false.

--- a/src/material/chips/chip.ts
+++ b/src/material/chips/chip.ts
@@ -116,9 +116,7 @@ export class MatChipAvatar {}
 })
 export class MatChipTrailingIcon {}
 
-/**
- * Material design styled Chip component. Used inside the MatChipList component.
- */
+/** Material Design styled chip directive. Used inside the MatChipList component. */
 @Directive({
   selector: `mat-basic-chip, [mat-basic-chip], mat-chip, [mat-chip]`,
   inputs: ['color', 'disableRipple', 'tabIndex'],


### PR DESCRIPTION
Fixes that we were referring to `MatChip` as a component even though it's a directive.

Fixes #24779.