### PR TITLE
docs(material/autocomplete): change documentation for the optionActivated event

### DIFF
--- a/src/material/autocomplete/autocomplete.ts
+++ b/src/material/autocomplete/autocomplete.ts
@@ -185,7 +185,7 @@ export abstract class _MatAutocompleteBase
   /** Event that is emitted when the autocomplete panel is closed. */
   @Output() readonly closed: EventEmitter<void> = new EventEmitter<void>();
 
-  /** Emits whenever an option is activated using the keyboard. */
+  /** Emits whenever an option is activated. */
   @Output() readonly optionActivated: EventEmitter<MatAutocompleteActivatedEvent> =
     new EventEmitter<MatAutocompleteActivatedEvent>();
 


### PR DESCRIPTION
Hi! I removed 'using the keyabord' since it's not correct.
btw, I'm not sure the current description is accurate enough. Perhaps we should include some information about the active index logic.

Fixes #24799