### PR TITLE
fix(material/datepicker): announce the "to" when reading year range

### DIFF
--- a/src/material/datepicker/calendar-header.html
+++ b/src/material/datepicker/calendar-header.html
@@ -2,11 +2,10 @@
   <div class="mat-calendar-controls">
     <button mat-button type="button" class="mat-calendar-period-button"
             (click)="currentPeriodClicked()" [attr.aria-label]="periodButtonLabel"
-            [attr.aria-describedby]="_buttonDescriptionId"
-            aria-live="polite">
-      <span [attr.id]="_buttonDescriptionId">{{periodButtonText}}</span>
+            [attr.aria-describedby]="_periodButtonLabelId" aria-live="polite">
+      <span aria-hidden="true">{{periodButtonText}}</span>
       <svg class="mat-calendar-arrow" [class.mat-calendar-invert]="calendar.currentView !== 'month'"
-           viewBox="0 0 10 5" focusable="false">
+           viewBox="0 0 10 5" focusable="false" aria-hidden="true">
            <polygon points="0,0 5,5 10,0"/>
       </svg>
     </button>
@@ -26,3 +25,4 @@
     </button>
   </div>
 </div>
+<label [id]="_periodButtonLabelId" class="mat-calendar-hidden-label">{{periodButtonDescription}}</label>

--- a/src/material/datepicker/calendar-header.spec.ts
+++ b/src/material/datepicker/calendar-header.spec.ts
@@ -191,10 +191,16 @@ describe('MatCalendarHeader', () => {
     });
 
     it('should label and describe period button for assistive technology', () => {
-      const description = periodButton.querySelector('span[id]');
+      expect(calendarInstance.currentView).toBe('month');
+
+      periodButton.click();
+      fixture.detectChanges();
+
+      expect(calendarInstance.currentView).toBe('multi-year');
       expect(periodButton.hasAttribute('aria-label')).toBe(true);
+      expect(periodButton.getAttribute('aria-label')).toMatch(/^[a-z0-9\s]+$/i);
       expect(periodButton.hasAttribute('aria-describedby')).toBe(true);
-      expect(periodButton.getAttribute('aria-describedby')).toBe(description?.getAttribute('id')!);
+      expect(periodButton.getAttribute('aria-describedby')).toMatch(/mat-calendar-header-[0-9]+/i);
     });
   });
 

--- a/src/material/datepicker/calendar.scss
+++ b/src/material/datepicker/calendar.scss
@@ -139,3 +139,8 @@ $calendar-next-icon-transform: translateX(-2px) rotate(45deg);
 .mat-calendar-body-cell:focus .mat-focus-indicator::before {
   content: '';
 }
+
+// Label that is not rendered and removed from the accessibility tree.
+.mat-calendar-hidden-label {
+  display: none;
+}

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -291,15 +291,15 @@ export type MatCalendarCellCssClasses = string | string[] | Set<string> | {
 export class MatCalendarHeader<D> {
     constructor(_intl: MatDatepickerIntl, calendar: MatCalendar<D>, _dateAdapter: DateAdapter<D>, _dateFormats: MatDateFormats, changeDetectorRef: ChangeDetectorRef);
     // (undocumented)
-    _buttonDescriptionId: string;
-    // (undocumented)
     calendar: MatCalendar<D>;
     currentPeriodClicked(): void;
     get nextButtonLabel(): string;
     nextClicked(): void;
     nextEnabled(): boolean;
-    // (undocumented)
+    get periodButtonDescription(): string;
     get periodButtonLabel(): string;
+    // (undocumented)
+    _periodButtonLabelId: string;
     get periodButtonText(): string;
     get prevButtonLabel(): string;
     previousClicked(): void;


### PR DESCRIPTION
    fix(material/datepicker): announce the "to" when reading year range

    Create period button's `aria-description` using `formatYearRangeLabel`
    method. Format year range in a TTS friendly way (e.g. "2019 to 2020").
    Previously, some screen readers would announce the range as "2019 2020".

    Fixes #23467.