### PR TITLE
refactor(multiple): deprecate HighContrastModeDetector

### DIFF
--- a/src/cdk/a11y/_index.scss
+++ b/src/cdk/a11y/_index.scss
@@ -54,12 +54,39 @@
   }
 }
 
+/// @deprecated Use `active` target instead.
+/// @breaking-change 18.0.0
+///
+/// Emits the mixin's content nested under a `.cdk-high-contrast-black-on-white` or
+/// `.cdk-high-contrast-white-on-black-on-white` selector if $target is black-on-white or
+/// white-on-black.
+///
+/// Supports the deprecated `black-on-white` and `white-on-black` targets, which depend on
+/// deprecated `HighContrastModeDetector`. To be removed when `HighContrastModeDetector` is
+/// removed.
+///
+/// @param {String} target Type of high contrast setting to target. Can be `active`,
+///     `white-on-black` or `black-on-white`.
+@mixin _optinally-nest-target-class($target) {
+  @if ($target == 'black-on-white' or $target == 'white-on-black') {
+    .cdk-high-contrast-#{$target} {
+      @content;
+    }
+  }
+  @else {
+    @content;
+  }
+}
+
 /// Applies styles for users in high contrast mode. Note that this only applies
 /// to Microsoft browsers. Chrome can be included by checking for the `html[hc]`
 /// attribute, however Chrome handles high contrast differently.
 ///
-/// @param {String} target Type of high contrast setting to target. Defaults to `active`, can be
-///     `white-on-black` or `black-on-white`.
+/// Target of `white-on-black` and `black-on-white` are deprecated. Functionality will be removed
+/// in a future version. Use `active` target or forced-colors media query instead.
+///
+/// @param {String} target Type of high contrast setting to target. Defaults to `active`. Types of
+///     `white-on-black` and `black-on-white` are deprecated.
 /// @param {String} encapsulation Whether to emit styles for view encapsulation. Values are:
 ///     * `on` - works for `Emulated`, `Native`, and `ShadowDom`
 ///     * `off` - works for `None`
@@ -68,6 +95,12 @@
   @if ($target != 'active' and $target != 'black-on-white' and $target != 'white-on-black') {
     @error 'Unknown cdk-high-contrast value "#{$target}" provided. ' +
            'Allowed values are "active", "black-on-white", and "white-on-black"';
+  }
+
+  @if ($target == 'black-on-white' or $target == 'white-on-black') {
+    @warn 'Deprecated cdk-high-contrast value "#{$target}" provided. ' +
+          'Support for "#{$target}" will be removed in a future version. ' +
+          'Use "active" value or forced-colors media query instead.';
   }
 
   @if ($encapsulation != 'on' and $encapsulation != 'off' and $encapsulation != 'any') {
@@ -84,7 +117,7 @@
     @if ($encapsulation != 'on') {
       // Note that if this selector is updated, the same change has to be made inside
       // `_overlay.scss` which can't depend on this mixin due to some infrastructure limitations.
-      .cdk-high-contrast-#{$target} {
+      @include _optinally-nest-target-class($target) {
         @include _optionally-nest-content($selector-context) {
           @content;
         }
@@ -92,9 +125,11 @@
     }
 
     @if ($encapsulation != 'off') {
-      .cdk-high-contrast-#{$target} :host {
-        @include _optionally-nest-content($selector-context) {
-          @content;
+      @include _optinally-nest-target-class($target) {
+        :host {
+          @include _optionally-nest-content($selector-context) {
+            @content;
+          }
         }
       }
     }

--- a/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
+++ b/src/cdk/a11y/high-contrast-mode/high-contrast-mode-detector.ts
@@ -12,20 +12,40 @@ import {Platform} from '@angular/cdk/platform';
 import {DOCUMENT} from '@angular/common';
 import {Subscription} from 'rxjs';
 
-/** Set of possible high-contrast mode backgrounds. */
+/**
+ * Set of possible high-contrast mode backgrounds.
+ *
+ * @deprecated Use `forced-colors` media query instead.
+ * @breaking-change 18.0.0
+ */
 export const enum HighContrastMode {
   NONE,
   BLACK_ON_WHITE,
   WHITE_ON_BLACK,
 }
 
-/** CSS class applied to the document body when in black-on-white high-contrast mode. */
+/**
+ * CSS class applied to the document body when in black-on-white high-contrast mode.
+ *
+ * @deprecated Use `forced-colors` media query instead.
+ * @breaking-change 18.0.0
+ */
 export const BLACK_ON_WHITE_CSS_CLASS = 'cdk-high-contrast-black-on-white';
 
-/** CSS class applied to the document body when in white-on-black high-contrast mode. */
+/**
+ * CSS class applied to the document body when in white-on-black high-contrast mode.
+ *
+ * @deprecated Use `forced-colors` media query instead.
+ * @breaking-change 18.0.0
+ */
 export const WHITE_ON_BLACK_CSS_CLASS = 'cdk-high-contrast-white-on-black';
 
-/** CSS class applied to the document body when in high-contrast mode. */
+/**
+ * CSS class applied to the document body when in high-contrast mode.
+ *
+ * @deprecated Use `forced-colors` media query instead.
+ * @breaking-change 18.0.0
+ */
 export const HIGH_CONTRAST_MODE_ACTIVE_CSS_CLASS = 'cdk-high-contrast-active';
 
 /**
@@ -38,6 +58,9 @@ export const HIGH_CONTRAST_MODE_ACTIVE_CSS_CLASS = 'cdk-high-contrast-active';
  * IE, Edge, and Firefox currently support this mode. Chrome does not support Windows High Contrast
  * Mode. This service does not detect high-contrast mode as added by the Chrome "High Contrast"
  * browser extension.
+ *
+ * @deprecated Use `forced-colors` media query instead.
+ * @breaking-change 18.0.0
  */
 @Injectable({providedIn: 'root'})
 export class HighContrastModeDetector implements OnDestroy {
@@ -62,7 +85,12 @@ export class HighContrastModeDetector implements OnDestroy {
       });
   }
 
-  /** Gets the current high-contrast-mode for the page. */
+  /**
+   * Gets the current high-contrast-mode for the page.
+   *
+   * @deprecated Use `forced-colors` media query instead.
+   * @breaking-change 18.0.0
+   */
   getHighContrastMode(): HighContrastMode {
     if (!this._platform.isBrowser) {
       return HighContrastMode.NONE;
@@ -111,7 +139,12 @@ export class HighContrastModeDetector implements OnDestroy {
     this._breakpointSubscription.unsubscribe();
   }
 
-  /** Applies CSS classes indicating high-contrast mode to document body (browser-only). */
+  /**
+   * Applies CSS classes indicating high-contrast mode to document body (browser-only).
+   *
+   * @deprecated Use `forced-colors` media query instead.
+   * @breaking-change 18.0.0
+   */
   _applyBodyHighContrastModeCssClasses(): void {
     if (!this._hasCheckedHighContrastMode && this._platform.isBrowser && this._document.body) {
       const bodyClasses = this._document.body.classList;

--- a/src/material-experimental/popover-edit/BUILD.bazel
+++ b/src/material-experimental/popover-edit/BUILD.bazel
@@ -26,7 +26,6 @@ sass_library(
     name = "popover_edit_scss_lib",
     srcs = glob(["**/_*.scss"]),
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material:sass_lib",
     ],
 )

--- a/src/material-experimental/popover-edit/_popover-edit-theme.scss
+++ b/src/material-experimental/popover-edit/_popover-edit-theme.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '@angular/cdk';
 @use '@angular/material' as mat;
 
 @function _hover-content-background($direction, $background-color) {
@@ -83,7 +82,7 @@
     display: block;
     padding: 16px 24px;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       // Note that normally we use 1px for high contrast outline, however here we use 3,
       // because the popover is rendered on top of a table which already has some borders
       // and doesn't have a backdrop. The thicker outline makes it easier to differentiate.

--- a/src/material/autocomplete/BUILD.bazel
+++ b/src/material/autocomplete/BUILD.bazel
@@ -36,7 +36,6 @@ sass_binary(
     src = "autocomplete.scss",
     deps = [
         "//:mdc_sass_lib",
-        "//src/cdk:sass_lib",
     ],
 )
 

--- a/src/material/autocomplete/autocomplete.scss
+++ b/src/material/autocomplete/autocomplete.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use '@material/menu-surface/mixins' as mdc-menu-surface;
 @use '@material/list/evolution-mixins' as mdc-list;
 
@@ -16,7 +15,7 @@
   transform-origin: center top;
 
   @include mdc-list.list-base($query: structure);
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 

--- a/src/material/badge/BUILD.bazel
+++ b/src/material/badge/BUILD.bazel
@@ -31,7 +31,6 @@ sass_library(
     name = "badge_scss_lib",
     srcs = glob(["**/_*.scss"]),
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/badge/_badge-theme.scss
+++ b/src/material/badge/_badge-theme.scss
@@ -5,7 +5,6 @@
 @use 'sass:map';
 @use 'sass:meta';
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/theming/theming';
 @use '../core/typography/typography';
@@ -167,7 +166,7 @@ $_badge-structure-emitted: false !default;
     color: theming.get-color-from-palette($primary, default-contrast);
     background: theming.get-color-from-palette($primary);
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       outline: solid 1px;
       border-radius: 0;
     }

--- a/src/material/bottom-sheet/BUILD.bazel
+++ b/src/material/bottom-sheet/BUILD.bazel
@@ -46,7 +46,6 @@ sass_library(
 sass_binary(
     name = "bottom_sheet_container_scss",
     src = "bottom-sheet-container.scss",
-    deps = ["//src/cdk:sass_lib"],
 )
 
 ng_test_library(

--- a/src/material/bottom-sheet/bottom-sheet-container.scss
+++ b/src/material/bottom-sheet/bottom-sheet-container.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 // The bottom sheet minimum width on larger screen sizes is based
 // on increments of the toolbar, according to the spec. See:
 // https://material.io/guidelines/components/bottom-sheets.html#bottom-sheets-specs
@@ -17,7 +15,7 @@ $container-horizontal-padding: 16px !default;
   max-height: 80vh;
   overflow: auto;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: 1px solid;
   }
 }

--- a/src/material/button-toggle/BUILD.bazel
+++ b/src/material/button-toggle/BUILD.bazel
@@ -43,7 +43,6 @@ sass_binary(
     name = "button_toggle_scss",
     src = "button-toggle.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/button-toggle/button-toggle.scss
+++ b/src/material/button-toggle/button-toggle.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/vendor-prefixes';
 @use '../core/style/layout-common';
 
@@ -23,7 +21,7 @@ $legacy-border-radius: 2px !default;
   // Fixes the ripples not being clipped to the border radius on Safari.
   transform: translateZ(0);
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }
@@ -32,7 +30,7 @@ $legacy-border-radius: 2px !default;
 .mat-button-toggle-group-appearance-standard {
   border-radius: $standard-border-radius;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: 0;
   }
 }
@@ -116,7 +114,7 @@ $legacy-border-radius: 2px !default;
   opacity: 0;
 }
 
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   // Changing the background color for the selected item won't be visible in high contrast mode.
   // We fall back to using the overlay to draw a brighter, semi-transparent tint on top instead.
   // It uses a border, because the browser will render it using a brighter color.
@@ -125,6 +123,11 @@ $legacy-border-radius: 2px !default;
       border-bottom: solid $legacy-height;
       opacity: 0.5;
       height: 0;
+    }
+
+    // Ensure opacity is correctly set for legacy appearance.
+    &.cdk-keyboard-focused .mat-button-toggle-focus-overlay {
+      opacity: 0.5;
     }
 
     &:hover .mat-button-toggle-focus-overlay {

--- a/src/material/button/BUILD.bazel
+++ b/src/material/button/BUILD.bazel
@@ -60,9 +60,6 @@ sass_binary(
 sass_binary(
     name = "button_high_contrast_scss",
     src = "button-high-contrast.scss",
-    deps = [
-        "//src/cdk:sass_lib",
-    ],
 )
 
 sass_binary(

--- a/src/material/button/button-high-contrast.scss
+++ b/src/material/button/button-high-contrast.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 // Add an outline to make buttons more visible in high contrast mode. Stroked buttons and FABs
 // don't need a special look in high-contrast mode, because those already have an outline.
 .mat-mdc-button:not(.mdc-button--outlined),
@@ -7,7 +5,7 @@
 .mat-mdc-raised-button:not(.mdc-button--outlined),
 .mat-mdc-outlined-button:not(.mdc-button--outlined),
 .mat-mdc-icon-button {
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }

--- a/src/material/checkbox/checkbox.scss
+++ b/src/material/checkbox/checkbox.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use '@material/checkbox/checkbox' as mdc-checkbox;
 @use '@material/checkbox/checkbox-theme' as mdc-checkbox-theme;
 @use '@material/form-field' as mdc-form-field;
@@ -100,7 +99,7 @@
     }
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     &.mat-mdc-checkbox-disabled {
       opacity: 0.5;
     }

--- a/src/material/chips/BUILD.bazel
+++ b/src/material/chips/BUILD.bazel
@@ -47,7 +47,6 @@ sass_binary(
     src = "chip.scss",
     deps = [
         "//:mdc_sass_lib",
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/chips/chip.scss
+++ b/src/material/chips/chip.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use '@material/chips/chip' as mdc-chip;
 @use '@material/chips/chip-theme' as mdc-chip-theme;
 @use '../core/mdc-helpers/mdc-helpers';
@@ -104,7 +103,7 @@
     ));
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
 
     .mdc-evolution-chip__checkmark-path {
@@ -299,7 +298,7 @@
 // Single-selection chips show their selected state using a background color which won't be visible
 // in high contrast mode. This isn't necessary in multi-selection since there's a checkmark.
 .mat-mdc-chip-selected:not(.mat-mdc-chip-multiple) {
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline-width: 3px;
   }
 }

--- a/src/material/core/focus-indicators/_private.scss
+++ b/src/material/core/focus-indicators/_private.scss
@@ -1,6 +1,5 @@
 @use 'sass:map';
 @use 'sass:meta';
-@use '@angular/cdk';
 @use '../style/layout-common';
 @use '../theming/theming';
 
@@ -46,7 +45,7 @@ $default-border-radius: 4px;
   }
 
   // Enable the indicator in high contrast mode.
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     @include customize-focus-indicators((display: block), $prefix);
   }
 }

--- a/src/material/core/option/option.scss
+++ b/src/material/core/option/option.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '@angular/cdk';
 @use '@material/list/evolution-mixins' as mdc-list-mixins;
 @use '@material/list/evolution-variables' as mdc-list-variables;
 
@@ -86,7 +85,7 @@
     text-transform: inherit;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     // In single selection mode, the selected option is indicated by changing its
     // background color, but that doesn't work in high contrast mode. We add an
     // alternate indication by rendering out a circle.

--- a/src/material/core/ripple/_ripple.scss
+++ b/src/material/core/ripple/_ripple.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @mixin ripple() {
   // The host element of an mat-ripple directive should always have a position of "absolute" or
   // "relative" so that the ripples inside are correctly positioned relatively to the container.
@@ -36,7 +34,7 @@
     transform: scale3d(0, 0, 0);
 
     // In high contrast mode the ripple is opaque, causing it to obstruct the content.
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       display: none;
     }
   }

--- a/src/material/core/style/_menu-common.scss
+++ b/src/material/core/style/_menu-common.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use './list-common';
 @use './layout-common';
 
@@ -85,7 +83,7 @@ $icon-margin: 16px !default;
   }
 
   // Fix for Chromium-based browsers blending in the `currentColor` with the background.
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     fill: CanvasText;
   }
 }

--- a/src/material/datepicker/BUILD.bazel
+++ b/src/material/datepicker/BUILD.bazel
@@ -62,14 +62,12 @@ sass_binary(
 sass_binary(
     name = "datepicker_toggle_scss",
     src = "datepicker-toggle.scss",
-    deps = ["//src/cdk:sass_lib"],
 )
 
 sass_binary(
     name = "calendar_scss",
     src = "calendar.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )
@@ -78,7 +76,6 @@ sass_binary(
     name = "calendar_body_scss",
     src = "calendar-body.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )
@@ -87,7 +84,6 @@ sass_binary(
     name = "date_range_input_scss",
     src = "date-range-input.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/datepicker/calendar-body.scss
+++ b/src/material/datepicker/calendar-body.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/button-common';
 
@@ -173,7 +172,7 @@ $calendar-range-end-body-cell-size:
   // Fade out the disabled cells so that they can be distinguished from the enabled ones. Note that
   // ideally we'd use `color: GreyText` here which is what the browser uses for disabled buttons,
   // but we can't because Firefox doesn't recognize it.
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     opacity: 0.5;
   }
 }
@@ -206,12 +205,12 @@ $calendar-range-end-body-cell-size:
     position: absolute;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     border: none;
   }
 }
 
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   $main-range-border: solid 1px;
   $comparison-range-border: dashed 1px;
 
@@ -227,7 +226,10 @@ $calendar-range-end-body-cell-size:
   // These backgrounds need to be removed, because they'll block the date ranges.
   .mat-calendar-body-cell::before,
   .mat-calendar-body-cell::after,
-  .mat-calendar-body-selected {
+  .mat-calendar-body-selected,
+  .mat-calendar-body-in-range.mat-calendar-body-cell::before,
+  .mat-calendar-body-in-range.mat-calendar-body-cell::after,
+  .mat-calendar-body-in-range .mat-calendar-body-selected {
     background: none;
   }
 

--- a/src/material/datepicker/calendar.scss
+++ b/src/material/datepicker/calendar.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/layout-common';
 @use '../core/focus-indicators/private';
 
@@ -64,7 +62,7 @@ $calendar-next-icon-transform: translateX(-2px) rotate(45deg);
     margin: 0 $calendar-arrow-size 0 0;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     // Setting the fill to `currentColor` doesn't work on Chromium browsers.
     fill: CanvasText;
   }

--- a/src/material/datepicker/date-range-input.scss
+++ b/src/material/datepicker/date-range-input.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/variables';
 @use '../core/style/vendor-prefixes';
@@ -103,7 +102,7 @@ $date-range-input-part-max-width: calc(50% - #{$date-range-input-separator-spaci
       -webkit-text-fill-color: transparent;
       transition: none;
 
-      @include cdk.high-contrast(active, off) {
+      @media(forced-colors: active) {
         // In high contrast mode the browser will render the
         // placeholder despite the `color: transparent` above.
         opacity: 0;

--- a/src/material/datepicker/datepicker-toggle.scss
+++ b/src/material/datepicker/datepicker-toggle.scss
@@ -1,12 +1,10 @@
-@use '@angular/cdk';
-
 // We support the case where the form field is disabled, but the datepicker is not.
 // MDC sets `pointer-events: none` on disabled form fields which prevents clicks on the toggle.
 .mat-datepicker-toggle {
   pointer-events: auto;
 }
 
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   .mat-datepicker-toggle-default-icon {
     // On Chromium-based browsers the icon doesn't appear to inherit the text color in high
     // contrast mode so we have to set it explicitly. This is a no-op on IE and Firefox.

--- a/src/material/expansion/BUILD.bazel
+++ b/src/material/expansion/BUILD.bazel
@@ -57,7 +57,6 @@ sass_binary(
     src = "expansion-panel-header.scss",
     deps = [
         ":expansion_scss_lib",
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/expansion/expansion-panel-header.scss
+++ b/src/material/expansion/expansion-panel-header.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use './expansion-variables';
 
 .mat-expansion-panel-header {
@@ -98,7 +97,7 @@
   vertical-align: middle;
 }
 
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   .mat-expansion-panel-content {
     border-top: 1px solid;
     border-top-left-radius: 0;

--- a/src/material/expansion/expansion-panel.scss
+++ b/src/material/expansion/expansion-panel.scss
@@ -1,6 +1,4 @@
 
-@use '@angular/cdk';
-
 @use '../core/style/variables';
 @use '../core/style/elevation';
 
@@ -35,7 +33,7 @@
     }
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 

--- a/src/material/form-field/BUILD.bazel
+++ b/src/material/form-field/BUILD.bazel
@@ -65,7 +65,6 @@ sass_library(
     ],
     deps = [
         "//:mdc_sass_lib",
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/form-field/_form-field-high-contrast.scss
+++ b/src/material/form-field/_form-field-high-contrast.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @mixin private-form-field-high-contrast() {
   $focus-indicator-width: 3px;
   $focus-indicator-style: dashed;
@@ -8,14 +6,14 @@
     // The outline of the `fill` appearance is achieved through a background color
     // which won't be visible in high contrast mode. Add an outline to replace it.
     .mat-mdc-text-field-wrapper {
-      @include cdk.high-contrast(active, off) {
+      @media(forced-colors: active) {
         outline: solid 1px;
       }
     }
 
     // Use GreyText for the disabled outline color which will account for the user's configuration.
     &.mat-form-field-disabled .mat-mdc-text-field-wrapper {
-      @include cdk.high-contrast(active, off) {
+      @media(forced-colors: active) {
         outline-color: GrayText;
       }
     }
@@ -24,7 +22,7 @@
   // If a form field with fill appearance is focused, update the outline to be
   // dashed and thicker to indicate focus.
   .mat-form-field-appearance-fill.mat-focused .mat-mdc-text-field-wrapper {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       outline: $focus-indicator-style $focus-indicator-width;
     }
   }
@@ -32,7 +30,7 @@
   // For form fields with outline appearance, we show a dashed thick border on top
   // of the solid notched-outline border to indicate focus.
   .mat-mdc-form-field.mat-focused .mdc-notched-outline {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       border: $focus-indicator-style $focus-indicator-width;
     }
   }

--- a/src/material/legacy-autocomplete/BUILD.bazel
+++ b/src/material/legacy-autocomplete/BUILD.bazel
@@ -39,7 +39,6 @@ sass_binary(
     name = "legacy_autocomplete_scss",
     src = "autocomplete.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-autocomplete/autocomplete.scss
+++ b/src/material/legacy-autocomplete/autocomplete.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/menu-common';
 
 // The max-height of the panel, currently matching mat-select value.
@@ -37,7 +35,7 @@ $panel-border-radius: 4px !default;
     margin-top: -1px;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }

--- a/src/material/legacy-button/BUILD.bazel
+++ b/src/material/legacy-button/BUILD.bazel
@@ -39,7 +39,6 @@ sass_binary(
     src = "button.scss",
     deps = [
         ":legacy_button_scss_lib",
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
         "//src/material/datepicker:datepicker_scss_lib",
     ],

--- a/src/material/legacy-button/button.scss
+++ b/src/material/legacy-button/button.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use './button-base';
 @use '../core/style/layout-common';
 @use '../core/focus-indicators/private';
@@ -178,7 +176,7 @@
 
 // Add an outline to make buttons more visible in high contrast mode. Stroked buttons
 // don't need a special look in high-contrast mode, because those already have an outline.
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   .mat-button, .mat-flat-button, .mat-raised-button, .mat-icon-button, .mat-fab, .mat-mini-fab {
     outline: solid 1px;
   }

--- a/src/material/legacy-card/BUILD.bazel
+++ b/src/material/legacy-card/BUILD.bazel
@@ -30,7 +30,6 @@ sass_binary(
     name = "card_scss",
     src = "card.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-card/card.scss
+++ b/src/material/legacy-card/card.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/variables';
 @use '../core/style/elevation';
@@ -39,7 +38,7 @@ $header-size: 40px !default;
     }
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }

--- a/src/material/legacy-checkbox/checkbox.scss
+++ b/src/material/legacy-checkbox/checkbox.scss
@@ -290,12 +290,14 @@ $_mark-stroke-size: math.div(2, 15) * checkbox-common.$legacy-size !default;
   ._mat-animation-noopable & {
     transition: none;
   }
+}
 
-  // `.mat-checkbox` here is redundant, but we need it to increase the specificity so that
-  // these styles don't get overwritten by the `background-color` from the theme.
-  .mat-checkbox & {
-    @include cdk.high-contrast(active, off) {
-      // Needs to be removed because it hides the checkbox outline.
+// `.mat-checkbox`, `.mat-checkbox-checked` and `.mat-checkbox-indeterminate` here are redundant,
+// but we need it to increase the specificity so that these styles don't get overwritten by the
+// `background-color` from the theme.
+@media(forced-colors: active) {
+  .mat-checkbox, .mat-checkbox.mat-checkbox-checked, .mat-checkbox.mat-checkbox-indeterminate {
+    .mat-checkbox-background {
       background: none;
     }
   }
@@ -361,7 +363,7 @@ $_mark-stroke-size: math.div(2, 15) * checkbox-common.$legacy-size !default;
   transform: scaleX(0) rotate(0deg);
   border-radius: 2px;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     height: 0;
     border-top: solid $height;
     margin-top: $height;
@@ -425,7 +427,7 @@ $_mark-stroke-size: math.div(2, 15) * checkbox-common.$legacy-size !default;
 .mat-checkbox-disabled {
   cursor: default;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     opacity: 0.5;
   }
 }

--- a/src/material/legacy-chips/BUILD.bazel
+++ b/src/material/legacy-chips/BUILD.bazel
@@ -41,7 +41,6 @@ sass_binary(
     name = "chips_scss",
     src = "chips.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-chips/chips.scss
+++ b/src/material/legacy-chips/chips.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/variables';
 @use '../core/style/elevation';
 @use '../core/style/layout-common';
@@ -99,12 +97,14 @@ $chip-remove-size: 18px;
     }
   }
 
-  @include cdk.high-contrast(active, off) {
-    outline: solid 1px;
+  @media(forced-colors: active) {
+    &.mat-focus-indicator {
+      outline: solid 1px;
 
-    // Seleted state is shown using a background color which isn't visible in high contrast mode.
-    &.mat-chip-selected {
-      outline-width: 3px;
+      // Seleted state is shown using a background color which isn't visible in high contrast mode.
+      &.mat-chip-selected {
+        outline-width: 3px;
+      }
     }
   }
 

--- a/src/material/legacy-core/option/option.scss
+++ b/src/material/legacy-core/option/option.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use 'sass:math';
 
 @use '../../core/style/menu-common';
@@ -36,7 +35,7 @@
     content: '';
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     // Fade out the option when it is disabled so that it can be distinguished from the enabled
     // options. Note that ideally we'd use `color: GreyText` here which is what the browser uses
     // for disabled buttons, but we can't because Firefox doesn't recognize it.

--- a/src/material/legacy-dialog/BUILD.bazel
+++ b/src/material/legacy-dialog/BUILD.bazel
@@ -43,7 +43,6 @@ sass_binary(
     name = "dialog_scss",
     src = "dialog.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-dialog/dialog.scss
+++ b/src/material/legacy-dialog/dialog.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 $padding: 24px !default;
 $border-radius: 4px !default;
 $max-height: 65vh !default;
@@ -22,7 +20,7 @@ $button-margin: 8px !default;
   min-height: inherit;
   max-height: inherit;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }

--- a/src/material/legacy-form-field/BUILD.bazel
+++ b/src/material/legacy-form-field/BUILD.bazel
@@ -48,7 +48,6 @@ sass_binary(
     name = "legacy_form_field_scss",
     src = "form-field.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
         "//src/material/datepicker:datepicker_scss_lib",
     ],
@@ -58,7 +57,6 @@ sass_binary(
     name = "form_field_fill_scss",
     src = "form-field-fill.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )
@@ -67,7 +65,6 @@ sass_binary(
     name = "form_field_input_scss",
     src = "form-field-input.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )
@@ -76,7 +73,6 @@ sass_binary(
     name = "form_field_legacy_scss",
     src = "form-field-legacy.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )
@@ -85,7 +81,6 @@ sass_binary(
     name = "form_field_outline_scss",
     src = "form-field-outline.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )
@@ -94,7 +89,6 @@ sass_binary(
     name = "form_field_standard_scss",
     src = "form-field-standard.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-form-field/form-field-fill.scss
+++ b/src/material/legacy-form-field/form-field-fill.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/variables';
 
@@ -28,19 +27,19 @@ $fill-subscript-padding: math.div($fill-side-padding, $fill-subscript-font-scale
     padding: $fill-line-spacing $fill-side-padding 0
              $fill-side-padding;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       outline: solid 1px;
     }
   }
 
   &.mat-form-field-disabled .mat-form-field-flex {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       outline-color: GrayText;
     }
   }
 
   &.mat-focused .mat-form-field-flex {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       outline: dashed 3px;
     }
   }
@@ -58,7 +57,7 @@ $fill-subscript-padding: math.div($fill-side-padding, $fill-subscript-font-scale
     bottom: 0;
     height: $fill-underline-ripple-height;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       // In high-contrast mode, we hide the ripple as we have a dashed outline as
       // focus indicator.
       height: 0;

--- a/src/material/legacy-form-field/form-field-input.scss
+++ b/src/material/legacy-form-field/form-field-input.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/variables';
 @use '../core/style/vendor-prefixes';
@@ -120,7 +119,7 @@
       // from overlapping when the label comes back down.
       transition: none;
 
-      @include cdk.high-contrast(active, off) {
+      @media(forced-colors: active) {
         // In high contrast mode the browser will render the
         // placeholder despite the `color: transparent` above.
         opacity: 0;

--- a/src/material/legacy-form-field/form-field-legacy.scss
+++ b/src/material/legacy-form-field/form-field-legacy.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 // Styles that only apply to the legacy appearance of the form-field.
 
 // The height of the underline.
@@ -34,7 +32,7 @@ $legacy-underline-height: 1px !default;
   .mat-form-field-underline {
     height: $legacy-underline-height;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       height: 0;
       border-top: solid $legacy-underline-height;
     }
@@ -49,7 +47,7 @@ $legacy-underline-height: 1px !default;
     // the desired form-field ripple height. See: angular/components#6351
     overflow: hidden;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       height: 0;
       border-top: solid $height;
     }
@@ -59,7 +57,7 @@ $legacy-underline-height: 1px !default;
     background-position: 0;
     background-color: transparent;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       border-top-style: dotted;
       border-top-width: 2px;
       border-top-color: GrayText;

--- a/src/material/legacy-form-field/form-field-outline.scss
+++ b/src/material/legacy-form-field/form-field-outline.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/variables';
 
@@ -119,7 +118,7 @@ $outline-subscript-padding: math.div($outline-side-padding, $outline-subscript-f
   }
 
   &.mat-focused .mat-form-field-outline-thick {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       border: 3px dashed;
     }
   }
@@ -140,7 +139,7 @@ $outline-subscript-padding: math.div($outline-side-padding, $outline-subscript-f
   }
 
   &.mat-form-field-disabled .mat-form-field-outline {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       color: GrayText;
     }
   }

--- a/src/material/legacy-form-field/form-field-standard.scss
+++ b/src/material/legacy-form-field/form-field-standard.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/variables';
 
 
@@ -22,7 +20,7 @@ $standard-padding-top: 0.75em !default;
   .mat-form-field-underline {
     height: $standard-underline-height;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       height: 0;
       border-top: solid $standard-underline-height;
     }
@@ -33,7 +31,7 @@ $standard-padding-top: 0.75em !default;
     bottom: 0;
     height: $height;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       height: 0;
       border-top: solid $height;
     }
@@ -43,7 +41,7 @@ $standard-padding-top: 0.75em !default;
     background-position: 0;
     background-color: transparent;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       border-top-style: dotted;
       border-top-width: 2px;
     }

--- a/src/material/legacy-form-field/form-field.scss
+++ b/src/material/legacy-form-field/form-field.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/variables';
 @use '../datepicker/datepicker-legacy-compat';
 
@@ -58,7 +56,7 @@ $default-infix-width: 180px !default;
   // Since we can't remove the border altogether or replace it with a margin, because it'll throw
   // off the baseline, and we can't use a base64-encoded 1x1 transparent image because of CSP,
   // we work around it by setting a linear gradient that goes from `transparent` to `transparent`.
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     border-image: linear-gradient(transparent, transparent);
   }
 }
@@ -115,7 +113,7 @@ $default-infix-width: 180px !default;
   }
 
   .mat-form-field-disabled & {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       color: GrayText;
     }
   }

--- a/src/material/legacy-list/BUILD.bazel
+++ b/src/material/legacy-list/BUILD.bazel
@@ -44,7 +44,6 @@ sass_binary(
     name = "list_scss",
     src = "list.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
         "//src/material/divider:divider_scss_lib",
     ],

--- a/src/material/legacy-list/list.scss
+++ b/src/material/legacy-list/list.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/list-common';
 @use '../core/style/layout-common';
 @use '../divider/divider-offset';
@@ -310,12 +308,12 @@ mat-action-list {
 
   // Since we can't use a color to indicate that the list
   // item is disabled, we have to use opacity instead.
-  @include cdk.high-contrast {
+  @media(forced-colors: active) {
     opacity: 0.5;
   }
 }
 
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   .mat-list-option,
   .mat-nav-list .mat-list-item,
   mat-action-list .mat-list-item {

--- a/src/material/legacy-menu/BUILD.bazel
+++ b/src/material/legacy-menu/BUILD.bazel
@@ -37,7 +37,6 @@ sass_binary(
     name = "menu_scss",
     src = "menu.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-menu/menu.scss
+++ b/src/material/legacy-menu/menu.scss
@@ -1,6 +1,4 @@
 
-@use '@angular/cdk';
-
 @use '../core/style/button-common';
 @use '../core/style/menu-common';
 
@@ -38,7 +36,7 @@ mat-menu {
     pointer-events: none;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }
@@ -68,7 +66,7 @@ mat-menu {
     right: 0;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     $outline-width: 1px;
 
     // We need to move the item 1px down, because Firefox seems to have

--- a/src/material/legacy-paginator/BUILD.bazel
+++ b/src/material/legacy-paginator/BUILD.bazel
@@ -41,9 +41,6 @@ sass_library(
 sass_binary(
     name = "paginator_scss",
     src = "paginator.scss",
-    deps = [
-        "//src/cdk:sass_lib",
-    ],
 )
 
 ng_test_library(

--- a/src/material/legacy-paginator/paginator.scss
+++ b/src/material/legacy-paginator/paginator.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 $padding: 0 8px;
 $page-size-margin-right: 8px;
 
@@ -77,7 +75,7 @@ $button-icon-size: 28px;
     transform: rotate(180deg);
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     // On Chromium browsers the `currentColor` blends in with the
     // background for SVGs so we have to fall back to `CanvasText`.
     fill: CanvasText;

--- a/src/material/legacy-progress-bar/BUILD.bazel
+++ b/src/material/legacy-progress-bar/BUILD.bazel
@@ -37,7 +37,6 @@ sass_binary(
     name = "progress_bar_scss",
     src = "progress-bar.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-progress-bar/progress-bar.scss
+++ b/src/material/legacy-progress-bar/progress-bar.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/vendor-prefixes';
 @use '../core/style/private';
 
@@ -32,7 +30,7 @@ $piece-animation-duration: 250ms !default;
     // during the background scroll animation.
     width: calc(100% + 10px);
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       display: none;
     }
   }
@@ -43,7 +41,7 @@ $piece-animation-duration: 250ms !default;
     transform-origin: top left;
     transition: transform $piece-animation-duration ease;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       border-top: solid 5px;
       opacity: 0.5;
     }
@@ -61,7 +59,7 @@ $piece-animation-duration: 250ms !default;
     transform-origin: top left;
     transition: transform $piece-animation-duration ease;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       border-top: solid $height;
     }
   }

--- a/src/material/legacy-progress-spinner/BUILD.bazel
+++ b/src/material/legacy-progress-spinner/BUILD.bazel
@@ -39,7 +39,6 @@ sass_binary(
     name = "progress_spinner_scss",
     src = "progress-spinner.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-progress-spinner/progress-spinner.scss
+++ b/src/material/legacy-progress-spinner/progress-spinner.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/variables';
 
 $_default-radius: 45px;
@@ -26,7 +24,7 @@ $_default-circumference: variables.$pi * $_default-radius * 2;
     fill: transparent;
     transition: stroke-dashoffset 225ms linear;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       // SVG colors aren't inverted automatically in high contrast mode. Set the
       // stroke to `CanvasText` in order to respect the user's color settings.
       // Note that we use `CanvasText` instead of `currentColor`, because

--- a/src/material/legacy-radio/BUILD.bazel
+++ b/src/material/legacy-radio/BUILD.bazel
@@ -39,7 +39,6 @@ sass_binary(
     name = "radio_scss",
     src = "radio.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-radio/radio.scss
+++ b/src/material/legacy-radio/radio.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/variables';
 @use '../core/ripple/ripple';
@@ -96,7 +95,7 @@ $ripple-radius: 20px;
     opacity: 1;
     transition: $base-transition;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       // Since we use a background color to render the circle, it won't be
       // displayed in high contrast mode. Use a border as a fallback.
       border: solid math.div($size, 2);
@@ -216,7 +215,7 @@ $ripple-radius: 20px;
   content: '';
 }
 
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   .mat-radio-disabled {
     opacity: 0.5;
   }

--- a/src/material/legacy-select/BUILD.bazel
+++ b/src/material/legacy-select/BUILD.bazel
@@ -33,7 +33,6 @@ sass_binary(
     name = "legacy_select_scss",
     src = "select.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-select/select.scss
+++ b/src/material/legacy-select/select.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/menu-common';
 @use '../core/style/list-common';
@@ -110,7 +109,7 @@ $placeholder-arrow-space: 2 * ($arrow-size + $arrow-margin);
   border-radius: 4px;
   outline: 0;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }

--- a/src/material/legacy-slide-toggle/BUILD.bazel
+++ b/src/material/legacy-slide-toggle/BUILD.bazel
@@ -39,7 +39,6 @@ sass_binary(
     name = "slide_toggle_scss",
     src = "slide-toggle.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-slide-toggle/slide-toggle.scss
+++ b/src/material/legacy-slide-toggle/slide-toggle.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 
 @use '../core/style/vendor-prefixes';
 @use '../core/style/variables';
@@ -228,7 +227,7 @@ $bar-track-width: $bar-width - $thumb-size;
 }
 
 // Custom styling to make the slide-toggle usable in high contrast mode.
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   .mat-slide-toggle-thumb,
   .mat-slide-toggle-bar {
     border: 1px solid;

--- a/src/material/legacy-slider/BUILD.bazel
+++ b/src/material/legacy-slider/BUILD.bazel
@@ -42,7 +42,6 @@ sass_binary(
     name = "slider_scss",
     src = "slider.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/legacy-slider/slider.scss
+++ b/src/material/legacy-slider/slider.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use 'sass:math';
 
 @use '../core/style/variables';
@@ -153,7 +152,7 @@ $focus-ring-size: 30px !default;
     border-radius  variables.$swift-ease-out-duration variables.$swift-ease-out-timing-function,
     background-color  variables.$swift-ease-out-duration variables.$swift-ease-out-timing-function;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }
@@ -314,7 +313,7 @@ $focus-ring-size: 30px !default;
     height: $track-thickness;
     width: 100%;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       height: 0;
       outline: solid $track-thickness;
       top: math.div($track-thickness, 2);
@@ -354,7 +353,7 @@ $focus-ring-size: 30px !default;
       transform: rotate(45deg);
     }
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       .mat-slider-thumb-label,
       .mat-slider-thumb-label-text {
         transform: none;
@@ -404,7 +403,7 @@ $focus-ring-size: 30px !default;
     width: $track-thickness;
     height: 100%;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       width: 0;
       outline: solid $track-thickness;
       left: math.div($track-thickness, 2);

--- a/src/material/legacy-snack-bar/BUILD.bazel
+++ b/src/material/legacy-snack-bar/BUILD.bazel
@@ -45,9 +45,6 @@ sass_library(
 sass_binary(
     name = "snack_bar_container_scss",
     src = "snack-bar-container.scss",
-    deps = [
-        "//src/cdk:sass_lib",
-    ],
 )
 
 sass_binary(

--- a/src/material/legacy-snack-bar/snack-bar-container.scss
+++ b/src/material/legacy-snack-bar/snack-bar-container.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 $padding: 14px 16px !default;
 $min-height: 48px !default;
 $min-width: 344px !default;
@@ -19,7 +17,7 @@ $spacing-margin-handset: 8px !default;
   min-height: $min-height;
   transform-origin: center;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     border: solid 1px;
   }
 }

--- a/src/material/legacy-tabs/_tabs-common.scss
+++ b/src/material/legacy-tabs/_tabs-common.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/variables';
 @use '../core/style/private';
 @use '../core/style/vendor-prefixes';
@@ -34,7 +32,7 @@ $tab-animation-duration: 500ms !default;
   &.mat-tab-disabled {
     cursor: default;
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       opacity: 0.5;
     }
   }
@@ -46,7 +44,7 @@ $tab-animation-duration: 500ms !default;
     white-space: nowrap;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     opacity: 1;
   }
 }
@@ -68,7 +66,7 @@ $tab-animation-duration: 500ms !default;
     top: 0;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid $height;
     height: 0;
   }

--- a/src/material/legacy-tooltip/BUILD.bazel
+++ b/src/material/legacy-tooltip/BUILD.bazel
@@ -44,9 +44,6 @@ sass_library(
 sass_binary(
     name = "tooltip_scss",
     src = "tooltip.scss",
-    deps = [
-        "//src/cdk:sass_lib",
-    ],
 )
 
 ng_test_library(

--- a/src/material/legacy-tooltip/tooltip.scss
+++ b/src/material/legacy-tooltip/tooltip.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 $horizontal-padding: 8px;
 $max-width: 250px;
 $margin: 14px;
@@ -23,7 +21,7 @@ $handset-margin: 24px;
     transform: scale(1);
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }

--- a/src/material/list/BUILD.bazel
+++ b/src/material/list/BUILD.bazel
@@ -39,9 +39,6 @@ ng_module(
 sass_library(
     name = "hcm_indicator_scss_lib",
     srcs = ["_list-item-hcm-indicator.scss"],
-    deps = [
-        "//:mdc_sass_lib",
-    ],
 )
 
 sass_library(

--- a/src/material/list/_list-item-hcm-indicator.scss
+++ b/src/material/list/_list-item-hcm-indicator.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use '@material/list/evolution-variables' as mdc-list-variables;
 
 // Renders a circle indicator when Windows Hich Constrast mode (HCM) is enabled. In some
@@ -6,7 +5,7 @@
 // its background color. Since that doesn't work in HCM, this mixin provides an alternative by
 // rendering a circle.
 @mixin private-high-contrast-list-item-indicator() {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
         &::after {
             $size: 10px;
             content: '';

--- a/src/material/menu/BUILD.bazel
+++ b/src/material/menu/BUILD.bazel
@@ -45,7 +45,6 @@ sass_binary(
     src = "menu.scss",
     deps = [
         "//:mdc_sass_lib",
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/menu/menu.scss
+++ b/src/material/menu/menu.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '@angular/cdk';
 @use '@material/menu-surface' as mdc-menu-surface;
 @use '@material/list/evolution-mixins' as mdc-list-mixins;
 @use '@material/list/evolution-variables' as mdc-list-variables;
@@ -22,7 +21,7 @@ mat-menu {
 }
 
 .mat-mdc-menu-panel {
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 }
@@ -119,7 +118,7 @@ mat-menu {
     @include menu-common.item-submenu-trigger(mdc-list-variables.$side-padding);
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     $outline-width: 1px;
 
     // We need to move the item 1px down, because Firefox seems to have

--- a/src/material/paginator/BUILD.bazel
+++ b/src/material/paginator/BUILD.bazel
@@ -43,9 +43,6 @@ sass_library(
 sass_binary(
     name = "paginator_scss",
     src = "paginator.scss",
-    deps = [
-        "//src/cdk:sass_lib",
-    ],
 )
 
 ng_test_library(

--- a/src/material/paginator/paginator.scss
+++ b/src/material/paginator/paginator.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 $padding: 0 8px;
 $page-size-margin-right: 8px;
 
@@ -79,7 +77,7 @@ $button-icon-size: 28px;
   }
 }
 
-@include cdk.high-contrast(active, off) {
+@media(forced-colors: active) {
   // The disabled button icon has to be set explicitly since the selector is too specific.
   .mat-mdc-icon-button[disabled] .mat-mdc-paginator-icon,
   .mat-mdc-paginator-icon {

--- a/src/material/progress-spinner/progress-spinner.scss
+++ b/src/material/progress-spinner/progress-spinner.scss
@@ -1,6 +1,5 @@
 @use 'sass:map';
 @use '../core/mdc-helpers/mdc-helpers';
-@use '@angular/cdk';
 @use '@material/circular-progress/circular-progress' as mdc-circular-progress;
 @use '@material/circular-progress/circular-progress-theme' as mdc-circular-progress-theme;
 
@@ -61,7 +60,7 @@
     }
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     .mdc-circular-progress__indeterminate-circle-graphic,
     .mdc-circular-progress__determinate-circle {
       // SVG colors aren't inverted automatically in high contrast mode. Set the

--- a/src/material/select/BUILD.bazel
+++ b/src/material/select/BUILD.bazel
@@ -54,7 +54,6 @@ sass_binary(
     src = "select.scss",
     deps = [
         "//:mdc_sass_lib",
-        "//src/cdk:sass_lib",
         "//src/material:sass_lib",
     ],
 )

--- a/src/material/select/select.scss
+++ b/src/material/select/select.scss
@@ -1,5 +1,4 @@
 @use 'sass:math';
-@use '@angular/cdk';
 @use '@material/menu-surface' as mdc-menu-surface;
 @use '@material/list/evolution-mixins' as mdc-list;
 @use '../core/style/vendor-prefixes';
@@ -79,7 +78,7 @@ $scale: 0.75 !default;
     left: 50%;
     transform: translate(-50%, -50%);
 
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       // On Chromium browsers the `currentColor` blends in with the
       // background for SVGs so we have to fall back to `CanvasText`.
       fill: CanvasText;
@@ -100,7 +99,7 @@ $scale: 0.75 !default;
   outline: 0;
 
   @include mdc-list.list-base($query: structure);
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 

--- a/src/material/sidenav/BUILD.bazel
+++ b/src/material/sidenav/BUILD.bazel
@@ -45,7 +45,6 @@ sass_binary(
     name = "drawer_scss",
     src = "drawer.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/sidenav/drawer.scss
+++ b/src/material/sidenav/drawer.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/variables';
 @use '../core/style/layout-common';
 
@@ -84,7 +82,7 @@ $drawer-over-drawer-z-index: 4;
     }
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     opacity: 0.5;
   }
 }
@@ -121,13 +119,13 @@ $drawer-over-drawer-z-index: 4;
   transform: translate3d(-100%, 0, 0);
 
   &, [dir='rtl'] &.mat-drawer-end {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       border-right: $high-contrast-border;
     }
   }
 
   [dir='rtl'] &, &.mat-drawer-end {
-    @include cdk.high-contrast(active, off) {
+    @media(forced-colors: active) {
       border-left: $high-contrast-border;
       border-right: none;
     }

--- a/src/material/snack-bar/BUILD.bazel
+++ b/src/material/snack-bar/BUILD.bazel
@@ -49,7 +49,6 @@ sass_binary(
     src = "snack-bar-container.scss",
     deps = [
         "//:mdc_sass_lib",
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/snack-bar/snack-bar-container.scss
+++ b/src/material/snack-bar/snack-bar-container.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '@angular/cdk';
 @use '@material/snackbar/snackbar' as mdc-snackbar;
 @use '@material/snackbar/snackbar-theme' as mdc-snackbar-theme;
 @use '../core/mdc-helpers/mdc-helpers';
@@ -60,7 +59,7 @@
   // of positions, so we'll defer logic there.
   position: static;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     border: solid 1px;
   }
 

--- a/src/material/sort/BUILD.bazel
+++ b/src/material/sort/BUILD.bazel
@@ -39,7 +39,6 @@ sass_binary(
     name = "sort_header_scss",
     src = "sort-header.scss",
     deps = [
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/sort/sort-header.scss
+++ b/src/material/sort/sort-header.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/focus-indicators/private';
 
 $header-arrow-margin: 6px;
@@ -79,7 +77,7 @@ $header-arrow-hint-opacity: 0.38;
   display: flex;
   align-items: center;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     width: 0;
     border-left: solid $header-arrow-thickness;
   }
@@ -102,7 +100,7 @@ $header-arrow-hint-opacity: 0.38;
   background: currentColor;
   transform: rotate(45deg);
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     width: 0;
     height: 0;
     border-top: solid $header-arrow-thickness;
@@ -118,7 +116,7 @@ $header-arrow-hint-opacity: 0.38;
   position: absolute;
   top: 0;
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     width: 0;
     height: 0;
     border-left: solid $header-arrow-pointer-length;

--- a/src/material/stepper/BUILD.bazel
+++ b/src/material/stepper/BUILD.bazel
@@ -51,7 +51,6 @@ sass_binary(
     src = "stepper.scss",
     deps = [
         ":stepper_scss_lib",
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )
@@ -61,7 +60,6 @@ sass_binary(
     src = "step-header.scss",
     deps = [
         ":stepper_scss_lib",
-        "//src/cdk:sass_lib",
         "//src/material/core:core_scss_lib",
     ],
 )

--- a/src/material/stepper/step-header.scss
+++ b/src/material/stepper/step-header.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 @use '../core/style/layout-common';
 @use './stepper-variables';
 
@@ -17,7 +15,7 @@
     content: '';
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
 
     &[aria-selected='true'] {

--- a/src/material/stepper/stepper.scss
+++ b/src/material/stepper/stepper.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use 'sass:math';
 
 @use '../core/style/variables';
@@ -145,7 +144,7 @@
 }
 
 .mat-horizontal-content-container {
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 
@@ -158,7 +157,7 @@
 }
 
 .mat-vertical-content-container {
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 

--- a/src/material/tabs/tab-header.scss
+++ b/src/material/tabs/tab-header.scss
@@ -1,4 +1,3 @@
-@use '@angular/cdk';
 @use './tabs-common';
 
 @include tabs-common.paginated-tab-header;
@@ -18,7 +17,7 @@
     margin: 5px;
   }
 
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     // When a tab is disabled in high contrast mode, set the text color to the disabled
     // color, which is (unintuitively) named "GrayText".
     &[aria-disabled='true'] {

--- a/src/material/toolbar/BUILD.bazel
+++ b/src/material/toolbar/BUILD.bazel
@@ -39,9 +39,6 @@ sass_library(
 sass_binary(
     name = "toolbar_scss",
     src = "toolbar.scss",
-    deps = [
-        "//src/cdk:sass_lib",
-    ],
 )
 
 ng_test_library(

--- a/src/material/toolbar/toolbar.scss
+++ b/src/material/toolbar/toolbar.scss
@@ -1,5 +1,3 @@
-@use '@angular/cdk';
-
 $row-padding: 16px !default;
 
 // @deprecated @breaking-change 8.0.0
@@ -7,7 +5,7 @@ $row-padding: 16px !default;
 $height-mobile-portrait: 56px !default;
 
 .mat-toolbar {
-  @include cdk.high-contrast(active, off) {
+  @media(forced-colors: active) {
     outline: solid 1px;
   }
 

--- a/tools/public_api_guard/cdk/a11y.md
+++ b/tools/public_api_guard/cdk/a11y.md
@@ -255,7 +255,7 @@ export interface FocusTrapInertStrategy {
     preventFocus(focusTrap: FocusTrap): void;
 }
 
-// @public
+// @public @deprecated
 export const enum HighContrastMode {
     // (undocumented)
     BLACK_ON_WHITE = 1,
@@ -265,10 +265,12 @@ export const enum HighContrastMode {
     WHITE_ON_BLACK = 2
 }
 
-// @public
+// @public @deprecated
 export class HighContrastModeDetector implements OnDestroy {
     constructor(_platform: Platform, document: any);
+    // @deprecated
     _applyBodyHighContrastModeCssClasses(): void;
+    // @deprecated
     getHighContrastMode(): HighContrastMode;
     // (undocumented)
     ngOnDestroy(): void;


### PR DESCRIPTION
Completely deprecate `HighContrastModeDetector` and use forced-colors
media query instead.

This is still a draft because every component needs to be smoke tested. that's because switching to `forced-colors` changes the specificity and could cause issues.

High contrast mode is a Windows feature but testing can be done on other platforms on Firefox and Chrome.
https://developer.chrome.com/blog/new-in-devtools-98/#forced-colors