### PR TITLE
build: changes for renaming primary branch to `main` [12.2.x]

### DIFF
--- a/.circleci/rebase-pr.js
+++ b/.circleci/rebase-pr.js
@@ -152,7 +152,7 @@ function getShaFromRef(ref) {
  * by committerdate.
  *
  * example:
- *   upstream/master
+ *   upstream/main
  *   upstream/9.0.x
  *   upstream/test
  *   upstream/1.1.x

--- a/.ng-dev/github.ts
+++ b/.ng-dev/github.ts
@@ -7,5 +7,5 @@ import {GithubConfig} from '@angular/dev-infra-private/ng-dev/utils/config';
 export const github: GithubConfig = {
   owner: 'angular',
   name: 'components',
-  mainBranchName: 'master',
+  mainBranchName: 'main',
 };

--- a/scripts/deploy/publish-build-artifacts.sh
+++ b/scripts/deploy/publish-build-artifacts.sh
@@ -39,7 +39,7 @@ publishPackage() {
 
   buildDir="$(pwd)/dist/releases/${packageName}"
   buildVersion=$(node -pe "require('./package.json').version")
-  branchName=${CIRCLE_BRANCH:-'master'}
+  branchName=${CIRCLE_BRANCH:-'main'}
 
   commitSha=$(git rev-parse --short HEAD)
   commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)

--- a/scripts/deploy/publish-docs-content.sh
+++ b/scripts/deploy/publish-docs-content.sh
@@ -34,7 +34,7 @@ docsContentRepoUrl="https://github.com/angular/material2-docs-content"
 buildVersion=$(node -pe "require('./package.json').version")
 
 # Name of the branch that is currently being deployed.
-branchName=${CIRCLE_BRANCH:-'master'}
+branchName=${CIRCLE_BRANCH:-'main'}
 
 # Additional information about the last commit for docs-content commits.
 commitSha=$(git rev-parse --short HEAD)


### PR DESCRIPTION
Changes of the `DIRECT` phase for the "renaming master to
main" migration/planning doc.