### PR TITLE
feat(youtube-player): support no cookie mode

### DIFF
--- a/src/dev-app/youtube-player/BUILD.bazel
+++ b/src/dev-app/youtube-player/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
         ":youtube_player_demo_scss",
     ],
     deps = [
+        "//src/material/legacy-checkbox",
         "//src/material/legacy-radio",
         "//src/youtube-player",
         "@npm//@angular/forms",

--- a/src/dev-app/youtube-player/youtube-player-demo.html
+++ b/src/dev-app/youtube-player/youtube-player-demo.html
@@ -10,7 +10,11 @@
         <mat-radio-button [value]="undefined">Unset</mat-radio-button>
       </mat-radio-group>
     </div>
+    <div class="demo-video-selection">
+      <mat-checkbox [(ngModel)]="disableCookies">Disable cookies</mat-checkbox>
+    </div>
     <youtube-player [videoId]="selectedVideo && selectedVideo.id"
-                    [width]="videoWidth" [height]="videoHeight"></youtube-player>
+                    [width]="videoWidth" [height]="videoHeight"
+                    [disableCookies]="disableCookies"></youtube-player>
   </section>
 </div>

--- a/src/dev-app/youtube-player/youtube-player-demo.ts
+++ b/src/dev-app/youtube-player/youtube-player-demo.ts
@@ -18,6 +18,7 @@ import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {MatLegacyRadioModule} from '@angular/material/legacy-radio';
 import {YouTubePlayerModule} from '@angular/youtube-player';
+import {MatLegacyCheckboxModule} from '@angular/material/legacy-checkbox';
 
 interface Video {
   id: string;
@@ -44,7 +45,13 @@ const VIDEOS: Video[] = [
   templateUrl: 'youtube-player-demo.html',
   styleUrls: ['youtube-player-demo.css'],
   standalone: true,
-  imports: [CommonModule, FormsModule, MatLegacyRadioModule, YouTubePlayerModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatLegacyRadioModule,
+    MatLegacyCheckboxModule,
+    YouTubePlayerModule,
+  ],
 })
 export class YouTubePlayerDemo implements AfterViewInit, OnDestroy {
   @ViewChild('demoYouTubePlayer') demoYouTubePlayer: ElementRef<HTMLDivElement>;
@@ -52,6 +59,7 @@ export class YouTubePlayerDemo implements AfterViewInit, OnDestroy {
   videos = VIDEOS;
   videoWidth: number | undefined;
   videoHeight: number | undefined;
+  disableCookies = false;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {
     this._loadApi();

--- a/src/youtube-player/youtube-player.spec.ts
+++ b/src/youtube-player/youtube-player.spec.ts
@@ -380,6 +380,28 @@ describe('YoutubePlayer', () => {
 
       expect(playerSpy.seekTo).toHaveBeenCalledWith(1337, true);
     });
+
+    it('should be able to disable cookies', () => {
+      const containerElement = fixture.nativeElement.querySelector('div');
+
+      expect(playerCtorSpy).toHaveBeenCalledWith(
+        containerElement,
+        jasmine.objectContaining({
+          host: undefined,
+        }),
+      );
+
+      playerCtorSpy.calls.reset();
+      fixture.componentInstance.disableCookies = true;
+      fixture.detectChanges();
+
+      expect(playerCtorSpy).toHaveBeenCalledWith(
+        containerElement,
+        jasmine.objectContaining({
+          host: 'https://www.youtube-nocookie.com',
+        }),
+      );
+    });
   });
 
   describe('API loaded asynchronously', () => {
@@ -498,6 +520,7 @@ describe('YoutubePlayer', () => {
     <youtube-player #player [videoId]="videoId" *ngIf="visible" [width]="width" [height]="height"
       [startSeconds]="startSeconds" [endSeconds]="endSeconds" [suggestedQuality]="suggestedQuality"
       [playerVars]="playerVars"
+      [disableCookies]="disableCookies"
       (ready)="onReady($event)"
       (stateChange)="onStateChange($event)"
       (playbackQualityChange)="onPlaybackQualityChange($event)"
@@ -509,6 +532,7 @@ describe('YoutubePlayer', () => {
 })
 class TestApp {
   videoId: string | undefined = VIDEO_ID;
+  disableCookies = false;
   visible = true;
   width: number | undefined;
   height: number | undefined;

--- a/tools/public_api_guard/youtube-player/youtube-player.md
+++ b/tools/public_api_guard/youtube-player/youtube-player.md
@@ -25,6 +25,8 @@ export class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     constructor(_ngZone: NgZone, platformId: Object);
     // (undocumented)
     readonly apiChange: Observable<YT.PlayerEvent>;
+    get disableCookies(): boolean;
+    set disableCookies(value: unknown);
     set endSeconds(endSeconds: number | undefined);
     // (undocumented)
     readonly error: Observable<YT.OnErrorEvent>;
@@ -74,7 +76,7 @@ export class YouTubePlayer implements AfterViewInit, OnDestroy, OnInit {
     set width(width: number | undefined);
     youtubeContainer: ElementRef<HTMLElement>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<YouTubePlayer, "youtube-player", never, { "videoId": "videoId"; "height": "height"; "width": "width"; "startSeconds": "startSeconds"; "endSeconds": "endSeconds"; "suggestedQuality": "suggestedQuality"; "playerVars": "playerVars"; "showBeforeIframeApiLoads": "showBeforeIframeApiLoads"; }, { "ready": "ready"; "stateChange": "stateChange"; "error": "error"; "apiChange": "apiChange"; "playbackQualityChange": "playbackQualityChange"; "playbackRateChange": "playbackRateChange"; }, never, never, false>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<YouTubePlayer, "youtube-player", never, { "videoId": "videoId"; "height": "height"; "width": "width"; "startSeconds": "startSeconds"; "endSeconds": "endSeconds"; "suggestedQuality": "suggestedQuality"; "playerVars": "playerVars"; "disableCookies": "disableCookies"; "showBeforeIframeApiLoads": "showBeforeIframeApiLoads"; }, { "ready": "ready"; "stateChange": "stateChange"; "error": "error"; "apiChange": "apiChange"; "playbackQualityChange": "playbackQualityChange"; "playbackRateChange": "playbackRateChange"; }, never, never, false>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<YouTubePlayer, never>;
 }


### PR DESCRIPTION
Adds a `disableCookies` input that puts the player into "no cookie" mode.

Fixes #19681.