### PR TITLE
build: ensure ng-dev command works on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "postinstall": "node tools/postinstall/apply-patches.js",
-    "ng-dev": "TS_NODE_PROJECT=$PWD/.ng-dev/tsconfig.json node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
+    "ng-dev": "yarn ts-node --esm --project .ng-dev/tsconfig.json node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
     "build": "ts-node --esm --project scripts/tsconfig.json ./scripts/build-packages-dist-main.mts",
     "build-docs-content": "ts-node --esm --project scripts/tsconfig.json ./scripts/build-docs-content-main.mts",
     "build-and-check-release-output": "ts-node --esm --project scripts/tsconfig.json scripts/build-and-check-release-output.mts",


### PR DESCRIPTION
Apparently the `ng-dev` command does not work with Git Bash on windows
because of the environment variable being set. We should use `ts-node`
directly to avoid this issue, and also avoid the `$PWD` access which
might not work depending on the shell.

Also on the dev-infra side we would need to remove the ts-node shebang
and leave the responsibility to the consumer project.