### PR TITLE
fix(cdk/drag-drop): constrainPosition not working as expected

### DIFF
--- a/src/cdk/drag-drop/directives/drag.spec.ts
+++ b/src/cdk/drag-drop/directives/drag.spec.ts
@@ -1081,8 +1081,12 @@ describe('CdkDrag', () => {
       expect(spy).toHaveBeenCalledWith(
         jasmine.objectContaining({x: 300, y: 300}),
         jasmine.any(DragRef),
+        jasmine.anything(),
       );
-      expect(dragElement.style.transform).toBe('translate3d(50px, 50px, 0px)');
+
+      const elementRect = dragElement.getBoundingClientRect();
+      expect(Math.floor(elementRect.top)).toBe(50);
+      expect(Math.floor(elementRect.left)).toBe(50);
     }));
 
     it('should throw if drag item is attached to an ng-container', fakeAsync(() => {
@@ -3680,6 +3684,7 @@ describe('CdkDrag', () => {
       expect(spy).toHaveBeenCalledWith(
         jasmine.objectContaining({x: 200, y: 200}),
         jasmine.any(DragRef),
+        jasmine.anything(),
       );
       expect(Math.floor(previewRect.top)).toBe(50);
       expect(Math.floor(previewRect.left)).toBe(50);

--- a/src/cdk/drag-drop/directives/drag.ts
+++ b/src/cdk/drag-drop/directives/drag.ts
@@ -132,10 +132,14 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
   /**
    * Function that can be used to customize the logic of how the position of the drag item
    * is limited while it's being dragged. Gets called with a point containing the current position
-   * of the user's pointer on the page and should return a point describing where the item should
-   * be rendered.
+   * of the user's pointer on the page, a reference to the item being dragged and its dimenstions.
+   * Should return a point describing where the item should be rendered.
    */
-  @Input('cdkDragConstrainPosition') constrainPosition?: (point: Point, dragRef: DragRef) => Point;
+  @Input('cdkDragConstrainPosition') constrainPosition?: (
+    userPointerPosition: Point,
+    dragRef: DragRef,
+    dimensions: ClientRect,
+  ) => Point;
 
   /** Class to be added to the preview element. */
   @Input('cdkDragPreviewClass') previewClass: string | string[];

--- a/tools/public_api_guard/cdk/drag-drop.md
+++ b/tools/public_api_guard/cdk/drag-drop.md
@@ -55,7 +55,7 @@ export class CdkDrag<T = any> implements AfterViewInit, OnChanges, OnDestroy {
     dropContainer: CdkDropListInternal,
     _document: any, _ngZone: NgZone, _viewContainerRef: ViewContainerRef, config: DragDropConfig, _dir: Directionality, dragDrop: DragDrop, _changeDetectorRef: ChangeDetectorRef, _selfHandle?: CdkDragHandle | undefined, _parentDrag?: CdkDrag<any> | undefined);
     boundaryElement: string | ElementRef<HTMLElement> | HTMLElement;
-    constrainPosition?: (point: Point, dragRef: DragRef) => Point;
+    constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: ClientRect) => Point;
     data: T;
     get disabled(): boolean;
     set disabled(value: BooleanInput);
@@ -359,7 +359,7 @@ export class DragDropRegistry<I extends {
 export class DragRef<T = any> {
     constructor(element: ElementRef<HTMLElement> | HTMLElement, _config: DragRefConfig, _document: Document, _ngZone: NgZone, _viewportRuler: ViewportRuler, _dragDropRegistry: DragDropRegistry<DragRef, DropListRefInternal>);
     readonly beforeStarted: Subject<void>;
-    constrainPosition?: (point: Point, dragRef: DragRef) => Point;
+    constrainPosition?: (userPointerPosition: Point, dragRef: DragRef, dimensions: ClientRect) => Point;
     data: T;
     get disabled(): boolean;
     set disabled(value: boolean);


### PR DESCRIPTION
Fixes that the `constrainPosition` input wasn't constraining the position as described in the docs. This may have worked at some point, but it's definitely broken now. Our tests didn't catch it, because they were looking at the `transform` which was wrong, instead of the position the element ended up at.

I've also added the current element dimensions to the callback since they could be useful.

Fixes #25046.