### PR TITLE
refactor(material-experimental/mdc-slide-toggle): remove usage of MDC adapter

### DIFF
--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.html
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.html
@@ -6,6 +6,8 @@
     type="button"
     [class.mdc-switch--selected]="checked"
     [class.mdc-switch--unselected]="!checked"
+    [class.mdc-switch--checked]="checked"
+    [class.mdc-switch--disabled]="disabled"
     [tabIndex]="tabIndex"
     [disabled]="disabled"
     [attr.id]="buttonId"
@@ -14,7 +16,8 @@
     [attr.aria-labelledby]="_getAriaLabelledBy()"
     [attr.aria-describedby]="ariaDescribedby"
     [attr.aria-required]="required || null"
-    (click)="_handleClick($event)"
+    [attr.aria-checked]="checked"
+    (click)="_handleClick()"
     #switch>
     <div class="mdc-switch__track"></div>
     <div class="mdc-switch__handle-track">

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.spec.ts
@@ -220,7 +220,7 @@ describe('MDC-based MatSlideToggle without forms', () => {
 
       // We fall back to pointing to the label if a value isn't provided.
       expect(buttonElement.getAttribute('aria-labelledby')).toMatch(
-        /mat-mdc-slide-toggle-label-\d+/,
+        /mat-mdc-slide-toggle-\d+-label/,
       );
     }));
 

--- a/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
+++ b/src/material-experimental/mdc-slide-toggle/slide-toggle.ts
@@ -10,40 +10,25 @@ import {
   ChangeDetectionStrategy,
   Component,
   ViewEncapsulation,
-  AfterViewInit,
-  OnDestroy,
   forwardRef,
   ViewChild,
   ElementRef,
-  Input,
-  Output,
-  EventEmitter,
   ChangeDetectorRef,
   Attribute,
   Inject,
   Optional,
 } from '@angular/core';
-import {deprecated} from '@material/switch';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {
-  BooleanInput,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-  NumberInput,
-} from '@angular/cdk/coercion';
+import {NG_VALUE_ACCESSOR} from '@angular/forms';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
-import {ThemePalette} from '@angular/material-experimental/mdc-core';
 import {FocusMonitor} from '@angular/cdk/a11y';
+import {_MatSlideToggleBase} from '@angular/material/slide-toggle';
 import {
   MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS,
   MatSlideToggleDefaultOptions,
 } from './slide-toggle-config';
 
-// Increasing integer for generating unique ids for slide-toggle components.
-let nextUniqueId = 0;
-
 /** @docs-private */
-export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
+export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => MatSlideToggle),
   multi: true,
@@ -63,6 +48,7 @@ export class MatSlideToggleChange {
   selector: 'mat-slide-toggle',
   templateUrl: 'slide-toggle.html',
   styleUrls: ['slide-toggle.css'],
+  inputs: ['disabled', 'disableRipple', 'color', 'tabIndex'],
   host: {
     'class': 'mat-mdc-slide-toggle',
     '[id]': 'id',
@@ -71,9 +57,6 @@ export class MatSlideToggleChange {
     '[attr.aria-label]': 'null',
     '[attr.name]': 'null',
     '[attr.aria-labelledby]': 'null',
-    '[class.mat-primary]': 'color === "primary"',
-    '[class.mat-accent]': 'color !== "primary" && color !== "warn"',
-    '[class.mat-warn]': 'color === "warn"',
     '[class.mat-mdc-slide-toggle-focused]': '_focused',
     '[class.mat-mdc-slide-toggle-checked]': 'checked',
     '[class._mat-animation-noopable]': '_noopAnimations',
@@ -83,116 +66,9 @@ export class MatSlideToggleChange {
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [MAT_SLIDE_TOGGLE_VALUE_ACCESSOR],
 })
-export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDestroy {
-  private _onChange = (_: any) => {};
-  private _onTouched = () => {};
-
-  private _uniqueId: string = `mat-mdc-slide-toggle-${++nextUniqueId}`;
-  private _required: boolean = false;
-  private _checked: boolean = false;
-  private _foundation: deprecated.MDCSwitchFoundation;
-  private _adapter: deprecated.MDCSwitchAdapter = {
-    addClass: className => this._switchElement.nativeElement.classList.add(className),
-    removeClass: className => this._switchElement.nativeElement.classList.remove(className),
-    setNativeControlChecked: checked => (this._checked = checked),
-    setNativeControlDisabled: disabled => (this._disabled = disabled),
-    setNativeControlAttr: (name, value) => {
-      this._switchElement.nativeElement.setAttribute(name, value);
-    },
-  };
-
-  /** Whether the slide toggle is currently focused. */
-  _focused: boolean;
-
-  /** Whether noop animations are enabled. */
-  _noopAnimations: boolean;
-
+export class MatSlideToggle extends _MatSlideToggleBase<MatSlideToggleChange> {
   /** Unique ID for the label element. */
-  _labelId = `mat-mdc-slide-toggle-label-${++nextUniqueId}`;
-
-  /** The color palette  for this slide toggle. */
-  @Input() color: ThemePalette;
-
-  /** Name value will be applied to the button element if present. */
-  @Input() name: string | null = null;
-
-  /** A unique id for the slide-toggle button. If none is supplied, it will be auto-generated. */
-  @Input() id: string = this._uniqueId;
-
-  /** Tabindex for the input element. */
-  @Input()
-  get tabIndex(): number {
-    return this._tabIndex;
-  }
-  set tabIndex(value: NumberInput) {
-    this._tabIndex = coerceNumberProperty(value);
-  }
-  private _tabIndex: number;
-
-  /** Whether the label should appear after or before the slide-toggle. Defaults to 'after'. */
-  @Input() labelPosition: 'before' | 'after' = 'after';
-
-  /** Used to set the aria-label attribute on the underlying button element. */
-  @Input('aria-label') ariaLabel: string | null = null;
-
-  /** Used to set the aria-labelledby attribute on the underlying button element. */
-  @Input('aria-labelledby') ariaLabelledby: string | null = null;
-
-  /** Used to set the aria-describedby attribute on the underlying button element. */
-  @Input('aria-describedby') ariaDescribedby: string;
-
-  /** Whether the slide-toggle is required. */
-  @Input()
-  get required(): boolean {
-    return this._required;
-  }
-  set required(value: BooleanInput) {
-    this._required = coerceBooleanProperty(value);
-  }
-
-  /** Whether the slide-toggle element is checked or not. */
-  @Input()
-  get checked(): boolean {
-    return this._checked;
-  }
-  set checked(value: BooleanInput) {
-    this._checked = coerceBooleanProperty(value);
-
-    if (this._foundation) {
-      this._foundation.setChecked(this._checked);
-    }
-  }
-
-  /** Whether to disable the ripple on this checkbox. */
-  @Input()
-  get disableRipple(): boolean {
-    return this._disableRipple;
-  }
-  set disableRipple(disableRipple: BooleanInput) {
-    this._disableRipple = coerceBooleanProperty(disableRipple);
-  }
-  private _disableRipple = false;
-
-  /** Whether the slide toggle is disabled. */
-  @Input()
-  get disabled(): boolean {
-    return this._disabled;
-  }
-  set disabled(disabled: BooleanInput) {
-    this._disabled = coerceBooleanProperty(disabled);
-
-    if (this._foundation) {
-      this._foundation.setDisabled(this._disabled);
-    }
-  }
-  private _disabled = false;
-
-  /** An event will be dispatched each time the slide-toggle changes its value. */
-  @Output() readonly change: EventEmitter<MatSlideToggleChange> =
-    new EventEmitter<MatSlideToggleChange>();
-
-  /** Event will be dispatched each time the slide-toggle input is toggled. */
-  @Output() readonly toggleChange: EventEmitter<void> = new EventEmitter<void>();
+  _labelId: string;
 
   /** Returns the unique id for the visual hidden button. */
   get buttonId(): string {
@@ -203,51 +79,29 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
   @ViewChild('switch') _switchElement: ElementRef<HTMLElement>;
 
   constructor(
-    private _elementRef: ElementRef,
-    private _focusMonitor: FocusMonitor,
-    private _changeDetectorRef: ChangeDetectorRef,
+    elementRef: ElementRef,
+    focusMonitor: FocusMonitor,
+    changeDetectorRef: ChangeDetectorRef,
     @Attribute('tabindex') tabIndex: string,
     @Inject(MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS)
-    public defaults: MatSlideToggleDefaultOptions,
+    defaults: MatSlideToggleDefaultOptions,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
   ) {
-    this.tabIndex = parseInt(tabIndex) || 0;
-    this.color = defaults.color || 'accent';
-    this._noopAnimations = animationMode === 'NoopAnimations';
-  }
-
-  ngAfterViewInit() {
-    const foundation = (this._foundation = new deprecated.MDCSwitchFoundation(this._adapter));
-    foundation.setDisabled(this.disabled);
-    foundation.setChecked(this.checked);
-
-    this._focusMonitor.monitor(this._elementRef, true).subscribe(focusOrigin => {
-      if (focusOrigin === 'keyboard' || focusOrigin === 'program') {
-        this._focused = true;
-      } else if (!focusOrigin) {
-        // When a focused element becomes disabled, the browser *immediately* fires a blur event.
-        // Angular does not expect events to be raised during change detection, so any state
-        // change (such as a form control's ng-touched) will cause a changed-after-checked error.
-        // See https://github.com/angular/angular/issues/17793. To work around this, we defer
-        // telling the form control it has been touched until the next tick.
-        Promise.resolve().then(() => {
-          this._focused = false;
-          this._onTouched();
-          this._changeDetectorRef.markForCheck();
-        });
-      }
-    });
-  }
-
-  ngOnDestroy() {
-    this._focusMonitor.stopMonitoring(this._elementRef);
-    this._foundation?.destroy();
+    super(
+      elementRef,
+      focusMonitor,
+      changeDetectorRef,
+      tabIndex,
+      defaults,
+      animationMode,
+      'mat-mdc-slide-toggle-',
+    );
+    this._labelId = this._uniqueId + '-label';
   }
 
   /** Method being called whenever the underlying button is clicked. */
-  _handleClick(event: Event) {
+  _handleClick() {
     this.toggleChange.emit();
-    this._foundation.handleChange(event);
 
     if (!this.defaults.disableToggleValue) {
       this.checked = !this.checked;
@@ -256,37 +110,13 @@ export class MatSlideToggle implements ControlValueAccessor, AfterViewInit, OnDe
     }
   }
 
-  /** Implemented as part of ControlValueAccessor. */
-  writeValue(value: any): void {
-    this.checked = !!value;
-    this._changeDetectorRef.markForCheck();
-  }
-
-  /** Implemented as part of ControlValueAccessor. */
-  registerOnChange(fn: any): void {
-    this._onChange = fn;
-  }
-
-  /** Implemented as part of ControlValueAccessor. */
-  registerOnTouched(fn: any): void {
-    this._onTouched = fn;
-  }
-
-  /** Implemented as a part of ControlValueAccessor. */
-  setDisabledState(isDisabled: boolean): void {
-    this.disabled = isDisabled;
-    this._changeDetectorRef.markForCheck();
-  }
-
   /** Focuses the slide-toggle. */
   focus(): void {
     this._switchElement.nativeElement.focus();
   }
 
-  /** Toggles the checked state of the slide-toggle. */
-  toggle(): void {
-    this.checked = !this.checked;
-    this._onChange(this.checked);
+  protected _createChangeEvent(isChecked: boolean) {
+    return new MatSlideToggleChange(this, isChecked);
   }
 
   _getAriaLabelledBy() {

--- a/src/material/slide-toggle/slide-toggle.html
+++ b/src/material/slide-toggle/slide-toggle.html
@@ -1,5 +1,5 @@
 <label [attr.for]="inputId" class="mat-slide-toggle-label" #label>
-  <span #toggleBar class="mat-slide-toggle-bar"
+  <span class="mat-slide-toggle-bar"
        [class.mat-slide-toggle-bar-no-side-margin]="!labelContent.textContent || !labelContent.textContent.trim()">
 
     <input #input class="mat-slide-toggle-input cdk-visually-hidden" type="checkbox"
@@ -17,7 +17,7 @@
            (change)="_onChangeEvent($event)"
            (click)="_onInputClick($event)">
 
-    <span class="mat-slide-toggle-thumb-container" #thumbContainer>
+    <span class="mat-slide-toggle-thumb-container">
       <span class="mat-slide-toggle-thumb"></span>
       <span class="mat-slide-toggle-ripple mat-focus-indicator" mat-ripple
            [matRippleTrigger]="label"

--- a/src/material/slide-toggle/slide-toggle.ts
+++ b/src/material/slide-toggle/slide-toggle.ts
@@ -24,6 +24,7 @@ import {
   ViewEncapsulation,
   Optional,
   Inject,
+  Directive,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {
@@ -46,7 +47,7 @@ import {
 let nextUniqueId = 0;
 
 /** @docs-private */
-export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: any = {
+export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => MatSlideToggle),
   multi: true,
@@ -64,7 +65,7 @@ export class MatSlideToggleChange {
 
 // Boilerplate for applying mixins to MatSlideToggle.
 /** @docs-private */
-const _MatSlideToggleBase = mixinTabIndex(
+const _MatSlideToggleMixinBase = mixinTabIndex(
   mixinColor(
     mixinDisableRipple(
       mixinDisabled(
@@ -76,32 +77,9 @@ const _MatSlideToggleBase = mixinTabIndex(
   ),
 );
 
-/** Represents a slidable "switch" toggle that can be moved between on and off. */
-@Component({
-  selector: 'mat-slide-toggle',
-  exportAs: 'matSlideToggle',
-  host: {
-    'class': 'mat-slide-toggle',
-    '[id]': 'id',
-    // Needs to be removed since it causes some a11y issues (see #21266).
-    '[attr.tabindex]': 'null',
-    '[attr.aria-label]': 'null',
-    '[attr.aria-labelledby]': 'null',
-    '[attr.name]': 'null',
-    '[class.mat-checked]': 'checked',
-    '[class.mat-disabled]': 'disabled',
-    '[class.mat-slide-toggle-label-before]': 'labelPosition == "before"',
-    '[class._mat-animation-noopable]': '_noopAnimations',
-  },
-  templateUrl: 'slide-toggle.html',
-  styleUrls: ['slide-toggle.css'],
-  providers: [MAT_SLIDE_TOGGLE_VALUE_ACCESSOR],
-  inputs: ['disabled', 'disableRipple', 'color', 'tabIndex'],
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-export class MatSlideToggle
-  extends _MatSlideToggleBase
+@Directive()
+export abstract class _MatSlideToggleBase<T>
+  extends _MatSlideToggleMixinBase
   implements
     OnDestroy,
     AfterContentInit,
@@ -111,27 +89,27 @@ export class MatSlideToggle
     HasTabIndex,
     CanDisableRipple
 {
-  private _onChange = (_: any) => {};
+  protected _onChange = (_: any) => {};
   private _onTouched = () => {};
 
-  private _uniqueId: string = `mat-slide-toggle-${++nextUniqueId}`;
+  protected _uniqueId: string;
   private _required: boolean = false;
   private _checked: boolean = false;
+
+  protected abstract _createChangeEvent(isChecked: boolean): T;
+  abstract focus(options?: FocusOptions, origin?: FocusOrigin): void;
 
   /** Whether noop animations are enabled. */
   _noopAnimations: boolean;
 
-  /** Reference to the thumb HTMLElement. */
-  @ViewChild('thumbContainer') _thumbEl: ElementRef;
-
-  /** Reference to the thumb bar HTMLElement. */
-  @ViewChild('toggleBar') _thumbBarEl: ElementRef;
+  /** Whether the slide toggle is currently focused. */
+  _focused: boolean;
 
   /** Name value will be applied to the input element if present. */
   @Input() name: string | null = null;
 
   /** A unique id for the slide-toggle input. If none is supplied, it will be auto-generated. */
-  @Input() id: string = this._uniqueId;
+  @Input() id: string;
 
   /** Whether the label should appear after or before the slide-toggle. Defaults to 'after'. */
   @Input() labelPosition: 'before' | 'after' = 'after';
@@ -164,8 +142,7 @@ export class MatSlideToggle
     this._changeDetectorRef.markForCheck();
   }
   /** An event will be dispatched each time the slide-toggle changes its value. */
-  @Output() readonly change: EventEmitter<MatSlideToggleChange> =
-    new EventEmitter<MatSlideToggleChange>();
+  @Output() readonly change: EventEmitter<T> = new EventEmitter<T>();
 
   /**
    * An event will be dispatched each time the slide-toggle input is toggled.
@@ -179,39 +156,131 @@ export class MatSlideToggle
     return `${this.id || this._uniqueId}-input`;
   }
 
-  /** Reference to the underlying input element. */
-  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
-
   constructor(
     elementRef: ElementRef,
-    private _focusMonitor: FocusMonitor,
-    private _changeDetectorRef: ChangeDetectorRef,
-    @Attribute('tabindex') tabIndex: string,
-    @Inject(MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS)
+    protected _focusMonitor: FocusMonitor,
+    protected _changeDetectorRef: ChangeDetectorRef,
+    tabIndex: string,
     public defaults: MatSlideToggleDefaultOptions,
-    @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
+    animationMode: string | undefined,
+    idPrefix: string,
   ) {
     super(elementRef);
     this.tabIndex = parseInt(tabIndex) || 0;
     this.color = this.defaultColor = defaults.color || 'accent';
     this._noopAnimations = animationMode === 'NoopAnimations';
+    this.id = this._uniqueId = `${idPrefix}${++nextUniqueId}`;
   }
 
   ngAfterContentInit() {
     this._focusMonitor.monitor(this._elementRef, true).subscribe(focusOrigin => {
-      if (!focusOrigin) {
+      if (focusOrigin === 'keyboard' || focusOrigin === 'program') {
+        this._focused = true;
+      } else if (!focusOrigin) {
         // When a focused element becomes disabled, the browser *immediately* fires a blur event.
         // Angular does not expect events to be raised during change detection, so any state
-        // change (such as a form control's 'ng-touched') will cause a changed-after-checked
-        // error. See https://github.com/angular/angular/issues/17793. To work around this,
-        // we defer telling the form control it has been touched until the next tick.
-        Promise.resolve().then(() => this._onTouched());
+        // change (such as a form control's ng-touched) will cause a changed-after-checked error.
+        // See https://github.com/angular/angular/issues/17793. To work around this, we defer
+        // telling the form control it has been touched until the next tick.
+        Promise.resolve().then(() => {
+          this._focused = false;
+          this._onTouched();
+          this._changeDetectorRef.markForCheck();
+        });
       }
     });
   }
 
   ngOnDestroy() {
     this._focusMonitor.stopMonitoring(this._elementRef);
+  }
+
+  /** Implemented as part of ControlValueAccessor. */
+  writeValue(value: any): void {
+    this.checked = !!value;
+  }
+
+  /** Implemented as part of ControlValueAccessor. */
+  registerOnChange(fn: any): void {
+    this._onChange = fn;
+  }
+
+  /** Implemented as part of ControlValueAccessor. */
+  registerOnTouched(fn: any): void {
+    this._onTouched = fn;
+  }
+
+  /** Implemented as a part of ControlValueAccessor. */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+    this._changeDetectorRef.markForCheck();
+  }
+
+  /** Toggles the checked state of the slide-toggle. */
+  toggle(): void {
+    this.checked = !this.checked;
+    this._onChange(this.checked);
+  }
+
+  /**
+   * Emits a change event on the `change` output. Also notifies the FormControl about the change.
+   */
+  protected _emitChangeEvent() {
+    this._onChange(this.checked);
+    this.change.emit(this._createChangeEvent(this.checked));
+  }
+}
+
+/** Represents a slidable "switch" toggle that can be moved between on and off. */
+@Component({
+  selector: 'mat-slide-toggle',
+  exportAs: 'matSlideToggle',
+  host: {
+    'class': 'mat-slide-toggle',
+    '[id]': 'id',
+    // Needs to be removed since it causes some a11y issues (see #21266).
+    '[attr.tabindex]': 'null',
+    '[attr.aria-label]': 'null',
+    '[attr.aria-labelledby]': 'null',
+    '[attr.name]': 'null',
+    '[class.mat-checked]': 'checked',
+    '[class.mat-disabled]': 'disabled',
+    '[class.mat-slide-toggle-label-before]': 'labelPosition == "before"',
+    '[class._mat-animation-noopable]': '_noopAnimations',
+  },
+  templateUrl: 'slide-toggle.html',
+  styleUrls: ['slide-toggle.css'],
+  providers: [MAT_SLIDE_TOGGLE_VALUE_ACCESSOR],
+  inputs: ['disabled', 'disableRipple', 'color', 'tabIndex'],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MatSlideToggle extends _MatSlideToggleBase<MatSlideToggleChange> {
+  /** Reference to the underlying input element. */
+  @ViewChild('input') _inputElement: ElementRef<HTMLInputElement>;
+
+  constructor(
+    elementRef: ElementRef,
+    focusMonitor: FocusMonitor,
+    changeDetectorRef: ChangeDetectorRef,
+    @Attribute('tabindex') tabIndex: string,
+    @Inject(MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS)
+    defaults: MatSlideToggleDefaultOptions,
+    @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
+  ) {
+    super(
+      elementRef,
+      focusMonitor,
+      changeDetectorRef,
+      tabIndex,
+      defaults,
+      animationMode,
+      'mat-slide-toggle-',
+    );
+  }
+
+  protected _createChangeEvent(isChecked: boolean) {
+    return new MatSlideToggleChange(this, isChecked);
   }
 
   /** Method being called whenever the underlying input emits a change event. */
@@ -250,27 +319,6 @@ export class MatSlideToggle
     event.stopPropagation();
   }
 
-  /** Implemented as part of ControlValueAccessor. */
-  writeValue(value: any): void {
-    this.checked = !!value;
-  }
-
-  /** Implemented as part of ControlValueAccessor. */
-  registerOnChange(fn: any): void {
-    this._onChange = fn;
-  }
-
-  /** Implemented as part of ControlValueAccessor. */
-  registerOnTouched(fn: any): void {
-    this._onTouched = fn;
-  }
-
-  /** Implemented as a part of ControlValueAccessor. */
-  setDisabledState(isDisabled: boolean): void {
-    this.disabled = isDisabled;
-    this._changeDetectorRef.markForCheck();
-  }
-
   /** Focuses the slide-toggle. */
   focus(options?: FocusOptions, origin?: FocusOrigin): void {
     if (origin) {
@@ -278,20 +326,6 @@ export class MatSlideToggle
     } else {
       this._inputElement.nativeElement.focus(options);
     }
-  }
-
-  /** Toggles the checked state of the slide-toggle. */
-  toggle(): void {
-    this.checked = !this.checked;
-    this._onChange(this.checked);
-  }
-
-  /**
-   * Emits a change event on the `change` output. Also notifies the FormControl about the change.
-   */
-  private _emitChangeEvent() {
-    this._onChange(this.checked);
-    this.change.emit(new MatSlideToggleChange(this, this.checked));
   }
 
   /** Method being called whenever the label text changes. */

--- a/tools/public_api_guard/material/slide-toggle.md
+++ b/tools/public_api_guard/material/slide-toggle.md
@@ -26,6 +26,7 @@ import { InjectionToken } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { Provider } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
+import { Type } from '@angular/core';
 
 // @public
 export const MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS: InjectionToken<MatSlideToggleDefaultOptions>;
@@ -34,22 +35,50 @@ export const MAT_SLIDE_TOGGLE_DEFAULT_OPTIONS: InjectionToken<MatSlideToggleDefa
 export const MAT_SLIDE_TOGGLE_REQUIRED_VALIDATOR: Provider;
 
 // @public
-export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: any;
+export const MAT_SLIDE_TOGGLE_VALUE_ACCESSOR: {
+    provide: InjectionToken<readonly ControlValueAccessor[]>;
+    useExisting: Type<any>;
+    multi: boolean;
+};
 
 // @public
-export class MatSlideToggle extends _MatSlideToggleBase implements OnDestroy, AfterContentInit, ControlValueAccessor, CanDisable, CanColor, HasTabIndex, CanDisableRipple {
-    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, defaults: MatSlideToggleDefaultOptions, animationMode?: string);
+export class MatSlideToggle extends _MatSlideToggleBase<MatSlideToggleChange> {
+    constructor(elementRef: ElementRef, focusMonitor: FocusMonitor, changeDetectorRef: ChangeDetectorRef, tabIndex: string, defaults: MatSlideToggleDefaultOptions, animationMode?: string);
+    // (undocumented)
+    protected _createChangeEvent(isChecked: boolean): MatSlideToggleChange;
+    focus(options?: FocusOptions, origin?: FocusOrigin): void;
+    _inputElement: ElementRef<HTMLInputElement>;
+    _onChangeEvent(event: Event): void;
+    _onInputClick(event: Event): void;
+    _onLabelTextChange(): void;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatSlideToggle, "mat-slide-toggle", ["matSlideToggle"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "color": "color"; "tabIndex": "tabIndex"; }, {}, never, ["*"], false>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<MatSlideToggle, [null, null, null, { attribute: "tabindex"; }, null, { optional: true; }]>;
+}
+
+// @public (undocumented)
+export abstract class _MatSlideToggleBase<T> extends _MatSlideToggleMixinBase implements OnDestroy, AfterContentInit, ControlValueAccessor, CanDisable, CanColor, HasTabIndex, CanDisableRipple {
+    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef, tabIndex: string, defaults: MatSlideToggleDefaultOptions, animationMode: string | undefined, idPrefix: string);
     ariaDescribedby: string;
     ariaLabel: string | null;
     ariaLabelledby: string | null;
-    readonly change: EventEmitter<MatSlideToggleChange>;
+    readonly change: EventEmitter<T>;
+    // (undocumented)
+    protected _changeDetectorRef: ChangeDetectorRef;
     get checked(): boolean;
     set checked(value: BooleanInput);
     // (undocumented)
+    protected abstract _createChangeEvent(isChecked: boolean): T;
+    // (undocumented)
     defaults: MatSlideToggleDefaultOptions;
-    focus(options?: FocusOptions, origin?: FocusOrigin): void;
+    protected _emitChangeEvent(): void;
+    // (undocumented)
+    abstract focus(options?: FocusOptions, origin?: FocusOrigin): void;
+    _focused: boolean;
+    // (undocumented)
+    protected _focusMonitor: FocusMonitor;
     id: string;
-    _inputElement: ElementRef<HTMLInputElement>;
     get inputId(): string;
     labelPosition: 'before' | 'after';
     name: string | null;
@@ -58,23 +87,22 @@ export class MatSlideToggle extends _MatSlideToggleBase implements OnDestroy, Af
     // (undocumented)
     ngOnDestroy(): void;
     _noopAnimations: boolean;
-    _onChangeEvent(event: Event): void;
-    _onInputClick(event: Event): void;
-    _onLabelTextChange(): void;
+    // (undocumented)
+    protected _onChange: (_: any) => void;
     registerOnChange(fn: any): void;
     registerOnTouched(fn: any): void;
     get required(): boolean;
     set required(value: BooleanInput);
     setDisabledState(isDisabled: boolean): void;
-    _thumbBarEl: ElementRef;
-    _thumbEl: ElementRef;
     toggle(): void;
     readonly toggleChange: EventEmitter<void>;
+    // (undocumented)
+    protected _uniqueId: string;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<MatSlideToggle, "mat-slide-toggle", ["matSlideToggle"], { "disabled": "disabled"; "disableRipple": "disableRipple"; "color": "color"; "tabIndex": "tabIndex"; "name": "name"; "id": "id"; "labelPosition": "labelPosition"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; "ariaDescribedby": "aria-describedby"; "required": "required"; "checked": "checked"; }, { "change": "change"; "toggleChange": "toggleChange"; }, never, ["*"], false>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<_MatSlideToggleBase<any>, never, never, { "name": "name"; "id": "id"; "labelPosition": "labelPosition"; "ariaLabel": "aria-label"; "ariaLabelledby": "aria-labelledby"; "ariaDescribedby": "aria-describedby"; "required": "required"; "checked": "checked"; }, { "change": "change"; "toggleChange": "toggleChange"; }, never, never, false>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<MatSlideToggle, [null, null, null, { attribute: "tabindex"; }, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<_MatSlideToggleBase<any>, never>;
 }
 
 // @public


### PR DESCRIPTION
Bases the MDC slide toggle on top of the non-MDC one, instead of the MDC adapter.