### PR TITLE
build: speed up TS compilations and type bundling by removing locale files

### DIFF
--- a/tools/postinstall/apply-patches.js
+++ b/tools/postinstall/apply-patches.js
@@ -55,6 +55,10 @@ function applyPatches() {
   // Switches the devmode output for Angular Bazel to ES2020 target and module.
   applyPatch(path.join(__dirname, './devmode-es2020-bazel.patch'));
 
+  // Similar to the `rxjs` performance improvement below, see:
+  // https://github.com/angular/angular/pull/46187.
+  shelljs.rm('-rf', ['node_modules/@angular/common/locales']);
+
   // More info in https://github.com/angular/angular/pull/33786
   shelljs.rm('-rf', [
     'node_modules/rxjs/add/',


### PR DESCRIPTION
Removing the locale files will help us reduce Bazel action inputs and
therefore speed up compilations/type bundling because the bazel sandbox
would not need as much files to be sandboxed/symlinked.

More info can be found here: https://github.com/angular/angular/pull/46187

cc. @mmalerba (here as well -- along with the actual PR fix in Angular Bazel)