### PR TITLE
docs(material/portal): Removed the non-working syntax to get a portal

### DIFF
--- a/src/cdk/portal/portal.md
+++ b/src/cdk/portal/portal.md
@@ -37,13 +37,6 @@ Usage:
 <ng-template cdkPortal>
   <p>The content of this template is captured by the portal.</p>
 </ng-template>
-
-<!-- OR -->
-
-<!-- This result here is identical to the syntax above -->
-<p *cdkPortal>
-  The content of this template is captured by the portal.
-</p>
 ```
 
 A component can use `@ViewChild` or `@ViewChildren` to get a reference to a


### PR DESCRIPTION
Update documentation to remove the suggestion of using *cdkPortal to get a portal as viewchild binds to undefined when *cdkPortal is used.

Fixes #21092