### PR TITLE
build: avoid use of `yarn ts-node` to avoid nested yarn execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "postinstall": "node tools/postinstall/apply-patches.js",
-    "ng-dev": "yarn ts-node --esm --project .ng-dev/tsconfig.json node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
+    "ng-dev": "ts-node --esm --project .ng-dev/tsconfig.json node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
     "build": "ts-node --esm --project scripts/tsconfig.json ./scripts/build-packages-dist-main.mts",
     "build-docs-content": "ts-node --esm --project scripts/tsconfig.json ./scripts/build-docs-content-main.mts",
     "build-and-check-release-output": "ts-node --esm --project scripts/tsconfig.json scripts/build-and-check-release-output.mts",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -198,9 +198,6 @@ def ng_package(name, srcs = [], deps = [], externals = PKG_EXTERNALS, readme_md 
         # two mappings for `@angular/cdk` and the linker will complain. For a better development
         # experience, we want the mapping to resolve to the direct outputs of the `ts_library`
         # instead of requiring tests and other targets to assemble the NPM package first.
-        # TODO(devversion): consider removing this if `rules_nodejs` allows for duplicate
-        # linker mappings where transitive-determined mappings are skipped on conflicts.
-        # https://github.com/bazelbuild/rules_nodejs/issues/2810.
         package_name = None,
         validate = False,
         readme_md = readme_md,
@@ -233,9 +230,6 @@ def pkg_npm(name, visibility = None, **kwargs):
         # two mappings for `@angular/cdk` and the linker will complain. For a better development
         # experience, we want the mapping to resolve to the direct outputs of the `ts_library`
         # instead of requiring tests and other targets to assemble the NPM package first.
-        # TODO(devversion): consider removing this if `rules_nodejs` allows for duplicate
-        # linker mappings where transitive-determined mappings are skipped on conflicts.
-        # https://github.com/bazelbuild/rules_nodejs/issues/2810.
         package_name = None,
         validate = False,
         substitutions = npmPackageSubstitutions,


### PR DESCRIPTION
We can directly use `ts-node` to avoid printing errors twice when
the nested execution fails.

e.g.

```
Not enough non-option arguments: got 0, need at least 1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```