### PR TITLE
fix(material/datepicker): actions not re-rendering if swapped out while calendar is open

### DIFF
--- a/src/material/datepicker/datepicker-actions.spec.ts
+++ b/src/material/datepicker/datepicker-actions.spec.ts
@@ -257,6 +257,28 @@ describe('MatDatepickerActions', () => {
     expect(control.value).toBeTruthy();
     expect(onDateChange).toHaveBeenCalledTimes(1);
   }));
+
+  it('should be able to toggle the actions while the datepicker is open', fakeAsync(() => {
+    const fixture = createComponent(DatepickerWithActions);
+    fixture.componentInstance.renderActions = false;
+    fixture.detectChanges();
+
+    fixture.componentInstance.datepicker.open();
+    fixture.detectChanges();
+    tick();
+    flush();
+
+    const content = document.querySelector('.mat-datepicker-content')!;
+    expect(content.querySelector('.mat-datepicker-actions')).toBeFalsy();
+
+    fixture.componentInstance.renderActions = true;
+    fixture.detectChanges();
+    expect(content.querySelector('.mat-datepicker-actions')).toBeTruthy();
+
+    fixture.componentInstance.renderActions = false;
+    fixture.detectChanges();
+    expect(content.querySelector('.mat-datepicker-actions')).toBeFalsy();
+  }));
 });
 
 @Component({

--- a/tools/public_api_guard/material/datepicker.md
+++ b/tools/public_api_guard/material/datepicker.md
@@ -427,6 +427,7 @@ export class MatDatepickerContent<S, D = ExtractDateTypeFromSelection<S>> extend
     readonly _animationDone: Subject<void>;
     _animationState: 'enter-dropdown' | 'enter-dialog' | 'void';
     _applyPendingSelection(): void;
+    _assignActions(portal: TemplatePortal<any> | null, forceRerender: boolean): void;
     _calendar: MatCalendar<D>;
     _closeButtonFocused: boolean;
     _closeButtonText: string;


### PR DESCRIPTION
Fixes that we were only refreshing the actions while the calendar is closed.

Fixes #25122.