### PR TITLE
docs(material/autocomplete): use single map instead of two maps in a row

### DIFF
--- a/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.ts
@@ -26,7 +26,7 @@ export class AutocompleteDisplayExample implements OnInit {
       map(value => {
         const name = typeof value === 'string' ? value : value?.name;
         return name ? this._filter(name as string) : this.options.slice();
-      })
+      }),
     );
   }
 

--- a/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.ts
+++ b/src/components-examples/material/autocomplete/autocomplete-display/autocomplete-display-example.ts
@@ -23,8 +23,10 @@ export class AutocompleteDisplayExample implements OnInit {
   ngOnInit() {
     this.filteredOptions = this.myControl.valueChanges.pipe(
       startWith(''),
-      map(value => (typeof value === 'string' ? value : value?.name)),
-      map(name => (name ? this._filter(name) : this.options.slice())),
+      map(value => {
+        const name = typeof value === 'string' ? value : value?.name;
+        return name ? this._filter(name as string) : this.options.slice();
+      })
     );
   }
 


### PR DESCRIPTION
### Why: 
The example code is highly trusted and sometimes
taken as is (copy-paste), so it is important to
have it optimised if possible.

### what
Each map means an iteration over the array items.
By using single map, an iteration is saved, and
an approximate performance of about 38% is won.

I measured the performance here: https://jsbench.me/dbl4wkw3r9/1