### PR TITLE
fix(material/stepper): isErrorState accepts AbstractControl instead of UntypedFormControl to avoid compiler errors when strict typing is enabled

### DIFF
--- a/src/material/core/common-behaviors/error-state.ts
+++ b/src/material/core/common-behaviors/error-state.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {UntypedFormControl, FormGroupDirective, NgControl, NgForm} from '@angular/forms';
+import {AbstractControl, FormGroupDirective, NgControl, NgForm} from '@angular/forms';
 import {Subject} from 'rxjs';
 import {ErrorStateMatcher} from '../error/error-options';
 import {AbstractConstructor, Constructor} from './constructor';
@@ -59,7 +59,7 @@ export function mixinErrorState<T extends Constructor<HasErrorState>>(
       const oldState = this.errorState;
       const parent = this._parentFormGroup || this._parentForm;
       const matcher = this.errorStateMatcher || this._defaultErrorStateMatcher;
-      const control = this.ngControl ? (this.ngControl.control as UntypedFormControl) : null;
+      const control = this.ngControl ? (this.ngControl.control as AbstractControl) : null;
       const newState = matcher.isErrorState(control, parent);
 
       if (newState !== oldState) {

--- a/src/material/stepper/stepper.ts
+++ b/src/material/stepper/stepper.ts
@@ -37,7 +37,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import {UntypedFormControl, FormGroupDirective, NgForm} from '@angular/forms';
+import {AbstractControl, FormGroupDirective, NgForm} from '@angular/forms';
 import {ErrorStateMatcher, ThemePalette} from '@angular/material/core';
 import {TemplatePortal} from '@angular/cdk/portal';
 import {Subject, Subscription} from 'rxjs';
@@ -110,10 +110,7 @@ export class MatStep extends CdkStep implements ErrorStateMatcher, AfterContentI
   }
 
   /** Custom error state matcher that additionally checks for validity of interacted form. */
-  isErrorState(
-    control: UntypedFormControl | null,
-    form: FormGroupDirective | NgForm | null,
-  ): boolean {
+  isErrorState(control: AbstractControl | null, form: FormGroupDirective | NgForm | null): boolean {
     const originalErrorState = this._errorStateMatcher.isErrorState(control, form);
 
     // Custom error state checks for the validity of form that is not submitted or touched

--- a/tools/public_api_guard/material/stepper.md
+++ b/tools/public_api_guard/material/stepper.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { _AbstractConstructor } from '@angular/material/core';
+import { AbstractControl } from '@angular/forms';
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
@@ -42,7 +43,6 @@ import { Subject } from 'rxjs';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { TemplateRef } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
-import { UntypedFormControl } from '@angular/forms';
 import { ViewContainerRef } from '@angular/core';
 
 // @public
@@ -59,7 +59,7 @@ export function MAT_STEPPER_INTL_PROVIDER_FACTORY(parentIntl: MatStepperIntl): M
 export class MatStep extends CdkStep implements ErrorStateMatcher, AfterContentInit, OnDestroy {
     constructor(stepper: MatStepper, _errorStateMatcher: ErrorStateMatcher, _viewContainerRef: ViewContainerRef, stepperOptions?: StepperOptions);
     color: ThemePalette;
-    isErrorState(control: UntypedFormControl | null, form: FormGroupDirective | NgForm | null): boolean;
+    isErrorState(control: AbstractControl | null, form: FormGroupDirective | NgForm | null): boolean;
     _lazyContent: MatStepContent;
     // (undocumented)
     ngAfterContentInit(): void;


### PR DESCRIPTION
Fixes #25103 