### PR TITLE
build: dependencies duplicated when deploying snapshots

### DIFF
--- a/scripts/docs-deploy/install-built-packages.mts
+++ b/scripts/docs-deploy/install-built-packages.mts
@@ -7,23 +7,13 @@ import {getPackageJsonOfProject} from './utils.mjs';
 export async function installBuiltPackagesInRepo(repoPath: string, builtPackages: BuiltPackage[]) {
   const {parsed: packageJson, path: packageJsonPath} = await getPackageJsonOfProject(repoPath);
 
-  // We will use Yarn resolutions to install the built packages.
-  if (packageJson.resolutions === undefined) {
-    packageJson.resolutions = {};
-  }
-
   for (const builtPackage of builtPackages) {
     const pkgName = builtPackage.name;
     const destinationUrl = url.pathToFileURL(builtPackage.outputPath);
 
-    // Add resolutions for each package in the format "**/{PACKAGE}" so that all
-    // nested versions of that specific package will have the same version.
-    packageJson.resolutions[`**/${pkgName}`] = destinationUrl;
-
-    // Since the resolutions only control the version of all nested installs, we also need
-    // to explicitly set the version for the package listed in the project "package.json".
-    // e.g. the resolution above ensures transitive installs of `@angular/cdk` are updated,
-    // while the `dependencies` field overrides the workspace install of `@angular/cdk`.
+    // Override the dependencies to point to the local files instead of the version on npm.
+    // Note that we don't want to change the `resolutions` to point to the same files, because it
+    // can cause duplicated dependencies (see #24992).
     packageJson.dependencies[pkgName] = destinationUrl;
 
     // In case this dependency was previously a dev dependency, just remove it because we


### PR DESCRIPTION
We were adding a `resolutions` field to the package.json of the docs site when deploying it from the main repo to try and control the version that is installed. This appears to be causing an issue where Yarn duplicates the dependencies which in turn causes Webpack to bundle them once for the main site and another for the lazy-loaded chunks with the examples. These changes resolve the issue by not adding the `resolutions` field.

For reference, currently the docs package depends on `@angular/cdk@14.1.0-next.1+sha-7d87068-with-local-changes` whereas the docs site depends on `@angular/cdk@file://path/to/repo/dist/releases/cdk`.

Fixes #24992.