### PR TITLE
build: invalidate github action cache to prune old files

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -11,8 +11,8 @@ runs:
         # Cache key. Whenever the postinstall patches change, the cache needs to be invalidated.
         # If just the `yarn.lock` file changes, the most recent cache can be restored though.
         # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action.
-        key: v3-${{hashFiles('tools/postinstall/apply-patches.js')}}-${{hashFiles('yarn.lock')}}
-        restore-keys: v3-${{hashFiles('tools/postinstall/apply-patches.js')}}-
+        key: v4-${{hashFiles('tools/postinstall/apply-patches.js')}}-${{hashFiles('yarn.lock')}}
+        restore-keys: v4-${{hashFiles('tools/postinstall/apply-patches.js')}}-
 
     - run: yarn install --frozen-lockfile --non-interactive
       shell: bash


### PR DESCRIPTION
With Angular v14, and the CLDR update one of the files got renamed
just in casing. Yarn 1.x. does not seem to prune the old files
causing two files to have the same name (ignoring casing). This throws
off Bazel and we need to prune the cache like we did for CircleCI.