### PR TITLE
docs: release notes for the v14.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="14.0.1"></a>
+# 14.0.1 "titanium-night" (2022-06-07)
+### material-experimental
+| Commit | Type | Description |
+| -- | -- | -- |
+| [a7688a8b6](https://github.com/angular/components/commit/a7688a8b6cf0286cf9b4fecbdbedc5bdd7d524c1) | fix | **mdc-radio:** fix ripple color ([#24986](https://github.com/angular/components/pull/24986)) |
+## Special Thanks
+Kristiyan Kostadinov, Miles Malerba and renovate[bot]
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.0.0"></a>
 # 14.0.0 "cotton-peanut" (2022-06-02)
 ## Breaking Changes


### PR DESCRIPTION
Cherry-picks the changelog from the "14.0.x" branch to the next branch (main).