### PR TITLE
Set line-height in .mat-button-wrapper to initial

### DIFF
--- a/src/material/button/_button-base.scss
+++ b/src/material/button/_button-base.scss
@@ -103,6 +103,6 @@ $mini-fab-padding: 8px !default;
   .mat-button-wrapper {
     padding: $padding 0;
     display: inline-block;
-    line-height: $button-line-height;
+    line-height: initial;
   }
 }


### PR DESCRIPTION
This centers the content in the button. Setting the `line-height` to a specific value makes the span slightly bigger than the content, making the content off-center. You can see this by putting a round icon into the button:
```html
<button mat-mini-fab>
    <mat-icon>info</mat-icon>
</button>
```
The `.mat-button-wrapper` has a height of 25.1px in this case, and the icon is slightly below the center line