### PR TITLE
ci: fix slack notification script failing due to missing `ts-node`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ var_20: &slack_notify_on_failure
   run:
     name: 'Notifying team about job failure'
     when: on_fail
-    command: node ./scripts/circleci/notify-slack-job-failure.mjs
+    command: yarn ci-notify-slack-failure
 
 # Branch filter that only matches the main branch.
 var_21: &only_main_branch_filter
@@ -509,7 +509,7 @@ jobs:
           name: Running size integration tests (failures are reported in Slack only).
           command: |
             # If the size integration tests fail, report the failure to a dedicated #components-ci-size-tracking Slack channel.
-            yarn integration-tests:size-test || node ./scripts/circleci/notify-slack-job-failure.mjs components-ci-size-tracking
+            yarn integration-tests:size-test || yarn ci-notify-slack-failure components-ci-size-tracking
       - *slack_notify_on_failure
 
   # ----------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "tsc": "node ./node_modules/typescript/bin/tsc",
     "ci-push-deploy-docs-app": "ts-node --esm --project scripts/tsconfig.json scripts/docs-deploy/deploy-ci-push.mts",
     "ci-docs-monitor-test": "ts-node --esm --project scripts/tsconfig.json scripts/docs-deploy/monitoring/ci-test.mts",
+    "ci-notify-slack-failure": "ts-node --esm --project scripts/tsconfig.json scripts/circleci/notify-slack-job-failure.mts",
     "prepare": "husky install"
   },
   "version": "14.1.0-next.0",

--- a/scripts/circleci/notify-slack-job-failure.mts
+++ b/scripts/circleci/notify-slack-job-failure.mts
@@ -11,17 +11,15 @@ import {
   assertValidGithubConfig,
 } from '@angular/dev-infra-private/ng-dev';
 
-if (process.env.CIRCLE_PR_NUMBER) {
+if (process.env.CIRCLE_PR_NUMBER !== undefined) {
   console.info('Skipping notifications for pull requests.');
   process.exit(0);
 }
 
-const {
-  CIRCLE_JOB: jobName,
-  CIRCLE_BRANCH: branchName,
-  CIRCLE_BUILD_URL: jobUrl,
-  SLACK_COMPONENTS_CI_FAILURES_WEBHOOK_URL: webhookUrl,
-} = process.env;
+const jobName = process.env.CIRCLE_JOB!;
+const branchName = process.env.CIRCLE_BRANCH!;
+const jobUrl = process.env.CIRCLE_BUILD_URL!;
+const webhookUrl = process.env.SLACK_COMPONENTS_CI_FAILURES_WEBHOOK_URL!;
 
 const {github} = await getConfig([assertValidGithubConfig]);
 const isPublishBranch = isVersionBranch(branchName) || branchName === github.mainBranchName;
@@ -35,7 +33,7 @@ if (isPublishBranch === false) {
 const {echo, set} = require('shelljs');
 
 const text = `\`${jobName}\` failed in branch: ${branchName}: ${jobUrl}`;
-const payload = {text};
+const payload: {text: string; channel?: string} = {text};
 const [channelName] = process.argv.slice(2);
 
 set('-e');


### PR DESCRIPTION
TS node is no longer automatically registering in the `ng-dev` tool, so
the config cannot be loaded anymore. Callers of `getConfig()` are
required to manually wire up TS-Node, mostly now because ESM ts-node
**cannot** be registered at runtime anymore. So, the fix here is to
either run the slack notify script with `node --loader ts-node/esm` or
just run it using `ts-node` directly, while writing it in TS.

The latter one seems the most reasonable.