### PR TITLE
test(multiple): enable easy extension of harnesses

### DIFF
--- a/src/material-experimental/mdc-autocomplete/testing/autocomplete-harness.ts
+++ b/src/material-experimental/mdc-autocomplete/testing/autocomplete-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {
   MatOptgroupHarness,
   MatOptionHarness,
@@ -33,16 +33,17 @@ export class MatAutocompleteHarness extends _MatAutocompleteHarnessBase<
   static hostSelector = '.mat-mdc-autocomplete-trigger';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatAutocompleteHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for an autocomplete with specific
+   * attributes.
    * @param options Options for filtering which autocomplete instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: AutocompleteHarnessFilters = {}): HarnessPredicate<MatAutocompleteHarness> {
-    return new HarnessPredicate(MatAutocompleteHarness, options).addOption(
-      'value',
-      options.value,
-      (harness, value) => HarnessPredicate.stringMatches(harness.getValue(), value),
+  static with<T extends MatAutocompleteHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: AutocompleteHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption('value', options.value, (harness, value) =>
+      HarnessPredicate.stringMatches(harness.getValue(), value),
     );
   }
 }

--- a/src/material-experimental/mdc-button/testing/button-harness.ts
+++ b/src/material-experimental/mdc-button/testing/button-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ContentContainerComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarnessConstructor,
+  ContentContainerComponentHarness,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {ButtonHarnessFilters} from '@angular/material/button/testing';
 
@@ -23,11 +27,12 @@ export class MatButtonHarness extends ContentContainerComponentHarness {
    *   - `text` finds a button with specific text content.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ButtonHarnessFilters = {}): HarnessPredicate<MatButtonHarness> {
-    return new HarnessPredicate(MatButtonHarness, options).addOption(
-      'text',
-      options.text,
-      (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text),
+  static with<T extends MatButtonHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ButtonHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption('text', options.text, (harness, text) =>
+      HarnessPredicate.stringMatches(harness.getText(), text),
     );
   }
 

--- a/src/material-experimental/mdc-card/testing/card-harness.ts
+++ b/src/material-experimental/mdc-card/testing/card-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate, ContentContainerComponentHarness} from '@angular/cdk/testing';
+import {
+  ComponentHarnessConstructor,
+  ContentContainerComponentHarness,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {CardHarnessFilters} from './card-harness-filters';
 
 /** Selectors for different sections of the mat-card that can container user content. */
@@ -23,13 +27,15 @@ export class MatCardHarness extends ContentContainerComponentHarness<MatCardSect
   static hostSelector = '.mat-mdc-card';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatCardHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a card with specific attributes.
    * @param options Options for filtering which card instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: CardHarnessFilters = {}): HarnessPredicate<MatCardHarness> {
-    return new HarnessPredicate(MatCardHarness, options)
+  static with<T extends MatCardHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: CardHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options)
       .addOption('text', options.text, (harness, text) =>
         HarnessPredicate.stringMatches(harness.getText(), text),
       )

--- a/src/material-experimental/mdc-checkbox/testing/checkbox-harness.ts
+++ b/src/material-experimental/mdc-checkbox/testing/checkbox-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {CheckboxHarnessFilters, _MatCheckboxHarnessBase} from '@angular/material/checkbox/testing';
 
 /** Harness for interacting with a MDC-based mat-checkbox in tests. */
@@ -21,9 +21,12 @@ export class MatCheckboxHarness extends _MatCheckboxHarnessBase {
    *   - `name` finds a checkbox with specific name.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: CheckboxHarnessFilters = {}): HarnessPredicate<MatCheckboxHarness> {
+  static with<T extends MatCheckboxHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: CheckboxHarnessFilters = {},
+  ): HarnessPredicate<T> {
     return (
-      new HarnessPredicate(MatCheckboxHarness, options)
+      new HarnessPredicate(this, options)
         .addOption('label', options.label, (harness, label) =>
           HarnessPredicate.stringMatches(harness.getLabelText(), label),
         )

--- a/src/material-experimental/mdc-chips/testing/chip-avatar-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-avatar-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate, ComponentHarness} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {ChipAvatarHarnessFilters} from './chip-harness-filters';
 
 /** Harness for interacting with a standard Material chip avatar in tests. */
@@ -14,12 +18,15 @@ export class MatChipAvatarHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-chip-avatar';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatChipAvatarHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a chip avatar with specific
+   * attributes.
    * @param options Options for filtering which input instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ChipAvatarHarnessFilters = {}): HarnessPredicate<MatChipAvatarHarness> {
-    return new HarnessPredicate(MatChipAvatarHarness, options);
+  static with<T extends MatChipAvatarHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ChipAvatarHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 }

--- a/src/material-experimental/mdc-chips/testing/chip-grid-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-grid-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {
   ChipGridHarnessFilters,
   ChipInputHarnessFilters,
@@ -21,9 +25,14 @@ export class MatChipGridHarness extends ComponentHarness {
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip grid with specific attributes.
+   * @param options Options for filtering which chip grid instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ChipGridHarnessFilters = {}): HarnessPredicate<MatChipGridHarness> {
-    return new HarnessPredicate(MatChipGridHarness, options);
+  static with<T extends MatChipGridHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ChipGridHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   /** Gets whether the chip grid is disabled. */

--- a/src/material-experimental/mdc-chips/testing/chip-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-harness.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ContentContainerComponentHarness, HarnessPredicate, TestKey} from '@angular/cdk/testing';
+import {
+  ComponentHarnessConstructor,
+  ContentContainerComponentHarness,
+  HarnessPredicate,
+  TestKey,
+} from '@angular/cdk/testing';
 import {MatChipAvatarHarness} from './chip-avatar-harness';
 import {
   ChipAvatarHarnessFilters,
@@ -23,20 +28,16 @@ export class MatChipHarness extends ContentContainerComponentHarness {
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip with specific attributes.
+   * @param options Options for narrowing the search.
+   * @return a `HarnessPredicate` configured with the given options.
    */
-  // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
-  // methods. See https://github.com/microsoft/TypeScript/issues/5863
-  static with<T extends typeof MatChipHarness>(
-    this: T,
+  static with<T extends MatChipHarness>(
+    this: ComponentHarnessConstructor<T>,
     options: ChipHarnessFilters = {},
-  ): HarnessPredicate<InstanceType<T>> {
-    return new HarnessPredicate(MatChipHarness, options).addOption(
-      'text',
-      options.text,
-      (harness, label) => {
-        return HarnessPredicate.stringMatches(harness.getText(), label);
-      },
-    ) as unknown as HarnessPredicate<InstanceType<T>>;
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption('text', options.text, (harness, label) => {
+      return HarnessPredicate.stringMatches(harness.getText(), label);
+    });
   }
 
   /** Gets a promise for the text content the option. */

--- a/src/material-experimental/mdc-chips/testing/chip-input-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-input-harness.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate, TestKey} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+  TestKey,
+} from '@angular/cdk/testing';
 import {ChipInputHarnessFilters} from './chip-harness-filters';
 
 /** Harness for interacting with a grid's chip input in tests. */
@@ -14,13 +19,16 @@ export class MatChipInputHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-chip-input';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatChipInputHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a chip input with specific
+   * attributes.
    * @param options Options for filtering which input instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ChipInputHarnessFilters = {}): HarnessPredicate<MatChipInputHarness> {
-    return new HarnessPredicate(MatChipInputHarness, options)
+  static with<T extends MatChipInputHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ChipInputHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options)
       .addOption('value', options.value, async (harness, value) => {
         return (await harness.getValue()) === value;
       })

--- a/src/material-experimental/mdc-chips/testing/chip-listbox-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-listbox-harness.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+  parallel,
+} from '@angular/cdk/testing';
 import {ChipListboxHarnessFilters, ChipOptionHarnessFilters} from './chip-harness-filters';
 import {MatChipOptionHarness} from './chip-option-harness';
 
@@ -17,9 +22,14 @@ export class MatChipListboxHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip listbox with specific
    * attributes.
+   * @param options Options for narrowing the search.
+   * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ChipListboxHarnessFilters = {}): HarnessPredicate<MatChipListboxHarness> {
-    return new HarnessPredicate(MatChipListboxHarness, options);
+  static with<T extends MatChipListboxHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ChipListboxHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   /** Gets whether the chip listbox is disabled. */

--- a/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-option-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {MatChipHarness} from './chip-harness';
 import {ChipOptionHarnessFilters} from './chip-harness-filters';
 
@@ -17,13 +17,13 @@ export class MatChipOptionHarness extends MatChipHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip option with specific
    * attributes.
+   * @param options Options for narrowing the search.
+   * @return a `HarnessPredicate` configured with the given options.
    */
-  // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
-  // methods. See https://github.com/microsoft/TypeScript/issues/5863
-  static override with<T extends typeof MatChipHarness>(
-    this: T,
+  static override with<T extends MatChipHarness>(
+    this: ComponentHarnessConstructor<T>,
     options: ChipOptionHarnessFilters = {},
-  ): HarnessPredicate<InstanceType<T>> {
+  ): HarnessPredicate<T> {
     return new HarnessPredicate(MatChipOptionHarness, options)
       .addOption('text', options.text, (harness, label) =>
         HarnessPredicate.stringMatches(harness.getText(), label),
@@ -32,7 +32,7 @@ export class MatChipOptionHarness extends MatChipHarness {
         'selected',
         options.selected,
         async (harness, selected) => (await harness.isSelected()) === selected,
-      ) as unknown as HarnessPredicate<InstanceType<T>>;
+      ) as unknown as HarnessPredicate<T>;
   }
 
   /** Whether the chip is selected. */

--- a/src/material-experimental/mdc-chips/testing/chip-remove-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-remove-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate, ComponentHarness} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {ChipRemoveHarnessFilters} from './chip-harness-filters';
 
 /** Harness for interacting with a standard Material chip remove button in tests. */
@@ -14,13 +18,16 @@ export class MatChipRemoveHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-chip-remove';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatChipRemoveHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a chip remove with specific
+   * attributes.
    * @param options Options for filtering which input instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ChipRemoveHarnessFilters = {}): HarnessPredicate<MatChipRemoveHarness> {
-    return new HarnessPredicate(MatChipRemoveHarness, options);
+  static with<T extends MatChipRemoveHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ChipRemoveHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   /** Clicks the remove button. */

--- a/src/material-experimental/mdc-chips/testing/chip-row-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-row-harness.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
-import {ChipRowHarnessFilters} from './chip-harness-filters';
 import {MatChipHarness} from './chip-harness';
 
 // TODO(crisbeto): add harness for the chip edit input inside the row.
@@ -15,20 +13,6 @@ import {MatChipHarness} from './chip-harness';
 /** Harness for interacting with a mat-chip-row in tests. */
 export class MatChipRowHarness extends MatChipHarness {
   static override hostSelector = '.mat-mdc-chip-row';
-
-  /**
-   * Gets a `HarnessPredicate` that can be used to search for a chip row with specific attributes.
-   */
-  // Note(mmalerba): generics are used as a workaround for lack of polymorphic `this` in static
-  // methods. See https://github.com/microsoft/TypeScript/issues/5863
-  static override with<T extends typeof MatChipHarness>(
-    this: T,
-    options: ChipRowHarnessFilters = {},
-  ): HarnessPredicate<InstanceType<T>> {
-    return new HarnessPredicate(MatChipRowHarness, options) as unknown as HarnessPredicate<
-      InstanceType<T>
-    >;
-  }
 
   /** Whether the chip is editable. */
   async isEditable(): Promise<boolean> {

--- a/src/material-experimental/mdc-chips/testing/chip-set-harness.ts
+++ b/src/material-experimental/mdc-chips/testing/chip-set-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarnessConstructor,
+  ComponentHarness,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {MatChipHarness} from './chip-harness';
 import {ChipHarnessFilters, ChipSetHarnessFilters} from './chip-harness-filters';
 
@@ -16,9 +20,14 @@ export class MatChipSetHarness extends ComponentHarness {
 
   /**
    * Gets a `HarnessPredicate` that can be used to search for a chip set with specific attributes.
+   * @param options Options for filtering which chip set instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ChipSetHarnessFilters = {}): HarnessPredicate<MatChipSetHarness> {
-    return new HarnessPredicate(MatChipSetHarness, options);
+  static with<T extends MatChipSetHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ChipSetHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   /** Gets promise of the harnesses for the chips. */

--- a/src/material-experimental/mdc-core/testing/optgroup-harness.ts
+++ b/src/material-experimental/mdc-core/testing/optgroup-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {OptgroupHarnessFilters} from './optgroup-harness-filters';
 import {MatOptionHarness} from './option-harness';
 import {OptionHarnessFilters} from './option-harness-filters';
@@ -18,13 +22,16 @@ export class MatOptgroupHarness extends ComponentHarness {
   private _label = this.locatorFor('.mat-mdc-optgroup-label');
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatOptgroupHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a option group with specific
+   * attributes.
    * @param options Options for filtering which option instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: OptgroupHarnessFilters = {}) {
-    return new HarnessPredicate(MatOptgroupHarness, options).addOption(
+  static with<T extends MatOptgroupHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: OptgroupHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption(
       'labelText',
       options.labelText,
       async (harness, title) => HarnessPredicate.stringMatches(await harness.getLabelText(), title),

--- a/src/material-experimental/mdc-core/testing/option-harness.ts
+++ b/src/material-experimental/mdc-core/testing/option-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {OptionHarnessFilters} from './option-harness-filters';
 
 /** Harness for interacting with an MDC-based `mat-option` in tests. */
@@ -18,13 +22,15 @@ export class MatOptionHarness extends ComponentHarness {
   private _text = this.locatorFor('.mdc-list-item__primary-text');
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatOptionsHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for an option with specific attributes.
    * @param options Options for filtering which option instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: OptionHarnessFilters = {}) {
-    return new HarnessPredicate(MatOptionHarness, options)
+  static with<T extends MatOptionHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: OptionHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options)
       .addOption('text', options.text, async (harness, title) =>
         HarnessPredicate.stringMatches(await harness.getText(), title),
       )

--- a/src/material-experimental/mdc-dialog/testing/dialog-harness.ts
+++ b/src/material-experimental/mdc-dialog/testing/dialog-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {DialogHarnessFilters, _MatDialogHarnessBase} from '@angular/material/dialog/testing';
 
 /** Selectors for different sections of the mat-dialog that can contain user content. */
@@ -22,13 +22,15 @@ export class MatDialogHarness extends _MatDialogHarnessBase {
   static hostSelector = '.mat-mdc-dialog-container';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatDialogHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a dialog with specific attributes.
    * @param options Options for filtering which dialog instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: DialogHarnessFilters = {}): HarnessPredicate<MatDialogHarness> {
-    return new HarnessPredicate(MatDialogHarness, options);
+  static with<T extends MatDialogHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: DialogHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   protected override _title = this.locatorForOptional(MatDialogSection.TITLE);

--- a/src/material-experimental/mdc-form-field/testing/form-field-harness.ts
+++ b/src/material-experimental/mdc-form-field/testing/form-field-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {
   FormFieldHarnessFilters,
   _MatFormFieldHarnessBase,
@@ -31,13 +31,16 @@ export class MatFormFieldHarness extends _MatFormFieldHarnessBase<FormFieldContr
   static hostSelector = '.mat-mdc-form-field';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatFormFieldHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a form field with specific
+   * attributes.
    * @param options Options for filtering which form field instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: FormFieldHarnessFilters = {}): HarnessPredicate<MatFormFieldHarness> {
-    return new HarnessPredicate(MatFormFieldHarness, options)
+  static with<T extends MatFormFieldHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: FormFieldHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options)
       .addOption('floatingLabelText', options.floatingLabelText, async (harness, text) =>
         HarnessPredicate.stringMatches(await harness.getLabel(), text),
       )

--- a/src/material-experimental/mdc-list/testing/action-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/action-list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {MatListHarnessBase} from './list-harness-base';
 import {ActionListHarnessFilters, ActionListItemHarnessFilters} from './list-harness-filters';
 import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
@@ -21,13 +21,16 @@ export class MatActionListHarness extends MatListHarnessBase<
   static hostSelector = '.mat-mdc-action-list';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatActionListHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for an action list with specific
+   * attributes.
    * @param options Options for filtering which action list instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ActionListHarnessFilters = {}): HarnessPredicate<MatActionListHarness> {
-    return new HarnessPredicate(MatActionListHarness, options);
+  static with<T extends MatActionListHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ActionListHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   override _itemHarness = MatActionListItemHarness;
@@ -39,15 +42,16 @@ export class MatActionListItemHarness extends MatListItemHarnessBase {
   static hostSelector = `${MatActionListHarness.hostSelector} .mat-mdc-list-item`;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatActionListItemHarness` that
-   * meets certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a list item with specific
+   * attributes.
    * @param options Options for filtering which action list item instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(
+  static with<T extends MatActionListItemHarness>(
+    this: ComponentHarnessConstructor<T>,
     options: ActionListItemHarnessFilters = {},
-  ): HarnessPredicate<MatActionListItemHarness> {
-    return getListItemPredicate(MatActionListItemHarness, options);
+  ): HarnessPredicate<T> {
+    return getListItemPredicate(this, options);
   }
 
   /** Clicks on the action list item. */

--- a/src/material-experimental/mdc-list/testing/list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {MatListHarnessBase} from './list-harness-base';
 import {ListHarnessFilters, ListItemHarnessFilters} from './list-harness-filters';
 import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
@@ -21,13 +21,15 @@ export class MatListHarness extends MatListHarnessBase<
   static hostSelector = '.mat-mdc-list';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatListHarness` that meets certain
-   * criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a list with specific attributes.
    * @param options Options for filtering which list instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ListHarnessFilters = {}): HarnessPredicate<MatListHarness> {
-    return new HarnessPredicate(MatListHarness, options);
+  static with<T extends MatListHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ListHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   override _itemHarness = MatListItemHarness;
@@ -39,12 +41,14 @@ export class MatListItemHarness extends MatListItemHarnessBase {
   static hostSelector = `${MatListHarness.hostSelector} .mat-mdc-list-item`;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatListItemHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a list item with specific attributes.
    * @param options Options for filtering which list item instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ListItemHarnessFilters = {}): HarnessPredicate<MatListItemHarness> {
-    return getListItemPredicate(MatListItemHarness, options);
+  static with<T extends MatListItemHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ListItemHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return getListItemPredicate(this, options);
   }
 }

--- a/src/material-experimental/mdc-list/testing/nav-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/nav-list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {MatListHarnessBase} from './list-harness-base';
 import {NavListHarnessFilters, NavListItemHarnessFilters} from './list-harness-filters';
 import {getListItemPredicate, MatListItemHarnessBase} from './list-item-harness-base';
@@ -21,13 +21,16 @@ export class MatNavListHarness extends MatListHarnessBase<
   static hostSelector = '.mat-mdc-nav-list';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatNavListHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a nav list with specific
+   * attributes.
    * @param options Options for filtering which nav list instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: NavListHarnessFilters = {}): HarnessPredicate<MatNavListHarness> {
-    return new HarnessPredicate(MatNavListHarness, options);
+  static with<T extends MatNavListHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: NavListHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   override _itemHarness = MatNavListItemHarness;
@@ -39,13 +42,16 @@ export class MatNavListItemHarness extends MatListItemHarnessBase {
   static hostSelector = `${MatNavListHarness.hostSelector} .mat-mdc-list-item`;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatNavListItemHarness` that
-   * meets certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a nav list item with specific
+   * attributes.
    * @param options Options for filtering which nav list item instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: NavListItemHarnessFilters = {}): HarnessPredicate<MatNavListItemHarness> {
-    return getListItemPredicate(MatNavListItemHarness, options).addOption(
+  static with<T extends MatNavListItemHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: NavListItemHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return getListItemPredicate(this, options).addOption(
       'href',
       options.href,
       async (harness, href) => HarnessPredicate.stringMatches(harness.getHref(), href),

--- a/src/material-experimental/mdc-list/testing/selection-list-harness.ts
+++ b/src/material-experimental/mdc-list/testing/selection-list-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate, parallel} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate, parallel} from '@angular/cdk/testing';
 import {MatListOptionCheckboxPosition} from '@angular/material-experimental/mdc-list';
 import {MatListHarnessBase} from './list-harness-base';
 import {
@@ -26,15 +26,16 @@ export class MatSelectionListHarness extends MatListHarnessBase<
   static hostSelector = '.mat-mdc-selection-list';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatSelectionListHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a selection list with specific
+   * attributes.
    * @param options Options for filtering which selection list instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(
+  static with<T extends MatSelectionListHarness>(
+    this: ComponentHarnessConstructor<T>,
     options: SelectionListHarnessFilters = {},
-  ): HarnessPredicate<MatSelectionListHarness> {
-    return new HarnessPredicate(MatSelectionListHarness, options);
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   override _itemHarness = MatListOptionHarness;
@@ -80,13 +81,16 @@ export class MatListOptionHarness extends MatListItemHarnessBase {
   static hostSelector = '.mat-mdc-list-option';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatListOptionHarness` that
-   * meets certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a list option with specific
+   * attributes.
    * @param options Options for filtering which list option instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ListOptionHarnessFilters = {}): HarnessPredicate<MatListOptionHarness> {
-    return getListItemPredicate(MatListOptionHarness, options).addOption(
+  static with<T extends MatListOptionHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ListOptionHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return getListItemPredicate(this, options).addOption(
       'is selected',
       options.selected,
       async (harness, selected) => (await harness.isSelected()) === selected,

--- a/src/material-experimental/mdc-menu/testing/menu-harness.ts
+++ b/src/material-experimental/mdc-menu/testing/menu-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {
   MenuHarnessFilters,
   MenuItemHarnessFilters,
@@ -25,13 +25,15 @@ export class MatMenuHarness extends _MatMenuHarnessBase<
   protected _itemClass = MatMenuItemHarness;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatMenuHarness` that meets certain
-   * criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a menu with specific attributes.
    * @param options Options for filtering which menu instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: MenuHarnessFilters = {}): HarnessPredicate<MatMenuHarness> {
-    return new HarnessPredicate(MatMenuHarness, options).addOption(
+  static with<T extends MatMenuHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: MenuHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption(
       'triggerText',
       options.triggerText,
       (harness, text) => HarnessPredicate.stringMatches(harness.getTriggerText(), text),
@@ -49,13 +51,15 @@ export class MatMenuItemHarness extends _MatMenuItemHarnessBase<
   protected _menuClass = MatMenuHarness;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatMenuItemHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a menu item with specific attributes.
    * @param options Options for filtering which menu item instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: MenuItemHarnessFilters = {}): HarnessPredicate<MatMenuItemHarness> {
-    return new HarnessPredicate(MatMenuItemHarness, options)
+  static with<T extends MatMenuItemHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: MenuItemHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options)
       .addOption('text', options.text, (harness, text) =>
         HarnessPredicate.stringMatches(harness.getText(), text),
       )

--- a/src/material-experimental/mdc-paginator/testing/paginator-harness.ts
+++ b/src/material-experimental/mdc-paginator/testing/paginator-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {MatSelectHarness} from '@angular/material-experimental/mdc-select/testing';
 import {
   PaginatorHarnessFilters,
@@ -30,12 +30,14 @@ export class MatPaginatorHarness extends _MatPaginatorHarnessBase {
   protected _rangeLabel = this.locatorFor('.mat-mdc-paginator-range-label');
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatPaginatorHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a paginator with specific attributes.
    * @param options Options for filtering which paginator instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: PaginatorHarnessFilters = {}): HarnessPredicate<MatPaginatorHarness> {
-    return new HarnessPredicate(MatPaginatorHarness, options);
+  static with<T extends MatPaginatorHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: PaginatorHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 }

--- a/src/material-experimental/mdc-progress-bar/testing/progress-bar-harness.ts
+++ b/src/material-experimental/mdc-progress-bar/testing/progress-bar-harness.ts
@@ -7,7 +7,11 @@
  */
 
 import {coerceNumberProperty} from '@angular/cdk/coercion';
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {ProgressBarHarnessFilters} from '@angular/material/progress-bar/testing';
 
 /** Harness for interacting with an MDC-based `mat-progress-bar` in tests. */
@@ -17,9 +21,14 @@ export class MatProgressBarHarness extends ComponentHarness {
   /**
    * Gets a `HarnessPredicate` that can be used to search for a progress bar with specific
    * attributes.
+   * @param options Options for filtering which progress bar instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: ProgressBarHarnessFilters = {}): HarnessPredicate<MatProgressBarHarness> {
-    return new HarnessPredicate(MatProgressBarHarness, options);
+  static with<T extends MatProgressBarHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: ProgressBarHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   /** Gets a promise for the progress bar's value. */

--- a/src/material-experimental/mdc-progress-spinner/testing/progress-spinner-harness.ts
+++ b/src/material-experimental/mdc-progress-spinner/testing/progress-spinner-harness.ts
@@ -7,7 +7,11 @@
  */
 
 import {coerceNumberProperty} from '@angular/cdk/coercion';
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {ProgressSpinnerMode} from '@angular/material/progress-spinner';
 import {ProgressSpinnerHarnessFilters} from '@angular/material/progress-spinner/testing';
 
@@ -17,15 +21,16 @@ export class MatProgressSpinnerHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-progress-spinner';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatProgressSpinnerHarness` that
-   * meets certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a progress spinnner with specific
+   * attributes.
    * @param options Options for filtering which progress spinner instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(
+  static with<T extends MatProgressSpinnerHarness>(
+    this: ComponentHarnessConstructor<T>,
     options: ProgressSpinnerHarnessFilters = {},
-  ): HarnessPredicate<MatProgressSpinnerHarness> {
-    return new HarnessPredicate(MatProgressSpinnerHarness, options);
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   /** Gets the progress spinner's value. */

--- a/src/material-experimental/mdc-radio/testing/radio-harness.ts
+++ b/src/material-experimental/mdc-radio/testing/radio-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {
   RadioButtonHarnessFilters,
   RadioGroupHarnessFilters,
@@ -25,16 +25,19 @@ export class MatRadioGroupHarness extends _MatRadioGroupHarnessBase<
   protected _buttonClass = MatRadioButtonHarness;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatRadioGroupHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a radio group with specific
+   * attributes.
    * @param options Options for filtering which radio group instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: RadioGroupHarnessFilters = {}): HarnessPredicate<MatRadioGroupHarness> {
-    return new HarnessPredicate<MatRadioGroupHarness>(MatRadioGroupHarness, options).addOption(
+  static with<T extends MatRadioGroupHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: RadioGroupHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption(
       'name',
       options.name,
-      this._checkRadioGroupName,
+      MatRadioGroupHarness._checkRadioGroupName,
     );
   }
 }
@@ -45,13 +48,16 @@ export class MatRadioButtonHarness extends _MatRadioButtonHarnessBase {
   static hostSelector = '.mat-mdc-radio-button';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatRadioButtonHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a radio button with specific
+   * attributes.
    * @param options Options for filtering which radio button instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: RadioButtonHarnessFilters = {}): HarnessPredicate<MatRadioButtonHarness> {
-    return new HarnessPredicate<MatRadioButtonHarness>(MatRadioButtonHarness, options)
+  static with<T extends MatRadioButtonHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: RadioButtonHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options)
       .addOption('label', options.label, (harness, label) =>
         HarnessPredicate.stringMatches(harness.getLabelText(), label),
       )

--- a/src/material-experimental/mdc-select/testing/select-harness.ts
+++ b/src/material-experimental/mdc-select/testing/select-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {_MatSelectHarnessBase} from '@angular/material/select/testing';
 import {
   MatOptionHarness,
@@ -31,12 +31,14 @@ export class MatSelectHarness extends _MatSelectHarnessBase<
   protected _optionGroupClass = MatOptgroupHarness;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatSelectHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a select with specific attributes.
    * @param options Options for filtering which select instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: SelectHarnessFilters = {}): HarnessPredicate<MatSelectHarness> {
-    return new HarnessPredicate(MatSelectHarness, options);
+  static with<T extends MatSelectHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: SelectHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 }

--- a/src/material-experimental/mdc-slide-toggle/testing/slide-toggle-harness.ts
+++ b/src/material-experimental/mdc-slide-toggle/testing/slide-toggle-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 import {
   _MatSlideToggleHarnessBase,
@@ -25,9 +25,12 @@ export class MatSlideToggleHarness extends _MatSlideToggleHarnessBase {
    *   - `label` finds a slide-toggle with specific label text.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: SlideToggleHarnessFilters = {}): HarnessPredicate<MatSlideToggleHarness> {
+  static with<T extends MatSlideToggleHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: SlideToggleHarnessFilters = {},
+  ): HarnessPredicate<T> {
     return (
-      new HarnessPredicate(MatSlideToggleHarness, options)
+      new HarnessPredicate(this, options)
         .addOption('label', options.label, (harness, label) =>
           HarnessPredicate.stringMatches(harness.getLabelText(), label),
         )

--- a/src/material-experimental/mdc-slider/testing/slider-harness.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {coerceNumberProperty} from '@angular/cdk/coercion';
 import {SliderHarnessFilters, ThumbPosition} from './slider-harness-filters';
 import {MatSliderThumbHarness} from './slider-thumb-harness';
@@ -16,13 +20,15 @@ export class MatSliderHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-slider';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatSliderHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a slider with specific attributes.
    * @param options Options for filtering which input instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: SliderHarnessFilters = {}): HarnessPredicate<MatSliderHarness> {
-    return new HarnessPredicate(MatSliderHarness, options).addOption(
+  static with<T extends MatSliderHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: SliderHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption(
       'isRange',
       options.isRange,
       async (harness, value) => {

--- a/src/material-experimental/mdc-slider/testing/slider-thumb-harness.ts
+++ b/src/material-experimental/mdc-slider/testing/slider-thumb-harness.ts
@@ -7,7 +7,12 @@
  */
 
 import {coerceNumberProperty} from '@angular/cdk/coercion';
-import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+  parallel,
+} from '@angular/cdk/testing';
 import {SliderThumbHarnessFilters, ThumbPosition} from './slider-harness-filters';
 
 /** Harness for interacting with a thumb inside of a Material slider in tests. */
@@ -16,13 +21,15 @@ export class MatSliderThumbHarness extends ComponentHarness {
     'input[matSliderThumb], input[matSliderStartThumb], input[matSliderEndThumb]';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatSliderThumbHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a slider thumb with specific attributes.
    * @param options Options for filtering which thumb instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: SliderThumbHarnessFilters = {}): HarnessPredicate<MatSliderThumbHarness> {
-    return new HarnessPredicate(MatSliderThumbHarness, options).addOption(
+  static with<T extends MatSliderThumbHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: SliderThumbHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption(
       'position',
       options.position,
       async (harness, value) => {

--- a/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
+++ b/src/material-experimental/mdc-snack-bar/testing/snack-bar-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {
   MatSnackBarHarness as BaseMatSnackBarHarness,
   SnackBarHarnessFilters,
@@ -25,15 +25,15 @@ export class MatSnackBarHarness extends BaseMatSnackBarHarness {
   protected override _actionButtonSelector = '.mat-mdc-snack-bar-action';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatSnackBarHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a snack bar with specific attributes.
    * @param options Options for filtering which snack bar instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static override with(
+  static override with<T extends BaseMatSnackBarHarness>(
+    this: ComponentHarnessConstructor<T>,
     options: SnackBarHarnessFilters = {},
-  ): HarnessPredicate<BaseMatSnackBarHarness> {
-    return new HarnessPredicate<BaseMatSnackBarHarness>(MatSnackBarHarness, options);
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   protected override async _assertContentAnnotated() {}

--- a/src/material-experimental/mdc-table/testing/cell-harness.ts
+++ b/src/material-experimental/mdc-table/testing/cell-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {
   MatCellHarness as BaseMatCellHarness,
   MatHeaderCellHarness as BaseMatHeaderCellHarness,
@@ -24,8 +24,11 @@ export class MatCellHarness extends BaseMatCellHarness {
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static override with(options: CellHarnessFilters = {}): HarnessPredicate<MatCellHarness> {
-    return BaseMatCellHarness._getCellPredicate(MatCellHarness, options);
+  static override with<T extends MatCellHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: CellHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return BaseMatCellHarness._getCellPredicate(this, options);
   }
 }
 
@@ -35,13 +38,16 @@ export class MatHeaderCellHarness extends BaseMatHeaderCellHarness {
   static override hostSelector = '.mat-mdc-header-cell';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for
-   * a table header cell with specific attributes.
+   * Gets a `HarnessPredicate` that can be used to search for a table header cell with specific
+   * attributes.
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static override with(options: CellHarnessFilters = {}): HarnessPredicate<MatHeaderCellHarness> {
-    return BaseMatHeaderCellHarness._getCellPredicate(MatHeaderCellHarness, options);
+  static override with<T extends MatHeaderCellHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: CellHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return BaseMatHeaderCellHarness._getCellPredicate(this, options);
   }
 }
 
@@ -51,12 +57,15 @@ export class MatFooterCellHarness extends BaseMatFooterCellHarness {
   static override hostSelector = '.mat-mdc-footer-cell';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for
-   * a table footer cell with specific attributes.
+   * Gets a `HarnessPredicate` that can be used to search for a table footer cell with specific
+   * attributes.
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static override with(options: CellHarnessFilters = {}): HarnessPredicate<MatFooterCellHarness> {
-    return BaseMatFooterCellHarness._getCellPredicate(MatFooterCellHarness, options);
+  static override with<T extends MatFooterCellHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: CellHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return BaseMatFooterCellHarness._getCellPredicate(this, options);
   }
 }

--- a/src/material-experimental/mdc-table/testing/row-harness.ts
+++ b/src/material-experimental/mdc-table/testing/row-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {_MatRowHarnessBase, RowHarnessFilters} from '@angular/material/table/testing';
 import {MatCellHarness, MatHeaderCellHarness, MatFooterCellHarness} from './cell-harness';
 
@@ -21,8 +21,11 @@ export class MatRowHarness extends _MatRowHarnessBase<typeof MatCellHarness, Mat
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: RowHarnessFilters = {}): HarnessPredicate<MatRowHarness> {
-    return new HarnessPredicate(MatRowHarness, options);
+  static with<T extends MatRowHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: RowHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 }
 
@@ -36,13 +39,16 @@ export class MatHeaderRowHarness extends _MatRowHarnessBase<
   protected _cellHarness = MatHeaderCellHarness;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for
-   * a table header row with specific attributes.
+   * Gets a `HarnessPredicate` that can be used to search for a table header row with specific
+   * attributes.
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: RowHarnessFilters = {}): HarnessPredicate<MatHeaderRowHarness> {
-    return new HarnessPredicate(MatHeaderRowHarness, options);
+  static with<T extends MatHeaderRowHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: RowHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 }
 
@@ -56,12 +62,15 @@ export class MatFooterRowHarness extends _MatRowHarnessBase<
   protected _cellHarness = MatFooterCellHarness;
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for
-   * a table footer row cell with specific attributes.
+   * Gets a `HarnessPredicate` that can be used to search for a table footer row cell with specific
+   * attributes.
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: RowHarnessFilters = {}): HarnessPredicate<MatFooterRowHarness> {
-    return new HarnessPredicate(MatFooterRowHarness, options);
+  static with<T extends MatFooterRowHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: RowHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 }

--- a/src/material-experimental/mdc-table/testing/table-harness.ts
+++ b/src/material-experimental/mdc-table/testing/table-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {TableHarnessFilters, _MatTableHarnessBase} from '@angular/material/table/testing';
 import {MatRowHarness, MatHeaderRowHarness, MatFooterRowHarness} from './row-harness';
 
@@ -30,7 +30,10 @@ export class MatTableHarness extends _MatTableHarnessBase<
    * @param options Options for narrowing the search
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: TableHarnessFilters = {}): HarnessPredicate<MatTableHarness> {
-    return new HarnessPredicate(MatTableHarness, options);
+  static with<T extends MatTableHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: TableHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 }

--- a/src/material-experimental/mdc-tabs/testing/tab-group-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-group-harness.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+  parallel,
+} from '@angular/cdk/testing';
 import {TabGroupHarnessFilters, TabHarnessFilters} from './tab-harness-filters';
 import {MatTabHarness} from './tab-harness';
 
@@ -16,13 +21,15 @@ export class MatTabGroupHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-tab-group';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatTabGroupHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a tab group with specific attributes.
    * @param options Options for filtering which tab group instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: TabGroupHarnessFilters = {}): HarnessPredicate<MatTabGroupHarness> {
-    return new HarnessPredicate(MatTabGroupHarness, options).addOption(
+  static with<T extends MatTabGroupHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: TabGroupHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption(
       'selectedTabLabel',
       options.selectedTabLabel,
       async (harness, label) => {

--- a/src/material-experimental/mdc-tabs/testing/tab-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-harness.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ComponentHarnessConstructor,
   ContentContainerComponentHarness,
   HarnessLoader,
   HarnessPredicate,
@@ -19,16 +20,16 @@ export class MatTabHarness extends ContentContainerComponentHarness<string> {
   static hostSelector = '.mat-mdc-tab';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatTabHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a tab with specific attributes.
    * @param options Options for filtering which tab instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: TabHarnessFilters = {}): HarnessPredicate<MatTabHarness> {
-    return new HarnessPredicate(MatTabHarness, options).addOption(
-      'label',
-      options.label,
-      (harness, label) => HarnessPredicate.stringMatches(harness.getLabel(), label),
+  static with<T extends MatTabHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: TabHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption('label', options.label, (harness, label) =>
+      HarnessPredicate.stringMatches(harness.getLabel(), label),
     );
   }
 

--- a/src/material-experimental/mdc-tabs/testing/tab-link-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-link-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {TabLinkHarnessFilters} from './tab-harness-filters';
 
 /** Harness for interacting with an MDC-based Angular Material tab link in tests. */
@@ -15,16 +19,16 @@ export class MatTabLinkHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-tab-link';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatTabLinkHarness` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a tab link with specific attributes.
    * @param options Options for filtering which tab link instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: TabLinkHarnessFilters = {}): HarnessPredicate<MatTabLinkHarness> {
-    return new HarnessPredicate(MatTabLinkHarness, options).addOption(
-      'label',
-      options.label,
-      (harness, label) => HarnessPredicate.stringMatches(harness.getLabel(), label),
+  static with<T extends MatTabLinkHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: TabLinkHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options).addOption('label', options.label, (harness, label) =>
+      HarnessPredicate.stringMatches(harness.getLabel(), label),
     );
   }
 

--- a/src/material-experimental/mdc-tabs/testing/tab-nav-bar-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-nav-bar-harness.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentHarness, HarnessPredicate, parallel} from '@angular/cdk/testing';
+import {
+  ComponentHarness,
+  ComponentHarnessConstructor,
+  HarnessPredicate,
+  parallel,
+} from '@angular/cdk/testing';
 import {
   TabNavBarHarnessFilters,
   TabNavPanelHarnessFilters,
@@ -21,13 +26,16 @@ export class MatTabNavBarHarness extends ComponentHarness {
   static hostSelector = '.mat-mdc-tab-nav-bar';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatTabNavBar` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a tab nav bar with specific
+   * attributes.
    * @param options Options for filtering which tab nav bar instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: TabNavBarHarnessFilters = {}): HarnessPredicate<MatTabNavBarHarness> {
-    return new HarnessPredicate(MatTabNavBarHarness, options);
+  static with<T extends MatTabNavBarHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: TabNavBarHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   /**

--- a/src/material-experimental/mdc-tabs/testing/tab-nav-panel-harness.ts
+++ b/src/material-experimental/mdc-tabs/testing/tab-nav-panel-harness.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ContentContainerComponentHarness, HarnessPredicate} from '@angular/cdk/testing';
+import {
+  ComponentHarnessConstructor,
+  ContentContainerComponentHarness,
+  HarnessPredicate,
+} from '@angular/cdk/testing';
 import {TabNavPanelHarnessFilters} from './tab-harness-filters';
 
 /** Harness for interacting with a standard mat-tab-nav-panel in tests. */
@@ -15,13 +19,16 @@ export class MatTabNavPanelHarness extends ContentContainerComponentHarness {
   static hostSelector = '.mat-mdc-tab-nav-panel';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search for a `MatTabNavPanel` that meets
-   * certain criteria.
+   * Gets a `HarnessPredicate` that can be used to search for a tab nav panel with specific
+   * attributes.
    * @param options Options for filtering which tab nav panel instances are considered a match.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: TabNavPanelHarnessFilters = {}): HarnessPredicate<MatTabNavPanelHarness> {
-    return new HarnessPredicate(MatTabNavPanelHarness, options);
+  static with<T extends MatTabNavPanelHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: TabNavPanelHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 
   /** Gets the tab panel text content. */

--- a/src/material-experimental/mdc-tooltip/testing/tooltip-harness.ts
+++ b/src/material-experimental/mdc-tooltip/testing/tooltip-harness.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HarnessPredicate} from '@angular/cdk/testing';
+import {ComponentHarnessConstructor, HarnessPredicate} from '@angular/cdk/testing';
 import {_MatTooltipHarnessBase, TooltipHarnessFilters} from '@angular/material/tooltip/testing';
 
 /** Harness for interacting with a standard mat-tooltip in tests. */
@@ -19,12 +19,15 @@ export class MatTooltipHarness extends _MatTooltipHarnessBase {
   protected _hideAnimationName = 'mat-mdc-tooltip-hide';
 
   /**
-   * Gets a `HarnessPredicate` that can be used to search
-   * for a tooltip trigger with specific attributes.
+   * Gets a `HarnessPredicate` that can be used to search for a tooltip trigger with specific
+   * attributes.
    * @param options Options for narrowing the search.
    * @return a `HarnessPredicate` configured with the given options.
    */
-  static with(options: TooltipHarnessFilters = {}): HarnessPredicate<MatTooltipHarness> {
-    return new HarnessPredicate(MatTooltipHarness, options);
+  static with<T extends MatTooltipHarness>(
+    this: ComponentHarnessConstructor<T>,
+    options: TooltipHarnessFilters = {},
+  ): HarnessPredicate<T> {
+    return new HarnessPredicate(this, options);
   }
 }


### PR DESCRIPTION
Add the capability to extend a harness without having to duplicate the `with` method
used to load it. This was necessary before because the returned predicate was of type
the parent harness which resulted in loading a harness instance of the parent type
instead of the derived class unless the method is overridden.