### PR TITLE
fix(material-experimental/mdc-checkbox): remove extra a11y tree node for the <label/>

### DIFF
--- a/src/material-experimental/mdc-checkbox/checkbox.html
+++ b/src/material-experimental/mdc-checkbox/checkbox.html
@@ -37,9 +37,9 @@
       [matRippleDisabled]="disableRipple || disabled"
       [matRippleCentered]="true"></div>
   </div>
-  <label #label
-         [for]="inputId"
-         (click)="$event.stopPropagation()">
-    <ng-content></ng-content>
-  </label>
+  <span (click)="$event.stopPropagation()">
+    <label #label [for]="inputId">
+      <ng-content></ng-content>
+    </label>
+  </span>
 </div>


### PR DESCRIPTION
In the mdc checkbox component, moves the click handler on the label to
its parent, the .mdc-checkbox. This removes the extra a11y
tree node on the label and fixes TalkBack having an extra navigation
stop (#14385).

A11y tree before this commit. It has an un-necessary node, which
coresponds to the `<label>` element.
```
- Generic
 - Checkbox, "Field A"
 - Textlabel, "Field A"
```

A11y tree with this commit applied
```
- Generic
 - Checkbox, "Field A"
```

fixes #14385