### PR TITLE
build: prepare for v15 and exceptional minors for v14

### DIFF
--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -16,4 +16,8 @@ export const pullRequest: PullRequestConfig = {
   mergeReadyLabel: 'merge ready',
   commitMessageFixupLabel: 'commit message fixup',
   caretakerNoteLabel: 'caretaker note',
+
+  // TODO(EXCEPTIONAL_MINOR): Remove this when v15 moves into RC / or when exceptional
+  // minors are supported.
+  __specialTreatRcAsExceptionalMinor: true,
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ci-notify-slack-failure": "ts-node --esm --project scripts/tsconfig.json scripts/circleci/notify-slack-job-failure.mts",
     "prepare": "husky install"
   },
-  "version": "14.1.0-next.2",
+  "version": "15.0.0-next.0",
   "dependencies": {
     "@angular/animations": "^14.0.1",
     "@angular/common": "^14.0.1",
@@ -76,7 +76,7 @@
     "@angular/bazel": "^14.0.1",
     "@angular/cli": "^14.0.1",
     "@angular/compiler-cli": "^14.0.1",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#f2ca0a57e8ede868dc51c3b80a0d3ca56d5fdf65",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#714bb709f6d7ee3386a7f1097a75a54ab92c285d",
     "@angular/localize": "^14.0.1",
     "@angular/platform-browser-dynamic": "^14.0.1",
     "@angular/platform-server": "^14.0.1",

--- a/scripts/docs-deploy/deploy-ci-push.mts
+++ b/scripts/docs-deploy/deploy-ci-push.mts
@@ -30,7 +30,11 @@ async function main() {
 
   if (branchName === active.next.branchName) {
     const major = active.next.version.major;
-    const targets = [{projectId, description, site: sites.next}];
+
+    const targets = [
+      // TODO(EXCEPTIONAL_MINOR): Restore the original logic for `next.material.angular.io`.
+      // {projectId, description, site: sites.next}
+    ];
 
     // If the next release train is for a new major that is not published as part of the
     // other active release trains, we also publish to e.g. `v14.material.angular.io`.
@@ -68,7 +72,11 @@ async function main() {
 
   if (branchName === active.releaseCandidate?.branchName) {
     const major = active.releaseCandidate.version.major;
-    const targets = [{projectId, description, site: sites.rc}];
+    const targets = [
+      // TODO(EXCEPTIONAL_MINOR): Restore the original logic for `next.material.angular.io`.
+      {projectId, description, site: sites.next},
+      {projectId, description, site: sites.rc},
+    ];
 
     // If the RC is for a new major that `latest` does not publish yet, we will deploy
     // the dedicated major site like `v13.material.angular.io` using the `rc` branch.

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,9 +327,9 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#f2ca0a57e8ede868dc51c3b80a0d3ca56d5fdf65":
-  version "0.0.0-04a54cdfa050a7b6ed1dab8f0054f85022827ed5"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#f2ca0a57e8ede868dc51c3b80a0d3ca56d5fdf65"
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#714bb709f6d7ee3386a7f1097a75a54ab92c285d":
+  version "0.0.0-3e07a8f0335813ddeee471c7c1db12325c07325e"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#714bb709f6d7ee3386a7f1097a75a54ab92c285d"
   dependencies:
     "@angular-devkit/build-angular" "14.1.0-next.1"
     "@angular/benchpress" "0.3.0"


### PR DESCRIPTION
Important notes:

1. `main` will temporarily not deploy to `next.material.angular.io`. We will just deploy to v15.material.angular.io
2. The v15 docs site is based on the `material.angular.io` repo `15.x` branch (preparation can land there)
3. Exceptional minors are published to `next.material.angular.io` and `rc.material.angular.io`. 