### PR TITLE
fix(cdk/keycodes): types for the `hasModifierKey` have been updated

### DIFF
--- a/src/cdk/keycodes/modifiers.ts
+++ b/src/cdk/keycodes/modifiers.ts
@@ -7,12 +7,13 @@
  */
 
 type ModifierKey = 'altKey' | 'shiftKey' | 'ctrlKey' | 'metaKey';
+type ModifierEvent = KeyboardEvent | MouseEvent | TouchEvent;
 
 /**
  * Checks whether a modifier key is pressed.
  * @param event Event to be checked.
  */
-export function hasModifierKey(event: KeyboardEvent, ...modifiers: ModifierKey[]): boolean {
+export function hasModifierKey(event: ModifierEvent, ...modifiers: ModifierKey[]): boolean {
   if (modifiers.length) {
     return modifiers.some(modifier => event[modifier]);
   }

--- a/tools/public_api_guard/cdk/keycodes.md
+++ b/tools/public_api_guard/cdk/keycodes.md
@@ -146,7 +146,7 @@ export const G = 71;
 export const H = 72;
 
 // @public
-export function hasModifierKey(event: KeyboardEvent, ...modifiers: ModifierKey[]): boolean;
+export function hasModifierKey(event: ModifierEvent, ...modifiers: ModifierKey[]): boolean;
 
 // @public (undocumented)
 export const HOME = 36;


### PR DESCRIPTION
Fixes #25079.