### PR TITLE
fix(material-experimental/mdc-chips): missing role for trailing actions container

### DIFF
--- a/src/material-experimental/mdc-chips/chip-row.html
+++ b/src/material-experimental/mdc-chips/chip-row.html
@@ -32,6 +32,7 @@
 
 <span
   class="mdc-evolution-chip__cell mdc-evolution-chip__cell--trailing"
+  role="gridcell"
   *ngIf="_hasTrailingIcon()">
   <ng-content select="mat-chip-trailing-icon,[matChipRemove],[matChipTrailingIcon]"></ng-content>
 </span>


### PR DESCRIPTION
Fixes that we didn't have a `role="gridcell"` around the trailing action of a `mat-chip-row`.