### PR TITLE
fix(material/expansion): inconsistent spacing for anchor buttons

### DIFF
--- a/src/material/expansion/expansion-panel.scss
+++ b/src/material/expansion/expansion-panel.scss
@@ -88,7 +88,7 @@
   justify-content: flex-end;
   padding: 16px 8px 16px 24px;
 
-  button.mat-button-base, button.mat-mdc-button-base {
+  .mat-button-base, .mat-mdc-button-base {
     margin-left: 8px;
 
     [dir='rtl'] & {


### PR DESCRIPTION
Fixes that the expansion panel was applying the margin only to `mat-button` set on a `button` node.