### PR TITLE
build: update sass bazel rules and fix yarn repository Bazel warning

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,10 +15,10 @@ http_archive(
 # Add sass rules
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "bfb89ca97a4ad452ca5f623dfde23d2a5f3a848a97478d715881b69b4767d3bb",
-    strip_prefix = "rules_sass-1.49.4",
+    sha256 = "4b6153ae6c454c5bd44f3e47e5430f8a634d4affb983a237d21ca6199e13991c",
+    strip_prefix = "rules_sass-1.50.1",
     urls = [
-        "https://github.com/bazelbuild/rules_sass/archive/1.49.4.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/1.50.1.zip",
     ],
 )
 
@@ -103,7 +103,9 @@ web_test_repositories()
 # Setup the Sass rule repositories.
 load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 
-sass_repositories()
+sass_repositories(
+    yarn_script = "//:.yarn/releases/yarn-1.22.17.cjs",
+)
 
 # Setup repositories for browsers provided by the shared dev-infra package.
 load(

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "requirejs": "^2.3.6",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "sass": "^1.49.4",
+    "sass": "^1.50.1",
     "selenium-webdriver": "^3.6.0",
     "semver": "^7.3.5",
     "send": "^0.17.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,7 +225,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#94108cd31fae6c341fdce4394c9a050f134b25fa":
   version "0.0.0-8a7e038d773fbae483d5366d7f27bd403f072665"
-  uid "94108cd31fae6c341fdce4394c9a050f134b25fa"
   resolved "https://github.com/angular/dev-infra-private-builds.git#94108cd31fae6c341fdce4394c9a050f134b25fa"
   dependencies:
     "@angular-devkit/build-angular" "14.0.0-next.9"
@@ -12820,10 +12819,19 @@ sass-lookup@^3.0.0:
   dependencies:
     commander "^2.16.0"
 
-sass@1.50.0, sass@^1.49.4:
+sass@1.50.0:
   version "1.50.0"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.50.0.tgz#3e407e2ebc53b12f1e35ce45efb226ea6063c7c8"
   integrity sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
+sass@^1.50.1:
+  version "1.50.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.50.1.tgz#e9b078a1748863013c4712d2466ce8ca4e4ed292"
+  integrity sha512-noTnY41KnlW2A9P8sdwESpDmo+KBNkukI1i8+hOK3footBUcohNHtdOJbckp46XO95nuvcHDDZ+4tmOnpK3hjw==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"


### PR DESCRIPTION
Updates to the latest version of the Sass Bazel rules. We landed
a fix upstream, allowing us to provide a vendored Yarn script, instead
of needing a separate download of Yarn (with a warning polluting the
Bazel output)