### PR TITLE
chore: replace all git.io link

### DIFF
--- a/src/cdk/schematics/testing/test-case-setup.ts
+++ b/src/cdk/schematics/testing/test-case-setup.ts
@@ -147,7 +147,8 @@ export function findBazelVersionTestCases(basePath: string) {
   }
 
   // In case runfiles are not symlinked (e.g. on Windows), we resolve all test case files using
-  // the Bazel runfiles manifest. Read more about the manifest here: https://git.io/fhIZE
+  // the Bazel runfiles manifest. Read more about the manifest here:
+  // https://github.com/bazelbuild/bazel/blob/701913139adc0eba49a7a9963fea4f555fcd844f/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java#L214-L221
   readFileSync(manifestPath, 'utf8')
     .split('\n')
     .forEach(line => {

--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/gesture-config.template
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/gesture-config.template
@@ -4,7 +4,7 @@
  * automatically to this application because ng-update detected that this application
  * directly used custom HammerJS gestures defined by Angular Material.
  *
- * Read more in the dedicated guide: https://git.io/ng-material-v9-hammer-migration
+ * Read more in the dedicated guide: https://github.com/angular/components/blob/3a204da37fd1366cae411b5c234517ecad199737/guides/v9-hammerjs-migration.md?
  */
 
 import {Injectable, Inject, Optional, Type} from '@angular/core';

--- a/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
+++ b/src/material/schematics/ng-update/migrations/hammer-gestures-v9/hammer-gestures-migration.ts
@@ -172,7 +172,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
             'manually set up in combination with references to the Angular Material gesture ' +
             'config. This target cannot be migrated completely, but all references to the ' +
             'deprecated Angular Material gesture have been removed. Read more here: ' +
-            'https://git.io/ng-material-v9-hammer-ambiguous-usage',
+            'https://github.com/angular/components/blob/3a204da37fd1366cae411b5c234517ecad199737/guides/v9-hammerjs-migration.md#the-migration-reported-ambiguous-usage-what-should-i-do',
         );
       } else if (usedInTemplate && this._gestureConfigReferences.length) {
         // Since there is a reference to the Angular Material gesture config, and we detected
@@ -184,7 +184,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
             'manually set up in combination with references to the Angular Material gesture ' +
             'config. This target cannot be migrated completely. Please manually remove ' +
             'references to the deprecated Angular Material gesture config. Read more here: ' +
-            'https://git.io/ng-material-v9-hammer-ambiguous-usage',
+            'https://github.com/angular/components/blob/3a204da37fd1366cae411b5c234517ecad199737/guides/v9-hammerjs-migration.md#the-migration-reported-ambiguous-usage-what-should-i-do',
         );
       }
     } else if (this._usedInRuntime || usedInTemplate) {
@@ -226,7 +226,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
         'The HammerJS v9 migration for Angular Components migrated the ' +
           'project to keep HammerJS installed, but detected ambiguous usage of HammerJS. Please ' +
           'manually check if you can remove HammerJS from your application. More details: ' +
-          'https://git.io/ng-material-v9-hammer-ambiguous-usage',
+          'https://github.com/angular/components/blob/3a204da37fd1366cae411b5c234517ecad199737/guides/v9-hammerjs-migration.md#the-migration-reported-ambiguous-usage-what-should-i-do',
       );
     }
   }
@@ -955,7 +955,7 @@ export class HammerGesturesMigration extends DevkitMigration<null> {
         (this.globalUsesHammer ? 'the deprecated Angular Material gesture config.' : 'HammerJS.'),
     );
     context.logger.info(
-      'Read more about migrating tests: https://git.io/ng-material-v9-hammer-migrate-tests',
+      'Read more about migrating tests: https://github.com/angular/components/blob/3a204da37fd1366cae411b5c234517ecad199737/guides/v9-hammerjs-migration.md#how-to-migrate-my-tests',
     );
 
     if (!this.globalUsesHammer && this._removeHammerFromPackageJson(tree)) {


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

---

Alternative solution: should angular provide its own redirection under the domain `angular.io`?