### PR TITLE
build: avoid use of ts-node wrapper script as it breaks child process forking

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "postinstall": "node tools/postinstall/apply-patches.js",
-    "ng-dev": "ts-node --esm --project .ng-dev/tsconfig.json node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
+    "ng-dev": "cross-env TS_NODE_PROJECT=$PWD/.ng-dev/tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node --no-warnings --loader ts-node/esm node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
     "build": "ts-node --esm --project scripts/tsconfig.json ./scripts/build-packages-dist-main.mts",
     "build-docs-content": "ts-node --esm --project scripts/tsconfig.json ./scripts/build-docs-content-main.mts",
     "build-and-check-release-output": "ts-node --esm --project scripts/tsconfig.json scripts/build-and-check-release-output.mts",
@@ -166,6 +166,7 @@
     "browser-sync": "2.26.13",
     "chalk": "^4.1.0",
     "codelyzer": "^6.0.2",
+    "cross-env": "^7.0.3",
     "date-fns": "^2.28.0",
     "dgeni": "^0.4.14",
     "dgeni-packages": "^0.29.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,7 +329,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#f2ca0a57e8ede868dc51c3b80a0d3ca56d5fdf65":
   version "0.0.0-04a54cdfa050a7b6ed1dab8f0054f85022827ed5"
-  uid f2ca0a57e8ede868dc51c3b80a0d3ca56d5fdf65
   resolved "https://github.com/angular/dev-infra-private-builds.git#f2ca0a57e8ede868dc51c3b80a0d3ca56d5fdf65"
   dependencies:
     "@angular-devkit/build-angular" "14.1.0-next.1"
@@ -6414,6 +6413,13 @@ cross-env@^5.1.3:
   integrity sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==
   dependencies:
     cross-spawn "^6.0.5"
+
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
 
 cross-spawn@^5.0.1:
   version "5.1.0"


### PR DESCRIPTION
`ts-node` spawns a custom node launcher script and has a brotli-base64
encoded configuration that will point to the user-provided entry-point.

This breaks child process forking as we wouldn't be able to specify our
custom build worker and basically `ng-dev` would run inside `ng-dev`
again.