### PR TITLE
build: fix benchpress build errors

### DIFF
--- a/test/benchmarks/cdk/testing/component-harness/BUILD.bazel
+++ b/test/benchmarks/cdk/testing/component-harness/BUILD.bazel
@@ -20,7 +20,7 @@ ts_library(
     srcs = [":protractor-benchmark-utilities.ts"],
     deps = [
         ":constants",
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//@types/node",
     ],
 )
@@ -69,7 +69,7 @@ ng_test_library(
         "//src/cdk/testing/testbed",
         "//src/material/button",
         "//src/material/button/testing",
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
     ],
 )
 

--- a/test/benchmarks/cdk/testing/component-harness/testbed.perf-spec.ts
+++ b/test/benchmarks/cdk/testing/component-harness/testbed.perf-spec.ts
@@ -106,7 +106,10 @@ describe('performance for the testbed harness environment', () => {
     });
   });
 
-  it('should fail intentionally so performance numbers are logged', fail);
+  // Enable this to see performance numbers in the console. Otherwise benchmark
+  // results are either put by benchpress into the runfile directory, or
+  // the `--test_output=streamed` Bazel flag should be used.
+  // it('should fail intentionally so performance numbers are logged', fail);
 });
 
 @Component({

--- a/test/benchmarks/material/button/BUILD.bazel
+++ b/test/benchmarks/material/button/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":button.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/card/BUILD.bazel
+++ b/test/benchmarks/material/card/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":card.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/checkbox/BUILD.bazel
+++ b/test/benchmarks/material/checkbox/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":checkbox.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/chips/BUILD.bazel
+++ b/test/benchmarks/material/chips/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":chips.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/form-field/BUILD.bazel
+++ b/test/benchmarks/material/form-field/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":form-field.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/menu/BUILD.bazel
+++ b/test/benchmarks/material/menu/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":menu.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/radio/BUILD.bazel
+++ b/test/benchmarks/material/radio/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":radio.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/slide-toggle/BUILD.bazel
+++ b/test/benchmarks/material/slide-toggle/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":slide-toggle.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/table/BUILD.bazel
+++ b/test/benchmarks/material/table/BUILD.bazel
@@ -4,7 +4,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":table.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/material/tabs/BUILD.bazel
+++ b/test/benchmarks/material/tabs/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":tabs.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/button/BUILD.bazel
+++ b/test/benchmarks/mdc/button/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":button.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/card/BUILD.bazel
+++ b/test/benchmarks/mdc/card/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":card.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/checkbox/BUILD.bazel
+++ b/test/benchmarks/mdc/checkbox/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":checkbox.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/chips/BUILD.bazel
+++ b/test/benchmarks/mdc/chips/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":chips.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/form-field/BUILD.bazel
+++ b/test/benchmarks/mdc/form-field/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":form-field.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/menu/BUILD.bazel
+++ b/test/benchmarks/mdc/menu/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":menu.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/radio/BUILD.bazel
+++ b/test/benchmarks/mdc/radio/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":radio.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/slide-toggle/BUILD.bazel
+++ b/test/benchmarks/mdc/slide-toggle/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":slide-toggle.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/table/BUILD.bazel
+++ b/test/benchmarks/mdc/table/BUILD.bazel
@@ -4,7 +4,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":table.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],

--- a/test/benchmarks/mdc/tabs/BUILD.bazel
+++ b/test/benchmarks/mdc/tabs/BUILD.bazel
@@ -7,7 +7,7 @@ component_benchmark(
     name = "benchmark",
     driver = "tabs.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private",
+        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
         "@npm//protractor",
         "@npm//@types/jasmine",
     ],


### PR DESCRIPTION
Fixes the benchpress test build errors due to an old change
where the driver utilities have been moved.

Note that most benchpress-tests are still failing currently at runtime as it seems,
mostly because `@angular/core` imports from `rxjs/operators` without an
explicit extension, breaking runtime ESM resolution. We would need to consider
bundling tests in benchmark tests, similar to how we do it in the CLI or elsehwere.

(or we wait until we eventually use the new node resolution in Angular framework as well..)