### PR TITLE
Schematics: use `workingDirectory` smart provider in path option

### DIFF
--- a/src/cdk/schematics/ng-generate/drag-drop/schema.json
+++ b/src/cdk/schematics/ng-generate/drag-drop/schema.json
@@ -7,6 +7,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path to create the component.",
       "visible": false
     },

--- a/src/material/schematics/ng-generate/address-form/schema.json
+++ b/src/material/schematics/ng-generate/address-form/schema.json
@@ -7,6 +7,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path to create the component.",
       "visible": false
     },

--- a/src/material/schematics/ng-generate/dashboard/schema.json
+++ b/src/material/schematics/ng-generate/dashboard/schema.json
@@ -7,6 +7,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path to create the component.",
       "visible": false
     },

--- a/src/material/schematics/ng-generate/navigation/schema.json
+++ b/src/material/schematics/ng-generate/navigation/schema.json
@@ -7,6 +7,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path to create the component.",
       "visible": false
     },

--- a/src/material/schematics/ng-generate/table/schema.json
+++ b/src/material/schematics/ng-generate/table/schema.json
@@ -7,6 +7,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path to create the component.",
       "visible": false
     },

--- a/src/material/schematics/ng-generate/tree/schema.json
+++ b/src/material/schematics/ng-generate/tree/schema.json
@@ -7,6 +7,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path to create the component.",
       "visible": false
     },


### PR DESCRIPTION

The Angular CLI, handles options with both name and format `path` as a special case. This behaviour has been deprecated and instead the `workingDirectory` smart provider should be used instead. Currently, when not using the provider a deprecation warning will be issue.
    
See: https://github.com/angular/angular-cli/pull/23212