### PR TITLE
fix(material-experimental/mdc-table): add inherit background to rows

### DIFF
--- a/src/material-experimental/mdc-table/table.scss
+++ b/src/material-experimental/mdc-table/table.scss
@@ -35,10 +35,10 @@ mat-row.mat-mdc-row, mat-header-row.mat-mdc-header-row, mat-footer-row.mat-mdc-f
 }
 
 // Cells need to inherit their background in order to overlap each other when sticky.
-// The background needs to be inherited from the table, tbody/tfoot, row
-// (already set in MDC), and cell.
+// The background needs to be inherited from the table, tbody/tfoot, row, and cell.
 .mat-mdc-table tbody, .mat-mdc-table tfoot, .mat-mdc-table thead,
 .mat-mdc-cell, .mat-mdc-footer-cell,
+.mat-mdc-header-row, .mat-mdc-row, .mat-mdc-footer-row,
 .mat-mdc-table .mat-mdc-header-cell {
   background: inherit;
 }


### PR DESCRIPTION
I think this used to be present in MDC but is no longer there. This causes the background to be inherited down so that elements share the same background set on the table. This fixes the sticky headers