### PR TITLE
fix(material/menu): focus first item when opening menu with iOS VoiceOver (`_animationDone` approach)

### DIFF
--- a/src/components-examples/material/menu/menu-overview/menu-overview-example.html
+++ b/src/components-examples/material/menu/menu-overview/menu-overview-example.html
@@ -1,6 +1,7 @@
 <!-- #docregion mat-menu-trigger-for -->
 <button mat-button [matMenuTriggerFor]="menu">Menu</button>
 <!-- #enddocregion mat-menu-trigger-for -->
+<button mat-button (click)="doubleOpen()">Double open</button>
 <mat-menu #menu="matMenu">
   <button mat-menu-item>Item 1</button>
   <button mat-menu-item>Item 2</button>

--- a/src/components-examples/material/menu/menu-overview/menu-overview-example.ts
+++ b/src/components-examples/material/menu/menu-overview/menu-overview-example.ts
@@ -1,4 +1,5 @@
-import {Component} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
+import {MatMenuTrigger} from '@angular/material/menu';
 
 /**
  * @title Basic menu
@@ -7,4 +8,10 @@ import {Component} from '@angular/core';
   selector: 'menu-overview-example',
   templateUrl: 'menu-overview-example.html',
 })
-export class MenuOverviewExample {}
+export class MenuOverviewExample {
+  @ViewChild(MatMenuTrigger) trigger?: MatMenuTrigger;
+  doubleOpen() {
+    this.trigger?.openMenu();
+    this.trigger?.openMenu();
+  }
+}

--- a/src/material/menu/menu.spec.ts
+++ b/src/material/menu/menu.spec.ts
@@ -338,6 +338,7 @@ describe('MatMenu', () => {
     dispatchFakeEvent(triggerEl, 'mousedown');
     triggerEl.click();
     fixture.detectChanges();
+    flush();
 
     expect(overlayContainerElement.querySelector('.mat-menu-panel')).toBeTruthy();
 
@@ -860,6 +861,7 @@ describe('MatMenu', () => {
 
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
+    flush();
     tick(500);
 
     expect(triggerEl.getAttribute('aria-expanded')).toBe('true');


### PR DESCRIPTION
…Over

When opening the menu using the iOS VoiceOver screen reader, focus the first item in the menu.
Previously, the first menu item would focus on other screen readers, like desktop VoiceOver, but
not with iOS VoiceOver.

Atempting to fix this by waiting until `_animationDone`.

Fixes angular#24735