### PR TITLE
feat(google-maps): switch to non-deprecated API for clustering

### DIFF
--- a/src/dev-app/google-map/google-map-demo.html
+++ b/src/dev-app/google-map/google-map-demo.html
@@ -8,7 +8,7 @@
               (mapMousemove)="handleMove($event)"
               (mapRightclick)="handleRightclick()"
               [mapTypeId]="mapTypeId">
-    <map-marker-clusterer [imagePath]="markerClustererImagePath">
+    <map-marker-clusterer>
       <map-marker #firstMarker="mapMarker"
                   [position]="center"
                   (mapClick)="clickMarker(firstMarker)"></map-marker>

--- a/src/dev-app/google-map/google-map-demo.ts
+++ b/src/dev-app/google-map/google-map-demo.ts
@@ -119,9 +119,6 @@ export class GoogleMapDemo {
     google.maps.MapTypeId.TERRAIN,
   ];
 
-  markerClustererImagePath =
-    'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m';
-
   directionsResult?: google.maps.DirectionsResult;
 
   constructor(private readonly _mapDirectionsService: MapDirectionsService) {}

--- a/src/dev-app/index.html
+++ b/src/dev-app/index.html
@@ -20,7 +20,7 @@
 
   <script src="zone.js/dist/zone.js"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
-  <script src="https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js"></script>
+  <script src="https://unpkg.com/@googlemaps/markerclusterer/dist/index.min.js"></script>
   <script>
     (function loadGoogleMaps() {
       // Key can be set through the `GOOGLE_MAPS_KEY` environment variable.

--- a/src/google-maps/map-marker-clusterer/README.md
+++ b/src/google-maps/map-marker-clusterer/README.md
@@ -1,13 +1,13 @@
-#MapMarkerClusterer
+# MapMarkerClusterer
 
-The `MapMarkerClusterer` component wraps the [`MarkerClusterer` class](https://googlemaps.github.io/js-markerclustererplus/classes/markerclusterer.html) from the [Google Maps JavaScript MarkerClustererPlus Library](https://github.com/googlemaps/js-markerclustererplus). The `MapMarkerClusterer` component displays a cluster of markers that are children of the `<map-marker-clusterer>` tag. Unlike the other Google Maps components, MapMarkerClusterer does not have an `options` input, so any input (listed in the [documentation](https://googlemaps.github.io/js-markerclustererplus/index.html) for the `MarkerClusterer` class) should be set directly.
+The `MapMarkerClusterer` component wraps the [`MarkerClusterer` class](https://googlemaps.github.io/js-markerclusterer/classes/MarkerClusterer.html) from the [Google Maps JavaScript MarkerClusterer Library](https://github.com/googlemaps/js-markerclusterer). The `MapMarkerClusterer` component displays a cluster of markers that are children of the `<map-marker-clusterer>` tag. Unlike the other Google Maps components, MapMarkerClusterer does not have an `options` input, so any input (listed in the [documentation](https://googlemaps.github.io/js-markerclusterer/) for the `MarkerClusterer` class) should be set directly.
 
 ## Loading the Library
 
-Like the Google Maps JavaScript API, the MarkerClustererPlus library needs to be loaded separately. This can be accomplished by using this script tag:
+Like the Google Maps JavaScript API, the MarkerClusterer library needs to be loaded separately. This can be accomplished by using this script tag:
 
 ```html
-<script src="https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js"></script>
+<script src="https://unpkg.com/@googlemaps/markerclusterer/dist/index.min.js"></script>
 ```
 
 Additional information can be found by looking at [Marker Clustering](https://developers.google.com/maps/documentation/javascript/marker-clustering) in the Google Maps JavaScript API documentation.
@@ -26,8 +26,6 @@ export class GoogleMapDemo {
   center: google.maps.LatLngLiteral = {lat: 24, lng: 12};
   zoom = 4;
   markerPositions: google.maps.LatLngLiteral[] = [];
-  markerClustererImagePath =
-      'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m';
 
   addMarker(event: google.maps.MapMouseEvent) {
     this.markerPositions.push(event.latLng.toJSON());
@@ -42,7 +40,7 @@ export class GoogleMapDemo {
             [center]="center"
             [zoom]="zoom"
             (mapClick)="addMarker($event)">
-  <map-marker-clusterer [imagePath]="markerClustererImagePath">
+  <map-marker-clusterer>
     <map-marker *ngFor="let markerPosition of markerPositions"
                 [position]="markerPosition"></map-marker>
   </map-marker-clusterer>

--- a/src/google-maps/map-marker-clusterer/map-marker-clusterer.spec.ts
+++ b/src/google-maps/map-marker-clusterer/map-marker-clusterer.spec.ts
@@ -50,11 +50,11 @@ describe('MapMarkerClusterer', () => {
 
   afterEach(() => {
     (window.google as any) = undefined;
-    (window as any).MarkerClusterer = undefined;
+    (window as any).markerClusterer = undefined;
   });
 
   it('throws an error if the clustering library has not been loaded', () => {
-    (window as any).MarkerClusterer = undefined;
+    (window as any).markerClusterer = undefined;
     markerClustererConstructorSpy = createMarkerClustererConstructorSpy(
       markerClustererSpy,
       false,
@@ -63,8 +63,8 @@ describe('MapMarkerClusterer', () => {
     expect(() => fixture.detectChanges()).toThrow(
       new Error(
         'MarkerClusterer class not found, cannot construct a marker cluster. ' +
-          'Please install the MarkerClustererPlus library: ' +
-          'https://github.com/googlemaps/js-markerclustererplus',
+          'Please install the MarkerClusterer library: ' +
+          'https://github.com/googlemaps/js-markerclusterer',
       ),
     );
   });
@@ -72,106 +72,47 @@ describe('MapMarkerClusterer', () => {
   it('initializes a Google Map Marker Clusterer', () => {
     fixture.detectChanges();
 
-    expect(markerClustererConstructorSpy).toHaveBeenCalledWith(mapSpy, [], {
-      ariaLabelFn: undefined,
-      averageCenter: undefined,
-      batchSize: undefined,
-      batchSizeIE: undefined,
-      calculator: undefined,
-      clusterClass: undefined,
-      enableRetinaIcons: undefined,
-      gridSize: undefined,
-      ignoreHidden: undefined,
-      imageExtension: undefined,
-      imagePath: undefined,
-      imageSizes: undefined,
-      maxZoom: undefined,
-      minimumClusterSize: undefined,
-      styles: undefined,
-      title: undefined,
-      zIndex: undefined,
-      zoomOnClick: undefined,
+    expect(markerClustererConstructorSpy).toHaveBeenCalledWith({
+      map: mapSpy,
+      renderer: undefined,
+      algorithm: undefined,
+      onClusterClick: jasmine.any(Function),
     });
   });
 
   it('sets marker clusterer inputs', () => {
-    fixture.componentInstance.ariaLabelFn = (testString: string) => testString;
-    fixture.componentInstance.averageCenter = true;
-    fixture.componentInstance.batchSize = 1;
-    fixture.componentInstance.clusterClass = 'testClusterClass';
-    fixture.componentInstance.enableRetinaIcons = true;
-    fixture.componentInstance.gridSize = 2;
-    fixture.componentInstance.ignoreHidden = true;
-    fixture.componentInstance.imageExtension = 'testImageExtension';
-    fixture.componentInstance.imagePath = 'testImagePath';
-    fixture.componentInstance.imageSizes = [3];
-    fixture.componentInstance.maxZoom = 4;
-    fixture.componentInstance.minimumClusterSize = 5;
-    fixture.componentInstance.styles = [];
-    fixture.componentInstance.title = 'testTitle';
-    fixture.componentInstance.zIndex = 6;
-    fixture.componentInstance.zoomOnClick = true;
+    fixture.componentInstance.algorithm = {name: 'custom'};
+    fixture.componentInstance.renderer = {render: () => null!};
     fixture.detectChanges();
 
-    expect(markerClustererConstructorSpy).toHaveBeenCalledWith(mapSpy, [], {
-      ariaLabelFn: jasmine.any(Function),
-      averageCenter: true,
-      batchSize: 1,
-      batchSizeIE: undefined,
-      calculator: undefined,
-      clusterClass: 'testClusterClass',
-      enableRetinaIcons: true,
-      gridSize: 2,
-      ignoreHidden: true,
-      imageExtension: 'testImageExtension',
-      imagePath: 'testImagePath',
-      imageSizes: [3],
-      maxZoom: 4,
-      minimumClusterSize: 5,
-      styles: [],
-      title: 'testTitle',
-      zIndex: 6,
-      zoomOnClick: true,
+    expect(markerClustererConstructorSpy).toHaveBeenCalledWith({
+      map: mapSpy,
+      algorithm: fixture.componentInstance.algorithm,
+      renderer: fixture.componentInstance.renderer,
+      onClusterClick: jasmine.any(Function),
     });
   });
 
-  it('sets marker clusterer options', () => {
-    fixture.detectChanges();
-    const options: MarkerClustererOptions = {
-      enableRetinaIcons: true,
-      gridSize: 1337,
-      ignoreHidden: true,
-      imageExtension: 'png',
-    };
-    fixture.componentInstance.options = options;
-    fixture.detectChanges();
-    expect(markerClustererSpy.setOptions).toHaveBeenCalledWith(jasmine.objectContaining(options));
-  });
-
-  it('gives precedence to specific inputs over options', () => {
-    fixture.detectChanges();
-    const options: MarkerClustererOptions = {
-      enableRetinaIcons: true,
-      gridSize: 1337,
-      ignoreHidden: true,
-      imageExtension: 'png',
-    };
-    const expectedOptions: MarkerClustererOptions = {
-      enableRetinaIcons: false,
-      gridSize: 42,
-      ignoreHidden: false,
-      imageExtension: 'jpeg',
-    };
-    fixture.componentInstance.enableRetinaIcons = expectedOptions.enableRetinaIcons;
-    fixture.componentInstance.gridSize = expectedOptions.gridSize;
-    fixture.componentInstance.ignoreHidden = expectedOptions.ignoreHidden;
-    fixture.componentInstance.imageExtension = expectedOptions.imageExtension;
-    fixture.componentInstance.options = options;
+  it('recreates the clusterer if the options change', () => {
+    fixture.componentInstance.algorithm = {name: 'custom1'};
     fixture.detectChanges();
 
-    expect(markerClustererSpy.setOptions).toHaveBeenCalledWith(
-      jasmine.objectContaining(expectedOptions),
-    );
+    expect(markerClustererConstructorSpy).toHaveBeenCalledWith({
+      map: mapSpy,
+      algorithm: jasmine.objectContaining({name: 'custom1'}),
+      renderer: undefined,
+      onClusterClick: jasmine.any(Function),
+    });
+
+    fixture.componentInstance.algorithm = {name: 'custom2'};
+    fixture.detectChanges();
+
+    expect(markerClustererConstructorSpy).toHaveBeenCalledWith({
+      map: mapSpy,
+      algorithm: jasmine.objectContaining({name: 'custom2'}),
+      renderer: undefined,
+      onClusterClick: jasmine.any(Function),
+    });
   });
 
   it('sets Google Maps Markers in the MarkerClusterer', () => {
@@ -196,7 +137,7 @@ describe('MapMarkerClusterer', () => {
 
     expect(markerClustererSpy.addMarkers).toHaveBeenCalledWith([anyMarkerMatcher], true);
     expect(markerClustererSpy.removeMarkers).toHaveBeenCalledWith([anyMarkerMatcher], true);
-    expect(markerClustererSpy.repaint).toHaveBeenCalledTimes(1);
+    expect(markerClustererSpy.render).toHaveBeenCalledTimes(1);
 
     fixture.componentInstance.state = 'state0';
     fixture.detectChanges();
@@ -206,149 +147,50 @@ describe('MapMarkerClusterer', () => {
       [anyMarkerMatcher, anyMarkerMatcher],
       true,
     );
-    expect(markerClustererSpy.repaint).toHaveBeenCalledTimes(2);
+    expect(markerClustererSpy.render).toHaveBeenCalledTimes(2);
   });
 
-  it('exposes marker clusterer methods', () => {
+  it('initializes event handlers on the map related to clustering', () => {
     fixture.detectChanges();
-    const markerClustererComponent = fixture.componentInstance.markerClusterer;
 
-    markerClustererComponent.fitMapToMarkers(5);
-    expect(markerClustererSpy.fitMapToMarkers).toHaveBeenCalledWith(5);
-
-    markerClustererSpy.getAverageCenter.and.returnValue(true);
-    expect(markerClustererComponent.getAverageCenter()).toBe(true);
-
-    markerClustererSpy.getBatchSizeIE.and.returnValue(6);
-    expect(markerClustererComponent.getBatchSizeIE()).toBe(6);
-
-    const calculator = (markers: google.maps.Marker[], count: number) => ({
-      index: 1,
-      text: 'testText',
-      title: 'testTitle',
-    });
-    markerClustererSpy.getCalculator.and.returnValue(calculator);
-    expect(markerClustererComponent.getCalculator()).toBe(calculator);
-
-    markerClustererSpy.getClusterClass.and.returnValue('testClusterClass');
-    expect(markerClustererComponent.getClusterClass()).toBe('testClusterClass');
-
-    markerClustererSpy.getClusters.and.returnValue([]);
-    expect(markerClustererComponent.getClusters()).toEqual([]);
-
-    markerClustererSpy.getEnableRetinaIcons.and.returnValue(true);
-    expect(markerClustererComponent.getEnableRetinaIcons()).toBe(true);
-
-    markerClustererSpy.getGridSize.and.returnValue(7);
-    expect(markerClustererComponent.getGridSize()).toBe(7);
-
-    markerClustererSpy.getIgnoreHidden.and.returnValue(true);
-    expect(markerClustererComponent.getIgnoreHidden()).toBe(true);
-
-    markerClustererSpy.getImageExtension.and.returnValue('testImageExtension');
-    expect(markerClustererComponent.getImageExtension()).toBe('testImageExtension');
-
-    markerClustererSpy.getImagePath.and.returnValue('testImagePath');
-    expect(markerClustererComponent.getImagePath()).toBe('testImagePath');
-
-    markerClustererSpy.getImageSizes.and.returnValue([]);
-    expect(markerClustererComponent.getImageSizes()).toEqual([]);
-
-    markerClustererSpy.getMaxZoom.and.returnValue(8);
-    expect(markerClustererComponent.getMaxZoom()).toBe(8);
-
-    markerClustererSpy.getMinimumClusterSize.and.returnValue(9);
-    expect(markerClustererComponent.getMinimumClusterSize()).toBe(9);
-
-    markerClustererSpy.getStyles.and.returnValue([]);
-    expect(markerClustererComponent.getStyles()).toEqual([]);
-
-    markerClustererSpy.getTitle.and.returnValue('testTitle');
-    expect(markerClustererComponent.getTitle()).toBe('testTitle');
-
-    markerClustererSpy.getTotalClusters.and.returnValue(10);
-    expect(markerClustererComponent.getTotalClusters()).toBe(10);
-
-    markerClustererSpy.getTotalMarkers.and.returnValue(11);
-    expect(markerClustererComponent.getTotalMarkers()).toBe(11);
-
-    markerClustererSpy.getZIndex.and.returnValue(12);
-    expect(markerClustererComponent.getZIndex()).toBe(12);
-
-    markerClustererSpy.getZoomOnClick.and.returnValue(true);
-    expect(markerClustererComponent.getZoomOnClick()).toBe(true);
+    expect(mapSpy.addListener).toHaveBeenCalledWith('clusteringbegin', jasmine.any(Function));
+    expect(mapSpy.addListener).not.toHaveBeenCalledWith('clusteringend', jasmine.any(Function));
   });
 
-  it('initializes marker clusterer event handlers', () => {
+  it('emits to clusterClick when the `onClusterClick` callback is invoked', () => {
     fixture.detectChanges();
 
-    expect(markerClustererSpy.addListener).toHaveBeenCalledWith(
-      'clusteringbegin',
-      jasmine.any(Function),
-    );
-    expect(markerClustererSpy.addListener).not.toHaveBeenCalledWith(
-      'clusteringend',
-      jasmine.any(Function),
-    );
-    expect(markerClustererSpy.addListener).toHaveBeenCalledWith('click', jasmine.any(Function));
+    expect(fixture.componentInstance.onClusterClick).not.toHaveBeenCalled();
+
+    const callback = markerClustererConstructorSpy.calls.mostRecent().args[0].onClusterClick;
+    callback({}, {}, {});
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.onClusterClick).toHaveBeenCalledTimes(1);
   });
 });
 
 @Component({
   selector: 'test-app',
-  template: `<google-map>
-               <map-marker-clusterer [ariaLabelFn]="ariaLabelFn"
-                                     [averageCenter]="averageCenter"
-                                     [batchSize]="batchSize"
-                                     [batchSizeIE]="batchSizeIE"
-                                     [calculator]="calculator"
-                                     [clusterClass]="clusterClass"
-                                     [enableRetinaIcons]="enableRetinaIcons"
-                                     [gridSize]="gridSize"
-                                     [ignoreHidden]="ignoreHidden"
-                                     [imageExtension]="imageExtension"
-                                     [imagePath]="imagePath"
-                                     [imageSizes]="imageSizes"
-                                     [maxZoom]="maxZoom"
-                                     [minimumClusterSize]="minimumClusterSize"
-                                     [styles]="styles"
-                                     [title]="title"
-                                     [zIndex]="zIndex"
-                                     [zoomOnClick]="zoomOnClick"
-                                     [options]="options"
-                                     (clusteringbegin)="onClusteringBegin()"
-                                     (clusterClick)="onClusterClick()">
-                 <map-marker *ngIf="state === 'state1'"></map-marker>
-                 <map-marker *ngIf="state === 'state1' || state === 'state2'"></map-marker>
-                 <map-marker *ngIf="state === 'state2'"></map-marker>
-               </map-marker-clusterer>
-             </google-map>`,
+  template: `
+    <google-map>
+      <map-marker-clusterer
+        (clusteringbegin)="onClusteringBegin()"
+        (clusterClick)="onClusterClick()"
+        [renderer]="renderer"
+        [algorithm]="algorithm">
+        <map-marker *ngIf="state === 'state1'"></map-marker>
+        <map-marker *ngIf="state === 'state1' || state === 'state2'"></map-marker>
+        <map-marker *ngIf="state === 'state2'"></map-marker>
+      </map-marker-clusterer>
+    </google-map>
+  `,
 })
 class TestApp {
   @ViewChild(MapMarkerClusterer) markerClusterer: MapMarkerClusterer;
-
-  ariaLabelFn?: AriaLabelFn;
-  averageCenter?: boolean;
-  batchSize?: number;
-  batchSizeIE?: number;
-  calculator?: Calculator;
-  clusterClass?: string;
-  enableRetinaIcons?: boolean;
-  gridSize?: number;
-  ignoreHidden?: boolean;
-  imageExtension?: string;
-  imagePath?: string;
-  imageSizes?: number[];
-  maxZoom?: number;
-  minimumClusterSize?: number;
-  styles?: ClusterIconStyle[];
-  title?: string;
-  zIndex?: number;
-  zoomOnClick?: boolean;
-  options?: MarkerClustererOptions;
-
+  renderer: Renderer;
+  algorithm: Algorithm;
   state = 'state1';
-
-  onClusteringBegin() {}
-  onClusterClick() {}
+  onClusteringBegin = jasmine.createSpy('onclusteringbegin spy');
+  onClusterClick = jasmine.createSpy('clusterClick spy');
 }

--- a/src/google-maps/map-marker-clusterer/marker-clusterer-types.ts
+++ b/src/google-maps/map-marker-clusterer/marker-clusterer-types.ts
@@ -8,177 +8,153 @@
 
 /// <reference types="google.maps" />
 
+// tslint:disable
+
+declare type onClusterClickHandler = (
+  event: google.maps.MapMouseEvent,
+  cluster: Cluster,
+  map: google.maps.Map,
+) => void;
+
 /**
- * Class for clustering markers on a Google Map.
- *
- * See
- * googlemaps.github.io/v3-utility-library/classes/_google_markerclustererplus.markerclusterer.html
+ * MarkerClusterer creates and manages per-zoom-level clusters for large amounts
+ * of markers. See {@link MarkerClustererOptions} for more details.
  */
 declare class MarkerClusterer {
-  constructor(
-    map: google.maps.Map,
-    markers?: google.maps.Marker[],
-    options?: MarkerClustererOptions,
-  );
-  ariaLabelFn: AriaLabelFn;
-  static BATCH_SIZE: number;
-  static BATCH_SIZE_IE: number;
-  static IMAGE_EXTENSION: string;
-  static IMAGE_PATH: string;
-  static IMAGE_SIZES: number[];
-  addListener(eventName: string, handler: Function): google.maps.MapsEventListener;
-  addMarker(marker: MarkerClusterer, nodraw: boolean): void;
-  addMarkers(markers: google.maps.Marker[], nodraw?: boolean): void;
-  bindTo(key: string, target: google.maps.MVCObject, targetKey: string, noNotify: boolean): void;
-  changed(key: string): void;
-  clearMarkers(): void;
-  fitMapToMarkers(padding: number | google.maps.Padding): void;
-  get(key: string): any;
-  getAverageCenter(): boolean;
-  getBatchSizeIE(): number;
-  getCalculator(): Calculator;
-  getClusterClass(): string;
-  getClusters(): Cluster[];
-  getEnableRetinaIcons(): boolean;
-  getGridSize(): number;
-  getIgnoreHidden(): boolean;
-  getImageExtension(): string;
-  getImagePath(): string;
-  getImageSizes(): number[];
-  getMap(): google.maps.Map | google.maps.StreetViewPanorama;
-  getMarkers(): google.maps.Marker[];
-  getMaxZoom(): number;
-  getMinimumClusterSize(): number;
-  getPanes(): google.maps.MapPanes;
-  getProjection(): google.maps.MapCanvasProjection;
-  getStyles(): ClusterIconStyle[];
-  getTitle(): string;
-  getTotalClusters(): number;
-  getTotalMarkers(): number;
-  getZIndex(): number;
-  getZoomOnClick(): boolean;
-  notify(key: string): void;
-  removeMarker(marker: google.maps.Marker, nodraw: boolean): boolean;
-  removeMarkers(markers: google.maps.Marker[], nodraw?: boolean): boolean;
-  repaint(): void;
-  set(key: string, value: any): void;
-  setAverageCenter(averageCenter: boolean): void;
-  setBatchSizeIE(batchSizeIE: number): void;
-  setCalculator(calculator: Calculator): void;
-  setClusterClass(clusterClass: string): void;
-  setEnableRetinaIcons(enableRetinaIcons: boolean): void;
-  setGridSize(gridSize: number): void;
-  setIgnoreHidden(ignoreHidden: boolean): void;
-  setImageExtension(imageExtension: string): void;
-  setImagePath(imagePath: string): void;
-  setImageSizes(imageSizes: number[]): void;
-  setMap(map: google.maps.Map | null): void;
-  setMaxZoom(maxZoom: number): void;
-  setMinimumClusterSize(minimumClusterSize: number): void;
-  setStyles(styles: ClusterIconStyle[]): void;
-  setTitle(title: string): void;
-  setValues(values: any): void;
-  setZIndex(zIndex: number): void;
-  setZoomOnClick(zoomOnClick: boolean): void;
-  // Note: This one doesn't appear in the docs page, but it exists at runtime.
-  setOptions(options: MarkerClustererOptions): void;
-  unbind(key: string): void;
-  unbindAll(): void;
-  static CALCULATOR(markers: google.maps.Marker[], numStyles: number): ClusterIconInfo;
-  static withDefaultStyle(overrides: ClusterIconStyle): ClusterIconStyle;
+  /** @see {@link MarkerClustererOptions.onClusterClick} */
+  onClusterClick: onClusterClickHandler;
+  constructor({map, markers, algorithm, renderer, onClusterClick}: MarkerClustererOptions);
+  addMarker(marker: google.maps.Marker, noDraw?: boolean): void;
+  addMarkers(markers: google.maps.Marker[], noDraw?: boolean): void;
+  removeMarker(marker: google.maps.Marker, noDraw?: boolean): boolean;
+  removeMarkers(markers: google.maps.Marker[], noDraw?: boolean): boolean;
+  clearMarkers(noDraw?: boolean): void;
+  /**
+   * Recalculates and draws all the marker clusters.
+   */
+  render(): void;
+  onAdd(): void;
+  onRemove(): void;
 }
 
-/**
- * Cluster class from the @google/markerclustererplus library.
- *
- * See googlemaps.github.io/v3-utility-library/classes/_google_markerclustererplus.cluster.html
- */
+interface MarkerClustererOptions {
+  markers?: google.maps.Marker[];
+  /**
+   * An algorithm to cluster markers. Default is {@link SuperClusterAlgorithm}. Must
+   * provide a `calculate` method accepting {@link AlgorithmInput} and returning
+   * an array of {@link Cluster}.
+   */
+  algorithm?: Algorithm;
+  map?: google.maps.Map | null;
+  /**
+   * An object that converts a {@link Cluster} into a `google.maps.Marker`.
+   * Default is {@link DefaultRenderer}.
+   */
+  renderer?: Renderer;
+  onClusterClick?: onClusterClickHandler;
+}
+
+declare enum MarkerClustererEvents {
+  CLUSTERING_BEGIN = 'clusteringbegin',
+  CLUSTERING_END = 'clusteringend',
+  CLUSTER_CLICK = 'click',
+}
+
+interface ClusterOptions {
+  position?: google.maps.LatLng | google.maps.LatLngLiteral;
+  markers?: google.maps.Marker[];
+}
+
 declare class Cluster {
-  constructor(markerClusterer: MarkerClusterer);
-  getCenter(): google.maps.LatLng;
-  getMarkers(): google.maps.Marker[];
-  getSize(): number;
-  updateIcon(): void;
+  marker: google.maps.Marker;
+  readonly markers?: google.maps.Marker[];
+  constructor({markers, position}: ClusterOptions);
+  get bounds(): google.maps.LatLngBounds | undefined;
+  get position(): google.maps.LatLng;
+  /**
+   * Get the count of **visible** markers.
+   */
+  get count(): number;
+  /**
+   * Add a marker to the cluster.
+   */
+  push(marker: google.maps.Marker): void;
+  /**
+   * Cleanup references and remove marker from map.
+   */
+  delete(): void;
 }
 
-/**
- * Options for constructing a MarkerClusterer from the @google/markerclustererplus library.
- *
- * See
- * googlemaps.github.io/v3-utility-library/classes/
- * _google_markerclustererplus.markerclustereroptions.html
- */
-declare interface MarkerClustererOptions {
-  ariaLabelFn?: AriaLabelFn;
-  averageCenter?: boolean;
-  batchSize?: number;
-  batchSizeIE?: number;
-  calculator?: Calculator;
-  clusterClass?: string;
-  enableRetinaIcons?: boolean;
-  gridSize?: number;
-  ignoreHidden?: boolean;
-  imageExtension?: string;
-  imagePath?: string;
-  imageSizes?: number[];
-  maxZoom?: number;
-  minimumClusterSize?: number;
-  styles?: ClusterIconStyle[];
-  title?: string;
-  zIndex?: number;
-  zoomOnClick?: boolean;
+declare class ClusterStats {
+  readonly markers: {
+    sum: number;
+  };
+  readonly clusters: {
+    count: number;
+    markers: {
+      mean: number;
+      sum: number;
+      min: number;
+      max: number;
+    };
+  };
+  constructor(markers: google.maps.Marker[], clusters: Cluster[]);
 }
 
-/**
- * Style interface for a marker cluster icon.
- *
- * See
- * googlemaps.github.io/v3-utility-library/interfaces/
- * _google_markerclustererplus.clustericonstyle.html
- */
-declare interface ClusterIconStyle {
-  anchorIcon?: [number, number];
-  anchorText?: [number, number];
-  backgroundPosition?: string;
-  className?: string;
-  fontFamily?: string;
-  fontStyle?: string;
-  fontWeight?: string;
-  height: number;
-  textColor?: string;
-  textDecoration?: string;
-  textLineHeight?: number;
-  textSize?: number;
-  url?: string;
-  width: number;
+interface Renderer {
+  /**
+   * Turn a {@link Cluster} into a `google.maps.Marker`.
+   *
+   * Below is a simple example to create a marker with the number of markers in the cluster as a label.
+   *
+   * ```typescript
+   * return new google.maps.Marker({
+   *   position,
+   *   label: String(markers.length),
+   * });
+   * ```
+   */
+  render(cluster: Cluster, stats: ClusterStats): google.maps.Marker;
 }
 
-/**
- * Info interface for a marker cluster icon.
- *
- * See
- * googlemaps.github.io/v3-utility-library/interfaces/
- * _google_markerclustererplus.clustericoninfo.html
- */
-declare interface ClusterIconInfo {
-  index: number;
-  text: string;
-  title: string;
+declare class DefaultRenderer implements Renderer {
+  /**
+   * The default render function for the library used by {@link MarkerClusterer}.
+   *
+   * Currently set to use the following:
+   *
+   * ```typescript
+   * // change color if this cluster has more markers than the mean cluster
+   * const color =
+   *   count > Math.max(10, stats.clusters.markers.mean)
+   *     ? "#ff0000"
+   *     : "#0000ff";
+   *
+   * // create svg url with fill color
+   * const svg = window.btoa(`
+   * <svg fill="${color}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+   *   <circle cx="120" cy="120" opacity=".6" r="70" />
+   *   <circle cx="120" cy="120" opacity=".3" r="90" />
+   *   <circle cx="120" cy="120" opacity=".2" r="110" />
+   *   <circle cx="120" cy="120" opacity=".1" r="130" />
+   * </svg>`);
+   *
+   * // create marker using svg icon
+   * return new google.maps.Marker({
+   *   position,
+   *   icon: {
+   *     url: `data:image/svg+xml;base64,${svg}`,
+   *     scaledSize: new google.maps.Size(45, 45),
+   *   },
+   *   label: {
+   *     text: String(count),
+   *     color: "rgba(255,255,255,0.9)",
+   *     fontSize: "12px",
+   *   },
+   *   // adjust zIndex to be above other markers
+   *   zIndex: 1000 + count,
+   * });
+   * ```
+   */
+  render({count, position}: Cluster, stats: ClusterStats): google.maps.Marker;
 }
-
-/**
- * Function type alias for determining the aria label on a Google Maps marker cluster.
- *
- * See googlemaps.github.io/v3-utility-library/modules/_google_markerclustererplus.html#arialabelfn
- */
-declare type AriaLabelFn = (text: string) => string;
-
-/**
- * Function type alias for calculating how a marker cluster is displayed.
- *
- * See googlemaps.github.io/v3-utility-library/modules/_google_markerclustererplus.html#calculator
- */
-declare type Calculator = (
-  markers: google.maps.Marker[],
-  clusterIconStylesCount: number,
-) => ClusterIconInfo;

--- a/src/google-maps/testing/fake-google-map-utils.ts
+++ b/src/google-maps/testing/fake-google-map-utils.ts
@@ -37,7 +37,10 @@ export interface TestingWindow extends Window {
       Geocoder?: jasmine.Spy;
     };
   };
-  MarkerClusterer?: jasmine.Spy;
+  markerClusterer?: {
+    MarkerClusterer?: jasmine.Spy;
+    defaultOnClusterClickHandler?: jasmine.Spy;
+  };
 }
 
 /** Creates a jasmine.SpyObj for a google.maps.Map. */
@@ -504,52 +507,16 @@ export function createBicyclingLayerConstructorSpy(
 
 /** Creates a jasmine.SpyObj for a MarkerClusterer */
 export function createMarkerClustererSpy(): jasmine.SpyObj<MarkerClusterer> {
-  const markerClustererSpy = jasmine.createSpyObj('MarkerClusterer', [
-    'addListener',
+  return jasmine.createSpyObj('MarkerClusterer', [
+    'addMarker',
     'addMarkers',
-    'fitMapToMarkers',
-    'getAverageCenter',
-    'getBatchSizeIE',
-    'getCalculator',
-    'getClusterClass',
-    'getClusters',
-    'getEnableRetinaIcons',
-    'getGridSize',
-    'getIgnoreHidden',
-    'getImageExtension',
-    'getImagePath',
-    'getImageSizes',
-    'getMaxZoom',
-    'getMinimumClusterSize',
-    'getStyles',
-    'getTitle',
-    'getTotalClusters',
-    'getTotalMarkers',
-    'getZIndex',
-    'getZoomOnClick',
+    'removeMarker',
     'removeMarkers',
-    'repaint',
-    'setAverageCenter',
-    'setBatchSizeIE',
-    'setCalculator',
-    'setClusterClass',
-    'setEnableRetinaIcons',
-    'setGridSize',
-    'setIgnoreHidden',
-    'setImageExtension',
-    'setImagePath',
-    'setImageSizes',
-    'setMap',
-    'setMaxZoom',
-    'setMinimumClusterSize',
-    'setStyles',
-    'setTitle',
-    'setZIndex',
-    'setZoomOnClick',
-    'setOptions',
+    'clearMarkers',
+    'render',
+    'onAdd',
+    'onRemove',
   ]);
-  markerClustererSpy.addListener.and.returnValue({remove: () => {}});
-  return markerClustererSpy;
 }
 
 /** Creates a jasmine.Spy to watch for the constructor of a MarkerClusterer */
@@ -566,7 +533,10 @@ export function createMarkerClustererConstructorSpy(
   );
   if (apiLoaded) {
     const testingWindow: TestingWindow = window;
-    testingWindow['MarkerClusterer'] = markerClustererConstructorSpy;
+    testingWindow.markerClusterer = {
+      MarkerClusterer: markerClustererConstructorSpy,
+      defaultOnClusterClickHandler: jasmine.createSpy('defaultOnClusterClickHandler'),
+    };
   }
   return markerClustererConstructorSpy;
 }

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -426,82 +426,15 @@ export class MapMarker implements OnInit, OnChanges, OnDestroy, MapAnchorPoint {
 }
 
 // @public
-export class MapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, OnDestroy {
+export class MapMarkerClusterer implements OnInit, OnChanges, AfterContentInit, OnDestroy {
     constructor(_googleMap: GoogleMap, _ngZone: NgZone);
-    // (undocumented)
-    ariaLabelFn: AriaLabelFn;
-    // (undocumented)
-    set averageCenter(averageCenter: boolean);
-    // (undocumented)
-    batchSize?: number;
-    // (undocumented)
-    set batchSizeIE(batchSizeIE: number);
-    // (undocumented)
-    set calculator(calculator: Calculator);
-    // (undocumented)
-    set clusterClass(clusterClass: string);
-    readonly clusterClick: Observable<Cluster>;
+    algorithm: Algorithm;
+    readonly clusterClick: EventEmitter<Cluster>;
     readonly clusteringbegin: Observable<void>;
     readonly clusteringend: Observable<void>;
-    // (undocumented)
-    set enableRetinaIcons(enableRetinaIcons: boolean);
-    // (undocumented)
-    fitMapToMarkers(padding: number | google.maps.Padding): void;
-    // (undocumented)
-    getAverageCenter(): boolean;
-    // (undocumented)
-    getBatchSizeIE(): number;
-    // (undocumented)
-    getCalculator(): Calculator;
-    // (undocumented)
-    getClusterClass(): string;
-    // (undocumented)
-    getClusters(): Cluster[];
-    // (undocumented)
-    getEnableRetinaIcons(): boolean;
-    // (undocumented)
-    getGridSize(): number;
-    // (undocumented)
-    getIgnoreHidden(): boolean;
-    // (undocumented)
-    getImageExtension(): string;
-    // (undocumented)
-    getImagePath(): string;
-    // (undocumented)
-    getImageSizes(): number[];
-    // (undocumented)
-    getMaxZoom(): number;
-    // (undocumented)
-    getMinimumClusterSize(): number;
-    // (undocumented)
-    getStyles(): ClusterIconStyle[];
-    // (undocumented)
-    getTitle(): string;
-    // (undocumented)
-    getTotalClusters(): number;
-    // (undocumented)
-    getTotalMarkers(): number;
-    // (undocumented)
-    getZIndex(): number;
-    // (undocumented)
-    getZoomOnClick(): boolean;
-    // (undocumented)
-    set gridSize(gridSize: number);
-    // (undocumented)
-    set ignoreHidden(ignoreHidden: boolean);
-    // (undocumented)
-    set imageExtension(imageExtension: string);
-    // (undocumented)
-    set imagePath(imagePath: string);
-    // (undocumented)
-    set imageSizes(imageSizes: number[]);
     markerClusterer?: MarkerClusterer;
     // (undocumented)
     _markers: QueryList<MapMarker>;
-    // (undocumented)
-    set maxZoom(maxZoom: number);
-    // (undocumented)
-    set minimumClusterSize(minimumClusterSize: number);
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)
@@ -510,18 +443,9 @@ export class MapMarkerClusterer implements OnInit, AfterContentInit, OnChanges, 
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
+    renderer: Renderer;
     // (undocumented)
-    set options(options: MarkerClustererOptions);
-    // (undocumented)
-    set styles(styles: ClusterIconStyle[]);
-    // (undocumented)
-    set title(title: string);
-    // (undocumented)
-    set zIndex(zIndex: number);
-    // (undocumented)
-    set zoomOnClick(zoomOnClick: boolean);
-    // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MapMarkerClusterer, "map-marker-clusterer", ["mapMarkerClusterer"], { "ariaLabelFn": "ariaLabelFn"; "averageCenter": "averageCenter"; "batchSize": "batchSize"; "batchSizeIE": "batchSizeIE"; "calculator": "calculator"; "clusterClass": "clusterClass"; "enableRetinaIcons": "enableRetinaIcons"; "gridSize": "gridSize"; "ignoreHidden": "ignoreHidden"; "imageExtension": "imageExtension"; "imagePath": "imagePath"; "imageSizes": "imageSizes"; "maxZoom": "maxZoom"; "minimumClusterSize": "minimumClusterSize"; "styles": "styles"; "title": "title"; "zIndex": "zIndex"; "zoomOnClick": "zoomOnClick"; "options": "options"; }, { "clusteringbegin": "clusteringbegin"; "clusteringend": "clusteringend"; "clusterClick": "clusterClick"; }, ["_markers"], ["*"], false>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MapMarkerClusterer, "map-marker-clusterer", ["mapMarkerClusterer"], { "renderer": "renderer"; "algorithm": "algorithm"; }, { "clusteringbegin": "clusteringbegin"; "clusteringend": "clusteringend"; "clusterClick": "clusterClick"; }, ["_markers"], ["*"], false>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MapMarkerClusterer, never>;
 }


### PR DESCRIPTION
The marker clusterer component is currently based on the `@googlemaps/markerclustererplus` package which is deprecated. These changes rewrite the component to use `@googlemaps/markerclusterer` instead.

BREAKING CHANGE:
The new `@googlemaps/markerclusterer` API should be imported instead of the old one. Read more at: https://github.com/googlemaps/js-markerclusterer

Furthermore, the new clustering package doesn't offer the same set of public APIs. As a result, the following inputs to the `MapMarkerClusterer` component have been removed:
* `ariaLabelFn`
* `averageCenter`
* `batchSizeIE`
* `calculator`
* `clusterClass`
* `enableRetinaIcons`
* `gridSize`
* `ignoreHidden`
* `imageExtension`
* `imagePath`
* `imageSizes`
* `maxZoom`
* `minimumClusterSize`
* `styles`
* `title`
* `zIndex`
* `zoomOnClick`
* `options`

It is now recommended to customize the cluster using the `renderer` and `algorithm` inputs.

Fixes #23695.