### PR TITLE
refactor: explicitly set the display of the mat-paginator-icon to inline

### DIFF
--- a/src/material-experimental/mdc-paginator/paginator.scss
+++ b/src/material-experimental/mdc-paginator/paginator.scss
@@ -76,6 +76,7 @@ $button-icon-size: 28px;
 }
 
 .mat-mdc-paginator-icon {
+  display: inline-block;
   width: $button-icon-size;
 
   [dir='rtl'] & {

--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -69,6 +69,7 @@ $button-icon-size: 28px;
 }
 
 .mat-paginator-icon {
+  display: inline-block;
   width: $button-icon-size;
   fill: currentColor;
 


### PR DESCRIPTION
Some CSS resets like [Tailwind's Preflight](https://unpkg.com/tailwindcss@3.1.4/src/css/preflight.css) set the `display` value of the SVG element to `block` which break the design
of the mat-paginator-icon by making it not properly centered inside the button.

## Before

<img width="201" alt="Screenshot 2022-06-22 at 23 32 33" src="https://user-images.githubusercontent.com/8947112/175144699-cfdce0b6-318f-43df-adf7-1b2b3e6c9222.png">

## After

<img width="198" alt="Screenshot 2022-06-22 at 23 32 00" src="https://user-images.githubusercontent.com/8947112/175144747-2ac6a267-ef0e-47e9-a3f7-f5c1950f720a.png">


