### PR TITLE
fix(material/select): don't announce selected value multiple times

### DIFF
--- a/src/material-experimental/mdc-select/select.html
+++ b/src/material-experimental/mdc-select/select.html
@@ -13,7 +13,7 @@
      (click)="toggle()"
      #fallbackOverlayOrigin="cdkOverlayOrigin"
      #trigger>
-  <div class="mat-mdc-select-value" [ngSwitch]="empty" [attr.id]="_valueId">
+  <div class="mat-mdc-select-value" [ngSwitch]="empty" [attr.id]="_valueId" aria-hidden="true">
     <span class="mat-mdc-select-placeholder mat-mdc-select-min-line" *ngSwitchCase="true">{{placeholder}}</span>
     <span class="mat-mdc-select-value-text" *ngSwitchCase="false" [ngSwitch]="!!customTrigger">
       <span class="mat-mdc-select-min-line" *ngSwitchDefault>{{triggerValue}}</span>

--- a/src/material/select/select.html
+++ b/src/material/select/select.html
@@ -13,7 +13,7 @@
      (click)="toggle()"
      #origin="cdkOverlayOrigin"
      #trigger>
-  <div class="mat-select-value" [ngSwitch]="empty" [attr.id]="_valueId">
+  <div class="mat-select-value" [ngSwitch]="empty" [attr.id]="_valueId" aria-hidden="true">
     <span class="mat-select-placeholder mat-select-min-line" *ngSwitchCase="true">{{placeholder}}</span>
     <span class="mat-select-value-text" *ngSwitchCase="false" [ngSwitch]="!!customTrigger">
       <span class="mat-select-min-line" *ngSwitchDefault>{{triggerValue}}</span>


### PR DESCRIPTION
Screen readers announce the selected value multiple times. NVDA e.g. reads "Favorite food Pizza Pizza combobox Pizza collapsed".

1. First, the Screen Reader (SR) reads the value of the label (see 1st `aria-labelledby`): "Favorite food"
2. SR reads the content of the combobox (because of the label's `aria-owns` attribute): "Pizza"
3. SR reads the value of the combobox (see 2nd `aria-labelledby`): "Pizza"
4. SR reads the content of the combobox again: "Pizza"

To fix this, an `aria-hidden` attribute is added to the element containing the selected value. NVDA e.g. now reads "Favorite food Pizza combobox collapsed".

Successfully tested with NVDA, JAWS, Narrator and the _Screen Reader_ Chrome plugin.

Closes #24899 