### PR TITLE
fix(material-experimental/mdc-chips): checkmark blending into background in high contrast mode

### DIFF
--- a/src/material-experimental/mdc-chips/chip.scss
+++ b/src/material-experimental/mdc-chips/chip.scss
@@ -45,7 +45,7 @@
       // by default, it'll blend in with the background in black-on-white mode. Override the
       // color to ensure that it's visible. We need !important, because the theme styles are
       // very specific.
-      stroke: #000 !important;
+      stroke: CanvasText !important;
     }
   }
 


### PR DESCRIPTION
Fixes that the checkmark on the MDC chips was blending into the background for high contrast mode users.

Fixes #25071.