### PR TITLE
CDK dialog docs

### DIFF
--- a/src/cdk/dialog/dialog.md
+++ b/src/cdk/dialog/dialog.md
@@ -1,1 +1,189 @@
-<!-- TODO -->
+The `Dialog` service can be used to open unstyled modal dialogs and to build your own dialog
+services.
+
+<!-- example(cdk-dialog-overview) -->
+
+You can open a dialog by calling the `open` method either with a component or with a `TemplateRef`
+representing the dialog content. The method additionally accepts an optional configuration object.
+The `open` method returns a `DialogRef` instance:
+
+```ts
+const dialogRef = dialog.open(UserProfileComponent, {
+  height: '400px',
+  width: '600px',
+  panelClass: 'my-dialog',
+});
+```
+
+The `DialogRef` provides a reference to the opened dialog. You can use the `DialogRef` to close the
+dialog, subscribe to dialog events, and modify dialog state. All `Observable` instances on the
+`DialogRef` complete when the dialog closes.
+
+```ts
+dialogRef.closed.subscribe(result => {
+  console.log(`Dialog result: ${result}`); // Pizza!
+});
+
+dialogRef.close('Pizza!');
+```
+
+Components created via `Dialog` can _inject_ `DialogRef` and use it to close the dialog
+in which they are contained. When closing, an optional result value can be provided. This result
+value is forwarded as the result of the `closed` Observable.
+
+```ts
+@Component({/* ... */})
+export class YourDialog {
+  constructor(public dialogRef: DialogRef<string>) {}
+
+  closeDialog() {
+    this.dialogRef.close('Pizza!');
+  }
+}
+```
+
+### Dialog styling
+
+The `Dialog` service includes an intentionally limited set of structural styles. You can customize
+the dialog's appearance using one of the following approaches.
+
+#### `panelClass` option
+The `panelClass` property of `DialogConfig` allows you to apply one or more CSS classes to the
+overlay element that contains the custom dialog content. Any styles targeting these CSS classes
+must be global styles.
+
+#### Styling the dialog component
+You can use the `styles` or `styleUrls` of a custom component to style the dialog content:
+
+```ts
+// MyDialog is rendered via `dialog.open(MyDialog)`
+@Component({
+  selector: 'my-dialog',
+  styles: [`
+    :host {
+      display: block;
+      background: #fff;
+      border-radius: 8px;
+      padding: 16px;
+    }
+  `]
+})
+class MyDialog {}
+```
+
+<!-- example(cdk-dialog-styling) -->
+
+#### Providing a custom dialog contaier
+If you want more control over the dialog's behavior and styling, you can provide your own dialog
+container component using the `container` option in `DialogConfig`. This approach requires more
+code up-front, but it allows you to customize the DOM structure and behavior of the container
+around the dialog content. Custom container components can optionally extend `CdkDialogContainer`
+to inherit standard behaviors, such as accessible focus management.
+
+```ts
+import {CdkDialogContainer} from '@angular/cdk/dialog';
+
+@Component({
+  selector: 'my-dialog-container',
+  styles: [`
+    :host {
+      display: block;
+      background: #fff;
+      border-radius: 8px;
+      padding: 16px;
+    }
+  `]
+})
+class MyDialogContainer extends CdkDialogContainer {}
+```
+
+### Specifying global configuration defaults
+Default dialog options can be specified by providing an instance of `DialogConfig` for
+`DEFAULT_DIALOG_CONFIG` in your application's root module.
+
+```ts
+@NgModule({
+  providers: [
+    {provide: DEFAULT_DIALOG_CONFIG, useValue: {hasBackdrop: false}}
+  ]
+})
+```
+
+### Sharing data with the Dialog component.
+You can use the `data` option to pass information to the dialog component.
+
+```ts
+const dialogRef = dialog.open(YourDialog, {
+  data: {name: 'frodo'},
+});
+```
+
+Access the data in your dialog component with the `DIALOG_DATA` injection token:
+
+```ts
+import {Component, Inject} from '@angular/core';
+import {DIALOG_DATA} from '@angular/cdk/dialog';
+
+@Component({
+  selector: 'your-dialog',
+  template: 'passed in {{ data.name }}',
+})
+export class YourDialog {
+  constructor(@Inject(DIALOG_DATA) public data: {name: string}) { }
+}
+```
+
+If you're using a `TemplateRef` for your dialog content, the data is available in the template:
+
+```html
+<ng-template let-data>
+  Hello, {{data.name}}
+</ng-template>
+```
+
+<!-- example(cdk-dialog-data) -->
+
+### Accessibility
+
+`Dialog` creates modal dialogs that implement the ARIA `role="dialog"` pattern by default.
+You can change the dialog's role to `alertdialog` via the `DialogConfig`.
+
+You should provide an accessible label to this root dialog element by setting the `ariaLabel` or
+`ariaLabelledBy` properties of `DialogConfig`. You can additionally specify a description element
+ID via the `ariaDescribedBy` property of `DialogConfig`.
+
+#### Keyboard interaction
+
+By default, the escape key closes `Dialog`. While you can disable this behavior via the
+`disableClose` property of `DialogConfig`, doing this breaks the expected interaction pattern
+for the ARIA `role="dialog"` pattern.
+
+#### Focus management
+
+When opened, `Dialog` traps browser focus such that it cannot escape the root
+`role="dialog"` element. By default, the first tabbable element in the dialog receives focus.
+You can customize which element receives focus with the `autoFocus` property of
+`DialogConfig`, which supports the following values.
+
+| Value            | Behavior                                                                 |
+|------------------|--------------------------------------------------------------------------|
+| `first-tabbable` | Focus the first tabbable element. This is the default setting.           |
+| `first-header`   | Focus the first header element (`role="heading"`, `h1` through `h6`)     |
+| `dialog`         | Focus the root `role="dialog"` element.                                  |
+| Any CSS selector | Focus the first element matching the given selector.                     |
+
+While the default setting applies the best behavior for most applications, special cases may benefit
+from these alternatives. Always test your application to verify the behavior that works best for
+your users.
+
+#### Focus restoration
+
+When closed, `Dialog` restores focus to the element that previously held focus when the
+dialog opened by default. You can customize the focus restoration behavior using the `restoreFocus`
+property of `DialogConfig`. It supports the following values.
+
+| Value type       | Behavior                                                                                                         |
+|------------------|------------------------------------------------------------------------------------------------------------------|
+| `boolean`        | When `true`, focus will be restored to the previously-focused element, otherwise focus won't be restored at all. |
+| `string`         | Value is treated as a CSS selector. Focus will be restored to the element matching the selector.                 |
+| `HTMLElement`    | Specific element that focus should be restored to.                                                               |

--- a/src/components-examples/cdk/dialog/BUILD.bazel
+++ b/src/components-examples/cdk/dialog/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "dialog",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*.spec.ts"],
+    ),
+    assets = glob([
+        "**/*.html",
+        "**/*.css",
+    ]),
+    deps = [
+        "//src/cdk/dialog",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+        "@npm//@angular/platform-browser-dynamic",
+    ],
+)
+
+filegroup(
+    name = "source-files",
+    srcs = glob([
+        "**/*.html",
+        "**/*.css",
+        "**/*.ts",
+    ]),
+)

--- a/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example-dialog.css
+++ b/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example-dialog.css
@@ -1,0 +1,6 @@
+:host {
+  display: block;
+  background: #fff;
+  border-radius: 8px;
+  padding: 8px 16px;
+}

--- a/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example-dialog.html
+++ b/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example-dialog.html
@@ -1,0 +1,15 @@
+<h1>Favorite Animal</h1>
+<div>
+  My favorite animal is:
+  <ul>
+    <li>
+      <span *ngIf="data.animal === 'panda'">&#10003;</span> Panda
+    </li>
+    <li>
+      <span *ngIf="data.animal === 'unicorn'">&#10003;</span> Unicorn
+    </li>
+    <li>
+      <span *ngIf="data.animal === 'lion'">&#10003;</span> Lion
+    </li>
+  </ul>
+</div>

--- a/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example.html
+++ b/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example.html
@@ -1,0 +1,1 @@
+<button (click)="openDialog()">Open dialog</button>

--- a/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example.ts
+++ b/src/components-examples/cdk/dialog/cdk-dialog-data/cdk-dialog-data-example.ts
@@ -1,0 +1,35 @@
+import {Component, Inject} from '@angular/core';
+import {Dialog, DIALOG_DATA} from '@angular/cdk/dialog';
+
+export interface DialogData {
+  animal: 'panda' | 'unicorn' | 'lion';
+}
+
+/**
+ * @title Injecting data when opening a dialog
+ */
+@Component({
+  selector: 'cdk-dialog-data-example',
+  templateUrl: 'cdk-dialog-data-example.html',
+})
+export class CdkDialogDataExample {
+  constructor(public dialog: Dialog) {}
+
+  openDialog() {
+    this.dialog.open(CdkDialogDataExampleDialog, {
+      minWidth: '300px',
+      data: {
+        animal: 'panda',
+      },
+    });
+  }
+}
+
+@Component({
+  selector: 'cdk-dialog-data-example-dialog',
+  templateUrl: 'cdk-dialog-data-example-dialog.html',
+  styleUrls: ['./cdk-dialog-data-example-dialog.css'],
+})
+export class CdkDialogDataExampleDialog {
+  constructor(@Inject(DIALOG_DATA) public data: DialogData) {}
+}

--- a/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example-dialog.css
+++ b/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example-dialog.css
@@ -1,0 +1,14 @@
+:host {
+  display: block;
+  background: #fff;
+  border-radius: 8px;
+  padding: 8px 16px 16px;
+}
+
+input {
+  margin: 8px 0;
+}
+
+button + button {
+  margin-left: 8px;
+}

--- a/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example-dialog.html
+++ b/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example-dialog.html
@@ -1,0 +1,9 @@
+<h1>Hi {{data.name}}</h1>
+<div>
+  <label id="favorite-animal">What's your favorite animal?</label>
+  <input for="favorite-animal" [(ngModel)]="data.animal" placeholder="Enter your name">
+</div>
+<div>
+  <button (click)="dialogRef.close(data.animal)">OK</button>
+  <button (click)="dialogRef.close()">Cancel</button>
+</div>

--- a/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example.html
+++ b/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example.html
@@ -1,0 +1,12 @@
+<ol>
+  <li>
+    <label id="dialog-user-name">What's your name?</label>
+    <input for="dialog-user-name" [(ngModel)]="name">
+  </li>
+  <li>
+    <button (click)="openDialog()">Pick one</button>
+  </li>
+  <li *ngIf="animal">
+    You chose: <i>{{animal}}</i>
+  </li>
+</ol>

--- a/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example.ts
+++ b/src/components-examples/cdk/dialog/cdk-dialog-overview/cdk-dialog-overview-example.ts
@@ -1,0 +1,42 @@
+import {Component, Inject} from '@angular/core';
+import {Dialog, DialogRef, DIALOG_DATA} from '@angular/cdk/dialog';
+
+export interface DialogData {
+  animal: string;
+  name: string;
+}
+
+/**
+ * @title CDK Dialog Overview
+ */
+@Component({
+  selector: 'cdk-dialog-overview-example',
+  templateUrl: 'cdk-dialog-overview-example.html',
+})
+export class CdkDialogOverviewExample {
+  animal: string | undefined;
+  name: string;
+
+  constructor(public dialog: Dialog) {}
+
+  openDialog(): void {
+    const dialogRef = this.dialog.open<string>(CdkDialogOverviewExampleDialog, {
+      width: '250px',
+      data: {name: this.name, animal: this.animal},
+    });
+
+    dialogRef.closed.subscribe(result => {
+      console.log('The dialog was closed');
+      this.animal = result;
+    });
+  }
+}
+
+@Component({
+  selector: 'cdk-dialog-overview-example-dialog',
+  templateUrl: 'cdk-dialog-overview-example-dialog.html',
+  styleUrls: ['cdk-dialog-overview-example-dialog.css'],
+})
+export class CdkDialogOverviewExampleDialog {
+  constructor(public dialogRef: DialogRef<string>, @Inject(DIALOG_DATA) public data: DialogData) {}
+}

--- a/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example-dialog.css
+++ b/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example-dialog.css
@@ -1,0 +1,18 @@
+:host {
+  display: block;
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  max-width: 500px;
+  animation: custom-dialog-enter 1s ease;
+}
+
+@keyframes custom-dialog-enter {
+  from {
+    transform: scale(0) rotate(360deg);
+  }
+
+  to {
+    transform: none;
+  }
+}

--- a/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example-dialog.html
+++ b/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example-dialog.html
@@ -1,0 +1,12 @@
+Did you ever hear the tragedy of Darth Plagueis The Wise? I thought not. It's not a story the Jedi
+would tell you. It's a Sith legend. Darth Plagueis was a Dark Lord of the Sith, so powerful and so
+wise he could use the Force to influence the midichlorians to create life… He had such a knowledge
+of the dark side that he could even keep the ones he cared about from dying. The dark side of the
+Force is a pathway to many abilities some consider to be unnatural. He became so powerful… the only
+thing he was afraid of was losing his power, which eventually, of course, he did. Unfortunately,
+he taught his apprentice everything he knew, then his apprentice killed him in his sleep. Ironic.
+He could save others from death, but not himself.
+
+<hr>
+
+<button (click)="dialogRef.close()">Close</button>

--- a/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example.html
+++ b/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example.html
@@ -1,0 +1,1 @@
+<button (click)="openDialog()">Open custom dialog</button>

--- a/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example.ts
+++ b/src/components-examples/cdk/dialog/cdk-dialog-styling/cdk-dialog-styling-example.ts
@@ -1,0 +1,26 @@
+import {Component} from '@angular/core';
+import {Dialog, DialogRef} from '@angular/cdk/dialog';
+
+/**
+ * @title CDK Dialog Styling
+ */
+@Component({
+  selector: 'cdk-dialog-styling-example',
+  templateUrl: 'cdk-dialog-styling-example.html',
+})
+export class CdkDialogStylingExample {
+  constructor(public dialog: Dialog) {}
+
+  openDialog(): void {
+    this.dialog.open<string>(CdkDialogStylingExampleDialog);
+  }
+}
+
+@Component({
+  selector: 'cdk-dialog-styling-example-dialog',
+  templateUrl: 'cdk-dialog-styling-example-dialog.html',
+  styleUrls: ['cdk-dialog-styling-example-dialog.css'],
+})
+export class CdkDialogStylingExampleDialog {
+  constructor(public dialogRef: DialogRef) {}
+}

--- a/src/components-examples/cdk/dialog/index.ts
+++ b/src/components-examples/cdk/dialog/index.ts
@@ -1,0 +1,41 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {DialogModule} from '@angular/cdk/dialog';
+import {
+  CdkDialogDataExample,
+  CdkDialogDataExampleDialog,
+} from './cdk-dialog-data/cdk-dialog-data-example';
+import {
+  CdkDialogOverviewExample,
+  CdkDialogOverviewExampleDialog,
+} from './cdk-dialog-overview/cdk-dialog-overview-example';
+import {
+  CdkDialogStylingExample,
+  CdkDialogStylingExampleDialog,
+} from './cdk-dialog-styling/cdk-dialog-styling-example';
+
+export {
+  CdkDialogDataExample,
+  CdkDialogDataExampleDialog,
+  CdkDialogOverviewExample,
+  CdkDialogOverviewExampleDialog,
+  CdkDialogStylingExample,
+  CdkDialogStylingExampleDialog,
+};
+
+const EXAMPLES = [
+  CdkDialogDataExample,
+  CdkDialogDataExampleDialog,
+  CdkDialogOverviewExample,
+  CdkDialogOverviewExampleDialog,
+  CdkDialogStylingExample,
+  CdkDialogStylingExampleDialog,
+];
+
+@NgModule({
+  imports: [CommonModule, DialogModule, FormsModule],
+  declarations: EXAMPLES,
+  exports: EXAMPLES,
+})
+export class DialogExamplesModule {}

--- a/src/components-examples/config.bzl
+++ b/src/components-examples/config.bzl
@@ -56,6 +56,7 @@ ALL_EXAMPLES = [
     "//src/components-examples/cdk/layout",
     "//src/components-examples/cdk/menu",
     "//src/components-examples/cdk/overlay",
+    "//src/components-examples/cdk/dialog",
     "//src/components-examples/cdk-experimental/popover-edit",
     "//src/components-examples/cdk-experimental/selection",
 ]

--- a/src/material/dialog/dialog.md
+++ b/src/material/dialog/dialog.md
@@ -118,37 +118,6 @@ You can control which elements are tab stops with the `tabindex` attribute
 
 <!-- example(dialog-content) -->
 
-### Configuring dialog content via `entryComponents`
-
-Because `MatDialog` instantiates components at run-time, the Angular compiler needs extra
-information to create the necessary `ComponentFactory` for your dialog content component.
-
-For any component loaded into a dialog, you must include your component class in the list of
-`entryComponents` in your NgModule definition so that the Angular compiler knows to create
-the `ComponentFactory` for it.
-
-```ts
-@NgModule({
-  imports: [
-    // ...
-    MatDialogModule
-  ],
-
-  declarations: [
-    AppComponent,
-    ExampleDialogComponent
-  ],
-
-  entryComponents: [
-    ExampleDialogComponent
-  ],
-
-  providers: [],
-  bootstrap: [AppComponent]
-})
-export class AppModule {}
-```
-
 ### Controlling the dialog animation
 You can control the duration of the dialog's enter and exit animations using the
 `enterAnimationDuration` and `exitAnimationDuration` options. If you want to disable the dialog's


### PR DESCRIPTION
Adds docs and live examples for the CDK dialog. Also removes the section about `entryComponents` from the Material dialog.