### PR TITLE
fix(material/datepicker): add ability to have numeric zero value in input

### DIFF
--- a/src/material/datepicker/datepicker-input-base.ts
+++ b/src/material/datepicker/datepicker-input-base.ts
@@ -344,9 +344,8 @@ export abstract class MatDatepickerInputBase<S, D = ExtractDateTypeFromSelection
 
   /** Formats a value and sets it on the input element. */
   protected _formatValue(value: D | null) {
-    this._elementRef.nativeElement.value = value
-      ? this._dateAdapter.format(value, this._dateFormats.display.dateInput)
-      : '';
+    this._elementRef.nativeElement.value =
+      value != null ? this._dateAdapter.format(value, this._dateFormats.display.dateInput) : '';
   }
 
   /** Assigns a value to the model. */


### PR DESCRIPTION
fix(material/datepicker): add ability to have numeric zero value in input

Shows valid formatted value for 'falsy' values (exp 0)
Custom DateAdapter (exp TimestampDateAdapter) can have valid numeric 0 value (for timestamp it is 1/1/1970), but datepicker input doesn't show formatted value