### PR TITLE
refactor(material-experimental/mdc-tabs): remove usage of MDC adapter

### DIFF
--- a/src/material-experimental/mdc-tabs/BUILD.bazel
+++ b/src/material-experimental/mdc-tabs/BUILD.bazel
@@ -39,7 +39,6 @@ ng_module(
         "@npm//@angular/animations",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@material/tab-indicator",
     ],
 )
 

--- a/src/material-experimental/mdc-tabs/ink-bar.ts
+++ b/src/material-experimental/mdc-tabs/ink-bar.ts
@@ -6,21 +6,25 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ElementRef, QueryList} from '@angular/core';
-import {
-  MDCSlidingTabIndicatorFoundation,
-  MDCTabIndicatorAdapter,
-  MDCTabIndicatorFoundation,
-} from '@material/tab-indicator';
+import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {ElementRef, OnDestroy, OnInit, QueryList} from '@angular/core';
 
 /**
  * Item inside a tab header relative to which the ink bar can be aligned.
  * @docs-private
  */
-export interface MatInkBarItem {
-  _foundation: MatInkBarFoundation;
+export interface MatInkBarItem extends OnInit, OnDestroy {
   elementRef: ElementRef<HTMLElement>;
+  activateInkBar(previousIndicatorClientRect?: ClientRect): void;
+  deactivateInkBar(): void;
+  fitInkBarToContent: boolean;
 }
+
+/** Class that is applied when a tab indicator is active. */
+const ACTIVE_CLASS = 'mdc-tab-indicator--active';
+
+/** Class that is applied when the tab indicator should not transition. */
+const NO_TRANSITION_CLASS = 'mdc-tab-indicator--no-transition';
 
 /**
  * Abstraction around the MDC tab indicator that acts as the tab header's ink bar.
@@ -34,7 +38,7 @@ export class MatInkBar {
 
   /** Hides the ink bar. */
   hide() {
-    this._items.forEach(item => item._foundation.deactivate());
+    this._items.forEach(item => item.deactivateInkBar());
   }
 
   /** Aligns the ink bar to a DOM node. */
@@ -42,149 +46,136 @@ export class MatInkBar {
     const correspondingItem = this._items.find(item => item.elementRef.nativeElement === element);
     const currentItem = this._currentItem;
 
-    if (currentItem) {
-      currentItem._foundation.deactivate();
-    }
+    currentItem?.deactivateInkBar();
 
     if (correspondingItem) {
-      const clientRect = currentItem
-        ? currentItem._foundation.computeContentClientRect()
-        : undefined;
+      const clientRect = currentItem?.elementRef.nativeElement.getBoundingClientRect?.();
 
       // The ink bar won't animate unless we give it the `ClientRect` of the previous item.
-      correspondingItem._foundation.activate(clientRect);
+      correspondingItem.activateInkBar(clientRect);
       this._currentItem = correspondingItem;
     }
   }
 }
 
 /**
- * Implementation of MDC's sliding tab indicator (ink bar) foundation.
+ * Mixin that can be used to apply the `MatInkBarItem` behavior to a class.
+ * Base on MDC's `MDCSlidingTabIndicatorFoundation`:
+ * https://github.com/material-components/material-components-web/blob/c0a11ef0d000a098fd0c372be8f12d6a99302855/packages/mdc-tab-indicator/sliding-foundation.ts
  * @docs-private
  */
-export class MatInkBarFoundation {
-  private _destroyed: boolean;
-  private _foundation: MDCTabIndicatorFoundation;
-  private _inkBarElement: HTMLElement;
-  private _inkBarContentElement: HTMLElement;
-  private _fitToContent = false;
-  private _adapter: MDCTabIndicatorAdapter = {
-    addClass: className => {
-      if (!this._destroyed) {
-        this._hostElement.classList.add(className);
+export function mixinInkBarItem<
+  T extends new (...args: any[]) => {elementRef: ElementRef<HTMLElement>},
+>(base: T): T & (new (...args: any[]) => MatInkBarItem) {
+  return class extends base {
+    constructor(...args: any[]) {
+      super(...args);
+    }
+
+    private _inkBarElement: HTMLElement | null;
+    private _inkBarContentElement: HTMLElement | null;
+    private _fitToContent = false;
+
+    /** Whether the ink bar should fit to the entire tab or just its content. */
+    get fitInkBarToContent(): boolean {
+      return this._fitToContent;
+    }
+    set fitInkBarToContent(v: BooleanInput) {
+      const newValue = coerceBooleanProperty(v);
+
+      if (this._fitToContent !== newValue) {
+        this._fitToContent = newValue;
+
+        if (this._inkBarElement) {
+          this._appendInkBarElement();
+        }
       }
-    },
-    removeClass: className => {
-      if (!this._destroyed) {
-        this._hostElement.classList.remove(className);
+    }
+
+    /** Aligns the ink bar to the current item. */
+    activateInkBar(previousIndicatorClientRect?: ClientRect) {
+      const element = this.elementRef.nativeElement;
+
+      // Early exit if no indicator is present to handle cases where an indicator
+      // may be activated without a prior indicator state
+      if (
+        !previousIndicatorClientRect ||
+        !element.getBoundingClientRect ||
+        !this._inkBarContentElement
+      ) {
+        element.classList.add(ACTIVE_CLASS);
+        return;
       }
-    },
-    setContentStyleProperty: (propName, value) => {
-      if (!this._destroyed) {
-        this._inkBarContentElement.style.setProperty(propName, value);
+
+      // This animation uses the FLIP approach. You can read more about it at the link below:
+      // https://aerotwist.com/blog/flip-your-animations/
+
+      // Calculate the dimensions based on the dimensions of the previous indicator
+      const currentClientRect = element.getBoundingClientRect();
+      const widthDelta = previousIndicatorClientRect.width / currentClientRect.width;
+      const xPosition = previousIndicatorClientRect.left - currentClientRect.left;
+      element.classList.add(NO_TRANSITION_CLASS);
+      this._inkBarContentElement.style.setProperty(
+        'transform',
+        `translateX(${xPosition}px) scaleX(${widthDelta})`,
+      );
+
+      // Force repaint before updating classes and transform to ensure the transform properly takes effect
+      element.getBoundingClientRect();
+
+      element.classList.remove(NO_TRANSITION_CLASS);
+      element.classList.add(ACTIVE_CLASS);
+      this._inkBarContentElement.style.setProperty('transform', '');
+    }
+
+    /** Removes the ink bar from the current item. */
+    deactivateInkBar() {
+      this.elementRef.nativeElement.classList.remove(ACTIVE_CLASS);
+    }
+
+    /** Initializes the foundation. */
+    ngOnInit() {
+      this._createInkBarElement();
+    }
+
+    /** Destroys the foundation. */
+    ngOnDestroy() {
+      this._inkBarElement?.remove();
+      this._inkBarElement = this._inkBarContentElement = null!;
+    }
+
+    /** Creates and appends the ink bar element. */
+    private _createInkBarElement() {
+      const documentNode = this.elementRef.nativeElement.ownerDocument || document;
+      this._inkBarElement = documentNode.createElement('span');
+      this._inkBarContentElement = documentNode.createElement('span');
+
+      this._inkBarElement.className = 'mdc-tab-indicator';
+      this._inkBarContentElement.className =
+        'mdc-tab-indicator__content mdc-tab-indicator__content--underline';
+
+      this._inkBarElement.appendChild(this._inkBarContentElement);
+      this._appendInkBarElement();
+    }
+
+    /**
+     * Appends the ink bar to the tab host element or content, depending on whether
+     * the ink bar should fit to content.
+     */
+    private _appendInkBarElement() {
+      if (!this._inkBarElement && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+        throw Error('Ink bar element has not been created and cannot be appended');
       }
-    },
-    computeContentClientRect: () => {
-      // `getBoundingClientRect` isn't available on the server.
-      return this._destroyed || !this._inkBarContentElement.getBoundingClientRect
-        ? ({
-            width: 0,
-            height: 0,
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            x: 0,
-            y: 0,
-          } as ClientRect)
-        : this._inkBarContentElement.getBoundingClientRect();
-    },
+
+      const parentElement = this._fitToContent
+        ? this.elementRef.nativeElement.querySelector('.mdc-tab__content')
+        : this.elementRef.nativeElement;
+
+      if (!parentElement && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+        throw Error('Missing element to host the ink bar');
+      }
+
+      parentElement!.appendChild(this._inkBarElement!);
+    }
   };
-
-  constructor(private _hostElement: HTMLElement, private _document: Document) {
-    this._foundation = new MDCSlidingTabIndicatorFoundation(this._adapter);
-  }
-
-  /** Aligns the ink bar to the current item. */
-  activate(clientRect?: ClientRect) {
-    this._foundation.activate(clientRect);
-  }
-
-  /** Removes the ink bar from the current item. */
-  deactivate() {
-    this._foundation.deactivate();
-  }
-
-  /** Gets the ClientRect of the ink bar. */
-  computeContentClientRect() {
-    return this._foundation.computeContentClientRect();
-  }
-
-  /** Initializes the foundation. */
-  init() {
-    this._createInkBarElement();
-    this._foundation.init();
-  }
-
-  /** Destroys the foundation. */
-  destroy() {
-    this._inkBarElement.remove();
-    this._hostElement = this._inkBarElement = this._inkBarContentElement = null!;
-    this._foundation.destroy();
-    this._destroyed = true;
-  }
-
-  /**
-   * Sets whether the ink bar should be appended to the content, which will cause the ink bar
-   * to match the width of the content rather than the tab host element.
-   */
-  setFitToContent(fitToContent: boolean) {
-    if (this._fitToContent !== fitToContent) {
-      this._fitToContent = fitToContent;
-      if (this._inkBarElement) {
-        this._appendInkBarElement();
-      }
-    }
-  }
-
-  /**
-   * Gets whether the ink bar should be appended to the content, which will cause the ink bar
-   * to match the width of the content rather than the tab host element.
-   */
-  getFitToContent(): boolean {
-    return this._fitToContent;
-  }
-
-  /** Creates and appends the ink bar element. */
-  private _createInkBarElement() {
-    this._inkBarElement = this._document.createElement('span');
-    this._inkBarContentElement = this._document.createElement('span');
-
-    this._inkBarElement.className = 'mdc-tab-indicator';
-    this._inkBarContentElement.className =
-      'mdc-tab-indicator__content' + ' mdc-tab-indicator__content--underline';
-
-    this._inkBarElement.appendChild(this._inkBarContentElement);
-    this._appendInkBarElement();
-  }
-
-  /**
-   * Appends the ink bar to the tab host element or content, depending on whether
-   * the ink bar should fit to content.
-   */
-  private _appendInkBarElement() {
-    if (!this._inkBarElement && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      throw Error('Ink bar element has not been created and cannot be appended');
-    }
-
-    const parentElement = this._fitToContent
-      ? this._hostElement.querySelector('.mdc-tab__content')
-      : this._hostElement;
-
-    if (!parentElement && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      throw Error('Missing element to host the ink bar');
-    }
-
-    parentElement!.appendChild(this._inkBarElement);
-  }
 }

--- a/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
+++ b/src/material-experimental/mdc-tabs/tab-label-wrapper.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Inject, Input, OnDestroy, OnInit} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import {Directive} from '@angular/core';
 import {MatTabLabelWrapper as BaseMatTabLabelWrapper} from '@angular/material/tabs';
-import {MatInkBarFoundation, MatInkBarItem} from './ink-bar';
-import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
+import {MatInkBarItem, mixinInkBarItem} from './ink-bar';
+
+const _MatTabLabelWrapperBase = mixinInkBarItem(BaseMatTabLabelWrapper);
 
 /**
  * Used in the `mat-tab-group` view to display tab labels.
@@ -18,40 +18,10 @@ import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
  */
 @Directive({
   selector: '[matTabLabelWrapper]',
-  inputs: ['disabled'],
+  inputs: ['disabled', 'fitInkBarToContent'],
   host: {
     '[class.mat-mdc-tab-disabled]': 'disabled',
     '[attr.aria-disabled]': '!!disabled',
   },
 })
-export class MatTabLabelWrapper
-  extends BaseMatTabLabelWrapper
-  implements MatInkBarItem, OnInit, OnDestroy
-{
-  private _document: Document;
-
-  _foundation: MatInkBarFoundation;
-
-  /** Whether the ink bar should fit its width to the size of the tab label content. */
-  @Input()
-  get fitInkBarToContent(): boolean {
-    return this._foundation.getFitToContent();
-  }
-  set fitInkBarToContent(v: BooleanInput) {
-    this._foundation.setFitToContent(coerceBooleanProperty(v));
-  }
-
-  constructor(elementRef: ElementRef, @Inject(DOCUMENT) _document: any) {
-    super(elementRef);
-    this._document = _document;
-    this._foundation = new MatInkBarFoundation(elementRef.nativeElement, this._document);
-  }
-
-  ngOnInit() {
-    this._foundation.init();
-  }
-
-  ngOnDestroy() {
-    this._foundation.destroy();
-  }
-}
+export class MatTabLabelWrapper extends _MatTabLabelWrapperBase implements MatInkBarItem {}

--- a/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/src/material-experimental/mdc-tabs/tab-nav-bar/tab-nav-bar.ts
@@ -22,7 +22,6 @@ import {
   AfterViewInit,
   NgZone,
   ChangeDetectorRef,
-  OnInit,
   Input,
 } from '@angular/core';
 import {ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
@@ -33,18 +32,19 @@ import {
 import {FocusMonitor} from '@angular/cdk/a11y';
 import {
   _MatTabNavBase,
-  _MatTabLinkBase,
+  _MatTabLinkBase as BaseMatTabLink,
   MAT_TABS_CONFIG,
   MatTabsConfig,
 } from '@angular/material/tabs';
-import {DOCUMENT} from '@angular/common';
 import {Directionality} from '@angular/cdk/bidi';
 import {ViewportRuler} from '@angular/cdk/scrolling';
 import {Platform} from '@angular/cdk/platform';
-import {MatInkBar, MatInkBarItem, MatInkBarFoundation} from '../ink-bar';
+import {MatInkBar, MatInkBarItem, mixinInkBarItem} from '../ink-bar';
 import {BooleanInput, coerceBooleanProperty} from '@angular/cdk/coercion';
 import {BehaviorSubject, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+
+const _MatTabLinkBase = mixinInkBarItem(BaseMatTabLink);
 
 /**
  * Navigation component matching the styles of the tab group header.
@@ -140,7 +140,7 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit, After
 @Component({
   selector: '[mat-tab-link], [matTabLink]',
   exportAs: 'matTabLink',
-  inputs: ['disabled', 'disableRipple', 'tabIndex'],
+  inputs: ['disabled', 'disableRipple', 'tabIndex', 'active', 'id'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   templateUrl: 'tab-link.html',
@@ -160,9 +160,7 @@ export class MatTabNav extends _MatTabNavBase implements AfterContentInit, After
     '(keydown)': '_handleKeydown($event)',
   },
 })
-export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnInit, OnDestroy {
-  _foundation = new MatInkBarFoundation(this.elementRef.nativeElement, this._document);
-
+export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnDestroy {
   private readonly _destroyed = new Subject<void>();
 
   constructor(
@@ -171,25 +169,19 @@ export class MatTabLink extends _MatTabLinkBase implements MatInkBarItem, OnInit
     @Optional() @Inject(MAT_RIPPLE_GLOBAL_OPTIONS) globalRippleOptions: RippleGlobalOptions | null,
     @Attribute('tabindex') tabIndex: string,
     focusMonitor: FocusMonitor,
-    @Inject(DOCUMENT) private _document: any,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
   ) {
     super(tabNavBar, elementRef, globalRippleOptions, tabIndex, focusMonitor, animationMode);
 
     tabNavBar._fitInkBarToContent.pipe(takeUntil(this._destroyed)).subscribe(fitInkBarToContent => {
-      this._foundation.setFitToContent(fitInkBarToContent);
+      this.fitInkBarToContent = fitInkBarToContent;
     });
-  }
-
-  ngOnInit() {
-    this._foundation.init();
   }
 
   override ngOnDestroy() {
     this._destroyed.next();
     this._destroyed.complete();
     super.ngOnDestroy();
-    this._foundation.destroy();
   }
 }
 


### PR DESCRIPTION
Reworks the MDC tab ink bar so that it doesn't depend upon the MDC adapter and foundation.