### PR TITLE
Fix: update table predicate filter

### DIFF
--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -235,7 +235,7 @@ export class _MatTableDataSource<
    * @param filter Filter string that has been set on the data source.
    * @returns Whether the filter matches against the data
    */
-   filterPredicate: ((data: T, filter: string) => boolean) = (data: T, filter: string): boolean => {
+  filterPredicate: (data: T, filter: string) => boolean = (data: T, filter: string): boolean => {
     // Transform the filter by converting it to lowercase and removing whitespace.
     const transformedFilter = filter.trim().toLowerCase();
     // Loops over the values in the array and returns true if any of them match the filter string

--- a/src/material/table/table-data-source.ts
+++ b/src/material/table/table-data-source.ts
@@ -235,24 +235,16 @@ export class _MatTableDataSource<
    * @param filter Filter string that has been set on the data source.
    * @returns Whether the filter matches against the data
    */
-  filterPredicate: (data: T, filter: string) => boolean = (data: T, filter: string): boolean => {
-    // Transform the data into a lowercase string of all property values.
-    const dataStr = Object.keys(data)
-      .reduce((currentTerm: string, key: string) => {
-        // Use an obscure Unicode character to delimit the words in the concatenated string.
-        // This avoids matches where the values of two columns combined will match the user's query
-        // (e.g. `Flute` and `Stop` will match `Test`). The character is intended to be something
-        // that has a very low chance of being typed in by somebody in a text field. This one in
-        // particular is "White up-pointing triangle with dot" from
-        // https://en.wikipedia.org/wiki/List_of_Unicode_characters
-        return currentTerm + (data as {[key: string]: any})[key] + '◬';
-      }, '')
-      .toLowerCase();
-
+   filterPredicate: ((data: T, filter: string) => boolean) = (data: T, filter: string): boolean => {
     // Transform the filter by converting it to lowercase and removing whitespace.
     const transformedFilter = filter.trim().toLowerCase();
-
-    return dataStr.indexOf(transformedFilter) != -1;
+    // Loops over the values in the array and returns true if any of them match the filter string
+    for (let val of Object.values(data)) {
+      if (val.toLowerCase().includes(transformedFilter)) {
+        return true;
+      }
+    }
+    return false;
   };
 
   constructor(initialData: T[] = []) {


### PR DESCRIPTION
Change the table's predicate filter to iterate through the map's array of values and check for filter inclusion. This will involve fewer passes: the current function iterates over the keys, searches the map for each key to construct a string, then searches the string. It will also remove the risk presented by the unicode delimiter.
It will also present an improvement over @daniel-brenot's PR https://github.com/angular/components/pull/21362 which, similarly to the original function, iterates over the keys and then searches the map for their corresponding value. This check is superfluous when an array of values is available.
Performance-wise, a further gain in speed is present over both previous techniques. I have updated Daniel's benchmark script to include the new function, as well as some logic to print results for veracity, check failure performance, and populate a map with n generated UUIDs to help examine performance at scale.
https://jsbench.me/9bl258ffo3/2
At 1,000 entries, the original function is ~80% slower, Daniel's is ~42% slower at successes.
Failures are roughly 65%, 39% slower, respectively.
At 10,000 entries, successes are roughly 84%, 32% slower.
Failures at 10k are roughly 75%, 24% slower.
For completeness, at 10 entries, successes: 63, 11, failures: 55, 9.