### PR TITLE
refactor(google-maps): expose event manager

### DIFF
--- a/src/google-maps/public-api.ts
+++ b/src/google-maps/public-api.ts
@@ -35,3 +35,4 @@ export {
   AriaLabelFn,
   Calculator,
 } from './map-marker-clusterer/marker-clusterer-types';
+export {MapEventManager} from './map-event-manager';

--- a/tools/public_api_guard/google-maps/google-maps.md
+++ b/tools/public_api_guard/google-maps/google-maps.md
@@ -292,6 +292,14 @@ export class MapDirectionsService {
 }
 
 // @public
+export class MapEventManager {
+    constructor(_ngZone: NgZone);
+    destroy(): void;
+    getLazyEmitter<T>(name: string): Observable<T>;
+    setTarget(target: MapEventManagerTarget): void;
+}
+
+// @public
 export class MapGeocoder {
     constructor(_ngZone: NgZone);
     geocode(request: google.maps.GeocoderRequest): Observable<MapGeocoderResponse>;


### PR DESCRIPTION
Exposes the `MapEventManager` that we use to bind events in the Google Maps package so that users implementing their own components can consume it as well.